### PR TITLE
feat(identity): 建立 PostgreSQL 身份 Schema

### DIFF
--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -287,8 +287,46 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
 		[]any{secondUserID, strings.Repeat("x", 80)},
 		"23514",
-		"identity_credentials_password_hash_algorithm_check",
+		"identity_credentials_password_hash_phc_shape_check",
 	)
+	malformedPasswordHashes := []struct {
+		name string
+		hash string
+	}{
+		{
+			name: "missing version",
+			hash: "$argon2id$$m=65536,t=3,p=4$" +
+				strings.Repeat("c", 24) + "$" + strings.Repeat("d", 43),
+		},
+		{
+			name: "missing parameters",
+			hash: "$argon2id$v=19$$" +
+				strings.Repeat("c", 24) + "$" + strings.Repeat("d", 43),
+		},
+		{
+			name: "missing salt",
+			hash: "$argon2id$v=19$m=65536,t=3,p=4$$" +
+				strings.Repeat("d", 43),
+		},
+		{
+			name: "missing hash",
+			hash: "$argon2id$v=19$m=65536,t=3,p=4$" +
+				strings.Repeat("c", 64) + "$",
+		},
+	}
+	for _, malformedPasswordHash := range malformedPasswordHashes {
+		t.Run("rejects PHC "+malformedPasswordHash.name, func(t *testing.T) {
+			assertConstraintViolation(
+				t,
+				admin,
+				ctx,
+				"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
+				[]any{secondUserID, malformedPasswordHash.hash},
+				"23514",
+				"identity_credentials_password_hash_phc_shape_check",
+			)
+		})
+	}
 	assertConstraintViolation(
 		t,
 		admin,

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -140,7 +141,11 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		firstSessionID  = "20000000-0000-4000-8000-000000000001"
 		secondSessionID = "20000000-0000-4000-8000-000000000002"
 		thirdSessionID  = "20000000-0000-4000-8000-000000000003"
-		passwordHash    = "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo"
+	)
+	goRawStdEncodedPasswordHash := fmt.Sprintf(
+		"$argon2id$v=19$m=65536,t=3,p=2$%s$%s",
+		base64.RawStdEncoding.EncodeToString([]byte("1234567890abcdef")),
+		base64.RawStdEncoding.EncodeToString(bytesOf(0x42, 32)),
 	)
 	createdAt := time.Date(2026, time.July, 24, 10, 0, 0, 0, time.UTC)
 	expiresAt := createdAt.Add(24 * time.Hour)
@@ -169,7 +174,7 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		ctx,
 		"INSERT INTO "+credentials+" (user_id, password_hash, updated_at) VALUES ($1, $2, $3)",
 		firstUserID,
-		passwordHash,
+		goRawStdEncodedPasswordHash,
 		createdAt,
 	); err != nil {
 		t.Fatalf("insert credential: %v", err)
@@ -267,7 +272,7 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		admin,
 		ctx,
 		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
-		[]any{firstUserID, passwordHash},
+		[]any{firstUserID, goRawStdEncodedPasswordHash},
 		"23505",
 		"identity_credentials_pkey",
 	)
@@ -276,7 +281,7 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		admin,
 		ctx,
 		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
-		[]any{unknownUserID, passwordHash},
+		[]any{unknownUserID, goRawStdEncodedPasswordHash},
 		"23503",
 		"identity_credentials_user_id_fkey",
 	)
@@ -324,6 +329,49 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 				[]any{secondUserID, malformedPasswordHash.hash},
 				"23514",
 				"identity_credentials_password_hash_phc_shape_check",
