### PR TITLE
feat(api): 定义 Identity API 与安全契约

### DIFF
--- a/api/common/errors.yaml
+++ b/api/common/errors.yaml
@@ -50,6 +50,10 @@ components:
       description: Stable machine-readable Delivery error code.
       enum:
         - invalid_request
+        - authentication_required
+        - invalid_credentials
+        - account_registration_unavailable
+        - rate_limited
         - resource_not_found
         - resource_conflict
         - idempotency_key_conflict
@@ -86,6 +90,8 @@ components:
         invalid_request: 400
         answer_invalid: 400
         unsupported_message: 400
+        authentication_required: 401
+        invalid_credentials: 401
         practice_participant_not_authorized: 403
         scenario_definition_not_found: 404
         role_definition_not_found: 404
@@ -98,6 +104,7 @@ components:
         feedback_item_not_found: 404
         retry_request_not_found: 404
         resource_not_found: 404
+        account_registration_unavailable: 409
         idempotency_key_conflict: 409
         resource_conflict: 409
         preparation_version_conflict: 409
@@ -115,6 +122,7 @@ components:
         turn_analysis_conflict: 409
         retry_request_conflict: 409
         transcript_unavailable: 422
+        rate_limited: 429
         internal_error: 500
   responses:
     BadRequest:
@@ -132,6 +140,25 @@ components:
               details:
                 - field: body
                   reason: One or more fields are invalid.
+    Unauthorized:
+      description: A valid Bearer Session is required for this operation.
+      headers:
+        WWW-Authenticate:
+          description: Authentication scheme required by the API.
+          schema:
+            type: string
+            const: Bearer
+          example: Bearer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: authentication_required
+              message: Authentication is required.
+              retryable: false
+              correlation_id: corr_authentication_required
     NotFound:
       description: The requested resource does not exist for the current actor.
       content:
@@ -168,6 +195,25 @@ components:
               message: Resource state conflicts with this operation.
               retryable: false
               correlation_id: corr_conflict
+    TooManyRequests:
+      description: The caller must wait before attempting this operation again.
+      headers:
+        Retry-After:
+          description: Minimum number of seconds before the caller retries.
+          schema:
+            type: integer
+            minimum: 1
+          example: 60
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: rate_limited
+              message: Too many requests. Try again later.
+              retryable: true
+              correlation_id: corr_rate_limited
     DefaultError:
       description: A stable error response.
       content:

--- a/api/modules/conversation.yaml
+++ b/api/modules/conversation.yaml
@@ -238,6 +238,13 @@ paths:
       operationId: connectPracticeSessionEvents
       parameters:
         - $ref: '#/components/parameters/PracticeSessionId'
+        - name: Sec-WebSocket-Protocol
+          in: header
+          required: true
+          description: Required application event-stream subprotocol.
+          schema:
+            type: string
+            const: speakup.events.v1
         - name: after_sequence
           in: query
           required: false

--- a/api/modules/conversation.yaml
+++ b/api/modules/conversation.yaml
@@ -20,6 +20,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConversationBootstrap'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -64,6 +66,8 @@ paths:
                 created_at: '2026-07-23T10:04:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -156,6 +160,8 @@ paths:
                     created_at: '2026-07-23T10:06:01Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '403':
           $ref: ../common/errors.yaml#/components/responses/Forbidden
         '404':
@@ -194,6 +200,8 @@ paths:
                 submitted_at: '2026-07-23T10:05:00Z'
                 created_at: '2026-07-23T10:05:00Z'
                 completed_at: '2026-07-23T10:05:02Z'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -208,6 +216,25 @@ paths:
         increasing per-session `sequence`. Reconnect with `after_sequence`; when
         retained events cannot close a gap, the server emits
         `stream.resync_required` and the client reloads REST resources.
+
+        The Upgrade request's `Authorization` header is the only credential
+        location and uses the same Bearer Session as protected REST requests.
+        Production connections require `wss`; local loopback development may use
+        `ws`. Every initial connection and reconnect authenticates again before
+        the Upgrade. Missing or invalid authentication fails with HTTP 401, while
+        a valid actor that cannot see the target Session receives HTTP 404.
+
+        `Sec-WebSocket-Protocol` only negotiates `speakup.events.v1` and never
+        carries credentials. `after_sequence` is only a replay cursor and is not
+        a credential. The accepted connection is bound to the authenticated
+        UserID, SessionID, and path PracticeSessionID and cannot switch targets.
+        Logout closes every connection bound to the revoked SessionID. Until that
+        close propagates, every replay batch and private outbound event rechecks
+        both Session validity and resource ownership. If the bound Session becomes
+        invalid after the Upgrade, the server closes the connection with code 4401
+        and reason `session_invalid` before sending further application events.
+        An ordinary network disconnect is recoverable and does not revoke the
+        Session or perform logout.
       operationId: connectPracticeSessionEvents
       parameters:
         - $ref: '#/components/parameters/PracticeSessionId'
@@ -230,12 +257,65 @@ paths:
                 const: speakup.events.v1
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
       x-websocket-event-schema:
         $ref: ../websocket/conversation-events.schema.json
+      x-websocket-security:
+        credential_location: authorization_header
+        header: Authorization
+        scheme: Bearer
+        other_credential_locations_allowed: false
+        production_transport: wss
+        local_loopback_transport: ws
+        pre_upgrade:
+          validation_order:
+            - session
+            - actor
+            - resource_ownership
+            - replay_cursor
+            - subprotocol
+            - upgrade
+          authentication_failure:
+            http_status: 401
+            error_code: authentication_required
+          resource_not_visible:
+            http_status: 404
+            error_code: resource_not_found
+        reconnect:
+          reauthenticate: true
+        connection_binding:
+          actor_fields:
+            - user_id
+            - session_id
+          target_field: practice_session_id
+          target_switch_allowed: false
+        logout:
+          close_connections_by: session_id
+          all_matching_connections: true
+        active_connection:
+          authorization_recheck:
+            before_replay_batch: true
+            before_private_outbound_event: true
+            checks:
+              - session_validity
+              - resource_ownership
+          invalid_session:
+            close_code: 4401
+            close_reason: session_invalid
+            send_application_events_before_close: false
+          ordinary_disconnect:
+            is_logout: false
+        subprotocol:
+          allowed:
+            - speakup.events.v1
+          carries_credentials: false
+        after_sequence:
+          is_credential: false
 components:
   parameters:
     PracticeSessionId:

