### PR TITLE
[功能] 提供当前账号的正式 Review 历史分页接口

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ QIANWEN_MAX_OUTPUT_TOKENS=512
 AGENT_CONTEXT_MAX_CHARACTERS=12000
 DASHSCOPE_API_KEY=
 
+# Stable, server-only HMAC key for Review history cursors. Generate exactly
+# 32 random bytes and encode them as unpadded base64url. Keep the same value
+# across restarts and replicas; rotating it invalidates outstanding cursors.
+REVIEW_HISTORY_CURSOR_SIGNING_KEY=
+
 # Explicit opt-in for a local real-provider test; public CI leaves this disabled.
 # Enabling it sends a real request and may incur charges.
 QIANWEN_LIVE_TEST=0

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -128,6 +128,7 @@ jobs:
           QIANWEN_TTS_VOICE: loongeva_v3.6
           QIANWEN_TTS_LANGUAGE: en
           DASHSCOPE_API_KEY: ci-readiness-not-a-secret
+          REVIEW_HISTORY_CURSOR_SIGNING_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY
         run: |
           set -euo pipefail
 

--- a/api/modules/review.yaml
+++ b/api/modules/review.yaml
@@ -28,7 +28,7 @@ paths:
             type: string
             minLength: 1
             maxLength: 512
-            pattern: '^[A-Za-z0-9_-]+$'
+            pattern: '^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$'
       responses:
         '200':
           description: Actor-owned completed formal Reviews in stable order.

--- a/api/modules/review.yaml
+++ b/api/modules/review.yaml
@@ -1,4 +1,67 @@
 paths:
+  /v1/formal-reviews:
+    get:
+      tags:
+        - Review
+      summary: List the current Actor's completed formal Reviews
+      description: |
+        Returns only completed, Review-owned results ordered by
+        `created_at DESC, review_id DESC`. Pagination uses an opaque keyset
+        cursor; clients must not synthesize or inspect it. `next_cursor` is
+        omitted, never `null`, when no older result remains. The server fully
+        encodes the response before writing it and rejects a body larger than
+        768 KiB without returning a partial Review page.
+      operationId: listFormalReviews
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 512
+            pattern: '^[A-Za-z0-9_-]+$'
+      responses:
+        '200':
+          description: Actor-owned completed formal Reviews in stable order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormalReviewHistoryPage'
+              example:
+                items:
+                  - review_id: 20000000-0000-4000-8000-000000000002
+                    practice_session_id: session_demo_002
+                    status: completed
+                    implementation_version: qianwen-voice-review-v1
+                    source_turn_id: turn_demo_006
+                    source_turn_version: conversation-turn:evidence-v1
+                    result:
+                      overall_score: 91
+                      summary: The answer is clear and outcome-focused.
+                      conclusions:
+                        - key: clarity
+                          category: clarity
+                          message: The response is easy to follow.
+                          suggestion: Add one concrete metric.
+                    created_at: '2026-07-26T10:00:00Z'
+                    updated_at: '2026-07-26T10:00:01Z'
+                    completed_at: '2026-07-26T10:00:01Z'
+                next_cursor: eyJjcmVhdGVkX2F0IjoiMjAyNi0wNy0yNlQxMDowMDowMFoiLCJyZXZpZXdfaWQiOiIyMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDIifQ
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/turns/{turn_id}/turn-analyses:
     post:
       tags:
@@ -232,6 +295,165 @@ components:
     IdempotencyKey:
       $ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey
   schemas:
+    FormalReviewHistoryPage:
+      type: object
+      additionalProperties: false
+      description: |
+        One completed Review history page. The complete UTF-8 JSON response is
+        limited to 768 KiB (786432 bytes), including field names and escaping.
+      x-max-json-bytes: 786432
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/CompletedFormalReview'
+        next_cursor:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: |
+            Opaque cursor. The encoded cursor is limited to 512 characters;
+            its decoded metadata fields remain subject to the server's
+            128-byte UTF-8 metadata boundary.
+          pattern: '^[A-Za-z0-9_-]+$'
+    CompletedFormalReview:
+      allOf:
+        - $ref: ./conversation.yaml#/components/schemas/FormalReview
+        - type: object
+          description: |
+            Completed Review projection. Each metadata string uses
+            PostgreSQL-compatible valid UTF-8, excludes U+0000, and is at most
+            128 UTF-8 bytes, even where maxLength counts Unicode code points.
+          required:
+            - result
+            - completed_at
+          properties:
+            review_id:
+              allOf:
+                - $ref: '#/components/schemas/ResourceId'
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              description: |
+                PostgreSQL-compatible valid UTF-8 without U+0000; at most
+                128 UTF-8 bytes.
+              x-max-utf8-bytes: 128
+            practice_session_id:
+              allOf:
+                - $ref: '#/components/schemas/ResourceId'
+              pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+              description: |
+                PostgreSQL-compatible valid UTF-8 without U+0000; at most
+                128 UTF-8 bytes.
+              x-max-utf8-bytes: 128
+            status:
+              const: completed
+            implementation_version:
+              type: string
+              minLength: 1
+              maxLength: 128
+              pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+              description: |
+                PostgreSQL-compatible valid UTF-8 without U+0000; at most
+                128 UTF-8 bytes.
+              x-max-utf8-bytes: 128
+            source_turn_id:
+              allOf:
+                - $ref: '#/components/schemas/ResourceId'
+              pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+              description: |
+                PostgreSQL-compatible valid UTF-8 without U+0000; at most
+                128 UTF-8 bytes.
+              x-max-utf8-bytes: 128
+            source_turn_version:
+              type: string
+              minLength: 1
+              maxLength: 128
+              pattern: '^conversation-turn:evidence-v[1-9][0-9]*$'
+              description: |
+                PostgreSQL-compatible valid UTF-8 without U+0000; at most
+                128 UTF-8 bytes.
+              x-max-utf8-bytes: 128
+            result:
+              $ref: '#/components/schemas/CompletedFormalReviewResult'
+    CompletedFormalReviewResult:
+      type: object
+      additionalProperties: false
+      description: |
+        Completed Review result. The complete encoded JSON value is limited to
+        12 KiB (12288 bytes), in addition to the field-level limits below.
+        Every string uses PostgreSQL-compatible valid UTF-8 and excludes
+        U+0000.
+      x-max-json-bytes: 12288
+      required:
+        - overall_score
+        - summary
+        - conclusions
+      properties:
+        overall_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        summary:
+          type: string
+          minLength: 1
+          maxLength: 2048
+          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+          description: |
+            Non-blank PostgreSQL-compatible valid UTF-8 text without
+            U+0000, at most 2048 UTF-8 bytes.
+          x-max-utf8-bytes: 2048
+        conclusions:
+          type: array
+          minItems: 1
+          maxItems: 8
+          items:
+            $ref: '#/components/schemas/CompletedFormalReviewConclusion'
+    CompletedFormalReviewConclusion:
+      type: object
+      additionalProperties: false
+      required:
+        - key
+        - category
+        - message
+      properties:
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: '^(?![\s\S]*\u0000)\S(?:[\s\S]*\S)?(?![\s\S])'
+          description: |
+            Trimmed, non-empty PostgreSQL-compatible valid UTF-8 key without
+            U+0000, at most 64 UTF-8 bytes.
+          x-max-utf8-bytes: 64
+        category:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+          description: |
+            Non-blank PostgreSQL-compatible valid UTF-8 category
+            without U+0000, at most 64 UTF-8 bytes.
+          x-max-utf8-bytes: 64
+        message:
+          type: string
+          minLength: 1
+          maxLength: 2048
+          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+          description: |
+            Non-blank PostgreSQL-compatible valid UTF-8 message
+            without U+0000, at most 2048 UTF-8 bytes.
+          x-max-utf8-bytes: 2048
+        suggestion:
+          type: string
+          minLength: 1
+          maxLength: 2048
+          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
+          description: |
+            When present, non-blank PostgreSQL-compatible valid UTF-8 text
+            without U+0000, at most 2048 UTF-8 bytes.
+          x-max-utf8-bytes: 2048
     ResourceId:
       type: string
       minLength: 1

--- a/api/modules/review.yaml
+++ b/api/modules/review.yaml
@@ -55,7 +55,7 @@ paths:
                     created_at: '2026-07-26T10:00:00Z'
                     updated_at: '2026-07-26T10:00:01Z'
                     completed_at: '2026-07-26T10:00:01Z'
-                next_cursor: eyJjcmVhdGVkX2F0IjoiMjAyNi0wNy0yNlQxMDowMDowMFoiLCJyZXZpZXdfaWQiOiIyMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDIifQ
+                next_cursor: eyJ2IjoxLCJraW5kIjoiZm9ybWFsX3Jldmlld3MifQ.QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
         '401':
@@ -318,7 +318,7 @@ components:
             Opaque cursor. The encoded cursor is limited to 512 characters;
             its decoded metadata fields remain subject to the server's
             128-byte UTF-8 metadata boundary.
-          pattern: '^[A-Za-z0-9_-]+$'
+          pattern: '^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$'
     CompletedFormalReview:
       allOf:
         - $ref: ./conversation.yaml#/components/schemas/FormalReview
@@ -376,84 +376,12 @@ components:
                 128 UTF-8 bytes.
               x-max-utf8-bytes: 128
             result:
-              $ref: '#/components/schemas/CompletedFormalReviewResult'
-    CompletedFormalReviewResult:
-      type: object
-      additionalProperties: false
-      description: |
-        Completed Review result. The complete encoded JSON value is limited to
-        12 KiB (12288 bytes), in addition to the field-level limits below.
-        Every string uses PostgreSQL-compatible valid UTF-8 and excludes
-        U+0000.
-      x-max-json-bytes: 12288
-      required:
-        - overall_score
-        - summary
-        - conclusions
-      properties:
-        overall_score:
-          type: integer
-          minimum: 0
-          maximum: 100
-        summary:
-          type: string
-          minLength: 1
-          maxLength: 2048
-          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
-          description: |
-            Non-blank PostgreSQL-compatible valid UTF-8 text without
-            U+0000, at most 2048 UTF-8 bytes.
-          x-max-utf8-bytes: 2048
-        conclusions:
-          type: array
-          minItems: 1
-          maxItems: 8
-          items:
-            $ref: '#/components/schemas/CompletedFormalReviewConclusion'
-    CompletedFormalReviewConclusion:
-      type: object
-      additionalProperties: false
-      required:
-        - key
-        - category
-        - message
-      properties:
-        key:
-          type: string
-          minLength: 1
-          maxLength: 64
-          pattern: '^(?![\s\S]*\u0000)\S(?:[\s\S]*\S)?(?![\s\S])'
-          description: |
-            Trimmed, non-empty PostgreSQL-compatible valid UTF-8 key without
-            U+0000, at most 64 UTF-8 bytes.
-          x-max-utf8-bytes: 64
-        category:
-          type: string
-          minLength: 1
-          maxLength: 64
-          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
-          description: |
-            Non-blank PostgreSQL-compatible valid UTF-8 category
-            without U+0000, at most 64 UTF-8 bytes.
-          x-max-utf8-bytes: 64
-        message:
-          type: string
-          minLength: 1
-          maxLength: 2048
-          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
-          description: |
-            Non-blank PostgreSQL-compatible valid UTF-8 message
-            without U+0000, at most 2048 UTF-8 bytes.
-          x-max-utf8-bytes: 2048
-        suggestion:
-          type: string
-          minLength: 1
-          maxLength: 2048
-          pattern: '^(?![\s\S]*\u0000)[\s\S]*\S[\s\S]*$'
-          description: |
-            When present, non-blank PostgreSQL-compatible valid UTF-8 text
-            without U+0000, at most 2048 UTF-8 bytes.
-          x-max-utf8-bytes: 2048
+              description: |
+                New writes are bounded by the Review service. Results committed
+                before that limit remain readable; the complete page is still
+                subject to the 768 KiB response budget.
+              allOf:
+                - $ref: ./conversation.yaml#/components/schemas/FormalReviewResult
     ResourceId:
       type: string
       minLength: 1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -105,6 +105,8 @@ paths:
     $ref: ./modules/conversation.yaml#/paths/~1v1~1transcription-candidates~1{candidate_id}~1confirmations
   /v1/voice-questions/{question_id}/speech:
     $ref: ./modules/conversation.yaml#/paths/~1v1~1voice-questions~1{question_id}~1speech
+  /v1/formal-reviews:
+    $ref: ./modules/review.yaml#/paths/~1v1~1formal-reviews
   /v1/formal-reviews/{review_id}:
     $ref: ./modules/conversation.yaml#/paths/~1v1~1formal-reviews~1{review_id}
   /v1/scenario-definitions/{scenario_definition_id}:

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -872,6 +872,35 @@ assert.equal(
 );
 assert.equal(websocketParameters.after_sequence?.in, 'query');
 