+			)
+		})
+	}
+	malformedBase64Segments := []struct {
+		name       string
+		hash       string
+		constraint string
+	}{
+		{
+			name: "salt length modulo four is one",
+			hash: "$argon2id$v=19$m=65536,t=3,p=2$A$" +
+				strings.Repeat("d", 43),
+			constraint: "identity_credentials_password_hash_base64_length_check",
+		},
+		{
+			name: "hash length modulo four is one",
+			hash: "$argon2id$v=19$m=65536,t=3,p=2$" +
+				strings.Repeat("c", 22) + "$" + strings.Repeat("d", 41),
+			constraint: "identity_credentials_password_hash_base64_length_check",
+		},
+		{
+			name: "salt contains padding",
+			hash: "$argon2id$v=19$m=65536,t=3,p=2$" +
+				strings.Repeat("c", 22) + "==$" + strings.Repeat("d", 43),
+			constraint: "identity_credentials_password_hash_phc_shape_check",
+		},
+		{
+			name: "hash contains padding",
+			hash: "$argon2id$v=19$m=65536,t=3,p=2$" +
+				strings.Repeat("c", 22) + "$" + strings.Repeat("d", 43) + "=",
+			constraint: "identity_credentials_password_hash_phc_shape_check",
+		},
+	}
+	for _, malformedBase64Segment := range malformedBase64Segments {
+		t.Run("rejects PHC "+malformedBase64Segment.name, func(t *testing.T) {
+			assertConstraintViolation(
+				t,
+				admin,
+				ctx,
+				"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
+				[]any{secondUserID, malformedBase64Segment.hash},
+				"23514",
+				malformedBase64Segment.constraint,
 			)
 		})
 	}

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -12,9 +12,10 @@ import (
 
 	migratedatabase "github.com/golang-migrate/migrate/v4/database"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-func TestRunnerAppliesIdempotentlyAndRevertsBaseline(t *testing.T) {
+func TestRunnerAppliesIdempotentlyAndRevertsLatestMigration(t *testing.T) {
 	migrationConfig, _, _ := isolatedMigrationConfig(t)
 
 	runner, err := openConfig(migrationConfig)
@@ -101,6 +102,356 @@ func TestRunnerAppliesIdempotentlyAndRevertsBaseline(t *testing.T) {
 		ForceConfirmation(int(latestVersion)),
 	); !errors.Is(err, ErrForceRequiresDirty) {
 		t.Fatalf("Force on clean database error = %v, want %v", err, ErrForceRequiresDirty)
+	}
+}
+
+func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
+	migrationConfig, admin, schema := isolatedMigrationConfig(t)
+
+	runner, err := openConfig(migrationConfig)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+
+	changed, err := runner.Up()
+	if err != nil {
+		t.Fatalf("apply identity migration: %v", err)
+	}
+	if !changed {
+		t.Fatal("identity migration reported no change on an empty schema")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	users := pgx.Identifier{schema, "identity_users"}.Sanitize()
+	credentials := pgx.Identifier{schema, "identity_credentials"}.Sanitize()
+	sessions := pgx.Identifier{schema, "identity_auth_sessions"}.Sanitize()
+
+	const (
+		firstUserID     = "10000000-0000-4000-8000-000000000001"
+		secondUserID    = "10000000-0000-4000-8000-000000000002"
+		unknownUserID   = "10000000-0000-4000-8000-000000000099"
+		firstSessionID  = "20000000-0000-4000-8000-000000000001"
+		secondSessionID = "20000000-0000-4000-8000-000000000002"
+		thirdSessionID  = "20000000-0000-4000-8000-000000000003"
+		passwordHash    = "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo"
+	)
+	createdAt := time.Date(2026, time.July, 24, 10, 0, 0, 0, time.UTC)
+	expiresAt := createdAt.Add(24 * time.Hour)
+
+	if _, err := admin.Exec(
+		ctx,
+		"INSERT INTO "+users+
+			" (id, canonical_email, created_at, updated_at) VALUES ($1, $2, $3, $3)",
+		firstUserID,
+		"first@example.com",
+		createdAt,
+	); err != nil {
+		t.Fatalf("insert first user: %v", err)
+	}
+	if _, err := admin.Exec(
+		ctx,
+		"INSERT INTO "+users+
+			" (id, canonical_email, created_at, updated_at) VALUES ($1, $2, $3, $3)",
+		secondUserID,
+		"second@example.com",
+		createdAt,
+	); err != nil {
+		t.Fatalf("insert second user: %v", err)
+	}
+	if _, err := admin.Exec(
+		ctx,
+		"INSERT INTO "+credentials+" (user_id, password_hash, updated_at) VALUES ($1, $2, $3)",
+		firstUserID,
+		passwordHash,
+		createdAt,
+	); err != nil {
+		t.Fatalf("insert credential: %v", err)
+	}
+	if _, err := admin.Exec(
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $5)",
+		firstSessionID,
+		firstUserID,
+		bytesOf(0x11, 32),
+		createdAt,
+		expiresAt,
+	); err != nil {
+		t.Fatalf("insert first session: %v", err)
+	}
+	if _, err := admin.Exec(
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $5)",
+		secondSessionID,
+		firstUserID,
+		bytesOf(0x22, 32),
+		createdAt.Add(time.Minute),
+		expiresAt,
+	); err != nil {
+		t.Fatalf("insert second session for same user: %v", err)
+	}
+
+	var sessionCount int
+	if err := admin.QueryRow(
+		ctx,
+		"SELECT count(*) FROM "+sessions+" WHERE user_id = $1",
+		firstUserID,
+	).Scan(&sessionCount); err != nil {
+		t.Fatalf("count multiple sessions: %v", err)
+	}
+	if sessionCount != 2 {
+		t.Fatalf("session count = %d, want 2", sessionCount)
+	}
+
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+users+" (id, canonical_email) VALUES ($1, $2)",
+		[]any{"10000000-0000-4000-8000-000000000003", "first@example.com"},
+		"23505",
+		"identity_users_canonical_email_key",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+users+" (id, canonical_email) VALUES ($1, $2)",
+		[]any{"10000000-0000-4000-8000-000000000004", "Upper@example.com"},
+		"23514",
+		"identity_users_canonical_email_lowercase_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+users+" (id, canonical_email) VALUES ($1, $2)",
+		[]any{"10000000-0000-4000-8000-000000000005", "space @example.com"},
+		"23514",
+		"identity_users_canonical_email_ascii_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+users+" (id, canonical_email, account_status) VALUES ($1, $2, $3)",
+		[]any{"10000000-0000-4000-8000-000000000006", "status@example.com", "disabled"},
+		"23514",
+		"identity_users_account_status_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+users+
+			" (id, canonical_email, created_at, updated_at) VALUES ($1, $2, $3, $4)",
+		[]any{
+			"10000000-0000-4000-8000-000000000007",
+			"time@example.com",
+			createdAt,
+			createdAt.Add(-time.Second),
+		},
+		"23514",
+		"identity_users_timestamps_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
+		[]any{firstUserID, passwordHash},
+		"23505",
+		"identity_credentials_pkey",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
+		[]any{unknownUserID, passwordHash},
+		"23503",
+		"identity_credentials_user_id_fkey",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+credentials+" (user_id, password_hash) VALUES ($1, $2)",
+		[]any{secondUserID, strings.Repeat("x", 80)},
+		"23514",
+		"identity_credentials_password_hash_algorithm_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $5)",
+		[]any{thirdSessionID, unknownUserID, bytesOf(0x33, 32), createdAt, expiresAt},
+		"23503",
+		"identity_auth_sessions_user_id_fkey",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $5)",
+		[]any{thirdSessionID, secondUserID, bytesOf(0x33, 31), createdAt, expiresAt},
+		"23514",
+		"identity_auth_sessions_token_digest_length_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $5)",
+		[]any{thirdSessionID, secondUserID, bytesOf(0x11, 32), createdAt, expiresAt},
+		"23505",
+		"identity_auth_sessions_token_digest_key",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at) VALUES ($1, $2, $3, $4, $4)",
+		[]any{thirdSessionID, secondUserID, bytesOf(0x33, 32), createdAt},
+		"23514",
+		"identity_auth_sessions_expiry_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at, revoked_at)"+
+			" VALUES ($1, $2, $3, $4, $5, $6)",
+		[]any{
+			thirdSessionID,
+			secondUserID,
+			bytesOf(0x33, 32),
+			createdAt,
+			expiresAt,
+			createdAt.Add(time.Minute),
+		},
+		"23514",
+		"identity_auth_sessions_revocation_pair_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at, revoked_at, revocation_reason)"+
+			" VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		[]any{
+			thirdSessionID,
+			secondUserID,
+			bytesOf(0x33, 32),
+			createdAt,
+			expiresAt,
+			createdAt.Add(-time.Second),
+			"logout",
+		},
+		"23514",
+		"identity_auth_sessions_revoked_at_check",
+	)
+	assertConstraintViolation(
+		t,
+		admin,
+		ctx,
+		"INSERT INTO "+sessions+
+			" (id, user_id, token_digest, created_at, expires_at, revoked_at, revocation_reason)"+
+			" VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		[]any{
+			thirdSessionID,
+			secondUserID,
+			bytesOf(0x33, 32),
+			createdAt,
+			expiresAt,
+			createdAt.Add(time.Minute),
+			"contains spaces",
+		},
+		"23514",
+		"identity_auth_sessions_revocation_reason_check",
+	)
+
+	assertIdentityIndexes(t, admin, ctx, schema)
+	assertNoRawIdentitySecrets(t, admin, ctx, schema)
+
+	if _, err := admin.Exec(ctx, "DELETE FROM "+users+" WHERE id = $1", firstUserID); err != nil {
+		t.Fatalf("delete user for cascade check: %v", err)
+	}
+	var credentialCount int
+	if err := admin.QueryRow(
+		ctx,
+		"SELECT count(*) FROM "+credentials+" WHERE user_id = $1",
+		firstUserID,
+	).Scan(&credentialCount); err != nil {
+		t.Fatalf("count credentials after user delete: %v", err)
+	}
+	if credentialCount != 0 {
+		t.Fatalf("credential count after user delete = %d, want 0", credentialCount)
+	}
+	if err := admin.QueryRow(
+		ctx,
+		"SELECT count(*) FROM "+sessions+" WHERE user_id = $1",
+		firstUserID,
+	).Scan(&sessionCount); err != nil {
+		t.Fatalf("count sessions after user delete: %v", err)
+	}
+	if sessionCount != 0 {
+		t.Fatalf("session count after user delete = %d, want 0", sessionCount)
+	}
+
+	changed, err = runner.DownOne()
+	if err != nil {
+		t.Fatalf("revert identity migration: %v", err)
+	}
+	if !changed {
+		t.Fatal("identity down migration reported no change")
+	}
+	status, err := runner.Version()
+	if err != nil {
+		t.Fatalf("read version after identity down migration: %v", err)
+	}
+	if !status.Present || status.Version != 1 || status.Dirty {
+		t.Fatalf("status after identity down migration = %+v, want version 1 clean", status)
+	}
+	for _, table := range []string{
+		"identity_users",
+		"identity_credentials",
+		"identity_auth_sessions",
+	} {
+		var relation *string
+		if err := admin.QueryRow(
+			ctx,
+			"SELECT to_regclass($1)",
+			schema+"."+table,
+		).Scan(&relation); err != nil {
+			t.Fatalf("inspect %s after down migration: %v", table, err)
+		}
+		if relation != nil {
+			t.Fatalf("%s still exists after down migration as %q", table, *relation)
+		}
+	}
+
+	changed, err = runner.Up()
+	if err != nil {
+		t.Fatalf("reapply identity migration from baseline: %v", err)
+	}
+	if !changed {
+		t.Fatal("identity migration reported no change when reapplied from baseline")
 	}
 }
 
