### PR TITLE
feat(smoke): 串联确定性 Mock 主链路

### DIFF
--- a/server/cmd/mock-smoke-server/main.go
+++ b/server/cmd/mock-smoke-server/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/logging"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/smoke"
+)
+
+func main() {
+	cfg := config.Load()
+	logger := logging.New(cfg.LogLevel)
+	server := &http.Server{
+		Addr:    "127.0.0.1:" + cfg.Port,
+		Handler: smoke.NewServer(logger).Handler(),
+	}
+	logger.Info("deterministic mock smoke server started", slog.String("address", server.Addr))
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("mock smoke server stopped", slog.Any("error", err))
+		os.Exit(1)
+	}
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.5
 require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
 )
 

--- a/server/go.sum
+++ b/server/go.sum
@@ -57,6 +57,8 @@ github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjY
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/server/internal/conversation/module.go
+++ b/server/internal/conversation/module.go
@@ -6,3 +6,170 @@ type Module struct{}
 func New() Module { return Module{} }
 
 func (Module) Name() string { return "conversation" }
+
+type Question struct {
+	ID               string   `json:"question_id"`
+	SessionID        string   `json:"practice_session_id"`
+	SpeakerID        string   `json:"speaker_participant_id"`
+	AddresseeIDs     []string `json:"addressee_participant_ids"`
+	ObjectiveID      string   `json:"objective_id"`
+	Type             string   `json:"question_type"`
+	ParentQuestionID string   `json:"parent_question_id,omitempty"`
+	Content          string   `json:"content"`
+	Sequence         int      `json:"sequence"`
+	CreatedAt        string   `json:"created_at"`
+}
+
+type Turn struct {
+	ID              string `json:"turn_id"`
+	SessionID       string `json:"practice_session_id"`
+	QuestionID      string `json:"question_id"`
+	RespondentID    string `json:"respondent_participant_id"`
+	Sequence        int    `json:"sequence"`
+	InteractionMode string `json:"interaction_mode,omitempty"`
+	AnswerText      string `json:"answer_text,omitempty"`
+	AudioAssetID    string `json:"audio_asset_id,omitempty"`
+	Status          string `json:"turn_status"`
+	IsRetry         bool   `json:"-"`
+	SubmittedAt     string `json:"submitted_at,omitempty"`
+	CreatedAt       string `json:"created_at"`
+	CompletedAt     string `json:"completed_at,omitempty"`
+}
+
+type Event struct {
+	ID            string         `json:"event_id"`
+	Type          string         `json:"event_type"`
+	Version       int            `json:"event_version"`
+	OccurredAt    string         `json:"occurred_at"`
+	SessionID     string         `json:"practice_session_id"`
+	Sequence      int            `json:"sequence,omitempty"`
+	CorrelationID string         `json:"correlation_id"`
+	CausationID   string         `json:"causation_id,omitempty"`
+	Replayable    bool           `json:"replayable"`
+	Payload       map[string]any `json:"payload"`
+}
+
+type SubmitTurnRequest struct {
+	InteractionMode string `json:"interaction_mode"`
+	AnswerText      string `json:"answer_text"`
+	AudioAssetID    string `json:"audio_asset_id,omitempty"`
+	RetryRequestID  string `json:"retry_request_id,omitempty"`
+}
+
+type QuestionDraft struct {
+	ObjectiveID      string
+	Type             string
+	ParentQuestionID string
+	Content          string
+}
+
+// QuestionProvider supplies generated question content without owning any
+// Conversation resource or lifecycle state.
+type QuestionProvider interface {
+	BuildQuestion(int) (QuestionDraft, error)
+}
+
+// Backend is the state/provider-facing boundary owned by Conversation.
+type Backend interface {
+	Bootstrap(string) (map[string]any, error)
+	CurrentQuestion(string) (Question, bool, error)
+	SaveQuestion(string, int, QuestionDraft) (Question, error)
+	PrepareTurn(string, SubmitTurnRequest) (Turn, error)
+	CommitTurn(Turn) (Turn, error)
+	CreateRetryTurn(string, string) (Turn, error)
+	PublishProcessingFailure(string)
+	PublishReviewCompleted(string, string, int, string)
+	PublishSessionStarted(int)
+	PublishSessionCompleted(int, string)
+	GetQuestion(string) (Question, bool)
+	GetTurn(string) (Turn, bool)
+	Subscribe(string, int) ([]Event, <-chan Event, func(), error)
+	StreamReady(string) (Event, error)
+}
+
+// Service is Conversation's formal application-service entry point.
+type Service struct {
+	backend  Backend
+	provider QuestionProvider
+}
+
+func NewService(backend Backend, provider QuestionProvider) *Service {
+	return &Service{backend: backend, provider: provider}
+}
+
+func (s *Service) Bootstrap(sessionID string) (map[string]any, error) {
+	return s.backend.Bootstrap(sessionID)
+}
+
+func (s *Service) EnsureCurrentQuestion(sessionID string) (Question, error) {
+	if question, found, err := s.backend.CurrentQuestion(sessionID); err != nil || found {
+		return question, err
+	}
+	return s.CreateNextQuestion(sessionID, 1)
+}
+
+func (s *Service) CreateNextQuestion(
+	sessionID string,
+	sequence int,
+) (Question, error) {
+	draft, err := s.provider.BuildQuestion(sequence)
+	if err != nil {
+		return Question{}, err
+	}
+	return s.backend.SaveQuestion(sessionID, sequence, draft)
+}
+
+func (s *Service) PrepareTurn(
+	questionID string,
+	request SubmitTurnRequest,
+) (Turn, error) {
+	return s.backend.PrepareTurn(questionID, request)
+}
+
+func (s *Service) CommitTurn(turn Turn) (Turn, error) {
+	return s.backend.CommitTurn(turn)
+}
+
+func (s *Service) CreateRetryTurn(retryID string, originalTurnID string) (Turn, error) {
+	return s.backend.CreateRetryTurn(retryID, originalTurnID)
+}
+
+func (s *Service) PublishProcessingFailure(questionID string) {
+	s.backend.PublishProcessingFailure(questionID)
+}
+
+func (s *Service) PublishReviewCompleted(
+	analysisID string,
+	turnID string,
+	score int,
+	summary string,
+) {
+	s.backend.PublishReviewCompleted(analysisID, turnID, score, summary)
+}
+
+func (s *Service) PublishSessionStarted(version int) {
+	s.backend.PublishSessionStarted(version)
+}
+
+func (s *Service) PublishSessionCompleted(version int, reason string) {
+	s.backend.PublishSessionCompleted(version, reason)
+}
+
+func (s *Service) GetQuestion(id string) (Question, bool) {
+	return s.backend.GetQuestion(id)
+}
+
+func (s *Service) GetTurn(id string) (Turn, bool) {
+	return s.backend.GetTurn(id)
+}
+
+func (s *Service) Subscribe(
+	sessionID string,
+	afterSequence int,
+) ([]Event, <-chan Event, func(), error) {
+	return s.backend.Subscribe(sessionID, afterSequence)
+}
+
+func (s *Service) StreamReady(sessionID string) (Event, error) {
+	return s.backend.StreamReady(sessionID)
+}

--- a/server/internal/practice/module.go
+++ b/server/internal/practice/module.go
@@ -6,3 +6,89 @@ type Module struct{}
 func New() Module { return Module{} }
 
 func (Module) Name() string { return "practice" }
+
+type CreatePlanRequest struct {
+	ScenarioDefinitionID      string   `json:"scenario_definition_id"`
+	ScenarioDefinitionVersion int      `json:"scenario_definition_version"`
+	ScenarioConfigID          string   `json:"scenario_config_id"`
+	ScenarioConfigVersion     int      `json:"scenario_config_version"`
+	PreparationProfileID      string   `json:"preparation_profile_id"`
+	SelectedRoleIDs           []string `json:"selected_role_ids"`
+}
+
+type CreateSessionRequest struct {
+	ExpectedPlanRevision  int      `json:"expected_plan_revision"`
+	PreparationSnapshotID string   `json:"preparation_snapshot_id"`
+	PracticeOptionID      string   `json:"practice_option_id"`
+	RoleDefinitionIDs     []string `json:"role_definition_ids"`
+}
+
+type TurnOutcome struct {
+	SessionID string
+	TurnID    string
+	IsRetry   bool
+}
+
+type TurnDecision struct {
+	EffectiveTurns     int
+	Completed          bool
+	NextQuestionNumber int
+	SessionVersion     int
+	EndReason          string
+}
+
+// Backend is the storage-facing boundary owned by Practice.
+type Backend interface {
+	CreatePlan(CreatePlanRequest) (map[string]any, error)
+	PlanExists(string) bool
+	CreateSession(string, CreateSessionRequest) (map[string]any, error)
+	GetSession(string) (map[string]any, bool)
+	GetSnapshot(string) (map[string]any, bool)
+	StartSession(string) (int, bool, error)
+	AuthorizeTurn(string, bool) error
+	RecordTurnOutcome(TurnOutcome) (TurnDecision, error)
+}
+
+// Service is Practice's formal application-service entry point.
+type Service struct {
+	backend Backend
+}
+
+func NewService(backend Backend) *Service {
+	return &Service{backend: backend}
+}
+
+func (s *Service) CreatePlan(request CreatePlanRequest) (map[string]any, error) {
+	return s.backend.CreatePlan(request)
+}
+
+func (s *Service) PlanExists(id string) bool {
+	return s.backend.PlanExists(id)
+}
+
+func (s *Service) CreateSession(
+	planID string,
+	request CreateSessionRequest,
+) (map[string]any, error) {
+	return s.backend.CreateSession(planID, request)
+}
+
+func (s *Service) GetSession(id string) (map[string]any, bool) {
+	return s.backend.GetSession(id)
+}
+
+func (s *Service) GetSnapshot(sessionID string) (map[string]any, bool) {
+	return s.backend.GetSnapshot(sessionID)
+}
+
+func (s *Service) StartSession(sessionID string) (int, bool, error) {
+	return s.backend.StartSession(sessionID)
+}
+
+func (s *Service) AuthorizeTurn(sessionID string, retry bool) error {
+	return s.backend.AuthorizeTurn(sessionID, retry)
+}
+
+func (s *Service) RecordTurnOutcome(outcome TurnOutcome) (TurnDecision, error) {
+	return s.backend.RecordTurnOutcome(outcome)
+}

--- a/server/internal/preparation/module.go
+++ b/server/internal/preparation/module.go
@@ -6,3 +6,63 @@ type Module struct{}
 func New() Module { return Module{} }
 
 func (Module) Name() string { return "preparation" }
+
+// CreateProfileRequest is the application input for one preparation profile.
+type CreateProfileRequest struct {
+	ResumeRef         string `json:"resume_ref,omitempty"`
+	JobDescriptionRef string `json:"job_description_ref,omitempty"`
+	BackgroundSummary string `json:"background_summary"`
+}
+
+// CreateSnapshotRequest pins one immutable version of a preparation profile.
+type CreateSnapshotRequest struct {
+	SourceVersion int `json:"source_version"`
+}
+
+// Backend is the persistence/provider-facing boundary owned by Preparation.
+// Production and deterministic smoke adapters implement the same application
+// operations without exposing transport concerns to the module.
+type Backend interface {
+	GetScenario(string) (map[string]any, bool)
+	ListRoles(string) ([]map[string]any, bool)
+	CreateProfile(CreateProfileRequest) (map[string]any, error)
+	CreateSnapshot(string, CreateSnapshotRequest) (map[string]any, error)
+	ProfileExists(string) bool
+	SnapshotExists(string) bool
+}
+
+// Service is Preparation's formal application-service entry point.
+type Service struct {
+	backend Backend
+}
+
+func NewService(backend Backend) *Service {
+	return &Service{backend: backend}
+}
+
+func (s *Service) GetScenario(id string) (map[string]any, bool) {
+	return s.backend.GetScenario(id)
+}
+
+func (s *Service) ListRoles(scenarioID string) ([]map[string]any, bool) {
+	return s.backend.ListRoles(scenarioID)
+}
+
+func (s *Service) CreateProfile(request CreateProfileRequest) (map[string]any, error) {
+	return s.backend.CreateProfile(request)
+}
+
+func (s *Service) CreateSnapshot(
+	profileID string,
+	request CreateSnapshotRequest,
+) (map[string]any, error) {
+	return s.backend.CreateSnapshot(profileID, request)
+}
+
+func (s *Service) ProfileExists(id string) bool {
+	return s.backend.ProfileExists(id)
+}
+
+func (s *Service) SnapshotExists(id string) bool {
+	return s.backend.SnapshotExists(id)
+}

--- a/server/internal/review/module.go
+++ b/server/internal/review/module.go
@@ -6,3 +6,130 @@ type Module struct{}
 func New() Module { return Module{} }
 
 func (Module) Name() string { return "review" }