--- a/api/modules/identity.yaml
+++ b/api/modules/identity.yaml
@@ -1,0 +1,267 @@
+paths:
+  /v1/auth/register:
+    post:
+      tags:
+        - Identity
+      summary: Register a minimal email and password account
+      description: |
+        Creates a User without creating a Session. The service trims leading
+        and trailing ASCII whitespace from the email, validates the remaining
+        ASCII address, and stores and returns its lowercase canonical form.
+        Concurrent or repeated registration of the same canonical email does
+        not modify the existing account.
+      operationId: registerUser
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+            example:
+              email: learner@example.com
+              password: correct horse battery staple
+      responses:
+        '201':
+          description: The minimal User was created. No Session Token is issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              example:
+                user_id: user_01k1example
+                email: learner@example.com
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '409':
+          $ref: '#/components/responses/RegistrationUnavailable'
+        '429':
+          $ref: ../common/errors.yaml#/components/responses/TooManyRequests
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/auth/login:
+    post:
+      tags:
+        - Identity
+      summary: Create an opaque Session for one device
+      description: |
+        Authenticates an email and password without revealing whether the
+        account exists or why authentication failed. The raw opaque Session
+        Token is returned only in this successful response.
+      operationId: loginUser
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              email: learner@example.com
+              password: correct horse battery staple
+      responses:
+        '200':
+          description: A finite-lifetime Session was created for the User.
+          headers:
+            Cache-Control:
+              description: Prevents storage of the raw Session Token response.
+              schema:
+                type: string
+                const: no-store
+            Pragma:
+              description: Compatibility directive preventing response caching.
+              schema:
+                type: string
+                const: no-cache
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              example:
+                user:
+                  user_id: user_01k1example
+                  email: learner@example.com
+                session_token: sess_Q7ZfMrq3Jst8ahRck4ExampleOpaqueValue
+                token_type: Bearer
+                expires_at: '2026-08-23T10:00:00Z'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: '#/components/responses/InvalidCredentials'
+        '429':
+          $ref: ../common/errors.yaml#/components/responses/TooManyRequests
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/auth/logout:
+    post:
+      tags:
+        - Identity
+      summary: Revoke the current Session
+      description: |
+        Revokes only the Session represented by the Bearer credential. The
+        request has no body and never accepts a client-supplied `user_id` or
+        `session_id`.
+      operationId: logoutCurrentSession
+      responses:
+        '204':
+          description: The current Session was revoked.
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/me:
+    get:
+      tags:
+        - Identity
+      summary: Get the current User
+      description: |
+        Resolves the trusted User from the validated Session. The response does
+        not expose a password, credential hash, Session Token, Session digest,
+        or long-term information.
+      operationId: getCurrentUser
+      responses:
+        '200':
+          description: The minimal User represented by the current Session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              example:
+                user_id: user_01k1example
+                email: learner@example.com
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  responses:
+    InvalidCredentials:
+      description: |
+        Authentication failed. The response is identical for an unknown email,
+        incorrect password, disabled account, or account deletion state.
+      content:
+        application/json:
+          schema:
+            $ref: ../common/errors.yaml#/components/schemas/ErrorResponse
+          example:
+            error:
+              code: invalid_credentials
+              message: Email or password is invalid.
+              retryable: false
+              correlation_id: corr_invalid_credentials
+    RegistrationUnavailable:
+      description: |
+        Registration cannot create the requested account. The response does not
+        reveal the existing account state.
+      content:
+        application/json:
+          schema:
+            $ref: ../common/errors.yaml#/components/schemas/ErrorResponse
+          example:
+            error:
+              code: account_registration_unavailable
+              message: Account registration is unavailable.
+              retryable: false
+              correlation_id: corr_registration_unavailable
+  schemas:
+    UserId:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+    EmailInput:
+      type: string
+      pattern: "^[\\x09-\\x0D\\x20]*(?=[^\\x09-\\x0D\\x20]{3,254}[\\x09-\\x0D\\x20]*$)[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+[\\x09-\\x0D\\x20]*$"
+      description: |
+        An ASCII email address with an ASCII or Punycode domain. The service
+        removes leading and trailing ASCII whitespace (U+0009 through U+000D
+        and U+0020) before validation. The pattern constrains the post-trim
+        value to 3 through 254 ASCII bytes. Provider-specific dot or
+        plus-address transformations are forbidden.
+    Email:
+      type: string
+      format: email
+      minLength: 3
+      maxLength: 254
+      pattern: "^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$"
+      description: |
+        The lowercase canonical form of an ASCII email address. Punycode domain
+        labels are allowed; provider-specific dot or plus transformations are
+        never applied.
+      readOnly: true
+    Password:
+      type: string
+      minLength: 15
+      maxLength: 128
+      writeOnly: true
+      description: |
+        An opaque password string. The service does not trim, case-fold,
+        truncate, or apply Unicode normalization. No character-class
+        composition rule is required.
+    User:
+      type: object
+      additionalProperties: false
+      required:
+        - user_id
+        - email
+      properties:
+        user_id:
+          $ref: '#/components/schemas/UserId'
+          readOnly: true
+        email:
+          $ref: '#/components/schemas/Email'
+    RegisterRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+        - password
+      properties:
+        email:
+          $ref: '#/components/schemas/EmailInput'
+        password:
+          $ref: '#/components/schemas/Password'
+    LoginRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+        - password
+      properties:
+        email:
+          $ref: '#/components/schemas/EmailInput'
+        password:
+          $ref: '#/components/schemas/Password'
+    OpaqueSessionToken:
+      type: string
+      minLength: 1
+      pattern: '^[A-Za-z0-9._~+/-]+={0,}$'
+      readOnly: true
+      description: |
+        A high-entropy first-party opaque Session Token returned only by a
+        successful login response. Its wire representation follows the RFC 6750
+        `b64token` character set so it can be carried safely by the Bearer
+        Authorization scheme. It is not a JWT and must not be logged or persisted
+        by the server in raw form. Its generated entropy and exact length are
+        frozen by the runtime implementation Issue, not by this contract.
+    LoginResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - user
+        - session_token
+        - token_type
+        - expires_at
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+        session_token:
+          $ref: '#/components/schemas/OpaqueSessionToken'
+        token_type:
+          type: string
+          const: Bearer
+          readOnly: true
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true

--- a/api/modules/identity.yaml
+++ b/api/modules/identity.yaml
@@ -234,16 +234,18 @@ components:
           $ref: '#/components/schemas/Password'
     OpaqueSessionToken:
       type: string
-      minLength: 1
-      pattern: '^[A-Za-z0-9._~+/-]+={0,}$'
+      minLength: 6
+      pattern: '^sess_[A-Za-z0-9._~+/-]+={0,}$'
       readOnly: true
       description: |
         A high-entropy first-party opaque Session Token returned only by a
