### PR TITLE
feat(review): 建立复盘模块接口骨架

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 server/bin/
 *.test
 *.out
+# Local Review architecture documents
+server/internal/review/docs/

--- a/server/internal/review/analyze.go
+++ b/server/internal/review/analyze.go
@@ -1,0 +1,52 @@
+package review
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrAnalysisNotFound 表示不存在指定的 Review Analysis。
+	ErrAnalysisNotFound = errors.New("analysis not found")
+	// ErrFeedbackNotFound 表示不存在指定的 Review Feedback。
+	ErrFeedbackNotFound = errors.New("feedback not found")
+)
+
+// AnalyzeUseCase 定义 Turn 分析和证据反馈查询能力。
+// 本接口只描述应用契约，不包含具体分析流程。
+type AnalyzeUseCase interface {
+	// AnalyzeTurn 请求分析一个已完成的来源 Turn。
+	// 相同 TurnID 和评分版本的幂等处理由后续具体实现负责。
+	AnalyzeTurn(ctx context.Context, command AnalyzeTurnCommand) (AnalyzeTurnResult, error)
+
+	// GetTurnReview 根据稳定 AnalysisID 返回一次确定的复盘结果。
+	GetTurnReview(ctx context.Context, query GetTurnReviewQuery) (TurnReviewDetail, error)
+
+	// GetFeedback 返回一条句子级证据反馈。
+	// Feedback 只保存音频时间范围；音频内容和播放能力仍归 Conversation 所有。
+	GetFeedback(ctx context.Context, feedbackID string) (FeedbackItem, error)
+}
+
+// AnalyzeTurnCommand 标识需要分析的来源 Turn。
+// Review 只引用稳定 ID，不修改来源 Turn、Transcript、音频或 PracticeSession。
+type AnalyzeTurnCommand struct {
+	TurnID string
+}
+
+// AnalyzeTurnResult 是 Turn 分析用例的返回结果。
+type AnalyzeTurnResult struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+	Reused   bool
+}
+
+// GetTurnReviewQuery 使用稳定 AnalysisID 查询一次确定的复盘结果。
+type GetTurnReviewQuery struct {
+	AnalysisID string
+}
+
+// TurnReviewDetail 聚合一次 Analysis 及其证据反馈。
+type TurnReviewDetail struct {
+	Analysis TurnAnalysis
+	Feedback []FeedbackItem
+}

--- a/server/internal/review/history.go
+++ b/server/internal/review/history.go
@@ -1,0 +1,31 @@
+package review
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrInvalidHistoryQuery 表示 Review 历史查询条件无效。
+var ErrInvalidHistoryQuery = errors.New("invalid review history query")
+
+// HistoryQueryUseCase 定义 Review 复盘历史的只读查询契约。
+// 它不表示 PracticeSession 进度或 Conversation 对话历史。
+type HistoryQueryUseCase interface {
+	// ListReviewHistory 返回 Review 自己维护的只读历史投影。
+	// SessionID 为空表示不按 Session 过滤；Limit 和 Offset 必须为非负数。
+	// 默认排序为 ReviewedAt 倒序，具体校验和查询由后续实现负责。
+	ListReviewHistory(ctx context.Context, query ListReviewHistoryQuery) (ListReviewHistoryResult, error)
+}
+
+// ListReviewHistoryQuery 描述 Review 历史的过滤和分页条件。
+// 它不包含 PracticeSession 状态或 Conversation 对话筛选条件。
+type ListReviewHistoryQuery struct {
+	SessionID string
+	Limit     int
+	Offset    int
+}
+
+// ListReviewHistoryResult 返回 Review 自己维护的最小历史投影。
+type ListReviewHistoryResult struct {
+	Records []HistoryRecord
+}

