### PR TITLE
feat(preparation):建立Preparation模块架构骨架

### DIFF
--- a/server/internal/preparation/model.go
+++ b/server/internal/preparation/model.go
@@ -1,0 +1,140 @@
+package preparation
+
+import "time"
+
+// 来源类型，区分内置与用户自定义。
+type Source string
+
+const (
+	SourceBuiltIn Source = "built_in" // 系统内置，如程序员面试场景
+	SourceUser    Source = "user"     // 用户自行创建
+)
+
+// 练习场景定义，聚合角色规则、会话规则和评分维度。
+type ScenarioDefinition struct {
+	ID                     string
+	Version                string
+	Source                 Source
+	Name                   string
+	BackgroundRequirements BackgroundRequirements
+	RolePolicy             RolePolicy
+	SessionPolicy          SessionPolicy
+	EvaluationRubric       EvaluationRubric
+}
+
+// 背景信息要求，声明某场景需要用户提供哪些字段。
+type BackgroundRequirements struct {
+	JobTitleRequired       bool
+	JobDescriptionRequired bool
+	ExperienceRequired     bool
+	FocusAreasRequired     bool
+}
+
+// 角色数量约束。
+type RolePolicy struct {
+	MinRoles int
+	MaxRoles int
+}
+
+// 回合数与追问约束。
+type SessionPolicy struct {
+	MinTurns      int
+	MaxTurns      int
+	AllowFollowUp bool
+}
+
+// 评分维度及版本。
+type EvaluationRubric struct {
+	Version    string
+	Dimensions []string
+}
+
+// 角色定义，包含人设、目标、说话风格和行为约束。
+type RoleDefinition struct {
+	ID            string
+	ScenarioID    string
+	Version       string
+	Source        Source
+	Name          string
+	Persona       string
+	Goal          string
+	SpeakingStyle string
+	Constraints   []string
+	VoiceID       string
+}
+
+// 简历，包含上传文件和解析后的文本。
+type Resume struct {
+	ID             string
+	UserID         string
+	FileStorageKey string
+	FileName       string
+	ParsedText     string
+	Status         ResumeStatus
+	CreatedAt      time.Time
+}
+
+// 简历解析状态。
+type ResumeStatus string
+
+const (
+	ResumeStatusPending   ResumeStatus = "pending"   // 已上传，待解析
+	ResumeStatusParsed    ResumeStatus = "parsed"    // 已解析，待确认
+	ResumeStatusConfirmed ResumeStatus = "confirmed" // 已确认
+)
+
+// 候选人资料。
+type Candidate struct {
+	ID          string
+	UserID      string
+	DisplayName string
+	Resumes     []string
+}
+
+// 背景快照，用户确认后不可变，被练习引用后不再修改。
+type BackgroundSnapshot struct {
+	ID                  string
+	UserID              string
+	JobTitle            string
+	JobDescription      string
+	ExperienceHighlight string
+	FocusAreas          []string
+	AdditionalNotes     string
+	ResumeID            string
+	ResumeStorageKey    string
+	CandidateID         string
+	CreatedAt           time.Time
+}
+
+// 场景只读快照，供练习模块引用，隔离后续编辑。
+type ScenarioSnapshot struct {
+	ScenarioID    string
+	Version       string
+	Name          string
+	SessionPolicy SessionPolicy
+	RolePolicy    RolePolicy
+	Roles         []RoleSnapshot
+}
+
+// 角色只读快照。
+type RoleSnapshot struct {
+	RoleID        string
+	ScenarioID    string
+	Version       string
+	Name          string
+	Persona       string
+	Goal          string
+	SpeakingStyle string
+	Constraints   []string
+	VoiceID       string
+}
+
+// 简历只读快照。
+type ResumeSnapshot struct {
+	ResumeID       string
+	UserID         string
+	FileStorageKey string
+	FileName       string
+	ParsedText     string
+	Status         ResumeStatus
+}

