### PR TITLE
[功能] 建立 Matter、AgentThread、AgentMessage 与可信 Actor 最小纵向链路

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -45,6 +45,24 @@ paths:
   /v1/matters/{matter_id}:
     parameters:
       - $ref: '#/components/parameters/MatterId'
+    get:
+      tags:
+        - Matter
+      summary: Restore one Matter owned by the trusted Actor
+      operationId: getMatter
+      responses:
+        '200':
+          description: The current durable Matter state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Matter'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
     patch:
       tags:
         - Matter

--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -1,0 +1,479 @@
+paths:
+  /v1/matters:
+    post:
+      tags:
+        - Matter
+      summary: Create a user-owned real-world Matter
+      operationId: createMatter
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMatterRequest'
+            example:
+              title: Customer renewal meeting
+      responses:
+        '201':
+          description: The Matter was created for the trusted Actor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Matter'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    get:
+      tags:
+        - Matter
+      summary: List Matters owned by the trusted Actor
+      operationId: listMatters
+      responses:
+        '200':
+          description: The Actor's Matters ordered by latest update.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatterList'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/matters/{matter_id}:
+    parameters:
+      - $ref: '#/components/parameters/MatterId'
+    patch:
+      tags:
+        - Matter
+      summary: Complete, archive, or reopen an owned Matter
+      operationId: changeMatterStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeMatterStatusRequest'
+      responses:
+        '200':
+          description: The Matter lifecycle transition was committed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Matter'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads:
+    post:
+      tags:
+        - Agent
+      summary: Create a durable Agent Thread
+      description: |
+        The optional active Matter must belong to the trusted Actor and be
+        active. The Thread can start without a Matter for direct expression
+        help. This operation does not create a Run or call a model.
+      operationId: createAgentThread
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentThreadRequest'
+            example:
+              active_matter_id: 10000000-0000-4000-8000-000000000001
+      responses:
+        '201':
+          description: The durable Thread was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentThread'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    get:
+      tags:
+        - Agent
+      summary: List durable Agent Threads owned by the trusted Actor
+      operationId: listAgentThreads
+      responses:
+        '200':
+          description: The Actor's Threads ordered by latest update.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentThreadList'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads/{thread_id}:
+    parameters:
+      - $ref: '#/components/parameters/AgentThreadId'
+    get:
+      tags:
+        - Agent
+      summary: Restore one durable Agent Thread
+      operationId: getAgentThread
+      responses:
+        '200':
+          description: The owned Thread and its selected active Matter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentThread'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads/{thread_id}/active-matter:
+    parameters:
+      - $ref: '#/components/parameters/AgentThreadId'
+    put:
+      tags:
+        - Agent
+      summary: Select one active Matter for a Thread
+      description: |
+        The link is owned by Agent Runtime. Matter remains authoritative for
+        its lifecycle and must be revalidated by every future Run.
+      operationId: setAgentThreadActiveMatter
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetActiveMatterRequest'
+      responses:
+        '200':
+          description: The Matter is now the Thread's single selected Matter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadMatterLink'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads/{thread_id}/messages:
+    parameters:
+      - $ref: '#/components/parameters/AgentThreadId'
+    post:
+      tags:
+        - Agent
+      summary: Append one idempotent user Message
+      description: |
+        `client_message_id` is the Message-specific business idempotency key.
+        The same Actor and Thread replaying the same ID and content receives
+        the original Message. Reusing it with different content returns 409.
+        This does not implement the cross-module REST Idempotency-Key platform.
+      operationId: appendAgentUserMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppendAgentMessageRequest'
+      responses:
+        '201':
+          description: |
+            The original or replayed durable Message. Both paths return the
+            same status and body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentMessage'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    get:
+      tags:
+        - Agent
+      summary: Restore committed Messages in stable Thread order
+      operationId: listAgentMessages
+      responses:
+        '200':
+          description: Messages ordered by the server-assigned sequence.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentMessageList'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  parameters:
+    MatterId:
+      name: matter_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    AgentThreadId:
+      name: thread_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    MatterStatus:
+      type: string
+      enum:
+        - active
+        - completed
+        - archived
+    Matter:
+      type: object
+      additionalProperties: false
+      required:
+        - matter_id
+        - title
+        - status
+        - version
+        - created_at
+        - updated_at
+      properties:
+        matter_id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+          x-max-utf8-bytes: 512
+        status:
+          $ref: '#/components/schemas/MatterStatus'
+        version:
+          type: integer
+          format: int64
+          minimum: 1
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    MatterList:
+      type: object
+      additionalProperties: false
+      required:
+        - matters
+      properties:
+        matters:
+          type: array
+          items:
+            $ref: '#/components/schemas/Matter'
+    CreateMatterRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+          x-max-utf8-bytes: 512
+    ChangeMatterStatusRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - expected_version
+      properties:
+        status:
+          $ref: '#/components/schemas/MatterStatus'
+        expected_version:
+          type: integer
+          format: int64
+          minimum: 1
+    AgentThread:
+      type: object
+      additionalProperties: false
+      required:
+        - thread_id
+        - created_at
+        - updated_at
+      properties:
+        thread_id:
+          type: string
+          format: uuid
+          readOnly: true
+        active_matter_id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    AgentThreadList:
+      type: object
+      additionalProperties: false
+      required:
+        - threads
+      properties:
+        threads:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentThread'
+    CreateAgentThreadRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        active_matter_id:
+          type: string
+          format: uuid
+    SetActiveMatterRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - matter_id
+      properties:
+        matter_id:
+          type: string
+          format: uuid
+    ThreadMatterLink:
+      type: object
+      additionalProperties: false
+      required:
+        - thread_id
+        - matter_id
+        - active
+        - linked_at
+        - updated_at
+      properties:
+        thread_id:
+          type: string
+          format: uuid
+          readOnly: true
+        matter_id:
+          type: string
+          format: uuid
+          readOnly: true
+        active:
+          type: boolean
+          const: true
+          readOnly: true
+        linked_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    AgentMessage:
+      type: object
+      additionalProperties: false
+      required:
+        - message_id
+        - thread_id
+        - sequence
+        - role
+        - client_message_id
+        - content
+        - created_at
+      properties:
+        message_id:
+          type: string
+          format: uuid
+          readOnly: true
+        thread_id:
+          type: string
+          format: uuid
+          readOnly: true
+        sequence:
+          type: integer
+          format: int64
+          minimum: 1
+          readOnly: true
+        role:
+          type: string
+          const: user
+          readOnly: true
+        client_message_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        content:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          x-max-utf8-bytes: 16384
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+    AgentMessageList:
+      type: object
+      additionalProperties: false
+      required:
+        - messages
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentMessage'
+    AppendAgentMessageRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - client_message_id
+        - content
+      properties:
+        client_message_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        content:
+          type: string
+          minLength: 1
+          maxLength: 4096
+          x-max-utf8-bytes: 16384

--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -154,7 +154,8 @@ paths:
       summary: Select one active Matter for a Thread
       description: |
         The link is owned by Agent Runtime. Matter remains authoritative for
-        its lifecycle and must be revalidated by every future Run.
+        its lifecycle and must be revalidated by every future Run. Replaying an
+        unchanged eligible selection is idempotent and preserves its timestamps.
       operationId: setAgentThreadActiveMatter
       requestBody:
         required: true
@@ -277,6 +278,7 @@ components:
           type: string
           minLength: 1
           maxLength: 200
+          pattern: '^[^\u0000]*$'
           x-max-utf8-bytes: 512
         status:
           $ref: '#/components/schemas/MatterStatus'
@@ -313,6 +315,7 @@ components:
           type: string
           minLength: 1
           maxLength: 200
+          pattern: '^[^\u0000]*$'
           x-max-utf8-bytes: 512
     ChangeMatterStatusRequest:
       type: object
@@ -445,6 +448,7 @@ components:
           type: string
           minLength: 1
           maxLength: 4096
+          pattern: '^[^\u0000]*$'
           x-max-utf8-bytes: 16384
         created_at:
           type: string
@@ -476,4 +480,5 @@ components:
           type: string
           minLength: 1
           maxLength: 4096
+          pattern: '^[^\u0000]*$'
           x-max-utf8-bytes: 16384

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27,6 +27,10 @@ x-json-null-policy: omit
 tags:
   - name: Identity
     description: Minimal account registration, opaque Session, and current-user operations.
+  - name: Matter
+    description: User-owned real-world activities and their lifecycle.
+  - name: Agent
+    description: Durable Agent Threads, Matter links, and committed Messages.
   - name: Preparation
     description: Scenario, role, profile, and immutable preparation snapshot resources.
   - name: Practice
@@ -67,6 +71,18 @@ paths:
     $ref: ./modules/identity.yaml#/paths/~1v1~1auth~1logout
   /v1/me:
     $ref: ./modules/identity.yaml#/paths/~1v1~1me
+  /v1/matters:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1matters
+  /v1/matters/{matter_id}:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1matters~1{matter_id}
+  /v1/agent-threads:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads
+  /v1/agent-threads/{thread_id}:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}
+  /v1/agent-threads/{thread_id}/active-matter:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1active-matter
+  /v1/agent-threads/{thread_id}/messages:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1messages
   /v1/scenario-definitions/{scenario_definition_id}:
     $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}
   /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
@@ -152,6 +168,14 @@ components:
       $ref: ./modules/identity.yaml#/components/schemas/LoginRequest
     LoginResponse:
       $ref: ./modules/identity.yaml#/components/schemas/LoginResponse
+    Matter:
+      $ref: ./modules/agent.yaml#/components/schemas/Matter
+    AgentThread:
+      $ref: ./modules/agent.yaml#/components/schemas/AgentThread
+    ThreadMatterLink:
+      $ref: ./modules/agent.yaml#/components/schemas/ThreadMatterLink
+    AgentMessage:
+      $ref: ./modules/agent.yaml#/components/schemas/AgentMessage
     ScenarioDefinition:
       $ref: ./modules/preparation.yaml#/components/schemas/ScenarioDefinition
     ScenarioConfig:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -44,20 +44,21 @@ func run() int {
 	}
 	defer databasePool.Close()
 