--- a/server/internal/review/model.go
+++ b/server/internal/review/model.go
@@ -1,0 +1,541 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalidAnalysis      = errors.New("invalid turn analysis")
+	ErrInvalidFeedback      = errors.New("invalid feedback item")
+	ErrInvalidEvidence      = errors.New("invalid evidence")
+	ErrInvalidRetryRequest  = errors.New("invalid retry request")
+	ErrInvalidHistoryRecord = errors.New("invalid history record")
+	ErrInvalidStateChange   = errors.New("invalid state change")
+	ErrFeedbackNotRetryable = errors.New("feedback is not retryable")
+)
+
+// AnalysisStatus 表示一次分析的生命周期，不会改变来源 Turn 或
+// PracticeSession 的生命周期。
+type AnalysisStatus string
+
+const (
+	AnalysisStatusPending   AnalysisStatus = "pending"
+	AnalysisStatusCompleted AnalysisStatus = "completed"
+	AnalysisStatusFailed    AnalysisStatus = "failed"
+)
+
+// AnalysisKey 是保证评分幂等的稳定标识。
+// Repository 不得为同一个 Key 创建两份分析。
+type AnalysisKey struct {
+	TurnID           string
+	EvaluatorVersion string
+}
+
+// TurnAnalysis 是 Review 对一个已完成 Turn 的持久化分析结果。
+// Score 使用指针，是因为 0 可能是有效分数，而 nil 表示尚未生成分数。
+type TurnAnalysis struct {
+	ID                 string
+	TurnID             string
+	EvaluatorVersion   string
+	Status             AnalysisStatus
+	Score              *int
+	Summary            string
+	AnalysisTranscript string
+	FailureReason      string
+	CreatedAt          time.Time
+	CompletedAt        *time.Time
+	FailedAt           *time.Time
+}
+
+// NewTurnAnalysis 创建一条待处理分析。
+// 来源 Turn 仍归 Conversation 所有，Review 只通过稳定 ID 引用它。
+func NewTurnAnalysis(id, turnID, evaluatorVersion string, createdAt time.Time) (TurnAnalysis, error) {
+	analysis := TurnAnalysis{
+		ID:               strings.TrimSpace(id),
+		TurnID:           strings.TrimSpace(turnID),
+		EvaluatorVersion: strings.TrimSpace(evaluatorVersion),
+		Status:           AnalysisStatusPending,
+		CreatedAt:        createdAt,
+	}
+	if err := analysis.Validate(); err != nil {
+		return TurnAnalysis{}, err
+	}
+	return analysis, nil
+}
+
+// Key 返回该分析在 Repository 中使用的唯一键。
+func (a TurnAnalysis) Key() AnalysisKey {
+	return AnalysisKey{TurnID: a.TurnID, EvaluatorVersion: a.EvaluatorVersion}
+}
+
+// Complete 使用最终评分结果将待处理分析转换为已完成状态。
+func (a *TurnAnalysis) Complete(score int, summary, analysisTranscript string, completedAt time.Time) error {
+	if a == nil {
+		return fmt.Errorf("%w: analysis is nil", ErrInvalidAnalysis)
+	}
+	if a.Status != AnalysisStatusPending {
+		return fmt.Errorf("%w: analysis %q is %q", ErrInvalidStateChange, a.ID, a.Status)
+	}
+	if strings.TrimSpace(summary) == "" {
+		return fmt.Errorf("%w: completed analysis requires summary", ErrInvalidAnalysis)
+	}
+	if err := validateTerminalTime(a.CreatedAt, completedAt); err != nil {
+		return fmt.Errorf("%w: completed_at: %v", ErrInvalidAnalysis, err)
+	}
+
+	candidate := *a
+	candidate.Status = AnalysisStatusCompleted
+	candidate.Score = intPointer(score)
+	candidate.Summary = strings.TrimSpace(summary)
+	candidate.AnalysisTranscript = analysisTranscript
+	candidate.CompletedAt = timePointer(completedAt)
+	candidate.FailureReason = ""
+	candidate.FailedAt = nil
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*a = candidate
+	return nil
+}
+
+// Fail 将待处理分析转换为失败状态，但不会修改来源 Turn。
+func (a *TurnAnalysis) Fail(reason string, failedAt time.Time) error {
+	if a == nil {
+		return fmt.Errorf("%w: analysis is nil", ErrInvalidAnalysis)
+	}
+	if a.Status != AnalysisStatusPending {
+		return fmt.Errorf("%w: analysis %q is %q", ErrInvalidStateChange, a.ID, a.Status)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("%w: failed analysis requires reason", ErrInvalidAnalysis)
+	}
+	if err := validateTerminalTime(a.CreatedAt, failedAt); err != nil {
+		return fmt.Errorf("%w: failed_at: %v", ErrInvalidAnalysis, err)
+	}
+
+	candidate := *a
+	candidate.Status = AnalysisStatusFailed
+	candidate.Score = nil
+	candidate.Summary = ""
+	candidate.FailureReason = strings.TrimSpace(reason)
+	candidate.CompletedAt = nil
+	candidate.FailedAt = timePointer(failedAt)
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*a = candidate
+	return nil
+}
+
+// Validate 校验分析在各个持久化状态下必须满足的不变量。
+func (a TurnAnalysis) Validate() error {
+	if strings.TrimSpace(a.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidAnalysis)
+	}
+	if strings.TrimSpace(a.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidAnalysis)
+	}
+	if strings.TrimSpace(a.EvaluatorVersion) == "" {
+		return fmt.Errorf("%w: evaluator_version is required", ErrInvalidAnalysis)
+	}
+	if a.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at is required", ErrInvalidAnalysis)
+	}
+
+	switch a.Status {
+	case AnalysisStatusPending:
+		if a.Score != nil || strings.TrimSpace(a.Summary) != "" || strings.TrimSpace(a.FailureReason) != "" || a.CompletedAt != nil || a.FailedAt != nil {
+			return fmt.Errorf("%w: pending analysis contains terminal fields", ErrInvalidAnalysis)
+		}
+	case AnalysisStatusCompleted:
+		if a.Score == nil {
+			return fmt.Errorf("%w: completed analysis requires score", ErrInvalidAnalysis)
+		}
+		if strings.TrimSpace(a.Summary) == "" {
+			return fmt.Errorf("%w: completed analysis requires summary", ErrInvalidAnalysis)
+		}
+		if a.CompletedAt == nil {
+			return fmt.Errorf("%w: completed analysis requires completed_at", ErrInvalidAnalysis)
+		}
+		if err := validateTerminalTime(a.CreatedAt, *a.CompletedAt); err != nil {
+			return fmt.Errorf("%w: completed_at: %v", ErrInvalidAnalysis, err)
+		}
+		if strings.TrimSpace(a.FailureReason) != "" || a.FailedAt != nil {
+			return fmt.Errorf("%w: completed analysis contains failure fields", ErrInvalidAnalysis)
+		}
+	case AnalysisStatusFailed:
+		if strings.TrimSpace(a.FailureReason) == "" {
+			return fmt.Errorf("%w: failed analysis requires reason", ErrInvalidAnalysis)
+		}
+		if a.FailedAt == nil {
+			return fmt.Errorf("%w: failed analysis requires failed_at", ErrInvalidAnalysis)
+		}
+		if err := validateTerminalTime(a.CreatedAt, *a.FailedAt); err != nil {
+			return fmt.Errorf("%w: failed_at: %v", ErrInvalidAnalysis, err)
+		}
+		if a.Score != nil || strings.TrimSpace(a.Summary) != "" || a.CompletedAt != nil {
+			return fmt.Errorf("%w: failed analysis contains completion fields", ErrInvalidAnalysis)
+		}
+	default:
+		return fmt.Errorf("%w: unknown status %q", ErrInvalidAnalysis, a.Status)
+	}
+
+	return nil
+}
+
+// FeedbackCategory 是稳定的协议类型。
+// 具体枚举值将在反馈契约中统一冻结，本模块不会提前猜测。
+type FeedbackCategory string
+
+// Evidence 指向用户的真实回答。TranscriptText 只保存必要的引用片段，
+// 不能复制完整的来源 Transcript。StartMS 和 EndMS 必须同时存在或同时为空。
+type Evidence struct {
+	TranscriptText string
+	StartMS        *int64
+	EndMS          *int64
+}
+
+// Validate 校验证据能够通过文字、音频时间范围或二者共同定位。
+func (e Evidence) Validate() error {
+	hasText := strings.TrimSpace(e.TranscriptText) != ""
+	hasStart := e.StartMS != nil
+	hasEnd := e.EndMS != nil
+
+	if !hasText && !hasStart && !hasEnd {
+		return fmt.Errorf("%w: text or audio range is required", ErrInvalidEvidence)
+	}
+	if hasStart != hasEnd {
+		return fmt.Errorf("%w: start_ms and end_ms must be provided together", ErrInvalidEvidence)
+	}
+	if hasStart {
+		if *e.StartMS < 0 || *e.EndMS < 0 {
+			return fmt.Errorf("%w: audio range cannot be negative", ErrInvalidEvidence)
+		}
+		if *e.EndMS < *e.StartMS {
+			return fmt.Errorf("%w: end_ms cannot be before start_ms", ErrInvalidEvidence)
+		}
+	}
+	return nil
+}
+
+// FeedbackItem 是根据 TurnAnalysis 生成的一条带证据反馈。
+type FeedbackItem struct {
+	ID         string
+	AnalysisID string
+	Category   FeedbackCategory
+	Message    string
+	Suggestion string
+	Evidence   []Evidence
+	Retryable  bool
+	CreatedAt  time.Time
+}
+
+// NewFeedbackItem 创建反馈并复制证据切片，避免调用方后续追加元素时
+// 意外改变反馈内部保存的证据集合。
+func NewFeedbackItem(
+	id, analysisID string,
+	category FeedbackCategory,
+	message, suggestion string,
+	evidence []Evidence,
+	retryable bool,
+	createdAt time.Time,
+) (FeedbackItem, error) {
+	item := FeedbackItem{
+		ID:         strings.TrimSpace(id),
+		AnalysisID: strings.TrimSpace(analysisID),
+		Category:   FeedbackCategory(strings.TrimSpace(string(category))),
+		Message:    strings.TrimSpace(message),
+		Suggestion: strings.TrimSpace(suggestion),
+		Evidence:   append([]Evidence(nil), evidence...),
+		Retryable:  retryable,
+		CreatedAt:  createdAt,
+	}
+	if err := item.Validate(); err != nil {
+		return FeedbackItem{}, err
+	}
+	return item, nil
+}
+
+// Validate 校验反馈已经关联分析，并且包含可定位的具体证据。
+func (f FeedbackItem) Validate() error {
+	if strings.TrimSpace(f.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(f.AnalysisID) == "" {
+		return fmt.Errorf("%w: analysis_id is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(string(f.Category)) == "" {
+		return fmt.Errorf("%w: category is required", ErrInvalidFeedback)
+	}
+	if strings.TrimSpace(f.Message) == "" {
+		return fmt.Errorf("%w: message is required", ErrInvalidFeedback)
+	}
+	if len(f.Evidence) == 0 {
+		return fmt.Errorf("%w: evidence is required", ErrInvalidFeedback)
+	}
+	for i, evidence := range f.Evidence {
+		if err := evidence.Validate(); err != nil {
+			return fmt.Errorf("%w: evidence[%d]: %v", ErrInvalidFeedback, i, err)
+		}
+	}
+	if f.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at is required", ErrInvalidFeedback)
+	}
+	return nil
+}
+
+// RetryStatus 表示 Review 中重答请求的状态。
+// 它不表示新 Turn 的生命周期，新 Turn 仍归 Conversation 所有。
+type RetryStatus string
+
+const (
+	RetryStatusPending     RetryStatus = "pending"
+	RetryStatusTurnCreated RetryStatus = "turn_created"
+	RetryStatusFailed      RetryStatus = "failed"
+)
+
+// RetryRequest 请求 Conversation 针对原问题创建一个新 Turn。
+// ID 同时也是跨模块调用使用的幂等键。
+type RetryRequest struct {
+	ID             string
+	OriginalTurnID string
+	FeedbackID     string
+	NewTurnID      string
+	Status         RetryStatus
+	FailureReason  string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// NewRetryRequest 只允许根据可重答反馈创建待处理请求。
+func NewRetryRequest(id, originalTurnID string, feedback FeedbackItem, createdAt time.Time) (RetryRequest, error) {
+	if err := feedback.Validate(); err != nil {
+		return RetryRequest{}, fmt.Errorf("%w: feedback: %v", ErrInvalidRetryRequest, err)
+	}
+	if !feedback.Retryable {
+		return RetryRequest{}, ErrFeedbackNotRetryable
+	}
+
+	request := RetryRequest{
+		ID:             strings.TrimSpace(id),
+		OriginalTurnID: strings.TrimSpace(originalTurnID),
+		FeedbackID:     feedback.ID,
+		Status:         RetryStatusPending,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+	if err := request.Validate(); err != nil {
+		return RetryRequest{}, err
+	}
+	return request, nil
+}
+
+// MarkTurnCreated 记录 Conversation 创建的新 Turn 的稳定 ID。
+func (r *RetryRequest) MarkTurnCreated(newTurnID string, updatedAt time.Time) error {
+	if r == nil {
+		return fmt.Errorf("%w: retry request is nil", ErrInvalidRetryRequest)
+	}
+	if r.Status != RetryStatusPending {
+		return fmt.Errorf("%w: retry request %q is %q", ErrInvalidStateChange, r.ID, r.Status)
+	}
+	if strings.TrimSpace(newTurnID) == "" {
+		return fmt.Errorf("%w: new_turn_id is required", ErrInvalidRetryRequest)
+	}
+	if err := validateUpdatedAt(r.CreatedAt, r.UpdatedAt, updatedAt); err != nil {
+		return fmt.Errorf("%w: updated_at: %v", ErrInvalidRetryRequest, err)
+	}
+
+	candidate := *r
+	candidate.Status = RetryStatusTurnCreated
+	candidate.NewTurnID = strings.TrimSpace(newTurnID)
+	candidate.FailureReason = ""
+	candidate.UpdatedAt = updatedAt
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*r = candidate
+	return nil
+}
+
+// MarkFailed 记录创建新 Turn 失败的结果。
+func (r *RetryRequest) MarkFailed(reason string, updatedAt time.Time) error {
+	if r == nil {
+		return fmt.Errorf("%w: retry request is nil", ErrInvalidRetryRequest)
+	}
+	if r.Status != RetryStatusPending {
+		return fmt.Errorf("%w: retry request %q is %q", ErrInvalidStateChange, r.ID, r.Status)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("%w: failed retry requires reason", ErrInvalidRetryRequest)
+	}
+	if err := validateUpdatedAt(r.CreatedAt, r.UpdatedAt, updatedAt); err != nil {
+		return fmt.Errorf("%w: updated_at: %v", ErrInvalidRetryRequest, err)
+	}
+
+	candidate := *r
+	candidate.Status = RetryStatusFailed
+	candidate.NewTurnID = ""
+	candidate.FailureReason = strings.TrimSpace(reason)
+	candidate.UpdatedAt = updatedAt
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*r = candidate
+	return nil
+}
+
+// Validate 校验 RetryRequest 的状态和时间戳不变量。
+func (r RetryRequest) Validate() error {
+	if strings.TrimSpace(r.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidRetryRequest)
+	}
+	if strings.TrimSpace(r.OriginalTurnID) == "" {
+		return fmt.Errorf("%w: original_turn_id is required", ErrInvalidRetryRequest)
+	}
+	if strings.TrimSpace(r.FeedbackID) == "" {
+		return fmt.Errorf("%w: feedback_id is required", ErrInvalidRetryRequest)
+	}
+	if r.CreatedAt.IsZero() || r.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: timestamps are required", ErrInvalidRetryRequest)
+	}
+	if r.UpdatedAt.Before(r.CreatedAt) {
+		return fmt.Errorf("%w: updated_at cannot be before created_at", ErrInvalidRetryRequest)
+	}
+
+	switch r.Status {
+	case RetryStatusPending:
+		if strings.TrimSpace(r.NewTurnID) != "" || strings.TrimSpace(r.FailureReason) != "" {
+			return fmt.Errorf("%w: pending retry contains terminal fields", ErrInvalidRetryRequest)
+		}
+	case RetryStatusTurnCreated:
+		if strings.TrimSpace(r.NewTurnID) == "" {
+			return fmt.Errorf("%w: created retry requires new_turn_id", ErrInvalidRetryRequest)
+		}
+		if strings.TrimSpace(r.FailureReason) != "" {
+			return fmt.Errorf("%w: created retry contains failure reason", ErrInvalidRetryRequest)
+		}
+	case RetryStatusFailed:
+		if strings.TrimSpace(r.FailureReason) == "" {
+			return fmt.Errorf("%w: failed retry requires reason", ErrInvalidRetryRequest)
+		}
+		if strings.TrimSpace(r.NewTurnID) != "" {
+			return fmt.Errorf("%w: failed retry contains new_turn_id", ErrInvalidRetryRequest)
+		}
+	default:
+		return fmt.Errorf("%w: unknown status %q", ErrInvalidRetryRequest, r.Status)
+	}
+	return nil
+}
+
+// HistoryKey 标识一条分析投影。History 可以通过来源 ID 重建，
+// 不能成为第二个可写的权威数据源。
+type HistoryKey struct {
+	SessionID  string
+	TurnID     string
+	AnalysisID string
+}
+
+// HistoryRecord 只保存历史列表展示所需的最小字段。
+type HistoryRecord struct {
+	ID             string
+	SessionID      string
+	TurnID         string
+	AnalysisID     string
+	RetryRequestID string
+	Score          *int
+	Summary        string
+	ReviewedAt     time.Time
+}
+
+// NewHistoryRecord 将一条已完成分析投影为历史只读模型。
+func NewHistoryRecord(id, sessionID string, analysis TurnAnalysis, reviewedAt time.Time) (HistoryRecord, error) {
+	if err := analysis.Validate(); err != nil {
+		return HistoryRecord{}, fmt.Errorf("%w: analysis: %v", ErrInvalidHistoryRecord, err)
+	}
+	if analysis.Status != AnalysisStatusCompleted {
+		return HistoryRecord{}, fmt.Errorf("%w: analysis must be completed", ErrInvalidHistoryRecord)
+	}
+	if reviewedAt.IsZero() || reviewedAt.Before(analysis.CreatedAt) {
+		return HistoryRecord{}, fmt.Errorf("%w: invalid reviewed_at", ErrInvalidHistoryRecord)
+	}
+
+	record := HistoryRecord{
+		ID:         strings.TrimSpace(id),
+		SessionID:  strings.TrimSpace(sessionID),
+		TurnID:     analysis.TurnID,
+		AnalysisID: analysis.ID,
+		Score:      intPointer(*analysis.Score),
+		Summary:    analysis.Summary,
+		ReviewedAt: reviewedAt,
+	}
+	if err := record.Validate(); err != nil {
+		return HistoryRecord{}, err
+	}
+	return record, nil
+}
+
+// Key 返回用于幂等更新投影的稳定来源 ID。
+func (h HistoryRecord) Key() HistoryKey {
+	return HistoryKey{SessionID: h.SessionID, TurnID: h.TurnID, AnalysisID: h.AnalysisID}
+}
+
+// Validate 校验历史只读模型必须具备的最小字段。
+func (h HistoryRecord) Validate() error {
+	if strings.TrimSpace(h.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.SessionID) == "" {
+		return fmt.Errorf("%w: session_id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.AnalysisID) == "" {
+		return fmt.Errorf("%w: analysis_id is required", ErrInvalidHistoryRecord)
+	}
+	if h.Score == nil {
+		return fmt.Errorf("%w: score is required", ErrInvalidHistoryRecord)
+	}
+	if strings.TrimSpace(h.Summary) == "" {
+		return fmt.Errorf("%w: summary is required", ErrInvalidHistoryRecord)
+	}
+	if h.ReviewedAt.IsZero() {
+		return fmt.Errorf("%w: reviewed_at is required", ErrInvalidHistoryRecord)
+	}
+	return nil
+}
+
+func validateTerminalTime(createdAt, terminalAt time.Time) error {
+	if terminalAt.IsZero() {
+		return errors.New("timestamp is required")
+	}
+	if terminalAt.Before(createdAt) {
+		return errors.New("timestamp cannot be before created_at")
+	}
+	return nil
+}
+
+func validateUpdatedAt(createdAt, currentUpdatedAt, nextUpdatedAt time.Time) error {
+	if nextUpdatedAt.IsZero() {
+		return errors.New("timestamp is required")
+	}
+	if nextUpdatedAt.Before(createdAt) || nextUpdatedAt.Before(currentUpdatedAt) {
+		return errors.New("timestamp cannot move backwards")
+	}
+	return nil
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/server/internal/review/model.go
+++ b/server/internal/review/model.go
@@ -235,8 +235,8 @@ type FeedbackItem struct {
 	CreatedAt  time.Time
 }
 
-// NewFeedbackItem 创建反馈并复制证据切片，避免调用方后续追加元素时
-// 意外改变反馈内部保存的证据集合。
+// NewFeedbackItem 创建反馈并深拷贝证据，避免调用方后续修改切片元素或
+// 音频范围指针时意外改变反馈内部保存的证据集合。
 func NewFeedbackItem(
 	id, analysisID string,
 	category FeedbackCategory,
@@ -251,7 +251,7 @@ func NewFeedbackItem(
 		Category:   FeedbackCategory(strings.TrimSpace(string(category))),
 		Message:    strings.TrimSpace(message),
 		Suggestion: strings.TrimSpace(suggestion),
-		Evidence:   append([]Evidence(nil), evidence...),
+		Evidence:   cloneEvidence(evidence),
 		Retryable:  retryable,
 		CreatedAt:  createdAt,
 	}
@@ -462,7 +462,7 @@ func NewHistoryRecord(id, sessionID string, analysis TurnAnalysis, reviewedAt ti
 	if analysis.Status != AnalysisStatusCompleted {
 		return HistoryRecord{}, fmt.Errorf("%w: analysis must be completed", ErrInvalidHistoryRecord)
 	}
-	if reviewedAt.IsZero() || reviewedAt.Before(analysis.CreatedAt) {
+	if reviewedAt.IsZero() || reviewedAt.Before(*analysis.CompletedAt) {
 		return HistoryRecord{}, fmt.Errorf("%w: invalid reviewed_at", ErrInvalidHistoryRecord)
 	}
 
@@ -534,6 +534,24 @@ func validateUpdatedAt(createdAt, currentUpdatedAt, nextUpdatedAt time.Time) err
 
 func intPointer(value int) *int {
 	return &value
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func cloneEvidence(source []Evidence) []Evidence {
+	cloned := make([]Evidence, len(source))
+	for i, evidence := range source {
+		cloned[i] = evidence
+		if evidence.StartMS != nil {
+			cloned[i].StartMS = int64Pointer(*evidence.StartMS)
+		}
+		if evidence.EndMS != nil {
+			cloned[i].EndMS = int64Pointer(*evidence.EndMS)
+		}
+	}
+	return cloned
 }
 
 func timePointer(value time.Time) *time.Time {

--- a/server/internal/review/model_test.go
+++ b/server/internal/review/model_test.go
@@ -128,7 +128,13 @@ func TestEvidenceValidate(t *testing.T) {
 }
 
 func TestNewFeedbackItemCopiesEvidence(t *testing.T) {
-	evidence := []review.Evidence{{TranscriptText: "I reduced latency by 30%."}}
+	startMS := int64(100)
+	endMS := int64(200)
+	evidence := []review.Evidence{{
+		TranscriptText: "I reduced latency by 30%.",
+		StartMS:        &startMS,
+		EndMS:          &endMS,
+	}}
 	item, err := review.NewFeedbackItem(
 		"feedback-1",
 		"analysis-1",
@@ -144,8 +150,13 @@ func TestNewFeedbackItemCopiesEvidence(t *testing.T) {
 	}
 
 	evidence[0].TranscriptText = "changed by caller"
+	startMS = -1
+	endMS = 50
 	if item.Evidence[0].TranscriptText != "I reduced latency by 30%." {
 		t.Fatalf("feedback evidence changed through caller slice: %#v", item.Evidence)
+	}
+	if *item.Evidence[0].StartMS != 100 || *item.Evidence[0].EndMS != 200 {
+		t.Fatalf("feedback evidence range changed through caller pointers: %#v", item.Evidence)
 	}
 	if err := item.Validate(); err != nil {
 		t.Fatalf("feedback should validate: %v", err)
@@ -234,6 +245,18 @@ func TestNewHistoryRecordUsesStableSourceIDs(t *testing.T) {
 	}
 	if err := record.Validate(); err != nil {
 		t.Fatalf("history record should validate: %v", err)
+	}
+}
+
+func TestNewHistoryRecordRejectsReviewBeforeAnalysisCompletion(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	if err := analysis.Complete(72, "The answer needs a clearer result.", "", testTime.Add(time.Minute)); err != nil {
+		t.Fatalf("complete analysis: %v", err)
+	}
+
+	_, err := review.NewHistoryRecord("history-1", "session-1", analysis, testTime.Add(30*time.Second))
+	if !errors.Is(err, review.ErrInvalidHistoryRecord) {
+		t.Fatalf("expected history before analysis completion to fail, got %v", err)
 	}
 }
 

--- a/server/internal/review/model_test.go
+++ b/server/internal/review/model_test.go
@@ -1,0 +1,274 @@
+package review_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+)
+
+var testTime = time.Date(2026, time.July, 15, 10, 0, 0, 0, time.UTC)
+
+func TestNewTurnAnalysisRejectsMissingTurnID(t *testing.T) {
+	_, err := review.NewTurnAnalysis("analysis-1", "", "evaluator-v1", testTime)
+	if !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected ErrInvalidAnalysis, got %v", err)
+	}
+}
+
+func TestTurnAnalysisCompleteRequiresResult(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+
+	if err := analysis.Complete(0, " ", "", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected blank summary to fail, got %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusPending {
+		t.Fatalf("failed transition changed status to %q", analysis.Status)
+	}
+
+	completedAt := testTime.Add(time.Minute)
+	if err := analysis.Complete(0, "The answer is relevant.", "scoring transcript", completedAt); err != nil {
+		t.Fatalf("complete analysis: %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusCompleted {
+		t.Fatalf("expected completed, got %q", analysis.Status)
+	}
+	if analysis.Score == nil || *analysis.Score != 0 {
+		t.Fatalf("expected valid zero score, got %#v", analysis.Score)
+	}
+	if analysis.CompletedAt == nil || !analysis.CompletedAt.Equal(completedAt) {
+		t.Fatalf("unexpected completed_at: %#v", analysis.CompletedAt)
+	}
+	if err := analysis.Validate(); err != nil {
+		t.Fatalf("completed analysis should validate: %v", err)
+	}
+	if err := analysis.Complete(1, "again", "", completedAt); !errors.Is(err, review.ErrInvalidStateChange) {
+		t.Fatalf("expected terminal analysis to reject second completion, got %v", err)
+	}
+}
+
+func TestTurnAnalysisFailedRequiresReason(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+
+	if err := analysis.Fail(" ", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected blank reason to fail, got %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusPending {
+		t.Fatalf("failed transition changed status to %q", analysis.Status)
+	}
+
+	failedAt := testTime.Add(time.Minute)
+	if err := analysis.Fail("provider unavailable", failedAt); err != nil {
+		t.Fatalf("fail analysis: %v", err)
+	}
+	if analysis.Status != review.AnalysisStatusFailed || analysis.FailureReason != "provider unavailable" {
+		t.Fatalf("unexpected failed analysis: %#v", analysis)
+	}
+	if analysis.FailedAt == nil || !analysis.FailedAt.Equal(failedAt) {
+		t.Fatalf("unexpected failed_at: %#v", analysis.FailedAt)
+	}
+	if err := analysis.Validate(); err != nil {
+		t.Fatalf("failed analysis should validate: %v", err)
+	}
+}
+
+func TestTurnAnalysisFailedTransitionDoesNotMutateReceiver(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	before := analysis
+
+	err := analysis.Complete(80, "valid summary", "", testTime.Add(-time.Minute))
+	if !errors.Is(err, review.ErrInvalidAnalysis) {
+		t.Fatalf("expected invalid completion time to fail, got %v", err)
+	}
+	if analysis != before {
+		t.Fatalf("failed transition mutated analysis: before %#v after %#v", before, analysis)
+	}
+}
+
+func TestTurnAnalysisKeyUsesTurnAndEvaluatorVersion(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	want := (review.AnalysisKey{TurnID: "turn-1", EvaluatorVersion: "evaluator-v1"})
+	if got := analysis.Key(); got != want {
+		t.Fatalf("unexpected analysis key: got %#v want %#v", got, want)
+	}
+}
+
+func TestEvidenceValidate(t *testing.T) {
+	negative := int64(-1)
+	zero := int64(0)
+	ten := int64(10)
+	twenty := int64(20)
+
+	tests := []struct {
+		name    string
+		value   review.Evidence
+		wantErr bool
+	}{
+		{name: "text only", value: review.Evidence{TranscriptText: "I led the migration."}},
+		{name: "range only", value: review.Evidence{StartMS: &zero, EndMS: &ten}},
+		{name: "text and range", value: review.Evidence{TranscriptText: "I led it.", StartMS: &ten, EndMS: &twenty}},
+		{name: "empty", value: review.Evidence{}, wantErr: true},
+		{name: "negative", value: review.Evidence{StartMS: &negative, EndMS: &ten}, wantErr: true},
+		{name: "reversed", value: review.Evidence{StartMS: &twenty, EndMS: &ten}, wantErr: true},
+		{name: "missing end", value: review.Evidence{StartMS: &zero}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.value.Validate()
+			if tt.wantErr && !errors.Is(err, review.ErrInvalidEvidence) {
+				t.Fatalf("expected ErrInvalidEvidence, got %v", err)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected valid evidence, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewFeedbackItemCopiesEvidence(t *testing.T) {
+	evidence := []review.Evidence{{TranscriptText: "I reduced latency by 30%."}}
+	item, err := review.NewFeedbackItem(
+		"feedback-1",
+		"analysis-1",
+		review.FeedbackCategory("evidence"),
+		"The answer includes a measurable result.",
+		"Keep the metric in the final answer.",
+		evidence,
+		true,
+		testTime,
+	)
+	if err != nil {
+		t.Fatalf("new feedback: %v", err)
+	}
+
+	evidence[0].TranscriptText = "changed by caller"
+	if item.Evidence[0].TranscriptText != "I reduced latency by 30%." {
+		t.Fatalf("feedback evidence changed through caller slice: %#v", item.Evidence)
+	}
+	if err := item.Validate(); err != nil {
+		t.Fatalf("feedback should validate: %v", err)
+	}
+}
+
+func TestNewRetryRequestRejectsNonRetryableFeedback(t *testing.T) {
+	feedback := mustFeedback(t, false)
+	_, err := review.NewRetryRequest("retry-1", "turn-1", feedback, testTime)
+	if !errors.Is(err, review.ErrFeedbackNotRetryable) {
+		t.Fatalf("expected ErrFeedbackNotRetryable, got %v", err)
+	}
+}
+
+func TestRetryRequestTransitions(t *testing.T) {
+	t.Run("turn created", func(t *testing.T) {
+		request := mustRetryRequest(t)
+		if err := request.MarkTurnCreated("", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidRetryRequest) {
+			t.Fatalf("expected missing new turn to fail, got %v", err)
+		}
+		if request.Status != review.RetryStatusPending {
+			t.Fatalf("failed transition changed status to %q", request.Status)
+		}
+
+		if err := request.MarkTurnCreated("turn-2", testTime.Add(time.Minute)); err != nil {
+			t.Fatalf("mark turn created: %v", err)
+		}
+		if request.Status != review.RetryStatusTurnCreated || request.NewTurnID != "turn-2" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+		if err := request.Validate(); err != nil {
+			t.Fatalf("created request should validate: %v", err)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		request := mustRetryRequest(t)
+		if err := request.MarkFailed(" ", testTime.Add(time.Minute)); !errors.Is(err, review.ErrInvalidRetryRequest) {
+			t.Fatalf("expected missing reason to fail, got %v", err)
+		}
+		if request.Status != review.RetryStatusPending {
+			t.Fatalf("failed transition changed status to %q", request.Status)
+		}
+
+		if err := request.MarkFailed("conversation unavailable", testTime.Add(time.Minute)); err != nil {
+			t.Fatalf("mark failed: %v", err)
+		}
+		if request.Status != review.RetryStatusFailed || request.FailureReason != "conversation unavailable" {
+			t.Fatalf("unexpected request: %#v", request)
+		}
+		if err := request.Validate(); err != nil {
+			t.Fatalf("failed request should validate: %v", err)
+		}
+	})
+}
+
+func TestRetryFailedTransitionDoesNotMutateReceiver(t *testing.T) {
+	request := mustRetryRequest(t)
+	before := request
+
+	err := request.MarkTurnCreated("turn-2", testTime.Add(-time.Minute))
+	if !errors.Is(err, review.ErrInvalidRetryRequest) {
+		t.Fatalf("expected backwards timestamp to fail, got %v", err)
+	}
+	if request != before {
+		t.Fatalf("failed transition mutated request: before %#v after %#v", before, request)
+	}
+}
+
+func TestNewHistoryRecordUsesStableSourceIDs(t *testing.T) {
+	analysis := mustPendingAnalysis(t)
+	if err := analysis.Complete(72, "The answer needs a clearer result.", "", testTime.Add(time.Minute)); err != nil {
+		t.Fatalf("complete analysis: %v", err)
+	}
+
+	record, err := review.NewHistoryRecord("history-1", "session-1", analysis, testTime.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("new history record: %v", err)
+	}
+	wantKey := (review.HistoryKey{SessionID: "session-1", TurnID: "turn-1", AnalysisID: "analysis-1"})
+	if got := record.Key(); got != wantKey {
+		t.Fatalf("unexpected history key: got %#v want %#v", got, wantKey)
+	}
+	if record.Score == nil || *record.Score != 72 {
+		t.Fatalf("unexpected projected score: %#v", record.Score)
+	}
+	if err := record.Validate(); err != nil {
+		t.Fatalf("history record should validate: %v", err)
+	}
+}
+
+func mustPendingAnalysis(t *testing.T) review.TurnAnalysis {
+	t.Helper()
+	analysis, err := review.NewTurnAnalysis("analysis-1", "turn-1", "evaluator-v1", testTime)
+	if err != nil {
+		t.Fatalf("new analysis: %v", err)
+	}
+	return analysis
+}
+
+func mustFeedback(t *testing.T, retryable bool) review.FeedbackItem {
+	t.Helper()
+	item, err := review.NewFeedbackItem(
+		"feedback-1",
+		"analysis-1",
+		review.FeedbackCategory("evidence"),
+		"Add a measurable result.",
+		"State the outcome with a metric.",
+		[]review.Evidence{{TranscriptText: "We finished the project."}},
+		retryable,
+		testTime,
+	)
+	if err != nil {
+		t.Fatalf("new feedback: %v", err)
+	}
+	return item
+}
+
+func mustRetryRequest(t *testing.T) review.RetryRequest {
+	t.Helper()
+	request, err := review.NewRetryRequest("retry-1", "turn-1", mustFeedback(t, true), testTime)
+	if err != nil {
+		t.Fatalf("new retry request: %v", err)
+	}
+	return request
+}

--- a/server/internal/review/ports.go
+++ b/server/internal/review/ports.go
@@ -1,0 +1,196 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+var (
+	// ErrTurnReviewSourceNotFound 表示 Conversation 中不存在指定 Turn。
+	ErrTurnReviewSourceNotFound = errors.New("turn review source not found")
+	// ErrTurnNotCompleted 表示 Turn 尚未完成，当前不能用于复盘。
+	ErrTurnNotCompleted = errors.New("turn is not completed")
+	// ErrTranscriptNotReady 表示 Turn 的 Transcript 尚不可用。
+	ErrTranscriptNotReady = errors.New("transcript is not ready")
+	// ErrAudioNotReady 表示 Turn 的音频引用或元数据尚不可用。
+	ErrAudioNotReady = errors.New("audio is not ready")
+	// ErrAudioNotFound 表示音频不存在或已被删除。
+	ErrAudioNotFound = errors.New("audio not found")
+	// ErrUnsupportedAudioFormat 表示当前 Review 评分链路不支持该音频格式。
+	ErrUnsupportedAudioFormat = errors.New("unsupported audio format")
+	// ErrAudioLimitExceeded 表示音频大小或时长超过评分限制。
+	ErrAudioLimitExceeded = errors.New("audio limit exceeded")
+	// ErrRetryNotAllowed 表示原 Turn 不允许创建同题重答。
+	ErrRetryNotAllowed = errors.New("retry not allowed")
+	// ErrRetryTurnCreationFailed 表示 Conversation 未能创建重答 Turn。
+	ErrRetryTurnCreationFailed = errors.New("retry turn creation failed")
+	// ErrEvaluationFailed 表示评分或证据生成失败。
+	ErrEvaluationFailed = errors.New("evaluation failed")
+)
+
+// RetryReasonReview 是 Review 请求 Conversation 创建同题重答的稳定原因值。
+const RetryReasonReview = "review_retry"
+
+// TurnReviewSourceReader 是 Review 获取已完成 Turn 复盘资料的读取端口。
+//
+// 实现方应返回与 Conversation 内部可变状态脱离的快照，包括独立的
+// TranscriptSegment 切片。该端口不传输音频内容；Review 后续使用
+// AudioReference.AudioID 通过独立的音频读取端口打开只读流。
+type TurnReviewSourceReader interface {
+	GetCompletedTurnReviewSource(ctx context.Context, turnID string) (TurnReviewSource, error)
+}
+
+// TurnReviewSource 是 Review 评分和生成历史投影所需的最小只读快照。
+// 它不是 Conversation 的领域对象，不得用于修改来源 Turn、
+// Question、Transcript 或音频。
+type TurnReviewSource struct {
+	TurnID       string
+	SessionID    string
+	QuestionID   string
+	QuestionText string
+	Transcript   TranscriptSnapshot
+	Audio        AudioReference
+	CompletedAt  time.Time
+}
+
+// TranscriptSnapshot 是 Conversation 产生的 Transcript 只读快照。
+// Status 保留 Conversation 公开的稳定状态值；Review 不在此复制其完整状态机。
+type TranscriptSnapshot struct {
+	TranscriptID string
+	Text         string
+	Language     string
+	Status       string
+	Segments     []TranscriptSegment
+}
+
+// TranscriptSegment 将 Transcript 中的必要文字片段定位到原始音频时间范围。
+type TranscriptSegment struct {
+	StartMS int64
+	EndMS   int64
+	Text    string
+}
+
+// AudioReference 是 Conversation 所拥有音频的稳定引用和最小元数据。
+// AudioID 不是本地文件路径或对象存储位置；Checksum 为空表示来源未提供校验值。
+type AudioReference struct {
+	AudioID     string
+	ContentType string
+	Format      string
+	SizeBytes   int64
+	DurationMS  int64
+	Checksum    string
+}
+
+// AudioContentReader 根据 Conversation 提供的稳定 AudioID 打开音频。
+//
+// 相同 AudioID 的每次成功调用都必须返回一个新的只读流，以支持
+// 失败后重试。调用方 Review Service 拥有返回流的关闭责任。
+type AudioContentReader interface {
+	OpenAudio(ctx context.Context, audioID string) (io.ReadCloser, error)
+}
+
+// RetryTurnPort 请求 Conversation 为原 Turn 创建同题重答 Turn。
+type RetryTurnPort interface {
+	CreateRetryTurn(ctx context.Context, command CreateRetryTurnCommand) (RetryTurnResult, error)
+}
+
+// CreateRetryTurnCommand 是 Review 发送给 Conversation 的重答命令。
+// RetryRequestID 是跨模块幂等键；Conversation 对相同键必须返回
+// 同一 NewTurnID，不得创建多个 Turn。
+type CreateRetryTurnCommand struct {
+	RetryRequestID string
+	OriginalTurnID string
+	Reason         string
+}
+
+// RetryTurnResult 只返回 Conversation 所拥有的新 Turn 稳定 ID。
+type RetryTurnResult struct {
+	NewTurnID string
+}
+
+// TurnEvaluator 封装真实或 Mock 的评分和证据生成实现。
+// Version 必须返回能区分评分行为的稳定版本，Review 使用
+// TurnID + Version 保证 TurnAnalysis 幂等。
+type TurnEvaluator interface {
+	Version() string
+	EvaluateTurn(ctx context.Context, input EvaluationInput) (EvaluationResult, error)
+}
+
+// EvaluationInput 是评分实现所需的最小输入。
+// Audio 由 Review Service 打开和关闭，Evaluator 只负责读取。
+type EvaluationInput struct {
+	TurnID        string
+	QuestionID    string
+	QuestionText  string
+	Transcript    TranscriptSnapshot
+	Audio         io.Reader
+	AudioMetadata AudioReference
+}
+
+// EvaluationResult 是与具体模型供应商无关的结构化评分结果。
+type EvaluationResult struct {
+	Score              int
+	Summary            string
+	AnalysisTranscript string
+	Suggestions        []EvaluationSuggestion
+}
+
+// EvaluationSuggestion 描述一条可转换为 FeedbackItem 的建议和证据。
+// Evidence 是必要的 Transcript 文字片段；StartMS 和 EndMS 用于
+// 可选的音频时间定位。
+type EvaluationSuggestion struct {
+	Category  FeedbackCategory
+	Message   string
+	Evidence  string
+	StartMS   *int64
+	EndMS     *int64
+	Retryable bool
+}
+
+// AnalysisRepository 持久化 Review 拥有的 TurnAnalysis。
+// Save 必须维护 AnalysisKey 的唯一性，并能保存合法的状态转换。
+type AnalysisRepository interface {
+	FindByID(ctx context.Context, analysisID string) (TurnAnalysis, bool, error)
+	FindByKey(ctx context.Context, key AnalysisKey) (TurnAnalysis, bool, error)
+	Save(ctx context.Context, analysis TurnAnalysis) error
+}
+
+// FeedbackRepository 持久化和读取 Review 生成的 FeedbackItem。
+// SaveAll 用于保存同一次分析产生的反馈集合。
+type FeedbackRepository interface {
+	FindByID(ctx context.Context, feedbackID string) (FeedbackItem, bool, error)
+	ListByAnalysisID(ctx context.Context, analysisID string) ([]FeedbackItem, error)
+	SaveAll(ctx context.Context, feedback []FeedbackItem) error
+}
+
+// RetryRepository 持久化 Review 拥有的 RetryRequest。
+// FindByFeedbackID 用于保证对同一条反馈的重复请求保持幂等。
+type RetryRepository interface {
+	FindByID(ctx context.Context, retryRequestID string) (RetryRequest, bool, error)
+	FindByFeedbackID(ctx context.Context, feedbackID string) (RetryRequest, bool, error)
+	Save(ctx context.Context, request RetryRequest) error
+	Update(ctx context.Context, request RetryRequest) error
+}
+
+// HistoryRepository 管理可重建的 HistoryRecord 只读投影。
+// Upsert 使用 HistoryRecord.Key 保持幂等；ListBySession 必须按
+// ReviewedAt 倒序返回，limit 和 offset 用于分页。
+type HistoryRepository interface {
+	Upsert(ctx context.Context, record HistoryRecord) error
+	FindByAnalysisID(ctx context.Context, analysisID string) (HistoryRecord, bool, error)
+	ListBySession(ctx context.Context, sessionID string, limit, offset int) ([]HistoryRecord, error)
+}
+
+// IDGenerator 为 Review 领域对象生成稳定唯一 ID。
+// 这是团队统一实现出现前的模块内最小端口。
+type IDGenerator interface {
+	NewID() string
+}
+
+// Clock 为 Review Service 提供可测试的当前时间。
+// 这是团队统一实现出现前的模块内最小端口。
+type Clock interface {
+	Now() time.Time
+}

--- a/server/internal/review/retry.go
+++ b/server/internal/review/retry.go
@@ -1,0 +1,24 @@
+package review
+
+import "context"
+
+// RetryUseCase 定义根据可重答 Feedback 发起同题重答的应用契约。
+// 新 Turn 仍由 Conversation 创建和拥有。
+type RetryUseCase interface {
+	// RequestRetry 请求为一条可重答 Feedback 创建同题重答。
+	// Feedback 不存在或不可重答时分别返回 ErrFeedbackNotFound 或
+	// ErrFeedbackNotRetryable；具体查询、保存和跨模块调用由后续实现负责。
+	RequestRetry(ctx context.Context, command RequestRetryCommand) (RequestRetryResult, error)
+}
+
+// RequestRetryCommand 使用 FeedbackID 标识需要再次练习的反馈。
+// 原 Turn 由未来 Service 根据 Review 内部关联确定，调用方不重复提交 TurnID。
+type RequestRetryCommand struct {
+	FeedbackID string
+}
+
+// RequestRetryResult 返回 Review 所拥有的重答请求。
+// NewTurnID 通过 Request.NewTurnID 表达；为空表示 Conversation 尚未创建新 Turn。
+type RequestRetryResult struct {
+	Request RetryRequest
+}

--- a/server/internal/review/service.go
+++ b/server/internal/review/service.go
@@ -1,0 +1,9 @@
+package review
+
+// ReviewService 组合 Review 模块对内公开的应用用例契约。
+// 具体业务流程由后续实现提供。
+type ReviewService interface {
+	AnalyzeUseCase
+	RetryUseCase
+	HistoryQueryUseCase
+}


### PR DESCRIPTION
## 功能描述

- 建立 Review 模块领域模型与不变量，覆盖 TurnAnalysis、Evidence Feedback、RetryRequest 和 History Read Model。
- 定义 Conversation、评分器与 Repository 等外部依赖 Port。
- 按分析、同题重答和历史查询拆分应用用例接口骨架，不提供具体 Service 方法体。
- 忽略仅供本地使用的 Review 架构文档，架构与跨模块决策以关联 Issue 为权威来源。

## 实现思路

- 使用稳定 ID、只读 Snapshot、Command 和 Result 表达模块边界。
- Review 拥有分析、反馈、重答请求和历史投影；Question、Turn、Transcript、音频及 PracticeSession 仍由原模块拥有。
- 仅声明领域规则、Port 和用例接口，不包含 Handler、Adapter、数据库、AI Provider 或业务流程实现。
- Session 级复盘后续复用 Practice 的 `GetPracticeSessionSnapshot` 和 Conversation 的 `ListPracticeSessionTurns`，本 PR 不提前加入未冻结字段。

## 测试方式

```bash
cd server
gofmt -d internal/review/*.go
go test ./internal/review/...
go vet ./internal/review/...
go test ./...
go vet ./...
git diff --check origin/main...HEAD
```

以上检查均已通过。

## 相关 Issue / 备注

- 主要关联 #31
- 跨模块 Session 级复盘契约参考 #38
- 替代因分支来源和文档边界不符合仓库规范而关闭的 #39。
- 本 PR 只交付 Review 架构骨架；具体 Service、Handler、Adapter、Repository 和供应商接入留给后续 Issue。

## AI 辅助说明

- AI 协助内容：根据成员职责、产品原型和冻结契约整理 Review 模块接口骨架。
- 主要约束：只写可编译骨架，不创建具体实现，不跨模块访问 Repository 或内部模型。
- 人工复核重点：领域所有权、状态不变量、接口命名，以及 #34/#35/#37 的跨模块能力复用。