### PR TITLE
feat(api): 定义 MS1 REST 与 WebSocket 最小契约

### DIFF
--- a/api/common/errors.yaml
+++ b/api/common/errors.yaml
@@ -1,0 +1,176 @@
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+    Error:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+        - retryable
+        - correlation_id
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          type: string
+          minLength: 1
+          description: Sanitized user-facing summary.
+        retryable:
+          type: boolean
+        correlation_id:
+          type: string
+          minLength: 1
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+    ErrorDetail:
+      type: object
+      additionalProperties: false
+      required:
+        - field
+        - reason
+      properties:
+        field:
+          type: string
+          minLength: 1
+        reason:
+          type: string
+          minLength: 1
+    ErrorCode:
+      type: string
+      description: Stable machine-readable Delivery error code.
+      enum:
+        - invalid_request
+        - resource_not_found
+        - resource_conflict
+        - idempotency_key_conflict
+        - scenario_definition_not_found
+        - role_definition_not_found
+        - preparation_profile_not_found
+        - preparation_version_conflict
+        - practice_plan_not_found
+        - practice_plan_not_ready
+        - practice_plan_archived
+        - practice_plan_has_active_session
+        - practice_plan_revision_conflict
+        - practice_session_not_found
+        - practice_session_transition_not_allowed
+        - practice_session_already_terminal
+        - practice_session_version_conflict
+        - practice_participant_invalid
+        - practice_participant_not_authorized
+        - practice_option_invalid
+        - question_not_found
+        - answer_invalid
+        - turn_not_found
+        - turn_conflict
+        - turn_outcome_session_mismatch
+        - turn_analysis_not_found
+        - turn_analysis_conflict
+        - feedback_item_not_found
+        - retry_request_not_found
+        - retry_request_conflict
+        - transcript_unavailable
+        - unsupported_message
+        - internal_error
+      x-http-status-map:
+        invalid_request: 400
+        answer_invalid: 400
+        unsupported_message: 400
+        practice_participant_not_authorized: 403
+        scenario_definition_not_found: 404
+        role_definition_not_found: 404
+        preparation_profile_not_found: 404
+        practice_plan_not_found: 404
+        practice_session_not_found: 404
+        question_not_found: 404
+        turn_not_found: 404
+        turn_analysis_not_found: 404
+        feedback_item_not_found: 404
+        retry_request_not_found: 404
+        resource_not_found: 404
+        idempotency_key_conflict: 409
+        resource_conflict: 409
+        preparation_version_conflict: 409
+        practice_plan_not_ready: 409
+        practice_plan_archived: 409
+        practice_plan_has_active_session: 409
+        practice_plan_revision_conflict: 409
+        practice_session_transition_not_allowed: 409
+        practice_session_already_terminal: 409
+        practice_session_version_conflict: 409
+        practice_participant_invalid: 409
+        practice_option_invalid: 409
+        turn_conflict: 409
+        turn_outcome_session_mismatch: 409
+        turn_analysis_conflict: 409
+        retry_request_conflict: 409
+        transcript_unavailable: 422
+        internal_error: 500
+  responses:
+    BadRequest:
+      description: The request is malformed or violates a field constraint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: invalid_request
+              message: Request validation failed.
+              retryable: false
+              correlation_id: corr_invalid_request
+              details:
+                - field: body
+                  reason: One or more fields are invalid.
+    NotFound:
+      description: The requested resource does not exist for the current actor.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: resource_not_found
+              message: Resource was not found.
+              retryable: false
+              correlation_id: corr_not_found
+    Forbidden:
+      description: The current actor cannot perform this operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: practice_participant_not_authorized
+              message: The current actor is not an addressee for this question.
+              retryable: false
+              correlation_id: corr_forbidden
+    Conflict:
+      description: The request conflicts with the current resource state.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: resource_conflict
+              message: Resource state conflicts with this operation.
+              retryable: false
+              correlation_id: corr_conflict
+    DefaultError:
+      description: A stable error response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'

--- a/api/common/event-envelope.schema.json
+++ b/api/common/event-envelope.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speak-up.top/api/schemas/common/event-envelope.schema.json",
+  "title": "SpeakUp event envelope",
+  "description": "Ordered server-to-client event envelope for one practice session.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id",
+    "event_type",
+    "event_version",
+    "occurred_at",
+    "practice_session_id",
+    "correlation_id",
+    "replayable",
+    "payload"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_type": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+    },
+    "event_version": {
+      "const": 1,
+      "description": "This schema accepts only protocol version 1."
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "practice_session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic sequence within one practice session."
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "causation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "replayable": {
+      "type": "boolean"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "replayable": {
+            "const": true
+          }
+        },
+        "required": [
+          "replayable"
+        ]
+      },
+      "then": {
+        "properties": {
+          "sequence": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "sequence"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "sequence"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/api/common/parameters.yaml
+++ b/api/common/parameters.yaml
@@ -1,0 +1,23 @@
+components:
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      description: |
+        Stable client-generated key for one write intent. Its scope is the
+        current actor, HTTP method, and canonical path.
+
+        The server fingerprints the request body. Concurrent or repeated
+        requests with the same key and fingerprint return the original status
+        code and response body without repeating side effects. Reusing the same
+        key with a different fingerprint returns HTTP 409 with
+        `idempotency_key_conflict`.
+
+        Results remain available for the lifetime of the created resource and
+        for at least 24 hours when no durable resource is created.
+      schema:
+        type: string
+        minLength: 8
+        maxLength: 128
+      example: intent-demo-0001

--- a/api/examples/mock-main-flow.json
+++ b/api/examples/mock-main-flow.json
@@ -1,0 +1,292 @@
+{
+  "fixture_id": "mock_main_flow_v1",
+  "practice_session": {
+    "practice_session_id": "session_demo_001",
+    "practice_plan_id": "plan_demo_backend",
+    "scenario_type": "INTERVIEW",
+    "snapshot_id": "snapshot_session_demo_001",
+    "practice_session_status": "completed",
+    "session_version": 6,
+    "started_at": "2026-07-23T10:04:00Z",
+    "ended_at": "2026-07-23T10:20:00Z",
+    "end_reason": "COVERAGE_SATISFIED_AT_CHECKPOINT",
+    "created_at": "2026-07-23T10:03:00Z"
+  },
+  "session_policy": {
+    "suggested_duration_seconds": 900,
+    "min_effective_turns": 4,
+    "max_effective_turns": 6,
+    "coverage_checkpoint_turn": 4,
+    "max_follow_ups_per_question": 1,
+    "target_objectives": [
+      {
+        "objective_id": "introduction",
+        "description": "Explain current experience clearly."
+      },
+      {
+        "objective_id": "system_design",
+        "description": "Explain a technical design and its trade-offs."
+      },
+      {
+        "objective_id": "project_depth",
+        "description": "Provide evidence of individual contribution."
+      },
+      {
+        "objective_id": "collaboration",
+        "description": "Explain cross-team communication and outcomes."
+      }
+    ],
+    "early_completion_rule": "COVERAGE_SATISFIED_AFTER_CHECKPOINT"
+  },
+  "participants": [
+    {
+      "practice_participant_id": "participant_interviewer_001",
+      "practice_session_id": "session_demo_001",
+      "participant_role": "INTERVIEWER",
+      "subject_ref": {
+        "namespace": "mock.actor",
+        "subject_id": "interviewer_technical"
+      },
+      "participant_order": 1
+    },
+    {
+      "practice_participant_id": "participant_candidate_001",
+      "practice_session_id": "session_demo_001",
+      "participant_role": "CANDIDATE",
+      "subject_ref": {
+        "namespace": "speakup.user",
+        "subject_id": "user_demo"
+      },
+      "participant_order": 2
+    }
+  ],
+  "questions": [
+    {
+      "question_id": "question_demo_001",
+      "practice_session_id": "session_demo_001",
+      "speaker_participant_id": "participant_interviewer_001",
+      "addressee_participant_ids": [
+        "participant_candidate_001"
+      ],
+      "objective_id": "introduction",
+      "question_type": "PRIMARY",
+      "content": "Please introduce yourself and the backend project you are most proud of.",
+      "sequence": 1,
+      "created_at": "2026-07-23T10:04:00Z"
+    },
+    {
+      "question_id": "question_demo_002",
+      "practice_session_id": "session_demo_001",
+      "speaker_participant_id": "participant_interviewer_001",
+      "addressee_participant_ids": [
+        "participant_candidate_001"
+      ],
+      "objective_id": "system_design",
+      "question_type": "PRIMARY",
+      "content": "How did you design the reliability controls for that API?",
+      "sequence": 2,
+      "created_at": "2026-07-23T10:08:00Z"
+    },
+    {
+      "question_id": "question_demo_003",
+      "practice_session_id": "session_demo_001",
+      "speaker_participant_id": "participant_interviewer_001",
+      "addressee_participant_ids": [
+        "participant_candidate_001"
+      ],
+      "objective_id": "project_depth",
+      "question_type": "FOLLOW_UP",
+      "parent_question_id": "question_demo_002",
+      "content": "Which design decision was yours, and what trade-off did you make?",
+      "sequence": 3,
+      "created_at": "2026-07-23T10:12:00Z"
+    },
+    {
+      "question_id": "question_demo_004",
+      "practice_session_id": "session_demo_001",
+      "speaker_participant_id": "participant_interviewer_001",
+      "addressee_participant_ids": [
+        "participant_candidate_001"
+      ],
+      "objective_id": "collaboration",
+      "question_type": "PRIMARY",
+      "content": "How did you align the rollout with the teams that consumed the API?",
+      "sequence": 4,
+      "created_at": "2026-07-23T10:16:00Z"
+    }
+  ],
+  "effective_turns": [
+    {
+      "turn_id": "turn_demo_001",
+      "practice_session_id": "session_demo_001",
+      "question_id": "question_demo_001",
+      "respondent_participant_id": "participant_candidate_001",
+      "sequence": 1,
+      "interaction_mode": "PUSH_TO_TALK",
+      "answer_text": "I led a Go API reliability project and reduced incident recovery time.",
+      "turn_status": "completed",
+      "submitted_at": "2026-07-23T10:05:00Z",
+      "created_at": "2026-07-23T10:05:00Z",
+      "completed_at": "2026-07-23T10:05:02Z"
+    },
+    {
+      "turn_id": "turn_demo_002",
+      "practice_session_id": "session_demo_001",
+      "question_id": "question_demo_002",
+      "respondent_participant_id": "participant_candidate_001",
+      "sequence": 2,
+      "interaction_mode": "PUSH_TO_TALK",
+      "answer_text": "I introduced request tracing, defined an error budget, and staged the rollout.",
+      "turn_status": "completed",
+      "submitted_at": "2026-07-23T10:09:00Z",
+      "created_at": "2026-07-23T10:09:00Z",
+      "completed_at": "2026-07-23T10:09:02Z"
+    },
+    {
+      "turn_id": "turn_demo_003",
+      "practice_session_id": "session_demo_001",
+      "question_id": "question_demo_003",
+      "respondent_participant_id": "participant_candidate_001",
+      "sequence": 3,
+      "interaction_mode": "PUSH_TO_TALK",
+      "answer_text": "I chose sampling by endpoint risk to control cost while preserving failure evidence.",
+      "turn_status": "completed",
+      "submitted_at": "2026-07-23T10:13:00Z",
+      "created_at": "2026-07-23T10:13:00Z",
+      "completed_at": "2026-07-23T10:13:02Z"
+    },
+    {
+      "turn_id": "turn_demo_004",
+      "practice_session_id": "session_demo_001",
+      "question_id": "question_demo_004",
+      "respondent_participant_id": "participant_candidate_001",
+      "sequence": 4,
+      "interaction_mode": "PUSH_TO_TALK",
+      "answer_text": "I published the error budget, ran a canary review, and agreed rollback signals.",
+      "turn_status": "completed",
+      "submitted_at": "2026-07-23T10:17:00Z",
+      "created_at": "2026-07-23T10:17:00Z",
+      "completed_at": "2026-07-23T10:17:02Z"
+    }
+  ],
+  "turn_analyses": [
+    {
+      "turn_analysis_id": "analysis_demo_001",
+      "turn_id": "turn_demo_001",
+      "evaluator_version": "mock-review-v1",
+      "analysis_status": "completed",
+      "score": 82,
+      "summary": "Clear ownership and impact; explain the design trade-off more explicitly.",
+      "analysis_transcript": "I led a Go API reliability project and reduced incident recovery time.",
+      "created_at": "2026-07-23T10:05:03Z",
+      "completed_at": "2026-07-23T10:05:04Z"
+    },
+    {
+      "turn_analysis_id": "analysis_demo_002",
+      "turn_id": "turn_demo_002",
+      "evaluator_version": "mock-review-v1",
+      "analysis_status": "pending",
+      "created_at": "2026-07-23T10:09:03Z"
+    },
+    {
+      "turn_analysis_id": "analysis_demo_003",
+      "turn_id": "turn_demo_003",
+      "evaluator_version": "mock-review-v1",
+      "analysis_status": "pending",
+      "created_at": "2026-07-23T10:13:03Z"
+    },
+    {
+      "turn_analysis_id": "analysis_demo_004",
+      "turn_id": "turn_demo_004",
+      "evaluator_version": "mock-review-v1",
+      "analysis_status": "pending",
+      "created_at": "2026-07-23T10:17:03Z"
+    }
+  ],
+  "feedback_items": [
+    {
+      "feedback_item_id": "feedback_demo_001",
+      "turn_analysis_id": "analysis_demo_001",
+      "feedback_category": "STRUCTURE",
+      "message": "The answer establishes ownership and outcome.",
+      "suggestion": "Add one sentence explaining why tracing was chosen before rollout.",
+      "evidence": [
+        {
+          "transcript_text": "I introduced request tracing, defined an error budget."
+        }
+      ],
+      "retryable": true,
+      "created_at": "2026-07-23T10:05:04Z"
+    }
+  ],
+  "retry_request_pending": {
+    "retry_request_id": "retry_demo_001",
+    "original_turn_id": "turn_demo_001",
+    "feedback_item_id": "feedback_demo_001",
+    "retry_status": "pending",
+    "created_at": "2026-07-23T10:06:00Z",
+    "updated_at": "2026-07-23T10:06:00Z"
+  },
+  "create_retry_turn_command": {
+    "retry_request_id": "retry_demo_001",
+    "original_turn_id": "turn_demo_001",
+    "reason": "review_retry"
+  },
+  "create_retry_turn_results": [
+    {
+      "retry_request_id": "retry_demo_001",
+      "new_turn_id": "turn_retry_demo_001"
+    },
+    {
+      "retry_request_id": "retry_demo_001",
+      "new_turn_id": "turn_retry_demo_001"
+    }
+  ],
+  "retry_turn_created": {
+    "turn_id": "turn_retry_demo_001",
+    "practice_session_id": "session_demo_001",
+    "question_id": "question_demo_001",
+    "respondent_participant_id": "participant_candidate_001",
+    "sequence": 1,
+    "turn_status": "answering",
+    "created_at": "2026-07-23T10:06:01Z"
+  },
+  "retry_request": {
+    "retry_request_id": "retry_demo_001",
+    "original_turn_id": "turn_demo_001",
+    "feedback_item_id": "feedback_demo_001",
+    "new_turn_id": "turn_retry_demo_001",
+    "retry_status": "turn_created",
+    "created_at": "2026-07-23T10:06:00Z",
+    "updated_at": "2026-07-23T10:06:01Z"
+  },
+  "retry_turn": {
+    "turn_id": "turn_retry_demo_001",
+    "practice_session_id": "session_demo_001",
+    "question_id": "question_demo_001",
+    "respondent_participant_id": "participant_candidate_001",
+    "sequence": 1,
+    "interaction_mode": "PUSH_TO_TALK",
+    "answer_text": "I led the reliability project, selected tracing after comparing cost and coverage, and reduced recovery time.",
+    "turn_status": "completed",
+    "submitted_at": "2026-07-23T10:07:00Z",
+    "created_at": "2026-07-23T10:06:01Z",
+    "completed_at": "2026-07-23T10:07:02Z"
+  },
+  "retry_progress_decision": {
+    "decided_by": "PracticeSessionPolicy",
+    "counts_toward_effective_turn_limit": false
+  },
+  "history_records": [
+    {
+      "history_record_id": "history_demo_001",
+      "practice_session_id": "session_demo_001",
+      "turn_id": "turn_demo_001",
+      "turn_analysis_id": "analysis_demo_001",
+      "retry_request_id": "retry_demo_001",
+      "score": 82,
+      "summary": "Clear ownership and impact; explain the design trade-off more explicitly.",
+      "reviewed_at": "2026-07-23T10:05:04Z"
+    }
+  ]
+}

--- a/api/examples/websocket/01-stream-ready.json
+++ b/api/examples/websocket/01-stream-ready.json
@@ -1,0 +1,12 @@
+{
+  "event_id": "event_stream_ready_001",
+  "event_type": "stream.ready",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:03:30Z",
+  "practice_session_id": "session_demo_001",
+  "correlation_id": "corr_stream_001",
+  "replayable": false,
+  "payload": {
+    "last_sequence": 0
+  }
+}

--- a/api/examples/websocket/02-question-created.json
+++ b/api/examples/websocket/02-question-created.json
@@ -1,0 +1,21 @@
+{
+  "event_id": "event_question_001",
+  "event_type": "question.created",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:04:00Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 1,
+  "correlation_id": "corr_question_001",
+  "replayable": true,
+  "payload": {
+    "question_id": "question_demo_001",
+    "speaker_participant_id": "participant_interviewer_001",
+    "addressee_participant_ids": [
+      "participant_candidate_001"
+    ],
+    "objective_id": "introduction",
+    "question_type": "PRIMARY",
+    "content": "Tell me about your backend experience and one project you are proud of.",
+    "sequence": 1
+  }
+}

--- a/api/examples/websocket/03-turn-submitted.json
+++ b/api/examples/websocket/03-turn-submitted.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "event_turn_submitted_001",
+  "event_type": "turn.submitted",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:05:00Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 2,
+  "correlation_id": "corr_turn_001",
+  "causation_id": "event_question_001",
+  "replayable": true,
+  "payload": {
+    "turn_id": "turn_demo_001",
+    "question_id": "question_demo_001",
+    "turn_status": "submitted"
+  }
+}

--- a/api/examples/websocket/04-turn-processing.json
+++ b/api/examples/websocket/04-turn-processing.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "event_turn_processing_001",
+  "event_type": "turn.processing",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:05:01Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 3,
+  "correlation_id": "corr_turn_001",
+  "causation_id": "event_turn_submitted_001",
+  "replayable": true,
+  "payload": {
+    "turn_id": "turn_demo_001",
+    "question_id": "question_demo_001",
+    "turn_status": "processing"
+  }
+}