@@ -372,6 +723,154 @@ COMMIT;
 	if status.Present {
 		t.Fatalf("status after Force recovery = %+v, want no applied version", status)
 	}
+}
+
+func assertConstraintViolation(
+	t *testing.T,
+	conn *pgx.Conn,
+	ctx context.Context,
+	query string,
+	arguments []any,
+	code string,
+	constraint string,
+) {
+	t.Helper()
+
+	_, err := conn.Exec(ctx, query, arguments...)
+	if err == nil {
+		t.Fatalf("statement unexpectedly succeeded; want constraint %s", constraint)
+	}
+
+	var postgresError *pgconn.PgError
+	if !errors.As(err, &postgresError) {
+		t.Fatalf("statement error = %v, want PostgreSQL constraint violation", err)
+	}
+	if postgresError.Code != code || postgresError.ConstraintName != constraint {
+		t.Fatalf(
+			"statement error code/constraint = %s/%s, want %s/%s",
+			postgresError.Code,
+			postgresError.ConstraintName,
+			code,
+			constraint,
+		)
+	}
+}
+
+func assertIdentityIndexes(
+	t *testing.T,
+	conn *pgx.Conn,
+	ctx context.Context,
+	schema string,
+) {
+	t.Helper()
+
+	rows, err := conn.Query(
+		ctx,
+		`SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = $1
+  AND tablename IN ('identity_users', 'identity_auth_sessions')`,
+		schema,
+	)
+	if err != nil {
+		t.Fatalf("query identity indexes: %v", err)
+	}
+	defer rows.Close()
+
+	indexes := make(map[string]string)
+	for rows.Next() {
+		var name string
+		var definition string
+		if err := rows.Scan(&name, &definition); err != nil {
+			t.Fatalf("scan identity index: %v", err)
+		}
+		indexes[name] = definition
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate identity indexes: %v", err)
+	}
+
+	expectedFragments := map[string][]string{
+		"identity_users_canonical_email_key": {
+			"UNIQUE INDEX",
+			"(canonical_email)",
+		},
+		"identity_auth_sessions_token_digest_key": {
+			"UNIQUE INDEX",
+			"(token_digest)",
+		},
+		"identity_auth_sessions_user_created_idx": {
+			"(user_id, created_at DESC)",
+		},
+		"identity_auth_sessions_active_user_idx": {
+			"(user_id)",
+			"WHERE (revoked_at IS NULL)",
+		},
+		"identity_auth_sessions_active_expiry_idx": {
+			"(expires_at)",
+			"WHERE (revoked_at IS NULL)",
+		},
+	}
+	for name, fragments := range expectedFragments {
+		definition, ok := indexes[name]
+		if !ok {
+			t.Errorf("identity index %s is missing", name)
+			continue
+		}
+		for _, fragment := range fragments {
+			if !strings.Contains(definition, fragment) {
+				t.Errorf(
+					"identity index %s definition %q does not contain %q",
+					name,
+					definition,
+					fragment,
+				)
+			}
+		}
+	}
+}
+
+func assertNoRawIdentitySecrets(
+	t *testing.T,
+	conn *pgx.Conn,
+	ctx context.Context,
+	schema string,
+) {
+	t.Helper()
+
+	var forbiddenColumnCount int
+	if err := conn.QueryRow(
+		ctx,
+		`SELECT count(*)
+FROM information_schema.columns
+WHERE table_schema = $1
+  AND table_name IN (
+      'identity_users',
+      'identity_credentials',
+      'identity_auth_sessions'
+  )
+  AND (
+      (
+          column_name ~ '(^|_)(password|token|authorization)(_|$)'
+          AND column_name NOT IN ('password_hash', 'token_digest')
+      )
+      OR column_name = 'actor_id'
+  )`,
+		schema,
+	).Scan(&forbiddenColumnCount); err != nil {
+		t.Fatalf("inspect forbidden identity columns: %v", err)
+	}
+	if forbiddenColumnCount != 0 {
+		t.Fatalf("found %d forbidden raw identity columns", forbiddenColumnCount)
+	}
+}
+
+func bytesOf(value byte, count int) []byte {
+	result := make([]byte, count)
+	for index := range result {
+		result[index] = value
+	}
+	return result
 }
 
 func isolatedMigrationConfig(

--- a/server/migrations/000002_identity_schema.down.sql
+++ b/server/migrations/000002_identity_schema.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE identity_auth_sessions;
+DROP TABLE identity_credentials;
+DROP TABLE identity_users;
+
+COMMIT;

--- a/server/migrations/000002_identity_schema.up.sql
+++ b/server/migrations/000002_identity_schema.up.sql
@@ -36,7 +36,12 @@ CREATE TABLE identity_credentials (
     CONSTRAINT identity_credentials_password_hash_phc_shape_check
         CHECK (
             password_hash ~
-            '^\$argon2id\$v=[0-9]+\$[A-Za-z0-9._-]+=[A-Za-z0-9._-]+(,[A-Za-z0-9._-]+=[A-Za-z0-9._-]+)*\$[A-Za-z0-9+/]+={0,2}\$[A-Za-z0-9+/]+={0,2}$'
+            '^\$argon2id\$v=[0-9]+\$[A-Za-z0-9._-]+=[A-Za-z0-9._-]+(,[A-Za-z0-9._-]+=[A-Za-z0-9._-]+)*\$[A-Za-z0-9+/]+\$[A-Za-z0-9+/]+$'
+        ),
+    CONSTRAINT identity_credentials_password_hash_base64_length_check
+        CHECK (
+            octet_length(split_part(password_hash, '$', 5)) % 4 <> 1
+            AND octet_length(split_part(password_hash, '$', 6)) % 4 <> 1
         )
 );
 

--- a/server/migrations/000002_identity_schema.up.sql
+++ b/server/migrations/000002_identity_schema.up.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+CREATE TABLE identity_users (
+    id uuid PRIMARY KEY,
+    canonical_email text NOT NULL,
+    account_status text NOT NULL DEFAULT 'active',
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT identity_users_canonical_email_key UNIQUE (canonical_email),
+    CONSTRAINT identity_users_canonical_email_length_check
+        CHECK (octet_length(canonical_email) BETWEEN 3 AND 254),
+    CONSTRAINT identity_users_canonical_email_ascii_check
+        CHECK (canonical_email !~ '[^\x21-\x7e]'),
+    CONSTRAINT identity_users_canonical_email_shape_check
+        CHECK (canonical_email ~ '^[^@]+@[^@]+$'),
+    CONSTRAINT identity_users_canonical_email_lowercase_check
+        CHECK (canonical_email = lower(canonical_email)),
+    CONSTRAINT identity_users_account_status_check
+        CHECK (account_status IN ('active', 'deleting', 'deleted')),
+    CONSTRAINT identity_users_timestamps_check
+        CHECK (updated_at >= created_at)
+);
+
+CREATE TABLE identity_credentials (
+    user_id uuid PRIMARY KEY,
+    password_hash text NOT NULL,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT identity_credentials_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES identity_users (id)
+        ON DELETE CASCADE,
+    CONSTRAINT identity_credentials_password_hash_length_check
+        CHECK (octet_length(password_hash) BETWEEN 64 AND 512),
+    CONSTRAINT identity_credentials_password_hash_ascii_check
+        CHECK (password_hash !~ '[^\x21-\x7e]'),
+    CONSTRAINT identity_credentials_password_hash_algorithm_check
+        CHECK (password_hash LIKE '$argon2id$%')
+);
+
+CREATE TABLE identity_auth_sessions (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL,
+    token_digest bytea NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at timestamp with time zone NOT NULL,
+    revoked_at timestamp with time zone,
+    revocation_reason text,
+    CONSTRAINT identity_auth_sessions_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES identity_users (id)
+        ON DELETE CASCADE,
+    CONSTRAINT identity_auth_sessions_token_digest_key UNIQUE (token_digest),
+    CONSTRAINT identity_auth_sessions_token_digest_length_check
+        CHECK (octet_length(token_digest) = 32),
+    CONSTRAINT identity_auth_sessions_expiry_check
+        CHECK (expires_at > created_at),
+    CONSTRAINT identity_auth_sessions_revocation_pair_check
+        CHECK (
+            (revoked_at IS NULL AND revocation_reason IS NULL)
+            OR
+            (revoked_at IS NOT NULL AND revocation_reason IS NOT NULL)
+        ),
+    CONSTRAINT identity_auth_sessions_revoked_at_check
+        CHECK (revoked_at IS NULL OR revoked_at >= created_at),
+    CONSTRAINT identity_auth_sessions_revocation_reason_check
+        CHECK (
+            revocation_reason IS NULL
+            OR revocation_reason ~ '^[a-z][a-z0-9_]{0,63}$'
+        )
+);
+
+CREATE INDEX identity_auth_sessions_user_created_idx
+    ON identity_auth_sessions (user_id, created_at DESC);
+
+CREATE INDEX identity_auth_sessions_active_user_idx
+    ON identity_auth_sessions (user_id)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX identity_auth_sessions_active_expiry_idx
+    ON identity_auth_sessions (expires_at)
+    WHERE revoked_at IS NULL;
+
+COMMIT;

--- a/server/migrations/000002_identity_schema.up.sql
+++ b/server/migrations/000002_identity_schema.up.sql
@@ -33,8 +33,11 @@ CREATE TABLE identity_credentials (
         CHECK (octet_length(password_hash) BETWEEN 64 AND 512),
     CONSTRAINT identity_credentials_password_hash_ascii_check
         CHECK (password_hash !~ '[^\x21-\x7e]'),
-    CONSTRAINT identity_credentials_password_hash_algorithm_check
-        CHECK (password_hash LIKE '$argon2id$%')
+    CONSTRAINT identity_credentials_password_hash_phc_shape_check
+        CHECK (
+            password_hash ~
+            '^\$argon2id\$v=[0-9]+\$[A-Za-z0-9._-]+=[A-Za-z0-9._-]+(,[A-Za-z0-9._-]+=[A-Za-z0-9._-]+)*\$[A-Za-z0-9+/]+={0,2}\$[A-Za-z0-9+/]+={0,2}$'
+        )
 );
 
 CREATE TABLE identity_auth_sessions (


### PR DESCRIPTION
## 功能说明

- 新增只追加的 Identity Migration，建立 `identity_users`、`identity_credentials` 与 `identity_auth_sessions`。
- 使用 PostgreSQL 原生 `uuid` 作为 User 与 Session 的物理 ID，保持与字符串 ResourceId 兼容。
- Canonical Email 限定为 3–254 字节 ASCII、小写、单一 `@` 结构，并通过唯一约束保护并发注册。
- 每个 User 以 Credential 的 `user_id` 主键保证只有一个当前密码凭据；密码只保存 64–512 字节 Argon2id PHC 编码。
- Session 只保存 32 字节 SHA-256 Token Digest，允许一个 User 拥有多个设备 Session；不保存原始 Token、Authorization Header 或客户端 Actor。
- 账户状态固定为 `active / deleting / deleted`；Session 过期、撤销时间与撤销原因具有数据库时间顺序和成对约束。
- User 删除在 Identity 模块内部级联删除 Credential 与 AuthSession。

## 索引设计

- Canonical Email 唯一约束提供登录等值查询 B-tree。
- Token Digest 唯一约束提供 Session 鉴权等值查询 B-tree。
- `(user_id, created_at DESC)` 支持按用户查询 Session。
- 未撤销 Session 的 `user_id` 部分索引支持当前 Session 批量撤销。
- 未撤销 Session 的 `expires_at` 部分索引支持全局过期清理。

## 集成验证

PostgreSQL 集成测试覆盖：

- 空库执行、重复 `up`、`down-one` 回到版本 1、从既有基线重新升级到版本 2；
- Canonical Email 唯一、规范化、账户状态与时间约束负例；
- 单一 Credential、Argon2id PHC 结构和外键负例；
- 多 Session、Digest 长度与唯一性、过期和撤销字段负例；
- User 删除级联行为、关键索引定义和敏感原文字段缺失。

已执行：

- `make check-go`
- `TEST_DATABASE_URL=... go test -count=1 ./internal/platform/migration`
- CI 同构迁移生命周期：`up → status → repeated up → down-one → up → status`
- `make check-smoke`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- `git diff --check`

## 范围边界

本 PR 只修改 `server/migrations/` 和迁移 PostgreSQL 集成测试；不包含 Go Identity Handler、Repository、Argon2id 实现、Session Middleware、Flutter、OpenAPI、WebSocket、Docker Compose、CI 或其他业务表。

Closes #79
