### PR TITLE
feat(practice): 实现后端架构骨架

### DIFF
--- a/server/internal/practice/errors.go
+++ b/server/internal/practice/errors.go
@@ -1,0 +1,23 @@
+package practice
+
+import "errors"
+
+var (
+	ErrPracticeCommandInvalid           = errors.New("practice_command_invalid")
+	ErrPracticePlanInvalid              = errors.New("practice_plan_invalid")
+	ErrPracticePlanTransitionNotAllowed = errors.New("practice_plan_transition_not_allowed")
+	ErrPracticePlanHasActiveSession     = errors.New("practice_plan_has_active_session")
+	// 已产生过场次的计划必须保留，不能按空计划删除
+	ErrPracticePlanHasSessions             = errors.New("practice_plan_has_sessions")
+	ErrPracticeSessionInvalid              = errors.New("practice_session_invalid")
+	ErrPracticeSessionInvalidTime          = errors.New("practice_session_invalid_time")
+	ErrPracticeSessionTransitionNotAllowed = errors.New("practice_session_transition_not_allowed")
+	ErrPracticeParticipantInvalid          = errors.New("practice_participant_invalid")
+	ErrPracticeSessionSnapshotInvalid      = errors.New("practice_session_snapshot_invalid")
+	ErrPracticePlanNotFound                = errors.New("practice_plan_not_found")
+	ErrPracticeSessionNotFound             = errors.New("practice_session_not_found")
+	ErrPracticePlanRevisionConflict        = errors.New("practice_plan_revision_conflict")
+	ErrPracticeResourceForbidden           = errors.New("practice_resource_forbidden")
+	// 同一幂等键只能绑定一组请求参数
+	ErrPracticeIdempotencyConflict = errors.New("practice_idempotency_conflict")
+)

