### PR TITLE
feat(platform): 实现公共错误组件与统一 REST 错误协议

### DIFF
--- a/server/internal/bootstrap/router.go
+++ b/server/internal/bootstrap/router.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
 )
 
 // Module is the narrow boundary used by the application composition root.
@@ -32,15 +35,20 @@ func NewRouter(logger *slog.Logger, modules ...Module) *gin.Engine {
 	})
 
 	router.NoRoute(func(c *gin.Context) {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": gin.H{
-				"code":    "route_not_found",
-				"message": "route not found",
-			},
-		})
+		err := apperror.NotFound(
+			"route not found",
+			apperror.WithReason("route_not_found"),
+		)
+		httpresponse.Write(c, err, requestIDFromContext(c))
 	})
 
 	return router
+}
+
+func requestIDFromContext(c *gin.Context) string {
+	requestID, _ := c.Get("request_id")
+	value, _ := requestID.(string)
+	return value
 }
 
 func requestLogger(logger *slog.Logger) gin.HandlerFunc {

--- a/server/internal/bootstrap/router_test.go
+++ b/server/internal/bootstrap/router_test.go
@@ -61,13 +61,38 @@ func TestUnknownRouteUsesStableErrorShape(t *testing.T) {
 
 	var body struct {
 		Error struct {
-			Code string `json:"code"`
+			Code      string `json:"code"`
+			Reason    string `json:"reason"`
+			Message   string `json:"message"`
+			Retryable bool   `json:"retryable"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if body.Error.Code != "route_not_found" {
+	if body.Error.Code != "not_found" {
 		t.Fatalf("unexpected error code: %q", body.Error.Code)
+	}
+	if body.Error.Reason != "route_not_found" {
+		t.Fatalf("unexpected error reason: %q", body.Error.Reason)
+	}
+	if body.Error.Message != "route not found" || body.Error.Retryable {
+		t.Fatalf("unexpected error response: %#v", body.Error)
+	}
+}
+
+func TestHealthResponseIsUnchanged(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := bootstrap.NewRouter(logger)
+
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+	if got, want := response.Body.String(), `{"modules":[],"status":"ok"}`; got != want {
+		t.Fatalf("health response changed: got %s, want %s", got, want)
 	}
 }

--- a/server/internal/platform/apperror/code.go
+++ b/server/internal/platform/apperror/code.go
@@ -1,0 +1,40 @@
+package apperror
+
+// Code 表示稳定且与传输协议无关的错误分类。
+type Code string
+
+const (
+	CodeInvalidArgument    Code = "invalid_argument"
+	CodeUnauthenticated    Code = "unauthenticated"
+	CodePermissionDenied   Code = "permission_denied"
+	CodeNotFound           Code = "not_found"
+	CodeAlreadyExists      Code = "already_exists"
+	CodeConflict           Code = "conflict"
+	CodeFailedPrecondition Code = "failed_precondition"
+	CodeResourceExhausted  Code = "resource_exhausted"
+	CodeDeadlineExceeded   Code = "deadline_exceeded"
+	CodeUnimplemented      Code = "unimplemented"
+	CodeUnavailable        Code = "unavailable"
+	CodeInternal           Code = "internal"
+)
+
+var validCodes = map[Code]struct{}{
+	CodeInvalidArgument:    {},
+	CodeUnauthenticated:    {},
+	CodePermissionDenied:   {},
+	CodeNotFound:           {},
+	CodeAlreadyExists:      {},
+	CodeConflict:           {},
+	CodeFailedPrecondition: {},
+	CodeResourceExhausted:  {},
+	CodeDeadlineExceeded:   {},
+	CodeUnimplemented:      {},
+	CodeUnavailable:        {},
+	CodeInternal:           {},
+}
+
+// IsValidCode 判断 code 是否属于公共错误码集合。
+func IsValidCode(code Code) bool {
+	_, ok := validCodes[code]
+	return ok
+}

--- a/server/internal/platform/apperror/defaults.go
+++ b/server/internal/platform/apperror/defaults.go
@@ -1,0 +1,44 @@
+package apperror
+
+var retryableByCode = map[Code]bool{
+	CodeInvalidArgument:    false,
+	CodeUnauthenticated:    false,
+	CodePermissionDenied:   false,
+	CodeNotFound:           false,
+	CodeAlreadyExists:      false,
+	CodeConflict:           false,
+	CodeFailedPrecondition: false,
+	CodeResourceExhausted:  true,
+	CodeDeadlineExceeded:   false,
+	CodeUnimplemented:      false,
+	CodeUnavailable:        false,
+	CodeInternal:           false,
+}
+
+func defaultRetryable(code Code) bool {
+	return retryableByCode[code]
+}
+
+// CodeOf 返回 err 携带的公共错误码，未知错误安全降级为 CodeInternal。
+func CodeOf(err error) Code {
+	appErr, ok := As(err)
+	if !ok || !IsValidCode(appErr.Code) {
+		return CodeInternal
+	}
+	return appErr.Code
+}
+
+// ReasonOf 返回应用错误携带的稳定业务原因。
+func ReasonOf(err error) string {
+	appErr, ok := As(err)
+	if !ok || !IsValidCode(appErr.Code) {
+		return ""
+	}
+	return appErr.Reason
+}
+
+// IsRetryable 根据应用错误判断失败操作是否可重试，未知错误不可重试。
+func IsRetryable(err error) bool {
+	appErr, ok := As(err)
+	return ok && IsValidCode(appErr.Code) && appErr.Retryable
+}

--- a/server/internal/platform/apperror/error.go
+++ b/server/internal/platform/apperror/error.go
@@ -1,0 +1,97 @@
+package apperror
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error 描述与交付协议无关的应用失败。
+// Cause 仅供内部错误链和日志使用，禁止序列化后返回客户端。
+type Error struct {
+	Code      Code
+	Reason    string
+	Message   string
+	Detail    string
+	Details   map[string]any
+	Retryable bool
+	Cause     error
+}
+
+// New 创建应用错误。
+// 非法错误码会安全降级为内部错误，且不会保留调用方提供的公开字段。
+func New(code Code, message string, options ...Option) *Error {
+	invalidCode := !IsValidCode(code)
+	if invalidCode {
+		code = CodeInternal
+		message = ""
+	}
+
+	appErr := &Error{
+		Code:      code,
+		Message:   message,
+		Retryable: defaultRetryable(code),
+	}
+	for _, option := range options {
+		if option != nil {
+			option(appErr)
+		}
+	}
+	if invalidCode {
+		appErr.Reason = ""
+		appErr.Detail = ""
+		appErr.Details = nil
+		appErr.Retryable = false
+	}
+	return appErr
+}
+
+// Error 返回安全的公开错误上下文，并且不会包含 Cause。
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message == "" {
+		return string(e.Code)
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap 向 Go 错误链操作和内部日志开放 Cause。
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// As 从错误链中提取应用错误。
+func As(err error) (*Error, bool) {
+	var appErr *Error
+	if !errors.As(err, &appErr) || appErr == nil {
+		return nil, false
+	}
+	return appErr, true
+}
+
+func InvalidArgument(message string, options ...Option) *Error {
+	return New(CodeInvalidArgument, message, options...)
+}
+
+func NotFound(message string, options ...Option) *Error {
+	return New(CodeNotFound, message, options...)
+}
+
+func FailedPrecondition(message string, options ...Option) *Error {
+	return New(CodeFailedPrecondition, message, options...)
+}
+
+func Unavailable(message string, options ...Option) *Error {
+	return New(CodeUnavailable, message, options...)
+}
+
+func Internal(options ...Option) *Error {
+	return New(CodeInternal, "", options...)
+}

--- a/server/internal/platform/apperror/error_test.go
+++ b/server/internal/platform/apperror/error_test.go
@@ -1,0 +1,153 @@
+package apperror_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+)
+
+func TestPublicCodesAreValid(t *testing.T) {
+	codes := []apperror.Code{
+		apperror.CodeInvalidArgument,
+		apperror.CodeUnauthenticated,
+		apperror.CodePermissionDenied,
+		apperror.CodeNotFound,
+		apperror.CodeAlreadyExists,
+		apperror.CodeConflict,
+		apperror.CodeFailedPrecondition,
+		apperror.CodeResourceExhausted,
+		apperror.CodeDeadlineExceeded,
+		apperror.CodeUnimplemented,
+		apperror.CodeUnavailable,
+		apperror.CodeInternal,
+	}
+
+	for _, code := range codes {
+		if !apperror.IsValidCode(code) {
+			t.Errorf("expected %q to be valid", code)
+		}
+	}
+	if apperror.IsValidCode("review_analysis_not_found") {
+		t.Fatal("business reason must not be accepted as a public code")
+	}
+}
+
+func TestNewNormalizesInvalidCode(t *testing.T) {
+	cause := errors.New("internal diagnostic")
+	err := apperror.New(
+		"custom_failure",
+		"unsafe classification",
+		apperror.WithReason("unreviewed_reason"),
+		apperror.WithDetail("unsafe detail"),
+		apperror.WithDetails(map[string]any{"secret": true}),
+		apperror.WithRetryable(true),
+		apperror.WithCause(cause),
+	)
+
+	if err.Code != apperror.CodeInternal {
+		t.Fatalf("expected internal code, got %q", err.Code)
+	}
+	if err.Message != "" || err.Reason != "" || err.Detail != "" || err.Details != nil || err.Retryable {
+		t.Fatalf("invalid code retained public fields: %#v", err)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("invalid code normalization discarded the internal cause")
+	}
+	if apperror.CodeOf(err) != apperror.CodeInternal {
+		t.Fatalf("unexpected CodeOf result: %q", apperror.CodeOf(err))
+	}
+}
+
+func TestErrorChainAndSafeString(t *testing.T) {
+	cause := errors.New("database password=secret")
+	appErr := apperror.NotFound(
+		"analysis not found",
+		apperror.WithReason("review_analysis_not_found"),
+		apperror.WithCause(cause),
+	)
+	wrapped := fmt.Errorf("delivery mapping: %w", appErr)
+
+	if strings.Contains(appErr.Error(), cause.Error()) {
+		t.Fatal("Error() leaked the internal cause")
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Fatal("errors.Is did not traverse the application error")
+	}
+
+	var extracted *apperror.Error
+	if !errors.As(wrapped, &extracted) || extracted != appErr {
+		t.Fatal("errors.As did not extract the application error")
+	}
+	if got, ok := apperror.As(wrapped); !ok || got != appErr {
+		t.Fatal("apperror.As did not extract the application error")
+	}
+}
+
+func TestDefaultsAndQueries(t *testing.T) {
+	retryable := apperror.New(
+		apperror.CodeResourceExhausted,
+		"quota exhausted",
+		apperror.WithReason("rate_limit_exceeded"),
+	)
+	if !apperror.IsRetryable(retryable) {
+		t.Fatal("resource_exhausted should be retryable by default")
+	}
+	if apperror.ReasonOf(retryable) != "rate_limit_exceeded" {
+		t.Fatalf("unexpected reason: %q", apperror.ReasonOf(retryable))
+	}
+
+	overridden := apperror.New(
+		apperror.CodeResourceExhausted,
+		"hard quota exhausted",
+		apperror.WithRetryable(false),
+	)
+	if apperror.IsRetryable(overridden) {
+		t.Fatal("WithRetryable did not override the default")
+	}
+	if apperror.IsRetryable(errors.New("unknown")) {
+		t.Fatal("unknown errors must not be retryable")
+	}
+	if apperror.CodeOf(errors.New("unknown")) != apperror.CodeInternal {
+		t.Fatal("unknown errors must fall back to internal")
+	}
+	if apperror.ReasonOf(errors.New("unknown")) != "" {
+		t.Fatal("unknown errors must not expose a reason")
+	}
+}
+
+func TestInternalIsNotRetryableByDefault(t *testing.T) {
+	if apperror.Internal().Retryable {
+		t.Fatal("internal must not be retryable by default")
+	}
+}
+
+func TestWithDetailsCopiesInputMap(t *testing.T) {
+	input := map[string]any{"field": "original"}
+	err := apperror.InvalidArgument("invalid input", apperror.WithDetails(input))
+	input["field"] = "changed"
+	input["extra"] = true
+
+	if got := err.Details["field"]; got != "original" {
+		t.Fatalf("details changed with caller map: %#v", err.Details)
+	}
+	if _, exists := err.Details["extra"]; exists {
+		t.Fatalf("details unexpectedly contains caller mutation: %#v", err.Details)
+	}
+}
+
+func TestEmptyOptionalValuesAreAllowed(t *testing.T) {
+	err := apperror.New(
+		apperror.CodeInvalidArgument,
+		"",
+		apperror.WithReason(""),
+		apperror.WithDetail(""),
+		apperror.WithDetails(nil),
+	)
+
+	if err.Reason != "" || err.Detail != "" || err.Details != nil {
+		t.Fatalf("unexpected optional values: %#v", err)
+	}
+}

--- a/server/internal/platform/apperror/error_test.go
+++ b/server/internal/platform/apperror/error_test.go
@@ -125,13 +125,23 @@ func TestInternalIsNotRetryableByDefault(t *testing.T) {
 }
 
 func TestWithDetailsCopiesInputMap(t *testing.T) {
-	input := map[string]any{"field": "original"}
+	input := map[string]any{
+		"field": map[string]any{"value": "original"},
+		"items": []any{map[string]any{"name": "first"}},
+	}
 	err := apperror.InvalidArgument("invalid input", apperror.WithDetails(input))
-	input["field"] = "changed"
+
+	input["field"].(map[string]any)["value"] = "changed"
+	input["items"].([]any)[0].(map[string]any)["name"] = "changed"
 	input["extra"] = true
 
-	if got := err.Details["field"]; got != "original" {
-		t.Fatalf("details changed with caller map: %#v", err.Details)
+	field := err.Details["field"].(map[string]any)
+	if got := field["value"]; got != "original" {
+		t.Fatalf("nested map changed with caller input: %#v", err.Details)
+	}
+	items := err.Details["items"].([]any)
+	if got := items[0].(map[string]any)["name"]; got != "first" {
+		t.Fatalf("nested slice changed with caller input: %#v", err.Details)
 	}
 	if _, exists := err.Details["extra"]; exists {
 		t.Fatalf("details unexpectedly contains caller mutation: %#v", err.Details)

--- a/server/internal/platform/apperror/options.go
+++ b/server/internal/platform/apperror/options.go
@@ -1,0 +1,42 @@
+package apperror
+
+// Option 用于在创建位置配置应用错误。
+type Option func(*Error)
+
+func WithReason(reason string) Option {
+	return func(err *Error) {
+		err.Reason = reason
+	}
+}
+
+func WithDetail(detail string) Option {
+	return func(err *Error) {
+		err.Detail = detail
+	}
+}
+
+func WithDetails(details map[string]any) Option {
+	return func(err *Error) {
+		if details == nil {
+			err.Details = nil
+			return
+		}
+
+		err.Details = make(map[string]any, len(details))
+		for key, value := range details {
+			err.Details[key] = value
+		}
+	}
+}
+
+func WithCause(cause error) Option {
+	return func(err *Error) {
+		err.Cause = cause
+	}
+}
+
+func WithRetryable(retryable bool) Option {
+	return func(err *Error) {
+		err.Retryable = retryable
+	}
+}

--- a/server/internal/platform/apperror/options.go
+++ b/server/internal/platform/apperror/options.go
@@ -17,15 +17,34 @@ func WithDetail(detail string) Option {
 
 func WithDetails(details map[string]any) Option {
 	return func(err *Error) {
-		if details == nil {
-			err.Details = nil
-			return
-		}
+		err.Details = cloneDetails(details)
+	}
+}
 
-		err.Details = make(map[string]any, len(details))
-		for key, value := range details {
-			err.Details[key] = value
+func cloneDetails(details map[string]any) map[string]any {
+	if details == nil {
+		return nil
+	}
+
+	cloned := make(map[string]any, len(details))
+	for key, value := range details {
+		cloned[key] = cloneDetailValue(value)
+	}
+	return cloned
+}
+
+func cloneDetailValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		return cloneDetails(value)
+	case []any:
+		cloned := make([]any, len(value))
+		for index, item := range value {
+			cloned[index] = cloneDetailValue(item)
 		}
+		return cloned
+	default:
+		return value
 	}
 }
 

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -116,9 +116,25 @@ func copyDetails(details map[string]any) map[string]any {
 	if details == nil {
 		return nil
 	}
+
 	copied := make(map[string]any, len(details))
 	for key, value := range details {
-		copied[key] = value
+		copied[key] = copyDetailValue(value)
 	}
 	return copied
+}
+
+func copyDetailValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		return copyDetails(value)
+	case []any:
+		copied := make([]any, len(value))
+		for index, item := range value {
+			copied[index] = copyDetailValue(item)
+		}
+		return copied
+	default:
+		return value
+	}
 }

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -1,0 +1,124 @@
+package httpresponse
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+)
+
+const (
+	internalReason  = "service_internal_error"
+	internalMessage = "an internal service error occurred"
+)
+
+var statusByCode = map[apperror.Code]int{
+	apperror.CodeInvalidArgument:    http.StatusBadRequest,
+	apperror.CodeUnauthenticated:    http.StatusUnauthorized,
+	apperror.CodePermissionDenied:   http.StatusForbidden,
+	apperror.CodeNotFound:           http.StatusNotFound,
+	apperror.CodeAlreadyExists:      http.StatusConflict,
+	apperror.CodeConflict:           http.StatusConflict,
+	apperror.CodeFailedPrecondition: http.StatusConflict,
+	apperror.CodeResourceExhausted:  http.StatusTooManyRequests,
+	apperror.CodeDeadlineExceeded:   http.StatusGatewayTimeout,
+	apperror.CodeUnimplemented:      http.StatusNotImplemented,
+	apperror.CodeUnavailable:        http.StatusServiceUnavailable,
+	apperror.CodeInternal:           http.StatusInternalServerError,
+}
+
+var defaultMessageByCode = map[apperror.Code]string{
+	apperror.CodeInvalidArgument:    "invalid request",
+	apperror.CodeUnauthenticated:    "authentication required",
+	apperror.CodePermissionDenied:   "permission denied",
+	apperror.CodeNotFound:           "resource not found",
+	apperror.CodeAlreadyExists:      "resource already exists",
+	apperror.CodeConflict:           "request conflicts with current state",
+	apperror.CodeFailedPrecondition: "operation is not allowed in the current state",
+	apperror.CodeResourceExhausted:  "resource limit exceeded",
+	apperror.CodeDeadlineExceeded:   "request deadline exceeded",
+	apperror.CodeUnimplemented:      "operation is not implemented",
+	apperror.CodeUnavailable:        "service temporarily unavailable",
+	apperror.CodeInternal:           internalMessage,
+}
+
+// ErrorEnvelope 是稳定的 REST 顶层错误响应。
+type ErrorEnvelope struct {
+	Error ErrorBody `json:"error"`
+}
+
+// ErrorBody 包含可安全返回客户端的应用错误字段。
+type ErrorBody struct {
+	Code      apperror.Code  `json:"code"`
+	Reason    string         `json:"reason,omitempty"`
+	Message   string         `json:"message"`
+	Detail    string         `json:"detail,omitempty"`
+	Details   map[string]any `json:"details,omitempty"`
+	Retryable bool           `json:"retryable"`
+	RequestID string         `json:"request_id,omitempty"`
+}
+
+// Render 将任意错误转换为 HTTP 状态码和客户端安全的错误响应。
+func Render(err error, requestID string) (int, ErrorEnvelope) {
+	appErr, ok := apperror.As(err)
+	if !ok || !apperror.IsValidCode(appErr.Code) {
+		return internalResponse(requestID)
+	}
+
+	status, ok := statusByCode[appErr.Code]
+	if !ok {
+		return internalResponse(requestID)
+	}
+
+	message := appErr.Message
+	if message == "" {
+		message = defaultMessageByCode[appErr.Code]
+	}
+
+	reason := appErr.Reason
+	if appErr.Code == apperror.CodeInternal && reason == "" {
+		reason = internalReason
+	}
+
+	return status, ErrorEnvelope{
+		Error: ErrorBody{
+			Code:      appErr.Code,
+			Reason:    reason,
+			Message:   message,
+			Detail:    appErr.Detail,
+			Details:   copyDetails(appErr.Details),
+			Retryable: appErr.Retryable,
+			RequestID: requestID,
+		},
+	}
+}
+
+// Write 渲染 err 并通过 Gin 写入响应。
+func Write(c *gin.Context, err error, requestID string) {
+	status, envelope := Render(err, requestID)
+	c.JSON(status, envelope)
+}
+
+func internalResponse(requestID string) (int, ErrorEnvelope) {
+	return http.StatusInternalServerError, ErrorEnvelope{
+		Error: ErrorBody{
+			Code:      apperror.CodeInternal,
+			Reason:    internalReason,
+			Message:   internalMessage,
+			Retryable: false,
+			RequestID: requestID,
+		},
+	}
+}
+
+func copyDetails(details map[string]any) map[string]any {
+	if details == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(details))
+	for key, value := range details {
+		copied[key] = value
+	}
+	return copied
+}

--- a/server/internal/platform/httpresponse/error_test.go
+++ b/server/internal/platform/httpresponse/error_test.go
@@ -1,0 +1,185 @@
+package httpresponse_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+)
+
+func TestEveryPublicCodeHasExplicitStatus(t *testing.T) {
+	tests := map[apperror.Code]int{
+		apperror.CodeInvalidArgument:    http.StatusBadRequest,
+		apperror.CodeUnauthenticated:    http.StatusUnauthorized,
+		apperror.CodePermissionDenied:   http.StatusForbidden,
+		apperror.CodeNotFound:           http.StatusNotFound,
+		apperror.CodeAlreadyExists:      http.StatusConflict,
+		apperror.CodeConflict:           http.StatusConflict,
+		apperror.CodeFailedPrecondition: http.StatusConflict,
+		apperror.CodeResourceExhausted:  http.StatusTooManyRequests,
+		apperror.CodeDeadlineExceeded:   http.StatusGatewayTimeout,
+		apperror.CodeUnimplemented:      http.StatusNotImplemented,
+		apperror.CodeUnavailable:        http.StatusServiceUnavailable,
+		apperror.CodeInternal:           http.StatusInternalServerError,
+	}
+
+	for code, wantStatus := range tests {
+		t.Run(string(code), func(t *testing.T) {
+			status, envelope := httpresponse.Render(apperror.New(code, "safe"), "")
+			if status != wantStatus {
+				t.Fatalf("expected status %d, got %d", wantStatus, status)
+			}
+			if envelope.Error.Code != code {
+				t.Fatalf("expected code %q, got %q", code, envelope.Error.Code)
+			}
+		})
+	}
+}
+
+func TestRenderPreservesSafeFieldsAndStructuredDetails(t *testing.T) {
+	err := apperror.InvalidArgument(
+		"request is invalid",
+		apperror.WithReason("request_invalid_json"),
+		apperror.WithDetail("field limit must be positive"),
+		apperror.WithDetails(map[string]any{
+			"field": "limit",
+			"min":   float64(1),
+		}),
+		apperror.WithRetryable(true),
+	)
+
+	status, envelope := httpresponse.Render(err, "req_123")
+	if status != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", status)
+	}
+	body, marshalErr := json.Marshal(envelope)
+	if marshalErr != nil {
+		t.Fatalf("marshal envelope: %v", marshalErr)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	errorBody := decoded["error"].(map[string]any)
+	if errorBody["code"] != "invalid_argument" ||
+		errorBody["reason"] != "request_invalid_json" ||
+		errorBody["message"] != "request is invalid" ||
+		errorBody["detail"] != "field limit must be positive" ||
+		errorBody["retryable"] != true ||
+		errorBody["request_id"] != "req_123" {
+		t.Fatalf("unexpected envelope: %#v", errorBody)
+	}
+	details := errorBody["details"].(map[string]any)
+	if details["field"] != "limit" || details["min"] != float64(1) {
+		t.Fatalf("details lost structured types: %#v", details)
+	}
+}
+
+func TestRenderOmitsEmptyOptionalFields(t *testing.T) {
+	_, envelope := httpresponse.Render(apperror.NotFound("missing"), "")
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	text := string(body)
+	for _, field := range []string{`"reason"`, `"detail"`, `"details"`, `"request_id"`} {
+		if strings.Contains(text, field) {
+			t.Fatalf("empty optional field %s was serialized: %s", field, text)
+		}
+	}
+	if !strings.Contains(text, `"retryable":false`) {
+		t.Fatalf("retryable must always be serialized: %s", text)
+	}
+}
+
+func TestCauseNeverAppearsInJSON(t *testing.T) {
+	cause := errors.New("postgres password=secret")
+	err := apperror.New(
+		apperror.CodeUnavailable,
+		"service temporarily unavailable",
+		apperror.WithCause(cause),
+	)
+
+	_, envelope := httpresponse.Render(err, "")
+	body, marshalErr := json.Marshal(envelope)
+	if marshalErr != nil {
+		t.Fatalf("marshal envelope: %v", marshalErr)
+	}
+	if strings.Contains(string(body), cause.Error()) || strings.Contains(string(body), "cause") {
+		t.Fatalf("cause leaked into response: %s", body)
+	}
+}
+
+func TestUnknownErrorFallsBackToInternal(t *testing.T) {
+	status, envelope := httpresponse.Render(errors.New("sensitive provider failure"), "")
+
+	if status != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", status)
+	}
+	if envelope.Error.Code != apperror.CodeInternal ||
+		envelope.Error.Reason != "service_internal_error" ||
+		envelope.Error.Retryable {
+		t.Fatalf("unexpected internal fallback: %#v", envelope.Error)
+	}
+	if strings.Contains(envelope.Error.Message, "sensitive") {
+		t.Fatalf("unknown error leaked into message: %q", envelope.Error.Message)
+	}
+}
+
+func TestManuallyConstructedUnknownCodeFallsBackToInternal(t *testing.T) {
+	status, envelope := httpresponse.Render(&apperror.Error{
+		Code:    "unreviewed_code",
+		Message: "must not be exposed",
+	}, "")
+
+	if status != http.StatusInternalServerError ||
+		envelope.Error.Code != apperror.CodeInternal ||
+		envelope.Error.Reason != "service_internal_error" {
+		t.Fatalf("unexpected fallback: status=%d body=%#v", status, envelope.Error)
+	}
+}
+
+func TestInvalidCodeCreatedThroughConstructorUsesSafeFallback(t *testing.T) {
+	status, envelope := httpresponse.Render(
+		apperror.New("unreviewed_code", "must not be exposed"),
+		"",
+	)
+
+	if status != http.StatusInternalServerError ||
+		envelope.Error.Code != apperror.CodeInternal ||
+		envelope.Error.Reason != "service_internal_error" ||
+		strings.Contains(envelope.Error.Message, "exposed") {
+		t.Fatalf("unexpected fallback: status=%d body=%#v", status, envelope.Error)
+	}
+}
+
+func TestEmptyMessageUsesSafeDefault(t *testing.T) {
+	_, envelope := httpresponse.Render(apperror.NotFound(""), "")
+	if envelope.Error.Message != "resource not found" {
+		t.Fatalf("unexpected default message: %q", envelope.Error.Message)
+	}
+}
+
+func TestWriteUsesGinAndInjectsRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+
+	httpresponse.Write(context, apperror.NotFound("missing"), "req_write")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), `"request_id":"req_write"`) {
+		t.Fatalf("request id missing from response: %s", recorder.Body.String())
+	}
+}

--- a/server/internal/platform/httpresponse/error_test.go
+++ b/server/internal/platform/httpresponse/error_test.go
@@ -83,6 +83,29 @@ func TestRenderPreservesSafeFieldsAndStructuredDetails(t *testing.T) {
 	}
 }
 
+func TestRenderCopiesNestedStructuredDetails(t *testing.T) {
+	err := apperror.InvalidArgument(
+		"request is invalid",
+		apperror.WithDetails(map[string]any{
+			"field": map[string]any{"value": "original"},
+			"items": []any{map[string]any{"name": "first"}},
+		}),
+	)
+
+	_, envelope := httpresponse.Render(err, "")
+	err.Details["field"].(map[string]any)["value"] = "changed"
+	err.Details["items"].([]any)[0].(map[string]any)["name"] = "changed"
+
+	field := envelope.Error.Details["field"].(map[string]any)
+	if got := field["value"]; got != "original" {
+		t.Fatalf("rendered nested map changed with source error: %#v", envelope.Error.Details)
+	}
+	items := envelope.Error.Details["items"].([]any)
+	if got := items[0].(map[string]any)["name"]; got != "first" {
+		t.Fatalf("rendered nested slice changed with source error: %#v", envelope.Error.Details)
+	}
+}
+
 func TestRenderOmitsEmptyOptionalFields(t *testing.T) {
 	_, envelope := httpresponse.Render(apperror.NotFound("missing"), "")
 	body, err := json.Marshal(envelope)


### PR DESCRIPTION
## 功能描述

实现与业务模块解耦的公共应用错误组件和统一 REST Error Renderer，并以未知路由作为首个真实平台调用方。

## 实现内容

- 在 `internal/platform/apperror` 定义 12 个稳定公共 Code、`Error`、Options、默认重试属性和错误链查询能力
- 对非法 Code 和未知普通错误执行安全的 `internal` 降级
- 在 `internal/platform/httpresponse` 定义统一 Error Envelope 和所有公共 Code 的显式 HTTP Status 映射
- 支持安全 message、detail、details、retryable 和 request_id，Cause 不进入 JSON
- 将 `route_not_found` 接入公共 `not_found` Code 和统一 Renderer
- 保持 `/health` 成功响应不变

本 PR 不迁移 Preparation、Practice、Conversation 或 Review 的业务错误。

## 验证方式

```bash
cd server
go test ./internal/platform/apperror/...
go test ./internal/platform/httpresponse/...
go test ./internal/bootstrap/...
go test ./...
go vet ./...
```

额外执行了相关包的竞态测试：

```bash
go test -race ./internal/platform/apperror/... ./internal/platform/httpresponse/... ./internal/bootstrap/...
```

Closes #52