### PR TITLE
feat(mobile): 完成 App Shell 与模块导航

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -6,6 +6,7 @@ SpeakUp 的 Flutter Android/iOS 正式客户端。
 
 ```shell
 flutter pub get
-dart format --output=none --set-exit-if-changed lib
+dart format --output=none --set-exit-if-changed lib test
 flutter analyze
+flutter test
 ```

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/features/conversation/conversation.dart';
+import 'package:speakup/features/practice/practice.dart';
+import 'package:speakup/features/preparation/preparation.dart';
+import 'package:speakup/features/review/review.dart';
+
+const _homeRoute = '/';
+const _preparationRoute = '/preparation';
+const _practiceRoute = '/practice';
+const _conversationRoute = '/conversation';
+const _reviewRoute = '/review';
+
+class SpeakUpApp extends StatelessWidget {
+  const SpeakUpApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'SpeakUp',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        useMaterial3: true,
+      ),
+      initialRoute: _homeRoute,
+      routes: {
+        _homeRoute: (_) => const _HomePage(),
+        _preparationRoute: (_) => const PreparationPage(),
+        _practiceRoute: (_) => const PracticePage(),
+        _conversationRoute: (_) => const ConversationPage(),
+        _reviewRoute: (_) => const ReviewPage(),
+      },
+    );
+  }
+}
+
+class _HomePage extends StatelessWidget {
+  const _HomePage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('SpeakUp')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.assignment_outlined),
+            title: const Text('Preparation'),
+            subtitle: const Text('Prepare the context for a practice session.'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.pushNamed(context, _preparationRoute),
+          ),
+          ListTile(
+            leading: const Icon(Icons.route_outlined),
+            title: const Text('Practice'),
+            subtitle: const Text('Review the plan for a practice session.'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.pushNamed(context, _practiceRoute),
+          ),
+          ListTile(
+            leading: const Icon(Icons.forum_outlined),
+            title: const Text('Conversation'),
+            subtitle: const Text('Take part in a guided conversation.'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.pushNamed(context, _conversationRoute),
+          ),
+          ListTile(
+            leading: const Icon(Icons.rate_review_outlined),
+            title: const Text('Review'),
+            subtitle: const Text('Review feedback after a practice session.'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.pushNamed(context, _reviewRoute),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -1,2 +1,16 @@
 /// Conversation module boundary.
 library;
+
+import 'package:flutter/material.dart';
+
+class ConversationPage extends StatelessWidget {
+  const ConversationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Conversation')),
+      body: const Center(child: Text('Conversation module')),
+    );
+  }
+}

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -1,2 +1,16 @@
 /// Practice module boundary.
 library;
+
+import 'package:flutter/material.dart';
+
+class PracticePage extends StatelessWidget {
+  const PracticePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Practice')),
+      body: const Center(child: Text('Practice module')),
+    );
+  }
+}

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -1,2 +1,16 @@
 /// Preparation module boundary.
 library;
+
+import 'package:flutter/material.dart';
+
+class PreparationPage extends StatelessWidget {
+  const PreparationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Preparation')),
+      body: const Center(child: Text('Preparation module')),
+    );
+  }
+}

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -1,2 +1,16 @@
 /// Review module boundary.
 library;
+
+import 'package:flutter/material.dart';
+
+class ReviewPage extends StatelessWidget {
+  const ReviewPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Review')),
+      body: const Center(child: Text('Review module')),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/app/speak_up_app.dart';
 
 void main() {
-  runApp(
-    const MaterialApp(
-      home: Scaffold(body: Center(child: Text('SpeakUp'))),
-    ),
-  );
+  runApp(const SpeakUpApp());
 }

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/conversation/conversation.dart';
+import 'package:speakup/features/practice/practice.dart';
+import 'package:speakup/features/preparation/preparation.dart';
+import 'package:speakup/features/review/review.dart';
+
+void main() {
+  testWidgets('app starts and exposes every feature entry point', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp());
+
+    expect(find.text('SpeakUp'), findsOneWidget);
+
+    await _expectNavigationTo<PreparationPage>(tester, 'Preparation');
+    await _expectNavigationTo<PracticePage>(tester, 'Practice');
+    await _expectNavigationTo<ConversationPage>(tester, 'Conversation');
+    await _expectNavigationTo<ReviewPage>(tester, 'Review');
+  });
+}
+
+Future<void> _expectNavigationTo<T extends Widget>(
+  WidgetTester tester,
+  String entryLabel,
+) async {
+  await tester.tap(find.text(entryLabel));
+  await tester.pumpAndSettle();
+
+  expect(find.byType(T), findsOneWidget);
+
+  await tester.pageBack();
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## 功能描述

- 建立最小 Flutter App Shell，集中组装应用入口、主题和导航。
- 提供 Preparation、Practice、Conversation、Review 四个模块的可见入口。
- 为四个 Feature 保留稳定公开页面入口。
- 增加覆盖应用启动和四个入口可达性的 Widget 冒烟测试。

## 实现思路

- `main.dart` 只负责启动 `SpeakUpApp`。
- 使用 Flutter 内置 `MaterialApp.routes` 和 Material 3 主题，不引入第三方路由、状态管理或依赖注入框架。
- App Shell 只通过各 Feature 的公开文件导入占位页面，Feature 之间没有相互依赖。
- 更新移动端 README，记录供后续 CI 直接调用的检查命令。

## 测试方式

```shell
cd mobile
flutter pub get --enforce-lockfile
dart format --output=none --set-exit-if-changed lib test
flutter analyze
flutter test
```

本地结果：

- 格式检查通过。
- Flutter 静态分析通过，无问题。
- Widget 测试通过，覆盖应用启动及四个模块入口。
- 已在 iOS 18.3 `XE3 iPhone 16 Pro` 模拟器启动，并验证热重载。

## 范围说明

- 未实现任何 Feature 业务流程或业务状态。
- 未接入 REST、WebSocket、Provider 或完整依赖注入。
- 未新增 Flutter Web、Prototype 页面、后端或 CI 改动。

Closes #59