--- a/api/examples/websocket/05-turn-completed.json
+++ b/api/examples/websocket/05-turn-completed.json
@@ -1,0 +1,18 @@
+{
+  "event_id": "event_turn_completed_001",
+  "event_type": "turn.completed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:05:02Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 4,
+  "correlation_id": "corr_turn_001",
+  "causation_id": "event_turn_processing_001",
+  "replayable": true,
+  "payload": {
+    "turn_id": "turn_demo_001",
+    "question_id": "question_demo_001",
+    "respondent_participant_id": "participant_candidate_001",
+    "turn_status": "completed",
+    "completed_at": "2026-07-23T10:05:02Z"
+  }
+}

--- a/api/examples/websocket/06-analysis-completed.json
+++ b/api/examples/websocket/06-analysis-completed.json
@@ -1,0 +1,17 @@
+{
+  "event_id": "event_analysis_completed_001",
+  "event_type": "turn_analysis.completed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:05:04Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 5,
+  "correlation_id": "corr_analysis_001",
+  "causation_id": "event_turn_completed_001",
+  "replayable": true,
+  "payload": {
+    "turn_analysis_id": "analysis_demo_001",
+    "turn_id": "turn_demo_001",
+    "score": 82,
+    "summary": "Clear ownership and measurable impact; make the trade-off more explicit."
+  }
+}

--- a/api/examples/websocket/07-analysis-failed.json
+++ b/api/examples/websocket/07-analysis-failed.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "event_analysis_failed_002",
+  "event_type": "turn_analysis.failed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:05:05Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 6,
+  "correlation_id": "corr_analysis_002",
+  "causation_id": "event_turn_completed_001",
+  "replayable": true,
+  "payload": {
+    "turn_analysis_id": "analysis_demo_002",
+    "turn_id": "turn_demo_001",
+    "failure_reason": "Deterministic failure fixture for retry verification."
+  }
+}

--- a/api/examples/websocket/08-processing-failed.json
+++ b/api/examples/websocket/08-processing-failed.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "event_processing_failed_001",
+  "event_type": "answer.processing_failed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:07:00Z",
+  "practice_session_id": "session_demo_001",
+  "correlation_id": "corr_invalid_turn_001",
+  "replayable": false,
+  "payload": {
+    "question_id": "question_demo_002",
+    "code": "transcript_unavailable",
+    "message": "No valid final transcript was produced; retry the same question.",
+    "retryable": true
+  }
+}

--- a/api/examples/websocket/09-resync-required.json
+++ b/api/examples/websocket/09-resync-required.json
@@ -1,0 +1,12 @@
+{
+  "event_id": "event_resync_001",
+  "event_type": "stream.resync_required",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:08:00Z",
+  "practice_session_id": "session_demo_001",
+  "correlation_id": "corr_stream_resume_001",
+  "replayable": false,
+  "payload": {
+    "last_available_sequence": 18
+  }
+}

--- a/api/examples/websocket/10-system-error.json
+++ b/api/examples/websocket/10-system-error.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "event_system_error_001",
+  "event_type": "system.error",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:08:30Z",
+  "practice_session_id": "session_demo_001",
+  "correlation_id": "corr_unknown_command_001",
+  "replayable": false,
+  "payload": {
+    "code": "unsupported_message",
+    "message": "The received WebSocket message is not supported.",
+    "retryable": false
+  }
+}

--- a/api/examples/websocket/11-heartbeat.json
+++ b/api/examples/websocket/11-heartbeat.json
@@ -1,0 +1,12 @@
+{
+  "event_id": "event_heartbeat_001",
+  "event_type": "system.heartbeat",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:09:00Z",
+  "practice_session_id": "session_demo_001",
+  "correlation_id": "corr_stream_001",
+  "replayable": false,
+  "payload": {
+    "server_time": "2026-07-23T10:09:00Z"
+  }
+}

--- a/api/examples/websocket/12-session-completed.json
+++ b/api/examples/websocket/12-session-completed.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "event_session_completed_001",
+  "event_type": "practice_session.completed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:20:00Z",
+  "practice_session_id": "session_demo_001",
+  "sequence": 7,
+  "correlation_id": "corr_turn_004",
+  "causation_id": "event_turn_completed_004",
+  "replayable": true,
+  "payload": {
+    "practice_session_status": "completed",
+    "session_version": 6,
+    "end_reason": "COVERAGE_SATISFIED_AT_CHECKPOINT"
+  }
+}

--- a/api/examples/websocket/13-session-started.json
+++ b/api/examples/websocket/13-session-started.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "event_session_started_001",
+  "event_type": "practice_session.started",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:04:00Z",
+  "practice_session_id": "session_lifecycle_started_001",
+  "sequence": 1,
+  "correlation_id": "corr_session_started_001",
+  "replayable": true,
+  "payload": {
+    "practice_session_status": "in_progress",
+    "session_version": 2
+  }
+}

--- a/api/examples/websocket/14-session-paused.json
+++ b/api/examples/websocket/14-session-paused.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "event_session_paused_001",
+  "event_type": "practice_session.paused",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:10:00Z",
+  "practice_session_id": "session_lifecycle_paused_001",
+  "sequence": 1,
+  "correlation_id": "corr_session_paused_001",
+  "replayable": true,
+  "payload": {
+    "practice_session_status": "paused",
+    "session_version": 3
+  }
+}

--- a/api/examples/websocket/15-session-resumed.json
+++ b/api/examples/websocket/15-session-resumed.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "event_session_resumed_001",
+  "event_type": "practice_session.resumed",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:12:00Z",
+  "practice_session_id": "session_lifecycle_resumed_001",
+  "sequence": 1,
+  "correlation_id": "corr_session_resumed_001",
+  "replayable": true,
+  "payload": {
+    "practice_session_status": "in_progress",
+    "session_version": 4
+  }
+}

--- a/api/examples/websocket/16-session-ended-early.json
+++ b/api/examples/websocket/16-session-ended-early.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "event_session_ended_early_001",
+  "event_type": "practice_session.ended_early",
+  "event_version": 1,
+  "occurred_at": "2026-07-23T10:14:00Z",
+  "practice_session_id": "session_lifecycle_ended_early_001",
+  "sequence": 1,
+  "correlation_id": "corr_session_ended_early_001",
+  "replayable": true,
+  "payload": {
+    "practice_session_status": "ended_early",
+    "session_version": 5,
+    "end_reason": "USER_ENDED"
+  }
+}

