### PR TITLE
[功能] 实现 Go Identity 注册登录与可信 Actor 纵向链路

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -44,7 +44,14 @@ func run() int {
 	}
 	defer databasePool.Close()
 
+	identityModule, err := bootstrap.NewIdentityModule(databasePool.Native())
+	if err != nil {
+		logger.Error("identity startup failed", slog.Any("error", err))
+		return 1
+	}
+
 	router := bootstrap.NewRouterWithReadiness(logger, databasePool,
+		identityModule,
 		preparation.New(),
 		practice.New(),
 		conversation.New(),

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -44,14 +44,19 @@ func run() int {
 	}
 	defer databasePool.Close()
 
-	identityModule, err := bootstrap.NewIdentityModule(databasePool.Native())
+	identityModule, err := bootstrap.NewIdentityModule(
+		databasePool.Native(),
+		cfg.TrustedProxyCIDRs,
+	)
 	if err != nil {
 		logger.Error("identity startup failed", slog.Any("error", err))
 		return 1
 	}
 
-	router := bootstrap.NewRouterWithReadiness(logger, databasePool,
-		identityModule,
+	router := bootstrap.NewRouterWithReadinessAndRoutes(
+		logger,
+		databasePool,
+		[]bootstrap.RouteRegistrar{identityModule},
 		preparation.New(),
 		practice.New(),
 		conversation.New(),

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -47,6 +47,7 @@ func run() int {
 	identityModule, err := bootstrap.NewIdentityModule(
 		databasePool.Native(),
 		cfg.TrustedProxyCIDRs,
+		cfg.TrustedProxyHeader,
 	)
 	if err != nil {
 		logger.Error("identity startup failed", slog.Any("error", err))

--- a/server/go.mod
+++ b/server/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
+	golang.org/x/crypto v0.54.0
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	golang.org/x/arch v0.20.0 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/server/internal/bootstrap/identity.go
+++ b/server/internal/bootstrap/identity.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+import (
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NewIdentityModule builds the production Identity composition. It has no
+// fixed-Actor fallback; startup fails if any real dependency cannot be built.
+func NewIdentityModule(database *pgxpool.Pool) (*identity.Module, error) {
+	if database == nil {
+		return nil, errors.New("bootstrap: identity database is required")
+	}
+	clock := identity.SystemClock{}
+	passwords, err := identity.NewDefaultArgon2idHasher()
+	if err != nil {
+		return nil, err
+	}
+	tokens := identity.NewOpaqueSessionTokens(nil)
+	dummyMaterial, _, err := tokens.Generate()
+	if err != nil {
+		return nil, errors.New("bootstrap: identity random source unavailable")
+	}
+	dummyHash, err := passwords.Hash(dummyMaterial)
+	if err != nil {
+		return nil, errors.New("bootstrap: identity password hashing unavailable")
+	}
+	repository, err := identity.NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		return nil, err
+	}
+	service, err := identity.NewService(
+		repository,
+		passwords,
+		tokens,
+		clock,
+		dummyHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+	rateLimits, err := identity.NewDefaultRateLimiters(clock)
+	if err != nil {
+		return nil, err
+	}
+	handler, err := identity.NewHTTPHandler(
+		service,
+		service,
+		rateLimits,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return identity.NewModule(handler)
+}

--- a/server/internal/bootstrap/identity.go
+++ b/server/internal/bootstrap/identity.go
@@ -13,6 +13,7 @@ import (
 func NewIdentityModule(
 	database *pgxpool.Pool,
 	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
 ) (*identity.Module, error) {
 	if database == nil {
 		return nil, errors.New("bootstrap: identity database is required")
@@ -51,7 +52,10 @@ func NewIdentityModule(
 	if err != nil {
 		return nil, err
 	}
-	sourceIPs, err := identity.NewTrustedProxyResolver(trustedProxyCIDRs)
+	sourceIPs, err := identity.NewTrustedProxyResolver(
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/bootstrap/identity.go
+++ b/server/internal/bootstrap/identity.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
@@ -9,7 +10,10 @@ import (
 
 // NewIdentityModule builds the production Identity composition. It has no
 // fixed-Actor fallback; startup fails if any real dependency cannot be built.
-func NewIdentityModule(database *pgxpool.Pool) (*identity.Module, error) {
+func NewIdentityModule(
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+) (*identity.Module, error) {
 	if database == nil {
 		return nil, errors.New("bootstrap: identity database is required")
 	}
@@ -23,7 +27,7 @@ func NewIdentityModule(database *pgxpool.Pool) (*identity.Module, error) {
 	if err != nil {
 		return nil, errors.New("bootstrap: identity random source unavailable")
 	}
-	dummyHash, err := passwords.Hash(dummyMaterial)
+	dummyHash, err := passwords.Hash(context.Background(), dummyMaterial)
 	if err != nil {
 		return nil, errors.New("bootstrap: identity password hashing unavailable")
 	}
@@ -38,7 +42,6 @@ func NewIdentityModule(database *pgxpool.Pool) (*identity.Module, error) {
 		repository,
 		passwords,
 		tokens,
-		clock,
 		dummyHash,
 	)
 	if err != nil {
@@ -48,11 +51,16 @@ func NewIdentityModule(database *pgxpool.Pool) (*identity.Module, error) {
 	if err != nil {
 		return nil, err
 	}
+	sourceIPs, err := identity.NewTrustedProxyResolver(trustedProxyCIDRs)
+	if err != nil {
+		return nil, err
+	}
 	handler, err := identity.NewHTTPHandler(
 		service,
 		service,
 		rateLimits,
 		nil,
+		identity.WithSourceIPResolver(sourceIPs),
 	)
 	if err != nil {
 		return nil, err

--- a/server/internal/bootstrap/router.go
+++ b/server/internal/bootstrap/router.go
@@ -30,7 +30,7 @@ type ReadinessChecker interface {
 const readinessTimeout = 2 * time.Second
 
 func NewRouter(logger *slog.Logger, modules ...Module) *gin.Engine {
-	return newRouter(logger, nil, modules...)
+	return newRouter(logger, nil, nil, modules...)
 }
 
 func NewRouterWithReadiness(
@@ -38,12 +38,24 @@ func NewRouterWithReadiness(
 	readiness ReadinessChecker,
 	modules ...Module,
 ) *gin.Engine {
-	return newRouter(logger, readiness, modules...)
+	return newRouter(logger, readiness, nil, modules...)
+}
+
+// NewRouterWithReadinessAndRoutes mounts infrastructure route registrars
+// without advertising them as business modules in the frozen /health contract.
+func NewRouterWithReadinessAndRoutes(
+	logger *slog.Logger,
+	readiness ReadinessChecker,
+	routes []RouteRegistrar,
+	modules ...Module,
+) *gin.Engine {
+	return newRouter(logger, readiness, routes, modules...)
 }
 
 func newRouter(
 	logger *slog.Logger,
 	readiness ReadinessChecker,
+	routes []RouteRegistrar,
 	modules ...Module,
 ) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
@@ -56,6 +68,9 @@ func newRouter(
 		if registrar, ok := module.(RouteRegistrar); ok {
 			registrar.RegisterRoutes(router)
 		}
+	}
+	for _, registrar := range routes {
+		registrar.RegisterRoutes(router)
 	}
 
 	router.GET("/health", func(c *gin.Context) {

--- a/server/internal/bootstrap/router.go
+++ b/server/internal/bootstrap/router.go
@@ -15,6 +15,12 @@ type Module interface {
 	Name() string
 }
 
+// RouteRegistrar is implemented by modules with production HTTP routes.
+// Explicit Mock/Test composition roots may keep their own deterministic routes.
+type RouteRegistrar interface {
+	RegisterRoutes(*gin.Engine)
+}
+
 // ReadinessChecker reports whether an external dependency can currently
 // accept work. pgxpool.Pool satisfies this interface.
 type ReadinessChecker interface {
@@ -47,6 +53,9 @@ func newRouter(
 	moduleNames := make([]string, 0, len(modules))
 	for _, module := range modules {
 		moduleNames = append(moduleNames, module.Name())
+		if registrar, ok := module.(RouteRegistrar); ok {
+			registrar.RegisterRoutes(router)
+		}
 	}
 
 	router.GET("/health", func(c *gin.Context) {

--- a/server/internal/bootstrap/router_test.go
+++ b/server/internal/bootstrap/router_test.go
@@ -29,8 +29,6 @@ func (checker readinessChecker) Ping(ctx context.Context) error {
 
 type routedModule struct{}
 
-func (routedModule) Name() string { return "routed" }
-
 func (routedModule) RegisterRoutes(router *gin.Engine) {
 	router.GET("/module-route", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
@@ -88,7 +86,15 @@ func TestHealthDoesNotDependOnDatabaseReadiness(t *testing.T) {
 
 func TestModuleCanRegisterProductionRoutes(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	router := bootstrap.NewRouter(logger, routedModule{})
+	router := bootstrap.NewRouterWithReadinessAndRoutes(
+		logger,
+		nil,
+		[]bootstrap.RouteRegistrar{routedModule{}},
+		preparation.New(),
+		practice.New(),
+		conversation.New(),
+		review.New(),
+	)
 
 	request := httptest.NewRequest(http.MethodGet, "/module-route", nil)
 	response := httptest.NewRecorder()
@@ -96,6 +102,20 @@ func TestModuleCanRegisterProductionRoutes(t *testing.T) {
 
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("expected status %d, got %d", http.StatusNoContent, response.Code)
+	}
+
+	healthRequest := httptest.NewRequest(http.MethodGet, "/health", nil)
+	healthResponse := httptest.NewRecorder()
+	router.ServeHTTP(healthResponse, healthRequest)
+	var healthBody struct {
+		Modules []string `json:"modules"`
+	}
+	if err := json.Unmarshal(healthResponse.Body.Bytes(), &healthBody); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	wantModules := []string{"preparation", "practice", "conversation", "review"}
+	if !reflect.DeepEqual(healthBody.Modules, wantModules) {
+		t.Fatalf("health modules = %#v, want %#v", healthBody.Modules, wantModules)
 	}
 }
 

--- a/server/internal/bootstrap/router_test.go
+++ b/server/internal/bootstrap/router_test.go
@@ -1,6 +1,7 @@
 package bootstrap_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,12 +18,23 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/preparation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
+	"github.com/gin-gonic/gin"
 )
 
 type readinessChecker func(context.Context) error
 
 func (checker readinessChecker) Ping(ctx context.Context) error {
 	return checker(ctx)
+}
+
+type routedModule struct{}
+
+func (routedModule) Name() string { return "routed" }
+
+func (routedModule) RegisterRoutes(router *gin.Engine) {
+	router.GET("/module-route", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
 }
 
 func TestHealthIncludesRegisteredModules(t *testing.T) {
@@ -71,6 +83,39 @@ func TestHealthDoesNotDependOnDatabaseReadiness(t *testing.T) {
 
 	if response.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+}
+
+func TestModuleCanRegisterProductionRoutes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := bootstrap.NewRouter(logger, routedModule{})
+
+	request := httptest.NewRequest(http.MethodGet, "/module-route", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, response.Code)
+	}
+}
+
+func TestRequestLoggerNeverLogsAuthorization(t *testing.T) {
+	const rawToken = "sess_must_not_appear_in_logs"
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	router := bootstrap.NewRouter(logger)
+
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	request.Header.Set("Authorization", "Bearer "+rawToken)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+	if strings.Contains(output.String(), rawToken) ||
+		strings.Contains(output.String(), "Authorization") {
+		t.Fatalf("request log leaked credential metadata: %s", output.String())
 	}
 }
 

--- a/server/internal/identity/email.go
+++ b/server/internal/identity/email.go
@@ -1,0 +1,34 @@
+package identity
+
+import (
+	"regexp"
+	"strings"
+)
+
+const maxEmailBytes = 254
+
+var canonicalEmailPattern = regexp.MustCompile(
+	`^[a-z0-9!#$%&'*+/=?^_` + "`" + `{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_` + "`" + `{|}~-]+)*@` +
+		`[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$`,
+)
+
+// NormalizeEmail implements the v1 wire contract: trim only ASCII whitespace
+// U+0009 through U+000D and U+0020, require an ASCII/Punycode address, lowercase
+// the whole address, and never apply provider-specific alias rules.
+func NormalizeEmail(value string) (string, error) {
+	trimmed := strings.Trim(value, "\t\n\v\f\r ")
+	if len(trimmed) < 3 || len(trimmed) > maxEmailBytes {
+		return "", ErrInvalidRequest
+	}
+	for i := range len(trimmed) {
+		if trimmed[i] > 0x7f {
+			return "", ErrInvalidRequest
+		}
+	}
+
+	canonical := strings.ToLower(trimmed)
+	if !canonicalEmailPattern.MatchString(canonical) {
+		return "", ErrInvalidRequest
+	}
+	return canonical, nil
+}

--- a/server/internal/identity/email_test.go
+++ b/server/internal/identity/email_test.go
@@ -1,0 +1,44 @@
+package identity
+
+import "testing"
+
+func TestNormalizeEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"lowercases and trims ASCII", "\t Learner@XN--BCHER-KVA.example\r", "learner@xn--bcher-kva.example"},
+		{"preserves plus addressing", "First.Last+tag@Example.COM", "first.last+tag@example.com"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NormalizeEmail(test.input)
+			if err != nil || got != test.want {
+				t.Fatalf("NormalizeEmail() = %q, %v; want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeEmailRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{
+		"learner@example",
+		"learner@example..com",
+		"learner\u00a0@example.com",
+		"ü@example.com",
+		".learner@example.com",
+		"learner@-example.com",
+	} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := NormalizeEmail(input); err == nil {
+				t.Fatalf("expected %q to be rejected", input)
+			}
+		})
+	}
+}

--- a/server/internal/identity/errors.go
+++ b/server/internal/identity/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrNotFound                = errors.New("identity repository: not found")
 	ErrConflict                = errors.New("identity repository: conflict")
 	ErrRepository              = errors.New("identity repository: operation failed")
+	ErrAuthenticationChanged   = errors.New("identity repository: authentication state changed")
+	ErrPasswordUnavailable     = errors.New("identity: password hashing unavailable")
 )

--- a/server/internal/identity/errors.go
+++ b/server/internal/identity/errors.go
@@ -1,0 +1,14 @@
+package identity
+
+import "errors"
+
+var (
+	ErrInvalidRequest          = errors.New("identity: invalid request")
+	ErrInvalidCredentials      = errors.New("identity: invalid credentials")
+	ErrRegistrationUnavailable = errors.New("identity: registration unavailable")
+	ErrAuthenticationRequired  = errors.New("identity: authentication required")
+	ErrRateLimited             = errors.New("identity: rate limited")
+	ErrNotFound                = errors.New("identity repository: not found")
+	ErrConflict                = errors.New("identity repository: conflict")
+	ErrRepository              = errors.New("identity repository: operation failed")
+)

--- a/server/internal/identity/http.go
+++ b/server/internal/identity/http.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,15 +18,42 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const maxIdentityRequestBody = 4096
+const (
+	maxIdentityRequestBody     = 4096
+	defaultIdentityReadTimeout = 5 * time.Second
+)
 
 type CorrelationIDGenerator func() string
 
 type HTTPHandler struct {
-	application   Application
-	authenticator Authenticator
-	rateLimits    RateLimiters
-	correlationID CorrelationIDGenerator
+	application     Application
+	authenticator   Authenticator
+	rateLimits      RateLimiters
+	correlationID   CorrelationIDGenerator
+	sourceIP        SourceIPResolver
+	bodyReadTimeout time.Duration
+}
+
+type HTTPOption func(*HTTPHandler) error
+
+func WithSourceIPResolver(resolver SourceIPResolver) HTTPOption {
+	return func(handler *HTTPHandler) error {
+		if resolver == nil {
+			return errors.New("identity: source IP resolver is required")
+		}
+		handler.sourceIP = resolver
+		return nil
+	}
+}
+
+func WithBodyReadTimeout(timeout time.Duration) HTTPOption {
+	return func(handler *HTTPHandler) error {
+		if timeout <= 0 {
+			return errors.New("identity: body read timeout must be positive")
+		}
+		handler.bodyReadTimeout = timeout
+		return nil
+	}
 }
 
 func NewHTTPHandler(
@@ -34,6 +61,7 @@ func NewHTTPHandler(
 	authenticator Authenticator,
 	rateLimits RateLimiters,
 	correlationID CorrelationIDGenerator,
+	options ...HTTPOption,
 ) (*HTTPHandler, error) {
 	if application == nil || authenticator == nil ||
 		rateLimits.RegistrationIP == nil ||
@@ -44,12 +72,20 @@ func NewHTTPHandler(
 	if correlationID == nil {
 		correlationID = newCorrelationID
 	}
-	return &HTTPHandler{
-		application:   application,
-		authenticator: authenticator,
-		rateLimits:    rateLimits,
-		correlationID: correlationID,
-	}, nil
+	handler := &HTTPHandler{
+		application:     application,
+		authenticator:   authenticator,
+		rateLimits:      rateLimits,
+		correlationID:   correlationID,
+		sourceIP:        directSourceIPResolver{},
+		bodyReadTimeout: defaultIdentityReadTimeout,
+	}
+	for _, option := range options {
+		if err := option(handler); err != nil {
+			return nil, err
+		}
+	}
+	return handler, nil
 }
 
 func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
@@ -66,11 +102,11 @@ func (h *HTTPHandler) register(c *gin.Context) {
 	if !h.enforceLimit(
 		c,
 		h.rateLimits.RegistrationIP,
-		"register-ip:"+remoteIP(c.Request),
+		"register-ip:"+h.sourceIP.Resolve(c.Request),
 	) {
 		return
 	}
-	request, ok := decodeCredentials(c)
+	request, ok := h.decodeCredentials(c)
 	if !ok {
 		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
 		return
@@ -88,11 +124,11 @@ func (h *HTTPHandler) register(c *gin.Context) {
 }
 
 func (h *HTTPHandler) login(c *gin.Context) {
-	sourceIP := remoteIP(c.Request)
+	sourceIP := h.sourceIP.Resolve(c.Request)
 	if !h.enforceLimit(c, h.rateLimits.LoginIP, "login-ip:"+sourceIP) {
 		return
 	}
-	request, ok := decodeCredentials(c)
+	request, ok := h.decodeCredentials(c)
 	if !ok {
 		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
 		return
@@ -230,6 +266,9 @@ func (h *HTTPHandler) writeApplicationError(c *gin.Context, err error) {
 		)
 	case errors.Is(err, ErrAuthenticationRequired):
 		h.writeAuthenticationRequired(c)
+	case errors.Is(err, ErrPasswordUnavailable):
+		c.Header("Retry-After", "1")
+		h.writeError(c, http.StatusTooManyRequests, "rate_limited", true)
 	default:
 		h.writeError(c, http.StatusInternalServerError, "internal_error", true)
 	}
@@ -269,25 +308,145 @@ type credentialsRequest struct {
 	Password string `json:"password"`
 }
 
-func decodeCredentials(c *gin.Context) (credentialsRequest, bool) {
+func (h *HTTPHandler) decodeCredentials(c *gin.Context) (credentialsRequest, bool) {
 	var request credentialsRequest
+	if !validJSONContentType(c.GetHeader("Content-Type")) {
+		return request, false
+	}
+	controller := http.NewResponseController(c.Writer)
+	if err := controller.SetReadDeadline(time.Now().Add(h.bodyReadTimeout)); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		return request, false
+	}
 	body := http.MaxBytesReader(c.Writer, c.Request.Body, maxIdentityRequestBody)
 	raw, err := io.ReadAll(body)
-	if err != nil || !utf8.Valid(raw) {
+	if err != nil {
 		return credentialsRequest{}, false
 	}
+	if err := controller.SetReadDeadline(time.Time{}); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		return credentialsRequest{}, false
+	}
+	if !utf8.Valid(raw) || !validJSONSurrogates(raw) {
+		return credentialsRequest{}, false
+	}
+	return decodeCredentialObject(raw)
+}
+
+func validJSONContentType(value string) bool {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	for name, value := range parameters {
+		if !strings.EqualFold(name, "charset") ||
+			!strings.EqualFold(value, "utf-8") {
+			return false
+		}
+	}
+	return true
+}
+
+func decodeCredentialObject(raw []byte) (credentialsRequest, bool) {
+	var request credentialsRequest
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return credentialsRequest{}, false
+	}
+	seen := map[string]bool{}
+	for decoder.More() {
+		token, err := decoder.Token()
+		key, ok := token.(string)
+		if err != nil || !ok || seen[key] || (key != "email" && key != "password") {
+			return credentialsRequest{}, false
+		}
+		seen[key] = true
+		var value string
+		if err := decoder.Decode(&value); err != nil {
+			return credentialsRequest{}, false
+		}
+		if key == "email" {
+			request.Email = value
+		} else {
+			request.Password = value
+		}
+	}
+	if token, err = decoder.Token(); err != nil || token != json.Delim('}') {
 		return credentialsRequest{}, false
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return credentialsRequest{}, false
 	}
-	if request.Email == "" || request.Password == "" {
+	if !seen["email"] || !seen["password"] ||
+		request.Email == "" || request.Password == "" {
 		return credentialsRequest{}, false
 	}
 	return request, true
+}
+
+func validJSONSurrogates(raw []byte) bool {
+	inString := false
+	for index := 0; index < len(raw); index++ {
+		switch raw[index] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString {
+				continue
+			}
+			if index+1 >= len(raw) {
+				return false
+			}
+			if raw[index+1] != 'u' {
+				index++
+				continue
+			}
+			codeUnit, ok := parseHexCodeUnit(raw, index+2)
+			if !ok {
+				return false
+			}
+			switch {
+			case codeUnit >= 0xd800 && codeUnit <= 0xdbff:
+				if index+12 > len(raw) ||
+					raw[index+6] != '\\' ||
+					raw[index+7] != 'u' {
+					return false
+				}
+				low, ok := parseHexCodeUnit(raw, index+8)
+				if !ok || low < 0xdc00 || low > 0xdfff {
+					return false
+				}
+				index += 11
+			case codeUnit >= 0xdc00 && codeUnit <= 0xdfff:
+				return false
+			default:
+				index += 5
+			}
+		}
+	}
+	return true
+}
+
+func parseHexCodeUnit(raw []byte, start int) (uint16, bool) {
+	if start+4 > len(raw) {
+		return 0, false
+	}
+	var value uint16
+	for _, character := range raw[start : start+4] {
+		value <<= 4
+		switch {
+		case character >= '0' && character <= '9':
+			value |= uint16(character - '0')
+		case character >= 'a' && character <= 'f':
+			value |= uint16(character-'a') + 10
+		case character >= 'A' && character <= 'F':
+			value |= uint16(character-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return value, true
 }
 
 func userResponse(user User) gin.H {
@@ -295,14 +454,6 @@ func userResponse(user User) gin.H {
 		"user_id": user.ID,
 		"email":   user.Email,
 	}
-}
-
-func remoteIP(request *http.Request) string {
-	host, _, err := net.SplitHostPort(request.RemoteAddr)
-	if err == nil {
-		return host
-	}
-	return request.RemoteAddr
 }
 
 func newCorrelationID() string {

--- a/server/internal/identity/http.go
+++ b/server/internal/identity/http.go
@@ -155,7 +155,7 @@ func (h *HTTPHandler) login(c *gin.Context) {
 		"user":          userResponse(result.User),
 		"session_token": result.Token,
 		"token_type":    "Bearer",
-		"expires_at":    result.ExpiresAt.UTC().Format(time.RFC3339),
+		"expires_at":    result.ExpiresAt.UTC().Format(time.RFC3339Nano),
 	})
 }
 

--- a/server/internal/identity/http.go
+++ b/server/internal/identity/http.go
@@ -1,0 +1,314 @@
+package identity
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+const maxIdentityRequestBody = 4096
+
+type CorrelationIDGenerator func() string
+
+type HTTPHandler struct {
+	application   Application
+	authenticator Authenticator
+	rateLimits    RateLimiters
+	correlationID CorrelationIDGenerator
+}
+
+func NewHTTPHandler(
+	application Application,
+	authenticator Authenticator,
+	rateLimits RateLimiters,
+	correlationID CorrelationIDGenerator,
+) (*HTTPHandler, error) {
+	if application == nil || authenticator == nil ||
+		rateLimits.RegistrationIP == nil ||
+		rateLimits.LoginIP == nil ||
+		rateLimits.LoginAccount == nil {
+		return nil, errors.New("identity: HTTP dependency is required")
+	}
+	if correlationID == nil {
+		correlationID = newCorrelationID
+	}
+	return &HTTPHandler{
+		application:   application,
+		authenticator: authenticator,
+		rateLimits:    rateLimits,
+		correlationID: correlationID,
+	}, nil
+}
+
+func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
+	router.POST("/v1/auth/register", h.register)
+	router.POST("/v1/auth/login", h.login)
+
+	protected := router.Group("")
+	protected.Use(h.AuthenticationMiddleware())
+	protected.POST("/v1/auth/logout", h.logout)
+	protected.GET("/v1/me", h.currentUser)
+}
+
+func (h *HTTPHandler) register(c *gin.Context) {
+	if !h.enforceLimit(
+		c,
+		h.rateLimits.RegistrationIP,
+		"register-ip:"+remoteIP(c.Request),
+	) {
+		return
+	}
+	request, ok := decodeCredentials(c)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	user, err := h.application.Register(
+		c.Request.Context(),
+		request.Email,
+		request.Password,
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, userResponse(user))
+}
+
+func (h *HTTPHandler) login(c *gin.Context) {
+	sourceIP := remoteIP(c.Request)
+	if !h.enforceLimit(c, h.rateLimits.LoginIP, "login-ip:"+sourceIP) {
+		return
+	}
+	request, ok := decodeCredentials(c)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	if !h.enforceLimit(
+		c,
+		h.rateLimits.LoginAccount,
+		accountRateLimitKey(request.Email),
+	) {
+		return
+	}
+	result, err := h.application.Login(
+		c.Request.Context(),
+		request.Email,
+		request.Password,
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.JSON(http.StatusOK, gin.H{
+		"user":          userResponse(result.User),
+		"session_token": result.Token,
+		"token_type":    "Bearer",
+		"expires_at":    result.ExpiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+func (h *HTTPHandler) logout(c *gin.Context) {
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	if err := h.application.Logout(c.Request.Context(), actor); err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *HTTPHandler) currentUser(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	user, err := h.application.CurrentUser(c.Request.Context(), actor)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, userResponse(user))
+}
+
+// AuthenticationMiddleware accepts only an Authorization Bearer credential,
+// resolves it through the Session authority, and injects a server-trusted
+// Actor into the standard request context for protected HTTP or WebSocket
+// handlers.
+func (h *HTTPHandler) AuthenticationMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawToken, ok := bearerToken(c.Request.Header.Values("Authorization"))
+		if !ok {
+			h.writeAuthenticationRequired(c)
+			c.Abort()
+			return
+		}
+		actor, err := h.authenticator.AuthenticateSession(
+			c.Request.Context(),
+			rawToken,
+		)
+		if err != nil {
+			if errors.Is(err, ErrAuthenticationRequired) {
+				h.writeAuthenticationRequired(c)
+			} else {
+				h.writeError(c, http.StatusInternalServerError, "internal_error", true)
+			}
+			c.Abort()
+			return
+		}
+		c.Request = c.Request.WithContext(
+			requestcontext.WithActor(c.Request.Context(), actor),
+		)
+		c.Next()
+	}
+}
+
+func bearerToken(values []string) (string, bool) {
+	if len(values) != 1 {
+		return "", false
+	}
+	parts := strings.Fields(values[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func (h *HTTPHandler) enforceLimit(
+	c *gin.Context,
+	limiter RateLimiter,
+	key string,
+) bool {
+	decision := limiter.Allow(key)
+	if decision.Allowed {
+		return true
+	}
+	seconds := int64((decision.RetryAfter + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	c.Header("Retry-After", strconv.FormatInt(seconds, 10))
+	h.writeError(c, http.StatusTooManyRequests, "rate_limited", true)
+	return false
+}
+
+func (h *HTTPHandler) writeApplicationError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrInvalidRequest):
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+	case errors.Is(err, ErrInvalidCredentials):
+		h.writeError(c, http.StatusUnauthorized, "invalid_credentials", false)
+	case errors.Is(err, ErrRegistrationUnavailable):
+		h.writeError(
+			c,
+			http.StatusConflict,
+			"account_registration_unavailable",
+			false,
+		)
+	case errors.Is(err, ErrAuthenticationRequired):
+		h.writeAuthenticationRequired(c)
+	default:
+		h.writeError(c, http.StatusInternalServerError, "internal_error", true)
+	}
+}
+
+func (h *HTTPHandler) writeAuthenticationRequired(c *gin.Context) {
+	c.Header("WWW-Authenticate", "Bearer")
+	h.writeError(c, http.StatusUnauthorized, "authentication_required", false)
+}
+
+func (h *HTTPHandler) writeError(
+	c *gin.Context,
+	status int,
+	code string,
+	retryable bool,
+) {
+	messages := map[string]string{
+		"invalid_request":                  "Request validation failed.",
+		"authentication_required":          "Authentication is required.",
+		"invalid_credentials":              "Email or password is invalid.",
+		"account_registration_unavailable": "Account registration is unavailable.",
+		"rate_limited":                     "Too many requests. Try again later.",
+		"internal_error":                   "An internal error occurred.",
+	}
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"code":           code,
+			"message":        messages[code],
+			"retryable":      retryable,
+			"correlation_id": h.correlationID(),
+		},
+	})
+}
+
+type credentialsRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func decodeCredentials(c *gin.Context) (credentialsRequest, bool) {
+	var request credentialsRequest
+	body := http.MaxBytesReader(c.Writer, c.Request.Body, maxIdentityRequestBody)
+	raw, err := io.ReadAll(body)
+	if err != nil || !utf8.Valid(raw) {
+		return credentialsRequest{}, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		return credentialsRequest{}, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return credentialsRequest{}, false
+	}
+	if request.Email == "" || request.Password == "" {
+		return credentialsRequest{}, false
+	}
+	return request, true
+}
+
+func userResponse(user User) gin.H {
+	return gin.H{
+		"user_id": user.ID,
+		"email":   user.Email,
+	}
+}
+
+func remoteIP(request *http.Request) string {
+	host, _, err := net.SplitHostPort(request.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return request.RemoteAddr
+}
+
+func newCorrelationID() string {
+	value := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, value); err != nil {
+		return "corr_unavailable"
+	}
+	return "corr_" + base64.RawURLEncoding.EncodeToString(value)
+}

--- a/server/internal/identity/http.go
+++ b/server/internal/identity/http.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -28,6 +29,7 @@ type CorrelationIDGenerator func() string
 type HTTPHandler struct {
 	application     Application
 	authenticator   Authenticator
+	logoutSessions  LogoutSessionResolver
 	rateLimits      RateLimiters
 	correlationID   CorrelationIDGenerator
 	sourceIP        SourceIPResolver
@@ -69,12 +71,17 @@ func NewHTTPHandler(
 		rateLimits.LoginAccount == nil {
 		return nil, errors.New("identity: HTTP dependency is required")
 	}
+	logoutSessions, ok := authenticator.(LogoutSessionResolver)
+	if !ok {
+		return nil, errors.New("identity: logout Session resolver is required")
+	}
 	if correlationID == nil {
 		correlationID = newCorrelationID
 	}
 	handler := &HTTPHandler{
 		application:     application,
 		authenticator:   authenticator,
+		logoutSessions:  logoutSessions,
 		rateLimits:      rateLimits,
 		correlationID:   correlationID,
 		sourceIP:        directSourceIPResolver{},
@@ -91,10 +98,14 @@ func NewHTTPHandler(
 func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
 	router.POST("/v1/auth/register", h.register)
 	router.POST("/v1/auth/login", h.login)
+	router.POST(
+		"/v1/auth/logout",
+		h.logoutAuthenticationMiddleware(),
+		h.logout,
+	)
 
 	protected := router.Group("")
 	protected.Use(h.AuthenticationMiddleware())
-	protected.POST("/v1/auth/logout", h.logout)
 	protected.GET("/v1/me", h.currentUser)
 }
 
@@ -195,6 +206,18 @@ func (h *HTTPHandler) currentUser(c *gin.Context) {
 // Actor into the standard request context for protected HTTP or WebSocket
 // handlers.
 func (h *HTTPHandler) AuthenticationMiddleware() gin.HandlerFunc {
+	return h.actorMiddleware(h.authenticator.AuthenticateSession)
+}
+
+// logoutAuthenticationMiddleware keeps logout retryable after the first
+// revocation without granting a revoked Session access to any other route.
+func (h *HTTPHandler) logoutAuthenticationMiddleware() gin.HandlerFunc {
+	return h.actorMiddleware(h.logoutSessions.ResolveSessionForLogout)
+}
+
+func (h *HTTPHandler) actorMiddleware(
+	resolve func(context.Context, string) (requestcontext.Actor, error),
+) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		rawToken, ok := bearerToken(c.Request.Header.Values("Authorization"))
 		if !ok {
@@ -202,10 +225,7 @@ func (h *HTTPHandler) AuthenticationMiddleware() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		actor, err := h.authenticator.AuthenticateSession(
-			c.Request.Context(),
-			rawToken,
-		)
+		actor, err := resolve(c.Request.Context(), rawToken)
 		if err != nil {
 			if errors.Is(err, ErrAuthenticationRequired) {
 				h.writeAuthenticationRequired(c)

--- a/server/internal/identity/http_test.go
+++ b/server/internal/identity/http_test.go
@@ -91,7 +91,16 @@ func (l denyLimiter) Allow(string) RateLimitDecision {
 }
 
 func TestIdentityHTTPContract(t *testing.T) {
-	expiresAt := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	expiresAt := time.Date(
+		2026,
+		8,
+		23,
+		12,
+		0,
+		0,
+		123456000,
+		time.UTC,
+	)
 	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
 	app := completeApplicationStub()
 	app.register = func(
@@ -165,7 +174,7 @@ func TestIdentityHTTPContract(t *testing.T) {
 		t,
 		login,
 		http.StatusOK,
-		`{"expires_at":"2026-08-23T12:00:00Z","session_token":"sess_secret","token_type":"Bearer","user":{"email":"learner@example.com","user_id":"user-1"}}`,
+		`{"expires_at":"2026-08-23T12:00:00.123456Z","session_token":"sess_secret","token_type":"Bearer","user":{"email":"learner@example.com","user_id":"user-1"}}`,
 	)
 	if login.Header().Get("Cache-Control") != "no-store" ||
 		login.Header().Get("Pragma") != "no-cache" {

--- a/server/internal/identity/http_test.go
+++ b/server/internal/identity/http_test.go
@@ -1,0 +1,509 @@
+package identity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+type applicationStub struct {
+	register    func(context.Context, string, string) (User, error)
+	login       func(context.Context, string, string) (LoginResult, error)
+	logout      func(context.Context, requestcontext.Actor) error
+	currentUser func(context.Context, requestcontext.Actor) (User, error)
+	revokeAll   func(context.Context, string, string) error
+}
+
+func (a applicationStub) Register(
+	ctx context.Context,
+	email string,
+	password string,
+) (User, error) {
+	return a.register(ctx, email, password)
+}
+
+func (a applicationStub) Login(
+	ctx context.Context,
+	email string,
+	password string,
+) (LoginResult, error) {
+	return a.login(ctx, email, password)
+}
+
+func (a applicationStub) Logout(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) error {
+	return a.logout(ctx, actor)
+}
+
+func (a applicationStub) CurrentUser(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) (User, error) {
+	return a.currentUser(ctx, actor)
+}
+
+func (a applicationStub) RevokeAllSessionsForUser(
+	ctx context.Context,
+	userID string,
+	reason string,
+) error {
+	return a.revokeAll(ctx, userID, reason)
+}
+
+type authenticatorStub func(
+	context.Context,
+	string,
+) (requestcontext.Actor, error)
+
+func (a authenticatorStub) AuthenticateSession(
+	ctx context.Context,
+	token string,
+) (requestcontext.Actor, error) {
+	return a(ctx, token)
+}
+
+type allowLimiter struct{}
+
+func (allowLimiter) Allow(string) RateLimitDecision {
+	return RateLimitDecision{Allowed: true}
+}
+
+type denyLimiter struct {
+	retryAfter time.Duration
+}
+
+func (l denyLimiter) Allow(string) RateLimitDecision {
+	return RateLimitDecision{RetryAfter: l.retryAfter}
+}
+
+func TestIdentityHTTPContract(t *testing.T) {
+	expiresAt := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	app := completeApplicationStub()
+	app.register = func(
+		_ context.Context,
+		email string,
+		password string,
+	) (User, error) {
+		if email != "Learner@Example.com" ||
+			password != "correct horse battery staple" {
+			t.Fatalf("unexpected registration input")
+		}
+		return User{ID: "user-1", Email: "learner@example.com"}, nil
+	}
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		return LoginResult{
+			User:      User{ID: "user-1", Email: "learner@example.com"},
+			Token:     "sess_secret",
+			ExpiresAt: expiresAt,
+		}, nil
+	}
+	app.currentUser = func(
+		_ context.Context,
+		got requestcontext.Actor,
+	) (User, error) {
+		if got != actor {
+			t.Fatalf("unexpected actor: %#v", got)
+		}
+		return User{ID: actor.UserID, Email: "learner@example.com"}, nil
+	}
+	app.logout = func(
+		_ context.Context,
+		got requestcontext.Actor,
+	) error {
+		if got != actor {
+			t.Fatalf("unexpected actor: %#v", got)
+		}
+		return nil
+	}
+	router := newTestRouter(t, app, authenticatorStub(func(
+		_ context.Context,
+		token string,
+	) (requestcontext.Actor, error) {
+		if token != "sess_secret" {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}
+		return actor, nil
+	}), defaultTestRateLimits())
+
+	register := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/register",
+		`{"email":"Learner@Example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	assertStatusAndJSON(
+		t,
+		register,
+		http.StatusCreated,
+		`{"email":"learner@example.com","user_id":"user-1"}`,
+	)
+
+	login := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/login",
+		`{"email":"Learner@Example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	assertStatusAndJSON(
+		t,
+		login,
+		http.StatusOK,
+		`{"expires_at":"2026-08-23T12:00:00Z","session_token":"sess_secret","token_type":"Bearer","user":{"email":"learner@example.com","user_id":"user-1"}}`,
+	)
+	if login.Header().Get("Cache-Control") != "no-store" ||
+		login.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("login response is cacheable: %#v", login.Header())
+	}
+
+	me := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/me",
+		"",
+		"Bearer sess_secret",
+	)
+	assertStatusAndJSON(
+		t,
+		me,
+		http.StatusOK,
+		`{"email":"learner@example.com","user_id":"user-1"}`,
+	)
+	if strings.Contains(me.Body.String(), "sess_secret") {
+		t.Fatal("/v1/me leaked the session token")
+	}
+
+	logout := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/logout",
+		"",
+		"Bearer sess_secret",
+	)
+	if logout.Code != http.StatusNoContent || logout.Body.Len() != 0 {
+		t.Fatalf("unexpected logout response: %d %q", logout.Code, logout.Body)
+	}
+}
+
+func TestAuthenticationMiddlewareHasStableFailure(t *testing.T) {
+	router := newTestRouter(
+		t,
+		completeApplicationStub(),
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+
+	for _, authorization := range []string{
+		"",
+		"Basic secret",
+		"Bearer",
+		"Bearer unknown",
+	} {
+		response := performRequest(
+			router,
+			http.MethodGet,
+			"/v1/me",
+			"",
+			authorization,
+		)
+		if response.Code != http.StatusUnauthorized ||
+			response.Header().Get("WWW-Authenticate") != "Bearer" {
+			t.Fatalf(
+				"unexpected auth response for %q: %d %#v",
+				authorization,
+				response.Code,
+				response.Header(),
+			)
+		}
+		assertErrorCode(t, response, "authentication_required")
+	}
+}
+
+func TestIdentityRequestsRejectClientControlledActor(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		t.Fatal("application must not receive request with forged actor")
+		return User{}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/register",
+		`{"email":"learner@example.com","password":"correct horse battery staple","user_id":"forged"}`,
+		"",
+	)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", response.Code)
+	}
+	assertErrorCode(t, response, "invalid_request")
+}
+
+func TestIdentityRequestsRejectInvalidUTF8WithoutChangingPassword(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		t.Fatal("application must not receive rewritten invalid UTF-8")
+		return User{}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	raw := append(
+		[]byte(`{"email":"learner@example.com","password":"correct horse `),
+		0xff,
+	)
+	raw = append(raw, []byte(` battery staple"}`)...)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/auth/register",
+		bytes.NewReader(raw),
+	)
+	request.RemoteAddr = "192.0.2.1:12345"
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", response.Code)
+	}
+	assertErrorCode(t, response, "invalid_request")
+}
+
+func TestLoginFailuresAreIndistinguishable(t *testing.T) {
+	app := completeApplicationStub()
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		return LoginResult{}, ErrInvalidCredentials
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/login",
+		`{"email":"unknown@example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status: %d", response.Code)
+	}
+	assertErrorCode(t, response, "invalid_credentials")
+	if response.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("invalid_credentials must not masquerade as missing authentication")
+	}
+}
+
+func TestRateLimitIncludesDeterministicRetryAfter(t *testing.T) {
+	limits := defaultTestRateLimits()
+	limits.LoginIP = denyLimiter{retryAfter: 1500 * time.Millisecond}
+	app := completeApplicationStub()
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		t.Fatal("limited request reached application")
+		return LoginResult{}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, nil
+		}),
+		limits,
+	)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/login",
+		`{"email":"learner@example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	if response.Code != http.StatusTooManyRequests ||
+		response.Header().Get("Retry-After") != "2" {
+		t.Fatalf("unexpected limited response: %d %#v", response.Code, response.Header())
+	}
+	assertErrorCode(t, response, "rate_limited")
+}
+
+func TestAuthenticationInternalErrorIsSanitized(t *testing.T) {
+	const sensitive = "postgres://user:password@internal/database"
+	router := newTestRouter(
+		t,
+		completeApplicationStub(),
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, errors.New(sensitive)
+		}),
+		defaultTestRateLimits(),
+	)
+	response := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/me",
+		"",
+		"Bearer sess_secret",
+	)
+	if response.Code != http.StatusInternalServerError ||
+		strings.Contains(response.Body.String(), sensitive) {
+		t.Fatalf("unsafe response: %d %q", response.Code, response.Body)
+	}
+	assertErrorCode(t, response, "internal_error")
+}
+
+func newTestRouter(
+	t *testing.T,
+	app Application,
+	authenticator Authenticator,
+	limits RateLimiters,
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler, err := NewHTTPHandler(
+		app,
+		authenticator,
+		limits,
+		func() string { return "corr_test" },
+	)
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	return router
+}
+
+func defaultTestRateLimits() RateLimiters {
+	return RateLimiters{
+		RegistrationIP: allowLimiter{},
+		LoginIP:        allowLimiter{},
+		LoginAccount:   allowLimiter{},
+	}
+}
+
+func performRequest(
+	handler http.Handler,
+	method string,
+	path string,
+	body string,
+	authorization string,
+) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.RemoteAddr = "192.0.2.1:12345"
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func assertStatusAndJSON(
+	t *testing.T,
+	response *httptest.ResponseRecorder,
+	status int,
+	want string,
+) {
+	t.Helper()
+	if response.Code != status {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	var gotValue, wantValue any
+	if err := json.Unmarshal(response.Body.Bytes(), &gotValue); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("decode expected response: %v", err)
+	}
+	gotJSON, _ := json.Marshal(gotValue)
+	wantJSON, _ := json.Marshal(wantValue)
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("response = %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func assertErrorCode(
+	t *testing.T,
+	response *httptest.ResponseRecorder,
+	want string,
+) {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if body.Error.Code != want {
+		t.Fatalf("error code = %q, want %q", body.Error.Code, want)
+	}
+}
+
+func completeApplicationStub() applicationStub {
+	return applicationStub{
+		register: func(context.Context, string, string) (User, error) {
+			return User{}, nil
+		},
+		login: func(context.Context, string, string) (LoginResult, error) {
+			return LoginResult{}, nil
+		},
+		logout: func(context.Context, requestcontext.Actor) error {
+			return nil
+		},
+		currentUser: func(
+			context.Context,
+			requestcontext.Actor,
+		) (User, error) {
+			return User{}, nil
+		},
+		revokeAll: func(context.Context, string, string) error {
+			return nil
+		},
+	}
+}

--- a/server/internal/identity/http_test.go
+++ b/server/internal/identity/http_test.go
@@ -1,10 +1,13 @@
 package identity
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -295,12 +298,295 @@ func TestIdentityRequestsRejectInvalidUTF8WithoutChangingPassword(t *testing.T) 
 		bytes.NewReader(raw),
 	)
 	request.RemoteAddr = "192.0.2.1:12345"
+	request.Header.Set("Content-Type", "application/json")
 	response := httptest.NewRecorder()
 	router.ServeHTTP(response, request)
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("unexpected status: %d", response.Code)
 	}
 	assertErrorCode(t, response, "invalid_request")
+}
+
+func TestIdentityRequestsRejectUnpairedJSONSurrogates(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		t.Fatal("register must not receive an unpaired surrogate")
+		return User{}, nil
+	}
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		t.Fatal("login must not receive an unpaired surrogate")
+		return LoginResult{}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	tests := []struct {
+		name     string
+		endpoint string
+		body     string
+	}{
+		{
+			name:     "register lone high surrogate",
+			endpoint: "/v1/auth/register",
+			body:     `{"email":"learner@example.com","password":"12345678901234\ud800"}`,
+		},
+		{
+			name:     "login lone low surrogate",
+			endpoint: "/v1/auth/login",
+			body:     `{"email":"learner@example.com","password":"12345678901234\udc00"}`,
+		},
+		{
+			name:     "login mismatched pair",
+			endpoint: "/v1/auth/login",
+			body:     `{"email":"learner@example.com","password":"12345678901234\ud800\u0041"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := performRequest(
+				router,
+				http.MethodPost,
+				test.endpoint,
+				test.body,
+				"",
+			)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status: %d", response.Code)
+			}
+			assertErrorCode(t, response, "invalid_request")
+		})
+	}
+}
+
+func TestIdentityRequestsPreserveValidJSONSurrogatePairs(t *testing.T) {
+	const password = "12345678901234😀"
+	app := completeApplicationStub()
+	app.register = func(
+		_ context.Context,
+		_ string,
+		gotPassword string,
+	) (User, error) {
+		if gotPassword != password {
+			t.Fatalf("register password = %q, want %q", gotPassword, password)
+		}
+		return User{ID: "user-1", Email: "learner@example.com"}, nil
+	}
+	app.login = func(
+		_ context.Context,
+		_ string,
+		gotPassword string,
+	) (LoginResult, error) {
+		if gotPassword != password {
+			t.Fatalf("login password = %q, want %q", gotPassword, password)
+		}
+		return LoginResult{
+			User:      User{ID: "user-1", Email: "learner@example.com"},
+			Token:     "sess_secret",
+			ExpiresAt: time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC),
+		}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(
+			context.Context,
+			string,
+		) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	body := `{"email":"learner@example.com","password":"12345678901234\ud83d\ude00"}`
+	for _, test := range []struct {
+		endpoint string
+		status   int
+	}{
+		{"/v1/auth/register", http.StatusCreated},
+		{"/v1/auth/login", http.StatusOK},
+	} {
+		response := performRequest(
+			router,
+			http.MethodPost,
+			test.endpoint,
+			body,
+			"",
+		)
+		if response.Code != test.status {
+			t.Fatalf(
+				"%s status = %d, body = %s",
+				test.endpoint,
+				response.Code,
+				response.Body,
+			)
+		}
+	}
+}
+
+func TestJSONSurrogateValidationDoesNotRejectLiteralReplacementCharacter(t *testing.T) {
+	for _, raw := range [][]byte{
+		[]byte(`{"password":"12345678901234\ufffd"}`),
+		[]byte(`{"password":"12345678901234�"}`),
+		[]byte(`{"password":"12345678901234\\ud800"}`),
+	} {
+		if !validJSONSurrogates(raw) {
+			t.Fatalf("valid JSON string rejected: %s", raw)
+		}
+	}
+}
+
+func TestIdentityCredentialsRequireExactUnambiguousJSON(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		t.Fatal("ambiguous register request reached application")
+		return User{}, nil
+	}
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		t.Fatal("ambiguous login request reached application")
+		return LoginResult{}, nil
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(context.Context, string) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	bodies := []string{
+		`{"email":"first@example.com","email":"second@example.com","password":"correct horse battery staple"}`,
+		`{"Email":"learner@example.com","password":"correct horse battery staple"}`,
+		`{"email":"learner@example.com","Password":"correct horse battery staple"}`,
+	}
+	for _, endpoint := range []string{"/v1/auth/register", "/v1/auth/login"} {
+		for _, body := range bodies {
+			response := performRequest(router, http.MethodPost, endpoint, body, "")
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("%s accepted %s: %d", endpoint, body, response.Code)
+			}
+			assertErrorCode(t, response, "invalid_request")
+		}
+	}
+}
+
+func TestIdentityCredentialsRequireApplicationJSON(t *testing.T) {
+	router := newTestRouter(
+		t,
+		completeApplicationStub(),
+		authenticatorStub(func(context.Context, string) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	body := `{"email":"learner@example.com","password":"correct horse battery staple"}`
+	tests := []struct {
+		name        string
+		contentType string
+		want        int
+	}{
+		{name: "missing", contentType: "", want: http.StatusBadRequest},
+		{name: "text", contentType: "text/plain", want: http.StatusBadRequest},
+		{name: "invalid charset", contentType: "application/json; charset=iso-8859-1", want: http.StatusBadRequest},
+		{name: "utf8 charset", contentType: "application/json; charset=UTF-8", want: http.StatusCreated},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/v1/auth/register",
+				strings.NewReader(body),
+			)
+			request.RemoteAddr = "192.0.2.1:12345"
+			if test.contentType != "" {
+				request.Header.Set("Content-Type", test.contentType)
+			}
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != test.want {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+			}
+		})
+	}
+}
+
+func TestIdentityBodyReadDeadlineRejectsSlowDrip(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		t.Fatal("timed-out body reached application")
+		return User{}, nil
+	}
+	router := newTestRouterWithOptions(
+		t,
+		app,
+		authenticatorStub(func(context.Context, string) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+		WithBodyReadTimeout(30*time.Millisecond),
+	)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	connection, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatalf("dial server: %v", err)
+	}
+	defer connection.Close()
+	if _, err := fmt.Fprintf(
+		connection,
+		"POST /v1/auth/register HTTP/1.1\r\nHost: %s\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{\"email\":",
+		address,
+	); err != nil {
+		t.Fatalf("write slow request: %v", err)
+	}
+	response, err := http.ReadResponse(bufio.NewReader(connection), nil)
+	if err != nil {
+		t.Fatalf("read timeout response: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("slow body status = %d", response.StatusCode)
+	}
+}
+
+func TestPasswordAdmissionFailureHasStablePublicBoundary(t *testing.T) {
+	app := completeApplicationStub()
+	app.register = func(context.Context, string, string) (User, error) {
+		return User{}, ErrPasswordUnavailable
+	}
+	app.login = func(context.Context, string, string) (LoginResult, error) {
+		return LoginResult{}, ErrPasswordUnavailable
+	}
+	router := newTestRouter(
+		t,
+		app,
+		authenticatorStub(func(context.Context, string) (requestcontext.Actor, error) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}),
+		defaultTestRateLimits(),
+	)
+	for _, endpoint := range []string{"/v1/auth/register", "/v1/auth/login"} {
+		response := performRequest(
+			router,
+			http.MethodPost,
+			endpoint,
+			`{"email":"learner@example.com","password":"correct horse battery staple"}`,
+			"",
+		)
+		if response.Code != http.StatusTooManyRequests ||
+			response.Header().Get("Retry-After") != "1" {
+			t.Fatalf("%s unavailable response = %d %#v", endpoint, response.Code, response.Header())
+		}
+		assertErrorCode(t, response, "rate_limited")
+	}
 }
 
 func TestLoginFailuresAreIndistinguishable(t *testing.T) {
@@ -401,6 +687,16 @@ func newTestRouter(
 	authenticator Authenticator,
 	limits RateLimiters,
 ) *gin.Engine {
+	return newTestRouterWithOptions(t, app, authenticator, limits)
+}
+
+func newTestRouterWithOptions(
+	t *testing.T,
+	app Application,
+	authenticator Authenticator,
+	limits RateLimiters,
+	options ...HTTPOption,
+) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	handler, err := NewHTTPHandler(
@@ -408,6 +704,7 @@ func newTestRouter(
 		authenticator,
 		limits,
 		func() string { return "corr_test" },
+		options...,
 	)
 	if err != nil {
 		t.Fatalf("new handler: %v", err)
@@ -434,6 +731,9 @@ func performRequest(
 ) *httptest.ResponseRecorder {
 	request := httptest.NewRequest(method, path, strings.NewReader(body))
 	request.RemoteAddr = "192.0.2.1:12345"
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
 	if authorization != "" {
 		request.Header.Set("Authorization", authorization)
 	}

--- a/server/internal/identity/http_test.go
+++ b/server/internal/identity/http_test.go
@@ -76,6 +76,32 @@ func (a authenticatorStub) AuthenticateSession(
 	return a(ctx, token)
 }
 
+func (a authenticatorStub) ResolveSessionForLogout(
+	ctx context.Context,
+	token string,
+) (requestcontext.Actor, error) {
+	return a(ctx, token)
+}
+
+type splitAuthenticatorStub struct {
+	authenticate  authenticatorStub
+	resolveLogout authenticatorStub
+}
+
+func (a splitAuthenticatorStub) AuthenticateSession(
+	ctx context.Context,
+	token string,
+) (requestcontext.Actor, error) {
+	return a.authenticate(ctx, token)
+}
+
+func (a splitAuthenticatorStub) ResolveSessionForLogout(
+	ctx context.Context,
+	token string,
+) (requestcontext.Actor, error) {
+	return a.resolveLogout(ctx, token)
+}
+
 type allowLimiter struct{}
 
 func (allowLimiter) Allow(string) RateLimitDecision {
@@ -246,6 +272,105 @@ func TestAuthenticationMiddlewareHasStableFailure(t *testing.T) {
 			)
 		}
 		assertErrorCode(t, response, "authentication_required")
+	}
+}
+
+func TestLogoutIsHTTPIdempotentWithoutTrustingRevokedSessionElsewhere(
+	t *testing.T,
+) {
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	var revoked bool
+	var logoutCalls int
+	app := completeApplicationStub()
+	app.logout = func(
+		_ context.Context,
+		got requestcontext.Actor,
+	) error {
+		if got != actor {
+			t.Fatalf("unexpected actor: %#v", got)
+		}
+		revoked = true
+		logoutCalls++
+		return nil
+	}
+	authenticator := splitAuthenticatorStub{
+		authenticate: func(
+			_ context.Context,
+			token string,
+		) (requestcontext.Actor, error) {
+			if token != "sess_secret" || revoked {
+				return requestcontext.Actor{}, ErrAuthenticationRequired
+			}
+			return actor, nil
+		},
+		resolveLogout: func(
+			_ context.Context,
+			token string,
+		) (requestcontext.Actor, error) {
+			if token != "sess_secret" {
+				return requestcontext.Actor{}, ErrAuthenticationRequired
+			}
+			return actor, nil
+		},
+	}
+	router := newTestRouter(t, app, authenticator, defaultTestRateLimits())
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		response := performRequest(
+			router,
+			http.MethodPost,
+			"/v1/auth/logout",
+			"",
+			"Bearer sess_secret",
+		)
+		if response.Code != http.StatusNoContent || response.Body.Len() != 0 {
+			t.Fatalf(
+				"logout attempt %d = %d %q",
+				attempt,
+				response.Code,
+				response.Body,
+			)
+		}
+	}
+	if logoutCalls != 2 {
+		t.Fatalf("logout calls = %d, want 2", logoutCalls)
+	}
+
+	rejected := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/me",
+		"",
+		"Bearer sess_secret",
+	)
+	if rejected.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked Session accessed /v1/me: %d", rejected.Code)
+	}
+
+	for _, authorization := range []string{
+		"Bearer sess_unknown",
+		"Bearer malformed token",
+	} {
+		response := performRequest(
+			router,
+			http.MethodPost,
+			"/v1/auth/logout",
+			"",
+			authorization,
+		)
+		if response.Code != http.StatusUnauthorized ||
+			response.Header().Get("WWW-Authenticate") != "Bearer" {
+			t.Fatalf(
+				"unknown logout %q = %d %#v",
+				authorization,
+				response.Code,
+				response.Header(),
+			)
+		}
+		assertErrorCode(t, response, "authentication_required")
+	}
+	if logoutCalls != 2 {
+		t.Fatalf("unknown token reached logout: calls = %d", logoutCalls)
 	}
 }
 

--- a/server/internal/identity/limiter.go
+++ b/server/internal/identity/limiter.go
@@ -1,0 +1,135 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+)
+
+const (
+	identityRateLimitWindow   = 15 * time.Minute
+	registrationAttemptsPerIP = 5
+	loginAttemptsPerIP        = 30
+	loginAttemptsPerAccount   = 10
+)
+
+type RateLimitDecision struct {
+	Allowed    bool
+	RetryAfter time.Duration
+}
+
+type RateLimiter interface {
+	Allow(key string) RateLimitDecision
+}
+
+type rateLimitWindow struct {
+	start time.Time
+	count int
+}
+
+// FixedWindowLimiter is process-local admission control for expensive public
+// Identity endpoints. The Repository remains responsible for database
+// uniqueness. A future multi-instance deployment must replace this adapter
+// behind RateLimiter with shared admission control.
+type FixedWindowLimiter struct {
+	mu      sync.Mutex
+	limit   int
+	window  time.Duration
+	clock   Clock
+	entries map[string]rateLimitWindow
+}
+
+func NewFixedWindowLimiter(
+	limit int,
+	window time.Duration,
+	clock Clock,
+) (*FixedWindowLimiter, error) {
+	if limit < 1 || window <= 0 || clock == nil {
+		return nil, errors.New("identity: invalid rate limiter configuration")
+	}
+	return &FixedWindowLimiter{
+		limit:   limit,
+		window:  window,
+		clock:   clock,
+		entries: make(map[string]rateLimitWindow),
+	}, nil
+}
+
+func (l *FixedWindowLimiter) Allow(key string) RateLimitDecision {
+	now := l.clock.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry, found := l.entries[key]
+	if !found || !now.Before(entry.start.Add(l.window)) {
+		l.pruneExpired(now)
+		l.entries[key] = rateLimitWindow{start: now, count: 1}
+		return RateLimitDecision{Allowed: true}
+	}
+	if entry.count >= l.limit {
+		return RateLimitDecision{
+			Allowed:    false,
+			RetryAfter: entry.start.Add(l.window).Sub(now),
+		}
+	}
+	entry.count++
+	l.entries[key] = entry
+	return RateLimitDecision{Allowed: true}
+}
+
+func (l *FixedWindowLimiter) pruneExpired(now time.Time) {
+	for key, entry := range l.entries {
+		if !now.Before(entry.start.Add(l.window)) {
+			delete(l.entries, key)
+		}
+	}
+}
+
+type RateLimiters struct {
+	RegistrationIP RateLimiter
+	LoginIP        RateLimiter
+	LoginAccount   RateLimiter
+}
+
+func NewDefaultRateLimiters(clock Clock) (RateLimiters, error) {
+	registration, err := NewFixedWindowLimiter(
+		registrationAttemptsPerIP,
+		identityRateLimitWindow,
+		clock,
+	)
+	if err != nil {
+		return RateLimiters{}, err
+	}
+	loginIP, err := NewFixedWindowLimiter(
+		loginAttemptsPerIP,
+		identityRateLimitWindow,
+		clock,
+	)
+	if err != nil {
+		return RateLimiters{}, err
+	}
+	loginAccount, err := NewFixedWindowLimiter(
+		loginAttemptsPerAccount,
+		identityRateLimitWindow,
+		clock,
+	)
+	if err != nil {
+		return RateLimiters{}, err
+	}
+	return RateLimiters{
+		RegistrationIP: registration,
+		LoginIP:        loginIP,
+		LoginAccount:   loginAccount,
+	}, nil
+}
+
+func accountRateLimitKey(email string) string {
+	canonical, err := NormalizeEmail(email)
+	if err != nil {
+		canonical = email
+	}
+	digest := sha256.Sum256([]byte(canonical))
+	return "login-account:" + hex.EncodeToString(digest[:])
+}

--- a/server/internal/identity/limiter.go
+++ b/server/internal/identity/limiter.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"container/heap"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -13,7 +14,16 @@ const (
 	registrationAttemptsPerIP = 5
 	loginAttemptsPerIP        = 30
 	loginAttemptsPerAccount   = 10
+	defaultRateLimitCapacity  = 10_000
 )
+
+type Clock interface {
+	Now() time.Time
+}
+
+type SystemClock struct{}
+
+func (SystemClock) Now() time.Time { return time.Now() }
 
 type RateLimitDecision struct {
 	Allowed    bool
@@ -25,20 +35,38 @@ type RateLimiter interface {
 }
 
 type rateLimitWindow struct {
-	start time.Time
-	count int
+	expiresAt time.Time
+	count     int
 }
 
-// FixedWindowLimiter is process-local admission control for expensive public
-// Identity endpoints. The Repository remains responsible for database
-// uniqueness. A future multi-instance deployment must replace this adapter
-// behind RateLimiter with shared admission control.
+type expiryEntry struct {
+	key       string
+	expiresAt time.Time
+}
+
+type expiryHeap []expiryEntry
+
+func (h expiryHeap) Len() int           { return len(h) }
+func (h expiryHeap) Less(i, j int) bool { return h[i].expiresAt.Before(h[j].expiresAt) }
+func (h expiryHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *expiryHeap) Push(value any)    { *h = append(*h, value.(expiryEntry)) }
+func (h *expiryHeap) Pop() any {
+	old := *h
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return last
+}
+
+// FixedWindowLimiter bounds both CPU and memory under high-cardinality input.
+// Expiration work is amortized O(log n), and a full live-key set fails closed.
 type FixedWindowLimiter struct {
-	mu      sync.Mutex
-	limit   int
-	window  time.Duration
-	clock   Clock
-	entries map[string]rateLimitWindow
+	mu       sync.Mutex
+	limit    int
+	window   time.Duration
+	capacity int
+	clock    Clock
+	entries  map[string]rateLimitWindow
+	expiry   expiryHeap
 }
 
 func NewFixedWindowLimiter(
@@ -46,14 +74,30 @@ func NewFixedWindowLimiter(
 	window time.Duration,
 	clock Clock,
 ) (*FixedWindowLimiter, error) {
-	if limit < 1 || window <= 0 || clock == nil {
+	return NewFixedWindowLimiterWithCapacity(
+		limit,
+		window,
+		defaultRateLimitCapacity,
+		clock,
+	)
+}
+
+func NewFixedWindowLimiterWithCapacity(
+	limit int,
+	window time.Duration,
+	capacity int,
+	clock Clock,
+) (*FixedWindowLimiter, error) {
+	if limit < 1 || window <= 0 || capacity < 1 || clock == nil {
 		return nil, errors.New("identity: invalid rate limiter configuration")
 	}
 	return &FixedWindowLimiter{
-		limit:   limit,
-		window:  window,
-		clock:   clock,
-		entries: make(map[string]rateLimitWindow),
+		limit:    limit,
+		window:   window,
+		capacity: capacity,
+		clock:    clock,
+		entries:  make(map[string]rateLimitWindow, capacity),
+		expiry:   make(expiryHeap, 0, capacity),
 	}, nil
 }
 
@@ -62,29 +106,48 @@ func (l *FixedWindowLimiter) Allow(key string) RateLimitDecision {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	entry, found := l.entries[key]
-	if !found || !now.Before(entry.start.Add(l.window)) {
-		l.pruneExpired(now)
-		l.entries[key] = rateLimitWindow{start: now, count: 1}
+	l.expire(now)
+	if entry, found := l.entries[key]; found {
+		if entry.count >= l.limit {
+			return RateLimitDecision{
+				Allowed:    false,
+				RetryAfter: positiveDuration(entry.expiresAt.Sub(now)),
+			}
+		}
+		entry.count++
+		l.entries[key] = entry
 		return RateLimitDecision{Allowed: true}
 	}
-	if entry.count >= l.limit {
-		return RateLimitDecision{
-			Allowed:    false,
-			RetryAfter: entry.start.Add(l.window).Sub(now),
+
+	if len(l.entries) >= l.capacity {
+		retryAfter := l.window
+		if len(l.expiry) > 0 {
+			retryAfter = positiveDuration(l.expiry[0].expiresAt.Sub(now))
 		}
+		return RateLimitDecision{Allowed: false, RetryAfter: retryAfter}
 	}
-	entry.count++
+
+	entry := rateLimitWindow{expiresAt: now.Add(l.window), count: 1}
 	l.entries[key] = entry
+	heap.Push(&l.expiry, expiryEntry{key: key, expiresAt: entry.expiresAt})
 	return RateLimitDecision{Allowed: true}
 }
 
-func (l *FixedWindowLimiter) pruneExpired(now time.Time) {
-	for key, entry := range l.entries {
-		if !now.Before(entry.start.Add(l.window)) {
-			delete(l.entries, key)
+func (l *FixedWindowLimiter) expire(now time.Time) {
+	for len(l.expiry) > 0 && !now.Before(l.expiry[0].expiresAt) {
+		expired := heap.Pop(&l.expiry).(expiryEntry)
+		entry, found := l.entries[expired.key]
+		if found && entry.expiresAt.Equal(expired.expiresAt) {
+			delete(l.entries, expired.key)
 		}
 	}
+}
+
+func positiveDuration(value time.Duration) time.Duration {
+	if value <= 0 {
+		return time.Nanosecond
+	}
+	return value
 }
 
 type RateLimiters struct {

--- a/server/internal/identity/limiter_test.go
+++ b/server/internal/identity/limiter_test.go
@@ -1,0 +1,50 @@
+package identity
+
+import (
+	"testing"
+	"time"
+)
+
+type mutableClock struct {
+	now time.Time
+}
+
+func (c *mutableClock) Now() time.Time { return c.now }
+
+func TestFixedWindowLimiterIsDeterministic(t *testing.T) {
+	clock := &mutableClock{
+		now: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+	}
+	limiter, err := NewFixedWindowLimiter(2, time.Minute, clock)
+	if err != nil {
+		t.Fatalf("new limiter: %v", err)
+	}
+	if !limiter.Allow("scope").Allowed || !limiter.Allow("scope").Allowed {
+		t.Fatal("expected first two attempts to pass")
+	}
+	decision := limiter.Allow("scope")
+	if decision.Allowed || decision.RetryAfter != time.Minute {
+		t.Fatalf("unexpected limited decision: %#v", decision)
+	}
+
+	clock.now = clock.now.Add(30 * time.Second)
+	decision = limiter.Allow("scope")
+	if decision.Allowed || decision.RetryAfter != 30*time.Second {
+		t.Fatalf("unexpected retry delay: %#v", decision)
+	}
+
+	clock.now = clock.now.Add(30 * time.Second)
+	if !limiter.Allow("scope").Allowed {
+		t.Fatal("expected new window to admit request")
+	}
+}
+
+func TestLoginAccountScopeDoesNotContainEmail(t *testing.T) {
+	key := accountRateLimitKey("Learner@Example.com")
+	if key == "" || key == "login-account:learner@example.com" {
+		t.Fatalf("unsafe account scope: %q", key)
+	}
+	if key != accountRateLimitKey(" learner@example.com ") {
+		t.Fatal("canonical email variants must share a scope")
+	}
+}

--- a/server/internal/identity/limiter_test.go
+++ b/server/internal/identity/limiter_test.go
@@ -48,3 +48,31 @@ func TestLoginAccountScopeDoesNotContainEmail(t *testing.T) {
 		t.Fatal("canonical email variants must share a scope")
 	}
 }
+
+func TestFixedWindowLimiterFailsClosedAtCapacityAndReusesExpiredSpace(t *testing.T) {
+	clock := &mutableClock{now: time.Unix(1_000, 0)}
+	limiter, err := NewFixedWindowLimiterWithCapacity(1, time.Minute, 3, clock)
+	if err != nil {
+		t.Fatalf("new limiter: %v", err)
+	}
+	for _, key := range []string{"one", "two", "three"} {
+		if !limiter.Allow(key).Allowed {
+			t.Fatalf("expected %q to be admitted", key)
+		}
+	}
+	decision := limiter.Allow("high-cardinality-four")
+	if decision.Allowed || decision.RetryAfter != time.Minute {
+		t.Fatalf("capacity must fail closed: %#v", decision)
+	}
+	if len(limiter.entries) != 3 || len(limiter.expiry) != 3 {
+		t.Fatalf("limiter exceeded capacity: %d/%d", len(limiter.entries), len(limiter.expiry))
+	}
+
+	clock.now = clock.now.Add(time.Minute)
+	if !limiter.Allow("replacement").Allowed {
+		t.Fatal("expired capacity was not reclaimed")
+	}
+	if len(limiter.entries) != 1 || len(limiter.expiry) != 1 {
+		t.Fatalf("expired entries were not bounded: %d/%d", len(limiter.entries), len(limiter.expiry))
+	}
+}

--- a/server/internal/identity/model.go
+++ b/server/internal/identity/model.go
@@ -27,6 +27,7 @@ type User struct {
 type Credential struct {
 	User         User
 	PasswordHash string
+	UpdatedAt    time.Time
 }
 
 type Session struct {
@@ -48,12 +49,12 @@ type LoginResult struct {
 }
 
 type CreateSessionParams struct {
-	UserID          string
-	TokenDigest     []byte
-	CreatedAt       time.Time
-	ExpiresAt       time.Time
-	PreviousHash    string
-	ReplacementHash string
+	UserID              string
+	TokenDigest         []byte
+	CredentialUpdatedAt time.Time
+	Lifetime            time.Duration
+	PreviousHash        string
+	ReplacementHash     string
 }
 
 // Repository is the persistence boundary owned by Identity. Implementations
@@ -63,44 +64,40 @@ type Repository interface {
 		ctx context.Context,
 		canonicalEmail string,
 		passwordHash string,
-		now time.Time,
 	) (User, error)
 	FindCredentialByEmail(ctx context.Context, canonicalEmail string) (Credential, error)
 	CreateSession(ctx context.Context, params CreateSessionParams) (Session, error)
 	FindSessionByTokenDigest(
 		ctx context.Context,
 		tokenDigest []byte,
-		now time.Time,
 	) (SessionIdentity, error)
 	FindUserByID(ctx context.Context, userID string) (User, error)
 	RevokeSession(
 		ctx context.Context,
 		userID string,
 		sessionID string,
-		revokedAt time.Time,
 		reason string,
 	) error
 	RevokeAllSessionsForUser(
 		ctx context.Context,
 		userID string,
-		revokedAt time.Time,
 		reason string,
 	) error
 }
 
 type PasswordHasher interface {
-	Hash(password string) (string, error)
-	Verify(password, encodedHash string) (valid bool, needsRehash bool, err error)
+	Hash(ctx context.Context, password string) (string, error)
+	Verify(
+		ctx context.Context,
+		password string,
+		encodedHash string,
+	) (valid bool, needsRehash bool, err error)
 }
 
 type SessionTokens interface {
 	Generate() (raw string, digest []byte, err error)
 	Digest(raw string) []byte
 	ValidWireFormat(raw string) bool
-}
-
-type Clock interface {
-	Now() time.Time
 }
 
 type Application interface {

--- a/server/internal/identity/model.go
+++ b/server/internal/identity/model.go
@@ -1,0 +1,112 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type AccountStatus string
+
+const (
+	AccountActive   AccountStatus = "active"
+	AccountDisabled AccountStatus = "disabled"
+	AccountDeleting AccountStatus = "deleting"
+	AccountDeleted  AccountStatus = "deleted"
+)
+
+type User struct {
+	ID        string
+	Email     string
+	Status    AccountStatus
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type Credential struct {
+	User         User
+	PasswordHash string
+}
+
+type Session struct {
+	ID        string
+	UserID    string
+	ExpiresAt time.Time
+}
+
+type SessionIdentity struct {
+	User      User
+	SessionID string
+	ExpiresAt time.Time
+}
+
+type LoginResult struct {
+	User      User
+	Token     string
+	ExpiresAt time.Time
+}
+
+type CreateSessionParams struct {
+	UserID          string
+	TokenDigest     []byte
+	CreatedAt       time.Time
+	ExpiresAt       time.Time
+	PreviousHash    string
+	ReplacementHash string
+}
+
+// Repository is the persistence boundary owned by Identity. Implementations
+// must use the reviewed migration history and must not create tables.
+type Repository interface {
+	CreateUserWithCredential(
+		ctx context.Context,
+		canonicalEmail string,
+		passwordHash string,
+		now time.Time,
+	) (User, error)
+	FindCredentialByEmail(ctx context.Context, canonicalEmail string) (Credential, error)
+	CreateSession(ctx context.Context, params CreateSessionParams) (Session, error)
+	FindSessionByTokenDigest(
+		ctx context.Context,
+		tokenDigest []byte,
+		now time.Time,
+	) (SessionIdentity, error)
+	FindUserByID(ctx context.Context, userID string) (User, error)
+	RevokeSession(
+		ctx context.Context,
+		userID string,
+		sessionID string,
+		revokedAt time.Time,
+		reason string,
+	) error
+	RevokeAllSessionsForUser(
+		ctx context.Context,
+		userID string,
+		revokedAt time.Time,
+		reason string,
+	) error
+}
+
+type PasswordHasher interface {
+	Hash(password string) (string, error)
+	Verify(password, encodedHash string) (valid bool, needsRehash bool, err error)
+}
+
+type SessionTokens interface {
+	Generate() (raw string, digest []byte, err error)
+	Digest(raw string) []byte
+	ValidWireFormat(raw string) bool
+}
+
+type Clock interface {
+	Now() time.Time
+}
+
+type Application interface {
+	Register(ctx context.Context, email, password string) (User, error)
+	Login(ctx context.Context, email, password string) (LoginResult, error)
+	Logout(ctx context.Context, actor requestcontext.Actor) error
+	CurrentUser(ctx context.Context, actor requestcontext.Actor) (User, error)
+	RevokeAllSessionsForUser(ctx context.Context, userID, reason string) error
+}

--- a/server/internal/identity/model.go
+++ b/server/internal/identity/model.go
@@ -71,6 +71,10 @@ type Repository interface {
 		ctx context.Context,
 		tokenDigest []byte,
 	) (SessionIdentity, error)
+	FindSessionForLogoutByTokenDigest(
+		ctx context.Context,
+		tokenDigest []byte,
+	) (SessionIdentity, error)
 	FindUserByID(ctx context.Context, userID string) (User, error)
 	RevokeSession(
 		ctx context.Context,

--- a/server/internal/identity/module.go
+++ b/server/internal/identity/module.go
@@ -1,0 +1,20 @@
+package identity
+
+import "github.com/gin-gonic/gin"
+
+type Module struct {
+	handler *HTTPHandler
+}
+
+func NewModule(handler *HTTPHandler) (*Module, error) {
+	if handler == nil {
+		return nil, ErrInvalidRequest
+	}
+	return &Module{handler: handler}, nil
+}
+
+func (*Module) Name() string { return "identity" }
+
+func (m *Module) RegisterRoutes(router *gin.Engine) {
+	m.handler.RegisterRoutes(router)
+}

--- a/server/internal/identity/module.go
+++ b/server/internal/identity/module.go
@@ -13,8 +13,6 @@ func NewModule(handler *HTTPHandler) (*Module, error) {
 	return &Module{handler: handler}, nil
 }
 
-func (*Module) Name() string { return "identity" }
-
 func (m *Module) RegisterRoutes(router *gin.Engine) {
 	m.handler.RegisterRoutes(router)
 }

--- a/server/internal/identity/password.go
+++ b/server/internal/identity/password.go
@@ -1,0 +1,221 @@
+package identity
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	minPasswordCharacters  = 15
+	maxPasswordCharacters  = 128
+	defaultHashConcurrency = 2
+	maxArgon2MemoryKiB     = 256 * 1024
+	maxArgon2Iterations    = 10
+	maxArgon2Parallelism   = 8
+)
+
+var ErrInvalidPasswordHash = errors.New("identity: invalid password hash")
+
+type Argon2idParams struct {
+	MemoryKiB   uint32
+	Iterations  uint32
+	Parallelism uint8
+	SaltLength  uint32
+	KeyLength   uint32
+}
+
+// DefaultArgon2idParams targets interactive login on the MS2 development
+// machine. BenchmarkArgon2idDefault records the reproducible local cost.
+func DefaultArgon2idParams() Argon2idParams {
+	return Argon2idParams{
+		MemoryKiB:   64 * 1024,
+		Iterations:  3,
+		Parallelism: 2,
+		SaltLength:  16,
+		KeyLength:   32,
+	}
+}
+
+type Argon2idHasher struct {
+	params    Argon2idParams
+	random    io.Reader
+	semaphore chan struct{}
+}
+
+func NewArgon2idHasher(
+	params Argon2idParams,
+	random io.Reader,
+	maxConcurrent int,
+) (*Argon2idHasher, error) {
+	if err := validateArgon2idParams(params); err != nil {
+		return nil, err
+	}
+	if random == nil {
+		random = rand.Reader
+	}
+	if maxConcurrent < 1 {
+		return nil, errors.New("identity: Argon2id concurrency must be positive")
+	}
+	return &Argon2idHasher{
+		params:    params,
+		random:    random,
+		semaphore: make(chan struct{}, maxConcurrent),
+	}, nil
+}
+
+// NewDefaultArgon2idHasher caps concurrent hashes at two, bounding this
+// process's default Argon2id working set to approximately 128 MiB.
+func NewDefaultArgon2idHasher() (*Argon2idHasher, error) {
+	return NewArgon2idHasher(
+		DefaultArgon2idParams(),
+		rand.Reader,
+		defaultHashConcurrency,
+	)
+}
+
+func ValidatePassword(password string) error {
+	if !utf8.ValidString(password) {
+		return ErrInvalidRequest
+	}
+	characters := utf8.RuneCountInString(password)
+	if characters < minPasswordCharacters || characters > maxPasswordCharacters {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+func (h *Argon2idHasher) Hash(password string) (string, error) {
+	h.semaphore <- struct{}{}
+	defer func() { <-h.semaphore }()
+
+	salt := make([]byte, h.params.SaltLength)
+	if _, err := io.ReadFull(h.random, salt); err != nil {
+		return "", errors.New("identity: password salt generation failed")
+	}
+	hash := argon2.IDKey(
+		[]byte(password),
+		salt,
+		h.params.Iterations,
+		h.params.MemoryKiB,
+		h.params.Parallelism,
+		h.params.KeyLength,
+	)
+	return encodeArgon2id(h.params, salt, hash), nil
+}
+
+func (h *Argon2idHasher) Verify(
+	password string,
+	encodedHash string,
+) (bool, bool, error) {
+	params, salt, expected, err := parseArgon2id(encodedHash)
+	if err != nil {
+		return false, false, err
+	}
+
+	h.semaphore <- struct{}{}
+	actual := argon2.IDKey(
+		[]byte(password),
+		salt,
+		params.Iterations,
+		params.MemoryKiB,
+		params.Parallelism,
+		uint32(len(expected)),
+	)
+	<-h.semaphore
+
+	valid := subtle.ConstantTimeCompare(actual, expected) == 1
+	return valid, valid && params != h.params, nil
+}
+
+func encodeArgon2id(params Argon2idParams, salt, hash []byte) string {
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		params.MemoryKiB,
+		params.Iterations,
+		params.Parallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	)
+}
+
+func parseArgon2id(encoded string) (Argon2idParams, []byte, []byte, error) {
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 6 || parts[0] != "" || parts[1] != "argon2id" {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	if parts[2] != "v="+strconv.Itoa(argon2.Version) {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+
+	parameters := strings.Split(parts[3], ",")
+	if len(parameters) != 3 {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	memory, ok := parsePHCParameter(parameters[0], "m")
+	if !ok {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	iterations, ok := parsePHCParameter(parameters[1], "t")
+	if !ok {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	parallelism, ok := parsePHCParameter(parameters[2], "p")
+	if !ok || parallelism > 255 {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	params := Argon2idParams{
+		MemoryKiB:   memory,
+		Iterations:  iterations,
+		Parallelism: uint8(parallelism),
+	}
+
+	salt, err := base64.RawStdEncoding.Strict().DecodeString(parts[4])
+	if err != nil {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	hash, err := base64.RawStdEncoding.Strict().DecodeString(parts[5])
+	if err != nil {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	params.SaltLength = uint32(len(salt))
+	params.KeyLength = uint32(len(hash))
+	if err := validateArgon2idParams(params); err != nil {
+		return Argon2idParams{}, nil, nil, ErrInvalidPasswordHash
+	}
+	return params, salt, hash, nil
+}
+
+func parsePHCParameter(value, name string) (uint32, bool) {
+	prefix := name + "="
+	if !strings.HasPrefix(value, prefix) {
+		return 0, false
+	}
+	parsed, err := strconv.ParseUint(strings.TrimPrefix(value, prefix), 10, 32)
+	return uint32(parsed), err == nil
+}
+
+func validateArgon2idParams(params Argon2idParams) error {
+	if params.MemoryKiB < 8*uint32(params.Parallelism) ||
+		params.MemoryKiB > maxArgon2MemoryKiB ||
+		params.Iterations < 1 ||
+		params.Iterations > maxArgon2Iterations ||
+		params.Parallelism < 1 ||
+		params.Parallelism > maxArgon2Parallelism ||
+		params.SaltLength < 8 ||
+		params.SaltLength > 64 ||
+		params.KeyLength < 16 ||
+		params.KeyLength > 64 {
+		return ErrInvalidPasswordHash
+	}
+	return nil
+}

--- a/server/internal/identity/password.go
+++ b/server/internal/identity/password.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
@@ -9,6 +10,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"golang.org/x/crypto/argon2"
@@ -18,6 +20,8 @@ const (
 	minPasswordCharacters  = 15
 	maxPasswordCharacters  = 128
 	defaultHashConcurrency = 2
+	defaultHashQueue       = 4
+	defaultHashWait        = 2 * time.Second
 	maxArgon2MemoryKiB     = 256 * 1024
 	maxArgon2Iterations    = 10
 	maxArgon2Parallelism   = 8
@@ -46,9 +50,11 @@ func DefaultArgon2idParams() Argon2idParams {
 }
 
 type Argon2idHasher struct {
-	params    Argon2idParams
-	random    io.Reader
-	semaphore chan struct{}
+	params        Argon2idParams
+	random        io.Reader
+	semaphore     chan struct{}
+	admission     chan struct{}
+	admissionWait time.Duration
 }
 
 func NewArgon2idHasher(
@@ -56,29 +62,49 @@ func NewArgon2idHasher(
 	random io.Reader,
 	maxConcurrent int,
 ) (*Argon2idHasher, error) {
+	return NewArgon2idHasherWithAdmission(
+		params,
+		random,
+		maxConcurrent,
+		maxConcurrent*2,
+		defaultHashWait,
+	)
+}
+
+func NewArgon2idHasherWithAdmission(
+	params Argon2idParams,
+	random io.Reader,
+	maxConcurrent int,
+	maxQueued int,
+	admissionWait time.Duration,
+) (*Argon2idHasher, error) {
 	if err := validateArgon2idParams(params); err != nil {
 		return nil, err
 	}
 	if random == nil {
 		random = rand.Reader
 	}
-	if maxConcurrent < 1 {
-		return nil, errors.New("identity: Argon2id concurrency must be positive")
+	if maxConcurrent < 1 || maxQueued < 0 || admissionWait <= 0 {
+		return nil, errors.New("identity: invalid Argon2id admission configuration")
 	}
 	return &Argon2idHasher{
-		params:    params,
-		random:    random,
-		semaphore: make(chan struct{}, maxConcurrent),
+		params:        params,
+		random:        random,
+		semaphore:     make(chan struct{}, maxConcurrent),
+		admission:     make(chan struct{}, maxConcurrent+maxQueued),
+		admissionWait: admissionWait,
 	}, nil
 }
 
 // NewDefaultArgon2idHasher caps concurrent hashes at two, bounding this
 // process's default Argon2id working set to approximately 128 MiB.
 func NewDefaultArgon2idHasher() (*Argon2idHasher, error) {
-	return NewArgon2idHasher(
+	return NewArgon2idHasherWithAdmission(
 		DefaultArgon2idParams(),
 		rand.Reader,
 		defaultHashConcurrency,
+		defaultHashQueue,
+		defaultHashWait,
 	)
 }
 
@@ -93,9 +119,21 @@ func ValidatePassword(password string) error {
 	return nil
 }
 
-func (h *Argon2idHasher) Hash(password string) (string, error) {
-	h.semaphore <- struct{}{}
-	defer func() { <-h.semaphore }()
+func (h *Argon2idHasher) Hash(
+	ctx context.Context,
+	password string,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	release, err := h.acquire(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
 	salt := make([]byte, h.params.SaltLength)
 	if _, err := io.ReadFull(h.random, salt); err != nil {
@@ -113,6 +151,7 @@ func (h *Argon2idHasher) Hash(password string) (string, error) {
 }
 
 func (h *Argon2idHasher) Verify(
+	ctx context.Context,
 	password string,
 	encodedHash string,
 ) (bool, bool, error) {
@@ -120,8 +159,18 @@ func (h *Argon2idHasher) Verify(
 	if err != nil {
 		return false, false, err
 	}
+	if err := ctx.Err(); err != nil {
+		return false, false, err
+	}
 
-	h.semaphore <- struct{}{}
+	release, err := h.acquire(ctx)
+	if err != nil {
+		return false, false, err
+	}
+	defer release()
+	if err := ctx.Err(); err != nil {
+		return false, false, err
+	}
 	actual := argon2.IDKey(
 		[]byte(password),
 		salt,
@@ -130,10 +179,45 @@ func (h *Argon2idHasher) Verify(
 		params.Parallelism,
 		uint32(len(expected)),
 	)
-	<-h.semaphore
-
 	valid := subtle.ConstantTimeCompare(actual, expected) == 1
 	return valid, valid && params != h.params, nil
+}
+
+func (h *Argon2idHasher) acquire(ctx context.Context) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case h.admission <- struct{}{}:
+	default:
+		return nil, ErrPasswordUnavailable
+	}
+
+	timer := time.NewTimer(h.admissionWait)
+	select {
+	case h.semaphore <- struct{}{}:
+		stopTimer(timer)
+		return func() {
+			<-h.semaphore
+			<-h.admission
+		}, nil
+	case <-ctx.Done():
+		stopTimer(timer)
+		<-h.admission
+		return nil, ctx.Err()
+	case <-timer.C:
+		<-h.admission
+		return nil, ErrPasswordUnavailable
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 func encodeArgon2id(params Argon2idParams, salt, hash []byte) string {

--- a/server/internal/identity/password_test.go
+++ b/server/internal/identity/password_test.go
@@ -1,0 +1,127 @@
+package identity
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+var testArgon2idParams = Argon2idParams{
+	MemoryKiB:   8,
+	Iterations:  1,
+	Parallelism: 1,
+	SaltLength:  8,
+	KeyLength:   16,
+}
+
+func TestArgon2idHashAndVerify(t *testing.T) {
+	hasher, err := NewArgon2idHasher(
+		testArgon2idParams,
+		bytes.NewReader([]byte("12345678abcdefgh")),
+		1,
+	)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
+
+	encoded, err := hasher.Hash("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if !strings.HasPrefix(encoded, "$argon2id$v=19$m=8,t=1,p=1$") {
+		t.Fatalf("unexpected PHC encoding: %q", encoded)
+	}
+
+	valid, needsRehash, err := hasher.Verify(
+		"correct horse battery staple",
+		encoded,
+	)
+	if err != nil || !valid || needsRehash {
+		t.Fatalf("verify = %v, %v, %v", valid, needsRehash, err)
+	}
+
+	valid, _, err = hasher.Verify("incorrect password value", encoded)
+	if err != nil || valid {
+		t.Fatalf("incorrect password verified: %v, %v", valid, err)
+	}
+}
+
+func TestArgon2idNeedsRehash(t *testing.T) {
+	oldHasher, err := NewArgon2idHasher(
+		testArgon2idParams,
+		bytes.NewReader([]byte("12345678")),
+		1,
+	)
+	if err != nil {
+		t.Fatalf("new old hasher: %v", err)
+	}
+	encoded, err := oldHasher.Hash("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+
+	newParams := testArgon2idParams
+	newParams.Iterations = 2
+	newHasher, err := NewArgon2idHasher(
+		newParams,
+		bytes.NewReader([]byte("abcdefgh")),
+		1,
+	)
+	if err != nil {
+		t.Fatalf("new current hasher: %v", err)
+	}
+	valid, needsRehash, err := newHasher.Verify(
+		"correct horse battery staple",
+		encoded,
+	)
+	if err != nil || !valid || !needsRehash {
+		t.Fatalf("verify = %v, %v, %v", valid, needsRehash, err)
+	}
+}
+
+func TestArgon2idRejectsUnsafeStoredParameters(t *testing.T) {
+	hasher, err := NewArgon2idHasher(
+		testArgon2idParams,
+		bytes.NewReader([]byte("12345678")),
+		1,
+	)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
+	_, _, err = hasher.Verify(
+		"correct horse battery staple",
+		"$argon2id$v=19$m=4294967295,t=1,p=1$MTIzNDU2Nzg$MTIzNDU2Nzg5MGFiY2RlZg",
+	)
+	if err == nil {
+		t.Fatal("expected unsafe parameters to be rejected")
+	}
+}
+
+func TestValidatePasswordUsesCharacterLengthWithoutNormalization(t *testing.T) {
+	if err := ValidatePassword("ééééééééééééééé"); err != nil {
+		t.Fatalf("expected 15-character password to pass: %v", err)
+	}
+	if err := ValidatePassword("short password"); err == nil {
+		t.Fatal("expected short password to fail")
+	}
+	if err := ValidatePassword(strings.Repeat("a", 129)); err == nil {
+		t.Fatal("expected long password to fail")
+	}
+}
+
+func BenchmarkArgon2idDefault(b *testing.B) {
+	hasher, err := NewArgon2idHasher(
+		DefaultArgon2idParams(),
+		bytes.NewReader(bytes.Repeat([]byte("benchmark-salt-material"), b.N+1)),
+		1,
+	)
+	if err != nil {
+		b.Fatalf("new hasher: %v", err)
+	}
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := hasher.Hash("correct horse battery staple"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/server/internal/identity/password_test.go
+++ b/server/internal/identity/password_test.go
@@ -2,8 +2,13 @@ package identity
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 var testArgon2idParams = Argon2idParams{
@@ -24,15 +29,22 @@ func TestArgon2idHashAndVerify(t *testing.T) {
 		t.Fatalf("new hasher: %v", err)
 	}
 
-	encoded, err := hasher.Hash("correct horse battery staple")
+	encoded, err := hasher.Hash(context.Background(), "correct horse battery staple")
 	if err != nil {
 		t.Fatalf("hash: %v", err)
 	}
 	if !strings.HasPrefix(encoded, "$argon2id$v=19$m=8,t=1,p=1$") {
 		t.Fatalf("unexpected PHC encoding: %q", encoded)
 	}
+	parts := strings.Split(encoded, "$")
+	for _, part := range parts[4:] {
+		if strings.Contains(part, "=") || len(part)%4 == 1 {
+			t.Fatalf("PHC segment is not unpadded RawStd Base64: %q", part)
+		}
+	}
 
 	valid, needsRehash, err := hasher.Verify(
+		context.Background(),
 		"correct horse battery staple",
 		encoded,
 	)
@@ -40,9 +52,22 @@ func TestArgon2idHashAndVerify(t *testing.T) {
 		t.Fatalf("verify = %v, %v, %v", valid, needsRehash, err)
 	}
 
-	valid, _, err = hasher.Verify("incorrect password value", encoded)
+	valid, _, err = hasher.Verify(
+		context.Background(),
+		"incorrect password value",
+		encoded,
+	)
 	if err != nil || valid {
 		t.Fatalf("incorrect password verified: %v, %v", valid, err)
+	}
+
+	parts[4] += "="
+	if _, _, err := hasher.Verify(
+		context.Background(),
+		"correct horse battery staple",
+		strings.Join(parts, "$"),
+	); err == nil {
+		t.Fatal("expected padded salt to be rejected")
 	}
 }
 
@@ -55,7 +80,10 @@ func TestArgon2idNeedsRehash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new old hasher: %v", err)
 	}
-	encoded, err := oldHasher.Hash("correct horse battery staple")
+	encoded, err := oldHasher.Hash(
+		context.Background(),
+		"correct horse battery staple",
+	)
 	if err != nil {
 		t.Fatalf("hash: %v", err)
 	}
@@ -71,6 +99,7 @@ func TestArgon2idNeedsRehash(t *testing.T) {
 		t.Fatalf("new current hasher: %v", err)
 	}
 	valid, needsRehash, err := newHasher.Verify(
+		context.Background(),
 		"correct horse battery staple",
 		encoded,
 	)
@@ -89,6 +118,7 @@ func TestArgon2idRejectsUnsafeStoredParameters(t *testing.T) {
 		t.Fatalf("new hasher: %v", err)
 	}
 	_, _, err = hasher.Verify(
+		context.Background(),
 		"correct horse battery staple",
 		"$argon2id$v=19$m=4294967295,t=1,p=1$MTIzNDU2Nzg$MTIzNDU2Nzg5MGFiY2RlZg",
 	)
@@ -109,6 +139,114 @@ func TestValidatePasswordUsesCharacterLengthWithoutNormalization(t *testing.T) {
 	}
 }
 
+type blockingReader struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingReader) Read(buffer []byte) (int, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.release
+	for index := range buffer {
+		buffer[index] = byte(index + 1)
+	}
+	return len(buffer), nil
+}
+
+func TestArgon2idAdmissionHonorsCancellationAndCapacity(t *testing.T) {
+	random := &blockingReader{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	hasher, err := NewArgon2idHasherWithAdmission(
+		testArgon2idParams,
+		random,
+		1,
+		1,
+		time.Second,
+	)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := hasher.Hash(context.Background(), "correct horse battery staple")
+		firstDone <- err
+	}()
+	<-random.started
+
+	queuedContext, cancel := context.WithCancel(context.Background())
+	queuedDone := make(chan error, 1)
+	go func() {
+		_, err := hasher.Hash(queuedContext, "another correct password")
+		queuedDone <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for len(hasher.admission) != 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("queued hash did not enter admission")
+		}
+		runtime.Gosched()
+	}
+	if _, err := hasher.Hash(
+		context.Background(),
+		"capacity overflow password",
+	); !errors.Is(err, ErrPasswordUnavailable) {
+		t.Fatalf("queue-full error = %v", err)
+	}
+	cancel()
+	if err := <-queuedDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("queued cancellation = %v", err)
+	}
+
+	close(random.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first hash: %v", err)
+	}
+	if len(hasher.admission) != 0 || len(hasher.semaphore) != 0 {
+		t.Fatal("Argon2id admission slot leaked")
+	}
+}
+
+func TestArgon2idAdmissionWaitIsFiniteAndReleasesQueueSlot(t *testing.T) {
+	random := &blockingReader{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	hasher, err := NewArgon2idHasherWithAdmission(
+		testArgon2idParams,
+		random,
+		1,
+		1,
+		20*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new hasher: %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := hasher.Hash(context.Background(), "correct horse battery staple")
+		firstDone <- err
+	}()
+	<-random.started
+	if _, err := hasher.Hash(
+		context.Background(),
+		"another correct password",
+	); !errors.Is(err, ErrPasswordUnavailable) {
+		t.Fatalf("admission timeout = %v", err)
+	}
+	if len(hasher.admission) != 1 {
+		t.Fatal("timed-out queue slot was not released")
+	}
+	close(random.release)
+	if err := <-firstDone; err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("first hash: %v", err)
+	}
+}
+
 func BenchmarkArgon2idDefault(b *testing.B) {
 	hasher, err := NewArgon2idHasher(
 		DefaultArgon2idParams(),
@@ -120,7 +258,10 @@ func BenchmarkArgon2idDefault(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for range b.N {
-		if _, err := hasher.Hash("correct horse battery staple"); err != nil {
+		if _, err := hasher.Hash(
+			context.Background(),
+			"correct horse battery staple",
+		); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/server/internal/identity/postgres.go
+++ b/server/internal/identity/postgres.go
@@ -1,0 +1,301 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type PostgreSQL interface {
+	Begin(context.Context) (pgx.Tx, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}
+
+// PostgresRepository is the sole Identity adapter for the reviewed PostgreSQL
+// schema. It never creates or migrates tables.
+type PostgresRepository struct {
+	database PostgreSQL
+	ids      IDGenerator
+}
+
+func NewPostgresRepository(
+	database PostgreSQL,
+	ids IDGenerator,
+) (*PostgresRepository, error) {
+	if database == nil || ids == nil {
+		return nil, ErrRepository
+	}
+	return &PostgresRepository{database: database, ids: ids}, nil
+}
+
+func (r *PostgresRepository) CreateUserWithCredential(
+	ctx context.Context,
+	canonicalEmail string,
+	passwordHash string,
+	now time.Time,
+) (_ User, resultErr error) {
+	userID, err := r.ids.NewID()
+	if err != nil {
+		return User{}, ErrRepository
+	}
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return User{}, ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, `
+INSERT INTO identity_users (
+    id,
+    canonical_email,
+    account_status,
+    created_at,
+    updated_at
+) VALUES ($1, $2, 'active', $3, $3)`,
+		userID,
+		canonicalEmail,
+		now,
+	); err != nil {
+		return User{}, mapPostgresError(err)
+	}
+	if _, err := tx.Exec(ctx, `
+INSERT INTO identity_credentials (user_id, password_hash, updated_at)
+VALUES ($1, $2, $3)`,
+		userID,
+		passwordHash,
+		now,
+	); err != nil {
+		return User{}, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return User{}, ErrRepository
+	}
+	return User{
+		ID:        userID,
+		Email:     canonicalEmail,
+		Status:    AccountActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+func (r *PostgresRepository) FindCredentialByEmail(
+	ctx context.Context,
+	canonicalEmail string,
+) (Credential, error) {
+	var credential Credential
+	var status string
+	err := r.database.QueryRow(ctx, `
+SELECT
+    users.id::text,
+    users.canonical_email,
+    users.account_status,
+    users.created_at,
+    users.updated_at,
+    credentials.password_hash
+FROM identity_users AS users
+JOIN identity_credentials AS credentials ON credentials.user_id = users.id
+WHERE users.canonical_email = $1`,
+		canonicalEmail,
+	).Scan(
+		&credential.User.ID,
+		&credential.User.Email,
+		&status,
+		&credential.User.CreatedAt,
+		&credential.User.UpdatedAt,
+		&credential.PasswordHash,
+	)
+	if err != nil {
+		return Credential{}, mapPostgresError(err)
+	}
+	credential.User.Status = AccountStatus(status)
+	return credential, nil
+}
+
+func (r *PostgresRepository) CreateSession(
+	ctx context.Context,
+	params CreateSessionParams,
+) (_ Session, resultErr error) {
+	sessionID, err := r.ids.NewID()
+	if err != nil {
+		return Session{}, ErrRepository
+	}
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return Session{}, ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if params.ReplacementHash != "" {
+		if _, err := tx.Exec(ctx, `
+UPDATE identity_credentials
+SET password_hash = $1, updated_at = $2
+WHERE user_id = $3 AND password_hash = $4`,
+			params.ReplacementHash,
+			params.CreatedAt,
+			params.UserID,
+			params.PreviousHash,
+		); err != nil {
+			return Session{}, mapPostgresError(err)
+		}
+	}
+	if _, err := tx.Exec(ctx, `
+INSERT INTO identity_auth_sessions (
+    id,
+    user_id,
+    token_digest,
+    created_at,
+    expires_at
+) VALUES ($1, $2, $3, $4, $5)`,
+		sessionID,
+		params.UserID,
+		params.TokenDigest,
+		params.CreatedAt,
+		params.ExpiresAt,
+	); err != nil {
+		return Session{}, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Session{}, ErrRepository
+	}
+	return Session{
+		ID:        sessionID,
+		UserID:    params.UserID,
+		ExpiresAt: params.ExpiresAt,
+	}, nil
+}
+
+func (r *PostgresRepository) FindSessionByTokenDigest(
+	ctx context.Context,
+	tokenDigest []byte,
+	now time.Time,
+) (SessionIdentity, error) {
+	var identity SessionIdentity
+	var status string
+	err := r.database.QueryRow(ctx, `
+SELECT
+    sessions.id::text,
+    sessions.expires_at,
+    users.id::text,
+    users.canonical_email,
+    users.account_status,
+    users.created_at,
+    users.updated_at
+FROM identity_auth_sessions AS sessions
+JOIN identity_users AS users ON users.id = sessions.user_id
+WHERE sessions.token_digest = $1
+  AND sessions.revoked_at IS NULL
+  AND sessions.expires_at > $2`,
+		tokenDigest,
+		now,
+	).Scan(
+		&identity.SessionID,
+		&identity.ExpiresAt,
+		&identity.User.ID,
+		&identity.User.Email,
+		&status,
+		&identity.User.CreatedAt,
+		&identity.User.UpdatedAt,
+	)
+	if err != nil {
+		return SessionIdentity{}, mapPostgresError(err)
+	}
+	identity.User.Status = AccountStatus(status)
+	return identity, nil
+}
+
+func (r *PostgresRepository) FindUserByID(
+	ctx context.Context,
+	userID string,
+) (User, error) {
+	var user User
+	var status string
+	err := r.database.QueryRow(ctx, `
+SELECT id::text, canonical_email, account_status, created_at, updated_at
+FROM identity_users
+WHERE id = $1`,
+		userID,
+	).Scan(
+		&user.ID,
+		&user.Email,
+		&status,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+	if err != nil {
+		return User{}, mapPostgresError(err)
+	}
+	user.Status = AccountStatus(status)
+	return user, nil
+}
+
+func (r *PostgresRepository) RevokeSession(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	revokedAt time.Time,
+	reason string,
+) error {
+	tag, err := r.database.Exec(ctx, `
+UPDATE identity_auth_sessions
+SET
+    revoked_at = COALESCE(revoked_at, $3),
+    revocation_reason = COALESCE(revocation_reason, $4)
+WHERE id = $1 AND user_id = $2`,
+		sessionID,
+		userID,
+		revokedAt,
+		reason,
+	)
+	if err != nil {
+		return mapPostgresError(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *PostgresRepository) RevokeAllSessionsForUser(
+	ctx context.Context,
+	userID string,
+	revokedAt time.Time,
+	reason string,
+) error {
+	_, err := r.database.Exec(ctx, `
+UPDATE identity_auth_sessions
+SET revoked_at = $2, revocation_reason = $3
+WHERE user_id = $1 AND revoked_at IS NULL`,
+		userID,
+		revokedAt,
+		reason,
+	)
+	return mapPostgresError(err)
+}
+
+func mapPostgresError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) &&
+		postgresError.Code == "23505" {
+		return ErrConflict
+	}
+	return ErrRepository
+}

--- a/server/internal/identity/postgres.go
+++ b/server/internal/identity/postgres.go
@@ -9,10 +9,11 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+const transactionRollbackTimeout = 5 * time.Second
+
 type PostgreSQL interface {
 	Begin(context.Context) (pgx.Tx, error)
 	QueryRow(context.Context, string, ...any) pgx.Row
-	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
 }
 
 // PostgresRepository is the sole Identity adapter for the reviewed PostgreSQL
@@ -36,7 +37,6 @@ func (r *PostgresRepository) CreateUserWithCredential(
 	ctx context.Context,
 	canonicalEmail string,
 	passwordHash string,
-	now time.Time,
 ) (_ User, resultErr error) {
 	userID, err := r.ids.NewID()
 	if err != nil {
@@ -48,30 +48,31 @@ func (r *PostgresRepository) CreateUserWithCredential(
 	}
 	defer func() {
 		if resultErr != nil {
-			_ = tx.Rollback(ctx)
+			rollback(tx)
 		}
 	}()
 
-	if _, err := tx.Exec(ctx, `
+	var createdAt time.Time
+	var updatedAt time.Time
+	if err := tx.QueryRow(ctx, `
 INSERT INTO identity_users (
     id,
     canonical_email,
     account_status,
     created_at,
     updated_at
-) VALUES ($1, $2, 'active', $3, $3)`,
+) VALUES ($1, $2, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+RETURNING created_at, updated_at`,
 		userID,
 		canonicalEmail,
-		now,
-	); err != nil {
+	).Scan(&createdAt, &updatedAt); err != nil {
 		return User{}, mapPostgresError(err)
 	}
 	if _, err := tx.Exec(ctx, `
 INSERT INTO identity_credentials (user_id, password_hash, updated_at)
-VALUES ($1, $2, $3)`,
+VALUES ($1, $2, CURRENT_TIMESTAMP)`,
 		userID,
 		passwordHash,
-		now,
 	); err != nil {
 		return User{}, mapPostgresError(err)
 	}
@@ -82,8 +83,8 @@ VALUES ($1, $2, $3)`,
 		ID:        userID,
 		Email:     canonicalEmail,
 		Status:    AccountActive,
-		CreatedAt: now,
-		UpdatedAt: now,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
 	}, nil
 }
 
@@ -100,7 +101,8 @@ SELECT
     users.account_status,
     users.created_at,
     users.updated_at,
-    credentials.password_hash
+    credentials.password_hash,
+    credentials.updated_at
 FROM identity_users AS users
 JOIN identity_credentials AS credentials ON credentials.user_id = users.id
 WHERE users.canonical_email = $1`,
@@ -112,6 +114,7 @@ WHERE users.canonical_email = $1`,
 		&credential.User.CreatedAt,
 		&credential.User.UpdatedAt,
 		&credential.PasswordHash,
+		&credential.UpdatedAt,
 	)
 	if err != nil {
 		return Credential{}, mapPostgresError(err)
@@ -124,6 +127,11 @@ func (r *PostgresRepository) CreateSession(
 	ctx context.Context,
 	params CreateSessionParams,
 ) (_ Session, resultErr error) {
+	if params.Lifetime <= 0 ||
+		params.Lifetime%time.Second != 0 ||
+		len(params.TokenDigest) != 32 {
+		return Session{}, ErrRepository
+	}
 	sessionID, err := r.ids.NewID()
 	if err != nil {
 		return Session{}, ErrRepository
@@ -134,37 +142,83 @@ func (r *PostgresRepository) CreateSession(
 	}
 	defer func() {
 		if resultErr != nil {
-			_ = tx.Rollback(ctx)
+			rollback(tx)
 		}
 	}()
 
+	var status string
+	if err := tx.QueryRow(ctx, `
+SELECT account_status
+FROM identity_users
+WHERE id = $1
+FOR UPDATE`,
+		params.UserID,
+	).Scan(&status); err != nil {
+		return Session{}, mapPostgresError(err)
+	}
+	var currentHash string
+	var credentialUpdatedAt time.Time
+	if err := tx.QueryRow(ctx, `
+SELECT password_hash, updated_at
+FROM identity_credentials
+WHERE user_id = $1
+FOR UPDATE`,
+		params.UserID,
+	).Scan(&currentHash, &credentialUpdatedAt); err != nil {
+		return Session{}, mapPostgresError(err)
+	}
+	if AccountStatus(status) != AccountActive ||
+		currentHash != params.PreviousHash ||
+		!credentialUpdatedAt.Equal(params.CredentialUpdatedAt) {
+		return Session{}, ErrAuthenticationChanged
+	}
+
 	if params.ReplacementHash != "" {
-		if _, err := tx.Exec(ctx, `
+		tag, err := tx.Exec(ctx, `
 UPDATE identity_credentials
-SET password_hash = $1, updated_at = $2
-WHERE user_id = $3 AND password_hash = $4`,
+SET
+    password_hash = $1,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE user_id = $2
+  AND password_hash = $3
+  AND updated_at = $4`,
 			params.ReplacementHash,
-			params.CreatedAt,
 			params.UserID,
 			params.PreviousHash,
-		); err != nil {
+			params.CredentialUpdatedAt,
+		)
+		if err != nil {
 			return Session{}, mapPostgresError(err)
 		}
+		if tag.RowsAffected() != 1 {
+			return Session{}, ErrAuthenticationChanged
+		}
 	}
-	if _, err := tx.Exec(ctx, `
+	var createdAt time.Time
+	var expiresAt time.Time
+	if err := tx.QueryRow(ctx, `
 INSERT INTO identity_auth_sessions (
     id,
     user_id,
     token_digest,
     created_at,
     expires_at
-) VALUES ($1, $2, $3, $4, $5)`,
+) VALUES (
+    $1,
+    $2,
+    $3,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP + ($4::bigint * INTERVAL '1 second')
+)
+RETURNING created_at, expires_at`,
 		sessionID,
 		params.UserID,
 		params.TokenDigest,
-		params.CreatedAt,
-		params.ExpiresAt,
-	); err != nil {
+		int64(params.Lifetime/time.Second),
+	).Scan(&createdAt, &expiresAt); err != nil {
 		return Session{}, mapPostgresError(err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -173,14 +227,13 @@ INSERT INTO identity_auth_sessions (
 	return Session{
 		ID:        sessionID,
 		UserID:    params.UserID,
-		ExpiresAt: params.ExpiresAt,
+		ExpiresAt: expiresAt,
 	}, nil
 }
 
 func (r *PostgresRepository) FindSessionByTokenDigest(
 	ctx context.Context,
 	tokenDigest []byte,
-	now time.Time,
 ) (SessionIdentity, error) {
 	var identity SessionIdentity
 	var status string
@@ -197,9 +250,9 @@ FROM identity_auth_sessions AS sessions
 JOIN identity_users AS users ON users.id = sessions.user_id
 WHERE sessions.token_digest = $1
   AND sessions.revoked_at IS NULL
-  AND sessions.expires_at > $2`,
+  AND sessions.created_at <= CURRENT_TIMESTAMP
+  AND sessions.expires_at > CURRENT_TIMESTAMP`,
 		tokenDigest,
-		now,
 	).Scan(
 		&identity.SessionID,
 		&identity.ExpiresAt,
@@ -245,18 +298,38 @@ func (r *PostgresRepository) RevokeSession(
 	ctx context.Context,
 	userID string,
 	sessionID string,
-	revokedAt time.Time,
 	reason string,
-) error {
-	tag, err := r.database.Exec(ctx, `
+) (resultErr error) {
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			rollback(tx)
+		}
+	}()
+	var lockedUserID string
+	if err := tx.QueryRow(ctx, `
+SELECT id::text
+FROM identity_users
+WHERE id = $1
+FOR UPDATE`,
+		userID,
+	).Scan(&lockedUserID); err != nil {
+		return mapPostgresError(err)
+	}
+	tag, err := tx.Exec(ctx, `
 UPDATE identity_auth_sessions
 SET
-    revoked_at = COALESCE(revoked_at, $3),
-    revocation_reason = COALESCE(revocation_reason, $4)
+    revoked_at = COALESCE(
+        revoked_at,
+        GREATEST(CURRENT_TIMESTAMP, created_at)
+    ),
+    revocation_reason = COALESCE(revocation_reason, $3)
 WHERE id = $1 AND user_id = $2`,
 		sessionID,
 		userID,
-		revokedAt,
 		reason,
 	)
 	if err != nil {
@@ -265,24 +338,72 @@ WHERE id = $1 AND user_id = $2`,
 	if tag.RowsAffected() == 0 {
 		return ErrNotFound
 	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrRepository
+	}
 	return nil
 }
 
 func (r *PostgresRepository) RevokeAllSessionsForUser(
 	ctx context.Context,
 	userID string,
-	revokedAt time.Time,
 	reason string,
-) error {
-	_, err := r.database.Exec(ctx, `
+) (resultErr error) {
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			rollback(tx)
+		}
+	}()
+	var lockedUserID string
+	if err := tx.QueryRow(ctx, `
+SELECT id::text
+FROM identity_users
+WHERE id = $1
+FOR UPDATE`,
+		userID,
+	).Scan(&lockedUserID); err != nil {
+		return mapPostgresError(err)
+	}
+	tag, err := tx.Exec(ctx, `
+UPDATE identity_credentials
+SET updated_at = GREATEST(
+    CURRENT_TIMESTAMP,
+    updated_at + INTERVAL '1 microsecond'
+)
+WHERE user_id = $1`,
+		userID,
+	)
+	if err != nil {
+		return mapPostgresError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrNotFound
+	}
+	if _, err := tx.Exec(ctx, `
 UPDATE identity_auth_sessions
-SET revoked_at = $2, revocation_reason = $3
+SET
+    revoked_at = GREATEST(CURRENT_TIMESTAMP, created_at),
+    revocation_reason = $2
 WHERE user_id = $1 AND revoked_at IS NULL`,
 		userID,
-		revokedAt,
 		reason,
-	)
-	return mapPostgresError(err)
+	); err != nil {
+		return mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrRepository
+	}
+	return nil
+}
+
+func rollback(tx pgx.Tx) {
+	ctx, cancel := context.WithTimeout(context.Background(), transactionRollbackTimeout)
+	defer cancel()
+	_ = tx.Rollback(ctx)
 }
 
 func mapPostgresError(err error) error {

--- a/server/internal/identity/postgres.go
+++ b/server/internal/identity/postgres.go
@@ -235,6 +235,21 @@ func (r *PostgresRepository) FindSessionByTokenDigest(
 	ctx context.Context,
 	tokenDigest []byte,
 ) (SessionIdentity, error) {
+	return r.findSessionByTokenDigest(ctx, tokenDigest, false)
+}
+
+func (r *PostgresRepository) FindSessionForLogoutByTokenDigest(
+	ctx context.Context,
+	tokenDigest []byte,
+) (SessionIdentity, error) {
+	return r.findSessionByTokenDigest(ctx, tokenDigest, true)
+}
+
+func (r *PostgresRepository) findSessionByTokenDigest(
+	ctx context.Context,
+	tokenDigest []byte,
+	includeRevoked bool,
+) (SessionIdentity, error) {
 	var identity SessionIdentity
 	var status string
 	err := r.database.QueryRow(ctx, `
@@ -249,10 +264,11 @@ SELECT
 FROM identity_auth_sessions AS sessions
 JOIN identity_users AS users ON users.id = sessions.user_id
 WHERE sessions.token_digest = $1
-  AND sessions.revoked_at IS NULL
+  AND ($2::boolean OR sessions.revoked_at IS NULL)
   AND sessions.created_at <= CURRENT_TIMESTAMP
   AND sessions.expires_at > CURRENT_TIMESTAMP`,
 		tokenDigest,
+		includeRevoked,
 	).Scan(
 		&identity.SessionID,
 		&identity.ExpiresAt,

--- a/server/internal/identity/postgres_integration_test.go
+++ b/server/internal/identity/postgres_integration_test.go
@@ -27,12 +27,15 @@ const integrationPasswordHash = "$argon2id$v=19$m=8,t=1,p=1$MDEyMzQ1Njc4OWFiY2Rl
 
 func TestPostgresIdentityVerticalSlice(t *testing.T) {
 	pool := identityTestDatabase(t)
-	repository, err := NewPostgresRepository(
+	postgresRepository, err := NewPostgresRepository(
 		pool,
 		NewUUIDv4Generator(nil),
 	)
 	if err != nil {
 		t.Fatalf("new repository: %v", err)
+	}
+	repository := &sessionRecordingRepository{
+		Repository: postgresRepository,
 	}
 	integrationParams := testArgon2idParams
 	integrationParams.SaltLength = 16
@@ -210,7 +213,7 @@ WHERE token_digest = $1`,
 
 	testConcurrentPostgresRegistration(t, service)
 	testConcurrentPostgresLogin(t, service)
-	testPostgresHTTPVerticalSlice(t, service)
+	testPostgresHTTPVerticalSlice(t, service, repository, pool)
 }
 
 func TestPostgresCreateSessionRejectsSecurityEventInterleaving(t *testing.T) {
@@ -453,8 +456,10 @@ WHERE user_id = $1`,
 
 func TestPostgresCreateUserRollsBackAllFailurePaths(t *testing.T) {
 	tests := []struct {
-		name    string
-		install string
+		name        string
+		install     string
+		wantCommit  bool
+		probeCommit bool
 	}{
 		{
 			name: "second write",
@@ -463,17 +468,26 @@ CREATE FUNCTION reject_credential_insert() RETURNS trigger
 LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'credential failure'; END $$;
 CREATE TRIGGER reject_credential
 BEFORE INSERT ON identity_credentials
-FOR EACH ROW EXECUTE FUNCTION reject_credential_insert()`,
+			FOR EACH ROW EXECUTE FUNCTION reject_credential_insert()`,
+			wantCommit: false,
 		},
 		{
 			name: "commit",
 			install: `
+CREATE SEQUENCE commit_trigger_probe;
 CREATE FUNCTION reject_user_commit() RETURNS trigger
-LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'commit failure'; END $$;
+LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM nextval('commit_trigger_probe');
+    RAISE EXCEPTION 'commit failure';
+END
+$$;
 CREATE CONSTRAINT TRIGGER reject_user
 AFTER INSERT ON identity_users
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE FUNCTION reject_user_commit()`,
+			wantCommit:  true,
+			probeCommit: true,
 		},
 	}
 	for _, test := range tests {
@@ -482,16 +496,39 @@ FOR EACH ROW EXECUTE FUNCTION reject_user_commit()`,
 			if _, err := pool.Exec(context.Background(), test.install); err != nil {
 				t.Fatalf("install failure: %v", err)
 			}
-			repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+			database := &commitRecordingDatabase{pool: pool}
+			repository, err := NewPostgresRepository(
+				database,
+				NewUUIDv4Generator(nil),
+			)
 			if err != nil {
 				t.Fatalf("new repository: %v", err)
 			}
 			if _, err := repository.CreateUserWithCredential(
 				context.Background(),
 				test.name+"@example.com",
-				"stored-hash",
+				integrationPasswordHash,
 			); !errors.Is(err, ErrRepository) {
 				t.Fatalf("create failure = %v", err)
+			}
+			if database.commitCalled.Load() != test.wantCommit {
+				t.Fatalf(
+					"Commit called = %v, want %v",
+					database.commitCalled.Load(),
+					test.wantCommit,
+				)
+			}
+			if test.probeCommit {
+				var commitTriggerCalled bool
+				if err := pool.QueryRow(
+					context.Background(),
+					"SELECT is_called FROM commit_trigger_probe",
+				).Scan(&commitTriggerCalled); err != nil {
+					t.Fatalf("read commit trigger probe: %v", err)
+				}
+				if !commitTriggerCalled {
+					t.Fatal("deferred failure did not execute during Commit")
+				}
 			}
 			assertNoIdentityRows(t, pool)
 		})
@@ -509,11 +546,73 @@ func TestPostgresCreateUserHonorsCanceledContext(t *testing.T) {
 	if _, err := repository.CreateUserWithCredential(
 		ctx,
 		"canceled@example.com",
-		"stored-hash",
+		integrationPasswordHash,
 	); !errors.Is(err, ErrRepository) {
 		t.Fatalf("canceled create = %v", err)
 	}
 	assertNoIdentityRows(t, pool)
+}
+
+type commitRecordingDatabase struct {
+	pool         *pgxpool.Pool
+	commitCalled atomic.Bool
+}
+
+type sessionRecordingRepository struct {
+	Repository
+	mu        sync.Mutex
+	latest    Session
+	hasLatest bool
+}
+
+func (r *sessionRecordingRepository) CreateSession(
+	ctx context.Context,
+	params CreateSessionParams,
+) (Session, error) {
+	session, err := r.Repository.CreateSession(ctx, params)
+	if err != nil {
+		return Session{}, err
+	}
+	r.mu.Lock()
+	r.latest = session
+	r.hasLatest = true
+	r.mu.Unlock()
+	return session, nil
+}
+
+func (r *sessionRecordingRepository) LatestSession() (Session, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.latest, r.hasLatest
+}
+
+func (d *commitRecordingDatabase) Begin(ctx context.Context) (pgx.Tx, error) {
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &commitRecordingTx{
+		Tx:           tx,
+		commitCalled: &d.commitCalled,
+	}, nil
+}
+
+func (d *commitRecordingDatabase) QueryRow(
+	ctx context.Context,
+	query string,
+	args ...any,
+) pgx.Row {
+	return d.pool.QueryRow(ctx, query, args...)
+}
+
+type commitRecordingTx struct {
+	pgx.Tx
+	commitCalled *atomic.Bool
+}
+
+func (tx *commitRecordingTx) Commit(ctx context.Context) error {
+	tx.commitCalled.Store(true)
+	return tx.Tx.Commit(ctx)
 }
 
 func waitForBlockedPostgresQuery(
@@ -635,8 +734,34 @@ func testConcurrentPostgresLogin(
 	}
 }
 
-func testPostgresHTTPVerticalSlice(t *testing.T, service *Service) {
+func testPostgresHTTPVerticalSlice(
+	t *testing.T,
+	service *Service,
+	repository *sessionRecordingRepository,
+	pool *pgxpool.Pool,
+) {
 	t.Helper()
+	if _, err := pool.Exec(
+		context.Background(),
+		`CREATE FUNCTION stabilize_http_session_time() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    session_lifetime interval;
+BEGIN
+    session_lifetime := NEW.expires_at - NEW.created_at;
+    NEW.created_at := date_trunc('second', NEW.created_at)
+        - INTERVAL '1 second'
+        + INTERVAL '123456 microseconds';
+    NEW.expires_at := NEW.created_at + session_lifetime;
+    RETURN NEW;
+END
+$$;
+CREATE TRIGGER stabilize_http_session
+BEFORE INSERT ON identity_auth_sessions
+FOR EACH ROW EXECUTE FUNCTION stabilize_http_session_time()`,
+	); err != nil {
+		t.Fatalf("install deterministic session time: %v", err)
+	}
 	handler, err := NewHTTPHandler(
 		service,
 		service,
@@ -675,13 +800,44 @@ func testPostgresHTTPVerticalSlice(t *testing.T, service *Service) {
 		t.Fatalf("unexpected login response: %d %s", login.Code, login.Body)
 	}
 	var loginBody struct {
-		Token string `json:"session_token"`
+		Token     string `json:"session_token"`
+		ExpiresAt string `json:"expires_at"`
 	}
 	if err := json.Unmarshal(login.Body.Bytes(), &loginBody); err != nil {
 		t.Fatalf("decode login response: %v", err)
 	}
 	if !strings.HasPrefix(loginBody.Token, "sess_") {
 		t.Fatalf("unexpected token: %q", loginBody.Token)
+	}
+	responseExpiresAt, err := time.Parse(time.RFC3339Nano, loginBody.ExpiresAt)
+	if err != nil {
+		t.Fatalf("parse HTTP expires_at: %v", err)
+	}
+	repositorySession, ok := repository.LatestSession()
+	if !ok {
+		t.Fatal("repository did not return the HTTP session")
+	}
+	var databaseExpiresAt time.Time
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT expires_at
+FROM identity_auth_sessions
+WHERE id = $1`,
+		repositorySession.ID,
+	).Scan(&databaseExpiresAt); err != nil {
+		t.Fatalf("read HTTP session expiry: %v", err)
+	}
+	if !responseExpiresAt.Equal(repositorySession.ExpiresAt) ||
+		!responseExpiresAt.Equal(databaseExpiresAt) ||
+		loginBody.ExpiresAt != repositorySession.ExpiresAt.UTC().Format(time.RFC3339Nano) ||
+		loginBody.ExpiresAt != databaseExpiresAt.UTC().Format(time.RFC3339Nano) {
+		t.Fatalf(
+			"HTTP expires_at %q (%v) differs from repository %v or database %v",
+			loginBody.ExpiresAt,
+			responseExpiresAt,
+			repositorySession.ExpiresAt,
+			databaseExpiresAt,
+		)
 	}
 
 	me := performRequest(

--- a/server/internal/identity/postgres_integration_test.go
+++ b/server/internal/identity/postgres_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const integrationPasswordHash = "$argon2id$v=19$m=8,t=1,p=1$MDEyMzQ1Njc4OWFiY2RlZg$MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY"
 
 func TestPostgresIdentityVerticalSlice(t *testing.T) {
 	pool := identityTestDatabase(t)
@@ -41,19 +44,18 @@ func TestPostgresIdentityVerticalSlice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new password hasher: %v", err)
 	}
-	dummyHash, err := passwords.Hash("unknown account timing password")
+	dummyHash, err := passwords.Hash(
+		context.Background(),
+		"unknown account timing password",
+	)
 	if err != nil {
 		t.Fatalf("create dummy hash: %v", err)
-	}
-	clock := &mutableClock{
-		now: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
 	}
 	tokens := NewOpaqueSessionTokens(nil)
 	service, err := NewService(
 		repository,
 		passwords,
 		tokens,
-		clock,
 		dummyHash,
 	)
 	if err != nil {
@@ -189,7 +191,16 @@ func TestPostgresIdentityVerticalSlice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expiring login: %v", err)
 	}
-	clock.now = clock.now.Add(sessionLifetime)
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE identity_auth_sessions
+SET created_at = CURRENT_TIMESTAMP - INTERVAL '2 hours',
+    expires_at = CURRENT_TIMESTAMP - INTERVAL '1 second'
+WHERE token_digest = $1`,
+		tokens.Digest(expiringLogin.Token),
+	); err != nil {
+		t.Fatalf("expire token with database time: %v", err)
+	}
 	if _, err := service.AuthenticateSession(
 		context.Background(),
 		expiringLogin.Token,
@@ -198,8 +209,360 @@ func TestPostgresIdentityVerticalSlice(t *testing.T) {
 	}
 
 	testConcurrentPostgresRegistration(t, service)
-	testConcurrentPostgresLogin(t, service, clock)
+	testConcurrentPostgresLogin(t, service)
 	testPostgresHTTPVerticalSlice(t, service)
+}
+
+func TestPostgresCreateSessionRejectsSecurityEventInterleaving(t *testing.T) {
+	pool := identityTestDatabase(t)
+	repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+	if err != nil {
+		t.Fatalf("new repository: %v", err)
+	}
+	user, err := repository.CreateUserWithCredential(
+		context.Background(),
+		"interleave@example.com",
+		integrationPasswordHash,
+	)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	credential, err := repository.FindCredentialByEmail(
+		context.Background(),
+		user.Email,
+	)
+	if err != nil {
+		t.Fatalf("find credential: %v", err)
+	}
+
+	blocker, err := pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin blocker: %v", err)
+	}
+	defer func() { _ = blocker.Rollback(context.Background()) }()
+	if _, err := blocker.Exec(
+		context.Background(),
+		"SELECT id FROM identity_users WHERE id = $1 FOR UPDATE",
+		user.ID,
+	); err != nil {
+		t.Fatalf("lock user: %v", err)
+	}
+
+	revokeDone := make(chan error, 1)
+	go func() {
+		revokeDone <- repository.RevokeAllSessionsForUser(
+			context.Background(),
+			user.ID,
+			"security_event",
+		)
+	}()
+	waitForBlockedPostgresQuery(t, pool, "SELECT id::text\nFROM identity_users")
+
+	sessionDone := make(chan error, 1)
+	go func() {
+		_, err := repository.CreateSession(
+			context.Background(),
+			CreateSessionParams{
+				UserID:              user.ID,
+				TokenDigest:         bytes.Repeat([]byte{1}, 32),
+				CredentialUpdatedAt: credential.UpdatedAt,
+				Lifetime:            time.Hour,
+				PreviousHash:        credential.PasswordHash,
+			},
+		)
+		sessionDone <- err
+	}()
+	waitForBlockedPostgresQuery(t, pool, "SELECT account_status\nFROM identity_users")
+
+	if err := blocker.Commit(context.Background()); err != nil {
+		t.Fatalf("release blocker: %v", err)
+	}
+	if err := <-revokeDone; err != nil {
+		t.Fatalf("revoke security event: %v", err)
+	}
+	if err := <-sessionDone; !errors.Is(err, ErrAuthenticationChanged) {
+		t.Fatalf("stale login session result = %v", err)
+	}
+	var sessions int
+	if err := pool.QueryRow(
+		context.Background(),
+		"SELECT count(*) FROM identity_auth_sessions WHERE user_id = $1",
+		user.ID,
+	).Scan(&sessions); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if sessions != 0 {
+		t.Fatalf("security event admitted %d stale sessions", sessions)
+	}
+}
+
+func TestPostgresSessionUsesDatabaseTimeAndCannotRevive(t *testing.T) {
+	pool := identityTestDatabase(t)
+	repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+	if err != nil {
+		t.Fatalf("new repository: %v", err)
+	}
+	user, err := repository.CreateUserWithCredential(
+		context.Background(),
+		"database-time@example.com",
+		integrationPasswordHash,
+	)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	credential, err := repository.FindCredentialByEmail(context.Background(), user.Email)
+	if err != nil {
+		t.Fatalf("find credential: %v", err)
+	}
+	const lifetime = 90 * time.Minute
+	digest := bytes.Repeat([]byte{2}, 32)
+	session, err := repository.CreateSession(
+		context.Background(),
+		CreateSessionParams{
+			UserID:              user.ID,
+			TokenDigest:         digest,
+			CredentialUpdatedAt: credential.UpdatedAt,
+			Lifetime:            lifetime,
+			PreviousHash:        credential.PasswordHash,
+		},
+	)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	var createdAt, storedExpiresAt, databaseNow time.Time
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT created_at, expires_at, CURRENT_TIMESTAMP
+FROM identity_auth_sessions
+WHERE id = $1`,
+		session.ID,
+	).Scan(&createdAt, &storedExpiresAt, &databaseNow); err != nil {
+		t.Fatalf("read database times: %v", err)
+	}
+	if !session.ExpiresAt.Equal(storedExpiresAt) ||
+		storedExpiresAt.Sub(createdAt) != lifetime ||
+		createdAt.After(databaseNow) {
+		t.Fatalf(
+			"inconsistent database time: created=%v returned=%v stored=%v now=%v",
+			createdAt,
+			session.ExpiresAt,
+			storedExpiresAt,
+			databaseNow,
+		)
+	}
+
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE identity_auth_sessions
+SET created_at = CURRENT_TIMESTAMP + INTERVAL '1 hour',
+    expires_at = CURRENT_TIMESTAMP + INTERVAL '2 hours'
+WHERE id = $1`,
+		session.ID,
+	); err != nil {
+		t.Fatalf("simulate process clock skew: %v", err)
+	}
+	if _, err := repository.FindSessionByTokenDigest(
+		context.Background(),
+		digest,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("future-created session became valid: %v", err)
+	}
+	if err := repository.RevokeSession(
+		context.Background(),
+		user.ID,
+		session.ID,
+		"logout",
+	); err != nil {
+		t.Fatalf("revoke skewed session: %v", err)
+	}
+	var revokedAt time.Time
+	if err := pool.QueryRow(
+		context.Background(),
+		"SELECT created_at, revoked_at FROM identity_auth_sessions WHERE id = $1",
+		session.ID,
+	).Scan(&createdAt, &revokedAt); err != nil {
+		t.Fatalf("read revocation time: %v", err)
+	}
+	if revokedAt.Before(createdAt) {
+		t.Fatalf("revoked_at %v precedes created_at %v", revokedAt, createdAt)
+	}
+}
+
+func TestPostgresCreateSessionRequiresCurrentActiveCredential(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate string
+	}{
+		{
+			name:   "account deleting",
+			mutate: "UPDATE identity_users SET account_status = 'deleting' WHERE id = $1 AND $2 <> ''",
+		},
+		{
+			name: "password rotated",
+			mutate: `UPDATE identity_credentials
+SET password_hash = $2,
+    updated_at = GREATEST(CURRENT_TIMESTAMP, updated_at + INTERVAL '1 microsecond')
+WHERE user_id = $1`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := identityTestDatabase(t)
+			repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+			if err != nil {
+				t.Fatalf("new repository: %v", err)
+			}
+			user, err := repository.CreateUserWithCredential(
+				context.Background(),
+				strings.ReplaceAll(test.name, " ", "-")+"@example.com",
+				integrationPasswordHash,
+			)
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+			credential, err := repository.FindCredentialByEmail(
+				context.Background(),
+				user.Email,
+			)
+			if err != nil {
+				t.Fatalf("find credential: %v", err)
+			}
+			if _, err := pool.Exec(
+				context.Background(),
+				test.mutate,
+				user.ID,
+				integrationPasswordHash+"A",
+			); err != nil {
+				t.Fatalf("mutate authentication state: %v", err)
+			}
+			if _, err := repository.CreateSession(
+				context.Background(),
+				CreateSessionParams{
+					UserID:              user.ID,
+					TokenDigest:         bytes.Repeat([]byte{3}, 32),
+					CredentialUpdatedAt: credential.UpdatedAt,
+					Lifetime:            time.Hour,
+					PreviousHash:        credential.PasswordHash,
+				},
+			); !errors.Is(err, ErrAuthenticationChanged) {
+				t.Fatalf("stale authentication state = %v", err)
+			}
+		})
+	}
+}
+
+func TestPostgresCreateUserRollsBackAllFailurePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		install string
+	}{
+		{
+			name: "second write",
+			install: `
+CREATE FUNCTION reject_credential_insert() RETURNS trigger
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'credential failure'; END $$;
+CREATE TRIGGER reject_credential
+BEFORE INSERT ON identity_credentials
+FOR EACH ROW EXECUTE FUNCTION reject_credential_insert()`,
+		},
+		{
+			name: "commit",
+			install: `
+CREATE FUNCTION reject_user_commit() RETURNS trigger
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'commit failure'; END $$;
+CREATE CONSTRAINT TRIGGER reject_user
+AFTER INSERT ON identity_users
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION reject_user_commit()`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := identityTestDatabase(t)
+			if _, err := pool.Exec(context.Background(), test.install); err != nil {
+				t.Fatalf("install failure: %v", err)
+			}
+			repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+			if err != nil {
+				t.Fatalf("new repository: %v", err)
+			}
+			if _, err := repository.CreateUserWithCredential(
+				context.Background(),
+				test.name+"@example.com",
+				"stored-hash",
+			); !errors.Is(err, ErrRepository) {
+				t.Fatalf("create failure = %v", err)
+			}
+			assertNoIdentityRows(t, pool)
+		})
+	}
+}
+
+func TestPostgresCreateUserHonorsCanceledContext(t *testing.T) {
+	pool := identityTestDatabase(t)
+	repository, err := NewPostgresRepository(pool, NewUUIDv4Generator(nil))
+	if err != nil {
+		t.Fatalf("new repository: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := repository.CreateUserWithCredential(
+		ctx,
+		"canceled@example.com",
+		"stored-hash",
+	); !errors.Is(err, ErrRepository) {
+		t.Fatalf("canceled create = %v", err)
+	}
+	assertNoIdentityRows(t, pool)
+}
+
+func waitForBlockedPostgresQuery(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	queryFragment string,
+) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var blocked bool
+		err := pool.QueryRow(
+			context.Background(),
+			`SELECT EXISTS (
+    SELECT 1
+    FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND wait_event_type = 'Lock'
+      AND query LIKE '%' || $1 || '%'
+)`,
+			queryFragment,
+		).Scan(&blocked)
+		if err != nil {
+			t.Fatalf("inspect blocked query: %v", err)
+		}
+		if blocked {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("query did not block deterministically: %q", queryFragment)
+		}
+		runtime.Gosched()
+	}
+}
+
+func assertNoIdentityRows(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	var users, credentials int
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT
+    (SELECT count(*) FROM identity_users),
+    (SELECT count(*) FROM identity_credentials)`,
+	).Scan(&users, &credentials); err != nil {
+		t.Fatalf("count identity rows: %v", err)
+	}
+	if users != 0 || credentials != 0 {
+		t.Fatalf("partial transaction persisted: users=%d credentials=%d", users, credentials)
+	}
 }
 
 func testConcurrentPostgresRegistration(t *testing.T, service *Service) {
@@ -240,10 +603,8 @@ func testConcurrentPostgresRegistration(t *testing.T, service *Service) {
 func testConcurrentPostgresLogin(
 	t *testing.T,
 	service *Service,
-	clock *mutableClock,
 ) {
 	t.Helper()
-	clock.now = time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
 	const attempts = 6
 	tokens := make(chan string, attempts)
 	var wait sync.WaitGroup

--- a/server/internal/identity/postgres_integration_test.go
+++ b/server/internal/identity/postgres_integration_test.go
@@ -1,0 +1,500 @@
+package identity
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresIdentityVerticalSlice(t *testing.T) {
+	pool := identityTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		pool,
+		NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("new repository: %v", err)
+	}
+	integrationParams := testArgon2idParams
+	integrationParams.SaltLength = 16
+	passwords, err := NewArgon2idHasher(
+		integrationParams,
+		nil,
+		2,
+	)
+	if err != nil {
+		t.Fatalf("new password hasher: %v", err)
+	}
+	dummyHash, err := passwords.Hash("unknown account timing password")
+	if err != nil {
+		t.Fatalf("create dummy hash: %v", err)
+	}
+	clock := &mutableClock{
+		now: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+	}
+	tokens := NewOpaqueSessionTokens(nil)
+	service, err := NewService(
+		repository,
+		passwords,
+		tokens,
+		clock,
+		dummyHash,
+	)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	const password = "correct horse battery staple"
+	user, err := service.Register(
+		context.Background(),
+		" Learner@Example.COM ",
+		password,
+	)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if user.Email != "learner@example.com" || user.Status != AccountActive {
+		t.Fatalf("unexpected user: %#v", user)
+	}
+	assertDatabaseStoresNoRawCredential(t, pool, user.ID, password, "")
+
+	for _, email := range []string{
+		"unknown@example.com",
+		"learner@example.com",
+	} {
+		loginPassword := password
+		if email == "learner@example.com" {
+			loginPassword = "incorrect password value"
+		}
+		if _, err := service.Login(
+			context.Background(),
+			email,
+			loginPassword,
+		); !errors.Is(err, ErrInvalidCredentials) {
+			t.Fatalf("login failure for %q = %v", email, err)
+		}
+	}
+
+	firstLogin, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		password,
+	)
+	if err != nil {
+		t.Fatalf("first login: %v", err)
+	}
+	secondLogin, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		password,
+	)
+	if err != nil {
+		t.Fatalf("second login: %v", err)
+	}
+	if firstLogin.Token == secondLogin.Token ||
+		!strings.HasPrefix(firstLogin.Token, "sess_") {
+		t.Fatalf("invalid session tokens")
+	}
+	assertDatabaseStoresNoRawCredential(
+		t,
+		pool,
+		user.ID,
+		password,
+		firstLogin.Token,
+	)
+	assertStoredTokenDigest(t, pool, tokens, firstLogin.Token)
+
+	actor, err := service.AuthenticateSession(
+		context.Background(),
+		firstLogin.Token,
+	)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if actor.UserID != user.ID || actor.SessionID == "" {
+		t.Fatalf("unexpected actor: %#v", actor)
+	}
+	current, err := service.CurrentUser(context.Background(), actor)
+	if err != nil || current.ID != user.ID {
+		t.Fatalf("current user = %#v, %v", current, err)
+	}
+
+	if err := service.RevokeAllSessionsForUser(
+		context.Background(),
+		user.ID,
+		"security_event",
+	); err != nil {
+		t.Fatalf("revoke all: %v", err)
+	}
+	for _, token := range []string{firstLogin.Token, secondLogin.Token} {
+		if _, err := service.AuthenticateSession(
+			context.Background(),
+			token,
+		); !errors.Is(err, ErrAuthenticationRequired) {
+			t.Fatalf("revoked token authentication = %v", err)
+		}
+	}
+
+	logoutLogin, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		password,
+	)
+	if err != nil {
+		t.Fatalf("logout login: %v", err)
+	}
+	logoutActor, err := service.AuthenticateSession(
+		context.Background(),
+		logoutLogin.Token,
+	)
+	if err != nil {
+		t.Fatalf("authenticate logout session: %v", err)
+	}
+	for range 2 {
+		if err := service.Logout(
+			context.Background(),
+			logoutActor,
+		); err != nil {
+			t.Fatalf("idempotent logout: %v", err)
+		}
+	}
+	if _, err := service.AuthenticateSession(
+		context.Background(),
+		logoutLogin.Token,
+	); !errors.Is(err, ErrAuthenticationRequired) {
+		t.Fatalf("logged-out token authentication = %v", err)
+	}
+
+	expiringLogin, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		password,
+	)
+	if err != nil {
+		t.Fatalf("expiring login: %v", err)
+	}
+	clock.now = clock.now.Add(sessionLifetime)
+	if _, err := service.AuthenticateSession(
+		context.Background(),
+		expiringLogin.Token,
+	); !errors.Is(err, ErrAuthenticationRequired) {
+		t.Fatalf("expired token authentication = %v", err)
+	}
+
+	testConcurrentPostgresRegistration(t, service)
+	testConcurrentPostgresLogin(t, service, clock)
+	testPostgresHTTPVerticalSlice(t, service)
+}
+
+func testConcurrentPostgresRegistration(t *testing.T, service *Service) {
+	t.Helper()
+	const attempts = 6
+	var successes atomic.Int32
+	var conflicts atomic.Int32
+	var wait sync.WaitGroup
+	for range attempts {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, err := service.Register(
+				context.Background(),
+				"concurrent@example.com",
+				"another correct password value",
+			)
+			switch {
+			case err == nil:
+				successes.Add(1)
+			case errors.Is(err, ErrRegistrationUnavailable):
+				conflicts.Add(1)
+			default:
+				t.Errorf("concurrent registration: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+	if successes.Load() != 1 || conflicts.Load() != attempts-1 {
+		t.Fatalf(
+			"concurrent registration successes/conflicts = %d/%d",
+			successes.Load(),
+			conflicts.Load(),
+		)
+	}
+}
+
+func testConcurrentPostgresLogin(
+	t *testing.T,
+	service *Service,
+	clock *mutableClock,
+) {
+	t.Helper()
+	clock.now = time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	const attempts = 6
+	tokens := make(chan string, attempts)
+	var wait sync.WaitGroup
+	for range attempts {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			result, err := service.Login(
+				context.Background(),
+				"learner@example.com",
+				"correct horse battery staple",
+			)
+			if err != nil {
+				t.Errorf("concurrent login: %v", err)
+				return
+			}
+			tokens <- result.Token
+		}()
+	}
+	wait.Wait()
+	close(tokens)
+	unique := make(map[string]struct{})
+	for token := range tokens {
+		unique[token] = struct{}{}
+	}
+	if len(unique) != attempts {
+		t.Fatalf("unique concurrent tokens = %d, want %d", len(unique), attempts)
+	}
+}
+
+func testPostgresHTTPVerticalSlice(t *testing.T, service *Service) {
+	t.Helper()
+	handler, err := NewHTTPHandler(
+		service,
+		service,
+		defaultTestRateLimits(),
+		func() string { return "corr_postgres_integration" },
+	)
+	if err != nil {
+		t.Fatalf("new HTTP handler: %v", err)
+	}
+	module, err := NewModule(handler)
+	if err != nil {
+		t.Fatalf("new module: %v", err)
+	}
+	router := newIntegrationRouter(module)
+
+	register := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/register",
+		`{"email":"api@example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	if register.Code != http.StatusCreated ||
+		strings.Contains(register.Body.String(), "session_token") {
+		t.Fatalf("unexpected register response: %d %s", register.Code, register.Body)
+	}
+
+	login := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/login",
+		`{"email":"api@example.com","password":"correct horse battery staple"}`,
+		"",
+	)
+	if login.Code != http.StatusOK {
+		t.Fatalf("unexpected login response: %d %s", login.Code, login.Body)
+	}
+	var loginBody struct {
+		Token string `json:"session_token"`
+	}
+	if err := json.Unmarshal(login.Body.Bytes(), &loginBody); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	if !strings.HasPrefix(loginBody.Token, "sess_") {
+		t.Fatalf("unexpected token: %q", loginBody.Token)
+	}
+
+	me := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/me",
+		"",
+		"Bearer "+loginBody.Token,
+	)
+	if me.Code != http.StatusOK ||
+		strings.Contains(me.Body.String(), loginBody.Token) {
+		t.Fatalf("unexpected me response: %d %s", me.Code, me.Body)
+	}
+	logout := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/logout",
+		"",
+		"Bearer "+loginBody.Token,
+	)
+	if logout.Code != http.StatusNoContent {
+		t.Fatalf("unexpected logout response: %d %s", logout.Code, logout.Body)
+	}
+	rejected := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/me",
+		"",
+		"Bearer "+loginBody.Token,
+	)
+	if rejected.Code != http.StatusUnauthorized ||
+		rejected.Header().Get("WWW-Authenticate") != "Bearer" {
+		t.Fatalf(
+			"unexpected revoked response: %d %s",
+			rejected.Code,
+			rejected.Body,
+		)
+	}
+}
+
+func assertDatabaseStoresNoRawCredential(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	userID string,
+	rawPassword string,
+	rawToken string,
+) {
+	t.Helper()
+	var storedHash string
+	if err := pool.QueryRow(
+		context.Background(),
+		"SELECT password_hash FROM identity_credentials WHERE user_id = $1",
+		userID,
+	).Scan(&storedHash); err != nil {
+		t.Fatalf("read password hash: %v", err)
+	}
+	if storedHash == rawPassword ||
+		!strings.HasPrefix(storedHash, "$argon2id$") ||
+		strings.Contains(storedHash, rawPassword) {
+		t.Fatal("database did not store only an Argon2id PHC hash")
+	}
+	if rawToken == "" {
+		return
+	}
+	var rawTokenMatches int
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT count(*)
+FROM identity_auth_sessions
+WHERE encode(token_digest, 'escape') = $1`,
+		rawToken,
+	).Scan(&rawTokenMatches); err != nil {
+		t.Fatalf("check raw token persistence: %v", err)
+	}
+	if rawTokenMatches != 0 {
+		t.Fatal("database persisted a raw session token")
+	}
+}
+
+func assertStoredTokenDigest(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	tokens SessionTokens,
+	rawToken string,
+) {
+	t.Helper()
+	var stored []byte
+	if err := pool.QueryRow(
+		context.Background(),
+		"SELECT token_digest FROM identity_auth_sessions WHERE token_digest = $1",
+		tokens.Digest(rawToken),
+	).Scan(&stored); err != nil {
+		t.Fatalf("read token digest: %v", err)
+	}
+	if !bytes.Equal(stored, tokens.Digest(rawToken)) || len(stored) != 32 {
+		t.Fatalf("unexpected stored digest: %x", stored)
+	}
+}
+
+func identityTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	config, err := pgx.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	admin, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatal("connect to TEST_DATABASE_URL")
+	}
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("generate schema name: %v", err)
+	}
+	schema := "identity_repository_" + hex.EncodeToString(random)
+	if _, err := admin.Exec(
+		context.Background(),
+		"CREATE SCHEMA "+pgx.Identifier{schema}.Sanitize(),
+	); err != nil {
+		t.Fatalf("create test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := admin.Exec(
+			context.Background(),
+			"DROP SCHEMA "+pgx.Identifier{schema}.Sanitize()+" CASCADE",
+		); err != nil {
+			t.Errorf("drop test schema: %v", err)
+		}
+	})
+
+	scopedURL, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	query := scopedURL.Query()
+	query.Set("search_path", schema)
+	scopedURL.RawQuery = query.Encode()
+
+	runner, err := migration.Open(scopedURL.String())
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+	if _, err := runner.Up(); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(scopedURL.String())
+	if err != nil {
+		t.Fatal("parse scoped pool config")
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	if err != nil {
+		t.Fatal("open scoped pool")
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Fatal("ping scoped pool")
+	}
+	return pool
+}
+
+func newIntegrationRouter(module *Module) http.Handler {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	module.RegisterRoutes(router)
+	return router
+}

--- a/server/internal/identity/postgres_integration_test.go
+++ b/server/internal/identity/postgres_integration_test.go
@@ -210,6 +210,12 @@ WHERE token_digest = $1`,
 	); !errors.Is(err, ErrAuthenticationRequired) {
 		t.Fatalf("expired token authentication = %v", err)
 	}
+	if _, err := service.ResolveSessionForLogout(
+		context.Background(),
+		expiringLogin.Token,
+	); !errors.Is(err, ErrAuthenticationRequired) {
+		t.Fatalf("expired token logout resolution = %v", err)
+	}
 
 	testConcurrentPostgresRegistration(t, service)
 	testConcurrentPostgresLogin(t, service)
@@ -861,6 +867,21 @@ WHERE id = $1`,
 	if logout.Code != http.StatusNoContent {
 		t.Fatalf("unexpected logout response: %d %s", logout.Code, logout.Body)
 	}
+	retriedLogout := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/logout",
+		"",
+		"Bearer "+loginBody.Token,
+	)
+	if retriedLogout.Code != http.StatusNoContent ||
+		retriedLogout.Body.Len() != 0 {
+		t.Fatalf(
+			"unexpected retried logout response: %d %s",
+			retriedLogout.Code,
+			retriedLogout.Body,
+		)
+	}
 	rejected := performRequest(
 		router,
 		http.MethodGet,
@@ -876,6 +897,22 @@ WHERE id = $1`,
 			rejected.Body,
 		)
 	}
+	unknownLogout := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/auth/logout",
+		"",
+		"Bearer sess_unknown",
+	)
+	if unknownLogout.Code != http.StatusUnauthorized ||
+		unknownLogout.Header().Get("WWW-Authenticate") != "Bearer" {
+		t.Fatalf(
+			"unexpected unknown logout response: %d %s",
+			unknownLogout.Code,
+			unknownLogout.Body,
+		)
+	}
+	assertErrorCode(t, unknownLogout, "authentication_required")
 }
 
 func assertDatabaseStoresNoRawCredential(

--- a/server/internal/identity/service.go
+++ b/server/internal/identity/service.go
@@ -24,7 +24,6 @@ type Service struct {
 	repository Repository
 	passwords  PasswordHasher
 	tokens     SessionTokens
-	clock      Clock
 	dummyHash  string
 }
 
@@ -32,10 +31,9 @@ func NewService(
 	repository Repository,
 	passwords PasswordHasher,
 	tokens SessionTokens,
-	clock Clock,
 	dummyHash string,
 ) (*Service, error) {
-	if repository == nil || passwords == nil || tokens == nil || clock == nil ||
+	if repository == nil || passwords == nil || tokens == nil ||
 		dummyHash == "" {
 		return nil, errors.New("identity: service dependency is required")
 	}
@@ -43,7 +41,6 @@ func NewService(
 		repository: repository,
 		passwords:  passwords,
 		tokens:     tokens,
-		clock:      clock,
 		dummyHash:  dummyHash,
 	}, nil
 }
@@ -57,7 +54,7 @@ func (s *Service) Register(
 	if err != nil || ValidatePassword(password) != nil {
 		return User{}, ErrInvalidRequest
 	}
-	passwordHash, err := s.passwords.Hash(password)
+	passwordHash, err := s.passwords.Hash(ctx, password)
 	if err != nil {
 		return User{}, err
 	}
@@ -66,7 +63,6 @@ func (s *Service) Register(
 		ctx,
 		canonicalEmail,
 		passwordHash,
-		s.clock.Now().UTC(),
 	)
 	if errors.Is(err, ErrConflict) {
 		return User{}, ErrRegistrationUnavailable
@@ -98,7 +94,7 @@ func (s *Service) Login(
 		return LoginResult{}, repositoryErr
 	}
 
-	valid, needsRehash, err := s.passwords.Verify(password, encodedHash)
+	valid, needsRehash, err := s.passwords.Verify(ctx, password, encodedHash)
 	if err != nil {
 		return LoginResult{}, err
 	}
@@ -108,7 +104,7 @@ func (s *Service) Login(
 
 	var replacementHash string
 	if needsRehash {
-		replacementHash, err = s.passwords.Hash(password)
+		replacementHash, err = s.passwords.Hash(ctx, password)
 		if err != nil {
 			return LoginResult{}, err
 		}
@@ -118,16 +114,18 @@ func (s *Service) Login(
 	if err != nil {
 		return LoginResult{}, err
 	}
-	now := s.clock.Now().UTC()
 	session, err := s.repository.CreateSession(ctx, CreateSessionParams{
-		UserID:          credential.User.ID,
-		TokenDigest:     tokenDigest,
-		CreatedAt:       now,
-		ExpiresAt:       now.Add(sessionLifetime),
-		PreviousHash:    credential.PasswordHash,
-		ReplacementHash: replacementHash,
+		UserID:              credential.User.ID,
+		TokenDigest:         tokenDigest,
+		CredentialUpdatedAt: credential.UpdatedAt,
+		Lifetime:            sessionLifetime,
+		PreviousHash:        credential.PasswordHash,
+		ReplacementHash:     replacementHash,
 	})
 	if err != nil {
+		if errors.Is(err, ErrAuthenticationChanged) {
+			return LoginResult{}, ErrInvalidCredentials
+		}
 		return LoginResult{}, err
 	}
 	return LoginResult{
@@ -144,11 +142,9 @@ func (s *Service) AuthenticateSession(
 	if !s.tokens.ValidWireFormat(rawToken) {
 		return requestcontext.Actor{}, ErrAuthenticationRequired
 	}
-	now := s.clock.Now().UTC()
 	session, err := s.repository.FindSessionByTokenDigest(
 		ctx,
 		s.tokens.Digest(rawToken),
-		now,
 	)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -157,8 +153,7 @@ func (s *Service) AuthenticateSession(
 		return requestcontext.Actor{}, err
 	}
 	if session.User.Status != AccountActive ||
-		session.SessionID == "" ||
-		!session.ExpiresAt.After(now) {
+		session.SessionID == "" {
 		return requestcontext.Actor{}, ErrAuthenticationRequired
 	}
 	actor := requestcontext.Actor{
@@ -182,7 +177,6 @@ func (s *Service) Logout(
 		ctx,
 		actor.UserID,
 		actor.SessionID,
-		s.clock.Now().UTC(),
 		logoutReason,
 	)
 }
@@ -218,11 +212,6 @@ func (s *Service) RevokeAllSessionsForUser(
 	return s.repository.RevokeAllSessionsForUser(
 		ctx,
 		userID,
-		s.clock.Now().UTC(),
 		reason,
 	)
 }
-
-type SystemClock struct{}
-
-func (SystemClock) Now() time.Time { return time.Now() }

--- a/server/internal/identity/service.go
+++ b/server/internal/identity/service.go
@@ -1,0 +1,228 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	sessionLifetime = 30 * 24 * time.Hour
+	logoutReason    = "logout"
+)
+
+type Authenticator interface {
+	AuthenticateSession(
+		ctx context.Context,
+		rawToken string,
+	) (requestcontext.Actor, error)
+}
+
+type Service struct {
+	repository Repository
+	passwords  PasswordHasher
+	tokens     SessionTokens
+	clock      Clock
+	dummyHash  string
+}
+
+func NewService(
+	repository Repository,
+	passwords PasswordHasher,
+	tokens SessionTokens,
+	clock Clock,
+	dummyHash string,
+) (*Service, error) {
+	if repository == nil || passwords == nil || tokens == nil || clock == nil ||
+		dummyHash == "" {
+		return nil, errors.New("identity: service dependency is required")
+	}
+	return &Service{
+		repository: repository,
+		passwords:  passwords,
+		tokens:     tokens,
+		clock:      clock,
+		dummyHash:  dummyHash,
+	}, nil
+}
+
+func (s *Service) Register(
+	ctx context.Context,
+	email string,
+	password string,
+) (User, error) {
+	canonicalEmail, err := NormalizeEmail(email)
+	if err != nil || ValidatePassword(password) != nil {
+		return User{}, ErrInvalidRequest
+	}
+	passwordHash, err := s.passwords.Hash(password)
+	if err != nil {
+		return User{}, err
+	}
+
+	user, err := s.repository.CreateUserWithCredential(
+		ctx,
+		canonicalEmail,
+		passwordHash,
+		s.clock.Now().UTC(),
+	)
+	if errors.Is(err, ErrConflict) {
+		return User{}, ErrRegistrationUnavailable
+	}
+	if err != nil {
+		return User{}, err
+	}
+	return user, nil
+}
+
+func (s *Service) Login(
+	ctx context.Context,
+	email string,
+	password string,
+) (LoginResult, error) {
+	canonicalEmail, err := NormalizeEmail(email)
+	if err != nil || ValidatePassword(password) != nil {
+		return LoginResult{}, ErrInvalidRequest
+	}
+
+	credential, repositoryErr := s.repository.FindCredentialByEmail(
+		ctx,
+		canonicalEmail,
+	)
+	encodedHash := credential.PasswordHash
+	if errors.Is(repositoryErr, ErrNotFound) {
+		encodedHash = s.dummyHash
+	} else if repositoryErr != nil {
+		return LoginResult{}, repositoryErr
+	}
+
+	valid, needsRehash, err := s.passwords.Verify(password, encodedHash)
+	if err != nil {
+		return LoginResult{}, err
+	}
+	if repositoryErr != nil || !valid || credential.User.Status != AccountActive {
+		return LoginResult{}, ErrInvalidCredentials
+	}
+
+	var replacementHash string
+	if needsRehash {
+		replacementHash, err = s.passwords.Hash(password)
+		if err != nil {
+			return LoginResult{}, err
+		}
+	}
+
+	rawToken, tokenDigest, err := s.tokens.Generate()
+	if err != nil {
+		return LoginResult{}, err
+	}
+	now := s.clock.Now().UTC()
+	session, err := s.repository.CreateSession(ctx, CreateSessionParams{
+		UserID:          credential.User.ID,
+		TokenDigest:     tokenDigest,
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(sessionLifetime),
+		PreviousHash:    credential.PasswordHash,
+		ReplacementHash: replacementHash,
+	})
+	if err != nil {
+		return LoginResult{}, err
+	}
+	return LoginResult{
+		User:      credential.User,
+		Token:     rawToken,
+		ExpiresAt: session.ExpiresAt,
+	}, nil
+}
+
+func (s *Service) AuthenticateSession(
+	ctx context.Context,
+	rawToken string,
+) (requestcontext.Actor, error) {
+	if !s.tokens.ValidWireFormat(rawToken) {
+		return requestcontext.Actor{}, ErrAuthenticationRequired
+	}
+	now := s.clock.Now().UTC()
+	session, err := s.repository.FindSessionByTokenDigest(
+		ctx,
+		s.tokens.Digest(rawToken),
+		now,
+	)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return requestcontext.Actor{}, ErrAuthenticationRequired
+		}
+		return requestcontext.Actor{}, err
+	}
+	if session.User.Status != AccountActive ||
+		session.SessionID == "" ||
+		!session.ExpiresAt.After(now) {
+		return requestcontext.Actor{}, ErrAuthenticationRequired
+	}
+	actor := requestcontext.Actor{
+		UserID:    session.User.ID,
+		SessionID: session.SessionID,
+	}
+	if !actor.Valid() {
+		return requestcontext.Actor{}, ErrAuthenticationRequired
+	}
+	return actor, nil
+}
+
+func (s *Service) Logout(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) error {
+	if !actor.Valid() {
+		return ErrAuthenticationRequired
+	}
+	return s.repository.RevokeSession(
+		ctx,
+		actor.UserID,
+		actor.SessionID,
+		s.clock.Now().UTC(),
+		logoutReason,
+	)
+}
+
+func (s *Service) CurrentUser(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) (User, error) {
+	if !actor.Valid() {
+		return User{}, ErrAuthenticationRequired
+	}
+	user, err := s.repository.FindUserByID(ctx, actor.UserID)
+	if errors.Is(err, ErrNotFound) {
+		return User{}, ErrAuthenticationRequired
+	}
+	if err != nil {
+		return User{}, err
+	}
+	if user.Status != AccountActive {
+		return User{}, ErrAuthenticationRequired
+	}
+	return user, nil
+}
+
+func (s *Service) RevokeAllSessionsForUser(
+	ctx context.Context,
+	userID string,
+	reason string,
+) error {
+	if userID == "" || reason == "" {
+		return ErrInvalidRequest
+	}
+	return s.repository.RevokeAllSessionsForUser(
+		ctx,
+		userID,
+		s.clock.Now().UTC(),
+		reason,
+	)
+}
+
+type SystemClock struct{}
+
+func (SystemClock) Now() time.Time { return time.Now() }

--- a/server/internal/identity/service.go
+++ b/server/internal/identity/service.go
@@ -20,6 +20,16 @@ type Authenticator interface {
 	) (requestcontext.Actor, error)
 }
 
+// LogoutSessionResolver resolves a known, unexpired Session even after it has
+// been revoked. It is deliberately separate from Authenticator so a revoked
+// credential can only be reused for the idempotent logout endpoint.
+type LogoutSessionResolver interface {
+	ResolveSessionForLogout(
+		ctx context.Context,
+		rawToken string,
+	) (requestcontext.Actor, error)
+}
+
 type Service struct {
 	repository Repository
 	passwords  PasswordHasher
@@ -139,13 +149,35 @@ func (s *Service) AuthenticateSession(
 	ctx context.Context,
 	rawToken string,
 ) (requestcontext.Actor, error) {
+	return s.resolveSessionActor(ctx, rawToken, false)
+}
+
+func (s *Service) ResolveSessionForLogout(
+	ctx context.Context,
+	rawToken string,
+) (requestcontext.Actor, error) {
+	return s.resolveSessionActor(ctx, rawToken, true)
+}
+
+func (s *Service) resolveSessionActor(
+	ctx context.Context,
+	rawToken string,
+	includeRevoked bool,
+) (requestcontext.Actor, error) {
 	if !s.tokens.ValidWireFormat(rawToken) {
 		return requestcontext.Actor{}, ErrAuthenticationRequired
 	}
-	session, err := s.repository.FindSessionByTokenDigest(
-		ctx,
-		s.tokens.Digest(rawToken),
-	)
+	tokenDigest := s.tokens.Digest(rawToken)
+	var session SessionIdentity
+	var err error
+	if includeRevoked {
+		session, err = s.repository.FindSessionForLogoutByTokenDigest(
+			ctx,
+			tokenDigest,
+		)
+	} else {
+		session, err = s.repository.FindSessionByTokenDigest(ctx, tokenDigest)
+	}
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return requestcontext.Actor{}, ErrAuthenticationRequired

--- a/server/internal/identity/service_test.go
+++ b/server/internal/identity/service_test.go
@@ -13,22 +13,21 @@ import (
 )
 
 type repositoryStub struct {
-	createUser       func(context.Context, string, string, time.Time) (User, error)
+	createUser       func(context.Context, string, string) (User, error)
 	findCredential   func(context.Context, string) (Credential, error)
 	createSession    func(context.Context, CreateSessionParams) (Session, error)
-	findSession      func(context.Context, []byte, time.Time) (SessionIdentity, error)
+	findSession      func(context.Context, []byte) (SessionIdentity, error)
 	findUser         func(context.Context, string) (User, error)
-	revokeSession    func(context.Context, string, string, time.Time, string) error
-	revokeAllSession func(context.Context, string, time.Time, string) error
+	revokeSession    func(context.Context, string, string, string) error
+	revokeAllSession func(context.Context, string, string) error
 }
 
 func (r repositoryStub) CreateUserWithCredential(
 	ctx context.Context,
 	email string,
 	hash string,
-	now time.Time,
 ) (User, error) {
-	return r.createUser(ctx, email, hash, now)
+	return r.createUser(ctx, email, hash)
 }
 
 func (r repositoryStub) FindCredentialByEmail(
@@ -48,9 +47,8 @@ func (r repositoryStub) CreateSession(
 func (r repositoryStub) FindSessionByTokenDigest(
 	ctx context.Context,
 	digest []byte,
-	now time.Time,
 ) (SessionIdentity, error) {
-	return r.findSession(ctx, digest, now)
+	return r.findSession(ctx, digest)
 }
 
 func (r repositoryStub) FindUserByID(
@@ -64,35 +62,37 @@ func (r repositoryStub) RevokeSession(
 	ctx context.Context,
 	userID string,
 	sessionID string,
-	now time.Time,
 	reason string,
 ) error {
-	return r.revokeSession(ctx, userID, sessionID, now, reason)
+	return r.revokeSession(ctx, userID, sessionID, reason)
 }
 
 func (r repositoryStub) RevokeAllSessionsForUser(
 	ctx context.Context,
 	userID string,
-	now time.Time,
 	reason string,
 ) error {
-	return r.revokeAllSession(ctx, userID, now, reason)
+	return r.revokeAllSession(ctx, userID, reason)
 }
 
 type passwordHasherStub struct {
-	hash   func(string) (string, error)
-	verify func(string, string) (bool, bool, error)
+	hash   func(context.Context, string) (string, error)
+	verify func(context.Context, string, string) (bool, bool, error)
 }
 
-func (h passwordHasherStub) Hash(password string) (string, error) {
-	return h.hash(password)
+func (h passwordHasherStub) Hash(
+	ctx context.Context,
+	password string,
+) (string, error) {
+	return h.hash(ctx, password)
 }
 
 func (h passwordHasherStub) Verify(
+	ctx context.Context,
 	password string,
 	hash string,
 ) (bool, bool, error) {
-	return h.verify(password, hash)
+	return h.verify(ctx, password, hash)
 }
 
 type tokenStub struct{}
@@ -103,37 +103,28 @@ func (tokenStub) Generate() (string, []byte, error) {
 func (tokenStub) Digest(string) []byte        { return []byte("digest") }
 func (tokenStub) ValidWireFormat(string) bool { return true }
 
-type fixedClock time.Time
-
-func (c fixedClock) Now() time.Time { return time.Time(c) }
-
 func TestRegisterNormalizesEmailAndMapsConcurrentConflict(t *testing.T) {
-	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
 	var gotEmail, gotHash string
 	repository := completeRepositoryStub()
 	repository.createUser = func(
 		_ context.Context,
 		email string,
 		hash string,
-		gotNow time.Time,
 	) (User, error) {
 		gotEmail, gotHash = email, hash
-		if gotNow != now {
-			t.Fatalf("unexpected time: %v", gotNow)
-		}
 		return User{}, ErrConflict
 	}
 	service := mustService(t, repository, passwordHasherStub{
-		hash: func(password string) (string, error) {
+		hash: func(_ context.Context, password string) (string, error) {
 			if password != "correct horse battery staple" {
 				t.Fatalf("unexpected password")
 			}
 			return "phc-hash", nil
 		},
-		verify: func(string, string) (bool, bool, error) {
+		verify: func(context.Context, string, string) (bool, bool, error) {
 			return false, false, nil
 		},
-	}, now)
+	}, time.Time{})
 
 	_, err := service.Register(
 		context.Background(),
@@ -155,8 +146,8 @@ func TestLoginUsesDummyHashForUnknownAccount(t *testing.T) {
 	}
 	var verifiedHash string
 	service := mustService(t, repository, passwordHasherStub{
-		hash: func(string) (string, error) { return "hash", nil },
-		verify: func(_ string, hash string) (bool, bool, error) {
+		hash: func(context.Context, string) (string, error) { return "hash", nil },
+		verify: func(_ context.Context, _ string, hash string) (bool, bool, error) {
 			verifiedHash = hash
 			return true, false, nil
 		},
@@ -215,7 +206,11 @@ func TestLoginCreatesFiniteSessionAndCarriesRehashAtomically(t *testing.T) {
 	}
 	repository := completeRepositoryStub()
 	repository.findCredential = func(context.Context, string) (Credential, error) {
-		return Credential{User: user, PasswordHash: "old-hash"}, nil
+		return Credential{
+			User:         user,
+			PasswordHash: "old-hash",
+			UpdatedAt:    now,
+		}, nil
 	}
 	var got CreateSessionParams
 	repository.createSession = func(
@@ -226,12 +221,12 @@ func TestLoginCreatesFiniteSessionAndCarriesRehashAtomically(t *testing.T) {
 		return Session{
 			ID:        "session-1",
 			UserID:    user.ID,
-			ExpiresAt: params.ExpiresAt,
+			ExpiresAt: now.Add(params.Lifetime),
 		}, nil
 	}
 	service := mustService(t, repository, passwordHasherStub{
-		hash: func(string) (string, error) { return "new-hash", nil },
-		verify: func(_, hash string) (bool, bool, error) {
+		hash: func(context.Context, string) (string, error) { return "new-hash", nil },
+		verify: func(_ context.Context, _, hash string) (bool, bool, error) {
 			return hash == "old-hash", true, nil
 		},
 	}, now)
@@ -248,26 +243,75 @@ func TestLoginCreatesFiniteSessionAndCarriesRehashAtomically(t *testing.T) {
 		result.ExpiresAt != now.Add(30*24*time.Hour) ||
 		got.PreviousHash != "old-hash" ||
 		got.ReplacementHash != "new-hash" ||
+		got.CredentialUpdatedAt != now ||
+		got.Lifetime != sessionLifetime ||
 		!reflect.DeepEqual(got.TokenDigest, []byte("digest")) {
 		t.Fatalf("unexpected login result/params: %#v, %#v", result, got)
 	}
 }
 
-func TestAuthenticateSessionRejectsExpiredSession(t *testing.T) {
-	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+func TestLoginHidesAuthenticationStateChangedDuringSessionCommit(t *testing.T) {
+	repository := completeRepositoryStub()
+	repository.findCredential = func(context.Context, string) (Credential, error) {
+		return Credential{
+			User: User{
+				ID:     "user-1",
+				Email:  "learner@example.com",
+				Status: AccountActive,
+			},
+			PasswordHash: "stored-hash",
+			UpdatedAt:    time.Unix(1_000, 0),
+		}, nil
+	}
+	repository.createSession = func(
+		context.Context,
+		CreateSessionParams,
+	) (Session, error) {
+		return Session{}, ErrAuthenticationChanged
+	}
+	service := mustService(t, repository, defaultHasherStub(), time.Time{})
+	if _, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		"correct horse battery staple",
+	); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("authentication state change leaked: %v", err)
+	}
+}
+
+func TestServicePropagatesPasswordContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repository := completeRepositoryStub()
+	service := mustService(t, repository, passwordHasherStub{
+		hash: func(got context.Context, _ string) (string, error) {
+			if !errors.Is(got.Err(), context.Canceled) {
+				t.Fatalf("hash context was not propagated: %v", got.Err())
+			}
+			return "", got.Err()
+		},
+		verify: func(context.Context, string, string) (bool, bool, error) {
+			return false, false, nil
+		},
+	}, time.Time{})
+	if _, err := service.Register(
+		ctx,
+		"learner@example.com",
+		"correct horse battery staple",
+	); !errors.Is(err, context.Canceled) {
+		t.Fatalf("register cancellation = %v", err)
+	}
+}
+
+func TestAuthenticateSessionMapsRepositoryExpiryToAuthenticationRequired(t *testing.T) {
 	repository := completeRepositoryStub()
 	repository.findSession = func(
 		context.Context,
 		[]byte,
-		time.Time,
 	) (SessionIdentity, error) {
-		return SessionIdentity{
-			User:      User{ID: "user-1", Status: AccountActive},
-			SessionID: "session-1",
-			ExpiresAt: now,
-		}, nil
+		return SessionIdentity{}, ErrNotFound
 	}
-	service := mustService(t, repository, defaultHasherStub(), now)
+	service := mustService(t, repository, defaultHasherStub(), time.Time{})
 
 	if _, err := service.AuthenticateSession(
 		context.Background(),
@@ -285,12 +329,11 @@ func TestLogoutUsesOnlyTrustedActor(t *testing.T) {
 		_ context.Context,
 		userID string,
 		sessionID string,
-		revokedAt time.Time,
 		reason string,
 	) error {
 		got = requestcontext.Actor{UserID: userID, SessionID: sessionID}
-		if revokedAt != now || reason != "logout" {
-			t.Fatalf("unexpected revoke metadata: %v, %q", revokedAt, reason)
+		if reason != "logout" {
+			t.Fatalf("unexpected revoke reason: %q", reason)
 		}
 		return nil
 	}
@@ -312,7 +355,6 @@ func TestConcurrentRegistrationHasOneWinner(t *testing.T) {
 		context.Context,
 		string,
 		string,
-		time.Time,
 	) (User, error) {
 		if created.Add(1) == 1 {
 			return User{
@@ -364,7 +406,6 @@ func TestRepeatedLogoutIsIdempotentAtRepositoryBoundary(t *testing.T) {
 		context.Context,
 		string,
 		string,
-		time.Time,
 		string,
 	) error {
 		calls.Add(1)
@@ -393,7 +434,6 @@ func mustService(
 		repository,
 		hasher,
 		tokenStub{},
-		fixedClock(now),
 		"dummy-hash",
 	)
 	if err != nil {
@@ -404,8 +444,8 @@ func mustService(
 
 func defaultHasherStub() PasswordHasher {
 	return passwordHasherStub{
-		hash: func(string) (string, error) { return "hash", nil },
-		verify: func(string, string) (bool, bool, error) {
+		hash: func(context.Context, string) (string, error) { return "hash", nil },
+		verify: func(context.Context, string, string) (bool, bool, error) {
 			return true, false, nil
 		},
 	}
@@ -413,7 +453,7 @@ func defaultHasherStub() PasswordHasher {
 
 func completeRepositoryStub() repositoryStub {
 	return repositoryStub{
-		createUser: func(context.Context, string, string, time.Time) (User, error) {
+		createUser: func(context.Context, string, string) (User, error) {
 			return User{}, nil
 		},
 		findCredential: func(context.Context, string) (Credential, error) {
@@ -428,7 +468,6 @@ func completeRepositoryStub() repositoryStub {
 		findSession: func(
 			context.Context,
 			[]byte,
-			time.Time,
 		) (SessionIdentity, error) {
 			return SessionIdentity{}, ErrNotFound
 		},
@@ -439,7 +478,6 @@ func completeRepositoryStub() repositoryStub {
 			context.Context,
 			string,
 			string,
-			time.Time,
 			string,
 		) error {
 			return nil
@@ -447,7 +485,6 @@ func completeRepositoryStub() repositoryStub {
 		revokeAllSession: func(
 			context.Context,
 			string,
-			time.Time,
 			string,
 		) error {
 			return nil

--- a/server/internal/identity/service_test.go
+++ b/server/internal/identity/service_test.go
@@ -1,0 +1,456 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type repositoryStub struct {
+	createUser       func(context.Context, string, string, time.Time) (User, error)
+	findCredential   func(context.Context, string) (Credential, error)
+	createSession    func(context.Context, CreateSessionParams) (Session, error)
+	findSession      func(context.Context, []byte, time.Time) (SessionIdentity, error)
+	findUser         func(context.Context, string) (User, error)
+	revokeSession    func(context.Context, string, string, time.Time, string) error
+	revokeAllSession func(context.Context, string, time.Time, string) error
+}
+
+func (r repositoryStub) CreateUserWithCredential(
+	ctx context.Context,
+	email string,
+	hash string,
+	now time.Time,
+) (User, error) {
+	return r.createUser(ctx, email, hash, now)
+}
+
+func (r repositoryStub) FindCredentialByEmail(
+	ctx context.Context,
+	email string,
+) (Credential, error) {
+	return r.findCredential(ctx, email)
+}
+
+func (r repositoryStub) CreateSession(
+	ctx context.Context,
+	params CreateSessionParams,
+) (Session, error) {
+	return r.createSession(ctx, params)
+}
+
+func (r repositoryStub) FindSessionByTokenDigest(
+	ctx context.Context,
+	digest []byte,
+	now time.Time,
+) (SessionIdentity, error) {
+	return r.findSession(ctx, digest, now)
+}
+
+func (r repositoryStub) FindUserByID(
+	ctx context.Context,
+	userID string,
+) (User, error) {
+	return r.findUser(ctx, userID)
+}
+
+func (r repositoryStub) RevokeSession(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	now time.Time,
+	reason string,
+) error {
+	return r.revokeSession(ctx, userID, sessionID, now, reason)
+}
+
+func (r repositoryStub) RevokeAllSessionsForUser(
+	ctx context.Context,
+	userID string,
+	now time.Time,
+	reason string,
+) error {
+	return r.revokeAllSession(ctx, userID, now, reason)
+}
+
+type passwordHasherStub struct {
+	hash   func(string) (string, error)
+	verify func(string, string) (bool, bool, error)
+}
+
+func (h passwordHasherStub) Hash(password string) (string, error) {
+	return h.hash(password)
+}
+
+func (h passwordHasherStub) Verify(
+	password string,
+	hash string,
+) (bool, bool, error) {
+	return h.verify(password, hash)
+}
+
+type tokenStub struct{}
+
+func (tokenStub) Generate() (string, []byte, error) {
+	return "sess_raw", []byte("digest"), nil
+}
+func (tokenStub) Digest(string) []byte        { return []byte("digest") }
+func (tokenStub) ValidWireFormat(string) bool { return true }
+
+type fixedClock time.Time
+
+func (c fixedClock) Now() time.Time { return time.Time(c) }
+
+func TestRegisterNormalizesEmailAndMapsConcurrentConflict(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	var gotEmail, gotHash string
+	repository := completeRepositoryStub()
+	repository.createUser = func(
+		_ context.Context,
+		email string,
+		hash string,
+		gotNow time.Time,
+	) (User, error) {
+		gotEmail, gotHash = email, hash
+		if gotNow != now {
+			t.Fatalf("unexpected time: %v", gotNow)
+		}
+		return User{}, ErrConflict
+	}
+	service := mustService(t, repository, passwordHasherStub{
+		hash: func(password string) (string, error) {
+			if password != "correct horse battery staple" {
+				t.Fatalf("unexpected password")
+			}
+			return "phc-hash", nil
+		},
+		verify: func(string, string) (bool, bool, error) {
+			return false, false, nil
+		},
+	}, now)
+
+	_, err := service.Register(
+		context.Background(),
+		" Learner@Example.COM ",
+		"correct horse battery staple",
+	)
+	if !errors.Is(err, ErrRegistrationUnavailable) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotEmail != "learner@example.com" || gotHash != "phc-hash" {
+		t.Fatalf("unexpected repository input: %q, %q", gotEmail, gotHash)
+	}
+}
+
+func TestLoginUsesDummyHashForUnknownAccount(t *testing.T) {
+	repository := completeRepositoryStub()
+	repository.findCredential = func(context.Context, string) (Credential, error) {
+		return Credential{}, ErrNotFound
+	}
+	var verifiedHash string
+	service := mustService(t, repository, passwordHasherStub{
+		hash: func(string) (string, error) { return "hash", nil },
+		verify: func(_ string, hash string) (bool, bool, error) {
+			verifiedHash = hash
+			return true, false, nil
+		},
+	}, time.Now())
+
+	_, err := service.Login(
+		context.Background(),
+		"unknown@example.com",
+		"correct horse battery staple",
+	)
+	if !errors.Is(err, ErrInvalidCredentials) || verifiedHash != "dummy-hash" {
+		t.Fatalf("login error/hash = %v, %q", err, verifiedHash)
+	}
+}
+
+func TestLoginHidesUnavailableAccountState(t *testing.T) {
+	for _, status := range []AccountStatus{
+		AccountDisabled,
+		AccountDeleting,
+		AccountDeleted,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			repository := completeRepositoryStub()
+			repository.findCredential = func(
+				context.Context,
+				string,
+			) (Credential, error) {
+				return Credential{
+					User: User{
+						ID:     "user-1",
+						Email:  "learner@example.com",
+						Status: status,
+					},
+					PasswordHash: "stored-hash",
+				}, nil
+			}
+			service := mustService(t, repository, defaultHasherStub(), time.Now())
+			_, err := service.Login(
+				context.Background(),
+				"learner@example.com",
+				"correct horse battery staple",
+			)
+			if !errors.Is(err, ErrInvalidCredentials) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoginCreatesFiniteSessionAndCarriesRehashAtomically(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	user := User{
+		ID:     "user-1",
+		Email:  "learner@example.com",
+		Status: AccountActive,
+	}
+	repository := completeRepositoryStub()
+	repository.findCredential = func(context.Context, string) (Credential, error) {
+		return Credential{User: user, PasswordHash: "old-hash"}, nil
+	}
+	var got CreateSessionParams
+	repository.createSession = func(
+		_ context.Context,
+		params CreateSessionParams,
+	) (Session, error) {
+		got = params
+		return Session{
+			ID:        "session-1",
+			UserID:    user.ID,
+			ExpiresAt: params.ExpiresAt,
+		}, nil
+	}
+	service := mustService(t, repository, passwordHasherStub{
+		hash: func(string) (string, error) { return "new-hash", nil },
+		verify: func(_, hash string) (bool, bool, error) {
+			return hash == "old-hash", true, nil
+		},
+	}, now)
+
+	result, err := service.Login(
+		context.Background(),
+		"learner@example.com",
+		"correct horse battery staple",
+	)
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if result.Token != "sess_raw" ||
+		result.ExpiresAt != now.Add(30*24*time.Hour) ||
+		got.PreviousHash != "old-hash" ||
+		got.ReplacementHash != "new-hash" ||
+		!reflect.DeepEqual(got.TokenDigest, []byte("digest")) {
+		t.Fatalf("unexpected login result/params: %#v, %#v", result, got)
+	}
+}
+
+func TestAuthenticateSessionRejectsExpiredSession(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	repository := completeRepositoryStub()
+	repository.findSession = func(
+		context.Context,
+		[]byte,
+		time.Time,
+	) (SessionIdentity, error) {
+		return SessionIdentity{
+			User:      User{ID: "user-1", Status: AccountActive},
+			SessionID: "session-1",
+			ExpiresAt: now,
+		}, nil
+	}
+	service := mustService(t, repository, defaultHasherStub(), now)
+
+	if _, err := service.AuthenticateSession(
+		context.Background(),
+		"sess_raw",
+	); !errors.Is(err, ErrAuthenticationRequired) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLogoutUsesOnlyTrustedActor(t *testing.T) {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	repository := completeRepositoryStub()
+	var got requestcontext.Actor
+	repository.revokeSession = func(
+		_ context.Context,
+		userID string,
+		sessionID string,
+		revokedAt time.Time,
+		reason string,
+	) error {
+		got = requestcontext.Actor{UserID: userID, SessionID: sessionID}
+		if revokedAt != now || reason != "logout" {
+			t.Fatalf("unexpected revoke metadata: %v, %q", revokedAt, reason)
+		}
+		return nil
+	}
+	service := mustService(t, repository, defaultHasherStub(), now)
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	if err := service.Logout(context.Background(), actor); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if got != actor {
+		t.Fatalf("unexpected actor: %#v", got)
+	}
+}
+
+func TestConcurrentRegistrationHasOneWinner(t *testing.T) {
+	const attempts = 8
+	var created atomic.Int32
+	repository := completeRepositoryStub()
+	repository.createUser = func(
+		context.Context,
+		string,
+		string,
+		time.Time,
+	) (User, error) {
+		if created.Add(1) == 1 {
+			return User{
+				ID:     "user-1",
+				Email:  "learner@example.com",
+				Status: AccountActive,
+			}, nil
+		}
+		return User{}, ErrConflict
+	}
+	service := mustService(t, repository, defaultHasherStub(), time.Now())
+
+	var successes atomic.Int32
+	var unavailable atomic.Int32
+	var wait sync.WaitGroup
+	for range attempts {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, err := service.Register(
+				context.Background(),
+				"learner@example.com",
+				"correct horse battery staple",
+			)
+			switch {
+			case err == nil:
+				successes.Add(1)
+			case errors.Is(err, ErrRegistrationUnavailable):
+				unavailable.Add(1)
+			default:
+				t.Errorf("unexpected registration error: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+	if successes.Load() != 1 || unavailable.Load() != attempts-1 {
+		t.Fatalf(
+			"successes/unavailable = %d/%d",
+			successes.Load(),
+			unavailable.Load(),
+		)
+	}
+}
+
+func TestRepeatedLogoutIsIdempotentAtRepositoryBoundary(t *testing.T) {
+	repository := completeRepositoryStub()
+	var calls atomic.Int32
+	repository.revokeSession = func(
+		context.Context,
+		string,
+		string,
+		time.Time,
+		string,
+	) error {
+		calls.Add(1)
+		return nil
+	}
+	service := mustService(t, repository, defaultHasherStub(), time.Now())
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	for range 2 {
+		if err := service.Logout(context.Background(), actor); err != nil {
+			t.Fatalf("logout: %v", err)
+		}
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("revoke calls = %d, want 2", calls.Load())
+	}
+}
+
+func mustService(
+	t *testing.T,
+	repository Repository,
+	hasher PasswordHasher,
+	now time.Time,
+) *Service {
+	t.Helper()
+	service, err := NewService(
+		repository,
+		hasher,
+		tokenStub{},
+		fixedClock(now),
+		"dummy-hash",
+	)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return service
+}
+
+func defaultHasherStub() PasswordHasher {
+	return passwordHasherStub{
+		hash: func(string) (string, error) { return "hash", nil },
+		verify: func(string, string) (bool, bool, error) {
+			return true, false, nil
+		},
+	}
+}
+
+func completeRepositoryStub() repositoryStub {
+	return repositoryStub{
+		createUser: func(context.Context, string, string, time.Time) (User, error) {
+			return User{}, nil
+		},
+		findCredential: func(context.Context, string) (Credential, error) {
+			return Credential{}, ErrNotFound
+		},
+		createSession: func(
+			context.Context,
+			CreateSessionParams,
+		) (Session, error) {
+			return Session{}, nil
+		},
+		findSession: func(
+			context.Context,
+			[]byte,
+			time.Time,
+		) (SessionIdentity, error) {
+			return SessionIdentity{}, ErrNotFound
+		},
+		findUser: func(context.Context, string) (User, error) {
+			return User{}, ErrNotFound
+		},
+		revokeSession: func(
+			context.Context,
+			string,
+			string,
+			time.Time,
+			string,
+		) error {
+			return nil
+		},
+		revokeAllSession: func(
+			context.Context,
+			string,
+			time.Time,
+			string,
+		) error {
+			return nil
+		},
+	}
+}

--- a/server/internal/identity/service_test.go
+++ b/server/internal/identity/service_test.go
@@ -13,13 +13,14 @@ import (
 )
 
 type repositoryStub struct {
-	createUser       func(context.Context, string, string) (User, error)
-	findCredential   func(context.Context, string) (Credential, error)
-	createSession    func(context.Context, CreateSessionParams) (Session, error)
-	findSession      func(context.Context, []byte) (SessionIdentity, error)
-	findUser         func(context.Context, string) (User, error)
-	revokeSession    func(context.Context, string, string, string) error
-	revokeAllSession func(context.Context, string, string) error
+	createUser        func(context.Context, string, string) (User, error)
+	findCredential    func(context.Context, string) (Credential, error)
+	createSession     func(context.Context, CreateSessionParams) (Session, error)
+	findSession       func(context.Context, []byte) (SessionIdentity, error)
+	findLogoutSession func(context.Context, []byte) (SessionIdentity, error)
+	findUser          func(context.Context, string) (User, error)
+	revokeSession     func(context.Context, string, string, string) error
+	revokeAllSession  func(context.Context, string, string) error
 }
 
 func (r repositoryStub) CreateUserWithCredential(
@@ -49,6 +50,13 @@ func (r repositoryStub) FindSessionByTokenDigest(
 	digest []byte,
 ) (SessionIdentity, error) {
 	return r.findSession(ctx, digest)
+}
+
+func (r repositoryStub) FindSessionForLogoutByTokenDigest(
+	ctx context.Context,
+	digest []byte,
+) (SessionIdentity, error) {
+	return r.findLogoutSession(ctx, digest)
 }
 
 func (r repositoryStub) FindUserByID(
@@ -466,6 +474,12 @@ func completeRepositoryStub() repositoryStub {
 			return Session{}, nil
 		},
 		findSession: func(
+			context.Context,
+			[]byte,
+		) (SessionIdentity, error) {
+			return SessionIdentity{}, ErrNotFound
+		},
+		findLogoutSession: func(
 			context.Context,
 			[]byte,
 		) (SessionIdentity, error) {

--- a/server/internal/identity/source_ip.go
+++ b/server/internal/identity/source_ip.go
@@ -23,11 +23,23 @@ func (directSourceIPResolver) Resolve(request *http.Request) string {
 	return address.String()
 }
 
+type trustedProxyHeader uint8
+
+const (
+	trustedProxyHeaderNone trustedProxyHeader = iota
+	trustedProxyHeaderXForwardedFor
+	trustedProxyHeaderForwarded
+)
+
 type TrustedProxyResolver struct {
 	trusted []netip.Prefix
+	header  trustedProxyHeader
 }
 
-func NewTrustedProxyResolver(cidrs []string) (*TrustedProxyResolver, error) {
+func NewTrustedProxyResolver(
+	cidrs []string,
+	headerName string,
+) (*TrustedProxyResolver, error) {
 	trusted := make([]netip.Prefix, 0, len(cidrs))
 	for _, raw := range cidrs {
 		prefix, err := netip.ParsePrefix(strings.TrimSpace(raw))
@@ -36,34 +48,123 @@ func NewTrustedProxyResolver(cidrs []string) (*TrustedProxyResolver, error) {
 		}
 		trusted = append(trusted, prefix.Masked())
 	}
-	return &TrustedProxyResolver{trusted: trusted}, nil
+
+	var header trustedProxyHeader
+	switch strings.ToLower(strings.TrimSpace(headerName)) {
+	case "":
+		header = trustedProxyHeaderNone
+	case "x-forwarded-for":
+		header = trustedProxyHeaderXForwardedFor
+	case "forwarded":
+		header = trustedProxyHeaderForwarded
+	default:
+		return nil, errors.New("identity: invalid trusted proxy header")
+	}
+	if (header == trustedProxyHeaderNone) != (len(trusted) == 0) {
+		return nil, errors.New("identity: incomplete trusted proxy configuration")
+	}
+	return &TrustedProxyResolver{trusted: trusted, header: header}, nil
 }
 
 func (r *TrustedProxyResolver) Resolve(request *http.Request) string {
 	peer, ok := parseIP(request.RemoteAddr)
-	if !ok || !r.isTrusted(peer) {
+	if !ok || !r.isTrusted(peer) || r.header == trustedProxyHeaderNone {
 		return directSourceIPResolver{}.Resolve(request)
 	}
 
-	var chain []netip.Addr
-	if forwarded := request.Header.Values("Forwarded"); len(forwarded) > 0 {
-		chain, ok = forwardedChain(forwarded)
+	switch r.header {
+	case trustedProxyHeaderXForwardedFor:
+		return r.resolveXForwardedFor(
+			peer,
+			request.Header.Values("X-Forwarded-For"),
+		)
+	case trustedProxyHeaderForwarded:
+		return r.resolveForwarded(peer, request.Header.Values("Forwarded"))
+	default:
+		return peer.String()
+	}
+}
+
+// resolveXForwardedFor peels the proxy-appended chain from right to left.
+// Once the first valid non-trusted address is found, client-controlled values
+// further left are irrelevant and are deliberately not parsed.
+func (r *TrustedProxyResolver) resolveXForwardedFor(
+	peer netip.Addr,
+	values []string,
+) string {
+	elements := commaSeparatedElements(values)
+	if len(elements) == 0 {
+		return peer.String()
+	}
+	var leftmost netip.Addr
+	for index := len(elements) - 1; index >= 0; index-- {
+		address, ok := parseIP(strings.TrimSpace(elements[index]))
 		if !ok {
 			return peer.String()
 		}
-	} else {
-		chain, ok = xForwardedForChain(request.Header.Values("X-Forwarded-For"))
-	}
-	if !ok || len(chain) == 0 {
-		return peer.String()
-	}
-	chain = append(chain, peer)
-	for index := len(chain) - 1; index >= 0; index-- {
-		if !r.isTrusted(chain[index]) {
-			return chain[index].String()
+		leftmost = address
+		if !r.isTrusted(address) {
+			return address.String()
 		}
 	}
-	return chain[0].String()
+	return leftmost.String()
+}
+
+func (r *TrustedProxyResolver) resolveForwarded(
+	peer netip.Addr,
+	values []string,
+) string {
+	elements := commaSeparatedElements(values)
+	if len(elements) == 0 {
+		return peer.String()
+	}
+	var leftmost netip.Addr
+	for index := len(elements) - 1; index >= 0; index-- {
+		address, ok := forwardedAddress(elements[index])
+		if !ok {
+			return peer.String()
+		}
+		leftmost = address
+		if !r.isTrusted(address) {
+			return address.String()
+		}
+	}
+	return leftmost.String()
+}
+
+func commaSeparatedElements(values []string) []string {
+	var elements []string
+	for _, value := range values {
+		elements = append(elements, strings.Split(value, ",")...)
+	}
+	return elements
+}
+
+func forwardedAddress(element string) (netip.Addr, bool) {
+	var rawAddress string
+	found := false
+	for _, parameter := range strings.Split(element, ";") {
+		name, raw, ok := strings.Cut(strings.TrimSpace(parameter), "=")
+		if !ok || !strings.EqualFold(name, "for") {
+			continue
+		}
+		if found {
+			return netip.Addr{}, false
+		}
+		found = true
+		rawAddress = strings.TrimSpace(raw)
+	}
+	if !found || rawAddress == "" {
+		return netip.Addr{}, false
+	}
+	if strings.HasPrefix(rawAddress, `"`) {
+		unquoted, err := strconv.Unquote(rawAddress)
+		if err != nil {
+			return netip.Addr{}, false
+		}
+		rawAddress = unquoted
+	}
+	return parseIP(rawAddress)
 }
 
 func (r *TrustedProxyResolver) isTrusted(address netip.Addr) bool {
@@ -73,59 +174,6 @@ func (r *TrustedProxyResolver) isTrusted(address netip.Addr) bool {
 		}
 	}
 	return false
-}
-
-func forwardedChain(values []string) ([]netip.Addr, bool) {
-	if len(values) == 0 {
-		return nil, true
-	}
-	var result []netip.Addr
-	for _, value := range values {
-		for _, element := range strings.Split(value, ",") {
-			var found bool
-			for _, parameter := range strings.Split(element, ";") {
-				name, raw, ok := strings.Cut(strings.TrimSpace(parameter), "=")
-				if !ok || !strings.EqualFold(name, "for") {
-					continue
-				}
-				if found {
-					return nil, false
-				}
-				found = true
-				raw = strings.TrimSpace(raw)
-				if strings.HasPrefix(raw, `"`) {
-					unquoted, err := strconv.Unquote(raw)
-					if err != nil {
-						return nil, false
-					}
-					raw = unquoted
-				}
-				address, ok := parseIP(raw)
-				if !ok {
-					return nil, false
-				}
-				result = append(result, address)
-			}
-			if !found {
-				return nil, false
-			}
-		}
-	}
-	return result, true
-}
-
-func xForwardedForChain(values []string) ([]netip.Addr, bool) {
-	var result []netip.Addr
-	for _, value := range values {
-		for _, raw := range strings.Split(value, ",") {
-			address, ok := parseIP(strings.TrimSpace(raw))
-			if !ok {
-				return nil, false
-			}
-			result = append(result, address)
-		}
-	}
-	return result, true
 }
 
 func parseIP(raw string) (netip.Addr, bool) {

--- a/server/internal/identity/source_ip.go
+++ b/server/internal/identity/source_ip.go
@@ -1,0 +1,142 @@
+package identity
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+type SourceIPResolver interface {
+	Resolve(*http.Request) string
+}
+
+type directSourceIPResolver struct{}
+
+func (directSourceIPResolver) Resolve(request *http.Request) string {
+	address, ok := parseIP(request.RemoteAddr)
+	if !ok {
+		return request.RemoteAddr
+	}
+	return address.String()
+}
+
+type TrustedProxyResolver struct {
+	trusted []netip.Prefix
+}
+
+func NewTrustedProxyResolver(cidrs []string) (*TrustedProxyResolver, error) {
+	trusted := make([]netip.Prefix, 0, len(cidrs))
+	for _, raw := range cidrs {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(raw))
+		if err != nil {
+			return nil, errors.New("identity: invalid trusted proxy CIDR")
+		}
+		trusted = append(trusted, prefix.Masked())
+	}
+	return &TrustedProxyResolver{trusted: trusted}, nil
+}
+
+func (r *TrustedProxyResolver) Resolve(request *http.Request) string {
+	peer, ok := parseIP(request.RemoteAddr)
+	if !ok || !r.isTrusted(peer) {
+		return directSourceIPResolver{}.Resolve(request)
+	}
+
+	var chain []netip.Addr
+	if forwarded := request.Header.Values("Forwarded"); len(forwarded) > 0 {
+		chain, ok = forwardedChain(forwarded)
+		if !ok {
+			return peer.String()
+		}
+	} else {
+		chain, ok = xForwardedForChain(request.Header.Values("X-Forwarded-For"))
+	}
+	if !ok || len(chain) == 0 {
+		return peer.String()
+	}
+	chain = append(chain, peer)
+	for index := len(chain) - 1; index >= 0; index-- {
+		if !r.isTrusted(chain[index]) {
+			return chain[index].String()
+		}
+	}
+	return chain[0].String()
+}
+
+func (r *TrustedProxyResolver) isTrusted(address netip.Addr) bool {
+	for _, prefix := range r.trusted {
+		if prefix.Contains(address) {
+			return true
+		}
+	}
+	return false
+}
+
+func forwardedChain(values []string) ([]netip.Addr, bool) {
+	if len(values) == 0 {
+		return nil, true
+	}
+	var result []netip.Addr
+	for _, value := range values {
+		for _, element := range strings.Split(value, ",") {
+			var found bool
+			for _, parameter := range strings.Split(element, ";") {
+				name, raw, ok := strings.Cut(strings.TrimSpace(parameter), "=")
+				if !ok || !strings.EqualFold(name, "for") {
+					continue
+				}
+				if found {
+					return nil, false
+				}
+				found = true
+				raw = strings.TrimSpace(raw)
+				if strings.HasPrefix(raw, `"`) {
+					unquoted, err := strconv.Unquote(raw)
+					if err != nil {
+						return nil, false
+					}
+					raw = unquoted
+				}
+				address, ok := parseIP(raw)
+				if !ok {
+					return nil, false
+				}
+				result = append(result, address)
+			}
+			if !found {
+				return nil, false
+			}
+		}
+	}
+	return result, true
+}
+
+func xForwardedForChain(values []string) ([]netip.Addr, bool) {
+	var result []netip.Addr
+	for _, value := range values {
+		for _, raw := range strings.Split(value, ",") {
+			address, ok := parseIP(strings.TrimSpace(raw))
+			if !ok {
+				return nil, false
+			}
+			result = append(result, address)
+		}
+	}
+	return result, true
+}
+
+func parseIP(raw string) (netip.Addr, bool) {
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	} else if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		raw = strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]")
+	}
+	address, err := netip.ParseAddr(raw)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return address.Unmap(), true
+}

--- a/server/internal/identity/source_ip_test.go
+++ b/server/internal/identity/source_ip_test.go
@@ -1,0 +1,77 @@
+package identity
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTrustedProxyResolverUsesHeadersOnlyForTrustedImmediatePeer(t *testing.T) {
+	resolver, err := NewTrustedProxyResolver([]string{
+		"10.0.0.0/8",
+		"2001:db8:ffff::/48",
+	})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		xff        string
+		want       string
+	}{
+		{
+			name:       "direct ignores forged header",
+			remoteAddr: "192.0.2.44:1234",
+			xff:        "203.0.113.9",
+			want:       "192.0.2.44",
+		},
+		{
+			name:       "trusted proxy xff",
+			remoteAddr: "10.0.0.2:443",
+			xff:        "203.0.113.9, 10.0.0.1",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "forwarded takes precedence and normalizes IPv6",
+			remoteAddr: "[2001:db8:ffff::1]:443",
+			forwarded:  `for="[2001:db8::1234]";proto=https`,
+			xff:        "203.0.113.9",
+			want:       "2001:db8::1234",
+		},
+		{
+			name:       "malformed trusted header falls back to peer",
+			remoteAddr: "10.0.0.2:443",
+			forwarded:  "for=unknown",
+			xff:        "203.0.113.9",
+			want:       "10.0.0.2",
+		},
+		{
+			name:       "malformed xff falls back to peer",
+			remoteAddr: "10.0.0.2:443",
+			xff:        "unknown",
+			want:       "10.0.0.2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest("GET", "/", nil)
+			request.RemoteAddr = test.remoteAddr
+			if test.forwarded != "" {
+				request.Header.Set("Forwarded", test.forwarded)
+			}
+			if test.xff != "" {
+				request.Header.Set("X-Forwarded-For", test.xff)
+			}
+			if got := resolver.Resolve(request); got != test.want {
+				t.Fatalf("source IP = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTrustedProxyResolverRejectsInvalidCIDR(t *testing.T) {
+	if _, err := NewTrustedProxyResolver([]string{"not-a-cidr"}); err == nil {
+		t.Fatal("expected invalid CIDR to fail startup")
+	}
+}

--- a/server/internal/identity/source_ip_test.go
+++ b/server/internal/identity/source_ip_test.go
@@ -2,67 +2,93 @@ package identity
 
 import (
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestTrustedProxyResolverUsesHeadersOnlyForTrustedImmediatePeer(t *testing.T) {
-	resolver, err := NewTrustedProxyResolver([]string{
-		"10.0.0.0/8",
-		"2001:db8:ffff::/48",
-	})
+func TestTrustedProxyResolverDefaultsToRemoteAddr(t *testing.T) {
+	resolver, err := NewTrustedProxyResolver(nil, "")
 	if err != nil {
 		t.Fatalf("new resolver: %v", err)
 	}
+	request := httptest.NewRequest("GET", "/", nil)
+	request.RemoteAddr = "10.0.0.2:443"
+	request.Header.Set("Forwarded", "for=198.51.100.7")
+	request.Header.Set("X-Forwarded-For", "203.0.113.9")
+	if got := resolver.Resolve(request); got != "10.0.0.2" {
+		t.Fatalf("default source IP = %q", got)
+	}
+}
+
+func TestXForwardedForStrategyIgnoresClientForwardedHeader(t *testing.T) {
+	resolver := mustTrustedProxyResolver(
+		t,
+		[]string{"10.0.0.0/8"},
+		"x-forwarded-for",
+	)
+	request := httptest.NewRequest("GET", "/", nil)
+	request.RemoteAddr = "10.0.0.2:443"
+	request.Header.Set("Forwarded", "for=198.51.100.7")
+	request.Header.Set("X-Forwarded-For", "203.0.113.9")
+	if got := resolver.Resolve(request); got != "203.0.113.9" {
+		t.Fatalf("forged Forwarded overrode configured XFF: %q", got)
+	}
+}
+
+func TestXForwardedForStrategyPeelsTrustedChainFromRight(t *testing.T) {
+	resolver := mustTrustedProxyResolver(
+		t,
+		[]string{"10.0.0.0/8", "2001:db8:ffff::/48"},
+		"x-forwarded-for",
+	)
 	tests := []struct {
 		name       string
 		remoteAddr string
-		forwarded  string
 		xff        string
 		want       string
 	}{
 		{
-			name:       "direct ignores forged header",
+			name:       "untrusted direct peer ignores header",
 			remoteAddr: "192.0.2.44:1234",
 			xff:        "203.0.113.9",
 			want:       "192.0.2.44",
 		},
 		{
-			name:       "trusted proxy xff",
+			name:       "unknown client prefix is ignored",
 			remoteAddr: "10.0.0.2:443",
-			xff:        "203.0.113.9, 10.0.0.1",
+			xff:        "unknown, 203.0.113.9",
 			want:       "203.0.113.9",
 		},
 		{
-			name:       "forwarded takes precedence and normalizes IPv6",
+			name:       "garbage left of source and trusted chain is ignored",
+			remoteAddr: "10.0.0.3:443",
+			xff:        "garbage, 203.0.113.9, 10.0.0.2",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "all trusted chain returns leftmost",
+			remoteAddr: "10.0.0.3:443",
+			xff:        "10.0.0.1, 10.0.0.2",
+			want:       "10.0.0.1",
+		},
+		{
+			name:       "malformed required right segment fails closed",
+			remoteAddr: "10.0.0.3:443",
+			xff:        "203.0.113.9, malformed, 10.0.0.2",
+			want:       "10.0.0.3",
+		},
+		{
+			name:       "IPv6 source is normalized",
 			remoteAddr: "[2001:db8:ffff::1]:443",
-			forwarded:  `for="[2001:db8::1234]";proto=https`,
-			xff:        "203.0.113.9",
+			xff:        "2001:db8::1234",
 			want:       "2001:db8::1234",
-		},
-		{
-			name:       "malformed trusted header falls back to peer",
-			remoteAddr: "10.0.0.2:443",
-			forwarded:  "for=unknown",
-			xff:        "203.0.113.9",
-			want:       "10.0.0.2",
-		},
-		{
-			name:       "malformed xff falls back to peer",
-			remoteAddr: "10.0.0.2:443",
-			xff:        "unknown",
-			want:       "10.0.0.2",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			request := httptest.NewRequest("GET", "/", nil)
 			request.RemoteAddr = test.remoteAddr
-			if test.forwarded != "" {
-				request.Header.Set("Forwarded", test.forwarded)
-			}
-			if test.xff != "" {
-				request.Header.Set("X-Forwarded-For", test.xff)
-			}
+			request.Header.Set("X-Forwarded-For", test.xff)
 			if got := resolver.Resolve(request); got != test.want {
 				t.Fatalf("source IP = %q, want %q", got, test.want)
 			}
@@ -70,8 +96,96 @@ func TestTrustedProxyResolverUsesHeadersOnlyForTrustedImmediatePeer(t *testing.T
 	}
 }
 
-func TestTrustedProxyResolverRejectsInvalidCIDR(t *testing.T) {
-	if _, err := NewTrustedProxyResolver([]string{"not-a-cidr"}); err == nil {
-		t.Fatal("expected invalid CIDR to fail startup")
+func TestXForwardedForStrategyPreservesMultipleHeaderLineOrder(t *testing.T) {
+	resolver := mustTrustedProxyResolver(
+		t,
+		[]string{"10.0.0.0/8"},
+		"x-forwarded-for",
+	)
+	request := httptest.NewRequest("GET", "/", nil)
+	request.RemoteAddr = "10.0.0.3:443"
+	request.Header.Add("X-Forwarded-For", "unknown, 203.0.113.9")
+	request.Header.Add("X-Forwarded-For", "10.0.0.2")
+	if got := resolver.Resolve(request); got != "203.0.113.9" {
+		t.Fatalf("multiple-line XFF source IP = %q", got)
 	}
+}
+
+func TestForwardedStrategyIgnoresXForwardedFor(t *testing.T) {
+	resolver := mustTrustedProxyResolver(
+		t,
+		[]string{"10.0.0.0/8"},
+		"forwarded",
+	)
+	request := httptest.NewRequest("GET", "/", nil)
+	request.RemoteAddr = "10.0.0.2:443"
+	request.Header.Set("Forwarded", `for="[2001:db8::1234]";proto=https`)
+	request.Header.Set("X-Forwarded-For", "203.0.113.9")
+	if got := resolver.Resolve(request); got != "2001:db8::1234" {
+		t.Fatalf("configured Forwarded source IP = %q", got)
+	}
+}
+
+func TestTrustedProxyResolverRejectsInvalidConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		cidrs  []string
+		header string
+	}{
+		{name: "CIDR", cidrs: []string{"not-a-cidr"}},
+		{name: "header", cidrs: []string{"10.0.0.0/8"}, header: "both"},
+		{name: "header without CIDR", header: "x-forwarded-for"},
+		{
+			name:  "CIDR without header",
+			cidrs: []string{"10.0.0.0/8"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewTrustedProxyResolver(test.cidrs, test.header)
+			if err == nil {
+				t.Fatal("expected invalid trusted proxy configuration")
+			}
+			if strings.Contains(err.Error(), "10.0.0.0/8") ||
+				strings.Contains(err.Error(), test.header) && test.header != "" {
+				t.Fatalf("configuration error leaked input: %v", err)
+			}
+		})
+	}
+}
+
+func TestTrustedProxyResolverAcceptsCompleteModes(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		cidrs  []string
+		header string
+	}{
+		{name: "direct"},
+		{
+			name:   "proxy",
+			cidrs:  []string{"10.0.0.0/8"},
+			header: "x-forwarded-for",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := NewTrustedProxyResolver(
+				test.cidrs,
+				test.header,
+			); err != nil {
+				t.Fatalf("complete configuration rejected: %v", err)
+			}
+		})
+	}
+}
+
+func mustTrustedProxyResolver(
+	t *testing.T,
+	cidrs []string,
+	header string,
+) *TrustedProxyResolver {
+	t.Helper()
+	resolver, err := NewTrustedProxyResolver(cidrs, header)
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	return resolver
 }

--- a/server/internal/identity/token.go
+++ b/server/internal/identity/token.go
@@ -1,0 +1,42 @@
+package identity
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"regexp"
+)
+
+const sessionTokenEntropyBytes = 32
+
+var sessionTokenPattern = regexp.MustCompile(`^sess_[A-Za-z0-9._~+/-]+={0,}$`)
+
+type OpaqueSessionTokens struct {
+	random io.Reader
+}
+
+func NewOpaqueSessionTokens(random io.Reader) *OpaqueSessionTokens {
+	if random == nil {
+		random = rand.Reader
+	}
+	return &OpaqueSessionTokens{random: random}
+}
+
+func (t *OpaqueSessionTokens) Generate() (string, []byte, error) {
+	entropy := make([]byte, sessionTokenEntropyBytes)
+	if _, err := io.ReadFull(t.random, entropy); err != nil {
+		return "", nil, err
+	}
+	raw := "sess_" + base64.RawURLEncoding.EncodeToString(entropy)
+	return raw, t.Digest(raw), nil
+}
+
+func (*OpaqueSessionTokens) Digest(raw string) []byte {
+	digest := sha256.Sum256([]byte(raw))
+	return digest[:]
+}
+
+func (*OpaqueSessionTokens) ValidWireFormat(raw string) bool {
+	return len(raw) >= 6 && len(raw) <= 512 && sessionTokenPattern.MatchString(raw)
+}

--- a/server/internal/identity/token_test.go
+++ b/server/internal/identity/token_test.go
@@ -1,0 +1,41 @@
+package identity
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestOpaqueSessionTokenIsDeterministicWithInjectedRandomSource(t *testing.T) {
+	tokens := NewOpaqueSessionTokens(bytes.NewReader(make([]byte, 32)))
+	raw, digest, err := tokens.Generate()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if raw != "sess_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" {
+		t.Fatalf("unexpected token: %q", raw)
+	}
+	if hex.EncodeToString(digest) !=
+		"7f283130533b1378553599db97a56e061fffae72d28af83a02366530113ae5a2" {
+		t.Fatalf("unexpected digest: %x", digest)
+	}
+	if !tokens.ValidWireFormat(raw) {
+		t.Fatal("generated token does not satisfy Bearer wire format")
+	}
+}
+
+func TestOpaqueSessionTokenRejectsUnsafeWireValues(t *testing.T) {
+	tokens := NewOpaqueSessionTokens(nil)
+	for _, raw := range []string{
+		"",
+		"abc123==",
+		"sess_",
+		"sess_contains space",
+		"sess_line\nbreak",
+		"sess_padding=inside",
+	} {
+		if tokens.ValidWireFormat(raw) {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
+	}
+}

--- a/server/internal/identity/uuid.go
+++ b/server/internal/identity/uuid.go
@@ -1,0 +1,39 @@
+package identity
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+type IDGenerator interface {
+	NewID() (string, error)
+}
+
+type UUIDv4Generator struct {
+	random io.Reader
+}
+
+func NewUUIDv4Generator(random io.Reader) *UUIDv4Generator {
+	if random == nil {
+		random = rand.Reader
+	}
+	return &UUIDv4Generator{random: random}
+}
+
+func (g *UUIDv4Generator) NewID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := io.ReadFull(g.random, value); err != nil {
+		return "", ErrRepository
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return fmt.Sprintf(
+		"%08x-%04x-%04x-%04x-%012x",
+		value[0:4],
+		value[4:6],
+		value[6:8],
+		value[8:10],
+		value[10:16],
+	), nil
+}

--- a/server/internal/identity/uuid_test.go
+++ b/server/internal/identity/uuid_test.go
@@ -1,0 +1,17 @@
+package identity
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestUUIDv4GeneratorSetsVersionAndVariant(t *testing.T) {
+	generator := NewUUIDv4Generator(bytes.NewReader(make([]byte, 16)))
+	got, err := generator.NewID()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if got != "00000000-0000-4000-8000-000000000000" {
+		t.Fatalf("unexpected UUID: %q", got)
+	}
+}

--- a/server/internal/platform/config/config.go
+++ b/server/internal/platform/config/config.go
@@ -1,21 +1,40 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 type Config struct {
-	Host        string
-	Port        string
-	LogLevel    string
-	DatabaseURL string
+	Host              string
+	Port              string
+	LogLevel          string
+	DatabaseURL       string
+	TrustedProxyCIDRs []string
 }
 
 func Load() Config {
 	return Config{
-		Host:        valueOrDefault("SERVER_HOST", "0.0.0.0"),
-		Port:        valueOrDefault("SERVER_PORT", "8080"),
-		LogLevel:    valueOrDefault("LOG_LEVEL", "info"),
-		DatabaseURL: os.Getenv("DATABASE_URL"),
+		Host:              valueOrDefault("SERVER_HOST", "0.0.0.0"),
+		Port:              valueOrDefault("SERVER_PORT", "8080"),
+		LogLevel:          valueOrDefault("LOG_LEVEL", "info"),
+		DatabaseURL:       os.Getenv("DATABASE_URL"),
+		TrustedProxyCIDRs: splitCommaSeparated(os.Getenv("TRUSTED_PROXY_CIDRS")),
 	}
+}
+
+func splitCommaSeparated(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 func (c Config) Address() string { return c.Host + ":" + c.Port }

--- a/server/internal/platform/config/config.go
+++ b/server/internal/platform/config/config.go
@@ -6,20 +6,22 @@ import (
 )
 
 type Config struct {
-	Host              string
-	Port              string
-	LogLevel          string
-	DatabaseURL       string
-	TrustedProxyCIDRs []string
+	Host               string
+	Port               string
+	LogLevel           string
+	DatabaseURL        string
+	TrustedProxyCIDRs  []string
+	TrustedProxyHeader string
 }
 
 func Load() Config {
 	return Config{
-		Host:              valueOrDefault("SERVER_HOST", "0.0.0.0"),
-		Port:              valueOrDefault("SERVER_PORT", "8080"),
-		LogLevel:          valueOrDefault("LOG_LEVEL", "info"),
-		DatabaseURL:       os.Getenv("DATABASE_URL"),
-		TrustedProxyCIDRs: splitCommaSeparated(os.Getenv("TRUSTED_PROXY_CIDRS")),
+		Host:               valueOrDefault("SERVER_HOST", "0.0.0.0"),
+		Port:               valueOrDefault("SERVER_PORT", "8080"),
+		LogLevel:           valueOrDefault("LOG_LEVEL", "info"),
+		DatabaseURL:        os.Getenv("DATABASE_URL"),
+		TrustedProxyCIDRs:  splitCommaSeparated(os.Getenv("TRUSTED_PROXY_CIDRS")),
+		TrustedProxyHeader: os.Getenv("TRUSTED_PROXY_HEADER"),
 	}
 }
 

--- a/server/internal/platform/config/config_test.go
+++ b/server/internal/platform/config/config_test.go
@@ -7,11 +7,14 @@ func TestLoadUsesEnvironment(t *testing.T) {
 	t.Setenv("SERVER_PORT", "9000")
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("DATABASE_URL", "postgres://speakup:secret@127.0.0.1:5432/speakup")
+	t.Setenv("TRUSTED_PROXY_CIDRS", "10.0.0.0/8, 2001:db8::/32")
 
 	cfg := Load()
 	if cfg.Address() != "127.0.0.1:9000" ||
 		cfg.LogLevel != "debug" ||
-		cfg.DatabaseURL != "postgres://speakup:secret@127.0.0.1:5432/speakup" {
+		cfg.DatabaseURL != "postgres://speakup:secret@127.0.0.1:5432/speakup" ||
+		len(cfg.TrustedProxyCIDRs) != 2 ||
+		cfg.TrustedProxyCIDRs[1] != "2001:db8::/32" {
 		t.Fatalf("unexpected config: %#v", cfg)
 	}
 }

--- a/server/internal/platform/config/config_test.go
+++ b/server/internal/platform/config/config_test.go
@@ -8,13 +8,15 @@ func TestLoadUsesEnvironment(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("DATABASE_URL", "postgres://speakup:secret@127.0.0.1:5432/speakup")
 	t.Setenv("TRUSTED_PROXY_CIDRS", "10.0.0.0/8, 2001:db8::/32")
+	t.Setenv("TRUSTED_PROXY_HEADER", "x-forwarded-for")
 
 	cfg := Load()
 	if cfg.Address() != "127.0.0.1:9000" ||
 		cfg.LogLevel != "debug" ||
 		cfg.DatabaseURL != "postgres://speakup:secret@127.0.0.1:5432/speakup" ||
 		len(cfg.TrustedProxyCIDRs) != 2 ||
-		cfg.TrustedProxyCIDRs[1] != "2001:db8::/32" {
+		cfg.TrustedProxyCIDRs[1] != "2001:db8::/32" ||
+		cfg.TrustedProxyHeader != "x-forwarded-for" {
 		t.Fatalf("unexpected config: %#v", cfg)
 	}
 }

--- a/server/internal/platform/requestcontext/actor.go
+++ b/server/internal/platform/requestcontext/actor.go
@@ -1,0 +1,26 @@
+package requestcontext
+
+import "context"
+
+// Actor is the trusted identity derived by server-side authentication.
+// Values from request payloads, paths, query strings, or model output must
+// never be used to construct an Actor.
+type Actor struct {
+	UserID    string
+	SessionID string
+}
+
+func (a Actor) Valid() bool {
+	return a.UserID != "" && a.SessionID != ""
+}
+
+type actorContextKey struct{}
+
+func WithActor(ctx context.Context, actor Actor) context.Context {
+	return context.WithValue(ctx, actorContextKey{}, actor)
+}
+
+func ActorFromContext(ctx context.Context) (Actor, bool) {
+	actor, ok := ctx.Value(actorContextKey{}).(Actor)
+	return actor, ok && actor.Valid()
+}

--- a/server/internal/platform/requestcontext/actor_test.go
+++ b/server/internal/platform/requestcontext/actor_test.go
@@ -1,0 +1,21 @@
+package requestcontext
+
+import (
+	"context"
+	"testing"
+)
+
+func TestActorRoundTrip(t *testing.T) {
+	want := Actor{UserID: "user-1", SessionID: "session-1"}
+	got, ok := ActorFromContext(WithActor(context.Background(), want))
+	if !ok || got != want {
+		t.Fatalf("unexpected actor: %#v, %v", got, ok)
+	}
+}
+
+func TestActorRejectsIncompleteIdentity(t *testing.T) {
+	ctx := WithActor(context.Background(), Actor{UserID: "user-1"})
+	if _, ok := ActorFromContext(ctx); ok {
+		t.Fatal("expected incomplete actor to be rejected")
+	}
+}


### PR DESCRIPTION
## 功能说明

- 实现 `POST /v1/auth/register`、`POST /v1/auth/login`、`POST /v1/auth/logout` 与 `GET /v1/me`。
- 新增边界清晰的 `server/internal/identity` 模块、生产 Bootstrap 装配和可信 `Actor{UserID, SessionID}` 请求上下文。
- 邮箱按已合入的 Identity 契约规范化；密码保持不透明，不 Trim、不转换大小写、不做 Unicode 归一化。
- 密码仅以 Argon2id PHC 保存；Session 使用高熵不透明 Token，数据库只保存 SHA-256 Digest。
- Bearer Middleware 统一生成服务端可信 Actor；缺失、格式错误、未知、过期或撤销 Session 返回稳定的 `401 authentication_required`。
- 注册、登录包含有界限流、取消与超时；可信代理必须显式完整配置，防止伪造来源地址。
- 生产 Composition Root 只装配真实 PostgreSQL Repository，不回退到固定 Actor 或内存 Repository。

## 分支与依赖状态

- #78 与 #82 已合入 `upstream/dev`。
- 本分支已基于最新 `upstream/dev` 完成去栈，只保留 #80 的 Identity、最小 Bootstrap、配置和可信请求上下文修改。
- 当前 PR 不修改 Flutter、API 契约或 Migration，也不回退其他已合入实现。

## 实现边界

- Repository 端口由 Identity 模块拥有，不自动建表，也不修改已合入 Migration。
- 注册在单一事务中写入 User 与 Credential，并依赖 Canonical Email 唯一约束处理并发注册。
- 未知账户仍执行 Dummy Argon2id 校验，降低账户枚举时序差异。
- Session 创建与可选密码重哈希升级在同一事务完成；允许同一用户存在多个设备 Session。
- Session 使用固定 30 天绝对 TTL；普通 Logout 幂等撤销当前 Session，并提供内部 `RevokeAllSessionsForUser`。
- Handler 严格校验 Content-Type 与 JSON；日志不记录邮箱、密码、Token、Hash 或 Authorization Header。

## 可复现验证

```bash
TEST_DATABASE_URL=<隔离测试数据库连接串> make check
cd server
TEST_DATABASE_URL=<隔离测试数据库连接串> go test -race -count=2 ./internal/identity
go test -run '^$' -bench '^BenchmarkArgon2idDefault$' -benchtime=3x ./internal/identity
GOTOOLCHAIN=go1.26.5+auto go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
cd ..
git diff --check
```

已验证：

- 完整 `make check` 通过：Flutter 10 项测试、Go 与真实 PostgreSQL、28 个 API operation（5 个公开、23 个 Bearer 保护）、16 个 WebSocket event、7 个拒绝用例和确定性 Smoke 全绿。
- 当前 Head 的 GitHub `PostgreSQL migrations and readiness`、`Go`、`Deterministic smoke` 与 `Quality gate` 通过；`API contracts` 与 `Flutter` 因未修改对应区域而跳过。
- PostgreSQL 真实迁移与 Identity 纵向链路通过。
- Identity race 测试通过，`govulncheck` 未发现可达漏洞。
- 默认 Argon2id 参数为 64 MiB、3 次迭代、并行度 2；Intel i7-9750H、darwin/amd64、`benchtime=3x` 的当前基准为 `102717795 ns/op`（约 102.7 ms/op）、`67116157 B/op`、`68 allocs/op`。
- 并发注册、多 Session 登录、错误密码、未知账户、重复 Logout、过期、撤销、全部 Session 撤销和事务失败回滚均有覆盖。
- 数据库只保存 Argon2id PHC 与 32 字节 Token Digest，不保存原始密码或原始 Token。
- 当前 PR 已转为可审核状态，等待正式 Review。

## 明确不做

- 不修改 Identity Schema 或 API 契约。
- 不修改 Flutter。
- 不实现邮箱验证、密码找回、Refresh Token、OAuth、完整 Profile 或账户删除 API。
- 不实现其他业务资源和 WebSocket 的跨用户归属链。

关联 Issue：#80