-        successful login response. Its wire representation follows the RFC 6750
-        `b64token` character set so it can be carried safely by the Bearer
-        Authorization scheme. It is not a JWT and must not be logged or persisted
-        by the server in raw form. Its generated entropy and exact length are
-        frozen by the runtime implementation Issue, not by this contract.
+        successful login response. Its wire representation uses the fixed
+        `sess_` credential marker followed by the RFC 6750 `b64token` character
+        set so it can be carried safely by the Bearer Authorization scheme and
+        detected reliably by credential-leak validation. It is not a JWT and
+        must not be logged or persisted by the server in raw form. Its generated
+        entropy and exact length are frozen by the runtime implementation Issue,
+        not by this contract.
     LoginResponse:
       type: object
       additionalProperties: false

--- a/api/modules/practice.yaml
+++ b/api/modules/practice.yaml
@@ -45,6 +45,8 @@ paths:
                 updated_at: '2026-07-23T10:02:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '409':
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
@@ -64,6 +66,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PracticePlan'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -200,6 +204,8 @@ paths:
                   created_at: '2026-07-23T10:03:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -230,6 +236,8 @@ paths:
                 session_version: 2
                 started_at: '2026-07-23T10:04:00Z'
                 created_at: '2026-07-23T10:03:00Z'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -269,6 +277,8 @@ paths:
                 created_at: '2026-07-23T10:03:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -310,6 +320,8 @@ paths:
                 created_at: '2026-07-23T10:03:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -353,6 +365,8 @@ paths:
                 created_at: '2026-07-23T10:03:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -374,6 +388,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PracticeSessionSnapshot'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:

--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -5,6 +5,7 @@ paths:
         - Preparation
       summary: Get an active scenario definition and its MS1 configuration
       operationId: getScenarioDefinition
+      security: []
       parameters:
         - $ref: '#/components/parameters/ScenarioDefinitionId'
       responses:
@@ -55,6 +56,7 @@ paths:
         - Preparation
       summary: List role definitions available for a scenario
       operationId: listRoleDefinitions
+      security: []
       parameters:
         - $ref: '#/components/parameters/ScenarioDefinitionId'
       responses:
@@ -116,8 +118,9 @@ paths:
         - Preparation
       summary: Create or return the preparation profile for one intent
       description: |
-        The fixed MS1 user is resolved from server-side context. The request does
-        not accept a trusted `user_id`.
+        The authenticated actor is resolved from the Bearer Session and owns the
+        created profile. The request does not accept a trusted `user_id`. A fixed
+        actor may be supplied only by an explicit Mock or Test adapter.
       operationId: createPreparationProfile
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
@@ -152,6 +155,8 @@ paths:
                 updated_at: '2026-07-23T10:00:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '409':
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
@@ -192,6 +197,8 @@ paths:
                 created_at: '2026-07-23T10:01:00Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':

--- a/api/modules/review.yaml
+++ b/api/modules/review.yaml
@@ -26,6 +26,8 @@ paths:
                 created_at: '2026-07-23T10:05:03Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -59,6 +61,8 @@ paths:
                       recovery time through tracing and a staged rollout.
                     created_at: '2026-07-23T10:05:03Z'
                     completed_at: '2026-07-23T10:05:04Z'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -89,6 +93,8 @@ paths:
                       - transcript_text: I introduced request tracing, defined an error budget.
                     retryable: true
                     created_at: '2026-07-23T10:05:04Z'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -131,6 +137,8 @@ paths:
                 updated_at: '2026-07-23T10:06:01Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         '409':
@@ -152,6 +160,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetryRequest'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
@@ -187,6 +197,8 @@ paths:
                     reviewed_at: '2026-07-23T10:05:04Z'
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,9 +5,13 @@ info:
   version: 0.1.0
   description: |
     Language-neutral REST contract for the deterministic MS1 practice flow.
-    Authentication is intentionally out of scope. The MS1 adapter supplies a
-    fixed demo identity from server-side context; clients never submit trusted
-    user or respondent participant identifiers.
+    User-private operations require a first-party opaque Bearer Session. Only
+    explicitly marked public operations accept anonymous requests. Fixed demo
+    identities remain limited to explicit Mock and Test composition roots;
+    production requests derive their trusted actor from the validated Session.
+    Clients never submit trusted user or respondent participant identifiers.
+    The formal `Idempotency-Key` scope for protected writes is the trusted
+    Actor, HTTP method, canonical path, and key.
 
     Optional JSON properties use absent-only semantics: clients omit values that
     are not present and must not serialize them as explicit `null`.
@@ -17,9 +21,12 @@ info:
 servers:
   - url: http://localhost:8080
     description: Local deterministic MS1 server
-security: []
+security:
+  - BearerSession: []
 x-json-null-policy: omit
 tags:
+  - name: Identity
+    description: Minimal account registration, opaque Session, and current-user operations.
   - name: Preparation
     description: Scenario, role, profile, and immutable preparation snapshot resources.
   - name: Practice
@@ -33,6 +40,7 @@ paths:
     get:
       summary: Check the modular monolith process
       operationId: getHealth
+      security: []
       responses:
         '200':
           description: Process health and registered business modules.
@@ -51,6 +59,14 @@ paths:
           $ref: ./common/errors.yaml#/components/responses/BadRequest
         default:
           $ref: ./common/errors.yaml#/components/responses/DefaultError
+  /v1/auth/register:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1auth~1register
+  /v1/auth/login:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1auth~1login
+  /v1/auth/logout:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1auth~1logout
+  /v1/me:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1me
   /v1/scenario-definitions/{scenario_definition_id}:
     $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}
   /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
@@ -96,6 +112,15 @@ paths:
   /v1/history-records:
     $ref: ./modules/review.yaml#/paths/~1v1~1history-records
 components:
+  securitySchemes:
+    BearerSession:
+      type: http
+      scheme: bearer
+      bearerFormat: OpaqueSessionToken
+      description: |
+        A first-party, high-entropy opaque Session Token supplied only as
+        `Authorization: Bearer <opaque-session-token>`. It is not a JWT and must
+        not appear in URLs, request bodies, logs, telemetry, or error details.
   schemas:
     Health:
       type: object
@@ -119,6 +144,14 @@ components:
               - review
     ErrorResponse:
       $ref: ./common/errors.yaml#/components/schemas/ErrorResponse