--- a/api/modules/conversation.yaml
+++ b/api/modules/conversation.yaml
@@ -1,0 +1,626 @@
+paths:
+  /v1/practice-sessions/{practice_session_id}/bootstrap:
+    get:
+      tags:
+        - Conversation
+      summary: Reconcile the authorized client to current session state
+      description: |
+        Returns the immutable Session context, current Question/Turn when they
+        exist, and the latest replayable event sequence. Clients call this after
+        `stream.resync_required` before reconnecting with the returned sequence.
+        This MS1 bootstrap restores only the current interaction state; it does
+        not promise a historical event, Question, Turn, or analysis listing.
+      operationId: getPracticeSessionBootstrap
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: Current authorized Session view for connection recovery.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationBootstrap'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/questions:
+    post:
+      tags:
+        - Conversation
+      summary: Ensure the current policy-approved Question exists
+      description: |
+        The client cannot supply question content, objectives, speakers, or
+        addressees. Conversation derives them from the immutable session
+        snapshot and the Practice policy result.
+
+        For a `starting` Session, this operation idempotently creates the first
+        Question and advances the Session to `in_progress`. After a normal Turn
+        completes, Conversation itself applies TurnOutcome to Practice and
+        either creates the next Question or completes the Session. Clients use
+        this operation only to ensure/recover the current Question; repeating an
+        intent never skips policy or creates a duplicate.
+      operationId: ensureCurrentQuestion
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The existing or newly created current Question.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Question'
+              example:
+                question_id: question_demo_001
+                practice_session_id: session_demo_001
+                speaker_participant_id: participant_interviewer_001
+                addressee_participant_ids:
+                  - participant_candidate_001
+                objective_id: introduction
+                question_type: PRIMARY
+                content: Tell me about your backend experience and one project you are proud of.
+                sequence: 1
+                created_at: '2026-07-23T10:04:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/questions/{question_id}/turns:
+    post:
+      tags:
+        - Conversation
+      summary: Submit one valid answer for processing
+      description: |
+        This is the only MS1 client write entry for a final answer. Empty,
+        invalid, or technically incomplete input is rejected before a normal
+        Turn is created or a pre-created retry Turn advances. The server resolves
+        `respondent_participant_id` from actor context and verifies it is one of
+        the Question addressees.
+
+        The deterministic Mock supplies final transcript text while preserving
+        the accepted `PUSH_TO_TALK` interaction mode; this contract does not add
+        a separate text practice mode or define audio binary transport. When
+        `retry_request_id` is present, Review and Conversation must already have
+        created an `answering` Turn for the original Question. This request
+        advances that same Turn to `submitted`; it never creates a second Turn.
+        After completion, Conversation submits TurnOutcome to Practice, which
+        alone decides the progress effect from the immutable Session policy.
+      operationId: submitTurn
+      parameters:
+        - $ref: '#/components/parameters/QuestionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitTurnRequest'
+            examples:
+              normal_answer:
+                value:
+                  interaction_mode: PUSH_TO_TALK
+                  answer_text: |
+                    I led a Go API reliability project. I introduced request
+                    tracing, defined an error budget, and reduced incident recovery
+                    time by coordinating a staged rollout with two teams.
+              same_question_retry:
+                value:
+                  interaction_mode: PUSH_TO_TALK
+                  answer_text: |
+                    I chose tracing because the existing logs could not connect
+                    failures across services, then used the error budget to
+                    validate the rollout.
+                  retry_request_id: retry_demo_001
+      responses:
+        '202':
+          description: A valid Turn was saved and accepted for processing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Turn'
+              examples:
+                normal_submission:
+                  value:
+                    turn_id: turn_demo_001
+                    practice_session_id: session_demo_001
+                    question_id: question_demo_001
+                    respondent_participant_id: participant_candidate_001
+                    sequence: 1
+                    interaction_mode: PUSH_TO_TALK
+                    answer_text: |
+                      I led a Go API reliability project. I introduced request
+                      tracing, defined an error budget, and reduced incident
+                      recovery time by coordinating a staged rollout with two teams.
+                    turn_status: submitted
+                    submitted_at: '2026-07-23T10:05:00Z'
+                    created_at: '2026-07-23T10:05:00Z'
+                same_question_retry_submission:
+                  value:
+                    turn_id: turn_retry_demo_001
+                    practice_session_id: session_demo_001
+                    question_id: question_demo_001
+                    respondent_participant_id: participant_candidate_001
+                    sequence: 1
+                    interaction_mode: PUSH_TO_TALK
+                    answer_text: |
+                      I chose tracing because the existing logs could not connect
+                      failures across services, then used the error budget to
+                      validate the rollout.
+                    turn_status: submitted
+                    submitted_at: '2026-07-23T10:07:00Z'
+                    created_at: '2026-07-23T10:06:01Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '403':
+          $ref: ../common/errors.yaml#/components/responses/Forbidden
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/turns/{turn_id}:
+    get:
+      tags:
+        - Conversation
+      summary: Get a Turn lifecycle resource
+      operationId: getTurn
+      parameters:
+        - $ref: '#/components/parameters/TurnId'
+      responses:
+        '200':
+          description: The requested Turn and current processing state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Turn'
+              example:
+                turn_id: turn_demo_001
+                practice_session_id: session_demo_001
+                question_id: question_demo_001
+                respondent_participant_id: participant_candidate_001
+                sequence: 1
+                interaction_mode: PUSH_TO_TALK
+                answer_text: |
+                  I led a Go API reliability project. I introduced request
+                  tracing, defined an error budget, and reduced incident recovery
+                  time by coordinating a staged rollout with two teams.
+                turn_status: completed
+                submitted_at: '2026-07-23T10:05:00Z'
+                created_at: '2026-07-23T10:05:00Z'
+                completed_at: '2026-07-23T10:05:02Z'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/events:
+    get:
+      tags:
+        - Conversation
+      summary: Upgrade to the ordered session event stream
+      description: |
+        Upgrade this request to WebSocket. Replayable events use a monotonically
+        increasing per-session `sequence`. Reconnect with `after_sequence`; when
+        retained events cannot close a gap, the server emits
+        `stream.resync_required` and the client reloads REST resources.
+      operationId: connectPracticeSessionEvents
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - name: after_sequence
+          in: query
+          required: false
+          description: Last replayable sequence already applied by the client.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '101':
+          description: WebSocket protocol upgrade accepted.
+          headers:
+            Sec-WebSocket-Protocol:
+              description: Negotiated event protocol.
+              schema:
+                type: string
+                const: speakup.events.v1
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+      x-websocket-event-schema:
+        $ref: ../websocket/conversation-events.schema.json
+components:
+  parameters:
+    PracticeSessionId:
+      name: practice_session_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    QuestionId:
+      name: question_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    TurnId:
+      name: turn_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    IdempotencyKey:
+      $ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey
+  schemas:
+    ResourceId:
+      type: string
+      minLength: 1
+      maxLength: 128
+    Question:
+      type: object
+      additionalProperties: false
+      description: |
+        The speaker and every addressee must belong to the same immutable
+        PracticeSessionSnapshot. FOLLOW_UP Questions reference a PRIMARY
+        Question in the same Session.
+      required:
+        - question_id
+        - practice_session_id
+        - speaker_participant_id
+        - addressee_participant_ids
+        - question_type
+        - content
+        - sequence
+        - created_at
+      properties:
+        question_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        speaker_participant_id:
+          $ref: '#/components/schemas/ResourceId'
+        addressee_participant_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/ResourceId'
+        objective_id:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        question_type:
+          type: string
+          enum:
+            - PRIMARY
+            - FOLLOW_UP
+        parent_question_id:
+          $ref: '#/components/schemas/ResourceId'
+        content:
+          type: string
+          minLength: 1
+        sequence:
+          type: integer
+          minimum: 1
+        audio_asset_id:
+          $ref: '#/components/schemas/ResourceId'
+        created_at:
+          type: string
+          format: date-time
+      allOf:
+        - if:
+            properties:
+              question_type:
+                const: FOLLOW_UP
+            required:
+              - question_type
+          then:
+            required:
+              - parent_question_id
+        - if:
+            properties:
+              question_type:
+                const: PRIMARY
+            required:
+              - question_type
+          then:
+            not:
+              required:
+                - parent_question_id
+    SubmitTurnRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - interaction_mode
+        - answer_text
+      properties:
+        interaction_mode:
+          type: string
+          enum:
+            - PUSH_TO_TALK
+            - REALTIME
+        answer_text:
+          type: string
+          minLength: 1
+        audio_asset_id:
+          $ref: '#/components/schemas/ResourceId'
+        retry_request_id:
+          $ref: '#/components/schemas/ResourceId'
+    Turn:
+      type: object
+      additionalProperties: false
+      description: |
+        One answer lifecycle resource. For a normal answer, the server resolves
+        respondent_participant_id from actor context and verifies that it
+        belongs to the Question addressees in the same Session. For an
+        authorized same-question retry, Conversation reuses the original Turn's
+        respondent. The client never supplies this trusted field.
+
+        The one exception to final-answer creation timing is a same-question
+        retry: Conversation pre-creates an `answering` Turn from Review's
+        internal CreateRetryTurn command. That resource has no final answer yet
+        and becomes effective only after a valid submission advances it to
+        `submitted`.
+      required:
+        - turn_id
+        - practice_session_id
+        - question_id
+        - respondent_participant_id
+        - sequence
+        - turn_status
+        - created_at
+      properties:
+        turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        question_id:
+          $ref: '#/components/schemas/ResourceId'
+        respondent_participant_id:
+          $ref: '#/components/schemas/ResourceId'
+        sequence:
+          type: integer
+          minimum: 1
+        interaction_mode:
+          type: string
+          enum:
+            - PUSH_TO_TALK
+            - REALTIME
+        answer_text:
+          type: string
+          minLength: 1
+        audio_asset_id:
+          $ref: '#/components/schemas/ResourceId'
+        turn_status:
+          type: string
+          description: |
+            `answering` is the pre-submission capture state, including a retry
+            Turn pre-created by the internal module command. The final-answer
+            REST write returns the same or newly created resource at `submitted`.
+          enum:
+            - answering
+            - submitted
+            - processing
+            - completed
+        submitted_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+      oneOf:
+        - properties:
+            turn_status:
+              const: answering
+          required:
+            - turn_status
+          not:
+            anyOf:
+              - required:
+                  - answer_text
+              - required:
+                  - submitted_at
+              - required:
+                  - completed_at
+        - properties:
+            turn_status:
+              const: submitted
+          required:
+            - turn_status
+            - interaction_mode
+            - answer_text
+            - submitted_at
+          not:
+            required:
+              - completed_at
+        - properties:
+            turn_status:
+              const: processing
+          required:
+            - turn_status
+            - interaction_mode
+            - answer_text
+            - submitted_at
+          not:
+            required:
+              - completed_at
+        - properties:
+            turn_status:
+              const: completed
+          required:
+            - turn_status
+            - interaction_mode
+            - answer_text
+            - submitted_at
+            - completed_at
+    TranscriptSegment:
+      type: object
+      additionalProperties: false
+      required:
+        - start_ms
+        - end_ms
+        - text
+      properties:
+        start_ms:
+          type: integer
+          minimum: 0
+        end_ms:
+          type: integer
+          minimum: 1
+        text:
+          type: string
+          minLength: 1
+    TranscriptSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - transcript_id
+        - text
+        - language
+        - status
+      properties:
+        transcript_id:
+          $ref: '#/components/schemas/ResourceId'
+        text:
+          type: string
+          minLength: 1
+        language:
+          type: string
+          minLength: 2
+        status:
+          type: string
+          const: ready
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/TranscriptSegment'
+    AudioReference:
+      type: object
+      additionalProperties: false
+      required:
+        - audio_id
+        - content_type
+        - format
+        - size_bytes
+        - duration_ms
+      properties:
+        audio_id:
+          $ref: '#/components/schemas/ResourceId'
+        content_type:
+          type: string
+          pattern: '^audio/[A-Za-z0-9.+-]+$'
+        format:
+          type: string
+          minLength: 1
+        size_bytes:
+          type: integer
+          minimum: 1
+        duration_ms:
+          type: integer
+          minimum: 1
+        checksum:
+          type: string
+          minLength: 1
+    TurnReviewSource:
+      type: object
+      additionalProperties: false
+      description: |
+        Immutable Conversation projection consumed by Review. `session_id`
+        retains the exact canonical field frozen in Issue #34 and identifies a
+        PracticeSession; changing it requires a later incremental decision.
+      required:
+        - turn_id
+        - session_id
+        - question_id
+        - question_text
+        - question_speaker_participant_id
+        - addressee_participant_ids
+        - respondent_participant_id
+        - transcript
+        - completed_at
+      properties:
+        turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        session_id:
+          $ref: '#/components/schemas/ResourceId'
+        question_id:
+          $ref: '#/components/schemas/ResourceId'
+        question_text:
+          type: string
+          minLength: 1
+        question_speaker_participant_id:
+          $ref: '#/components/schemas/ResourceId'
+        addressee_participant_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/ResourceId'
+        respondent_participant_id:
+          $ref: '#/components/schemas/ResourceId'
+        transcript:
+          $ref: '#/components/schemas/TranscriptSnapshot'
+        audio:
+          $ref: '#/components/schemas/AudioReference'
+        completed_at:
+          type: string
+          format: date-time
+    CreateRetryTurnCommand:
+      type: object
+      additionalProperties: false
+      x-internal: true
+      description: |
+        Review-to-Conversation command. Review owns RetryRequest; Conversation
+        owns the new Turn and the idempotent retry-request-to-Turn mapping.
+      required:
+        - retry_request_id
+        - original_turn_id
+        - reason
+      properties:
+        retry_request_id:
+          $ref: '#/components/schemas/ResourceId'
+        original_turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        reason:
+          type: string
+          const: review_retry
+    CreateRetryTurnResult:
+      type: object
+      additionalProperties: false
+      x-internal: true
+      required:
+        - retry_request_id
+        - new_turn_id
+      properties:
+        retry_request_id:
+          $ref: '#/components/schemas/ResourceId'
+        new_turn_id:
+          $ref: '#/components/schemas/ResourceId'
+    ConversationBootstrap:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_session
+        - snapshot
+        - last_event_sequence
+      properties:
+        practice_session:
+          $ref: ./practice.yaml#/components/schemas/PracticeSession
+        snapshot:
+          $ref: ./practice.yaml#/components/schemas/PracticeSessionSnapshot
+        current_question:
+          $ref: '#/components/schemas/Question'
+        current_turn:
+          $ref: '#/components/schemas/Turn'
+        last_event_sequence:
+          type: integer
+          minimum: 0

