### PR TITLE
chore(mobile): 建立四个业务模块目录

### DIFF
--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -1,0 +1,2 @@
+/// Conversation module boundary.
+library;

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -1,0 +1,2 @@
+/// Practice module boundary.
+library;

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -1,0 +1,2 @@
+/// Preparation module boundary.
+library;

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -1,0 +1,2 @@
+/// Review module boundary.
+library;


### PR DESCRIPTION
## 功能描述

建立 Flutter 客户端的四个纵向业务模块目录：

- `preparation`
- `practice`
- `conversation`
- `review`

Refs #19
Refs #24

## 实现思路

- 每个模块目录只包含一个最小 Dart library 声明，用于让 Git 跟踪目录并接受静态分析。
- 不使用 `.gitkeep`，遵守目录需要包含可编译内容的约束。
- 不加入页面、路由、状态、数据模型或业务流程。

## 测试方式

```shell
cd mobile
dart format --output=none --set-exit-if-changed lib
flutter analyze
```

本地结果：

- 格式检查通过。
- `flutter analyze`：No issues found。

## 相关 Issue / 备注

- #28 已合并，本 PR 当前仅包含四个模块文件。
- 后续 App Shell、导航和具体模块入口应继续按独立任务实现。

## AI 辅助说明

- 使用 Codex 协助从原 PR 中拆出模块目录边界并执行格式、静态分析检查。
- Review 要点：四个目录命名是否与 #24 一致，以及本 PR 是否保持纯目录骨架边界。