--- a/server/internal/practice/model.go
+++ b/server/internal/practice/model.go
@@ -1,0 +1,501 @@
+package practice
+
+import "time"
+
+// 场景分支使用稳定判别值；MS1 只开放面试场景
+type ScenarioType string
+
+const (
+	ScenarioTypeInterview ScenarioType = "INTERVIEW"
+)
+
+// 区分场次中的系统职责，不等同于具体角色定义
+type ParticipantRole string
+
+const (
+	ParticipantRoleInterviewer ParticipantRole = "INTERVIEWER"
+	ParticipantRoleCandidate   ParticipantRole = "CANDIDATE"
+)
+
+// 只保存跨模块定位主体所需的信息，不复制主体详情
+type SubjectRef struct {
+	Namespace string
+	SubjectID string
+}
+
+// 计划状态只能通过 PracticePlan 提供的方法迁移
+type PracticePlanStatus string
+
+const (
+	PracticePlanConfiguring         PracticePlanStatus = "configuring"
+	PracticePlanConfigurationFailed PracticePlanStatus = "configuration_failed"
+	PracticePlanReady               PracticePlanStatus = "ready"
+	PracticePlanArchived            PracticePlanStatus = "archived"
+)
+
+// 场次进入终态后不可恢复，迁移规则由 PracticeSession 统一校验
+type PracticeSessionStatus string
+
+const (
+	PracticeSessionStarting   PracticeSessionStatus = "starting"
+	PracticeSessionInProgress PracticeSessionStatus = "in_progress"
+	PracticeSessionPaused     PracticeSessionStatus = "paused"
+	PracticeSessionCompleted  PracticeSessionStatus = "completed"
+	PracticeSessionEndedEarly PracticeSessionStatus = "ended_early"
+)
+
+// 保存可跨场次复用的配置；已有活动场次时不能修改或归档
+type PracticePlan struct {
+	id                   string
+	userID               string
+	scenarioDefinitionID string
+	scenarioType         ScenarioType
+	scenarioConfigID     string
+	preparationProfileID string
+	selectedRoleIDs      []string
+	revision             int
+	status               PracticePlanStatus
+}
+
+// 校验创建参数，并以第一个修订版进入配置中状态
+func NewPracticePlan(id, userID, scenarioDefinitionID string, scenarioType ScenarioType, scenarioConfigID, preparationProfileID string, selectedRoleIDs []string) (*PracticePlan, error) {
+	if id == "" || userID == "" || scenarioDefinitionID == "" || scenarioType != ScenarioTypeInterview || scenarioConfigID == "" || preparationProfileID == "" || !hasOneToFourNonEmptyValues(selectedRoleIDs) {
+		return nil, ErrPracticePlanInvalid
+	}
+
+	return &PracticePlan{
+		id:                   id,
+		userID:               userID,
+		scenarioDefinitionID: scenarioDefinitionID,
+		scenarioType:         scenarioType,
+		scenarioConfigID:     scenarioConfigID,
+		preparationProfileID: preparationProfileID,
+		selectedRoleIDs:      cloneStrings(selectedRoleIDs),
+		revision:             1,
+		status:               PracticePlanConfiguring,
+	}, nil
+}
+
+func (p *PracticePlan) ID() string { return p.id }
+
+func (p *PracticePlan) UserID() string { return p.userID }
+
+func (p *PracticePlan) ScenarioDefinitionID() string { return p.scenarioDefinitionID }
+
+func (p *PracticePlan) ScenarioType() ScenarioType { return p.scenarioType }
+
+func (p *PracticePlan) ScenarioConfigID() string { return p.scenarioConfigID }
+
+func (p *PracticePlan) PreparationProfileID() string { return p.preparationProfileID }
+
+// 返回副本，避免调用方绕过计划更新规则修改角色
+func (p *PracticePlan) SelectedRoleIDs() []string { return cloneStrings(p.selectedRoleIDs) }
+
+func (p *PracticePlan) Revision() int { return p.revision }
+
+func (p *PracticePlan) Status() PracticePlanStatus { return p.status }
+
+// 只接受尚未结束配置的计划
+func (p *PracticePlan) MarkConfigurationFailed() error {
+	if p.status != PracticePlanConfiguring {
+		return ErrPracticePlanTransitionNotAllowed
+	}
+	p.status = PracticePlanConfigurationFailed
+	return nil
+}
+
+// 允许首次配置成功，也允许失败后重试成功
+func (p *PracticePlan) MarkReady() error {
+	if p.status != PracticePlanConfiguring && p.status != PracticePlanConfigurationFailed {
+		return ErrPracticePlanTransitionNotAllowed
+	}
+	p.status = PracticePlanReady
+	return nil
+}
+
+// 拒绝修改存在活动场次的计划；成功后修订号递增
+func (p *PracticePlan) Update(scenarioConfigID, preparationProfileID string, selectedRoleIDs []string, hasActiveSession bool) error {
+	if hasActiveSession {
+		return ErrPracticePlanHasActiveSession
+	}
+	if p.status != PracticePlanReady {
+		return ErrPracticePlanTransitionNotAllowed
+	}
+	if scenarioConfigID == "" || preparationProfileID == "" || !hasOneToFourNonEmptyValues(selectedRoleIDs) {
+		return ErrPracticePlanInvalid
+	}
+	p.scenarioConfigID = scenarioConfigID
+	p.preparationProfileID = preparationProfileID
+	p.selectedRoleIDs = cloneStrings(selectedRoleIDs)
+	p.revision++
+	return nil
+}
+
+// 拒绝归档存在活动场次或尚未就绪的计划
+func (p *PracticePlan) Archive(hasActiveSession bool) error {
+	if hasActiveSession {
+		return ErrPracticePlanHasActiveSession
+	}
+	if p.status != PracticePlanReady {
+		return ErrPracticePlanTransitionNotAllowed
+	}
+	p.status = PracticePlanArchived
+	return nil
+}
+
+// 只恢复已归档的计划
+func (p *PracticePlan) Restore() error {
+	if p.status != PracticePlanArchived {
+		return ErrPracticePlanTransitionNotAllowed
+	}
+	p.status = PracticePlanReady
+	return nil
+}
+
+// 只保存运行状态；创建场次时的输入由独立快照冻结
+type PracticeSession struct {
+	id           string
+	planID       string
+	scenarioType ScenarioType
+	snapshotID   string
+	status       PracticeSessionStatus
+	createdAt    time.Time
+	startedAt    *time.Time
+	endedAt      *time.Time
+	endReason    string
+}
+
+// 校验关联标识和创建时间，初始状态为启动中
+func NewPracticeSession(id, planID string, scenarioType ScenarioType, snapshotID string, createdAt time.Time) (*PracticeSession, error) {
+	if id == "" || planID == "" || scenarioType != ScenarioTypeInterview || snapshotID == "" || createdAt.IsZero() {
+		return nil, ErrPracticeSessionInvalid
+	}
+	return &PracticeSession{id: id, planID: planID, scenarioType: scenarioType, snapshotID: snapshotID, status: PracticeSessionStarting, createdAt: createdAt}, nil
+}
+
+func (s *PracticeSession) ID() string { return s.id }
+
+func (s *PracticeSession) PlanID() string { return s.planID }
+
+func (s *PracticeSession) ScenarioType() ScenarioType { return s.scenarioType }
+
+func (s *PracticeSession) SnapshotID() string { return s.snapshotID }
+
+func (s *PracticeSession) Status() PracticeSessionStatus { return s.status }
+
+// 通过第二个返回值区分“尚未开始”和零值时间
+func (s *PracticeSession) StartedAt() (time.Time, bool) {
+	if s.startedAt == nil {
+		return time.Time{}, false
+	}
+	return *s.startedAt, true
+}
+
+// 拒绝早于场次创建时间的开始时间
+func (s *PracticeSession) Start(startedAt time.Time) error {
+	if s.status != PracticeSessionStarting {
+		return ErrPracticeSessionTransitionNotAllowed
+	}
+	if startedAt.Before(s.createdAt) {
+		return ErrPracticeSessionInvalidTime
+	}
+	s.startedAt = timePointer(startedAt)
+	s.status = PracticeSessionInProgress
+	return nil
+}
+
+// 只允许暂停进行中的场次
+func (s *PracticeSession) Pause() error {
+	if s.status != PracticeSessionInProgress {
+		return ErrPracticeSessionTransitionNotAllowed
+	}
+	s.status = PracticeSessionPaused
+	return nil
+}
+
+// 只允许恢复暂停中的场次
+func (s *PracticeSession) Resume() error {
+	if s.status != PracticeSessionPaused {
+		return ErrPracticeSessionTransitionNotAllowed
+	}
+	s.status = PracticeSessionInProgress
+	return nil
+}
+
+// 只允许结束已经开始且仍在进行的场次
+func (s *PracticeSession) Complete(endedAt time.Time) error {
+	return s.end(PracticeSessionCompleted, endedAt, "")
+}
+
+// 接受进行中或暂停中的场次，并要求记录原因
+func (s *PracticeSession) EndEarly(endedAt time.Time, reason string) error {
+	if reason == "" {
+		return ErrPracticeSessionInvalid
+	}
+	return s.end(PracticeSessionEndedEarly, endedAt, reason)
+}
+
+func (s *PracticeSession) end(status PracticeSessionStatus, endedAt time.Time, reason string) error {
+	if s.status != PracticeSessionInProgress && (status != PracticeSessionEndedEarly || s.status != PracticeSessionPaused) {
+		return ErrPracticeSessionTransitionNotAllowed
+	}
+	if s.startedAt == nil || endedAt.Before(*s.startedAt) {
+		return ErrPracticeSessionInvalidTime
+	}
+	s.endedAt = timePointer(endedAt)
+	s.endReason = reason
+	s.status = status
+	return nil
+}
+
+// 保留场次创建时使用的场景定义版本
+type ScenarioDefinitionSnapshot struct {
+	ScenarioDefinitionID string
+	ScenarioType         ScenarioType
+	Name                 string
+	Version              int
+	Status               string
+}
+
+// 保留场次创建时使用的场景配置版本
+type ScenarioConfigSnapshot struct {
+	ScenarioConfigID     string
+	ScenarioDefinitionID string
+	ConfigType           string
+	Version              int
+}
+
+// 固化生成本场练习所依据的用户准备资料
+type PreparationSnapshot struct {
+	PreparationSnapshotID  string
+	SourceProfileID        string
+	SourceVersion          int
+	ResumeSnapshot         string
+	JobDescriptionSnapshot string
+	BackgroundSnapshot     string
+	CreatedAt              time.Time
+}
+
+// 固化面试官在本场练习中的职责、风格和声音配置
+type RoleSnapshot struct {
+	RoleDefinitionID     string
+	ScenarioDefinitionID string
+	RoleType             string
+	DisplayName          string
+	Responsibilities     string
+	Style                string
+	FocusAreas           []string
+	VoiceConfigRef       string
+	Version              int
+}
+
+// 固化本场练习采用的选项版本
+type PracticeOptionSnapshot struct {
+	PracticeOptionID     string
+	ScenarioDefinitionID string
+	RoleDefinitionID     string
+	PracticeOptionType   string
+	DisplayName          string
+	Version              int
+}
+
+type PracticeParticipantInput struct {
+	ID               string
+	SessionID        string
+	ParticipantRole  ParticipantRole
+	SubjectRef       SubjectRef
+	RoleDefinitionID string
+	RoleSnapshot     RoleSnapshot
+	ParticipantOrder int
+}
+
+// 将主体引用与本场采用的角色版本绑定，后续角色变更不影响历史场次
+type PracticeParticipant struct {
+	id               string
+	sessionID        string
+	participantRole  ParticipantRole
+	subjectRef       SubjectRef
+	roleDefinitionID string
+	roleSnapshot     RoleSnapshot
+	participantOrder int
+}
+
+func (p PracticeParticipant) ID() string { return p.id }
+
+func (p PracticeParticipant) SessionID() string { return p.sessionID }
+
+func (p PracticeParticipant) ParticipantRole() ParticipantRole { return p.participantRole }
+
+func (p PracticeParticipant) SubjectRef() SubjectRef { return p.subjectRef }
+
+func (p PracticeParticipant) RoleDefinitionID() string { return p.roleDefinitionID }
+
+// 返回副本，避免调用方修改快照中的切片字段
+func (p PracticeParticipant) RoleSnapshot() RoleSnapshot { return cloneRoleSnapshot(p.roleSnapshot) }
+
+func (p PracticeParticipant) ParticipantOrder() int { return p.participantOrder }
+
+type PracticeSessionSnapshotInput struct {
+	ID                 string
+	SessionID          string
+	PlanRevision       int
+	ScenarioType       ScenarioType
+	ScenarioDefinition ScenarioDefinitionSnapshot
+	ScenarioConfig     ScenarioConfigSnapshot
+	Preparation        PreparationSnapshot
+	Participants       []PracticeParticipantInput
+	PracticeOption     PracticeOptionSnapshot
+	PracticeFocuses    []string
+	SessionPolicy      PracticeSessionPolicy
+	CreatedAt          time.Time
+}
+
+// 快照保存场次创建时的输入，后续读取不依赖源模块当前状态
+type PracticeSessionSnapshot struct {
+	id                 string
+	sessionID          string
+	planRevision       int
+	scenarioType       ScenarioType
+	scenarioDefinition ScenarioDefinitionSnapshot
+	scenarioConfig     ScenarioConfigSnapshot
+	preparation        PreparationSnapshot
+	participants       []PracticeParticipant
+	practiceOption     PracticeOptionSnapshot
+	practiceFocuses    []string
+	sessionPolicy      PracticeSessionPolicy
+	createdAt          time.Time
+}
+
+// 校验各快照来自同一场景和场次，并深拷贝可变字段
+func NewPracticeSessionSnapshot(input PracticeSessionSnapshotInput) (PracticeSessionSnapshot, error) {
+	if !validSnapshotInput(input) {
+		return PracticeSessionSnapshot{}, ErrPracticeSessionSnapshotInvalid
+	}
+	participants := make([]PracticeParticipant, len(input.Participants))
+	for index, participantInput := range input.Participants {
+		participants[index] = PracticeParticipant{
+			id: participantInput.ID, sessionID: participantInput.SessionID,
+			participantRole: participantInput.ParticipantRole, subjectRef: participantInput.SubjectRef,
+			roleDefinitionID: participantInput.RoleDefinitionID,
+			roleSnapshot:     cloneRoleSnapshot(participantInput.RoleSnapshot), participantOrder: participantInput.ParticipantOrder,
+		}
+	}
+	return PracticeSessionSnapshot{
+		id: input.ID, sessionID: input.SessionID, planRevision: input.PlanRevision, scenarioType: input.ScenarioType,
+		scenarioDefinition: input.ScenarioDefinition, scenarioConfig: input.ScenarioConfig,
+		preparation: input.Preparation, participants: participants, practiceOption: input.PracticeOption,
+		practiceFocuses: cloneStrings(input.PracticeFocuses), sessionPolicy: input.SessionPolicy, createdAt: input.CreatedAt,
+	}, nil
+}
+
+// 按参与者顺序返回非空的角色定义标识
+func (s PracticeSessionSnapshot) ParticipantRoleIDs() []string {
+	result := make([]string, 0, len(s.participants))
+	for _, participant := range s.participants {
+		if participant.RoleDefinitionID() != "" {
+			result = append(result, participant.RoleDefinitionID())
+		}
+	}
+	return result
+}
+
+// 返回副本，避免调用方修改快照状态
+func (s PracticeSessionSnapshot) PracticeFocuses() []string { return cloneStrings(s.practiceFocuses) }
+
+func (s PracticeSessionSnapshot) ID() string { return s.id }
+
+func (s PracticeSessionSnapshot) ScenarioType() ScenarioType { return s.scenarioType }
+
+func (s PracticeSessionSnapshot) ScenarioDefinition() ScenarioDefinitionSnapshot {
+	return s.scenarioDefinition
+}
+
+func (s PracticeSessionSnapshot) ScenarioConfig() ScenarioConfigSnapshot { return s.scenarioConfig }
+
+func (s PracticeSessionSnapshot) Preparation() PreparationSnapshot { return s.preparation }
+
+// 深拷贝参与者集合及其中的角色快照
+func (s PracticeSessionSnapshot) Participants() []PracticeParticipantInput {
+	result := make([]PracticeParticipantInput, len(s.participants))
+	for i, participant := range s.participants {
+		result[i] = PracticeParticipantInput{
+			ID: participant.ID(), SessionID: participant.SessionID(), ParticipantRole: participant.ParticipantRole(), SubjectRef: participant.SubjectRef(),
+			RoleDefinitionID: participant.RoleDefinitionID(), RoleSnapshot: participant.RoleSnapshot(), ParticipantOrder: participant.ParticipantOrder(),
+		}
+	}
+	return result
+}
+
+func (s PracticeSessionSnapshot) PreparationSnapshotID() string {
+	return s.preparation.PreparationSnapshotID
+}
+
+func (s PracticeSessionSnapshot) PracticeOptionID() string { return s.practiceOption.PracticeOptionID }
+
+func (s PracticeSessionSnapshot) PracticeOption() PracticeOptionSnapshot { return s.practiceOption }
+
+func (s PracticeSessionSnapshot) PlanRevision() int { return s.planRevision }
+
+func (s PracticeSessionSnapshot) SessionPolicy() PracticeSessionPolicy { return s.sessionPolicy }
+
+func validSnapshotInput(input PracticeSessionSnapshotInput) bool {
+	if input.ID == "" || input.SessionID == "" || input.PlanRevision < 1 || input.ScenarioType != ScenarioTypeInterview || input.CreatedAt.IsZero() || !validInterviewParticipants(input.SessionID, input.Participants) {
+		return false
+	}
+	return input.ScenarioDefinition.ScenarioDefinitionID != "" && input.ScenarioDefinition.ScenarioType == input.ScenarioType && input.ScenarioDefinition.Version > 0 &&
+		input.ScenarioConfig.ScenarioConfigID != "" && input.ScenarioConfig.ScenarioDefinitionID == input.ScenarioDefinition.ScenarioDefinitionID && input.ScenarioConfig.Version > 0 &&
+		input.Preparation.PreparationSnapshotID != "" && input.Preparation.SourceProfileID != "" && input.Preparation.SourceVersion > 0 && !input.Preparation.CreatedAt.IsZero() &&
+		input.PracticeOption.PracticeOptionID != "" && input.PracticeOption.ScenarioDefinitionID == input.ScenarioDefinition.ScenarioDefinitionID && input.PracticeOption.Version > 0 &&
+		input.Participants[0].RoleSnapshot.ScenarioDefinitionID == input.ScenarioDefinition.ScenarioDefinitionID &&
+		input.PracticeOption.RoleDefinitionID == input.Participants[0].RoleDefinitionID && input.SessionPolicy.valid()
+}
+
+func validInterviewParticipants(sessionID string, participants []PracticeParticipantInput) bool {
+	if len(participants) != 1 {
+		return false
+	}
+	roles := map[ParticipantRole]int{}
+	participantIDs := map[string]struct{}{}
+	subjects := map[SubjectRef]struct{}{}
+	for _, participant := range participants {
+		if participant.ID == "" || participant.SessionID != sessionID || participant.ParticipantRole == "" || participant.SubjectRef.Namespace == "" || participant.SubjectRef.SubjectID == "" || participant.ParticipantOrder < 1 {
+			return false
+		}
+		if _, exists := participantIDs[participant.ID]; exists {
+			return false
+		}
+		participantIDs[participant.ID] = struct{}{}
+		if _, exists := subjects[participant.SubjectRef]; exists {
+			return false
+		}
+		subjects[participant.SubjectRef] = struct{}{}
+		roles[participant.ParticipantRole]++
+		if participant.ParticipantRole == ParticipantRoleInterviewer {
+			if participant.RoleDefinitionID == "" || participant.RoleDefinitionID != participant.RoleSnapshot.RoleDefinitionID || participant.RoleSnapshot.Version < 1 {
+				return false
+			}
+		} else if participant.RoleDefinitionID != participant.RoleSnapshot.RoleDefinitionID || (participant.RoleDefinitionID != "" && participant.RoleSnapshot.Version < 1) {
+			return false
+		}
+	}
+	return roles[ParticipantRoleInterviewer] == 1 && len(roles) == 1
+}
+
+func cloneRoleSnapshot(snapshot RoleSnapshot) RoleSnapshot {
+	snapshot.FocusAreas = cloneStrings(snapshot.FocusAreas)
+	return snapshot
+}
+
+func hasOneNonEmptyValue(values []string) bool {
+	return len(values) == 1 && hasNonEmptyValues(values)
+}
+
+func hasOneToFourNonEmptyValues(values []string) bool {
+	return len(values) >= 1 && len(values) <= 4 && hasNonEmptyValues(values)
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func timePointer(value time.Time) *time.Time { return &value }

--- a/server/internal/practice/model_test.go
+++ b/server/internal/practice/model_test.go
@@ -1,0 +1,297 @@
+package practice_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+)
+
+func TestPracticePlanLifecycle(t *testing.T) {
+	plan, err := practice.NewPracticePlan("plan-1", "user-1", "scenario-1", practice.ScenarioTypeInterview, "config-1", "profile-1", []string{"role-1"})
+	if err != nil {
+		t.Fatalf("NewPracticePlan() error = %v", err)
+	}
+
+	if got := plan.Status(); got != practice.PracticePlanConfiguring {
+		t.Fatalf("Status() = %q, want %q", got, practice.PracticePlanConfiguring)
+	}
+	if err := plan.MarkConfigurationFailed(); err != nil {
+		t.Fatalf("MarkConfigurationFailed() error = %v", err)
+	}
+	if err := plan.MarkReady(); err != nil {
+		t.Fatalf("MarkReady() error = %v", err)
+	}
+	if err := plan.Update("config-2", "profile-2", []string{"role-2"}, false); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if got := plan.Revision(); got != 2 {
+		t.Fatalf("Revision() = %d, want 2", got)
+	}
+	if err := plan.Archive(false); err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+	if err := plan.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if got := plan.Status(); got != practice.PracticePlanReady {
+		t.Fatalf("Status() = %q, want %q", got, practice.PracticePlanReady)
+	}
+}
+
+func TestPracticePlanRejectsActiveSessionChanges(t *testing.T) {
+	plan := readyPlan(t)
+
+	if err := plan.Update("config-2", "profile-2", []string{"role-2"}, true); !errors.Is(err, practice.ErrPracticePlanHasActiveSession) {
+		t.Fatalf("Update() error = %v, want %v", err, practice.ErrPracticePlanHasActiveSession)
+	}
+	if err := plan.Archive(true); !errors.Is(err, practice.ErrPracticePlanHasActiveSession) {
+		t.Fatalf("Archive() error = %v, want %v", err, practice.ErrPracticePlanHasActiveSession)
+	}
+}
+
+func TestPracticePlanRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		userID   string
+		scenario string
+		config   string
+		profile  string
+		roleIDs  []string
+	}{
+		{name: "empty plan id", userID: "user-1", scenario: "scenario-1", config: "config-1", profile: "profile-1", roleIDs: []string{"role-1"}},
+		{name: "empty user id", id: "plan-1", scenario: "scenario-1", config: "config-1", profile: "profile-1", roleIDs: []string{"role-1"}},
+		{name: "empty scenario id", id: "plan-1", userID: "user-1", config: "config-1", profile: "profile-1", roleIDs: []string{"role-1"}},
+		{name: "no roles", id: "plan-1", userID: "user-1", scenario: "scenario-1", config: "config-1", profile: "profile-1"},
+		{name: "five roles", id: "plan-1", userID: "user-1", scenario: "scenario-1", config: "config-1", profile: "profile-1", roleIDs: []string{"role-1", "role-2", "role-3", "role-4", "role-5"}},
+		{name: "empty role", id: "plan-1", userID: "user-1", scenario: "scenario-1", config: "config-1", profile: "profile-1", roleIDs: []string{"role-1", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := practice.NewPracticePlan(tt.id, tt.userID, tt.scenario, practice.ScenarioTypeInterview, tt.config, tt.profile, tt.roleIDs)
+			if !errors.Is(err, practice.ErrPracticePlanInvalid) {
+				t.Fatalf("NewPracticePlan() error = %v, want %v", err, practice.ErrPracticePlanInvalid)
+			}
+		})
+	}
+}
+
+func TestPracticePlanAcceptsFourRoles(t *testing.T) {
+	roles := []string{"role-1", "role-2", "role-3", "role-4"}
+	plan, err := practice.NewPracticePlan("plan-1", "user-1", "scenario-1", practice.ScenarioTypeInterview, "config-1", "profile-1", roles)
+	if err != nil {
+		t.Fatalf("NewPracticePlan() error = %v", err)
+	}
+	if err := plan.MarkReady(); err != nil {
+		t.Fatalf("MarkReady() error = %v", err)
+	}
+	if err := plan.Update("config-2", "profile-2", roles, false); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+}
+
+func TestPracticeSessionLifecycle(t *testing.T) {
+	createdAt := time.Date(2026, 7, 17, 8, 0, 0, 0, time.UTC)
+	session, err := practice.NewPracticeSession("session-1", "plan-1", practice.ScenarioTypeInterview, "snapshot-1", createdAt)
+	if err != nil {
+		t.Fatalf("NewPracticeSession() error = %v", err)
+	}
+	if err := session.Start(createdAt.Add(time.Minute)); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := session.Pause(); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+	if err := session.Resume(); err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+	if err := session.Complete(createdAt.Add(10 * time.Minute)); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if err := session.Resume(); !errors.Is(err, practice.ErrPracticeSessionTransitionNotAllowed) {
+		t.Fatalf("Resume() after completion error = %v, want %v", err, practice.ErrPracticeSessionTransitionNotAllowed)
+	}
+}
+
+func TestPracticeSessionRejectsStartingEarlyEnd(t *testing.T) {
+	session, err := practice.NewPracticeSession("session-1", "plan-1", practice.ScenarioTypeInterview, "snapshot-1", time.Now())
+	if err != nil {
+		t.Fatalf("NewPracticeSession() error = %v", err)
+	}
+
+	err = session.EndEarly(time.Now(), "user_requested")
+	if !errors.Is(err, practice.ErrPracticeSessionTransitionNotAllowed) {
+		t.Fatalf("EndEarly() error = %v, want %v", err, practice.ErrPracticeSessionTransitionNotAllowed)
+	}
+}
+
+func TestPracticeSessionRejectsInvalidTime(t *testing.T) {
+	createdAt := time.Date(2026, 7, 17, 8, 0, 0, 0, time.UTC)
+	session, err := practice.NewPracticeSession("session-1", "plan-1", practice.ScenarioTypeInterview, "snapshot-1", createdAt)
+	if err != nil {
+		t.Fatalf("NewPracticeSession() error = %v", err)
+	}
+
+	err = session.Start(createdAt.Add(-time.Second))
+	if !errors.Is(err, practice.ErrPracticeSessionInvalidTime) {
+		t.Fatalf("Start() error = %v, want %v", err, practice.ErrPracticeSessionInvalidTime)
+	}
+}
+
+func TestPracticeSessionSnapshotCopiesCollections(t *testing.T) {
+	roleFocusAreas := []string{"communication", "clarity"}
+	focuses := []string{"communication", "clarity"}
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+	snapshot, err := practice.NewPracticeSessionSnapshot(practice.PracticeSessionSnapshotInput{
+		ID:           "snapshot-1",
+		SessionID:    "session-1",
+		PlanRevision: 1,
+		ScenarioType: practice.ScenarioTypeInterview,
+		ScenarioDefinition: practice.ScenarioDefinitionSnapshot{
+			ScenarioDefinitionID: "scenario-1", ScenarioType: practice.ScenarioTypeInterview, Name: "Interview", Version: 1, Status: "active",
+		},
+		ScenarioConfig: practice.ScenarioConfigSnapshot{
+			ScenarioConfigID: "config-1", ScenarioDefinitionID: "scenario-1", ConfigType: "INTERVIEW", Version: 1,
+		},
+		Preparation: practice.PreparationSnapshot{
+			PreparationSnapshotID: "preparation-1", SourceProfileID: "profile-1", SourceVersion: 1, ResumeSnapshot: "resume", JobDescriptionSnapshot: "job", BackgroundSnapshot: "background", CreatedAt: time.Now(),
+		},
+		Participants: []practice.PracticeParticipantInput{{
+			ID: "participant-1", SessionID: "session-1", ParticipantRole: practice.ParticipantRoleInterviewer,
+			SubjectRef: practice.SubjectRef{Namespace: "preparation", SubjectID: "interviewer-1"}, RoleDefinitionID: "role-1", ParticipantOrder: 1,
+			RoleSnapshot: practice.RoleSnapshot{RoleDefinitionID: "role-1", ScenarioDefinitionID: "scenario-1", RoleType: "INTERVIEWER", DisplayName: "Mia", FocusAreas: roleFocusAreas, Version: 1},
+		}},
+		PracticeOption:  practice.PracticeOptionSnapshot{PracticeOptionID: "option-1", ScenarioDefinitionID: "scenario-1", RoleDefinitionID: "role-1", PracticeOptionType: "FULL_SIMULATION", DisplayName: "Full", Version: 1},
+		PracticeFocuses: focuses,
+		SessionPolicy:   policy,
+		CreatedAt:       time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionSnapshot() error = %v", err)
+	}
+
+	roleFocusAreas[0] = "changed"
+	focuses[0] = "changed"
+	gotParticipants := snapshot.Participants()
+	gotFocuses := snapshot.PracticeFocuses()
+	gotParticipants[0].RoleSnapshot.FocusAreas[0] = "changed-again"
+	gotFocuses[0] = "changed-again"
+
+	if got := snapshot.Participants()[0].RoleSnapshot.FocusAreas[0]; got != "communication" {
+		t.Fatalf("Participants()[0].RoleSnapshot.FocusAreas[0] = %q, want communication", got)
+	}
+	if got := snapshot.PracticeFocuses()[0]; got != "communication" {
+		t.Fatalf("PracticeFocuses()[0] = %q, want communication", got)
+	}
+}
+
+func TestPracticeSessionSnapshotRequiresMS1InterviewParticipants(t *testing.T) {
+	valid := validInterviewSnapshotInput(t)
+
+	tests := []struct {
+		name   string
+		mutate func(*practice.PracticeSessionSnapshotInput)
+	}{
+		{name: "没有面试官", mutate: func(input *practice.PracticeSessionSnapshotInput) { input.Participants = nil }},
+		{name: "多于一个参与者", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.Participants = append(input.Participants, input.Participants[0])
+		}},
+		{name: "参与者不是面试官", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.Participants[0].ParticipantRole = practice.ParticipantRole("OBSERVER")
+		}},
+		{name: "主体命名空间为空", mutate: func(input *practice.PracticeSessionSnapshotInput) { input.Participants[0].SubjectRef.Namespace = "" }},
+		{name: "主体标识为空", mutate: func(input *practice.PracticeSessionSnapshotInput) { input.Participants[0].SubjectRef.SubjectID = "" }},
+		{name: "面试官缺少角色", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.Participants[0].RoleDefinitionID = ""
+			input.Participants[0].RoleSnapshot = practice.RoleSnapshot{}
+		}},
+		{name: "面试官角色不一致", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.Participants[0].RoleSnapshot.RoleDefinitionID = "other"
+		}},
+		{name: "角色来自其他场景", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.Participants[0].RoleSnapshot.ScenarioDefinitionID = "other"
+		}},
+		{name: "选项来自其他场景", mutate: func(input *practice.PracticeSessionSnapshotInput) {
+			input.PracticeOption.ScenarioDefinitionID = "other"
+		}},
+		{name: "选项属于其他角色", mutate: func(input *practice.PracticeSessionSnapshotInput) { input.PracticeOption.RoleDefinitionID = "other" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := valid
+			input.Participants = append([]practice.PracticeParticipantInput(nil), valid.Participants...)
+			tt.mutate(&input)
+			_, err := practice.NewPracticeSessionSnapshot(input)
+			if !errors.Is(err, practice.ErrPracticeSessionSnapshotInvalid) {
+				t.Fatalf("NewPracticeSessionSnapshot() error = %v, want %v", err, practice.ErrPracticeSessionSnapshotInvalid)
+			}
+		})
+	}
+}
+
+func TestPracticeSessionSnapshotKeepsOneInterviewer(t *testing.T) {
+	input := validInterviewSnapshotInput(t)
+	snapshot, err := practice.NewPracticeSessionSnapshot(input)
+	if err != nil {
+		t.Fatalf("NewPracticeSessionSnapshot() error = %v", err)
+	}
+
+	participants := snapshot.Participants()
+	if len(participants) != 1 {
+		t.Fatalf("Participants() count = %d, want 1", len(participants))
+	}
+	if got := participants[0].ParticipantRole; got != practice.ParticipantRoleInterviewer {
+		t.Fatalf("interviewer role = %q", got)
+	}
+}
+
+func TestNewPracticeSessionSnapshotRejectsInvalidPolicy(t *testing.T) {
+	_, err := practice.NewPracticeSessionSnapshot(practice.PracticeSessionSnapshotInput{
+		ID: "snapshot-1", SessionID: "session-1", PlanRevision: 1, ScenarioType: practice.ScenarioTypeInterview,
+		ScenarioDefinition: practice.ScenarioDefinitionSnapshot{ScenarioDefinitionID: "scenario-1", ScenarioType: practice.ScenarioTypeInterview, Version: 1},
+		ScenarioConfig:     practice.ScenarioConfigSnapshot{ScenarioConfigID: "config-1", ScenarioDefinitionID: "scenario-1", Version: 1},
+		Preparation:        practice.PreparationSnapshot{PreparationSnapshotID: "preparation-1", SourceProfileID: "profile-1", SourceVersion: 1, CreatedAt: time.Now()},
+		Participants:       []practice.PracticeParticipantInput{{ID: "participant-1", SessionID: "session-1", ParticipantRole: practice.ParticipantRoleInterviewer, SubjectRef: practice.SubjectRef{Namespace: "preparation", SubjectID: "interviewer-1"}, RoleDefinitionID: "role-1", RoleSnapshot: practice.RoleSnapshot{RoleDefinitionID: "role-1", ScenarioDefinitionID: "scenario-1", Version: 1}, ParticipantOrder: 1}},
+		PracticeOption:     practice.PracticeOptionSnapshot{PracticeOptionID: "option-1", Version: 1},
+		SessionPolicy:      practice.PracticeSessionPolicy{}, CreatedAt: time.Now(),
+	})
+	if !errors.Is(err, practice.ErrPracticeSessionSnapshotInvalid) {
+		t.Fatalf("NewPracticeSessionSnapshot() error = %v, want %v", err, practice.ErrPracticeSessionSnapshotInvalid)
+	}
+}
+
+func validInterviewSnapshotInput(t *testing.T) practice.PracticeSessionSnapshotInput {
+	t.Helper()
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+	return practice.PracticeSessionSnapshotInput{
+		ID: "snapshot-1", SessionID: "session-1", PlanRevision: 1, ScenarioType: practice.ScenarioTypeInterview,
+		ScenarioDefinition: practice.ScenarioDefinitionSnapshot{ScenarioDefinitionID: "scenario-1", ScenarioType: practice.ScenarioTypeInterview, Version: 1},
+		ScenarioConfig:     practice.ScenarioConfigSnapshot{ScenarioConfigID: "config-1", ScenarioDefinitionID: "scenario-1", Version: 1},
+		Preparation:        practice.PreparationSnapshot{PreparationSnapshotID: "preparation-1", SourceProfileID: "profile-1", SourceVersion: 1, CreatedAt: time.Now()},
+		Participants:       []practice.PracticeParticipantInput{{ID: "participant-1", SessionID: "session-1", ParticipantRole: practice.ParticipantRoleInterviewer, SubjectRef: practice.SubjectRef{Namespace: "preparation", SubjectID: "interviewer-1"}, RoleDefinitionID: "role-1", RoleSnapshot: practice.RoleSnapshot{RoleDefinitionID: "role-1", ScenarioDefinitionID: "scenario-1", Version: 1}, ParticipantOrder: 1}},
+		PracticeOption:     practice.PracticeOptionSnapshot{PracticeOptionID: "option-1", ScenarioDefinitionID: "scenario-1", RoleDefinitionID: "role-1", Version: 1},
+		SessionPolicy:      policy, CreatedAt: time.Now(),
+	}
+}
+
+func readyPlan(t *testing.T) *practice.PracticePlan {
+	t.Helper()
+	plan, err := practice.NewPracticePlan("plan-1", "user-1", "scenario-1", practice.ScenarioTypeInterview, "config-1", "profile-1", []string{"role-1"})
+	if err != nil {
+		t.Fatalf("NewPracticePlan() error = %v", err)
+	}
+	if err := plan.MarkReady(); err != nil {
+		t.Fatalf("MarkReady() error = %v", err)
+	}
+	return plan
+}

