### PR TITLE
feat(review): 建立复盘模块接口骨架

### DIFF
--- a/server/internal/review/analyze.go
+++ b/server/internal/review/analyze.go
@@ -1,0 +1,52 @@
+package review
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrAnalysisNotFound 表示不存在指定的 Review Analysis。
+	ErrAnalysisNotFound = errors.New("analysis not found")
+	// ErrFeedbackNotFound 表示不存在指定的 Review Feedback。
+	ErrFeedbackNotFound = errors.New("feedback not found")
+)
+
+// AnalyzeUseCase 定义 Turn 分析和证据反馈查询能力。
+// 本接口只描述应用契约，不包含具体分析流程。
+type AnalyzeUseCase interface {
+	// AnalyzeTurn 请求分析一个已完成的来源 Turn。
+	// 相同 TurnID 和评分版本的幂等处理由后续具体实现负责。
+	AnalyzeTurn(ctx context.Context, command AnalyzeTurnCommand) (AnalyzeTurnResult, error)
+
+	// GetTurnReview 根据稳定 AnalysisID 返回一次确定的复盘结果。
+	GetTurnReview(ctx context.Context, query GetTurnReviewQuery) (TurnReviewDetail, error)
+
+	// GetFeedback 返回一条句子级证据反馈。
+	// Feedback 只保存音频时间范围；音频内容和播放能力仍归 Conversation 所有。
+	GetFeedback(ctx context.Context, feedbackID string) (FeedbackItem, error)
+}
+
+// AnalyzeTurnCommand 标识需要分析的来源 Turn。
+// Review 只引用稳定 ID，不修改来源 Turn、Transcript、音频或 PracticeSession。
+type AnalyzeTurnCommand struct {
+	TurnID string
+}
+
+// AnalyzeTurnResult 是 Turn 分析用例的返回结果。
+type AnalyzeTurnResult struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+	Reused   bool
+}
+
+// GetTurnReviewQuery 使用稳定 AnalysisID 查询一次确定的复盘结果。
+type GetTurnReviewQuery struct {
+	AnalysisID string
+}
+
+// TurnReviewDetail 聚合一次 Analysis 及其证据反馈。
+type TurnReviewDetail struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+}

--- a/server/internal/review/docs/Review 模块跨模块接口需求.md
+++ b/server/internal/review/docs/Review 模块跨模块接口需求.md
@@ -1,0 +1,396 @@
+# Review 模块跨模块接口需求
+
+## 1. 文档目的
+
+本文档用于说明 `review` 模块在实现 TurnAnalysis、证据反馈、同题重答、历史记录和 Session 级复盘报告时，需要其他业务模块提供的公开能力。
+
+本文档只描述模块协作契约，不要求其他模块暴露内部领域模型、Repository、数据库表、本地文件路径或可变状态。最终接口名称和字段可以在联调时微调，但数据所有权和调用方向不应改变。
+
+## 2. 已确认的职责分工
+
+### Practice（成员 B）
+
+- 拥有 `PracticeSession`、训练目标和 Session 生命周期。
+- 向 Review 提供 Session 与训练目标的最小只读快照。
+- 不负责评分、证据反馈和 Session 复盘报告生成。
+
+### Conversation（成员 C）
+
+- 拥有 `Question`、`Turn`、`Transcript`、原始语音和媒体处理状态。
+- 向 Review 提供指定 Session 下已完成、可复盘的 Turn ID 列表。
+- 向 Review 提供已经完成的 Turn 对应的题目信息、Transcript 只读快照和音频引用。
+- 根据音频引用向 Review 提供只读音频流。
+- 根据 Review 的重答请求创建新的同题 Turn。
+- 不负责评分、评价、证据反馈和分析结果持久化。
+
+### Review（成员 D）
+
+- 获取已完成 Turn 的题目信息、Transcript 只读快照和音频数据。
+- 选择评分实现路径：直接把音频提交给支持音频的模型/API，或者先将音频转写为文字，再调用语言模型。
+- 创建并保存 `TurnAnalysis`。
+- 根据评分结果创建并保存带证据的 `FeedbackItem`。
+- 创建和管理 `RetryRequest`。
+- 关联原 Turn 与同题重答产生的新 Turn。
+- 建立和查询 History Read Model。
+- 汇总 Session 下的 TurnAnalysis 和 Feedback，生成 Session 级复盘报告。
+
+## 3. Review 模块边界
+
+Review 不负责：
+
+- 创建或修改原始 `Question`、`Turn` 和音频。
+- 直接读取 Conversation 的文件目录、对象存储或数据库表。
+- 把分析过程中生成的转写覆盖回 Conversation 的原始 Transcript。
+- 直接创建同题重答产生的新 Turn。
+- 修改 `PracticeSession` 的生命周期或训练进度。
+- 修改场景、角色和背景快照。
+
+## 4. 数据所有权
+
+| 数据 | 唯一写入模块 | Review 的使用方式 |
+|---|---|---|
+| `Question`、`Turn`、`Transcript` | `conversation` | 通过公开接口读取最小只读快照 |
+| 原始音频、音频媒体状态 | `conversation` | 先获取 `AudioID` 和元数据，再通过公开接口打开音频流 |
+| 分析用临时转写 | `review` | 仅用于评分和证据生成，不覆盖 Conversation 数据 |
+| `PracticeSession`、Session 进度 | `practice` | Review 不直接修改 |
+| Session 与训练目标只读快照 | `practice` | Review 仅用于生成 Session 级复盘报告 |
+| `TurnAnalysis`、`FeedbackItem` | `review` | Review 创建并保存 |
+| `RetryRequest` | `review` | Review 创建并维护状态 |
+| 同题重答产生的新 `Turn` | `conversation` | Review 只保存关联 ID |
+| History Read Model | `review` | 只读投影，不作为源数据 |
+| Session 级复盘只读视图 | `review` | Review 内部生成，只引用其他模块的稳定 ID；不新增跨模块公共核心对象 |
+
+## 5. 依赖总览
+
+```text
+practice
+  └── 提供 Session 与训练目标只读快照
+
+conversation
+  ├── 提供 Session 下已完成、可复盘的 Turn ID 列表
+  ├── 提供已完成 Turn 的题目和 Transcript
+  ├── 提供该 Turn 的 AudioID 与音频元数据
+  ├── 根据 AudioID 打开只读音频流
+  └── 根据 RetryRequest 创建同题重答 Turn
+             ↓
+review
+  ├── 调用音频评分 API
+  │        或
+  ├── 音频转写 → 语言模型评分
+  ├── TurnAnalysis
+  ├── Evidence Feedback
+  ├── RetryRequest
+  ├── History Read Model
+  └── Session Review Report
+```
+
+评分、评价和 Session 报告生成属于 Review，不要求 Practice 或 Conversation 提供评分接口。
+
+## 6. 向 Practice 模块请求的能力
+
+用途：Review 生成 Session 级报告时，需要知道本次练习的 Session 状态和训练目标，但不读取或修改 Practice 内部模型。
+
+Review 不要求 Practice 新增一套专用的 Session 复盘公共对象或查询接口。D 复用 #34、#35 已冻结的公开能力：
+
+```text
+GetPracticeSessionSnapshot(practice_session_id) -> PracticeSessionSnapshot
+```
+
+Review 可在自己的 `ports.go` 中定义消费方窄 Port，由后续 Adapter 调用上述 Practice Service：
+
+建议的 Review Port：
+
+```go
+type PracticeSessionSnapshotReader interface {
+	GetPracticeSessionSnapshot(
+		ctx context.Context,
+		practiceSessionID string,
+	) (PracticeSessionSnapshot, error)
+}
+```
+
+`PracticeSessionSnapshot` 的字段以 #34、#35 的冻结契约为准。Review 只消费报告所需字段，不在本模块复制 Practice 的完整领域模型。
+
+约束：
+
+- 只返回生成复盘报告所需的最小只读数据。
+- Review 不通过该接口修改 Session 状态、训练目标或主进度。
+- Practice 提供“计划练什么”，Review 负责判断“完成得怎么样”。
+- Session 不存在或当前不可生成报告时，需要返回可区分的错误。
+- 不新增重复的 `SessionReviewContext` 公共对象；如需裁剪字段，由 Review Adapter 完成投影。
+
+## 7. 向 Conversation 模块请求的能力
+
+Review 复用 Conversation 已冻结的 `ListPracticeSessionTurns` 等公开 Service 能力。Review 可在自己的 `ports.go` 中定义更窄的消费方 Port，联调时由 Adapter 完成过滤和数据投影，不要求 Conversation 新增重复查询。
+
+### 7.1 获取 Session 下可复盘的 Turn ID
+
+用途：Review 从 `SessionID` 开始生成完整报告时，需要先获得该 Session 下已经完成且允许复盘的 Turn。
+
+建议的 Review Port：
+
+```go
+type SessionReviewTurnReader interface {
+	ListCompletedReviewTurnIDs(
+		ctx context.Context,
+		actorUserID string,
+		practiceSessionID string,
+	) ([]string, error)
+}
+```
+
+后续 Adapter 调用 Conversation 的 `ListPracticeSessionTurns`，传入当前用户和 Practice Session 的稳定 ID，从结果中筛选已完成且可复盘的 Turn，并只向 Review 返回稳定 Turn ID。
+
+约束：
+
+- 只返回 Conversation 拥有的稳定 Turn ID，不返回可变 Turn 对象。
+- 只包含已完成且允许复盘的 Turn。
+- 返回顺序应稳定，建议按完成时间升序。
+- Session 不存在或没有可复盘 Turn 时，需要返回可区分的错误或空结果语义。
+- Review 获得 Turn ID 后，继续复用单 Turn 复盘接口读取详细资料。
+
+### 7.2 获取已完成 Turn 的复盘数据
+
+用途：Review 先获取评分所需的题目上下文、Transcript 只读快照、`AudioID` 和音频元数据；真正开始评分时，再根据 `AudioID` 打开音频流。
+
+建议拆成两个 Review Port：
+
+```go
+type TurnReviewSourceReader interface {
+	GetCompletedTurnReviewSource(
+		ctx context.Context,
+		turnID string,
+	) (TurnReviewSource, error)
+}
+
+type AudioContentReader interface {
+	OpenAudio(
+		ctx context.Context,
+		audioID string,
+	) (io.ReadCloser, error)
+}
+```
+
+建议的最小返回结构：
+
+```go
+type TurnReviewSource struct {
+	TurnID       string
+	SessionID    string
+	QuestionID   string
+	QuestionText string
+	Transcript   TranscriptSnapshot
+	Audio        AudioReference
+	CompletedAt  time.Time
+}
+
+type AudioReference struct {
+	AudioID     string
+	ContentType string
+	Format      string
+	SizeBytes   int64
+	DurationMS  int64
+	Checksum    string
+}
+
+type TranscriptSnapshot struct {
+	TranscriptID string
+	Text         string
+	Language     string
+	Status       string
+	Segments     []TranscriptSegment
+}
+
+type TranscriptSegment struct {
+	StartMS int64
+	EndMS   int64
+	Text    string
+}
+```
+
+字段说明：
+
+- `QuestionText`：评分时需要知道用户在回答什么问题。
+- `Transcript`：C 生成并拥有的对话文字只读快照；D 可以直接用于内容、语法和词汇评价。
+- `Segments`：带时间范围的转写分段，便于 D 把文字证据定位到原始音频。
+- `AudioID`：C 提供的稳定音频引用，不是对象存储路径。
+- `ContentType`：例如 `audio/wav`、`audio/mpeg` 或 `audio/webm`。
+- `Format`：明确容器或编码格式。
+- `SizeBytes`：用于调用外部 API 前校验大小限制。
+- `DurationMS`：用于超长音频校验、统计和超时设置。
+- `Checksum`：可选，用于完整性检查和幂等缓存。
+
+接口约束：
+
+- 只能返回已完成、可复盘的 Turn。
+- 获取复盘数据时不直接打开或传输大音频文件。
+- Review 需要音频时，通过 `AudioContentReader.OpenAudio` 取得只读流，使用完成后必须关闭。
+- 相同 `AudioID` 应支持重新调用 `OpenAudio`，以便外部评分失败后安全重试；每次调用返回新的流。
+- Turn 不存在、Turn 未完成、Transcript 未就绪、音频未就绪和音频已删除应返回可区分的错误或状态。
+- Conversation 不向 Review 暴露本地文件路径、存储桶凭证、Repository、ORM Model 或可变领域对象。
+- Review 只能读取音频，不能通过该接口修改或删除原始音频。
+- Review 只能读取 TranscriptSnapshot，不能覆盖 C 的原始 Transcript。
+- 双方需要统一 MS1 支持的音频格式、大小上限和时长上限。
+- D 不保存或持久化对象存储位置；对象存储迁移不应影响 Review。
+
+### 7.3 创建同题重答 Turn
+
+用途：Review 创建 `RetryRequest` 后，请求 Conversation 基于原 Question 创建新的 Turn。
+
+建议的 Review Port：
+
+```go
+type RetryTurnPort interface {
+	CreateRetryTurn(
+		ctx context.Context,
+		command CreateRetryTurnCommand,
+	) (RetryTurnResult, error)
+}
+```
+
+建议命令：
+
+```go
+type CreateRetryTurnCommand struct {
+	RetryRequestID string
+	OriginalTurnID string
+	Reason         string
+}
+```
+
+建议结果：
+
+```go
+type RetryTurnResult struct {
+	NewTurnID string
+}
+```
+
+约束：
+
+- 新 Turn 必须复用原 Turn 对应的 Question。
+- 新 Turn 由 Conversation 创建并拥有。
+- Review 只保存 `RetryRequestID`、`OriginalTurnID` 和 `NewTurnID` 的关联。
+- `RetryRequestID` 必须作为幂等键；相同请求重复调用不能创建多个新 Turn。
+- 原 Turn 不存在、原 Turn 不可重答和创建失败需要返回可区分的错误。
+- `Reason` 在 MS1 中建议使用稳定值 `review_retry`。
+
+## 8. Review 内部评分与报告能力
+
+评分、评价和证据生成属于 Review 内部能力，不要求 Conversation 实现。
+
+Session 级报告也由 Review 生成：Review 获取 Practice 的 Session/目标快照和 Conversation 的 Turn ID 列表，再汇总自己的 TurnAnalysis、Feedback 和 History。该报告是 Review 内部的只读查询视图，不新增名为 `SessionReport` 的跨模块公共核心对象。Review 不复制或修改 PracticeSession 进度，也不复制完整 Conversation 对话历史。
+
+Review 可在 `ports.go` 中定义统一的评分端口：
+
+```go
+type TurnEvaluator interface {
+	EvaluateTurn(
+		ctx context.Context,
+		input EvaluationInput,
+	) (EvaluationResult, error)
+}
+```
+
+建议输入：
+
+```go
+type EvaluationInput struct {
+	TurnID       string
+	QuestionID   string
+	QuestionText string
+	Transcript   TranscriptSnapshot
+	Audio        io.Reader
+	AudioMetadata AudioReference
+}
+```
+
+建议结果：
+
+```go
+type EvaluationResult struct {
+	Score              int
+	Summary            string
+	AnalysisTranscript string
+	Suggestions        []EvaluationSuggestion
+}
+
+type EvaluationSuggestion struct {
+	Category    string
+	Message     string
+	Evidence    string
+	StartMS     *int64
+	EndMS       *int64
+	Retryable   bool
+}
+```
+
+内部边界要求：
+
+- Review Service 只依赖 `TurnEvaluator`，不直接写死某家 API SDK。
+- 真实 API 和 Mock 的实现通过 Port 注入。
+- Review Service 通过 `AudioID` 打开音频流，并负责在评分结束后关闭该流；Evaluator 只消费 `io.Reader`。
+- 优先使用 C 提供的 `TranscriptSnapshot`；只有 Transcript 不可用或需要重新转写时，D 才执行备用 ASR。
+- `AnalysisTranscript` 是 D 备用转写产生的派生数据，不是 Conversation 原始 Transcript。
+- 如果保存 `AnalysisTranscript`，它应作为 Analysis 的附属数据管理，并遵守隐私和删除规则。
+- 证据优先使用音频时间范围 `StartMS`、`EndMS`；如果有分析用转写，也可以同时保存文字证据。
+- 相同 Turn 和相同评分版本的重复调用应由 Review 幂等处理。
+
+## 9. 错误和幂等语义
+
+跨模块联调时至少需要区分以下错误：
+
+| 场景 | 建议语义 |
+|---|---|
+| Session 不存在 | `session_not_found` |
+| Session 当前不可生成报告 | `session_not_reviewable` |
+| Session 没有可复盘 Turn | `session_has_no_reviewable_turns` |
+| Turn 不存在 | `turn_not_found` |
+| Turn 尚未完成 | `turn_not_completed` |
+| Transcript 尚未就绪 | `turn_transcript_not_ready` |
+| 音频尚未就绪 | `turn_audio_not_ready` |
+| 音频已经删除 | `turn_audio_not_found` |
+| 音频格式不支持 | `unsupported_audio_format` |
+| 音频超过评分限制 | `audio_limit_exceeded` |
+| 转写失败 | `transcription_failed` |
+| 评分/评价失败 | `evaluation_failed` |
+| 原 Turn 不允许重答 | `retry_not_allowed` |
+| RetryRequest 已成功处理 | 返回原 `NewTurnID`，不重复创建 |
+| 创建重答 Turn 失败 | `retry_turn_creation_failed` |
+
+幂等要求：
+
+- Review 使用 `turnID + 评分实现版本` 避免重复创建相同 Analysis。
+- Conversation 使用 `RetryRequestID` 避免重复创建重答 Turn。
+- History 使用稳定源 ID 更新投影，不能因重复调用产生重复记录。
+- Session 级报告使用 `SessionID + 报告版本` 保持幂等，不因重复调用产生重复报告。
+
+## 10. 联调验收条件
+
+### Practice 与 Review
+
+- Review 能复用 `GetPracticeSessionSnapshot`，根据 `PracticeSessionID` 获取 Session 状态和训练目标只读快照。
+- Review 不能通过该能力修改 Session 生命周期、目标或训练进度。
+- Session 不存在或不可生成报告时能够被明确识别。
+
+### Conversation 与 Review
+
+- Review 能通过 Adapter 复用 `ListPracticeSessionTurns`，根据 `PracticeSessionID` 获取已完成且可复盘的 Turn ID 列表。
+- Review 能读取一个已完成 Turn 的题目信息、Transcript、`AudioID` 和音频元数据。
+- Review 能根据 `AudioID` 打开只读音频流，并在使用后关闭。
+- 相同 `AudioID` 可以重新打开新的音频流用于失败重试。
+- 未完成 Turn、Transcript 未就绪或音频未就绪会被明确识别。
+- Review 能识别 Content-Type、格式、大小和时长。
+- Review 使用结束后能够正确关闭音频流。
+- Review 能独立完成音频评分或“转写后评分”。
+- Review 能把评分结果保存为自己的 Analysis 和 Feedback。
+- Review 能发起同题重答并取得新的 Turn ID。
+- 相同 `RetryRequestID` 重复调用只会得到同一个新 Turn。
+- 两个模块之间没有跨模块 Repository、文件路径或存储凭证共享。
+
+### Session 级报告
+
+- Review 能使用 Session/目标快照和 Turn ID 列表生成自己的 Session 级复盘报告。
+- 报告中的评价、目标达成判断和改进建议由 Review 负责。
+- 报告只引用 Practice 和 Conversation 的稳定 ID，不成为 Session、Turn 或 Transcript 的第二份权威来源。
+- 报告仅作为 Review 内部查询视图，不新增跨模块共享的 `SessionReport` 核心对象。