+const formalReviewHistory = requireOperation('GET /v1/formal-reviews');
+const formalReviewHistoryParameters = Object.fromEntries(
+  (formalReviewHistory.parameters ?? []).map((parameterValue) => {
+    const parameter = resolveLocalReference(parameterValue);
+    return [parameter.name, parameter];
+  }),
+);
+const formalReviewCursorPattern = resolveLocalReference(
+  formalReviewHistoryParameters.cursor?.schema,
+)?.pattern;
+const formalReviewHistoryResponse = resolveLocalReference(
+  formalReviewHistory.responses?.['200'],
+);
+const formalReviewHistorySchema = resolveLocalReference(
+  getJsonSchema(formalReviewHistoryResponse),
+);
+const formalReviewNextCursorPattern = resolveLocalReference(
+  formalReviewHistorySchema?.properties?.next_cursor,
+)?.pattern;
+assert.equal(
+  formalReviewCursorPattern,
+  formalReviewNextCursorPattern,
+  'Formal Review request cursor must accept the server next_cursor format.',
+);
+assert.match(
+  'signed_payload.signed_mac',
+  new RegExp(formalReviewCursorPattern, 'u'),
+);
+
 console.log(
   `Validated ${operations.length} operations: ` +
     `${actualPublicOperations.size} public and ` +

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -67,6 +67,11 @@ func run() int {
 		logger.Error("temporary audio configuration failed")
 		return 1
 	}
+	reviewHistoryConfig, err := config.LoadReviewHistory()
+	if err != nil {
+		logger.Error("Review history configuration failed")
+		return 1
+	}
 	audioVault, err := platformmedia.NewTemporaryAudioVault(
 		platformmedia.TemporaryAudioVaultConfig{
 			ScratchDirectory:              ttsConfig.TempDirectory,
@@ -153,6 +158,9 @@ func run() int {
 				// below it even when the shared provider client allows 60s.
 				ReviewGenerationTimeout: 20 * time.Second,
 				AudioReadTimeout:        temporaryAudioConfig.ReadTimeout,
+				ReviewHistoryCursorKey: []byte(
+					reviewHistoryConfig.CursorSigningKey.Reveal(),
+				),
 			},
 		)
 	if err != nil {

--- a/server/internal/agent/http.go
+++ b/server/internal/agent/http.go
@@ -30,6 +30,7 @@ const (
 	defaultThreadPageSize   = 20
 	defaultMessagePageSize  = 50
 	defaultVoiceReadTimeout = 15 * time.Second
+	maxReviewHistoryBody    = 768 * 1024
 )
 
 type CorrelationIDGenerator func() string
@@ -201,6 +202,7 @@ func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
 			"/v1/voice-questions/:question_id/speech",
 			h.questionSpeech,
 		)
+		protected.GET("/v1/formal-reviews", h.listFormalReviews)
 		protected.GET("/v1/formal-reviews/:review_id", h.getFormalReview)
 	}
 	if h.audioAssets != nil {
@@ -904,10 +906,71 @@ func (h *HTTPHandler) getFormalReview(c *gin.Context) {
 		c.Param("review_id"),
 	)
 	if err != nil {
+		if errors.Is(err, ErrInvalidContext) {
+			h.writeError(
+				c,
+				http.StatusInternalServerError,
+				"internal_error",
+				true,
+			)
+			return
+		}
 		h.writeVoiceError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, formalReviewResponse(formalReview))
+	h.writeBoundedReviewJSON(c, formalReviewResponse(formalReview))
+}
+
+func (h *HTTPHandler) listFormalReviews(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	query, ok := decodeReviewHistoryQuery(c.Request)
+	if !ok {
+		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
+		return
+	}
+	page, err := h.voice.ListReviews(c.Request.Context(), actor, query)
+	if err != nil {
+		if errors.Is(err, ErrInvalidContext) {
+			h.writeError(
+				c,
+				http.StatusInternalServerError,
+				"internal_error",
+				true,
+			)
+			return
+		}
+		h.writeVoiceError(c, err)
+		return
+	}
+	items := make([]gin.H, len(page.Items))
+	for index, item := range page.Items {
+		items[index] = formalReviewResponse(item)
+	}
+	result := gin.H{"items": items}
+	if page.Next != nil {
+		result["next_cursor"] = encodeReviewHistoryCursor(*page.Next)
+	}
+	h.writeBoundedReviewJSON(c, result)
+}
+
+func (h *HTTPHandler) writeBoundedReviewJSON(
+	c *gin.Context,
+	value any,
+) {
+	payload, err := json.Marshal(value)
+	if err != nil || len(payload) > maxReviewHistoryBody {
+		h.writeError(c, http.StatusInternalServerError, "internal_error", true)
+		return
+	}
+	c.Data(
+		http.StatusOK,
+		"application/json; charset=utf-8",
+		payload,
+	)
 }
 
 func (h *HTTPHandler) authenticationMiddleware() gin.HandlerFunc {
@@ -1173,6 +1236,81 @@ func formalReviewResponse(item VoiceSessionReview) gin.H {
 		result["completed_at"] = item.CompletedAt.UTC().Format(time.RFC3339Nano)
 	}
 	return result
+}
+
+func decodeReviewHistoryQuery(
+	request *http.Request,
+) (VoiceReviewHistoryQuery, bool) {
+	const defaultLimit = 20
+	values, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		return VoiceReviewHistoryQuery{}, false
+	}
+	for key := range values {
+		if key != "limit" && key != "cursor" {
+			return VoiceReviewHistoryQuery{}, false
+		}
+	}
+	query := VoiceReviewHistoryQuery{Limit: defaultLimit}
+	if limitValues, exists := values["limit"]; exists {
+		if len(limitValues) != 1 {
+			return VoiceReviewHistoryQuery{}, false
+		}
+		limit, err := strconv.Atoi(limitValues[0])
+		if err != nil || limit < 1 || limit > 50 {
+			return VoiceReviewHistoryQuery{}, false
+		}
+		query.Limit = limit
+	}
+	if cursorValues, exists := values["cursor"]; exists {
+		if len(cursorValues) != 1 {
+			return VoiceReviewHistoryQuery{}, false
+		}
+		cursor, ok := decodeReviewHistoryCursor(cursorValues[0])
+		if !ok {
+			return VoiceReviewHistoryQuery{}, false
+		}
+		query.Before = &cursor
+	}
+	return query, true
+}
+
+func encodeReviewHistoryCursor(cursor VoiceReviewHistoryCursor) string {
+	payload, _ := json.Marshal(gin.H{
+		"created_at": cursor.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"review_id":  cursor.ReviewID,
+	})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeReviewHistoryCursor(
+	value string,
+) (VoiceReviewHistoryCursor, bool) {
+	if value == "" || len(value) > 512 {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil || len(payload) > 256 {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	var object map[string]any
+	if err := json.Unmarshal(payload, &object); err != nil ||
+		len(object) != 2 {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	createdAtValue, createdAtOK := object["created_at"].(string)
+	reviewID, reviewIDOK := object["review_id"].(string)
+	if !createdAtOK || !reviewIDOK || !validUUID(reviewID) {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
+	if err != nil || createdAt.IsZero() {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	return VoiceReviewHistoryCursor{
+		CreatedAt: createdAt,
+		ReviewID:  reviewID,
+	}, true
 }
 
 func matterResponse(item matter.Matter) gin.H {

--- a/server/internal/agent/http.go
+++ b/server/internal/agent/http.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -31,12 +33,16 @@ const (
 	defaultMessagePageSize  = 50
 	defaultVoiceReadTimeout = 15 * time.Second
 	maxReviewHistoryBody    = 768 * 1024
+	reviewCursorVersion     = 1
+	reviewCursorKind        = "formal_reviews"
+	minReviewCursorKeyBytes = 32
 )
 
 type CorrelationIDGenerator func() string
 
 type VoiceHTTPOptions struct {
-	AudioReadTimeout time.Duration
+	AudioReadTimeout       time.Duration
+	ReviewHistoryCursorKey []byte
 }
 
 type HTTPHandler struct {
@@ -48,6 +54,7 @@ type HTTPHandler struct {
 	authenticator    identity.Authenticator
 	correlationID    CorrelationIDGenerator
 	voiceReadTimeout time.Duration
+	reviewCursorKey  []byte
 }
 
 func NewHTTPHandler(
@@ -124,10 +131,26 @@ func NewHTTPHandlerWithRunsVoiceAndAudio(
 		return nil, errors.New("agent: duplicate voice HTTP options")
 	}
 	if len(voiceOptions) == 1 {
-		if voiceOptions[0].AudioReadTimeout <= 0 {
+		if voiceOptions[0].AudioReadTimeout < 0 {
 			return nil, errors.New("agent: voice audio read timeout is required")
 		}
-		voiceReadTimeout = voiceOptions[0].AudioReadTimeout
+		if voiceOptions[0].AudioReadTimeout > 0 {
+			voiceReadTimeout = voiceOptions[0].AudioReadTimeout
+		}
+	}
+	var reviewCursorKey []byte
+	if voice != nil {
+		if len(voiceOptions) != 1 ||
+			len(voiceOptions[0].ReviewHistoryCursorKey) <
+				minReviewCursorKeyBytes {
+			return nil, errors.New(
+				"agent: Review history cursor signing key is required",
+			)
+		}
+		reviewCursorKey = append(
+			[]byte(nil),
+			voiceOptions[0].ReviewHistoryCursorKey...,
+		)
 	}
 	return &HTTPHandler{
 		application:      application,
@@ -138,6 +161,7 @@ func NewHTTPHandlerWithRunsVoiceAndAudio(
 		authenticator:    authenticator,
 		correlationID:    correlationID,
 		voiceReadTimeout: voiceReadTimeout,
+		reviewCursorKey:  reviewCursorKey,
 	}, nil
 }
 
@@ -927,7 +951,7 @@ func (h *HTTPHandler) listFormalReviews(c *gin.Context) {
 		h.writeAuthenticationRequired(c)
 		return
 	}
-	query, ok := decodeReviewHistoryQuery(c.Request)
+	query, ok := h.decodeReviewHistoryQuery(c.Request, actor.UserID)
 	if !ok {
 		h.writeError(c, http.StatusBadRequest, "invalid_request", false)
 		return
@@ -952,7 +976,20 @@ func (h *HTTPHandler) listFormalReviews(c *gin.Context) {
 	}
 	result := gin.H{"items": items}
 	if page.Next != nil {
-		result["next_cursor"] = encodeReviewHistoryCursor(*page.Next)
+		cursor, cursorOK := h.encodeReviewHistoryCursor(
+			actor.UserID,
+			*page.Next,
+		)
+		if !cursorOK {
+			h.writeError(
+				c,
+				http.StatusInternalServerError,
+				"internal_error",
+				true,
+			)
+			return
+		}
+		result["next_cursor"] = cursor
 	}
 	h.writeBoundedReviewJSON(c, result)
 }
@@ -1238,8 +1275,9 @@ func formalReviewResponse(item VoiceSessionReview) gin.H {
 	return result
 }
 
-func decodeReviewHistoryQuery(
+func (h *HTTPHandler) decodeReviewHistoryQuery(
 	request *http.Request,
+	actorUserID string,
 ) (VoiceReviewHistoryQuery, bool) {
 	const defaultLimit = 20
 	values, err := url.ParseQuery(request.URL.RawQuery)
@@ -1266,7 +1304,10 @@ func decodeReviewHistoryQuery(
 		if len(cursorValues) != 1 {
 			return VoiceReviewHistoryQuery{}, false
 		}
-		cursor, ok := decodeReviewHistoryCursor(cursorValues[0])
+		cursor, ok := h.decodeReviewHistoryCursor(
+			actorUserID,
+			cursorValues[0],
+		)
 		if !ok {
 			return VoiceReviewHistoryQuery{}, false
 		}
@@ -1275,42 +1316,105 @@ func decodeReviewHistoryQuery(
 	return query, true
 }
 
-func encodeReviewHistoryCursor(cursor VoiceReviewHistoryCursor) string {
-	payload, _ := json.Marshal(gin.H{
-		"created_at": cursor.CreatedAt.UTC().Format(time.RFC3339Nano),
-		"review_id":  cursor.ReviewID,
-	})
-	return base64.RawURLEncoding.EncodeToString(payload)
+type reviewHistoryCursorEnvelope struct {
+	Version   int    `json:"v"`
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at"`
+	ReviewID  string `json:"review_id"`
 }
 
-func decodeReviewHistoryCursor(
+func (h *HTTPHandler) encodeReviewHistoryCursor(
+	actorUserID string,
+	cursor VoiceReviewHistoryCursor,
+) (string, bool) {
+	if h == nil || len(h.reviewCursorKey) < minReviewCursorKeyBytes ||
+		strings.TrimSpace(actorUserID) == "" ||
+		cursor.CreatedAt.IsZero() ||
+		!validUUID(cursor.ReviewID) {
+		return "", false
+	}
+	payload, err := json.Marshal(reviewHistoryCursorEnvelope{
+		Version:   reviewCursorVersion,
+		Kind:      reviewCursorKind,
+		CreatedAt: cursor.CreatedAt.UTC().Format(time.RFC3339Nano),
+		ReviewID:  cursor.ReviewID,
+	})
+	if err != nil {
+		return "", false
+	}
+	signature := reviewHistoryCursorMAC(
+		h.reviewCursorKey,
+		actorUserID,
+		payload,
+	)
+	return base64.RawURLEncoding.EncodeToString(payload) + "." +
+		base64.RawURLEncoding.EncodeToString(signature), true
+}
+
+func (h *HTTPHandler) decodeReviewHistoryCursor(
+	actorUserID string,
 	value string,
 ) (VoiceReviewHistoryCursor, bool) {
-	if value == "" || len(value) > 512 {
+	if h == nil || len(h.reviewCursorKey) < minReviewCursorKeyBytes ||
+		strings.TrimSpace(actorUserID) == "" ||
+		value == "" || len(value) > 512 ||
+		strings.Count(value, ".") != 1 {
 		return VoiceReviewHistoryCursor{}, false
 	}
-	payload, err := base64.RawURLEncoding.DecodeString(value)
+	parts := strings.SplitN(value, ".", 2)
+	payload, err := base64.RawURLEncoding.Strict().DecodeString(parts[0])
 	if err != nil || len(payload) > 256 {
 		return VoiceReviewHistoryCursor{}, false
 	}
-	var object map[string]any
-	if err := json.Unmarshal(payload, &object); err != nil ||
-		len(object) != 2 {
+	signature, err := base64.RawURLEncoding.Strict().DecodeString(parts[1])
+	if err != nil || len(signature) != sha256.Size ||
+		!hmac.Equal(
+			signature,
+			reviewHistoryCursorMAC(
+				h.reviewCursorKey,
+				actorUserID,
+				payload,
+			),
+		) {
 		return VoiceReviewHistoryCursor{}, false
 	}
-	createdAtValue, createdAtOK := object["created_at"].(string)
-	reviewID, reviewIDOK := object["review_id"].(string)
-	if !createdAtOK || !reviewIDOK || !validUUID(reviewID) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var envelope reviewHistoryCursorEnvelope
+	if err := decoder.Decode(&envelope); err != nil ||
+		decoder.Decode(&struct{}{}) != io.EOF ||
+		envelope.Version != reviewCursorVersion ||
+		envelope.Kind != reviewCursorKind ||
+		!validUUID(envelope.ReviewID) {
 		return VoiceReviewHistoryCursor{}, false
 	}
-	createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
+	createdAt, err := time.Parse(time.RFC3339Nano, envelope.CreatedAt)
 	if err != nil || createdAt.IsZero() {
 		return VoiceReviewHistoryCursor{}, false
 	}
-	return VoiceReviewHistoryCursor{
+	cursor := VoiceReviewHistoryCursor{
 		CreatedAt: createdAt,
-		ReviewID:  reviewID,
-	}, true
+		ReviewID:  envelope.ReviewID,
+	}
+	canonical, ok := h.encodeReviewHistoryCursor(actorUserID, cursor)
+	if !ok || canonical != value {
+		return VoiceReviewHistoryCursor{}, false
+	}
+	return cursor, true
+}
+
+func reviewHistoryCursorMAC(
+	key []byte,
+	actorUserID string,
+	payload []byte,
+) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(reviewCursorKind))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(actorUserID))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write(payload)
+	return mac.Sum(nil)
 }
 
 func matterResponse(item matter.Matter) gin.H {

--- a/server/internal/agent/voice_http_test.go
+++ b/server/internal/agent/voice_http_test.go
@@ -22,6 +22,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func testVoiceHTTPOptions() VoiceHTTPOptions {
+	return VoiceHTTPOptions{
+		AudioReadTimeout: defaultVoiceReadTimeout,
+		ReviewHistoryCursorKey: []byte(
+			"0123456789abcdef0123456789abcdef",
+		),
+	}
+}
+
 func TestVoiceHTTPUsesFrozenResponseDTOs(t *testing.T) {
 	conversations := newAgentVoiceConversation(3)
 	practice := newAgentVoicePractice(0)
@@ -46,6 +55,7 @@ func TestVoiceHTTPUsesFrozenResponseDTOs(t *testing.T) {
 		voiceHTTPMatters{},
 		voiceHTTPAuthenticator{},
 		func() string { return "corr_voice" },
+		testVoiceHTTPOptions(),
 	)
 	if err != nil {
 		t.Fatalf("new voice HTTP handler: %v", err)
@@ -236,6 +246,7 @@ func TestVoiceHTTPListsAuthenticatedReviewHistoryWithOpaqueCursor(
 		voiceHTTPMatters{},
 		voiceHTTPAuthenticator{},
 		func() string { return "corr_review_history" },
+		testVoiceHTTPOptions(),
 	)
 	if err != nil {
 		t.Fatalf("new voice HTTP handler: %v", err)
@@ -329,6 +340,48 @@ func TestVoiceHTTPListsAuthenticatedReviewHistoryWithOpaqueCursor(
 		if response.Code != http.StatusBadRequest {
 			t.Fatalf("invalid history %q status = %d", path, response.Code)
 		}
+	}
+}
+
+func TestReviewHistoryCursorIsSignedCanonicalAndActorBound(t *testing.T) {
+	key := testVoiceHTTPOptions().ReviewHistoryCursorKey
+	handler := &HTTPHandler{reviewCursorKey: key}
+	cursor := VoiceReviewHistoryCursor{
+		CreatedAt: time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC),
+		ReviewID:  "20000000-0000-4000-8000-000000000002",
+	}
+	encoded, ok := handler.encodeReviewHistoryCursor("actor-a", cursor)
+	if !ok || strings.Count(encoded, ".") != 1 {
+		t.Fatalf("encodeReviewHistoryCursor() = %q, %t", encoded, ok)
+	}
+	decoded, ok := handler.decodeReviewHistoryCursor("actor-a", encoded)
+	if !ok || decoded != cursor {
+		t.Fatalf("decodeReviewHistoryCursor() = %+v, %t", decoded, ok)
+	}
+	if _, ok := handler.decodeReviewHistoryCursor("actor-b", encoded); ok {
+		t.Fatal("cursor was accepted for another Actor")
+	}
+	otherHandler := &HTTPHandler{
+		reviewCursorKey: []byte("fedcba9876543210fedcba9876543210"),
+	}
+	if _, ok := otherHandler.decodeReviewHistoryCursor(
+		"actor-a",
+		encoded,
+	); ok {
+		t.Fatal("cursor was accepted with another signing key")
+	}
+	tampered := "A" + encoded[1:]
+	if _, ok := handler.decodeReviewHistoryCursor(
+		"actor-a",
+		tampered,
+	); ok {
+		t.Fatal("tampered cursor was accepted")
+	}
+	if _, ok := handler.decodeReviewHistoryCursor(
+		"actor-a",
+		encoded+"=",
+	); ok {
+		t.Fatal("non-canonical padded cursor was accepted")
 	}
 }
 
@@ -583,7 +636,11 @@ func TestVoiceHTTPReadDeadlineInterruptsStalledUpload(t *testing.T) {
 		voiceHTTPMatters{},
 		voiceHTTPAuthenticator{},
 		func() string { return "corr_voice_timeout" },
-		VoiceHTTPOptions{AudioReadTimeout: 100 * time.Millisecond},
+		VoiceHTTPOptions{
+			AudioReadTimeout: 100 * time.Millisecond,
+			ReviewHistoryCursorKey: testVoiceHTTPOptions().
+				ReviewHistoryCursorKey,
+		},
 	)
 	if err != nil {
 		t.Fatalf("new voice HTTP handler: %v", err)
@@ -669,6 +726,7 @@ func TestVoiceHTTPTTSFailureKeepsTextQuestionAvailable(t *testing.T) {
 		voiceHTTPMatters{},
 		voiceHTTPAuthenticator{},
 		func() string { return "corr_voice" },
+		testVoiceHTTPOptions(),
 	)
 	if err != nil {
 		t.Fatalf("new voice HTTP handler: %v", err)
@@ -826,6 +884,7 @@ func voiceHistoryTestRouterWithReader(
 		voiceHTTPMatters{},
 		voiceHTTPAuthenticator{},
 		func() string { return "corr_review_budget" },
+		testVoiceHTTPOptions(),
 	)
 	if err != nil {
 		t.Fatalf("new voice HTTP handler: %v", err)

--- a/server/internal/agent/voice_http_test.go
+++ b/server/internal/agent/voice_http_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -190,6 +191,320 @@ func TestVoiceHTTPUsesFrozenResponseDTOs(t *testing.T) {
 			"status",
 			"updated_at",
 		)
+	}
+}
+
+func TestVoiceHTTPListsAuthenticatedReviewHistoryWithOpaqueCursor(
+	t *testing.T,
+) {
+	conversations := newAgentVoiceConversation(3)
+	practice := newAgentVoicePractice(0)
+	reviews := newAgentVoiceReview()
+	orchestrator := newAgentVoiceOrchestrator(
+		t,
+		conversations,
+		practice,
+		reviews,
+	)
+	voice := newVoiceSessionTestApplication(
+		t,
+		conversations,
+		practice,
+		reviews,
+		orchestrator,
+	)
+	newerCreatedAt := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	olderCreatedAt := newerCreatedAt.Add(-time.Hour)
+	newer := completedVoiceHistoryReview(
+		"20000000-0000-4000-8000-000000000002",
+		newerCreatedAt,
+		91,
+	)
+	older := completedVoiceHistoryReview(
+		"20000000-0000-4000-8000-000000000001",
+		olderCreatedAt,
+		78,
+	)
+	voice.reviews = voiceSessionTestReviews{
+		reviews: reviews,
+		history: []VoiceSessionReview{newer, older},
+	}
+	handler, err := NewHTTPHandlerWithRunsAndVoice(
+		voiceHTTPApplication{},
+		nil,
+		voice,
+		voiceHTTPMatters{},
+		voiceHTTPAuthenticator{},
+		func() string { return "corr_review_history" },
+	)
+	if err != nil {
+		t.Fatalf("new voice HTTP handler: %v", err)
+	}
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	unauthenticated := httptest.NewRecorder()
+	router.ServeHTTP(
+		unauthenticated,
+		httptest.NewRequest(http.MethodGet, "/v1/formal-reviews", nil),
+	)
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated history status = %d", unauthenticated.Code)
+	}
+
+	firstResponse := voiceHTTPRequest(
+		t,
+		router,
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1",
+		nil,
+		nil,
+	)
+	if firstResponse.Code != http.StatusOK {
+		t.Fatalf(
+			"first history status = %d, body = %s",
+			firstResponse.Code,
+			firstResponse.Body,
+		)
+	}
+	first := decodeVoiceJSONObject(t, firstResponse)
+	requireVoiceKeys(t, first, "items", "next_cursor")
+	firstItems := first["items"].([]any)
+	if len(firstItems) != 1 {
+		t.Fatalf("first history items = %#v", firstItems)
+	}
+	firstItem := firstItems[0].(map[string]any)
+	if firstItem["review_id"] != newer.ID ||
+		firstItem["practice_session_id"] != newer.SessionID ||
+		firstItem["status"] != "completed" {
+		t.Fatalf("first history item = %#v", firstItem)
+	}
+	if _, leaked := firstItem["owner_user_id"]; leaked {
+		t.Fatalf("history DTO leaked owner: %#v", firstItem)
+	}
+	cursor, ok := first["next_cursor"].(string)
+	if !ok || cursor == "" || strings.Contains(cursor, newer.ID) {
+		t.Fatalf("history cursor is not opaque: %#v", first["next_cursor"])
+	}
+
+	secondResponse := voiceHTTPRequest(
+		t,
+		router,
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1&cursor="+cursor,
+		nil,
+		nil,
+	)
+	if secondResponse.Code != http.StatusOK {
+		t.Fatalf(
+			"second history status = %d, body = %s",
+			secondResponse.Code,
+			secondResponse.Body,
+		)
+	}
+	second := decodeVoiceJSONObject(t, secondResponse)
+	requireVoiceKeys(t, second, "items")
+	secondItems := second["items"].([]any)
+	if len(secondItems) != 1 ||
+		secondItems[0].(map[string]any)["review_id"] != older.ID {
+		t.Fatalf("second history items = %#v", secondItems)
+	}
+
+	for _, path := range []string{
+		"/v1/formal-reviews?limit=51",
+		"/v1/formal-reviews?limit=1&limit=2",
+		"/v1/formal-reviews?cursor=not-base64",
+		"/v1/formal-reviews?offset=1",
+		"/v1/formal-reviews?limit=1;offset=1",
+	} {
+		response := voiceHTTPRequest(
+			t,
+			router,
+			http.MethodGet,
+			path,
+			nil,
+			nil,
+		)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("invalid history %q status = %d", path, response.Code)
+		}
+	}
+}
+
+func TestVoiceHTTPReviewHistoryResponseBudget(t *testing.T) {
+	t.Run("maximum legal 50 item page stays below 768 KiB", func(t *testing.T) {
+		router := voiceHistoryTestRouter(
+			t,
+			maximumVoiceHistoryPage(t),
+		)
+		response := voiceHTTPRequest(
+			t,
+			router,
+			http.MethodGet,
+			"/v1/formal-reviews?limit=50",
+			nil,
+			nil,
+		)
+		if response.Code != http.StatusOK {
+			t.Fatalf(
+				"maximum history status = %d, body = %s",
+				response.Code,
+				response.Body,
+			)
+		}
+		if response.Body.Len() >= maxReviewHistoryBody {
+			t.Fatalf(
+				"maximum history bytes = %d, limit = %d",
+				response.Body.Len(),
+				maxReviewHistoryBody,
+			)
+		}
+		items := decodeVoiceJSONObject(t, response)["items"].([]any)
+		if len(items) != 50 {
+			t.Fatalf("maximum history item count = %d", len(items))
+		}
+		root := decodeVoiceJSONObject(t, response)
+		cursor, ok := root["next_cursor"].(string)
+		if !ok || cursor == "" {
+			t.Fatalf("maximum history omitted next_cursor: %#v", root)
+		}
+		continuation := voiceHTTPRequest(
+			t,
+			router,
+			http.MethodGet,
+			"/v1/formal-reviews?limit=50&cursor="+cursor,
+			nil,
+			nil,
+		)
+		if continuation.Code != http.StatusOK {
+			t.Fatalf(
+				"maximum history continuation status = %d, body = %s",
+				continuation.Code,
+				continuation.Body,
+			)
+		}
+		continuationRoot := decodeVoiceJSONObject(t, continuation)
+		continuationItems := continuationRoot["items"].([]any)
+		if len(continuationItems) != 1 {
+			t.Fatalf(
+				"maximum history continuation items = %d",
+				len(continuationItems),
+			)
+		}
+		if _, present := continuationRoot["next_cursor"]; present {
+			t.Fatalf(
+				"maximum history continuation exposed cursor: %#v",
+				continuationRoot,
+			)
+		}
+	})
+
+	t.Run("oversized fake adapter page returns only safe 500", func(t *testing.T) {
+		history := maximumVoiceHistoryPage(t)
+		router := voiceHistoryTestRouterWithReader(
+			t,
+			oversizedVoiceHistoryReader{items: history},
+		)
+		response := voiceHTTPRequest(
+			t,
+			router,
+			http.MethodGet,
+			"/v1/formal-reviews?limit=50",
+			nil,
+			nil,
+		)
+		if response.Code != http.StatusInternalServerError {
+			t.Fatalf(
+				"oversized history status = %d, body bytes = %d",
+				response.Code,
+				response.Body.Len(),
+			)
+		}
+		root := decodeVoiceJSONObject(t, response)
+		requireVoiceKeys(t, root, "error")
+		failure := root["error"].(map[string]any)
+		if failure["code"] != "internal_error" ||
+			failure["retryable"] != true ||
+			strings.Contains(response.Body.String(), `"items"`) ||
+			strings.Contains(response.Body.String(), `"review_id"`) {
+			t.Fatalf(
+				"unsafe oversized history response bytes = %d",
+				response.Body.Len(),
+			)
+		}
+	})
+
+	t.Run("hard cap rejects a fully encoded response before any product bytes", func(t *testing.T) {
+		gin.SetMode(gin.ReleaseMode)
+		recorder := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(recorder)
+		handler := &HTTPHandler{
+			correlationID: func() string { return "corr_review_cap" },
+		}
+		handler.writeBoundedReviewJSON(context, gin.H{
+			"items": []string{strings.Repeat("x", maxReviewHistoryBody)},
+		})
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf(
+				"hard-cap status = %d, body bytes = %d",
+				recorder.Code,
+				recorder.Body.Len(),
+			)
+		}
+		root := decodeVoiceJSONObject(t, recorder)
+		requireVoiceKeys(t, root, "error")
+		if strings.Contains(recorder.Body.String(), strings.Repeat("x", 64)) ||
+			strings.Contains(recorder.Body.String(), `"items"`) {
+			t.Fatalf(
+				"hard-cap response leaked product bytes; response bytes = %d",
+				recorder.Body.Len(),
+			)
+		}
+	})
+}
+
+func TestVoiceHTTPRejectsOverBudgetReviewResultAdapterAsInternalError(
+	t *testing.T,
+) {
+	item := completedVoiceHistoryReview(
+		"20000000-0000-4000-8000-000000000001",
+		time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC),
+		80,
+	)
+	item.Result = maximumVoiceReviewResult(t)
+	item.Result.Summary = "<" + item.Result.Summary[1:]
+	encoded, err := json.Marshal(item.Result)
+	if err != nil {
+		t.Fatalf("marshal over-budget fake Result: %v", err)
+	}
+	if len(encoded) <= maxVoiceReviewResultJSONBytes {
+		t.Fatalf(
+			"fake Result bytes = %d, want over %d",
+			len(encoded),
+			maxVoiceReviewResultJSONBytes,
+		)
+	}
+	response := voiceHTTPRequest(
+		t,
+		voiceHistoryTestRouter(t, []VoiceSessionReview{item}),
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1",
+		nil,
+		nil,
+	)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf(
+			"invalid adapter history status = %d, body = %s",
+			response.Code,
+			response.Body,
+		)
+	}
+	root := decodeVoiceJSONObject(t, response)
+	requireVoiceKeys(t, root, "error")
+	if strings.Contains(response.Body.String(), `"items"`) ||
+		strings.Contains(response.Body.String(), strings.Repeat("s", 64)) {
+		t.Fatalf("invalid adapter data leaked: %s", response.Body)
 	}
 }
 
@@ -436,6 +751,143 @@ func (voiceHTTPAuthenticator) AuthenticateSession(
 		return requestcontext.Actor{}, identity.ErrAuthenticationRequired
 	}
 	return agentVoiceActor("a"), nil
+}
+
+func completedVoiceHistoryReview(
+	id string,
+	createdAt time.Time,
+	score int,
+) VoiceSessionReview {
+	completedAt := createdAt.Add(time.Minute)
+	return VoiceSessionReview{
+		ID:                    id,
+		SessionID:             "session-" + id,
+		Status:                "completed",
+		ImplementationVersion: "review-v1",
+		SourceTurnID:          "turn-" + id,
+		SourceTurnVersion:     "conversation-turn:evidence-v1",
+		Result: &VoiceReviewResult{
+			OverallScore: score,
+			Summary:      "Server-owned review history.",
+			Conclusions: []VoiceReviewConclusion{{
+				Key:        "clarity",
+				Category:   "clarity",
+				Message:    "Clear response.",
+				Suggestion: "Add one concrete outcome.",
+			}},
+		},
+		CreatedAt:   createdAt,
+		UpdatedAt:   completedAt,
+		CompletedAt: &completedAt,
+	}
+}
+
+func voiceHistoryTestRouter(
+	t *testing.T,
+	history []VoiceSessionReview,
+) http.Handler {
+	t.Helper()
+	reviews := newAgentVoiceReview()
+	return voiceHistoryTestRouterWithReader(
+		t,
+		voiceSessionTestReviews{
+			reviews: reviews,
+			history: history,
+		},
+	)
+}
+
+func voiceHistoryTestRouterWithReader(
+	t *testing.T,
+	reader VoiceReviewReader,
+) http.Handler {
+	t.Helper()
+	conversations := newAgentVoiceConversation(3)
+	practice := newAgentVoicePractice(0)
+	reviews := newAgentVoiceReview()
+	orchestrator := newAgentVoiceOrchestrator(
+		t,
+		conversations,
+		practice,
+		reviews,
+	)
+	voice := newVoiceSessionTestApplication(
+		t,
+		conversations,
+		practice,
+		reviews,
+		orchestrator,
+	)
+	voice.reviews = reader
+	handler, err := NewHTTPHandlerWithRunsAndVoice(
+		voiceHTTPApplication{},
+		nil,
+		voice,
+		voiceHTTPMatters{},
+		voiceHTTPAuthenticator{},
+		func() string { return "corr_review_budget" },
+	)
+	if err != nil {
+		t.Fatalf("new voice HTTP handler: %v", err)
+	}
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	return router
+}
+
+func maximumVoiceHistoryPage(
+	t *testing.T,
+) []VoiceSessionReview {
+	t.Helper()
+	result := maximumVoiceReviewResult(t)
+	history := make([]VoiceSessionReview, 51)
+	escapedMetadata := strings.Repeat(
+		"<",
+		maxVoiceReviewMetadataUTF8Bytes,
+	)
+	baseCreatedAt := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	for index := range history {
+		createdAt := baseCreatedAt.Add(-time.Duration(index) * time.Second)
+		completedAt := createdAt.Add(time.Millisecond)
+		id := fmt.Sprintf(
+			"20000000-0000-4000-8000-%012d",
+			50-index,
+		)
+		history[index] = VoiceSessionReview{
+			ID:                    id,
+			SessionID:             escapedMetadata,
+			Status:                "completed",
+			ImplementationVersion: escapedMetadata,
+			SourceTurnID:          escapedMetadata,
+			SourceTurnVersion:     "conversation-turn:evidence-v1",
+			Result:                result,
+			CreatedAt:             createdAt,
+			UpdatedAt:             completedAt,
+			CompletedAt:           &completedAt,
+		}
+	}
+	return history
+}
+
+type oversizedVoiceHistoryReader struct {
+	items []VoiceSessionReview
+}
+
+func (reader oversizedVoiceHistoryReader) GetReview(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (VoiceSessionReview, error) {
+	return VoiceSessionReview{}, ErrNotFound
+}
+
+func (reader oversizedVoiceHistoryReader) ListReviews(
+	context.Context,
+	requestcontext.Actor,
+	VoiceReviewHistoryQuery,
+) (VoiceReviewHistoryPage, error) {
+	return VoiceReviewHistoryPage{Items: reader.items}, nil
 }
 
 func voiceHTTPRequest(

--- a/server/internal/agent/voice_http_test.go
+++ b/server/internal/agent/voice_http_test.go
@@ -517,7 +517,7 @@ func TestVoiceHTTPReviewHistoryResponseBudget(t *testing.T) {
 	})
 }
 
-func TestVoiceHTTPRejectsOverBudgetReviewResultAdapterAsInternalError(
+func TestVoiceHTTPRestoresLegacyOverBudgetReviewResult(
 	t *testing.T,
 ) {
 	item := completedVoiceHistoryReview(
@@ -546,18 +546,21 @@ func TestVoiceHTTPRejectsOverBudgetReviewResultAdapterAsInternalError(
 		nil,
 		nil,
 	)
-	if response.Code != http.StatusInternalServerError {
+	if response.Code != http.StatusOK {
 		t.Fatalf(
-			"invalid adapter history status = %d, body = %s",
+			"legacy adapter history status = %d, body = %s",
 			response.Code,
 			response.Body,
 		)
 	}
 	root := decodeVoiceJSONObject(t, response)
-	requireVoiceKeys(t, root, "error")
-	if strings.Contains(response.Body.String(), `"items"`) ||
-		strings.Contains(response.Body.String(), strings.Repeat("s", 64)) {
-		t.Fatalf("invalid adapter data leaked: %s", response.Body)
+	items, ok := root["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("legacy adapter history = %#v", root)
+	}
+	result, ok := items[0].(map[string]any)["result"].(map[string]any)
+	if !ok || result["summary"] != item.Result.Summary {
+		t.Fatalf("legacy adapter result = %#v", items[0])
 	}
 }
 

--- a/server/internal/agent/voice_session.go
+++ b/server/internal/agent/voice_session.go
@@ -2,14 +2,25 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	maxVoiceReviewMetadataUTF8Bytes = 128
+	maxVoiceReviewResultJSONBytes   = 12 * 1024
+	maxVoiceReviewSummaryUTF8Bytes  = 2048
+	maxVoiceReviewConclusions       = 8
+	maxVoiceReviewLabelUTF8Bytes    = 64
+	maxVoiceReviewTextUTF8Bytes     = 2048
 )
 
 // VoicePracticeSession is the Agent application view of Practice state. It
@@ -78,6 +89,11 @@ type VoiceReviewReader interface {
 		requestcontext.Actor,
 		string,
 	) (VoiceSessionReview, error)
+	ListReviews(
+		context.Context,
+		requestcontext.Actor,
+		VoiceReviewHistoryQuery,
+	) (VoiceReviewHistoryPage, error)
 }
 
 // VoiceSessionReview is the Agent application view of Review. Review owns the
@@ -106,6 +122,21 @@ type VoiceReviewConclusion struct {
 	Category   string `json:"category"`
 	Message    string `json:"message"`
 	Suggestion string `json:"suggestion,omitempty"`
+}
+
+type VoiceReviewHistoryCursor struct {
+	CreatedAt time.Time
+	ReviewID  string
+}
+
+type VoiceReviewHistoryQuery struct {
+	Limit  int
+	Before *VoiceReviewHistoryCursor
+}
+
+type VoiceReviewHistoryPage struct {
+	Items []VoiceSessionReview
+	Next  *VoiceReviewHistoryCursor
 }
 
 type VoiceSessionState struct {
@@ -278,6 +309,73 @@ func (application *VoiceSessionApplication) GetReview(
 	return item, nil
 }
 
+func (application *VoiceSessionApplication) ListReviews(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	query VoiceReviewHistoryQuery,
+) (VoiceReviewHistoryPage, error) {
+	if err := validateVoiceActor(ctx, actor); err != nil ||
+		query.Limit < 1 || query.Limit > 50 ||
+		(query.Before != nil &&
+			(query.Before.CreatedAt.IsZero() ||
+				!validUUID(query.Before.ReviewID))) {
+		return VoiceReviewHistoryPage{}, ErrInvalidRequest
+	}
+	page, err := application.reviews.ListReviews(ctx, actor, query)
+	if err != nil {
+		return VoiceReviewHistoryPage{}, err
+	}
+	if len(page.Items) > query.Limit ||
+		(page.Next != nil && len(page.Items) != query.Limit) {
+		return VoiceReviewHistoryPage{}, ErrInvalidContext
+	}
+	var previous *VoiceSessionReview
+	seen := make(map[string]struct{}, len(page.Items))
+	for index := range page.Items {
+		item := &page.Items[index]
+		if !validUUID(item.ID) ||
+			!validVoiceSessionReview(*item, item.ID) ||
+			item.Status != "completed" {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+		if _, exists := seen[item.ID]; exists {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+		seen[item.ID] = struct{}{}
+		if previous != nil &&
+			!reviewHistoryKeyBefore(
+				item.CreatedAt,
+				item.ID,
+				previous.CreatedAt,
+				previous.ID,
+			) {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+		if query.Before != nil &&
+			!reviewHistoryKeyBefore(
+				item.CreatedAt,
+				item.ID,
+				query.Before.CreatedAt,
+				query.Before.ReviewID,
+			) {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+		previous = item
+	}
+	if page.Next != nil {
+		if len(page.Items) == 0 {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+		last := page.Items[len(page.Items)-1]
+		if !validUUID(page.Next.ReviewID) ||
+			!page.Next.CreatedAt.Equal(last.CreatedAt) ||
+			page.Next.ReviewID != last.ID {
+			return VoiceReviewHistoryPage{}, ErrInvalidContext
+		}
+	}
+	return page, nil
+}
+
 func (application *VoiceSessionApplication) state(
 	ctx context.Context,
 	actor requestcontext.Actor,
@@ -413,9 +511,11 @@ func validVoiceSessionReview(
 	expectedID string,
 ) bool {
 	if item.ID != expectedID ||
-		item.SessionID == "" ||
-		item.ImplementationVersion == "" ||
-		item.SourceTurnID == "" ||
+		!validVoiceReviewMetadata(item.ID) ||
+		!validVoiceReviewMetadata(item.SessionID) ||
+		!validVoiceReviewMetadata(item.ImplementationVersion) ||
+		!validVoiceReviewMetadata(item.SourceTurnID) ||
+		!validVoiceReviewMetadata(item.SourceTurnVersion) ||
 		!validVoiceSourceTurnVersion(item.SourceTurnVersion) ||
 		item.CreatedAt.IsZero() ||
 		item.UpdatedAt.Before(item.CreatedAt) {
@@ -428,23 +528,74 @@ func validVoiceSessionReview(
 	default:
 		return false
 	}
-	if item.Result == nil ||
-		item.Result.OverallScore < 0 ||
-		item.Result.OverallScore > 100 ||
-		strings.TrimSpace(item.Result.Summary) == "" ||
-		len(item.Result.Conclusions) == 0 ||
+	if !validVoiceReviewResult(item.Result) ||
 		item.CompletedAt == nil ||
 		item.CompletedAt.Before(item.CreatedAt) {
 		return false
 	}
-	for _, conclusion := range item.Result.Conclusions {
-		if strings.TrimSpace(conclusion.Key) == "" ||
-			strings.TrimSpace(conclusion.Category) == "" ||
-			strings.TrimSpace(conclusion.Message) == "" {
+	return true
+}
+
+func validVoiceReviewResult(result *VoiceReviewResult) bool {
+	if result == nil ||
+		result.OverallScore < 0 ||
+		result.OverallScore > 100 ||
+		!validVoiceReviewText(
+			result.Summary,
+			maxVoiceReviewSummaryUTF8Bytes,
+		) ||
+		len(result.Conclusions) == 0 ||
+		len(result.Conclusions) > maxVoiceReviewConclusions {
+		return false
+	}
+	seen := make(map[string]struct{}, len(result.Conclusions))
+	for _, conclusion := range result.Conclusions {
+		key := strings.TrimSpace(conclusion.Key)
+		if key == "" ||
+			key != conclusion.Key ||
+			!validVoiceReviewText(
+				conclusion.Key,
+				maxVoiceReviewLabelUTF8Bytes,
+			) ||
+			!validVoiceReviewText(
+				conclusion.Category,
+				maxVoiceReviewLabelUTF8Bytes,
+			) ||
+			!validVoiceReviewText(
+				conclusion.Message,
+				maxVoiceReviewTextUTF8Bytes,
+			) ||
+			!validOptionalVoiceReviewText(
+				conclusion.Suggestion,
+				maxVoiceReviewTextUTF8Bytes,
+			) {
 			return false
 		}
+		if _, exists := seen[key]; exists {
+			return false
+		}
+		seen[key] = struct{}{}
 	}
-	return true
+	encoded, err := json.Marshal(result)
+	return err == nil && len(encoded) <= maxVoiceReviewResultJSONBytes
+}
+
+func validVoiceReviewMetadata(value string) bool {
+	return validVoiceReviewText(value, maxVoiceReviewMetadataUTF8Bytes)
+}
+
+func validVoiceReviewText(value string, maximumBytes int) bool {
+	return utf8.ValidString(value) &&
+		!strings.ContainsRune(value, '\x00') &&
+		len(value) <= maximumBytes &&
+		strings.TrimSpace(value) != ""
+}
+
+func validOptionalVoiceReviewText(value string, maximumBytes int) bool {
+	return utf8.ValidString(value) &&
+		!strings.ContainsRune(value, '\x00') &&
+		len(value) <= maximumBytes &&
+		(value == "" || strings.TrimSpace(value) != "")
 }
 
 func validVoiceSourceTurnVersion(value string) bool {
@@ -458,4 +609,14 @@ func validVoiceSourceTurnVersion(value string) bool {
 		64,
 	)
 	return err == nil && version >= 1
+}
+
+func reviewHistoryKeyBefore(
+	createdAt time.Time,
+	reviewID string,
+	boundaryCreatedAt time.Time,
+	boundaryReviewID string,
+) bool {
+	return createdAt.Before(boundaryCreatedAt) ||
+		(createdAt.Equal(boundaryCreatedAt) && reviewID < boundaryReviewID)
 }

--- a/server/internal/agent/voice_session.go
+++ b/server/internal/agent/voice_session.go
@@ -303,7 +303,7 @@ func (application *VoiceSessionApplication) GetReview(
 	if err != nil {
 		return VoiceSessionReview{}, err
 	}
-	if !validVoiceSessionReview(item, reviewID) {
+	if !validPersistedVoiceSessionReview(item, reviewID) {
 		return VoiceSessionReview{}, ErrInvalidContext
 	}
 	return item, nil
@@ -334,7 +334,7 @@ func (application *VoiceSessionApplication) ListReviews(
 	for index := range page.Items {
 		item := &page.Items[index]
 		if !validUUID(item.ID) ||
-			!validVoiceSessionReview(*item, item.ID) ||
+			!validPersistedVoiceSessionReview(*item, item.ID) ||
 			item.Status != "completed" {
 			return VoiceReviewHistoryPage{}, ErrInvalidContext
 		}
@@ -510,6 +510,29 @@ func validVoiceSessionReview(
 	item VoiceSessionReview,
 	expectedID string,
 ) bool {
+	return validVoiceSessionReviewWithResult(
+		item,
+		expectedID,
+		validVoiceReviewResult,
+	)
+}
+
+func validPersistedVoiceSessionReview(
+	item VoiceSessionReview,
+	expectedID string,
+) bool {
+	return validVoiceSessionReviewWithResult(
+		item,
+		expectedID,
+		validPersistedVoiceReviewResult,
+	)
+}
+
+func validVoiceSessionReviewWithResult(
+	item VoiceSessionReview,
+	expectedID string,
+	validResult func(*VoiceReviewResult) bool,
+) bool {
 	if item.ID != expectedID ||
 		!validVoiceReviewMetadata(item.ID) ||
 		!validVoiceReviewMetadata(item.SessionID) ||
@@ -528,10 +551,35 @@ func validVoiceSessionReview(
 	default:
 		return false
 	}
-	if !validVoiceReviewResult(item.Result) ||
+	if !validResult(item.Result) ||
 		item.CompletedAt == nil ||
 		item.CompletedAt.Before(item.CreatedAt) {
 		return false
+	}
+	return true
+}
+
+func validPersistedVoiceReviewResult(result *VoiceReviewResult) bool {
+	if result == nil ||
+		result.OverallScore < 0 ||
+		result.OverallScore > 100 ||
+		strings.TrimSpace(result.Summary) == "" ||
+		len(result.Conclusions) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(result.Conclusions))
+	for _, conclusion := range result.Conclusions {
+		key := strings.TrimSpace(conclusion.Key)
+		if key == "" ||
+			key != conclusion.Key ||
+			strings.TrimSpace(conclusion.Category) == "" ||
+			strings.TrimSpace(conclusion.Message) == "" {
+			return false
+		}
+		if _, exists := seen[key]; exists {
+			return false
+		}
+		seen[key] = struct{}{}
 	}
 	return true
 }

--- a/server/internal/agent/voice_session_test.go
+++ b/server/internal/agent/voice_session_test.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -172,6 +175,243 @@ func TestVoiceSessionReviewRequiresFrozenCompletedShape(t *testing.T) {
 	}
 }
 
+func TestVoiceSessionReviewEnforcesMetadataAndResultBudgets(t *testing.T) {
+	now := time.Unix(2, 0).UTC()
+	valid := VoiceSessionReview{
+		ID:                    "review-1",
+		SessionID:             "session-1",
+		Status:                "completed",
+		ImplementationVersion: "review-v1",
+		SourceTurnID:          "turn-3",
+		SourceTurnVersion:     "conversation-turn:evidence-v1",
+		Result:                maximumVoiceReviewResult(t),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		CompletedAt:           &now,
+	}
+	if !validVoiceSessionReview(valid, valid.ID) {
+		t.Fatal("maximum valid Review result was rejected")
+	}
+
+	invalidUTF8 := string([]byte{0xff})
+	for name, mutate := range map[string]func(*VoiceSessionReview){
+		"review id over 128 bytes": func(item *VoiceSessionReview) {
+			item.ID = strings.Repeat("r", 129)
+		},
+		"session id over 128 bytes": func(item *VoiceSessionReview) {
+			item.SessionID = strings.Repeat("s", 129)
+		},
+		"implementation version over 128 bytes": func(item *VoiceSessionReview) {
+			item.ImplementationVersion = strings.Repeat("i", 129)
+		},
+		"source turn id over 128 bytes": func(item *VoiceSessionReview) {
+			item.SourceTurnID = strings.Repeat("t", 129)
+		},
+		"metadata invalid UTF-8": func(item *VoiceSessionReview) {
+			item.ImplementationVersion = invalidUTF8
+		},
+		"metadata contains NUL": func(item *VoiceSessionReview) {
+			item.ImplementationVersion = "review\x00v1"
+		},
+		"summary over 2048 bytes": func(item *VoiceSessionReview) {
+			item.Result.Summary = strings.Repeat("s", 2049)
+		},
+		"more than eight conclusions": func(item *VoiceSessionReview) {
+			item.Result.Conclusions = append(
+				item.Result.Conclusions,
+				item.Result.Conclusions[0],
+			)
+		},
+		"key over 64 bytes": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Key = strings.Repeat("k", 65)
+		},
+		"category over 64 bytes": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Category = strings.Repeat("c", 65)
+		},
+		"message over 2048 bytes": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Message = strings.Repeat("m", 2049)
+		},
+		"suggestion over 2048 bytes": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Suggestion = strings.Repeat("s", 2049)
+		},
+		"suggestion trims to empty": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Suggestion = " \t\n"
+		},
+		"result string invalid UTF-8": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Message = invalidUTF8
+		},
+		"result string contains NUL": func(item *VoiceSessionReview) {
+			item.Result.Conclusions[0].Message = "clear\x00answer"
+		},
+		"marshaled result over 12 KiB": func(item *VoiceSessionReview) {
+			for index := range item.Result.Conclusions {
+				item.Result.Conclusions[index].Message =
+					strings.Repeat("m", maxVoiceReviewTextUTF8Bytes)
+				item.Result.Conclusions[index].Suggestion =
+					strings.Repeat("s", maxVoiceReviewTextUTF8Bytes)
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			item := valid
+			result := *valid.Result
+			result.Conclusions = append(
+				[]VoiceReviewConclusion(nil),
+				valid.Result.Conclusions...,
+			)
+			item.Result = &result
+			mutate(&item)
+			if validVoiceSessionReview(item, item.ID) {
+				t.Fatalf("invalid Review accepted: %#v", item)
+			}
+		})
+	}
+}
+
+func TestVoiceSessionListReviewsRejectsNonUUIDCursorIdentifiers(
+	t *testing.T,
+) {
+	now := time.Unix(2, 0).UTC()
+	completedAt := now.Add(time.Second)
+	valid := VoiceSessionReview{
+		ID:                    "20000000-0000-4000-8000-000000000001",
+		SessionID:             "session-1",
+		Status:                "completed",
+		ImplementationVersion: "review-v1",
+		SourceTurnID:          "turn-3",
+		SourceTurnVersion:     "conversation-turn:evidence-v1",
+		Result: &VoiceReviewResult{
+			OverallScore: 80,
+			Summary:      "Clear answer.",
+			Conclusions: []VoiceReviewConclusion{{
+				Key:      "overall",
+				Category: "fluency",
+				Message:  "Clear.",
+			}},
+		},
+		CreatedAt:   now,
+		UpdatedAt:   completedAt,
+		CompletedAt: &completedAt,
+	}
+	tests := []struct {
+		name    string
+		page    VoiceReviewHistoryPage
+		query   VoiceReviewHistoryQuery
+		wantErr error
+	}{
+		{
+			name: "item Review ID is not UUID",
+			page: VoiceReviewHistoryPage{Items: []VoiceSessionReview{
+				func() VoiceSessionReview {
+					item := valid
+					item.ID = "review-not-uuid"
+					return item
+				}(),
+			}},
+			wantErr: ErrInvalidContext,
+		},
+		{
+			name: "next Review ID is not UUID",
+			page: VoiceReviewHistoryPage{
+				Items: []VoiceSessionReview{valid},
+				Next: &VoiceReviewHistoryCursor{
+					CreatedAt: valid.CreatedAt,
+					ReviewID:  "review-not-uuid",
+				},
+			},
+			wantErr: ErrInvalidContext,
+		},
+		{
+			name: "input cursor Review ID is not UUID",
+			page: VoiceReviewHistoryPage{
+				Items: []VoiceSessionReview{valid},
+			},
+			query: VoiceReviewHistoryQuery{
+				Limit: 1,
+				Before: &VoiceReviewHistoryCursor{
+					CreatedAt: now.Add(time.Second),
+					ReviewID:  "review-not-uuid",
+				},
+			},
+			wantErr: ErrInvalidRequest,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conversations := newAgentVoiceConversation(3)
+			practice := newAgentVoicePractice(0)
+			reviews := newAgentVoiceReview()
+			orchestrator := newAgentVoiceOrchestrator(
+				t,
+				conversations,
+				practice,
+				reviews,
+			)
+			application := newVoiceSessionTestApplication(
+				t,
+				conversations,
+				practice,
+				reviews,
+				orchestrator,
+			)
+			application.reviews = fixedVoiceReviewPageReader{
+				page: test.page,
+			}
+			query := test.query
+			if query.Limit == 0 {
+				query.Limit = 1
+			}
+			if _, err := application.ListReviews(
+				context.Background(),
+				agentVoiceActor("a"),
+				query,
+			); !errors.Is(err, test.wantErr) {
+				t.Fatalf("non-UUID adapter identifier error = %v", err)
+			}
+		})
+	}
+}
+
+func maximumVoiceReviewResult(t *testing.T) *VoiceReviewResult {
+	t.Helper()
+	result := &VoiceReviewResult{
+		OverallScore: 100,
+		Summary:      strings.Repeat("s", maxVoiceReviewSummaryUTF8Bytes),
+		Conclusions: make(
+			[]VoiceReviewConclusion,
+			maxVoiceReviewConclusions,
+		),
+	}
+	for index := range result.Conclusions {
+		result.Conclusions[index] = VoiceReviewConclusion{
+			Key: fmt.Sprintf("%02d", index) +
+				strings.Repeat("k", maxVoiceReviewLabelUTF8Bytes-2),
+			Category: strings.Repeat(
+				"c",
+				maxVoiceReviewLabelUTF8Bytes,
+			),
+			Message:    strings.Repeat("m", 700),
+			Suggestion: strings.Repeat("s", 300),
+		}
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal Voice Review Result fixture: %v", err)
+	}
+	remaining := maxVoiceReviewResultJSONBytes - len(payload)
+	last := &result.Conclusions[len(result.Conclusions)-1]
+	if remaining < 0 ||
+		len(last.Suggestion)+remaining > maxVoiceReviewTextUTF8Bytes {
+		t.Fatalf(
+			"Voice Review fixture cannot reach budget: bytes=%d remaining=%d",
+			len(payload),
+			remaining,
+		)
+	}
+	last.Suggestion += strings.Repeat("x", remaining)
+	return result
+}
+
 func newVoiceSessionTestApplication(
 	t *testing.T,
 	conversations *agentVoiceConversation,
@@ -296,6 +536,7 @@ func (checkpoints voiceSessionTestCheckpoints) LatestTurn(
 
 type voiceSessionTestReviews struct {
 	reviews *agentVoiceReview
+	history []VoiceSessionReview
 }
 
 func (reader voiceSessionTestReviews) GetReview(
@@ -331,6 +572,70 @@ func (reader voiceSessionTestReviews) GetReview(
 		}
 	}
 	return VoiceSessionReview{}, ErrNotFound
+}
+
+func (reader voiceSessionTestReviews) ListReviews(
+	_ context.Context,
+	_ requestcontext.Actor,
+	query VoiceReviewHistoryQuery,
+) (VoiceReviewHistoryPage, error) {
+	items := make([]VoiceSessionReview, 0, query.Limit)
+	for _, item := range reader.history {
+		if query.Before != nil &&
+			!reviewHistoryKeyBefore(
+				item.CreatedAt,
+				item.ID,
+				query.Before.CreatedAt,
+				query.Before.ReviewID,
+			) {
+			continue
+		}
+		items = append(items, item)
+		if len(items) == query.Limit {
+			break
+		}
+	}
+	page := VoiceReviewHistoryPage{Items: items}
+	consumed := 0
+	for _, item := range reader.history {
+		if query.Before == nil ||
+			reviewHistoryKeyBefore(
+				item.CreatedAt,
+				item.ID,
+				query.Before.CreatedAt,
+				query.Before.ReviewID,
+			) {
+			consumed++
+		}
+	}
+	if consumed > len(items) && len(items) > 0 {
+		last := items[len(items)-1]
+		page.Next = &VoiceReviewHistoryCursor{
+			CreatedAt: last.CreatedAt,
+			ReviewID:  last.ID,
+		}
+	}
+	return page, nil
+}
+
+type fixedVoiceReviewPageReader struct {
+	page VoiceReviewHistoryPage
+}
+
+func (reader fixedVoiceReviewPageReader) GetReview(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (VoiceSessionReview, error) {
+	return VoiceSessionReview{}, ErrNotFound
+}
+
+func (reader fixedVoiceReviewPageReader) ListReviews(
+	context.Context,
+	requestcontext.Actor,
+	VoiceReviewHistoryQuery,
+) (VoiceReviewHistoryPage, error) {
+	return reader.page, nil
 }
 
 type voiceSessionTestMatters struct{}

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -89,12 +89,15 @@ func NewIdentityAndAgentModules(
 		}
 	}
 	var voiceHTTPOptions []agent.VoiceHTTPOptions
-	if len(voiceConfigurations) == 1 &&
-		voiceConfigurations[0].AudioReadTimeout > 0 {
+	if len(voiceConfigurations) == 1 {
 		voiceHTTPOptions = append(
 			voiceHTTPOptions,
 			agent.VoiceHTTPOptions{
 				AudioReadTimeout: voiceConfigurations[0].AudioReadTimeout,
+				ReviewHistoryCursorKey: append(
+					[]byte(nil),
+					voiceConfigurations[0].ReviewHistoryCursorKey...,
+				),
 			},
 		)
 	}

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -66,6 +66,7 @@ type VoiceConfiguration struct {
 	ASRLease                time.Duration
 	ReviewGenerationTimeout time.Duration
 	AudioReadTimeout        time.Duration
+	ReviewHistoryCursorKey  []byte
 }
 
 // NewSpeechRecognizer is the server-side ASR registration boundary. Production

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -260,7 +260,7 @@ func buildProductionVoiceApplication(
 	)
 	reviewAdapter := &voiceReviewAdapter{
 		service:      ensureReviews,
-		repository:   reviewRepository,
+		history:      review.NewHistoryService(reviewRepository),
 		sourceReader: sourceReader,
 	}
 	orchestrator, err := agent.NewVoiceRoundOrchestrator(
@@ -1226,7 +1226,7 @@ func (adapter *voiceCheckpointAdapter) LatestTurn(
 
 type voiceReviewAdapter struct {
 	service      *review.EnsureService
-	repository   review.ReviewRepository
+	history      *review.HistoryService
 	sourceReader review.ReviewSourceReader
 }
 
@@ -1276,13 +1276,55 @@ func (adapter *voiceReviewAdapter) GetReview(
 	actor requestcontext.Actor,
 	reviewID string,
 ) (agent.VoiceSessionReview, error) {
-	formalReview, err := adapter.repository.Get(ctx, review.Actor{
+	formalReview, err := adapter.history.Get(ctx, review.Actor{
 		UserID: actor.UserID,
 	}, reviewID)
 	if err != nil {
-		return agent.VoiceSessionReview{}, mapReviewError(err)
+		return agent.VoiceSessionReview{}, mapReviewReadError(err)
 	}
 	return mapVoiceSessionReview(formalReview), nil
+}
+
+func (adapter *voiceReviewAdapter) ListReviews(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	query agent.VoiceReviewHistoryQuery,
+) (agent.VoiceReviewHistoryPage, error) {
+	reviewQuery := review.HistoryQuery{Limit: query.Limit}
+	if query.Before != nil {
+		reviewQuery.Before = &review.HistoryCursor{
+			CreatedAt: query.Before.CreatedAt,
+			ReviewID:  query.Before.ReviewID,
+		}
+	}
+	page, err := adapter.history.ListCompleted(
+		ctx,
+		review.Actor{UserID: actor.UserID},
+		reviewQuery,
+	)
+	if err != nil {
+		return agent.VoiceReviewHistoryPage{}, mapReviewReadError(err)
+	}
+	result := agent.VoiceReviewHistoryPage{
+		Items: make([]agent.VoiceSessionReview, len(page.Items)),
+	}
+	for index, item := range page.Items {
+		result.Items[index] = mapVoiceSessionReview(item)
+	}
+	if page.Next != nil {
+		result.Next = &agent.VoiceReviewHistoryCursor{
+			CreatedAt: page.Next.CreatedAt,
+			ReviewID:  page.Next.ReviewID,
+		}
+	}
+	return result, nil
+}
+
+func mapReviewReadError(err error) error {
+	if errors.Is(err, review.ErrInvalidReview) {
+		return agent.ErrInvalidContext
+	}
+	return mapReviewError(err)
 }
 
 func mapReviewError(err error) error {

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -34,6 +34,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+var testReviewHistoryCursorKey = []byte(
+	"0123456789abcdef0123456789abcdef",
+)
+
 func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 	t *testing.T,
 ) {
@@ -65,6 +69,7 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 			AudioStagedTTL:          time.Hour,
 			ASRLease:                5 * time.Second,
 			ReviewGenerationTimeout: 2 * time.Second,
+			ReviewHistoryCursorKey:  testReviewHistoryCursorKey,
 		},
 	)
 	if err != nil {
@@ -721,6 +726,7 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 			AudioStagedTTL:          time.Hour,
 			ASRLease:                5 * time.Second,
 			ReviewGenerationTimeout: 2 * time.Second,
+			ReviewHistoryCursorKey:  testReviewHistoryCursorKey,
 		},
 	)
 	if err != nil {
@@ -1119,6 +1125,7 @@ WHERE review_id = $1`,
 			TemporaryAudio:          terminalVault,
 			ASRLease:                5 * time.Second,
 			ReviewGenerationTimeout: 2 * time.Second,
+			ReviewHistoryCursorKey:  testReviewHistoryCursorKey,
 		},
 	)
 	if err != nil {
@@ -1223,6 +1230,7 @@ func TestVoiceRecordingCleanupWinNeverLeavesRecoverableTurn(
 				AudioStagedTTL:          time.Hour,
 				ASRLease:                5 * time.Second,
 				ReviewGenerationTimeout: 2 * time.Second,
+				ReviewHistoryCursorKey:  testReviewHistoryCursorKey,
 			},
 		)
 		if err != nil {

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -561,6 +561,46 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 		reviewOwnerID,
 		"restart-cursor-older",
 	)
+	legacyHistorySummary := strings.Repeat("legacy summary ", 1100)
+	legacyHistoryResult := *olderHistoryReview.Result
+	legacyHistoryResult.Summary = legacyHistorySummary
+	legacyHistoryPayload, err := json.Marshal(legacyHistoryResult)
+	if err != nil {
+		t.Fatalf("marshal legacy HTTP Review: %v", err)
+	}
+	if len(legacyHistoryPayload) <= 12*1024 {
+		t.Fatalf(
+			"legacy HTTP Review bytes = %d, want over 12 KiB",
+			len(legacyHistoryPayload),
+		)
+	}
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE reviews SET result = $1::jsonb WHERE id = $2`,
+		legacyHistoryPayload,
+		olderHistoryReview.ID,
+	); err != nil {
+		t.Fatalf("stage legacy HTTP Review: %v", err)
+	}
+	legacyHistoryItem := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodGet,
+		"/v1/formal-reviews/"+olderHistoryReview.ID,
+		"",
+		"",
+		http.StatusOK,
+	)
+	legacyHistoryHTTPResult, ok :=
+		legacyHistoryItem["result"].(map[string]any)
+	if !ok ||
+		legacyHistoryHTTPResult["summary"] != legacyHistorySummary {
+		t.Fatalf(
+			"legacy HTTP Review result = %#v",
+			legacyHistoryItem,
+		)
+	}
 	oldestHistoryReview := completeBootstrapHistoryReview(
 		t,
 		pool,
@@ -841,6 +881,13 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 		continuedReview["review_id"] != olderHistoryReview.ID {
 		t.Fatalf(
 			"restart cursor first continuation item = %#v",
+			restartedContinuation,
+		)
+	}
+	continuedResult, ok := continuedReview["result"].(map[string]any)
+	if !ok || continuedResult["summary"] != legacyHistorySummary {
+		t.Fatalf(
+			"restart cursor lost legacy Review result: %#v",
 			restartedContinuation,
 		)
 	}
@@ -1168,7 +1215,7 @@ WHERE review_id = $1`,
 			to_jsonb($1::text)
 		)
 		WHERE id = $2
-	`, strings.Repeat("s", 2049), reviewID); err != nil {
+	`, " \t\n", reviewID); err != nil {
 		t.Fatalf("stage corrupt persisted Review for HTTP boundary: %v", err)
 	}
 	for _, path := range []string{

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -29,6 +29,7 @@ import (
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -540,6 +541,66 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 			"conversation-turn:evidence-v1" {
 		t.Fatalf("formal Review lost source identity: %#v", reviewResult)
 	}
+	var reviewOwnerID string
+	var reviewCreatedAt time.Time
+	if err := pool.QueryRow(context.Background(), `
+		SELECT owner_user_id::text, created_at
+		FROM reviews
+		WHERE id = $1
+	`, reviewID).Scan(&reviewOwnerID, &reviewCreatedAt); err != nil {
+		t.Fatalf("read formal Review history key: %v", err)
+	}
+	olderHistoryReview := completeBootstrapHistoryReview(
+		t,
+		pool,
+		reviewOwnerID,
+		"restart-cursor-older",
+	)
+	oldestHistoryReview := completeBootstrapHistoryReview(
+		t,
+		pool,
+		reviewOwnerID,
+		"restart-cursor-oldest",
+	)
+	for index, item := range []review.FormalReview{
+		olderHistoryReview,
+		oldestHistoryReview,
+	} {
+		if _, err := pool.Exec(
+			context.Background(),
+			`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+			reviewCreatedAt.Add(-time.Duration(index+1)*time.Minute),
+			item.ID,
+		); err != nil {
+			t.Fatalf("set restart cursor Review %d key: %v", index, err)
+		}
+	}
+	historyResult := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1",
+		"",
+		"",
+		http.StatusOK,
+	)
+	historyItems, ok := historyResult["items"].([]any)
+	if !ok || len(historyItems) != 1 {
+		t.Fatalf("formal Review history items = %#v, want one", historyResult)
+	}
+	historyReview, ok := historyItems[0].(map[string]any)
+	if !ok || historyReview["review_id"] != reviewID ||
+		historyReview["source_turn_id"] != thirdTurnID {
+		t.Fatalf("formal Review history lost source identity: %#v", historyResult)
+	}
+	restartHistoryCursor, ok := historyResult["next_cursor"].(string)
+	if !ok || restartHistoryCursor == "" {
+		t.Fatalf(
+			"formal Review history omitted restart cursor: %#v",
+			historyResult,
+		)
+	}
 	var evidenceCount int
 	var matchedEvidenceCount int
 	if err := pool.QueryRow(
@@ -599,6 +660,19 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 		server.URL,
 		"voice-b@example.com",
 	)
+	otherHistory := voiceJSONRequest(
+		t,
+		server.URL,
+		otherToken,
+		http.MethodGet,
+		"/v1/formal-reviews",
+		"",
+		"",
+		http.StatusOK,
+	)
+	if items, ok := otherHistory["items"].([]any); !ok || len(items) != 0 {
+		t.Fatalf("foreign user history = %#v, want empty", otherHistory)
+	}
 	for _, path := range []string{
 		"/v1/agent-threads/" + threadID + "/voice-practice-session",
 		"/v1/formal-reviews/" + reviewID,
@@ -695,6 +769,106 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 		t.Fatalf(
 			"restart lost formal Review evidence identity: %#v",
 			recoveredFormalReview,
+		)
+	}
+	recoveredHistory := voiceJSONRequest(
+		t,
+		restartedServer.URL,
+		token,
+		http.MethodGet,
+		"/v1/formal-reviews",
+		"",
+		"",
+		http.StatusOK,
+	)
+	recoveredHistoryItems, ok := recoveredHistory["items"].([]any)
+	if !ok || len(recoveredHistoryItems) != 3 {
+		t.Fatalf(
+			"restart lost formal Review history: %#v",
+			recoveredHistory,
+		)
+	}
+	recoveredHistoryReview, ok :=
+		recoveredHistoryItems[0].(map[string]any)
+	if !ok || recoveredHistoryReview["review_id"] != reviewID ||
+		recoveredHistoryReview["source_turn_id"] != thirdTurnID {
+		t.Fatalf(
+			"restart changed formal Review history: %#v",
+			recoveredHistory,
+		)
+	}
+	for index, reviewID := range []string{
+		olderHistoryReview.ID,
+		oldestHistoryReview.ID,
+	} {
+		item, ok := recoveredHistoryItems[index+1].(map[string]any)
+		if !ok || item["review_id"] != reviewID {
+			t.Fatalf(
+				"restart history item %d = %#v, want %s",
+				index+1,
+				recoveredHistoryItems[index+1],
+				reviewID,
+			)
+		}
+	}
+	restartedContinuation := voiceJSONRequest(
+		t,
+		restartedServer.URL,
+		token,
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1&cursor="+
+			url.QueryEscape(restartHistoryCursor),
+		"",
+		"",
+		http.StatusOK,
+	)
+	continuationItems, ok :=
+		restartedContinuation["items"].([]any)
+	if !ok || len(continuationItems) != 1 {
+		t.Fatalf(
+			"restart cursor continuation = %#v",
+			restartedContinuation,
+		)
+	}
+	continuedReview, ok := continuationItems[0].(map[string]any)
+	if !ok ||
+		continuedReview["review_id"] != olderHistoryReview.ID {
+		t.Fatalf(
+			"restart cursor first continuation item = %#v",
+			restartedContinuation,
+		)
+	}
+	restartedTailCursor, ok :=
+		restartedContinuation["next_cursor"].(string)
+	if !ok || restartedTailCursor == "" {
+		t.Fatalf(
+			"restart cursor first continuation omitted tail: %#v",
+			restartedContinuation,
+		)
+	}
+	restartedTail := voiceJSONRequest(
+		t,
+		restartedServer.URL,
+		token,
+		http.MethodGet,
+		"/v1/formal-reviews?limit=1&cursor="+
+			url.QueryEscape(restartedTailCursor),
+		"",
+		"",
+		http.StatusOK,
+	)
+	tailItems, ok := restartedTail["items"].([]any)
+	if !ok || len(tailItems) != 1 {
+		t.Fatalf("restart cursor tail = %#v", restartedTail)
+	}
+	tailReview, ok := tailItems[0].(map[string]any)
+	if !ok || tailReview["review_id"] != oldestHistoryReview.ID {
+		t.Fatalf("restart cursor tail item = %#v", restartedTail)
+	}
+	if _, present := restartedTail["next_cursor"]; present {
+		t.Fatalf(
+			"restart cursor tail exposed another cursor: %#v",
+			restartedTail,
 		)
 	}
 	recoveredTurn := recovered["current_turn"].(map[string]any)
@@ -977,6 +1151,43 @@ WHERE review_id = $1`,
 			got,
 			quotaReviewCalls,
 		)
+	}
+
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE reviews
+		SET result = jsonb_set(
+			result,
+			'{summary}',
+			to_jsonb($1::text)
+		)
+		WHERE id = $2
+	`, strings.Repeat("s", 2049), reviewID); err != nil {
+		t.Fatalf("stage corrupt persisted Review for HTTP boundary: %v", err)
+	}
+	for _, path := range []string{
+		"/v1/formal-reviews/" + reviewID,
+		"/v1/formal-reviews",
+	} {
+		failure := voiceJSONRequest(
+			t,
+			terminalServer.URL,
+			token,
+			http.MethodGet,
+			path,
+			"",
+			"",
+			http.StatusInternalServerError,
+		)
+		errorObject, ok := failure["error"].(map[string]any)
+		if !ok ||
+			errorObject["code"] != "internal_error" ||
+			errorObject["retryable"] != true {
+			t.Fatalf(
+				"corrupt persisted Review response for %s = %#v",
+				path,
+				failure,
+			)
+		}
 	}
 }
 
@@ -1270,6 +1481,71 @@ func assertQuotaExhaustedVoiceResponse(
 		payload.Error.Retryable {
 		t.Fatalf("quota response = %#v", payload)
 	}
+}
+
+func completeBootstrapHistoryReview(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	ownerUserID string,
+	sessionID string,
+) review.FormalReview {
+	t.Helper()
+	repository := review.NewPostgresRepository(pool)
+	actor := review.Actor{UserID: ownerUserID}
+	sourceTurnID := "turn-" + sessionID
+	sourceTurnVersion := "conversation-turn:evidence-v1"
+	pending, err := repository.EnsurePending(
+		context.Background(),
+		review.EnsureReviewCommand{
+			Actor:                     actor,
+			PracticeSessionID:         sessionID,
+			ImplementationVersion:     voiceReviewImplementation,
+			SourceTurnID:              sourceTurnID,
+			SourceTurnVersion:         sourceTurnVersion,
+			SourceManifestFingerprint: "manifest-" + sessionID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ensure bootstrap history Review %s: %v", sessionID, err)
+	}
+	_, claim, claimed, err := repository.ClaimGeneration(
+		context.Background(),
+		actor,
+		pending.ID,
+		time.Minute,
+	)
+	if err != nil || !claimed {
+		t.Fatalf(
+			"claim bootstrap history Review %s: claimed=%v err=%v",
+			sessionID,
+			claimed,
+			err,
+		)
+	}
+	completed, err := repository.CompleteGeneration(
+		context.Background(),
+		claim,
+		review.ReviewResult{
+			OverallScore: 80,
+			Summary:      "Persisted restart cursor fixture.",
+			Conclusions: []review.ReviewConclusion{{
+				Key:        "summary",
+				Category:   "clarity",
+				Message:    "The response is clear.",
+				Suggestion: "Add one concrete outcome.",
+			}},
+		},
+		[]review.ReviewEvidence{{
+			ConclusionKey: "summary",
+			SourceType:    review.SourceTypeConversationTurn,
+			SourceID:      sourceTurnID,
+			SourceVersion: sourceTurnVersion,
+		}},
+	)
+	if err != nil {
+		t.Fatalf("complete bootstrap history Review %s: %v", sessionID, err)
+	}
+	return completed
 }
 
 func registerAndLoginVoiceUser(

--- a/server/internal/platform/config/review_history.go
+++ b/server/internal/platform/config/review_history.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"encoding/base64"
+	"errors"
+	"os"
+	"strings"
+)
+
+const reviewHistoryCursorKeyBytes = 32
+
+var ErrReviewHistoryCursorSigningKey = errors.New(
+	"REVIEW_HISTORY_CURSOR_SIGNING_KEY must be an unpadded base64url value encoding exactly 32 bytes",
+)
+
+type ReviewHistoryConfig struct {
+	CursorSigningKey Secret
+}
+
+func LoadReviewHistory() (ReviewHistoryConfig, error) {
+	raw := strings.TrimSpace(os.Getenv("REVIEW_HISTORY_CURSOR_SIGNING_KEY"))
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(raw)
+	if err != nil || len(decoded) != reviewHistoryCursorKeyBytes {
+		return ReviewHistoryConfig{}, ErrReviewHistoryCursorSigningKey
+	}
+	return ReviewHistoryConfig{
+		CursorSigningKey: Secret{value: raw},
+	}, nil
+}

--- a/server/internal/platform/config/review_history_test.go
+++ b/server/internal/platform/config/review_history_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestLoadReviewHistory(t *testing.T) {
+	encoded := base64.RawURLEncoding.EncodeToString(
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+	t.Setenv("REVIEW_HISTORY_CURSOR_SIGNING_KEY", encoded)
+
+	configuration, err := LoadReviewHistory()
+	if err != nil {
+		t.Fatalf("LoadReviewHistory() error = %v", err)
+	}
+	if configuration.CursorSigningKey.Reveal() != encoded ||
+		strings.Contains(configuration.CursorSigningKey.String(), encoded) {
+		t.Fatal("LoadReviewHistory() did not preserve a redacted key")
+	}
+}
+
+func TestLoadReviewHistoryRejectsInvalidSigningKey(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"not-base64url!",
+		base64.RawURLEncoding.EncodeToString([]byte("too-short")),
+		base64.RawURLEncoding.EncodeToString(make([]byte, 33)),
+	} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("REVIEW_HISTORY_CURSOR_SIGNING_KEY", value)
+			_, err := LoadReviewHistory()
+			if !errors.Is(err, ErrReviewHistoryCursorSigningKey) {
+				t.Fatalf(
+					"LoadReviewHistory() error = %v, want %v",
+					err,
+					ErrReviewHistoryCursorSigningKey,
+				)
+			}
+		})
+	}
+}

--- a/server/internal/review/formal_model.go
+++ b/server/internal/review/formal_model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type FormalReviewStatus string
@@ -17,6 +18,12 @@ const (
 	FormalReviewFailed     FormalReviewStatus = "failed"
 
 	SourceTypeConversationTurn = "conversation_turn"
+
+	maxReviewResultJSONBytes      = 12 * 1024
+	maxReviewSummaryUTF8Bytes     = 2048
+	maxReviewConclusions          = 8
+	maxReviewConclusionLabelBytes = 64
+	maxReviewConclusionTextBytes  = 2048
 )
 
 var (
@@ -358,8 +365,9 @@ func validateCompletionPayload(
 func validateReviewResult(result ReviewResult) error {
 	if result.OverallScore < 0 ||
 		result.OverallScore > 100 ||
-		strings.TrimSpace(result.Summary) == "" ||
-		len(result.Conclusions) == 0 {
+		!validReviewText(result.Summary, maxReviewSummaryUTF8Bytes) ||
+		len(result.Conclusions) == 0 ||
+		len(result.Conclusions) > maxReviewConclusions {
 		return ErrInvalidReview
 	}
 	conclusions := make(map[string]struct{}, len(result.Conclusions))
@@ -367,8 +375,22 @@ func validateReviewResult(result ReviewResult) error {
 		key := strings.TrimSpace(conclusion.Key)
 		if key == "" ||
 			key != conclusion.Key ||
-			strings.TrimSpace(conclusion.Category) == "" ||
-			strings.TrimSpace(conclusion.Message) == "" {
+			!validReviewText(
+				conclusion.Key,
+				maxReviewConclusionLabelBytes,
+			) ||
+			!validReviewText(
+				conclusion.Category,
+				maxReviewConclusionLabelBytes,
+			) ||
+			!validReviewText(
+				conclusion.Message,
+				maxReviewConclusionTextBytes,
+			) ||
+			!validOptionalReviewText(
+				conclusion.Suggestion,
+				maxReviewConclusionTextBytes,
+			) {
 			return ErrInvalidReview
 		}
 		if _, exists := conclusions[key]; exists {
@@ -376,7 +398,25 @@ func validateReviewResult(result ReviewResult) error {
 		}
 		conclusions[key] = struct{}{}
 	}
+	encoded, err := json.Marshal(result)
+	if err != nil || len(encoded) > maxReviewResultJSONBytes {
+		return ErrInvalidReview
+	}
 	return nil
+}
+
+func validReviewText(value string, maximumBytes int) bool {
+	return utf8.ValidString(value) &&
+		!strings.ContainsRune(value, '\x00') &&
+		len(value) <= maximumBytes &&
+		strings.TrimSpace(value) != ""
+}
+
+func validOptionalReviewText(value string, maximumBytes int) bool {
+	return utf8.ValidString(value) &&
+		!strings.ContainsRune(value, '\x00') &&
+		len(value) <= maximumBytes &&
+		(value == "" || strings.TrimSpace(value) != "")
 }
 
 func validStableErrorCategory(category string) bool {

--- a/server/internal/review/formal_model.go
+++ b/server/internal/review/formal_model.go
@@ -363,22 +363,18 @@ func validateCompletionPayload(
 }
 
 func validateReviewResult(result ReviewResult) error {
-	if result.OverallScore < 0 ||
-		result.OverallScore > 100 ||
-		!validReviewText(result.Summary, maxReviewSummaryUTF8Bytes) ||
-		len(result.Conclusions) == 0 ||
+	if err := validatePersistedReviewResult(result); err != nil {
+		return err
+	}
+	if !validReviewText(result.Summary, maxReviewSummaryUTF8Bytes) ||
 		len(result.Conclusions) > maxReviewConclusions {
 		return ErrInvalidReview
 	}
-	conclusions := make(map[string]struct{}, len(result.Conclusions))
 	for _, conclusion := range result.Conclusions {
-		key := strings.TrimSpace(conclusion.Key)
-		if key == "" ||
-			key != conclusion.Key ||
-			!validReviewText(
-				conclusion.Key,
-				maxReviewConclusionLabelBytes,
-			) ||
+		if !validReviewText(
+			conclusion.Key,
+			maxReviewConclusionLabelBytes,
+		) ||
 			!validReviewText(
 				conclusion.Category,
 				maxReviewConclusionLabelBytes,
@@ -393,14 +389,38 @@ func validateReviewResult(result ReviewResult) error {
 			) {
 			return ErrInvalidReview
 		}
-		if _, exists := conclusions[key]; exists {
-			return ErrInvalidReview
-		}
-		conclusions[key] = struct{}{}
 	}
 	encoded, err := json.Marshal(result)
 	if err != nil || len(encoded) > maxReviewResultJSONBytes {
 		return ErrInvalidReview
+	}
+	return nil
+}
+
+// validatePersistedReviewResult preserves the validation contract that was in
+// production before response budgets were introduced. Reads must continue to
+// restore those committed results; the stricter limits apply only to new
+// writes, while the HTTP layer still enforces its total response budget.
+func validatePersistedReviewResult(result ReviewResult) error {
+	if result.OverallScore < 0 ||
+		result.OverallScore > 100 ||
+		strings.TrimSpace(result.Summary) == "" ||
+		len(result.Conclusions) == 0 {
+		return ErrInvalidReview
+	}
+	conclusions := make(map[string]struct{}, len(result.Conclusions))
+	for _, conclusion := range result.Conclusions {
+		key := strings.TrimSpace(conclusion.Key)
+		if key == "" ||
+			key != conclusion.Key ||
+			strings.TrimSpace(conclusion.Category) == "" ||
+			strings.TrimSpace(conclusion.Message) == "" {
+			return ErrInvalidReview
+		}
+		if _, exists := conclusions[key]; exists {
+			return ErrInvalidReview
+		}
+		conclusions[key] = struct{}{}
 	}
 	return nil
 }

--- a/server/internal/review/formal_model_test.go
+++ b/server/internal/review/formal_model_test.go
@@ -1,0 +1,211 @@
+package review
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestReviewResultAcceptsTheMaximumJSONBudget(t *testing.T) {
+	result := maximumValidReviewResult(t)
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal maximum Result: %v", err)
+	}
+	if len(payload) != maxReviewResultJSONBytes {
+		t.Fatalf(
+			"maximum Result bytes = %d, want %d",
+			len(payload),
+			maxReviewResultJSONBytes,
+		)
+	}
+	if err := validateReviewResult(result); err != nil {
+		t.Fatalf("maximum valid Result rejected: %v", err)
+	}
+}
+
+func TestReviewResultRejectsEveryFrozenBudgetViolation(t *testing.T) {
+	invalidUTF8 := string([]byte{0xff})
+	tests := []struct {
+		name   string
+		mutate func(*ReviewResult)
+	}{
+		{
+			name: "summary over 2048 UTF-8 bytes",
+			mutate: func(result *ReviewResult) {
+				result.Summary = strings.Repeat("界", 683)
+			},
+		},
+		{
+			name: "summary invalid UTF-8",
+			mutate: func(result *ReviewResult) {
+				result.Summary = invalidUTF8
+			},
+		},
+		{
+			name: "summary contains NUL",
+			mutate: func(result *ReviewResult) {
+				result.Summary = "clear\x00answer"
+			},
+		},
+		{
+			name: "no conclusions",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions = nil
+			},
+		},
+		{
+			name: "more than eight conclusions",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions = append(
+					result.Conclusions,
+					result.Conclusions[0],
+				)
+			},
+		},
+		{
+			name: "key over 64 UTF-8 bytes",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Key = strings.Repeat("k", 65)
+			},
+		},
+		{
+			name: "key invalid UTF-8",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Key = invalidUTF8
+			},
+		},
+		{
+			name: "key contains NUL",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Key = "clarity\x00detail"
+			},
+		},
+		{
+			name: "category over 64 UTF-8 bytes",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Category = strings.Repeat("c", 65)
+			},
+		},
+		{
+			name: "category invalid UTF-8",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Category = invalidUTF8
+			},
+		},
+		{
+			name: "category contains NUL",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Category = "clarity\x00detail"
+			},
+		},
+		{
+			name: "message over 2048 UTF-8 bytes",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Message = strings.Repeat("m", 2049)
+			},
+		},
+		{
+			name: "message invalid UTF-8",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Message = invalidUTF8
+			},
+		},
+		{
+			name: "message contains NUL",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Message = "clear\x00answer"
+			},
+		},
+		{
+			name: "suggestion over 2048 UTF-8 bytes",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Suggestion = strings.Repeat("s", 2049)
+			},
+		},
+		{
+			name: "suggestion invalid UTF-8",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Suggestion = invalidUTF8
+			},
+		},
+		{
+			name: "suggestion contains NUL",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Suggestion = "add\x00detail"
+			},
+		},
+		{
+			name: "non-empty suggestion trims to empty",
+			mutate: func(result *ReviewResult) {
+				result.Conclusions[0].Suggestion = " \t\n"
+			},
+		},
+		{
+			name: "marshaled Result over 12 KiB",
+			mutate: func(result *ReviewResult) {
+				for index := range result.Conclusions {
+					result.Conclusions[index].Message =
+						strings.Repeat("m", maxReviewConclusionTextBytes)
+					result.Conclusions[index].Suggestion =
+						strings.Repeat("s", maxReviewConclusionTextBytes)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := maximumValidReviewResult(t)
+			test.mutate(&result)
+			if err := validateReviewResult(result); !errors.Is(
+				err,
+				ErrInvalidReview,
+			) {
+				t.Fatalf("invalid Result error = %v", err)
+			}
+		})
+	}
+}
+
+func maximumValidReviewResult(t *testing.T) ReviewResult {
+	t.Helper()
+	result := ReviewResult{
+		OverallScore: 100,
+		Summary:      strings.Repeat("s", maxReviewSummaryUTF8Bytes),
+		Conclusions: make(
+			[]ReviewConclusion,
+			maxReviewConclusions,
+		),
+	}
+	for index := range result.Conclusions {
+		result.Conclusions[index] = ReviewConclusion{
+			Key: fmt.Sprintf("%02d", index) +
+				strings.Repeat("k", maxReviewConclusionLabelBytes-2),
+			Category: strings.Repeat(
+				"c",
+				maxReviewConclusionLabelBytes,
+			),
+			Message:    strings.Repeat("m", 700),
+			Suggestion: strings.Repeat("s", 300),
+		}
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal Result fixture: %v", err)
+	}
+	remaining := maxReviewResultJSONBytes - len(payload)
+	last := &result.Conclusions[len(result.Conclusions)-1]
+	if remaining < 0 ||
+		len(last.Suggestion)+remaining > maxReviewConclusionTextBytes {
+		t.Fatalf(
+			"Result fixture cannot reach budget: bytes=%d remaining=%d",
+			len(payload),
+			remaining,
+		)
+	}
+	last.Suggestion += strings.Repeat("x", remaining)
+	return result
+}

--- a/server/internal/review/history.go
+++ b/server/internal/review/history.go
@@ -1,0 +1,83 @@
+package review
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+const MaxHistoryPageSize = 50
+
+// HistoryCursor is the stable keyset boundary for the Review-owned history
+// read model. CreatedAt and ReviewID match the repository order exactly.
+type HistoryCursor struct {
+	CreatedAt time.Time
+	ReviewID  string
+}
+
+type HistoryQuery struct {
+	Limit  int
+	Before *HistoryCursor
+}
+
+type HistoryPage struct {
+	Items []FormalReview
+	Next  *HistoryCursor
+}
+
+// HistoryRepository is deliberately narrower than the mutation repository.
+// The Review module remains the only owner of its history query semantics.
+type HistoryRepository interface {
+	Get(
+		ctx context.Context,
+		actor Actor,
+		reviewID string,
+	) (FormalReview, error)
+	ListCompletedHistory(
+		ctx context.Context,
+		actor Actor,
+		query HistoryQuery,
+	) (HistoryPage, error)
+}
+
+type HistoryService struct {
+	repository HistoryRepository
+}
+
+func NewHistoryService(repository HistoryRepository) *HistoryService {
+	return &HistoryService{repository: repository}
+}
+
+func (service *HistoryService) Get(
+	ctx context.Context,
+	actor Actor,
+	reviewID string,
+) (FormalReview, error) {
+	if service == nil || service.repository == nil ||
+		actor.validate() != nil || strings.TrimSpace(reviewID) == "" {
+		return FormalReview{}, ErrInvalidReview
+	}
+	return service.repository.Get(ctx, actor, reviewID)
+}
+
+// ListCompleted returns only authoritative completed results. Offset
+// pagination is intentionally excluded because concurrent Review creation
+// would otherwise duplicate or skip rows.
+func (service *HistoryService) ListCompleted(
+	ctx context.Context,
+	actor Actor,
+	query HistoryQuery,
+) (HistoryPage, error) {
+	if service == nil || service.repository == nil ||
+		actor.validate() != nil || query.Limit < 1 ||
+		query.Limit > MaxHistoryPageSize ||
+		(query.Before != nil && !validHistoryCursor(*query.Before)) {
+		return HistoryPage{}, ErrInvalidReview
+	}
+	return service.repository.ListCompletedHistory(ctx, actor, query)
+}
+
+func validHistoryCursor(cursor HistoryCursor) bool {
+	return !cursor.CreatedAt.IsZero() &&
+		validUUID(cursor.ReviewID)
+}

--- a/server/internal/review/postgres.go
+++ b/server/internal/review/postgres.go
@@ -517,37 +517,41 @@ func (r *PostgresRepository) Get(
 		strings.TrimSpace(reviewID) == "" {
 		return FormalReview{}, ErrInvalidReview
 	}
-	unavailable, err := accountUnavailable(ctx, r.pool, actor.UserID)
+	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return FormalReview{}, err
 	}
-	if unavailable {
-		return FormalReview{}, ErrAccountDeleted
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockReviewUser(ctx, tx, actor.UserID); err != nil {
+		return FormalReview{}, err
 	}
-	review, err := scanReview(r.pool.QueryRow(ctx, reviewSelect+`
-		WHERE id = $1 AND owner_user_id = $2
-	`, reviewID, actor.UserID))
+	if err := lockActiveIdentityUser(
+		ctx,
+		tx,
+		actor.UserID,
+		actor.DeletionGeneration,
+	); err != nil {
+		return FormalReview{}, err
+	}
+	review, err := scanReview(tx.QueryRow(ctx, reviewSelect+`
+		WHERE id = $1
+		  AND owner_user_id = $2
+		  AND deletion_generation = $3
+	`, reviewID, actor.UserID, actor.DeletionGeneration))
 	if errors.Is(err, pgx.ErrNoRows) {
-		deleted, checkErr := accountUnavailable(ctx, r.pool, actor.UserID)
-		if checkErr != nil {
-			return FormalReview{}, checkErr
-		}
-		if deleted {
-			return FormalReview{}, ErrAccountDeleted
-		}
 		return FormalReview{}, ErrReviewNotFound
 	}
 	if err != nil {
 		return FormalReview{}, err
 	}
-	if review.DeletionGeneration != actor.DeletionGeneration {
-		return FormalReview{}, ErrAccountDeleted
-	}
-	evidence, err := listEvidence(ctx, r.pool, review.ID, actor.UserID)
+	evidence, err := listEvidence(ctx, tx, review.ID, actor.UserID)
 	if err != nil {
 		return FormalReview{}, err
 	}
 	review.Evidence = evidence
+	if err := tx.Commit(ctx); err != nil {
+		return FormalReview{}, err
+	}
 	return review, nil
 }
 
@@ -840,7 +844,7 @@ func scanReview(row rowScanner) (FormalReview, error) {
 		if err := json.Unmarshal(resultJSON, &result); err != nil {
 			return FormalReview{}, ErrInvalidReview
 		}
-		if err := validateReviewResult(result); err != nil {
+		if err := validatePersistedReviewResult(result); err != nil {
 			return FormalReview{}, ErrInvalidReview
 		}
 		review.Result = &result

--- a/server/internal/review/postgres.go
+++ b/server/internal/review/postgres.go
@@ -588,6 +588,86 @@ func (r *PostgresRepository) List(
 	return reviews, nil
 }
 
+func (r *PostgresRepository) ListCompletedHistory(
+	ctx context.Context,
+	actor Actor,
+	query HistoryQuery,
+) (HistoryPage, error) {
+	if r == nil || r.pool == nil || actor.validate() != nil ||
+		query.Limit < 1 || query.Limit > MaxHistoryPageSize ||
+		(query.Before != nil && !validHistoryCursor(*query.Before)) {
+		return HistoryPage{}, ErrInvalidReview
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return HistoryPage{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockReviewUser(ctx, tx, actor.UserID); err != nil {
+		return HistoryPage{}, err
+	}
+	if err := lockActiveIdentityUser(
+		ctx,
+		tx,
+		actor.UserID,
+		actor.DeletionGeneration,
+	); err != nil {
+		return HistoryPage{}, err
+	}
+
+	var beforeCreatedAt any
+	var beforeReviewID any
+	if query.Before != nil {
+		beforeCreatedAt = query.Before.CreatedAt
+		beforeReviewID = query.Before.ReviewID
+	}
+	rows, err := tx.Query(ctx, reviewSelect+`
+		WHERE owner_user_id = $1
+		  AND deletion_generation = $2
+		  AND status = 'completed'
+		  AND (
+		      $3::timestamptz IS NULL
+		      OR created_at < $3
+		      OR (created_at = $3 AND id < $4::uuid)
+		  )
+		ORDER BY created_at DESC, id DESC
+		LIMIT $5
+	`, actor.UserID, actor.DeletionGeneration,
+		beforeCreatedAt, beforeReviewID, query.Limit+1)
+	if err != nil {
+		return HistoryPage{}, err
+	}
+	defer rows.Close()
+
+	items := make([]FormalReview, 0, query.Limit+1)
+	for rows.Next() {
+		item, scanErr := scanReview(rows)
+		if scanErr != nil {
+			return HistoryPage{}, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return HistoryPage{}, err
+	}
+	rows.Close()
+
+	page := HistoryPage{Items: items}
+	if len(page.Items) > query.Limit {
+		page.Items = page.Items[:query.Limit]
+		last := page.Items[len(page.Items)-1]
+		page.Next = &HistoryCursor{
+			CreatedAt: last.CreatedAt,
+			ReviewID:  last.ID,
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return HistoryPage{}, err
+	}
+	return page, nil
+}
+
 func (r *PostgresRepository) ListAttempts(
 	ctx context.Context,
 	actor Actor,
@@ -758,7 +838,10 @@ func scanReview(row rowScanner) (FormalReview, error) {
 	if len(resultJSON) > 0 {
 		var result ReviewResult
 		if err := json.Unmarshal(resultJSON, &result); err != nil {
-			return FormalReview{}, err
+			return FormalReview{}, ErrInvalidReview
+		}
+		if err := validateReviewResult(result); err != nil {
+			return FormalReview{}, ErrInvalidReview
 		}
 		review.Result = &result
 	}
@@ -899,3 +982,4 @@ func errInvalidClaim(claim GenerationJobContext) bool {
 }
 
 var _ ReviewRepository = (*PostgresRepository)(nil)
+var _ HistoryRepository = (*PostgresRepository)(nil)

--- a/server/internal/review/postgres_integration_test.go
+++ b/server/internal/review/postgres_integration_test.go
@@ -922,36 +922,48 @@ func TestPostgresCompletedHistoryUsesOwnerScopedStableKeysetPagination(
 		t.Fatalf("second history page = %+v", second)
 	}
 
-	// PostgreSQL jsonb rejects U+0000 before it can become a readable row.
-	// An over-budget but otherwise valid jsonb value is therefore the reachable
-	// persisted-corruption case for the repository read-boundary check.
-	corruptResult := validResult()
-	corruptResult.Summary = strings.Repeat("s", 2049)
-	corruptPayload, err := json.Marshal(corruptResult)
+	// Results committed before the write budget was introduced remain valid
+	// history. New writes are stricter, but repository reads preserve the
+	// previous production validation contract.
+	legacyResult := validResult()
+	legacyResult.Summary = strings.Repeat("s", 2049)
+	legacyPayload, err := json.Marshal(legacyResult)
 	if err != nil {
-		t.Fatalf("marshal over-budget persisted Review: %v", err)
+		t.Fatalf("marshal legacy persisted Review: %v", err)
 	}
 	if _, err := pool.Exec(
 		context.Background(),
 		`UPDATE reviews SET result = $1::jsonb WHERE id = $2`,
-		corruptPayload,
+		legacyPayload,
 		ownerReviews[0].ID,
 	); err != nil {
-		t.Fatalf("stage over-budget persisted Review: %v", err)
+		t.Fatalf("stage legacy persisted Review: %v", err)
 	}
-	if _, err := repository.Get(
+	legacy, err := repository.Get(
 		context.Background(),
 		actor(userA),
 		ownerReviews[0].ID,
-	); !errors.Is(err, review.ErrInvalidReview) {
-		t.Fatalf("over-budget persisted Review get error = %v", err)
+	)
+	if err != nil || legacy.Result == nil ||
+		legacy.Result.Summary != legacyResult.Summary {
+		t.Fatalf("legacy persisted Review = %+v, %v", legacy, err)
 	}
-	if _, err := history.ListCompleted(
+	legacyPage, err := history.ListCompleted(
 		context.Background(),
 		actor(userA),
 		review.HistoryQuery{Limit: 2},
-	); !errors.Is(err, review.ErrInvalidReview) {
-		t.Fatalf("over-budget persisted Review history error = %v", err)
+	)
+	legacyIndex := slices.IndexFunc(
+		legacyPage.Items,
+		func(item review.FormalReview) bool {
+			return item.ID == ownerReviews[0].ID
+		},
+	)
+	if err != nil || len(legacyPage.Items) != 2 ||
+		legacyIndex < 0 ||
+		legacyPage.Items[legacyIndex].Result == nil ||
+		legacyPage.Items[legacyIndex].Result.Summary != legacyResult.Summary {
+		t.Fatalf("legacy persisted Review history = %+v, %v", legacyPage, err)
 	}
 
 	setAccountStatus(t, pool, userA, "deleting")
@@ -1458,6 +1470,68 @@ func TestPostgresCompletedHistoryAppliesForeignCursorOnlyAsActorKeyset(
 	}
 }
 
+func TestPostgresHistoryRestoresLegacyResultAboveNewWriteBudget(t *testing.T) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA)
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	history := review.NewHistoryService(repository)
+	item, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "legacy-large-result"),
+	)
+	if err != nil {
+		t.Fatalf("ensure legacy Review: %v", err)
+	}
+	legacyResult := validResult()
+	legacyResult.Summary = strings.Repeat("legacy summary ", 1100)
+	encoded, err := json.Marshal(legacyResult)
+	if err != nil {
+		t.Fatalf("marshal legacy result: %v", err)
+	}
+	if len(encoded) <= 12*1024 {
+		t.Fatalf("legacy result fixture is only %d bytes", len(encoded))
+	}
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE reviews
+		SET result = $2::jsonb
+		WHERE id = $1
+	`, item.ID, encoded); err != nil {
+		t.Fatalf("persist legacy result: %v", err)
+	}
+
+	recovered, err := history.Get(
+		context.Background(),
+		actor(userA),
+		item.ID,
+	)
+	if err != nil {
+		t.Fatalf("restore legacy Review: %v", err)
+	}
+	if recovered.Result == nil ||
+		recovered.Result.Summary != legacyResult.Summary {
+		t.Fatalf("restored legacy Review = %+v", recovered)
+	}
+	page, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 20},
+	)
+	if err != nil {
+		t.Fatalf("list legacy Review: %v", err)
+	}
+	if len(page.Items) != 1 ||
+		page.Items[0].ID != item.ID ||
+		page.Items[0].Result == nil ||
+		page.Items[0].Result.Summary != legacyResult.Summary {
+		t.Fatalf("legacy history page = %+v", page)
+	}
+}
+
 func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 	t *testing.T,
 ) {
@@ -1529,7 +1603,12 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 		page review.HistoryPage
 		err  error
 	}
+	type getResult struct {
+		item review.FormalReview
+		err  error
+	}
 	listed := make(chan listResult, 1)
+	got := make(chan getResult, 1)
 	deleted := make(chan error, 1)
 	go func() {
 		page, listErr := history.ListCompleted(
@@ -1540,6 +1619,14 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 		listed <- listResult{page: page, err: listErr}
 	}()
 	go func() {
+		item, getErr := history.Get(
+			context.Background(),
+			actor(userA),
+			ownerReview.ID,
+		)
+		got <- getResult{item: item, err: getErr}
+	}()
+	go func() {
 		deleted <- repository.DeleteUserData(
 			context.Background(),
 			review.DeleteUserReviewsCommand{
@@ -1548,7 +1635,7 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 			},
 		)
 	}()
-	waitForReviewAdvisoryWaiters(t, pool, blockerPID, 2)
+	waitForReviewAdvisoryWaiters(t, pool, blockerPID, 3)
 	if err := blocker.Commit(context.Background()); err != nil {
 		t.Fatalf("release shared Review user lock: %v", err)
 	}
@@ -1566,6 +1653,19 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("concurrent history did not resume")
+	}
+	select {
+	case result := <-got:
+		if !errors.Is(result.err, review.ErrAccountDeleted) ||
+			result.item.ID != "" {
+			t.Fatalf(
+				"concurrent Review get after deletion intent = %+v, %v",
+				result.item,
+				result.err,
+			)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Review get did not resume")
 	}
 	select {
 	case err := <-deleted:

--- a/server/internal/review/postgres_integration_test.go
+++ b/server/internal/review/postgres_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/review"
 	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -1598,6 +1599,20 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 	); err != nil {
 		t.Fatalf("hold shared Review user lock: %v", err)
 	}
+	monitorConfig, err := pgxpool.ParseConfig(
+		os.Getenv("TEST_DATABASE_URL"),
+	)
+	if err != nil {
+		t.Fatalf("parse Review lock monitor config: %v", err)
+	}
+	monitor, err := pgx.ConnectConfig(
+		context.Background(),
+		monitorConfig.ConnConfig,
+	)
+	if err != nil {
+		t.Fatalf("connect Review lock monitor: %v", err)
+	}
+	defer func() { _ = monitor.Close(context.Background()) }()
 
 	type listResult struct {
 		page review.HistoryPage
@@ -1635,7 +1650,7 @@ func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
 			},
 		)
 	}()
-	waitForReviewAdvisoryWaiters(t, pool, blockerPID, 3)
+	waitForReviewAdvisoryWaiters(t, monitor, blockerPID, 3)
 	if err := blocker.Commit(context.Background()); err != nil {
 		t.Fatalf("release shared Review user lock: %v", err)
 	}
@@ -2458,7 +2473,7 @@ func waitForBlockedIdentityShareLock(t *testing.T, pool *pgxpool.Pool) {
 
 func waitForReviewAdvisoryWaiters(
 	t *testing.T,
-	pool *pgxpool.Pool,
+	monitor *pgx.Conn,
 	blockerPID int,
 	want int,
 ) {
@@ -2466,7 +2481,7 @@ func waitForReviewAdvisoryWaiters(
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		var blocked int
-		err := pool.QueryRow(context.Background(), `
+		err := monitor.QueryRow(context.Background(), `
 			WITH RECURSIVE blocked(pid) AS (
 				SELECT activity.pid
 				FROM pg_stat_activity activity

--- a/server/internal/review/postgres_integration_test.go
+++ b/server/internal/review/postgres_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -811,6 +812,825 @@ func TestPostgresReviewOwnerIsolationDeletionAndOldWorkerFence(t *testing.T) {
 	assertReviewCount(t, pool, userC, 0)
 }
 
+func TestPostgresCompletedHistoryUsesOwnerScopedStableKeysetPagination(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA, userB)
+
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	history := review.NewHistoryService(repository)
+
+	var ownerReviews []review.FormalReview
+	for index := 1; index <= 3; index++ {
+		item, err := ensure.EnsureReview(
+			context.Background(),
+			ensureCommand(userA, fmt.Sprintf("history-session-%d", index)),
+		)
+		if err != nil {
+			t.Fatalf("ensure owner Review %d: %v", index, err)
+		}
+		ownerReviews = append(ownerReviews, item)
+	}
+	foreign, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userB, "foreign-newer-history-session"),
+	)
+	if err != nil {
+		t.Fatalf("ensure foreign Review: %v", err)
+	}
+	if _, err := repository.EnsurePending(
+		context.Background(),
+		ensureCommand(userA, "history-pending"),
+	); err != nil {
+		t.Fatalf("ensure pending Review: %v", err)
+	}
+
+	newerCreatedAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(
+		time.Microsecond,
+	)
+	olderCreatedAt := newerCreatedAt.Add(-time.Hour)
+	for _, item := range ownerReviews[:2] {
+		if _, err := pool.Exec(
+			context.Background(),
+			`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+			newerCreatedAt,
+			item.ID,
+		); err != nil {
+			t.Fatalf("align owner Review created_at: %v", err)
+		}
+	}
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+		olderCreatedAt,
+		ownerReviews[2].ID,
+	); err != nil {
+		t.Fatalf("set older owner Review created_at: %v", err)
+	}
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+		newerCreatedAt.Add(time.Hour),
+		foreign.ID,
+	); err != nil {
+		t.Fatalf("set foreign Review created_at: %v", err)
+	}
+
+	newerIDs := []string{ownerReviews[0].ID, ownerReviews[1].ID}
+	slices.Sort(newerIDs)
+	slices.Reverse(newerIDs)
+	first, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2},
+	)
+	if err != nil {
+		t.Fatalf("list first history page: %v", err)
+	}
+	if len(first.Items) != 2 ||
+		first.Items[0].ID != newerIDs[0] ||
+		first.Items[1].ID != newerIDs[1] ||
+		first.Next == nil ||
+		first.Next.ReviewID != newerIDs[1] ||
+		!first.Next.CreatedAt.Equal(newerCreatedAt) {
+		t.Fatalf("first history page = %+v", first)
+	}
+	for _, item := range first.Items {
+		if item.OwnerUserID != userA ||
+			item.Status != review.FormalReviewCompleted {
+			t.Fatalf("history leaked non-owner/non-result: %+v", item)
+		}
+	}
+
+	second, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2, Before: first.Next},
+	)
+	if err != nil {
+		t.Fatalf("list second history page: %v", err)
+	}
+	if len(second.Items) != 1 ||
+		second.Items[0].ID != ownerReviews[2].ID ||
+		second.Next != nil {
+		t.Fatalf("second history page = %+v", second)
+	}
+
+	// PostgreSQL jsonb rejects U+0000 before it can become a readable row.
+	// An over-budget but otherwise valid jsonb value is therefore the reachable
+	// persisted-corruption case for the repository read-boundary check.
+	corruptResult := validResult()
+	corruptResult.Summary = strings.Repeat("s", 2049)
+	corruptPayload, err := json.Marshal(corruptResult)
+	if err != nil {
+		t.Fatalf("marshal over-budget persisted Review: %v", err)
+	}
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE reviews SET result = $1::jsonb WHERE id = $2`,
+		corruptPayload,
+		ownerReviews[0].ID,
+	); err != nil {
+		t.Fatalf("stage over-budget persisted Review: %v", err)
+	}
+	if _, err := repository.Get(
+		context.Background(),
+		actor(userA),
+		ownerReviews[0].ID,
+	); !errors.Is(err, review.ErrInvalidReview) {
+		t.Fatalf("over-budget persisted Review get error = %v", err)
+	}
+	if _, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2},
+	); !errors.Is(err, review.ErrInvalidReview) {
+		t.Fatalf("over-budget persisted Review history error = %v", err)
+	}
+
+	setAccountStatus(t, pool, userA, "deleting")
+	if err := repository.DeleteUserData(
+		context.Background(),
+		review.DeleteUserReviewsCommand{
+			UserID:             userA,
+			DeletionGeneration: 1,
+		},
+	); err != nil {
+		t.Fatalf("delete owner Review data: %v", err)
+	}
+	if _, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2},
+	); !errors.Is(err, review.ErrAccountDeleted) {
+		t.Fatalf("deleted account history error = %v", err)
+	}
+}
+
+func TestPostgresReviewRejectsNULBeforeJSONBWrite(t *testing.T) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA)
+	repository := review.NewPostgresRepository(pool)
+	command := ensureCommand(userA, "nul-result-session")
+	pending, err := repository.EnsurePending(
+		context.Background(),
+		command,
+	)
+	if err != nil {
+		t.Fatalf("ensure pending NUL Review: %v", err)
+	}
+	_, claim, claimed, err := repository.ClaimGeneration(
+		context.Background(),
+		command.Actor,
+		pending.ID,
+		time.Minute,
+	)
+	if err != nil || !claimed {
+		t.Fatalf("claim NUL Review: claimed=%v err=%v", claimed, err)
+	}
+	nulResult := validResult()
+	nulResult.Summary = "clear\x00answer"
+	if _, err := repository.CompleteGeneration(
+		context.Background(),
+		claim,
+		nulResult,
+		validEvidence(),
+	); !errors.Is(err, review.ErrInvalidReview) {
+		t.Fatalf("NUL Result completion error = %v", err)
+	}
+	persisted, err := repository.Get(
+		context.Background(),
+		command.Actor,
+		pending.ID,
+	)
+	if err != nil {
+		t.Fatalf("read Review after rejected NUL completion: %v", err)
+	}
+	if persisted.Status != review.FormalReviewGenerating ||
+		persisted.Result != nil {
+		t.Fatalf("rejected NUL completion changed Review: %+v", persisted)
+	}
+
+	_, err = pool.Exec(
+		context.Background(),
+		`SELECT $1::jsonb`,
+		`{"summary":"clear\u0000answer"}`,
+	)
+	var postgresError *pgconn.PgError
+	if !errors.As(err, &postgresError) ||
+		postgresError.Code != "22P05" {
+		t.Fatalf(
+			"PostgreSQL NUL jsonb error = %v, want SQLSTATE 22P05",
+			err,
+		)
+	}
+}
+
+func TestPostgresMaximumReviewResultCompletesAndReadsBackAtEveryBoundary(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA)
+	repository := review.NewPostgresRepository(pool)
+	command := ensureCommand(userA, "maximum-result-session")
+	pending, err := repository.EnsurePending(
+		context.Background(),
+		command,
+	)
+	if err != nil {
+		t.Fatalf("ensure maximum Result Review: %v", err)
+	}
+	_, claim, claimed, err := repository.ClaimGeneration(
+		context.Background(),
+		command.Actor,
+		pending.ID,
+		time.Minute,
+	)
+	if err != nil || !claimed {
+		t.Fatalf(
+			"claim maximum Result Review: claimed=%v err=%v",
+			claimed,
+			err,
+		)
+	}
+	maximum := maximumPersistedReviewResult(t)
+	assertReviewResultJSONBytes(t, maximum, 12*1024)
+	completed, err := repository.CompleteGeneration(
+		context.Background(),
+		claim,
+		maximum,
+		evidenceForReviewResult(maximum),
+	)
+	if err != nil {
+		t.Fatalf("complete maximum Result Review: %v", err)
+	}
+	if completed.Status != review.FormalReviewCompleted ||
+		completed.Result == nil {
+		t.Fatalf("completed maximum Result Review = %+v", completed)
+	}
+	assertReviewResultJSONBytes(t, *completed.Result, 12*1024)
+
+	recovered, err := repository.Get(
+		context.Background(),
+		command.Actor,
+		completed.ID,
+	)
+	if err != nil {
+		t.Fatalf("get maximum Result Review: %v", err)
+	}
+	if recovered.ID != completed.ID || recovered.Result == nil {
+		t.Fatalf("recovered maximum Result Review = %+v", recovered)
+	}
+	assertReviewResultJSONBytes(t, *recovered.Result, 12*1024)
+
+	page, err := review.NewHistoryService(repository).ListCompleted(
+		context.Background(),
+		command.Actor,
+		review.HistoryQuery{Limit: 1},
+	)
+	if err != nil {
+		t.Fatalf("list maximum Result Review: %v", err)
+	}
+	if len(page.Items) != 1 ||
+		page.Items[0].ID != completed.ID ||
+		page.Items[0].Result == nil ||
+		page.Next != nil {
+		t.Fatalf("maximum Result history page = %+v", page)
+	}
+	assertReviewResultJSONBytes(t, *page.Items[0].Result, 12*1024)
+}
+
+func TestPostgresCompletedHistoryExcludesEveryNonCompletedState(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA)
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	completed, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "status-completed"),
+	)
+	if err != nil {
+		t.Fatalf("ensure completed status fixture: %v", err)
+	}
+	pending, err := repository.EnsurePending(
+		context.Background(),
+		ensureCommand(userA, "status-pending"),
+	)
+	if err != nil {
+		t.Fatalf("ensure pending status fixture: %v", err)
+	}
+	generating, err := repository.EnsurePending(
+		context.Background(),
+		ensureCommand(userA, "status-generating"),
+	)
+	if err != nil {
+		t.Fatalf("ensure generating status fixture: %v", err)
+	}
+	generating, _, claimed, err := repository.ClaimGeneration(
+		context.Background(),
+		actor(userA),
+		generating.ID,
+		time.Minute,
+	)
+	if err != nil || !claimed {
+		t.Fatalf(
+			"claim generating status fixture: claimed=%v err=%v",
+			claimed,
+			err,
+		)
+	}
+	failed, err := repository.EnsurePending(
+		context.Background(),
+		ensureCommand(userA, "status-failed"),
+	)
+	if err != nil {
+		t.Fatalf("ensure failed status fixture: %v", err)
+	}
+	failed, failedClaim, claimed, err := repository.ClaimGeneration(
+		context.Background(),
+		actor(userA),
+		failed.ID,
+		time.Minute,
+	)
+	if err != nil || !claimed {
+		t.Fatalf(
+			"claim failed status fixture: claimed=%v err=%v",
+			claimed,
+			err,
+		)
+	}
+	if err := repository.FailGeneration(
+		context.Background(),
+		failedClaim,
+		"provider_timeout",
+	); err != nil {
+		t.Fatalf("fail status fixture: %v", err)
+	}
+
+	expectedStates := map[string]review.FormalReviewStatus{
+		pending.ID:    review.FormalReviewPending,
+		generating.ID: review.FormalReviewGenerating,
+		failed.ID:     review.FormalReviewFailed,
+	}
+	for reviewID, expectedStatus := range expectedStates {
+		item, err := repository.Get(
+			context.Background(),
+			actor(userA),
+			reviewID,
+		)
+		if err != nil {
+			t.Fatalf("get %s status fixture: %v", expectedStatus, err)
+		}
+		if item.Status != expectedStatus {
+			t.Fatalf(
+				"status fixture %s = %s",
+				reviewID,
+				item.Status,
+			)
+		}
+	}
+
+	page, err := review.NewHistoryService(repository).ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 50},
+	)
+	if err != nil {
+		t.Fatalf("list completed-only status page: %v", err)
+	}
+	if len(page.Items) != 1 ||
+		page.Items[0].ID != completed.ID ||
+		page.Items[0].Status != review.FormalReviewCompleted ||
+		page.Next != nil {
+		t.Fatalf("completed-only status page = %+v", page)
+	}
+}
+
+func TestPostgresCompletedHistoryCursorKeepsItsKeysetBoundaryAfterNewerInsert(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA)
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	history := review.NewHistoryService(repository)
+
+	baseCreatedAt := time.Now().UTC().Add(-time.Hour).Truncate(
+		time.Microsecond,
+	)
+	originals := make([]review.FormalReview, 4)
+	for index := range originals {
+		item, err := ensure.EnsureReview(
+			context.Background(),
+			ensureCommand(
+				userA,
+				fmt.Sprintf("cursor-boundary-original-%d", index),
+			),
+		)
+		if err != nil {
+			t.Fatalf("ensure original Review %d: %v", index, err)
+		}
+		createdAt := baseCreatedAt.Add(
+			-time.Duration(index) * time.Minute,
+		)
+		if _, err := pool.Exec(
+			context.Background(),
+			`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+			createdAt,
+			item.ID,
+		); err != nil {
+			t.Fatalf("set original Review %d key: %v", index, err)
+		}
+		item.CreatedAt = createdAt
+		originals[index] = item
+	}
+
+	first, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2},
+	)
+	if err != nil {
+		t.Fatalf("list keyset first page: %v", err)
+	}
+	if len(first.Items) != 2 ||
+		first.Items[0].ID != originals[0].ID ||
+		first.Items[1].ID != originals[1].ID ||
+		first.Next == nil {
+		t.Fatalf("keyset first page = %+v", first)
+	}
+
+	inserted, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "cursor-boundary-newer-insert"),
+	)
+	if err != nil {
+		t.Fatalf("ensure newly inserted Review: %v", err)
+	}
+	insertedCreatedAt := baseCreatedAt.Add(time.Minute)
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+		insertedCreatedAt,
+		inserted.ID,
+	); err != nil {
+		t.Fatalf("set newly inserted Review key: %v", err)
+	}
+
+	// The cursor is a stable lower keyset boundary, not an MVCC snapshot:
+	// a newly inserted row ahead of that boundary belongs only to a fresh
+	// traversal, while the old continuation still covers the original tail.
+	continuation, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2, Before: first.Next},
+	)
+	if err != nil {
+		t.Fatalf("continue from old keyset cursor: %v", err)
+	}
+	if len(continuation.Items) != 2 ||
+		continuation.Items[0].ID != originals[2].ID ||
+		continuation.Items[1].ID != originals[3].ID ||
+		continuation.Next != nil {
+		t.Fatalf("old keyset continuation = %+v", continuation)
+	}
+	for _, item := range continuation.Items {
+		if item.ID == inserted.ID ||
+			item.ID == first.Items[0].ID ||
+			item.ID == first.Items[1].ID {
+			t.Fatalf(
+				"old keyset continuation repeated/mixed item: %+v",
+				item,
+			)
+		}
+	}
+
+	fresh, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 2},
+	)
+	if err != nil {
+		t.Fatalf("list fresh keyset page: %v", err)
+	}
+	if len(fresh.Items) != 2 ||
+		fresh.Items[0].ID != inserted.ID ||
+		fresh.Items[1].ID != originals[0].ID {
+		t.Fatalf("fresh keyset page after insert = %+v", fresh)
+	}
+}
+
+func TestPostgresCompletedHistoryAppliesForeignCursorOnlyAsActorKeyset(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA, userB)
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	history := review.NewHistoryService(repository)
+	baseCreatedAt := time.Now().UTC().Add(-time.Hour).Truncate(
+		time.Microsecond,
+	)
+
+	ownerReviews := make([]review.FormalReview, 2)
+	for index := range ownerReviews {
+		item, err := ensure.EnsureReview(
+			context.Background(),
+			ensureCommand(
+				userA,
+				fmt.Sprintf("foreign-cursor-owner-%d", index),
+			),
+		)
+		if err != nil {
+			t.Fatalf("ensure cursor owner Review %d: %v", index, err)
+		}
+		createdAt := baseCreatedAt.Add(
+			-time.Duration(index*3) * time.Minute,
+		)
+		if _, err := pool.Exec(
+			context.Background(),
+			`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+			createdAt,
+			item.ID,
+		); err != nil {
+			t.Fatalf("set cursor owner Review %d key: %v", index, err)
+		}
+		ownerReviews[index] = item
+	}
+	ownerFirst, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 1},
+	)
+	if err != nil {
+		t.Fatalf("list cursor owner first page: %v", err)
+	}
+	if len(ownerFirst.Items) != 1 ||
+		ownerFirst.Items[0].ID != ownerReviews[0].ID ||
+		ownerFirst.Next == nil {
+		t.Fatalf("cursor owner first page = %+v", ownerFirst)
+	}
+
+	foreignReviews := make([]review.FormalReview, 3)
+	foreignOffsets := []time.Duration{
+		time.Minute,
+		-time.Minute,
+		-2 * time.Minute,
+	}
+	for index := range foreignReviews {
+		item, err := ensure.EnsureReview(
+			context.Background(),
+			ensureCommand(
+				userB,
+				fmt.Sprintf("foreign-cursor-reader-%d", index),
+			),
+		)
+		if err != nil {
+			t.Fatalf("ensure cursor reader Review %d: %v", index, err)
+		}
+		if _, err := pool.Exec(
+			context.Background(),
+			`UPDATE reviews SET created_at = $1 WHERE id = $2`,
+			baseCreatedAt.Add(foreignOffsets[index]),
+			item.ID,
+		); err != nil {
+			t.Fatalf("set cursor reader Review %d key: %v", index, err)
+		}
+		foreignReviews[index] = item
+	}
+
+	reused, err := history.ListCompleted(
+		context.Background(),
+		actor(userB),
+		review.HistoryQuery{Limit: 50, Before: ownerFirst.Next},
+	)
+	if err != nil {
+		t.Fatalf("reuse owner cursor as foreign Actor: %v", err)
+	}
+	if len(reused.Items) != 2 ||
+		reused.Items[0].ID != foreignReviews[1].ID ||
+		reused.Items[1].ID != foreignReviews[2].ID ||
+		reused.Next != nil {
+		t.Fatalf("foreign Actor reused cursor page = %+v", reused)
+	}
+	for _, item := range reused.Items {
+		if item.OwnerUserID != userB ||
+			item.ID == ownerReviews[0].ID ||
+			item.ID == ownerReviews[1].ID ||
+			item.ID == foreignReviews[0].ID {
+			t.Fatalf("foreign cursor leaked/crossed keyset: %+v", item)
+		}
+	}
+
+	fresh, err := history.ListCompleted(
+		context.Background(),
+		actor(userB),
+		review.HistoryQuery{Limit: 50},
+	)
+	if err != nil {
+		t.Fatalf("list fresh foreign Actor page: %v", err)
+	}
+	if len(fresh.Items) != 3 ||
+		fresh.Items[0].ID != foreignReviews[0].ID ||
+		fresh.Items[1].ID != foreignReviews[1].ID ||
+		fresh.Items[2].ID != foreignReviews[2].ID {
+		t.Fatalf("fresh foreign Actor page = %+v", fresh)
+	}
+}
+
+func TestPostgresHistoryListAndDeleteUserLinearizeOnSharedFence(
+	t *testing.T,
+) {
+	pool := reviewDatabase(t)
+	insertUsers(t, pool, userA, userB)
+	repository := review.NewPostgresRepository(pool)
+	ensure := review.NewEnsureService(
+		repository,
+		sourceReader{},
+		&countingGenerator{},
+	)
+	history := review.NewHistoryService(repository)
+	ownerReview, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "list-delete-owner"),
+	)
+	if err != nil {
+		t.Fatalf("ensure list/delete owner Review: %v", err)
+	}
+	if _, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "list-delete-owner-older"),
+	); err != nil {
+		t.Fatalf("ensure older list/delete owner Review: %v", err)
+	}
+	foreignReview, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userB, "list-delete-foreign"),
+	)
+	if err != nil {
+		t.Fatalf("ensure list/delete foreign Review: %v", err)
+	}
+	preDeletePage, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 1},
+	)
+	if err != nil {
+		t.Fatalf("list pre-delete owner cursor page: %v", err)
+	}
+	if len(preDeletePage.Items) != 1 ||
+		preDeletePage.Next == nil {
+		t.Fatalf("pre-delete owner cursor page = %+v", preDeletePage)
+	}
+	preDeleteCursor := *preDeletePage.Next
+	setAccountStatus(t, pool, userA, "deleting")
+
+	blocker, err := pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin shared Review lock blocker: %v", err)
+	}
+	defer func() { _ = blocker.Rollback(context.Background()) }()
+	var blockerPID int
+	if err := blocker.QueryRow(
+		context.Background(),
+		`SELECT pg_backend_pid()`,
+	).Scan(&blockerPID); err != nil {
+		t.Fatalf("read shared Review lock blocker PID: %v", err)
+	}
+	if _, err := blocker.Exec(
+		context.Background(),
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		userA,
+	); err != nil {
+		t.Fatalf("hold shared Review user lock: %v", err)
+	}
+
+	type listResult struct {
+		page review.HistoryPage
+		err  error
+	}
+	listed := make(chan listResult, 1)
+	deleted := make(chan error, 1)
+	go func() {
+		page, listErr := history.ListCompleted(
+			context.Background(),
+			actor(userA),
+			review.HistoryQuery{Limit: 50},
+		)
+		listed <- listResult{page: page, err: listErr}
+	}()
+	go func() {
+		deleted <- repository.DeleteUserData(
+			context.Background(),
+			review.DeleteUserReviewsCommand{
+				UserID:             userA,
+				DeletionGeneration: 1,
+			},
+		)
+	}()
+	waitForReviewAdvisoryWaiters(t, pool, blockerPID, 2)
+	if err := blocker.Commit(context.Background()); err != nil {
+		t.Fatalf("release shared Review user lock: %v", err)
+	}
+
+	select {
+	case result := <-listed:
+		if !errors.Is(result.err, review.ErrAccountDeleted) ||
+			len(result.page.Items) != 0 ||
+			result.page.Next != nil {
+			t.Fatalf(
+				"concurrent history after deletion intent = %+v, %v",
+				result.page,
+				result.err,
+			)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent history did not resume")
+	}
+	select {
+	case err := <-deleted:
+		if err != nil {
+			t.Fatalf("concurrent DeleteUserData: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent DeleteUserData did not resume")
+	}
+
+	assertReviewCount(t, pool, userA, 0)
+	assertReviewCount(t, pool, userB, 1)
+	var fenceGeneration int64
+	if err := pool.QueryRow(context.Background(), `
+		SELECT deletion_generation
+		FROM review_deletion_fences
+		WHERE owner_user_id = $1
+	`, userA).Scan(&fenceGeneration); err != nil {
+		t.Fatalf("read committed Review deletion fence: %v", err)
+	}
+	if fenceGeneration != 1 {
+		t.Fatalf("Review deletion fence = %d, want 1", fenceGeneration)
+	}
+	if _, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{Limit: 50},
+	); !errors.Is(err, review.ErrAccountDeleted) {
+		t.Fatalf("post-delete owner history error = %v", err)
+	}
+	if _, err := history.ListCompleted(
+		context.Background(),
+		actor(userA),
+		review.HistoryQuery{
+			Limit:  50,
+			Before: &preDeleteCursor,
+		},
+	); !errors.Is(err, review.ErrAccountDeleted) {
+		t.Fatalf("post-delete old cursor history error = %v", err)
+	}
+	if _, err := ensure.EnsureReview(
+		context.Background(),
+		ensureCommand(userA, "list-delete-resurrection"),
+	); !errors.Is(err, review.ErrAccountDeleted) {
+		t.Fatalf("post-delete Review resurrection error = %v", err)
+	}
+	assertReviewCount(t, pool, userA, 0)
+	foreignPage, err := history.ListCompleted(
+		context.Background(),
+		actor(userB),
+		review.HistoryQuery{Limit: 50},
+	)
+	if err != nil {
+		t.Fatalf("list foreign history after owner deletion: %v", err)
+	}
+	if len(foreignPage.Items) != 1 ||
+		foreignPage.Items[0].ID != foreignReview.ID ||
+		foreignPage.Items[0].ID == ownerReview.ID {
+		t.Fatalf(
+			"owner deletion changed/leaked foreign history: %+v",
+			foreignPage,
+		)
+	}
+}
+
 func TestPostgresReviewDeleteWinsAgainstGeneratingWorker(t *testing.T) {
 	pool := reviewDatabase(t)
 	insertUsers(t, pool, userA)
@@ -1273,6 +2093,90 @@ func validEvidence() []review.ReviewEvidence {
 	}}
 }
 
+func maximumPersistedReviewResult(t *testing.T) review.ReviewResult {
+	t.Helper()
+	const (
+		maximumResultBytes = 12 * 1024
+		maximumSummary     = 2048
+		maximumConclusions = 8
+		maximumLabel       = 64
+		maximumText        = 2048
+	)
+	result := review.ReviewResult{
+		OverallScore: 100,
+		Summary:      strings.Repeat("s", maximumSummary),
+		Conclusions: make(
+			[]review.ReviewConclusion,
+			maximumConclusions,
+		),
+	}
+	for index := range result.Conclusions {
+		result.Conclusions[index] = review.ReviewConclusion{
+			Key: fmt.Sprintf("%02d", index) +
+				strings.Repeat("k", maximumLabel-2),
+			Category: strings.Repeat("c", maximumLabel),
+			Message:  strings.Repeat("m", 700),
+			Suggestion: strings.Repeat(
+				"s",
+				300,
+			),
+		}
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal maximum persisted Result fixture: %v", err)
+	}
+	remaining := maximumResultBytes - len(encoded)
+	last := &result.Conclusions[len(result.Conclusions)-1]
+	if remaining < 0 ||
+		len(last.Suggestion)+remaining > maximumText {
+		t.Fatalf(
+			"maximum persisted Result fixture bytes=%d remaining=%d",
+			len(encoded),
+			remaining,
+		)
+	}
+	last.Suggestion += strings.Repeat("x", remaining)
+	return result
+}
+
+func evidenceForReviewResult(
+	result review.ReviewResult,
+) []review.ReviewEvidence {
+	evidence := make(
+		[]review.ReviewEvidence,
+		len(result.Conclusions),
+	)
+	for index, conclusion := range result.Conclusions {
+		evidence[index] = review.ReviewEvidence{
+			ConclusionKey: conclusion.Key,
+			SourceType:    review.SourceTypeConversationTurn,
+			SourceID:      "turn-3",
+			SourceVersion: "confirmed-v2",
+		}
+	}
+	return evidence
+}
+
+func assertReviewResultJSONBytes(
+	t *testing.T,
+	result review.ReviewResult,
+	want int,
+) {
+	t.Helper()
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal persisted Review Result: %v", err)
+	}
+	if len(encoded) != want {
+		t.Fatalf(
+			"persisted Review Result bytes = %d, want %d",
+			len(encoded),
+			want,
+		)
+	}
+}
+
 func actor(userID string) review.Actor {
 	return review.Actor{UserID: userID, DeletionGeneration: 0}
 }
@@ -1450,4 +2354,49 @@ func waitForBlockedIdentityShareLock(t *testing.T, pool *pgxpool.Pool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("Review write did not block on Identity user row")
+}
+
+func waitForReviewAdvisoryWaiters(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	blockerPID int,
+	want int,
+) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var blocked int
+		err := pool.QueryRow(context.Background(), `
+			WITH RECURSIVE blocked(pid) AS (
+				SELECT activity.pid
+				FROM pg_stat_activity activity
+				WHERE $1 = ANY(pg_blocking_pids(activity.pid))
+				UNION
+				SELECT activity.pid
+				FROM pg_stat_activity activity
+				JOIN blocked blocker
+				  ON blocker.pid =
+				     ANY(pg_blocking_pids(activity.pid))
+			)
+			SELECT count(*)
+			FROM blocked
+			JOIN pg_stat_activity activity USING (pid)
+			WHERE activity.wait_event_type = 'Lock'
+			  AND position(
+			      'pg_advisory_xact_lock(hashtextextended($1, 0))'
+			      IN activity.query
+			  ) > 0
+		`, blockerPID).Scan(&blocked)
+		if err != nil {
+			t.Fatalf("inspect shared Review lock waiters: %v", err)
+		}
+		if blocked >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf(
+		"shared Review user lock waiters did not reach %d",
+		want,
+	)
 }


### PR DESCRIPTION
## 功能说明

为当前登录账号提供正式 Review 历史分页接口：

- `GET /v1/formal-reviews`
- 默认每页 20 条，允许 1～50 条
- 只返回当前 Actor 拥有且状态为 `completed` 的正式 Review
- 使用 `created_at DESC, review_id DESC` 的稳定 Keyset 分页
- 返回不可由客户端解释或拼装的 opaque cursor

## 实现边界

- Review 模块继续拥有 Formal Review 数据、查询语义和 PostgreSQL Repository。
- Agent HTTP 层只消费窄化的 History Port，不跨模块访问 Repository。
- 身份只来自服务端可信 Actor，客户端不能提交 `user_id`。
- 历史读取与账户删除共享删除围栏，删除获胜后旧 cursor 不能继续读取数据。
- 单条读取与列表读取均在同一事务内持有删除围栏和 Identity 锁。
- 历史 cursor 使用版本化、端点隔离、Actor 绑定的 HMAC-SHA256；
  `REVIEW_HISTORY_CURSOR_SIGNING_KEY` 必须在所有副本间稳定一致。
- 新写入继续执行严格结果预算；升级前已提交的较大合法 Review 保持可读，
  完整页面仍受 768 KiB 出站预算保护。
- 复用既有索引，不新增数据库迁移。
- 不修改 Flutter、Review 生成、语音、OSS 或 Practice 流程。

## 去栈结果

- 前置 PR #96 已合入 `upstream/dev`。
- 当前分支已从最新 `upstream/dev@f71b10c` 干净重建。
- 相对 `upstream/dev` 仅包含 #101 自身实现和审核修复。
- 不再携带 #96、#98 或其他历史堆叠提交。

## 验证

- `make check-go check-api check-smoke`
- `go test -race -count=1 ./internal/review ./internal/agent ./internal/bootstrap`
- 真实 PostgreSQL：稳定分页、双用户隔离、并发新增、单条/列表删除围栏、
  服务重启恢复及旧版大结果兼容
- cursor：篡改、跨 Actor、换密钥、未知字段与非规范编码拒绝
- OpenAPI：54 个操作，6 个公开、48 个 Bearer 保护
- WebSocket：16 个正例、7 个拒绝用例
- `git diff --check`

## 后续关系

#95 的 Flutter Review 历史页面依赖本接口；本 PR 自身已经不依赖任何未合入 PR。

关联 Issue：#101