--- a/api/modules/practice.yaml
+++ b/api/modules/practice.yaml
@@ -1,0 +1,768 @@
+paths:
+  /v1/practice-plans:
+    post:
+      tags:
+        - Practice
+      summary: Create or return a practice plan for one intent
+      operationId: createPracticePlan
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePracticePlanRequest'
+            example:
+              scenario_definition_id: scn_programmer_interview
+              scenario_definition_version: 1
+              scenario_config_id: scfg_backend_engineer
+              scenario_config_version: 1
+              preparation_profile_id: prep_demo_backend
+              selected_role_ids:
+                - role_technical_interviewer
+      responses:
+        '201':
+          description: A ready practice plan for the current actor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticePlan'
+              example:
+                practice_plan_id: plan_demo_backend
+                user_id: user_demo
+                scenario_definition_id: scn_programmer_interview
+                scenario_definition_version: 1
+                scenario_type: INTERVIEW
+                scenario_config_id: scfg_backend_engineer
+                scenario_config_version: 1
+                preparation_profile_id: prep_demo_backend
+                selected_role_ids:
+                  - role_technical_interviewer
+                plan_revision: 1
+                practice_plan_status: ready
+                created_at: '2026-07-23T10:02:00Z'
+                updated_at: '2026-07-23T10:02:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-plans/{practice_plan_id}:
+    get:
+      tags:
+        - Practice
+      summary: Get a practice plan
+      operationId: getPracticePlan
+      parameters:
+        - $ref: '#/components/parameters/PracticePlanId'
+      responses:
+        '200':
+          description: The requested practice plan.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticePlan'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-plans/{practice_plan_id}/practice-sessions:
+    post:
+      tags:
+        - Practice
+      summary: Create a session and its immutable snapshot
+      description: |
+        The server resolves the candidate from actor context and constructs the
+        immutable participant collection. The client selects a role definition
+        but never submits trusted participant identifiers. The service verifies
+        that the preparation snapshot belongs to the Plan profile, every role is
+        selected by the Plan, and the practice option belongs to the frozen
+        Scenario before atomically creating the Session and Snapshot.
+      operationId: createPracticeSession
+      parameters:
+        - $ref: '#/components/parameters/PracticePlanId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePracticeSessionRequest'
+            example:
+              expected_plan_revision: 1
+              preparation_snapshot_id: psnap_demo_backend_v1
+              practice_option_id: option_full_simulation
+              role_definition_ids:
+                - role_technical_interviewer
+      responses:
+        '201':
+          description: Session and immutable bootstrap snapshot created atomically.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSessionBootstrap'
+              example:
+                practice_session:
+                  practice_session_id: session_demo_001
+                  practice_plan_id: plan_demo_backend
+                  scenario_type: INTERVIEW
+                  snapshot_id: snapshot_session_demo_001
+                  practice_session_status: starting
+                  session_version: 1
+                  created_at: '2026-07-23T10:03:00Z'
+                snapshot:
+                  snapshot_id: snapshot_session_demo_001
+                  practice_session_id: session_demo_001
+                  plan_revision: 1
+                  scenario_type: INTERVIEW
+                  scenario_definition_snapshot:
+                    scenario_definition_id: scn_programmer_interview
+                    scenario_type: INTERVIEW
+                    name: Programmer English interview
+                    version: 1
+                    status: active
+                  scenario_config_snapshot:
+                    scenario_config_id: scfg_backend_engineer
+                    scenario_definition_id: scn_programmer_interview
+                    config_type: INTERVIEW
+                    version: 1
+                    job_title: Backend engineer
+                    job_description: Build reliable APIs and explain engineering trade-offs.
+                    focus_areas:
+                      - introduction
+                      - system_design
+                      - project_depth
+                      - collaboration
+                  preparation_snapshot:
+                    preparation_snapshot_id: psnap_demo_backend_v1
+                    source_profile_id: prep_demo_backend
+                    source_version: 1
+                    resume_snapshot: Go backend engineer; API reliability project.
+                    job_description_snapshot: Build reliable APIs and explain engineering trade-offs.
+                    background_snapshot: |
+                      Backend engineer with three years of Go experience,
+                      responsible for an API reliability project.
+                    created_at: '2026-07-23T10:01:00Z'
+                  participants:
+                    - practice_participant_id: participant_interviewer_001
+                      practice_session_id: session_demo_001
+                      participant_role: INTERVIEWER
+                      subject_ref:
+                        namespace: mock.actor
+                        subject_id: interviewer_technical
+                      role_definition_id: role_technical_interviewer
+                      role_snapshot:
+                        role_definition_id: role_technical_interviewer
+                        scenario_definition_id: scn_programmer_interview
+                        role_type: TECHNICAL_INTERVIEWER
+                        display_name: Technical interviewer
+                        responsibilities: Probe technical depth and decision making.
+                        style: Precise and evidence seeking.
+                        focus_areas:
+                          - system_design
+                          - project_depth
+                        version: 1
+                      participant_order: 1
+                    - practice_participant_id: participant_candidate_001
+                      practice_session_id: session_demo_001
+                      participant_role: CANDIDATE
+                      subject_ref:
+                        namespace: speakup.user
+                        subject_id: user_demo
+                      participant_order: 2
+                  practice_option:
+                    practice_option_id: option_full_simulation
+                    scenario_definition_id: scn_programmer_interview
+                    practice_option_type: FULL_SIMULATION
+                    display_name: Full simulation
+                    version: 1
+                  session_policy:
+                    suggested_duration_seconds: 900
+                    min_effective_turns: 4
+                    max_effective_turns: 6
+                    coverage_checkpoint_turn: 4
+                    max_follow_ups_per_question: 1
+                    target_objectives:
+                      - objective_id: introduction
+                        description: Explain current experience clearly.
+                      - objective_id: system_design
+                        description: Explain a technical design and its trade-offs.
+                      - objective_id: project_depth
+                        description: Provide evidence of individual contribution.
+                      - objective_id: collaboration
+                        description: Explain cross-team communication and outcomes.
+                    early_completion_rule: COVERAGE_SATISFIED_AFTER_CHECKPOINT
+                  practice_focuses:
+                    - objective_id: system_design
+                      description: Explain trade-offs with concrete evidence.
+                  created_at: '2026-07-23T10:03:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}:
+    get:
+      tags:
+        - Practice
+      summary: Get a practice session
+      operationId: getPracticeSession
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: Current session lifecycle state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSession'
+              example:
+                practice_session_id: session_demo_001
+                practice_plan_id: plan_demo_backend
+                scenario_type: INTERVIEW
+                snapshot_id: snapshot_session_demo_001
+                practice_session_status: in_progress
+                session_version: 2
+                started_at: '2026-07-23T10:04:00Z'
+                created_at: '2026-07-23T10:03:00Z'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/pause:
+    post:
+      tags:
+        - Practice
+      summary: Pause an in-progress practice session
+      operationId: pausePracticeSession
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionLifecycleCommand'
+            example:
+              expected_session_version: 2
+      responses:
+        '200':
+          description: The paused Session; repeating the same intent returns this state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSession'
+              example:
+                practice_session_id: session_demo_001
+                practice_plan_id: plan_demo_backend
+                scenario_type: INTERVIEW
+                snapshot_id: snapshot_session_demo_001
+                practice_session_status: paused
+                session_version: 3
+                started_at: '2026-07-23T10:04:00Z'
+                created_at: '2026-07-23T10:03:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/resume:
+    post:
+      tags:
+        - Practice
+      summary: Resume a paused practice session
+      operationId: resumePracticeSession
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionLifecycleCommand'
+            example:
+              expected_session_version: 3
+      responses:
+        '200':
+          description: The resumed Session; repeating the same intent returns this state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSession'
+              example:
+                practice_session_id: session_demo_001
+                practice_plan_id: plan_demo_backend
+                scenario_type: INTERVIEW
+                snapshot_id: snapshot_session_demo_001
+                practice_session_status: in_progress
+                session_version: 4
+                started_at: '2026-07-23T10:04:00Z'
+                created_at: '2026-07-23T10:03:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/end-early:
+    post:
+      tags:
+        - Practice
+      summary: End an active practice session early
+      operationId: endPracticeSessionEarly
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionLifecycleCommand'
+            example:
+              expected_session_version: 4
+      responses:
+        '200':
+          description: The terminal Session; repeating the same intent returns this state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSession'
+              example:
+                practice_session_id: session_demo_001
+                practice_plan_id: plan_demo_backend
+                scenario_type: INTERVIEW
+                snapshot_id: snapshot_session_demo_001
+                practice_session_status: ended_early
+                session_version: 5
+                started_at: '2026-07-23T10:04:00Z'
+                ended_at: '2026-07-23T10:10:00Z'
+                end_reason: USER_ENDED
+                created_at: '2026-07-23T10:03:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/snapshot:
+    get:
+      tags:
+        - Practice
+      summary: Get the immutable session snapshot
+      operationId: getPracticeSessionSnapshot
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: Immutable context used by Conversation and Review.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSessionSnapshot'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  parameters:
+    PracticePlanId:
+      name: practice_plan_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    PracticeSessionId:
+      name: practice_session_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    IdempotencyKey:
+      $ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey
+  schemas:
+    ResourceId:
+      type: string
+      minLength: 1
+      maxLength: 128
+    Version:
+      type: integer
+      minimum: 1
+    ScenarioType:
+      $ref: ./preparation.yaml#/components/schemas/ScenarioType
+    CreatePracticePlanRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - scenario_definition_id
+        - scenario_definition_version
+        - scenario_config_id
+        - scenario_config_version
+        - preparation_profile_id
+        - selected_role_ids
+      properties:
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_version:
+          $ref: '#/components/schemas/Version'
+        scenario_config_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_config_version:
+          $ref: '#/components/schemas/Version'
+        preparation_profile_id:
+          $ref: '#/components/schemas/ResourceId'
+        selected_role_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/ResourceId'
+    PracticePlan:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_plan_id
+        - user_id
+        - scenario_definition_id
+        - scenario_definition_version
+        - scenario_type
+        - scenario_config_id
+        - scenario_config_version
+        - preparation_profile_id
+        - selected_role_ids
+        - plan_revision
+        - practice_plan_status
+        - created_at
+        - updated_at
+      properties:
+        practice_plan_id:
+          $ref: '#/components/schemas/ResourceId'
+        user_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_version:
+          $ref: '#/components/schemas/Version'
+        scenario_type:
+          $ref: '#/components/schemas/ScenarioType'
+        scenario_config_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_config_version:
+          $ref: '#/components/schemas/Version'
+        preparation_profile_id:
+          $ref: '#/components/schemas/ResourceId'
+        selected_role_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/ResourceId'
+        plan_revision:
+          type: integer
+          minimum: 1
+        practice_plan_status:
+          type: string
+          enum:
+            - configuring
+            - configuration_failed
+            - ready
+            - archived
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    CreatePracticeSessionRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - expected_plan_revision
+        - preparation_snapshot_id
+        - practice_option_id
+        - role_definition_ids
+      properties:
+        expected_plan_revision:
+          type: integer
+          minimum: 1
+        preparation_snapshot_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_option_id:
+          $ref: '#/components/schemas/ResourceId'
+        role_definition_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          description: |
+            Role selections remain collection-shaped. The MS1 INTERVIEW
+            capability validates exactly one role; the shared DTO does not
+            encode that scenario-specific cardinality.
+          items:
+            $ref: '#/components/schemas/ResourceId'
+    PracticeSession:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_session_id
+        - practice_plan_id
+        - scenario_type
+        - snapshot_id
+        - practice_session_status
+        - session_version
+        - created_at
+      properties:
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_plan_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_type:
+          $ref: '#/components/schemas/ScenarioType'
+        snapshot_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_status:
+          type: string
+          enum:
+            - starting
+            - in_progress
+            - paused
+            - completed
+            - ended_early
+        session_version:
+          type: integer
+          minimum: 1
+        started_at:
+          type: string
+          format: date-time
+        ended_at:
+          type: string
+          format: date-time
+        end_reason:
+          type: string
+          pattern: '^[A-Z][A-Z0-9_]*$'
+        created_at:
+          type: string
+          format: date-time
+      allOf:
+        - if:
+            properties:
+              practice_session_status:
+                enum:
+                  - in_progress
+                  - paused
+                  - completed
+                  - ended_early
+            required:
+              - practice_session_status
+          then:
+            required:
+              - started_at
+        - if:
+            properties:
+              practice_session_status:
+                enum:
+                  - completed
+                  - ended_early
+            required:
+              - practice_session_status
+          then:
+            required:
+              - ended_at
+              - end_reason
+          else:
+            not:
+              anyOf:
+                - required:
+                    - ended_at
+                - required:
+                    - end_reason
+    SessionLifecycleCommand:
+      type: object
+      additionalProperties: false
+      required:
+        - expected_session_version
+      properties:
+        expected_session_version:
+          type: integer
+          minimum: 1
+    SubjectRef:
+      type: object
+      additionalProperties: false
+      required:
+        - namespace
+        - subject_id
+      properties:
+        namespace:
+          type: string
+          pattern: '^[a-z][a-z0-9._-]*$'
+        subject_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+    PracticeParticipant:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_participant_id
+        - practice_session_id
+        - participant_role
+        - subject_ref
+        - participant_order
+      properties:
+        practice_participant_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        participant_role:
+          type: string
+          pattern: '^[A-Z][A-Z0-9_]*$'
+        subject_ref:
+          $ref: '#/components/schemas/SubjectRef'
+        role_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        role_snapshot:
+          $ref: ./preparation.yaml#/components/schemas/RoleDefinition
+        participant_order:
+          type: integer
+          minimum: 1
+      dependentRequired:
+        role_definition_id:
+          - role_snapshot
+        role_snapshot:
+          - role_definition_id
+    PracticeObjective:
+      type: object
+      additionalProperties: false
+      required:
+        - objective_id
+        - description
+      properties:
+        objective_id:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        description:
+          type: string
+          minLength: 1
+    PracticeSessionPolicy:
+      type: object
+      additionalProperties: false
+      description: |
+        Scenario-owned effective-Turn budget. Services enforce
+        min_effective_turns <= coverage_checkpoint_turn <= max_effective_turns;
+        invalid input and technical failures do not advance this budget. After
+        a completed same-question retry, Practice alone evaluates this frozen
+        policy and returns NextAction; Review and the client cannot decide or
+        submit the retry's progress effect. The accepted MS1 INTERVIEW policy
+        keeps same-question retries outside the original Session budget, while
+        the shared DTO does not turn that scenario rule into a platform shape.
+      required:
+        - suggested_duration_seconds
+        - min_effective_turns
+        - max_effective_turns
+        - coverage_checkpoint_turn
+        - max_follow_ups_per_question
+        - target_objectives
+        - early_completion_rule
+      properties:
+        suggested_duration_seconds:
+          type: integer
+          minimum: 1
+        min_effective_turns:
+          type: integer
+          minimum: 1
+        max_effective_turns:
+          type: integer
+          minimum: 1
+        coverage_checkpoint_turn:
+          type: integer
+          minimum: 1
+        max_follow_ups_per_question:
+          type: integer
+          minimum: 0
+        target_objectives:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/PracticeObjective'
+        early_completion_rule:
+          type: string
+          pattern: '^[A-Z][A-Z0-9_]*$'
+    PracticeSessionSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - snapshot_id
+        - practice_session_id
+        - plan_revision
+        - scenario_type
+        - scenario_definition_snapshot
+        - scenario_config_snapshot
+        - preparation_snapshot
+        - participants
+        - practice_option
+        - session_policy
+        - practice_focuses
+        - created_at
+      properties:
+        snapshot_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        plan_revision:
+          type: integer
+          minimum: 1
+        scenario_type:
+          $ref: '#/components/schemas/ScenarioType'
+        scenario_definition_snapshot:
+          $ref: ./preparation.yaml#/components/schemas/ScenarioDefinition
+        scenario_config_snapshot:
+          $ref: ./preparation.yaml#/components/schemas/ScenarioConfig
+        preparation_snapshot:
+          $ref: ./preparation.yaml#/components/schemas/PreparationSnapshot
+        participants:
+          type: array
+          minItems: 2
+          description: |
+            Stable immutable participant relations. Subject references and
+            participant IDs are unique within the Snapshot. The MS1 INTERVIEW
+            capability validates exactly one INTERVIEWER and one CANDIDATE;
+            the shared collection remains open for a separately accepted future
+            scenario capability.
+          items:
+            $ref: '#/components/schemas/PracticeParticipant'
+        practice_option:
+          $ref: ./preparation.yaml#/components/schemas/PracticeOptionDefinition
+        session_policy:
+          $ref: '#/components/schemas/PracticeSessionPolicy'
+        practice_focuses:
+          type: array
+          items:
+            $ref: '#/components/schemas/PracticeObjective'
+        created_at:
+          type: string
+          format: date-time
+    PracticeSessionBootstrap:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_session
+        - snapshot
+      properties:
+        practice_session:
+          $ref: '#/components/schemas/PracticeSession'
+        snapshot:
+          $ref: '#/components/schemas/PracticeSessionSnapshot'