--- a/server/internal/preparation/ports.go
+++ b/server/internal/preparation/ports.go
@@ -1,0 +1,38 @@
+package preparation
+
+import "context"
+
+// 场景仓库，持久化场景定义，当前只提供查询。
+type ScenarioRepository interface {
+	FindByID(ctx context.Context, id string) (*ScenarioDefinition, error)
+	List(ctx context.Context) ([]*ScenarioDefinition, error)
+}
+
+// 角色仓库，持久化角色定义；内置角色不可修改，仅用户角色可保存。
+type RoleRepository interface {
+	FindByScenario(ctx context.Context, scenarioID string) ([]*RoleDefinition, error)
+	FindByID(ctx context.Context, id string) (*RoleDefinition, error)
+	Save(ctx context.Context, role *RoleDefinition) error
+}
+
+// 简历仓库，持久化用户上传的简历。
+type ResumeRepository interface {
+	Save(ctx context.Context, resume *Resume) error
+	FindByID(ctx context.Context, id string) (*Resume, error)
+	FindByUser(ctx context.Context, userID string) ([]*Resume, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// 背景快照仓库，快照不可变，故无更新方法。
+type BackgroundRepository interface {
+	Save(ctx context.Context, snapshot *BackgroundSnapshot) error
+	FindByID(ctx context.Context, id string) (*BackgroundSnapshot, error)
+	FindByUser(ctx context.Context, userID string) ([]*BackgroundSnapshot, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// 跨模块只读接口，返回快照以隔离后续编辑，供练习模块调用。
+type ScenarioReader interface {
+	GetScenarioSnapshot(ctx context.Context, scenarioID, version string) (ScenarioSnapshot, error)
+	GetRoleSnapshot(ctx context.Context, roleID string) (RoleSnapshot, error)
+}

--- a/server/internal/preparation/service.go
+++ b/server/internal/preparation/service.go
@@ -1,0 +1,105 @@
+package preparation
+
+import "context"
+
+// 业务服务，方法体待后续接入仓库后补充。
+type Service struct {
+	scenarios   ScenarioRepository
+	roles       RoleRepository
+	resumes     ResumeRepository
+	backgrounds BackgroundRepository
+}
+
+func NewService(s ScenarioRepository, r RoleRepository, m ResumeRepository, b BackgroundRepository) *Service {
+	return &Service{scenarios: s, roles: r, resumes: m, backgrounds: b}
+}
+
+// --- 场景 ---
+
+// 返回所有场景。
+func (s *Service) ListScenarios(ctx context.Context) ([]*ScenarioDefinition, error) {
+	return nil, nil
+}
+
+// 按编号返回单个场景。
+func (s *Service) GetScenario(ctx context.Context, scenarioID string) (*ScenarioDefinition, error) {
+	return nil, nil
+}
+
+// --- 角色 ---
+
+// 返回某场景下的全部角色。
+func (s *Service) ListRoles(ctx context.Context, scenarioID string) ([]*RoleDefinition, error) {
+	return nil, nil
+}
+
+// 按编号返回单个角色。
+func (s *Service) GetRole(ctx context.Context, roleID string) (*RoleDefinition, error) {
+	return nil, nil
+}
+
+// 更新用户自定义角色；内置角色不可修改。
+func (s *Service) UpdateRole(ctx context.Context, role *RoleDefinition) (*RoleDefinition, error) {
+	return nil, nil
+}
+
+// --- 简历 ---
+
+// 保存上传的简历并进入解析流程。
+func (s *Service) CreateResume(ctx context.Context, resume *Resume) (*Resume, error) {
+	return nil, nil
+}
+
+// 按编号返回简历。
+func (s *Service) GetResume(ctx context.Context, id string) (*Resume, error) {
+	return nil, nil
+}
+
+// 返回某用户的全部简历。
+func (s *Service) ListResumes(ctx context.Context, userID string) ([]*Resume, error) {
+	return nil, nil
+}
+
+// 删除简历；历史快照不受影响。
+func (s *Service) DeleteResume(ctx context.Context, id string) error {
+	return nil
+}
+
+// --- 背景快照 ---
+
+// 创建不可变的背景快照。
+func (s *Service) CreateBackground(ctx context.Context, snapshot *BackgroundSnapshot) (*BackgroundSnapshot, error) {
+	return nil, nil
+}
+
+// 按编号返回背景快照。
+func (s *Service) GetBackground(ctx context.Context, id string) (*BackgroundSnapshot, error) {
+	return nil, nil
+}
+
+// 返回某用户的全部背景快照。
+func (s *Service) ListBackgrounds(ctx context.Context, userID string) ([]*BackgroundSnapshot, error) {
+	return nil, nil
+}
+
+// 修改未被引用的背景快照；已被引用时应新建而非覆盖。
+func (s *Service) UpdateBackground(ctx context.Context, snapshot *BackgroundSnapshot) (*BackgroundSnapshot, error) {
+	return nil, nil
+}
+
+// 删除背景快照；历史练习不受影响。
+func (s *Service) DeleteBackground(ctx context.Context, id string) error {
+	return nil
+}
+
+// --- 跨模块只读 ---
+
+// 返回场景只读快照，供练习模块使用。
+func (s *Service) GetScenarioSnapshot(ctx context.Context, scenarioID, version string) (ScenarioSnapshot, error) {
+	return ScenarioSnapshot{}, nil
+}
+
+// 返回角色只读快照，供练习模块使用。
+func (s *Service) GetRoleSnapshot(ctx context.Context, roleID string) (RoleSnapshot, error) {
+	return RoleSnapshot{}, nil
+}


### PR DESCRIPTION
## 功能描述

为 preparation 模块建立 MS1 阶段架构骨架，包含领域模型、端口接口和服务方法签名三部分。practice 模块可通过 `ScenarioReader` 只读端口消费快照，不直接引用 preparation 内部包。

## 实现思路

### 1. model.go — 领域模型

按仓库既有风格声明不可变快照与可写实体两类类型：

- 可写实体：`ScenarioDefinition`、`RoleDefinition`、`Resume`、`Candidate`
- 只读快照：`ScenarioSnapshot`、`RoleSnapshot`、`ResumeSnapshot`、`BackgroundSnapshot`
- 枚举：`Source`（built_in / user）、`ResumeStatus`（pending / parsed / confirmed）
- 严格遵守「preparation 不持有 InterviewPlan / PracticeSession / SessionSnapshot」边界

### 2. ports.go — 端口

四个仓库接口按场景 / 角色 / 简历 / 背景分组，并显式声明：

- `RoleRepository.Save` 仅允许保存用户角色
- `BackgroundRepository` 不提供更新方法（快照不可变）
- `ScenarioReader` 为跨模块只读接口，practice 模块仅能消费 `*Snapshot` 类型

### 3. service.go — 服务

`Service` 持有四个仓库依赖，方法签名覆盖职责表 100%，方法体暂以零值返回（`nil, nil` / `*, nil`），不引入业务实现。

## 测试方式

```bash
cd server
go build ./...
go vet ./...
go test ./...
```

预期：

1. `go build ./...` 无错误
2. `go vet ./...` 无告警
3. `bootstrap` 与 `platform/config` 既有测试通过；新增 `preparation` 包无测试文件
4. 预期结果：所有命令退出码 0，无新增输出

## 相关 Issue / 备注

- Closes #15（MS1 系统架构 - preparation 模块落地）
- Refs #9（产品范围与功能边界）
- Refs #24（场景与角色扩展模型）

## AI 辅助说明

本 PR 的架构代码由 AI 辅助生成，已由作者人工逐行 Review，确保：

- 模块边界（preparation 与 practice 通过 `ScenarioReader` 解耦）符合 Issue #15
- 注释为纯中文，不含混合英文标识符
- 方法体为占位零值，不引入未授权的业务实现
- 与上游 `1024XEngineer/XE3-ESL:main` 仅差 3 个新增文件

## 提交前检查

- [x] 本 PR 只对应一个 Issue（#15 preparation 模块），不包含无关改动
- [x] 变更来自个人 Fork `zhiwilliam1-cell/XE3-ESL`，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits：`feat(preparation): add module architecture skeleton`
- [x] 已提供可复现的测试步骤并完成本地 `go build` / `go vet` / `go test` 验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