-	identityModule, err := bootstrap.NewIdentityModule(
-		databasePool.Native(),
-		cfg.TrustedProxyCIDRs,
-		cfg.TrustedProxyHeader,
-	)
+	identityModule, agentDataModule, err :=
+		bootstrap.NewIdentityAndAgentDataModules(
+			databasePool.Native(),
+			cfg.TrustedProxyCIDRs,
+			cfg.TrustedProxyHeader,
+		)
 	if err != nil {
-		logger.Error("identity startup failed", slog.Any("error", err))
+		logger.Error("application startup failed", slog.Any("error", err))
 		return 1
 	}
 
 	router := bootstrap.NewRouterWithReadinessAndRoutes(
 		logger,
 		databasePool,
-		[]bootstrap.RouteRegistrar{identityModule},
+		[]bootstrap.RouteRegistrar{identityModule, agentDataModule},
 		preparation.New(),
 		practice.New(),
 		conversation.New(),

--- a/server/internal/agent/errors.go
+++ b/server/internal/agent/errors.go
@@ -1,0 +1,11 @@
+package agent
+
+import "errors"
+
+var (
+	ErrInvalidRequest      = errors.New("agent: invalid request")
+	ErrNotFound            = errors.New("agent: not found")
+	ErrConflict            = errors.New("agent: conflict")
+	ErrIdempotencyConflict = errors.New("agent: idempotency conflict")
+	ErrRepository          = errors.New("agent repository: operation failed")
+)

--- a/server/internal/agent/http.go
+++ b/server/internal/agent/http.go
@@ -1,0 +1,641 @@
+package agent
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	maxAgentDataRequestBody = 32768
+	agentDataReadTimeout    = 5 * time.Second
+)
+
+type CorrelationIDGenerator func() string
+
+type HTTPHandler struct {
+	application   Application
+	matters       matter.Application
+	authenticator identity.Authenticator
+	correlationID CorrelationIDGenerator
+}
+
+func NewHTTPHandler(
+	application Application,
+	matters matter.Application,
+	authenticator identity.Authenticator,
+	correlationID CorrelationIDGenerator,
+) (*HTTPHandler, error) {
+	if application == nil || matters == nil || authenticator == nil {
+		return nil, errors.New("agent: HTTP dependency is required")
+	}
+	if correlationID == nil {
+		correlationID = newCorrelationID
+	}
+	return &HTTPHandler{
+		application:   application,
+		matters:       matters,
+		authenticator: authenticator,
+		correlationID: correlationID,
+	}, nil
+}
+
+func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
+	protected := router.Group("")
+	protected.Use(h.authenticationMiddleware())
+
+	protected.POST("/v1/matters", h.createMatter)
+	protected.GET("/v1/matters", h.listMatters)
+	protected.PATCH("/v1/matters/:matter_id", h.changeMatterStatus)
+
+	protected.POST("/v1/agent-threads", h.createThread)
+	protected.GET("/v1/agent-threads", h.listThreads)
+	protected.GET("/v1/agent-threads/:thread_id", h.getThread)
+	protected.PUT(
+		"/v1/agent-threads/:thread_id/active-matter",
+		h.setActiveMatter,
+	)
+	protected.POST(
+		"/v1/agent-threads/:thread_id/messages",
+		h.appendMessage,
+	)
+	protected.GET(
+		"/v1/agent-threads/:thread_id/messages",
+		h.listMessages,
+	)
+}
+
+func (h *HTTPHandler) createMatter(c *gin.Context) {
+	values, ok := decodeObject(c, []string{"title"}, []string{"title"})
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	title, ok := decodeString(values["title"])
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	item, err := h.matters.Create(c.Request.Context(), actor, title)
+	if err != nil {
+		h.writeMatterError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, matterResponse(item))
+}
+
+func (h *HTTPHandler) listMatters(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	items, err := h.matters.List(c.Request.Context(), actor)
+	if err != nil {
+		h.writeMatterError(c, err)
+		return
+	}
+	result := make([]gin.H, 0, len(items))
+	for _, item := range items {
+		result = append(result, matterResponse(item))
+	}
+	c.JSON(http.StatusOK, gin.H{"matters": result})
+}
+
+func (h *HTTPHandler) changeMatterStatus(c *gin.Context) {
+	values, ok := decodeObject(
+		c,
+		[]string{"status", "expected_version"},
+		[]string{"status", "expected_version"},
+	)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	status, statusOK := decodeString(values["status"])
+	expectedVersion, versionOK := decodeInt64(values["expected_version"])
+	if !statusOK || !versionOK {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	item, err := h.matters.ChangeStatus(
+		c.Request.Context(),
+		actor,
+		c.Param("matter_id"),
+		expectedVersion,
+		matter.Status(status),
+	)
+	if err != nil {
+		h.writeMatterError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, matterResponse(item))
+}
+
+func (h *HTTPHandler) createThread(c *gin.Context) {
+	values, ok := decodeObject(
+		c,
+		[]string{"active_matter_id"},
+		nil,
+	)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	activeMatterID := ""
+	if raw, exists := values["active_matter_id"]; exists {
+		activeMatterID, ok = decodeString(raw)
+		if !ok || activeMatterID == "" {
+			h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+			return
+		}
+	}
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	thread, err := h.application.CreateThread(
+		c.Request.Context(),
+		actor,
+		activeMatterID,
+	)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, threadResponse(thread))
+}
+
+func (h *HTTPHandler) listThreads(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	threads, err := h.application.ListThreads(c.Request.Context(), actor)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	result := make([]gin.H, 0, len(threads))
+	for _, thread := range threads {
+		result = append(result, threadResponse(thread))
+	}
+	c.JSON(http.StatusOK, gin.H{"threads": result})
+}
+
+func (h *HTTPHandler) getThread(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	thread, err := h.application.GetThread(
+		c.Request.Context(),
+		actor,
+		c.Param("thread_id"),
+	)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, threadResponse(thread))
+}
+
+func (h *HTTPHandler) setActiveMatter(c *gin.Context) {
+	values, ok := decodeObject(c, []string{"matter_id"}, []string{"matter_id"})
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	matterID, ok := decodeString(values["matter_id"])
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	link, err := h.application.SetActiveMatter(
+		c.Request.Context(),
+		actor,
+		c.Param("thread_id"),
+		matterID,
+	)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, linkResponse(link))
+}
+
+func (h *HTTPHandler) appendMessage(c *gin.Context) {
+	values, ok := decodeObject(
+		c,
+		[]string{"client_message_id", "content"},
+		[]string{"client_message_id", "content"},
+	)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	clientMessageID, clientIDOK := decodeString(values["client_message_id"])
+	content, contentOK := decodeString(values["content"])
+	if !clientIDOK || !contentOK {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	message, err := h.application.AppendUserMessage(
+		c.Request.Context(),
+		actor,
+		c.Param("thread_id"),
+		clientMessageID,
+		content,
+	)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, messageResponse(message))
+}
+
+func (h *HTTPHandler) listMessages(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	messages, err := h.application.ListMessages(
+		c.Request.Context(),
+		actor,
+		c.Param("thread_id"),
+	)
+	if err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	result := make([]gin.H, 0, len(messages))
+	for _, message := range messages {
+		result = append(result, messageResponse(message))
+	}
+	c.JSON(http.StatusOK, gin.H{"messages": result})
+}
+
+func (h *HTTPHandler) authenticationMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token, ok := bearerToken(c.Request.Header.Values("Authorization"))
+		if !ok {
+			h.writeAuthenticationRequired(c)
+			c.Abort()
+			return
+		}
+		actor, err := h.authenticator.AuthenticateSession(
+			c.Request.Context(),
+			token,
+		)
+		if err != nil {
+			if errors.Is(err, identity.ErrAuthenticationRequired) {
+				h.writeAuthenticationRequired(c)
+			} else {
+				h.writeError(
+					c,
+					http.StatusInternalServerError,
+					"internal_error",
+					true,
+				)
+			}
+			c.Abort()
+			return
+		}
+		c.Request = c.Request.WithContext(
+			requestcontext.WithActor(c.Request.Context(), actor),
+		)
+		c.Next()
+	}
+}
+
+func bearerToken(values []string) (string, bool) {
+	if len(values) != 1 {
+		return "", false
+	}
+	parts := strings.Fields(values[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func trustedActor(c *gin.Context) (requestcontext.Actor, bool) {
+	return requestcontext.ActorFromContext(c.Request.Context())
+}
+
+func (h *HTTPHandler) writeMatterError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, matter.ErrInvalidRequest):
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+	case errors.Is(err, matter.ErrNotFound):
+		h.writeError(c, http.StatusNotFound, "resource_not_found", false)
+	case errors.Is(err, matter.ErrConflict):
+		h.writeError(c, http.StatusConflict, "resource_conflict", false)
+	default:
+		h.writeError(c, http.StatusInternalServerError, "internal_error", true)
+	}
+}
+
+func (h *HTTPHandler) writeAgentError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrInvalidRequest):
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+	case errors.Is(err, ErrNotFound):
+		h.writeError(c, http.StatusNotFound, "resource_not_found", false)
+	case errors.Is(err, ErrIdempotencyConflict):
+		h.writeError(c, http.StatusConflict, "idempotency_key_conflict", false)
+	case errors.Is(err, ErrConflict):
+		h.writeError(c, http.StatusConflict, "resource_conflict", false)
+	default:
+		h.writeError(c, http.StatusInternalServerError, "internal_error", true)
+	}
+}
+
+func (h *HTTPHandler) writeAuthenticationRequired(c *gin.Context) {
+	c.Header("WWW-Authenticate", "Bearer")
+	h.writeError(c, http.StatusUnauthorized, "authentication_required", false)
+}
+
+func (h *HTTPHandler) writeError(
+	c *gin.Context,
+	status int,
+	code string,
+	retryable bool,
+) {
+	messages := map[string]string{
+		"invalid_request":          "Request validation failed.",
+		"authentication_required":  "Authentication is required.",
+		"resource_not_found":       "Resource was not found.",
+		"resource_conflict":        "Resource state conflicts with this operation.",
+		"idempotency_key_conflict": "Idempotency key conflicts with the original request.",
+		"internal_error":           "An internal error occurred.",
+	}
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"code":           code,
+			"message":        messages[code],
+			"retryable":      retryable,
+			"correlation_id": h.correlationID(),
+		},
+	})
+}
+
+func matterResponse(item matter.Matter) gin.H {
+	return gin.H{
+		"matter_id":  item.ID,
+		"title":      item.Title,
+		"status":     item.Status,
+		"version":    item.Version,
+		"created_at": item.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"updated_at": item.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func threadResponse(thread Thread) gin.H {
+	result := gin.H{
+		"thread_id":  thread.ID,
+		"created_at": thread.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"updated_at": thread.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if thread.ActiveMatterID != "" {
+		result["active_matter_id"] = thread.ActiveMatterID
+	}
+	return result
+}
+
+func linkResponse(link ThreadMatterLink) gin.H {
+	return gin.H{
+		"thread_id":  link.ThreadID,
+		"matter_id":  link.MatterID,
+		"active":     link.Active,
+		"linked_at":  link.LinkedAt.UTC().Format(time.RFC3339Nano),
+		"updated_at": link.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func messageResponse(message Message) gin.H {
+	result := gin.H{
+		"message_id": message.ID,
+		"thread_id":  message.ThreadID,
+		"sequence":   message.Sequence,
+		"role":       message.Role,
+		"content":    message.Content,
+		"created_at": message.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if message.ClientMessageID != "" {
+		result["client_message_id"] = message.ClientMessageID
+	}
+	return result
+}
+
+func decodeObject(
+	c *gin.Context,
+	allowed []string,
+	required []string,
+) (map[string]json.RawMessage, bool) {
+	result := make(map[string]json.RawMessage)
+	if !validJSONContentType(c.GetHeader("Content-Type")) {
+		return result, false
+	}
+	controller := http.NewResponseController(c.Writer)
+	if err := controller.SetReadDeadline(
+		time.Now().Add(agentDataReadTimeout),
+	); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return result, false
+	}
+	body := http.MaxBytesReader(
+		c.Writer,
+		c.Request.Body,
+		maxAgentDataRequestBody,
+	)
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return result, false
+	}
+	if err := controller.SetReadDeadline(time.Time{}); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		return result, false
+	}
+	if !utf8.Valid(raw) || !validJSONSurrogates(raw) {
+		return result, false
+	}
+
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		allowedSet[key] = struct{}{}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return result, false
+	}
+	for decoder.More() {
+		token, err := decoder.Token()
+		key, ok := token.(string)
+		if err != nil || !ok {
+			return result, false
+		}
+		if _, exists := result[key]; exists {
+			return result, false
+		}
+		if _, exists := allowedSet[key]; !exists {
+			return result, false
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return result, false
+		}
+		result[key] = value
+	}
+	if token, err = decoder.Token(); err != nil || token != json.Delim('}') {
+		return result, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return result, false
+	}
+	for _, key := range required {
+		if _, exists := result[key]; !exists {
+			return result, false
+		}
+	}
+	return result, true
+}
+
+func decodeString(raw json.RawMessage) (string, bool) {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func decodeInt64(raw json.RawMessage) (int64, bool) {
+	var value int64
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func validJSONContentType(value string) bool {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	for name, value := range parameters {
+		if !strings.EqualFold(name, "charset") ||
+			!strings.EqualFold(value, "utf-8") {
+			return false
+		}
+	}
+	return true
+}
+
+func validJSONSurrogates(raw []byte) bool {
+	inString := false
+	for index := 0; index < len(raw); index++ {
+		switch raw[index] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString {
+				continue
+			}
+			if index+1 >= len(raw) {
+				return false
+			}
+			if raw[index+1] != 'u' {
+				index++
+				continue
+			}
+			codeUnit, ok := parseHexCodeUnit(raw, index+2)
+			if !ok {
+				return false
+			}
+			switch {
+			case codeUnit >= 0xd800 && codeUnit <= 0xdbff:
+				if index+12 > len(raw) ||
+					raw[index+6] != '\\' ||
+					raw[index+7] != 'u' {
+					return false
+				}
+				low, ok := parseHexCodeUnit(raw, index+8)
+				if !ok || low < 0xdc00 || low > 0xdfff {
+					return false
+				}
+				index += 11
+			case codeUnit >= 0xdc00 && codeUnit <= 0xdfff:
+				return false
+			default:
+				index += 5
+			}
+		}
+	}
+	return true
+}
+
+func parseHexCodeUnit(raw []byte, start int) (uint16, bool) {
+	if start+4 > len(raw) {
+		return 0, false
+	}
+	var value uint16
+	for _, character := range raw[start : start+4] {
+		value <<= 4
+		switch {
+		case character >= '0' && character <= '9':
+			value |= uint16(character - '0')
+		case character >= 'a' && character <= 'f':
+			value |= uint16(character-'a') + 10
+		case character >= 'A' && character <= 'F':
+			value |= uint16(character-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return value, true
+}
+
+func newCorrelationID() string {
+	value := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, value); err != nil {
+		return "corr_unavailable"
+	}
+	return "corr_" + base64.RawURLEncoding.EncodeToString(value)
+}

--- a/server/internal/agent/http.go
+++ b/server/internal/agent/http.go
@@ -59,6 +59,7 @@ func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
 
 	protected.POST("/v1/matters", h.createMatter)
 	protected.GET("/v1/matters", h.listMatters)
+	protected.GET("/v1/matters/:matter_id", h.getMatter)
 	protected.PATCH("/v1/matters/:matter_id", h.changeMatterStatus)
 
 	protected.POST("/v1/agent-threads", h.createThread)
@@ -118,6 +119,24 @@ func (h *HTTPHandler) listMatters(c *gin.Context) {
 		result = append(result, matterResponse(item))
 	}
 	c.JSON(http.StatusOK, gin.H{"matters": result})
+}
+
+func (h *HTTPHandler) getMatter(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	item, err := h.matters.ReadOwned(
+		c.Request.Context(),
+		actor,
+		c.Param("matter_id"),
+	)
+	if err != nil {
+		h.writeMatterError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, matterResponse(item))
 }
 
 func (h *HTTPHandler) changeMatterStatus(c *gin.Context) {

--- a/server/internal/agent/http.go
+++ b/server/internal/agent/http.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	maxAgentDataRequestBody = 32768
+	maxAgentDataRequestBody = 64 * 1024
 	agentDataReadTimeout    = 5 * time.Second
 )
 

--- a/server/internal/agent/model.go
+++ b/server/internal/agent/model.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type MessageRole string
+
+const (
+	MessageRoleUser MessageRole = "user"
+)
+
+type Thread struct {
+	ID             string
+	OwnerID        string
+	ActiveMatterID string
+	NextMessageSeq int64
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type ThreadMatterLink struct {
+	OwnerID   string
+	ThreadID  string
+	MatterID  string
+	Active    bool
+	LinkedAt  time.Time
+	UpdatedAt time.Time
+}
+
+type Message struct {
+	ID              string
+	OwnerID         string
+	ThreadID        string
+	Sequence        int64
+	Role            MessageRole
+	ClientMessageID string
+	Content         string
+	CreatedAt       time.Time
+}
+
+type Repository interface {
+	CreateThread(
+		ctx context.Context,
+		ownerID string,
+		activeMatterID string,
+	) (Thread, error)
+	ListThreads(ctx context.Context, ownerID string) ([]Thread, error)
+	FindThread(ctx context.Context, ownerID, threadID string) (Thread, error)
+	SetActiveMatter(
+		ctx context.Context,
+		ownerID string,
+		threadID string,
+		matterID string,
+	) (ThreadMatterLink, error)
+	AppendUserMessage(
+		ctx context.Context,
+		ownerID string,
+		threadID string,
+		clientMessageID string,
+		content string,
+	) (Message, error)
+	ListMessages(
+		ctx context.Context,
+		ownerID string,
+		threadID string,
+	) ([]Message, error)
+}
+
+type Application interface {
+	CreateThread(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		activeMatterID string,
+	) (Thread, error)
+	ListThreads(
+		ctx context.Context,
+		actor requestcontext.Actor,
+	) ([]Thread, error)
+	GetThread(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		threadID string,
+	) (Thread, error)
+	SetActiveMatter(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		threadID string,
+		matterID string,
+	) (ThreadMatterLink, error)
+	AppendUserMessage(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		threadID string,
+		clientMessageID string,
+		content string,
+	) (Message, error)
+	ListMessages(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		threadID string,
+	) ([]Message, error)
+}
+
+type IDGenerator interface {
+	NewID() (string, error)
+}

--- a/server/internal/agent/module.go
+++ b/server/internal/agent/module.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Module struct {
+	handler *HTTPHandler
+}
+
+func NewModule(handler *HTTPHandler) (*Module, error) {
+	if handler == nil {
+		return nil, errors.New("agent: HTTP handler is required")
+	}
+	return &Module{handler: handler}, nil
+}
+
+func (m *Module) RegisterRoutes(router *gin.Engine) {
+	m.handler.RegisterRoutes(router)
+}

--- a/server/internal/agent/postgres.go
+++ b/server/internal/agent/postgres.go
@@ -47,6 +47,16 @@ func (r *PostgresRepository) CreateThread(
 	}
 	defer rollback(tx)
 
+	if activeMatterID != "" {
+		if err := lockActiveMatter(
+			ctx,
+			tx,
+			ownerID,
+			activeMatterID,
+		); err != nil {
+			return Thread{}, err
+		}
+	}
 	var result Thread
 	if err := tx.QueryRow(ctx, `
 INSERT INTO agent_threads (
@@ -203,6 +213,9 @@ FOR UPDATE`,
 		ownerID,
 	).Scan(&lockedThreadID); err != nil {
 		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+	if err := lockActiveMatter(ctx, tx, ownerID, matterID); err != nil {
+		return ThreadMatterLink{}, err
 	}
 
 	var current ThreadMatterLink
@@ -469,6 +482,29 @@ ORDER BY sequence_no ASC`,
 		return nil, ErrRepository
 	}
 	return result, nil
+}
+
+func lockActiveMatter(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+	matterID string,
+) error {
+	var active bool
+	if err := tx.QueryRow(ctx, `
+SELECT status = 'active'
+FROM matters
+WHERE id = $1 AND owner_user_id = $2
+FOR UPDATE`,
+		matterID,
+		ownerID,
+	).Scan(&active); err != nil {
+		return mapPostgresError(err)
+	}
+	if !active {
+		return ErrConflict
+	}
+	return nil
 }
 
 func findMessageByClientID(

--- a/server/internal/agent/postgres.go
+++ b/server/internal/agent/postgres.go
@@ -36,7 +36,7 @@ func (r *PostgresRepository) CreateThread(
 	ctx context.Context,
 	ownerID string,
 	activeMatterID string,
-) (_ Thread, resultErr error) {
+) (Thread, error) {
 	threadID, err := r.ids.NewID()
 	if err != nil {
 		return Thread{}, ErrRepository
@@ -45,11 +45,7 @@ func (r *PostgresRepository) CreateThread(
 	if err != nil {
 		return Thread{}, ErrRepository
 	}
-	defer func() {
-		if resultErr != nil {
-			rollback(tx)
-		}
-	}()
+	defer rollback(tx)
 
 	var result Thread
 	if err := tx.QueryRow(ctx, `
@@ -190,16 +186,12 @@ func (r *PostgresRepository) SetActiveMatter(
 	ownerID string,
 	threadID string,
 	matterID string,
-) (_ ThreadMatterLink, resultErr error) {
+) (ThreadMatterLink, error) {
 	tx, err := r.database.Begin(ctx)
 	if err != nil {
 		return ThreadMatterLink{}, ErrRepository
 	}
-	defer func() {
-		if resultErr != nil {
-			rollback(tx)
-		}
-	}()
+	defer rollback(tx)
 
 	var lockedThreadID string
 	if err := tx.QueryRow(ctx, `
@@ -210,6 +202,39 @@ FOR UPDATE`,
 		threadID,
 		ownerID,
 	).Scan(&lockedThreadID); err != nil {
+		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+
+	var current ThreadMatterLink
+	err = tx.QueryRow(ctx, `
+SELECT
+    owner_user_id::text,
+    thread_id::text,
+    matter_id::text,
+    is_active,
+    linked_at,
+    updated_at
+FROM agent_thread_matter_links
+WHERE thread_id = $1
+  AND owner_user_id = $2
+  AND is_active`,
+		threadID,
+		ownerID,
+	).Scan(
+		&current.OwnerID,
+		&current.ThreadID,
+		&current.MatterID,
+		&current.Active,
+		&current.LinkedAt,
+		&current.UpdatedAt,
+	)
+	if err == nil && current.MatterID == matterID {
+		if err := tx.Commit(ctx); err != nil {
+			return ThreadMatterLink{}, ErrRepository
+		}
+		return current, nil
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return ThreadMatterLink{}, mapPostgresError(err)
 	}
 	if _, err := tx.Exec(ctx, `
@@ -291,16 +316,12 @@ func (r *PostgresRepository) AppendUserMessage(
 	threadID string,
 	clientMessageID string,
 	content string,
-) (_ Message, resultErr error) {
+) (Message, error) {
 	tx, err := r.database.Begin(ctx)
 	if err != nil {
 		return Message{}, ErrRepository
 	}
-	defer func() {
-		if resultErr != nil {
-			rollback(tx)
-		}
-	}()
+	defer rollback(tx)
 
 	var nextSequence int64
 	if err := tx.QueryRow(ctx, `

--- a/server/internal/agent/postgres.go
+++ b/server/internal/agent/postgres.go
@@ -1,0 +1,524 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const rollbackTimeout = 5 * time.Second
+
+type PostgreSQL interface {
+	Begin(context.Context) (pgx.Tx, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type PostgresRepository struct {
+	database PostgreSQL
+	ids      IDGenerator
+}
+
+func NewPostgresRepository(
+	database PostgreSQL,
+	ids IDGenerator,
+) (*PostgresRepository, error) {
+	if database == nil || ids == nil {
+		return nil, ErrRepository
+	}
+	return &PostgresRepository{database: database, ids: ids}, nil
+}
+
+func (r *PostgresRepository) CreateThread(
+	ctx context.Context,
+	ownerID string,
+	activeMatterID string,
+) (_ Thread, resultErr error) {
+	threadID, err := r.ids.NewID()
+	if err != nil {
+		return Thread{}, ErrRepository
+	}
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return Thread{}, ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			rollback(tx)
+		}
+	}()
+
+	var result Thread
+	if err := tx.QueryRow(ctx, `
+INSERT INTO agent_threads (
+    id,
+    owner_user_id,
+    next_message_sequence,
+    created_at,
+    updated_at
+) VALUES ($1, $2, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+RETURNING
+    id::text,
+    owner_user_id::text,
+    next_message_sequence,
+    created_at,
+    updated_at`,
+		threadID,
+		ownerID,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.NextMessageSeq,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	); err != nil {
+		return Thread{}, mapPostgresError(err)
+	}
+
+	if activeMatterID != "" {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO agent_thread_matter_links (
+    owner_user_id,
+    thread_id,
+    matter_id,
+    is_active,
+    linked_at,
+    updated_at
+) VALUES ($1, $2, $3, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			ownerID,
+			threadID,
+			activeMatterID,
+		); err != nil {
+			return Thread{}, mapPostgresError(err)
+		}
+		result.ActiveMatterID = activeMatterID
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Thread{}, ErrRepository
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) ListThreads(
+	ctx context.Context,
+	ownerID string,
+) ([]Thread, error) {
+	rows, err := r.database.Query(ctx, `
+SELECT
+    threads.id::text,
+    threads.owner_user_id::text,
+    COALESCE(active_link.matter_id::text, ''),
+    threads.next_message_sequence,
+    threads.created_at,
+    threads.updated_at
+FROM agent_threads AS threads
+LEFT JOIN agent_thread_matter_links AS active_link
+  ON active_link.thread_id = threads.id
+ AND active_link.owner_user_id = threads.owner_user_id
+ AND active_link.is_active
+WHERE threads.owner_user_id = $1
+ORDER BY threads.updated_at DESC, threads.id DESC`,
+		ownerID,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	result := make([]Thread, 0)
+	for rows.Next() {
+		var item Thread
+		if err := rows.Scan(
+			&item.ID,
+			&item.OwnerID,
+			&item.ActiveMatterID,
+			&item.NextMessageSeq,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, ErrRepository
+		}
+		result = append(result, item)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) FindThread(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+) (Thread, error) {
+	var result Thread
+	err := r.database.QueryRow(ctx, `
+SELECT
+    threads.id::text,
+    threads.owner_user_id::text,
+    COALESCE(active_link.matter_id::text, ''),
+    threads.next_message_sequence,
+    threads.created_at,
+    threads.updated_at
+FROM agent_threads AS threads
+LEFT JOIN agent_thread_matter_links AS active_link
+  ON active_link.thread_id = threads.id
+ AND active_link.owner_user_id = threads.owner_user_id
+ AND active_link.is_active
+WHERE threads.id = $1 AND threads.owner_user_id = $2`,
+		threadID,
+		ownerID,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.ActiveMatterID,
+		&result.NextMessageSeq,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+	if err != nil {
+		return Thread{}, mapPostgresError(err)
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) SetActiveMatter(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+	matterID string,
+) (_ ThreadMatterLink, resultErr error) {
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return ThreadMatterLink{}, ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			rollback(tx)
+		}
+	}()
+
+	var lockedThreadID string
+	if err := tx.QueryRow(ctx, `
+SELECT id::text
+FROM agent_threads
+WHERE id = $1 AND owner_user_id = $2
+FOR UPDATE`,
+		threadID,
+		ownerID,
+	).Scan(&lockedThreadID); err != nil {
+		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_thread_matter_links
+SET
+    is_active = false,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE thread_id = $1
+  AND owner_user_id = $2
+  AND is_active`,
+		threadID,
+		ownerID,
+	); err != nil {
+		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+
+	var result ThreadMatterLink
+	if err := tx.QueryRow(ctx, `
+INSERT INTO agent_thread_matter_links (
+    owner_user_id,
+    thread_id,
+    matter_id,
+    is_active,
+    linked_at,
+    updated_at
+) VALUES ($1, $2, $3, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (thread_id, matter_id) DO UPDATE
+SET
+    is_active = true,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        agent_thread_matter_links.updated_at + INTERVAL '1 microsecond'
+    )
+WHERE agent_thread_matter_links.owner_user_id = EXCLUDED.owner_user_id
+RETURNING
+    owner_user_id::text,
+    thread_id::text,
+    matter_id::text,
+    is_active,
+    linked_at,
+    updated_at`,
+		ownerID,
+		threadID,
+		matterID,
+	).Scan(
+		&result.OwnerID,
+		&result.ThreadID,
+		&result.MatterID,
+		&result.Active,
+		&result.LinkedAt,
+		&result.UpdatedAt,
+	); err != nil {
+		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_threads
+SET updated_at = GREATEST(
+    CURRENT_TIMESTAMP,
+    updated_at + INTERVAL '1 microsecond'
+)
+WHERE id = $1 AND owner_user_id = $2`,
+		threadID,
+		ownerID,
+	); err != nil {
+		return ThreadMatterLink{}, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ThreadMatterLink{}, ErrRepository
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) AppendUserMessage(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+	clientMessageID string,
+	content string,
+) (_ Message, resultErr error) {
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return Message{}, ErrRepository
+	}
+	defer func() {
+		if resultErr != nil {
+			rollback(tx)
+		}
+	}()
+
+	var nextSequence int64
+	if err := tx.QueryRow(ctx, `
+SELECT next_message_sequence
+FROM agent_threads
+WHERE id = $1 AND owner_user_id = $2
+FOR UPDATE`,
+		threadID,
+		ownerID,
+	).Scan(&nextSequence); err != nil {
+		return Message{}, mapPostgresError(err)
+	}
+
+	existing, found, err := findMessageByClientID(
+		ctx,
+		tx,
+		ownerID,
+		threadID,
+		clientMessageID,
+	)
+	if err != nil {
+		return Message{}, err
+	}
+	if found {
+		if existing.Content != content || existing.Role != MessageRoleUser {
+			return Message{}, ErrIdempotencyConflict
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return Message{}, ErrRepository
+		}
+		return existing, nil
+	}
+
+	messageID, err := r.ids.NewID()
+	if err != nil {
+		return Message{}, ErrRepository
+	}
+	var result Message
+	var role string
+	if err := tx.QueryRow(ctx, `
+INSERT INTO agent_messages (
+    id,
+    owner_user_id,
+    thread_id,
+    sequence_no,
+    role,
+    client_message_id,
+    content,
+    created_at
+) VALUES ($1, $2, $3, $4, 'user', $5, $6, CURRENT_TIMESTAMP)
+RETURNING
+    id::text,
+    owner_user_id::text,
+    thread_id::text,
+    sequence_no,
+    role,
+    client_message_id,
+    content,
+    created_at`,
+		messageID,
+		ownerID,
+		threadID,
+		nextSequence,
+		clientMessageID,
+		content,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.ThreadID,
+		&result.Sequence,
+		&role,
+		&result.ClientMessageID,
+		&result.Content,
+		&result.CreatedAt,
+	); err != nil {
+		return Message{}, mapPostgresError(err)
+	}
+	result.Role = MessageRole(role)
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_threads
+SET
+    next_message_sequence = next_message_sequence + 1,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE id = $1 AND owner_user_id = $2`,
+		threadID,
+		ownerID,
+	); err != nil {
+		return Message{}, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Message{}, ErrRepository
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) ListMessages(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+) ([]Message, error) {
+	rows, err := r.database.Query(ctx, `
+SELECT
+    id::text,
+    owner_user_id::text,
+    thread_id::text,
+    sequence_no,
+    role,
+    COALESCE(client_message_id, ''),
+    content,
+    created_at
+FROM agent_messages
+WHERE owner_user_id = $1 AND thread_id = $2
+ORDER BY sequence_no ASC`,
+		ownerID,
+		threadID,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	result := make([]Message, 0)
+	for rows.Next() {
+		var item Message
+		var role string
+		if err := rows.Scan(
+			&item.ID,
+			&item.OwnerID,
+			&item.ThreadID,
+			&item.Sequence,
+			&role,
+			&item.ClientMessageID,
+			&item.Content,
+			&item.CreatedAt,
+		); err != nil {
+			return nil, ErrRepository
+		}
+		item.Role = MessageRole(role)
+		result = append(result, item)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	return result, nil
+}
+
+func findMessageByClientID(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+	threadID string,
+	clientMessageID string,
+) (Message, bool, error) {
+	var result Message
+	var role string
+	err := tx.QueryRow(ctx, `
+SELECT
+    id::text,
+    owner_user_id::text,
+    thread_id::text,
+    sequence_no,
+    role,
+    client_message_id,
+    content,
+    created_at
+FROM agent_messages
+WHERE owner_user_id = $1
+  AND thread_id = $2
+  AND client_message_id = $3`,
+		ownerID,
+		threadID,
+		clientMessageID,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.ThreadID,
+		&result.Sequence,
+		&role,
+		&result.ClientMessageID,
+		&result.Content,
+		&result.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Message{}, false, nil
+	}
+	if err != nil {
+		return Message{}, false, mapPostgresError(err)
+	}
+	result.Role = MessageRole(role)
+	return result, true, nil
+}
+
+func rollback(tx pgx.Tx) {
+	ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+	defer cancel()
+	_ = tx.Rollback(ctx)
+}
+
+func mapPostgresError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		switch postgresError.Code {
+		case "23503":
+			return ErrNotFound
+		case "23505":
+			return ErrConflict
+		case "23514":
+			return ErrInvalidRequest
+		}
+	}
+	return ErrRepository
+}

--- a/server/internal/agent/postgres_integration_test.go
+++ b/server/internal/agent/postgres_integration_test.go
@@ -431,7 +431,18 @@ func TestPostgresAgentDataVerticalSlice(t *testing.T) {
 	}
 	database.pool.Close()
 	reopenedPool := database.reopen(t)
-	_, recoveredService := newAgentDataServices(t, reopenedPool)
+	recoveredMatterService, recoveredService := newAgentDataServices(t, reopenedPool)
+	recoveredMatter, err := recoveredMatterService.ReadOwned(
+		context.Background(),
+		actorA,
+		matterA.ID,
+	)
+	if err != nil ||
+		recoveredMatter.Title != reopened.Title ||
+		recoveredMatter.Status != reopened.Status ||
+		recoveredMatter.Version != reopened.Version {
+		t.Fatalf("recovered Matter = %#v, %v", recoveredMatter, err)
+	}
 	recoveredThread, err := recoveredService.GetThread(
 		context.Background(),
 		actorA,

--- a/server/internal/agent/postgres_integration_test.go
+++ b/server/internal/agent/postgres_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
@@ -466,6 +467,189 @@ func TestPostgresAgentDataVerticalSlice(t *testing.T) {
 	}
 }
 
+func TestPostgresActiveMatterBindingSerializesWithLifecycleTransition(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name         string
+		targetStatus matter.Status
+		createThread bool
+	}{
+		{
+			name:         "create thread while Matter is archived",
+			targetStatus: matter.StatusArchived,
+			createThread: true,
+		},
+		{
+			name:         "select Matter while it is completed",
+			targetStatus: matter.StatusCompleted,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			database := newAgentTestDatabase(t)
+			matterService, normalService := newAgentDataServices(t, database.pool)
+			actor := requestcontext.Actor{
+				UserID:    agentTestUserA,
+				SessionID: "20000000-0000-4000-8000-000000000001",
+			}
+			item, err := matterService.Create(
+				context.Background(),
+				actor,
+				"Concurrent lifecycle transition",
+			)
+			if err != nil {
+				t.Fatalf("create Matter: %v", err)
+			}
+			var thread Thread
+			if !testCase.createThread {
+				thread, err = normalService.CreateThread(
+					context.Background(),
+					actor,
+					"",
+				)
+				if err != nil {
+					t.Fatalf("create Thread: %v", err)
+				}
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			transition, err := database.pool.Begin(ctx)
+			if err != nil {
+				t.Fatalf("begin Matter transition: %v", err)
+			}
+			defer func() {
+				_ = transition.Rollback(context.Background())
+			}()
+			if _, err := transition.Exec(ctx, `
+UPDATE matters
+SET
+    status = $3,
+    version = version + 1,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE id = $1 AND owner_user_id = $2`,
+				item.ID,
+				actor.UserID,
+				string(testCase.targetStatus),
+			); err != nil {
+				t.Fatalf("stage Matter transition: %v", err)
+			}
+
+			lockAttempted := make(chan struct{}, 1)
+			observedDatabase := &queryObservingPostgreSQL{
+				Pool: database.pool,
+				observeQuery: func(query string) {
+					if strings.Contains(query, "FROM matters") &&
+						strings.Contains(query, "FOR UPDATE") {
+						select {
+						case lockAttempted <- struct{}{}:
+						default:
+						}
+					}
+				},
+			}
+			repository, err := NewPostgresRepository(
+				observedDatabase,
+				identity.NewUUIDv4Generator(nil),
+			)
+			if err != nil {
+				t.Fatalf("new observed Agent repository: %v", err)
+			}
+			observedService, err := NewService(repository, matterService)
+			if err != nil {
+				t.Fatalf("new observed Agent service: %v", err)
+			}
+			result := make(chan error, 1)
+			go func() {
+				if testCase.createThread {
+					_, operationErr := observedService.CreateThread(
+						ctx,
+						actor,
+						item.ID,
+					)
+					result <- operationErr
+					return
+				}
+				_, operationErr := observedService.SetActiveMatter(
+					ctx,
+					actor,
+					thread.ID,
+					item.ID,
+				)
+				result <- operationErr
+			}()
+
+			select {
+			case <-lockAttempted:
+			case operationErr := <-result:
+				t.Fatalf(
+					"binding completed before atomic Matter lock: %v",
+					operationErr,
+				)
+			case <-ctx.Done():
+				t.Fatal("binding did not attempt the atomic Matter lock")
+			}
+			select {
+			case operationErr := <-result:
+				t.Fatalf(
+					"binding escaped the uncommitted Matter transition: %v",
+					operationErr,
+				)
+			default:
+			}
+			if err := transition.Commit(ctx); err != nil {
+				t.Fatalf("commit Matter transition: %v", err)
+			}
+			select {
+			case operationErr := <-result:
+				if !errors.Is(operationErr, ErrConflict) {
+					t.Fatalf(
+						"binding error after Matter transition = %v, want conflict",
+						operationErr,
+					)
+				}
+			case <-ctx.Done():
+				t.Fatal("binding did not finish after Matter transition")
+			}
+
+			if testCase.createThread {
+				threads, err := normalService.ListThreads(
+					context.Background(),
+					actor,
+				)
+				if err != nil {
+					t.Fatalf("list Threads after rejected binding: %v", err)
+				}
+				if len(threads) != 0 {
+					t.Fatalf(
+						"Thread count after rejected binding = %d, want 0",
+						len(threads),
+					)
+				}
+			} else {
+				recovered, err := normalService.GetThread(
+					context.Background(),
+					actor,
+					thread.ID,
+				)
+				if err != nil {
+					t.Fatalf("recover Thread after rejected binding: %v", err)
+				}
+				if recovered.ActiveMatterID != "" {
+					t.Fatalf(
+						"active Matter after rejected binding = %q, want empty",
+						recovered.ActiveMatterID,
+					)
+				}
+			}
+		})
+	}
+}
+
 func TestPostgresAgentDataProtectedHTTP(t *testing.T) {
 	database := newAgentTestDatabase(t)
 	matterService, service := newAgentDataServices(t, database.pool)
@@ -736,6 +920,40 @@ type idGeneratorFunc func() (string, error)
 
 func (f idGeneratorFunc) NewID() (string, error) {
 	return f()
+}
+
+type queryObservingPostgreSQL struct {
+	*pgxpool.Pool
+	observeQuery func(string)
+}
+
+func (database *queryObservingPostgreSQL) Begin(
+	ctx context.Context,
+) (pgx.Tx, error) {
+	tx, err := database.Pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &queryObservingTx{
+		Tx:           tx,
+		observeQuery: database.observeQuery,
+	}, nil
+}
+
+type queryObservingTx struct {
+	pgx.Tx
+	observeQuery func(string)
+}
+
+func (tx *queryObservingTx) QueryRow(
+	ctx context.Context,
+	query string,
+	args ...any,
+) pgx.Row {
+	if tx.observeQuery != nil {
+		tx.observeQuery(query)
+	}
+	return tx.Tx.QueryRow(ctx, query, args...)
 }
 
 type agentTestDatabase struct {

--- a/server/internal/agent/postgres_integration_test.go
+++ b/server/internal/agent/postgres_integration_test.go
@@ -1,0 +1,892 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	agentTestUserA = "10000000-0000-4000-8000-000000000001"
+	agentTestUserB = "10000000-0000-4000-8000-000000000002"
+)
+
+func TestPostgresAgentDataVerticalSlice(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	matterService, service := newAgentDataServices(t, database.pool)
+	actorA := requestcontext.Actor{
+		UserID:    agentTestUserA,
+		SessionID: "20000000-0000-4000-8000-000000000001",
+	}
+	actorB := requestcontext.Actor{
+		UserID:    agentTestUserB,
+		SessionID: "20000000-0000-4000-8000-000000000002",
+	}
+
+	matterA, err := matterService.Create(
+		context.Background(),
+		actorA,
+		"Customer renewal meeting",
+	)
+	if err != nil {
+		t.Fatalf("create matter A: %v", err)
+	}
+	secondMatterA, err := matterService.Create(
+		context.Background(),
+		actorA,
+		"Quarterly presentation",
+	)
+	if err != nil {
+		t.Fatalf("create second matter A: %v", err)
+	}
+	matterB, err := matterService.Create(
+		context.Background(),
+		actorB,
+		"Private interview",
+	)
+	if err != nil {
+		t.Fatalf("create matter B: %v", err)
+	}
+	listA, err := matterService.List(context.Background(), actorA)
+	if err != nil {
+		t.Fatalf("list matters A: %v", err)
+	}
+	if len(listA) != 2 {
+		t.Fatalf("matter A count = %d, want 2", len(listA))
+	}
+	if _, err := matterService.ReadOwned(
+		context.Background(),
+		actorA,
+		matterB.ID,
+	); !errors.Is(err, matter.ErrNotFound) {
+		t.Fatalf("cross-owner Matter read error = %v, want not found", err)
+	}
+
+	threadA, err := service.CreateThread(
+		context.Background(),
+		actorA,
+		matterA.ID,
+	)
+	if err != nil {
+		t.Fatalf("create thread A: %v", err)
+	}
+	if threadA.ActiveMatterID != matterA.ID {
+		t.Fatalf("active matter = %q, want %q", threadA.ActiveMatterID, matterA.ID)
+	}
+	threadB, err := service.CreateThread(
+		context.Background(),
+		actorB,
+		matterB.ID,
+	)
+	if err != nil {
+		t.Fatalf("create thread B: %v", err)
+	}
+	if _, err := service.CreateThread(
+		context.Background(),
+		actorA,
+		matterB.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Matter link error = %v, want not found", err)
+	}
+	if _, err := service.GetThread(
+		context.Background(),
+		actorA,
+		threadB.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Thread read error = %v, want not found", err)
+	}
+	if _, err := service.AppendUserMessage(
+		context.Background(),
+		actorA,
+		threadB.ID,
+		"cross-owner-message",
+		"must not be stored",
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Message write error = %v, want not found", err)
+	}
+	if _, err := service.ListMessages(
+		context.Background(),
+		actorA,
+		threadB.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Message read error = %v, want not found", err)
+	}
+
+	first, err := service.AppendUserMessage(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		"client-message-1",
+		"Help me prepare a concise opening.",
+	)
+	if err != nil {
+		t.Fatalf("append first message: %v", err)
+	}
+	replayed, err := service.AppendUserMessage(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		"client-message-1",
+		"Help me prepare a concise opening.",
+	)
+	if err != nil {
+		t.Fatalf("replay first message: %v", err)
+	}
+	if replayed.ID != first.ID || replayed.Sequence != first.Sequence {
+		t.Fatalf("replay = %#v, want original %#v", replayed, first)
+	}
+	if _, err := service.AppendUserMessage(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		"client-message-1",
+		"Different content must conflict.",
+	); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("changed replay error = %v, want idempotency conflict", err)
+	}
+
+	const concurrentMessages = 16
+	start := make(chan struct{})
+	results := make(chan Message, concurrentMessages)
+	failures := make(chan error, concurrentMessages)
+	var writers sync.WaitGroup
+	for index := 0; index < concurrentMessages; index++ {
+		index := index
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			<-start
+			message, err := service.AppendUserMessage(
+				context.Background(),
+				actorA,
+				threadA.ID,
+				fmt.Sprintf("parallel-%02d", index),
+				fmt.Sprintf("parallel content %02d", index),
+			)
+			if err != nil {
+				failures <- err
+				return
+			}
+			results <- message
+		}()
+	}
+	close(start)
+	writers.Wait()
+	close(results)
+	close(failures)
+	for err := range failures {
+		t.Errorf("parallel append: %v", err)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+	sequences := []int64{first.Sequence}
+	for message := range results {
+		sequences = append(sequences, message.Sequence)
+	}
+	sort.Slice(sequences, func(left, right int) bool {
+		return sequences[left] < sequences[right]
+	})
+	for index, sequence := range sequences {
+		want := int64(index + 1)
+		if sequence != want {
+			t.Fatalf("sequence[%d] = %d, want %d", index, sequence, want)
+		}
+	}
+
+	sameKeyThread, err := service.CreateThread(
+		context.Background(),
+		actorA,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("create same-key thread: %v", err)
+	}
+	const sameKeyWriters = 8
+	sameKeyStart := make(chan struct{})
+	sameKeyResults := make(chan Message, sameKeyWriters)
+	sameKeyFailures := make(chan error, sameKeyWriters)
+	writers = sync.WaitGroup{}
+	for range sameKeyWriters {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			<-sameKeyStart
+			message, err := service.AppendUserMessage(
+				context.Background(),
+				actorA,
+				sameKeyThread.ID,
+				"same-client-message",
+				"Store this exactly once.",
+			)
+			if err != nil {
+				sameKeyFailures <- err
+				return
+			}
+			sameKeyResults <- message
+		}()
+	}
+	close(sameKeyStart)
+	writers.Wait()
+	close(sameKeyResults)
+	close(sameKeyFailures)
+	for err := range sameKeyFailures {
+		t.Errorf("same-key append: %v", err)
+	}
+	var sameKeyID string
+	for result := range sameKeyResults {
+		if sameKeyID == "" {
+			sameKeyID = result.ID
+		}
+		if result.ID != sameKeyID || result.Sequence != 1 {
+			t.Fatalf("same-key result = %#v, want one sequence-1 message", result)
+		}
+	}
+
+	link, err := service.SetActiveMatter(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		secondMatterA.ID,
+	)
+	if err != nil {
+		t.Fatalf("change active matter: %v", err)
+	}
+	if !link.Active || link.MatterID != secondMatterA.ID {
+		t.Fatalf("unexpected active link: %#v", link)
+	}
+	if _, err := service.SetActiveMatter(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		matterB.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner active Matter error = %v, want not found", err)
+	}
+
+	archived, err := matterService.ChangeStatus(
+		context.Background(),
+		actorA,
+		matterA.ID,
+		matterA.Version,
+		matter.StatusArchived,
+	)
+	if err != nil {
+		t.Fatalf("archive Matter: %v", err)
+	}
+	if _, err := service.SetActiveMatter(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		archived.ID,
+	); !errors.Is(err, ErrConflict) {
+		t.Fatalf("select archived Matter error = %v, want conflict", err)
+	}
+	reopened, err := matterService.ChangeStatus(
+		context.Background(),
+		actorA,
+		archived.ID,
+		archived.Version,
+		matter.StatusActive,
+	)
+	if err != nil || reopened.Status != matter.StatusActive {
+		t.Fatalf("reopen Matter = %#v, %v", reopened, err)
+	}
+
+	assertCrossOwnerDatabaseConstraints(
+		t,
+		database.pool,
+		threadA.ID,
+		threadB.ID,
+		matterA.ID,
+		matterB.ID,
+	)
+	assertRestrictedCrossModuleDeletes(
+		t,
+		database.pool,
+		secondMatterA.ID,
+	)
+
+	messages, err := service.ListMessages(
+		context.Background(),
+		actorA,
+		threadA.ID,
+	)
+	if err != nil {
+		t.Fatalf("list messages before reconnect: %v", err)
+	}
+	if len(messages) != concurrentMessages+1 {
+		t.Fatalf(
+			"message count = %d, want %d",
+			len(messages),
+			concurrentMessages+1,
+		)
+	}
+	database.pool.Close()
+	reopenedPool := database.reopen(t)
+	_, recoveredService := newAgentDataServices(t, reopenedPool)
+	recoveredThread, err := recoveredService.GetThread(
+		context.Background(),
+		actorA,
+		threadA.ID,
+	)
+	if err != nil || recoveredThread.ActiveMatterID != secondMatterA.ID {
+		t.Fatalf("recovered thread = %#v, %v", recoveredThread, err)
+	}
+	recoveredMessages, err := recoveredService.ListMessages(
+		context.Background(),
+		actorA,
+		threadA.ID,
+	)
+	if err != nil || len(recoveredMessages) != len(messages) {
+		t.Fatalf(
+			"recovered messages = %d, %v; want %d",
+			len(recoveredMessages),
+			err,
+			len(messages),
+		)
+	}
+}
+
+func TestPostgresAgentDataProtectedHTTP(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	matterService, service := newAgentDataServices(t, database.pool)
+	actors := map[string]requestcontext.Actor{
+		"token-a": {
+			UserID:    agentTestUserA,
+			SessionID: "20000000-0000-4000-8000-000000000001",
+		},
+		"token-b": {
+			UserID:    agentTestUserB,
+			SessionID: "20000000-0000-4000-8000-000000000002",
+		},
+	}
+	handler, err := NewHTTPHandler(
+		service,
+		matterService,
+		authenticatorFunc(func(
+			_ context.Context,
+			token string,
+		) (requestcontext.Actor, error) {
+			actor, ok := actors[token]
+			if !ok {
+				return requestcontext.Actor{}, identity.ErrAuthenticationRequired
+			}
+			return actor, nil
+		}),
+		func() string { return "corr_agent_data_test" },
+	)
+	if err != nil {
+		t.Fatalf("new HTTP handler: %v", err)
+	}
+	module, err := NewModule(handler)
+	if err != nil {
+		t.Fatalf("new module: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	module.RegisterRoutes(router)
+
+	missingAuth := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/matters",
+		"",
+		"",
+	)
+	if missingAuth.Code != http.StatusUnauthorized ||
+		missingAuth.Header().Get("WWW-Authenticate") != "Bearer" {
+		t.Fatalf("missing auth response: %d %s", missingAuth.Code, missingAuth.Body)
+	}
+
+	forged := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/matters",
+		`{"title":"Forged","owner_user_id":"`+agentTestUserB+`"}`,
+		"token-a",
+	)
+	if forged.Code != http.StatusBadRequest {
+		t.Fatalf("forged owner response: %d %s", forged.Code, forged.Body)
+	}
+
+	createdMatter := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/matters",
+		`{"title":"Customer meeting"}`,
+		"token-a",
+	)
+	if createdMatter.Code != http.StatusCreated {
+		t.Fatalf(
+			"create Matter response: %d %s",
+			createdMatter.Code,
+			createdMatter.Body,
+		)
+	}
+	var matterBody struct {
+		ID string `json:"matter_id"`
+	}
+	if err := json.Unmarshal(createdMatter.Body.Bytes(), &matterBody); err != nil {
+		t.Fatalf("decode Matter response: %v", err)
+	}
+
+	createdThread := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads",
+		`{"active_matter_id":"`+matterBody.ID+`"}`,
+		"token-a",
+	)
+	if createdThread.Code != http.StatusCreated {
+		t.Fatalf(
+			"create Thread response: %d %s",
+			createdThread.Code,
+			createdThread.Body,
+		)
+	}
+	var threadBody struct {
+		ID string `json:"thread_id"`
+	}
+	if err := json.Unmarshal(createdThread.Body.Bytes(), &threadBody); err != nil {
+		t.Fatalf("decode Thread response: %v", err)
+	}
+
+	firstMessage := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		`{"client_message_id":"mobile-0001","content":"Help me prepare."}`,
+		"token-a",
+	)
+	replayedMessage := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		`{"client_message_id":"mobile-0001","content":"Help me prepare."}`,
+		"token-a",
+	)
+	if firstMessage.Code != http.StatusCreated ||
+		replayedMessage.Code != http.StatusCreated ||
+		!bytes.Equal(firstMessage.Body.Bytes(), replayedMessage.Body.Bytes()) {
+		t.Fatalf(
+			"idempotent HTTP responses differ: %d %s / %d %s",
+			firstMessage.Code,
+			firstMessage.Body,
+			replayedMessage.Code,
+			replayedMessage.Body,
+		)
+	}
+
+	privateThread := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/agent-threads/"+threadBody.ID,
+		"",
+		"token-b",
+	)
+	if privateThread.Code != http.StatusNotFound {
+		t.Fatalf(
+			"cross-user Thread response: %d %s",
+			privateThread.Code,
+			privateThread.Body,
+		)
+	}
+	privateMessages := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		"",
+		"token-b",
+	)
+	if privateMessages.Code != http.StatusNotFound {
+		t.Fatalf(
+			"cross-user Messages response: %d %s",
+			privateMessages.Code,
+			privateMessages.Body,
+		)
+	}
+	messages := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		"",
+		"token-a",
+	)
+	if messages.Code != http.StatusOK ||
+		!strings.Contains(messages.Body.String(), `"sequence":1`) {
+		t.Fatalf("list messages response: %d %s", messages.Code, messages.Body)
+	}
+}
+
+type authenticatorFunc func(
+	context.Context,
+	string,
+) (requestcontext.Actor, error)
+
+func (f authenticatorFunc) AuthenticateSession(
+	ctx context.Context,
+	token string,
+) (requestcontext.Actor, error) {
+	return f(ctx, token)
+}
+
+type agentTestDatabase struct {
+	pool      *pgxpool.Pool
+	scopedURL string
+}
+
+func newAgentTestDatabase(t *testing.T) agentTestDatabase {
+	t.Helper()
+	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	config, err := pgx.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	admin, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatal("connect to TEST_DATABASE_URL")
+	}
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("generate schema name: %v", err)
+	}
+	schema := "agent_data_" + hex.EncodeToString(random)
+	identifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(
+		context.Background(),
+		"CREATE SCHEMA "+identifier,
+	); err != nil {
+		t.Fatalf("create test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := admin.Exec(
+			context.Background(),
+			"DROP SCHEMA "+identifier+" CASCADE",
+		); err != nil {
+			t.Errorf("drop test schema: %v", err)
+		}
+	})
+
+	scopedURL, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	query := scopedURL.Query()
+	query.Set("search_path", schema)
+	scopedURL.RawQuery = query.Encode()
+
+	runner, err := migration.Open(scopedURL.String())
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+	if _, err := runner.Up(); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(scopedURL.String())
+	if err != nil {
+		t.Fatal("parse scoped pool config")
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	if err != nil {
+		t.Fatal("open scoped pool")
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Fatal("ping scoped pool")
+	}
+	for _, user := range []struct {
+		id    string
+		email string
+	}{
+		{id: agentTestUserA, email: "agent-a@example.com"},
+		{id: agentTestUserB, email: "agent-b@example.com"},
+	} {
+		if _, err := pool.Exec(
+			context.Background(),
+			`INSERT INTO identity_users (id, canonical_email)
+VALUES ($1, $2)`,
+			user.id,
+			user.email,
+		); err != nil {
+			t.Fatalf("insert identity user: %v", err)
+		}
+	}
+	return agentTestDatabase{
+		pool:      pool,
+		scopedURL: scopedURL.String(),
+	}
+}
+
+func (database agentTestDatabase) reopen(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	config, err := pgxpool.ParseConfig(database.scopedURL)
+	if err != nil {
+		t.Fatal("parse reopened pool config")
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+	if err != nil {
+		t.Fatal("reopen scoped pool")
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Fatal("ping reopened pool")
+	}
+	return pool
+}
+
+func newAgentDataServices(
+	t *testing.T,
+	pool *pgxpool.Pool,
+) (*matter.Service, *Service) {
+	t.Helper()
+	ids := identity.NewUUIDv4Generator(nil)
+	matterRepository, err := matter.NewPostgresRepository(pool, ids)
+	if err != nil {
+		t.Fatalf("new Matter repository: %v", err)
+	}
+	matterService, err := matter.NewService(matterRepository)
+	if err != nil {
+		t.Fatalf("new Matter service: %v", err)
+	}
+	repository, err := NewPostgresRepository(pool, ids)
+	if err != nil {
+		t.Fatalf("new Agent repository: %v", err)
+	}
+	service, err := NewService(repository, matterService)
+	if err != nil {
+		t.Fatalf("new Agent service: %v", err)
+	}
+	return matterService, service
+}
+
+func assertCrossOwnerDatabaseConstraints(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	threadA string,
+	threadB string,
+	matterA string,
+	matterB string,
+) {
+	t.Helper()
+	assertPostgresConstraint(
+		t,
+		pool,
+		`INSERT INTO agent_thread_matter_links (
+    owner_user_id,
+    thread_id,
+    matter_id,
+    is_active
+) VALUES ($1, $2, $3, false)`,
+		[]any{agentTestUserA, threadA, matterB},
+		"23503",
+		"agent_thread_matter_links_matter_owner_fkey",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		`INSERT INTO agent_messages (
+    id,
+    owner_user_id,
+    thread_id,
+    sequence_no,
+    role,
+    client_message_id,
+    content
+) VALUES (
+    '30000000-0000-4000-8000-000000000001',
+    $1,
+    $2,
+    999,
+    'user',
+    'forged-owner',
+    'must fail'
+)`,
+		[]any{agentTestUserA, threadB},
+		"23503",
+		"agent_messages_thread_owner_fkey",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		`UPDATE agent_thread_matter_links
+SET is_active = true
+WHERE owner_user_id = $1 AND thread_id = $2 AND matter_id = $3`,
+		[]any{agentTestUserA, threadA, matterA},
+		"23505",
+		"agent_thread_matter_links_one_active_idx",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		`INSERT INTO agent_messages (
+    id,
+    owner_user_id,
+    thread_id,
+    sequence_no,
+    role,
+    client_message_id,
+    content
+) VALUES (
+    '30000000-0000-4000-8000-000000000002',
+    $1,
+    $2,
+    1000,
+    'user',
+    'client-message-1',
+    'duplicate client identifier'
+)`,
+		[]any{agentTestUserA, threadA},
+		"23505",
+		"agent_messages_client_idempotency_key",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		`INSERT INTO agent_messages (
+    id,
+    owner_user_id,
+    thread_id,
+    sequence_no,
+    role,
+    client_message_id,
+    content
+) VALUES (
+    '30000000-0000-4000-8000-000000000003',
+    $1,
+    $2,
+    1,
+    'user',
+    'duplicate-sequence',
+    'duplicate sequence'
+)`,
+		[]any{agentTestUserA, threadA},
+		"23505",
+		"agent_messages_thread_sequence_key",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		`INSERT INTO agent_messages (
+    id,
+    owner_user_id,
+    thread_id,
+    sequence_no,
+    role,
+    client_message_id,
+    content
+) VALUES (
+    '30000000-0000-4000-8000-000000000004',
+    $1,
+    $2,
+    1001,
+    'user',
+    'oversized-content',
+    $3
+)`,
+		[]any{agentTestUserA, threadA, strings.Repeat("x", 4097)},
+		"23514",
+		"agent_messages_content_length_check",
+	)
+}
+
+func assertRestrictedCrossModuleDeletes(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	matterID string,
+) {
+	t.Helper()
+	assertPostgresConstraint(
+		t,
+		pool,
+		"DELETE FROM matters WHERE id = $1",
+		[]any{matterID},
+		"23001",
+		"agent_thread_matter_links_matter_owner_fkey",
+	)
+	assertPostgresConstraint(
+		t,
+		pool,
+		"DELETE FROM identity_users WHERE id = $1",
+		[]any{agentTestUserA},
+		"23001",
+		"matters_owner_user_id_fkey",
+	)
+}
+
+func assertPostgresConstraint(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	statement string,
+	arguments []any,
+	code string,
+	constraint string,
+) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), statement, arguments...)
+	if err == nil {
+		t.Fatalf("statement unexpectedly succeeded; want %s", constraint)
+	}
+	var postgresError *pgconn.PgError
+	if !errors.As(err, &postgresError) ||
+		postgresError.Code != code ||
+		postgresError.ConstraintName != constraint {
+		t.Fatalf(
+			"statement error = %v, want %s/%s",
+			err,
+			code,
+			constraint,
+		)
+	}
+}
+
+func performAgentRequest(
+	handler http.Handler,
+	method string,
+	path string,
+	body string,
+	token string,
+) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/server/internal/agent/postgres_integration_test.go
+++ b/server/internal/agent/postgres_integration_test.go
@@ -547,6 +547,35 @@ func TestPostgresAgentDataProtectedHTTP(t *testing.T) {
 	if nulMatter.Code != http.StatusBadRequest {
 		t.Fatalf("NUL Matter response: %d %s", nulMatter.Code, nulMatter.Body)
 	}
+	recoveredMatter := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/matters/"+matterBody.ID,
+		"",
+		"token-a",
+	)
+	if recoveredMatter.Code != http.StatusOK ||
+		!strings.Contains(recoveredMatter.Body.String(), `"title":"Customer meeting"`) {
+		t.Fatalf(
+			"recover Matter response: %d %s",
+			recoveredMatter.Code,
+			recoveredMatter.Body,
+		)
+	}
+	privateMatter := performAgentRequest(
+		router,
+		http.MethodGet,
+		"/v1/matters/"+matterBody.ID,
+		"",
+		"token-b",
+	)
+	if privateMatter.Code != http.StatusNotFound {
+		t.Fatalf(
+			"cross-user Matter response: %d %s",
+			privateMatter.Code,
+			privateMatter.Body,
+		)
+	}
 
 	createdThread := performAgentRequest(
 		router,

--- a/server/internal/agent/postgres_integration_test.go
+++ b/server/internal/agent/postgres_integration_test.go
@@ -264,6 +264,58 @@ func TestPostgresAgentDataVerticalSlice(t *testing.T) {
 		}
 	}
 
+	panicThread, err := service.CreateThread(
+		context.Background(),
+		actorA,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("create panic rollback thread: %v", err)
+	}
+	panicRepository, err := NewPostgresRepository(
+		database.pool,
+		idGeneratorFunc(func() (string, error) {
+			panic("test ID generator panic")
+		}),
+	)
+	if err != nil {
+		t.Fatalf("new panic repository: %v", err)
+	}
+	acquiredBeforePanic := database.pool.Stat().AcquiredConns()
+	var recovered any
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+		_, _ = panicRepository.AppendUserMessage(
+			context.Background(),
+			actorA.UserID,
+			panicThread.ID,
+			"panic-rolls-back",
+			"this transaction must be released",
+		)
+	}()
+	if recovered == nil {
+		t.Fatal("panic ID generator did not panic")
+	}
+	if acquiredAfterPanic := database.pool.Stat().AcquiredConns(); acquiredAfterPanic !=
+		acquiredBeforePanic {
+		t.Fatalf(
+			"acquired connections after panic = %d, want %d",
+			acquiredAfterPanic,
+			acquiredBeforePanic,
+		)
+	}
+	if _, err := service.AppendUserMessage(
+		context.Background(),
+		actorA,
+		panicThread.ID,
+		"after-panic",
+		"the Thread lock was released",
+	); err != nil {
+		t.Fatalf("append after repository panic: %v", err)
+	}
+
 	link, err := service.SetActiveMatter(
 		context.Background(),
 		actorA,
@@ -275,6 +327,40 @@ func TestPostgresAgentDataVerticalSlice(t *testing.T) {
 	}
 	if !link.Active || link.MatterID != secondMatterA.ID {
 		t.Fatalf("unexpected active link: %#v", link)
+	}
+	threadAfterSelection, err := service.GetThread(
+		context.Background(),
+		actorA,
+		threadA.ID,
+	)
+	if err != nil {
+		t.Fatalf("get Thread after active Matter selection: %v", err)
+	}
+	replayedLink, err := service.SetActiveMatter(
+		context.Background(),
+		actorA,
+		threadA.ID,
+		secondMatterA.ID,
+	)
+	if err != nil {
+		t.Fatalf("replay active Matter selection: %v", err)
+	}
+	threadAfterSelectionReplay, err := service.GetThread(
+		context.Background(),
+		actorA,
+		threadA.ID,
+	)
+	if err != nil {
+		t.Fatalf("get Thread after active Matter replay: %v", err)
+	}
+	if !replayedLink.LinkedAt.Equal(link.LinkedAt) ||
+		!replayedLink.UpdatedAt.Equal(link.UpdatedAt) ||
+		!threadAfterSelectionReplay.UpdatedAt.Equal(threadAfterSelection.UpdatedAt) {
+		t.Fatalf(
+			"replayed active Matter changed timestamps: %#v / %#v",
+			link,
+			replayedLink,
+		)
 	}
 	if _, err := service.SetActiveMatter(
 		context.Background(),
@@ -451,6 +537,16 @@ func TestPostgresAgentDataProtectedHTTP(t *testing.T) {
 	if err := json.Unmarshal(createdMatter.Body.Bytes(), &matterBody); err != nil {
 		t.Fatalf("decode Matter response: %v", err)
 	}
+	nulMatter := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/matters",
+		`{"title":"invalid\u0000title"}`,
+		"token-a",
+	)
+	if nulMatter.Code != http.StatusBadRequest {
+		t.Fatalf("NUL Matter response: %d %s", nulMatter.Code, nulMatter.Body)
+	}
 
 	createdThread := performAgentRequest(
 		router,
@@ -496,6 +592,50 @@ func TestPostgresAgentDataProtectedHTTP(t *testing.T) {
 			firstMessage.Body,
 			replayedMessage.Code,
 			replayedMessage.Body,
+		)
+	}
+	conflictingReplay := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		`{"client_message_id":"mobile-0001","content":"Changed content"}`,
+		"token-a",
+	)
+	if conflictingReplay.Code != http.StatusConflict ||
+		!strings.Contains(
+			conflictingReplay.Body.String(),
+			`"code":"idempotency_key_conflict"`,
+		) {
+		t.Fatalf(
+			"idempotency conflict response: %d %s",
+			conflictingReplay.Code,
+			conflictingReplay.Body,
+		)
+	}
+	nulMessage := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		`{"client_message_id":"mobile-nul","content":"invalid\u0000content"}`,
+		"token-a",
+	)
+	if nulMessage.Code != http.StatusBadRequest {
+		t.Fatalf("NUL Message response: %d %s", nulMessage.Code, nulMessage.Body)
+	}
+	maxEscapedMessage := performAgentRequest(
+		router,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadBody.ID+"/messages",
+		`{"client_message_id":"mobile-max-escaped","content":"`+
+			strings.Repeat(`\ud83d\ude00`, maxMessageContentRunes)+
+			`"}`,
+		"token-a",
+	)
+	if maxEscapedMessage.Code != http.StatusCreated {
+		t.Fatalf(
+			"maximum escaped Message response: %d %s",
+			maxEscapedMessage.Code,
+			maxEscapedMessage.Body,
 		)
 	}
 
@@ -550,6 +690,12 @@ func (f authenticatorFunc) AuthenticateSession(
 	token string,
 ) (requestcontext.Actor, error) {
 	return f(ctx, token)
+}
+
+type idGeneratorFunc func() (string, error)
+
+func (f idGeneratorFunc) NewID() (string, error) {
+	return f()
 }
 
 type agentTestDatabase struct {

--- a/server/internal/agent/service.go
+++ b/server/internal/agent/service.go
@@ -154,5 +154,6 @@ func validMessageContent(value string) bool {
 		len(value) >= 1 &&
 		utf8.RuneCountInString(value) <= maxMessageContentRunes &&
 		len(value) <= maxMessageContentBytes &&
+		!strings.ContainsRune(value, '\x00') &&
 		strings.TrimSpace(value) != ""
 }

--- a/server/internal/agent/service.go
+++ b/server/internal/agent/service.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	maxMessageContentRunes = 4096
+	maxMessageContentBytes = 16384
+)
+
+type Service struct {
+	repository Repository
+	matters    matter.Reader
+}
+
+func NewService(
+	repository Repository,
+	matters matter.Reader,
+) (*Service, error) {
+	if repository == nil || matters == nil {
+		return nil, errors.New("agent: service dependency is required")
+	}
+	return &Service{repository: repository, matters: matters}, nil
+}
+
+func (s *Service) CreateThread(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	activeMatterID string,
+) (Thread, error) {
+	if !actor.Valid() {
+		return Thread{}, ErrInvalidRequest
+	}
+	if activeMatterID != "" {
+		if err := s.requireActiveMatter(ctx, actor, activeMatterID); err != nil {
+			return Thread{}, err
+		}
+	}
+	return s.repository.CreateThread(ctx, actor.UserID, activeMatterID)
+}
+
+func (s *Service) ListThreads(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) ([]Thread, error) {
+	if !actor.Valid() {
+		return nil, ErrInvalidRequest
+	}
+	return s.repository.ListThreads(ctx, actor.UserID)
+}
+
+func (s *Service) GetThread(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) (Thread, error) {
+	if !actor.Valid() || !validUUID(threadID) {
+		return Thread{}, ErrNotFound
+	}
+	return s.repository.FindThread(ctx, actor.UserID, threadID)
+}
+
+func (s *Service) SetActiveMatter(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+	matterID string,
+) (ThreadMatterLink, error) {
+	if !actor.Valid() || !validUUID(threadID) {
+		return ThreadMatterLink{}, ErrNotFound
+	}
+	if err := s.requireActiveMatter(ctx, actor, matterID); err != nil {
+		return ThreadMatterLink{}, err
+	}
+	return s.repository.SetActiveMatter(
+		ctx,
+		actor.UserID,
+		threadID,
+		matterID,
+	)
+}
+
+func (s *Service) AppendUserMessage(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+	clientMessageID string,
+	content string,
+) (Message, error) {
+	if !actor.Valid() || !validUUID(threadID) {
+		return Message{}, ErrNotFound
+	}
+	if !clientMessageIDPattern.MatchString(clientMessageID) ||
+		!validMessageContent(content) {
+		return Message{}, ErrInvalidRequest
+	}
+	return s.repository.AppendUserMessage(
+		ctx,
+		actor.UserID,
+		threadID,
+		clientMessageID,
+		content,
+	)
+}
+
+func (s *Service) ListMessages(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) ([]Message, error) {
+	if !actor.Valid() || !validUUID(threadID) {
+		return nil, ErrNotFound
+	}
+	if _, err := s.repository.FindThread(
+		ctx,
+		actor.UserID,
+		threadID,
+	); err != nil {
+		return nil, err
+	}
+	return s.repository.ListMessages(ctx, actor.UserID, threadID)
+}
+
+func (s *Service) requireActiveMatter(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	matterID string,
+) error {
+	if !validUUID(matterID) {
+		return ErrNotFound
+	}
+	item, err := s.matters.ReadOwned(ctx, actor, matterID)
+	if errors.Is(err, matter.ErrNotFound) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return ErrRepository
+	}
+	if item.Status != matter.StatusActive {
+		return ErrConflict
+	}
+	return nil
+}
+
+func validMessageContent(value string) bool {
+	return utf8.ValidString(value) &&
+		len(value) >= 1 &&
+		utf8.RuneCountInString(value) <= maxMessageContentRunes &&
+		len(value) <= maxMessageContentBytes &&
+		strings.TrimSpace(value) != ""
+}

--- a/server/internal/agent/validation.go
+++ b/server/internal/agent/validation.go
@@ -1,0 +1,16 @@
+package agent
+
+import "regexp"
+
+var (
+	uuidPattern = regexp.MustCompile(
+		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+	)
+	clientMessageIDPattern = regexp.MustCompile(
+		`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
+	)
+)
+
+func validUUID(value string) bool {
+	return uuidPattern.MatchString(value)
+}

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+import (
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func NewIdentityAndAgentDataModules(
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
+) (*identity.Module, *agent.Module, error) {
+	if database == nil {
+		return nil, nil, errors.New(
+			"bootstrap: agent data database is required",
+		)
+	}
+	identityModule, authenticator, err := newIdentityComposition(
+		database,
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	ids := identity.NewUUIDv4Generator(nil)
+	matterRepository, err := matter.NewPostgresRepository(database, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	matterService, err := matter.NewService(matterRepository)
+	if err != nil {
+		return nil, nil, err
+	}
+	agentRepository, err := agent.NewPostgresRepository(database, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	agentService, err := agent.NewService(agentRepository, matterService)
+	if err != nil {
+		return nil, nil, err
+	}
+	handler, err := agent.NewHTTPHandler(
+		agentService,
+		matterService,
+		authenticator,
+		nil,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	agentModule, err := agent.NewModule(handler)
+	if err != nil {
+		return nil, nil, err
+	}
+	return identityModule, agentModule, nil
+}

--- a/server/internal/bootstrap/identity.go
+++ b/server/internal/bootstrap/identity.go
@@ -15,29 +15,46 @@ func NewIdentityModule(
 	trustedProxyCIDRs []string,
 	trustedProxyHeader string,
 ) (*identity.Module, error) {
+	module, _, err := newIdentityComposition(
+		database,
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+	)
+	return module, err
+}
+
+func newIdentityComposition(
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
+) (*identity.Module, *identity.Service, error) {
 	if database == nil {
-		return nil, errors.New("bootstrap: identity database is required")
+		return nil, nil, errors.New("bootstrap: identity database is required")
 	}
 	clock := identity.SystemClock{}
 	passwords, err := identity.NewDefaultArgon2idHasher()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	tokens := identity.NewOpaqueSessionTokens(nil)
 	dummyMaterial, _, err := tokens.Generate()
 	if err != nil {
-		return nil, errors.New("bootstrap: identity random source unavailable")
+		return nil, nil, errors.New(
+			"bootstrap: identity random source unavailable",
+		)
 	}
 	dummyHash, err := passwords.Hash(context.Background(), dummyMaterial)
 	if err != nil {
-		return nil, errors.New("bootstrap: identity password hashing unavailable")
+		return nil, nil, errors.New(
+			"bootstrap: identity password hashing unavailable",
+		)
 	}
 	repository, err := identity.NewPostgresRepository(
 		database,
 		identity.NewUUIDv4Generator(nil),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	service, err := identity.NewService(
 		repository,
@@ -46,18 +63,18 @@ func NewIdentityModule(
 		dummyHash,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	rateLimits, err := identity.NewDefaultRateLimiters(clock)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	sourceIPs, err := identity.NewTrustedProxyResolver(
 		trustedProxyCIDRs,
 		trustedProxyHeader,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	handler, err := identity.NewHTTPHandler(
 		service,
@@ -67,7 +84,11 @@ func NewIdentityModule(
 		identity.WithSourceIPResolver(sourceIPs),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return identity.NewModule(handler)
+	module, err := identity.NewModule(handler)
+	if err != nil {
+		return nil, nil, err
+	}
+	return module, service, nil
 }

--- a/server/internal/matter/errors.go
+++ b/server/internal/matter/errors.go
@@ -1,0 +1,10 @@
+package matter
+
+import "errors"
+
+var (
+	ErrInvalidRequest = errors.New("matter: invalid request")
+	ErrNotFound       = errors.New("matter: not found")
+	ErrConflict       = errors.New("matter: conflict")
+	ErrRepository     = errors.New("matter repository: operation failed")
+)

--- a/server/internal/matter/model.go
+++ b/server/internal/matter/model.go
@@ -1,0 +1,73 @@
+package matter
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type Status string
+
+const (
+	StatusActive    Status = "active"
+	StatusCompleted Status = "completed"
+	StatusArchived  Status = "archived"
+)
+
+type Matter struct {
+	ID        string
+	OwnerID   string
+	Title     string
+	Status    Status
+	Version   int64
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type Repository interface {
+	Create(ctx context.Context, ownerID, title string) (Matter, error)
+	ListOwned(ctx context.Context, ownerID string) ([]Matter, error)
+	FindOwned(ctx context.Context, ownerID, matterID string) (Matter, error)
+	UpdateStatus(
+		ctx context.Context,
+		ownerID string,
+		matterID string,
+		expectedVersion int64,
+		status Status,
+	) (Matter, error)
+}
+
+// Reader is Matter's public ownership and state port for other modules.
+// Implementations resolve ownership from a trusted Actor, never request data.
+type Reader interface {
+	ReadOwned(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		matterID string,
+	) (Matter, error)
+}
+
+type Application interface {
+	Reader
+	Create(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		title string,
+	) (Matter, error)
+	List(
+		ctx context.Context,
+		actor requestcontext.Actor,
+	) ([]Matter, error)
+	ChangeStatus(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		matterID string,
+		expectedVersion int64,
+		status Status,
+	) (Matter, error)
+}
+
+type IDGenerator interface {
+	NewID() (string, error)
+}

--- a/server/internal/matter/postgres.go
+++ b/server/internal/matter/postgres.go
@@ -1,0 +1,234 @@
+package matter
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type PostgreSQL interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type PostgresRepository struct {
+	database PostgreSQL
+	ids      IDGenerator
+}
+
+func NewPostgresRepository(
+	database PostgreSQL,
+	ids IDGenerator,
+) (*PostgresRepository, error) {
+	if database == nil || ids == nil {
+		return nil, ErrRepository
+	}
+	return &PostgresRepository{database: database, ids: ids}, nil
+}
+
+func (r *PostgresRepository) Create(
+	ctx context.Context,
+	ownerID string,
+	title string,
+) (Matter, error) {
+	matterID, err := r.ids.NewID()
+	if err != nil {
+		return Matter{}, ErrRepository
+	}
+	var result Matter
+	var status string
+	err = r.database.QueryRow(ctx, `
+INSERT INTO matters (
+    id,
+    owner_user_id,
+    title,
+    status,
+    version,
+    created_at,
+    updated_at
+) VALUES ($1, $2, $3, 'active', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+RETURNING
+    id::text,
+    owner_user_id::text,
+    title,
+    status,
+    version,
+    created_at,
+    updated_at`,
+		matterID,
+		ownerID,
+		title,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.Title,
+		&status,
+		&result.Version,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+	if err != nil {
+		return Matter{}, mapPostgresError(err)
+	}
+	result.Status = Status(status)
+	return result, nil
+}
+
+func (r *PostgresRepository) ListOwned(
+	ctx context.Context,
+	ownerID string,
+) ([]Matter, error) {
+	rows, err := r.database.Query(ctx, `
+SELECT
+    id::text,
+    owner_user_id::text,
+    title,
+    status,
+    version,
+    created_at,
+    updated_at
+FROM matters
+WHERE owner_user_id = $1
+ORDER BY updated_at DESC, id DESC`,
+		ownerID,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	result := make([]Matter, 0)
+	for rows.Next() {
+		var item Matter
+		var status string
+		if err := rows.Scan(
+			&item.ID,
+			&item.OwnerID,
+			&item.Title,
+			&status,
+			&item.Version,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, ErrRepository
+		}
+		item.Status = Status(status)
+		result = append(result, item)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) FindOwned(
+	ctx context.Context,
+	ownerID string,
+	matterID string,
+) (Matter, error) {
+	var result Matter
+	var status string
+	err := r.database.QueryRow(ctx, `
+SELECT
+    id::text,
+    owner_user_id::text,
+    title,
+    status,
+    version,
+    created_at,
+    updated_at
+FROM matters
+WHERE id = $1 AND owner_user_id = $2`,
+		matterID,
+		ownerID,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.Title,
+		&status,
+		&result.Version,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+	if err != nil {
+		return Matter{}, mapPostgresError(err)
+	}
+	result.Status = Status(status)
+	return result, nil
+}
+
+func (r *PostgresRepository) UpdateStatus(
+	ctx context.Context,
+	ownerID string,
+	matterID string,
+	expectedVersion int64,
+	status Status,
+) (Matter, error) {
+	var result Matter
+	var persistedStatus string
+	err := r.database.QueryRow(ctx, `
+UPDATE matters
+SET
+    status = $4,
+    version = version + 1,
+    updated_at = GREATEST(
+        CURRENT_TIMESTAMP,
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE id = $1
+  AND owner_user_id = $2
+  AND version = $3
+RETURNING
+    id::text,
+    owner_user_id::text,
+    title,
+    status,
+    version,
+    created_at,
+    updated_at`,
+		matterID,
+		ownerID,
+		expectedVersion,
+		status,
+	).Scan(
+		&result.ID,
+		&result.OwnerID,
+		&result.Title,
+		&persistedStatus,
+		&result.Version,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		if _, findErr := r.FindOwned(ctx, ownerID, matterID); findErr != nil {
+			return Matter{}, findErr
+		}
+		return Matter{}, ErrConflict
+	}
+	if err != nil {
+		return Matter{}, mapPostgresError(err)
+	}
+	result.Status = Status(persistedStatus)
+	return result, nil
+}
+
+func mapPostgresError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		switch postgresError.Code {
+		case "23503":
+			return ErrNotFound
+		case "23505":
+			return ErrConflict
+		}
+	}
+	return ErrRepository
+}

--- a/server/internal/matter/service.go
+++ b/server/internal/matter/service.go
@@ -1,0 +1,127 @@
+package matter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	maxMatterTitleRunes = 200
+	maxMatterTitleBytes = 512
+)
+
+type Service struct {
+	repository Repository
+}
+
+func NewService(repository Repository) (*Service, error) {
+	if repository == nil {
+		return nil, errors.New("matter: repository is required")
+	}
+	return &Service{repository: repository}, nil
+}
+
+func (s *Service) Create(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	title string,
+) (Matter, error) {
+	if !actor.Valid() {
+		return Matter{}, ErrInvalidRequest
+	}
+	normalizedTitle, ok := normalizeTitle(title)
+	if !ok {
+		return Matter{}, ErrInvalidRequest
+	}
+	return s.repository.Create(ctx, actor.UserID, normalizedTitle)
+}
+
+func (s *Service) List(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) ([]Matter, error) {
+	if !actor.Valid() {
+		return nil, ErrInvalidRequest
+	}
+	return s.repository.ListOwned(ctx, actor.UserID)
+}
+
+func (s *Service) ReadOwned(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	matterID string,
+) (Matter, error) {
+	if !actor.Valid() || !validUUID(matterID) {
+		return Matter{}, ErrNotFound
+	}
+	return s.repository.FindOwned(ctx, actor.UserID, matterID)
+}
+
+func (s *Service) ChangeStatus(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	matterID string,
+	expectedVersion int64,
+	status Status,
+) (Matter, error) {
+	if !actor.Valid() || !validUUID(matterID) || expectedVersion < 1 ||
+		!validStatus(status) {
+		return Matter{}, ErrInvalidRequest
+	}
+	current, err := s.repository.FindOwned(ctx, actor.UserID, matterID)
+	if err != nil {
+		return Matter{}, err
+	}
+	if current.Version != expectedVersion {
+		return Matter{}, ErrConflict
+	}
+	if current.Status == status {
+		return current, nil
+	}
+	if !canTransition(current.Status, status) {
+		return Matter{}, ErrConflict
+	}
+	return s.repository.UpdateStatus(
+		ctx,
+		actor.UserID,
+		matterID,
+		expectedVersion,
+		status,
+	)
+}
+
+func normalizeTitle(title string) (string, bool) {
+	if !utf8.ValidString(title) {
+		return "", false
+	}
+	title = strings.TrimSpace(title)
+	if title == "" ||
+		utf8.RuneCountInString(title) > maxMatterTitleRunes ||
+		len(title) > maxMatterTitleBytes {
+		return "", false
+	}
+	return title, true
+}
+
+func validStatus(status Status) bool {
+	return status == StatusActive ||
+		status == StatusCompleted ||
+		status == StatusArchived
+}
+
+func canTransition(from, to Status) bool {
+	switch from {
+	case StatusActive:
+		return to == StatusCompleted || to == StatusArchived
+	case StatusCompleted:
+		return to == StatusActive || to == StatusArchived
+	case StatusArchived:
+		return to == StatusActive
+	default:
+		return false
+	}
+}

--- a/server/internal/matter/service.go
+++ b/server/internal/matter/service.go
@@ -100,6 +100,7 @@ func normalizeTitle(title string) (string, bool) {
 	}
 	title = strings.TrimSpace(title)
 	if title == "" ||
+		strings.ContainsRune(title, '\x00') ||
 		utf8.RuneCountInString(title) > maxMatterTitleRunes ||
 		len(title) > maxMatterTitleBytes {
 		return "", false

--- a/server/internal/matter/validation.go
+++ b/server/internal/matter/validation.go
@@ -1,0 +1,11 @@
+package matter
+
+import "regexp"
+
+var uuidPattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+)
+
+func validUUID(value string) bool {
+	return uuidPattern.MatchString(value)
+}

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -500,6 +500,48 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 		t.Fatalf("session count after user delete = %d, want 0", sessionCount)
 	}
 
+	status, err := runner.Version()
+	if err != nil {
+		t.Fatalf("read version before identity down migration: %v", err)
+	}
+	for status.Present && status.Version > 2 {
+		changed, err = runner.DownOne()
+		if err != nil {
+			t.Fatalf("revert migration newer than identity: %v", err)
+		}
+		if !changed {
+			t.Fatal("newer migration down reported no change")
+		}
+		status, err = runner.Version()
+		if err != nil {
+			t.Fatalf("read version while reverting newer migrations: %v", err)
+		}
+	}
+	if !status.Present || status.Version != 2 || status.Dirty {
+		t.Fatalf(
+			"status before identity down migration = %+v, want version 2 clean",
+			status,
+		)
+	}
+	for _, table := range []string{
+		"matters",
+		"agent_threads",
+		"agent_thread_matter_links",
+		"agent_messages",
+	} {
+		var relation *string
+		if err := admin.QueryRow(
+			ctx,
+			"SELECT to_regclass($1)",
+			schema+"."+table,
+		).Scan(&relation); err != nil {
+			t.Fatalf("inspect %s after newer migrations down: %v", table, err)
+		}
+		if relation != nil {
+			t.Fatalf("%s still exists after its down migration as %q", table, *relation)
+		}
+	}
+
 	changed, err = runner.DownOne()
 	if err != nil {
 		t.Fatalf("revert identity migration: %v", err)
@@ -507,7 +549,7 @@ func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 	if !changed {
 		t.Fatal("identity down migration reported no change")
 	}
-	status, err := runner.Version()
+	status, err = runner.Version()
 	if err != nil {
 		t.Fatalf("read version after identity down migration: %v", err)
 	}

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -106,6 +106,157 @@ func TestRunnerAppliesIdempotentlyAndRevertsLatestMigration(t *testing.T) {
 	}
 }
 
+func TestAgentDataMigrationUpgradesIdentitySchemaAndReapplies(t *testing.T) {
+	migrationConfig, admin, schema := isolatedMigrationConfig(t)
+	runner, err := openConfig(migrationConfig)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+
+	if err := runner.migrate.Steps(2); err != nil {
+		t.Fatalf("apply migrations through Identity: %v", err)
+	}
+	status, err := runner.Version()
+	if err != nil {
+		t.Fatalf("read Identity migration version: %v", err)
+	}
+	if !status.Present || status.Version != 2 || status.Dirty {
+		t.Fatalf("Identity migration status = %+v, want clean version 2", status)
+	}
+
+	scoped, err := pgx.ConnectConfig(context.Background(), migrationConfig)
+	if err != nil {
+		t.Fatalf("connect to Identity schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := scoped.Close(context.Background()); err != nil {
+			t.Errorf("close Identity schema connection: %v", err)
+		}
+	})
+	const existingUserID = "10000000-0000-4000-8000-000000000085"
+	if _, err := scoped.Exec(
+		context.Background(),
+		`INSERT INTO identity_users (id, canonical_email)
+VALUES ($1, 'agent-data-upgrade@example.com')`,
+		existingUserID,
+	); err != nil {
+		t.Fatalf("insert pre-upgrade Identity user: %v", err)
+	}
+
+	if err := runner.migrate.Steps(1); err != nil {
+		t.Fatalf("upgrade Identity schema to Agent data: %v", err)
+	}
+	status, err = runner.Version()
+	if err != nil {
+		t.Fatalf("read Agent data migration version: %v", err)
+	}
+	if !status.Present || status.Version != 3 || status.Dirty {
+		t.Fatalf("Agent data migration status = %+v, want clean version 3", status)
+	}
+	assertAgentDataTables(t, admin, schema, true)
+	assertIdentityUserPreserved(t, scoped, existingUserID)
+
+	changed, err := runner.DownOne()
+	if err != nil {
+		t.Fatalf("revert Agent data migration: %v", err)
+	}
+	if !changed {
+		t.Fatal("Agent data down migration reported no change")
+	}
+	status, err = runner.Version()
+	if err != nil {
+		t.Fatalf("read version after Agent data down: %v", err)
+	}
+	if !status.Present || status.Version != 2 || status.Dirty {
+		t.Fatalf("status after Agent data down = %+v, want clean version 2", status)
+	}
+	assertAgentDataTables(t, admin, schema, false)
+	assertIdentityUserPreserved(t, scoped, existingUserID)
+
+	changed, err = runner.Up()
+	if err != nil {
+		t.Fatalf("reapply Agent data migration: %v", err)
+	}
+	if !changed {
+		t.Fatal("Agent data reapply reported no change")
+	}
+	assertAgentDataTables(t, admin, schema, true)
+	assertIdentityUserPreserved(t, scoped, existingUserID)
+
+	changed, err = runner.Up()
+	if err != nil {
+		t.Fatalf("repeat Agent data migration: %v", err)
+	}
+	if changed {
+		t.Fatal("repeat Agent data migration unexpectedly changed the schema")
+	}
+}
+
+func assertAgentDataTables(
+	t *testing.T,
+	admin *pgx.Conn,
+	schema string,
+	wantPresent bool,
+) {
+	t.Helper()
+	var tableCount int
+	if err := admin.QueryRow(
+		context.Background(),
+		`SELECT count(*)
+FROM information_schema.tables
+WHERE table_schema = $1
+  AND table_name IN (
+      'matters',
+      'agent_threads',
+      'agent_thread_matter_links',
+      'agent_messages'
+  )`,
+		schema,
+	).Scan(&tableCount); err != nil {
+		t.Fatalf("inspect Agent data tables: %v", err)
+	}
+	wantCount := 0
+	if wantPresent {
+		wantCount = 4
+	}
+	if tableCount != wantCount {
+		t.Fatalf(
+			"Agent data table count = %d, want %d",
+			tableCount,
+			wantCount,
+		)
+	}
+}
+
+func assertIdentityUserPreserved(
+	t *testing.T,
+	scoped *pgx.Conn,
+	userID string,
+) {
+	t.Helper()
+	var canonicalEmail string
+	if err := scoped.QueryRow(
+		context.Background(),
+		`SELECT canonical_email
+FROM identity_users
+WHERE id = $1`,
+		userID,
+	).Scan(&canonicalEmail); err != nil {
+		t.Fatalf("read preserved Identity user: %v", err)
+	}
+	if canonicalEmail != "agent-data-upgrade@example.com" {
+		t.Fatalf(
+			"preserved canonical email = %q, want agent-data-upgrade@example.com",
+			canonicalEmail,
+		)
+	}
+}
+
 func TestIdentityMigrationEnforcesConstraintsAndIndexes(t *testing.T) {
 	migrationConfig, admin, schema := isolatedMigrationConfig(t)
 

--- a/server/migrations/000003_agent_data.down.sql
+++ b/server/migrations/000003_agent_data.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP TABLE agent_messages;
+DROP TABLE agent_thread_matter_links;
+DROP TABLE agent_threads;
+DROP TABLE matters;
+
+COMMIT;

--- a/server/migrations/000003_agent_data.up.sql
+++ b/server/migrations/000003_agent_data.up.sql
@@ -1,0 +1,114 @@
+BEGIN;
+
+CREATE TABLE matters (
+    id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    title text NOT NULL,
+    status text NOT NULL DEFAULT 'active',
+    version bigint NOT NULL DEFAULT 1,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT matters_owner_user_id_fkey
+        FOREIGN KEY (owner_user_id)
+        REFERENCES identity_users (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT matters_id_owner_key UNIQUE (id, owner_user_id),
+    CONSTRAINT matters_title_length_check
+        CHECK (
+            char_length(title) BETWEEN 1 AND 200
+            AND octet_length(title) <= 512
+        ),
+    CONSTRAINT matters_title_trimmed_check
+        CHECK (title = btrim(title) AND title !~ '^[[:space:]]*$'),
+    CONSTRAINT matters_status_check
+        CHECK (status IN ('active', 'completed', 'archived')),
+    CONSTRAINT matters_version_check CHECK (version > 0),
+    CONSTRAINT matters_timestamps_check CHECK (updated_at >= created_at)
+);
+
+CREATE INDEX matters_owner_updated_idx
+    ON matters (owner_user_id, updated_at DESC, id DESC);
+
+CREATE TABLE agent_threads (
+    id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    next_message_sequence bigint NOT NULL DEFAULT 1,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT agent_threads_owner_user_id_fkey
+        FOREIGN KEY (owner_user_id)
+        REFERENCES identity_users (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT agent_threads_id_owner_key UNIQUE (id, owner_user_id),
+    CONSTRAINT agent_threads_next_sequence_check
+        CHECK (next_message_sequence > 0),
+    CONSTRAINT agent_threads_timestamps_check
+        CHECK (updated_at >= created_at)
+);
+
+CREATE INDEX agent_threads_owner_updated_idx
+    ON agent_threads (owner_user_id, updated_at DESC, id DESC);
+
+CREATE TABLE agent_thread_matter_links (
+    owner_user_id uuid NOT NULL,
+    thread_id uuid NOT NULL,
+    matter_id uuid NOT NULL,
+    is_active boolean NOT NULL DEFAULT false,
+    linked_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT agent_thread_matter_links_pkey
+        PRIMARY KEY (thread_id, matter_id),
+    CONSTRAINT agent_thread_matter_links_thread_owner_fkey
+        FOREIGN KEY (thread_id, owner_user_id)
+        REFERENCES agent_threads (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_thread_matter_links_matter_owner_fkey
+        FOREIGN KEY (matter_id, owner_user_id)
+        REFERENCES matters (id, owner_user_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT agent_thread_matter_links_timestamps_check
+        CHECK (updated_at >= linked_at)
+);
+
+CREATE UNIQUE INDEX agent_thread_matter_links_one_active_idx
+    ON agent_thread_matter_links (owner_user_id, thread_id)
+    WHERE is_active;
+
+CREATE INDEX agent_thread_matter_links_matter_idx
+    ON agent_thread_matter_links (owner_user_id, matter_id, thread_id);
+
+CREATE TABLE agent_messages (
+    id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    thread_id uuid NOT NULL,
+    sequence_no bigint NOT NULL,
+    role text NOT NULL,
+    client_message_id text COLLATE "C" NOT NULL,
+    content text NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT agent_messages_thread_owner_fkey
+        FOREIGN KEY (thread_id, owner_user_id)
+        REFERENCES agent_threads (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_messages_thread_sequence_key
+        UNIQUE (owner_user_id, thread_id, sequence_no),
+    CONSTRAINT agent_messages_client_idempotency_key
+        UNIQUE (owner_user_id, thread_id, client_message_id),
+    CONSTRAINT agent_messages_sequence_check CHECK (sequence_no > 0),
+    CONSTRAINT agent_messages_role_check
+        CHECK (role = 'user'),
+    CONSTRAINT agent_messages_client_id_check
+        CHECK (
+            octet_length(client_message_id) BETWEEN 1 AND 128
+            AND client_message_id ~
+                '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        ),
+    CONSTRAINT agent_messages_content_length_check
+        CHECK (
+            char_length(content) BETWEEN 1 AND 4096
+            AND octet_length(content) <= 16384
+            AND content !~ '^[[:space:]]*$'
+        )
+);
+
+COMMIT;


### PR DESCRIPTION
## 功能说明

- 建立 Matter、AgentThread、ThreadMatterLink 与 AgentMessage 的最小 PostgreSQL 纵向链路。
- 登录用户可创建、列出和按 ID 恢复自己的 Matter。
- 登录用户可建立或恢复 Agent Thread，关联 active Matter，并按稳定顺序读取消息。
- 用户消息使用 `client_message_id` 幂等；重复请求返回同一消息，不产生第二次写入。
- 所有私有操作从服务端可信 Actor 派生 Owner，不接受客户端 `user_id`。
- 提供最小受保护 REST 接口与生产 Bootstrap 装配。

## 数据与并发边界

- Matter 生命周期由 Matter 模块拥有；Agent 只通过 Reader/Service 使用。
- Thread 可关联多个 Matter，一次运行只选择一个 active Matter。
- Message 使用服务端分配的线程内单调序号，不依赖客户端时间排序。
- ThreadMatterLink 与 Message 使用数据库组合外键证明父子对象属于同一用户。
- 同一 `client_message_id` 的 8 并发请求 exactly-once；16 并发消息仍保持唯一稳定序号。
- 用户 A 读取、关联或写入用户 B 的 Matter、Thread、Message 均失败。
- 服务和 PostgreSQL 重启后可恢复 Matter、Thread 和消息。

## 依赖同步

- PR #84 与 PR #83 已合入 `upstream/dev`。
- 本分支基于最新 `upstream/dev`（`26d313b`），当前仅包含 #85 的 5 个自有提交。
- 当前 Head 为 `ff23d83`，最终差异只包含 #85 范围内的 21 个文件，没有夹带依赖分支提交。

## 可复现验证

```bash
TEST_DATABASE_URL=<隔离测试数据库连接串> make check
cd server
TEST_DATABASE_URL=<隔离测试数据库连接串> \
  go test -race -count=2 ./internal/agent ./internal/matter ./internal/platform/migration
TEST_DATABASE_URL=<隔离测试数据库连接串> \
  go test -count=5 -run "^TestPostgresAgentDataVerticalSlice$" ./internal/agent
GOTOOLCHAIN=go1.26.5+auto go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
cd ..
git diff --check
```

本地已验证：

- 完整 `make check` 通过：Flutter 111 项测试、Go 与真实 PostgreSQL、38 个 API operation（5 个公开、33 个 Bearer 保护）、16 个 WebSocket event、7 个拒绝用例和确定性 Smoke 全绿。
- Migration `000003` 的空库、Identity v2 升级、Down、重放与重复 Up 测试通过，已有 Identity 数据保持不变。
- Matter、Thread、Message 双用户负例、并发幂等和服务/数据库重启恢复通过。
- race 测试与 5 次真实 PostgreSQL 纵向链路通过。
- `govulncheck` 未发现可达漏洞，`git diff --check` 通过。

## 明确不做

- 不实现 AgentRun、模型 Provider、ContextAssembler、ToolCall 或长期信息。
- 不实现 ASR、TTS、Practice、Conversation 或 Review。
- 不修改其他成员负责的旧 Practice、Conversation 或 Review Issue。
- 不迁移 Agent Demo 的固定用户、JSON、SQLite 或 Mem0。

Closes #85