--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -1,0 +1,466 @@
+paths:
+  /v1/scenario-definitions/{scenario_definition_id}:
+    get:
+      tags:
+        - Preparation
+      summary: Get an active scenario definition and its MS1 configuration
+      operationId: getScenarioDefinition
+      parameters:
+        - $ref: '#/components/parameters/ScenarioDefinitionId'
+      responses:
+        '200':
+          description: Scenario definition, current configuration, and practice options.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioDetail'
+              example:
+                scenario_definition:
+                  scenario_definition_id: scn_programmer_interview
+                  scenario_type: INTERVIEW
+                  name: Programmer English interview
+                  version: 1
+                  status: active
+                scenario_config:
+                  scenario_config_id: scfg_backend_engineer
+                  scenario_definition_id: scn_programmer_interview
+                  config_type: INTERVIEW
+                  version: 1
+                  job_title: Backend engineer
+                  job_description: Build reliable APIs and explain engineering trade-offs.
+                  focus_areas:
+                    - introduction
+                    - system_design
+                    - project_depth
+                    - collaboration
+                practice_options:
+                  - practice_option_id: option_full_simulation
+                    scenario_definition_id: scn_programmer_interview
+                    practice_option_type: FULL_SIMULATION
+                    display_name: Full simulation
+                    version: 1
+                  - practice_option_id: option_technical_focus
+                    scenario_definition_id: scn_programmer_interview
+                    role_definition_id: role_technical_interviewer
+                    practice_option_type: FOCUS
+                    display_name: Technical deep dive
+                    version: 1
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
+    get:
+      tags:
+        - Preparation
+      summary: List role definitions available for a scenario
+      operationId: listRoleDefinitions
+      parameters:
+        - $ref: '#/components/parameters/ScenarioDefinitionId'
+      responses:
+        '200':
+          description: Role definitions in stable display order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleDefinitionList'
+              example:
+                roles:
+                  - role_definition_id: role_hr_interviewer
+                    scenario_definition_id: scn_programmer_interview
+                    role_type: HR_INTERVIEWER
+                    display_name: HR interviewer
+                    responsibilities: Validate motivation and communication clarity.
+                    style: Warm and structured.
+                    focus_areas:
+                      - motivation
+                      - communication
+                    version: 1
+                  - role_definition_id: role_technical_interviewer
+                    scenario_definition_id: scn_programmer_interview
+                    role_type: TECHNICAL_INTERVIEWER
+                    display_name: Technical interviewer
+                    responsibilities: Probe technical depth and decision making.
+                    style: Precise and evidence seeking.
+                    focus_areas:
+                      - system_design
+                      - project_depth
+                    version: 1
+                  - role_definition_id: role_project_manager
+                    scenario_definition_id: scn_programmer_interview
+                    role_type: PROJECT_MANAGER
+                    display_name: Project manager
+                    responsibilities: Explore delivery, ownership, and collaboration.
+                    style: Outcome oriented.
+                    focus_areas:
+                      - delivery
+                      - collaboration
+                    version: 1
+                  - role_definition_id: role_executive_interviewer
+                    scenario_definition_id: scn_programmer_interview
+                    role_type: EXECUTIVE_INTERVIEWER
+                    display_name: Executive interviewer
+                    responsibilities: Test strategic judgment and impact.
+                    style: Concise and high level.
+                    focus_areas:
+                      - impact
+                      - judgment
+                    version: 1
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/preparation-profiles:
+    post:
+      tags:
+        - Preparation
+      summary: Create or return the preparation profile for one intent
+      description: |
+        The fixed MS1 user is resolved from server-side context. The request does
+        not accept a trusted `user_id`.
+      operationId: createPreparationProfile
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePreparationProfileRequest'
+            example:
+              resume_ref: resume_demo_backend_v1
+              job_description_ref: jd_demo_backend_v1
+              background_summary: |
+                Backend engineer with three years of Go experience, responsible
+                for an API reliability project and cross-team delivery.
+      responses:
+        '201':
+          description: The preparation profile created for the current actor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreparationProfile'
+              example:
+                preparation_profile_id: prep_demo_backend
+                user_id: user_demo
+                resume_ref: resume_demo_backend_v1
+                job_description_ref: jd_demo_backend_v1
+                background_summary: |
+                  Backend engineer with three years of Go experience, responsible
+                  for an API reliability project and cross-team delivery.
+                version: 1
+                updated_at: '2026-07-23T10:00:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/preparation-profiles/{preparation_profile_id}/snapshots:
+    post:
+      tags:
+        - Preparation
+      summary: Freeze a confirmed preparation profile
+      operationId: createPreparationSnapshot
+      parameters:
+        - $ref: '#/components/parameters/PreparationProfileId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePreparationSnapshotRequest'
+            example:
+              source_version: 1
+      responses:
+        '201':
+          description: Immutable preparation content for a future session snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreparationSnapshot'
+              example:
+                preparation_snapshot_id: psnap_demo_backend_v1
+                source_profile_id: prep_demo_backend
+                source_version: 1
+                resume_snapshot: Go backend engineer; API reliability project.
+                job_description_snapshot: Build reliable APIs and explain engineering trade-offs.
+                background_snapshot: |
+                  Backend engineer with three years of Go experience, responsible
+                  for an API reliability project and cross-team delivery.
+                created_at: '2026-07-23T10:01:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  parameters:
+    ScenarioDefinitionId:
+      name: scenario_definition_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    PreparationProfileId:
+      name: preparation_profile_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    IdempotencyKey:
+      $ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey
+  schemas:
+    ResourceId:
+      type: string
+      minLength: 1
+      maxLength: 128
+    Version:
+      type: integer
+      minimum: 1
+    ScenarioType:
+      type: string
+      enum:
+        - INTERVIEW
+    ScenarioDefinition:
+      type: object
+      additionalProperties: false
+      required:
+        - scenario_definition_id
+        - scenario_type
+        - name
+        - version
+        - status
+      properties:
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_type:
+          $ref: '#/components/schemas/ScenarioType'
+        name:
+          type: string
+          minLength: 1
+        version:
+          $ref: '#/components/schemas/Version'
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+    ScenarioConfig:
+      oneOf:
+        - $ref: '#/components/schemas/InterviewScenarioConfig'
+      discriminator:
+        propertyName: config_type
+        mapping:
+          INTERVIEW: '#/components/schemas/InterviewScenarioConfig'
+    InterviewScenarioConfig:
+      type: object
+      additionalProperties: false
+      required:
+        - scenario_config_id
+        - scenario_definition_id
+        - config_type
+        - version
+        - job_title
+        - job_description
+        - focus_areas
+      properties:
+        scenario_config_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        config_type:
+          type: string
+          const: INTERVIEW
+        version:
+          $ref: '#/components/schemas/Version'
+        job_title:
+          type: string
+          minLength: 1
+        job_description:
+          type: string
+          minLength: 1
+        focus_areas:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+    RoleDefinition:
+      type: object
+      additionalProperties: false
+      required:
+        - role_definition_id
+        - scenario_definition_id
+        - role_type
+        - display_name
+        - responsibilities
+        - style
+        - focus_areas
+        - version
+      properties:
+        role_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        role_type:
+          type: string
+          pattern: '^[A-Z][A-Z0-9_]*$'
+        display_name:
+          type: string
+          minLength: 1
+        responsibilities:
+          type: string
+          minLength: 1
+        style:
+          type: string
+          minLength: 1
+        focus_areas:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+        voice_config_ref:
+          type: string
+          minLength: 1
+        version:
+          $ref: '#/components/schemas/Version'
+    PracticeOptionDefinition:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_option_id
+        - scenario_definition_id
+        - practice_option_type
+        - display_name
+        - version
+      properties:
+        practice_option_id:
+          $ref: '#/components/schemas/ResourceId'
+        scenario_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        role_definition_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_option_type:
+          type: string
+          enum:
+            - FULL_SIMULATION
+            - FOCUS
+        display_name:
+          type: string
+          minLength: 1
+        version:
+          $ref: '#/components/schemas/Version'
+    ScenarioDetail:
+      type: object
+      additionalProperties: false
+      required:
+        - scenario_definition
+        - scenario_config
+        - practice_options
+      properties:
+        scenario_definition:
+          $ref: '#/components/schemas/ScenarioDefinition'
+        scenario_config:
+          $ref: '#/components/schemas/ScenarioConfig'
+        practice_options:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/PracticeOptionDefinition'
+    RoleDefinitionList:
+      type: object
+      additionalProperties: false
+      required:
+        - roles
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleDefinition'
+    CreatePreparationProfileRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - background_summary
+      properties:
+        resume_ref:
+          type: string
+          minLength: 1
+        job_description_ref:
+          type: string
+          minLength: 1
+        background_summary:
+          type: string
+          minLength: 1
+    PreparationProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - preparation_profile_id
+        - user_id
+        - background_summary
+        - version
+        - updated_at
+      properties:
+        preparation_profile_id:
+          $ref: '#/components/schemas/ResourceId'
+        user_id:
+          $ref: '#/components/schemas/ResourceId'
+        resume_ref:
+          type: string
+          minLength: 1
+        job_description_ref:
+          type: string
+          minLength: 1
+        background_summary:
+          type: string
+          minLength: 1
+        version:
+          $ref: '#/components/schemas/Version'
+        updated_at:
+          type: string
+          format: date-time
+    CreatePreparationSnapshotRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - source_version
+      properties:
+        source_version:
+          $ref: '#/components/schemas/Version'
+    PreparationSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - preparation_snapshot_id
+        - source_profile_id
+        - source_version
+        - background_snapshot
+        - created_at
+      properties:
+        preparation_snapshot_id:
+          $ref: '#/components/schemas/ResourceId'
+        source_profile_id:
+          $ref: '#/components/schemas/ResourceId'
+        source_version:
+          $ref: '#/components/schemas/Version'
+        resume_snapshot:
+          type: string
+          minLength: 1
+        job_description_snapshot:
+          type: string
+          minLength: 1
+        background_snapshot:
+          type: string
+          minLength: 1
+        created_at:
+          type: string
+          format: date-time