+    User:
+      $ref: ./modules/identity.yaml#/components/schemas/User
+    RegisterRequest:
+      $ref: ./modules/identity.yaml#/components/schemas/RegisterRequest
+    LoginRequest:
+      $ref: ./modules/identity.yaml#/components/schemas/LoginRequest
+    LoginResponse:
+      $ref: ./modules/identity.yaml#/components/schemas/LoginResponse
     ScenarioDefinition:
       $ref: ./modules/preparation.yaml#/components/schemas/ScenarioDefinition
     ScenarioConfig:

--- a/api/package.json
+++ b/api/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Validation entrypoint for the SpeakUp REST and WebSocket contracts.",
   "scripts": {
-    "check": "npm run lint:openapi && npm run validate:websocket && npm run validate:fixture",
+    "check": "npm run lint:openapi && npm run validate:security && npm run validate:websocket && npm run validate:fixture",
     "lint:openapi": "redocly lint openapi.yaml --config redocly.yaml",
+    "validate:security": "node scripts/validate-security.mjs",
     "validate:websocket": "node scripts/validate-events.mjs",
     "validate:fixture": "node scripts/validate-main-flow.mjs"
   },

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -596,10 +596,16 @@ const opaqueSessionTokenPattern = new RegExp(
   opaqueSessionToken?.pattern,
   'u',
 );
