### PR TITLE
feat(assistant): 建立 AI 助手编排层接口骨架

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/assistant"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/bootstrap"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
@@ -26,6 +27,7 @@ func main() {
 	logger := logging.New(cfg.LogLevel)
 
 	router := bootstrap.NewRouter(logger,
+		assistant.New(),
 		preparation.New(),
 		practice.New(),
 		conversation.New(),

--- a/server/internal/assistant/model.go
+++ b/server/internal/assistant/model.go
@@ -28,8 +28,7 @@ const (
 	ConfirmationStatusExpired  ConfirmationStatus = "expired"
 )
 
-// AssistantThread is the long-lived conversation between a user and SpeakUp.
-// PracticeSession remains owned by the practice module.
+// AssistantThread 表示用户与 SpeakUp 助手之间的长期对话，PracticeSession 仍由 practice 模块拥有。
 type AssistantThread struct {
 	ID             string
 	UserID         string
@@ -39,7 +38,7 @@ type AssistantThread struct {
 	UpdatedAt      time.Time
 }
 
-// TaskRun tracks one user goal being orchestrated inside an AssistantThread.
+// TaskRun 记录 AssistantThread 中一次用户目标的编排过程。
 type TaskRun struct {
 	ID          string
 	ThreadID    string
@@ -51,7 +50,7 @@ type TaskRun struct {
 	UpdatedAt   time.Time
 }
 
-// ToolCall records one structured invocation of a registered business tool.
+// ToolCall 记录一次已注册业务工具的结构化调用。
 type ToolCall struct {
 	ID             string
 	TaskRunID      string

--- a/server/internal/assistant/model.go
+++ b/server/internal/assistant/model.go
@@ -19,6 +19,15 @@ const (
 	TaskRunStatusFailed          TaskRunStatus = "failed"
 )
 
+type ConfirmationStatus string
+
+const (
+	ConfirmationStatusPending  ConfirmationStatus = "pending"
+	ConfirmationStatusApproved ConfirmationStatus = "approved"
+	ConfirmationStatusRejected ConfirmationStatus = "rejected"
+	ConfirmationStatusExpired  ConfirmationStatus = "expired"
+)
+
 // AssistantThread is the long-lived conversation between a user and SpeakUp.
 // PracticeSession remains owned by the practice module.
 type AssistantThread struct {
@@ -59,7 +68,7 @@ type ConfirmationRequest struct {
 	Action    string
 	RiskLevel string
 	Summary   string
-	Status    string
+	Status    ConfirmationStatus
 	ExpiresAt time.Time
 }
 

--- a/server/internal/assistant/model.go
+++ b/server/internal/assistant/model.go
@@ -1,0 +1,78 @@
+package assistant
+
+import "time"
+
+type ThreadStatus string
+
+const (
+	ThreadStatusActive ThreadStatus = "active"
+	ThreadStatusClosed ThreadStatus = "closed"
+)
+
+type TaskRunStatus string
+
+const (
+	TaskRunStatusPending         TaskRunStatus = "pending"
+	TaskRunStatusRunning         TaskRunStatus = "running"
+	TaskRunStatusAwaitingConfirm TaskRunStatus = "awaiting_confirmation"
+	TaskRunStatusCompleted       TaskRunStatus = "completed"
+	TaskRunStatusFailed          TaskRunStatus = "failed"
+)
+
+// AssistantThread is the long-lived conversation between a user and SpeakUp.
+// PracticeSession remains owned by the practice module.
+type AssistantThread struct {
+	ID             string
+	UserID         string
+	Status         ThreadStatus
+	ContextSummary string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// TaskRun tracks one user goal being orchestrated inside an AssistantThread.
+type TaskRun struct {
+	ID          string
+	ThreadID    string
+	Intent      string
+	Status      TaskRunStatus
+	CurrentStep string
+	Result      map[string]any
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// ToolCall records one structured invocation of a registered business tool.
+type ToolCall struct {
+	ID             string
+	TaskRunID      string
+	ToolName       string
+	Arguments      map[string]any
+	Result         map[string]any
+	IdempotencyKey string
+	CreatedAt      time.Time
+}
+
+type ConfirmationRequest struct {
+	ID        string
+	TaskRunID string
+	Action    string
+	RiskLevel string
+	Summary   string
+	Status    string
+	ExpiresAt time.Time
+}
+
+type Plan struct {
+	Intent string
+	Steps  []PlanStep
+}
+
+type PlanStep struct {
+	ToolName  string
+	Arguments map[string]any
+}
+
+type ToolResult struct {
+	Output map[string]any
+}

--- a/server/internal/assistant/module.go
+++ b/server/internal/assistant/module.go
@@ -1,5 +1,4 @@
-// Package assistant coordinates user intents across the public services exposed
-// by SpeakUp's business modules. It does not own their domain data.
+// Package assistant 负责跨业务模块编排用户意图，但不拥有各模块的领域数据。
 package assistant
 
 type Module struct{}

--- a/server/internal/assistant/module.go
+++ b/server/internal/assistant/module.go
@@ -1,0 +1,9 @@
+// Package assistant coordinates user intents across the public services exposed
+// by SpeakUp's business modules. It does not own their domain data.
+package assistant
+
+type Module struct{}
+
+func New() Module { return Module{} }
+
+func (Module) Name() string { return "assistant" }

--- a/server/internal/assistant/module_test.go
+++ b/server/internal/assistant/module_test.go
@@ -1,0 +1,13 @@
+package assistant_test
+
+import (
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/assistant"
+)
+
+func TestModuleName(t *testing.T) {
+	if got := assistant.New().Name(); got != "assistant" {
+		t.Fatalf("expected assistant module name, got %q", got)
+	}
+}

--- a/server/internal/assistant/ports.go
+++ b/server/internal/assistant/ports.go
@@ -1,0 +1,36 @@
+package assistant
+
+import "context"
+
+// Planner turns a user goal into structured, reviewable tool steps.
+type Planner interface {
+	Plan(context.Context, PlanRequest) (Plan, error)
+}
+
+type PlanRequest struct {
+	ThreadID       string
+	UserMessage    string
+	ContextSummary string
+}
+
+// ToolRegistry exposes only explicitly registered business capabilities.
+// Implementations adapt the public services of preparation, practice,
+// conversation, and review; they must not expose repositories.
+type ToolRegistry interface {
+	Execute(context.Context, ToolInvocation) (ToolResult, error)
+}
+
+type ToolInvocation struct {
+	TaskRunID      string
+	ToolName       string
+	Arguments      map[string]any
+	IdempotencyKey string
+}
+
+// ConversationStore persists assistant-owned orchestration state only.
+type ConversationStore interface {
+	GetThread(context.Context, string) (AssistantThread, error)
+	SaveThread(context.Context, AssistantThread) error
+	SaveTaskRun(context.Context, TaskRun) error
+	SaveToolCall(context.Context, ToolCall) error
+}

--- a/server/internal/assistant/ports.go
+++ b/server/internal/assistant/ports.go
@@ -2,7 +2,7 @@ package assistant
 
 import "context"
 
-// Planner turns a user goal into structured, reviewable tool steps.
+// Planner 将用户目标拆解为结构化、可审核的工具步骤。
 type Planner interface {
 	Plan(context.Context, PlanRequest) (Plan, error)
 }
@@ -13,16 +13,13 @@ type PlanRequest struct {
 	ContextSummary string
 }
 
-// ToolRegistry exposes only explicitly registered business capabilities.
-// Implementations adapt the public services of preparation, practice,
-// conversation, and review; they must not expose repositories.
+// ToolRegistry 只暴露显式注册的业务能力，不允许直接暴露 Repository。
 type ToolRegistry interface {
 	Execute(context.Context, ToolInvocation) (ToolResult, error)
 }
 
 type ToolInvocation struct {
-	// ActorUserID comes from the authenticated service command. Tool adapters
-	// must use it for authorization instead of trusting model-generated arguments.
+	// ActorUserID 来自已认证的服务命令，工具适配器必须使用它鉴权。
 	ActorUserID    string
 	TaskRunID      string
 	ToolName       string
@@ -30,19 +27,17 @@ type ToolInvocation struct {
 	IdempotencyKey string
 }
 
-// ConversationStore persists assistant-owned orchestration state only.
+// ConversationStore 只持久化 assistant 模块拥有的编排状态。
 type ConversationStore interface {
 	GetThread(context.Context, string) (AssistantThread, error)
 	SaveThread(context.Context, AssistantThread) error
 	SaveTaskRun(context.Context, TaskRun) error
 	SaveToolCall(context.Context, ToolCall) error
-	// GetPendingConfirmationRequest restores an unfinished confirmation when a
-	// TaskRun resumes after a process restart.
+	// GetPendingConfirmationRequest 用于在进程重启后恢复未完成的确认请求。
 	GetPendingConfirmationRequest(
 		ctx context.Context,
 		taskRunID string,
 	) (ConfirmationRequest, error)
-	// SaveConfirmationRequest persists both newly created requests and later
-	// status transitions such as approval, rejection, or expiration.
+	// SaveConfirmationRequest 保存确认请求及其批准、拒绝或过期等状态变化。
 	SaveConfirmationRequest(context.Context, ConfirmationRequest) error
 }

--- a/server/internal/assistant/ports.go
+++ b/server/internal/assistant/ports.go
@@ -21,6 +21,9 @@ type ToolRegistry interface {
 }
 
 type ToolInvocation struct {
+	// ActorUserID comes from the authenticated service command. Tool adapters
+	// must use it for authorization instead of trusting model-generated arguments.
+	ActorUserID    string
 	TaskRunID      string
 	ToolName       string
 	Arguments      map[string]any
@@ -33,4 +36,13 @@ type ConversationStore interface {
 	SaveThread(context.Context, AssistantThread) error
 	SaveTaskRun(context.Context, TaskRun) error
 	SaveToolCall(context.Context, ToolCall) error
+	// GetPendingConfirmationRequest restores an unfinished confirmation when a
+	// TaskRun resumes after a process restart.
+	GetPendingConfirmationRequest(
+		ctx context.Context,
+		taskRunID string,
+	) (ConfirmationRequest, error)
+	// SaveConfirmationRequest persists both newly created requests and later
+	// status transitions such as approval, rejection, or expiration.
+	SaveConfirmationRequest(context.Context, ConfirmationRequest) error
 }

--- a/server/internal/assistant/ports_test.go
+++ b/server/internal/assistant/ports_test.go
@@ -1,0 +1,58 @@
+package assistant_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/assistant"
+)
+
+type conversationStoreStub struct{}
+
+func (*conversationStoreStub) GetThread(context.Context, string) (assistant.AssistantThread, error) {
+	return assistant.AssistantThread{}, nil
+}
+
+func (*conversationStoreStub) SaveThread(context.Context, assistant.AssistantThread) error {
+	return nil
+}
+
+func (*conversationStoreStub) SaveTaskRun(context.Context, assistant.TaskRun) error {
+	return nil
+}
+
+func (*conversationStoreStub) SaveToolCall(context.Context, assistant.ToolCall) error {
+	return nil
+}
+
+func (*conversationStoreStub) GetPendingConfirmationRequest(
+	context.Context,
+	string,
+) (assistant.ConfirmationRequest, error) {
+	return assistant.ConfirmationRequest{}, nil
+}
+
+func (*conversationStoreStub) SaveConfirmationRequest(
+	context.Context,
+	assistant.ConfirmationRequest,
+) error {
+	return nil
+}
+
+var _ assistant.ConversationStore = (*conversationStoreStub)(nil)
+
+func TestToolInvocationKeepsAuthenticatedActorSeparateFromArguments(t *testing.T) {
+	invocation := assistant.ToolInvocation{
+		ActorUserID: "user-1",
+		Arguments: map[string]any{
+			"historyLimit": 10,
+		},
+	}
+
+	if invocation.ActorUserID != "user-1" {
+		t.Fatalf("unexpected actor user ID: %q", invocation.ActorUserID)
+	}
+	if _, exists := invocation.Arguments["userId"]; exists {
+		t.Fatal("actor identity must not be supplied through model-generated arguments")
+	}
+}

--- a/server/internal/assistant/service.go
+++ b/server/internal/assistant/service.go
@@ -1,0 +1,60 @@
+package assistant
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrNotImplemented = errors.New("assistant: not implemented")
+
+// AssistantService is the application entry point used by HTTP or WebSocket
+// delivery adapters. Concrete orchestration is added after the tool contracts
+// of the four business modules are available.
+type AssistantService interface {
+	StartTask(context.Context, StartTaskCommand) (TaskRun, error)
+	ResumeTask(context.Context, ResumeTaskCommand) (TaskRun, error)
+	GetThread(context.Context, GetThreadQuery) (AssistantThread, error)
+}
+
+type Dependencies struct {
+	Planner           Planner
+	Tools             ToolRegistry
+	ConversationStore ConversationStore
+}
+
+type Service struct {
+	dependencies Dependencies
+}
+
+func NewService(dependencies Dependencies) *Service {
+	return &Service{dependencies: dependencies}
+}
+
+type StartTaskCommand struct {
+	ActorUserID    string
+	ThreadID       string
+	UserMessage    string
+	IdempotencyKey string
+}
+
+type ResumeTaskCommand struct {
+	ActorUserID string
+	TaskRunID   string
+}
+
+type GetThreadQuery struct {
+	ActorUserID string
+	ThreadID    string
+}
+
+func (*Service) StartTask(context.Context, StartTaskCommand) (TaskRun, error) {
+	return TaskRun{}, ErrNotImplemented
+}
+
+func (*Service) ResumeTask(context.Context, ResumeTaskCommand) (TaskRun, error) {
+	return TaskRun{}, ErrNotImplemented
+}
+
+func (*Service) GetThread(context.Context, GetThreadQuery) (AssistantThread, error) {
+	return AssistantThread{}, ErrNotImplemented
+}

--- a/server/internal/assistant/service.go
+++ b/server/internal/assistant/service.go
@@ -7,9 +7,7 @@ import (
 
 var ErrNotImplemented = errors.New("assistant: not implemented")
 
-// AssistantService is the application entry point used by HTTP or WebSocket
-// delivery adapters. Concrete orchestration is added after the tool contracts
-// of the four business modules are available.
+// AssistantService 是 HTTP 或 WebSocket 调用助手编排能力的应用入口。
 type AssistantService interface {
 	StartTask(context.Context, StartTaskCommand) (TaskRun, error)
 	ResumeTask(context.Context, ResumeTaskCommand) (TaskRun, error)

--- a/server/internal/bootstrap/router_test.go
+++ b/server/internal/bootstrap/router_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/assistant"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/bootstrap"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
@@ -19,6 +20,7 @@ import (
 func TestHealthIncludesRegisteredModules(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	router := bootstrap.NewRouter(logger,
+		assistant.New(),
 		preparation.New(),
 		practice.New(),
 		conversation.New(),
@@ -41,7 +43,7 @@ func TestHealthIncludesRegisteredModules(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	wantModules := []string{"preparation", "practice", "conversation", "review"}
+	wantModules := []string{"assistant", "preparation", "practice", "conversation", "review"}
 	if body.Status != "ok" || !reflect.DeepEqual(body.Modules, wantModules) {
 		t.Fatalf("unexpected health response: %#v", body)
 	}


### PR DESCRIPTION
## 功能描述

- 建立 Assistant 模块基础模型与边界，覆盖 AssistantThread、TaskRun、ToolCall 和 ConfirmationRequest。
- 定义 Planner、ToolRegistry 和 ConversationStore 等外部依赖 Port。
- 建立任务开始、恢复和对话查询的应用服务接口骨架，不提供具体编排逻辑。
- 将 Assistant 模块注册到服务启动和健康检查，不修改 Flutter 客户端。

## 实现思路

- Assistant 只拥有对话线程、任务执行和工具调用等编排状态；岗位、PracticeSession、Turn 和 Feedback 仍由原业务模块拥有。
- ToolRegistry 只允许调用显式注册的业务能力，不暴露其他模块的 Repository 或内部模型。
- 训练语音继续由 Conversation 模块负责，Assistant 不重复定义训练 ASR、TTS 和媒体处理能力。
- 仅声明模型、Port 和用例接口，不包含 Handler、Adapter、数据库、真实 AI Provider 或具体业务流程实现。

## 测试方式

```bash
cd server
gofmt -d internal/assistant/*.go
go test ./internal/assistant/...
go vet ./internal/assistant/...
go test ./...
go vet ./...
git diff --check origin/main...HEAD
```

以上检查均已通过。

## 相关 Issue / 备注

- Closes #42
- AI 助手编排架构参考 #40。
- 场景、角色与训练会话边界参考 #24。
- 本 PR 只交付 Assistant 后端接口骨架；具体工具 Adapter、Handler、Repository、AI Provider 和编排流程留给后续 Issue。

## AI 辅助说明

- AI 协助内容：根据 #42 的验收范围和 #40 的架构边界整理 Assistant 模块接口骨架。
- 主要约束：只修改后端、只写可编译骨架、不创建具体实现、不跨模块访问 Repository 或内部模型。
- 人工复核重点：模块数据所有权、依赖方向、Port 职责、语音能力归属，以及健康检查注册结果。