--- a/server/internal/review/docs/架构开发计划.md
+++ b/server/internal/review/docs/架构开发计划.md
@@ -1,0 +1,654 @@
+# Review 模块架构开发计划
+
+## 1. 使用说明
+
+本文档用于跟踪 `review` 模块的骨架开发。模块负责 `TurnAnalysis`、证据反馈、同题重答和 Review 历史只读投影。
+
+本次交付范围仅包含可编译的领域模型、Port、应用用例接口和输入输出契约，不实现具体 Service、Repository、Adapter、HTTP Handler、模型供应商或跨模块调用流程。
+
+执行规则：
+
+- 按阶段推进，不要求一次完成全部架构。
+- 只有代码、测试和阶段验收条件全部完成后，才把对应任务从 `- [ ]` 修改为 `- [x]`。
+- 每完成一个阶段，先运行该阶段验证，再更新本文档。
+- 未经团队确认，不提前实现其他成员模块的内部逻辑。
+- 跨模块只通过公开 Port、Snapshot、Command 和稳定 ID 协作。
+- Go 接口按业务用例拆分到同一 `review` package 的不同文件，不额外创建 `interface/` 或 `impl/` 子目录。
+- 骨架文件只声明接口、Command、Query、Result 和稳定错误语义，不编写方法体或 `panic("TODO")` 占位实现。
+- 测试文件只在存在可测试的领域规则或具体实现后创建，不为了占位创建空测试。
+- 本计划不替代 API 契约、数据库设计或跨模块接口文档。
+
+相关资料：
+
+- GitHub Issue：[#31 构建 Review 模块分析、反馈、重答与历史框架](https://github.com/1024XEngineer/XE3-ESL/issues/31)
+- 模块边界：[#24 场景、角色与训练会话的可扩展模型](https://github.com/1024XEngineer/XE3-ESL/issues/24)
+- API 契约：[#22 定义 MS1 REST 与 WebSocket 最小接口契约](https://github.com/1024XEngineer/XE3-ESL/issues/22)
+- 数据设计：[#17 PostgreSQL 领域模型与 TurnAnalysis 数据设计](https://github.com/1024XEngineer/XE3-ESL/issues/17)
+- 跨模块协作：[Review 模块跨模块接口需求.md](./Review%20模块跨模块接口需求.md)
+
+## 2. 目标目录
+
+遵循团队确定的 Go 模块化单体结构，并按业务用例拆分文件：
+
+```text
+server/internal/review/
+├── module.go
+├── model.go
+├── ports.go
+├── service.go
+├── analyze.go
+├── retry.go
+├── history.go
+├── model_test.go
+├── analyze_test.go
+├── retry_test.go
+├── history_test.go
+└── docs/
+    ├── Review 模块跨模块接口需求.md
+    └── 架构开发计划.md
+```
+
+文件职责：
+
+- `service.go`：组合 Review 对外提供的应用用例接口，不放具体实现。
+- `analyze.go`：分析、复盘详情和 Feedback 查询接口及 DTO。
+- `retry.go`：同题重答接口及 DTO。
+- `history.go`：Review 历史查询接口及 DTO。
+- `ports.go`：Review 调用 Conversation、Evaluator 和 Repository 所需的外部依赖接口。
+- `model.go`：Review 拥有的领域模型和不变量。
+- `*_test.go`：对应具体领域规则或后续实现的测试；没有可测试行为时不创建空文件。
+
+暂不额外创建 `domain/`、`application/`、`repository/`、`interface/` 或 `impl/` 子目录。同一目录中的 Go 文件均属于 `review` package，编译时共同组成该模块。若后续单文件职责过重，需要先与组长确认再拆分。
+
+## 3. 模块依赖方向
+
+```text
+未来 Delivery / Bootstrap
+           ↓
+ service.go（组合用例接口）
+      ↙       ↓       ↘
+analyze.go  retry.go  history.go
+      \        |        /
+          model.go
+
+未来具体 Service 实现
+           ↓
+        ports.go
+       ↙    ↓    ↘
+Conversation  Evaluator  Review Repository
+
+model.go 不依赖 Gin、数据库、对象存储或具体 AI SDK。
+```
+
+边界约束：
+
+- `review` 拥有并写入 `TurnAnalysis`、`FeedbackItem`、`RetryRequest` 和 History Read Model。
+- `conversation` 拥有 `Question`、`Turn`、`Transcript` 和原始音频。
+- `review` 通过 `AudioID` 打开只读音频流，不读取对象存储路径和凭证。
+- `review` 不修改 `PracticeSession` 状态或进度。
+- 同题重答的新 Turn 由 `conversation` 创建。
+- Review History 是只读投影，不是 PracticeSession 进度或 Conversation 对话历史的第二份权威来源。
+- 本次只定义用例接口；图中的 Delivery、Bootstrap 和具体 Service 实现均不在本次范围内。
+
+## 4. 阶段 0：开发前基线确认
+
+目标：确保开发基于正确分支和团队骨架，避免把本地配置或无关文件带入模块 PR。
+
+- [x] 确认当前分支为 `feat/review-module`。
+- [x] 确认分支包含组长 PR #27 的 Go/Gin 模块化单体骨架。
+- [x] 确认 `server/internal/review/module.go` 现有公开入口仍可编译。
+- [x] 检查工作区已有改动，区分本人改动与无关的 `.idea/`、`.gitignore` 等文件。
+- [x] 确认本次开发只修改 Review 模块和必要测试；公共目录变更单独沟通。
+- [x] 与 C 确认 `AudioID + OpenAudio + TranscriptSnapshot` 为当前联调方向。
+- [x] 与 B、C、组长记录“同题重答是否计入 Session 主进度”为待确认规则，不在 Review 中写死。
+
+阶段完成标准：
+
+- [x] 分支、工作区和模块边界均已确认，没有未识别的开发基线问题。
+
+## 5. 阶段 1：领域模型与不变量
+
+目标：在 `model.go` 中定义 Review 唯一拥有的领域对象、状态和校验规则，不依赖外部实现。
+
+计划文件：
+
+```text
+server/internal/review/model.go
+server/internal/review/model_test.go
+```
+
+### 5.1 TurnAnalysis
+
+- [x] 定义 `TurnAnalysis`。
+- [x] 定义 Analysis 状态：`pending`、`completed`、`failed`。
+- [x] 保存 `TurnID` 和评分实现版本。
+- [x] 保存评分、总结和可选的分析用转写。
+- [x] 保存创建、完成和失败所需的时间与原因。
+- [x] 明确相同 `TurnID + EvaluatorVersion` 的唯一分析语义。
+- [x] `completed` 状态必须包含完整分析结果。
+- [x] `failed` 状态必须包含失败原因。
+
+### 5.2 FeedbackItem 与 Evidence
+
+- [x] 定义 `FeedbackItem`。
+- [x] 定义稳定的 Feedback Category 类型，但暂不写死未经确认的完整枚举集合。
+- [x] 定义 `Evidence`，支持 Transcript 文字片段和音频时间范围。
+- [x] Evidence 时间不能为负数。
+- [x] `EndMS` 不能小于 `StartMS`。
+- [x] Feedback 必须关联 `AnalysisID`。
+- [x] 定义 `Retryable` 语义。
+- [x] 不在 Feedback 中复制完整原始 Transcript。
+
+### 5.3 RetryRequest
+
+- [x] 定义 `RetryRequest`。
+- [x] 定义 Retry 状态：`pending`、`turn_created`、`failed`。
+- [x] 保存 `OriginalTurnID`、关联 Feedback 和可选的 `NewTurnID`。
+- [x] `turn_created` 状态必须包含 `NewTurnID`。
+- [x] `failed` 状态必须包含失败原因。
+- [x] 明确 RetryRequest ID 是调用 Conversation 的幂等键。
+
+### 5.4 HistoryRecord
+
+- [x] 定义 History Read Model。
+- [x] 保存 `SessionID`、`TurnID`、`AnalysisID` 和可选的 `RetryRequestID`。
+- [x] 保存历史列表需要的最小评分、摘要和时间字段。
+- [x] 明确 History 只能投影和查询，不能修改源数据。
+- [x] 明确 History 使用稳定源 ID 幂等更新。
+
+### 5.5 模型测试
+
+- [x] 测试无 TurnID 的 Analysis 被拒绝。
+- [x] 测试 completed Analysis 的必填字段。
+- [x] 测试 failed Analysis 的失败原因。
+- [x] 测试 Evidence 时间范围校验。
+- [x] 测试非 Retryable Feedback 不能创建重答请求。
+- [x] 测试 Retry 成功与失败状态的不变量。
+
+阶段验证：
+
+```bash
+cd server
+go test ./internal/review/...
+go vet ./internal/review/...
+```
+
+阶段完成标准：
+
+- [x] 领域模型不 import Gin、SQL、对象存储或具体 AI SDK。
+- [x] 模型测试全部通过。
+- [x] 模型所有权符合 #24 和跨模块接口文档。
+
+## 6. 阶段 2：Port 与跨模块契约
+
+目标：在 `ports.go` 中表达当前已确认的 Turn 级 Review 外部依赖，并保证 Service 不依赖具体实现。
+
+计划文件：
+
+```text
+server/internal/review/ports.go
+```
+
+### 6.1 Conversation 读取端口
+
+- [x] 定义 `TurnReviewSourceReader`。
+- [x] 定义 `GetCompletedTurnReviewSource(ctx, turnID)`。
+- [x] 定义 `TurnReviewSource` 最小 Snapshot。
+- [x] Snapshot 包含 Question、TranscriptSnapshot、AudioReference 和完成时间。
+- [x] 定义 `AudioReference`，包含 `AudioID`、格式、Content-Type、大小、时长和可选校验值。
+- [x] 定义 Transcript 文本、语言、状态和时间分段。
+- [x] 不暴露 Conversation 的 Repository、ORM Model 或对象存储路径。
+
+### 6.2 音频读取端口
+
+- [x] 定义 `AudioContentReader`。
+- [x] 定义 `OpenAudio(ctx, audioID) (io.ReadCloser, error)`。
+- [x] 明确每次调用返回新的只读流。
+- [x] 明确流的关闭责任属于 Review Service。
+- [x] 明确音频未就绪、已删除和格式不支持的错误语义。
+
+### 6.3 同题重答端口
+
+- [x] 定义 `RetryTurnPort`。
+- [x] 定义 `CreateRetryTurnCommand`。
+- [x] 命令包含 `RetryRequestID`、`OriginalTurnID` 和稳定 Reason。
+- [x] 定义 `RetryTurnResult`，返回 `NewTurnID`。
+- [x] 明确 C 使用 `RetryRequestID` 保证幂等。
+
+### 6.4 Review 评分端口
+
+- [x] 定义 `TurnEvaluator`。
+- [x] 定义 `EvaluationInput`，包含 Question、Transcript、音频 Reader 和元数据。
+- [x] 定义结构化 `EvaluationResult`。
+- [x] 结果支持分数、总结、证据建议、音频时间范围和可选分析用转写。
+- [x] 定义评分实现版本获取方式，用于分析幂等。
+- [x] Service 不感知真实供应商 SDK。
+
+### 6.5 Review Repository
+
+- [x] 定义 `AnalysisRepository` 的最小查询和保存方法。
+- [x] 定义 `FeedbackRepository` 的最小查询和保存方法。
+- [x] 定义 `RetryRepository` 的最小查询、保存和状态更新方法。
+- [x] 定义 `HistoryRepository` 的 Upsert 和查询方法。
+- [x] Repository 接口使用 Review 模型，不暴露 SQL 行结构。
+- [x] 不在本阶段实现生产 PostgreSQL Adapter。
+
+### 6.6 技术原语
+
+- [x] 检查 `shared` 是否已有团队统一的 ID 和 Clock。
+- [x] 如果尚未提供，在 Review Port 中临时定义最小 `IDGenerator` 和 `Clock` 接口。
+- [x] 不擅自向 `shared` 添加 Review 业务类型。
+
+### 6.7 Session 级报告依赖
+
+产品原型包含 Session 级“面试报告总结”；当前代码骨架只覆盖单个 Turn 的分析资料，Session 查询 Port 尚未写入代码。
+
+- [x] 已与团队确认 Session 级报告由 Review 生成和拥有。
+- [x] 确认复用 Practice 已冻结的 `GetPracticeSessionSnapshot` 能力，不新增重复公共查询。
+- [ ] 定义 Review 侧的 Practice Session/目标最小只读快照 Port。
+- [x] 确认复用 Conversation 已冻结的 `ListPracticeSessionTurns` 能力，不新增重复公共查询。
+- [ ] 定义 Review 侧的 Session Turn 列表读取 Port。
+- [x] 在跨模块字段未确认前，不向 `ports.go` 添加猜测性字段或实现。
+
+本节是 Session 级报告新增的骨架工作；现有 Turn 级 Port 骨架仍保持完成。
+
+阶段验证：
+
+```bash
+cd server
+go test ./internal/review/...
+go vet ./internal/review/...
+```
+
+阶段完成标准：
+
+- [x] 当前已确认的 Turn 级 Review 外部依赖都通过接口表达。
+- [x] `ports.go` 不包含具体数据库、对象存储或模型供应商实现。
+- [x] C 能根据接口文档判断需要提供哪些公开能力。
+- [x] 模块仍可独立编译。
+
+## 7. 阶段 3：应用用例总接口骨架
+
+目标：在 `service.go` 中组合 Review 对外提供的应用用例接口，不定义具体实现类型或方法体。
+
+计划文件：
+
+```text
+server/internal/review/service.go
+```
+
+### 7.1 ReviewService
+
+- [x] 定义 `ReviewService` 总接口。
+- [x] 通过嵌入小接口组合分析、重答和历史查询能力。
+- [x] 不在 `service.go` 中声明具体 `service struct`。
+- [x] 不定义构造函数、依赖字段或方法体。
+- [x] 不使用 `panic("TODO")` 或返回空结果的占位实现。
+- [x] 保持当前 `review.New()` 模块入口兼容。
+
+建议骨架：
+
+```go
+type ReviewService interface {
+	AnalyzeUseCase
+	RetryUseCase
+	HistoryQueryUseCase
+}
+```
+
+说明：
+
+- `ReviewService` 是模块对内公开的能力集合。
+- 小接口和各自的 Command、Query、Result 分别放在 `analyze.go`、`retry.go` 和 `history.go`。
+- Go 通过隐式接口实现关联未来的具体 Service，不需要在骨架阶段声明具体类型。
+
+阶段验证：
+
+```bash
+cd server
+go test ./internal/review/...
+go vet ./internal/review/...
+```
+
+阶段完成标准：
+
+- [x] Review 的应用能力由小接口组成。
+- [x] `service.go` 只有接口组合，不包含业务实现。
+- [x] 模块仍可独立编译。
+
+## 8. 阶段 4：分析与证据反馈接口骨架
+
+目标：在 `analyze.go` 中定义 Turn 分析、复盘详情和单条 Feedback 查询接口，不实现分析流程。
+
+计划文件：
+
+```text
+server/internal/review/analyze.go
+```
+
+### 8.1 AnalyzeUseCase
+
+- [x] 定义 `AnalyzeUseCase`。
+- [x] 定义 `AnalyzeTurn` 方法签名。
+- [x] 定义 `GetTurnReview` 方法签名。
+- [x] 定义 `GetFeedback` 方法签名，用于原型中的句子级反馈详情。
+- [x] 定义对应的 Command、Query 和 Result。
+- [x] 输入只使用稳定 ID 和必要查询条件。
+- [x] 输出只返回 Review 拥有的 Analysis、Feedback 和只读结果。
+
+建议骨架：
+
+```go
+type AnalyzeUseCase interface {
+	AnalyzeTurn(
+		ctx context.Context,
+		command AnalyzeTurnCommand,
+	) (AnalyzeTurnResult, error)
+
+	GetTurnReview(
+		ctx context.Context,
+		query GetTurnReviewQuery,
+	) (TurnReviewDetail, error)
+
+	GetFeedback(
+		ctx context.Context,
+		feedbackID string,
+	) (FeedbackItem, error)
+}
+
+type AnalyzeTurnCommand struct {
+	TurnID string
+}
+
+type AnalyzeTurnResult struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+	Reused   bool
+}
+
+type GetTurnReviewQuery struct {
+	AnalysisID string
+}
+
+type TurnReviewDetail struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+}
+```
+
+### 8.2 边界说明
+
+- [x] 明确相同 `TurnID + EvaluatorVersion` 的幂等语义，但不实现幂等流程。
+- [x] 复盘详情使用 `AnalysisID` 查询，避免同一 Turn 存在多个评分版本时产生歧义。
+- [x] 明确 Review 不修改来源 Turn、Transcript、音频或 PracticeSession。
+- [x] 明确音频播放仍由 Conversation 的公开能力提供。
+- [x] 明确错误使用稳定领域语义，不绑定 HTTP 状态码。
+- [x] 不查询 Repository。
+- [x] 不打开音频流。
+- [x] 不调用 Evaluator。
+- [x] 不保存 Analysis、Feedback 或 History。
+- [x] 不创建 `analyze_test.go` 空测试；具体流程实现时再补测试。
+
+### 8.3 实现前待确认规则
+
+- [ ] 确认 Transcript 未就绪时是拒绝分析还是允许备用 ASR。
+- [ ] 确认 `failed` Analysis 是否允许重新分析。
+- [ ] 确认 Score 的范围和稳定含义。
+- [ ] 确认 `EvaluationSuggestion` 与 `FeedbackItem` 的字段映射。
+- [ ] 确认 Analysis、Feedback 和 History 的一致性边界。
+
+阶段完成标准：
+
+- [x] 分析、复盘详情和句子级反馈能力均由接口表达。
+- [x] `analyze.go` 不包含具体 Service 类型或方法体。
+- [x] 没有 Fake、Mock 或主流程测试。
+
+## 9. 阶段 5：同题重答接口骨架
+
+目标：在 `retry.go` 中定义同题重答用例接口，不实现跨模块调用。
+
+计划文件：
+
+```text
+server/internal/review/retry.go
+```
+
+### 9.1 RetryUseCase
+
+- [x] 定义 `RetryUseCase`。
+- [x] 定义 `RequestRetry` 方法签名。
+- [x] 定义 `RequestRetryCommand` 和 `RequestRetryResult`。
+- [x] 命令优先使用 `FeedbackID`，由未来 Service 根据 Review 内部关系确定原 Turn，避免调用方提交互相冲突的 FeedbackID 和 TurnID。
+- [x] 结果返回 `RetryRequest` 当前状态和可选的 `NewTurnID`。
+
+建议骨架：
+
+```go
+type RetryUseCase interface {
+	RequestRetry(
+		ctx context.Context,
+		command RequestRetryCommand,
+	) (RequestRetryResult, error)
+}
+
+type RequestRetryCommand struct {
+	FeedbackID string
+}
+
+type RequestRetryResult struct {
+	Request RetryRequest
+}
+```
+
+### 9.2 边界说明
+
+- [x] 明确只有 `Retryable` Feedback 可以发起同题重答。
+- [x] 明确 RetryRequest 归 Review 所有。
+- [x] 明确新 Turn 归 Conversation 所有。
+- [x] 明确 Review 不修改 Session 生命周期和主进度。
+- [x] 不调用 `RetryTurnPort`。
+- [x] 不创建或保存 RetryRequest。
+- [x] 不实现失败恢复或重试调度。
+- [x] 不创建 `retry_test.go` 空测试；具体流程实现时再补测试。
+
+### 9.3 实现前待确认规则
+
+- [ ] 与 B、C 确认新 Turn 是否归属原 Session。
+- [ ] 确认 Session 已结束后是否允许重答。
+- [ ] 确认重答是否计入 Session 主进度。
+- [ ] 确认一个 Feedback 最多允许多少次重答。
+- [ ] 确认跨模块调用超时后的状态恢复语义。
+- [ ] 确认 `failed` RetryRequest 是否允许使用相同幂等键恢复为 `turn_created`。
+
+阶段完成标准：
+
+- [x] 同题重答的输入、输出和所有权由接口表达。
+- [x] `retry.go` 不包含具体 Service 类型或方法体。
+- [x] Review 没有直接创建或修改 Conversation Turn。
+
+## 10. 阶段 6：Review 历史查询接口骨架
+
+目标：在 `history.go` 中定义 Review 自己拥有的复盘历史查询接口，不实现投影写入、分页或聚合。
+
+计划文件：
+
+```text
+server/internal/review/history.go
+```
+
+### 10.1 HistoryQueryUseCase
+
+- [x] 定义 `HistoryQueryUseCase`。
+- [x] 定义 `ListReviewHistory` 方法签名。
+- [x] 定义 `ListReviewHistoryQuery` 和 `ListReviewHistoryResult`。
+- [x] 支持使用 `SessionID` 作为可选过滤条件。
+- [x] 定义 Limit 和 Offset 分页字段。
+- [x] 返回 Review 拥有的最小 HistoryRecord 列表。
+
+建议骨架：
+
+```go
+type HistoryQueryUseCase interface {
+	ListReviewHistory(
+		ctx context.Context,
+		query ListReviewHistoryQuery,
+	) (ListReviewHistoryResult, error)
+}
+
+type ListReviewHistoryQuery struct {
+	SessionID string
+	Limit     int
+	Offset    int
+}
+
+type ListReviewHistoryResult struct {
+	Records []HistoryRecord
+}
+```
+
+### 10.2 原型页面所有权边界
+
+| 原型能力 | 所属模块 |
+|---|---|
+| 练习进度、继续上次 Session | `practice` |
+| Session 生命周期和完成状态 | `practice` |
+| 对话消息、Transcript、录音播放 | `conversation` |
+| Turn 分析结果和复盘报告 | `review` |
+| 句子级证据反馈 | `review` |
+| 待复习 Feedback | `review` |
+| 同题重答请求 | `review` 发起，`conversation` 创建新 Turn |
+| Review 复盘历史 | `review` |
+
+### 10.3 Session 级报告接口骨架
+
+产品原型包含“面试报告总结”，它是 Session 级视图，不只是单个 TurnAnalysis。
+
+- [x] 已确认 Session 级报告由 Review 生成和拥有。
+- [x] 确认复用 Practice 的 `GetPracticeSessionSnapshot` 获取最小 Session 和目标只读快照。
+- [x] 确认复用 Conversation 的 `ListPracticeSessionTurns` 获取 Session 下 Turn，并由 Adapter 筛选可复盘 Turn ID。
+- [ ] 定义 Review 内部的 Session 级复盘 Query Result；不新增跨模块共享的 `SessionReport` 核心对象。
+- [ ] 定义 `GetSessionReview` 查询接口及 Query、Result。
+- [x] Review 不复制或修改 PracticeSession 的权威进度。
+- [x] Review 不复制完整 Conversation 对话历史。
+- [x] 跨模块字段确认前，不提前复制 Practice 或 Conversation 的完整模型。
+- [x] 不实现 History Upsert、分页或排序。
+- [x] 不创建 `history_test.go` 空测试；具体流程实现时再补测试。
+
+阶段完成标准：
+
+- [x] Review History 与 Practice 历史、Conversation 对话历史的边界明确。
+- [x] History 查询能力由接口表达。
+- [x] `history.go` 不包含具体 Service 类型或方法体。
+- [ ] Session 级报告的内部查询视图和查询接口由骨架表达。
+
+## 11. 阶段 7：跨模块与交付层边界声明
+
+目标：记录未来实现必须遵守的依赖方向，不创建 Handler、Adapter、Repository 或装配代码。
+
+### 11.1 HTTP 边界
+
+```text
+未来 HTTP Handler → ReviewService → Review 用例接口
+```
+
+- [x] 记录未来 HTTP Handler 只能依赖 `ReviewService`。
+- [x] Handler 只负责 HTTP DTO 与应用 DTO 转换。
+- [x] Handler 不直接访问 Repository。
+- [x] Handler 不直接调用 Conversation 或 Practice。
+- [x] Gin 类型不得进入 Review Model、Port 和用例接口。
+- [x] #22 API 契约确认前不创建空 Handler 文件或方法。
+- [x] 本阶段不注册路由、不映射 HTTP 错误、不编写 Handler 测试。
+
+### 11.2 未来实现和装配边界
+
+```text
+未来具体 Service → Review 定义的 Port
+                          ↑
+                  Conversation/Practice Adapter
+
+bootstrap 只负责创建实现并连接以上依赖。
+```
+
+- [x] 记录未来具体 Service 通过构造函数接收 Reader、Evaluator、Repository、IDGenerator 和 Clock。
+- [x] 未来构造函数使用 `NewService` 等名称，避免与现有 `review.New()` 冲突。
+- [x] bootstrap 只负责连接依赖，不包含业务判断。
+- [x] Adapter 负责把 Conversation 或 Practice 的公开能力适配到 Review Port。
+- [x] 本阶段不声明具体 Service 类型。
+- [x] 本阶段不定义构造函数或依赖结构体。
+- [x] 本阶段不创建 Conversation/Practice Adapter。
+- [x] 本阶段不创建 Repository 实现或 Mock Evaluator。
+- [x] 本阶段不修改 bootstrap。
+
+阶段完成标准：
+
+- [x] HTTP、Adapter 和 bootstrap 的依赖方向已记录。
+- [x] Review 骨架没有任何具体基础设施实现。
+- [x] 保持现有 `review.New()` 兼容。
+
+## 12. 阶段 8：骨架交付检查
+
+目标：验证 Review 模块骨架完整、可编译且没有提前实现具体业务。
+
+### 12.1 骨架完整性
+
+- [x] `model.go` 只包含 Review 领域对象和不变量。
+- [x] `ports.go` 只包含外部依赖接口和跨模块数据契约。
+- [x] `service.go` 只组合应用用例接口。
+- [x] `analyze.go` 只包含分析和反馈接口及 DTO。
+- [x] `retry.go` 只包含同题重答接口及 DTO。
+- [x] `history.go` 只包含 Review 历史查询接口及 DTO。
+- [x] `module.go` 保持现有模块入口兼容。
+- [x] 所有待团队确认的规则均明确标注，未在代码中写死。
+- [ ] B、C 字段确认后，在 `ports.go` 补充 Session 报告所需的两个读取 Port。
+- [ ] 补充 Session 级复盘 Query Result 和 `GetSessionReview` 查询接口骨架。
+
+### 12.2 禁止提前实现的内容
+
+- [x] 没有具体 Review Service 类型和方法体。
+- [x] 没有 `panic("TODO")` 或返回空结果的占位实现。
+- [x] 没有 Fake 或 Mock 主链路。
+- [x] 没有内存或 PostgreSQL Repository。
+- [x] 没有真实或 Mock AI Evaluator。
+- [x] 没有 Conversation/Practice Adapter。
+- [x] 没有 Gin Handler 和路由注册。
+- [x] 没有数据库迁移、对象存储接入或真实外部网络调用。
+
+### 12.3 最终验证
+
+```bash
+cd server
+gofmt -w internal/review/*.go
+go test ./internal/review/...
+go vet ./internal/review/...
+go test ./...
+go vet ./...
+git diff --check
+```
+
+最终完成标准：
+
+- [x] Review 模块骨架可以独立编译。
+- [x] Review 公开用例接口覆盖 Turn 分析、反馈、重答和 Review 历史。
+- [ ] Review 公开用例接口覆盖已确认归 D 的 Session 级报告。
+- [x] Practice、Conversation 和 Review 的所有权边界明确。
+- [x] 未提前实现具体 Service、Handler、Adapter 或 Repository。
+- [x] 未修改其他成员模块的内部实现。
+- [x] `server/internal/review/docs/` 纳入本次 PR，作为骨架边界和跨模块对齐依据。
+- [ ] PR 中明确说明具体实现将在后续 Issue 中完成。
+- [x] 所有真实完成项均已勾选，待确认项保持未勾选。
+
+## 13. 暂不实施事项
+
+- [ ] `AnalyzeTurn`、`RequestRetry` 和 History 查询的具体 Service 方法体，后续 Issue 实施。
+- [ ] `analyze_test.go`、`retry_test.go` 和 `history_test.go` 中的用例流程测试，在具体实现出现后补充。
+- [ ] Gin Handler、路由注册和 HTTP 错误映射，等待 #22 后实施。
+- [ ] Conversation/Practice Adapter、依赖注入和 bootstrap 装配，等待跨模块能力确认后实施。
+- [ ] 内存 Repository、Fake Evaluator 和 Mock 主链路，后续联调 Issue 实施。
+- [ ] 真实音频评分供应商接入，另开 Issue 后实施。
+- [ ] 真实 ASR + 语言模型供应商接入，另开 Issue 后实施。
+- [ ] PostgreSQL Repository 和迁移，等待 #17 与数据库实施任务。
+- [ ] 生产对象存储接入和签名 URL，等待存储任务。
+- [ ] 异步分析队列、Event Bus 和失败任务调度，不进入 MS1。
+- [ ] 复杂成长统计、跨 Session 趋势和推荐系统，不进入本次架构任务。
+
+本节中的复选框表示“未来事项尚未实施”，不计入 Issue #31 当前完成度。

--- a/server/internal/review/history.go
+++ b/server/internal/review/history.go
@@ -1,0 +1,31 @@
+package review
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrInvalidHistoryQuery 表示 Review 历史查询条件无效。
+var ErrInvalidHistoryQuery = errors.New("invalid review history query")
+
+// HistoryQueryUseCase 定义 Review 复盘历史的只读查询契约。
+// 它不表示 PracticeSession 进度或 Conversation 对话历史。
+type HistoryQueryUseCase interface {
+	// ListReviewHistory 返回 Review 自己维护的只读历史投影。
+	// SessionID 为空表示不按 Session 过滤；Limit 和 Offset 必须为非负数。
+	// 默认排序为 ReviewedAt 倒序，具体校验和查询由后续实现负责。
+	ListReviewHistory(ctx context.Context, query ListReviewHistoryQuery) (ListReviewHistoryResult, error)
+}
+
+// ListReviewHistoryQuery 描述 Review 历史的过滤和分页条件。
+// 它不包含 PracticeSession 状态或 Conversation 对话筛选条件。
+type ListReviewHistoryQuery struct {
+	SessionID string
+	Limit     int
+	Offset    int
+}
+
+// ListReviewHistoryResult 返回 Review 自己维护的最小历史投影。
+type ListReviewHistoryResult struct {
+	Records []HistoryRecord
+}

--- a/server/internal/review/model.go
+++ b/server/internal/review/model.go
@@ -1,0 +1,541 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalidAnalysis      = errors.New("invalid turn analysis")
+	ErrInvalidFeedback      = errors.New("invalid feedback item")
+	ErrInvalidEvidence      = errors.New("invalid evidence")
+	ErrInvalidRetryRequest  = errors.New("invalid retry request")
+	ErrInvalidHistoryRecord = errors.New("invalid history record")
+	ErrInvalidStateChange   = errors.New("invalid state change")
+	ErrFeedbackNotRetryable = errors.New("feedback is not retryable")
+)
+
+// AnalysisStatus 表示一次分析的生命周期，不会改变来源 Turn 或
+// PracticeSession 的生命周期。
+type AnalysisStatus string
+
+const (
+	AnalysisStatusPending   AnalysisStatus = "pending"
+	AnalysisStatusCompleted AnalysisStatus = "completed"
+	AnalysisStatusFailed    AnalysisStatus = "failed"
+)
+
+// AnalysisKey 是保证评分幂等的稳定标识。
+// Repository 不得为同一个 Key 创建两份分析。
+type AnalysisKey struct {
+	TurnID           string
+	EvaluatorVersion string
+}
+
+// TurnAnalysis 是 Review 对一个已完成 Turn 的持久化分析结果。
+// Score 使用指针，是因为 0 可能是有效分数，而 nil 表示尚未生成分数。
+type TurnAnalysis struct {
+	ID                 string
+	TurnID             string
+	EvaluatorVersion   string
+	Status             AnalysisStatus
+	Score              *int
+	Summary            string
+	AnalysisTranscript string
+	FailureReason      string
+	CreatedAt          time.Time
+	CompletedAt        *time.Time
+	FailedAt           *time.Time
+}
+
+// NewTurnAnalysis 创建一条待处理分析。
+// 来源 Turn 仍归 Conversation 所有，Review 只通过稳定 ID 引用它。
+func NewTurnAnalysis(id, turnID, evaluatorVersion string, createdAt time.Time) (TurnAnalysis, error) {
+	analysis := TurnAnalysis{
+		ID:               strings.TrimSpace(id),
+		TurnID:           strings.TrimSpace(turnID),
+		EvaluatorVersion: strings.TrimSpace(evaluatorVersion),
+		Status:           AnalysisStatusPending,
+		CreatedAt:        createdAt,
+	}
+	if err := analysis.Validate(); err != nil {
+		return TurnAnalysis{}, err
+	}
+	return analysis, nil
+}
+
+// Key 返回该分析在 Repository 中使用的唯一键。
+func (a TurnAnalysis) Key() AnalysisKey {
+	return AnalysisKey{TurnID: a.TurnID, EvaluatorVersion: a.EvaluatorVersion}
+}
+
+// Complete 使用最终评分结果将待处理分析转换为已完成状态。
+func (a *TurnAnalysis) Complete(score int, summary, analysisTranscript string, completedAt time.Time) error {
+	if a == nil {
+		return fmt.Errorf("%w: analysis is nil", ErrInvalidAnalysis)
+	}
+	if a.Status != AnalysisStatusPending {
+		return fmt.Errorf("%w: analysis %q is %q", ErrInvalidStateChange, a.ID, a.Status)
+	}
+	if strings.TrimSpace(summary) == "" {
+		return fmt.Errorf("%w: completed analysis requires summary", ErrInvalidAnalysis)
+	}
+	if err := validateTerminalTime(a.CreatedAt, completedAt); err != nil {
+		return fmt.Errorf("%w: completed_at: %v", ErrInvalidAnalysis, err)
+	}
+
+	candidate := *a
+	candidate.Status = AnalysisStatusCompleted
+	candidate.Score = intPointer(score)
+	candidate.Summary = strings.TrimSpace(summary)
+	candidate.AnalysisTranscript = analysisTranscript
+	candidate.CompletedAt = timePointer(completedAt)
+	candidate.FailureReason = ""
+	candidate.FailedAt = nil
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*a = candidate
+	return nil
+}
+
+// Fail 将待处理分析转换为失败状态，但不会修改来源 Turn。
+func (a *TurnAnalysis) Fail(reason string, failedAt time.Time) error {
+	if a == nil {
+		return fmt.Errorf("%w: analysis is nil", ErrInvalidAnalysis)
+	}
+	if a.Status != AnalysisStatusPending {
+		return fmt.Errorf("%w: analysis %q is %q", ErrInvalidStateChange, a.ID, a.Status)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("%w: failed analysis requires reason", ErrInvalidAnalysis)
+	}
+	if err := validateTerminalTime(a.CreatedAt, failedAt); err != nil {
+		return fmt.Errorf("%w: failed_at: %v", ErrInvalidAnalysis, err)
+	}
+
+	candidate := *a
+	candidate.Status = AnalysisStatusFailed
+	candidate.Score = nil
+	candidate.Summary = ""
+	candidate.FailureReason = strings.TrimSpace(reason)
+	candidate.CompletedAt = nil
+	candidate.FailedAt = timePointer(failedAt)
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*a = candidate
+	return nil
+}
+
+// Validate 校验分析在各个持久化状态下必须满足的不变量。
+func (a TurnAnalysis) Validate() error {
+	if strings.TrimSpace(a.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidAnalysis)
+	}
+	if strings.TrimSpace(a.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidAnalysis)
+	}
+	if strings.TrimSpace(a.EvaluatorVersion) == "" {
+		return fmt.Errorf("%w: evaluator_version is required", ErrInvalidAnalysis)
+	}
+	if a.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at is required", ErrInvalidAnalysis)
+	}
+
+	switch a.Status {
+	case AnalysisStatusPending:
+		if a.Score != nil || strings.TrimSpace(a.Summary) != "" || strings.TrimSpace(a.FailureReason) != "" || a.CompletedAt != nil || a.FailedAt != nil {
+			return fmt.Errorf("%w: pending analysis contains terminal fields", ErrInvalidAnalysis)
+		}
+	case AnalysisStatusCompleted:
+		if a.Score == nil {
+			return fmt.Errorf("%w: completed analysis requires score", ErrInvalidAnalysis)
+		}
+		if strings.TrimSpace(a.Summary) == "" {
+			return fmt.Errorf("%w: completed analysis requires summary", ErrInvalidAnalysis)
+		}
+		if a.CompletedAt == nil {
+			return fmt.Errorf("%w: completed analysis requires completed_at", ErrInvalidAnalysis)
+		}
+		if err := validateTerminalTime(a.CreatedAt, *a.CompletedAt); err != nil {
+			return fmt.Errorf("%w: completed_at: %v", ErrInvalidAnalysis, err)
+		}
+		if strings.TrimSpace(a.FailureReason) != "" || a.FailedAt != nil {
+			return fmt.Errorf("%w: completed analysis contains failure fields", ErrInvalidAnalysis)
+		}
+	case AnalysisStatusFailed:
+		if strings.TrimSpace(a.FailureReason) == "" {
+			return fmt.Errorf("%w: failed analysis requires reason", ErrInvalidAnalysis)
+		}
+		if a.FailedAt == nil {
+			return fmt.Errorf("%w: failed analysis requires failed_at", ErrInvalidAnalysis)
+		}
+		if err := validateTerminalTime(a.CreatedAt, *a.FailedAt); err != nil {
+			return fmt.Errorf("%w: failed_at: %v", ErrInvalidAnalysis, err)
+		}
+		if a.Score != nil || strings.TrimSpace(a.Summary) != "" || a.CompletedAt != nil {
+			return fmt.Errorf("%w: failed analysis contains completion fields", ErrInvalidAnalysis)
+		}
+	default:
+		return fmt.Errorf("%w: unknown status %q", ErrInvalidAnalysis, a.Status)
+	}
+
+	return nil
+}
+
+// FeedbackCategory 是稳定的协议类型。
+// 具体枚举值将在反馈契约中统一冻结，本模块不会提前猜测。
+type FeedbackCategory string
+
+// Evidence 指向用户的真实回答。TranscriptText 只保存必要的引用片段，
+// 不能复制完整的来源 Transcript。StartMS 和 EndMS 必须同时存在或同时为空。
+type Evidence struct {
+	TranscriptText string
+	StartMS        *int64
+	EndMS          *int64
+}
+
+// Validate 校验证据能够通过文字、音频时间范围或二者共同定位。
+func (e Evidence) Validate() error {
+	hasText := strings.TrimSpace(e.TranscriptText) != ""
+	hasStart := e.StartMS != nil
+	hasEnd := e.EndMS != nil
+
+	if !hasText && !hasStart && !hasEnd {
+		return fmt.Errorf("%w: text or audio range is required", ErrInvalidEvidence)
+	}
+	if hasStart != hasEnd {
+		return fmt.Errorf("%w: start_ms and end_ms must be provided together", ErrInvalidEvidence)
+	}
+	if hasStart {
+		if *e.StartMS < 0 || *e.EndMS < 0 {
+			return fmt.Errorf("%w: audio range cannot be negative", ErrInvalidEvidence)
+		}
+		if *e.EndMS < *e.StartMS {
+			return fmt.Errorf("%w: end_ms cannot be before start_ms", ErrInvalidEvidence)
+		}
+	}
+	return nil
+}
+
+// FeedbackItem 是根据 TurnAnalysis 生成的一条带证据反馈。
+type FeedbackItem struct {
+	ID         string
+	AnalysisID string
+	Category   FeedbackCategory
+	Message    string
+	Suggestion string
+	Evidence   []Evidence
+	Retryable  bool
+	CreatedAt  time.Time
+}
+
+// NewFeedbackItem 创建反馈并复制证据切片，避免调用方后续追加元素时
+// 意外改变反馈内部保存的证据集合。
+func NewFeedbackItem(
+	id, analysisID string,
+	category FeedbackCategory,
+	message, suggestion string,
+	evidence []Evidence,
+	retryable bool,
+	createdAt time.Time,
+) (FeedbackItem, error) {
+	item := FeedbackItem{
+		ID:         strings.TrimSpace(id),
+		AnalysisID: strings.TrimSpace(analysisID),
+		Category:   FeedbackCategory(strings.TrimSpace(string(category))),
+		Message:    strings.TrimSpace(message),
+		Suggestion: strings.TrimSpace(suggestion),
+		Evidence:   append([]Evidence(nil), evidence...),
+		Retryable:  retryable,
+		CreatedAt:  createdAt,
+	}
+	if err := item.Validate(); err != nil {
+		return FeedbackItem{}, err
+	}
+	return item, nil
+}
+
+// Validate 校验反馈已经关联分析，并且包含可定位的具体证据。
+func (f FeedbackItem) Validate() error {
+	if strings.TrimSpace(f.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(f.AnalysisID) == "" {
+		return fmt.Errorf("%w: analysis_id is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(string(f.Category)) == "" {
+		return fmt.Errorf("%w: category is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(f.Message) == "" {
+		return fmt.Errorf("%w: message is required", ErrInvalidFeedback)
+	}
+	if len(f.Evidence) == 0 {
+		return fmt.Errorf("%w: evidence is required", ErrInvalidFeedback)
+	}
+	for i, evidence := range f.Evidence {
+		if err := evidence.Validate(); err != nil {
+			return fmt.Errorf("%w: evidence[%d]: %v", ErrInvalidFeedback, i, err)
+		}
+	}
+	if f.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at is required", ErrInvalidFeedback)
+	}
+	return nil
+}
+
+// RetryStatus 表示 Review 中重答请求的状态。
+// 它不表示新 Turn 的生命周期，新 Turn 仍归 Conversation 所有。
+type RetryStatus string
+
+const (
+	RetryStatusPending     RetryStatus = "pending"
+	RetryStatusTurnCreated RetryStatus = "turn_created"
+	RetryStatusFailed      RetryStatus = "failed"
+)
+
+// RetryRequest 请求 Conversation 针对原问题创建一个新 Turn。
+// ID 同时也是跨模块调用使用的幂等键。
+type RetryRequest struct {
+	ID             string
+	OriginalTurnID string
+	FeedbackID     string
+	NewTurnID      string
+	Status         RetryStatus
+	FailureReason  string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// NewRetryRequest 只允许根据可重答反馈创建待处理请求。
+func NewRetryRequest(id, originalTurnID string, feedback FeedbackItem, createdAt time.Time) (RetryRequest, error) {
+	if err := feedback.Validate(); err != nil {
+		return RetryRequest{}, fmt.Errorf("%w: feedback: %v", ErrInvalidRetryRequest, err)
+	}
+	if !feedback.Retryable {
+		return RetryRequest{}, ErrFeedbackNotRetryable
+	}
+
+	request := RetryRequest{
+		ID:             strings.TrimSpace(id),
+		OriginalTurnID: strings.TrimSpace(originalTurnID),
+		FeedbackID:     feedback.ID,
+		Status:         RetryStatusPending,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+	if err := request.Validate(); err != nil {
+		return RetryRequest{}, err
+	}
+	return request, nil
+}
+
+// MarkTurnCreated 记录 Conversation 创建的新 Turn 的稳定 ID。
+func (r *RetryRequest) MarkTurnCreated(newTurnID string, updatedAt time.Time) error {
+	if r == nil {
+		return fmt.Errorf("%w: retry request is nil", ErrInvalidRetryRequest)
+	}
+	if r.Status != RetryStatusPending {
+		return fmt.Errorf("%w: retry request %q is %q", ErrInvalidStateChange, r.ID, r.Status)
+	}
+	if strings.TrimSpace(newTurnID) == "" {
+		return fmt.Errorf("%w: new_turn_id is required", ErrInvalidRetryRequest)
+	}
+	if err := validateUpdatedAt(r.CreatedAt, r.UpdatedAt, updatedAt); err != nil {
+		return fmt.Errorf("%w: updated_at: %v", ErrInvalidRetryRequest, err)
+	}
+
+	candidate := *r
+	candidate.Status = RetryStatusTurnCreated
+	candidate.NewTurnID = strings.TrimSpace(newTurnID)
+	candidate.FailureReason = ""
+	candidate.UpdatedAt = updatedAt
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*r = candidate
+	return nil
+}
+
+// MarkFailed 记录创建新 Turn 失败的结果。
+func (r *RetryRequest) MarkFailed(reason string, updatedAt time.Time) error {
+	if r == nil {
+		return fmt.Errorf("%w: retry request is nil", ErrInvalidRetryRequest)
+	}
+	if r.Status != RetryStatusPending {
+		return fmt.Errorf("%w: retry request %q is %q", ErrInvalidStateChange, r.ID, r.Status)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("%w: failed retry requires reason", ErrInvalidRetryRequest)
+	}
+	if err := validateUpdatedAt(r.CreatedAt, r.UpdatedAt, updatedAt); err != nil {
+		return fmt.Errorf("%w: updated_at: %v", ErrInvalidRetryRequest, err)
+	}
+
+	candidate := *r
+	candidate.Status = RetryStatusFailed
+	candidate.NewTurnID = ""
+	candidate.FailureReason = strings.TrimSpace(reason)
+	candidate.UpdatedAt = updatedAt
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*r = candidate
+	return nil
+}
+
+// Validate 校验 RetryRequest 的状态和时间戳不变量。
+func (r RetryRequest) Validate() error {
+	if strings.TrimSpace(r.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidRetryRequest)
+	}
+	if strings.TrimSpace(r.OriginalTurnID) == "" {
+		return fmt.Errorf("%w: original_turn_id is required", ErrInvalidRetryRequest)
+	}
+	if strings.TrimSpace(r.FeedbackID) == "" {
+		return fmt.Errorf("%w: feedback_id is required", ErrInvalidRetryRequest)
+	}
+	if r.CreatedAt.IsZero() || r.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: timestamps are required", ErrInvalidRetryRequest)
+	}
+	if r.UpdatedAt.Before(r.CreatedAt) {
+		return fmt.Errorf("%w: updated_at cannot be before created_at", ErrInvalidRetryRequest)
+	}
+
+	switch r.Status {
+	case RetryStatusPending:
+		if strings.TrimSpace(r.NewTurnID) != "" || strings.TrimSpace(r.FailureReason) != "" {
+			return fmt.Errorf("%w: pending retry contains terminal fields", ErrInvalidRetryRequest)
+		}
+	case RetryStatusTurnCreated:
+		if strings.TrimSpace(r.NewTurnID) == "" {
+			return fmt.Errorf("%w: created retry requires new_turn_id", ErrInvalidRetryRequest)
+		}
+		if strings.TrimSpace(r.FailureReason) != "" {
+			return fmt.Errorf("%w: created retry contains failure reason", ErrInvalidRetryRequest)
+		}
+	case RetryStatusFailed:
+		if strings.TrimSpace(r.FailureReason) == "" {
+			return fmt.Errorf("%w: failed retry requires reason", ErrInvalidRetryRequest)
+		}
+		if strings.TrimSpace(r.NewTurnID) != "" {
+			return fmt.Errorf("%w: failed retry contains new_turn_id", ErrInvalidRetryRequest)
+		}
+	default:
+		return fmt.Errorf("%w: unknown status %q", ErrInvalidRetryRequest, r.Status)
+	}
+	return nil
+}
+
+// HistoryKey 标识一条分析投影。History 可以通过来源 ID 重建，
+// 不能成为第二个可写的权威数据源。
+type HistoryKey struct {
+	SessionID  string
+	TurnID     string
+	AnalysisID string
+}
+
+// HistoryRecord 只保存历史列表展示所需的最小字段。
+type HistoryRecord struct {
+	ID             string
+	SessionID      string
+	TurnID         string
+	AnalysisID     string
+	RetryRequestID string
+	Score          *int
+	Summary        string
+	ReviewedAt     time.Time
+}
+
+// NewHistoryRecord 将一条已完成分析投影为历史只读模型。
+func NewHistoryRecord(id, sessionID string, analysis TurnAnalysis, reviewedAt time.Time) (HistoryRecord, error) {
+	if err := analysis.Validate(); err != nil {
+		return HistoryRecord{}, fmt.Errorf("%w: analysis: %v", ErrInvalidHistoryRecord, err)
+	}
+	if analysis.Status != AnalysisStatusCompleted {
+		return HistoryRecord{}, fmt.Errorf("%w: analysis must be completed", ErrInvalidHistoryRecord)
+	}
+	if reviewedAt.IsZero() || reviewedAt.Before(analysis.CreatedAt) {
+		return HistoryRecord{}, fmt.Errorf("%w: invalid reviewed_at", ErrInvalidHistoryRecord)
+	}
+
+	record := HistoryRecord{
+		ID:         strings.TrimSpace(id),
+		SessionID:  strings.TrimSpace(sessionID),
+		TurnID:     analysis.TurnID,
+		AnalysisID: analysis.ID,
+		Score:      intPointer(*analysis.Score),
+		Summary:    analysis.Summary,
+		ReviewedAt: reviewedAt,
+	}
+	if err := record.Validate(); err != nil {
+		return HistoryRecord{}, err
+	}
+	return record, nil
+}
+
+// Key 返回用于幂等更新投影的稳定来源 ID。
+func (h HistoryRecord) Key() HistoryKey {
+	return HistoryKey{SessionID: h.SessionID, TurnID: h.TurnID, AnalysisID: h.AnalysisID}
+}
+
+// Validate 校验历史只读模型必须具备的最小字段。
+func (h HistoryRecord) Validate() error {
+	if strings.TrimSpace(h.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.SessionID) == "" {
+		return fmt.Errorf("%w: session_id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.AnalysisID) == "" {
+		return fmt.Errorf("%w: analysis_id is required", ErrInvalidHistoryRecord)
+	}
+	if h.Score == nil {
+		return fmt.Errorf("%w: score is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.Summary) == "" {
+		return fmt.Errorf("%w: summary is required", ErrInvalidHistoryRecord)
+	}
+	if h.ReviewedAt.IsZero() {
+		return fmt.Errorf("%w: reviewed_at is required", ErrInvalidHistoryRecord)
+	}
+	return nil
+}
+
+func validateTerminalTime(createdAt, terminalAt time.Time) error {
+	if terminalAt.IsZero() {
+		return errors.New("timestamp is required")
+	}
+	if terminalAt.Before(createdAt) {
+		return errors.New("timestamp cannot be before created_at")
+	}
+	return nil
+}
+
+func validateUpdatedAt(createdAt, currentUpdatedAt, nextUpdatedAt time.Time) error {
+	if nextUpdatedAt.IsZero() {
+		return errors.New("timestamp is required")
+	}
+	if nextUpdatedAt.Before(createdAt) || nextUpdatedAt.Before(currentUpdatedAt) {
+		return errors.New("timestamp cannot move backwards")
+	}
+	return nil
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/server/internal/review/model_test.go
+++ b/server/internal/review/model_test.go
@@ -1,0 +1,274 @@
+package review_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+)
+
+var testTime = time.Date(2026, time.July, 15, 10, 0, 0, 0, time.UTC)
+
+func TestNewTurnAnalysisRejectsMissingTurnID(t *testing.T) {
+	_, err := review.NewTurnAnalysis("analysis-1", "", "evaluator-v1", testTime)
+	if !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected ErrInvalidAnalysis, got %v", err)
+	}
+}
+
+func TestTurnAnalysisCompleteRequiresResult(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+
+	if err := analysis.Complete(0, " ", "", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected blank summary to fail, got %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusPending {
+		t.Fatalf("failed transition changed status to %q", analysis.Status)
+	}
+
+	completedAt := testTime.Add(time.Minute)
+	if err := analysis.Complete(0, "The answer is relevant.", "scoring transcript", completedAt); err != nil {
+		t.Fatalf("complete analysis: %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusCompleted {
+		t.Fatalf("expected completed, got %q", analysis.Status)
+	}
+	if analysis.Score == nil || *analysis.Score != 0 {
+		t.Fatalf("expected valid zero score, got %#v", analysis.Score)
+	}
+	if analysis.CompletedAt == nil || !analysis.CompletedAt.Equal(completedAt) {
+		t.Fatalf("unexpected completed_at: %#v", analysis.CompletedAt)
+	}
+	if err := analysis.Validate(); err != nil {
+		t.Fatalf("completed analysis should validate: %v", err)
+	}
+	if err := analysis.Complete(1, "again", "", completedAt); !errors.Is(err, review.ErrInvalidStateChange) {
+		t.Fatalf("expected terminal analysis to reject second completion, got %v", err)
+	}
+}
+
+func TestTurnAnalysisFailedRequiresReason(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+
+	if err := analysis.Fail(" ", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected blank reason to fail, got %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusPending {
+		t.Fatalf("failed transition changed status to %q", analysis.Status)
+	}
+
+	failedAt := testTime.Add(time.Minute)
+	if err := analysis.Fail("provider unavailable", failedAt); err != nil {
+		t.Fatalf("fail analysis: %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusFailed || analysis.FailureReason != "provider unavailable" {
+		t.Fatalf("unexpected failed analysis: %#v", analysis)
+	}
+	if analysis.FailedAt == nil || !analysis.FailedAt.Equal(failedAt) {
+		t.Fatalf("unexpected failed_at: %#v", analysis.FailedAt)
+	}
+	if err := analysis.Validate(); err != nil {
+		t.Fatalf("failed analysis should validate: %v", err)
+	}
+}
+
+func TestTurnAnalysisFailedTransitionDoesNotMutateReceiver(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	before := analysis
+
+	err := analysis.Complete(80, "valid summary", "", testTime.Add(-time.Minute))
+	if !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected invalid completion time to fail, got %v", err)
+	}
+	if analysis != before {
+		t.Fatalf("failed transition mutated analysis: before %#v after %#v", before, analysis)
+	}
+}
+
+func TestTurnAnalysisKeyUsesTurnAndEvaluatorVersion(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	want := (review.AnalysisKey{TurnID: "turn-1", EvaluatorVersion: "evaluator-v1"})
+	if got := analysis.Key(); got != want {
+		t.Fatalf("unexpected analysis key: got %#v want %#v", got, want)
+	}
+}
+
+func TestEvidenceValidate(t *testing.T) {
+	negative := int64(-1)
+	zero := int64(0)
+	ten := int64(10)
+	twenty := int64(20)
+
+	tests := []struct {
+		name    string
+		value   review.Evidence
+		wantErr bool
+	}{
+		{name: "text only", value: review.Evidence{TranscriptText: "I led the migration."}},
+		{name: "range only", value: review.Evidence{StartMS: &zero, EndMS: &ten}},
+		{name: "text and range", value: review.Evidence{TranscriptText: "I led it.", StartMS: &ten, EndMS: &twenty}},
+		{name: "empty", value: review.Evidence{}, wantErr: true},
+		{name: "negative", value: review.Evidence{StartMS: &negative, EndMS: &ten}, wantErr: true},
+		{name: "reversed", value: review.Evidence{StartMS: &twenty, EndMS: &ten}, wantErr: true},
+		{name: "missing end", value: review.Evidence{StartMS: &zero}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.value.Validate()
+			if tt.wantErr && !errors.Is(err, review.ErrInvalidEvidence) {
+				t.Fatalf("expected ErrInvalidEvidence, got %v", err)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected valid evidence, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewFeedbackItemCopiesEvidence(t *testing.T) {
+	evidence := []review.Evidence{{TranscriptText: "I reduced latency by 30%."}}
+	item, err := review.NewFeedbackItem(
+		"feedback-1",
+		"analysis-1",
+		review.FeedbackCategory("evidence"),
+		"The answer includes a measurable result.",
+		"Keep the metric in the final answer.",
+		evidence,
+		true,
+		testTime,
+	)
+	if err != nil {
+		t.Fatalf("new feedback: %v", err)
+	}
+
+	evidence[0].TranscriptText = "changed by caller"
+	if item.Evidence[0].TranscriptText != "I reduced latency by 30%." {
+		t.Fatalf("feedback evidence changed through caller slice: %#v", item.Evidence)
+	}
+	if err := item.Validate(); err != nil {
+		t.Fatalf("feedback should validate: %v", err)
+	}
+}
+
+func TestNewRetryRequestRejectsNonRetryableFeedback(t *testing.T) {
+	feedback := mustFeedback(t, false)
+	_, err := review.NewRetryRequest("retry-1", "turn-1", feedback, testTime)
+	if !errors.Is(err, review.ErrFeedbackNotRetryable) {
+		t.Fatalf("expected ErrFeedbackNotRetryable, got %v", err)
+	}
+}
+
+func TestRetryRequestTransitions(t *testing.T) {
+	t.Run("turn created", func(t *testing.T) {
+		request := mustRetryRequest(t)
+		if err := request.MarkTurnCreated("", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidRetryRequest) {
+			t.Fatalf("expected missing new turn to fail, got %v", err)
+		}
+		if request.Status != review.RetryStatusPending {
+			t.Fatalf("failed transition changed status to %q", request.Status)
+		}
+
+		if err := request.MarkTurnCreated("turn-2", testTime.Add(time.Minute)); err != nil {
+			t.Fatalf("mark turn created: %v", err)
+		}
+		if request.Status != review.RetryStatusTurnCreated || request.NewTurnID != "turn-2" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+		if err := request.Validate(); err != nil {
+			t.Fatalf("created request should validate: %v", err)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		request := mustRetryRequest(t)
+		if err := request.MarkFailed(" ", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidRetryRequest) {
+			t.Fatalf("expected missing reason to fail, got %v", err)
+		}
+		if request.Status != review.RetryStatusPending {
+			t.Fatalf("failed transition changed status to %q", request.Status)
+		}
+
+		if err := request.MarkFailed("conversation unavailable", testTime.Add(time.Minute)); err != nil {
+			t.Fatalf("mark failed: %v", err)
+		}
+		if request.Status != review.RetryStatusFailed || request.FailureReason != "conversation unavailable" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+		if err := request.Validate(); err != nil {
+			t.Fatalf("failed request should validate: %v", err)
+		}
+	})
+}
+
+func TestRetryFailedTransitionDoesNotMutateReceiver(t *testing.T) {
+	request := mustRetryRequest(t)
+	before := request
+
+	err := request.MarkTurnCreated("turn-2", testTime.Add(-time.Minute))
+	if !errors.Is(err, review.ErrInvalidRetryRequest) {
+		t.Fatalf("expected backwards timestamp to fail, got %v", err)
+	}
+	if request != before {
+		t.Fatalf("failed transition mutated request: before %#v after %#v", before, request)
+	}
+}
+
+func TestNewHistoryRecordUsesStableSourceIDs(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	if err := analysis.Complete(72, "The answer needs a clearer result.", "", testTime.Add(time.Minute)); err != nil {
+		t.Fatalf("complete analysis: %v", err)
+	}
+
+	record, err := review.NewHistoryRecord("history-1", "session-1", analysis, testTime.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("new history record: %v", err)
+	}
+	wantKey := (review.HistoryKey{SessionID: "session-1", TurnID: "turn-1", AnalysisID: "analysis-1"})
+	if got := record.Key(); got != wantKey {
+		t.Fatalf("unexpected history key: got %#v want %#v", got, wantKey)
+	}
+	if record.Score == nil || *record.Score != 72 {
+		t.Fatalf("unexpected projected score: %#v", record.Score)
+	}
+	if err := record.Validate(); err != nil {
+		t.Fatalf("history record should validate: %v", err)
+	}
+}
+
+func mustPendingAnalysis(t *testing.T) review.TurnAnalysis {
+	t.Helper()
+	analysis, err := review.NewTurnAnalysis("analysis-1", "turn-1", "evaluator-v1", testTime)
+	if err != nil {
+		t.Fatalf("new analysis: %v", err)
+	}
+	return analysis
+}
+
+func mustFeedback(t *testing.T, retryable bool) review.FeedbackItem {
+	t.Helper()
+	item, err := review.NewFeedbackItem(
+		"feedback-1",
+		"analysis-1",
+		review.FeedbackCategory("evidence"),
+		"Add a measurable result.",
+		"State the outcome with a metric.",
+		[]review.Evidence{{TranscriptText: "We finished the project."}},
+		retryable,
+		testTime,
+	)
+	if err != nil {
+		t.Fatalf("new feedback: %v", err)
+	}
+	return item
+}
+
+func mustRetryRequest(t *testing.T) review.RetryRequest {
+	t.Helper()
+	request, err := review.NewRetryRequest("retry-1", "turn-1", mustFeedback(t, true), testTime)
+	if err != nil {
+		t.Fatalf("new retry request: %v", err)
+	}
+	return request
+}

--- a/server/internal/review/ports.go
+++ b/server/internal/review/ports.go
@@ -1,0 +1,196 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+var (
+	// ErrTurnReviewSourceNotFound 表示 Conversation 中不存在指定 Turn。
+	ErrTurnReviewSourceNotFound = errors.New("turn review source not found")
+	// ErrTurnNotCompleted 表示 Turn 尚未完成，当前不能用于复盘。
+	ErrTurnNotCompleted = errors.New("turn is not completed")
+	// ErrTranscriptNotReady 表示 Turn 的 Transcript 尚不可用。
+	ErrTranscriptNotReady = errors.New("transcript is not ready")
+	// ErrAudioNotReady 表示 Turn 的音频引用或元数据尚不可用。
+	ErrAudioNotReady = errors.New("audio is not ready")
+	// ErrAudioNotFound 表示音频不存在或已被删除。
+	ErrAudioNotFound = errors.New("audio not found")
+	// ErrUnsupportedAudioFormat 表示当前 Review 评分链路不支持该音频格式。
+	ErrUnsupportedAudioFormat = errors.New("unsupported audio format")
+	// ErrAudioLimitExceeded 表示音频大小或时长超过评分限制。
+	ErrAudioLimitExceeded = errors.New("audio limit exceeded")
+	// ErrRetryNotAllowed 表示原 Turn 不允许创建同题重答。
+	ErrRetryNotAllowed = errors.New("retry not allowed")
+	// ErrRetryTurnCreationFailed 表示 Conversation 未能创建重答 Turn。
+	ErrRetryTurnCreationFailed = errors.New("retry turn creation failed")
+	// ErrEvaluationFailed 表示评分或证据生成失败。
+	ErrEvaluationFailed = errors.New("evaluation failed")
+)
+
+// RetryReasonReview 是 Review 请求 Conversation 创建同题重答的稳定原因值。
+const RetryReasonReview = "review_retry"
+
+// TurnReviewSourceReader 是 Review 获取已完成 Turn 复盘资料的读取端口。
+//
+// 实现方应返回与 Conversation 内部可变状态脱离的快照，包括独立的
+// TranscriptSegment 切片。该端口不传输音频内容；Review 后续使用
+// AudioReference.AudioID 通过独立的音频读取端口打开只读流。
+type TurnReviewSourceReader interface {
+	GetCompletedTurnReviewSource(ctx context.Context, turnID string) (TurnReviewSource, error)
+}
+
+// TurnReviewSource 是 Review 评分和生成历史投影所需的最小只读快照。
+// 它不是 Conversation 的领域对象，不得用于修改来源 Turn、
+// Question、Transcript 或音频。
+type TurnReviewSource struct {
+	TurnID       string
+	SessionID    string
+	QuestionID   string
+	QuestionText string
+	Transcript   TranscriptSnapshot
+	Audio        AudioReference
+	CompletedAt  time.Time
+}
+
+// TranscriptSnapshot 是 Conversation 产生的 Transcript 只读快照。
+// Status 保留 Conversation 公开的稳定状态值；Review 不在此复制其完整状态机。
+type TranscriptSnapshot struct {
+	TranscriptID string
+	Text         string
+	Language     string
+	Status       string
+	Segments     []TranscriptSegment
+}
+
+// TranscriptSegment 将 Transcript 中的必要文字片段定位到原始音频时间范围。
+type TranscriptSegment struct {
+	StartMS int64
+	EndMS   int64
+	Text    string
+}
+
+// AudioReference 是 Conversation 所拥有音频的稳定引用和最小元数据。
+// AudioID 不是本地文件路径或对象存储位置；Checksum 为空表示来源未提供校验值。
+type AudioReference struct {
+	AudioID     string
+	ContentType string
+	Format      string
+	SizeBytes   int64
+	DurationMS  int64
+	Checksum    string
+}
+
+// AudioContentReader 根据 Conversation 提供的稳定 AudioID 打开音频。
+//
+// 相同 AudioID 的每次成功调用都必须返回一个新的只读流，以支持
+// 失败后重试。调用方 Review Service 拥有返回流的关闭责任。
+type AudioContentReader interface {
+	OpenAudio(ctx context.Context, audioID string) (io.ReadCloser, error)
+}
+
+// RetryTurnPort 请求 Conversation 为原 Turn 创建同题重答 Turn。
+type RetryTurnPort interface {
+	CreateRetryTurn(ctx context.Context, command CreateRetryTurnCommand) (RetryTurnResult, error)
+}
+
+// CreateRetryTurnCommand 是 Review 发送给 Conversation 的重答命令。
+// RetryRequestID 是跨模块幂等键；Conversation 对相同键必须返回
+// 同一 NewTurnID，不得创建多个 Turn。
+type CreateRetryTurnCommand struct {
+	RetryRequestID string
+	OriginalTurnID string
+	Reason         string
+}
+
+// RetryTurnResult 只返回 Conversation 所拥有的新 Turn 稳定 ID。
+type RetryTurnResult struct {
+	NewTurnID string
+}
+
+// TurnEvaluator 封装真实或 Mock 的评分和证据生成实现。
+// Version 必须返回能区分评分行为的稳定版本，Review 使用
+// TurnID + Version 保证 TurnAnalysis 幂等。
+type TurnEvaluator interface {
+	Version() string
+	EvaluateTurn(ctx context.Context, input EvaluationInput) (EvaluationResult, error)
+}
+
+// EvaluationInput 是评分实现所需的最小输入。
+// Audio 由 Review Service 打开和关闭，Evaluator 只负责读取。
+type EvaluationInput struct {
+	TurnID        string
+	QuestionID    string
+	QuestionText  string
+	Transcript    TranscriptSnapshot
+	Audio         io.Reader
+	AudioMetadata AudioReference
+}
+
+// EvaluationResult 是与具体模型供应商无关的结构化评分结果。
+type EvaluationResult struct {
+	Score              int
+	Summary            string
+	AnalysisTranscript string
+	Suggestions        []EvaluationSuggestion
+}
+
+// EvaluationSuggestion 描述一条可转换为 FeedbackItem 的建议和证据。
+// Evidence 是必要的 Transcript 文字片段；StartMS 和 EndMS 用于
+// 可选的音频时间定位。
+type EvaluationSuggestion struct {
+	Category  FeedbackCategory
+	Message   string
+	Evidence  string
+	StartMS   *int64
+	EndMS     *int64
+	Retryable bool
+}
+
+// AnalysisRepository 持久化 Review 拥有的 TurnAnalysis。
+// Save 必须维护 AnalysisKey 的唯一性，并能保存合法的状态转换。
+type AnalysisRepository interface {
+	FindByID(ctx context.Context, analysisID string) (TurnAnalysis, bool, error)
+	FindByKey(ctx context.Context, key AnalysisKey) (TurnAnalysis, bool, error)
+	Save(ctx context.Context, analysis TurnAnalysis) error
+}
+
+// FeedbackRepository 持久化和读取 Review 生成的 FeedbackItem。
+// SaveAll 用于保存同一次分析产生的反馈集合。
+type FeedbackRepository interface {
+	FindByID(ctx context.Context, feedbackID string) (FeedbackItem, bool, error)
+	ListByAnalysisID(ctx context.Context, analysisID string) ([]FeedbackItem, error)
+	SaveAll(ctx context.Context, feedback []FeedbackItem) error
+}
+
+// RetryRepository 持久化 Review 拥有的 RetryRequest。
+// FindByFeedbackID 用于保证对同一条反馈的重复请求保持幂等。
+type RetryRepository interface {
+	FindByID(ctx context.Context, retryRequestID string) (RetryRequest, bool, error)
+	FindByFeedbackID(ctx context.Context, feedbackID string) (RetryRequest, bool, error)
+	Save(ctx context.Context, request RetryRequest) error
+	Update(ctx context.Context, request RetryRequest) error
+}
+
+// HistoryRepository 管理可重建的 HistoryRecord 只读投影。
+// Upsert 使用 HistoryRecord.Key 保持幂等；ListBySession 必须按
+// ReviewedAt 倒序返回，limit 和 offset 用于分页。
+type HistoryRepository interface {
+	Upsert(ctx context.Context, record HistoryRecord) error
+	FindByAnalysisID(ctx context.Context, analysisID string) (HistoryRecord, bool, error)
+	ListBySession(ctx context.Context, sessionID string, limit, offset int) ([]HistoryRecord, error)
+}
+
+// IDGenerator 为 Review 领域对象生成稳定唯一 ID。
+// 这是团队统一实现出现前的模块内最小端口。
+type IDGenerator interface {
+	NewID() string
+}
+
+// Clock 为 Review Service 提供可测试的当前时间。
+// 这是团队统一实现出现前的模块内最小端口。
+type Clock interface {
+	Now() time.Time
+}

--- a/server/internal/review/retry.go
+++ b/server/internal/review/retry.go
@@ -1,0 +1,24 @@
+package review
+
+import "context"
+
+// RetryUseCase 定义根据可重答 Feedback 发起同题重答的应用契约。
+// 新 Turn 仍由 Conversation 创建和拥有。
+type RetryUseCase interface {
+	// RequestRetry 请求为一条可重答 Feedback 创建同题重答。
+	// Feedback 不存在或不可重答时分别返回 ErrFeedbackNotFound 或
+	// ErrFeedbackNotRetryable；具体查询、保存和跨模块调用由后续实现负责。
+	RequestRetry(ctx context.Context, command RequestRetryCommand) (RequestRetryResult, error)
+}
+
+// RequestRetryCommand 使用 FeedbackID 标识需要再次练习的反馈。
+// 原 Turn 由未来 Service 根据 Review 内部关联确定，调用方不重复提交 TurnID。
+type RequestRetryCommand struct {
+	FeedbackID string
+}
+
+// RequestRetryResult 返回 Review 所拥有的重答请求。
+// NewTurnID 通过 Request.NewTurnID 表达；为空表示 Conversation 尚未创建新 Turn。
+type RequestRetryResult struct {
+	Request RetryRequest
+}

--- a/server/internal/review/service.go
+++ b/server/internal/review/service.go
@@ -1,0 +1,9 @@
+package review
+
+// ReviewService 组合 Review 模块对内公开的应用用例契约。
+// 具体业务流程由后续实现提供。
+type ReviewService interface {
+	AnalyzeUseCase
+	RetryUseCase
+	HistoryQueryUseCase
+}


### PR DESCRIPTION
## 功能描述

- 建立 Review 模块的领域模型与不变量，覆盖 TurnAnalysis、Evidence Feedback、RetryRequest 和 History Read Model。
- 定义 Conversation、评分器和 Repository 等外部依赖 Port。
- 按分析、同题重答、历史查询拆分应用用例接口骨架，不提供具体 Service 方法体。
- 补充架构开发计划和跨模块接口需求文档。

## 实现思路

- 使用稳定 ID、只读 Snapshot、Command 和 Result 表达模块边界。
- Review 自己拥有分析、反馈、重答请求和历史投影；Question、Turn、Transcript、音频及 PracticeSession 仍由原模块拥有。
- 仅声明领域规则、Port 和用例接口，不包含 Handler、Adapter、数据库、AI Provider 或业务流程实现。
- Session 级复盘后续复用 Practice 的 `GetPracticeSessionSnapshot` 和 Conversation 的 `ListPracticeSessionTurns`，由 Review 定义消费方窄 Port；本 PR 不提前写入未完成对齐的字段。

## 测试方式

```bash
cd server
gofmt -d internal/review/*.go
go test ./internal/review/...
go vet ./internal/review/...
go test ./...
go vet ./...
```

以上检查均已通过。

## 相关 Issue / 备注

- Related to #31
- Related to #38
- 本 PR 只交付 Review 架构骨架；具体 Service、Handler、Adapter、Repository 和供应商接入留给后续 Issue。
- Session 级复盘 Query/Result 与两个消费方读取 Port 尚未写入代码，等待 #38 对齐完成后补充。

## AI 辅助说明

- AI 协助内容：根据成员职责、产品原型和现有冻结契约整理 Review 模块骨架、文档与提交。
- 主要约束：只写可编译骨架，不创建具体实现，不跨模块访问 Repository 或内部模型。
- 人工复核重点：领域所有权、接口命名、Evidence 与 Retry 不变量，以及 #34/#35/#37 的跨模块能力复用。