--- a/api/modules/review.yaml
+++ b/api/modules/review.yaml
@@ -1,0 +1,499 @@
+paths:
+  /v1/turns/{turn_id}/turn-analyses:
+    post:
+      tags:
+        - Review
+      summary: Start or return one analysis attempt
+      description: |
+        A completed Turn remains immutable if analysis fails. Reusing the same
+        idempotency key returns the same analysis resource.
+      operationId: analyzeTurn
+      parameters:
+        - $ref: '#/components/parameters/TurnId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '202':
+          description: The analysis exists and is pending.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TurnAnalysis'
+              example:
+                turn_analysis_id: analysis_demo_001
+                turn_id: turn_demo_001
+                evaluator_version: mock-review-v1
+                analysis_status: pending
+                created_at: '2026-07-23T10:05:03Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    get:
+      tags:
+        - Review
+      summary: List analyses for a Turn
+      operationId: listTurnAnalyses
+      parameters:
+        - $ref: '#/components/parameters/TurnId'
+      responses:
+        '200':
+          description: Analysis resources for the requested Turn.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TurnAnalysisList'
+              example:
+                analyses:
+                  - turn_analysis_id: analysis_demo_001
+                    turn_id: turn_demo_001
+                    evaluator_version: mock-review-v1
+                    analysis_status: completed
+                    score: 82
+                    summary: Clear ownership and measurable impact; make the trade-off more explicit.
+                    analysis_transcript: |
+                      I led a Go API reliability project and reduced incident
+                      recovery time through tracing and a staged rollout.
+                    created_at: '2026-07-23T10:05:03Z'
+                    completed_at: '2026-07-23T10:05:04Z'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/turn-analyses/{turn_analysis_id}/feedback-items:
+    get:
+      tags:
+        - Review
+      summary: List evidence-backed feedback for an analysis
+      operationId: listFeedbackItems
+      parameters:
+        - $ref: '#/components/parameters/TurnAnalysisId'
+      responses:
+        '200':
+          description: Feedback items generated only from a completed analysis.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedbackItemList'
+              example:
+                feedback_items:
+                  - feedback_item_id: feedback_demo_001
+                    turn_analysis_id: analysis_demo_001
+                    feedback_category: STRUCTURE
+                    message: The answer establishes ownership and outcome.
+                    suggestion: Add one sentence explaining why tracing was chosen before rollout.
+                    evidence:
+                      - transcript_text: I introduced request tracing, defined an error budget.
+                    retryable: true
+                    created_at: '2026-07-23T10:05:04Z'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/feedback-items/{feedback_item_id}/retry-requests:
+    post:
+      tags:
+        - Review
+      summary: Request an idempotent same-question retry
+      description: |
+        Review first saves a pending immutable relation to the original Turn and
+        feedback, then invokes Conversation's internal CreateRetryTurn command.
+        Conversation idempotently creates one `answering` Turn for the original
+        Question; Review records its ID and returns `turn_created`. The client
+        never invokes or coordinates the cross-module command.
+
+        After the client submits a valid final answer to the original Question
+        with this `retry_request_id`, Conversation advances that same Turn
+        instead of creating another one. On completion, Conversation submits
+        TurnOutcome normally and Practice alone decides the progress effect from
+        the immutable PracticeSessionPolicy.
+      operationId: requestRetry
+      parameters:
+        - $ref: '#/components/parameters/FeedbackItemId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '201':
+          description: The retry relation and its pre-created answering Turn.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetryRequest'
+              example:
+                retry_request_id: retry_demo_001
+                original_turn_id: turn_demo_001
+                feedback_item_id: feedback_demo_001
+                new_turn_id: turn_retry_demo_001
+                retry_status: turn_created
+                created_at: '2026-07-23T10:06:00Z'
+                updated_at: '2026-07-23T10:06:01Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/retry-requests/{retry_request_id}:
+    get:
+      tags:
+        - Review
+      summary: Get a same-question retry request
+      operationId: getRetryRequest
+      parameters:
+        - $ref: '#/components/parameters/RetryRequestId'
+      responses:
+        '200':
+          description: Retry relation and its current status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetryRequest'
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/history-records:
+    get:
+      tags:
+        - Review
+      summary: List review history for a practice session
+      operationId: listHistoryRecords
+      parameters:
+        - name: practice_session_id
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceId'
+      responses:
+        '200':
+          description: Rebuildable read projections ordered by review time descending.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryRecordList'
+              example:
+                history_records:
+                  - history_record_id: history_demo_001
+                    practice_session_id: session_demo_001
+                    turn_id: turn_demo_001
+                    turn_analysis_id: analysis_demo_001
+                    retry_request_id: retry_demo_001
+                    score: 82
+                    summary: Clear ownership and measurable impact; make the trade-off more explicit.
+                    reviewed_at: '2026-07-23T10:05:04Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  parameters:
+    TurnId:
+      name: turn_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    TurnAnalysisId:
+      name: turn_analysis_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    FeedbackItemId:
+      name: feedback_item_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    RetryRequestId:
+      name: retry_request_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/ResourceId'
+    IdempotencyKey:
+      $ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey
+  schemas:
+    ResourceId:
+      type: string
+      minLength: 1
+      maxLength: 128
+    TurnAnalysis:
+      type: object
+      additionalProperties: false
+      description: |
+        At most one effective analysis exists for each
+        `(turn_id, evaluator_version)` pair. Failed analysis never mutates or
+        rolls back the source Turn or PracticeSession.
+      required:
+        - turn_analysis_id
+        - turn_id
+        - evaluator_version
+        - analysis_status
+        - created_at
+      properties:
+        turn_analysis_id:
+          $ref: '#/components/schemas/ResourceId'
+        turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        evaluator_version:
+          type: string
+          minLength: 1
+        analysis_status:
+          type: string
+          enum:
+            - pending
+            - completed
+            - failed
+        score:
+          type: number
+          description: No public score range is frozen for MS1.
+        summary:
+          type: string
+          minLength: 1
+        analysis_transcript:
+          type: string
+          minLength: 1
+        failure_reason:
+          type: string
+          minLength: 1
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        failed_at:
+          type: string
+          format: date-time
+      oneOf:
+        - properties:
+            analysis_status:
+              const: pending
+          required:
+            - analysis_status
+          not:
+            anyOf:
+              - required:
+                  - score
+              - required:
+                  - summary
+              - required:
+                  - failure_reason
+              - required:
+                  - completed_at
+              - required:
+                  - failed_at
+        - properties:
+            analysis_status:
+              const: completed
+          required:
+            - analysis_status
+            - score
+            - summary
+            - completed_at
+          not:
+            anyOf:
+              - required:
+                  - failure_reason
+              - required:
+                  - failed_at
+        - properties:
+            analysis_status:
+              const: failed
+          required:
+            - analysis_status
+            - failure_reason
+            - failed_at
+          not:
+            anyOf:
+              - required:
+                  - score
+              - required:
+                  - summary
+              - required:
+                  - completed_at
+    TurnAnalysisList:
+      type: object
+      additionalProperties: false
+      required:
+        - analyses
+      properties:
+        analyses:
+          type: array
+          items:
+            $ref: '#/components/schemas/TurnAnalysis'
+    Evidence:
+      type: object
+      additionalProperties: false
+      properties:
+        transcript_text:
+          type: string
+          minLength: 1
+        start_ms:
+          type: integer
+          minimum: 0
+        end_ms:
+          type: integer
+          minimum: 1
+      anyOf:
+        - required:
+            - transcript_text
+        - required:
+            - start_ms
+            - end_ms
+    FeedbackItem:
+      type: object
+      additionalProperties: false
+      required:
+        - feedback_item_id
+        - turn_analysis_id
+        - feedback_category
+        - message
+        - evidence
+        - retryable
+        - created_at
+      properties:
+        feedback_item_id:
+          $ref: '#/components/schemas/ResourceId'
+        turn_analysis_id:
+          $ref: '#/components/schemas/ResourceId'
+        feedback_category:
+          type: string
+          pattern: '^[A-Z][A-Z0-9_]*$'
+        message:
+          type: string
+          minLength: 1
+        suggestion:
+          type: string
+          minLength: 1
+        evidence:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Evidence'
+        retryable:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+    FeedbackItemList:
+      type: object
+      additionalProperties: false
+      required:
+        - feedback_items
+      properties:
+        feedback_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedbackItem'
+    RetryRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - retry_request_id
+        - original_turn_id
+        - feedback_item_id
+        - retry_status
+        - created_at
+        - updated_at
+      properties:
+        retry_request_id:
+          $ref: '#/components/schemas/ResourceId'
+        original_turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        feedback_item_id:
+          $ref: '#/components/schemas/ResourceId'
+        new_turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        retry_status:
+          type: string
+          enum:
+            - pending
+            - turn_created
+            - failed
+        failure_reason:
+          type: string
+          minLength: 1
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      oneOf:
+        - properties:
+            retry_status:
+              const: pending
+          required:
+            - retry_status
+          not:
+            anyOf:
+              - required:
+                  - new_turn_id
+              - required:
+                  - failure_reason
+        - properties:
+            retry_status:
+              const: turn_created
+          required:
+            - retry_status
+            - new_turn_id
+          not:
+            required:
+              - failure_reason
+        - properties:
+            retry_status:
+              const: failed
+          required:
+            - retry_status
+            - failure_reason
+          not:
+            required:
+              - new_turn_id
+    HistoryRecord:
+      type: object
+      additionalProperties: false
+      required:
+        - history_record_id
+        - practice_session_id
+        - turn_id
+        - turn_analysis_id
+        - score
+        - summary
+        - reviewed_at
+      properties:
+        history_record_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        turn_id:
+          $ref: '#/components/schemas/ResourceId'
+        turn_analysis_id:
+          $ref: '#/components/schemas/ResourceId'
+        retry_request_id:
+          $ref: '#/components/schemas/ResourceId'
+        score:
+          type: number
+        summary:
+          type: string
+          minLength: 1
+        reviewed_at:
+          type: string
+          format: date-time
+    HistoryRecordList:
+      type: object
+      additionalProperties: false
+      required:
+        - history_records
+      properties:
+        history_records:
+          type: array
+          items:
+            $ref: '#/components/schemas/HistoryRecord'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,226 @@
+openapi: 3.1.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+info:
+  title: SpeakUp MS1 API
+  version: 0.1.0
+  description: |
+    Language-neutral REST contract for the deterministic MS1 practice flow.
+    Authentication is intentionally out of scope. The MS1 adapter supplies a
+    fixed demo identity from server-side context; clients never submit trusted
+    user or respondent participant identifiers.
+
+    Optional JSON properties use absent-only semantics: clients omit values that
+    are not present and must not serialize them as explicit `null`.
+  license:
+    name: MIT
+    identifier: MIT
+servers:
+  - url: http://localhost:8080
+    description: Local deterministic MS1 server
+security: []
+x-json-null-policy: omit
+tags:
+  - name: Preparation
+    description: Scenario, role, profile, and immutable preparation snapshot resources.
+  - name: Practice
+    description: Practice plan, session lifecycle, participant, and policy snapshots.
+  - name: Conversation
+    description: Questions, effective Turns, and ordered session events.
+  - name: Review
+    description: Analysis, evidence feedback, same-question retry, and history projections.
+paths:
+  /health:
+    get:
+      summary: Check the modular monolith process
+      operationId: getHealth
+      responses:
+        '200':
+          description: Process health and registered business modules.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+              example:
+                status: ok
+                modules:
+                  - preparation
+                  - practice
+                  - conversation
+                  - review
+        '400':
+          $ref: ./common/errors.yaml#/components/responses/BadRequest
+        default:
+          $ref: ./common/errors.yaml#/components/responses/DefaultError
+  /v1/scenario-definitions/{scenario_definition_id}:
+    $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}
+  /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
+    $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}~1role-definitions
+  /v1/preparation-profiles:
+    $ref: ./modules/preparation.yaml#/paths/~1v1~1preparation-profiles
+  /v1/preparation-profiles/{preparation_profile_id}/snapshots:
+    $ref: ./modules/preparation.yaml#/paths/~1v1~1preparation-profiles~1{preparation_profile_id}~1snapshots
+  /v1/practice-plans:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-plans
+  /v1/practice-plans/{practice_plan_id}:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-plans~1{practice_plan_id}
+  /v1/practice-plans/{practice_plan_id}/practice-sessions:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-plans~1{practice_plan_id}~1practice-sessions
+  /v1/practice-sessions/{practice_session_id}:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}
+  /v1/practice-sessions/{practice_session_id}/snapshot:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1snapshot
+  /v1/practice-sessions/{practice_session_id}/pause:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1pause
+  /v1/practice-sessions/{practice_session_id}/resume:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1resume
+  /v1/practice-sessions/{practice_session_id}/end-early:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1end-early
+  /v1/practice-sessions/{practice_session_id}/bootstrap:
+    $ref: ./modules/conversation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1bootstrap
+  /v1/practice-sessions/{practice_session_id}/questions:
+    $ref: ./modules/conversation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1questions
+  /v1/questions/{question_id}/turns:
+    $ref: ./modules/conversation.yaml#/paths/~1v1~1questions~1{question_id}~1turns
+  /v1/turns/{turn_id}:
+    $ref: ./modules/conversation.yaml#/paths/~1v1~1turns~1{turn_id}
+  /v1/practice-sessions/{practice_session_id}/events:
+    $ref: ./modules/conversation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1events
+  /v1/turns/{turn_id}/turn-analyses:
+    $ref: ./modules/review.yaml#/paths/~1v1~1turns~1{turn_id}~1turn-analyses
+  /v1/turn-analyses/{turn_analysis_id}/feedback-items:
+    $ref: ./modules/review.yaml#/paths/~1v1~1turn-analyses~1{turn_analysis_id}~1feedback-items
+  /v1/feedback-items/{feedback_item_id}/retry-requests:
+    $ref: ./modules/review.yaml#/paths/~1v1~1feedback-items~1{feedback_item_id}~1retry-requests
+  /v1/retry-requests/{retry_request_id}:
+    $ref: ./modules/review.yaml#/paths/~1v1~1retry-requests~1{retry_request_id}
+  /v1/history-records:
+    $ref: ./modules/review.yaml#/paths/~1v1~1history-records
+components:
+  schemas:
+    Health:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - modules
+      properties:
+        status:
+          type: string
+          const: ok
+        modules:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum:
+              - preparation
+              - practice
+              - conversation
+              - review
+    ErrorResponse:
+      $ref: ./common/errors.yaml#/components/schemas/ErrorResponse
+    ScenarioDefinition:
+      $ref: ./modules/preparation.yaml#/components/schemas/ScenarioDefinition
+    ScenarioConfig:
+      $ref: ./modules/preparation.yaml#/components/schemas/ScenarioConfig
+    InterviewScenarioConfig:
+      $ref: ./modules/preparation.yaml#/components/schemas/InterviewScenarioConfig
+    RoleDefinition:
+      $ref: ./modules/preparation.yaml#/components/schemas/RoleDefinition
+    PracticeOptionDefinition:
+      $ref: ./modules/preparation.yaml#/components/schemas/PracticeOptionDefinition
+    PreparationProfile:
+      $ref: ./modules/preparation.yaml#/components/schemas/PreparationProfile
+    PreparationSnapshot:
+      $ref: ./modules/preparation.yaml#/components/schemas/PreparationSnapshot
+    PracticePlan:
+      $ref: ./modules/practice.yaml#/components/schemas/PracticePlan
+    PracticeSession:
+      $ref: ./modules/practice.yaml#/components/schemas/PracticeSession
+    PracticeParticipant:
+      $ref: ./modules/practice.yaml#/components/schemas/PracticeParticipant
+    PracticeSessionSnapshot:
+      $ref: ./modules/practice.yaml#/components/schemas/PracticeSessionSnapshot
+    PracticeSessionPolicy:
+      $ref: ./modules/practice.yaml#/components/schemas/PracticeSessionPolicy
+    Question:
+      $ref: ./modules/conversation.yaml#/components/schemas/Question
+    Turn:
+      $ref: ./modules/conversation.yaml#/components/schemas/Turn
+    TranscriptSnapshot:
+      $ref: ./modules/conversation.yaml#/components/schemas/TranscriptSnapshot
+    AudioReference:
+      $ref: ./modules/conversation.yaml#/components/schemas/AudioReference
+    TurnReviewSource:
+      $ref: ./modules/conversation.yaml#/components/schemas/TurnReviewSource
+    CreateRetryTurnCommand:
+      $ref: ./modules/conversation.yaml#/components/schemas/CreateRetryTurnCommand
+    CreateRetryTurnResult:
+      $ref: ./modules/conversation.yaml#/components/schemas/CreateRetryTurnResult
+    ConversationBootstrap:
+      $ref: ./modules/conversation.yaml#/components/schemas/ConversationBootstrap
+    TurnAnalysis:
+      $ref: ./modules/review.yaml#/components/schemas/TurnAnalysis
+    FeedbackItem:
+      $ref: ./modules/review.yaml#/components/schemas/FeedbackItem
+    RetryRequest:
+      $ref: ./modules/review.yaml#/components/schemas/RetryRequest
+    HistoryRecord:
+      $ref: ./modules/review.yaml#/components/schemas/HistoryRecord
+    ConversationEvent:
+      oneOf:
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/StreamReadyEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/QuestionCreatedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/TurnSubmittedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/TurnProcessingEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/TurnCompletedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/AnswerProcessingFailedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/TurnAnalysisCompletedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/TurnAnalysisFailedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionStartedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionPausedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionResumedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionCompletedEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionEndedEarlyEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/StreamResyncRequiredEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/SystemErrorEvent
+        - $ref: ./websocket/conversation-events.schema.json#/$defs/SystemHeartbeatEvent
+      discriminator:
+        propertyName: event_type
+        mapping:
+          stream.ready: ./websocket/conversation-events.schema.json#/$defs/StreamReadyEvent
+          question.created: ./websocket/conversation-events.schema.json#/$defs/QuestionCreatedEvent
+          turn.submitted: ./websocket/conversation-events.schema.json#/$defs/TurnSubmittedEvent
+          turn.processing: ./websocket/conversation-events.schema.json#/$defs/TurnProcessingEvent
+          turn.completed: ./websocket/conversation-events.schema.json#/$defs/TurnCompletedEvent
+          answer.processing_failed: ./websocket/conversation-events.schema.json#/$defs/AnswerProcessingFailedEvent
+          turn_analysis.completed: ./websocket/conversation-events.schema.json#/$defs/TurnAnalysisCompletedEvent
+          turn_analysis.failed: ./websocket/conversation-events.schema.json#/$defs/TurnAnalysisFailedEvent
+          practice_session.started: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionStartedEvent
+          practice_session.paused: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionPausedEvent
+          practice_session.resumed: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionResumedEvent
+          practice_session.completed: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionCompletedEvent
+          practice_session.ended_early: ./websocket/conversation-events.schema.json#/$defs/PracticeSessionEndedEarlyEvent
+          stream.resync_required: ./websocket/conversation-events.schema.json#/$defs/StreamResyncRequiredEvent
+          system.error: ./websocket/conversation-events.schema.json#/$defs/SystemErrorEvent
+          system.heartbeat: ./websocket/conversation-events.schema.json#/$defs/SystemHeartbeatEvent
+x-websocket-contract:
+  endpoint: /v1/practice-sessions/{practice_session_id}/events
+  schema:
+    $ref: '#/components/schemas/ConversationEvent'
+x-module-commands:
+  CreateRetryTurn:
+    visibility: internal
+    direction: 'Review -> Conversation'
+    request:
+      $ref: '#/components/schemas/CreateRetryTurnCommand'
+    result:
+      $ref: '#/components/schemas/CreateRetryTurnResult'
+    idempotency_key: retry_request_id
+    description: |
+      Review invokes this command after durably saving a pending RetryRequest.
+      Conversation validates that the original Turn is completed, reuses its
+      Session, Question, sequence, and respondent, and creates an `answering`
+      Turn. Replaying the same ID and payload returns the same `new_turn_id`;
+      changing `original_turn_id` for that ID is a conflict. This is an internal
+      modular-monolith contract and is never called by Flutter.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "@speakup/api-contract",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@speakup/api-contract",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@redocly/cli": "2.40.0",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.40.0.tgz",
+      "integrity": "sha512-1uQ4GeNjhApy9EtypZgp70ZN5GC2JFfst3UkNEXSqkXgVIPGdEAnlz5Xwgax/4cEUGOvaZoM3X25iSQcqbplFg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@speakup/api-contract",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Validation entrypoint for the SpeakUp REST and WebSocket contracts.",
+  "scripts": {
+    "check": "npm run lint:openapi && npm run validate:websocket && npm run validate:fixture",
+    "lint:openapi": "redocly lint openapi.yaml --config redocly.yaml",
+    "validate:websocket": "node scripts/validate-events.mjs",
+    "validate:fixture": "node scripts/validate-main-flow.mjs"
+  },
+  "devDependencies": {
+    "@redocly/cli": "2.40.0",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  }
+}

--- a/api/redocly.yaml
+++ b/api/redocly.yaml
@@ -1,0 +1,7 @@
+extends:
+  - recommended
+rules:
+  no-invalid-media-type-examples: error
+  no-required-schema-properties-undefined: off
+  no-server-example.com: off
+  no-unused-components: off

