### PR TITLE
feat(conversation): 定义Conversation模块核心实体与数据结构

### DIFF
--- a/server/internal/conversation/model.go
+++ b/server/internal/conversation/model.go
@@ -2,8 +2,7 @@ package conversation
 
 import "time"
 
-// QuestionType identifies whether a question starts an objective or follows up
-// on a primary question.
+// QuestionType 表示主问题或追问。
 type QuestionType string
 
 const (
@@ -11,7 +10,7 @@ const (
 	QuestionTypeFollowUp QuestionType = "FOLLOW_UP"
 )
 
-// InteractionMode identifies how an answer was captured.
+// InteractionMode 表示回答采用的语音交互方式。
 type InteractionMode string
 
 const (
@@ -19,8 +18,7 @@ const (
 	InteractionModeRealtime   InteractionMode = "REALTIME"
 )
 
-// TurnStatus tracks whether an effective answer is still being submitted to
-// Practice or has been accepted.
+// TurnStatus 表示有效回答的处理状态。
 type TurnStatus string
 
 const (
@@ -28,7 +26,7 @@ const (
 	TurnStatusCompleted  TurnStatus = "completed"
 )
 
-// AudioOwnerType identifies the Conversation entity that owns an audio asset.
+// AudioOwnerType 表示音频资产所属的 Conversation 实体类型。
 type AudioOwnerType string
 
 const (
@@ -36,7 +34,7 @@ const (
 	AudioOwnerTypeTurn     AudioOwnerType = "TURN"
 )
 
-// AudioStatus tracks the lifecycle of audio metadata managed by Conversation.
+// AudioStatus 表示音频资产的生命周期状态。
 type AudioStatus string
 
 const (
@@ -46,8 +44,7 @@ const (
 	AudioStatusDeleted AudioStatus = "deleted"
 )
 
-// AnswerValidity is kept compatible with the frozen cross-module contract.
-// Conversation only produces VALID outcomes in MS1.
+// AnswerValidity 保持与冻结的跨模块契约兼容，MS1 只产生 VALID 结果。
 type AnswerValidity string
 
 const (
@@ -55,7 +52,7 @@ const (
 	AnswerValidityInvalid AnswerValidity = "INVALID"
 )
 
-// ObjectiveCoverage describes how well an answer covers the current objective.
+// ObjectiveCoverage 表示回答对当前目标的覆盖程度。
 type ObjectiveCoverage string
 
 const (
@@ -64,7 +61,7 @@ const (
 	ObjectiveCoverageNotCovered       ObjectiveCoverage = "NOT_COVERED"
 )
 
-// ProcessingStage identifies an internal Conversation processing step.
+// ProcessingStage 表示 Conversation 内部处理阶段。
 type ProcessingStage string
 
 const (
@@ -72,8 +69,7 @@ const (
 	ProcessingStageTurnOutcomeSubmission ProcessingStage = "turn_outcome_submission"
 )
 
-// ProcessingAttemptStatus records the result of one append-only processing
-// attempt.
+// ProcessingAttemptStatus 表示一次追加式处理尝试的状态。
 type ProcessingAttemptStatus string
 
 const (
@@ -82,8 +78,7 @@ const (
 	ProcessingAttemptStatusFailed    ProcessingAttemptStatus = "failed"
 )
 
-// Question is an immutable interview question generated for a PracticeSession.
-// A FOLLOW_UP question references a PRIMARY question in the same session.
+// Question 表示为 PracticeSession 生成的不可变问题，追问必须关联同场主问题。
 type Question struct {
 	QuestionID           string
 	PracticeSessionID    string
@@ -97,8 +92,7 @@ type Question struct {
 	CreatedAt            time.Time
 }
 
-// Turn is one effective answer to a Question. Recording fragments, connection
-// events, empty answers, and failed transcription attempts do not create Turns.
+// Turn 表示对 Question 的一次有效回答，空回答或转录失败不会创建 Turn。
 type Turn struct {
 	TurnID               string
 	PracticeSessionID    string
@@ -114,14 +108,9 @@ type Turn struct {
 	CompletedAt          *time.Time
 }
 
-// AudioAsset contains business metadata for audio whose bytes are stored by a
-// Platform file-storage capability. StorageRef is a stable internal reference,
-// not a public URL or storage credential.
+// AudioAsset 保存音频业务元数据，实际内容由 Platform 文件存储能力管理。
 //
-// Question TTS and completed answer audio have an OwnerType and OwnerID. An
-// answer uploaded before transcription has no owner yet and instead references
-// its Question through PendingAnswerQuestionID. After a valid Turn is created,
-// the asset is bound to that Turn and PendingAnswerQuestionID is cleared.
+// 转录前的回答音频通过 PendingAnswerQuestionID 关联问题；创建有效 Turn 后再绑定 Owner，并清除临时关联。
 type AudioAsset struct {
 	AudioAssetID            string
 	OwnerType               *AudioOwnerType
@@ -136,8 +125,7 @@ type AudioAsset struct {
 	UpdatedAt               time.Time
 }
 
-// TurnOutcome is the idempotent control signal submitted to Practice after a
-// valid Turn is saved. TurnID is its idempotency key.
+// TurnOutcome 是有效 Turn 保存后提交给 Practice 的控制信号，TurnID 同时作为幂等键。
 type TurnOutcome struct {
 	TurnID                        string
 	PracticeSessionID             string
@@ -148,8 +136,7 @@ type TurnOutcome struct {
 	CompletedPrimaryQuestionCount int
 }
 
-// Transcript stores the internal ASR result. Other modules consume
-// Turn.AnswerText instead of depending on this structure.
+// Transcript 保存内部 ASR 结果，其他模块只使用 Turn.AnswerText。
 type Transcript struct {
 	TranscriptID string
 	QuestionID   string
@@ -161,14 +148,14 @@ type Transcript struct {
 	CreatedAt    time.Time
 }
 
-// TranscriptSegment is a time-bounded part of a Transcript.
+// TranscriptSegment 表示带音频时间范围的转录片段。
 type TranscriptSegment struct {
 	StartMS int64
 	EndMS   int64
 	Text    string
 }
 
-// ProcessingFailure describes why an internal processing attempt failed.
+// ProcessingFailure 描述内部处理尝试的失败原因。
 type ProcessingFailure struct {
 	Code      string
 	Message   string
@@ -176,9 +163,7 @@ type ProcessingFailure struct {
 	FailedAt  time.Time
 }
 
-// ProcessingAttempt is an append-only record of a Conversation processing
-// attempt. A transcription failure can be recorded before a Turn exists by
-// using QuestionID and AudioAssetID with a nil TurnID.
+// ProcessingAttempt 追加记录一次处理尝试，转录失败时允许 TurnID 为空。
 type ProcessingAttempt struct {
 	ProcessingAttemptID string
 	QuestionID          string

--- a/server/internal/conversation/model.go
+++ b/server/internal/conversation/model.go
@@ -117,17 +117,23 @@ type Turn struct {
 // AudioAsset contains business metadata for audio whose bytes are stored by a
 // Platform file-storage capability. StorageRef is a stable internal reference,
 // not a public URL or storage credential.
+//
+// Question TTS and completed answer audio have an OwnerType and OwnerID. An
+// answer uploaded before transcription has no owner yet and instead references
+// its Question through PendingAnswerQuestionID. After a valid Turn is created,
+// the asset is bound to that Turn and PendingAnswerQuestionID is cleared.
 type AudioAsset struct {
-	AudioAssetID string
-	OwnerType    AudioOwnerType
-	OwnerID      string
-	DurationMS   int64
-	StorageRef   *string
-	AudioStatus  AudioStatus
-	ContentType  *string
-	Language     *string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	AudioAssetID            string
+	OwnerType               *AudioOwnerType
+	OwnerID                 *string
+	PendingAnswerQuestionID *string
+	DurationMS              int64
+	StorageRef              *string
+	AudioStatus             AudioStatus
+	ContentType             *string
+	Language                *string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
 }
 
 // TurnOutcome is the idempotent control signal submitted to Practice after a

--- a/server/internal/conversation/model.go
+++ b/server/internal/conversation/model.go
@@ -1,0 +1,187 @@
+package conversation
+
+import "time"
+
+// QuestionType identifies whether a question starts an objective or follows up
+// on a primary question.
+type QuestionType string
+
+const (
+	QuestionTypePrimary  QuestionType = "PRIMARY"
+	QuestionTypeFollowUp QuestionType = "FOLLOW_UP"
+)
+
+// InteractionMode identifies how an answer was captured.
+type InteractionMode string
+
+const (
+	InteractionModePushToTalk InteractionMode = "PUSH_TO_TALK"
+	InteractionModeRealtime   InteractionMode = "REALTIME"
+)
+
+// TurnStatus tracks whether an effective answer is still being submitted to
+// Practice or has been accepted.
+type TurnStatus string
+
+const (
+	TurnStatusProcessing TurnStatus = "processing"
+	TurnStatusCompleted  TurnStatus = "completed"
+)
+
+// AudioOwnerType identifies the Conversation entity that owns an audio asset.
+type AudioOwnerType string
+
+const (
+	AudioOwnerTypeQuestion AudioOwnerType = "QUESTION"
+	AudioOwnerTypeTurn     AudioOwnerType = "TURN"
+)
+
+// AudioStatus tracks the lifecycle of audio metadata managed by Conversation.
+type AudioStatus string
+
+const (
+	AudioStatusPending AudioStatus = "pending"
+	AudioStatusReady   AudioStatus = "ready"
+	AudioStatusFailed  AudioStatus = "failed"
+	AudioStatusDeleted AudioStatus = "deleted"
+)
+
+// AnswerValidity is kept compatible with the frozen cross-module contract.
+// Conversation only produces VALID outcomes in MS1.
+type AnswerValidity string
+
+const (
+	AnswerValidityValid   AnswerValidity = "VALID"
+	AnswerValidityInvalid AnswerValidity = "INVALID"
+)
+
+// ObjectiveCoverage describes how well an answer covers the current objective.
+type ObjectiveCoverage string
+
+const (
+	ObjectiveCoverageCovered          ObjectiveCoverage = "COVERED"
+	ObjectiveCoveragePartiallyCovered ObjectiveCoverage = "PARTIALLY_COVERED"
+	ObjectiveCoverageNotCovered       ObjectiveCoverage = "NOT_COVERED"
+)
+
+// ProcessingStage identifies an internal Conversation processing step.
+type ProcessingStage string
+
+const (
+	ProcessingStageTranscription         ProcessingStage = "transcription"
+	ProcessingStageTurnOutcomeSubmission ProcessingStage = "turn_outcome_submission"
+)
+
+// ProcessingAttemptStatus records the result of one append-only processing
+// attempt.
+type ProcessingAttemptStatus string
+
+const (
+	ProcessingAttemptStatusStarted   ProcessingAttemptStatus = "started"
+	ProcessingAttemptStatusSucceeded ProcessingAttemptStatus = "succeeded"
+	ProcessingAttemptStatusFailed    ProcessingAttemptStatus = "failed"
+)
+
+// Question is an immutable interview question generated for a PracticeSession.
+// A FOLLOW_UP question references a PRIMARY question in the same session.
+type Question struct {
+	QuestionID           string
+	PracticeSessionID    string
+	SpeakerParticipantID string
+	ObjectiveID          *string
+	QuestionType         QuestionType
+	ParentQuestionID     *string
+	Content              string
+	Sequence             int
+	AudioAssetID         *string
+	CreatedAt            time.Time
+}
+
+// Turn is one effective answer to a Question. Recording fragments, connection
+// events, empty answers, and failed transcription attempts do not create Turns.
+type Turn struct {
+	TurnID               string
+	PracticeSessionID    string
+	QuestionID           string
+	SpeakerParticipantID string
+	Sequence             int
+	InteractionMode      InteractionMode
+	AnswerText           string
+	AudioAssetID         *string
+	TurnStatus           TurnStatus
+	SubmittedAt          time.Time
+	CreatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+// AudioAsset contains business metadata for audio whose bytes are stored by a
+// Platform file-storage capability. StorageRef is a stable internal reference,
+// not a public URL or storage credential.
+type AudioAsset struct {
+	AudioAssetID string
+	OwnerType    AudioOwnerType
+	OwnerID      string
+	DurationMS   int64
+	StorageRef   *string
+	AudioStatus  AudioStatus
+	ContentType  *string
+	Language     *string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// TurnOutcome is the idempotent control signal submitted to Practice after a
+// valid Turn is saved. TurnID is its idempotency key.
+type TurnOutcome struct {
+	TurnID                        string
+	PracticeSessionID             string
+	AnswerValidity                AnswerValidity
+	ObjectiveCoverage             ObjectiveCoverage
+	FollowUpGap                   bool
+	FollowUpCount                 int
+	CompletedPrimaryQuestionCount int
+}
+
+// Transcript stores the internal ASR result. Other modules consume
+// Turn.AnswerText instead of depending on this structure.
+type Transcript struct {
+	TranscriptID string
+	QuestionID   string
+	TurnID       *string
+	AudioAssetID string
+	RawText      string
+	Version      string
+	Segments     []TranscriptSegment
+	CreatedAt    time.Time
+}
+
+// TranscriptSegment is a time-bounded part of a Transcript.
+type TranscriptSegment struct {
+	StartMS int64
+	EndMS   int64
+	Text    string
+}
+
+// ProcessingFailure describes why an internal processing attempt failed.
+type ProcessingFailure struct {
+	Code      string
+	Message   string
+	Retryable bool
+	FailedAt  time.Time
+}
+
+// ProcessingAttempt is an append-only record of a Conversation processing
+// attempt. A transcription failure can be recorded before a Turn exists by
+// using QuestionID and AudioAssetID with a nil TurnID.
+type ProcessingAttempt struct {
+	ProcessingAttemptID string
+	QuestionID          string
+	TurnID              *string
+	AudioAssetID        *string
+	Stage               ProcessingStage
+	Status              ProcessingAttemptStatus
+	AttemptNumber       int
+	Failure             *ProcessingFailure
+	StartedAt           time.Time
+	FinishedAt          *time.Time
+}

--- a/server/internal/conversation/model_test.go
+++ b/server/internal/conversation/model_test.go
@@ -1,0 +1,83 @@
+package conversation_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+)
+
+func TestConversationEnumContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"primary question", string(conversation.QuestionTypePrimary), "PRIMARY"},
+		{"follow-up question", string(conversation.QuestionTypeFollowUp), "FOLLOW_UP"},
+		{"push-to-talk interaction", string(conversation.InteractionModePushToTalk), "PUSH_TO_TALK"},
+		{"realtime interaction", string(conversation.InteractionModeRealtime), "REALTIME"},
+		{"processing turn", string(conversation.TurnStatusProcessing), "processing"},
+		{"completed turn", string(conversation.TurnStatusCompleted), "completed"},
+		{"question audio owner", string(conversation.AudioOwnerTypeQuestion), "QUESTION"},
+		{"turn audio owner", string(conversation.AudioOwnerTypeTurn), "TURN"},
+		{"pending audio", string(conversation.AudioStatusPending), "pending"},
+		{"ready audio", string(conversation.AudioStatusReady), "ready"},
+		{"failed audio", string(conversation.AudioStatusFailed), "failed"},
+		{"deleted audio", string(conversation.AudioStatusDeleted), "deleted"},
+		{"valid answer", string(conversation.AnswerValidityValid), "VALID"},
+		{"invalid compatibility value", string(conversation.AnswerValidityInvalid), "INVALID"},
+		{"covered objective", string(conversation.ObjectiveCoverageCovered), "COVERED"},
+		{"partially covered objective", string(conversation.ObjectiveCoveragePartiallyCovered), "PARTIALLY_COVERED"},
+		{"not covered objective", string(conversation.ObjectiveCoverageNotCovered), "NOT_COVERED"},
+		{"transcription stage", string(conversation.ProcessingStageTranscription), "transcription"},
+		{"outcome submission stage", string(conversation.ProcessingStageTurnOutcomeSubmission), "turn_outcome_submission"},
+		{"started attempt", string(conversation.ProcessingAttemptStatusStarted), "started"},
+		{"succeeded attempt", string(conversation.ProcessingAttemptStatusSucceeded), "succeeded"},
+		{"failed attempt", string(conversation.ProcessingAttemptStatusFailed), "failed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Fatalf("got %q, want %q", test.got, test.want)
+			}
+		})
+	}
+}
+
+func TestProcessingAttemptSupportsFailureBeforeTurnCreation(t *testing.T) {
+	audioAssetID := "audio-1"
+	attempt := conversation.ProcessingAttempt{
+		QuestionID:   "question-1",
+		AudioAssetID: &audioAssetID,
+		Stage:        conversation.ProcessingStageTranscription,
+		Status:       conversation.ProcessingAttemptStatusFailed,
+		Failure: &conversation.ProcessingFailure{
+			Code:      "asr_unavailable",
+			Retryable: true,
+		},
+	}
+
+	if attempt.TurnID != nil {
+		t.Fatal("a failed pre-turn transcription must not reference a Turn")
+	}
+	if attempt.QuestionID == "" || attempt.AudioAssetID == nil {
+		t.Fatal("a failed pre-turn transcription must retain question and audio references")
+	}
+}
+
+func TestConversationModelsDoNotDuplicateUserOwnership(t *testing.T) {
+	models := []any{
+		conversation.Question{},
+		conversation.Turn{},
+		conversation.TurnOutcome{},
+	}
+
+	for _, model := range models {
+		modelType := reflect.TypeOf(model)
+		if _, exists := modelType.FieldByName("UserID"); exists {
+			t.Fatalf("%s must resolve user ownership through PracticeSessionID", modelType.Name())
+		}
+	}
+}

--- a/server/internal/conversation/model_test.go
+++ b/server/internal/conversation/model_test.go
@@ -47,9 +47,15 @@ func TestConversationEnumContracts(t *testing.T) {
 }
 
 func TestProcessingAttemptSupportsFailureBeforeTurnCreation(t *testing.T) {
+	questionID := "question-1"
 	audioAssetID := "audio-1"
+	audioAsset := conversation.AudioAsset{
+		AudioAssetID:            audioAssetID,
+		PendingAnswerQuestionID: &questionID,
+		AudioStatus:             conversation.AudioStatusReady,
+	}
 	attempt := conversation.ProcessingAttempt{
-		QuestionID:   "question-1",
+		QuestionID:   questionID,
 		AudioAssetID: &audioAssetID,
 		Stage:        conversation.ProcessingStageTranscription,
 		Status:       conversation.ProcessingAttemptStatusFailed,
@@ -59,6 +65,12 @@ func TestProcessingAttemptSupportsFailureBeforeTurnCreation(t *testing.T) {
 		},
 	}
 
+	if audioAsset.OwnerType != nil || audioAsset.OwnerID != nil {
+		t.Fatal("pre-turn answer audio must not reference a Turn that does not exist")
+	}
+	if audioAsset.PendingAnswerQuestionID == nil || *audioAsset.PendingAnswerQuestionID != attempt.QuestionID {
+		t.Fatal("pre-turn answer audio must retain its Question association")
+	}
 	if attempt.TurnID != nil {
 		t.Fatal("a failed pre-turn transcription must not reference a Turn")
 	}

--- a/server/internal/conversation/module.go
+++ b/server/internal/conversation/module.go
@@ -1,4 +1,5 @@
-// Package conversation owns questions, turns, transcripts, and media capability ports.
+// Package conversation owns questions, valid answer turns, transcripts, and
+// audio asset metadata for an interview conversation.
 package conversation
 
 type Module struct{}

--- a/server/internal/conversation/module.go
+++ b/server/internal/conversation/module.go
@@ -1,5 +1,4 @@
-// Package conversation owns questions, valid answer turns, transcripts, and
-// audio asset metadata for an interview conversation.
+// Package conversation 负责问题、有效回答、转录和音频资产元数据。
 package conversation
 
 type Module struct{}


### PR DESCRIPTION
## 功能描述

- 定义 Conversation 模块核心领域对象，包括 Question、Turn、AudioAsset 和 TurnOutcome。
- 补充 Transcript、TranscriptSegment、ProcessingFailure 和 ProcessingAttempt 等内部处理数据结构。
- 统一问题类型、交互模式、Turn 状态、音频状态和目标覆盖程度等枚举。
- 增加模型契约测试，不提供 Service、Repository、Handler 或业务函数实现。

## 实现思路

- 使用 `practice_session_id` 表达用户归属，Question、Turn 和 TurnOutcome 不重复保存 `user_id`。
- Turn 只表示完成转写和有效性校验后的有效回答，失败尝试通过 ProcessingAttempt 记录。
- Turn 仅包含 `processing` 和 `completed` 状态；Practice 接受 TurnOutcome 后才进入 completed。
- AudioAsset 只保存业务元数据，实际音频内容仍由 Platform 文件存储能力管理。
- 同题重答仍创建普通新 Turn，不在 Conversation 中定义 Review 所属的 RetryAttempt。
- 使用 TurnID 作为 TurnOutcome 的幂等标识，Conversation 不直接修改 PracticeSession 进度。

## 测试方式

```bash
cd server
gofmt -d internal/conversation/*.go
go test ./internal/conversation/...
go vet ./internal/conversation/...
go test ./...
go vet ./...
git diff --check origin/main...HEAD
```

以上检查均已通过。

## 相关 Issue / 备注

- Closes #32
- 本 PR 只实现 Conversation 实体与数据结构。
- 不包含 REST、WebSocket、Go Service 接口、数据库模型、迁移脚本或 Provider 接入。
- Conversation 接口与 Port 将在后续 Issue 中单独实现。

## AI 辅助说明

- AI 协助内容：根据 Issue #32 中确定的实体、字段和数据所有权整理 Conversation 领域模型及契约测试。
- 主要约束：只定义数据结构，不实现业务函数，不引入数据库、接口层或外部 Provider。
- 人工复核重点：字段命名、Turn 创建边界、跨模块数据所有权及枚举值是否与 Issue #32 一致。