+
+type Analysis struct {
+	ID                 string `json:"turn_analysis_id"`
+	TurnID             string `json:"turn_id"`
+	EvaluatorVersion   string `json:"evaluator_version"`
+	Status             string `json:"analysis_status"`
+	Score              int    `json:"score"`
+	Summary            string `json:"summary,omitempty"`
+	AnalysisTranscript string `json:"analysis_transcript,omitempty"`
+	CreatedAt          string `json:"created_at"`
+	CompletedAt        string `json:"completed_at,omitempty"`
+}
+
+type Feedback struct {
+	ID         string           `json:"feedback_item_id"`
+	AnalysisID string           `json:"turn_analysis_id"`
+	Category   string           `json:"feedback_category"`
+	Message    string           `json:"message"`
+	Suggestion string           `json:"suggestion"`
+	Evidence   []map[string]any `json:"evidence"`
+	Retryable  bool             `json:"retryable"`
+	CreatedAt  string           `json:"created_at"`
+}
+
+type RetryRequest struct {
+	ID             string `json:"retry_request_id"`
+	OriginalTurnID string `json:"original_turn_id"`
+	FeedbackID     string `json:"feedback_item_id"`
+	NewTurnID      string `json:"new_turn_id,omitempty"`
+	Status         string `json:"retry_status"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+	FailureReason  string `json:"failure_reason,omitempty"`
+}
+
+type HistoryRecord struct {
+	ID             string `json:"history_record_id"`
+	SessionID      string `json:"practice_session_id"`
+	TurnID         string `json:"turn_id"`
+	AnalysisID     string `json:"turn_analysis_id"`
+	RetryRequestID string `json:"retry_request_id,omitempty"`
+	Score          int    `json:"score"`
+	Summary        string `json:"summary"`
+	ReviewedAt     string `json:"reviewed_at"`
+}
+
+type Evaluation struct {
+	Score      int
+	Summary    string
+	Transcript string
+	Category   string
+	Message    string
+	Suggestion string
+	Evidence   []map[string]any
+}
+
+type TurnInput struct {
+	TurnID            string
+	SessionID         string
+	QuestionID        string
+	AnswerText        string
+	EffectiveSequence int
+	CompletedAt       string
+}
+
+// Provider evaluates answer content but never owns Review resources.
+type Provider interface {
+	Evaluate(TurnInput) (Evaluation, error)
+}
+
+// Backend is the persistence/provider-facing boundary owned by Review.
+type Backend interface {
+	ListAnalyses(string) []Analysis
+	ListFeedback(string) ([]Feedback, bool)
+	SaveEvaluation(TurnInput, Evaluation) (Analysis, Feedback, bool, error)
+	StartRetry(string) (RetryRequest, error)
+	CompleteRetry(string, string) (RetryRequest, error)
+	GetRetry(string) (RetryRequest, bool)
+	ListHistory(string) []HistoryRecord
+}
+
+// Service is Review's formal application-service entry point.
+type Service struct {
+	backend  Backend
+	provider Provider
+}
+
+func NewService(backend Backend, provider Provider) *Service {
+	return &Service{backend: backend, provider: provider}
+}
+
+func (s *Service) ListAnalyses(turnID string) []Analysis {
+	return s.backend.ListAnalyses(turnID)
+}
+
+func (s *Service) ListFeedback(analysisID string) ([]Feedback, bool) {
+	return s.backend.ListFeedback(analysisID)
+}
+
+func (s *Service) Evaluate(
+	turn TurnInput,
+) (Analysis, Feedback, bool, error) {
+	evaluation, err := s.provider.Evaluate(turn)
+	if err != nil {
+		return Analysis{}, Feedback{}, false, err
+	}
+	return s.backend.SaveEvaluation(turn, evaluation)
+}
+
+func (s *Service) StartRetry(feedbackID string) (RetryRequest, error) {
+	return s.backend.StartRetry(feedbackID)
+}
+
+func (s *Service) CompleteRetry(
+	retryID string,
+	newTurnID string,
+) (RetryRequest, error) {
+	return s.backend.CompleteRetry(retryID, newTurnID)
+}
+
+func (s *Service) GetRetry(id string) (RetryRequest, bool) {
+	return s.backend.GetRetry(id)
+}
+
+func (s *Service) ListHistory(sessionID string) []HistoryRecord {
+	return s.backend.ListHistory(sessionID)
+}

--- a/server/internal/smoke/application.go
+++ b/server/internal/smoke/application.go
@@ -1,0 +1,200 @@
+package smoke
+
+import (
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+)
+
+// Application is the smoke composition layer. It coordinates formal module
+// services while leaving every resource mutation with its owning module.
+type Application struct {
+	preparation  *preparation.Service
+	practice     *practice.Service
+	conversation *conversation.Service
+	review       *review.Service
+	failures     FailureControl
+}
+
+func NewApplication(
+	preparationService *preparation.Service,
+	practiceService *practice.Service,
+	conversationService *conversation.Service,
+	reviewService *review.Service,
+	failures FailureControl,
+) *Application {
+	return &Application{
+		preparation:  preparationService,
+		practice:     practiceService,
+		conversation: conversationService,
+		review:       reviewService,
+		failures:     failures,
+	}
+}
+
+func (a *Application) CreatePlan(
+	request practice.CreatePlanRequest,
+) (map[string]any, error) {
+	if _, ok := a.preparation.GetScenario(request.ScenarioDefinitionID); !ok {
+		return nil, ErrScenarioNotFound
+	}
+	if !a.preparation.ProfileExists(request.PreparationProfileID) {
+		return nil, ErrProfileNotFound
+	}
+	return a.practice.CreatePlan(request)
+}
+
+func (a *Application) CreateSession(
+	planID string,
+	request practice.CreateSessionRequest,
+) (map[string]any, error) {
+	if !a.practice.PlanExists(planID) {
+		return nil, ErrPlanNotFound
+	}
+	if !a.preparation.SnapshotExists(request.PreparationSnapshotID) {
+		return nil, ErrSnapshotNotFound
+	}
+	return a.practice.CreateSession(planID, request)
+}
+
+func (a *Application) Bootstrap(sessionID string) (map[string]any, error) {
+	session, ok := a.practice.GetSession(sessionID)
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	snapshot, ok := a.practice.GetSnapshot(sessionID)
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	result, err := a.conversation.Bootstrap(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	result["practice_session"] = session
+	result["snapshot"] = snapshot
+	return result, nil
+}
+
+func (a *Application) EnsureCurrentQuestion(sessionID string) (Question, error) {
+	version, started, err := a.practice.StartSession(sessionID)
+	if err != nil {
+		return Question{}, err
+	}
+	if started {
+		a.conversation.PublishSessionStarted(version)
+	}
+	return a.conversation.EnsureCurrentQuestion(sessionID)
+}
+
+func (a *Application) SubmitTurn(
+	questionID string,
+	request conversation.SubmitTurnRequest,
+	failOnce bool,
+) (Turn, error) {
+	question, ok := a.conversation.GetQuestion(questionID)
+	if !ok {
+		return Turn{}, ErrQuestionNotFound
+	}
+	if err := a.practice.AuthorizeTurn(
+		question.SessionID,
+		request.RetryRequestID != "",
+	); err != nil {
+		return Turn{}, err
+	}
+	turn, err := a.conversation.PrepareTurn(questionID, request)
+	if err != nil {
+		return Turn{}, err
+	}
+	if failOnce {
+		a.failures.ArmFailure(questionID, turn.AnswerText)
+	}
+	if err := a.failures.CheckFailure(questionID, turn.AnswerText); err != nil {
+		a.conversation.PublishProcessingFailure(questionID)
+		return Turn{}, err
+	}
+	turn, err = a.conversation.CommitTurn(turn)
+	if err != nil {
+		return Turn{}, err
+	}
+	decision, err := a.practice.RecordTurnOutcome(practice.TurnOutcome{
+		SessionID: turn.SessionID,
+		TurnID:    turn.ID,
+		IsRetry:   turn.IsRetry,
+	})
+	if err != nil {
+		return Turn{}, err
+	}
+	if !turn.IsRetry {
+		if decision.Completed {
+			a.conversation.PublishSessionCompleted(
+				decision.SessionVersion,
+				decision.EndReason,
+			)
+		} else {
+			if _, err := a.conversation.CreateNextQuestion(
+				turn.SessionID,
+				decision.NextQuestionNumber,
+			); err != nil {
+				return Turn{}, err
+			}
+		}
+	}
+	return turn, nil
+}
+
+func (a *Application) AnalyzeTurn(turnID string) (Analysis, error) {
+	turn, ok := a.conversation.GetTurn(turnID)
+	if !ok {
+		return Analysis{}, ErrTurnNotFound
+	}
+	if turn.Status != "completed" {
+		return Analysis{}, ErrResourceConflict
+	}
+	analysis, _, created, err := a.review.Evaluate(review.TurnInput{
+		TurnID:            turn.ID,
+		SessionID:         turn.SessionID,
+		QuestionID:        turn.QuestionID,
+		AnswerText:        turn.AnswerText,
+		EffectiveSequence: turn.Sequence,
+		CompletedAt:       turn.CompletedAt,
+	})
+	if err != nil {
+		return Analysis{}, err
+	}
+	if created {
+		a.conversation.PublishReviewCompleted(
+			analysis.ID,
+			analysis.TurnID,
+			analysis.Score,
+			analysis.Summary,
+		)
+	}
+	return analysis, nil
+}
+
+func (a *Application) ListAnalyses(turnID string) ([]Analysis, error) {
+	if _, ok := a.conversation.GetTurn(turnID); !ok {
+		return nil, ErrTurnNotFound
+	}
+	return a.review.ListAnalyses(turnID), nil
+}
+
+func (a *Application) CreateRetry(feedbackID string) (RetryRequest, error) {
+	retry, err := a.review.StartRetry(feedbackID)
+	if err != nil {
+		return RetryRequest{}, err
+	}
+	turn, err := a.conversation.CreateRetryTurn(retry.ID, retry.OriginalTurnID)
+	if err != nil {
+		return RetryRequest{}, err
+	}
+	return a.review.CompleteRetry(retry.ID, turn.ID)
+}
+
+func (a *Application) ListHistory(sessionID string) ([]HistoryRecord, error) {
+	if _, ok := a.practice.GetSession(sessionID); !ok {
+		return nil, ErrSessionNotFound
+	}
+	return a.review.ListHistory(sessionID), nil
+}

--- a/server/internal/smoke/contract_test.go
+++ b/server/internal/smoke/contract_test.go
@@ -1,0 +1,899 @@
+package smoke
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type contractClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type concurrentResponse struct {
+	status int
+	body   []byte
+	err    error
+}
+
+func newContractClient(t *testing.T) contractClient {
+	t.Helper()
+	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	return contractClient{baseURL: httpServer.URL, client: httpServer.Client()}
+}
+
+func TestStrictRequestAndIdempotencyKeyValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+		code string
+	}{
+		{"profile missing required field", "/v1/preparation-profiles", `{}`, "invalid_request"},
+		{"profile rejects unknown field", "/v1/preparation-profiles", `{"background_summary":"x","extra":true}`, "invalid_request"},
+		{"profile rejects null", "/v1/preparation-profiles", `{"background_summary":null}`, "invalid_request"},
+		{"profile rejects trailing JSON", "/v1/preparation-profiles", `{"background_summary":"x"} {}`, "invalid_request"},
+		{"snapshot requires body", "/v1/preparation-profiles/" + demoPreparationProfile + "/snapshots", ``, "invalid_request"},
+		{"snapshot rejects zero version", "/v1/preparation-profiles/" + demoPreparationProfile + "/snapshots", `{"source_version":0}`, "invalid_request"},
+		{"plan rejects duplicate roles", "/v1/practice-plans", `{
+			"scenario_definition_id":"scenario_programmer_interview",
+			"scenario_definition_version":1,
+			"scenario_config_id":"scenario_config_backend",
+			"scenario_config_version":1,
+			"preparation_profile_id":"profile_demo_001",
+			"selected_role_ids":["role_technical_interviewer","role_technical_interviewer"]
+		}`, "invalid_request"},
+		{"session requires fields", "/v1/practice-plans/" + demoPracticePlan + "/practice-sessions", `{}`, "invalid_request"},
+		{"question rejects body", "/v1/practice-sessions/" + demoPracticeSession + "/questions", `{}`, "invalid_request"},
+		{"turn requires mode", "/v1/questions/question_demo_001/turns", `{"answer_text":"hello"}`, "invalid_request"},
+		{"turn rejects unknown mode", "/v1/questions/question_demo_001/turns", `{"interaction_mode":"TEXT","answer_text":"hello"}`, "invalid_request"},
+		{"turn rejects unknown field", "/v1/questions/question_demo_001/turns", `{"interaction_mode":"PUSH_TO_TALK","answer_text":"hello","actor_id":"forged"}`, "invalid_request"},
+		{"analysis rejects body", "/v1/turns/turn_demo_001/turn-analyses", `{}`, "invalid_request"},
+		{"retry rejects body", "/v1/feedback-items/feedback_demo_001/retry-requests", `{}`, "invalid_request"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newContractClient(t)
+			status, body := client.request(
+				t,
+				http.MethodPost,
+				test.path,
+				test.body,
+				map[string]string{"Idempotency-Key": "validation-key-1"},
+			)
+			assertError(t, status, body, http.StatusBadRequest, test.code)
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		key  string
+	}{
+		{"missing", ""},
+		{"short", "short"},
+		{"too long", strings.Repeat("x", 129)},
+	} {
+		t.Run("idempotency key "+test.name, func(t *testing.T) {
+			client := newContractClient(t)
+			headers := map[string]string{}
+			if test.key != "" {
+				headers["Idempotency-Key"] = test.key
+			}
+			status, body := client.request(
+				t,
+				http.MethodPost,
+				"/v1/preparation-profiles",
+				`{"background_summary":"valid"}`,
+				headers,
+			)
+			assertError(t, status, body, http.StatusBadRequest, "invalid_request")
+		})
+	}
+}
+
+func TestIdempotencyReplayScopeAndNoRepeatedSideEffects(t *testing.T) {
+	client := newContractClient(t)
+
+	profileBody := `{"background_summary":"Backend engineer"}`
+	firstProfile := client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles",
+		profileBody,
+		map[string]string{"Idempotency-Key": "profile-replay-key"},
+		http.StatusCreated,
+	)
+	replayedProfile := client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles",
+		"{ \n \"background_summary\" : \"Backend engineer\" }",
+		map[string]string{"Idempotency-Key": "profile-replay-key"},
+		http.StatusCreated,
+	)
+	if !bytes.Equal(firstProfile, replayedProfile) {
+		t.Fatal("profile replay did not preserve the original response body")
+	}
+	status, body := client.request(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles",
+		`{"background_summary":"different"}`,
+		map[string]string{"Idempotency-Key": "profile-replay-key"},
+	)
+	assertError(t, status, body, http.StatusConflict, "idempotency_key_conflict")
+
+	snapshotBody := `{"source_version":1}`
+	assertReplay(
+		t,
+		client,
+		"/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots",
+		snapshotBody,
+		"snapshot-replay-key",
+		http.StatusCreated,
+	)
+	planBody := `{
+		"scenario_definition_id":"scenario_programmer_interview",
+		"scenario_definition_version":1,
+		"scenario_config_id":"scenario_config_backend",
+		"scenario_config_version":1,
+		"preparation_profile_id":"profile_demo_001",
+		"selected_role_ids":["role_technical_interviewer"]
+	}`
+	assertReplay(t, client, "/v1/practice-plans", planBody, "plan-replay-key", http.StatusCreated)
+	sessionBody := `{
+		"expected_plan_revision":1,
+		"preparation_snapshot_id":"preparation_snapshot_demo_001",
+		"practice_option_id":"option_full_interview",
+		"role_definition_ids":["role_technical_interviewer"]
+	}`
+	sessionPath := "/v1/practice-plans/" + demoPracticePlan + "/practice-sessions"
+	firstSession := client.must(
+		t,
+		http.MethodPost,
+		sessionPath,
+		sessionBody,
+		map[string]string{"Idempotency-Key": "session-replay-key"},
+		http.StatusCreated,
+	)
+
+	questionPath := "/v1/practice-sessions/" + demoPracticeSession + "/questions"
+	firstQuestion := client.must(
+		t,
+		http.MethodPost,
+		questionPath,
+		"",
+		map[string]string{"Idempotency-Key": "question-replay-key"},
+		http.StatusOK,
+	)
+	replayedQuestion := client.must(
+		t,
+		http.MethodPost,
+		questionPath,
+		"",
+		map[string]string{"Idempotency-Key": "question-replay-key"},
+		http.StatusOK,
+	)
+	if !bytes.Equal(firstQuestion, replayedQuestion) {
+		t.Fatal("question replay changed the response")
+	}
+	status, body = client.request(
+		t,
+		http.MethodPost,
+		questionPath,
+		`{}`,
+		map[string]string{"Idempotency-Key": "question-replay-key"},
+	)
+	assertError(t, status, body, http.StatusConflict, "idempotency_key_conflict")
+
+	replayedSession := client.must(
+		t,
+		http.MethodPost,
+		sessionPath,
+		sessionBody,
+		map[string]string{"Idempotency-Key": "session-replay-key"},
+		http.StatusCreated,
+	)
+	if !bytes.Equal(firstSession, replayedSession) {
+		t.Fatal("session replay did not preserve the original response")
+	}
+	currentSession := client.must(
+		t,
+		http.MethodGet,
+		"/v1/practice-sessions/"+demoPracticeSession,
+		"",
+		nil,
+		http.StatusOK,
+	)
+	var session map[string]any
+	if err := json.Unmarshal(currentSession, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session["practice_session_status"] != "in_progress" {
+		t.Fatalf("session replay reset lifecycle state: %#v", session)
+	}
+
+	sharedKey := "canonical-path-shared-key"
+	firstTurnBody := client.must(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_001/turns",
+		`{"interaction_mode":"PUSH_TO_TALK","answer_text":"first answer"}`,
+		map[string]string{"Idempotency-Key": sharedKey},
+		http.StatusAccepted,
+	)
+	var firstTurn Turn
+	if err := json.Unmarshal(firstTurnBody, &firstTurn); err != nil {
+		t.Fatal(err)
+	}
+	status, body = client.request(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_001/turns",
+		`{"interaction_mode":"REALTIME","answer_text":"first answer"}`,
+		map[string]string{"Idempotency-Key": sharedKey},
+	)
+	assertError(t, status, body, http.StatusConflict, "idempotency_key_conflict")
+
+	secondTurnBody := client.must(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_002/turns",
+		`{"interaction_mode":"REALTIME","answer_text":"second answer"}`,
+		map[string]string{"Idempotency-Key": sharedKey},
+		http.StatusAccepted,
+	)
+	var secondTurn Turn
+	if err := json.Unmarshal(secondTurnBody, &secondTurn); err != nil {
+		t.Fatal(err)
+	}
+	if firstTurn.ID == secondTurn.ID || secondTurn.QuestionID != "question_demo_002" ||
+		secondTurn.InteractionMode != "REALTIME" {
+		t.Fatalf("same key on different canonical paths was incorrectly aliased: %#v %#v", firstTurn, secondTurn)
+	}
+
+	analysisPath := "/v1/turns/" + firstTurn.ID + "/turn-analyses"
+	assertReplay(t, client, analysisPath, "", "analysis-replay-key", http.StatusAccepted)
+	analysesBody := client.must(t, http.MethodGet, analysisPath, "", nil, http.StatusOK)
+	var analyses struct {
+		Items []Analysis `json:"analyses"`
+	}
+	if err := json.Unmarshal(analysesBody, &analyses); err != nil || len(analyses.Items) != 1 {
+		t.Fatalf("analysis replay repeated a side effect: %v %#v", err, analyses)
+	}
+	feedbackBody := client.must(
+		t,
+		http.MethodGet,
+		"/v1/turn-analyses/"+analyses.Items[0].ID+"/feedback-items",
+		"",
+		nil,
+		http.StatusOK,
+	)
+	var feedback struct {
+		Items []Feedback `json:"feedback_items"`
+	}
+	if err := json.Unmarshal(feedbackBody, &feedback); err != nil || len(feedback.Items) != 1 {
+		t.Fatalf("feedback missing: %v %#v", err, feedback)
+	}
+	retryPath := "/v1/feedback-items/" + feedback.Items[0].ID + "/retry-requests"
+	assertReplay(t, client, retryPath, "", "retry-replay-key", http.StatusCreated)
+	historyBody := client.must(
+		t,
+		http.MethodGet,
+		"/v1/history-records?practice_session_id="+demoPracticeSession,
+		"",
+		nil,
+		http.StatusOK,
+	)
+	var history struct {
+		Items []HistoryRecord `json:"history_records"`
+	}
+	if err := json.Unmarshal(historyBody, &history); err != nil || len(history.Items) != 1 {
+		t.Fatalf("replayed analysis/retry duplicated history: %v %#v", err, history)
+	}
+}
+
+func TestConcurrentIdempotencyCoalescesAndRejectsConflicts(t *testing.T) {
+	t.Run("same fingerprint", func(t *testing.T) {
+		client := newContractClient(t)
+		client.must(
+			t,
+			http.MethodPost,
+			"/v1/preparation-profiles",
+			`{"background_summary":"Backend engineer"}`,
+			map[string]string{"Idempotency-Key": "concurrent-profile-key"},
+			http.StatusCreated,
+		)
+		client.must(
+			t,
+			http.MethodPost,
+			"/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots",
+			`{"source_version":1}`,
+			map[string]string{"Idempotency-Key": "concurrent-snapshot-key"},
+			http.StatusCreated,
+		)
+		client.must(
+			t,
+			http.MethodPost,
+			"/v1/practice-plans",
+			validPlanBody(),
+			map[string]string{"Idempotency-Key": "concurrent-plan-key"},
+			http.StatusCreated,
+		)
+
+		results := concurrentRequests(
+			client,
+			"/v1/practice-plans/"+demoPracticePlan+"/practice-sessions",
+			[]string{validSessionBody(), validSessionBody()},
+			"concurrent-session-key",
+		)
+		for _, result := range results {
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			if result.status != http.StatusCreated {
+				t.Fatalf("concurrent replay status=%d, want 201: %s", result.status, result.body)
+			}
+		}
+		if !bytes.Equal(results[0].body, results[1].body) {
+			t.Fatalf("concurrent replay returned different bodies:\n%s\n%s", results[0].body, results[1].body)
+		}
+	})
+
+	t.Run("different fingerprints", func(t *testing.T) {
+		client := newContractClient(t)
+		results := concurrentRequests(
+			client,
+			"/v1/preparation-profiles",
+			[]string{
+				`{"background_summary":"first"}`,
+				`{"background_summary":"second"}`,
+			},
+			"concurrent-conflict-key",
+		)
+		created := 0
+		conflicts := 0
+		for _, result := range results {
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			switch result.status {
+			case http.StatusCreated:
+				created++
+			case http.StatusConflict:
+				conflicts++
+				assertError(
+					t,
+					result.status,
+					result.body,
+					http.StatusConflict,
+					"idempotency_key_conflict",
+				)
+			default:
+				t.Fatalf("unexpected concurrent conflict status=%d: %s", result.status, result.body)
+			}
+		}
+		if created != 1 || conflicts != 1 {
+			t.Fatalf("created=%d conflicts=%d, want one of each", created, conflicts)
+		}
+	})
+}
+
+func TestPreparationReferencesGatePracticeResources(t *testing.T) {
+	client := newContractClient(t)
+
+	status, body := client.request(
+		t,
+		http.MethodPost,
+		"/v1/practice-plans",
+		validPlanBody(),
+		map[string]string{"Idempotency-Key": "plan-before-profile-key"},
+	)
+	assertError(t, status, body, http.StatusNotFound, "preparation_profile_not_found")
+
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles",
+		`{"background_summary":"Backend engineer"}`,
+		map[string]string{"Idempotency-Key": "profile-for-plan-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/practice-plans",
+		validPlanBody(),
+		map[string]string{"Idempotency-Key": "plan-with-profile-key"},
+		http.StatusCreated,
+	)
+
+	sessionPath := "/v1/practice-plans/" + demoPracticePlan + "/practice-sessions"
+	status, body = client.request(
+		t,
+		http.MethodPost,
+		sessionPath,
+		validSessionBody(),
+		map[string]string{"Idempotency-Key": "session-before-snapshot-key"},
+	)
+	assertError(t, status, body, http.StatusNotFound, "resource_not_found")
+
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots",
+		`{"source_version":1}`,
+		map[string]string{"Idempotency-Key": "snapshot-for-session-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		sessionPath,
+		validSessionBody(),
+		map[string]string{"Idempotency-Key": "session-with-snapshot-key"},
+		http.StatusCreated,
+	)
+}
+
+func TestPendingAnalysisOmitsCompletedFields(t *testing.T) {
+	client := newContractClient(t)
+	seedThroughQuestion(t, client)
+	turnBody := client.must(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_001/turns",
+		`{"interaction_mode":"PUSH_TO_TALK","answer_text":"A complete answer."}`,
+		map[string]string{"Idempotency-Key": "pending-analysis-turn-key"},
+		http.StatusAccepted,
+	)
+	var turn Turn
+	if err := json.Unmarshal(turnBody, &turn); err != nil {
+		t.Fatal(err)
+	}
+	pendingBody := client.must(
+		t,
+		http.MethodPost,
+		"/v1/turns/"+turn.ID+"/turn-analyses",
+		"",
+		map[string]string{"Idempotency-Key": "pending-analysis-key"},
+		http.StatusAccepted,
+	)
+	var pending map[string]json.RawMessage
+	if err := json.Unmarshal(pendingBody, &pending); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"score", "summary", "analysis_transcript", "completed_at"} {
+		if _, present := pending[field]; present {
+			t.Fatalf("pending analysis exposed %q: %s", field, pendingBody)
+		}
+	}
+	for _, field := range []string{
+		"turn_analysis_id",
+		"turn_id",
+		"evaluator_version",
+		"analysis_status",
+		"created_at",
+	} {
+		if _, present := pending[field]; !present {
+			t.Fatalf("pending analysis omitted %q: %s", field, pendingBody)
+		}
+	}
+}
+
+func TestRetryRequiresCompletedOriginalTurn(t *testing.T) {
+	runtime := NewRuntime()
+	runtime.mu.Lock()
+	runtime.turns = append(runtime.turns, Turn{
+		ID:        "turn_answering",
+		SessionID: demoPracticeSession,
+		Status:    "answering",
+	})
+	runtime.mu.Unlock()
+
+	if _, err := runtime.createRetryTurn("retry_pending_original", "turn_answering"); !errors.Is(err, ErrRetryConflict) {
+		t.Fatalf("createRetryTurn error=%v, want ErrRetryConflict", err)
+	}
+}
+
+func TestFailureInjectionRunsAfterResourceValidation(t *testing.T) {
+	client := newContractClient(t)
+	seedThroughQuestion(t, client)
+
+	futureAnswer := `{"interaction_mode":"PUSH_TO_TALK","answer_text":"future answer"}`
+	status, body := client.request(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_002/turns",
+		futureAnswer,
+		map[string]string{
+			"Idempotency-Key":  "future-question-failure-key",
+			"X-Mock-Fail-Once": "true",
+		},
+	)
+	assertError(t, status, body, http.StatusNotFound, "question_not_found")
+
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_001/turns",
+		`{"interaction_mode":"PUSH_TO_TALK","answer_text":"first answer"}`,
+		map[string]string{"Idempotency-Key": "create-future-question-key"},
+		http.StatusAccepted,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/questions/question_demo_002/turns",
+		futureAnswer,
+		map[string]string{"Idempotency-Key": "future-question-success-key"},
+		http.StatusAccepted,
+	)
+}
+
+func TestSlowSubscriberIsRemovedWithoutBlockingEventPublication(t *testing.T) {
+	runtime := NewRuntime()
+	_, live, unsubscribe := runtime.subscribe(0)
+
+	published := make(chan struct{})
+	go func() {
+		for index := 0; index < 129; index++ {
+			runtime.mu.Lock()
+			runtime.appendEventLocked("question.created", map[string]any{
+				"question_id": formatID("slow_subscriber_question", index+1),
+			})
+			runtime.mu.Unlock()
+		}
+		close(published)
+	}()
+
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("event publication blocked on a slow subscriber")
+	}
+
+	runtime.mu.Lock()
+	subscriberCount := len(runtime.subscribers)
+	runtime.mu.Unlock()
+	if subscriberCount != 0 {
+		t.Fatalf("slow subscriber was not removed: subscribers=%d", subscriberCount)
+	}
+	for range live {
+	}
+	unsubscribe()
+}
+
+func TestReplayabilityIsExplicitForEverySmokeEventType(t *testing.T) {
+	tests := map[string]bool{
+		"stream.ready":               false,
+		"answer.processing_failed":   false,
+		"question.created":           true,
+		"turn.submitted":             true,
+		"turn.processing":            true,
+		"turn.completed":             true,
+		"turn_analysis.completed":    true,
+		"practice_session.started":   true,
+		"practice_session.completed": true,
+	}
+	for eventType, expected := range tests {
+		if actual := isReplayableEvent(eventType); actual != expected {
+			t.Fatalf("isReplayableEvent(%q)=%t, want %t", eventType, actual, expected)
+		}
+	}
+}
+
+func TestResourceAndQueryErrors(t *testing.T) {
+	client := newContractClient(t)
+	tests := []struct {
+		method  string
+		path    string
+		body    string
+		headers map[string]string
+		status  int
+		code    string
+	}{
+		{http.MethodGet, "/v1/scenario-definitions/unknown", "", nil, 404, "scenario_definition_not_found"},
+		{http.MethodGet, "/v1/scenario-definitions/unknown/role-definitions", "", nil, 404, "scenario_definition_not_found"},
+		{http.MethodPost, "/v1/preparation-profiles/unknown/snapshots", `{"source_version":1}`, map[string]string{"Idempotency-Key": "unknown-profile-key"}, 404, "preparation_profile_not_found"},
+		{http.MethodPost, "/v1/practice-plans/unknown/practice-sessions", validSessionBody(), map[string]string{"Idempotency-Key": "unknown-plan-key"}, 404, "practice_plan_not_found"},
+		{http.MethodGet, "/v1/practice-sessions/unknown", "", nil, 404, "practice_session_not_found"},
+		{http.MethodGet, "/v1/practice-sessions/unknown/snapshot", "", nil, 404, "practice_session_not_found"},
+		{http.MethodGet, "/v1/practice-sessions/unknown/bootstrap", "", nil, 404, "practice_session_not_found"},
+		{http.MethodPost, "/v1/practice-sessions/unknown/questions", "", map[string]string{"Idempotency-Key": "unknown-session-key"}, 404, "practice_session_not_found"},
+		{http.MethodPost, "/v1/questions/unknown/turns", `{"interaction_mode":"PUSH_TO_TALK","answer_text":"valid"}`, map[string]string{"Idempotency-Key": "unknown-question-key"}, 404, "question_not_found"},
+		{http.MethodGet, "/v1/turns/unknown", "", nil, 404, "turn_not_found"},
+		{http.MethodPost, "/v1/turns/unknown/turn-analyses", "", map[string]string{"Idempotency-Key": "unknown-turn-key"}, 404, "turn_not_found"},
+		{http.MethodGet, "/v1/turns/unknown/turn-analyses", "", nil, 404, "turn_not_found"},
+		{http.MethodGet, "/v1/turn-analyses/unknown/feedback-items", "", nil, 404, "turn_analysis_not_found"},
+		{http.MethodPost, "/v1/feedback-items/unknown/retry-requests", "", map[string]string{"Idempotency-Key": "unknown-feedback-key"}, 404, "feedback_item_not_found"},
+		{http.MethodGet, "/v1/retry-requests/unknown", "", nil, 404, "retry_request_not_found"},
+		{http.MethodGet, "/v1/history-records", "", nil, 400, "invalid_request"},
+		{http.MethodGet, "/v1/history-records?practice_session_id=unknown", "", nil, 404, "practice_session_not_found"},
+	}
+	for _, test := range tests {
+		status, body := client.request(t, test.method, test.path, test.body, test.headers)
+		assertError(t, status, body, test.status, test.code)
+	}
+
+	seedThroughQuestion(t, client)
+	for index := 1; index <= 4; index++ {
+		client.must(
+			t,
+			http.MethodPost,
+			"/v1/questions/question_demo_00"+string(rune('0'+index))+"/turns",
+			`{"interaction_mode":"PUSH_TO_TALK","answer_text":"valid answer"}`,
+			map[string]string{"Idempotency-Key": "complete-turn-key-" + string(rune('0'+index))},
+			http.StatusAccepted,
+		)
+	}
+	status, body := client.request(
+		t,
+		http.MethodPost,
+		"/v1/questions/unknown-after-completion/turns",
+		`{"interaction_mode":"PUSH_TO_TALK","answer_text":"valid"}`,
+		map[string]string{"Idempotency-Key": "unknown-after-complete"},
+	)
+	assertError(t, status, body, http.StatusNotFound, "question_not_found")
+}
+
+func TestWebSocketHandshakeValidation(t *testing.T) {
+	client := newContractClient(t)
+	seedThroughQuestion(t, client)
+	base := WebSocketURL(client.baseURL) + "/v1/practice-sessions/"
+	assertWebSocketStatus(t, base+"unknown/events?after_sequence=0", []string{eventProtocol}, http.StatusNotFound)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=abc", []string{eventProtocol}, http.StatusBadRequest)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=-1", []string{eventProtocol}, http.StatusBadRequest)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=", []string{eventProtocol}, http.StatusBadRequest)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=0&after_sequence=1", []string{eventProtocol}, http.StatusBadRequest)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=0", nil, http.StatusBadRequest)
+	assertWebSocketStatus(t, base+demoPracticeSession+"/events?after_sequence=0", []string{"wrong.events.v1"}, http.StatusBadRequest)
+}
+
+func concurrentRequests(
+	client contractClient,
+	path string,
+	bodies []string,
+	key string,
+) []concurrentResponse {
+	start := make(chan struct{})
+	results := make(chan concurrentResponse, len(bodies))
+	for _, body := range bodies {
+		body := body
+		go func() {
+			<-start
+			request, err := http.NewRequest(
+				http.MethodPost,
+				client.baseURL+path,
+				strings.NewReader(body),
+			)
+			if err != nil {
+				results <- concurrentResponse{err: err}
+				return
+			}
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Idempotency-Key", key)
+			response, err := client.client.Do(request)
+			if err != nil {
+				results <- concurrentResponse{err: err}
+				return
+			}
+			payload, readErr := io.ReadAll(response.Body)
+			closeErr := response.Body.Close()
+			if readErr != nil {
+				results <- concurrentResponse{err: readErr}
+				return
+			}
+			if closeErr != nil {
+				results <- concurrentResponse{err: closeErr}
+				return
+			}
+			results <- concurrentResponse{
+				status: response.StatusCode,
+				body:   payload,
+			}
+		}()
+	}
+	close(start)
+
+	collected := make([]concurrentResponse, 0, len(bodies))
+	for range bodies {
+		collected = append(collected, <-results)
+	}
+	return collected
+}
+
+func seedThroughQuestion(t *testing.T, client contractClient) {
+	t.Helper()
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles",
+		`{"background_summary":"Backend engineer"}`,
+		map[string]string{"Idempotency-Key": "seed-profile-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots",
+		`{"source_version":1}`,
+		map[string]string{"Idempotency-Key": "seed-snapshot-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/practice-plans",
+		`{
+			"scenario_definition_id":"scenario_programmer_interview",
+			"scenario_definition_version":1,
+			"scenario_config_id":"scenario_config_backend",
+			"scenario_config_version":1,
+			"preparation_profile_id":"profile_demo_001",
+			"selected_role_ids":["role_technical_interviewer"]
+		}`,
+		map[string]string{"Idempotency-Key": "seed-plan-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/practice-plans/"+demoPracticePlan+"/practice-sessions",
+		validSessionBody(),
+		map[string]string{"Idempotency-Key": "seed-session-key"},
+		http.StatusCreated,
+	)
+	client.must(
+		t,
+		http.MethodPost,
+		"/v1/practice-sessions/"+demoPracticeSession+"/questions",
+		"",
+		map[string]string{"Idempotency-Key": "seed-question-key"},
+		http.StatusOK,
+	)
+}
+
+func validSessionBody() string {
+	return `{
+		"expected_plan_revision":1,
+		"preparation_snapshot_id":"preparation_snapshot_demo_001",
+		"practice_option_id":"option_full_interview",
+		"role_definition_ids":["role_technical_interviewer"]
+	}`
+}
+
+func validPlanBody() string {
+	return `{
+		"scenario_definition_id":"scenario_programmer_interview",
+		"scenario_definition_version":1,
+		"scenario_config_id":"scenario_config_backend",
+		"scenario_config_version":1,
+		"preparation_profile_id":"profile_demo_001",
+		"selected_role_ids":["role_technical_interviewer"]
+	}`
+}
+
+func assertReplay(
+	t *testing.T,
+	client contractClient,
+	path string,
+	body string,
+	key string,
+	status int,
+) {
+	t.Helper()
+	headers := map[string]string{"Idempotency-Key": key}
+	first := client.must(t, http.MethodPost, path, body, headers, status)
+	replayed := client.must(t, http.MethodPost, path, body, headers, status)
+	if !bytes.Equal(first, replayed) {
+		t.Fatalf("%s replay changed response:\n%s\n%s", path, first, replayed)
+	}
+}
+
+func (c contractClient) request(
+	t *testing.T,
+	method string,
+	path string,
+	body string,
+	headers map[string]string,
+) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	request, err := http.NewRequest(method, c.baseURL+path, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	response, err := c.client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response.StatusCode, payload
+}
+
+func (c contractClient) must(
+	t *testing.T,
+	method string,
+	path string,
+	body string,
+	headers map[string]string,
+	status int,
+) []byte {
+	t.Helper()
+	actual, payload := c.request(t, method, path, body, headers)
+	if actual != status {
+		t.Fatalf("%s %s returned %d, want %d: %s", method, path, actual, status, payload)
+	}
+	return payload
+}
+
+func assertError(
+	t *testing.T,
+	status int,
+	body []byte,
+	expectedStatus int,
+	expectedCode string,
+) {
+	t.Helper()
+	if status != expectedStatus {
+		t.Fatalf("status=%d, want %d: %s", status, expectedStatus, body)
+	}
+	var envelope errorEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode error response: %v: %s", err, body)
+	}
+	if envelope.Error.Code != expectedCode {
+		t.Fatalf("error code=%q, want %q: %s", envelope.Error.Code, expectedCode, body)
+	}
+}
+
+func assertWebSocketStatus(
+	t *testing.T,
+	url string,
+	protocols []string,
+	expectedStatus int,
+) {
+	t.Helper()
+	dialer := websocket.Dialer{Subprotocols: protocols}
+	connection, response, err := dialer.Dial(url, nil)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	if err == nil {
+		t.Fatalf("WebSocket handshake unexpectedly succeeded for %s", url)
+	}
+	if response == nil {
+		t.Fatalf("WebSocket handshake returned no HTTP response for %s: %v", url, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != expectedStatus {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("WebSocket status=%d, want %d: %s", response.StatusCode, expectedStatus, body)
+	}
+}

--- a/server/internal/smoke/http.go
+++ b/server/internal/smoke/http.go
@@ -1,13 +1,18 @@
 package smoke
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/bootstrap"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
@@ -18,20 +23,53 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const (
+	eventProtocol     = "speakup.events.v1"
+	eventWriteTimeout = 5 * time.Second
+	maxRequestBody    = 1 << 20
+)
+
 type Server struct {
-	runtime *Runtime
-	router  *gin.Engine
+	router       *gin.Engine
+	preparation  *preparation.Service
+	practice     *practice.Service
+	conversation *conversation.Service
+	review       *review.Service
+	application  *Application
+	idempotency  *idempotencyStore
 }
 
 func NewServer(logger *slog.Logger) *Server {
 	runtime := NewRuntime()
+	provider := NewDeterministicProvider()
+	preparationService := preparation.NewService(preparationBackend{runtime: runtime})
+	practiceService := practice.NewService(practiceBackend{runtime: runtime})
+	conversationService := conversation.NewService(
+		conversationBackend{runtime: runtime},
+		provider,
+	)
+	reviewService := review.NewService(reviewBackend{runtime: runtime}, provider)
 	router := bootstrap.NewRouter(logger,
 		preparation.New(),
 		practice.New(),
 		conversation.New(),
 		review.New(),
 	)
-	server := &Server{runtime: runtime, router: router}
+	server := &Server{
+		router:       router,
+		preparation:  preparationService,
+		practice:     practiceService,
+		conversation: conversationService,
+		review:       reviewService,
+		application: NewApplication(
+			preparationService,
+			practiceService,
+			conversationService,
+			reviewService,
+			provider,
+		),
+		idempotency: newIdempotencyStore(),
+	}
 	server.registerRoutes()
 	return server
 }
@@ -50,9 +88,10 @@ func (s *Server) registerRoutes() {
 	s.router.GET("/v1/practice-sessions/:practice_session_id", s.getSession)
 	s.router.GET("/v1/practice-sessions/:practice_session_id/snapshot", s.getSessionSnapshot)
 	s.router.GET("/v1/practice-sessions/:practice_session_id/bootstrap", s.bootstrapConversation)
-	s.router.POST("/v1/practice-sessions/:practice_session_id/questions", s.getCurrentQuestion)
+	s.router.POST("/v1/practice-sessions/:practice_session_id/questions", s.ensureCurrentQuestion)
 	s.router.POST("/v1/questions/:question_id/turns", s.submitTurn)
 	s.router.GET("/v1/turns/:turn_id", s.getTurn)
+	s.router.POST("/v1/turns/:turn_id/turn-analyses", s.analyzeTurn)
 	s.router.GET("/v1/turns/:turn_id/turn-analyses", s.listAnalyses)
 	s.router.GET("/v1/turn-analyses/:turn_analysis_id/feedback-items", s.listFeedback)
 	s.router.POST("/v1/feedback-items/:feedback_item_id/retry-requests", s.createRetry)
@@ -62,224 +101,342 @@ func (s *Server) registerRoutes() {
 }
 
 func (s *Server) getScenario(c *gin.Context) {
-	if c.Param("scenario_definition_id") != DemoScenarioDefinition {
-		writeError(c, http.StatusNotFound, "scenario_definition_not_found", "scenario definition not found", false)
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{
-		"scenario_definition": gin.H{
-			"scenario_definition_id": DemoScenarioDefinition,
-			"scenario_type":          "INTERVIEW",
-			"name":                   "Programmer English Interview",
-			"version":                1,
-			"status":                 "active",
-		},
-		"scenario_config": gin.H{
-			"scenario_config_id":     "scenario_config_backend",
-			"scenario_definition_id": DemoScenarioDefinition,
-			"config_type":            "INTERVIEW",
-			"version":                1,
-			"job_title":              "Backend Engineer",
-			"job_description":        "Build reliable APIs and explain engineering trade-offs.",
-			"focus_areas":            []string{"reliability", "ownership", "collaboration"},
-		},
-		"practice_options": []map[string]any{practiceOption()},
-	})
-}
-
-func (s *Server) listRoles(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"roles": []map[string]any{roleDefinition()}})
-}
-
-func (s *Server) createProfile(c *gin.Context) {
-	if !requireIdempotencyKey(c) {
-		return
-	}
-	if err := discardJSON(c); err != nil {
-		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
-		return
-	}
-	c.JSON(http.StatusCreated, s.runtime.createProfile())
-}
-
-func (s *Server) createSnapshot(c *gin.Context) {
-	if !requireIdempotencyKey(c) {
-		return
-	}
-	if c.Param("preparation_profile_id") != demoPreparationProfile {
-		writeError(c, http.StatusNotFound, "preparation_profile_not_found", "preparation profile not found", false)
-		return
-	}
-	result, err := s.runtime.createSnapshot()
-	if err != nil {
-		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
-		return
-	}
-	c.JSON(http.StatusCreated, result)
-}
-
-func (s *Server) createPlan(c *gin.Context) {
-	if !requireIdempotencyKey(c) {
-		return
-	}
-	if err := discardJSON(c); err != nil {
-		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
-		return
-	}
-	result, err := s.runtime.createPlan()
-	if err != nil {
-		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
-		return
-	}
-	c.JSON(http.StatusCreated, result)
-}
-
-func (s *Server) createSession(c *gin.Context) {
-	if !requireIdempotencyKey(c) {
-		return
-	}
-	if c.Param("practice_plan_id") != demoPracticePlan {
-		writeError(c, http.StatusNotFound, "practice_plan_not_found", "practice plan not found", false)
-		return
-	}
-	if err := discardJSON(c); err != nil {
-		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
-		return
-	}
-	result, err := s.runtime.createSession()
-	if err != nil {
-		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
-		return
-	}
-	c.JSON(http.StatusCreated, result)
-}
-
-func (s *Server) getSession(c *gin.Context) {
-	s.runtime.mu.Lock()
-	defer s.runtime.mu.Unlock()
-	if !s.runtime.sessionCreated || c.Param("practice_session_id") != demoPracticeSession {
-		writeError(c, http.StatusNotFound, "practice_session_not_found", "practice session not found", false)
-		return
-	}
-	c.JSON(http.StatusOK, s.runtime.sessionLocked())
-}
-
-func (s *Server) getSessionSnapshot(c *gin.Context) {
-	s.runtime.mu.Lock()
-	defer s.runtime.mu.Unlock()
-	c.JSON(http.StatusOK, s.runtime.snapshotLocked())
-}
-
-func (s *Server) bootstrapConversation(c *gin.Context) {
-	result, err := s.runtime.bootstrap()
-	if err != nil {
-		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
+	result, ok := s.preparation.GetScenario(c.Param("scenario_definition_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "scenario_definition_not_found", "Scenario definition was not found.", false)
 		return
 	}
 	c.JSON(http.StatusOK, result)
 }
 
-func (s *Server) getCurrentQuestion(c *gin.Context) {
-	question, err := s.runtime.ensureCurrentQuestion()
-	if err != nil {
-		writeError(c, http.StatusNotFound, "question_not_found", err.Error(), false)
+func (s *Server) listRoles(c *gin.Context) {
+	roles, ok := s.preparation.ListRoles(c.Param("scenario_definition_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "scenario_definition_not_found", "Scenario definition was not found.", false)
 		return
 	}
-	c.JSON(http.StatusOK, question)
+	c.JSON(http.StatusOK, gin.H{"roles": roles})
+}
+
+func (s *Server) createProfile(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		var request struct {
+			ResumeRef         *string `json:"resume_ref"`
+			JobDescriptionRef *string `json:"job_description_ref"`
+			BackgroundSummary *string `json:"background_summary"`
+		}
+		if err := decodeStrict(raw, &request); err != nil {
+			return invalidRequest()
+		}
+		if request.BackgroundSummary == nil || strings.TrimSpace(*request.BackgroundSummary) == "" ||
+			(request.ResumeRef != nil && strings.TrimSpace(*request.ResumeRef) == "") ||
+			(request.JobDescriptionRef != nil && strings.TrimSpace(*request.JobDescriptionRef) == "") {
+			return invalidRequest()
+		}
+		input := preparation.CreateProfileRequest{BackgroundSummary: *request.BackgroundSummary}
+		if request.ResumeRef != nil {
+			input.ResumeRef = *request.ResumeRef
+		}
+		if request.JobDescriptionRef != nil {
+			input.JobDescriptionRef = *request.JobDescriptionRef
+		}
+		result, err := s.preparation.CreateProfile(input)
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusCreated, payload: result}
+	})
+}
+
+func (s *Server) createSnapshot(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		var request preparation.CreateSnapshotRequest
+		if err := decodeStrict(raw, &request); err != nil || request.SourceVersion < 1 {
+			return invalidRequest()
+		}
+		result, err := s.preparation.CreateSnapshot(c.Param("preparation_profile_id"), request)
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusCreated, payload: result}
+	})
+}
+
+func (s *Server) createPlan(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		var request practice.CreatePlanRequest
+		if err := decodeStrict(raw, &request); err != nil ||
+			!validID(request.ScenarioDefinitionID) ||
+			request.ScenarioDefinitionVersion < 1 ||
+			!validID(request.ScenarioConfigID) ||
+			request.ScenarioConfigVersion < 1 ||
+			!validID(request.PreparationProfileID) ||
+			!validUniqueIDs(request.SelectedRoleIDs) {
+			return invalidRequest()
+		}
+		result, err := s.application.CreatePlan(request)
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusCreated, payload: result}
+	})
+}
+
+func (s *Server) createSession(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		var request practice.CreateSessionRequest
+		if err := decodeStrict(raw, &request); err != nil ||
+			request.ExpectedPlanRevision < 1 ||
+			!validID(request.PreparationSnapshotID) ||
+			!validID(request.PracticeOptionID) ||
+			!validUniqueIDs(request.RoleDefinitionIDs) {
+			return invalidRequest()
+		}
+		result, err := s.application.CreateSession(c.Param("practice_plan_id"), request)
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusCreated, payload: result}
+	})
+}
+
+func (s *Server) getSession(c *gin.Context) {
+	result, ok := s.practice.GetSession(c.Param("practice_session_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (s *Server) getSessionSnapshot(c *gin.Context) {
+	result, ok := s.practice.GetSnapshot(c.Param("practice_session_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (s *Server) bootstrapConversation(c *gin.Context) {
+	result, err := s.application.Bootstrap(c.Param("practice_session_id"))
+	if err != nil {
+		writeAPIResponse(c, serviceError(err))
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (s *Server) ensureCurrentQuestion(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		if !emptyBody(raw) {
+			return invalidRequest()
+		}
+		question, err := s.application.EnsureCurrentQuestion(c.Param("practice_session_id"))
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusOK, payload: question}
+	})
 }
 
 func (s *Server) submitTurn(c *gin.Context) {
-	var request struct {
-		InteractionMode string `json:"interaction_mode"`
-		AnswerText      string `json:"answer_text"`
-		RetryRequestID  string `json:"retry_request_id"`
-	}
-	if err := c.ShouldBindJSON(&request); err != nil {
-		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
+	raw, ok := readBody(c)
+	if !ok {
 		return
 	}
-	key := c.GetHeader("Idempotency-Key")
-	if key == "" {
-		writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
-		return
-	}
-	result, err := s.runtime.submitTurn(
-		c.Param("question_id"),
-		request.AnswerText,
-		request.RetryRequestID,
-		key,
-		c.GetHeader("X-Mock-Fail-Once") == "true",
-	)
-	switch {
-	case errors.Is(err, ErrInvalidAnswer):
-		writeError(c, http.StatusBadRequest, "answer_invalid", err.Error(), false)
-	case errors.Is(err, ErrRecoverableFailure):
-		writeError(c, http.StatusUnprocessableEntity, "transcript_unavailable", err.Error(), true)
-	case errors.Is(err, ErrIdempotencyConflict):
-		writeError(c, http.StatusConflict, "idempotency_key_conflict", err.Error(), false)
-	case err != nil:
-		writeError(c, http.StatusConflict, "turn_conflict", err.Error(), false)
-	default:
-		submitted := result.Turn
+	s.executeIdempotent(c, raw, func() apiResponse {
+		var request conversation.SubmitTurnRequest
+		if err := decodeStrict(raw, &request); err != nil {
+			return invalidRequest()
+		}
+		if request.InteractionMode != "PUSH_TO_TALK" && request.InteractionMode != "REALTIME" {
+			return invalidRequest()
+		}
+		if strings.TrimSpace(request.AnswerText) == "" {
+			return errorResponse(http.StatusBadRequest, "answer_invalid", "Answer text must not be empty.", false)
+		}
+		if (fieldPresent(raw, "audio_asset_id") && !validID(request.AudioAssetID)) ||
+			(fieldPresent(raw, "retry_request_id") && !validID(request.RetryRequestID)) {
+			return invalidRequest()
+		}
+		turn, err := s.application.SubmitTurn(
+			c.Param("question_id"),
+			request,
+			c.GetHeader("X-Mock-Fail-Once") == "true",
+		)
+		if errors.Is(err, ErrRecoverableFailure) {
+			return errorResponse(
+				http.StatusUnprocessableEntity,
+				"transcript_unavailable",
+				"Answer processing is temporarily unavailable.",
+				true,
+			)
+		}
+		if err != nil {
+			return serviceError(err)
+		}
+		submitted := turn
 		submitted.Status = "submitted"
 		submitted.CompletedAt = ""
-		c.JSON(http.StatusAccepted, submitted)
-	}
+		return apiResponse{status: http.StatusAccepted, payload: submitted}
+	})
 }
 
 func (s *Server) getTurn(c *gin.Context) {
-	turn, ok := s.runtime.getTurn(c.Param("turn_id"))
+	turn, ok := s.conversation.GetTurn(c.Param("turn_id"))
 	if !ok {
-		writeError(c, http.StatusNotFound, "turn_not_found", "turn not found", false)
+		writeError(c, http.StatusNotFound, "turn_not_found", "Turn was not found.", false)
 		return
 	}
 	c.JSON(http.StatusOK, turn)
 }
 
+func (s *Server) analyzeTurn(c *gin.Context) {
+	raw, ok := readBody(c)
+	if !ok {
+		return
+	}
+	s.executeIdempotent(c, raw, func() apiResponse {
+		if !emptyBody(raw) {
+			return invalidRequest()
+		}
+		analysis, err := s.application.AnalyzeTurn(c.Param("turn_id"))
+		if err != nil {
+			return serviceError(err)
+		}
+		pending := pendingAnalysisResponse{
+			ID:               analysis.ID,
+			TurnID:           analysis.TurnID,
+			EvaluatorVersion: analysis.EvaluatorVersion,
+			Status:           "pending",
+			CreatedAt:        analysis.CreatedAt,
+		}
+		return apiResponse{status: http.StatusAccepted, payload: pending}
+	})
+}
+
 func (s *Server) listAnalyses(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"analyses": s.runtime.analysesForTurn(c.Param("turn_id"))})
+	analyses, err := s.application.ListAnalyses(c.Param("turn_id"))
+	if err != nil {
+		writeAPIResponse(c, serviceError(err))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"analyses": analyses})
 }
 
 func (s *Server) listFeedback(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"feedback_items": s.runtime.feedbackForAnalysis(c.Param("turn_analysis_id"))})
+	feedback, ok := s.review.ListFeedback(c.Param("turn_analysis_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "turn_analysis_not_found", "Turn analysis was not found.", false)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"feedback_items": feedback})
 }
 
 func (s *Server) createRetry(c *gin.Context) {
-	key := c.GetHeader("Idempotency-Key")
-	if key == "" {
-		writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
+	raw, ok := readBody(c)
+	if !ok {
 		return
 	}
-	retry, _, err := s.runtime.createRetry(c.Param("feedback_item_id"), key)
-	if err != nil {
-		writeError(c, http.StatusNotFound, "feedback_item_not_found", err.Error(), false)
-		return
-	}
-	c.JSON(http.StatusCreated, retry)
+	s.executeIdempotent(c, raw, func() apiResponse {
+		if !emptyBody(raw) {
+			return invalidRequest()
+		}
+		retry, err := s.application.CreateRetry(c.Param("feedback_item_id"))
+		if err != nil {
+			return serviceError(err)
+		}
+		return apiResponse{status: http.StatusCreated, payload: retry}
+	})
 }
 
 func (s *Server) getRetry(c *gin.Context) {
-	retry, ok := s.runtime.getRetry(c.Param("retry_request_id"))
+	retry, ok := s.review.GetRetry(c.Param("retry_request_id"))
 	if !ok {
-		writeError(c, http.StatusNotFound, "retry_request_not_found", "retry request not found", false)
+		writeError(c, http.StatusNotFound, "retry_request_not_found", "Retry request was not found.", false)
 		return
 	}
 	c.JSON(http.StatusOK, retry)
 }
 
 func (s *Server) listHistory(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"history_records": s.runtime.historyRecords()})
+	values, present := c.Request.URL.Query()["practice_session_id"]
+	if !present || len(values) != 1 || !validID(values[0]) {
+		writeError(c, http.StatusBadRequest, "invalid_request", "practice_session_id is required.", false)
+		return
+	}
+	history, err := s.application.ListHistory(values[0])
+	if err != nil {
+		writeAPIResponse(c, serviceError(err))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"history_records": history})
 }
 
 func (s *Server) streamEvents(c *gin.Context) {
+	sessionID := c.Param("practice_session_id")
+	if _, ok := s.practice.GetSession(sessionID); !ok {
+		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
+		return
+	}
+	afterSequence := 0
+	if values, present := c.Request.URL.Query()["after_sequence"]; present {
+		if len(values) != 1 || values[0] == "" {
+			writeError(c, http.StatusBadRequest, "invalid_request", "after_sequence must be a non-negative integer.", false)
+			return
+		}
+		parsed, err := strconv.ParseInt(values[0], 10, 64)
+		if err != nil || parsed < 0 || parsed > int64(^uint(0)>>1) {
+			writeError(c, http.StatusBadRequest, "invalid_request", "after_sequence must be a non-negative integer.", false)
+			return
+		}
+		afterSequence = int(parsed)
+	}
+	if !containsString(websocket.Subprotocols(c.Request), eventProtocol) {
+		writeError(c, http.StatusBadRequest, "unsupported_message", "The required WebSocket protocol was not offered.", false)
+		return
+	}
+	replay, live, unsubscribe, err := s.conversation.Subscribe(sessionID, afterSequence)
+	if err != nil {
+		writeAPIResponse(c, serviceError(err))
+		return
+	}
+	defer unsubscribe()
+	ready, err := s.conversation.StreamReady(sessionID)
+	if err != nil {
+		writeAPIResponse(c, serviceError(err))
+		return
+	}
 	upgrader := websocket.Upgrader{
+		Subprotocols: []string{eventProtocol},
 		CheckOrigin: func(request *http.Request) bool {
 			origin := request.Header.Get("Origin")
 			if origin == "" {
 				return true
 			}
-			parsed, err := url.Parse(origin)
-			return err == nil && parsed.Host == request.Host
+			parsed, parseErr := url.Parse(origin)
+			return parseErr == nil && parsed.Host == request.Host
 		},
 	}
 	connection, err := upgrader.Upgrade(c.Writer, c.Request, nil)
@@ -287,17 +444,11 @@ func (s *Server) streamEvents(c *gin.Context) {
 		return
 	}
 	defer connection.Close()
-	afterSequence := 0
-	if raw := c.Query("after_sequence"); raw != "" {
-		afterSequence, err = strconv.Atoi(raw)
-		if err != nil || afterSequence < 0 {
-			return
-		}
+	if err := writeWebSocketJSON(connection, ready); err != nil {
+		return
 	}
-	replay, live, unsubscribe := s.runtime.subscribe(afterSequence)
-	defer unsubscribe()
 	for _, event := range replay {
-		if err := connection.WriteJSON(event); err != nil {
+		if err := writeWebSocketJSON(connection, event); err != nil {
 			return
 		}
 	}
@@ -305,42 +456,227 @@ func (s *Server) streamEvents(c *gin.Context) {
 		select {
 		case <-c.Request.Context().Done():
 			return
-		case event, ok := <-live:
-			if !ok {
+		case event, open := <-live:
+			if !open {
 				return
 			}
-			if err := connection.WriteJSON(event); err != nil {
+			if err := writeWebSocketJSON(connection, event); err != nil {
 				return
 			}
 		}
 	}
 }
 
-func discardJSON(c *gin.Context) error {
-	if c.Request.Body == nil {
-		return nil
-	}
-	var payload map[string]any
-	return json.NewDecoder(c.Request.Body).Decode(&payload)
+type pendingAnalysisResponse struct {
+	ID               string `json:"turn_analysis_id"`
+	TurnID           string `json:"turn_id"`
+	EvaluatorVersion string `json:"evaluator_version"`
+	Status           string `json:"analysis_status"`
+	CreatedAt        string `json:"created_at"`
 }
 
-func requireIdempotencyKey(c *gin.Context) bool {
-	if c.GetHeader("Idempotency-Key") != "" {
-		return true
+func writeWebSocketJSON(connection *websocket.Conn, value any) error {
+	if err := connection.SetWriteDeadline(time.Now().Add(eventWriteTimeout)); err != nil {
+		return err
 	}
-	writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
-	return false
+	return connection.WriteJSON(value)
 }
 
-func writeError(c *gin.Context, status int, code, message string, retryable bool) {
-	c.JSON(status, gin.H{"error": gin.H{
+type apiResponse struct {
+	status  int
+	payload any
+}
+
+func invalidRequest() apiResponse {
+	return errorResponse(http.StatusBadRequest, "invalid_request", "Request validation failed.", false)
+}
+
+func serviceError(err error) apiResponse {
+	switch {
+	case errors.Is(err, ErrInvalidAnswer):
+		return errorResponse(http.StatusBadRequest, "answer_invalid", "Answer text must not be empty.", false)
+	case errors.Is(err, ErrSessionCompleted):
+		return errorResponse(http.StatusConflict, "turn_conflict", "Practice session is already completed.", false)
+	}
+	status, code := mapServiceError(err)
+	return errorResponse(status, code, http.StatusText(status), false)
+}
+
+func errorResponse(status int, code, message string, retryable bool) apiResponse {
+	return apiResponse{status: status, payload: gin.H{"error": gin.H{
 		"code":           code,
 		"message":        message,
 		"retryable":      retryable,
 		"correlation_id": "correlation_mock_request",
-	}})
+	}}}
+}
+
+func writeError(c *gin.Context, status int, code, message string, retryable bool) {
+	writeAPIResponse(c, errorResponse(status, code, message, retryable))
+}
+
+func writeAPIResponse(c *gin.Context, response apiResponse) {
+	c.JSON(response.status, response.payload)
+}
+
+func readBody(c *gin.Context) ([]byte, bool) {
+	if c.Request.Body == nil {
+		return nil, true
+	}
+	limited := io.LimitReader(c.Request.Body, maxRequestBody+1)
+	body, err := io.ReadAll(limited)
+	if err != nil || len(body) > maxRequestBody {
+		writeError(c, http.StatusBadRequest, "invalid_request", "Request body is invalid.", false)
+		return nil, false
+	}
+	return body, true
+}
+
+func decodeStrict(body []byte, target any) error {
+	if emptyBody(body) {
+		return errors.New("request body is required")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("request body must contain exactly one JSON value")
+		}
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil || fields == nil {
+		return errors.New("request body must be a JSON object")
+	}
+	for _, value := range fields {
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return errors.New("null is not accepted")
+		}
+	}
+	return nil
+}
+
+func emptyBody(body []byte) bool {
+	return len(bytes.TrimSpace(body)) == 0
+}
+
+func fieldPresent(body []byte, field string) bool {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(body, &fields) != nil {
+		return false
+	}
+	_, ok := fields[field]
+	return ok
+}
+
+func validID(value string) bool {
+	length := len(value)
+	return length >= 1 && length <= 128 && strings.TrimSpace(value) == value
+}
+
+func validUniqueIDs(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if !validID(value) {
+			return false
+		}
+		if _, exists := seen[value]; exists {
+			return false
+		}
+		seen[value] = struct{}{}
+	}
+	return true
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func WebSocketURL(httpURL string) string {
 	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+type idempotencyRecord struct {
+	fingerprint [sha256.Size]byte
+	status      int
+	body        []byte
+}
+
+type idempotencyStore struct {
+	mu      sync.Mutex
+	records map[string]idempotencyRecord
+}
+
+func newIdempotencyStore() *idempotencyStore {
+	return &idempotencyStore{records: make(map[string]idempotencyRecord)}
+}
+
+func (s *Server) executeIdempotent(
+	c *gin.Context,
+	requestBody []byte,
+	action func() apiResponse,
+) {
+	key := c.GetHeader("Idempotency-Key")
+	if len(key) < 8 || len(key) > 128 {
+		writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key must contain 8 to 128 characters.", false)
+		return
+	}
+	scope := DemoUserID + "\x00" + c.Request.Method + "\x00" + c.Request.URL.Path
+	recordKey := scope + "\x00" + key
+	fingerprint := bodyFingerprint(requestBody)
+
+	s.idempotency.mu.Lock()
+	defer s.idempotency.mu.Unlock()
+	if existing, ok := s.idempotency.records[recordKey]; ok {
+		if existing.fingerprint != fingerprint {
+			writeError(c, http.StatusConflict, "idempotency_key_conflict", "Idempotency key was reused with a different request.", false)
+			return
+		}
+		c.Data(existing.status, "application/json; charset=utf-8", append([]byte(nil), existing.body...))
+		return
+	}
+
+	response := action()
+	body, err := json.Marshal(response.payload)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "internal_error", "Internal server error.", false)
+		return
+	}
+	s.idempotency.records[recordKey] = idempotencyRecord{
+		fingerprint: fingerprint,
+		status:      response.status,
+		body:        append([]byte(nil), body...),
+	}
+	c.Data(response.status, "application/json; charset=utf-8", body)
+}
+
+func bodyFingerprint(body []byte) [sha256.Size]byte {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return sha256.Sum256(nil)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err == nil {
+		var extra any
+		if errors.Is(decoder.Decode(&extra), io.EOF) {
+			if canonical, marshalErr := json.Marshal(value); marshalErr == nil {
+				return sha256.Sum256(canonical)
+			}
+		}
+	}
+	return sha256.Sum256(trimmed)
 }

--- a/server/internal/smoke/http.go
+++ b/server/internal/smoke/http.go
@@ -1,0 +1,346 @@
+package smoke
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/bootstrap"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+type Server struct {
+	runtime *Runtime
+	router  *gin.Engine
+}
+
+func NewServer(logger *slog.Logger) *Server {
+	runtime := NewRuntime()
+	router := bootstrap.NewRouter(logger,
+		preparation.New(),
+		practice.New(),
+		conversation.New(),
+		review.New(),
+	)
+	server := &Server{runtime: runtime, router: router}
+	server.registerRoutes()
+	return server
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.router
+}
+
+func (s *Server) registerRoutes() {
+	s.router.GET("/v1/scenario-definitions/:scenario_definition_id", s.getScenario)
+	s.router.GET("/v1/scenario-definitions/:scenario_definition_id/role-definitions", s.listRoles)
+	s.router.POST("/v1/preparation-profiles", s.createProfile)
+	s.router.POST("/v1/preparation-profiles/:preparation_profile_id/snapshots", s.createSnapshot)
+	s.router.POST("/v1/practice-plans", s.createPlan)
+	s.router.POST("/v1/practice-plans/:practice_plan_id/practice-sessions", s.createSession)
+	s.router.GET("/v1/practice-sessions/:practice_session_id", s.getSession)
+	s.router.GET("/v1/practice-sessions/:practice_session_id/snapshot", s.getSessionSnapshot)
+	s.router.GET("/v1/practice-sessions/:practice_session_id/bootstrap", s.bootstrapConversation)
+	s.router.POST("/v1/practice-sessions/:practice_session_id/questions", s.getCurrentQuestion)
+	s.router.POST("/v1/questions/:question_id/turns", s.submitTurn)
+	s.router.GET("/v1/turns/:turn_id", s.getTurn)
+	s.router.GET("/v1/turns/:turn_id/turn-analyses", s.listAnalyses)
+	s.router.GET("/v1/turn-analyses/:turn_analysis_id/feedback-items", s.listFeedback)
+	s.router.POST("/v1/feedback-items/:feedback_item_id/retry-requests", s.createRetry)
+	s.router.GET("/v1/retry-requests/:retry_request_id", s.getRetry)
+	s.router.GET("/v1/history-records", s.listHistory)
+	s.router.GET("/v1/practice-sessions/:practice_session_id/events", s.streamEvents)
+}
+
+func (s *Server) getScenario(c *gin.Context) {
+	if c.Param("scenario_definition_id") != DemoScenarioDefinition {
+		writeError(c, http.StatusNotFound, "scenario_definition_not_found", "scenario definition not found", false)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"scenario_definition": gin.H{
+			"scenario_definition_id": DemoScenarioDefinition,
+			"scenario_type":          "INTERVIEW",
+			"name":                   "Programmer English Interview",
+			"version":                1,
+			"status":                 "active",
+		},
+		"scenario_config": gin.H{
+			"scenario_config_id":     "scenario_config_backend",
+			"scenario_definition_id": DemoScenarioDefinition,
+			"config_type":            "INTERVIEW",
+			"version":                1,
+			"job_title":              "Backend Engineer",
+			"job_description":        "Build reliable APIs and explain engineering trade-offs.",
+			"focus_areas":            []string{"reliability", "ownership", "collaboration"},
+		},
+		"practice_options": []map[string]any{practiceOption()},
+	})
+}
+
+func (s *Server) listRoles(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"roles": []map[string]any{roleDefinition()}})
+}
+
+func (s *Server) createProfile(c *gin.Context) {
+	if !requireIdempotencyKey(c) {
+		return
+	}
+	if err := discardJSON(c); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusCreated, s.runtime.createProfile())
+}
+
+func (s *Server) createSnapshot(c *gin.Context) {
+	if !requireIdempotencyKey(c) {
+		return
+	}
+	if c.Param("preparation_profile_id") != demoPreparationProfile {
+		writeError(c, http.StatusNotFound, "preparation_profile_not_found", "preparation profile not found", false)
+		return
+	}
+	result, err := s.runtime.createSnapshot()
+	if err != nil {
+		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+func (s *Server) createPlan(c *gin.Context) {
+	if !requireIdempotencyKey(c) {
+		return
+	}
+	if err := discardJSON(c); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
+		return
+	}
+	result, err := s.runtime.createPlan()
+	if err != nil {
+		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+func (s *Server) createSession(c *gin.Context) {
+	if !requireIdempotencyKey(c) {
+		return
+	}
+	if c.Param("practice_plan_id") != demoPracticePlan {
+		writeError(c, http.StatusNotFound, "practice_plan_not_found", "practice plan not found", false)
+		return
+	}
+	if err := discardJSON(c); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
+		return
+	}
+	result, err := s.runtime.createSession()
+	if err != nil {
+		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+func (s *Server) getSession(c *gin.Context) {
+	s.runtime.mu.Lock()
+	defer s.runtime.mu.Unlock()
+	if !s.runtime.sessionCreated || c.Param("practice_session_id") != demoPracticeSession {
+		writeError(c, http.StatusNotFound, "practice_session_not_found", "practice session not found", false)
+		return
+	}
+	c.JSON(http.StatusOK, s.runtime.sessionLocked())
+}
+
+func (s *Server) getSessionSnapshot(c *gin.Context) {
+	s.runtime.mu.Lock()
+	defer s.runtime.mu.Unlock()
+	c.JSON(http.StatusOK, s.runtime.snapshotLocked())
+}
+
+func (s *Server) bootstrapConversation(c *gin.Context) {
+	result, err := s.runtime.bootstrap()
+	if err != nil {
+		writeError(c, http.StatusConflict, "resource_conflict", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (s *Server) getCurrentQuestion(c *gin.Context) {
+	question, err := s.runtime.ensureCurrentQuestion()
+	if err != nil {
+		writeError(c, http.StatusNotFound, "question_not_found", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusOK, question)
+}
+
+func (s *Server) submitTurn(c *gin.Context) {
+	var request struct {
+		InteractionMode string `json:"interaction_mode"`
+		AnswerText      string `json:"answer_text"`
+		RetryRequestID  string `json:"retry_request_id"`
+	}
+	if err := c.ShouldBindJSON(&request); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", err.Error(), false)
+		return
+	}
+	key := c.GetHeader("Idempotency-Key")
+	if key == "" {
+		writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
+		return
+	}
+	result, err := s.runtime.submitTurn(
+		c.Param("question_id"),
+		request.AnswerText,
+		request.RetryRequestID,
+		key,
+		c.GetHeader("X-Mock-Fail-Once") == "true",
+	)
+	switch {
+	case errors.Is(err, ErrInvalidAnswer):
+		writeError(c, http.StatusBadRequest, "answer_invalid", err.Error(), false)
+	case errors.Is(err, ErrRecoverableFailure):
+		writeError(c, http.StatusUnprocessableEntity, "transcript_unavailable", err.Error(), true)
+	case errors.Is(err, ErrIdempotencyConflict):
+		writeError(c, http.StatusConflict, "idempotency_key_conflict", err.Error(), false)
+	case err != nil:
+		writeError(c, http.StatusConflict, "turn_conflict", err.Error(), false)
+	default:
+		submitted := result.Turn
+		submitted.Status = "submitted"
+		submitted.CompletedAt = ""
+		c.JSON(http.StatusAccepted, submitted)
+	}
+}
+
+func (s *Server) getTurn(c *gin.Context) {
+	turn, ok := s.runtime.getTurn(c.Param("turn_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "turn_not_found", "turn not found", false)
+		return
+	}
+	c.JSON(http.StatusOK, turn)
+}
+
+func (s *Server) listAnalyses(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"analyses": s.runtime.analysesForTurn(c.Param("turn_id"))})
+}
+
+func (s *Server) listFeedback(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"feedback_items": s.runtime.feedbackForAnalysis(c.Param("turn_analysis_id"))})
+}
+
+func (s *Server) createRetry(c *gin.Context) {
+	key := c.GetHeader("Idempotency-Key")
+	if key == "" {
+		writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
+		return
+	}
+	retry, _, err := s.runtime.createRetry(c.Param("feedback_item_id"), key)
+	if err != nil {
+		writeError(c, http.StatusNotFound, "feedback_item_not_found", err.Error(), false)
+		return
+	}
+	c.JSON(http.StatusCreated, retry)
+}
+
+func (s *Server) getRetry(c *gin.Context) {
+	retry, ok := s.runtime.getRetry(c.Param("retry_request_id"))
+	if !ok {
+		writeError(c, http.StatusNotFound, "retry_request_not_found", "retry request not found", false)
+		return
+	}
+	c.JSON(http.StatusOK, retry)
+}
+
+func (s *Server) listHistory(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"history_records": s.runtime.historyRecords()})
+}
+
+func (s *Server) streamEvents(c *gin.Context) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(request *http.Request) bool {
+			origin := request.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			parsed, err := url.Parse(origin)
+			return err == nil && parsed.Host == request.Host
+		},
+	}
+	connection, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	afterSequence := 0
+	if raw := c.Query("after_sequence"); raw != "" {
+		afterSequence, err = strconv.Atoi(raw)
+		if err != nil || afterSequence < 0 {
+			return
+		}
+	}
+	replay, live, unsubscribe := s.runtime.subscribe(afterSequence)
+	defer unsubscribe()
+	for _, event := range replay {
+		if err := connection.WriteJSON(event); err != nil {
+			return
+		}
+	}
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case event, ok := <-live:
+			if !ok {
+				return
+			}
+			if err := connection.WriteJSON(event); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func discardJSON(c *gin.Context) error {
+	if c.Request.Body == nil {
+		return nil
+	}
+	var payload map[string]any
+	return json.NewDecoder(c.Request.Body).Decode(&payload)
+}
+
+func requireIdempotencyKey(c *gin.Context) bool {
+	if c.GetHeader("Idempotency-Key") != "" {
+		return true
+	}
+	writeError(c, http.StatusBadRequest, "invalid_request", "Idempotency-Key header is required", false)
+	return false
+}
+
+func writeError(c *gin.Context, status int, code, message string, retryable bool) {
+	c.JSON(status, gin.H{"error": gin.H{
+		"code":           code,
+		"message":        message,
+		"retryable":      retryable,
+		"correlation_id": "correlation_mock_request",
+	}})
+}
+
+func WebSocketURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}

--- a/server/internal/smoke/main_flow_test.go
+++ b/server/internal/smoke/main_flow_test.go
@@ -16,33 +16,49 @@ import (
 )
 
 type flowClient struct {
-	baseURL string
-	client  *http.Client
+	baseURL   string
+	client    *http.Client
+	exchanges *[]httpExchange
 }
 
-type flowSummary struct {
-	SessionID          string
-	EffectiveTurns     int
-	RetryTurnID        string
-	HistoryCount       int
-	EventTypes         []string
-	RecoverableFailure bool
+type httpExchange struct {
+	Method string
+	Path   string
+	Status int
+	Body   string
+}
+
+type flowTrace struct {
+	Exchanges    []httpExchange
+	Events       []Event
+	ReplayEvents []Event
+	Turns        []Turn
+	Analyses     []Analysis
+	Feedback     []Feedback
+	Retry        RetryRequest
+	History      []HistoryRecord
+	FinalSession map[string]any
 }
 
 func TestDeterministicMainFlow(t *testing.T) {
 	first := runMainFlow(t)
 	second := runMainFlow(t)
 	if !reflect.DeepEqual(first, second) {
-		t.Fatalf("same input produced different results:\nfirst:  %#v\nsecond: %#v", first, second)
+		t.Fatalf("same input produced a different complete trace:\nfirst:  %#v\nsecond: %#v", first, second)
 	}
 }
 
-func runMainFlow(t *testing.T) flowSummary {
+func runMainFlow(t *testing.T) flowTrace {
 	t.Helper()
 	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	httpServer := httptest.NewServer(server.Handler())
 	t.Cleanup(httpServer.Close)
-	client := flowClient{baseURL: httpServer.URL, client: httpServer.Client()}
+	trace := flowTrace{}
+	client := flowClient{
+		baseURL:   httpServer.URL,
+		client:    httpServer.Client(),
+		exchanges: &trace.Exchanges,
+	}
 
 	client.expect(t, http.MethodGet, "/v1/scenario-definitions/"+DemoScenarioDefinition, nil, nil, http.StatusOK, nil)
 	client.expect(t, http.MethodGet, "/v1/scenario-definitions/"+DemoScenarioDefinition+"/role-definitions", nil, nil, http.StatusOK, nil)
@@ -74,13 +90,19 @@ func runMainFlow(t *testing.T) flowSummary {
 		"Idempotency-Key": "question-key-1",
 	}, http.StatusOK, nil)
 	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession+"/bootstrap", nil, nil, http.StatusOK, nil)
-	events := startEventCollector(t, WebSocketURL(httpServer.URL)+"/v1/practice-sessions/"+demoPracticeSession+"/events?after_sequence=0")
+	events := startEventCollector(
+		t,
+		WebSocketURL(httpServer.URL)+"/v1/practice-sessions/"+demoPracticeSession+"/events?after_sequence=0",
+	)
 
-	var invalidError map[string]any
+	var invalidError errorEnvelope
 	client.expect(t, http.MethodPost, "/v1/questions/question_demo_001/turns", map[string]any{
 		"interaction_mode": "PUSH_TO_TALK",
 		"answer_text":      " ",
-	}, map[string]string{"Idempotency-Key": "invalid-turn"}, http.StatusBadRequest, &invalidError)
+	}, map[string]string{"Idempotency-Key": "invalid-turn-key"}, http.StatusBadRequest, &invalidError)
+	if invalidError.Error.Code != "answer_invalid" {
+		t.Fatalf("invalid answer returned %q", invalidError.Error.Code)
+	}
 
 	answers := []string{
 		"I led a Go API reliability project and reduced incident recovery time.",
@@ -89,116 +111,217 @@ func runMainFlow(t *testing.T) flowSummary {
 		"I published the error budget, ran a canary review, and agreed rollback signals.",
 	}
 	feedbackID := ""
-	recoverableFailure := false
 	for index, answer := range answers {
 		questionID := fmt.Sprintf("question_demo_%03d", index+1)
-		headers := map[string]string{"Idempotency-Key": fmt.Sprintf("turn-key-%d", index+1)}
 		if index == 1 {
-			headers["X-Mock-Fail-Once"] = "true"
-			client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+			var failure errorEnvelope
+			failureBody := client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
 				"interaction_mode": "PUSH_TO_TALK",
 				"answer_text":      answer,
-			}, headers, http.StatusUnprocessableEntity, nil)
-			recoverableFailure = true
+			}, map[string]string{
+				"Idempotency-Key":  "turn-failure-key-2",
+				"X-Mock-Fail-Once": "true",
+			}, http.StatusUnprocessableEntity, &failure)
+			if failure.Error.Code != "transcript_unavailable" || !failure.Error.Retryable {
+				t.Fatalf("recoverable failure is not contract-shaped: %#v", failure)
+			}
+			replayedFailure := client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+				"interaction_mode": "PUSH_TO_TALK",
+				"answer_text":      answer,
+			}, map[string]string{"Idempotency-Key": "turn-failure-key-2"}, http.StatusUnprocessableEntity, nil)
+			if !bytes.Equal(failureBody, replayedFailure) {
+				t.Fatal("the first 422 response was not replayed byte-for-byte")
+			}
 		}
-		var turn Turn
-		client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+
+		var submitted Turn
+		key := fmt.Sprintf("turn-success-key-%d", index+1)
+		firstBody := client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
 			"interaction_mode": "PUSH_TO_TALK",
 			"answer_text":      answer,
-		}, headers, http.StatusAccepted, &turn)
+		}, map[string]string{"Idempotency-Key": key}, http.StatusAccepted, &submitted)
+		if submitted.Status != "submitted" || submitted.QuestionID != questionID {
+			t.Fatalf("unexpected submitted Turn: %#v", submitted)
+		}
+		if index == 0 {
+			replayedBody := client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+				"answer_text":      answer,
+				"interaction_mode": "PUSH_TO_TALK",
+			}, map[string]string{"Idempotency-Key": key}, http.StatusAccepted, nil)
+			if !bytes.Equal(firstBody, replayedBody) {
+				t.Fatal("successful Turn response was not replayed byte-for-byte")
+			}
+		}
+		trace.Turns = append(trace.Turns, submitted)
+
+		var pending Analysis
+		client.expect(t, http.MethodPost, "/v1/turns/"+submitted.ID+"/turn-analyses", nil, map[string]string{
+			"Idempotency-Key": fmt.Sprintf("analysis-key-%d", index+1),
+		}, http.StatusAccepted, &pending)
+		if pending.Status != "pending" || pending.TurnID != submitted.ID {
+			t.Fatalf("unexpected pending analysis: %#v", pending)
+		}
 		var analyses struct {
 			Analyses []Analysis `json:"analyses"`
 		}
-		client.expect(t, http.MethodGet, "/v1/turns/"+turn.ID+"/turn-analyses", nil, nil, http.StatusOK, &analyses)
-		if len(analyses.Analyses) != 1 {
-			t.Fatalf("turn %s did not produce one analysis", turn.ID)
+		client.expect(t, http.MethodGet, "/v1/turns/"+submitted.ID+"/turn-analyses", nil, nil, http.StatusOK, &analyses)
+		if len(analyses.Analyses) != 1 || analyses.Analyses[0].Status != "completed" {
+			t.Fatalf("turn %s did not produce one completed analysis: %#v", submitted.ID, analyses)
 		}
+		trace.Analyses = append(trace.Analyses, analyses.Analyses[0])
 		var feedback struct {
 			Items []Feedback `json:"feedback_items"`
 		}
-		client.expect(t, http.MethodGet, "/v1/turn-analyses/"+analyses.Analyses[0].ID+"/feedback-items", nil, nil, http.StatusOK, &feedback)
+		client.expect(
+			t,
+			http.MethodGet,
+			"/v1/turn-analyses/"+analyses.Analyses[0].ID+"/feedback-items",
+			nil,
+			nil,
+			http.StatusOK,
+			&feedback,
+		)
 		if len(feedback.Items) != 1 {
-			t.Fatalf("analysis %s did not produce feedback", analyses.Analyses[0].ID)
+			t.Fatalf("analysis %s did not produce one feedback item", analyses.Analyses[0].ID)
 		}
+		trace.Feedback = append(trace.Feedback, feedback.Items[0])
 		if index == 0 {
 			feedbackID = feedback.Items[0].ID
-			var replay Turn
-			client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
-				"interaction_mode": "PUSH_TO_TALK",
-				"answer_text":      answer,
-			}, headers, http.StatusAccepted, &replay)
-			if replay.ID != turn.ID {
-				t.Fatalf("idempotent replay created a different turn: %s != %s", replay.ID, turn.ID)
-			}
 		}
 	}
 
-	var retryResponse RetryRequest
 	retryHeaders := map[string]string{"Idempotency-Key": "retry-key-1"}
-	client.expect(t, http.MethodPost, "/v1/feedback-items/"+feedbackID+"/retry-requests", map[string]any{}, retryHeaders, http.StatusCreated, &retryResponse)
+	client.expect(
+		t,
+		http.MethodPost,
+		"/v1/feedback-items/"+feedbackID+"/retry-requests",
+		nil,
+		retryHeaders,
+		http.StatusCreated,
+		&trace.Retry,
+	)
 	var replayRetry RetryRequest
-	client.expect(t, http.MethodPost, "/v1/feedback-items/"+feedbackID+"/retry-requests", map[string]any{}, retryHeaders, http.StatusCreated, &replayRetry)
-	if replayRetry.NewTurnID != retryResponse.NewTurnID {
-		t.Fatalf("idempotent retry created a different turn: %s != %s", replayRetry.NewTurnID, retryResponse.NewTurnID)
+	client.expect(
+		t,
+		http.MethodPost,
+		"/v1/feedback-items/"+feedbackID+"/retry-requests",
+		nil,
+		retryHeaders,
+		http.StatusCreated,
+		&replayRetry,
+	)
+	if replayRetry != trace.Retry {
+		t.Fatalf("retry replay changed the resource: %#v != %#v", replayRetry, trace.Retry)
 	}
+
+	var retryTurn Turn
 	client.expect(t, http.MethodPost, "/v1/questions/question_demo_001/turns", map[string]any{
 		"interaction_mode": "PUSH_TO_TALK",
 		"answer_text":      "I selected tracing after comparing cost and coverage, then reduced recovery time.",
-		"retry_request_id": retryResponse.ID,
-	}, map[string]string{"Idempotency-Key": "retry-turn-key-1"}, http.StatusAccepted, nil)
-
-	var finalSession map[string]any
-	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession, nil, nil, http.StatusOK, &finalSession)
-	if finalSession["practice_session_status"] != "completed" {
-		t.Fatalf("session did not complete: %#v", finalSession)
+		"retry_request_id": trace.Retry.ID,
+	}, map[string]string{"Idempotency-Key": "retry-turn-key-1"}, http.StatusAccepted, &retryTurn)
+	trace.Turns = append(trace.Turns, retryTurn)
+	var retryPending Analysis
+	client.expect(t, http.MethodPost, "/v1/turns/"+retryTurn.ID+"/turn-analyses", nil, map[string]string{
+		"Idempotency-Key": "retry-analysis-key-1",
+	}, http.StatusAccepted, &retryPending)
+	var retryAnalyses struct {
+		Analyses []Analysis `json:"analyses"`
 	}
+	client.expect(t, http.MethodGet, "/v1/turns/"+retryTurn.ID+"/turn-analyses", nil, nil, http.StatusOK, &retryAnalyses)
+	if len(retryAnalyses.Analyses) != 1 {
+		t.Fatalf("retry Turn did not produce one analysis: %#v", retryAnalyses)
+	}
+	trace.Analyses = append(trace.Analyses, retryAnalyses.Analyses[0])
 
+	client.expect(
+		t,
+		http.MethodGet,
+		"/v1/practice-sessions/"+demoPracticeSession,
+		nil,
+		nil,
+		http.StatusOK,
+		&trace.FinalSession,
+	)
+	if trace.FinalSession["practice_session_status"] != "completed" {
+		t.Fatalf("session did not complete: %#v", trace.FinalSession)
+	}
 	var history struct {
 		Items []HistoryRecord `json:"history_records"`
 	}
-	client.expect(t, http.MethodGet, "/v1/history-records?practice_session_id="+demoPracticeSession, nil, nil, http.StatusOK, &history)
-	if len(history.Items) != 5 {
-		t.Fatalf("history does not contain four original turns and one retry: %d", len(history.Items))
+	client.expect(
+		t,
+		http.MethodGet,
+		"/v1/history-records?practice_session_id="+demoPracticeSession,
+		nil,
+		nil,
+		http.StatusOK,
+		&history,
+	)
+	if len(history.Items) != 5 || len(trace.Turns) != 5 {
+		t.Fatalf("expected four effective Turns and one retry: turns=%d history=%d", len(trace.Turns), len(history.Items))
 	}
+	trace.History = history.Items
 
-	requiredEvents := []string{
+	expectedTypes := []string{
+		"stream.ready",
 		"practice_session.started",
+		"question.created",
+		"turn.submitted", "turn.processing", "turn.completed", "question.created", "turn_analysis.completed",
 		"answer.processing_failed",
-		"turn.completed",
-		"turn_analysis.completed",
-		"practice_session.completed",
+		"turn.submitted", "turn.processing", "turn.completed", "question.created", "turn_analysis.completed",
+		"turn.submitted", "turn.processing", "turn.completed", "question.created", "turn_analysis.completed",
+		"turn.submitted", "turn.processing", "turn.completed", "practice_session.completed", "turn_analysis.completed",
+		"turn.submitted", "turn.processing", "turn.completed", "turn_analysis.completed",
 	}
-	eventTypes := events.awaitAndStop(t, requiredEvents)
-	for _, required := range requiredEvents {
-		if !contains(eventTypes, required) {
-			t.Fatalf("event stream does not contain %q: %#v", required, eventTypes)
-		}
-	}
+	trace.Events = events.awaitAndStop(t, expectedTypes)
+	assertEventTrace(t, trace.Events, expectedTypes)
+
 	var bootstrap struct {
 		LastEventSequence int `json:"last_event_sequence"`
 	}
-	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession+"/bootstrap", nil, nil, http.StatusOK, &bootstrap)
-	replayed := readOneEvent(t, fmt.Sprintf(
-		"%s/v1/practice-sessions/%s/events?after_sequence=%d",
-		WebSocketURL(httpServer.URL),
-		demoPracticeSession,
-		bootstrap.LastEventSequence-1,
-	))
-	if !replayed.Replayable || replayed.Sequence != bootstrap.LastEventSequence {
-		t.Fatalf("event cursor replay is inconsistent: %#v", replayed)
+	client.expect(
+		t,
+		http.MethodGet,
+		"/v1/practice-sessions/"+demoPracticeSession+"/bootstrap",
+		nil,
+		nil,
+		http.StatusOK,
+		&bootstrap,
+	)
+	trace.ReplayEvents = readEvents(
+		t,
+		fmt.Sprintf(
+			"%s/v1/practice-sessions/%s/events?after_sequence=%d",
+			WebSocketURL(httpServer.URL),
+			demoPracticeSession,
+			bootstrap.LastEventSequence-1,
+		),
+		2,
+	)
+	if trace.ReplayEvents[0].Type != "stream.ready" ||
+		trace.ReplayEvents[1].Sequence != bootstrap.LastEventSequence {
+		t.Fatalf("cursor replay is inconsistent: %#v", trace.ReplayEvents)
 	}
-
-	return flowSummary{
-		SessionID:          sessionBootstrap.Session["practice_session_id"].(string),
-		EffectiveTurns:     len(answers),
-		RetryTurnID:        retryResponse.NewTurnID,
-		HistoryCount:       len(history.Items),
-		EventTypes:         eventTypes,
-		RecoverableFailure: recoverableFailure,
-	}
+	return trace
 }
 
-func (c flowClient) expect(t *testing.T, method, path string, body any, headers map[string]string, status int, target any) {
+type errorEnvelope struct {
+	Error struct {
+		Code      string `json:"code"`
+		Retryable bool   `json:"retryable"`
+	} `json:"error"`
+}
+
+func (c *flowClient) expect(
+	t *testing.T,
+	method string,
+	path string,
+	body any,
+	headers map[string]string,
+	status int,
+	target any,
+) []byte {
 	t.Helper()
 	var reader io.Reader
 	if body != nil {
@@ -230,95 +353,125 @@ func (c flowClient) expect(t *testing.T, method, path string, body any, headers 
 	if response.StatusCode != status {
 		t.Fatalf("%s %s returned %d, want %d: %s", method, path, response.StatusCode, status, payload)
 	}
+	*c.exchanges = append(*c.exchanges, httpExchange{
+		Method: method,
+		Path:   path,
+		Status: response.StatusCode,
+		Body:   string(payload),
+	})
 	if target != nil {
 		if err := json.Unmarshal(payload, target); err != nil {
 			t.Fatalf("decode %s %s: %v\n%s", method, path, err, payload)
 		}
 	}
+	return payload
 }
 
 type eventCollector struct {
 	connection *websocket.Conn
-	types      chan string
+	events     chan Event
 	done       chan struct{}
 }
 
 func startEventCollector(t *testing.T, url string) *eventCollector {
 	t.Helper()
-	connection, _, err := websocket.DefaultDialer.Dial(url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connection := dialEvents(t, url)
 	collector := &eventCollector{
 		connection: connection,
-		types:      make(chan string, 64),
+		events:     make(chan Event, 64),
 		done:       make(chan struct{}),
 	}
 	go func() {
 		defer close(collector.done)
-		defer close(collector.types)
+		defer close(collector.events)
 		for {
 			var event Event
 			if err := connection.ReadJSON(&event); err != nil {
 				return
 			}
-			collector.types <- event.Type
+			collector.events <- event
 		}
 	}()
 	return collector
 }
 
-func readOneEvent(t *testing.T, url string) Event {
+func dialEvents(t *testing.T, url string) *websocket.Conn {
 	t.Helper()
-	connection, _, err := websocket.DefaultDialer.Dial(url, nil)
+	dialer := websocket.Dialer{Subprotocols: []string{eventProtocol}}
+	connection, response, err := dialer.Dial(url, nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("dial event stream: %v", err)
 	}
-	defer connection.Close()
-	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
-	var event Event
-	if err := connection.ReadJSON(&event); err != nil {
-		t.Fatalf("read replayed event: %v", err)
+	if response == nil || response.Header.Get("Sec-WebSocket-Protocol") != eventProtocol ||
+		connection.Subprotocol() != eventProtocol {
+		_ = connection.Close()
+		t.Fatalf("event protocol was not negotiated: %#v", response)
 	}
-	return event
+	return connection
 }
 
-func (c *eventCollector) awaitAndStop(t *testing.T, required []string) []string {
+func readEvents(t *testing.T, url string, count int) []Event {
+	t.Helper()
+	connection := dialEvents(t, url)
+	defer connection.Close()
+	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+	events := make([]Event, 0, count)
+	for len(events) < count {
+		var event Event
+		if err := connection.ReadJSON(&event); err != nil {
+			t.Fatalf("read replayed event: %v", err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func (c *eventCollector) awaitAndStop(t *testing.T, expectedTypes []string) []Event {
 	t.Helper()
 	timer := time.NewTimer(2 * time.Second)
 	defer timer.Stop()
-	var eventTypes []string
-	for {
-		complete := true
-		for _, requiredType := range required {
-			if !contains(eventTypes, requiredType) {
-				complete = false
-				break
-			}
-		}
-		if complete {
-			break
-		}
+	events := make([]Event, 0, len(expectedTypes))
+	for len(events) < len(expectedTypes) {
 		select {
-		case eventType := <-c.types:
-			eventTypes = append(eventTypes, eventType)
+		case event, open := <-c.events:
+			if !open {
+				t.Fatalf("event stream closed after %d events", len(events))
+			}
+			events = append(events, event)
 		case <-timer.C:
-			t.Fatalf("timed out waiting for events; received %#v", eventTypes)
+			t.Fatalf("timed out waiting for events; received %#v", events)
 		}
 	}
 	_ = c.connection.Close()
 	<-c.done
-	for eventType := range c.types {
-		eventTypes = append(eventTypes, eventType)
+	for event := range c.events {
+		events = append(events, event)
 	}
-	return eventTypes
+	if len(events) != len(expectedTypes) {
+		t.Fatalf("event stream produced %d events, want %d: %#v", len(events), len(expectedTypes), events)
+	}
+	return events
 }
 
-func contains(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
+func assertEventTrace(t *testing.T, events []Event, expectedTypes []string) {
+	t.Helper()
+	nextSequence := 1
+	for index, event := range events {
+		if event.Type != expectedTypes[index] {
+			t.Fatalf("event %d type=%q, want %q", index, event.Type, expectedTypes[index])
+		}
+		if event.Version != 1 || event.SessionID != demoPracticeSession ||
+			event.ID == "" || event.OccurredAt == "" || event.CorrelationID == "" ||
+			event.Payload == nil {
+			t.Fatalf("event %d has an invalid envelope: %#v", index, event)
+		}
+		if event.Replayable {
+			if event.Sequence != nextSequence {
+				t.Fatalf("event %d sequence=%d, want %d", index, event.Sequence, nextSequence)
+			}
+			nextSequence++
+		} else if event.Sequence != 0 {
+			t.Fatalf("non-replayable event %d exposed sequence %d", index, event.Sequence)
 		}
 	}
-	return false
 }

--- a/server/internal/smoke/main_flow_test.go
+++ b/server/internal/smoke/main_flow_test.go
@@ -1,0 +1,324 @@
+package smoke
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type flowClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type flowSummary struct {
+	SessionID          string
+	EffectiveTurns     int
+	RetryTurnID        string
+	HistoryCount       int
+	EventTypes         []string
+	RecoverableFailure bool
+}
+
+func TestDeterministicMainFlow(t *testing.T) {
+	first := runMainFlow(t)
+	second := runMainFlow(t)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("same input produced different results:\nfirst:  %#v\nsecond: %#v", first, second)
+	}
+}
+
+func runMainFlow(t *testing.T) flowSummary {
+	t.Helper()
+	server := NewServer(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	client := flowClient{baseURL: httpServer.URL, client: httpServer.Client()}
+
+	client.expect(t, http.MethodGet, "/v1/scenario-definitions/"+DemoScenarioDefinition, nil, nil, http.StatusOK, nil)
+	client.expect(t, http.MethodGet, "/v1/scenario-definitions/"+DemoScenarioDefinition+"/role-definitions", nil, nil, http.StatusOK, nil)
+	client.expect(t, http.MethodPost, "/v1/preparation-profiles", map[string]any{
+		"background_summary": "Backend engineer preparing for an English technical interview.",
+	}, map[string]string{"Idempotency-Key": "profile-key-1"}, http.StatusCreated, nil)
+	client.expect(t, http.MethodPost, "/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots", map[string]any{
+		"source_version": 1,
+	}, map[string]string{"Idempotency-Key": "snapshot-key-1"}, http.StatusCreated, nil)
+	client.expect(t, http.MethodPost, "/v1/practice-plans", map[string]any{
+		"scenario_definition_id":      DemoScenarioDefinition,
+		"scenario_definition_version": 1,
+		"scenario_config_id":          "scenario_config_backend",
+		"scenario_config_version":     1,
+		"preparation_profile_id":      demoPreparationProfile,
+		"selected_role_ids":           []string{DemoRoleDefinition},
+	}, map[string]string{"Idempotency-Key": "plan-key-1"}, http.StatusCreated, nil)
+	var sessionBootstrap struct {
+		Session map[string]any `json:"practice_session"`
+	}
+	client.expect(t, http.MethodPost, "/v1/practice-plans/"+demoPracticePlan+"/practice-sessions", map[string]any{
+		"expected_plan_revision":  1,
+		"preparation_snapshot_id": demoPreparationSnapshot,
+		"practice_option_id":      DemoPracticeOption,
+		"role_definition_ids":     []string{DemoRoleDefinition},
+	}, map[string]string{"Idempotency-Key": "session-key-1"}, http.StatusCreated, &sessionBootstrap)
+	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession+"/snapshot", nil, nil, http.StatusOK, nil)
+	client.expect(t, http.MethodPost, "/v1/practice-sessions/"+demoPracticeSession+"/questions", nil, map[string]string{
+		"Idempotency-Key": "question-key-1",
+	}, http.StatusOK, nil)
+	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession+"/bootstrap", nil, nil, http.StatusOK, nil)
+	events := startEventCollector(t, WebSocketURL(httpServer.URL)+"/v1/practice-sessions/"+demoPracticeSession+"/events?after_sequence=0")
+
+	var invalidError map[string]any
+	client.expect(t, http.MethodPost, "/v1/questions/question_demo_001/turns", map[string]any{
+		"interaction_mode": "PUSH_TO_TALK",
+		"answer_text":      " ",
+	}, map[string]string{"Idempotency-Key": "invalid-turn"}, http.StatusBadRequest, &invalidError)
+
+	answers := []string{
+		"I led a Go API reliability project and reduced incident recovery time.",
+		"I introduced request tracing, defined an error budget, and staged the rollout.",
+		"I chose sampling by endpoint risk to control cost while preserving failure evidence.",
+		"I published the error budget, ran a canary review, and agreed rollback signals.",
+	}
+	feedbackID := ""
+	recoverableFailure := false
+	for index, answer := range answers {
+		questionID := fmt.Sprintf("question_demo_%03d", index+1)
+		headers := map[string]string{"Idempotency-Key": fmt.Sprintf("turn-key-%d", index+1)}
+		if index == 1 {
+			headers["X-Mock-Fail-Once"] = "true"
+			client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+				"interaction_mode": "PUSH_TO_TALK",
+				"answer_text":      answer,
+			}, headers, http.StatusUnprocessableEntity, nil)
+			recoverableFailure = true
+		}
+		var turn Turn
+		client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+			"interaction_mode": "PUSH_TO_TALK",
+			"answer_text":      answer,
+		}, headers, http.StatusAccepted, &turn)
+		var analyses struct {
+			Analyses []Analysis `json:"analyses"`
+		}
+		client.expect(t, http.MethodGet, "/v1/turns/"+turn.ID+"/turn-analyses", nil, nil, http.StatusOK, &analyses)
+		if len(analyses.Analyses) != 1 {
+			t.Fatalf("turn %s did not produce one analysis", turn.ID)
+		}
+		var feedback struct {
+			Items []Feedback `json:"feedback_items"`
+		}
+		client.expect(t, http.MethodGet, "/v1/turn-analyses/"+analyses.Analyses[0].ID+"/feedback-items", nil, nil, http.StatusOK, &feedback)
+		if len(feedback.Items) != 1 {
+			t.Fatalf("analysis %s did not produce feedback", analyses.Analyses[0].ID)
+		}
+		if index == 0 {
+			feedbackID = feedback.Items[0].ID
+			var replay Turn
+			client.expect(t, http.MethodPost, "/v1/questions/"+questionID+"/turns", map[string]any{
+				"interaction_mode": "PUSH_TO_TALK",
+				"answer_text":      answer,
+			}, headers, http.StatusAccepted, &replay)
+			if replay.ID != turn.ID {
+				t.Fatalf("idempotent replay created a different turn: %s != %s", replay.ID, turn.ID)
+			}
+		}
+	}
+
+	var retryResponse RetryRequest
+	retryHeaders := map[string]string{"Idempotency-Key": "retry-key-1"}
+	client.expect(t, http.MethodPost, "/v1/feedback-items/"+feedbackID+"/retry-requests", map[string]any{}, retryHeaders, http.StatusCreated, &retryResponse)
+	var replayRetry RetryRequest
+	client.expect(t, http.MethodPost, "/v1/feedback-items/"+feedbackID+"/retry-requests", map[string]any{}, retryHeaders, http.StatusCreated, &replayRetry)
+	if replayRetry.NewTurnID != retryResponse.NewTurnID {
+		t.Fatalf("idempotent retry created a different turn: %s != %s", replayRetry.NewTurnID, retryResponse.NewTurnID)
+	}
+	client.expect(t, http.MethodPost, "/v1/questions/question_demo_001/turns", map[string]any{
+		"interaction_mode": "PUSH_TO_TALK",
+		"answer_text":      "I selected tracing after comparing cost and coverage, then reduced recovery time.",
+		"retry_request_id": retryResponse.ID,
+	}, map[string]string{"Idempotency-Key": "retry-turn-key-1"}, http.StatusAccepted, nil)
+
+	var finalSession map[string]any
+	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession, nil, nil, http.StatusOK, &finalSession)
+	if finalSession["practice_session_status"] != "completed" {
+		t.Fatalf("session did not complete: %#v", finalSession)
+	}
+
+	var history struct {
+		Items []HistoryRecord `json:"history_records"`
+	}
+	client.expect(t, http.MethodGet, "/v1/history-records?practice_session_id="+demoPracticeSession, nil, nil, http.StatusOK, &history)
+	if len(history.Items) != 5 {
+		t.Fatalf("history does not contain four original turns and one retry: %d", len(history.Items))
+	}
+
+	requiredEvents := []string{
+		"practice_session.started",
+		"answer.processing_failed",
+		"turn.completed",
+		"turn_analysis.completed",
+		"practice_session.completed",
+	}
+	eventTypes := events.awaitAndStop(t, requiredEvents)
+	for _, required := range requiredEvents {
+		if !contains(eventTypes, required) {
+			t.Fatalf("event stream does not contain %q: %#v", required, eventTypes)
+		}
+	}
+	var bootstrap struct {
+		LastEventSequence int `json:"last_event_sequence"`
+	}
+	client.expect(t, http.MethodGet, "/v1/practice-sessions/"+demoPracticeSession+"/bootstrap", nil, nil, http.StatusOK, &bootstrap)
+	replayed := readOneEvent(t, fmt.Sprintf(
+		"%s/v1/practice-sessions/%s/events?after_sequence=%d",
+		WebSocketURL(httpServer.URL),
+		demoPracticeSession,
+		bootstrap.LastEventSequence-1,
+	))
+	if !replayed.Replayable || replayed.Sequence != bootstrap.LastEventSequence {
+		t.Fatalf("event cursor replay is inconsistent: %#v", replayed)
+	}
+
+	return flowSummary{
+		SessionID:          sessionBootstrap.Session["practice_session_id"].(string),
+		EffectiveTurns:     len(answers),
+		RetryTurnID:        retryResponse.NewTurnID,
+		HistoryCount:       len(history.Items),
+		EventTypes:         eventTypes,
+		RecoverableFailure: recoverableFailure,
+	}
+}
+
+func (c flowClient) expect(t *testing.T, method, path string, body any, headers map[string]string, status int, target any) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+	request, err := http.NewRequest(method, c.baseURL+path, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	response, err := c.client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != status {
+		t.Fatalf("%s %s returned %d, want %d: %s", method, path, response.StatusCode, status, payload)
+	}
+	if target != nil {
+		if err := json.Unmarshal(payload, target); err != nil {
+			t.Fatalf("decode %s %s: %v\n%s", method, path, err, payload)
+		}
+	}
+}
+
+type eventCollector struct {
+	connection *websocket.Conn
+	types      chan string
+	done       chan struct{}
+}
+
+func startEventCollector(t *testing.T, url string) *eventCollector {
+	t.Helper()
+	connection, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	collector := &eventCollector{
+		connection: connection,
+		types:      make(chan string, 64),
+		done:       make(chan struct{}),
+	}
+	go func() {
+		defer close(collector.done)
+		defer close(collector.types)
+		for {
+			var event Event
+			if err := connection.ReadJSON(&event); err != nil {
+				return
+			}
+			collector.types <- event.Type
+		}
+	}()
+	return collector
+}
+
+func readOneEvent(t *testing.T, url string) Event {
+	t.Helper()
+	connection, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+	_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var event Event
+	if err := connection.ReadJSON(&event); err != nil {
+		t.Fatalf("read replayed event: %v", err)
+	}
+	return event
+}
+
+func (c *eventCollector) awaitAndStop(t *testing.T, required []string) []string {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	var eventTypes []string
+	for {
+		complete := true
+		for _, requiredType := range required {
+			if !contains(eventTypes, requiredType) {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			break
+		}
+		select {
+		case eventType := <-c.types:
+			eventTypes = append(eventTypes, eventType)
+		case <-timer.C:
+			t.Fatalf("timed out waiting for events; received %#v", eventTypes)
+		}
+	}
+	_ = c.connection.Close()
+	<-c.done
+	for eventType := range c.types {
+		eventTypes = append(eventTypes, eventType)
+	}
+	return eventTypes
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/smoke/provider.go
+++ b/server/internal/smoke/provider.go
@@ -1,0 +1,112 @@
+package smoke
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+)
+
+// MockProvider is the explicit external-capability boundary exercised by the
+// offline smoke flow. A production adapter can replace question generation and
+// review without taking ownership of Session, Turn, retry, or history state.
+type MockProvider interface {
+	conversation.QuestionProvider
+	review.Provider
+	FailureController
+	FailureGate
+}
+
+// FailureController is a smoke-transport test hook. It intentionally remains
+// outside the formal Conversation service contract.
+type FailureController interface {
+	ArmFailure(questionID string, answerText string)
+}
+
+type FailureGate interface {
+	CheckFailure(questionID string, answerText string) error
+}
+
+type FailureControl interface {
+	FailureController
+	FailureGate
+}
+
+// DeterministicProvider is an offline, clock-free implementation. All
+// timestamps and resource identities are supplied by the application runtime,
+// so equal inputs produce equal outputs.
+type DeterministicProvider struct {
+	mu            sync.Mutex
+	armedIntents  map[string]struct{}
+	failedIntents map[string]struct{}
+}
+
+func NewDeterministicProvider() *DeterministicProvider {
+	return &DeterministicProvider{
+		armedIntents:  make(map[string]struct{}),
+		failedIntents: make(map[string]struct{}),
+	}
+}
+
+func (p *DeterministicProvider) ArmFailure(questionID string, answerText string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.armedIntents[questionID+"\x00"+strings.TrimSpace(answerText)] = struct{}{}
+}
+
+func (p *DeterministicProvider) CheckFailure(questionID string, answerText string) error {
+	intent := questionID + "\x00" + strings.TrimSpace(answerText)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, armed := p.armedIntents[intent]
+	_, failed := p.failedIntents[intent]
+	if armed && !failed {
+		p.failedIntents[intent] = struct{}{}
+		return ErrRecoverableFailure
+	}
+	return nil
+}
+
+func (p *DeterministicProvider) BuildQuestion(
+	sequence int,
+) (conversation.QuestionDraft, error) {
+	objectives := []string{"introduction", "system_design", "project_depth", "collaboration"}
+	contents := []string{
+		"Please introduce yourself and the backend project you are most proud of.",
+		"How did you design the reliability controls for that API?",
+		"Which design decision was yours, and what trade-off did you make?",
+		"How did you align the rollout with the teams that consumed the API?",
+	}
+	if sequence < 1 || sequence > len(contents) {
+		return conversation.QuestionDraft{},
+			fmt.Errorf("question sequence %d is outside the deterministic scenario", sequence)
+	}
+	questionType := "PRIMARY"
+	parentID := ""
+	if sequence == 3 {
+		questionType = "FOLLOW_UP"
+		parentID = "question_demo_002"
+	}
+	return conversation.QuestionDraft{
+		ObjectiveID:      objectives[sequence-1],
+		Type:             questionType,
+		ParentQuestionID: parentID,
+		Content:          contents[sequence-1],
+	}, nil
+}
+
+func (p *DeterministicProvider) Evaluate(
+	turn review.TurnInput,
+) (review.Evaluation, error) {
+	return review.Evaluation{
+		Score:      80 + turn.EffectiveSequence,
+		Summary:    "Deterministic review completed for the submitted answer.",
+		Transcript: turn.AnswerText,
+		Category:   "STRUCTURE",
+		Message:    "The answer is clear and grounded in an example.",
+		Suggestion: "State the trade-off and measurable outcome explicitly.",
+		Evidence:   []map[string]any{{"transcript_text": turn.AnswerText}},
+	}, nil
+}

--- a/server/internal/smoke/runtime.go
+++ b/server/internal/smoke/runtime.go
@@ -1,0 +1,806 @@
+package smoke
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DemoUserID              = "user_demo"
+	DemoScenarioDefinition  = "scenario_programmer_interview"
+	DemoRoleDefinition      = "role_technical_interviewer"
+	DemoPracticeOption      = "option_full_interview"
+	demoInterviewerID       = "participant_interviewer_001"
+	demoCandidateID         = "participant_candidate_001"
+	demoPreparationProfile  = "profile_demo_001"
+	demoPreparationSnapshot = "preparation_snapshot_demo_001"
+	demoPracticePlan        = "plan_demo_001"
+	demoPracticeSession     = "session_demo_001"
+)
+
+var (
+	ErrInvalidAnswer       = errors.New("answer_text must not be empty")
+	ErrRecoverableFailure  = errors.New("deterministic provider temporarily unavailable")
+	ErrSessionCompleted    = errors.New("practice session is already completed")
+	ErrQuestionNotFound    = errors.New("question not found")
+	ErrTurnNotFound        = errors.New("turn not found")
+	ErrFeedbackNotFound    = errors.New("feedback item not found")
+	ErrIdempotencyConflict = errors.New("idempotency key was reused with a different request")
+)
+
+type Question struct {
+	ID               string   `json:"question_id"`
+	SessionID        string   `json:"practice_session_id"`
+	SpeakerID        string   `json:"speaker_participant_id"`
+	AddresseeIDs     []string `json:"addressee_participant_ids"`
+	ObjectiveID      string   `json:"objective_id"`
+	Type             string   `json:"question_type"`
+	ParentQuestionID string   `json:"parent_question_id,omitempty"`
+	Content          string   `json:"content"`
+	Sequence         int      `json:"sequence"`
+	CreatedAt        string   `json:"created_at"`
+}
+
+type Turn struct {
+	ID              string `json:"turn_id"`
+	SessionID       string `json:"practice_session_id"`
+	QuestionID      string `json:"question_id"`
+	RespondentID    string `json:"respondent_participant_id"`
+	Sequence        int    `json:"sequence"`
+	InteractionMode string `json:"interaction_mode"`
+	AnswerText      string `json:"answer_text,omitempty"`
+	Status          string `json:"turn_status"`
+	IsRetry         bool   `json:"-"`
+	SubmittedAt     string `json:"submitted_at,omitempty"`
+	CreatedAt       string `json:"created_at"`
+	CompletedAt     string `json:"completed_at,omitempty"`
+}
+
+type Analysis struct {
+	ID                 string `json:"turn_analysis_id"`
+	TurnID             string `json:"turn_id"`
+	EvaluatorVersion   string `json:"evaluator_version"`
+	Status             string `json:"analysis_status"`
+	Score              int    `json:"score"`
+	Summary            string `json:"summary"`
+	AnalysisTranscript string `json:"analysis_transcript"`
+	CreatedAt          string `json:"created_at"`
+	CompletedAt        string `json:"completed_at"`
+}
+
+type Feedback struct {
+	ID         string           `json:"feedback_item_id"`
+	AnalysisID string           `json:"turn_analysis_id"`
+	Category   string           `json:"feedback_category"`
+	Message    string           `json:"message"`
+	Suggestion string           `json:"suggestion"`
+	Evidence   []map[string]any `json:"evidence"`
+	Retryable  bool             `json:"retryable"`
+	CreatedAt  string           `json:"created_at"`
+}
+
+type RetryRequest struct {
+	ID             string `json:"retry_request_id"`
+	OriginalTurnID string `json:"original_turn_id"`
+	FeedbackID     string `json:"feedback_item_id"`
+	NewTurnID      string `json:"new_turn_id"`
+	Status         string `json:"retry_status"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+type HistoryRecord struct {
+	ID             string `json:"history_record_id"`
+	SessionID      string `json:"practice_session_id"`
+	TurnID         string `json:"turn_id"`
+	AnalysisID     string `json:"turn_analysis_id"`
+	RetryRequestID string `json:"retry_request_id,omitempty"`
+	Score          int    `json:"score"`
+	Summary        string `json:"summary"`
+	ReviewedAt     string `json:"reviewed_at"`
+}
+
+type Event struct {
+	ID            string         `json:"event_id"`
+	Type          string         `json:"event_type"`
+	Version       int            `json:"event_version"`
+	OccurredAt    string         `json:"occurred_at"`
+	SessionID     string         `json:"practice_session_id"`
+	Sequence      int            `json:"sequence,omitempty"`
+	CorrelationID string         `json:"correlation_id"`
+	CausationID   string         `json:"causation_id,omitempty"`
+	Replayable    bool           `json:"replayable"`
+	Payload       map[string]any `json:"payload"`
+}
+
+type submitResult struct {
+	Turn     Turn     `json:"turn"`
+	Analysis Analysis `json:"turn_analysis"`
+	Feedback Feedback `json:"feedback_item"`
+}
+
+type idempotentTurn struct {
+	answer string
+	result submitResult
+}
+
+type Runtime struct {
+	mu sync.Mutex
+
+	now time.Time
+
+	profileCreated  bool
+	snapshotCreated bool
+	planCreated     bool
+	sessionCreated  bool
+	sessionStatus   string
+
+	questions []Question
+	turns     []Turn
+	analyses  []Analysis
+	feedback  []Feedback
+	retries   []RetryRequest
+	history   []HistoryRecord
+	events    []Event
+
+	failedOnce  map[string]bool
+	submitted   map[string]idempotentTurn
+	retryByKey  map[string]RetryRequest
+	subscribers map[chan Event]struct{}
+}
+
+func NewRuntime() *Runtime {
+	return &Runtime{
+		now:           time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC),
+		failedOnce:    make(map[string]bool),
+		submitted:     make(map[string]idempotentTurn),
+		retryByKey:    make(map[string]RetryRequest),
+		subscribers:   make(map[chan Event]struct{}),
+		sessionStatus: "not_started",
+	}
+}
+
+func (r *Runtime) timestamp(offset int) string {
+	return r.now.Add(time.Duration(offset) * time.Second).Format(time.RFC3339)
+}
+
+func (r *Runtime) createProfile() map[string]any {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.profileCreated = true
+	return map[string]any{
+		"preparation_profile_id": demoPreparationProfile,
+		"user_id":                DemoUserID,
+		"resume_ref":             "resume_demo_backend_v1",
+		"job_description_ref":    "jd_demo_backend_v1",
+		"background_summary":     "Backend engineer preparing for an English technical interview.",
+		"version":                1,
+		"updated_at":             r.timestamp(1),
+	}
+}
+
+func (r *Runtime) createSnapshot() (map[string]any, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.profileCreated {
+		return nil, errors.New("preparation profile must be created first")
+	}
+	r.snapshotCreated = true
+	return map[string]any{
+		"preparation_snapshot_id":  demoPreparationSnapshot,
+		"source_profile_id":        demoPreparationProfile,
+		"source_version":           1,
+		"resume_snapshot":          "Go backend engineer; API reliability project.",
+		"job_description_snapshot": "Build reliable APIs and explain engineering trade-offs.",
+		"background_snapshot":      "Backend engineer preparing for an English technical interview.",
+		"created_at":               r.timestamp(2),
+	}, nil
+}
+
+func (r *Runtime) createPlan() (map[string]any, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.snapshotCreated {
+		return nil, errors.New("preparation snapshot must be created first")
+	}
+	r.planCreated = true
+	return map[string]any{
+		"practice_plan_id":            demoPracticePlan,
+		"user_id":                     DemoUserID,
+		"scenario_definition_id":      DemoScenarioDefinition,
+		"scenario_definition_version": 1,
+		"scenario_type":               "INTERVIEW",
+		"scenario_config_id":          "scenario_config_backend",
+		"scenario_config_version":     1,
+		"preparation_profile_id":      demoPreparationProfile,
+		"selected_role_ids":           []string{DemoRoleDefinition},
+		"plan_revision":               1,
+		"practice_plan_status":        "ready",
+		"created_at":                  r.timestamp(3),
+		"updated_at":                  r.timestamp(3),
+	}, nil
+}
+
+func (r *Runtime) createSession() (map[string]any, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.planCreated {
+		return nil, errors.New("practice plan must be created first")
+	}
+	r.sessionCreated = true
+	r.sessionStatus = "starting"
+	return map[string]any{
+		"practice_session": r.sessionLocked(),
+		"snapshot":         r.snapshotLocked(),
+	}, nil
+}
+
+func (r *Runtime) sessionLocked() map[string]any {
+	session := map[string]any{
+		"practice_session_id":     demoPracticeSession,
+		"practice_plan_id":        demoPracticePlan,
+		"scenario_type":           "INTERVIEW",
+		"snapshot_id":             "snapshot_session_demo_001",
+		"practice_session_status": r.sessionStatus,
+		"session_version":         1,
+		"created_at":              r.timestamp(4),
+	}
+	if r.sessionStatus != "starting" {
+		session["started_at"] = r.timestamp(5)
+		session["session_version"] = 2
+	}
+	if r.sessionStatus == "completed" {
+		session["session_version"] = 6
+		session["ended_at"] = r.timestamp(80)
+		session["end_reason"] = "COVERAGE_SATISFIED_AT_CHECKPOINT"
+	}
+	return session
+}
+
+func (r *Runtime) bootstrap() (map[string]any, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.sessionCreated {
+		return nil, errors.New("practice session must be created first")
+	}
+	result := map[string]any{
+		"practice_session":    r.sessionLocked(),
+		"snapshot":            r.snapshotLocked(),
+		"last_event_sequence": r.lastEventSequenceLocked(),
+	}
+	if len(r.questions) > 0 {
+		result["current_question"] = r.questions[len(r.questions)-1]
+	}
+	return result, nil
+}
+
+func (r *Runtime) ensureCurrentQuestion() (Question, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.sessionCreated {
+		return Question{}, errors.New("practice session must be created first")
+	}
+	if len(r.questions) == 0 {
+		r.sessionStatus = "in_progress"
+		r.appendEventLocked("practice_session.started", map[string]any{
+			"practice_session_status": r.sessionStatus,
+			"session_version":         2,
+		})
+		r.questions = append(r.questions, r.newQuestionLocked(1))
+	}
+	return r.questions[len(r.questions)-1], nil
+}
+
+func (r *Runtime) currentQuestion() (Question, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.questions) == 0 {
+		return Question{}, ErrQuestionNotFound
+	}
+	return r.questions[len(r.questions)-1], nil
+}
+
+func (r *Runtime) submitTurn(questionID, answer, retryRequestID, key string, failOnce bool) (submitResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return submitResult{}, ErrInvalidAnswer
+	}
+	if existing, ok := r.submitted[key]; ok {
+		if existing.answer != answer {
+			return submitResult{}, ErrIdempotencyConflict
+		}
+		return existing.result, nil
+	}
+	if failOnce && !r.failedOnce[key] {
+		r.failedOnce[key] = true
+		r.appendEventLocked("answer.processing_failed", map[string]any{
+			"question_id": questionID,
+			"code":        "mock_provider_temporarily_unavailable",
+			"message":     "The deterministic provider failed once; retry the same answer.",
+			"retryable":   true,
+		})
+		return submitResult{}, ErrRecoverableFailure
+	}
+	isRetry := retryRequestID != ""
+	if r.sessionStatus == "completed" && !isRetry {
+		return submitResult{}, ErrSessionCompleted
+	}
+	question, ok := r.findQuestionLocked(questionID)
+	if !ok {
+		return submitResult{}, ErrQuestionNotFound
+	}
+
+	turnNumber := len(r.turns) + 1
+	effectiveSequence := r.effectiveTurnCountLocked() + 1
+	turn := Turn{}
+	if isRetry {
+		retry, ok := r.findRetryLocked(retryRequestID)
+		if !ok {
+			return submitResult{}, errors.New("retry request not found")
+		}
+		retryTurn, ok := r.findTurnLocked(retry.NewTurnID)
+		if !ok || retryTurn.QuestionID != questionID {
+			return submitResult{}, errors.New("retry turn does not match question")
+		}
+		turn = retryTurn
+		turn.AnswerText = answer
+		turn.InteractionMode = "PUSH_TO_TALK"
+		turn.Status = "completed"
+		turn.SubmittedAt = r.timestamp(20 + turnNumber*3)
+		turn.CompletedAt = r.timestamp(21 + turnNumber*3)
+		r.replaceTurnLocked(turn)
+	} else {
+		turn = Turn{
+			ID:              fmt.Sprintf("turn_demo_%03d", turnNumber),
+			SessionID:       demoPracticeSession,
+			QuestionID:      question.ID,
+			RespondentID:    demoCandidateID,
+			Sequence:        question.Sequence,
+			InteractionMode: "PUSH_TO_TALK",
+			AnswerText:      answer,
+			Status:          "completed",
+			IsRetry:         false,
+			SubmittedAt:     r.timestamp(20 + turnNumber*3),
+			CreatedAt:       r.timestamp(20 + turnNumber*3),
+			CompletedAt:     r.timestamp(21 + turnNumber*3),
+		}
+		r.turns = append(r.turns, turn)
+	}
+	r.appendEventLocked("turn.submitted", map[string]any{
+		"turn_id": turn.ID, "question_id": question.ID, "turn_status": "submitted",
+	})
+	r.appendEventLocked("turn.processing", map[string]any{
+		"turn_id": turn.ID, "question_id": question.ID, "turn_status": "processing",
+	})
+	r.appendEventLocked("turn.completed", map[string]any{
+		"turn_id":                   turn.ID,
+		"question_id":               question.ID,
+		"respondent_participant_id": turn.RespondentID,
+		"turn_status":               "completed",
+		"completed_at":              turn.CompletedAt,
+	})
+
+	analysisNumber := len(r.analyses) + 1
+	analysis := Analysis{
+		ID:                 fmt.Sprintf("analysis_demo_%03d", analysisNumber),
+		TurnID:             turn.ID,
+		EvaluatorVersion:   "mock-review-v1",
+		Status:             "completed",
+		Score:              80 + effectiveSequence,
+		Summary:            "Deterministic review completed for the submitted answer.",
+		AnalysisTranscript: answer,
+		CreatedAt:          r.timestamp(22 + turnNumber*3),
+		CompletedAt:        r.timestamp(23 + turnNumber*3),
+	}
+	feedback := Feedback{
+		ID:         fmt.Sprintf("feedback_demo_%03d", analysisNumber),
+		AnalysisID: analysis.ID,
+		Category:   "STRUCTURE",
+		Message:    "The answer is clear and grounded in an example.",
+		Suggestion: "State the trade-off and measurable outcome explicitly.",
+		Evidence:   []map[string]any{{"transcript_text": answer}},
+		Retryable:  true,
+		CreatedAt:  analysis.CompletedAt,
+	}
+	r.analyses = append(r.analyses, analysis)
+	r.feedback = append(r.feedback, feedback)
+	r.history = append(r.history, HistoryRecord{
+		ID:         fmt.Sprintf("history_demo_%03d", analysisNumber),
+		SessionID:  demoPracticeSession,
+		TurnID:     turn.ID,
+		AnalysisID: analysis.ID,
+		Score:      analysis.Score,
+		Summary:    analysis.Summary,
+		ReviewedAt: analysis.CompletedAt,
+	})
+	r.appendEventLocked("turn_analysis.completed", map[string]any{
+		"turn_id": turn.ID, "turn_analysis_id": analysis.ID,
+		"score": analysis.Score, "summary": analysis.Summary,
+	})
+
+	if !isRetry {
+		if r.effectiveTurnCountLocked() == 4 {
+			r.sessionStatus = "completed"
+			r.appendEventLocked("practice_session.completed", map[string]any{
+				"practice_session_status": "completed",
+				"session_version":         6,
+				"end_reason":              "COVERAGE_SATISFIED_AT_CHECKPOINT",
+			})
+		} else {
+			next := r.newQuestionLocked(len(r.questions) + 1)
+			r.questions = append(r.questions, next)
+		}
+	}
+
+	result := submitResult{Turn: turn, Analysis: analysis, Feedback: feedback}
+	r.submitted[key] = idempotentTurn{answer: answer, result: result}
+	return result, nil
+}
+
+func (r *Runtime) createRetry(feedbackID, key string) (RetryRequest, Turn, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if retry, ok := r.retryByKey[key]; ok {
+		turn, _ := r.findTurnLocked(retry.NewTurnID)
+		return retry, turn, nil
+	}
+	feedback, ok := r.findFeedbackLocked(feedbackID)
+	if !ok {
+		return RetryRequest{}, Turn{}, ErrFeedbackNotFound
+	}
+	var original Turn
+	for _, analysis := range r.analyses {
+		if analysis.ID == feedback.AnalysisID {
+			original, ok = r.findTurnLocked(analysis.TurnID)
+			break
+		}
+	}
+	if !ok {
+		return RetryRequest{}, Turn{}, ErrTurnNotFound
+	}
+	retryNumber := len(r.retries) + 1
+	retryID := fmt.Sprintf("retry_demo_%03d", retryNumber)
+	retryTurn := Turn{
+		ID:              fmt.Sprintf("turn_retry_demo_%03d", retryNumber),
+		SessionID:       original.SessionID,
+		QuestionID:      original.QuestionID,
+		RespondentID:    original.RespondentID,
+		Sequence:        original.Sequence,
+		InteractionMode: "PUSH_TO_TALK",
+		Status:          "answering",
+		IsRetry:         true,
+		CreatedAt:       r.timestamp(60 + retryNumber),
+	}
+	r.turns = append(r.turns, retryTurn)
+	retry := RetryRequest{
+		ID:             retryID,
+		OriginalTurnID: original.ID,
+		FeedbackID:     feedback.ID,
+		NewTurnID:      retryTurn.ID,
+		Status:         "turn_created",
+		CreatedAt:      r.timestamp(59 + retryNumber),
+		UpdatedAt:      retryTurn.CreatedAt,
+	}
+	r.retries = append(r.retries, retry)
+	r.retryByKey[key] = retry
+	for index := range r.history {
+		if r.history[index].TurnID == original.ID {
+			r.history[index].RetryRequestID = retry.ID
+		}
+	}
+	return retry, retryTurn, nil
+}
+
+func (r *Runtime) historyRecords() []HistoryRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result := make([]HistoryRecord, len(r.history))
+	for index := range r.history {
+		result[len(r.history)-1-index] = r.history[index]
+	}
+	return result
+}
+
+func (r *Runtime) eventsSnapshot() []Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Event(nil), r.events...)
+}
+
+func (r *Runtime) effectiveTurnCountLocked() int {
+	count := 0
+	for _, turn := range r.turns {
+		if turn.Status == "completed" && !turn.IsRetry {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *Runtime) lastEventSequenceLocked() int {
+	last := 0
+	for _, event := range r.events {
+		if event.Sequence > last {
+			last = event.Sequence
+		}
+	}
+	return last
+}
+
+func (r *Runtime) snapshotLocked() map[string]any {
+	objectives := []map[string]any{
+		{"objective_id": "introduction", "description": "Explain current experience clearly."},
+		{"objective_id": "system_design", "description": "Explain a technical design and its trade-offs."},
+		{"objective_id": "project_depth", "description": "Provide evidence of individual contribution."},
+		{"objective_id": "collaboration", "description": "Explain cross-team communication and outcomes."},
+	}
+	return map[string]any{
+		"snapshot_id":         "snapshot_session_demo_001",
+		"practice_session_id": demoPracticeSession,
+		"plan_revision":       1,
+		"scenario_type":       "INTERVIEW",
+		"scenario_definition_snapshot": map[string]any{
+			"scenario_definition_id": DemoScenarioDefinition,
+			"scenario_type":          "INTERVIEW",
+			"name":                   "Programmer English Interview",
+			"version":                1,
+			"status":                 "active",
+		},
+		"scenario_config_snapshot": map[string]any{
+			"scenario_config_id":     "scenario_config_backend",
+			"scenario_definition_id": DemoScenarioDefinition,
+			"config_type":            "INTERVIEW",
+			"version":                1,
+			"job_title":              "Backend Engineer",
+			"job_description":        "Build reliable APIs and explain engineering trade-offs.",
+			"focus_areas":            []string{"reliability", "ownership", "collaboration"},
+		},
+		"preparation_snapshot": map[string]any{
+			"preparation_snapshot_id":  demoPreparationSnapshot,
+			"source_profile_id":        demoPreparationProfile,
+			"source_version":           1,
+			"resume_snapshot":          "Go backend engineer; API reliability project.",
+			"job_description_snapshot": "Build reliable APIs and explain engineering trade-offs.",
+			"background_snapshot":      "Backend engineer preparing for an English technical interview.",
+			"created_at":               r.timestamp(2),
+		},
+		"participants": []map[string]any{
+			{
+				"practice_participant_id": demoInterviewerID,
+				"practice_session_id":     demoPracticeSession,
+				"participant_role":        "INTERVIEWER",
+				"subject_ref":             map[string]any{"namespace": "mock.actor", "subject_id": "interviewer_technical"},
+				"role_definition_id":      DemoRoleDefinition,
+				"role_snapshot":           roleDefinition(),
+				"participant_order":       1,
+			},
+			{
+				"practice_participant_id": demoCandidateID,
+				"practice_session_id":     demoPracticeSession,
+				"participant_role":        "CANDIDATE",
+				"subject_ref":             map[string]any{"namespace": "speakup.user", "subject_id": DemoUserID},
+				"participant_order":       2,
+			},
+		},
+		"practice_option": practiceOption(),
+		"session_policy": map[string]any{
+			"suggested_duration_seconds":  900,
+			"min_effective_turns":         4,
+			"max_effective_turns":         6,
+			"coverage_checkpoint_turn":    4,
+			"max_follow_ups_per_question": 1,
+			"target_objectives":           objectives,
+			"early_completion_rule":       "COVERAGE_SATISFIED_AFTER_CHECKPOINT",
+		},
+		"practice_focuses": objectives,
+		"created_at":       r.timestamp(4),
+	}
+}
+
+func roleDefinition() map[string]any {
+	return map[string]any{
+		"role_definition_id":     DemoRoleDefinition,
+		"scenario_definition_id": DemoScenarioDefinition,
+		"role_type":              "INTERVIEWER",
+		"display_name":           "Technical Interviewer",
+		"responsibilities":       "Ask focused questions and evaluate trade-offs.",
+		"style":                  "direct and constructive",
+		"focus_areas":            []string{"reliability", "ownership", "collaboration"},
+		"version":                1,
+	}
+}
+
+func practiceOption() map[string]any {
+	return map[string]any{
+		"practice_option_id":     DemoPracticeOption,
+		"scenario_definition_id": DemoScenarioDefinition,
+		"role_definition_id":     DemoRoleDefinition,
+		"practice_option_type":   "FULL_SIMULATION",
+		"display_name":           "Full interview simulation",
+		"version":                1,
+	}
+}
+
+func (r *Runtime) newQuestionLocked(sequence int) Question {
+	objectives := []string{"introduction", "system_design", "project_depth", "collaboration"}
+	contents := []string{
+		"Please introduce yourself and the backend project you are most proud of.",
+		"How did you design the reliability controls for that API?",
+		"Which design decision was yours, and what trade-off did you make?",
+		"How did you align the rollout with the teams that consumed the API?",
+	}
+	questionType := "PRIMARY"
+	parentID := ""
+	if sequence == 3 {
+		questionType = "FOLLOW_UP"
+		parentID = "question_demo_002"
+	}
+	question := Question{
+		ID:               fmt.Sprintf("question_demo_%03d", sequence),
+		SessionID:        demoPracticeSession,
+		SpeakerID:        demoInterviewerID,
+		AddresseeIDs:     []string{demoCandidateID},
+		ObjectiveID:      objectives[sequence-1],
+		Type:             questionType,
+		ParentQuestionID: parentID,
+		Content:          contents[sequence-1],
+		Sequence:         sequence,
+		CreatedAt:        r.timestamp(10 + sequence*4),
+	}
+	payload := map[string]any{
+		"question_id":               question.ID,
+		"speaker_participant_id":    question.SpeakerID,
+		"addressee_participant_ids": question.AddresseeIDs,
+		"objective_id":              question.ObjectiveID,
+		"question_type":             question.Type,
+		"content":                   question.Content,
+		"sequence":                  question.Sequence,
+	}
+	if question.ParentQuestionID != "" {
+		payload["parent_question_id"] = question.ParentQuestionID
+	}
+	r.appendEventLocked("question.created", payload)
+	return question
+}
+
+func (r *Runtime) appendEventLocked(eventType string, payload map[string]any) {
+	eventNumber := len(r.events) + 1
+	replayable := eventType != "answer.processing_failed"
+	sequence := 0
+	if replayable {
+		for _, event := range r.events {
+			if event.Replayable {
+				sequence++
+			}
+		}
+		sequence++
+	}
+	r.events = append(r.events, Event{
+		ID:            fmt.Sprintf("event_demo_%03d", eventNumber),
+		Type:          eventType,
+		Version:       1,
+		OccurredAt:    r.timestamp(100 + eventNumber),
+		SessionID:     demoPracticeSession,
+		Sequence:      sequence,
+		CorrelationID: fmt.Sprintf("correlation_demo_%03d", eventNumber),
+		Replayable:    replayable,
+		Payload:       payload,
+	})
+	event := r.events[len(r.events)-1]
+	for subscriber := range r.subscribers {
+		select {
+		case subscriber <- event:
+		default:
+		}
+	}
+}
+
+func (r *Runtime) subscribe(afterSequence int) ([]Event, <-chan Event, func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	replay := make([]Event, 0)
+	for _, event := range r.events {
+		if event.Replayable && event.Sequence > afterSequence {
+			replay = append(replay, event)
+		}
+	}
+	channel := make(chan Event, 64)
+	r.subscribers[channel] = struct{}{}
+	unsubscribe := func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if _, ok := r.subscribers[channel]; ok {
+			delete(r.subscribers, channel)
+			close(channel)
+		}
+	}
+	return replay, channel, unsubscribe
+}
+
+func (r *Runtime) findQuestionLocked(id string) (Question, bool) {
+	for _, question := range r.questions {
+		if question.ID == id {
+			return question, true
+		}
+	}
+	return Question{}, false
+}
+
+func (r *Runtime) findTurnLocked(id string) (Turn, bool) {
+	for _, turn := range r.turns {
+		if turn.ID == id {
+			return turn, true
+		}
+	}
+	return Turn{}, false
+}
+
+func (r *Runtime) replaceTurnLocked(updated Turn) {
+	for index := range r.turns {
+		if r.turns[index].ID == updated.ID {
+			r.turns[index] = updated
+			return
+		}
+	}
+}
+
+func (r *Runtime) findRetryLocked(id string) (RetryRequest, bool) {
+	for _, retry := range r.retries {
+		if retry.ID == id {
+			return retry, true
+		}
+	}
+	return RetryRequest{}, false
+}
+
+func (r *Runtime) getTurn(id string) (Turn, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.findTurnLocked(id)
+}
+
+func (r *Runtime) analysesForTurn(turnID string) []Analysis {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result := make([]Analysis, 0)
+	for _, analysis := range r.analyses {
+		if analysis.TurnID == turnID {
+			result = append(result, analysis)
+		}
+	}
+	return result
+}
+
+func (r *Runtime) feedbackForAnalysis(analysisID string) []Feedback {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result := make([]Feedback, 0)
+	for _, feedback := range r.feedback {
+		if feedback.AnalysisID == analysisID {
+			result = append(result, feedback)
+		}
+	}
+	return result
+}
+
+func (r *Runtime) getRetry(id string) (RetryRequest, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.findRetryLocked(id)
+}
+
+func (r *Runtime) findFeedbackLocked(id string) (Feedback, bool) {
+	for _, feedback := range r.feedback {
+		if feedback.ID == id {
+			return feedback, true
+		}
+	}
+	return Feedback{}, false
+}

--- a/server/internal/smoke/runtime.go
+++ b/server/internal/smoke/runtime.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
 )
 
 const (
@@ -22,110 +26,32 @@ const (
 )
 
 var (
-	ErrInvalidAnswer       = errors.New("answer_text must not be empty")
-	ErrRecoverableFailure  = errors.New("deterministic provider temporarily unavailable")
-	ErrSessionCompleted    = errors.New("practice session is already completed")
-	ErrQuestionNotFound    = errors.New("question not found")
-	ErrTurnNotFound        = errors.New("turn not found")
-	ErrFeedbackNotFound    = errors.New("feedback item not found")
-	ErrIdempotencyConflict = errors.New("idempotency key was reused with a different request")
+	ErrInvalidAnswer      = errors.New("answer_text must not be empty")
+	ErrRecoverableFailure = errors.New("deterministic provider temporarily unavailable")
+	ErrScenarioNotFound   = errors.New("scenario definition not found")
+	ErrProfileNotFound    = errors.New("preparation profile not found")
+	ErrSnapshotNotFound   = errors.New("preparation snapshot not found")
+	ErrPlanNotFound       = errors.New("practice plan not found")
+	ErrSessionNotFound    = errors.New("practice session not found")
+	ErrSessionCompleted   = errors.New("practice session is already completed")
+	ErrQuestionNotFound   = errors.New("question not found")
+	ErrTurnNotFound       = errors.New("turn not found")
+	ErrAnalysisNotFound   = errors.New("turn analysis not found")
+	ErrFeedbackNotFound   = errors.New("feedback item not found")
+	ErrRetryNotFound      = errors.New("retry request not found")
+	ErrRetryConflict      = errors.New("retry request already exists for feedback item")
+	ErrVersionConflict    = errors.New("resource version does not match")
+	ErrInvalidSelection   = errors.New("request does not match the deterministic scenario")
+	ErrResourceConflict   = errors.New("resource already exists")
 )
 
-type Question struct {
-	ID               string   `json:"question_id"`
-	SessionID        string   `json:"practice_session_id"`
-	SpeakerID        string   `json:"speaker_participant_id"`
-	AddresseeIDs     []string `json:"addressee_participant_ids"`
-	ObjectiveID      string   `json:"objective_id"`
-	Type             string   `json:"question_type"`
-	ParentQuestionID string   `json:"parent_question_id,omitempty"`
-	Content          string   `json:"content"`
-	Sequence         int      `json:"sequence"`
-	CreatedAt        string   `json:"created_at"`
-}
-
-type Turn struct {
-	ID              string `json:"turn_id"`
-	SessionID       string `json:"practice_session_id"`
-	QuestionID      string `json:"question_id"`
-	RespondentID    string `json:"respondent_participant_id"`
-	Sequence        int    `json:"sequence"`
-	InteractionMode string `json:"interaction_mode"`
-	AnswerText      string `json:"answer_text,omitempty"`
-	Status          string `json:"turn_status"`
-	IsRetry         bool   `json:"-"`
-	SubmittedAt     string `json:"submitted_at,omitempty"`
-	CreatedAt       string `json:"created_at"`
-	CompletedAt     string `json:"completed_at,omitempty"`
-}
-
-type Analysis struct {
-	ID                 string `json:"turn_analysis_id"`
-	TurnID             string `json:"turn_id"`
-	EvaluatorVersion   string `json:"evaluator_version"`
-	Status             string `json:"analysis_status"`
-	Score              int    `json:"score"`
-	Summary            string `json:"summary"`
-	AnalysisTranscript string `json:"analysis_transcript"`
-	CreatedAt          string `json:"created_at"`
-	CompletedAt        string `json:"completed_at"`
-}
-
-type Feedback struct {
-	ID         string           `json:"feedback_item_id"`
-	AnalysisID string           `json:"turn_analysis_id"`
-	Category   string           `json:"feedback_category"`
-	Message    string           `json:"message"`
-	Suggestion string           `json:"suggestion"`
-	Evidence   []map[string]any `json:"evidence"`
-	Retryable  bool             `json:"retryable"`
-	CreatedAt  string           `json:"created_at"`
-}
-
-type RetryRequest struct {
-	ID             string `json:"retry_request_id"`
-	OriginalTurnID string `json:"original_turn_id"`
-	FeedbackID     string `json:"feedback_item_id"`
-	NewTurnID      string `json:"new_turn_id"`
-	Status         string `json:"retry_status"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-}
-
-type HistoryRecord struct {
-	ID             string `json:"history_record_id"`
-	SessionID      string `json:"practice_session_id"`
-	TurnID         string `json:"turn_id"`
-	AnalysisID     string `json:"turn_analysis_id"`
-	RetryRequestID string `json:"retry_request_id,omitempty"`
-	Score          int    `json:"score"`
-	Summary        string `json:"summary"`
-	ReviewedAt     string `json:"reviewed_at"`
-}
-
-type Event struct {
-	ID            string         `json:"event_id"`
-	Type          string         `json:"event_type"`
-	Version       int            `json:"event_version"`
-	OccurredAt    string         `json:"occurred_at"`
-	SessionID     string         `json:"practice_session_id"`
-	Sequence      int            `json:"sequence,omitempty"`
-	CorrelationID string         `json:"correlation_id"`
-	CausationID   string         `json:"causation_id,omitempty"`
-	Replayable    bool           `json:"replayable"`
-	Payload       map[string]any `json:"payload"`
-}
-
-type submitResult struct {
-	Turn     Turn     `json:"turn"`
-	Analysis Analysis `json:"turn_analysis"`
-	Feedback Feedback `json:"feedback_item"`
-}
-
-type idempotentTurn struct {
-	answer string
-	result submitResult
-}
+type Question = conversation.Question
+type Turn = conversation.Turn
+type Event = conversation.Event
+type Analysis = review.Analysis
+type Feedback = review.Feedback
+type RetryRequest = review.RetryRequest
+type HistoryRecord = review.HistoryRecord
 
 type Runtime struct {
 	mu sync.Mutex
@@ -137,6 +63,8 @@ type Runtime struct {
 	planCreated     bool
 	sessionCreated  bool
 	sessionStatus   string
+	sessionVersion  int
+	effectiveTurns  int
 
 	questions []Question
 	turns     []Turn
@@ -146,20 +74,20 @@ type Runtime struct {
 	history   []HistoryRecord
 	events    []Event
 
-	failedOnce  map[string]bool
-	submitted   map[string]idempotentTurn
-	retryByKey  map[string]RetryRequest
-	subscribers map[chan Event]struct{}
+	retryTurnByRequest     map[string]string
+	retryOriginalByRequest map[string]string
+	turnDecisions          map[string]practice.TurnDecision
+	subscribers            map[chan Event]struct{}
 }
 
 func NewRuntime() *Runtime {
 	return &Runtime{
-		now:           time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC),
-		failedOnce:    make(map[string]bool),
-		submitted:     make(map[string]idempotentTurn),
-		retryByKey:    make(map[string]RetryRequest),
-		subscribers:   make(map[chan Event]struct{}),
-		sessionStatus: "not_started",
+		now:                    time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC),
+		retryTurnByRequest:     make(map[string]string),
+		retryOriginalByRequest: make(map[string]string),
+		turnDecisions:          make(map[string]practice.TurnDecision),
+		subscribers:            make(map[chan Event]struct{}),
+		sessionStatus:          "not_started",
 	}
 }
 
@@ -186,7 +114,7 @@ func (r *Runtime) createSnapshot() (map[string]any, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.profileCreated {
-		return nil, errors.New("preparation profile must be created first")
+		return nil, ErrResourceConflict
 	}
 	r.snapshotCreated = true
 	return map[string]any{
@@ -203,9 +131,6 @@ func (r *Runtime) createSnapshot() (map[string]any, error) {
 func (r *Runtime) createPlan() (map[string]any, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if !r.snapshotCreated {
-		return nil, errors.New("preparation snapshot must be created first")
-	}
 	r.planCreated = true
 	return map[string]any{
 		"practice_plan_id":            demoPracticePlan,
@@ -228,10 +153,14 @@ func (r *Runtime) createSession() (map[string]any, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.planCreated {
-		return nil, errors.New("practice plan must be created first")
+		return nil, ErrResourceConflict
+	}
+	if r.sessionCreated {
+		return nil, ErrResourceConflict
 	}
 	r.sessionCreated = true
 	r.sessionStatus = "starting"
+	r.sessionVersion = 1
 	return map[string]any{
 		"practice_session": r.sessionLocked(),
 		"snapshot":         r.snapshotLocked(),
@@ -245,53 +174,29 @@ func (r *Runtime) sessionLocked() map[string]any {
 		"scenario_type":           "INTERVIEW",
 		"snapshot_id":             "snapshot_session_demo_001",
 		"practice_session_status": r.sessionStatus,
-		"session_version":         1,
+		"session_version":         r.sessionVersion,
 		"created_at":              r.timestamp(4),
 	}
 	if r.sessionStatus != "starting" {
 		session["started_at"] = r.timestamp(5)
-		session["session_version"] = 2
 	}
 	if r.sessionStatus == "completed" {
-		session["session_version"] = 6
 		session["ended_at"] = r.timestamp(80)
 		session["end_reason"] = "COVERAGE_SATISFIED_AT_CHECKPOINT"
 	}
 	return session
 }
 
-func (r *Runtime) bootstrap() (map[string]any, error) {
+func (r *Runtime) conversationBootstrap() map[string]any {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if !r.sessionCreated {
-		return nil, errors.New("practice session must be created first")
-	}
 	result := map[string]any{
-		"practice_session":    r.sessionLocked(),
-		"snapshot":            r.snapshotLocked(),
 		"last_event_sequence": r.lastEventSequenceLocked(),
 	}
 	if len(r.questions) > 0 {
 		result["current_question"] = r.questions[len(r.questions)-1]
 	}
-	return result, nil
-}
-
-func (r *Runtime) ensureCurrentQuestion() (Question, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if !r.sessionCreated {
-		return Question{}, errors.New("practice session must be created first")
-	}
-	if len(r.questions) == 0 {
-		r.sessionStatus = "in_progress"
-		r.appendEventLocked("practice_session.started", map[string]any{
-			"practice_session_status": r.sessionStatus,
-			"session_version":         2,
-		})
-		r.questions = append(r.questions, r.newQuestionLocked(1))
-	}
-	return r.questions[len(r.questions)-1], nil
+	return result
 }
 
 func (r *Runtime) currentQuestion() (Question, error) {
@@ -303,170 +208,203 @@ func (r *Runtime) currentQuestion() (Question, error) {
 	return r.questions[len(r.questions)-1], nil
 }
 
-func (r *Runtime) submitTurn(questionID, answer, retryRequestID, key string, failOnce bool) (submitResult, error) {
+func (r *Runtime) saveQuestion(
+	sessionID string,
+	sequence int,
+	draft conversation.QuestionDraft,
+) (Question, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if sessionID != demoPracticeSession {
+		return Question{}, ErrSessionNotFound
+	}
+	if sequence != len(r.questions)+1 {
+		return Question{}, ErrResourceConflict
+	}
+	question := Question{
+		ID:               fmt.Sprintf("question_demo_%03d", sequence),
+		SessionID:        demoPracticeSession,
+		SpeakerID:        demoInterviewerID,
+		AddresseeIDs:     []string{demoCandidateID},
+		ObjectiveID:      draft.ObjectiveID,
+		Type:             draft.Type,
+		ParentQuestionID: draft.ParentQuestionID,
+		Content:          draft.Content,
+		Sequence:         sequence,
+		CreatedAt:        r.timestamp(10 + sequence*12),
+	}
+	r.questions = append(r.questions, question)
+	payload := map[string]any{
+		"question_id":               question.ID,
+		"speaker_participant_id":    question.SpeakerID,
+		"addressee_participant_ids": question.AddresseeIDs,
+		"objective_id":              question.ObjectiveID,
+		"question_type":             question.Type,
+		"content":                   question.Content,
+		"sequence":                  question.Sequence,
+	}
+	if question.ParentQuestionID != "" {
+		payload["parent_question_id"] = question.ParentQuestionID
+	}
+	r.appendEventLocked("question.created", payload)
+	return question, nil
+}
+
+func (r *Runtime) prepareTurn(
+	questionID string,
+	request conversation.SubmitTurnRequest,
+) (Turn, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	answer = strings.TrimSpace(answer)
+	answer := strings.TrimSpace(request.AnswerText)
 	if answer == "" {
-		return submitResult{}, ErrInvalidAnswer
-	}
-	if existing, ok := r.submitted[key]; ok {
-		if existing.answer != answer {
-			return submitResult{}, ErrIdempotencyConflict
-		}
-		return existing.result, nil
-	}
-	if failOnce && !r.failedOnce[key] {
-		r.failedOnce[key] = true
-		r.appendEventLocked("answer.processing_failed", map[string]any{
-			"question_id": questionID,
-			"code":        "mock_provider_temporarily_unavailable",
-			"message":     "The deterministic provider failed once; retry the same answer.",
-			"retryable":   true,
-		})
-		return submitResult{}, ErrRecoverableFailure
-	}
-	isRetry := retryRequestID != ""
-	if r.sessionStatus == "completed" && !isRetry {
-		return submitResult{}, ErrSessionCompleted
+		return Turn{}, ErrInvalidAnswer
 	}
 	question, ok := r.findQuestionLocked(questionID)
 	if !ok {
-		return submitResult{}, ErrQuestionNotFound
+		return Turn{}, ErrQuestionNotFound
 	}
 
 	turnNumber := len(r.turns) + 1
-	effectiveSequence := r.effectiveTurnCountLocked() + 1
 	turn := Turn{}
-	if isRetry {
-		retry, ok := r.findRetryLocked(retryRequestID)
+	if request.RetryRequestID != "" {
+		retryTurnID, ok := r.retryTurnByRequest[request.RetryRequestID]
 		if !ok {
-			return submitResult{}, errors.New("retry request not found")
+			return Turn{}, ErrRetryNotFound
 		}
-		retryTurn, ok := r.findTurnLocked(retry.NewTurnID)
-		if !ok || retryTurn.QuestionID != questionID {
-			return submitResult{}, errors.New("retry turn does not match question")
+		retryTurn, ok := r.findTurnLocked(retryTurnID)
+		if !ok || retryTurn.QuestionID != questionID || retryTurn.Status != "answering" {
+			return Turn{}, ErrRetryConflict
 		}
 		turn = retryTurn
 		turn.AnswerText = answer
-		turn.InteractionMode = "PUSH_TO_TALK"
+		turn.AudioAssetID = request.AudioAssetID
+		turn.InteractionMode = request.InteractionMode
 		turn.Status = "completed"
-		turn.SubmittedAt = r.timestamp(20 + turnNumber*3)
-		turn.CompletedAt = r.timestamp(21 + turnNumber*3)
-		r.replaceTurnLocked(turn)
+		turn.SubmittedAt = r.timestamp(72 + len(r.retryTurnByRequest)*2)
+		turn.CompletedAt = r.timestamp(73 + len(r.retryTurnByRequest)*2)
 	} else {
+		for _, existing := range r.turns {
+			if !existing.IsRetry && existing.QuestionID == questionID {
+				return Turn{}, ErrResourceConflict
+			}
+		}
 		turn = Turn{
 			ID:              fmt.Sprintf("turn_demo_%03d", turnNumber),
 			SessionID:       demoPracticeSession,
 			QuestionID:      question.ID,
 			RespondentID:    demoCandidateID,
 			Sequence:        question.Sequence,
-			InteractionMode: "PUSH_TO_TALK",
+			InteractionMode: request.InteractionMode,
 			AnswerText:      answer,
+			AudioAssetID:    request.AudioAssetID,
 			Status:          "completed",
 			IsRetry:         false,
-			SubmittedAt:     r.timestamp(20 + turnNumber*3),
-			CreatedAt:       r.timestamp(20 + turnNumber*3),
-			CompletedAt:     r.timestamp(21 + turnNumber*3),
+			SubmittedAt:     r.timestamp(13 + question.Sequence*12),
+			CreatedAt:       r.timestamp(13 + question.Sequence*12),
+			CompletedAt:     r.timestamp(14 + question.Sequence*12),
+		}
+	}
+	return turn, nil
+}
+
+func (r *Runtime) commitTurn(turn Turn) (Turn, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.findQuestionLocked(turn.QuestionID); !ok {
+		return Turn{}, ErrQuestionNotFound
+	}
+	if turn.IsRetry {
+		existing, ok := r.findTurnLocked(turn.ID)
+		if !ok || existing.Status != "answering" {
+			return Turn{}, ErrResourceConflict
+		}
+		r.replaceTurnLocked(turn)
+	} else {
+		for _, existing := range r.turns {
+			if !existing.IsRetry && existing.QuestionID == turn.QuestionID {
+				return Turn{}, ErrResourceConflict
+			}
 		}
 		r.turns = append(r.turns, turn)
 	}
 	r.appendEventLocked("turn.submitted", map[string]any{
-		"turn_id": turn.ID, "question_id": question.ID, "turn_status": "submitted",
+		"turn_id": turn.ID, "question_id": turn.QuestionID, "turn_status": "submitted",
 	})
 	r.appendEventLocked("turn.processing", map[string]any{
-		"turn_id": turn.ID, "question_id": question.ID, "turn_status": "processing",
+		"turn_id": turn.ID, "question_id": turn.QuestionID, "turn_status": "processing",
 	})
 	r.appendEventLocked("turn.completed", map[string]any{
 		"turn_id":                   turn.ID,
-		"question_id":               question.ID,
+		"question_id":               turn.QuestionID,
 		"respondent_participant_id": turn.RespondentID,
 		"turn_status":               "completed",
 		"completed_at":              turn.CompletedAt,
 	})
-
-	analysisNumber := len(r.analyses) + 1
-	analysis := Analysis{
-		ID:                 fmt.Sprintf("analysis_demo_%03d", analysisNumber),
-		TurnID:             turn.ID,
-		EvaluatorVersion:   "mock-review-v1",
-		Status:             "completed",
-		Score:              80 + effectiveSequence,
-		Summary:            "Deterministic review completed for the submitted answer.",
-		AnalysisTranscript: answer,
-		CreatedAt:          r.timestamp(22 + turnNumber*3),
-		CompletedAt:        r.timestamp(23 + turnNumber*3),
-	}
-	feedback := Feedback{
-		ID:         fmt.Sprintf("feedback_demo_%03d", analysisNumber),
-		AnalysisID: analysis.ID,
-		Category:   "STRUCTURE",
-		Message:    "The answer is clear and grounded in an example.",
-		Suggestion: "State the trade-off and measurable outcome explicitly.",
-		Evidence:   []map[string]any{{"transcript_text": answer}},
-		Retryable:  true,
-		CreatedAt:  analysis.CompletedAt,
-	}
-	r.analyses = append(r.analyses, analysis)
-	r.feedback = append(r.feedback, feedback)
-	r.history = append(r.history, HistoryRecord{
-		ID:         fmt.Sprintf("history_demo_%03d", analysisNumber),
-		SessionID:  demoPracticeSession,
-		TurnID:     turn.ID,
-		AnalysisID: analysis.ID,
-		Score:      analysis.Score,
-		Summary:    analysis.Summary,
-		ReviewedAt: analysis.CompletedAt,
-	})
-	r.appendEventLocked("turn_analysis.completed", map[string]any{
-		"turn_id": turn.ID, "turn_analysis_id": analysis.ID,
-		"score": analysis.Score, "summary": analysis.Summary,
-	})
-
-	if !isRetry {
-		if r.effectiveTurnCountLocked() == 4 {
-			r.sessionStatus = "completed"
-			r.appendEventLocked("practice_session.completed", map[string]any{
-				"practice_session_status": "completed",
-				"session_version":         6,
-				"end_reason":              "COVERAGE_SATISFIED_AT_CHECKPOINT",
-			})
-		} else {
-			next := r.newQuestionLocked(len(r.questions) + 1)
-			r.questions = append(r.questions, next)
-		}
-	}
-
-	result := submitResult{Turn: turn, Analysis: analysis, Feedback: feedback}
-	r.submitted[key] = idempotentTurn{answer: answer, result: result}
-	return result, nil
+	return turn, nil
 }
 
-func (r *Runtime) createRetry(feedbackID, key string) (RetryRequest, Turn, error) {
+func (r *Runtime) publishProcessingFailure(questionID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.appendEventLocked("answer.processing_failed", map[string]any{
+		"question_id": questionID,
+		"code":        "mock_provider_temporarily_unavailable",
+		"message":     "The deterministic provider failed once; retry the same answer.",
+		"retryable":   true,
+	})
+}
 
-	if retry, ok := r.retryByKey[key]; ok {
-		turn, _ := r.findTurnLocked(retry.NewTurnID)
-		return retry, turn, nil
-	}
-	feedback, ok := r.findFeedbackLocked(feedbackID)
-	if !ok {
-		return RetryRequest{}, Turn{}, ErrFeedbackNotFound
-	}
-	var original Turn
-	for _, analysis := range r.analyses {
-		if analysis.ID == feedback.AnalysisID {
-			original, ok = r.findTurnLocked(analysis.TurnID)
-			break
+func (r *Runtime) publishReviewCompleted(analysis Analysis) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.appendEventLocked("turn_analysis.completed", map[string]any{
+		"turn_id": analysis.TurnID, "turn_analysis_id": analysis.ID,
+		"score": analysis.Score, "summary": analysis.Summary,
+	})
+}
+
+func (r *Runtime) publishSessionStarted(version int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.appendEventLocked("practice_session.started", map[string]any{
+		"practice_session_status": "in_progress",
+		"session_version":         version,
+	})
+}
+
+func (r *Runtime) publishSessionCompleted(version int, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.appendEventLocked("practice_session.completed", map[string]any{
+		"practice_session_status": "completed",
+		"session_version":         version,
+		"end_reason":              reason,
+	})
+}
+
+func (r *Runtime) createRetryTurn(retryID, originalTurnID string) (Turn, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existingID, ok := r.retryTurnByRequest[retryID]; ok {
+		if r.retryOriginalByRequest[retryID] != originalTurnID {
+			return Turn{}, ErrRetryConflict
 		}
+		turn, found := r.findTurnLocked(existingID)
+		if !found {
+			return Turn{}, ErrTurnNotFound
+		}
+		return turn, nil
 	}
+	original, ok := r.findTurnLocked(originalTurnID)
 	if !ok {
-		return RetryRequest{}, Turn{}, ErrTurnNotFound
+		return Turn{}, ErrTurnNotFound
 	}
-	retryNumber := len(r.retries) + 1
-	retryID := fmt.Sprintf("retry_demo_%03d", retryNumber)
+	if original.Status != "completed" {
+		return Turn{}, ErrRetryConflict
+	}
+	retryNumber := len(r.retryTurnByRequest) + 1
 	retryTurn := Turn{
 		ID:              fmt.Sprintf("turn_retry_demo_%03d", retryNumber),
 		SessionID:       original.SessionID,
@@ -476,34 +414,22 @@ func (r *Runtime) createRetry(feedbackID, key string) (RetryRequest, Turn, error
 		InteractionMode: "PUSH_TO_TALK",
 		Status:          "answering",
 		IsRetry:         true,
-		CreatedAt:       r.timestamp(60 + retryNumber),
+		CreatedAt:       r.timestamp(70 + retryNumber),
 	}
 	r.turns = append(r.turns, retryTurn)
-	retry := RetryRequest{
-		ID:             retryID,
-		OriginalTurnID: original.ID,
-		FeedbackID:     feedback.ID,
-		NewTurnID:      retryTurn.ID,
-		Status:         "turn_created",
-		CreatedAt:      r.timestamp(59 + retryNumber),
-		UpdatedAt:      retryTurn.CreatedAt,
-	}
-	r.retries = append(r.retries, retry)
-	r.retryByKey[key] = retry
-	for index := range r.history {
-		if r.history[index].TurnID == original.ID {
-			r.history[index].RetryRequestID = retry.ID
-		}
-	}
-	return retry, retryTurn, nil
+	r.retryTurnByRequest[retryID] = retryTurn.ID
+	r.retryOriginalByRequest[retryID] = originalTurnID
+	return retryTurn, nil
 }
 
-func (r *Runtime) historyRecords() []HistoryRecord {
+func (r *Runtime) historyRecordsForSession(sessionID string) []HistoryRecord {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	result := make([]HistoryRecord, len(r.history))
-	for index := range r.history {
-		result[len(r.history)-1-index] = r.history[index]
+	result := make([]HistoryRecord, 0, len(r.history))
+	for index := len(r.history) - 1; index >= 0; index-- {
+		if r.history[index].SessionID == sessionID {
+			result = append(result, r.history[index])
+		}
 	}
 	return result
 }
@@ -628,51 +554,9 @@ func practiceOption() map[string]any {
 	}
 }
 
-func (r *Runtime) newQuestionLocked(sequence int) Question {
-	objectives := []string{"introduction", "system_design", "project_depth", "collaboration"}
-	contents := []string{
-		"Please introduce yourself and the backend project you are most proud of.",
-		"How did you design the reliability controls for that API?",
-		"Which design decision was yours, and what trade-off did you make?",
-		"How did you align the rollout with the teams that consumed the API?",
-	}
-	questionType := "PRIMARY"
-	parentID := ""
-	if sequence == 3 {
-		questionType = "FOLLOW_UP"
-		parentID = "question_demo_002"
-	}
-	question := Question{
-		ID:               fmt.Sprintf("question_demo_%03d", sequence),
-		SessionID:        demoPracticeSession,
-		SpeakerID:        demoInterviewerID,
-		AddresseeIDs:     []string{demoCandidateID},
-		ObjectiveID:      objectives[sequence-1],
-		Type:             questionType,
-		ParentQuestionID: parentID,
-		Content:          contents[sequence-1],
-		Sequence:         sequence,
-		CreatedAt:        r.timestamp(10 + sequence*4),
-	}
-	payload := map[string]any{
-		"question_id":               question.ID,
-		"speaker_participant_id":    question.SpeakerID,
-		"addressee_participant_ids": question.AddresseeIDs,
-		"objective_id":              question.ObjectiveID,
-		"question_type":             question.Type,
-		"content":                   question.Content,
-		"sequence":                  question.Sequence,
-	}
-	if question.ParentQuestionID != "" {
-		payload["parent_question_id"] = question.ParentQuestionID
-	}
-	r.appendEventLocked("question.created", payload)
-	return question
-}
-
 func (r *Runtime) appendEventLocked(eventType string, payload map[string]any) {
 	eventNumber := len(r.events) + 1
-	replayable := eventType != "answer.processing_failed"
+	replayable := isReplayableEvent(eventType)
 	sequence := 0
 	if replayable {
 		for _, event := range r.events {
@@ -698,7 +582,28 @@ func (r *Runtime) appendEventLocked(eventType string, payload map[string]any) {
 		select {
 		case subscriber <- event:
 		default:
+			delete(r.subscribers, subscriber)
+			close(subscriber)
 		}
+	}
+}
+
+func isReplayableEvent(eventType string) bool {
+	switch eventType {
+	case "question.created",
+		"turn.submitted",
+		"turn.processing",
+		"turn.completed",
+		"turn_analysis.completed",
+		"practice_session.started",
+		"practice_session.completed":
+		return true
+	case "answer.processing_failed":
+		return false
+	case "stream.ready":
+		return false
+	default:
+		panic("unclassified smoke event type: " + eventType)
 	}
 }
 
@@ -711,7 +616,7 @@ func (r *Runtime) subscribe(afterSequence int) ([]Event, <-chan Event, func()) {
 			replay = append(replay, event)
 		}
 	}
-	channel := make(chan Event, 64)
+	channel := make(chan Event, 128)
 	r.subscribers[channel] = struct{}{}
 	unsubscribe := func() {
 		r.mu.Lock()
@@ -764,6 +669,12 @@ func (r *Runtime) getTurn(id string) (Turn, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.findTurnLocked(id)
+}
+
+func (r *Runtime) getQuestion(id string) (Question, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.findQuestionLocked(id)
 }
 
 func (r *Runtime) analysesForTurn(turnID string) []Analysis {

--- a/server/internal/smoke/services.go
+++ b/server/internal/smoke/services.go
@@ -1,0 +1,549 @@
+package smoke
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+)
+
+type preparationBackend struct {
+	runtime *Runtime
+}
+
+func (b preparationBackend) GetScenario(id string) (map[string]any, bool) {
+	if id != DemoScenarioDefinition {
+		return nil, false
+	}
+	return map[string]any{
+		"scenario_definition": map[string]any{
+			"scenario_definition_id": DemoScenarioDefinition,
+			"scenario_type":          "INTERVIEW",
+			"name":                   "Programmer English Interview",
+			"version":                1,
+			"status":                 "active",
+		},
+		"scenario_config": map[string]any{
+			"scenario_config_id":     "scenario_config_backend",
+			"scenario_definition_id": DemoScenarioDefinition,
+			"config_type":            "INTERVIEW",
+			"version":                1,
+			"job_title":              "Backend Engineer",
+			"job_description":        "Build reliable APIs and explain engineering trade-offs.",
+			"focus_areas":            []string{"reliability", "ownership", "collaboration"},
+		},
+		"practice_options": []map[string]any{practiceOption()},
+	}, true
+}
+
+func (b preparationBackend) ListRoles(scenarioID string) ([]map[string]any, bool) {
+	if scenarioID != DemoScenarioDefinition {
+		return nil, false
+	}
+	return []map[string]any{roleDefinition()}, true
+}
+
+func (b preparationBackend) CreateProfile(
+	request preparation.CreateProfileRequest,
+) (map[string]any, error) {
+	result := b.runtime.createProfile()
+	result["background_summary"] = request.BackgroundSummary
+	if request.ResumeRef == "" {
+		delete(result, "resume_ref")
+	} else {
+		result["resume_ref"] = request.ResumeRef
+	}
+	if request.JobDescriptionRef == "" {
+		delete(result, "job_description_ref")
+	} else {
+		result["job_description_ref"] = request.JobDescriptionRef
+	}
+	return result, nil
+}
+
+func (b preparationBackend) CreateSnapshot(
+	profileID string,
+	request preparation.CreateSnapshotRequest,
+) (map[string]any, error) {
+	if !b.ProfileExists(profileID) {
+		return nil, ErrProfileNotFound
+	}
+	if request.SourceVersion != 1 {
+		return nil, ErrVersionConflict
+	}
+	return b.runtime.createSnapshot()
+}
+
+func (b preparationBackend) ProfileExists(id string) bool {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	return id == demoPreparationProfile && b.runtime.profileCreated
+}
+
+func (b preparationBackend) SnapshotExists(id string) bool {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	return id == demoPreparationSnapshot && b.runtime.snapshotCreated
+}
+
+type practiceBackend struct {
+	runtime *Runtime
+}
+
+func (b practiceBackend) CreatePlan(
+	request practice.CreatePlanRequest,
+) (map[string]any, error) {
+	if request.ScenarioDefinitionID != DemoScenarioDefinition {
+		return nil, ErrScenarioNotFound
+	}
+	if request.PreparationProfileID != demoPreparationProfile {
+		return nil, ErrProfileNotFound
+	}
+	if request.ScenarioDefinitionVersion != 1 ||
+		request.ScenarioConfigID != "scenario_config_backend" ||
+		request.ScenarioConfigVersion != 1 ||
+		len(request.SelectedRoleIDs) != 1 ||
+		request.SelectedRoleIDs[0] != DemoRoleDefinition {
+		return nil, ErrInvalidSelection
+	}
+	return b.runtime.createPlan()
+}
+
+func (b practiceBackend) PlanExists(id string) bool {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	return id == demoPracticePlan && b.runtime.planCreated
+}
+
+func (b practiceBackend) CreateSession(
+	planID string,
+	request practice.CreateSessionRequest,
+) (map[string]any, error) {
+	if planID != demoPracticePlan {
+		return nil, ErrPlanNotFound
+	}
+	if request.ExpectedPlanRevision != 1 {
+		return nil, ErrVersionConflict
+	}
+	if request.PreparationSnapshotID != demoPreparationSnapshot ||
+		request.PracticeOptionID != DemoPracticeOption ||
+		len(request.RoleDefinitionIDs) != 1 ||
+		request.RoleDefinitionIDs[0] != DemoRoleDefinition {
+		return nil, ErrInvalidSelection
+	}
+	return b.runtime.createSession()
+}
+
+func (b practiceBackend) GetSession(id string) (map[string]any, bool) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if !b.runtime.sessionCreated || id != demoPracticeSession {
+		return nil, false
+	}
+	return b.runtime.sessionLocked(), true
+}
+
+func (b practiceBackend) GetSnapshot(sessionID string) (map[string]any, bool) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
+		return nil, false
+	}
+	return b.runtime.snapshotLocked(), true
+}
+
+func (b practiceBackend) StartSession(sessionID string) (int, bool, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
+		return 0, false, ErrSessionNotFound
+	}
+	switch b.runtime.sessionStatus {
+	case "starting":
+		b.runtime.sessionStatus = "in_progress"
+		b.runtime.sessionVersion = 2
+		return 2, true, nil
+	case "in_progress":
+		return b.runtime.sessionVersion, false, nil
+	case "completed":
+		return b.runtime.sessionVersion, false, nil
+	default:
+		return 0, false, ErrResourceConflict
+	}
+}
+
+func (b practiceBackend) AuthorizeTurn(sessionID string, retry bool) error {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
+		return ErrSessionNotFound
+	}
+	if retry {
+		switch b.runtime.sessionStatus {
+		case "in_progress", "completed":
+			return nil
+		default:
+			return ErrResourceConflict
+		}
+	}
+	if b.runtime.sessionStatus != "in_progress" {
+		return ErrSessionCompleted
+	}
+	return nil
+}
+
+func (b practiceBackend) RecordTurnOutcome(
+	outcome practice.TurnOutcome,
+) (practice.TurnDecision, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if !b.runtime.sessionCreated || outcome.SessionID != demoPracticeSession {
+		return practice.TurnDecision{}, ErrSessionNotFound
+	}
+	if decision, ok := b.runtime.turnDecisions[outcome.TurnID]; ok {
+		return decision, nil
+	}
+	if outcome.IsRetry {
+		decision := practice.TurnDecision{
+			EffectiveTurns: b.runtime.effectiveTurns,
+			Completed:      b.runtime.sessionStatus == "completed",
+			SessionVersion: b.runtime.sessionVersion,
+		}
+		b.runtime.turnDecisions[outcome.TurnID] = decision
+		return decision, nil
+	}
+	if b.runtime.sessionStatus != "in_progress" {
+		return practice.TurnDecision{}, ErrSessionCompleted
+	}
+	b.runtime.effectiveTurns++
+	b.runtime.sessionVersion++
+	decision := practice.TurnDecision{
+		EffectiveTurns:     b.runtime.effectiveTurns,
+		NextQuestionNumber: b.runtime.effectiveTurns + 1,
+		SessionVersion:     b.runtime.sessionVersion,
+	}
+	if b.runtime.effectiveTurns == 4 {
+		b.runtime.sessionStatus = "completed"
+		b.runtime.sessionVersion = 6
+		decision.Completed = true
+		decision.NextQuestionNumber = 0
+		decision.SessionVersion = 6
+		decision.EndReason = "COVERAGE_SATISFIED_AT_CHECKPOINT"
+	}
+	b.runtime.turnDecisions[outcome.TurnID] = decision
+	return decision, nil
+}
+
+type conversationBackend struct {
+	runtime *Runtime
+}
+
+func (b conversationBackend) Bootstrap(sessionID string) (map[string]any, error) {
+	if sessionID != demoPracticeSession {
+		return nil, ErrSessionNotFound
+	}
+	return b.runtime.conversationBootstrap(), nil
+}
+
+func (b conversationBackend) CurrentQuestion(
+	sessionID string,
+) (Question, bool, error) {
+	if sessionID != demoPracticeSession {
+		return Question{}, false, ErrSessionNotFound
+	}
+	question, err := b.runtime.currentQuestion()
+	if errors.Is(err, ErrQuestionNotFound) {
+		return Question{}, false, nil
+	}
+	return question, err == nil, err
+}
+
+func (b conversationBackend) SaveQuestion(
+	sessionID string,
+	sequence int,
+	draft conversation.QuestionDraft,
+) (Question, error) {
+	return b.runtime.saveQuestion(sessionID, sequence, draft)
+}
+
+func (b conversationBackend) PrepareTurn(
+	questionID string,
+	request conversation.SubmitTurnRequest,
+) (Turn, error) {
+	return b.runtime.prepareTurn(questionID, request)
+}
+
+func (b conversationBackend) CommitTurn(turn Turn) (Turn, error) {
+	return b.runtime.commitTurn(turn)
+}
+
+func (b conversationBackend) CreateRetryTurn(
+	retryID string,
+	originalTurnID string,
+) (Turn, error) {
+	return b.runtime.createRetryTurn(retryID, originalTurnID)
+}
+
+func (b conversationBackend) PublishProcessingFailure(questionID string) {
+	b.runtime.publishProcessingFailure(questionID)
+}
+
+func (b conversationBackend) PublishReviewCompleted(
+	analysisID string,
+	turnID string,
+	score int,
+	summary string,
+) {
+	b.runtime.publishReviewCompleted(Analysis{
+		ID:      analysisID,
+		TurnID:  turnID,
+		Score:   score,
+		Summary: summary,
+	})
+}
+
+func (b conversationBackend) PublishSessionStarted(version int) {
+	b.runtime.publishSessionStarted(version)
+}
+
+func (b conversationBackend) PublishSessionCompleted(version int, reason string) {
+	b.runtime.publishSessionCompleted(version, reason)
+}
+
+func (b conversationBackend) GetTurn(id string) (Turn, bool) {
+	return b.runtime.getTurn(id)
+}
+
+func (b conversationBackend) GetQuestion(id string) (Question, bool) {
+	return b.runtime.getQuestion(id)
+}
+
+func (b conversationBackend) Subscribe(
+	sessionID string,
+	afterSequence int,
+) ([]Event, <-chan Event, func(), error) {
+	if sessionID != demoPracticeSession {
+		return nil, nil, nil, ErrSessionNotFound
+	}
+	replay, live, unsubscribe := b.runtime.subscribe(afterSequence)
+	return replay, live, unsubscribe, nil
+}
+
+func (b conversationBackend) StreamReady(sessionID string) (Event, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	if sessionID != demoPracticeSession {
+		return Event{}, ErrSessionNotFound
+	}
+	return Event{
+		ID:            "event_stream_ready_001",
+		Type:          "stream.ready",
+		Version:       1,
+		OccurredAt:    b.runtime.timestamp(99),
+		SessionID:     demoPracticeSession,
+		CorrelationID: "correlation_stream_ready_001",
+		Replayable:    false,
+		Payload: map[string]any{
+			"last_sequence": b.runtime.lastEventSequenceLocked(),
+		},
+	}, nil
+}
+
+type reviewBackend struct {
+	runtime *Runtime
+}
+
+func (b reviewBackend) ListAnalyses(turnID string) []Analysis {
+	return b.runtime.analysesForTurn(turnID)
+}
+
+func (b reviewBackend) ListFeedback(analysisID string) ([]Feedback, bool) {
+	b.runtime.mu.Lock()
+	found := false
+	for _, analysis := range b.runtime.analyses {
+		if analysis.ID == analysisID {
+			found = true
+			break
+		}
+	}
+	b.runtime.mu.Unlock()
+	if !found {
+		return nil, false
+	}
+	return b.runtime.feedbackForAnalysis(analysisID), true
+}
+
+func (b reviewBackend) SaveEvaluation(
+	turn review.TurnInput,
+	evaluation review.Evaluation,
+) (Analysis, Feedback, bool, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	for _, existing := range b.runtime.analyses {
+		if existing.TurnID == turn.TurnID {
+			for _, feedback := range b.runtime.feedback {
+				if feedback.AnalysisID == existing.ID {
+					return existing, feedback, false, nil
+				}
+			}
+		}
+	}
+	number := len(b.runtime.analyses) + 1
+	analysis := Analysis{
+		ID:                 formatID("analysis_demo", number),
+		TurnID:             turn.TurnID,
+		EvaluatorVersion:   "mock-review-v1",
+		Status:             "completed",
+		Score:              evaluation.Score,
+		Summary:            evaluation.Summary,
+		AnalysisTranscript: evaluation.Transcript,
+		CreatedAt:          addSeconds(turn.CompletedAt, 1),
+		CompletedAt:        addSeconds(turn.CompletedAt, 2),
+	}
+	feedback := Feedback{
+		ID:         formatID("feedback_demo", number),
+		AnalysisID: analysis.ID,
+		Category:   evaluation.Category,
+		Message:    evaluation.Message,
+		Suggestion: evaluation.Suggestion,
+		Evidence:   evaluation.Evidence,
+		Retryable:  true,
+		CreatedAt:  analysis.CompletedAt,
+	}
+	b.runtime.analyses = append(b.runtime.analyses, analysis)
+	b.runtime.feedback = append(b.runtime.feedback, feedback)
+	b.runtime.history = append(b.runtime.history, HistoryRecord{
+		ID:         formatID("history_demo", number),
+		SessionID:  turn.SessionID,
+		TurnID:     turn.TurnID,
+		AnalysisID: analysis.ID,
+		Score:      analysis.Score,
+		Summary:    analysis.Summary,
+		ReviewedAt: analysis.CompletedAt,
+	})
+	return analysis, feedback, true, nil
+}
+
+func (b reviewBackend) StartRetry(feedbackID string) (RetryRequest, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	feedback, ok := b.runtime.findFeedbackLocked(feedbackID)
+	if !ok {
+		return RetryRequest{}, ErrFeedbackNotFound
+	}
+	for _, existing := range b.runtime.retries {
+		if existing.FeedbackID == feedbackID {
+			return RetryRequest{}, ErrRetryConflict
+		}
+	}
+	originalTurnID := ""
+	for _, analysis := range b.runtime.analyses {
+		if analysis.ID == feedback.AnalysisID {
+			originalTurnID = analysis.TurnID
+			break
+		}
+	}
+	if originalTurnID == "" {
+		return RetryRequest{}, ErrTurnNotFound
+	}
+	number := len(b.runtime.retries) + 1
+	retry := RetryRequest{
+		ID:             formatID("retry_demo", number),
+		OriginalTurnID: originalTurnID,
+		FeedbackID:     feedbackID,
+		Status:         "pending",
+		CreatedAt:      b.runtime.timestamp(69 + number),
+		UpdatedAt:      b.runtime.timestamp(69 + number),
+	}
+	b.runtime.retries = append(b.runtime.retries, retry)
+	return retry, nil
+}
+
+func (b reviewBackend) CompleteRetry(
+	retryID string,
+	newTurnID string,
+) (RetryRequest, error) {
+	b.runtime.mu.Lock()
+	defer b.runtime.mu.Unlock()
+	for index := range b.runtime.retries {
+		if b.runtime.retries[index].ID != retryID {
+			continue
+		}
+		retry := &b.runtime.retries[index]
+		if retry.Status == "turn_created" {
+			if retry.NewTurnID != newTurnID {
+				return RetryRequest{}, ErrRetryConflict
+			}
+			return *retry, nil
+		}
+		if retry.Status != "pending" {
+			return RetryRequest{}, ErrRetryConflict
+		}
+		retry.NewTurnID = newTurnID
+		retry.Status = "turn_created"
+		retry.UpdatedAt = b.runtime.timestamp(71 + index)
+		for historyIndex := range b.runtime.history {
+			if b.runtime.history[historyIndex].TurnID == retry.OriginalTurnID {
+				b.runtime.history[historyIndex].RetryRequestID = retry.ID
+			}
+		}
+		return *retry, nil
+	}
+	return RetryRequest{}, ErrRetryNotFound
+}
+
+func (b reviewBackend) GetRetry(id string) (RetryRequest, bool) {
+	return b.runtime.getRetry(id)
+}
+
+func (b reviewBackend) ListHistory(sessionID string) []HistoryRecord {
+	return b.runtime.historyRecordsForSession(sessionID)
+}
+
+func mapServiceError(err error) (int, string) {
+	switch {
+	case errors.Is(err, ErrScenarioNotFound):
+		return 404, "scenario_definition_not_found"
+	case errors.Is(err, ErrProfileNotFound):
+		return 404, "preparation_profile_not_found"
+	case errors.Is(err, ErrSnapshotNotFound):
+		return 404, "resource_not_found"
+	case errors.Is(err, ErrPlanNotFound):
+		return 404, "practice_plan_not_found"
+	case errors.Is(err, ErrSessionNotFound):
+		return 404, "practice_session_not_found"
+	case errors.Is(err, ErrQuestionNotFound):
+		return 404, "question_not_found"
+	case errors.Is(err, ErrTurnNotFound):
+		return 404, "turn_not_found"
+	case errors.Is(err, ErrAnalysisNotFound):
+		return 404, "turn_analysis_not_found"
+	case errors.Is(err, ErrFeedbackNotFound):
+		return 404, "feedback_item_not_found"
+	case errors.Is(err, ErrRetryNotFound):
+		return 404, "retry_request_not_found"
+	case errors.Is(err, ErrVersionConflict), errors.Is(err, ErrInvalidSelection),
+		errors.Is(err, ErrResourceConflict):
+		return 409, "resource_conflict"
+	case errors.Is(err, ErrRetryConflict):
+		return 409, "retry_request_conflict"
+	default:
+		return 500, "internal_error"
+	}
+}
+
+func formatID(prefix string, number int) string {
+	return fmt.Sprintf("%s_%03d", prefix, number)
+}
+
+func addSeconds(value string, seconds int) string {
+	timestamp, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return timestamp.Add(time.Duration(seconds) * time.Second).Format(time.RFC3339)
+}


### PR DESCRIPTION
## 功能描述

建立固定身份到四个有效 Turn 的确定性离线 Mock 主链路，通过正式 REST 与 WebSocket 路径覆盖 Preparation、Practice、Conversation 和 Review。

本 PR 为堆叠开发，当前依赖 PR #69。#69 合并后会将本分支变基到最新 dev，再移除契约提交在本 PR 中的临时差异。

## 实现思路

- 提供仅监听本机的 mock-smoke-server 入口，不需要模型密钥或外部网络。
- 固定服务器端测试身份，创建背景快照、训练计划和 Session。
- 完成四个有效 Turn；空回答和技术失败不消耗轮次。
- 覆盖一次可恢复失败、同幂等键重试和同题重答。
- 每个有效 Turn 生成确定性分析、反馈和历史投影。
- WebSocket 在线接收不可重放失败事件，并按 after_sequence 重放有序事件。
- 使用真实 HTTP/WebSocket 测试客户端重复执行两次，断言输出完全一致。

## 可复现测试

- cd server && go test -race ./...
- cd server && go vet ./...
- cd api && npm ci && npm run check
- cd mobile && dart format --output=none --set-exit-if-changed lib && flutter analyze

Flutter 客户端集成测试按 #23 约定为可选后接；当前 dev 基线尚无 mobile/test 目录。

## 依赖

- Depends on #69

Closes #23