-for (const token of ['abc123-._~+/', 'abc123==']) {
+for (const token of ['sess_abc123-._~+/', 'sess_abc123==']) {
   assert.match(token, opaqueSessionTokenPattern);
 }
-for (const token of ['contains whitespace', 'line\nbreak', 'padding=inside']) {
+for (const token of [
+  'abc123==',
+  'sess_',
+  'sess_contains whitespace',
+  'sess_line\nbreak',
+  'sess_padding=inside',
+]) {
   assert.doesNotMatch(token, opaqueSessionTokenPattern);
 }
 
@@ -834,6 +840,14 @@ const websocketParameters = Object.fromEntries(
     const parameter = resolveLocalReference(parameterValue);
     return [parameter.name, parameter];
   }),
+);
+assert.equal(websocketParameters['Sec-WebSocket-Protocol']?.in, 'header');
+assert.equal(websocketParameters['Sec-WebSocket-Protocol']?.required, true);
+assert.equal(
+  resolveLocalReference(
+    websocketParameters['Sec-WebSocket-Protocol']?.schema,
+  )?.const,
+  'speakup.events.v1',
 );
 assert.equal(
   resolveLocalReference(websocket.responses?.['101'])?.headers?.[

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -1,0 +1,850 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const httpMethods = new Set([
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+]);
+const bearerSecurity = [{ BearerSession: [] }];
+const publicOperations = new Set([
+  'GET /health',
+  'POST /v1/auth/register',
+  'POST /v1/auth/login',
+  'GET /v1/scenario-definitions/{scenario_definition_id}',
+  'GET /v1/scenario-definitions/{scenario_definition_id}/role-definitions',
+]);
+const normalizeFieldName = (fieldName) =>
+  String(fieldName ?? '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replaceAll('-', '_')
+    .toLowerCase();
+const isTrustedIdentityField = (fieldName) => {
+  const normalized = normalizeFieldName(fieldName);
+  return (
+    /^(owner_|current_|authenticated_)?(user|actor)_id$/.test(normalized) ||
+    /^(owner_|current_|auth_)?session_id$/.test(normalized)
+  );
+};
+const isRawTokenField = (fieldName) =>
+  /^(?:token(?:_(?:value|secret|hash|digest))?|[a-z0-9_]+_token(?:_(?:value|secret|hash|digest))?)$/.test(
+    normalizeFieldName(fieldName),
+  );
+const isForbiddenRequestField = (fieldName) =>
+  isTrustedIdentityField(fieldName) ||
+  isRawTokenField(fieldName) ||
+  normalizeFieldName(fieldName) === 'token_type' ||
+  /(authorization|credential|bearer|cookie)/i.test(fieldName) ||
+  /(session.*(digest|hash|secret)|(digest|hash|secret).*session)/i.test(
+    fieldName,
+  );
+const isSensitiveResponseField = (fieldName) =>
+  /password/i.test(normalizeFieldName(fieldName)) ||
+  /credential/i.test(normalizeFieldName(fieldName)) ||
+  /(session.*(digest|hash|secret)|(digest|hash|secret).*session)/i.test(
+    normalizeFieldName(fieldName),
+  );
+const containsCredentialValue = (value) =>
+  /\bBearer\s+\S+/i.test(value) ||
+  /\bsess_[A-Za-z0-9._~+/-]+={0,}/.test(value);
+
+const bundleOpenApi = async () => {
+  const temporaryDirectory = await mkdtemp(
+    resolve(tmpdir(), 'speakup-security-bundle-'),
+  );
+  const bundlePath = resolve(temporaryDirectory, 'openapi.bundle.json');
+  const redoclyCliPath = resolve(
+    apiDirectory,
+    'node_modules/@redocly/cli/bin/cli.js',
+  );
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        redoclyCliPath,
+        'bundle',
+        resolve(apiDirectory, 'openapi.yaml'),
+        '--config',
+        resolve(apiDirectory, 'redocly.yaml'),
+        '--output',
+        bundlePath,
+        '--ext',
+        'json',
+      ],
+      {
+        cwd: apiDirectory,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    return JSON.parse(await readFile(bundlePath, 'utf8'));
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+const openApi = await bundleOpenApi();
+const schemas = openApi.components?.schemas ?? {};
+const responses = openApi.components?.responses ?? {};
+
+const resolveLocalReference = (value) => {
+  let current = value;
+  const visited = new Set();
+  while (
+    current !== null &&
+    typeof current === 'object' &&
+    typeof current.$ref === 'string'
+  ) {
+    assert.match(
+      current.$ref,
+      /^#\//,
+      `Expected a bundled local reference, received ${current.$ref}.`,
+    );
+    assert.ok(
+      !visited.has(current.$ref),
+      `Cyclic local reference detected at ${current.$ref}.`,
+    );
+    visited.add(current.$ref);
+    current = current.$ref
+      .slice(2)
+      .split('/')
+      .map((token) => token.replaceAll('~1', '/').replaceAll('~0', '~'))
+      .reduce((resolved, token) => resolved?.[token], openApi);
+    assert.notEqual(
+      current,
+      undefined,
+      `Unresolved bundled reference ${[...visited].at(-1)}.`,
+    );
+  }
+  return current;
+};
+
+const collectOperations = () => {
+  const operations = [];
+  for (const [path, pathItem] of Object.entries(openApi.paths ?? {})) {
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (httpMethods.has(method)) {
+        operations.push({
+          key: `${method.toUpperCase()} ${path}`,
+          method,
+          path,
+          operation,
+          pathParameters: pathItem.parameters ?? [],
+        });
+      }
+    }
+  }
+  return operations;
+};
+
+const collectSchemaPropertyNames = (
+  schemaValue,
+  names = new Set(),
+  visitedReferences = new Set(),
+) => {
+  if (Array.isArray(schemaValue)) {
+    for (const item of schemaValue) {
+      collectSchemaPropertyNames(item, names, visitedReferences);
+    }
+    return names;
+  }
+  if (schemaValue === null || typeof schemaValue !== 'object') {
+    return names;
+  }
+
+  if (typeof schemaValue.$ref === 'string') {
+    if (!visitedReferences.has(schemaValue.$ref)) {
+      visitedReferences.add(schemaValue.$ref);
+      collectSchemaPropertyNames(
+        resolveLocalReference(schemaValue),
+        names,
+        visitedReferences,
+      );
+    }
+  }
+
+  for (const propertyName of Object.keys(schemaValue.properties ?? {})) {
+    names.add(propertyName);
+  }
+  for (const [key, item] of Object.entries(schemaValue)) {
+    if (key === '$ref') {
+      continue;
+    }
+    collectSchemaPropertyNames(item, names, visitedReferences);
+  }
+  return names;
+};
+
+const getJsonSchema = (contentOwner) =>
+  resolveLocalReference(contentOwner)?.content?.['application/json']?.schema;
+const getContentSchemas = (contentOwner) =>
+  Object.values(resolveLocalReference(contentOwner)?.content ?? {})
+    .map((mediaType) => mediaType?.schema)
+    .filter((schema) => schema !== undefined);
+const getContentExamples = (contentOwner) => {
+  const examples = [];
+  const resolvedOwner = resolveLocalReference(contentOwner);
+  for (const mediaTypeValue of Object.values(resolvedOwner?.content ?? {})) {
+    const mediaType = resolveLocalReference(mediaTypeValue);
+    if (mediaType?.example !== undefined) {
+      examples.push(mediaType.example);
+    }
+    for (const exampleValue of Object.values(mediaType?.examples ?? {})) {
+      const example = resolveLocalReference(exampleValue);
+      examples.push(example?.value ?? example);
+    }
+  }
+  return examples;
+};
+const collectObjectKeys = (value, keys = new Set()) => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectObjectKeys(item, keys);
+    }
+    return keys;
+  }
+  if (value === null || typeof value !== 'object') {
+    return keys;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    keys.add(key);
+    collectObjectKeys(item, keys);
+  }
+  return keys;
+};
+const collectStrings = (value, strings = []) => {
+  if (typeof value === 'string') {
+    strings.push(value);
+    return strings;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStrings(item, strings);
+    }
+    return strings;
+  }
+  if (value === null || typeof value !== 'object') {
+    return strings;
+  }
+  for (const item of Object.values(value)) {
+    collectStrings(item, strings);
+  }
+  return strings;
+};
+const collectSchemaDeclaredValues = (
+  schemaValue,
+  values = [],
+  visitedReferences = new Set(),
+) => {
+  if (Array.isArray(schemaValue)) {
+    for (const item of schemaValue) {
+      collectSchemaDeclaredValues(item, values, visitedReferences);
+    }
+    return values;
+  }
+  if (schemaValue === null || typeof schemaValue !== 'object') {
+    return values;
+  }
+
+  if (typeof schemaValue.$ref === 'string') {
+    if (!visitedReferences.has(schemaValue.$ref)) {
+      visitedReferences.add(schemaValue.$ref);
+      collectSchemaDeclaredValues(
+        resolveLocalReference(schemaValue),
+        values,
+        visitedReferences,
+      );
+    }
+  }
+
+  for (const key of ['example', 'default', 'const', 'examples', 'enum']) {
+    if (schemaValue[key] !== undefined) {
+      values.push(schemaValue[key]);
+    }
+  }
+  for (const [key, item] of Object.entries(schemaValue)) {
+    if (
+      key === '$ref' ||
+      ['example', 'default', 'const', 'examples', 'enum'].includes(key)
+    ) {
+      continue;
+    }
+    collectSchemaDeclaredValues(item, values, visitedReferences);
+  }
+  return values;
+};
+const getDeclaredValues = (value) => {
+  const resolved = resolveLocalReference(value);
+  const declaredValues = [];
+  for (const key of ['example', 'default', 'const']) {
+    if (resolved?.[key] !== undefined) {
+      declaredValues.push(resolved[key]);
+    }
+  }
+  for (const exampleValue of Object.values(resolved?.examples ?? {})) {
+    const example = resolveLocalReference(exampleValue);
+    declaredValues.push(example?.value ?? example);
+  }
+  collectSchemaDeclaredValues(resolved?.schema, declaredValues);
+  for (const schema of getContentSchemas(resolved)) {
+    collectSchemaDeclaredValues(schema, declaredValues);
+  }
+  declaredValues.push(...getContentExamples(resolved));
+  return declaredValues;
+};
+const assertNoCredentialValues = (value, context) => {
+  for (const stringValue of collectStrings(value)) {
+    assert.ok(
+      !containsCredentialValue(stringValue),
+      `${context} contains a credential-like value.`,
+    );
+  }
+};
+const sorted = (values) => [...values].sort();
+
+for (const field of [
+  'user_id',
+  'actor_id',
+  'session_id',
+  'session_token',
+  'authToken',
+  'opaque_token',
+  'opaque_session_token',
+  'bearer_session_token',
+  'authorization_token',
+  'token_type',
+  'authorization',
+  'credential',
+  'session_digest',
+  'userId',
+  'actorId',
+  'sessionId',
+  'owner_user_id',
+]) {
+  assert.ok(
+    isForbiddenRequestField(field),
+    `Sensitive field accepted: ${field}`,
+  );
+}
+for (const field of [
+  'email',
+  'password',
+  'practice_session_id',
+  'max_tokens',
+  'input_tokens',
+  'output_token_count',
+  'token_budget',
+]) {
+  assert.ok(
+    !isForbiddenRequestField(field),
+    `Legitimate request field rejected: ${field}`,
+  );
+}
+assert.ok(
+  collectSchemaPropertyNames({
+    $ref: '#/components/schemas/RegisterRequest',
+    properties: {
+      session_id: {
+        type: 'string',
+      },
+    },
+  }).has('session_id'),
+  '$ref sibling properties must participate in sensitive-field checks.',
+);
+assert.ok(containsCredentialValue('Bearer sess_secret'));
+assert.ok(containsCredentialValue('debug value sess_secret'));
+assert.ok(!containsCredentialValue('Bearer'));
+assert.ok(
+  collectSchemaDeclaredValues({
+    type: 'object',
+    properties: {
+      reason: {
+        type: 'string',
+        example: 'Bearer sess_secret',
+      },
+    },
+  }).includes('Bearer sess_secret'),
+  'Nested Schema examples must participate in credential-value checks.',
+);
+
+const operations = collectOperations();
+const operationByKey = new Map(
+  operations.map((operation) => [operation.key, operation]),
+);
+assert.equal(
+  operationByKey.size,
+  operations.length,
+  'Every HTTP method and path pair must be unique.',
+);
+
+const bearerScheme = openApi.components?.securitySchemes?.BearerSession;
+assert.deepEqual(
+  openApi.security,
+  bearerSecurity,
+  'The root security policy must fail closed with BearerSession.',
+);
+assert.equal(bearerScheme?.type, 'http');
+assert.equal(bearerScheme?.scheme, 'bearer');
+assert.equal(bearerScheme?.bearerFormat, 'OpaqueSessionToken');
+assert.match(bearerScheme?.description ?? '', /opaque/i);
+assert.match(bearerScheme?.description ?? '', /not a JWT/i);
+for (const securityScheme of Object.values(
+  openApi.components?.securitySchemes ?? {},
+)) {
+  assert.notEqual(
+    securityScheme?.in,
+    'cookie',
+    'Cookie-based security schemes are outside the v1 contract.',
+  );
+}
+
+const actualPublicOperations = new Set();
+for (const { key, operation } of operations) {
+  const effectiveSecurity = operation.security ?? openApi.security;
+  if (Array.isArray(effectiveSecurity) && effectiveSecurity.length === 0) {
+    actualPublicOperations.add(key);
+    continue;
+  }
+
+  assert.deepEqual(
+    effectiveSecurity,
+    bearerSecurity,
+    `${key} must inherit or declare BearerSession.`,
+  );
+  assert.ok(
+    operation.responses?.['401'],
+    `${key} must document an Unauthorized response.`,
+  );
+  assert.equal(
+    operation.responses['401'].$ref,
+    '#/components/responses/Unauthorized',
+    `${key} must reuse the common Unauthorized response.`,
+  );
+}
+assert.deepEqual(
+  sorted(actualPublicOperations),
+  sorted(publicOperations),
+  'The explicit anonymous operation whitelist changed.',
+);
+
+for (const operationKey of publicOperations) {
+  assert.ok(
+    operationByKey.has(operationKey),
+    `Missing public operation ${operationKey}.`,
+  );
+}
+
+const requireOperation = (key) => {
+  const operation = operationByKey.get(key);
+  assert.ok(operation, `Missing required operation ${key}.`);
+  return operation.operation;
+};
+const register = requireOperation('POST /v1/auth/register');
+const login = requireOperation('POST /v1/auth/login');
+const logout = requireOperation('POST /v1/auth/logout');
+const me = requireOperation('GET /v1/me');
+
+assert.equal(register.operationId, 'registerUser');
+assert.equal(login.operationId, 'loginUser');
+assert.equal(logout.operationId, 'logoutCurrentSession');
+assert.equal(me.operationId, 'getCurrentUser');
+assert.ok(register.requestBody?.required);
+assert.ok(login.requestBody?.required);
+assert.equal(
+  getJsonSchema(register.requestBody)?.$ref,
+  '#/components/schemas/RegisterRequest',
+);
+assert.equal(
+  getJsonSchema(login.requestBody)?.$ref,
+  '#/components/schemas/LoginRequest',
+);
+assert.ok(register.responses?.['201']);
+assert.ok(register.responses?.['409']);
+assert.ok(register.responses?.['429']);
+assert.ok(login.responses?.['200']);
+assert.ok(login.responses?.['401']);
+assert.ok(login.responses?.['429']);
+assert.ok(logout.responses?.['204']);
+assert.ok(me.responses?.['200']);
+assert.equal(logout.requestBody, undefined);
+assert.equal(logout.responses?.['429'], undefined);
+assert.equal(me.responses?.['429'], undefined);
+assert.equal(
+  resolveLocalReference(register.responses['201'])?.content?.[
+    'application/json'
+  ]?.schema?.$ref,
+  '#/components/schemas/User',
+);
+assert.equal(
+  register.responses['409']?.$ref,
+  '#/components/responses/RegistrationUnavailable',
+);
+assert.equal(
+  register.responses['429']?.$ref,
+  '#/components/responses/TooManyRequests',
+);
+assert.equal(
+  resolveLocalReference(login.responses['200'])?.content?.['application/json']
+    ?.schema?.$ref,
+  '#/components/schemas/LoginResponse',
+);
+assert.equal(
+  login.responses['401']?.$ref,
+  '#/components/responses/InvalidCredentials',
+);
+assert.equal(
+  login.responses['429']?.$ref,
+  '#/components/responses/TooManyRequests',
+);
+const loginSuccess = resolveLocalReference(login.responses['200']);
+assert.equal(
+  loginSuccess?.headers?.['Cache-Control']?.schema?.const,
+  'no-store',
+);
+assert.equal(loginSuccess?.headers?.Pragma?.schema?.const, 'no-cache');
+assert.equal(
+  resolveLocalReference(me.responses['200'])?.content?.['application/json']
+    ?.schema?.$ref,
+  '#/components/schemas/User',
+);
+assert.ok(
+  register.requestBody?.content?.['application/json']?.example,
+  'Register must provide a request example.',
+);
+assert.ok(
+  login.requestBody?.content?.['application/json']?.example,
+  'Login must provide a request example.',
+);
+
+const userSchema = schemas.User;
+assert.deepEqual(sorted(userSchema?.required ?? []), ['email', 'user_id']);
+assert.equal(userSchema?.additionalProperties, false);
+assert.equal(userSchema?.properties?.user_id?.readOnly, true);
+for (const requestSchemaName of ['RegisterRequest', 'LoginRequest']) {
+  const requestSchema = schemas[requestSchemaName];
+  assert.deepEqual(sorted(requestSchema?.required ?? []), [
+    'email',
+    'password',
+  ]);
+  assert.deepEqual(sorted(Object.keys(requestSchema?.properties ?? {})), [
+    'email',
+    'password',
+  ]);
+  assert.equal(requestSchema?.additionalProperties, false);
+}
+const passwordSchema = schemas.Password;
+assert.equal(passwordSchema?.writeOnly, true);
+assert.equal(passwordSchema?.minLength, 15);
+assert.equal(passwordSchema?.maxLength, 128);
+const emailInputPattern = new RegExp(schemas.EmailInput?.pattern, 'u');
+for (const email of [
+  'learner@example.com',
+  'First.Last+practice@xn--fsqu00a.xn--0zwm56d',
+  '\t learner@example.com \r\n',
+]) {
+  assert.match(email, emailInputPattern, `Valid email rejected: ${email}`);
+}
+for (const email of [
+  '.learner@example.com',
+  'learner.@example.com',
+  'learn..er@example.com',
+  'learner@localhost',
+  'learn er@example.com',
+  '学习者@example.com',
+  `${'a'.repeat(250)}@example.com`,
+]) {
+  assert.doesNotMatch(
+    email,
+    emailInputPattern,
+    `Invalid email accepted: ${email}`,
+  );
+}
+const canonicalEmailPattern = new RegExp(schemas.Email?.pattern, 'u');
+assert.match('learner@example.com', canonicalEmailPattern);
+assert.doesNotMatch('Learner@example.com', canonicalEmailPattern);
+const loginResponseSchema = schemas.LoginResponse;
+assert.deepEqual(sorted(loginResponseSchema?.required ?? []), [
+  'expires_at',
+  'session_token',
+  'token_type',
+  'user',
+]);
+assert.equal(
+  resolveLocalReference(loginResponseSchema?.properties?.token_type)?.const,
+  'Bearer',
+);
+assert.equal(
+  resolveLocalReference(
+    loginResponseSchema?.properties?.session_token,
+  )?.readOnly,
+  true,
+);
+const opaqueSessionToken = schemas.OpaqueSessionToken;
+const opaqueSessionTokenPattern = new RegExp(
+  opaqueSessionToken?.pattern,
+  'u',
+);
+for (const token of ['abc123-._~+/', 'abc123==']) {
+  assert.match(token, opaqueSessionTokenPattern);
+}
+for (const token of ['contains whitespace', 'line\nbreak', 'padding=inside']) {
+  assert.doesNotMatch(token, opaqueSessionTokenPattern);
+}
+
+const errorCode = schemas.ErrorCode;
+const expectedIdentityErrors = new Map([
+  ['authentication_required', 401],
+  ['invalid_credentials', 401],
+  ['account_registration_unavailable', 409],
+  ['rate_limited', 429],
+]);
+for (const [errorName, status] of expectedIdentityErrors) {
+  assert.ok(errorCode?.enum?.includes(errorName), `Missing ${errorName}.`);
+  assert.equal(
+    errorCode?.['x-http-status-map']?.[errorName],
+    status,
+    `${errorName} must map to HTTP ${status}.`,
+  );
+}
+assert.equal(
+  responses.Unauthorized?.headers?.['WWW-Authenticate']?.schema?.const,
+  'Bearer',
+);
+assert.ok(responses.TooManyRequests?.headers?.['Retry-After']);
+assert.equal(
+  responses.Unauthorized?.content?.['application/json']?.example?.error?.code,
+  'authentication_required',
+);
+assert.equal(
+  responses.TooManyRequests?.content?.['application/json']?.example?.error
+    ?.code,
+  'rate_limited',
+);
+assert.equal(
+  responses.InvalidCredentials?.content?.['application/json']?.example?.error
+    ?.code,
+  'invalid_credentials',
+);
+assert.equal(
+  responses.RegistrationUnavailable?.content?.['application/json']?.example
+    ?.error?.code,
+  'account_registration_unavailable',
+);
+
+const tokenResponseLocations = new Set();
+for (const { key, operation, pathParameters } of operations) {
+  for (const requestSchema of getContentSchemas(operation.requestBody)) {
+    const requestFields = collectSchemaPropertyNames(requestSchema);
+    for (const field of requestFields) {
+      assert.ok(
+        !isForbiddenRequestField(field),
+        `${key} request must not accept trusted ${field}.`,
+      );
+    }
+    for (const declaredValue of collectSchemaDeclaredValues(requestSchema)) {
+      assertNoCredentialValues(declaredValue, `${key} request schema example`);
+    }
+  }
+  for (const example of getContentExamples(operation.requestBody)) {
+    assertNoCredentialValues(example, `${key} request example`);
+  }
+
+  for (const parameterValue of [
+    ...pathParameters,
+    ...(operation.parameters ?? []),
+  ]) {
+    const parameter = resolveLocalReference(parameterValue);
+    const parameterName = parameter?.name?.toLowerCase();
+    assert.ok(
+      !isForbiddenRequestField(parameterName),
+      `${key} must not accept trusted parameter ${parameterName}.`,
+    );
+    const parameterSchemas = [
+      parameter?.schema,
+      ...getContentSchemas(parameter),
+    ].filter((schema) => schema !== undefined);
+    for (const parameterSchema of parameterSchemas) {
+      const parameterFields = collectSchemaPropertyNames(parameterSchema);
+      for (const field of parameterFields) {
+        assert.ok(
+          !isForbiddenRequestField(field),
+          `${key} parameter schema must not accept trusted ${field}.`,
+        );
+      }
+    }
+    for (const declaredValue of getDeclaredValues(parameter)) {
+      for (const field of collectObjectKeys(declaredValue)) {
+        assert.ok(
+          !isForbiddenRequestField(field),
+          `${key} parameter example must not contain trusted ${field}.`,
+        );
+      }
+      assertNoCredentialValues(declaredValue, `${key} parameter example`);
+    }
+  }
+
+  for (const [status, responseValue] of Object.entries(
+    operation.responses ?? {},
+  )) {
+    const response = resolveLocalReference(responseValue);
+    for (const headerName of Object.keys(response?.headers ?? {})) {
+      const header = response.headers[headerName];
+      assert.ok(
+        !isForbiddenRequestField(headerName.toLowerCase()) &&
+          headerName.toLowerCase() !== 'set-cookie',
+        `${key} ${status} must not return credentials in ${headerName}.`,
+      );
+      const headerSchemas = [
+        resolveLocalReference(header)?.schema,
+        ...getContentSchemas(header),
+      ].filter((schema) => schema !== undefined);
+      for (const headerSchema of headerSchemas) {
+        for (const field of collectSchemaPropertyNames(headerSchema)) {
+          assert.ok(
+            !isSensitiveResponseField(field) && !isRawTokenField(field),
+            `${key} ${status} ${headerName} header exposes ${field}.`,
+          );
+        }
+      }
+      for (const declaredValue of getDeclaredValues(header)) {
+        for (const field of collectObjectKeys(declaredValue)) {
+          assert.ok(
+            !isSensitiveResponseField(field) && !isRawTokenField(field),
+            `${key} ${status} ${headerName} header example exposes ${field}.`,
+          );
+        }
+        assertNoCredentialValues(
+          declaredValue,
+          `${key} ${status} ${headerName} header`,
+        );
+      }
+    }
+    for (const responseSchema of getContentSchemas(response)) {
+      const responseFields = collectSchemaPropertyNames(responseSchema);
+      for (const field of responseFields) {
+        assert.ok(
+          !isSensitiveResponseField(field),
+          `${key} ${status} must not expose ${field}.`,
+        );
+        if (isRawTokenField(field)) {
+          tokenResponseLocations.add(`${key} ${status} ${field}`);
+        }
+      }
+      if (!(key === 'POST /v1/auth/login' && status === '200')) {
+        for (const declaredValue of collectSchemaDeclaredValues(
+          responseSchema,
+        )) {
+          assertNoCredentialValues(
+            declaredValue,
+            `${key} ${status} response schema example`,
+          );
+        }
+      }
+    }
+    for (const example of getContentExamples(response)) {
+      for (const field of collectObjectKeys(example)) {
+        assert.ok(
+          !isSensitiveResponseField(field),
+          `${key} ${status} example must not expose ${field}.`,
+        );
+        if (isRawTokenField(field)) {
+          tokenResponseLocations.add(`${key} ${status} ${field}`);
+        }
+      }
+      if (!(key === 'POST /v1/auth/login' && status === '200')) {
+        assertNoCredentialValues(example, `${key} ${status} response example`);
+      }
+    }
+  }
+}
+assert.deepEqual(sorted(tokenResponseLocations), [
+  'POST /v1/auth/login 200 session_token',
+]);
+
+const websocket = requireOperation(
+  'GET /v1/practice-sessions/{practice_session_id}/events',
+);
+const websocketSecurity = websocket['x-websocket-security'];
+assert.equal(websocketSecurity?.credential_location, 'authorization_header');
+assert.equal(websocketSecurity?.header, 'Authorization');
+assert.equal(websocketSecurity?.scheme, 'Bearer');
+assert.equal(websocketSecurity?.other_credential_locations_allowed, false);
+assert.equal(websocketSecurity?.production_transport, 'wss');
+assert.equal(websocketSecurity?.local_loopback_transport, 'ws');
+assert.deepEqual(websocketSecurity?.pre_upgrade?.validation_order, [
+  'session',
+  'actor',
+  'resource_ownership',
+  'replay_cursor',
+  'subprotocol',
+  'upgrade',
+]);
+assert.deepEqual(websocketSecurity?.pre_upgrade?.authentication_failure, {
+  http_status: 401,
+  error_code: 'authentication_required',
+});
+assert.deepEqual(websocketSecurity?.pre_upgrade?.resource_not_visible, {
+  http_status: 404,
+  error_code: 'resource_not_found',
+});
+assert.equal(websocketSecurity?.reconnect?.reauthenticate, true);
+assert.deepEqual(websocketSecurity?.connection_binding, {
+  actor_fields: ['user_id', 'session_id'],
+  target_field: 'practice_session_id',
+  target_switch_allowed: false,
+});
+assert.deepEqual(websocketSecurity?.logout, {
+  close_connections_by: 'session_id',
+  all_matching_connections: true,
+});
+assert.deepEqual(websocketSecurity?.active_connection?.authorization_recheck, {
+  before_replay_batch: true,
+  before_private_outbound_event: true,
+  checks: ['session_validity', 'resource_ownership'],
+});
+assert.deepEqual(websocketSecurity?.active_connection?.invalid_session, {
+  close_code: 4401,
+  close_reason: 'session_invalid',
+  send_application_events_before_close: false,
+});
+assert.equal(
+  websocketSecurity?.active_connection?.ordinary_disconnect?.is_logout,
+  false,
+);
+assert.deepEqual(websocketSecurity?.subprotocol?.allowed, [
+  'speakup.events.v1',
+]);
+assert.equal(websocketSecurity?.subprotocol?.carries_credentials, false);
+assert.equal(websocketSecurity?.after_sequence?.is_credential, false);
+
+const websocketParameters = Object.fromEntries(
+  (websocket.parameters ?? []).map((parameterValue) => {
+    const parameter = resolveLocalReference(parameterValue);
+    return [parameter.name, parameter];
+  }),
+);
+assert.equal(
+  resolveLocalReference(websocket.responses?.['101'])?.headers?.[
+    'Sec-WebSocket-Protocol'
+  ]?.schema?.const,
+  'speakup.events.v1',
+);
+assert.equal(websocketParameters.after_sequence?.in, 'query');
+
+console.log(
+  `Validated ${operations.length} operations: ` +
+    `${actualPublicOperations.size} public and ` +
+    `${operations.length - actualPublicOperations.size} Bearer-protected.`,
+);