--- a/server/internal/practice/module.go
+++ b/server/internal/practice/module.go
@@ -1,8 +1,50 @@
-// Package practice owns practice plans, sessions, and policy snapshots.
+// Package practice 管理练习计划、场次和推进策略
 package practice
 
-type Module struct{}
+import (
+	"errors"
+	"fmt"
+)
 
+var ErrPracticeModuleDependencyMissing = errors.New("practice_module_dependency_missing")
+
+// 只接收 Practice 的出站依赖，避免组装层泄漏其他模块实现
+type Dependencies struct {
+	PreparationReader  PreparationReader
+	Repository         Repository
+	TransactionManager TransactionManager
+	IDGenerator        IDGenerator
+	Clock              Clock
+}
+
+// 同时支持模块发现和显式依赖组装
+type Module struct {
+	service *Service
+}
+
+// 仅用于模块发现；需要调用应用服务时应使用 NewWithDependencies
 func New() Module { return Module{} }
 
+// 依赖缺失时拒绝构造，避免把不完整模块带到运行期
+func NewWithDependencies(dependencies Dependencies) (Module, error) {
+	checks := []struct {
+		name    string
+		missing bool
+	}{
+		{name: "PreparationReader", missing: dependencies.PreparationReader == nil},
+		{name: "Repository", missing: dependencies.Repository == nil},
+		{name: "TransactionManager", missing: dependencies.TransactionManager == nil},
+		{name: "IDGenerator", missing: dependencies.IDGenerator == nil},
+		{name: "Clock", missing: dependencies.Clock == nil},
+	}
+	for _, check := range checks {
+		if check.missing {
+			return Module{}, fmt.Errorf("%w: %s", ErrPracticeModuleDependencyMissing, check.name)
+		}
+	}
+	return Module{service: newService(dependencies)}, nil
+}
+
 func (Module) Name() string { return "practice" }
+
+func (m Module) Service() *Service { return m.service }

--- a/server/internal/practice/module_test.go
+++ b/server/internal/practice/module_test.go
@@ -1,0 +1,66 @@
+package practice
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNewKeepsCompatibilityWithoutService(t *testing.T) {
+	module := New()
+	if got := module.Name(); got != "practice" {
+		t.Fatalf("Name() = %q, want practice", got)
+	}
+	if module.Service() != nil {
+		t.Fatal("Service() is available without dependencies")
+	}
+}
+
+func TestNewWithDependenciesBuildsService(t *testing.T) {
+	repository := newFakeRepository()
+	module, err := NewWithDependencies(Dependencies{
+		PreparationReader:  &fakePreparationReader{},
+		Repository:         repository,
+		TransactionManager: fakeTransactions{repo: repository},
+		IDGenerator:        &fakeIDs{},
+		Clock:              fakeClock{},
+	})
+	if err != nil {
+		t.Fatalf("NewWithDependencies() error = %v", err)
+	}
+	if module.Name() != "practice" || module.Service() == nil {
+		t.Fatalf("module = %#v", module)
+	}
+}
+
+func TestNewWithDependenciesRejectsMissingDependency(t *testing.T) {
+	repository := newFakeRepository()
+	base := Dependencies{
+		PreparationReader:  &fakePreparationReader{},
+		Repository:         repository,
+		TransactionManager: fakeTransactions{repo: repository},
+		IDGenerator:        &fakeIDs{},
+		Clock:              fakeClock{},
+	}
+	tests := []struct {
+		name    string
+		missing string
+		change  func(*Dependencies)
+	}{
+		{name: "preparation reader", missing: "PreparationReader", change: func(d *Dependencies) { d.PreparationReader = nil }},
+		{name: "repository", missing: "Repository", change: func(d *Dependencies) { d.Repository = nil }},
+		{name: "transaction manager", missing: "TransactionManager", change: func(d *Dependencies) { d.TransactionManager = nil }},
+		{name: "id generator", missing: "IDGenerator", change: func(d *Dependencies) { d.IDGenerator = nil }},
+		{name: "clock", missing: "Clock", change: func(d *Dependencies) { d.Clock = nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dependencies := base
+			tt.change(&dependencies)
+			_, err := NewWithDependencies(dependencies)
+			if !errors.Is(err, ErrPracticeModuleDependencyMissing) || !strings.Contains(err.Error(), tt.missing) {
+				t.Fatalf("NewWithDependencies() error = %v", err)
+			}
+		})
+	}
+}

