### PR TITLE
feat(mobile): 搭建 Agent 首页与四栏导航

### DIFF
--- a/mobile/lib/app/app_routes.dart
+++ b/mobile/lib/app/app_routes.dart
@@ -1,0 +1,7 @@
+abstract final class AppRoutes {
+  static const home = '/';
+  static const preparation = '/preparation';
+  static const practice = '/practice';
+  static const conversation = '/conversation';
+  static const review = '/review';
+}

--- a/mobile/lib/app/glass_navigation_bar.dart
+++ b/mobile/lib/app/glass_navigation_bar.dart
@@ -1,0 +1,168 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+class GlassNavigationDestination {
+  const GlassNavigationDestination({
+    required this.label,
+    required this.icon,
+    required this.key,
+  });
+
+  final String label;
+  final IconData icon;
+  final Key key;
+}
+
+class GlassNavigationBar extends StatelessWidget {
+  const GlassNavigationBar({
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    super.key,
+  });
+
+  static const height = 74.0;
+  static const minimumBottomInset = 12.0;
+
+  final List<GlassNavigationDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final highContrast = MediaQuery.highContrastOf(context);
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+
+    return SafeArea(
+      minimum: const EdgeInsets.fromLTRB(16, 0, 16, minimumBottomInset),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(32),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x24513E70),
+              blurRadius: 38,
+              offset: Offset(0, 14),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(32),
+          child: BackdropFilter(
+            filter: ui.ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+            child: Container(
+              key: const Key('primary-navigation'),
+              height: height,
+              padding: const EdgeInsets.all(6),
+              decoration: BoxDecoration(
+                color: highContrast ? const Color(0xFFF8F8FB) : null,
+                gradient: highContrast
+                    ? null
+                    : const LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [Color(0xD9FFFFFF), Color(0x99FFFFFF)],
+                      ),
+                borderRadius: BorderRadius.circular(32),
+                border: Border.all(
+                  color: highContrast
+                      ? const Color(0xFFD8DAE2)
+                      : const Color(0xD9FFFFFF),
+                ),
+              ),
+              child: Semantics(
+                container: true,
+                label: '主导航',
+                child: Row(
+                  children: [
+                    for (var index = 0; index < destinations.length; index++)
+                      Expanded(
+                        child: _NavigationItem(
+                          destination: destinations[index],
+                          selected: selectedIndex == index,
+                          reduceMotion: reduceMotion,
+                          onTap: () => onDestinationSelected(index),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavigationItem extends StatelessWidget {
+  const _NavigationItem({
+    required this.destination,
+    required this.selected,
+    required this.reduceMotion,
+    required this.onTap,
+  });
+
+  final GlassNavigationDestination destination;
+  final bool selected;
+  final bool reduceMotion;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      key: destination.key,
+      button: true,
+      selected: selected,
+      label: destination.label,
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(26),
+            onTap: onTap,
+            child: AnimatedContainer(
+              duration: reduceMotion
+                  ? Duration.zero
+                  : const Duration(milliseconds: 180),
+              curve: Curves.easeOutCubic,
+              decoration: BoxDecoration(
+                color: selected ? const Color(0xB8E7E8F2) : Colors.transparent,
+                borderRadius: BorderRadius.circular(26),
+                border: selected
+                    ? Border.all(color: const Color(0xCFFFFFFF))
+                    : null,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    destination.icon,
+                    size: 23,
+                    color: selected
+                        ? const Color(0xFF111217)
+                        : const Color(0xFF686A72),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    destination.label,
+                    maxLines: 1,
+                    style: TextStyle(
+                      color: selected
+                          ? const Color(0xFF111217)
+                          : const Color(0xFF686A72),
+                      fontSize: 11,
+                      fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/app/glass_navigation_bar.dart
+++ b/mobile/lib/app/glass_navigation_bar.dart
@@ -41,9 +41,9 @@ class GlassNavigationBar extends StatelessWidget {
           borderRadius: BorderRadius.circular(32),
           boxShadow: const [
             BoxShadow(
-              color: Color(0x24513E70),
-              blurRadius: 38,
-              offset: Offset(0, 14),
+              color: Color(0x1C000000),
+              blurRadius: 34,
+              offset: Offset(0, 12),
             ),
           ],
         ),
@@ -56,14 +56,9 @@ class GlassNavigationBar extends StatelessWidget {
               height: height,
               padding: const EdgeInsets.all(6),
               decoration: BoxDecoration(
-                color: highContrast ? const Color(0xFFF8F8FB) : null,
-                gradient: highContrast
-                    ? null
-                    : const LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors: [Color(0xD9FFFFFF), Color(0x99FFFFFF)],
-                      ),
+                color: highContrast
+                    ? const Color(0xFFF8F8F6)
+                    : const Color(0xE6FFFFFF),
                 borderRadius: BorderRadius.circular(32),
                 border: Border.all(
                   color: highContrast
@@ -129,7 +124,7 @@ class _NavigationItem extends StatelessWidget {
                   : const Duration(milliseconds: 180),
               curve: Curves.easeOutCubic,
               decoration: BoxDecoration(
-                color: selected ? const Color(0xB8E7E8F2) : Colors.transparent,
+                color: selected ? const Color(0xFFE8E8E5) : Colors.transparent,
                 borderRadius: BorderRadius.circular(26),
                 border: selected
                     ? Border.all(color: const Color(0xCFFFFFFF))

--- a/mobile/lib/app/glass_navigation_bar.dart
+++ b/mobile/lib/app/glass_navigation_bar.dart
@@ -24,18 +24,39 @@ class GlassNavigationBar extends StatelessWidget {
 
   static const height = 74.0;
   static const minimumBottomInset = 12.0;
+  static const _maximumLabelScale = 1.5;
 
   final List<GlassNavigationDestination> destinations;
   final int selectedIndex;
   final ValueChanged<int> onDestinationSelected;
 
+  static double heightFor(BuildContext context) {
+    final labelScale = _labelScaleFor(context);
+    return height + ((labelScale - 1) * 14);
+  }
+
+  static double _labelScaleFor(BuildContext context) {
+    return MediaQuery.textScalerOf(
+      context,
+    ).scale(1).clamp(1.0, _maximumLabelScale).toDouble();
+  }
+
   @override
   Widget build(BuildContext context) {
     final highContrast = MediaQuery.highContrastOf(context);
     final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    final navigationHeight = heightFor(context);
+    final horizontalInset = MediaQuery.sizeOf(context).width >= 390
+        ? 20.0
+        : 16.0;
 
     return SafeArea(
-      minimum: const EdgeInsets.fromLTRB(16, 0, 16, minimumBottomInset),
+      minimum: EdgeInsets.fromLTRB(
+        horizontalInset,
+        0,
+        horizontalInset,
+        minimumBottomInset,
+      ),
       child: DecoratedBox(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(32),
@@ -53,12 +74,12 @@ class GlassNavigationBar extends StatelessWidget {
             filter: ui.ImageFilter.blur(sigmaX: 24, sigmaY: 24),
             child: Container(
               key: const Key('primary-navigation'),
-              height: height,
+              height: navigationHeight,
               padding: const EdgeInsets.all(6),
               decoration: BoxDecoration(
                 color: highContrast
                     ? const Color(0xFFF8F8F6)
-                    : const Color(0xE6FFFFFF),
+                    : const Color(0xDEFFFFFF),
                 borderRadius: BorderRadius.circular(32),
                 border: Border.all(
                   color: highContrast
@@ -106,6 +127,8 @@ class _NavigationItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final labelScale = GlassNavigationBar._labelScaleFor(context);
+
     return Semantics(
       key: destination.key,
       button: true,
@@ -124,7 +147,7 @@ class _NavigationItem extends StatelessWidget {
                   : const Duration(milliseconds: 180),
               curve: Curves.easeOutCubic,
               decoration: BoxDecoration(
-                color: selected ? const Color(0xFFE8E8E5) : Colors.transparent,
+                color: selected ? const Color(0xD9E8E8E5) : Colors.transparent,
                 borderRadius: BorderRadius.circular(26),
                 border: selected
                     ? Border.all(color: const Color(0xCFFFFFFF))
@@ -141,15 +164,21 @@ class _NavigationItem extends StatelessWidget {
                         : const Color(0xFF686A72),
                   ),
                   const SizedBox(height: 3),
-                  Text(
-                    destination.label,
-                    maxLines: 1,
-                    style: TextStyle(
-                      color: selected
-                          ? const Color(0xFF111217)
-                          : const Color(0xFF686A72),
-                      fontSize: 11,
-                      fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+                  FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      destination.label,
+                      maxLines: 1,
+                      textScaler: TextScaler.linear(labelScale),
+                      style: TextStyle(
+                        color: selected
+                            ? const Color(0xFF111217)
+                            : const Color(0xFF686A72),
+                        fontSize: 11,
+                        fontWeight: selected
+                            ? FontWeight.w600
+                            : FontWeight.w500,
+                      ),
                     ),
                   ),
                 ],

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -1,14 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/app/app_routes.dart';
+import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/conversation/conversation.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/review/review.dart';
-
-const _homeRoute = '/';
-const _preparationRoute = '/preparation';
-const _practiceRoute = '/practice';
-const _conversationRoute = '/conversation';
-const _reviewRoute = '/review';
 
 class SpeakUpApp extends StatelessWidget {
   const SpeakUpApp({super.key});
@@ -17,61 +13,27 @@ class SpeakUpApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'SpeakUp',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF767BF2),
+          surface: const Color(0xFFF8F8FC),
+        ),
+        scaffoldBackgroundColor: const Color(0xFFF8F8FC),
+        textTheme: ThemeData.light().textTheme.apply(
+          bodyColor: const Color(0xFF111217),
+          displayColor: const Color(0xFF111217),
+        ),
         useMaterial3: true,
       ),
-      initialRoute: _homeRoute,
+      initialRoute: AppRoutes.home,
       routes: {
-        _homeRoute: (_) => const _HomePage(),
-        _preparationRoute: (_) => const PreparationPage(),
-        _practiceRoute: (_) => const PracticePage(),
-        _conversationRoute: (_) => const ConversationPage(),
-        _reviewRoute: (_) => const ReviewPage(),
+        AppRoutes.home: (_) => const SpeakUpShell(),
+        AppRoutes.preparation: (_) => const PreparationPage(),
+        AppRoutes.practice: (_) => const PracticePage(),
+        AppRoutes.conversation: (_) => const ConversationPage(),
+        AppRoutes.review: (_) => const ReviewPage(),
       },
-    );
-  }
-}
-
-class _HomePage extends StatelessWidget {
-  const _HomePage();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('SpeakUp')),
-      body: ListView(
-        children: [
-          ListTile(
-            leading: const Icon(Icons.assignment_outlined),
-            title: const Text('Preparation'),
-            subtitle: const Text('Prepare the context for a practice session.'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.pushNamed(context, _preparationRoute),
-          ),
-          ListTile(
-            leading: const Icon(Icons.route_outlined),
-            title: const Text('Practice'),
-            subtitle: const Text('Review the plan for a practice session.'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.pushNamed(context, _practiceRoute),
-          ),
-          ListTile(
-            leading: const Icon(Icons.forum_outlined),
-            title: const Text('Conversation'),
-            subtitle: const Text('Take part in a guided conversation.'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.pushNamed(context, _conversationRoute),
-          ),
-          ListTile(
-            leading: const Icon(Icons.rate_review_outlined),
-            title: const Text('Review'),
-            subtitle: const Text('Review feedback after a practice session.'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.pushNamed(context, _reviewRoute),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -28,10 +28,11 @@ class SpeakUpApp extends StatelessWidget {
       initialRoute: AppRoutes.home,
       routes: {
         AppRoutes.home: (_) => const SpeakUpShell(),
-        AppRoutes.preparation: (_) => const PreparationPage(),
+        AppRoutes.preparation: (_) =>
+            const PreparationPage(showBackButton: true),
         AppRoutes.practice: (_) => const PracticePage(),
-        AppRoutes.conversation: (_) => const SpeakUpShell(),
-        AppRoutes.review: (_) => const ReviewPage(),
+        AppRoutes.conversation: (_) => const SpeakUpShell(showBackButton: true),
+        AppRoutes.review: (_) => const ReviewPage(showBackButton: true),
       },
     );
   }

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_shell.dart';
-import 'package:speakup/features/conversation/conversation.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/review/review.dart';
@@ -31,7 +30,7 @@ class SpeakUpApp extends StatelessWidget {
         AppRoutes.home: (_) => const SpeakUpShell(),
         AppRoutes.preparation: (_) => const PreparationPage(),
         AppRoutes.practice: (_) => const PracticePage(),
-        AppRoutes.conversation: (_) => const ConversationPage(),
+        AppRoutes.conversation: (_) => const SpeakUpShell(),
         AppRoutes.review: (_) => const ReviewPage(),
       },
     );

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -16,10 +16,10 @@ class SpeakUpApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF767BF2),
-          surface: const Color(0xFFF8F8FC),
+          seedColor: const Color(0xFF4F5054),
+          surface: const Color(0xFFF3F3F0),
         ),
-        scaffoldBackgroundColor: const Color(0xFFF8F8FC),
+        scaffoldBackgroundColor: const Color(0xFFF3F3F0),
         textTheme: ThemeData.light().textTheme.apply(
           bodyColor: const Color(0xFF111217),
           displayColor: const Color(0xFF111217),

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -18,7 +18,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   static const _destinations = [
     GlassNavigationDestination(
       label: 'SpeakUp',
-      icon: Icons.auto_awesome_rounded,
+      icon: Icons.chat_bubble_outline_rounded,
       key: Key('primary-tab-agent'),
     ),
     GlassNavigationDestination(
@@ -103,7 +103,7 @@ class _ConversationDrawer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Drawer(
       width: 300,
-      backgroundColor: const Color(0xFFF8F9FC),
+      backgroundColor: const Color(0xFFF5F5F2),
       child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
@@ -187,7 +187,7 @@ class _ProfilePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('profile-page'),
-      backgroundColor: const Color(0xFFF7F8FC),
+      backgroundColor: const Color(0xFFF3F3F0),
       body: SafeArea(
         bottom: false,
         child: ListView(

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -1,0 +1,219 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:speakup/app/app_routes.dart';
+import 'package:speakup/app/glass_navigation_bar.dart';
+import 'package:speakup/features/conversation/conversation.dart';
+import 'package:speakup/features/preparation/preparation.dart';
+import 'package:speakup/features/review/review.dart';
+
+class SpeakUpShell extends StatefulWidget {
+  const SpeakUpShell({super.key});
+
+  @override
+  State<SpeakUpShell> createState() => _SpeakUpShellState();
+}
+
+class _SpeakUpShellState extends State<SpeakUpShell> {
+  static const _destinations = [
+    GlassNavigationDestination(
+      label: 'SpeakUp',
+      icon: Icons.auto_awesome_rounded,
+      key: Key('primary-tab-agent'),
+    ),
+    GlassNavigationDestination(
+      label: '场景',
+      icon: Icons.grid_view_rounded,
+      key: Key('primary-tab-scenes'),
+    ),
+    GlassNavigationDestination(
+      label: '复盘',
+      icon: Icons.fact_check_outlined,
+      key: Key('primary-tab-review'),
+    ),
+    GlassNavigationDestination(
+      label: '我的',
+      icon: Icons.person_rounded,
+      key: Key('primary-tab-profile'),
+    ),
+  ];
+
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  int _selectedIndex = 0;
+
+  void _selectDestination(int index) {
+    if (_selectedIndex == index) {
+      return;
+    }
+    setState(() => _selectedIndex = index);
+  }
+
+  void _showMockNotice(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
+    final safeBottom = math.max(
+      MediaQuery.viewPaddingOf(context).bottom,
+      GlassNavigationBar.minimumBottomInset,
+    );
+    final composerBottomInset = GlassNavigationBar.height + safeBottom + 10;
+    final pages = [
+      ConversationPage(
+        restingComposerBottom: composerBottomInset,
+        onOpenMenu: () => _scaffoldKey.currentState?.openDrawer(),
+        onCreatePlan: () => _selectDestination(1),
+        onContinuePractice: () =>
+            Navigator.of(context).pushNamed(AppRoutes.practice),
+        onOpenReview: () => _selectDestination(2),
+        onVoicePlaceholder: () => _showMockNotice('语音能力将在后续任务接入'),
+      ),
+      const PreparationPage(),
+      const ReviewPage(),
+      const _ProfilePage(),
+    ];
+
+    return Scaffold(
+      key: _scaffoldKey,
+      extendBody: true,
+      resizeToAvoidBottomInset: false,
+      backgroundColor: Colors.transparent,
+      drawer: const _ConversationDrawer(),
+      drawerScrimColor: const Color(0x330E1120),
+      body: IndexedStack(index: _selectedIndex, children: pages),
+      bottomNavigationBar: keyboardVisible
+          ? null
+          : GlassNavigationBar(
+              destinations: _destinations,
+              selectedIndex: _selectedIndex,
+              onDestinationSelected: _selectDestination,
+            ),
+    );
+  }
+}
+
+class _ConversationDrawer extends StatelessWidget {
+  const _ConversationDrawer();
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      width: 300,
+      backgroundColor: const Color(0xFFF8F9FC),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      'SpeakUp',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '关闭对话菜单',
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                key: const Key('new-conversation-button'),
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.edit_square),
+                label: const Text('开始新对话'),
+              ),
+              const SizedBox(height: 28),
+              const Text(
+                '最近对话',
+                style: TextStyle(
+                  color: Color(0xFF777983),
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const _ConversationTile(title: '准备后端开发模拟面试', subtitle: '刚刚'),
+              const _ConversationTile(title: '项目经历怎么说更清楚', subtitle: '昨天'),
+              const _ConversationTile(title: '系统设计表达复盘', subtitle: '7 月 22 日'),
+              const Spacer(),
+              const Text(
+                '当前内容为 UI Mock',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Color(0xFF989AA3), fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ConversationTile extends StatelessWidget {
+  const _ConversationTile({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      leading: const Icon(Icons.chat_bubble_outline_rounded),
+      title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(subtitle),
+      onTap: () => Navigator.of(context).pop(),
+    );
+  }
+}
+
+class _ProfilePage extends StatelessWidget {
+  const _ProfilePage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('profile-page'),
+      backgroundColor: const Color(0xFFF7F8FC),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
+          children: const [
+            Text(
+              '我的',
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
+            ),
+            SizedBox(height: 8),
+            Text(
+              '个人资料与偏好将在后续任务中接入。',
+              style: TextStyle(color: Color(0xFF696B73), fontSize: 15),
+            ),
+            SizedBox(height: 28),
+            Card(
+              elevation: 0,
+              child: ListTile(
+                leading: CircleAvatar(child: Icon(Icons.person_rounded)),
+                title: Text('演示用户'),
+                subtitle: Text('固定身份 · UI Mock'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -8,7 +8,9 @@ import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/review/review.dart';
 
 class SpeakUpShell extends StatefulWidget {
-  const SpeakUpShell({super.key});
+  const SpeakUpShell({this.showBackButton = false, super.key});
+
+  final bool showBackButton;
 
   @override
   State<SpeakUpShell> createState() => _SpeakUpShellState();
@@ -67,15 +69,18 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       ConversationPage(
         restingComposerBottom: composerBottomInset,
         onOpenMenu: () => _scaffoldKey.currentState?.openDrawer(),
+        onNavigateBack: widget.showBackButton
+            ? () => Navigator.of(context).maybePop()
+            : null,
         onCreatePlan: () => _selectDestination(1),
         onContinuePractice: () =>
             Navigator.of(context).pushNamed(AppRoutes.practice),
         onOpenReview: () => _selectDestination(2),
         onVoicePlaceholder: () => _showMockNotice('该能力将在后续任务接入'),
       ),
-      const PreparationPage(),
-      const ReviewPage(),
-      const _ProfilePage(),
+      PreparationPage(showBackButton: widget.showBackButton),
+      ReviewPage(showBackButton: widget.showBackButton),
+      _ProfilePage(showBackButton: widget.showBackButton),
     ];
 
     return Scaffold(
@@ -176,13 +181,29 @@ class _ConversationTile extends StatelessWidget {
 }
 
 class _ProfilePage extends StatelessWidget {
-  const _ProfilePage();
+  const _ProfilePage({required this.showBackButton});
+
+  final bool showBackButton;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('profile-page'),
       backgroundColor: const Color(0xFFF3F3F0),
+      appBar: showBackButton
+          ? AppBar(
+              backgroundColor: const Color(0xFFF3F3F0),
+              surfaceTintColor: Colors.transparent,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              leading: IconButton(
+                key: const Key('profile-route-back-button'),
+                tooltip: '返回',
+                onPressed: () => Navigator.of(context).maybePop(),
+                icon: const Icon(Icons.arrow_back_rounded),
+              ),
+            )
+          : null,
       body: SafeArea(
         bottom: false,
         child: ListView(

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -61,7 +61,8 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       MediaQuery.viewPaddingOf(context).bottom,
       GlassNavigationBar.minimumBottomInset,
     );
-    final composerBottomInset = GlassNavigationBar.height + safeBottom + 10;
+    final composerBottomInset =
+        GlassNavigationBar.heightFor(context) + safeBottom + 10;
     final pages = [
       ConversationPage(
         restingComposerBottom: composerBottomInset,
@@ -70,7 +71,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onContinuePractice: () =>
             Navigator.of(context).pushNamed(AppRoutes.practice),
         onOpenReview: () => _selectDestination(2),
-        onVoicePlaceholder: () => _showMockNotice('语音能力将在后续任务接入'),
+        onVoicePlaceholder: () => _showMockNotice('该能力将在后续任务接入'),
       ),
       const PreparationPage(),
       const ReviewPage(),
@@ -105,57 +106,51 @@ class _ConversationDrawer extends StatelessWidget {
       width: 300,
       backgroundColor: const Color(0xFFF5F5F2),
       child: SafeArea(
-        child: Padding(
+        child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Row(
-                children: [
-                  const Expanded(
-                    child: Text(
-                      'SpeakUp',
-                      style: TextStyle(
-                        fontSize: 22,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
+          children: [
+            Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'SpeakUp',
+                    style: TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
                   ),
-                  IconButton(
-                    tooltip: '关闭对话菜单',
-                    onPressed: () => Navigator.of(context).pop(),
-                    icon: const Icon(Icons.close_rounded),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              FilledButton.icon(
-                key: const Key('new-conversation-button'),
-                onPressed: () => Navigator.of(context).pop(),
-                icon: const Icon(Icons.edit_square),
-                label: const Text('开始新对话'),
-              ),
-              const SizedBox(height: 28),
-              const Text(
-                '最近对话',
-                style: TextStyle(
-                  color: Color(0xFF777983),
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
                 ),
+                IconButton(
+                  tooltip: '关闭对话菜单',
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: const Key('new-conversation-button'),
+              onPressed: () => Navigator.of(context).pop(),
+              icon: const Icon(Icons.edit_square),
+              label: const Text('开始新对话'),
+            ),
+            const SizedBox(height: 28),
+            const Text(
+              '最近对话',
+              style: TextStyle(
+                color: Color(0xFF777983),
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
               ),
-              const SizedBox(height: 8),
-              const _ConversationTile(title: '准备后端开发模拟面试', subtitle: '刚刚'),
-              const _ConversationTile(title: '项目经历怎么说更清楚', subtitle: '昨天'),
-              const _ConversationTile(title: '系统设计表达复盘', subtitle: '7 月 22 日'),
-              const Spacer(),
-              const Text(
-                '当前内容为 UI Mock',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Color(0xFF989AA3), fontSize: 12),
-              ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 8),
+            const _ConversationTile(title: '准备后端开发模拟面试', subtitle: '刚刚'),
+            const _ConversationTile(title: '项目经历怎么说更清楚', subtitle: '昨天'),
+            const _ConversationTile(title: '系统设计表达复盘', subtitle: '7 月 22 日'),
+            const SizedBox(height: 28),
+            const Text(
+              '当前内容为 UI Mock',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Color(0xFF989AA3), fontSize: 12),
+            ),
+          ],
         ),
       ),
     );

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -29,7 +29,7 @@ class ConversationPage extends StatelessWidget {
     final horizontalPadding = width >= 390 ? 20.0 : 16.0;
     final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final textScaler = MediaQuery.textScalerOf(context);
-    final titleSize = width < 350 ? 32.0 : 38.0;
+    final titleSize = width < 350 ? 30.0 : 36.0;
 
     return Scaffold(
       key: const Key('agent-home-page'),
@@ -63,9 +63,7 @@ class ConversationPage extends StatelessWidget {
                           onOpenMenu: onOpenMenu,
                           onVoicePlaceholder: onVoicePlaceholder,
                         ),
-                        SizedBox(height: width < 350 ? 22 : 34),
-                        const Center(child: _AgentOrb()),
-                        SizedBox(height: width < 350 ? 24 : 34),
+                        SizedBox(height: width < 350 ? 32 : 48),
                         const _Greeting(),
                         const SizedBox(height: 8),
                         Text(
@@ -78,7 +76,7 @@ class ConversationPage extends StatelessWidget {
                             letterSpacing: -1.2,
                           ),
                         ),
-                        SizedBox(height: width < 350 ? 22 : 30),
+                        SizedBox(height: width < 350 ? 20 : 26),
                         _QuickActions(
                           compact: width < 350 || textScaler.scale(1) > 1.2,
                           onCreatePlan: onCreatePlan,
@@ -112,60 +110,7 @@ class _AgentBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ExcludeSemantics(
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          const DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color(0xFFDDF5F5),
-                  Color(0xFFF8F8FC),
-                  Color(0xFFE4E8FF),
-                  Color(0xFFF0ECFA),
-                ],
-                stops: [0, 0.42, 0.7, 1],
-              ),
-            ),
-          ),
-          Positioned(
-            top: -80,
-            right: -90,
-            child: ImageFiltered(
-              imageFilter: ui.ImageFilter.blur(sigmaX: 42, sigmaY: 42),
-              child: const _GlowCircle(size: 240, color: Color(0x667E8CFF)),
-            ),
-          ),
-          Positioned(
-            top: 170,
-            left: -110,
-            child: ImageFiltered(
-              imageFilter: ui.ImageFilter.blur(sigmaX: 50, sigmaY: 50),
-              child: const _GlowCircle(size: 230, color: Color(0x665DE1DD)),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _GlowCircle extends StatelessWidget {
-  const _GlowCircle({required this.size, required this.color});
-
-  final double size;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-    );
+    return const ExcludeSemantics(child: ColoredBox(color: Color(0xFFF3F3F0)));
   }
 }
 
@@ -219,7 +164,7 @@ class _RoundGlassButton extends StatelessWidget {
       child: BackdropFilter(
         filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
         child: Material(
-          color: const Color(0xAFFFFFFF),
+          color: const Color(0xD9FFFFFF),
           child: IconButton(
             tooltip: tooltip,
             onPressed: onPressed,
@@ -247,7 +192,7 @@ class _BrandCapsule extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 18),
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: const Color(0xA8FFFFFF),
+            color: const Color(0xD9FFFFFF),
             borderRadius: BorderRadius.circular(24),
             border: Border.all(color: const Color(0xBFFFFFFF)),
           ),
@@ -261,72 +206,19 @@ class _BrandCapsule extends StatelessWidget {
   }
 }
 
-class _AgentOrb extends StatelessWidget {
-  const _AgentOrb();
-
-  @override
-  Widget build(BuildContext context) {
-    return ExcludeSemantics(
-      child: Container(
-        width: 104,
-        height: 104,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          gradient: const RadialGradient(
-            center: Alignment(-0.35, -0.42),
-            radius: 1.05,
-            colors: [
-              Color(0xFFF5FFFF),
-              Color(0xFFCBE7FF),
-              Color(0xFFB8B9F4),
-              Color(0xFFA78FDF),
-            ],
-            stops: [0, 0.36, 0.7, 1],
-          ),
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x447A88D9),
-              blurRadius: 38,
-              spreadRadius: 4,
-              offset: Offset(0, 16),
-            ),
-          ],
-        ),
-        child: Align(
-          alignment: const Alignment(-0.24, -0.34),
-          child: Container(
-            width: 18,
-            height: 18,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: Color(0xBFFFFFFF),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _Greeting extends StatelessWidget {
   const _Greeting();
 
   @override
   Widget build(BuildContext context) {
-    return ShaderMask(
-      blendMode: BlendMode.srcIn,
-      shaderCallback: (bounds) => const LinearGradient(
-        colors: [Color(0xFF5B9DF5), Color(0xFFD76ABB)],
-      ).createShader(bounds),
-      child: const Text(
-        'Hi, 智',
-        style: TextStyle(
-          color: Colors.white,
-          fontSize: 34,
-          fontWeight: FontWeight.w500,
-          height: 1.1,
-          letterSpacing: -0.7,
-        ),
+    return const Text(
+      'Hi, 智',
+      style: TextStyle(
+        color: Color(0xFF5F6064),
+        fontSize: 29,
+        fontWeight: FontWeight.w500,
+        height: 1.1,
+        letterSpacing: -0.5,
       ),
     );
   }
@@ -352,30 +244,27 @@ class _QuickActions extends StatelessWidget {
       children: [
         _QuickActionButton(
           actionKey: const Key('quick-action-create-plan'),
-          icon: Icons.auto_awesome_rounded,
           label: '创建模拟面试',
           compact: compact,
           onPressed: onCreatePlan,
         ),
-        const SizedBox(height: 11),
+        const SizedBox(height: 10),
         _QuickActionButton(
           actionKey: const Key('quick-action-continue-practice'),
-          icon: Icons.play_circle_outline_rounded,
           label: '继续上次练习',
           compact: compact,
           onPressed: onContinuePractice,
         ),
-        const SizedBox(height: 11),
+        const SizedBox(height: 10),
         _QuickActionButton(
-          icon: Icons.grid_view_rounded,
+          actionKey: const Key('quick-action-browse-scenes'),
           label: '浏览练习场景',
           compact: compact,
           onPressed: onCreatePlan,
         ),
-        const SizedBox(height: 11),
+        const SizedBox(height: 10),
         _QuickActionButton(
           actionKey: const Key('quick-action-recent-review'),
-          icon: Icons.fact_check_outlined,
           label: '查看最近复盘',
           compact: compact,
           onPressed: onOpenReview,
@@ -388,14 +277,12 @@ class _QuickActions extends StatelessWidget {
 class _QuickActionButton extends StatelessWidget {
   const _QuickActionButton({
     this.actionKey,
-    required this.icon,
     required this.label,
     required this.compact,
     required this.onPressed,
   });
 
   final Key? actionKey;
-  final IconData icon;
   final String label;
   final bool compact;
   final VoidCallback? onPressed;
@@ -409,9 +296,9 @@ class _QuickActionButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(28),
           boxShadow: const [
             BoxShadow(
-              color: Color(0x14513E70),
-              blurRadius: 18,
-              offset: Offset(0, 8),
+              color: Color(0x12000000),
+              blurRadius: 16,
+              offset: Offset(0, 7),
             ),
           ],
         ),
@@ -420,36 +307,27 @@ class _QuickActionButton extends StatelessWidget {
           child: BackdropFilter(
             filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
             child: Material(
-              color: const Color(0xB8FFFFFF),
+              color: const Color(0xE6FFFFFF),
               child: InkWell(
                 key: actionKey,
                 onTap: onPressed,
                 child: Container(
-                  constraints: const BoxConstraints(minHeight: 52),
+                  constraints: const BoxConstraints(minHeight: 50),
                   padding: EdgeInsets.symmetric(
-                    horizontal: compact ? 16 : 20,
-                    vertical: 12,
+                    horizontal: compact ? 18 : 22,
+                    vertical: 11,
                   ),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(28),
-                    border: Border.all(color: const Color(0xCFFFFFFF)),
+                    border: Border.all(color: const Color(0xFFFFFFFF)),
                   ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(icon, size: 22, color: const Color(0xFF555AE6)),
-                      const SizedBox(width: 12),
-                      Flexible(
-                        child: Text(
-                          label,
-                          style: TextStyle(
-                            color: const Color(0xFF15161A),
-                            fontSize: compact ? 15 : 16,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ],
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      color: const Color(0xFF15161A),
+                      fontSize: compact ? 15 : 16,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),
@@ -477,9 +355,9 @@ class _AgentComposer extends StatelessWidget {
         borderRadius: BorderRadius.circular(28),
         boxShadow: const [
           BoxShadow(
-            color: Color(0x26513E70),
-            blurRadius: 32,
-            offset: Offset(0, 14),
+            color: Color(0x1C000000),
+            blurRadius: 28,
+            offset: Offset(0, 12),
           ),
         ],
       ),
@@ -492,13 +370,9 @@ class _AgentComposer extends StatelessWidget {
             constraints: BoxConstraints(minHeight: keyboardVisible ? 82 : 104),
             padding: const EdgeInsets.fromLTRB(12, 9, 10, 9),
             decoration: BoxDecoration(
-              gradient: const LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [Color(0xE6FFFFFF), Color(0xB8FFFFFF)],
-              ),
+              color: const Color(0xEFFFFFFF),
               borderRadius: BorderRadius.circular(28),
-              border: Border.all(color: const Color(0xE0FFFFFF)),
+              border: Border.all(color: const Color(0xFFFFFFFF)),
             ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -542,6 +416,10 @@ class _AgentComposer extends StatelessWidget {
                         child: IconButton.filledTonal(
                           tooltip: '语音输入，即将开放',
                           onPressed: onVoicePlaceholder,
+                          style: IconButton.styleFrom(
+                            backgroundColor: const Color(0xFFE8E8E5),
+                            foregroundColor: const Color(0xFF44464D),
+                          ),
                           icon: const Icon(Icons.mic_none_rounded),
                         ),
                       ),

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -1,16 +1,564 @@
 /// Conversation module boundary.
 library;
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 
 class ConversationPage extends StatelessWidget {
-  const ConversationPage({super.key});
+  const ConversationPage({
+    this.restingComposerBottom = 16,
+    this.onOpenMenu,
+    this.onCreatePlan,
+    this.onContinuePractice,
+    this.onOpenReview,
+    this.onVoicePlaceholder,
+    super.key,
+  });
+
+  final double restingComposerBottom;
+  final VoidCallback? onOpenMenu;
+  final VoidCallback? onCreatePlan;
+  final VoidCallback? onContinuePractice;
+  final VoidCallback? onOpenReview;
+  final VoidCallback? onVoicePlaceholder;
 
   @override
   Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final horizontalPadding = width >= 390 ? 20.0 : 16.0;
+    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
+    final textScaler = MediaQuery.textScalerOf(context);
+    final titleSize = width < 350 ? 32.0 : 38.0;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Conversation')),
-      body: const Center(child: Text('Conversation module')),
+      key: const Key('agent-home-page'),
+      resizeToAvoidBottomInset: true,
+      backgroundColor: Colors.transparent,
+      body: Stack(
+        children: [
+          const Positioned.fill(child: _AgentBackground()),
+          SafeArea(
+            bottom: false,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  padding: EdgeInsets.fromLTRB(
+                    horizontalPadding,
+                    12,
+                    horizontalPadding,
+                    keyboardVisible ? 142 : 250,
+                  ),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: (constraints.maxHeight - 230).clamp(
+                        300,
+                        double.infinity,
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _AgentTopBar(
+                          onOpenMenu: onOpenMenu,
+                          onVoicePlaceholder: onVoicePlaceholder,
+                        ),
+                        SizedBox(height: width < 350 ? 22 : 34),
+                        const Center(child: _AgentOrb()),
+                        SizedBox(height: width < 350 ? 24 : 34),
+                        const _Greeting(),
+                        const SizedBox(height: 8),
+                        Text(
+                          '我能为你做什么？',
+                          style: TextStyle(
+                            color: const Color(0xFF0B0B0D),
+                            fontSize: titleSize,
+                            fontWeight: FontWeight.w800,
+                            height: 1.12,
+                            letterSpacing: -1.2,
+                          ),
+                        ),
+                        SizedBox(height: width < 350 ? 22 : 30),
+                        _QuickActions(
+                          compact: width < 350 || textScaler.scale(1) > 1.2,
+                          onCreatePlan: onCreatePlan,
+                          onContinuePractice: onContinuePractice,
+                          onOpenReview: onOpenReview,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Positioned(
+            left: horizontalPadding,
+            right: horizontalPadding,
+            bottom: keyboardVisible ? 10 : restingComposerBottom,
+            child: _AgentComposer(
+              keyboardVisible: keyboardVisible,
+              onVoicePlaceholder: onVoicePlaceholder,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AgentBackground extends StatelessWidget {
+  const _AgentBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    return ExcludeSemantics(
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Color(0xFFDDF5F5),
+                  Color(0xFFF8F8FC),
+                  Color(0xFFE4E8FF),
+                  Color(0xFFF0ECFA),
+                ],
+                stops: [0, 0.42, 0.7, 1],
+              ),
+            ),
+          ),
+          Positioned(
+            top: -80,
+            right: -90,
+            child: ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(sigmaX: 42, sigmaY: 42),
+              child: const _GlowCircle(size: 240, color: Color(0x667E8CFF)),
+            ),
+          ),
+          Positioned(
+            top: 170,
+            left: -110,
+            child: ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(sigmaX: 50, sigmaY: 50),
+              child: const _GlowCircle(size: 230, color: Color(0x665DE1DD)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GlowCircle extends StatelessWidget {
+  const _GlowCircle({required this.size, required this.color});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}
+
+class _AgentTopBar extends StatelessWidget {
+  const _AgentTopBar({
+    required this.onOpenMenu,
+    required this.onVoicePlaceholder,
+  });
+
+  final VoidCallback? onOpenMenu;
+  final VoidCallback? onVoicePlaceholder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _RoundGlassButton(
+          key: const Key('conversation-menu-button'),
+          tooltip: '打开对话菜单',
+          icon: Icons.menu_rounded,
+          onPressed: onOpenMenu,
+        ),
+        const Spacer(),
+        const _BrandCapsule(),
+        const Spacer(),
+        _RoundGlassButton(
+          tooltip: '语音播放，尚未接入',
+          icon: Icons.volume_up_outlined,
+          onPressed: onVoicePlaceholder,
+        ),
+      ],
+    );
+  }
+}
+
+class _RoundGlassButton extends StatelessWidget {
+  const _RoundGlassButton({
+    required this.tooltip,
+    required this.icon,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipOval(
+      child: BackdropFilter(
+        filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: Material(
+          color: const Color(0xAFFFFFFF),
+          child: IconButton(
+            tooltip: tooltip,
+            onPressed: onPressed,
+            icon: Icon(icon, color: const Color(0xFF15161A)),
+            iconSize: 25,
+            constraints: const BoxConstraints.tightFor(width: 48, height: 48),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BrandCapsule extends StatelessWidget {
+  const _BrandCapsule();
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(24),
+      child: BackdropFilter(
+        filter: ui.ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+        child: Container(
+          height: 44,
+          padding: const EdgeInsets.symmetric(horizontal: 18),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: const Color(0xA8FFFFFF),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: const Color(0xBFFFFFFF)),
+          ),
+          child: const Text(
+            'SpeakUp',
+            style: TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentOrb extends StatelessWidget {
+  const _AgentOrb();
+
+  @override
+  Widget build(BuildContext context) {
+    return ExcludeSemantics(
+      child: Container(
+        width: 104,
+        height: 104,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: const RadialGradient(
+            center: Alignment(-0.35, -0.42),
+            radius: 1.05,
+            colors: [
+              Color(0xFFF5FFFF),
+              Color(0xFFCBE7FF),
+              Color(0xFFB8B9F4),
+              Color(0xFFA78FDF),
+            ],
+            stops: [0, 0.36, 0.7, 1],
+          ),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x447A88D9),
+              blurRadius: 38,
+              spreadRadius: 4,
+              offset: Offset(0, 16),
+            ),
+          ],
+        ),
+        child: Align(
+          alignment: const Alignment(-0.24, -0.34),
+          child: Container(
+            width: 18,
+            height: 18,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: Color(0xBFFFFFFF),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Greeting extends StatelessWidget {
+  const _Greeting();
+
+  @override
+  Widget build(BuildContext context) {
+    return ShaderMask(
+      blendMode: BlendMode.srcIn,
+      shaderCallback: (bounds) => const LinearGradient(
+        colors: [Color(0xFF5B9DF5), Color(0xFFD76ABB)],
+      ).createShader(bounds),
+      child: const Text(
+        'Hi, 智',
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: 34,
+          fontWeight: FontWeight.w500,
+          height: 1.1,
+          letterSpacing: -0.7,
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickActions extends StatelessWidget {
+  const _QuickActions({
+    required this.compact,
+    required this.onCreatePlan,
+    required this.onContinuePractice,
+    required this.onOpenReview,
+  });
+
+  final bool compact;
+  final VoidCallback? onCreatePlan;
+  final VoidCallback? onContinuePractice;
+  final VoidCallback? onOpenReview;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _QuickActionButton(
+          actionKey: const Key('quick-action-create-plan'),
+          icon: Icons.auto_awesome_rounded,
+          label: '创建模拟面试',
+          compact: compact,
+          onPressed: onCreatePlan,
+        ),
+        const SizedBox(height: 11),
+        _QuickActionButton(
+          actionKey: const Key('quick-action-continue-practice'),
+          icon: Icons.play_circle_outline_rounded,
+          label: '继续上次练习',
+          compact: compact,
+          onPressed: onContinuePractice,
+        ),
+        const SizedBox(height: 11),
+        _QuickActionButton(
+          icon: Icons.grid_view_rounded,
+          label: '浏览练习场景',
+          compact: compact,
+          onPressed: onCreatePlan,
+        ),
+        const SizedBox(height: 11),
+        _QuickActionButton(
+          actionKey: const Key('quick-action-recent-review'),
+          icon: Icons.fact_check_outlined,
+          label: '查看最近复盘',
+          compact: compact,
+          onPressed: onOpenReview,
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActionButton extends StatelessWidget {
+  const _QuickActionButton({
+    this.actionKey,
+    required this.icon,
+    required this.label,
+    required this.compact,
+    required this.onPressed,
+  });
+
+  final Key? actionKey;
+  final IconData icon;
+  final String label;
+  final bool compact;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(28),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x14513E70),
+              blurRadius: 18,
+              offset: Offset(0, 8),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(28),
+          child: BackdropFilter(
+            filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+            child: Material(
+              color: const Color(0xB8FFFFFF),
+              child: InkWell(
+                key: actionKey,
+                onTap: onPressed,
+                child: Container(
+                  constraints: const BoxConstraints(minHeight: 52),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: compact ? 16 : 20,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(28),
+                    border: Border.all(color: const Color(0xCFFFFFFF)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(icon, size: 22, color: const Color(0xFF555AE6)),
+                      const SizedBox(width: 12),
+                      Flexible(
+                        child: Text(
+                          label,
+                          style: TextStyle(
+                            color: const Color(0xFF15161A),
+                            fontSize: compact ? 15 : 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentComposer extends StatelessWidget {
+  const _AgentComposer({
+    required this.keyboardVisible,
+    required this.onVoicePlaceholder,
+  });
+
+  final bool keyboardVisible;
+  final VoidCallback? onVoicePlaceholder;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x26513E70),
+            blurRadius: 32,
+            offset: Offset(0, 14),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(28),
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+          child: Container(
+            key: const Key('agent-composer-surface'),
+            constraints: BoxConstraints(minHeight: keyboardVisible ? 82 : 104),
+            padding: const EdgeInsets.fromLTRB(12, 9, 10, 9),
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [Color(0xE6FFFFFF), Color(0xB8FFFFFF)],
+              ),
+              borderRadius: BorderRadius.circular(28),
+              border: Border.all(color: const Color(0xE0FFFFFF)),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  key: const Key('agent-composer-field'),
+                  minLines: 1,
+                  maxLines: 2,
+                  textInputAction: TextInputAction.send,
+                  decoration: const InputDecoration(
+                    hintText: '问问 SpeakUp',
+                    hintStyle: TextStyle(
+                      color: Color(0xFF989AA3),
+                      fontSize: 16,
+                    ),
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: EdgeInsets.fromLTRB(4, 4, 4, 2),
+                  ),
+                ),
+                if (!keyboardVisible) const SizedBox(height: 5),
+                Row(
+                  children: [
+                    IconButton(
+                      tooltip: '添加内容，尚未接入',
+                      onPressed: onVoicePlaceholder,
+                      icon: const Icon(Icons.add_rounded),
+                    ),
+                    IconButton(
+                      tooltip: '调整偏好，尚未接入',
+                      onPressed: onVoicePlaceholder,
+                      icon: const Icon(Icons.tune_rounded),
+                    ),
+                    const Spacer(),
+                    Semantics(
+                      key: const Key('agent-mic-placeholder'),
+                      button: true,
+                      label: '语音输入，即将开放',
+                      onTap: onVoicePlaceholder,
+                      child: ExcludeSemantics(
+                        child: IconButton.filledTonal(
+                          tooltip: '语音输入，即将开放',
+                          onPressed: onVoicePlaceholder,
+                          icon: const Icon(Icons.mic_none_rounded),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    const IconButton.filled(
+                      tooltip: '发送，尚未接入',
+                      onPressed: null,
+                      icon: Icon(Icons.arrow_upward_rounded),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -30,6 +30,7 @@ class ConversationPage extends StatelessWidget {
     final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final textScaler = MediaQuery.textScalerOf(context);
     final titleSize = width < 350 ? 30.0 : 36.0;
+    final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
 
     return Scaffold(
       key: const Key('agent-home-page'),
@@ -38,65 +39,67 @@ class ConversationPage extends StatelessWidget {
       body: Stack(
         children: [
           const Positioned.fill(child: _AgentBackground()),
-          SafeArea(
-            bottom: false,
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                return SingleChildScrollView(
-                  padding: EdgeInsets.fromLTRB(
-                    horizontalPadding,
-                    12,
-                    horizontalPadding,
-                    keyboardVisible ? 142 : 250,
-                  ),
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(
-                      minHeight: (constraints.maxHeight - 230).clamp(
-                        300,
-                        double.infinity,
+          Positioned.fill(
+            child: SafeArea(
+              bottom: false,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: composerBottom),
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: EdgeInsets.fromLTRB(
+                          horizontalPadding,
+                          12,
+                          horizontalPadding,
+                          0,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _AgentTopBar(
+                              onOpenMenu: onOpenMenu,
+                              onVoicePlaceholder: onVoicePlaceholder,
+                            ),
+                            SizedBox(height: width < 350 ? 32 : 48),
+                            const _Greeting(),
+                            const SizedBox(height: 8),
+                            Text(
+                              '我能为你做什么？',
+                              style: TextStyle(
+                                color: const Color(0xFF0B0B0D),
+                                fontSize: titleSize,
+                                fontWeight: FontWeight.w600,
+                                height: 1.12,
+                                letterSpacing: -0.8,
+                              ),
+                            ),
+                            SizedBox(height: width < 350 ? 20 : 26),
+                            _QuickActions(
+                              compact: width < 350 || textScaler.scale(1) > 1.2,
+                              onCreatePlan: onCreatePlan,
+                              onContinuePractice: onContinuePractice,
+                              onOpenReview: onOpenReview,
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        _AgentTopBar(
-                          onOpenMenu: onOpenMenu,
-                          onVoicePlaceholder: onVoicePlaceholder,
-                        ),
-                        SizedBox(height: width < 350 ? 32 : 48),
-                        const _Greeting(),
-                        const SizedBox(height: 8),
-                        Text(
-                          '我能为你做什么？',
-                          style: TextStyle(
-                            color: const Color(0xFF0B0B0D),
-                            fontSize: titleSize,
-                            fontWeight: FontWeight.w800,
-                            height: 1.12,
-                            letterSpacing: -1.2,
-                          ),
-                        ),
-                        SizedBox(height: width < 350 ? 20 : 26),
-                        _QuickActions(
-                          compact: width < 350 || textScaler.scale(1) > 1.2,
-                          onCreatePlan: onCreatePlan,
-                          onContinuePractice: onContinuePractice,
-                          onOpenReview: onOpenReview,
-                        ),
-                      ],
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        horizontalPadding,
+                        16,
+                        horizontalPadding,
+                        0,
+                      ),
+                      child: _AgentComposer(
+                        keyboardVisible: keyboardVisible,
+                        onVoicePlaceholder: onVoicePlaceholder,
+                      ),
                     ),
-                  ),
-                );
-              },
-            ),
-          ),
-          Positioned(
-            left: horizontalPadding,
-            right: horizontalPadding,
-            bottom: keyboardVisible ? 10 : restingComposerBottom,
-            child: _AgentComposer(
-              keyboardVisible: keyboardVisible,
-              onVoicePlaceholder: onVoicePlaceholder,
+                  ],
+                ),
+              ),
             ),
           ),
         ],
@@ -134,8 +137,6 @@ class _AgentTopBar extends StatelessWidget {
           onPressed: onOpenMenu,
         ),
         const Spacer(),
-        const _BrandCapsule(),
-        const Spacer(),
         _RoundGlassButton(
           tooltip: '语音播放，尚未接入',
           icon: Icons.volume_up_outlined,
@@ -171,34 +172,6 @@ class _RoundGlassButton extends StatelessWidget {
             icon: Icon(icon, color: const Color(0xFF15161A)),
             iconSize: 25,
             constraints: const BoxConstraints.tightFor(width: 48, height: 48),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _BrandCapsule extends StatelessWidget {
-  const _BrandCapsule();
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(24),
-      child: BackdropFilter(
-        filter: ui.ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-        child: Container(
-          height: 44,
-          padding: const EdgeInsets.symmetric(horizontal: 18),
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: const Color(0xD9FFFFFF),
-            borderRadius: BorderRadius.circular(24),
-            border: Border.all(color: const Color(0xBFFFFFFF)),
-          ),
-          child: const Text(
-            'SpeakUp',
-            style: TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
           ),
         ),
       ),
@@ -296,39 +269,34 @@ class _QuickActionButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(28),
           boxShadow: const [
             BoxShadow(
-              color: Color(0x12000000),
-              blurRadius: 16,
-              offset: Offset(0, 7),
+              color: Color(0x10000000),
+              blurRadius: 14,
+              offset: Offset(0, 6),
             ),
           ],
         ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(28),
-          child: BackdropFilter(
-            filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
-            child: Material(
-              color: const Color(0xE6FFFFFF),
-              child: InkWell(
-                key: actionKey,
-                onTap: onPressed,
-                child: Container(
-                  constraints: const BoxConstraints(minHeight: 50),
-                  padding: EdgeInsets.symmetric(
-                    horizontal: compact ? 18 : 22,
-                    vertical: 11,
-                  ),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(28),
-                    border: Border.all(color: const Color(0xFFFFFFFF)),
-                  ),
-                  child: Text(
-                    label,
-                    style: TextStyle(
-                      color: const Color(0xFF15161A),
-                      fontSize: compact ? 15 : 16,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
+        child: Material(
+          color: const Color(0xDEFFFFFF),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(28),
+            side: const BorderSide(color: Color(0xF2FFFFFF)),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            key: actionKey,
+            onTap: onPressed,
+            child: Container(
+              constraints: const BoxConstraints(minHeight: 50),
+              padding: EdgeInsets.symmetric(
+                horizontal: compact ? 18 : 22,
+                vertical: 11,
+              ),
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: const Color(0xFF15161A),
+                  fontSize: compact ? 15 : 16,
+                  fontWeight: FontWeight.w500,
                 ),
               ),
             ),
@@ -370,7 +338,7 @@ class _AgentComposer extends StatelessWidget {
             constraints: BoxConstraints(minHeight: keyboardVisible ? 82 : 104),
             padding: const EdgeInsets.fromLTRB(12, 9, 10, 9),
             decoration: BoxDecoration(
-              color: const Color(0xEFFFFFFF),
+              color: const Color(0xE6FFFFFF),
               borderRadius: BorderRadius.circular(28),
               border: Border.all(color: const Color(0xFFFFFFFF)),
             ),

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -9,6 +9,7 @@ class ConversationPage extends StatelessWidget {
   const ConversationPage({
     this.restingComposerBottom = 16,
     this.onOpenMenu,
+    this.onNavigateBack,
     this.onCreatePlan,
     this.onContinuePractice,
     this.onOpenReview,
@@ -18,6 +19,7 @@ class ConversationPage extends StatelessWidget {
 
   final double restingComposerBottom;
   final VoidCallback? onOpenMenu;
+  final VoidCallback? onNavigateBack;
   final VoidCallback? onCreatePlan;
   final VoidCallback? onContinuePractice;
   final VoidCallback? onOpenReview;
@@ -59,6 +61,7 @@ class ConversationPage extends StatelessWidget {
                           children: [
                             _AgentTopBar(
                               onOpenMenu: onOpenMenu,
+                              onNavigateBack: onNavigateBack,
                               onVoicePlaceholder: onVoicePlaceholder,
                             ),
                             SizedBox(height: width < 350 ? 32 : 48),
@@ -120,10 +123,12 @@ class _AgentBackground extends StatelessWidget {
 class _AgentTopBar extends StatelessWidget {
   const _AgentTopBar({
     required this.onOpenMenu,
+    required this.onNavigateBack,
     required this.onVoicePlaceholder,
   });
 
   final VoidCallback? onOpenMenu;
+  final VoidCallback? onNavigateBack;
   final VoidCallback? onVoicePlaceholder;
 
   @override
@@ -131,10 +136,16 @@ class _AgentTopBar extends StatelessWidget {
     return Row(
       children: [
         _RoundGlassButton(
-          key: const Key('conversation-menu-button'),
-          tooltip: '打开对话菜单',
-          icon: Icons.menu_rounded,
-          onPressed: onOpenMenu,
+          key: Key(
+            onNavigateBack == null
+                ? 'conversation-menu-button'
+                : 'conversation-route-back-button',
+          ),
+          tooltip: onNavigateBack == null ? '打开对话菜单' : '返回',
+          icon: onNavigateBack == null
+              ? Icons.menu_rounded
+              : Icons.arrow_back_rounded,
+          onPressed: onNavigateBack ?? onOpenMenu,
         ),
         const Spacer(),
         _RoundGlassButton(

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -9,8 +9,16 @@ class PracticePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Practice')),
-      body: const Center(child: Text('Practice module')),
+      appBar: AppBar(title: const Text('练习')),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            '练习模块入口已保留。\n真实 Session 与语音能力将在后续任务接入。',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -4,13 +4,29 @@ library;
 import 'package:flutter/material.dart';
 
 class PreparationPage extends StatelessWidget {
-  const PreparationPage({super.key});
+  const PreparationPage({this.showBackButton = false, super.key});
+
+  final bool showBackButton;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('scenes-page'),
       backgroundColor: const Color(0xFFF3F3F0),
+      appBar: showBackButton
+          ? AppBar(
+              backgroundColor: const Color(0xFFF3F3F0),
+              surfaceTintColor: Colors.transparent,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              leading: IconButton(
+                key: const Key('preparation-route-back-button'),
+                tooltip: '返回',
+                onPressed: () => Navigator.of(context).maybePop(),
+                icon: const Icon(Icons.arrow_back_rounded),
+              ),
+            )
+          : null,
       body: SafeArea(
         bottom: false,
         child: ListView(

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -9,8 +9,83 @@ class PreparationPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Preparation')),
-      body: const Center(child: Text('Preparation module')),
+      key: const Key('scenes-page'),
+      backgroundColor: const Color(0xFFF7F8FC),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
+          children: [
+            const Text(
+              '场景',
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '直接进入已经开放的练习；未实现的场景不会提前展示。',
+              style: TextStyle(color: Color(0xFF696B73), fontSize: 15),
+            ),
+            const SizedBox(height: 28),
+            Card(
+              elevation: 0,
+              color: Colors.white,
+              clipBehavior: Clip.antiAlias,
+              child: Padding(
+                padding: const EdgeInsets.all(18),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 52,
+                      height: 52,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFE8EAFF),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: const Icon(
+                        Icons.work_outline_rounded,
+                        color: Color(0xFF555AE6),
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    const Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '模拟英文面试',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          SizedBox(height: 5),
+                          Text(
+                            '准备岗位背景、选择面试视角，再开始一场受控练习。',
+                            style: TextStyle(
+                              color: Color(0xFF696B73),
+                              height: 1.4,
+                            ),
+                          ),
+                          SizedBox(height: 10),
+                          Text(
+                            '页面流程将在后续 Issue 接入',
+                            style: TextStyle(
+                              color: Color(0xFF555AE6),
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -10,7 +10,7 @@ class PreparationPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('scenes-page'),
-      backgroundColor: const Color(0xFFF7F8FC),
+      backgroundColor: const Color(0xFFF3F3F0),
       body: SafeArea(
         bottom: false,
         child: ListView(
@@ -39,12 +39,12 @@ class PreparationPage extends StatelessWidget {
                       width: 52,
                       height: 52,
                       decoration: BoxDecoration(
-                        color: const Color(0xFFE8EAFF),
+                        color: const Color(0xFFE8E8E5),
                         borderRadius: BorderRadius.circular(16),
                       ),
                       child: const Icon(
                         Icons.work_outline_rounded,
-                        color: Color(0xFF555AE6),
+                        color: Color(0xFF4F5054),
                       ),
                     ),
                     const SizedBox(width: 14),
@@ -71,7 +71,7 @@ class PreparationPage extends StatelessWidget {
                           Text(
                             '页面流程将在后续 Issue 接入',
                             style: TextStyle(
-                              color: Color(0xFF555AE6),
+                              color: Color(0xFF4F5054),
                               fontSize: 12,
                               fontWeight: FontWeight.w700,
                             ),

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -10,7 +10,7 @@ class ReviewPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('review-page'),
-      backgroundColor: const Color(0xFFF7F8FC),
+      backgroundColor: const Color(0xFFF3F3F0),
       body: SafeArea(
         bottom: false,
         child: ListView(

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -9,8 +9,56 @@ class ReviewPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Review')),
-      body: const Center(child: Text('Review module')),
+      key: const Key('review-page'),
+      backgroundColor: const Color(0xFFF7F8FC),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
+          children: const [
+            Text(
+              '复盘',
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
+            ),
+            SizedBox(height: 8),
+            Text(
+              '练习记录、证据反馈和再次练习会集中在这里。',
+              style: TextStyle(color: Color(0xFF696B73), fontSize: 15),
+            ),
+            SizedBox(height: 28),
+            Card(
+              elevation: 0,
+              color: Colors.white,
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 22, vertical: 34),
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.fact_check_outlined,
+                      size: 42,
+                      color: Color(0xFF8B8E99),
+                    ),
+                    SizedBox(height: 14),
+                    Text(
+                      '完成一次练习后再来看看',
+                      style: TextStyle(
+                        fontSize: 17,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    SizedBox(height: 6),
+                    Text(
+                      '当前页面为 UI Mock，不包含真实练习数据。',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Color(0xFF777983)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -4,13 +4,29 @@ library;
 import 'package:flutter/material.dart';
 
 class ReviewPage extends StatelessWidget {
-  const ReviewPage({super.key});
+  const ReviewPage({this.showBackButton = false, super.key});
+
+  final bool showBackButton;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('review-page'),
       backgroundColor: const Color(0xFFF3F3F0),
+      appBar: showBackButton
+          ? AppBar(
+              backgroundColor: const Color(0xFFF3F3F0),
+              surfaceTintColor: Colors.transparent,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              leading: IconButton(
+                key: const Key('review-route-back-button'),
+                tooltip: '返回',
+                onPressed: () => Navigator.of(context).maybePop(),
+                icon: const Icon(Icons.arrow_back_rounded),
+              ),
+            )
+          : null,
       body: SafeArea(
         bottom: false,
         child: ListView(

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -81,6 +81,38 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('keeps all four Agent actions above the composer on iPhone', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(402, 874);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(const SpeakUpApp());
+    await tester.pumpAndSettle();
+
+    const actionKeys = [
+      'quick-action-create-plan',
+      'quick-action-continue-practice',
+      'quick-action-browse-scenes',
+      'quick-action-recent-review',
+    ];
+    for (final key in actionKeys) {
+      final action = find.byKey(Key(key));
+      expect(action, findsOneWidget);
+      expect(tester.getRect(action).bottom, lessThan(874));
+    }
+
+    final lastActionRect = tester.getRect(
+      find.byKey(const Key('quick-action-recent-review')),
+    );
+    final composerRect = tester.getRect(
+      find.byKey(const Key('agent-composer-surface')),
+    );
+    expect(composerRect.top - lastActionRect.bottom, greaterThanOrEqualTo(16));
+  });
+
   testWidgets('conversation drawer contains no duplicate primary navigation', (
     tester,
   ) async {

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_app.dart';
@@ -39,6 +40,8 @@ void main() {
     );
     final navigationRect = tester.getRect(navigation);
     expect(navigationRect.top - composerRect.bottom, closeTo(10, 1));
+    expect(navigationRect.left, closeTo(composerRect.left, 1));
+    expect(navigationRect.right, closeTo(composerRect.right, 1));
 
     final semantics = tester.ensureSemantics();
     expect(
@@ -189,6 +192,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
 
+    final lastAction = find.byKey(const Key('quick-action-recent-review'));
+    await tester.ensureVisible(lastAction);
+    await tester.pumpAndSettle();
+    final lastActionRect = tester.getRect(lastAction);
+    final restingComposerRect = tester.getRect(
+      find.byKey(const Key('agent-composer-surface')),
+    );
+    expect(
+      restingComposerRect.top - lastActionRect.bottom,
+      greaterThanOrEqualTo(16),
+    );
+    expect(lastAction.hitTestable(), findsOneWidget);
+
     await tester.tap(find.byKey(const Key('primary-tab-scenes')));
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
@@ -209,6 +225,86 @@ void main() {
     expect(keyboardTop - composerRect.bottom, closeTo(10, 1));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('supports larger system text without covering Agent actions', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(402, 874);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 1.5;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await tester.pumpWidget(const SpeakUpApp());
+    await tester.pumpAndSettle();
+
+    final lastAction = find.byKey(const Key('quick-action-recent-review'));
+    await tester.ensureVisible(lastAction);
+    await tester.pumpAndSettle();
+
+    final lastActionRect = tester.getRect(lastAction);
+    final composerRect = tester.getRect(
+      find.byKey(const Key('agent-composer-surface')),
+    );
+    expect(composerRect.top - lastActionRect.bottom, greaterThanOrEqualTo(16));
+    expect(lastAction.hitTestable(), findsOneWidget);
+    expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'keeps navigation and drawer usable at accessibility text sizes',
+    (tester) async {
+      tester.view.physicalSize = const Size(320, 568);
+      tester.view.devicePixelRatio = 1;
+      tester.platformDispatcher.textScaleFactorTestValue = 3;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+      await tester.pumpWidget(const SpeakUpApp());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+      expect(tester.takeException(), isNull);
+      final selectedLabel = tester.renderObject<RenderParagraph>(
+        find.text('SpeakUp'),
+      );
+      expect(selectedLabel.didExceedMaxLines, isFalse);
+
+      final lastAction = find.byKey(const Key('quick-action-recent-review'));
+      await tester.ensureVisible(lastAction);
+      await tester.pumpAndSettle();
+      final lastActionRect = tester.getRect(lastAction);
+      final composerRect = tester.getRect(
+        find.byKey(const Key('agent-composer-surface')),
+      );
+      expect(
+        composerRect.top - lastActionRect.bottom,
+        greaterThanOrEqualTo(16),
+      );
+      expect(lastAction.hitTestable(), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(const SpeakUpApp());
+      await tester.pumpAndSettle();
+
+      final menuButton = find.byKey(const Key('conversation-menu-button'));
+      await tester.tap(menuButton);
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Drawer), findsOneWidget);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -1000));
+      await tester.pumpAndSettle();
+      final mockLabel = find.text('当前内容为 UI Mock');
+      expect(mockLabel.hitTestable(), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
 }
 
 const _primaryTabKeys = [

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,35 +1,224 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/conversation/conversation.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/review/review.dart';
 
 void main() {
-  testWidgets('app starts and exposes every feature entry point', (
+  testWidgets('starts on the Agent home with four glass navigation entries', (
     tester,
   ) async {
     await tester.pumpWidget(const SpeakUpApp());
 
-    expect(find.text('SpeakUp'), findsOneWidget);
+    expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
+    expect(find.text('我能为你做什么？'), findsOneWidget);
+    expect(find.byKey(const Key('quick-action-create-plan')), findsOneWidget);
+    expect(
+      find.byKey(const Key('quick-action-continue-practice')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('quick-action-recent-review')), findsOneWidget);
+    expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
 
-    await _expectNavigationTo<PreparationPage>(tester, 'Preparation');
-    await _expectNavigationTo<PracticePage>(tester, 'Practice');
-    await _expectNavigationTo<ConversationPage>(tester, 'Conversation');
-    await _expectNavigationTo<ReviewPage>(tester, 'Review');
+    for (final key in _primaryTabKeys) {
+      expect(find.byKey(Key(key)), findsOneWidget);
+    }
+
+    final navigation = find.byKey(const Key('primary-navigation'));
+    expect(navigation, findsOneWidget);
+    expect(
+      find.ancestor(of: navigation, matching: find.byType(BackdropFilter)),
+      findsOneWidget,
+    );
+    final composerRect = tester.getRect(
+      find.byKey(const Key('agent-composer-surface')),
+    );
+    final navigationRect = tester.getRect(navigation);
+    expect(navigationRect.top - composerRect.bottom, closeTo(10, 1));
+
+    final semantics = tester.ensureSemantics();
+    expect(
+      tester.getSemantics(find.byKey(const Key('primary-tab-agent'))),
+      isSemantics(
+        label: 'SpeakUp',
+        isButton: true,
+        hasSelectedState: true,
+        isSelected: true,
+        hasTapAction: true,
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('switches between every primary destination', (tester) async {
+    await tester.pumpWidget(const SpeakUpApp());
+    final semantics = tester.ensureSemantics();
+
+    await _tapPrimaryDestination(
+      tester,
+      key: 'primary-tab-scenes',
+      expectedPageKey: 'scenes-page',
+    );
+    await _tapPrimaryDestination(
+      tester,
+      key: 'primary-tab-review',
+      expectedPageKey: 'review-page',
+    );
+    await _tapPrimaryDestination(
+      tester,
+      key: 'primary-tab-profile',
+      expectedPageKey: 'profile-page',
+    );
+    await _tapPrimaryDestination(
+      tester,
+      key: 'primary-tab-agent',
+      expectedPageKey: 'agent-home-page',
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('conversation drawer contains no duplicate primary navigation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp());
+
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+    await tester.pumpAndSettle();
+
+    final drawer = find.byType(Drawer);
+    expect(drawer, findsOneWidget);
+    expect(
+      find.descendant(
+        of: drawer,
+        matching: find.byKey(const Key('new-conversation-button')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: drawer, matching: find.text('最近对话')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: drawer, matching: find.text('场景')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: drawer, matching: find.text('复盘')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: drawer, matching: find.text('我的')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('Agent actions reuse the existing feature entry points', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp());
+
+    await _tapVisible(tester, 'quick-action-create-plan');
+    expect(find.byKey(const Key('scenes-page')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('primary-tab-agent')));
+    await tester.pumpAndSettle();
+    await _tapVisible(tester, 'quick-action-recent-review');
+    expect(find.byKey(const Key('review-page')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('primary-tab-agent')));
+    await tester.pumpAndSettle();
+    await _tapVisible(tester, 'quick-action-continue-practice');
+    expect(find.byType(PracticePage), findsOneWidget);
+  });
+
+  testWidgets('keeps every formal feature route reachable', (tester) async {
+    await tester.pumpWidget(const SpeakUpApp());
+
+    await _expectNamedRoute<PreparationPage>(tester, AppRoutes.preparation);
+    await _expectNamedRoute<PracticePage>(tester, AppRoutes.practice);
+    await _expectNamedRoute<ConversationPage>(tester, AppRoutes.conversation);
+    await _expectNamedRoute<ReviewPage>(tester, AppRoutes.review);
+  });
+
+  testWidgets('stays usable on a narrow screen and with the keyboard open', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+
+    await tester.pumpWidget(const SpeakUpApp());
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byKey(const Key('primary-tab-scenes')));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byKey(const Key('primary-tab-agent')));
+    await tester.pumpAndSettle();
+    tester.view.viewInsets = const FakeViewPadding(bottom: 240);
+    await tester.showKeyboard(find.byKey(const Key('agent-composer-field')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
+    expect(find.byKey(const Key('primary-navigation')), findsNothing);
+    final keyboardTop =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio - 240;
+    final composerRect = tester.getRect(
+      find.byKey(const Key('agent-composer-surface')),
+    );
+    expect(keyboardTop - composerRect.bottom, closeTo(10, 1));
+    expect(tester.takeException(), isNull);
   });
 }
 
-Future<void> _expectNavigationTo<T extends Widget>(
+const _primaryTabKeys = [
+  'primary-tab-agent',
+  'primary-tab-scenes',
+  'primary-tab-review',
+  'primary-tab-profile',
+];
+
+Future<void> _tapPrimaryDestination(
+  WidgetTester tester, {
+  required String key,
+  required String expectedPageKey,
+}) async {
+  await tester.tap(find.byKey(Key(key)));
+  await tester.pumpAndSettle();
+
+  expect(find.byKey(Key(expectedPageKey)), findsOneWidget);
+  expect(
+    tester.getSemantics(find.byKey(Key(key))),
+    isSemantics(hasSelectedState: true, isSelected: true),
+  );
+}
+
+Future<void> _expectNamedRoute<T extends Widget>(
   WidgetTester tester,
-  String entryLabel,
+  String route,
 ) async {
-  await tester.tap(find.text(entryLabel));
+  final shellContext = tester.element(find.byType(SpeakUpShell));
+  Navigator.of(shellContext).pushNamed(route);
   await tester.pumpAndSettle();
 
   expect(find.byType(T), findsOneWidget);
 
-  await tester.pageBack();
+  Navigator.of(tester.element(find.byType(T))).pop();
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapVisible(WidgetTester tester, String key) async {
+  final finder = find.byKey(Key(key));
+  await tester.ensureVisible(finder);
+  await tester.pumpAndSettle();
+  await tester.tap(finder);
   await tester.pumpAndSettle();
 }

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -173,10 +173,68 @@ void main() {
   testWidgets('keeps every formal feature route reachable', (tester) async {
     await tester.pumpWidget(const SpeakUpApp());
 
-    await _expectNamedRoute<PreparationPage>(tester, AppRoutes.preparation);
-    await _expectNamedRoute<PracticePage>(tester, AppRoutes.practice);
-    await _expectNamedRoute<ConversationPage>(tester, AppRoutes.conversation);
-    await _expectNamedRoute<ReviewPage>(tester, AppRoutes.review);
+    await _expectNamedRoute<PreparationPage>(
+      tester,
+      AppRoutes.preparation,
+      backButton: find.byKey(const Key('preparation-route-back-button')),
+    );
+    await _expectNamedRoute<PracticePage>(
+      tester,
+      AppRoutes.practice,
+      backButton: find.byType(BackButton),
+    );
+    await _expectNamedRoute<ConversationPage>(
+      tester,
+      AppRoutes.conversation,
+      backButton: find.byKey(const Key('conversation-route-back-button')),
+    );
+    await _expectNamedRoute<ReviewPage>(
+      tester,
+      AppRoutes.review,
+      backButton: find.byKey(const Key('review-route-back-button')),
+    );
+  });
+
+  testWidgets('keeps the named conversation route escapable on every tab', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp());
+
+    final shellContext = tester.element(find.byType(SpeakUpShell));
+    Navigator.of(shellContext).pushNamed(AppRoutes.conversation);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('conversation-route-back-button')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('primary-tab-scenes')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('preparation-route-back-button')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('primary-tab-review')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('review-route-back-button')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pumpAndSettle();
+    final profileBackButton = find.byKey(
+      const Key('profile-route-back-button'),
+    );
+    expect(profileBackButton, findsOneWidget);
+
+    await tester.tap(profileBackButton);
+    await tester.pumpAndSettle();
+
+    expect(profileBackButton, findsNothing);
+    expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
+    expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+    final rootShellContext = tester.element(find.byType(SpeakUpShell));
+    expect(Navigator.of(rootShellContext).canPop(), isFalse);
   });
 
   testWidgets('stays usable on a narrow screen and with the keyboard open', (
@@ -327,20 +385,32 @@ Future<void> _tapPrimaryDestination(
     tester.getSemantics(find.byKey(Key(key))),
     isSemantics(hasSelectedState: true, isSelected: true),
   );
+  expect(find.byKey(const Key('preparation-route-back-button')), findsNothing);
+  expect(find.byKey(const Key('review-route-back-button')), findsNothing);
+  expect(find.byKey(const Key('conversation-route-back-button')), findsNothing);
+  expect(find.byKey(const Key('profile-route-back-button')), findsNothing);
 }
 
 Future<void> _expectNamedRoute<T extends Widget>(
   WidgetTester tester,
-  String route,
-) async {
+  String route, {
+  required Finder backButton,
+}) async {
   final shellContext = tester.element(find.byType(SpeakUpShell));
   Navigator.of(shellContext).pushNamed(route);
   await tester.pumpAndSettle();
 
   expect(find.byType(T), findsOneWidget);
+  expect(backButton, findsOneWidget);
 
-  Navigator.of(tester.element(find.byType(T))).pop();
+  await tester.tap(backButton);
   await tester.pumpAndSettle();
+
+  expect(backButton, findsNothing);
+  expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
+  expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+  final rootShellContext = tester.element(find.byType(SpeakUpShell));
+  expect(Navigator.of(rootShellContext).canPop(), isFalse);
 }
 
 Future<void> _tapVisible(WidgetTester tester, String key) async {


### PR DESCRIPTION
## 功能描述

- 将 Flutter App 默认入口调整为 SpeakUp Agent 首页。
- 建立 `SpeakUp / 场景 / 复盘 / 我的` 四个一级入口，并保留现有业务模块和正式命名路由。
- 提供问候语、四个快捷操作、固定输入区、语音视觉占位和仅包含新对话/最近对话的抽屉。
- 为场景、复盘和我的提供可导航的最小页面外壳，不迁入历史 Prototype 的冗余页面。

## 实现思路

- 使用 Flutter 原生 `BackdropFilter`、半透明中性色表面、白色描边、圆角和阴影实现底部玻璃拟态。
- 根据最新视觉反馈移除蓝紫渐变、Emoji 和中央装饰，只保留中性背景与必要的 Material 图标。
- 让滚动内容与输入框使用真实布局空间，避免短屏、大字号和键盘状态下快捷操作被输入框覆盖。
- 底栏适配 iOS Safe Area、窄屏和辅助字号；标签在可用宽度内缩放但保留完整语义。
- 快捷操作复用现有场景、练习和复盘入口，不复制第二套业务状态。
- 保留 `/preparation`、`/practice`、`/conversation`、`/review` 命名路由的可见返回路径；Tab 模式不显示多余返回按钮。

## UI Mock 边界

- 首页文案、最近对话和演示用户均为 UI Mock。
- 语音、添加、偏好和发送入口不包含真实 ASR、TTS、Agent、LLM、REST 或 WebSocket 能力。
- 本 PR 不修改后端、API 契约、认证、权限或 iOS Bundle Identity。

## 可复现验证

```shell
cd mobile
dart format --output=none --set-exit-if-changed lib test
flutter analyze --no-pub
flutter test --no-pub
```

结果：

- Flutter 静态分析通过。
- 10 项 Widget 测试通过，覆盖默认首页、四栏切换、快捷入口、抽屉边界、命名路由可见返回、键盘、`320 x 568` 窄屏以及 `1.5x / 3.0x` 系统字号。
- 已在 iOS 18.3 的 iPhone 16 Pro 和 iPhone SE 模拟器完成启动与视觉检查。

## iOS 模拟器截图

iOS 18.3 · iPhone 16 Pro · 默认 SpeakUp Agent 首页

<a href="https://github.com/user-attachments/assets/502c0f76-c56b-4fda-acbf-651125461f57">
  <img width="360" alt="SpeakUp Agent 首页（iPhone 16 Pro）" src="https://github.com/user-attachments/assets/502c0f76-c56b-4fda-acbf-651125461f57" />
</a>

页面文案、最近对话以及语音/工具入口均为 UI Mock。

Closes #71