--- a/api/scripts/validate-events.mjs
+++ b/api/scripts/validate-events.mjs
@@ -1,0 +1,128 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const envelopePath = resolve(
+  apiDirectory,
+  'common/event-envelope.schema.json',
+);
+const eventSchemaPath = resolve(
+  apiDirectory,
+  'websocket/conversation-events.schema.json',
+);
+const examplesDirectory = resolve(apiDirectory, 'examples/websocket');
+
+const readJson = async (filePath) =>
+  JSON.parse(await readFile(filePath, { encoding: 'utf8' }));
+
+const envelopeSchema = await readJson(envelopePath);
+const eventSchema = await readJson(eventSchemaPath);
+
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+ajv.addSchema(envelopeSchema);
+const validate = ajv.compile(eventSchema);
+
+const exampleNames = (await readdir(examplesDirectory))
+  .filter((name) => name.endsWith('.json'))
+  .sort();
+
+if (exampleNames.length === 0) {
+  throw new Error('No WebSocket event examples were found.');
+}
+
+let hasFailure = false;
+const exampleEventTypes = new Set();
+for (const exampleName of exampleNames) {
+  const example = await readJson(resolve(examplesDirectory, exampleName));
+  exampleEventTypes.add(example.event_type);
+  if (!validate(example)) {
+    hasFailure = true;
+    console.error(`${exampleName}: ${ajv.errorsText(validate.errors)}`);
+  }
+}
+
+const schemaEventTypes = new Set(
+  eventSchema.oneOf.map(({ $ref }) => {
+    const definitionName = $ref.split('/').at(-1);
+    return eventSchema.$defs[definitionName].allOf[1].properties.event_type.const;
+  }),
+);
+const missingExampleTypes = [...schemaEventTypes].filter(
+  (eventType) => !exampleEventTypes.has(eventType),
+);
+if (missingExampleTypes.length > 0) {
+  hasFailure = true;
+  console.error(
+    `Missing positive examples for: ${missingExampleTypes.join(', ')}`,
+  );
+}
+
+const replayableWithoutSequence = await readJson(
+  resolve(examplesDirectory, '02-question-created.json'),
+);
+delete replayableWithoutSequence.sequence;
+
+const ephemeralWithSequence = await readJson(
+  resolve(examplesDirectory, '01-stream-ready.json'),
+);
+ephemeralWithSequence.sequence = 1;
+
+const payloadWithClientControlledRespondent = await readJson(
+  resolve(examplesDirectory, '02-question-created.json'),
+);
+payloadWithClientControlledRespondent.payload.respondent_participant_id =
+  'participant_candidate_001';
+
+const mismatchedTurnStatus = await readJson(
+  resolve(examplesDirectory, '03-turn-submitted.json'),
+);
+mismatchedTurnStatus.payload.turn_status = 'processing';
+
+const unsupportedEventVersion = await readJson(
+  resolve(examplesDirectory, '02-question-created.json'),
+);
+unsupportedEventVersion.event_version = 2;
+
+const followUpWithoutParent = await readJson(
+  resolve(examplesDirectory, '02-question-created.json'),
+);
+followUpWithoutParent.payload.question_type = 'FOLLOW_UP';
+
+const primaryWithParent = await readJson(
+  resolve(examplesDirectory, '02-question-created.json'),
+);
+primaryWithParent.payload.parent_question_id = 'question_parent_001';
+
+const rejectionCases = [
+  ['replayable event without sequence', replayableWithoutSequence],
+  ['ephemeral event with sequence', ephemeralWithSequence],
+  [
+    'payload with an undeclared participant field',
+    payloadWithClientControlledRespondent,
+  ],
+  ['event type and Turn status mismatch', mismatchedTurnStatus],
+  ['unsupported event version', unsupportedEventVersion],
+  ['follow-up Question without parent', followUpWithoutParent],
+  ['primary Question with parent', primaryWithParent],
+];
+
+for (const [caseName, example] of rejectionCases) {
+  if (validate(example)) {
+    hasFailure = true;
+    console.error(`${caseName}: invalid event was accepted`);
+  }
+}
+
+if (hasFailure) {
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Validated ${exampleNames.length} WebSocket events and ` +
+      `${rejectionCases.length} rejection cases.`,
+  );
+}

--- a/api/scripts/validate-main-flow.mjs
+++ b/api/scripts/validate-main-flow.mjs
@@ -1,0 +1,525 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const execFileAsync = promisify(execFile);
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const fixture = JSON.parse(
+  await readFile(resolve(apiDirectory, 'examples/mock-main-flow.json'), 'utf8'),
+);
+
+const componentReferencePrefix = '#/components/schemas/';
+const formalDtoNames = [
+  'PracticeSession',
+  'PracticeParticipant',
+  'PracticeSessionPolicy',
+  'Question',
+  'Turn',
+  'CreateRetryTurnCommand',
+  'CreateRetryTurnResult',
+  'TurnAnalysis',
+  'FeedbackItem',
+  'RetryRequest',
+  'HistoryRecord',
+];
+
+const bundleOpenApi = async () => {
+  const temporaryDirectory = await mkdtemp(
+    resolve(tmpdir(), 'speakup-openapi-bundle-'),
+  );
+  const bundlePath = resolve(temporaryDirectory, 'openapi.bundle.json');
+  const redoclyCliPath = resolve(
+    apiDirectory,
+    'node_modules/@redocly/cli/bin/cli.js',
+  );
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        redoclyCliPath,
+        'bundle',
+        resolve(apiDirectory, 'openapi.yaml'),
+        '--config',
+        resolve(apiDirectory, 'redocly.yaml'),
+        '--output',
+        bundlePath,
+        '--ext',
+        'json',
+      ],
+      {
+        cwd: apiDirectory,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    return JSON.parse(await readFile(bundlePath, 'utf8'));
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+const decodeJsonPointerToken = (token) =>
+  token.replaceAll('~1', '/').replaceAll('~0', '~');
+const encodeJsonPointerToken = (token) =>
+  token.replaceAll('~', '~0').replaceAll('/', '~1');
+
+const findComponentReferences = (value, references = new Set()) => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      findComponentReferences(item, references);
+    }
+    return references;
+  }
+  if (value === null || typeof value !== 'object') {
+    return references;
+  }
+
+  if (
+    typeof value.$ref === 'string' &&
+    value.$ref.startsWith(componentReferencePrefix)
+  ) {
+    references.add(
+      decodeJsonPointerToken(value.$ref.slice(componentReferencePrefix.length)),
+    );
+  }
+  for (const item of Object.values(value)) {
+    findComponentReferences(item, references);
+  }
+  return references;
+};
+
+const rewriteComponentReferences = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(rewriteComponentReferences);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => {
+      if (
+        key === '$ref' &&
+        typeof item === 'string' &&
+        item.startsWith(componentReferencePrefix)
+      ) {
+        const schemaName = decodeJsonPointerToken(
+          item.slice(componentReferencePrefix.length),
+        );
+        return [key, `#/$defs/${encodeJsonPointerToken(schemaName)}`];
+      }
+      return [key, rewriteComponentReferences(item)];
+    }),
+  );
+};
+
+const openApiBundle = await bundleOpenApi();
+const componentSchemas = openApiBundle.components?.schemas;
+if (componentSchemas === undefined) {
+  throw new Error('The bundled OpenAPI document has no component schemas.');
+}
+
+const formalDefinitions = {};
+const collectFormalSchema = (schemaName) => {
+  if (Object.hasOwn(formalDefinitions, schemaName)) {
+    return;
+  }
+  const schema = componentSchemas[schemaName];
+  if (schema === undefined) {
+    throw new Error(`The bundled OpenAPI document has no ${schemaName} schema.`);
+  }
+
+  formalDefinitions[schemaName] = rewriteComponentReferences(schema);
+  for (const dependencyName of findComponentReferences(schema)) {
+    collectFormalSchema(dependencyName);
+  }
+};
+for (const schemaName of formalDtoNames) {
+  collectFormalSchema(schemaName);
+}
+
+const fixtureSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'fixture_id',
+    'practice_session',
+    'session_policy',
+    'participants',
+    'questions',
+    'effective_turns',
+    'turn_analyses',
+    'feedback_items',
+    'retry_request_pending',
+    'create_retry_turn_command',
+    'create_retry_turn_results',
+    'retry_turn_created',
+    'retry_request',
+    'retry_turn',
+    'retry_progress_decision',
+    'history_records',
+  ],
+  properties: {
+    fixture_id: {
+      type: 'string',
+      minLength: 1,
+    },
+    practice_session: {
+      $ref: '#/$defs/PracticeSession',
+    },
+    session_policy: {
+      $ref: '#/$defs/PracticeSessionPolicy',
+    },
+    participants: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/PracticeParticipant',
+      },
+    },
+    questions: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/Question',
+      },
+    },
+    effective_turns: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/Turn',
+      },
+    },
+    turn_analyses: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/TurnAnalysis',
+      },
+    },
+    feedback_items: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/FeedbackItem',
+      },
+    },
+    retry_request_pending: {
+      $ref: '#/$defs/RetryRequest',
+    },
+    create_retry_turn_command: {
+      $ref: '#/$defs/CreateRetryTurnCommand',
+    },
+    create_retry_turn_results: {
+      type: 'array',
+      minItems: 2,
+      items: {
+        $ref: '#/$defs/CreateRetryTurnResult',
+      },
+    },
+    retry_turn_created: {
+      $ref: '#/$defs/Turn',
+    },
+    retry_request: {
+      $ref: '#/$defs/RetryRequest',
+    },
+    retry_turn: {
+      $ref: '#/$defs/Turn',
+    },
+    retry_progress_decision: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'decided_by',
+        'counts_toward_effective_turn_limit',
+      ],
+      properties: {
+        decided_by: {
+          const: 'PracticeSessionPolicy',
+        },
+        counts_toward_effective_turn_limit: {
+          type: 'boolean',
+        },
+      },
+    },
+    history_records: {
+      type: 'array',
+      items: {
+        $ref: '#/$defs/HistoryRecord',
+      },
+    },
+  },
+  $defs: formalDefinitions,
+};
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: true,
+  strictRequired: false,
+});
+addFormats(ajv);
+ajv.addKeyword({
+  keyword: 'x-internal',
+  schemaType: 'boolean',
+});
+const validateFixture = ajv.compile(fixtureSchema);
+if (!validateFixture(fixture)) {
+  const errors = validateFixture.errors
+    .map(
+      ({ instancePath, keyword, message }) =>
+        `${instancePath || '/'} ${keyword}: ${message}`,
+    )
+    .join('\n');
+  throw new Error(`The main-flow fixture violates the OpenAPI DTOs:\n${errors}`);
+}
+
+const assertFixtureMutationRejected = (caseName, mutate) => {
+  const invalidFixture = structuredClone(fixture);
+  mutate(invalidFixture);
+  assert.equal(
+    validateFixture(invalidFixture),
+    false,
+    `${caseName}: invalid fixture mutation was accepted`,
+  );
+};
+
+assertFixtureMutationRejected('pending analysis with score', (invalid) => {
+  invalid.turn_analyses[1].score = 10;
+});
+assertFixtureMutationRejected(
+  'completed analysis with failure fields',
+  (invalid) => {
+    invalid.turn_analyses[0].failure_reason = 'must not coexist';
+    invalid.turn_analyses[0].failed_at = '2026-07-23T10:05:05Z';
+  },
+);
+assertFixtureMutationRejected(
+  'pending retry with a created Turn',
+  (invalid) => {
+    invalid.retry_request_pending.new_turn_id = 'turn_invalid';
+  },
+);
+assertFixtureMutationRejected(
+  'created retry with a failure reason',
+  (invalid) => {
+    invalid.retry_request.failure_reason = 'must not coexist';
+  },
+);
+assertFixtureMutationRejected(
+  'answering Turn with a final answer',
+  (invalid) => {
+    invalid.retry_turn_created.answer_text = 'not submitted yet';
+  },
+);
+assertFixtureMutationRejected(
+  'follow-up Question without a parent',
+  (invalid) => {
+    delete invalid.questions[2].parent_question_id;
+  },
+);
+
+const sessionId = fixture.practice_session.practice_session_id;
+const policy = fixture.session_policy;
+
+assert.ok(policy.min_effective_turns <= policy.coverage_checkpoint_turn);
+assert.ok(policy.coverage_checkpoint_turn <= policy.max_effective_turns);
+
+const participantById = new Map(
+  fixture.participants.map((participant) => [
+    participant.practice_participant_id,
+    participant,
+  ]),
+);
+assert.equal(participantById.size, fixture.participants.length);
+assert.equal(
+  fixture.participants.filter(
+    (participant) => participant.participant_role === 'INTERVIEWER',
+  ).length,
+  1,
+);
+assert.equal(
+  fixture.participants.filter(
+    (participant) => participant.participant_role === 'CANDIDATE',
+  ).length,
+  1,
+);
+assert.equal(
+  new Set(
+    fixture.participants.map(
+      (participant) =>
+        `${participant.subject_ref.namespace}:${participant.subject_ref.subject_id}`,
+    ),
+  ).size,
+  fixture.participants.length,
+);
+assert.ok(
+  fixture.participants.every(
+    (participant) => participant.practice_session_id === sessionId,
+  ),
+);
+
+const questionById = new Map(
+  fixture.questions.map((question) => [question.question_id, question]),
+);
+assert.equal(questionById.size, fixture.questions.length);
+for (const question of fixture.questions) {
+  assert.equal(question.practice_session_id, sessionId);
+  assert.equal(
+    participantById.get(question.speaker_participant_id)?.participant_role,
+    'INTERVIEWER',
+  );
+  assert.ok(question.addressee_participant_ids.length > 0);
+  assert.ok(
+    question.addressee_participant_ids.every((participantId) =>
+      participantById.has(participantId),
+    ),
+  );
+  if (question.question_type === 'FOLLOW_UP') {
+    assert.ok(questionById.has(question.parent_question_id));
+  }
+}
+
+assert.equal(
+  fixture.effective_turns.length,
+  policy.coverage_checkpoint_turn,
+);
+assert.ok(fixture.effective_turns.length >= policy.min_effective_turns);
+assert.ok(fixture.effective_turns.length <= policy.max_effective_turns);
+assert.equal(fixture.practice_session.practice_session_status, 'completed');
+
+const effectiveTurnById = new Map(
+  fixture.effective_turns.map((turn) => [turn.turn_id, turn]),
+);
+assert.equal(effectiveTurnById.size, fixture.effective_turns.length);
+for (const turn of fixture.effective_turns) {
+  const question = questionById.get(turn.question_id);
+  assert.ok(question);
+  assert.equal(turn.practice_session_id, sessionId);
+  assert.equal(turn.sequence, question.sequence);
+  assert.ok(
+    question.addressee_participant_ids.includes(
+      turn.respondent_participant_id,
+    ),
+  );
+  assert.equal(turn.turn_status, 'completed');
+}
+
+const analysisById = new Map(
+  fixture.turn_analyses.map((analysis) => [
+    analysis.turn_analysis_id,
+    analysis,
+  ]),
+);
+assert.equal(fixture.turn_analyses.length, fixture.effective_turns.length);
+assert.ok(
+  fixture.turn_analyses.every((analysis) =>
+    effectiveTurnById.has(analysis.turn_id),
+  ),
+);
+
+const feedbackById = new Map(
+  fixture.feedback_items.map((feedback) => [
+    feedback.feedback_item_id,
+    feedback,
+  ]),
+);
+for (const feedback of fixture.feedback_items) {
+  assert.equal(
+    analysisById.get(feedback.turn_analysis_id)?.analysis_status,
+    'completed',
+  );
+  assert.ok(feedback.evidence.length > 0);
+}
+
+const pendingRetry = fixture.retry_request_pending;
+const originalTurn = effectiveTurnById.get(pendingRetry.original_turn_id);
+assert.ok(originalTurn);
+assert.ok(feedbackById.has(pendingRetry.feedback_item_id));
+assert.equal(pendingRetry.retry_status, 'pending');
+
+const createRetryTurnCommand = fixture.create_retry_turn_command;
+assert.equal(
+  createRetryTurnCommand.retry_request_id,
+  pendingRetry.retry_request_id,
+);
+assert.equal(
+  createRetryTurnCommand.original_turn_id,
+  pendingRetry.original_turn_id,
+);
+
+const [firstCreateRetryTurnResult, ...replayedCreateRetryTurnResults] =
+  fixture.create_retry_turn_results;
+for (const replayedResult of replayedCreateRetryTurnResults) {
+  assert.deepEqual(replayedResult, firstCreateRetryTurnResult);
+}
+assert.equal(
+  firstCreateRetryTurnResult.retry_request_id,
+  createRetryTurnCommand.retry_request_id,
+);
+
+const createdRetryTurn = fixture.retry_turn_created;
+assert.equal(createdRetryTurn.turn_status, 'answering');
+assert.equal(
+  createdRetryTurn.turn_id,
+  firstCreateRetryTurnResult.new_turn_id,
+);
+assert.equal(createdRetryTurn.practice_session_id, sessionId);
+assert.equal(createdRetryTurn.question_id, originalTurn.question_id);
+assert.equal(
+  createdRetryTurn.respondent_participant_id,
+  originalTurn.respondent_participant_id,
+);
+assert.equal(createdRetryTurn.sequence, originalTurn.sequence);
+assert.equal(createdRetryTurn.answer_text, undefined);
+
+const retry = fixture.retry_request;
+assert.equal(retry.retry_request_id, pendingRetry.retry_request_id);
+assert.equal(retry.original_turn_id, pendingRetry.original_turn_id);
+assert.equal(retry.feedback_item_id, pendingRetry.feedback_item_id);
+assert.equal(retry.created_at, pendingRetry.created_at);
+assert.equal(retry.retry_status, 'turn_created');
+assert.equal(retry.new_turn_id, createdRetryTurn.turn_id);
+
+const completedRetryTurn = fixture.retry_turn;
+for (const immutableField of [
+  'turn_id',
+  'practice_session_id',
+  'question_id',
+  'respondent_participant_id',
+  'sequence',
+  'created_at',
+]) {
+  assert.equal(
+    completedRetryTurn[immutableField],
+    createdRetryTurn[immutableField],
+  );
+}
+assert.equal(completedRetryTurn.turn_status, 'completed');
+
+const retryProgressDecision = fixture.retry_progress_decision;
+assert.equal(retryProgressDecision.decided_by, 'PracticeSessionPolicy');
+assert.equal(
+  effectiveTurnById.has(completedRetryTurn.turn_id),
+  retryProgressDecision.counts_toward_effective_turn_limit,
+);
+
+for (const historyRecord of fixture.history_records) {
+  assert.equal(historyRecord.practice_session_id, sessionId);
+  assert.ok(effectiveTurnById.has(historyRecord.turn_id));
+  assert.equal(
+    analysisById.get(historyRecord.turn_analysis_id)?.analysis_status,
+    'completed',
+  );
+  if (historyRecord.retry_request_id !== undefined) {
+    assert.equal(historyRecord.retry_request_id, retry.retry_request_id);
+  }
+}
+
+console.log(
+  `Validated deterministic ${fixture.fixture_id}: ` +
+    `${fixture.effective_turns.length} effective Turns and one same-question retry.`,
+);