--- a/server/internal/practice/policy.go
+++ b/server/internal/practice/policy.go
@@ -1,0 +1,188 @@
+package practice
+
+import "errors"
+
+// 决定场次的回合预算和覆盖检查时机
+type PracticeMode string
+
+const (
+	PracticeModeFullSimulation  PracticeMode = "full_simulation"
+	PracticeModeFocusedPractice PracticeMode = "focused_practice"
+)
+
+// 覆盖程度由对话分析按单个训练目标给出
+type CoverageLevel string
+
+const (
+	CoverageCovered   CoverageLevel = "covered"
+	CoveragePartial   CoverageLevel = "partial"
+	CoverageUncovered CoverageLevel = "uncovered"
+)
+
+// 固化创建场次时采用的提前结束条件
+type EarlyCompletionRule string
+
+const (
+	EarlyCompletionObjectivesCovered EarlyCompletionRule = "objectives_covered"
+)
+
+// 下一轮对话只接受 Practice 输出的这组动作
+type NextAction string
+
+const (
+	NextActionFollowUpCurrent     NextAction = "FOLLOW_UP_CURRENT"
+	NextActionMoveToNextObjective NextAction = "MOVE_TO_NEXT_OBJECTIVE"
+	NextActionCompleteSession     NextAction = "COMPLETE_SESSION"
+)
+
+var (
+	ErrPracticeSessionPolicyInvalid = errors.New("practice_session_policy_invalid")
+	ErrTurnOutcomeInvalid           = errors.New("turn_outcome_invalid")
+)
+
+// 策略在场次创建时冻结，EvaluatePolicy 不读取外部状态
+type PracticeSessionPolicy struct {
+	mode                     PracticeMode
+	suggestedDurationSeconds int
+	minEffectiveTurns        int
+	maxEffectiveTurns        int
+	coverageCheckpointTurn   int
+	maxFollowUpsPerQuestion  int
+	targetObjectiveIDs       []string
+	earlyCompletionRule      EarlyCompletionRule
+}
+
+// 不同练习模式使用固定回合预算，未知模式或空目标会被拒绝
+func NewPracticeSessionPolicy(mode PracticeMode, targetObjectiveIDs []string) (PracticeSessionPolicy, error) {
+	if !hasNonEmptyValues(targetObjectiveIDs) {
+		return PracticeSessionPolicy{}, ErrPracticeSessionPolicyInvalid
+	}
+
+	policy := PracticeSessionPolicy{
+		mode:                    mode,
+		maxFollowUpsPerQuestion: 1,
+		targetObjectiveIDs:      cloneStrings(targetObjectiveIDs),
+		earlyCompletionRule:     EarlyCompletionObjectivesCovered,
+	}
+	switch mode {
+	case PracticeModeFullSimulation:
+		policy.suggestedDurationSeconds = 600
+		policy.minEffectiveTurns = 4
+		policy.maxEffectiveTurns = 6
+		policy.coverageCheckpointTurn = 4
+	case PracticeModeFocusedPractice:
+		policy.suggestedDurationSeconds = 300
+		policy.minEffectiveTurns = 2
+		policy.maxEffectiveTurns = 3
+		policy.coverageCheckpointTurn = 2
+	default:
+		return PracticeSessionPolicy{}, ErrPracticeSessionPolicyInvalid
+	}
+	return policy, nil
+}
+
+func (p PracticeSessionPolicy) Mode() PracticeMode { return p.mode }
+
+func (p PracticeSessionPolicy) SuggestedDurationSeconds() int { return p.suggestedDurationSeconds }
+
+func (p PracticeSessionPolicy) MinEffectiveTurns() int { return p.minEffectiveTurns }
+
+func (p PracticeSessionPolicy) MaxEffectiveTurns() int { return p.maxEffectiveTurns }
+
+func (p PracticeSessionPolicy) CoverageCheckpointTurn() int { return p.coverageCheckpointTurn }
+
+func (p PracticeSessionPolicy) MaxFollowUpsPerQuestion() int { return p.maxFollowUpsPerQuestion }
+
+// 返回副本，避免调用方修改已冻结的推进策略
+func (p PracticeSessionPolicy) TargetObjectiveIDs() []string {
+	return cloneStrings(p.targetObjectiveIDs)
+}
+
+func (p PracticeSessionPolicy) EarlyCompletionRule() EarlyCompletionRule {
+	return p.earlyCompletionRule
+}
+
+type ObjectiveCoverage struct {
+	ObjectiveID string
+	Level       CoverageLevel
+}
+
+// 只接受已通过对话模块有效性判断的回合结果
+type TurnOutcome struct {
+	TurnID                        string
+	SessionID                     string
+	AnswerValid                   bool
+	ObjectiveCoverage             []ObjectiveCoverage
+	FollowUpGap                   bool
+	FollowUpCount                 int
+	CompletedPrimaryQuestionCount int
+}
+
+type ProgressInput struct {
+	EffectiveTurnCount   int
+	RemainingTimeSeconds int
+	Outcome              TurnOutcome
+}
+
+// 纯计算，相同策略和进度始终得到相同动作
+func EvaluatePolicy(policy PracticeSessionPolicy, progress ProgressInput) (NextAction, error) {
+	if !policy.valid() {
+		return "", ErrPracticeSessionPolicyInvalid
+	}
+	if !progress.valid() {
+		return "", ErrTurnOutcomeInvalid
+	}
+	if progress.EffectiveTurnCount >= policy.maxEffectiveTurns {
+		return NextActionCompleteSession, nil
+	}
+	if progress.EffectiveTurnCount >= policy.coverageCheckpointTurn && progress.RemainingTimeSeconds <= 0 {
+		return NextActionCompleteSession, nil
+	}
+	if progress.Outcome.FollowUpGap && progress.Outcome.FollowUpCount < policy.maxFollowUpsPerQuestion {
+		return NextActionFollowUpCurrent, nil
+	}
+	if progress.EffectiveTurnCount >= policy.coverageCheckpointTurn && allObjectivesCovered(policy.targetObjectiveIDs, progress.Outcome.ObjectiveCoverage) {
+		return NextActionCompleteSession, nil
+	}
+	return NextActionMoveToNextObjective, nil
+}
+
+func (p PracticeSessionPolicy) valid() bool {
+	return (p.mode == PracticeModeFullSimulation || p.mode == PracticeModeFocusedPractice) &&
+		p.suggestedDurationSeconds > 0 && p.minEffectiveTurns > 0 && p.maxEffectiveTurns >= p.minEffectiveTurns &&
+		p.coverageCheckpointTurn >= p.minEffectiveTurns && p.coverageCheckpointTurn <= p.maxEffectiveTurns &&
+		p.maxFollowUpsPerQuestion >= 0 && hasNonEmptyValues(p.targetObjectiveIDs) &&
+		p.earlyCompletionRule == EarlyCompletionObjectivesCovered
+}
+
+func (p ProgressInput) valid() bool {
+	return p.EffectiveTurnCount > 0 && p.Outcome.TurnID != "" && p.Outcome.SessionID != "" &&
+		p.Outcome.AnswerValid && p.Outcome.FollowUpCount >= 0 && p.Outcome.CompletedPrimaryQuestionCount >= 0
+}
+
+func allObjectivesCovered(targetIDs []string, coverage []ObjectiveCoverage) bool {
+	covered := make(map[string]bool, len(coverage))
+	for _, item := range coverage {
+		if item.ObjectiveID != "" && item.Level == CoverageCovered {
+			covered[item.ObjectiveID] = true
+		}
+	}
+	for _, targetID := range targetIDs {
+		if !covered[targetID] {
+			return false
+		}
+	}
+	return true
+}
+
+func hasNonEmptyValues(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if value == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/practice/policy_test.go
+++ b/server/internal/practice/policy_test.go
@@ -1,0 +1,186 @@
+package practice_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+)
+
+func TestEvaluatePolicyProgression(t *testing.T) {
+	tests := []struct {
+		name           string
+		mode           practice.PracticeMode
+		effectiveTurns int
+		coverage       practice.CoverageLevel
+		followUpGap    bool
+		followUpCount  int
+		remainingTime  int
+		want           practice.NextAction
+	}{
+		{name: "full completes at checkpoint when covered", mode: practice.PracticeModeFullSimulation, effectiveTurns: 4, coverage: practice.CoverageCovered, remainingTime: 1, want: practice.NextActionCompleteSession},
+		{name: "full continues at checkpoint when uncovered", mode: practice.PracticeModeFullSimulation, effectiveTurns: 4, remainingTime: 1, want: practice.NextActionMoveToNextObjective},
+		{name: "full continues at checkpoint when partial", mode: practice.PracticeModeFullSimulation, effectiveTurns: 4, coverage: practice.CoveragePartial, remainingTime: 1, want: practice.NextActionMoveToNextObjective},
+		{name: "full completes at hard limit", mode: practice.PracticeModeFullSimulation, effectiveTurns: 6, followUpGap: true, want: practice.NextActionCompleteSession},
+		{name: "focused completes at checkpoint when covered", mode: practice.PracticeModeFocusedPractice, effectiveTurns: 2, coverage: practice.CoverageCovered, remainingTime: 1, want: practice.NextActionCompleteSession},
+		{name: "focused continues at checkpoint when uncovered", mode: practice.PracticeModeFocusedPractice, effectiveTurns: 2, remainingTime: 1, want: practice.NextActionMoveToNextObjective},
+		{name: "focused completes at hard limit", mode: practice.PracticeModeFocusedPractice, effectiveTurns: 3, followUpGap: true, want: practice.NextActionCompleteSession},
+		{name: "follows up below limit", mode: practice.PracticeModeFullSimulation, effectiveTurns: 2, followUpGap: true, followUpCount: 0, want: practice.NextActionFollowUpCurrent},
+		{name: "moves on at follow up limit", mode: practice.PracticeModeFullSimulation, effectiveTurns: 2, followUpGap: true, followUpCount: 1, want: practice.NextActionMoveToNextObjective},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := practice.NewPracticeSessionPolicy(tt.mode, []string{"objective-1"})
+			if err != nil {
+				t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+			}
+			got, err := practice.EvaluatePolicy(policy, practice.ProgressInput{
+				EffectiveTurnCount: tt.effectiveTurns, RemainingTimeSeconds: tt.remainingTime,
+				Outcome: practice.TurnOutcome{
+					TurnID:            "turn-1",
+					SessionID:         "session-1",
+					AnswerValid:       true,
+					FollowUpGap:       tt.followUpGap,
+					FollowUpCount:     tt.followUpCount,
+					ObjectiveCoverage: []practice.ObjectiveCoverage{{ObjectiveID: "objective-1", Level: tt.coverage}},
+				},
+			})
+			if err != nil {
+				t.Fatalf("EvaluatePolicy() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("EvaluatePolicy() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluatePolicyRequiresAllTargetObjectives(t *testing.T) {
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1", "objective-2"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+	tests := []struct {
+		name     string
+		coverage []practice.ObjectiveCoverage
+		want     practice.NextAction
+	}{
+		{name: "部分目标已覆盖", coverage: []practice.ObjectiveCoverage{{ObjectiveID: "objective-1", Level: practice.CoverageCovered}, {ObjectiveID: "objective-2", Level: practice.CoveragePartial}}, want: practice.NextActionMoveToNextObjective},
+		{name: "全部目标已覆盖", coverage: []practice.ObjectiveCoverage{{ObjectiveID: "objective-1", Level: practice.CoverageCovered}, {ObjectiveID: "objective-2", Level: practice.CoverageCovered}}, want: practice.NextActionCompleteSession},
+		{name: "无关目标不计入", coverage: []practice.ObjectiveCoverage{{ObjectiveID: "objective-other", Level: practice.CoverageCovered}}, want: practice.NextActionMoveToNextObjective},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := practice.EvaluatePolicy(policy, practice.ProgressInput{EffectiveTurnCount: 4, RemainingTimeSeconds: 1, Outcome: practice.TurnOutcome{TurnID: "turn-1", SessionID: "session-1", AnswerValid: true, ObjectiveCoverage: tt.coverage}})
+			if err != nil || got != tt.want {
+				t.Fatalf("EvaluatePolicy() = %q, %v, want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluatePolicyCompletesAtCheckpointWhenTimeBudgetIsExhausted(t *testing.T) {
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+	outcome := practice.TurnOutcome{TurnID: "turn-1", SessionID: "session-1", AnswerValid: true}
+	for _, tt := range []struct {
+		name             string
+		turns, remaining int
+		want             practice.NextAction
+	}{
+		{name: "检查点前不结束", turns: 3, remaining: 0, want: practice.NextActionMoveToNextObjective},
+		{name: "检查点时间刚好耗尽", turns: 4, remaining: 0, want: practice.NextActionCompleteSession},
+		{name: "检查点时间已超出", turns: 4, remaining: -1, want: practice.NextActionCompleteSession},
+		{name: "检查点仍有时间", turns: 4, remaining: 1, want: practice.NextActionMoveToNextObjective},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := practice.EvaluatePolicy(policy, practice.ProgressInput{EffectiveTurnCount: tt.turns, RemainingTimeSeconds: tt.remaining, Outcome: outcome})
+			if err != nil || got != tt.want {
+				t.Fatalf("EvaluatePolicy() = %q, %v, want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluatePolicyRejectsInvalidOutcome(t *testing.T) {
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+
+	tests := []practice.TurnOutcome{
+		{SessionID: "session-1", AnswerValid: true},
+		{TurnID: "turn-1", AnswerValid: true},
+		{TurnID: "turn-1", SessionID: "session-1", AnswerValid: false},
+		{TurnID: "turn-1", SessionID: "session-1", AnswerValid: true, CompletedPrimaryQuestionCount: -1},
+	}
+	for _, outcome := range tests {
+		_, err := practice.EvaluatePolicy(policy, practice.ProgressInput{EffectiveTurnCount: 1, Outcome: outcome})
+		if !errors.Is(err, practice.ErrTurnOutcomeInvalid) {
+			t.Fatalf("EvaluatePolicy() error = %v, want %v", err, practice.ErrTurnOutcomeInvalid)
+		}
+	}
+}
+
+func TestEvaluatePolicyIsDeterministic(t *testing.T) {
+	policy, err := practice.NewPracticeSessionPolicy(practice.PracticeModeFullSimulation, []string{"objective-1"})
+	if err != nil {
+		t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+	}
+	input := practice.ProgressInput{
+		EffectiveTurnCount: 3,
+		Outcome: practice.TurnOutcome{
+			TurnID:            "turn-1",
+			SessionID:         "session-1",
+			AnswerValid:       true,
+			ObjectiveCoverage: []practice.ObjectiveCoverage{{ObjectiveID: "objective-1", Level: practice.CoverageUncovered}},
+		},
+	}
+
+	first, firstErr := practice.EvaluatePolicy(policy, input)
+	second, secondErr := practice.EvaluatePolicy(policy, input)
+	if firstErr != nil || secondErr != nil {
+		t.Fatalf("EvaluatePolicy() errors = %v, %v", firstErr, secondErr)
+	}
+	if first != second {
+		t.Fatalf("EvaluatePolicy() results = %q, %q", first, second)
+	}
+}
+
+func TestPracticeSessionPolicyFields(t *testing.T) {
+	tests := []struct {
+		name                    string
+		mode                    practice.PracticeMode
+		wantDurationSeconds     int
+		wantMinTurns            int
+		wantMaxTurns            int
+		wantCoverageCheckpoint  int
+		wantEarlyCompletionRule practice.EarlyCompletionRule
+	}{
+		{name: "full simulation", mode: practice.PracticeModeFullSimulation, wantDurationSeconds: 600, wantMinTurns: 4, wantMaxTurns: 6, wantCoverageCheckpoint: 4, wantEarlyCompletionRule: practice.EarlyCompletionObjectivesCovered},
+		{name: "focused practice", mode: practice.PracticeModeFocusedPractice, wantDurationSeconds: 300, wantMinTurns: 2, wantMaxTurns: 3, wantCoverageCheckpoint: 2, wantEarlyCompletionRule: practice.EarlyCompletionObjectivesCovered},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objectives := []string{"objective-1"}
+			policy, err := practice.NewPracticeSessionPolicy(tt.mode, objectives)
+			if err != nil {
+				t.Fatalf("NewPracticeSessionPolicy() error = %v", err)
+			}
+			objectives[0] = "changed"
+			gotObjectives := policy.TargetObjectiveIDs()
+			gotObjectives[0] = "changed-again"
+
+			if policy.SuggestedDurationSeconds() != tt.wantDurationSeconds || policy.MinEffectiveTurns() != tt.wantMinTurns || policy.MaxEffectiveTurns() != tt.wantMaxTurns || policy.CoverageCheckpointTurn() != tt.wantCoverageCheckpoint || policy.EarlyCompletionRule() != tt.wantEarlyCompletionRule {
+				t.Fatalf("policy fields do not match mode %q", tt.mode)
+			}
+			if got := policy.TargetObjectiveIDs()[0]; got != "objective-1" {
+				t.Fatalf("TargetObjectiveIDs()[0] = %q, want objective-1", got)
+			}
+		})
+	}
+}

--- a/server/internal/practice/ports.go
+++ b/server/internal/practice/ports.go
@@ -1,0 +1,63 @@
+package practice
+
+import (
+	"context"
+	"time"
+)
+
+// 创建场次时从 Preparation 一次性读取全部准备数据
+type SessionPreparation struct {
+	ScenarioDefinition ScenarioDefinitionSnapshot
+	ScenarioConfig     ScenarioConfigSnapshot
+	Preparation        PreparationSnapshot
+	Role               RoleSnapshot
+	InterviewerSubject SubjectRef
+	PracticeOption     PracticeOptionSnapshot
+	PracticeFocuses    []string
+	Mode               PracticeMode
+	TargetObjectiveIDs []string
+}
+
+// Practice 仅通过此端口读取其他模块的数据
+type PreparationReader interface {
+	ValidatePlan(context.Context, CreatePracticePlanCommand) error
+	PrepareSession(context.Context, *PracticePlan, string, string) (SessionPreparation, error)
+}
+
+// 创建和锁定方法承担并发约束，Service 不在进程内重复加锁
+type Repository interface {
+	// 在调用外部依赖前读取首次创建结果，保证重放不受后续状态变化影响
+	FindPlanCreation(context.Context, string) (*PracticePlan, CreatePracticePlanCommand, bool, error)
+	// 原子创建计划；键已存在时返回首次创建的计划
+	CreatePlan(context.Context, string, CreatePracticePlanCommand, *PracticePlan) (*PracticePlan, CreatePracticePlanCommand, bool, error)
+	GetPlan(context.Context, string) (*PracticePlan, error)
+	// 在当前事务内锁定计划，直至事务结束
+	LockPlanForUpdate(context.Context, string) (*PracticePlan, error)
+	SavePlan(context.Context, *PracticePlan) error
+	HasActiveSession(context.Context, string) (bool, error)
+	HasSessions(context.Context, string) (bool, error)
+	// 原子删除从未产生场次的计划
+	DeletePlan(context.Context, string) error
+	// 在准备场次前读取首次创建结果
+	FindSessionCreation(context.Context, string) (*PracticeSession, PracticeSessionSnapshot, bool, error)
+	// 原子创建场次和快照；键已存在时返回首次创建的场次和快照
+	CreateActiveSession(context.Context, string, string, *PracticeSession, PracticeSessionSnapshot) (*PracticeSession, PracticeSessionSnapshot, bool, error)
+	GetSession(context.Context, string) (*PracticeSession, error)
+	// 在当前事务内锁定场次，直至事务结束
+	LockSessionForUpdate(context.Context, string) (*PracticeSession, error)
+	// 保存场次并在进入终态时释放计划的活动占位
+	SaveSession(context.Context, *PracticeSession) error
+	GetSnapshot(context.Context, string) (PracticeSessionSnapshot, error)
+	FindTurnAction(context.Context, string, string) (NextAction, bool, error)
+	EffectiveTurnCount(context.Context, string) (int, error)
+	SaveTurnProgress(context.Context, string, string, int, NextAction) error
+}
+
+// 保证回调中的读取、状态迁移和保存原子提交
+type TransactionManager interface {
+	WithinTransaction(context.Context, func(context.Context) error) error
+}
+
+type IDGenerator interface{ NewID() string }
+
+type Clock interface{ Now() time.Time }

--- a/server/internal/practice/service.go
+++ b/server/internal/practice/service.go
@@ -1,0 +1,448 @@
+package practice
+
+import (
+	"context"
+	"slices"
+)
+
+type CreatePracticePlanCommand struct {
+	UserID, ScenarioDefinitionID, ScenarioConfigID, PreparationProfileID string
+	ScenarioType                                                         ScenarioType
+	SelectedRoleIDs                                                      []string
+	IdempotencyKey                                                       string
+}
+
+type CreatePracticeSessionCommand struct {
+	UserID, PracticePlanID, ParticipantRoleID, PracticeOptionID, IdempotencyKey string
+	PlanRevision                                                                int
+}
+
+type UpdatePracticePlanCommand struct {
+	UserID, PracticePlanID, ScenarioConfigID, PreparationProfileID string
+	SelectedRoleIDs                                                []string
+	ExpectedRevision                                               int
+}
+
+type ApplyTurnOutcomeCommand struct {
+	UserID  string
+	Outcome TurnOutcome
+}
+
+// 在事务边界内编排领域对象和出站端口，不持有请求级状态
+type Service struct {
+	preparation  PreparationReader
+	repository   Repository
+	transactions TransactionManager
+	ids          IDGenerator
+	clock        Clock
+}
+
+func newService(dependencies Dependencies) *Service {
+	return &Service{
+		preparation:  dependencies.PreparationReader,
+		repository:   dependencies.Repository,
+		transactions: dependencies.TransactionManager,
+		ids:          dependencies.IDGenerator,
+		clock:        dependencies.Clock,
+	}
+}
+
+// 相同用户和幂等键会返回首次创建的计划；参数变化则返回幂等冲突
+func (s *Service) CreatePracticePlan(ctx context.Context, command CreatePracticePlanCommand) (*PracticePlan, error) {
+	if command.UserID == "" || command.IdempotencyKey == "" {
+		return nil, ErrPracticeCommandInvalid
+	}
+	var result *PracticePlan
+	err := s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		if command.ScenarioType == "" {
+			command.ScenarioType = ScenarioTypeInterview
+		}
+		key := command.UserID + ":" + command.IdempotencyKey
+		stored, original, found, err := s.repository.FindPlanCreation(ctx, key)
+		if err != nil {
+			return err
+		}
+		if found {
+			if !sameCreatePlanCommand(original, command) {
+				return ErrPracticeIdempotencyConflict
+			}
+			result = stored
+			return nil
+		}
+		if err := s.preparation.ValidatePlan(ctx, command); err != nil {
+			return err
+		}
+		plan, err := NewPracticePlan(s.ids.NewID(), command.UserID, command.ScenarioDefinitionID, command.ScenarioType, command.ScenarioConfigID, command.PreparationProfileID, command.SelectedRoleIDs)
+		if err != nil {
+			return err
+		}
+		if err := plan.MarkReady(); err != nil {
+			return err
+		}
+		stored, original, created, err := s.repository.CreatePlan(ctx, key, command, plan)
+		if err != nil {
+			return err
+		}
+		if !created && !sameCreatePlanCommand(original, command) {
+			return ErrPracticeIdempotencyConflict
+		}
+		result = stored
+		return nil
+	})
+	return result, err
+}
+
+// 只重试配置失败的计划，验证通过后恢复为可用状态
+func (s *Service) RetryPlanConfiguration(ctx context.Context, userID, planID string, expectedRevision int) (*PracticePlan, error) {
+	return s.changePlan(ctx, userID, planID, expectedRevision, func(ctx context.Context, plan *PracticePlan, _ bool) error {
+		if plan.Status() != PracticePlanConfigurationFailed {
+			return ErrPracticePlanTransitionNotAllowed
+		}
+		if err := s.preparation.ValidatePlan(ctx, createCommandFromPlan(plan)); err != nil {
+			return err
+		}
+		return plan.MarkReady()
+	})
+}
+
+// 更新前同时校验预期修订号和活动场次，成功后修订号递增
+func (s *Service) UpdatePracticePlan(ctx context.Context, command UpdatePracticePlanCommand) (*PracticePlan, error) {
+	return s.changePlan(ctx, command.UserID, command.PracticePlanID, command.ExpectedRevision, func(ctx context.Context, plan *PracticePlan, hasActiveSession bool) error {
+		validation := createCommandFromPlan(plan)
+		validation.ScenarioConfigID = command.ScenarioConfigID
+		validation.PreparationProfileID = command.PreparationProfileID
+		validation.SelectedRoleIDs = command.SelectedRoleIDs
+		if err := s.preparation.ValidatePlan(ctx, validation); err != nil {
+			return err
+		}
+		return plan.Update(command.ScenarioConfigID, command.PreparationProfileID, command.SelectedRoleIDs, hasActiveSession)
+	})
+}
+
+// 归档操作幂等，但存在活动场次时仍会被拒绝
+func (s *Service) ArchivePracticePlan(ctx context.Context, userID, planID string, expectedRevision int) (*PracticePlan, error) {
+	return s.changePlan(ctx, userID, planID, expectedRevision, func(_ context.Context, plan *PracticePlan, hasActiveSession bool) error {
+		if plan.Status() == PracticePlanArchived {
+			return nil
+		}
+		return plan.Archive(hasActiveSession)
+	})
+}
+
+// 已恢复的计划重复调用不会再次改变状态
+func (s *Service) RestorePracticePlan(ctx context.Context, userID, planID string, expectedRevision int) (*PracticePlan, error) {
+	return s.changePlan(ctx, userID, planID, expectedRevision, func(_ context.Context, plan *PracticePlan, _ bool) error {
+		if plan.Status() == PracticePlanReady {
+			return nil
+		}
+		return plan.Restore()
+	})
+}
+
+// 只删除从未产生过场次的计划，历史场次存在时必须保留计划
+func (s *Service) DeleteEmptyPracticePlan(ctx context.Context, userID, planID string, expectedRevision int) error {
+	return s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		plan, err := s.repository.LockPlanForUpdate(ctx, planID)
+		if err != nil {
+			return err
+		}
+		if err := validatePlanAccess(plan, userID, expectedRevision); err != nil {
+			return err
+		}
+		hasSessions, err := s.repository.HasSessions(ctx, planID)
+		if err != nil {
+			return err
+		}
+		if hasSessions {
+			return ErrPracticePlanHasSessions
+		}
+		return s.repository.DeletePlan(ctx, planID)
+	})
+}
+
+// 场次与输入快照在同一事务中创建；同一计划只能保留一个活动场次
+func (s *Service) CreatePracticeSession(ctx context.Context, command CreatePracticeSessionCommand) (*PracticeSession, error) {
+	if command.UserID == "" || command.IdempotencyKey == "" {
+		return nil, ErrPracticeCommandInvalid
+	}
+	var result *PracticeSession
+	err := s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		key := command.UserID + ":" + command.IdempotencyKey
+		stored, storedSnapshot, found, err := s.repository.FindSessionCreation(ctx, key)
+		if err != nil {
+			return err
+		}
+		if found {
+			if !sameSessionCommand(stored, storedSnapshot, command) {
+				return ErrPracticeIdempotencyConflict
+			}
+			result = stored
+			return nil
+		}
+		plan, err := s.repository.GetPlan(ctx, command.PracticePlanID)
+		if err != nil {
+			return err
+		}
+		if plan.UserID() != command.UserID {
+			return ErrPracticeResourceForbidden
+		}
+		if plan.Revision() != command.PlanRevision {
+			return ErrPracticePlanRevisionConflict
+		}
+		if plan.Status() != PracticePlanReady {
+			return ErrPracticePlanTransitionNotAllowed
+		}
+		if !slices.Contains(plan.SelectedRoleIDs(), command.ParticipantRoleID) {
+			return ErrPracticeParticipantInvalid
+		}
+		prepared, err := s.preparation.PrepareSession(ctx, plan, command.ParticipantRoleID, command.PracticeOptionID)
+		if err != nil {
+			return err
+		}
+		if prepared.Role.RoleDefinitionID != command.ParticipantRoleID || prepared.PracticeOption.PracticeOptionID != command.PracticeOptionID {
+			return ErrPracticeSessionSnapshotInvalid
+		}
+		policy, err := NewPracticeSessionPolicy(prepared.Mode, prepared.TargetObjectiveIDs)
+		if err != nil {
+			return err
+		}
+		sessionID, snapshotID := s.ids.NewID(), s.ids.NewID()
+		interviewerParticipantID := s.ids.NewID()
+		now := s.clock.Now()
+		snapshot, err := NewPracticeSessionSnapshot(PracticeSessionSnapshotInput{
+			ID:                 snapshotID,
+			SessionID:          sessionID,
+			PlanRevision:       plan.Revision(),
+			ScenarioType:       plan.ScenarioType(),
+			ScenarioDefinition: prepared.ScenarioDefinition,
+			ScenarioConfig:     prepared.ScenarioConfig,
+			Preparation:        prepared.Preparation,
+			Participants: []PracticeParticipantInput{{
+				ID: interviewerParticipantID, SessionID: sessionID, ParticipantRole: ParticipantRoleInterviewer, SubjectRef: prepared.InterviewerSubject,
+				RoleDefinitionID: prepared.Role.RoleDefinitionID,
+				RoleSnapshot:     prepared.Role, ParticipantOrder: 1,
+			}},
+			PracticeOption:  prepared.PracticeOption,
+			PracticeFocuses: prepared.PracticeFocuses,
+			SessionPolicy:   policy,
+			CreatedAt:       now,
+		})
+		if err != nil {
+			return err
+		}
+		session, err := NewPracticeSession(sessionID, plan.ID(), plan.ScenarioType(), snapshotID, now)
+		if err != nil {
+			return err
+		}
+		stored, storedSnapshot, created, err := s.repository.CreateActiveSession(ctx, key, plan.ID(), session, snapshot)
+		if err != nil {
+			return err
+		}
+		if !created {
+			if !sameSessionCommand(stored, storedSnapshot, command) {
+				return ErrPracticeIdempotencyConflict
+			}
+		}
+		result = stored
+		return nil
+	})
+	return result, err
+}
+
+// 已经开始的场次重复调用不会重置开始时间
+func (s *Service) StartPracticeSession(ctx context.Context, userID, sessionID string) (*PracticeSession, error) {
+	return s.changeSession(ctx, userID, sessionID, func(session *PracticeSession) error {
+		if session.Status() == PracticeSessionInProgress {
+			return nil
+		}
+		return session.Start(s.clock.Now())
+	})
+}
+
+// 已暂停的场次重复调用不会再次写入状态
+func (s *Service) PausePracticeSession(ctx context.Context, userID, sessionID string) (*PracticeSession, error) {
+	return s.changeSession(ctx, userID, sessionID, func(session *PracticeSession) error {
+		if session.Status() == PracticeSessionPaused {
+			return nil
+		}
+		return session.Pause()
+	})
+}
+
+// 已恢复的场次重复调用不会再次写入状态
+func (s *Service) ResumePracticeSession(ctx context.Context, userID, sessionID string) (*PracticeSession, error) {
+	return s.changeSession(ctx, userID, sessionID, func(session *PracticeSession) error {
+		if session.Status() == PracticeSessionInProgress {
+			return nil
+		}
+		return session.Resume()
+	})
+}
+
+// 提前结束操作幂等，首次结束时必须提供原因
+func (s *Service) EndPracticeSessionEarly(ctx context.Context, userID, sessionID, reason string) (*PracticeSession, error) {
+	return s.changeSession(ctx, userID, sessionID, func(session *PracticeSession) error {
+		if session.Status() == PracticeSessionEndedEarly {
+			return nil
+		}
+		return session.EndEarly(s.clock.Now(), reason)
+	})
+}
+
+// 读取前校验场次归属，返回创建场次时冻结的输入
+func (s *Service) GetPracticeSessionSnapshot(ctx context.Context, userID, sessionID string) (PracticeSessionSnapshot, error) {
+	session, err := s.ownedSession(ctx, userID, sessionID)
+	if err != nil {
+		return PracticeSessionSnapshot{}, err
+	}
+	return s.repository.GetSnapshot(ctx, session.SnapshotID())
+}
+
+// turn_id 已处理时返回首次保存的动作，不重复推进回合计数
+func (s *Service) ApplyTurnOutcome(ctx context.Context, command ApplyTurnOutcomeCommand) (NextAction, error) {
+	var result NextAction
+	err := s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		session, err := s.repository.LockSessionForUpdate(ctx, command.Outcome.SessionID)
+		if err != nil {
+			return err
+		}
+		if err := s.ensureSessionOwner(ctx, command.UserID, session); err != nil {
+			return err
+		}
+		if saved, ok, err := s.repository.FindTurnAction(ctx, session.ID(), command.Outcome.TurnID); err != nil {
+			return err
+		} else if ok {
+			result = saved
+			return nil
+		}
+		if session.Status() != PracticeSessionInProgress {
+			return ErrPracticeSessionTransitionNotAllowed
+		}
+		count, err := s.repository.EffectiveTurnCount(ctx, session.ID())
+		if err != nil {
+			return err
+		}
+		snapshot, err := s.repository.GetSnapshot(ctx, session.SnapshotID())
+		if err != nil {
+			return err
+		}
+		startedAt, ok := session.StartedAt()
+		if !ok {
+			return ErrPracticeSessionInvalidTime
+		}
+		now := s.clock.Now()
+		policy := snapshot.SessionPolicy()
+		remainingTimeSeconds := policy.SuggestedDurationSeconds() - int(now.Sub(startedAt).Seconds())
+		result, err = EvaluatePolicy(policy, ProgressInput{EffectiveTurnCount: count + 1, RemainingTimeSeconds: remainingTimeSeconds, Outcome: command.Outcome})
+		if err != nil {
+			return err
+		}
+		if result == NextActionCompleteSession {
+			if err := session.Complete(now); err != nil {
+				return err
+			}
+			if err := s.repository.SaveSession(ctx, session); err != nil {
+				return err
+			}
+		}
+		return s.repository.SaveTurnProgress(ctx, session.ID(), command.Outcome.TurnID, count+1, result)
+	})
+	return result, err
+}
+
+func (s *Service) changeSession(ctx context.Context, userID, id string, change func(*PracticeSession) error) (*PracticeSession, error) {
+	var result *PracticeSession
+	err := s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		session, err := s.repository.LockSessionForUpdate(ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := s.ensureSessionOwner(ctx, userID, session); err != nil {
+			return err
+		}
+		if err := change(session); err != nil {
+			return err
+		}
+		if err := s.repository.SaveSession(ctx, session); err != nil {
+			return err
+		}
+		result = session
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) changePlan(ctx context.Context, userID, planID string, expectedRevision int, change func(context.Context, *PracticePlan, bool) error) (*PracticePlan, error) {
+	var result *PracticePlan
+	err := s.transactions.WithinTransaction(ctx, func(ctx context.Context) error {
+		plan, err := s.repository.LockPlanForUpdate(ctx, planID)
+		if err != nil {
+			return err
+		}
+		if err := validatePlanAccess(plan, userID, expectedRevision); err != nil {
+			return err
+		}
+		hasActiveSession, err := s.repository.HasActiveSession(ctx, planID)
+		if err != nil {
+			return err
+		}
+		if err := change(ctx, plan, hasActiveSession); err != nil {
+			return err
+		}
+		if err := s.repository.SavePlan(ctx, plan); err != nil {
+			return err
+		}
+		result = plan
+		return nil
+	})
+	return result, err
+}
+
+func validatePlanAccess(plan *PracticePlan, userID string, expectedRevision int) error {
+	if userID == "" || expectedRevision < 1 {
+		return ErrPracticeCommandInvalid
+	}
+	if plan.UserID() != userID {
+		return ErrPracticeResourceForbidden
+	}
+	if plan.Revision() != expectedRevision {
+		return ErrPracticePlanRevisionConflict
+	}
+	return nil
+}
+
+func createCommandFromPlan(plan *PracticePlan) CreatePracticePlanCommand {
+	return CreatePracticePlanCommand{UserID: plan.UserID(), ScenarioDefinitionID: plan.ScenarioDefinitionID(), ScenarioType: plan.ScenarioType(), ScenarioConfigID: plan.ScenarioConfigID(), PreparationProfileID: plan.PreparationProfileID(), SelectedRoleIDs: plan.SelectedRoleIDs()}
+}
+func (s *Service) ensureSessionOwner(ctx context.Context, userID string, session *PracticeSession) error {
+	plan, err := s.repository.GetPlan(ctx, session.PlanID())
+	if err != nil {
+		return err
+	}
+	if plan.UserID() != userID {
+		return ErrPracticeResourceForbidden
+	}
+	return nil
+}
+func (s *Service) ownedSession(ctx context.Context, userID, id string) (*PracticeSession, error) {
+	session, err := s.repository.GetSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := s.repository.GetPlan(ctx, session.PlanID())
+	if err != nil {
+		return nil, err
+	}
+	if plan.UserID() != userID {
+		return nil, ErrPracticeResourceForbidden
+	}
+	return session, nil
+}
+func sameCreatePlanCommand(left, right CreatePracticePlanCommand) bool {
+	return left.UserID == right.UserID && left.ScenarioDefinitionID == right.ScenarioDefinitionID && left.ScenarioType == right.ScenarioType && left.ScenarioConfigID == right.ScenarioConfigID && left.PreparationProfileID == right.PreparationProfileID && slices.Equal(left.SelectedRoleIDs, right.SelectedRoleIDs)
+}
+
+func sameSessionCommand(session *PracticeSession, snapshot PracticeSessionSnapshot, command CreatePracticeSessionCommand) bool {
+	roles := snapshot.ParticipantRoleIDs()
+	return session.PlanID() == command.PracticePlanID && snapshot.PlanRevision() == command.PlanRevision && len(roles) == 1 && roles[0] == command.ParticipantRoleID && snapshot.PracticeOptionID() == command.PracticeOptionID
+}

--- a/server/internal/practice/service_test.go
+++ b/server/internal/practice/service_test.go
@@ -1,0 +1,924 @@
+package practice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestServicePracticeFlowAndIdempotency(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+
+	planCommand := CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "create-plan-1"}
+	plan, err := service.CreatePracticePlan(ctx, planCommand)
+	if err != nil {
+		t.Fatalf("CreatePracticePlan() error = %v", err)
+	}
+	replayedPlan, err := service.CreatePracticePlan(ctx, planCommand)
+	if err != nil || replayedPlan.ID() != plan.ID() {
+		t.Fatalf("replayed plan = %v, %v", replayedPlan, err)
+	}
+	changedPlanCommand := planCommand
+	changedPlanCommand.ScenarioConfigID = "config-other"
+	if _, err := service.CreatePracticePlan(ctx, changedPlanCommand); !errors.Is(err, ErrPracticeIdempotencyConflict) {
+		t.Fatalf("changed plan replay error = %v", err)
+	}
+
+	sessionCommand := CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "create-session-1"}
+	session, err := service.CreatePracticeSession(ctx, sessionCommand)
+	if err != nil {
+		t.Fatalf("CreatePracticeSession() error = %v", err)
+	}
+	replayedSession, err := service.CreatePracticeSession(ctx, sessionCommand)
+	if err != nil || replayedSession.ID() != session.ID() {
+		t.Fatalf("replayed session = %v, %v", replayedSession, err)
+	}
+	changedSessionCommand := sessionCommand
+	changedSessionCommand.PracticeOptionID = "focused"
+	if _, err := service.CreatePracticeSession(ctx, changedSessionCommand); !errors.Is(err, ErrPracticeIdempotencyConflict) {
+		t.Fatalf("changed session replay error = %v", err)
+	}
+	if _, err := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "other"}); !errors.Is(err, ErrPracticePlanHasActiveSession) {
+		t.Fatalf("second active session error = %v", err)
+	}
+
+	if _, err := service.StartPracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("StartPracticeSession() error = %v", err)
+	}
+	if _, err := service.StartPracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("replayed StartPracticeSession() error = %v", err)
+	}
+	outcome := TurnOutcome{TurnID: "turn-1", SessionID: session.ID(), AnswerValid: true, ObjectiveCoverage: []ObjectiveCoverage{{ObjectiveID: "objective-1", Level: CoverageUncovered}}, CompletedPrimaryQuestionCount: 1}
+	action, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: outcome})
+	if err != nil {
+		t.Fatalf("ApplyTurnOutcome() error = %v", err)
+	}
+	replayedAction, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: outcome})
+	if err != nil || replayedAction != action {
+		t.Fatalf("replayed action = %q, %v", replayedAction, err)
+	}
+	if got := repo.effectiveTurns[session.ID()]; got != 1 {
+		t.Fatalf("effective turns = %d, want 1", got)
+	}
+	snapshot, err := service.GetPracticeSessionSnapshot(ctx, "user-1", session.ID())
+	if err != nil || snapshot.PracticeFocuses()[0] != "focus" {
+		t.Fatalf("GetPracticeSessionSnapshot() = %v, %v", snapshot, err)
+	}
+	if got := snapshot.PreparationSnapshotID(); got != "preparation-snapshot-1" {
+		t.Fatalf("PreparationSnapshotID() = %q", got)
+	}
+	participants := snapshot.Participants()
+	if len(participants) != 1 {
+		t.Fatalf("Participants() count = %d, want 1", len(participants))
+	}
+	if participants[0].ParticipantRole != ParticipantRoleInterviewer || participants[0].SubjectRef != (SubjectRef{Namespace: "preparation", SubjectID: "interviewer-1"}) {
+		t.Fatalf("interviewer participant = %#v", participants[0])
+	}
+	if _, err := service.PausePracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("PausePracticeSession() error = %v", err)
+	}
+	if _, err := service.PausePracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("replayed PausePracticeSession() error = %v", err)
+	}
+	if _, err := service.ResumePracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("ResumePracticeSession() error = %v", err)
+	}
+	if _, err := service.ResumePracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatalf("replayed ResumePracticeSession() error = %v", err)
+	}
+	if _, err := service.EndPracticeSessionEarly(ctx, "user-1", session.ID(), "user_requested"); err != nil {
+		t.Fatalf("EndPracticeSessionEarly() error = %v", err)
+	}
+	if _, err := service.EndPracticeSessionEarly(ctx, "user-1", session.ID(), "user_requested"); err != nil {
+		t.Fatalf("replayed EndPracticeSessionEarly() error = %v", err)
+	}
+	if _, err := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "after-terminal"}); err != nil {
+		t.Fatalf("CreatePracticeSession() after terminal error = %v", err)
+	}
+}
+
+func TestCreatePracticePlanReplayUsesOriginalRequest(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	preparation := newFakePreparationReader()
+	service := newTestServiceWithPreparation(repo, fakeTransactions{repo: repo}, preparation)
+	command := CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"}
+	plan, err := service.CreatePracticePlan(ctx, command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.UpdatePracticePlan(ctx, UpdatePracticePlanCommand{UserID: "user-1", PracticePlanID: plan.ID(), ScenarioConfigID: "config-2", PreparationProfileID: "profile-2", SelectedRoleIDs: []string{"role-1"}, ExpectedRevision: plan.Revision()}); err != nil {
+		t.Fatal(err)
+	}
+	calls := preparation.validateCalls
+	preparation.validateErr = errors.New("preparation unavailable")
+	replayed, err := service.CreatePracticePlan(ctx, command)
+	if err != nil || replayed.ID() != plan.ID() {
+		t.Fatalf("CreatePracticePlan() replay = %v, %v", replayed, err)
+	}
+	if preparation.validateCalls != calls {
+		t.Fatalf("ValidatePlan() calls = %d, want %d", preparation.validateCalls, calls)
+	}
+}
+
+func TestCreatePracticeSessionReplaySkipsCurrentPlanAndPreparation(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	preparation := newFakePreparationReader()
+	service := newTestServiceWithPreparation(repo, fakeTransactions{repo: repo}, preparation)
+	plan, err := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"}
+	session, err := service.CreatePracticeSession(ctx, command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.StartPracticeSession(ctx, "user-1", session.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.EndPracticeSessionEarly(ctx, "user-1", session.ID(), "user_requested"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.UpdatePracticePlan(ctx, UpdatePracticePlanCommand{UserID: "user-1", PracticePlanID: plan.ID(), ScenarioConfigID: "config-2", PreparationProfileID: "profile-2", SelectedRoleIDs: []string{"role-1"}, ExpectedRevision: plan.Revision()}); err != nil {
+		t.Fatal(err)
+	}
+	calls := preparation.prepareCalls
+	preparation.prepareErr = errors.New("preparation unavailable")
+	replayed, err := service.CreatePracticeSession(ctx, command)
+	if err != nil || replayed.ID() != session.ID() {
+		t.Fatalf("CreatePracticeSession() replay = %v, %v", replayed, err)
+	}
+	if preparation.prepareCalls != calls {
+		t.Fatalf("PrepareSession() calls = %d, want %d", preparation.prepareCalls, calls)
+	}
+}
+
+func TestServiceRejectsInvalidCreateCommandsBeforeRepositoryAccess(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Service) error
+	}{
+		{name: "创建计划缺少用户", run: func(s *Service) error {
+			_, err := s.CreatePracticePlan(context.Background(), CreatePracticePlanCommand{IdempotencyKey: "key"})
+			return err
+		}},
+		{name: "创建计划缺少幂等键", run: func(s *Service) error {
+			_, err := s.CreatePracticePlan(context.Background(), CreatePracticePlanCommand{UserID: "user-1"})
+			return err
+		}},
+		{name: "创建场次缺少用户", run: func(s *Service) error {
+			_, err := s.CreatePracticeSession(context.Background(), CreatePracticeSessionCommand{IdempotencyKey: "key"})
+			return err
+		}},
+		{name: "创建场次缺少幂等键", run: func(s *Service) error {
+			_, err := s.CreatePracticeSession(context.Background(), CreatePracticeSessionCommand{UserID: "user-1"})
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newFakeRepository()
+			service := newTestService(repo, fakeTransactions{repo: repo})
+			if err := tt.run(service); !errors.Is(err, ErrPracticeCommandInvalid) {
+				t.Fatalf("error = %v, want %v", err, ErrPracticeCommandInvalid)
+			}
+			if repo.calls != 0 {
+				t.Fatalf("repository calls = %d, want 0", repo.calls)
+			}
+		})
+	}
+}
+
+func TestCreatePracticeSessionRejectsPreparationIdentityMismatch(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*SessionPreparation)
+	}{
+		{name: "角色不一致", mutate: func(p *SessionPreparation) { p.Role.RoleDefinitionID = "role-other" }},
+		{name: "练习选项不一致", mutate: func(p *SessionPreparation) { p.PracticeOption.PracticeOptionID = "option-other" }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := newFakeRepository()
+			base := newFakePreparationReader()
+			tt.mutate(&base.session)
+			service := newTestServiceWithPreparation(repo, fakeTransactions{repo: repo}, fixedPreparationReader{session: base.session})
+			plan, err := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+			if err != nil {
+				t.Fatalf("CreatePracticePlan() error = %v", err)
+			}
+			_, err = service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+			if !errors.Is(err, ErrPracticeSessionSnapshotInvalid) {
+				t.Fatalf("CreatePracticeSession() error = %v, want %v", err, ErrPracticeSessionSnapshotInvalid)
+			}
+		})
+	}
+}
+
+func TestApplyTurnOutcomeDerivesRemainingTimeFromSession(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	clock := &fakeClock{now: time.Date(2026, 7, 17, 8, 0, 0, 0, time.UTC)}
+	service := newTestServiceWithClock(repo, fakeTransactions{repo: repo}, newFakePreparationReader(), clock)
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	session, _ := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	_, _ = service.StartPracticeSession(ctx, "user-1", session.ID())
+	repo.effectiveTurns[session.ID()] = 3
+	clock.now = clock.now.Add(10 * time.Minute)
+	action, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: TurnOutcome{TurnID: "turn-4", SessionID: session.ID(), AnswerValid: true}})
+	if err != nil || action != NextActionCompleteSession {
+		t.Fatalf("ApplyTurnOutcome() = %q, %v, want %q", action, err, NextActionCompleteSession)
+	}
+}
+
+func TestServiceReplaysCompletingTurnAfterSessionIsTerminal(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	session, _ := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	_, _ = service.StartPracticeSession(ctx, "user-1", session.ID())
+	repo.effectiveTurns[session.ID()] = 5
+	outcome := TurnOutcome{TurnID: "turn-complete", SessionID: session.ID(), AnswerValid: true, CompletedPrimaryQuestionCount: 4}
+	first, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: outcome})
+	if err != nil || first != NextActionCompleteSession {
+		t.Fatalf("first action = %q, %v", first, err)
+	}
+	replayed, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: outcome})
+	if err != nil || replayed != first {
+		t.Fatalf("replayed action = %q, %v", replayed, err)
+	}
+}
+
+func TestServiceRejectsOwnershipAndRevisionMismatch(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	command := CreatePracticeSessionCommand{UserID: "other", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"}
+	if _, err := service.CreatePracticeSession(ctx, command); !errors.Is(err, ErrPracticeResourceForbidden) {
+		t.Fatalf("ownership error = %v", err)
+	}
+	command.UserID, command.PlanRevision = "user-1", plan.Revision()+1
+	if _, err := service.CreatePracticeSession(ctx, command); !errors.Is(err, ErrPracticePlanRevisionConflict) {
+		t.Fatalf("revision error = %v", err)
+	}
+}
+
+func TestServiceTransactionFailureLeavesNoPlan(t *testing.T) {
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo, fail: true})
+	_, err := service.CreatePracticePlan(context.Background(), CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	if err == nil {
+		t.Fatal("CreatePracticePlan() error = nil")
+	}
+	if len(repo.plans) != 0 {
+		t.Fatalf("plans = %d, want 0", len(repo.plans))
+	}
+}
+
+func TestCreatePracticePlanConcurrentReplayIsAtomic(t *testing.T) {
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	command := CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "same-key"}
+	const workers = 32
+	results := make(chan *PracticePlan, workers)
+	errorsFound := make(chan error, workers)
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			plan, err := service.CreatePracticePlan(context.Background(), command)
+			results <- plan
+			errorsFound <- err
+		}()
+	}
+	group.Wait()
+	close(results)
+	close(errorsFound)
+	for err := range errorsFound {
+		if err != nil {
+			t.Fatalf("CreatePracticePlan() error = %v", err)
+		}
+	}
+	var id string
+	for plan := range results {
+		if id == "" {
+			id = plan.ID()
+		}
+		if plan.ID() != id {
+			t.Fatalf("plan ID = %q, want %q", plan.ID(), id)
+		}
+	}
+	if len(repo.plans) != 1 {
+		t.Fatalf("plans = %d, want 1", len(repo.plans))
+	}
+}
+
+func TestCreatePracticeSessionConcurrentReplayAndActiveConstraintAreAtomic(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, err := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "same-key"}
+	const workers = 32
+	results := make(chan *PracticeSession, workers)
+	errorsFound := make(chan error, workers)
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			session, err := service.CreatePracticeSession(ctx, command)
+			results <- session
+			errorsFound <- err
+		}()
+	}
+	group.Wait()
+	close(results)
+	close(errorsFound)
+	for err := range errorsFound {
+		if err != nil {
+			t.Fatalf("CreatePracticeSession() error = %v", err)
+		}
+	}
+	var id string
+	for session := range results {
+		if id == "" {
+			id = session.ID()
+		}
+		if session.ID() != id {
+			t.Fatalf("session ID = %q, want %q", session.ID(), id)
+		}
+	}
+	if len(repo.sessions) != 1 || len(repo.snapshots) != 1 || len(repo.active) != 1 {
+		t.Fatalf("repository state = sessions:%d snapshots:%d active:%d", len(repo.sessions), len(repo.snapshots), len(repo.active))
+	}
+}
+
+func TestApplyTurnOutcomeConcurrentUpdatesDoNotLoseProgress(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	session, _ := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	_, _ = service.StartPracticeSession(ctx, "user-1", session.ID())
+	turnIDs := []string{"turn-1", "turn-1", "turn-2", "turn-3"}
+	var group sync.WaitGroup
+	errorsFound := make(chan error, len(turnIDs))
+	for _, turnID := range turnIDs {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: TurnOutcome{TurnID: turnID, SessionID: session.ID(), AnswerValid: true}})
+			errorsFound <- err
+		}()
+	}
+	group.Wait()
+	close(errorsFound)
+	for err := range errorsFound {
+		if err != nil {
+			t.Fatalf("ApplyTurnOutcome() error = %v", err)
+		}
+	}
+	if got := repo.effectiveTurns[session.ID()]; got != 3 {
+		t.Fatalf("effective turns = %d, want 3", got)
+	}
+	if len(repo.actions) != 3 {
+		t.Fatalf("turn actions = %d, want 3", len(repo.actions))
+	}
+}
+
+func TestTransactionFailuresRollbackCompleteSessionAndTurnState(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	failingCreate := newTestService(repo, fakeTransactions{repo: repo, fail: true})
+	_, err := failingCreate.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "failed-session"})
+	if err == nil {
+		t.Fatal("CreatePracticeSession() error = nil")
+	}
+	if len(repo.sessions) != 0 || len(repo.snapshots) != 0 || len(repo.active) != 0 || len(repo.sessionKeys) != 0 {
+		t.Fatalf("partial session state remains")
+	}
+	session, _ := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	_, _ = service.StartPracticeSession(ctx, "user-1", session.ID())
+	repo.failOperation = "save_turn_progress"
+	_, err = service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: TurnOutcome{TurnID: "turn-1", SessionID: session.ID(), AnswerValid: true}})
+	if err == nil {
+		t.Fatal("ApplyTurnOutcome() error = nil")
+	}
+	if repo.effectiveTurns[session.ID()] != 0 || len(repo.actions) != 0 {
+		t.Fatalf("partial turn state remains")
+	}
+	repo.failOperation = ""
+	repo.effectiveTurns[session.ID()] = 5
+	repo.failOperation = "save_turn_progress"
+	_, err = service.ApplyTurnOutcome(ctx, ApplyTurnOutcomeCommand{UserID: "user-1", Outcome: TurnOutcome{TurnID: "turn-complete", SessionID: session.ID(), AnswerValid: true}})
+	if err == nil {
+		t.Fatal("completing ApplyTurnOutcome() error = nil")
+	}
+	stored := repo.sessions[session.ID()]
+	if stored.Status() != PracticeSessionInProgress || repo.active[plan.ID()] != session.ID() {
+		t.Fatalf("completed session was not rolled back: status=%q active=%q", stored.Status(), repo.active[plan.ID()])
+	}
+	if repo.effectiveTurns[session.ID()] != 5 || len(repo.actions) != 0 {
+		t.Fatalf("completing turn progress was not rolled back")
+	}
+}
+
+func TestServiceFreezesPreparationInputInSessionSnapshot(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	preparation := newFakePreparationReader()
+	service := newTestServiceWithPreparation(repo, fakeTransactions{repo: repo}, preparation)
+	plan, err := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioType: ScenarioTypeInterview, ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	if err != nil {
+		t.Fatalf("CreatePracticePlan() error = %v", err)
+	}
+	session, err := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	if err != nil {
+		t.Fatalf("CreatePracticeSession() error = %v", err)
+	}
+
+	preparation.session.Role.FocusAreas[0] = "changed-by-a"
+	preparation.session.PracticeFocuses[0] = "changed-by-a"
+	preparation.session.ScenarioDefinition.Name = "changed-by-a"
+	first, err := service.GetPracticeSessionSnapshot(ctx, "user-1", session.ID())
+	if err != nil {
+		t.Fatalf("GetPracticeSessionSnapshot() error = %v", err)
+	}
+	participants := first.Participants()
+	participants[0].RoleSnapshot.FocusAreas[0] = "changed-by-consumer"
+
+	second, err := service.GetPracticeSessionSnapshot(ctx, "user-1", session.ID())
+	if err != nil {
+		t.Fatalf("GetPracticeSessionSnapshot() second error = %v", err)
+	}
+	if got := second.Participants()[0].RoleSnapshot.FocusAreas[0]; got != "communication" {
+		t.Fatalf("role focus = %q, want communication", got)
+	}
+	if got := second.PracticeFocuses()[0]; got != "focus" {
+		t.Fatalf("practice focus = %q, want focus", got)
+	}
+	if got := second.ScenarioDefinition().Name; got != "Interview" {
+		t.Fatalf("scenario name = %q, want Interview", got)
+	}
+	if got := second.ScenarioType(); got != ScenarioTypeInterview {
+		t.Fatalf("scenario type = %q, want %q", got, ScenarioTypeInterview)
+	}
+	if got := second.Preparation().ResumeSnapshot; got != "resume" {
+		t.Fatalf("resume snapshot = %q, want resume", got)
+	}
+}
+
+func TestServiceManagesPracticePlanLifecycle(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, err := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	if err != nil {
+		t.Fatalf("CreatePracticePlan() error = %v", err)
+	}
+
+	updated, err := service.UpdatePracticePlan(ctx, UpdatePracticePlanCommand{UserID: "user-1", PracticePlanID: plan.ID(), ExpectedRevision: plan.Revision(), ScenarioConfigID: "config-2", PreparationProfileID: "profile-2", SelectedRoleIDs: []string{"role-2"}})
+	if err != nil {
+		t.Fatalf("UpdatePracticePlan() error = %v", err)
+	}
+	if updated.Revision() != plan.Revision()+1 || updated.ScenarioConfigID() != "config-2" {
+		t.Fatalf("updated plan revision/config = %d/%q", updated.Revision(), updated.ScenarioConfigID())
+	}
+	archived, err := service.ArchivePracticePlan(ctx, "user-1", plan.ID(), updated.Revision())
+	if err != nil || archived.Status() != PracticePlanArchived {
+		t.Fatalf("ArchivePracticePlan() = %v, %v", archived, err)
+	}
+	if _, err := service.ArchivePracticePlan(ctx, "user-1", plan.ID(), updated.Revision()); err != nil {
+		t.Fatalf("replayed ArchivePracticePlan() error = %v", err)
+	}
+	restored, err := service.RestorePracticePlan(ctx, "user-1", plan.ID(), updated.Revision())
+	if err != nil || restored.Status() != PracticePlanReady {
+		t.Fatalf("RestorePracticePlan() = %v, %v", restored, err)
+	}
+	if _, err := service.RestorePracticePlan(ctx, "user-1", plan.ID(), updated.Revision()); err != nil {
+		t.Fatalf("replayed RestorePracticePlan() error = %v", err)
+	}
+	if err := service.DeleteEmptyPracticePlan(ctx, "user-1", plan.ID(), updated.Revision()); err != nil {
+		t.Fatalf("DeleteEmptyPracticePlan() error = %v", err)
+	}
+	if _, err := repo.GetPlan(ctx, plan.ID()); !errors.Is(err, ErrPracticePlanNotFound) {
+		t.Fatalf("GetPlan() error = %v, want %v", err, ErrPracticePlanNotFound)
+	}
+}
+
+func TestRetryPracticePlanConfiguration(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	preparation := newFakePreparationReader()
+	service := newTestServiceWithPreparation(repo, fakeTransactions{repo: repo}, preparation)
+	plan, _ := NewPracticePlan("plan-1", "user-1", "scenario-1", ScenarioTypeInterview, "config-1", "profile-1", []string{"role-1"})
+	_ = plan.MarkConfigurationFailed()
+	repo.plans[plan.ID()] = clonePlan(plan)
+
+	retried, err := service.RetryPlanConfiguration(ctx, "user-1", plan.ID(), plan.Revision())
+	if err != nil || retried.Status() != PracticePlanReady {
+		t.Fatalf("RetryPlanConfiguration() = %v, %v", retried, err)
+	}
+}
+
+func TestPlanLifecycleRejectsInvalidAccessAndState(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	update := UpdatePracticePlanCommand{UserID: "user-1", PracticePlanID: plan.ID(), ExpectedRevision: plan.Revision(), ScenarioConfigID: "config-2", PreparationProfileID: "profile-2", SelectedRoleIDs: []string{"role-1"}}
+
+	update.UserID = "other"
+	if _, err := service.UpdatePracticePlan(ctx, update); !errors.Is(err, ErrPracticeResourceForbidden) {
+		t.Fatalf("UpdatePracticePlan() ownership error = %v", err)
+	}
+	update.UserID, update.ExpectedRevision = "user-1", plan.Revision()+1
+	if _, err := service.UpdatePracticePlan(ctx, update); !errors.Is(err, ErrPracticePlanRevisionConflict) {
+		t.Fatalf("UpdatePracticePlan() revision error = %v", err)
+	}
+	update.ExpectedRevision = plan.Revision()
+	session, _ := service.CreatePracticeSession(ctx, CreatePracticeSessionCommand{UserID: "user-1", PracticePlanID: plan.ID(), PlanRevision: plan.Revision(), ParticipantRoleID: "role-1", PracticeOptionID: "full", IdempotencyKey: "session"})
+	if _, err := service.UpdatePracticePlan(ctx, update); !errors.Is(err, ErrPracticePlanHasActiveSession) {
+		t.Fatalf("UpdatePracticePlan() active error = %v", err)
+	}
+	if _, err := service.ArchivePracticePlan(ctx, "user-1", plan.ID(), plan.Revision()); !errors.Is(err, ErrPracticePlanHasActiveSession) {
+		t.Fatalf("ArchivePracticePlan() active error = %v", err)
+	}
+	_, _ = service.EndPracticeSessionEarly(ctx, "user-1", session.ID(), "done")
+	if err := service.DeleteEmptyPracticePlan(ctx, "user-1", plan.ID(), plan.Revision()); !errors.Is(err, ErrPracticePlanHasSessions) {
+		t.Fatalf("DeleteEmptyPracticePlan() history error = %v", err)
+	}
+}
+
+func TestPlanLifecycleTransactionFailureRollsBackChanges(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepository()
+	service := newTestService(repo, fakeTransactions{repo: repo})
+	plan, _ := service.CreatePracticePlan(ctx, CreatePracticePlanCommand{UserID: "user-1", ScenarioDefinitionID: "scenario-1", ScenarioConfigID: "config-1", PreparationProfileID: "profile-1", SelectedRoleIDs: []string{"role-1"}, IdempotencyKey: "plan"})
+	failing := newTestService(repo, fakeTransactions{repo: repo, fail: true})
+
+	_, err := failing.UpdatePracticePlan(ctx, UpdatePracticePlanCommand{UserID: "user-1", PracticePlanID: plan.ID(), ExpectedRevision: plan.Revision(), ScenarioConfigID: "config-2", PreparationProfileID: "profile-2", SelectedRoleIDs: []string{"role-2"}})
+	if err == nil {
+		t.Fatal("UpdatePracticePlan() error = nil")
+	}
+	stored, _ := repo.GetPlan(ctx, plan.ID())
+	if stored.Revision() != plan.Revision() || stored.ScenarioConfigID() != plan.ScenarioConfigID() {
+		t.Fatalf("stored plan changed after rollback: revision/config = %d/%q", stored.Revision(), stored.ScenarioConfigID())
+	}
+}
+
+type fakePreparationReader struct {
+	session       SessionPreparation
+	validateErr   error
+	prepareErr    error
+	validateCalls int
+	prepareCalls  int
+}
+
+type fixedPreparationReader struct{ session SessionPreparation }
+
+func (fixedPreparationReader) ValidatePlan(context.Context, CreatePracticePlanCommand) error {
+	return nil
+}
+func (f fixedPreparationReader) PrepareSession(context.Context, *PracticePlan, string, string) (SessionPreparation, error) {
+	return f.session, nil
+}
+
+func newFakePreparationReader() *fakePreparationReader {
+	return &fakePreparationReader{session: SessionPreparation{
+		ScenarioDefinition: ScenarioDefinitionSnapshot{ScenarioDefinitionID: "scenario-1", ScenarioType: ScenarioTypeInterview, Name: "Interview", Version: 1, Status: "active"},
+		ScenarioConfig:     ScenarioConfigSnapshot{ScenarioConfigID: "config-1", ScenarioDefinitionID: "scenario-1", ConfigType: "INTERVIEW", Version: 1},
+		Preparation:        PreparationSnapshot{PreparationSnapshotID: "preparation-snapshot-1", SourceProfileID: "profile-1", SourceVersion: 1, ResumeSnapshot: "resume", JobDescriptionSnapshot: "job", BackgroundSnapshot: "background", CreatedAt: time.Date(2026, 7, 17, 7, 0, 0, 0, time.UTC)},
+		Role:               RoleSnapshot{RoleDefinitionID: "role-1", ScenarioDefinitionID: "scenario-1", RoleType: "INTERVIEWER", DisplayName: "Mia", FocusAreas: []string{"communication"}, Version: 1},
+		InterviewerSubject: SubjectRef{Namespace: "preparation", SubjectID: "interviewer-1"},
+		PracticeOption:     PracticeOptionSnapshot{PracticeOptionID: "full", ScenarioDefinitionID: "scenario-1", PracticeOptionType: "FULL_SIMULATION", DisplayName: "Full", Version: 1},
+		PracticeFocuses:    []string{"focus"}, Mode: PracticeModeFullSimulation, TargetObjectiveIDs: []string{"objective-1"},
+	}}
+}
+
+func (f *fakePreparationReader) ValidatePlan(context.Context, CreatePracticePlanCommand) error {
+	f.validateCalls++
+	return f.validateErr
+}
+func (f *fakePreparationReader) PrepareSession(_ context.Context, _ *PracticePlan, roleID, optionID string) (SessionPreparation, error) {
+	f.prepareCalls++
+	if f.prepareErr != nil {
+		return SessionPreparation{}, f.prepareErr
+	}
+	mode := PracticeModeFullSimulation
+	if optionID == "focused" {
+		mode = PracticeModeFocusedPractice
+	}
+	result := f.session
+	result.Role.RoleDefinitionID = roleID
+	result.PracticeOption.PracticeOptionID = optionID
+	result.PracticeOption.RoleDefinitionID = roleID
+	result.Mode = mode
+	return result, nil
+}
+
+type fakeIDs struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (f *fakeIDs) NewID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.next++
+	return fmt.Sprintf("id-%d", f.next)
+}
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time {
+	if f.now.IsZero() {
+		return time.Date(2026, 7, 17, 8, 0, 0, 0, time.UTC)
+	}
+	return f.now
+}
+
+type fakeRepository struct {
+	mu             sync.Mutex
+	plans          map[string]*PracticePlan
+	planKeys       map[string]string
+	planCommands   map[string]CreatePracticePlanCommand
+	sessions       map[string]*PracticeSession
+	sessionKeys    map[string]string
+	snapshots      map[string]PracticeSessionSnapshot
+	active         map[string]string
+	actions        map[string]NextAction
+	effectiveTurns map[string]int
+	calls          int
+	failOperation  string
+}
+
+func newFakeRepository() *fakeRepository {
+	return &fakeRepository{plans: map[string]*PracticePlan{}, planKeys: map[string]string{}, planCommands: map[string]CreatePracticePlanCommand{}, sessions: map[string]*PracticeSession{}, sessionKeys: map[string]string{}, snapshots: map[string]PracticeSessionSnapshot{}, active: map[string]string{}, actions: map[string]NextAction{}, effectiveTurns: map[string]int{}}
+}
+func (r *fakeRepository) FindPlanCreation(_ context.Context, key string) (*PracticePlan, CreatePracticePlanCommand, bool, error) {
+	id, ok := r.planKeys[key]
+	if !ok {
+		return nil, CreatePracticePlanCommand{}, false, nil
+	}
+	return clonePlan(r.plans[id]), cloneCreatePlanCommand(r.planCommands[key]), true, nil
+}
+func (r *fakeRepository) CreatePlan(_ context.Context, key string, command CreatePracticePlanCommand, plan *PracticePlan) (*PracticePlan, CreatePracticePlanCommand, bool, error) {
+	r.calls++
+	if r.failOperation == "create_plan" {
+		return nil, CreatePracticePlanCommand{}, false, errors.New("create plan failed")
+	}
+	if id, ok := r.planKeys[key]; ok {
+		return clonePlan(r.plans[id]), cloneCreatePlanCommand(r.planCommands[key]), false, nil
+	}
+	r.plans[plan.ID()] = clonePlan(plan)
+	r.planKeys[key] = plan.ID()
+	r.planCommands[key] = cloneCreatePlanCommand(command)
+	return clonePlan(plan), cloneCreatePlanCommand(command), true, nil
+}
+func (r *fakeRepository) FindSessionCreation(_ context.Context, key string) (*PracticeSession, PracticeSessionSnapshot, bool, error) {
+	id, ok := r.sessionKeys[key]
+	if !ok {
+		return nil, PracticeSessionSnapshot{}, false, nil
+	}
+	session := r.sessions[id]
+	return cloneSession(session), cloneSnapshot(r.snapshots[session.SnapshotID()]), true, nil
+}
+func (r *fakeRepository) GetPlan(_ context.Context, id string) (*PracticePlan, error) {
+	p, ok := r.plans[id]
+	if !ok {
+		return nil, ErrPracticePlanNotFound
+	}
+	return clonePlan(p), nil
+}
+func (r *fakeRepository) LockPlanForUpdate(ctx context.Context, id string) (*PracticePlan, error) {
+	if !inFakeTransaction(ctx) {
+		return nil, errors.New("plan lock requires transaction")
+	}
+	return r.GetPlan(ctx, id)
+}
+func (r *fakeRepository) SavePlan(_ context.Context, plan *PracticePlan) error {
+	if r.failOperation == "save_plan" {
+		return errors.New("save plan failed")
+	}
+	r.plans[plan.ID()] = clonePlan(plan)
+	return nil
+}
+func (r *fakeRepository) HasActiveSession(_ context.Context, planID string) (bool, error) {
+	_, ok := r.active[planID]
+	return ok, nil
+}
+func (r *fakeRepository) HasSessions(_ context.Context, planID string) (bool, error) {
+	for _, session := range r.sessions {
+		if session.PlanID() == planID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (r *fakeRepository) DeletePlan(_ context.Context, planID string) error {
+	if _, ok := r.plans[planID]; !ok {
+		return ErrPracticePlanNotFound
+	}
+	delete(r.plans, planID)
+	for key, id := range r.planKeys {
+		if id == planID {
+			delete(r.planKeys, key)
+		}
+	}
+	return nil
+}
+func (r *fakeRepository) CreateActiveSession(_ context.Context, key, planID string, session *PracticeSession, snapshot PracticeSessionSnapshot) (*PracticeSession, PracticeSessionSnapshot, bool, error) {
+	if r.failOperation == "create_session" {
+		return nil, PracticeSessionSnapshot{}, false, errors.New("create session failed")
+	}
+	if id, ok := r.sessionKeys[key]; ok {
+		existing := r.sessions[id]
+		return cloneSession(existing), cloneSnapshot(r.snapshots[existing.SnapshotID()]), false, nil
+	}
+	if _, ok := r.active[planID]; ok {
+		return nil, PracticeSessionSnapshot{}, false, ErrPracticePlanHasActiveSession
+	}
+	r.sessions[session.ID()] = cloneSession(session)
+	r.sessionKeys[key] = session.ID()
+	r.snapshots[snapshot.ID()] = cloneSnapshot(snapshot)
+	r.active[planID] = session.ID()
+	return cloneSession(session), cloneSnapshot(snapshot), true, nil
+}
+func (r *fakeRepository) GetSession(_ context.Context, id string) (*PracticeSession, error) {
+	s, ok := r.sessions[id]
+	if !ok {
+		return nil, ErrPracticeSessionNotFound
+	}
+	return cloneSession(s), nil
+}
+func (r *fakeRepository) LockSessionForUpdate(ctx context.Context, id string) (*PracticeSession, error) {
+	if !inFakeTransaction(ctx) {
+		return nil, errors.New("session lock requires transaction")
+	}
+	return r.GetSession(ctx, id)
+}
+func (r *fakeRepository) SaveSession(_ context.Context, session *PracticeSession) error {
+	if r.failOperation == "save_session" {
+		return errors.New("save session failed")
+	}
+	r.sessions[session.ID()] = cloneSession(session)
+	if session.Status() == PracticeSessionCompleted || session.Status() == PracticeSessionEndedEarly {
+		delete(r.active, session.PlanID())
+	}
+	return nil
+}
+func (r *fakeRepository) GetSnapshot(_ context.Context, snapshotID string) (PracticeSessionSnapshot, error) {
+	if r.failOperation == "get_snapshot" {
+		return PracticeSessionSnapshot{}, errors.New("get snapshot failed")
+	}
+	return cloneSnapshot(r.snapshots[snapshotID]), nil
+}
+
+func newTestService(repository Repository, transactions TransactionManager) *Service {
+	return newTestServiceWithPreparation(repository, transactions, newFakePreparationReader())
+}
+func newTestServiceWithPreparation(repository Repository, transactions TransactionManager, preparation PreparationReader) *Service {
+	return newTestServiceWithClock(repository, transactions, preparation, fakeClock{})
+}
+func newTestServiceWithClock(repository Repository, transactions TransactionManager, preparation PreparationReader, clock Clock) *Service {
+	return newService(Dependencies{PreparationReader: preparation, Repository: repository, TransactionManager: transactions, IDGenerator: &fakeIDs{}, Clock: clock})
+}
+func (r *fakeRepository) FindTurnAction(_ context.Context, sessionID, turnID string) (NextAction, bool, error) {
+	a, ok := r.actions[sessionID+":"+turnID]
+	return a, ok, nil
+}
+func (r *fakeRepository) SaveTurnProgress(_ context.Context, sessionID, turnID string, turns int, action NextAction) error {
+	if r.failOperation == "save_turn_progress" {
+		return errors.New("save turn progress failed")
+	}
+	r.effectiveTurns[sessionID] = turns
+	r.actions[sessionID+":"+turnID] = action
+	return nil
+}
+func (r *fakeRepository) EffectiveTurnCount(_ context.Context, sessionID string) (int, error) {
+	return r.effectiveTurns[sessionID], nil
+}
+
+type fakeTransactions struct {
+	repo *fakeRepository
+	fail bool
+}
+
+func (f fakeTransactions) WithinTransaction(ctx context.Context, fn func(context.Context) error) error {
+	f.repo.mu.Lock()
+	defer f.repo.mu.Unlock()
+	before := cloneRepositoryState(f.repo)
+	err := fn(context.WithValue(ctx, fakeTransactionKey{}, true))
+	if err == nil && f.fail {
+		err = errors.New("transaction failed")
+	}
+	if err != nil {
+		restoreRepositoryState(f.repo, before)
+	}
+	return err
+}
+
+type fakeTransactionKey struct{}
+
+func inFakeTransaction(ctx context.Context) bool {
+	value, _ := ctx.Value(fakeTransactionKey{}).(bool)
+	return value
+}
+
+type fakeRepositoryState struct {
+	plans          map[string]*PracticePlan
+	planKeys       map[string]string
+	planCommands   map[string]CreatePracticePlanCommand
+	sessions       map[string]*PracticeSession
+	sessionKeys    map[string]string
+	snapshots      map[string]PracticeSessionSnapshot
+	active         map[string]string
+	actions        map[string]NextAction
+	effectiveTurns map[string]int
+	calls          int
+}
+
+func cloneRepositoryState(r *fakeRepository) fakeRepositoryState {
+	state := fakeRepositoryState{plans: map[string]*PracticePlan{}, planKeys: cloneMap(r.planKeys), planCommands: map[string]CreatePracticePlanCommand{}, sessions: map[string]*PracticeSession{}, sessionKeys: cloneMap(r.sessionKeys), snapshots: map[string]PracticeSessionSnapshot{}, active: cloneMap(r.active), actions: cloneMap(r.actions), effectiveTurns: cloneMap(r.effectiveTurns), calls: r.calls}
+	for key, command := range r.planCommands {
+		state.planCommands[key] = cloneCreatePlanCommand(command)
+	}
+	for id, plan := range r.plans {
+		state.plans[id] = clonePlan(plan)
+	}
+	for id, session := range r.sessions {
+		state.sessions[id] = cloneSession(session)
+	}
+	for id, snapshot := range r.snapshots {
+		state.snapshots[id] = cloneSnapshot(snapshot)
+	}
+	return state
+}
+
+func restoreRepositoryState(r *fakeRepository, state fakeRepositoryState) {
+	r.plans, r.planKeys, r.planCommands, r.sessions, r.sessionKeys = state.plans, state.planKeys, state.planCommands, state.sessions, state.sessionKeys
+	r.snapshots, r.active, r.actions, r.effectiveTurns, r.calls = state.snapshots, state.active, state.actions, state.effectiveTurns, state.calls
+}
+
+func cloneMap[K comparable, V any](source map[K]V) map[K]V {
+	result := make(map[K]V, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+func cloneCreatePlanCommand(command CreatePracticePlanCommand) CreatePracticePlanCommand {
+	command.SelectedRoleIDs = cloneStrings(command.SelectedRoleIDs)
+	return command
+}
+func clonePlan(plan *PracticePlan) *PracticePlan {
+	if plan == nil {
+		return nil
+	}
+	result := *plan
+	result.selectedRoleIDs = cloneStrings(plan.selectedRoleIDs)
+	return &result
+}
+func cloneSession(session *PracticeSession) *PracticeSession {
+	if session == nil {
+		return nil
+	}
+	result := *session
+	if session.startedAt != nil {
+		value := *session.startedAt
+		result.startedAt = &value
+	}
+	if session.endedAt != nil {
+		value := *session.endedAt
+		result.endedAt = &value
+	}
+	return &result
+}
+func cloneSnapshot(snapshot PracticeSessionSnapshot) PracticeSessionSnapshot {
+	result := snapshot
+	result.practiceFocuses = cloneStrings(snapshot.practiceFocuses)
+	result.sessionPolicy = snapshot.sessionPolicy
+	result.sessionPolicy.targetObjectiveIDs = cloneStrings(snapshot.sessionPolicy.targetObjectiveIDs)
+	result.participants = append([]PracticeParticipant(nil), snapshot.participants...)
+	for index := range result.participants {
+		result.participants[index].roleSnapshot = cloneRoleSnapshot(result.participants[index].roleSnapshot)
+	}
+	return result
+}


### PR DESCRIPTION
## 功能描述

为 Practice 模块补齐 Issue #36 冻结的后端架构骨架，使计划、场次和轮次推进具备可编译、可测试的领域与应用边界。

本 PR 按 #36 的 U1–U4 作为一个完整增量提交，未混入 Delivery、数据库适配器或跨模块协议变更。为降低审阅负担，代码拆成“领域模型与策略”和“生命周期服务与模块组装”两个提交。

## 实现思路

- 建立 `PracticePlan`、`PracticeSession`、不可变快照、稳定领域错误和合法状态迁移
- 以纯函数策略处理有效 Turn、追问、目标切换和场次完成判断
- 由 Practice 自己定义 Preparation、Repository 和事务窄端口，不依赖 Gin、SQL、ORM 或 Provider
- 原子保存场次与快照，并由 Repository 端口承担“每个计划最多一个活动场次”的并发语义
- 在外部读取和当前状态校验前查询首次幂等结果；首次请求指纹随创建结果保存，重放不受计划后续更新或 Preparation 临时故障影响
- 按 #34/#35 冻结契约将 MS1 参与者集合限制为一个面试官，并校验角色、练习选项和场景定义来自同一场景
- 保持现有 `bootstrap.Module` 兼容；依赖完整时才暴露 Practice Service
- 使用内存测试替身覆盖状态迁移、快照防御性复制、事务回滚、幂等重放和并发约束语义

## 测试方式

```bash
cd server
gofmt -l internal/practice
go test ./internal/practice
go test -race ./internal/practice
go test ./...
go vet ./...
```

预期 `gofmt -l` 无输出，其余命令全部通过。

## 相关 Issue / 备注

Closes #36

契约依据：#34、#35；父架构：#24。

本 PR 不包含 `docs/`、REST/WS Delivery、PostgreSQL Repository、数据库迁移或 Conversation/Review 实现。真实数据库适配器仍需在后续 Issue 中用物理约束或事务锁实现本 PR 冻结的 Repository 并发语义。

## AI 辅助说明

Codex 参与了实现、中文注释整理、冻结 Issue 契约核对和提交前代码审查。建议 Reviewer 重点检查状态机、首次请求指纹的幂等语义、快照归属校验以及 Repository 的原子约束。

## 提交前检查

- [x] 一个 Issue 对应一个分支和一个 PR
- [x] Commit 使用 Conventional Commits
- [x] 本地格式化、测试、竞态检测和静态检查通过
- [x] 未提交密钥、环境文件、缓存、构建产物或工程文档
- [x] 未增加未评审的跨模块协议字段
- [x] AI 生成或修改内容已逐项检查