### PR DESCRIPTION
## 功能说明

- 新增邮箱密码注册、登录、当前用户与当前 Session 注销的 Identity API 契约。
- OpenAPI 改为默认使用不透明 `BearerSession` 保护，仅保留 5 个显式匿名 Operation。
- 为现有私有 REST 与 WebSocket Operation 统一补充 `401`，冻结 `401 / 403 / 404 / 409 / 429` 边界。
- 冻结原生 Flutter WebSocket 的 Upgrade Header 鉴权、WSS、重连、连接绑定、注销传播、`4401 session_invalid` 与逐次授权复核语义。
- 新增安全矩阵校验，防止接口意外匿名、可信身份字段由客户端提交、Token 进入 URL / Query / 示例 / 错误详情或非登录响应。

## 实现边界

本 PR 只实现 `api/` 下的 wire contract 与自动校验：

- 不新增数据库表或 Migration；
- 不实现 Go Identity、Session Middleware、限流或 WebSocket 连接管理；
- 不实现 Flutter 注册登录、Keychain 或会话恢复；
- 当前固定演示 Actor 仍只属于 Mock / Test，不代表生产认证已经实现。

后端、Flutter 和数据库运行时实现继续按 #77 中列出的后续单一 Issue 拆分。

## 验证

- `make check`
- `make check-api`
- `make check-smoke`
- `git diff --check`

验证结果：

- 28 个 Operation：5 个显式公开，23 个 Bearer 保护；
- 16 类 WebSocket 事件与 7 个负例通过；
- Mock 主链 Fixture 与确定性 Smoke 通过；
- Flutter analyze/test、Go vet/test、OpenAPI lint 全部通过。

Closes #77