--- a/api/websocket/conversation-events.schema.json
+++ b/api/websocket/conversation-events.schema.json
@@ -1,0 +1,783 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speak-up.top/api/schemas/websocket/conversation-events.schema.json",
+  "title": "SpeakUp conversation events",
+  "description": "Server-to-client events for one practice session. Replayable events are ordered by the session sequence. Version 1 consumers reject unknown event types or versions, stop applying the stream, and reconcile to the current interaction state through the REST bootstrap instead of decoding them as a known payload. The MS1 bootstrap is not a historical event or resource listing.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/StreamReadyEvent"
+    },
+    {
+      "$ref": "#/$defs/QuestionCreatedEvent"
+    },
+    {
+      "$ref": "#/$defs/TurnSubmittedEvent"
+    },
+    {
+      "$ref": "#/$defs/TurnProcessingEvent"
+    },
+    {
+      "$ref": "#/$defs/TurnCompletedEvent"
+    },
+    {
+      "$ref": "#/$defs/AnswerProcessingFailedEvent"
+    },
+    {
+      "$ref": "#/$defs/TurnAnalysisCompletedEvent"
+    },
+    {
+      "$ref": "#/$defs/TurnAnalysisFailedEvent"
+    },
+    {
+      "$ref": "#/$defs/PracticeSessionStartedEvent"
+    },
+    {
+      "$ref": "#/$defs/PracticeSessionPausedEvent"
+    },
+    {
+      "$ref": "#/$defs/PracticeSessionResumedEvent"
+    },
+    {
+      "$ref": "#/$defs/PracticeSessionCompletedEvent"
+    },
+    {
+      "$ref": "#/$defs/PracticeSessionEndedEarlyEvent"
+    },
+    {
+      "$ref": "#/$defs/StreamResyncRequiredEvent"
+    },
+    {
+      "$ref": "#/$defs/SystemErrorEvent"
+    },
+    {
+      "$ref": "#/$defs/SystemHeartbeatEvent"
+    }
+  ],
+  "$defs": {
+    "StreamReadyEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "stream.ready"
+            },
+            "replayable": {
+              "const": false
+            },
+            "payload": {
+              "$ref": "#/$defs/StreamReadyPayload"
+            }
+          }
+        }
+      ]
+    },
+    "QuestionCreatedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "question.created"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/QuestionCreatedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "TurnSubmittedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "turn.submitted"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/TurnSubmittedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "TurnProcessingEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "turn.processing"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/TurnProcessingPayload"
+            }
+          }
+        }
+      ]
+    },
+    "TurnCompletedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "turn.completed"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/TurnCompletedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "AnswerProcessingFailedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "answer.processing_failed"
+            },
+            "replayable": {
+              "const": false
+            },
+            "payload": {
+              "$ref": "#/$defs/AnswerProcessingFailurePayload"
+            }
+          }
+        }
+      ]
+    },
+    "TurnAnalysisCompletedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "turn_analysis.completed"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/TurnAnalysisCompletedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "TurnAnalysisFailedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "turn_analysis.failed"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/TurnAnalysisFailedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "PracticeSessionStartedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "practice_session.started"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/PracticeSessionStartedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "PracticeSessionPausedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "practice_session.paused"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/PracticeSessionPausedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "PracticeSessionResumedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "practice_session.resumed"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/PracticeSessionStartedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "PracticeSessionCompletedEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "practice_session.completed"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/PracticeSessionCompletedPayload"
+            }
+          }
+        }
+      ]
+    },
+    "PracticeSessionEndedEarlyEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "practice_session.ended_early"
+            },
+            "replayable": {
+              "const": true
+            },
+            "payload": {
+              "$ref": "#/$defs/PracticeSessionEndedEarlyPayload"
+            }
+          }
+        }
+      ]
+    },
+    "StreamResyncRequiredEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "stream.resync_required"
+            },
+            "replayable": {
+              "const": false
+            },
+            "payload": {
+              "$ref": "#/$defs/StreamResyncRequiredPayload"
+            }
+          }
+        }
+      ]
+    },
+    "SystemErrorEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "system.error"
+            },
+            "replayable": {
+              "const": false
+            },
+            "payload": {
+              "$ref": "#/$defs/SystemErrorPayload"
+            }
+          }
+        }
+      ]
+    },
+    "SystemHeartbeatEvent": {
+      "allOf": [
+        {
+          "$ref": "../common/event-envelope.schema.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "event_type": {
+              "const": "system.heartbeat"
+            },
+            "replayable": {
+              "const": false
+            },
+            "payload": {
+              "$ref": "#/$defs/SystemHeartbeatPayload"
+            }
+          }
+        }
+      ]
+    },
+    "StreamReadyPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "last_sequence"
+      ],
+      "properties": {
+        "last_sequence": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "QuestionCreatedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "question_id",
+        "speaker_participant_id",
+        "addressee_participant_ids",
+        "question_type",
+        "content",
+        "sequence"
+      ],
+      "properties": {
+        "question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "speaker_participant_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "addressee_participant_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "objective_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "question_type": {
+          "enum": [
+            "PRIMARY",
+            "FOLLOW_UP"
+          ]
+        },
+        "parent_question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "question_type": {
+                "const": "FOLLOW_UP"
+              }
+            },
+            "required": [
+              "question_type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "parent_question_id": {}
+            },
+            "required": [
+              "parent_question_id"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "question_type": {
+                "const": "PRIMARY"
+              }
+            },
+            "required": [
+              "question_type"
+            ]
+          },
+          "then": {
+            "not": {
+              "properties": {
+                "parent_question_id": {}
+              },
+              "required": [
+                "parent_question_id"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "TurnSubmittedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "turn_id",
+        "question_id",
+        "turn_status"
+      ],
+      "properties": {
+        "turn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turn_status": {
+          "const": "submitted"
+        }
+      }
+    },
+    "TurnProcessingPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "turn_id",
+        "question_id",
+        "turn_status"
+      ],
+      "properties": {
+        "turn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turn_status": {
+          "const": "processing"
+        }
+      }
+    },
+    "TurnCompletedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "turn_id",
+        "question_id",
+        "respondent_participant_id",
+        "turn_status",
+        "completed_at"
+      ],
+      "properties": {
+        "turn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "respondent_participant_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turn_status": {
+          "const": "completed"
+        },
+        "completed_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "AnswerProcessingFailurePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "question_id",
+        "code",
+        "message",
+        "retryable"
+      ],
+      "properties": {
+        "question_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "TurnAnalysisCompletedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "turn_analysis_id",
+        "turn_id",
+        "score",
+        "summary"
+      ],
+      "properties": {
+        "turn_analysis_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "TurnAnalysisFailedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "turn_analysis_id",
+        "turn_id",
+        "failure_reason"
+      ],
+      "properties": {
+        "turn_analysis_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turn_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "failure_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "PracticeSessionStartedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "practice_session_status",
+        "session_version"
+      ],
+      "properties": {
+        "practice_session_status": {
+          "const": "in_progress"
+        },
+        "session_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "PracticeSessionPausedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "practice_session_status",
+        "session_version"
+      ],
+      "properties": {
+        "practice_session_status": {
+          "const": "paused"
+        },
+        "session_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "PracticeSessionCompletedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "practice_session_status",
+        "session_version",
+        "end_reason"
+      ],
+      "properties": {
+        "practice_session_status": {
+          "const": "completed"
+        },
+        "session_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "end_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "PracticeSessionEndedEarlyPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "practice_session_status",
+        "session_version",
+        "end_reason"
+      ],
+      "properties": {
+        "practice_session_status": {
+          "const": "ended_early"
+        },
+        "session_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "end_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "StreamResyncRequiredPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "last_available_sequence"
+      ],
+      "properties": {
+        "last_available_sequence": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "SystemErrorPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "retryable"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SystemHeartbeatPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "server_time"
+      ],
+      "properties": {
+        "server_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 功能描述

- 在 `api/` 建立 MS1 的 OpenAPI 3.1 REST 契约，覆盖 Preparation、Practice、Conversation、Review 四个稳定业务模块。
- 定义统一错误结构、幂等键语义、不可变 Session 快照、参与者集合和策略驱动的 4–6 / 2–3 有效 Turn 规则。
- 定义版本化 WebSocket 事件信封、16 类事件、顺序/重放/重同步语义及 Flutter 可识别的事件联合类型。
- 提供可自动校验的确定性主流程：4 个有效 Turn、主问/追问、分析反馈，以及同题重答的 pending → 幂等建 Turn → 最终回答闭环。

## 实现思路

- 以 #22 为任务范围，并按已接受的 #29、#34、#35、#47 增量契约更新原 Issue 中的旧术语：使用 `PreparationSnapshot`、`RetryRequest + new Turn`、策略驱动轮次和 `participants[]`。
- 客户端不能提交可信的 `user_id` 或 `respondent_participant_id`；回答者由服务端上下文解析。
- 同题重答由 Review 在服务端调用 Conversation 的 `CreateRetryTurn` 内部命令；相同 `retry_request_id` 重放返回同一 `new_turn_id`，客户端不承担跨模块编排。
- `TurnAnalysis`、`RetryRequest`、`Turn` 的状态相关字段使用互斥 Schema，避免 Flutter 与 Go 对非法组合产生不同解释。
- Mock fixture 直接从打包后的正式 OpenAPI DTO 提取 Schema 并使用 Ajv 校验，同时保留跨对象关系和反例断言，防止示例与契约漂移。
- 本 PR 不实现 Flutter Client、Go Handler、鉴权、音频二进制协议、Provider 或数据库结构。

## 测试方式

1. `cd api && npm ci && npm run check`
   - OpenAPI lint 通过
   - 16 个 WebSocket 正例与 7 个非法事件拒绝用例通过
   - `mock_main_flow_v1` 验证 4 个有效 Turn 和一次同题重答
2. `cd server && go test ./...`
   - 后端现有包全部通过
3. `git diff --check upstream/dev...HEAD`
   - 无空白或补丁格式问题

## 相关 Issue / 备注

Closes #22

Related to #15, #23, #24, #29, #34, #35, #47

- 目标分支为 `dev`；不直接进入 `main`。
- 当前在审的 Practice/Review 实现需要在后续实现 PR 中适配本契约，本 PR 不修改其他成员分支。

## AI 辅助说明

使用 AI 辅助比对已接受 Issue、审查 Schema 边界、生成确定性示例和校验脚本。提交前已人工复核模块所有权、重答幂等、参与者寻址、状态互斥与测试结果，并完成独立只读门禁审查。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
