### PR TITLE
[功能] 实现 AppError 核心与统一 REST 错误 Renderer

### DIFF
--- a/server/internal/bootstrap/router.go
+++ b/server/internal/bootstrap/router.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
 )
 
 // Module is the narrow boundary used by the application composition root.
@@ -61,6 +64,7 @@ func newRouter(
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 	router.Use(gin.Recovery(), requestLogger(logger))
+	errorRenderer := httpresponse.NewRenderer(nil)
 
 	moduleNames := make([]string, 0, len(modules))
 	for _, module := range modules {
@@ -103,12 +107,11 @@ func newRouter(
 	})
 
 	router.NoRoute(func(c *gin.Context) {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": gin.H{
-				"code":    "route_not_found",
-				"message": "route not found",
-			},
-		})
+		errorRenderer.Write(c, apperror.New(
+			apperror.NotFound,
+			"resource_not_found",
+			"Resource was not found.",
+		))
 	})
 
 	return router

--- a/server/internal/bootstrap/router_test.go
+++ b/server/internal/bootstrap/router_test.go
@@ -224,13 +224,25 @@ func TestUnknownRouteUsesStableErrorShape(t *testing.T) {
 
 	var body struct {
 		Error struct {
-			Code string `json:"code"`
+			Code          string `json:"code"`
+			Message       string `json:"message"`
+			Retryable     bool   `json:"retryable"`
+			CorrelationID string `json:"correlation_id"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if body.Error.Code != "route_not_found" {
+	if body.Error.Code != "resource_not_found" {
 		t.Fatalf("unexpected error code: %q", body.Error.Code)
+	}
+	if body.Error.Message != "Resource was not found." {
+		t.Fatalf("unexpected error message: %q", body.Error.Message)
+	}
+	if body.Error.Retryable {
+		t.Fatal("route-not-found response must not be retryable")
+	}
+	if strings.TrimSpace(body.Error.CorrelationID) == "" {
+		t.Fatal("route-not-found response must include a correlation ID")
 	}
 }

--- a/server/internal/platform/apperror/apperror.go
+++ b/server/internal/platform/apperror/apperror.go
@@ -1,0 +1,193 @@
+// Package apperror defines transport-independent application errors.
+//
+// Business modules own their stable delivery codes. This package owns only the
+// common categories used by delivery adapters to select protocol semantics.
+package apperror
+
+import "errors"
+
+// Category classifies an application error without coupling it to a delivery
+// protocol such as HTTP.
+type Category string
+
+const (
+	InvalidArgument    Category = "invalid_argument"
+	Unauthenticated    Category = "unauthenticated"
+	PermissionDenied   Category = "permission_denied"
+	NotFound           Category = "not_found"
+	AlreadyExists      Category = "already_exists"
+	Conflict           Category = "conflict"
+	FailedPrecondition Category = "failed_precondition"
+	ResourceExhausted  Category = "resource_exhausted"
+	DeadlineExceeded   Category = "deadline_exceeded"
+	Unimplemented      Category = "unimplemented"
+	Unavailable        Category = "unavailable"
+	Internal           Category = "internal"
+)
+
+// Valid reports whether category is one of the common categories owned by this
+// package.
+func (category Category) Valid() bool {
+	switch category {
+	case InvalidArgument,
+		Unauthenticated,
+		PermissionDenied,
+		NotFound,
+		AlreadyExists,
+		Conflict,
+		FailedPrecondition,
+		ResourceExhausted,
+		DeadlineExceeded,
+		Unimplemented,
+		Unavailable,
+		Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Detail is a sanitized, field-specific explanation suitable for a delivery
+// adapter. It must not contain internal causes or diagnostic data.
+type Detail struct {
+	Field  string
+	Reason string
+}
+
+// AppError contains transport-independent application error semantics.
+//
+// Its fields are intentionally private so callers cannot mutate an error after
+// construction. Accessors that return slices also return defensive copies.
+type AppError struct {
+	category  Category
+	code      string
+	message   string
+	retryable bool
+	details   []Detail
+	cause     error
+}
+
+// Option configures an AppError.
+type Option func(*AppError)
+
+// New constructs an AppError. Validation that is specific to a delivery
+// protocol belongs to that delivery adapter.
+func New(category Category, code, message string, options ...Option) *AppError {
+	appError := &AppError{
+		category: category,
+		code:     code,
+		message:  message,
+	}
+
+	for _, option := range options {
+		if option != nil {
+			option(appError)
+		}
+	}
+
+	appError.details = cloneDetails(appError.details)
+	return appError
+}
+
+// WithRetryable records whether retrying the operation can be useful.
+func WithRetryable(retryable bool) Option {
+	return func(appError *AppError) {
+		appError.retryable = retryable
+	}
+}
+
+// WithDetails records sanitized field details. The supplied slice is copied
+// both when this option is created and when it is applied.
+func WithDetails(details ...Detail) Option {
+	snapshot := cloneDetails(details)
+	return func(appError *AppError) {
+		appError.details = cloneDetails(snapshot)
+	}
+}
+
+// WithCause preserves an internal cause for errors.Is/errors.As without making
+// it part of the public delivery payload.
+func WithCause(cause error) Option {
+	return func(appError *AppError) {
+		appError.cause = cause
+	}
+}
+
+// Error returns only the sanitized public message. It never appends the
+// internal cause.
+func (appError *AppError) Error() string {
+	if appError == nil || appError.message == "" {
+		return "application error"
+	}
+	return appError.message
+}
+
+// Unwrap exposes the internal cause to the standard error chain.
+func (appError *AppError) Unwrap() error {
+	if appError == nil {
+		return nil
+	}
+	return appError.cause
+}
+
+// Category returns the common application error category.
+func (appError *AppError) Category() Category {
+	if appError == nil {
+		return ""
+	}
+	return appError.category
+}
+
+// Code returns the stable code owned by the calling module or delivery mapper.
+func (appError *AppError) Code() string {
+	if appError == nil {
+		return ""
+	}
+	return appError.code
+}
+
+// Message returns the sanitized public message.
+func (appError *AppError) Message() string {
+	if appError == nil {
+		return ""
+	}
+	return appError.message
+}
+
+// Retryable reports whether the operation can be retried.
+func (appError *AppError) Retryable() bool {
+	return appError != nil && appError.retryable
+}
+
+// Details returns a defensive copy of the sanitized field details.
+func (appError *AppError) Details() []Detail {
+	if appError == nil {
+		return nil
+	}
+	return cloneDetails(appError.details)
+}
+
+// From finds the first AppError in err's chain.
+func From(err error) (*AppError, bool) {
+	var appError *AppError
+	if !errors.As(err, &appError) || appError == nil {
+		return nil, false
+	}
+	return appError, true
+}
+
+// IsCategory reports whether err's chain contains an AppError with category.
+func IsCategory(err error, category Category) bool {
+	appError, ok := From(err)
+	return ok && appError.Category() == category
+}
+
+func cloneDetails(details []Detail) []Detail {
+	if len(details) == 0 {
+		return nil
+	}
+
+	clone := make([]Detail, len(details))
+	copy(clone, details)
+	return clone
+}

--- a/server/internal/platform/apperror/apperror_test.go
+++ b/server/internal/platform/apperror/apperror_test.go
@@ -1,0 +1,181 @@
+package apperror_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+)
+
+func TestEveryPublicCategoryIsValid(t *testing.T) {
+	t.Parallel()
+
+	categories := []apperror.Category{
+		apperror.InvalidArgument,
+		apperror.Unauthenticated,
+		apperror.PermissionDenied,
+		apperror.NotFound,
+		apperror.AlreadyExists,
+		apperror.Conflict,
+		apperror.FailedPrecondition,
+		apperror.ResourceExhausted,
+		apperror.DeadlineExceeded,
+		apperror.Unimplemented,
+		apperror.Unavailable,
+		apperror.Internal,
+	}
+
+	for _, category := range categories {
+		category := category
+		t.Run(string(category), func(t *testing.T) {
+			t.Parallel()
+			if !category.Valid() {
+				t.Fatalf("expected category %q to be valid", category)
+			}
+		})
+	}
+
+	if apperror.Category("future_category").Valid() {
+		t.Fatal("unexpected unknown category acceptance")
+	}
+}
+
+func TestNewUsesSafeDefaultsAndQueries(t *testing.T) {
+	t.Parallel()
+
+	appError := apperror.New(
+		apperror.NotFound,
+		"matter_not_found",
+		"Matter was not found.",
+	)
+
+	if appError.Category() != apperror.NotFound {
+		t.Fatalf("unexpected category: %q", appError.Category())
+	}
+	if appError.Code() != "matter_not_found" {
+		t.Fatalf("unexpected code: %q", appError.Code())
+	}
+	if appError.Message() != "Matter was not found." {
+		t.Fatalf("unexpected message: %q", appError.Message())
+	}
+	if appError.Error() != "Matter was not found." {
+		t.Fatalf("unexpected Error result: %q", appError.Error())
+	}
+	if appError.Retryable() {
+		t.Fatal("new errors must be non-retryable by default")
+	}
+	if appError.Details() != nil {
+		t.Fatalf("new errors must have no details by default: %#v", appError.Details())
+	}
+	if appError.Unwrap() != nil {
+		t.Fatalf("new errors must have no cause by default: %v", appError.Unwrap())
+	}
+	if !apperror.IsCategory(appError, apperror.NotFound) {
+		t.Fatal("expected category query to match")
+	}
+	if apperror.IsCategory(appError, apperror.Internal) {
+		t.Fatal("unexpected category query match")
+	}
+}
+
+func TestOptionsPreserveErrorChain(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("database DSN must stay internal")
+	appError := apperror.New(
+		apperror.Unavailable,
+		"matter_temporarily_unavailable",
+		"Matter is temporarily unavailable.",
+		apperror.WithRetryable(true),
+		apperror.WithCause(cause),
+		apperror.WithDetails(apperror.Detail{
+			Field:  "matter_id",
+			Reason: "Matter is not currently available.",
+		}),
+		nil,
+	)
+	wrapped := fmt.Errorf("application boundary: %w", appError)
+
+	if !errors.Is(wrapped, cause) {
+		t.Fatal("errors.Is must reach the internal cause")
+	}
+
+	var target *apperror.AppError
+	if !errors.As(wrapped, &target) || target != appError {
+		t.Fatalf("errors.As did not recover the AppError: %#v", target)
+	}
+
+	from, ok := apperror.From(wrapped)
+	if !ok || from != appError {
+		t.Fatalf("From did not recover the AppError: %#v, %v", from, ok)
+	}
+	if !appError.Retryable() {
+		t.Fatal("expected retryable option to be applied")
+	}
+	if appError.Error() == cause.Error() {
+		t.Fatal("Error must not expose the internal cause")
+	}
+}
+
+func TestDetailsAreDeepCopiedAtEveryBoundary(t *testing.T) {
+	t.Parallel()
+
+	input := []apperror.Detail{{
+		Field:  "body.email",
+		Reason: "Email is invalid.",
+	}}
+	option := apperror.WithDetails(input...)
+	input[0].Field = "mutated before construction"
+
+	appError := apperror.New(
+		apperror.InvalidArgument,
+		"invalid_request",
+		"Request validation failed.",
+		option,
+	)
+	input[0].Reason = "mutated after construction"
+
+	want := []apperror.Detail{{
+		Field:  "body.email",
+		Reason: "Email is invalid.",
+	}}
+	if got := appError.Details(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("constructor retained caller-owned detail storage: %#v", got)
+	}
+
+	output := appError.Details()
+	output[0].Field = "mutated output"
+	if got := appError.Details(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Details returned mutable internal storage: %#v", got)
+	}
+}
+
+func TestNilAppErrorAccessorsAreSafe(t *testing.T) {
+	t.Parallel()
+
+	var appError *apperror.AppError
+	if appError.Error() != "application error" {
+		t.Fatalf("unexpected nil error string: %q", appError.Error())
+	}
+	if appError.Unwrap() != nil ||
+		appError.Category() != "" ||
+		appError.Code() != "" ||
+		appError.Message() != "" ||
+		appError.Retryable() ||
+		appError.Details() != nil {
+		t.Fatal("nil AppError accessors must return zero values")
+	}
+}
+
+func TestFromRejectsOrdinaryAndNilErrors(t *testing.T) {
+	t.Parallel()
+
+	if appError, ok := apperror.From(errors.New("ordinary")); ok || appError != nil {
+		t.Fatalf("ordinary error unexpectedly matched: %#v, %v", appError, ok)
+	}
+	if appError, ok := apperror.From(nil); ok || appError != nil {
+		t.Fatalf("nil error unexpectedly matched: %#v, %v", appError, ok)
+	}
+}

--- a/server/internal/platform/httpresponse/contract_test.go
+++ b/server/internal/platform/httpresponse/contract_test.go
@@ -1,0 +1,180 @@
+package httpresponse
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+)
+
+func TestStatusForCategoryMapsEveryCategoryExplicitly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		category apperror.Category
+		status   int
+	}{
+		{apperror.InvalidArgument, http.StatusBadRequest},
+		{apperror.Unauthenticated, http.StatusUnauthorized},
+		{apperror.PermissionDenied, http.StatusForbidden},
+		{apperror.NotFound, http.StatusNotFound},
+		{apperror.AlreadyExists, http.StatusConflict},
+		{apperror.Conflict, http.StatusConflict},
+		{apperror.FailedPrecondition, http.StatusPreconditionFailed},
+		{apperror.ResourceExhausted, http.StatusTooManyRequests},
+		{apperror.DeadlineExceeded, http.StatusGatewayTimeout},
+		{apperror.Unimplemented, http.StatusNotImplemented},
+		{apperror.Unavailable, http.StatusServiceUnavailable},
+		{apperror.Internal, http.StatusInternalServerError},
+	}
+
+	for _, test := range tests {
+		status, ok := statusForCategory(test.category)
+		if !ok || status != test.status {
+			t.Fatalf(
+				"statusForCategory(%q) = %d, %v; want %d, true",
+				test.category,
+				status,
+				ok,
+				test.status,
+			)
+		}
+	}
+
+	if status, ok := statusForCategory(apperror.Category("future")); ok || status != 0 {
+		t.Fatalf("unknown category mapped to %d, %v", status, ok)
+	}
+}
+
+func TestCanonicalHTTPStatusByCodeMatchesAPIContract(t *testing.T) {
+	t.Parallel()
+
+	enumCodes, apiStatuses := readAPIErrorContract(t)
+	if len(enumCodes) != len(apiStatuses) {
+		t.Fatalf(
+			"ErrorCode enum has %d entries but x-http-status-map has %d",
+			len(enumCodes),
+			len(apiStatuses),
+		)
+	}
+	if len(canonicalHTTPStatusByCode) != len(apiStatuses) {
+		t.Fatalf(
+			"renderer has %d codes but API contract has %d",
+			len(canonicalHTTPStatusByCode),
+			len(apiStatuses),
+		)
+	}
+
+	for code := range enumCodes {
+		apiStatus, exists := apiStatuses[code]
+		if !exists {
+			t.Fatalf("ErrorCode %q has no x-http-status-map entry", code)
+		}
+		rendererStatus, exists := canonicalHTTPStatusByCode[code]
+		if !exists {
+			t.Fatalf("renderer does not recognize API ErrorCode %q", code)
+		}
+		if rendererStatus != apiStatus {
+			t.Fatalf(
+				"renderer maps %q to %d; API contract maps it to %d",
+				code,
+				rendererStatus,
+				apiStatus,
+			)
+		}
+	}
+
+	for code := range canonicalHTTPStatusByCode {
+		if _, exists := enumCodes[code]; !exists {
+			t.Fatalf("renderer recognizes undeclared ErrorCode %q", code)
+		}
+	}
+}
+
+func readAPIErrorContract(t *testing.T) (map[string]struct{}, map[string]int) {
+	t.Helper()
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	contractPath := filepath.Join(
+		filepath.Dir(sourceFile),
+		"..",
+		"..",
+		"..",
+		"..",
+		"api",
+		"common",
+		"errors.yaml",
+	)
+	contract, err := os.Open(contractPath)
+	if err != nil {
+		t.Fatalf("open API error contract: %v", err)
+	}
+	defer contract.Close()
+
+	enumCodes := make(map[string]struct{})
+	statuses := make(map[string]int)
+	inErrorCode := false
+	section := ""
+
+	scanner := bufio.NewScanner(contract)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch line {
+		case "    ErrorCode:":
+			inErrorCode = true
+			continue
+		case "      enum:":
+			if inErrorCode {
+				section = "enum"
+			}
+			continue
+		case "      x-http-status-map:":
+			if inErrorCode {
+				section = "status"
+			}
+			continue
+		}
+
+		if !inErrorCode {
+			continue
+		}
+		if section == "enum" && strings.HasPrefix(line, "        - ") {
+			enumCodes[strings.TrimSpace(strings.TrimPrefix(line, "        - "))] = struct{}{}
+			continue
+		}
+		if section == "status" {
+			if !strings.HasPrefix(line, "        ") {
+				break
+			}
+			key, rawStatus, found := strings.Cut(strings.TrimSpace(line), ":")
+			if !found {
+				t.Fatalf("parse x-http-status-map line %q", line)
+			}
+			status, err := strconv.Atoi(strings.TrimSpace(rawStatus))
+			if err != nil {
+				t.Fatalf("parse status for %q: %v", key, err)
+			}
+			statuses[key] = status
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan API error contract: %v", err)
+	}
+	if len(enumCodes) == 0 || len(statuses) == 0 {
+		t.Fatalf(
+			"API ErrorCode contract was not found: enum=%d statuses=%d",
+			len(enumCodes),
+			len(statuses),
+		)
+	}
+	return enumCodes, statuses
+}

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -1,0 +1,230 @@
+// Package httpresponse renders application errors for the REST API.
+package httpresponse
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+)
+
+const (
+	internalErrorCode    = "internal_error"
+	internalErrorMessage = "Internal server error."
+)
+
+type correlationIDContextKey struct{}
+
+// ErrorResponse is the canonical REST error response.
+type ErrorResponse struct {
+	Error ErrorPayload `json:"error"`
+}
+
+// ErrorPayload contains only fields declared by api/common/errors.yaml.
+type ErrorPayload struct {
+	Code          string        `json:"code"`
+	Message       string        `json:"message"`
+	Retryable     bool          `json:"retryable"`
+	CorrelationID string        `json:"correlation_id"`
+	Details       []ErrorDetail `json:"details,omitempty"`
+}
+
+// ErrorDetail is a sanitized field-specific REST error detail.
+type ErrorDetail struct {
+	Field  string `json:"field"`
+	Reason string `json:"reason"`
+}
+
+// CorrelationIDGenerator supplies correlation IDs until ERR-2 introduces
+// centralized middleware.
+type CorrelationIDGenerator func() string
+
+// Renderer converts application errors into canonical REST responses.
+type Renderer struct {
+	generateCorrelationID CorrelationIDGenerator
+}
+
+// NewRenderer creates a REST error renderer. A nil generator uses the package's
+// non-empty default generator.
+func NewRenderer(generator CorrelationIDGenerator) *Renderer {
+	if generator == nil {
+		generator = newCorrelationID
+	}
+	return &Renderer{generateCorrelationID: generator}
+}
+
+// WithCorrelationID stores a request-scoped correlation ID in ctx. ERR-2 can
+// use this boundary when centralized request middleware is introduced.
+func WithCorrelationID(ctx context.Context, correlationID string) context.Context {
+	return context.WithValue(ctx, correlationIDContextKey{}, correlationID)
+}
+
+// CorrelationIDFromContext returns a valid request-scoped correlation ID.
+func CorrelationIDFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	correlationID, ok := ctx.Value(correlationIDContextKey{}).(string)
+	return correlationID, ok && validPublicText(correlationID)
+}
+
+// Write renders err without exposing its internal cause or raw error string.
+func (renderer *Renderer) Write(c *gin.Context, err error) {
+	status, payload := payloadFor(err)
+	payload.CorrelationID = renderer.correlationID(c.Request.Context())
+	c.JSON(status, ErrorResponse{Error: payload})
+}
+
+func (renderer *Renderer) correlationID(ctx context.Context) string {
+	if correlationID, ok := CorrelationIDFromContext(ctx); ok {
+		return correlationID
+	}
+
+	if renderer != nil && renderer.generateCorrelationID != nil {
+		if correlationID := renderer.generateCorrelationID(); validPublicText(correlationID) {
+			return correlationID
+		}
+	}
+	return newCorrelationID()
+}
+
+func payloadFor(err error) (int, ErrorPayload) {
+	appError, ok := apperror.From(err)
+	if !ok {
+		return internalPayload()
+	}
+
+	status, ok := statusForCategory(appError.Category())
+	if !ok ||
+		!validCode(appError.Code()) ||
+		!validPublicText(appError.Message()) {
+		return internalPayload()
+	}
+
+	details, ok := responseDetails(appError.Details())
+	if !ok {
+		return internalPayload()
+	}
+
+	return status, ErrorPayload{
+		Code:      appError.Code(),
+		Message:   appError.Message(),
+		Retryable: appError.Retryable(),
+		Details:   details,
+	}
+}
+
+func internalPayload() (int, ErrorPayload) {
+	return http.StatusInternalServerError, ErrorPayload{
+		Code:      internalErrorCode,
+		Message:   internalErrorMessage,
+		Retryable: false,
+	}
+}
+
+func statusForCategory(category apperror.Category) (int, bool) {
+	switch category {
+	case apperror.InvalidArgument:
+		return http.StatusBadRequest, true
+	case apperror.Unauthenticated:
+		return http.StatusUnauthorized, true
+	case apperror.PermissionDenied:
+		return http.StatusForbidden, true
+	case apperror.NotFound:
+		return http.StatusNotFound, true
+	case apperror.AlreadyExists:
+		return http.StatusConflict, true
+	case apperror.Conflict:
+		return http.StatusConflict, true
+	case apperror.FailedPrecondition:
+		return http.StatusPreconditionFailed, true
+	case apperror.ResourceExhausted:
+		return http.StatusTooManyRequests, true
+	case apperror.DeadlineExceeded:
+		return http.StatusGatewayTimeout, true
+	case apperror.Unimplemented:
+		return http.StatusNotImplemented, true
+	case apperror.Unavailable:
+		return http.StatusServiceUnavailable, true
+	case apperror.Internal:
+		return http.StatusInternalServerError, true
+	default:
+		return 0, false
+	}
+}
+
+func responseDetails(details []apperror.Detail) ([]ErrorDetail, bool) {
+	if len(details) == 0 {
+		return nil, true
+	}
+
+	response := make([]ErrorDetail, len(details))
+	for index, detail := range details {
+		if !validPublicText(detail.Field) || !validPublicText(detail.Reason) {
+			return nil, false
+		}
+		response[index] = ErrorDetail{
+			Field:  detail.Field,
+			Reason: detail.Reason,
+		}
+	}
+	return response, true
+}
+
+func validCode(code string) bool {
+	if code == "" {
+		return false
+	}
+
+	for index := 0; index < len(code); index++ {
+		character := code[index]
+		if character >= 'a' && character <= 'z' {
+			continue
+		}
+		if index > 0 && character >= '0' && character <= '9' {
+			continue
+		}
+		if index > 0 && character == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validPublicText(value string) bool {
+	if !utf8.ValidString(value) || strings.TrimSpace(value) == "" {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+var fallbackCorrelationSequence atomic.Uint64
+
+func newCorrelationID() string {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err == nil {
+		return "corr_" + hex.EncodeToString(random)
+	}
+
+	return fmt.Sprintf(
+		"corr_%x_%x",
+		time.Now().UnixNano(),
+		fallbackCorrelationSequence.Add(1),
+	)
+}

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -105,8 +105,10 @@ func payloadFor(err error) (int, ErrorPayload) {
 	}
 
 	status, ok := statusForCategory(appError.Category())
+	contractStatus, codeOK := canonicalHTTPStatusByCode[appError.Code()]
 	if !ok ||
-		!validCode(appError.Code()) ||
+		!codeOK ||
+		contractStatus != status ||
 		!validPublicText(appError.Message()) {
 		return internalPayload()
 	}
@@ -163,6 +165,52 @@ func statusForCategory(category apperror.Category) (int, bool) {
 	}
 }
 
+// canonicalHTTPStatusByCode mirrors ErrorCode.x-http-status-map in
+// api/common/errors.yaml for delivery-time validation. Business modules still
+// own and select their error codes; this snapshot only prevents the REST
+// renderer from emitting codes or code/status combinations outside the public
+// API contract. A regression test keeps the snapshot synchronized with the
+// schema.
+var canonicalHTTPStatusByCode = map[string]int{
+	"invalid_request":                         http.StatusBadRequest,
+	"answer_invalid":                          http.StatusBadRequest,
+	"unsupported_message":                     http.StatusBadRequest,
+	"authentication_required":                 http.StatusUnauthorized,
+	"invalid_credentials":                     http.StatusUnauthorized,
+	"practice_participant_not_authorized":     http.StatusForbidden,
+	"scenario_definition_not_found":           http.StatusNotFound,
+	"role_definition_not_found":               http.StatusNotFound,
+	"preparation_profile_not_found":           http.StatusNotFound,
+	"practice_plan_not_found":                 http.StatusNotFound,
+	"practice_session_not_found":              http.StatusNotFound,
+	"question_not_found":                      http.StatusNotFound,
+	"turn_not_found":                          http.StatusNotFound,
+	"turn_analysis_not_found":                 http.StatusNotFound,
+	"feedback_item_not_found":                 http.StatusNotFound,
+	"retry_request_not_found":                 http.StatusNotFound,
+	"resource_not_found":                      http.StatusNotFound,
+	"account_registration_unavailable":        http.StatusConflict,
+	"idempotency_key_conflict":                http.StatusConflict,
+	"resource_conflict":                       http.StatusConflict,
+	"preparation_version_conflict":            http.StatusConflict,
+	"practice_plan_not_ready":                 http.StatusConflict,
+	"practice_plan_archived":                  http.StatusConflict,
+	"practice_plan_has_active_session":        http.StatusConflict,
+	"practice_plan_revision_conflict":         http.StatusConflict,
+	"practice_session_transition_not_allowed": http.StatusConflict,
+	"practice_session_already_terminal":       http.StatusConflict,
+	"practice_session_version_conflict":       http.StatusConflict,
+	"practice_participant_invalid":            http.StatusConflict,
+	"practice_option_invalid":                 http.StatusConflict,
+	"turn_conflict":                           http.StatusConflict,
+	"turn_outcome_session_mismatch":           http.StatusConflict,
+	"turn_analysis_conflict":                  http.StatusConflict,
+	"retry_request_conflict":                  http.StatusConflict,
+	"transcript_unavailable":                  http.StatusUnprocessableEntity,
+	"rate_limited":                            http.StatusTooManyRequests,
+	internalErrorCode:                         http.StatusInternalServerError,
+}
+
 func responseDetails(details []apperror.Detail) ([]ErrorDetail, bool) {
 	if len(details) == 0 {
 		return nil, true
@@ -179,27 +227,6 @@ func responseDetails(details []apperror.Detail) ([]ErrorDetail, bool) {
 		}
 	}
 	return response, true
-}
-
-func validCode(code string) bool {
-	if code == "" {
-		return false
-	}
-
-	for index := 0; index < len(code); index++ {
-		character := code[index]
-		if character >= 'a' && character <= 'z' {
-			continue
-		}
-		if index > 0 && character >= '0' && character <= '9' {
-			continue
-		}
-		if index > 0 && character == '_' {
-			continue
-		}
-		return false
-	}
-	return true
 }
 
 func validPublicText(value string) bool {

--- a/server/internal/platform/httpresponse/error_test.go
+++ b/server/internal/platform/httpresponse/error_test.go
@@ -1,0 +1,327 @@
+package httpresponse_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+)
+
+func TestRendererMapsEveryCategoryExplicitly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		category apperror.Category
+		status   int
+	}{
+		{apperror.InvalidArgument, http.StatusBadRequest},
+		{apperror.Unauthenticated, http.StatusUnauthorized},
+		{apperror.PermissionDenied, http.StatusForbidden},
+		{apperror.NotFound, http.StatusNotFound},
+		{apperror.AlreadyExists, http.StatusConflict},
+		{apperror.Conflict, http.StatusConflict},
+		{apperror.FailedPrecondition, http.StatusPreconditionFailed},
+		{apperror.ResourceExhausted, http.StatusTooManyRequests},
+		{apperror.DeadlineExceeded, http.StatusGatewayTimeout},
+		{apperror.Unimplemented, http.StatusNotImplemented},
+		{apperror.Unavailable, http.StatusServiceUnavailable},
+		{apperror.Internal, http.StatusInternalServerError},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(string(test.category), func(t *testing.T) {
+			t.Parallel()
+			response := render(
+				t,
+				httpresponse.NewRenderer(func() string { return "corr_category" }),
+				context.Background(),
+				apperror.New(
+					test.category,
+					"module_error",
+					"Public error.",
+					apperror.WithRetryable(true),
+				),
+			)
+
+			if response.Code != test.status {
+				t.Fatalf("expected status %d, got %d", test.status, response.Code)
+			}
+			payload := decodeResponse(t, response)
+			if payload.Error.Code != "module_error" ||
+				payload.Error.Message != "Public error." ||
+				!payload.Error.Retryable ||
+				payload.Error.CorrelationID != "corr_category" {
+				t.Fatalf("unexpected payload: %#v", payload)
+			}
+		})
+	}
+}
+
+func TestRendererWritesOnlyCanonicalFields(t *testing.T) {
+	t.Parallel()
+
+	sensitiveCause := errors.New("postgres://admin:secret@private.internal/app")
+	response := render(
+		t,
+		httpresponse.NewRenderer(func() string { return "corr_canonical" }),
+		context.Background(),
+		apperror.New(
+			apperror.InvalidArgument,
+			"invalid_request",
+			"Request validation failed.",
+			apperror.WithCause(sensitiveCause),
+			apperror.WithDetails(apperror.Detail{
+				Field:  "body.email",
+				Reason: "Email is invalid.",
+			}),
+		),
+	)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, response.Code)
+	}
+	if strings.Contains(response.Body.String(), sensitiveCause.Error()) {
+		t.Fatalf("response leaked cause: %s", response.Body.String())
+	}
+
+	var document map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil {
+		t.Fatalf("decode response document: %v", err)
+	}
+	if keys := sortedKeys(document); !reflect.DeepEqual(keys, []string{"error"}) {
+		t.Fatalf("unexpected top-level fields: %#v", keys)
+	}
+	errorDocument, ok := document["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error is not an object: %#v", document["error"])
+	}
+	wantKeys := []string{"code", "correlation_id", "details", "message", "retryable"}
+	if keys := sortedKeys(errorDocument); !reflect.DeepEqual(keys, wantKeys) {
+		t.Fatalf("unexpected error fields: %#v", keys)
+	}
+	details, ok := errorDocument["details"].([]any)
+	if !ok || len(details) != 1 {
+		t.Fatalf("unexpected details: %#v", errorDocument["details"])
+	}
+	detail, ok := details[0].(map[string]any)
+	if !ok {
+		t.Fatalf("detail is not an object: %#v", details[0])
+	}
+	if keys := sortedKeys(detail); !reflect.DeepEqual(keys, []string{"field", "reason"}) {
+		t.Fatalf("unexpected detail fields: %#v", keys)
+	}
+}
+
+func TestRendererOmitsEmptyDetails(t *testing.T) {
+	t.Parallel()
+
+	response := render(
+		t,
+		httpresponse.NewRenderer(func() string { return "corr_no_details" }),
+		context.Background(),
+		apperror.New(apperror.NotFound, "resource_not_found", "Resource was not found."),
+	)
+
+	var document map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil {
+		t.Fatalf("decode response document: %v", err)
+	}
+	errorDocument := document["error"].(map[string]any)
+	if _, exists := errorDocument["details"]; exists {
+		t.Fatalf("empty details must be omitted: %#v", errorDocument)
+	}
+}
+
+func TestRendererPrefersRequestCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	var generatorCalls atomic.Int64
+	renderer := httpresponse.NewRenderer(func() string {
+		generatorCalls.Add(1)
+		return "corr_generated"
+	})
+	ctx := httpresponse.WithCorrelationID(context.Background(), "corr_existing")
+	response := render(
+		t,
+		renderer,
+		ctx,
+		apperror.New(apperror.NotFound, "resource_not_found", "Resource was not found."),
+	)
+
+	payload := decodeResponse(t, response)
+	if payload.Error.CorrelationID != "corr_existing" {
+		t.Fatalf("unexpected correlation ID: %q", payload.Error.CorrelationID)
+	}
+	if generatorCalls.Load() != 0 {
+		t.Fatalf("generator called despite existing ID: %d", generatorCalls.Load())
+	}
+
+	if correlationID, ok := httpresponse.CorrelationIDFromContext(ctx); !ok ||
+		correlationID != "corr_existing" {
+		t.Fatalf("context query failed: %q, %v", correlationID, ok)
+	}
+}
+
+func TestRendererGeneratesNonEmptyCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	response := render(
+		t,
+		httpresponse.NewRenderer(func() string { return "" }),
+		context.Background(),
+		apperror.New(apperror.NotFound, "resource_not_found", "Resource was not found."),
+	)
+	payload := decodeResponse(t, response)
+	if strings.TrimSpace(payload.Error.CorrelationID) == "" {
+		t.Fatal("correlation ID must not be empty")
+	}
+}
+
+func TestRendererSafelyFallsBackForUnrenderableErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "ordinary error",
+			err:  errors.New("raw provider token and stack"),
+		},
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "unknown category",
+			err: apperror.New(
+				apperror.Category("future"),
+				"future_error",
+				"Future error.",
+			),
+		},
+		{
+			name: "empty code",
+			err:  apperror.New(apperror.Internal, "", "Public error."),
+		},
+		{
+			name: "invalid code",
+			err:  apperror.New(apperror.Internal, "Internal Error", "Public error."),
+		},
+		{
+			name: "empty message",
+			err:  apperror.New(apperror.Internal, "module_error", " \t"),
+		},
+		{
+			name: "control in message",
+			err:  apperror.New(apperror.Internal, "module_error", "Public\nsecret"),
+		},
+		{
+			name: "empty detail field",
+			err: apperror.New(
+				apperror.InvalidArgument,
+				"invalid_request",
+				"Request validation failed.",
+				apperror.WithDetails(apperror.Detail{Reason: "Invalid."}),
+			),
+		},
+		{
+			name: "control in detail reason",
+			err: apperror.New(
+				apperror.InvalidArgument,
+				"invalid_request",
+				"Request validation failed.",
+				apperror.WithDetails(apperror.Detail{
+					Field:  "body",
+					Reason: "Invalid.\nraw SQL",
+				}),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			response := render(
+				t,
+				httpresponse.NewRenderer(func() string { return "corr_fallback" }),
+				context.Background(),
+				test.err,
+			)
+
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf(
+					"expected status %d, got %d",
+					http.StatusInternalServerError,
+					response.Code,
+				)
+			}
+			payload := decodeResponse(t, response)
+			if payload.Error.Code != "internal_error" ||
+				payload.Error.Message != "Internal server error." ||
+				payload.Error.Retryable ||
+				payload.Error.CorrelationID != "corr_fallback" ||
+				payload.Error.Details != nil {
+				t.Fatalf("unexpected safe fallback: %#v", payload)
+			}
+			if test.err != nil && strings.Contains(response.Body.String(), test.err.Error()) {
+				t.Fatalf("response leaked raw error: %s", response.Body.String())
+			}
+		})
+	}
+}
+
+func render(
+	t *testing.T,
+	renderer *httpresponse.Renderer,
+	ctx context.Context,
+	err error,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	response := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(response)
+	request := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	ginContext.Request = request
+	renderer.Write(ginContext, err)
+	return response
+}
+
+func decodeResponse(
+	t *testing.T,
+	response *httptest.ResponseRecorder,
+) httpresponse.ErrorResponse {
+	t.Helper()
+
+	var payload httpresponse.ErrorResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return payload
+}
+
+func sortedKeys(document map[string]any) []string {
+	keys := make([]string, 0, len(document))
+	for key := range document {
+		keys = append(keys, key)
+	}
+	for index := 1; index < len(keys); index++ {
+		for current := index; current > 0 && keys[current] < keys[current-1]; current-- {
+			keys[current], keys[current-1] = keys[current-1], keys[current]
+		}
+	}
+	return keys
+}

--- a/server/internal/platform/httpresponse/error_test.go
+++ b/server/internal/platform/httpresponse/error_test.go
@@ -17,30 +17,31 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
 )
 
-func TestRendererMapsEveryCategoryExplicitly(t *testing.T) {
+func TestRendererAcceptsMatchingCanonicalCodeStatusPairs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		category apperror.Category
+		code     string
 		status   int
 	}{
-		{apperror.InvalidArgument, http.StatusBadRequest},
-		{apperror.Unauthenticated, http.StatusUnauthorized},
-		{apperror.PermissionDenied, http.StatusForbidden},
-		{apperror.NotFound, http.StatusNotFound},
-		{apperror.AlreadyExists, http.StatusConflict},
-		{apperror.Conflict, http.StatusConflict},
-		{apperror.FailedPrecondition, http.StatusPreconditionFailed},
-		{apperror.ResourceExhausted, http.StatusTooManyRequests},
-		{apperror.DeadlineExceeded, http.StatusGatewayTimeout},
-		{apperror.Unimplemented, http.StatusNotImplemented},
-		{apperror.Unavailable, http.StatusServiceUnavailable},
-		{apperror.Internal, http.StatusInternalServerError},
+		{apperror.InvalidArgument, "invalid_request", http.StatusBadRequest},
+		{apperror.Unauthenticated, "invalid_credentials", http.StatusUnauthorized},
+		{
+			apperror.PermissionDenied,
+			"practice_participant_not_authorized",
+			http.StatusForbidden,
+		},
+		{apperror.NotFound, "resource_not_found", http.StatusNotFound},
+		{apperror.AlreadyExists, "account_registration_unavailable", http.StatusConflict},
+		{apperror.Conflict, "resource_conflict", http.StatusConflict},
+		{apperror.ResourceExhausted, "rate_limited", http.StatusTooManyRequests},
+		{apperror.Internal, "internal_error", http.StatusInternalServerError},
 	}
 
 	for _, test := range tests {
 		test := test
-		t.Run(string(test.category), func(t *testing.T) {
+		t.Run(test.code, func(t *testing.T) {
 			t.Parallel()
 			response := render(
 				t,
@@ -48,7 +49,7 @@ func TestRendererMapsEveryCategoryExplicitly(t *testing.T) {
 				context.Background(),
 				apperror.New(
 					test.category,
-					"module_error",
+					test.code,
 					"Public error.",
 					apperror.WithRetryable(true),
 				),
@@ -58,7 +59,7 @@ func TestRendererMapsEveryCategoryExplicitly(t *testing.T) {
 				t.Fatalf("expected status %d, got %d", test.status, response.Code)
 			}
 			payload := decodeResponse(t, response)
-			if payload.Error.Code != "module_error" ||
+			if payload.Error.Code != test.code ||
 				payload.Error.Message != "Public error." ||
 				!payload.Error.Retryable ||
 				payload.Error.CorrelationID != "corr_category" {
@@ -207,7 +208,7 @@ func TestRendererSafelyFallsBackForUnrenderableErrors(t *testing.T) {
 			name: "unknown category",
 			err: apperror.New(
 				apperror.Category("future"),
-				"future_error",
+				"internal_error",
 				"Future error.",
 			),
 		},
@@ -220,12 +221,28 @@ func TestRendererSafelyFallsBackForUnrenderableErrors(t *testing.T) {
 			err:  apperror.New(apperror.Internal, "Internal Error", "Public error."),
 		},
 		{
+			name: "well formed but undeclared code",
+			err: apperror.New(
+				apperror.NotFound,
+				"resource_not_foud",
+				"Resource was not found.",
+			),
+		},
+		{
+			name: "canonical code with mismatched category",
+			err: apperror.New(
+				apperror.NotFound,
+				"internal_error",
+				"Resource was not found.",
+			),
+		},
+		{
 			name: "empty message",
-			err:  apperror.New(apperror.Internal, "module_error", " \t"),
+			err:  apperror.New(apperror.Internal, "internal_error", " \t"),
 		},
 		{
 			name: "control in message",
-			err:  apperror.New(apperror.Internal, "module_error", "Public\nsecret"),
+			err:  apperror.New(apperror.Internal, "internal_error", "Public\nsecret"),
 		},
 		{
 			name: "empty detail field",


### PR DESCRIPTION
## 功能说明

本 PR 实现 Issue #52 的统一应用错误基础设施，并以 Bootstrap `route_not_found` 作为首个真实调用方：

- 新增与 Gin、HTTP 和业务模块解耦的 `AppError` 核心；
- 新增严格符合现行 `ErrorResponse` 契约的 REST Renderer；
- 未识别或非法错误安全降级为 `500 / internal_error`；
- `NoRoute` 统一返回 `404 / resource_not_found` 和非空 `correlation_id`；
- 保持 `/health`、`/readyz` 及现有业务 Handler 不变。

## 实现思路

### AppError 核心

- 平台层只拥有 12 个公共 `Category`，不建立业务错误码总表。
- `Code` 和已脱敏 `Message` 由业务模块或 Delivery Mapper 提供。
- `[]Detail` 在 Option 创建、错误构造和读取时均进行防御性复制。
- 内部 `Cause` 只通过 `Unwrap` 服务于 `errors.Is` / `errors.As`，不进入响应。

### REST Renderer

- 使用显式表把每个 `Category` 映射到 HTTP Status，不从字符串或数值推导。
- 响应顶层只有 `error`，并严格输出 `code`、`message`、`retryable`、`correlation_id`；非空时才输出 `details`。
- 未知普通错误、未知分类、未在 `ErrorCode` 中声明的 Code、非法公开消息或 Detail 统一返回固定安全响应，不序列化底层 `err.Error()`。
- Renderer 仍由 `Category` 显式选择 HTTP Status，同时要求 Code 在 `x-http-status-map` 中声明且状态一致；不一致组合安全降级为 `500 / internal_error`。
- Go 侧验证快照由回归测试与 `api/common/errors.yaml` 的枚举及状态映射做精确同步校验，业务模块仍拥有并选择具体 Code。
- 优先读取 Request Context 中已有的 correlation ID；没有时使用注入的 Generator，Generator 失效时仍保证安全生成非空 ID。

## 精确文件范围

新增：

- `server/internal/platform/apperror/apperror.go`
- `server/internal/platform/apperror/apperror_test.go`
- `server/internal/platform/httpresponse/error.go`
- `server/internal/platform/httpresponse/error_test.go`

修改：

- `server/internal/bootstrap/router.go`
- `server/internal/bootstrap/router_test.go`

现有 `api/common/errors.yaml` 已符合 Issue 冻结的 canonical shape，因此未作无必要修改。本 PR 未批量迁移 Identity、Agent、Conversation、Smoke 或其他业务 Handler。

## 可复现测试

以下命令均已在本分支通过：

```bash
make check-api
make check-go
(cd server && go test -race ./internal/platform/apperror ./internal/platform/httpresponse ./internal/bootstrap)
make check-smoke
git diff --check
```

覆盖重点：

- 所有公共 Category 与显式 HTTP Status 映射；
- `errors.Is`、`errors.As`、`Unwrap` 和默认值；
- Detail 防御性复制；
- canonical JSON 字段与空 `details` 省略；
- Cause、未知错误和非法公开字段不泄漏；
- correlation ID 上下文优先与生成降级；
- `route_not_found`、健康检查和 Readiness 回归。

## 分支与合入状态

- 分支已 rebase 到最新 `upstream/dev`：`26d313bdfd49c617bc7c439cc7e196e66799ac78`。
- 当前 Head：`21b83d3134efa4879b2d295c5331f403b65600b0`。
- 本 PR 当前为 Ready，尚未合并；两条 correctness review 已在 `21b83d3` 修复并解决，等待 required review。

Closes #52
