### PR TITLE
[功能] 贯通英文面试场景到正式语音练习

### DIFF
--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -42,6 +42,7 @@ void main() {
         authController: dependencies.authController,
         agentController: dependencies.agentController,
         preparationController: dependencies.preparationController,
+        preparationLaunchController: dependencies.preparationLaunchController,
         reviewHistoryController: dependencies.reviewHistoryController,
       ),
     );
@@ -65,39 +66,13 @@ void main() {
     }
 
     if (find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty) {
-      await _verifySignedInAccount(tester, email);
-    } else {
-      await tester.tap(find.text('创建账号'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextFormField).at(0), email);
-      await tester.enterText(find.byType(TextFormField).at(1), password);
-      await tester.tap(find.widgetWithText(FilledButton, '创建账号'));
-      await _waitUntil(
-        tester,
-        () =>
-            find.text('账号创建成功，请登录后继续。').evaluate().isNotEmpty ||
-            find.text('无法使用这些信息创建账号。').evaluate().isNotEmpty,
-        const Duration(seconds: 15),
-      );
-      if (find.text('无法使用这些信息创建账号。').evaluate().isNotEmpty) {
-        await tester.tap(find.text('返回登录'));
-        await _waitUntil(
-          tester,
-          () => find.text('欢迎回来').evaluate().isNotEmpty,
-          const Duration(seconds: 5),
-        );
+      final sameAccount = await _signedInAccountMatches(tester, email);
+      if (!sameAccount) {
+        await _signOut(tester);
+        await _registerOrSignIn(tester, email: email, password: password);
       }
-
-      await tester.enterText(find.byType(TextFormField).at(0), email);
-      await tester.enterText(find.byType(TextFormField).at(1), password);
-      await tester.tap(find.text('登录'));
-      await _waitUntil(
-        tester,
-        () =>
-            find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
-            _composerIsReady(tester),
-        const Duration(seconds: 20),
-      );
+    } else {
+      await _registerOrSignIn(tester, email: email, password: password);
     }
 
     const prompt =
@@ -182,6 +157,49 @@ void main() {
   });
 }
 
+Future<void> _registerOrSignIn(
+  WidgetTester tester, {
+  required String email,
+  required String password,
+}) async {
+  await _waitUntil(
+    tester,
+    () => find.text('欢迎回来').evaluate().isNotEmpty,
+    const Duration(seconds: 15),
+  );
+  await tester.tap(find.text('创建账号'));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField).at(0), email);
+  await tester.enterText(find.byType(TextFormField).at(1), password);
+  await tester.tap(find.widgetWithText(FilledButton, '创建账号'));
+  await _waitUntil(
+    tester,
+    () =>
+        find.text('账号创建成功，请登录后继续。').evaluate().isNotEmpty ||
+        find.text('无法使用这些信息创建账号。').evaluate().isNotEmpty,
+    const Duration(seconds: 15),
+  );
+  if (find.text('无法使用这些信息创建账号。').evaluate().isNotEmpty) {
+    await tester.tap(find.text('返回登录'));
+    await _waitUntil(
+      tester,
+      () => find.text('欢迎回来').evaluate().isNotEmpty,
+      const Duration(seconds: 5),
+    );
+  }
+
+  await tester.enterText(find.byType(TextFormField).at(0), email);
+  await tester.enterText(find.byType(TextFormField).at(1), password);
+  await tester.tap(find.text('登录'));
+  await _waitUntil(
+    tester,
+    () =>
+        find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
+        _composerIsReady(tester),
+    const Duration(seconds: 20),
+  );
+}
+
 Future<void> _signIn(
   WidgetTester tester, {
   required String email,
@@ -209,30 +227,61 @@ Future<void> _completeRealVoicePractice(
   required AgentController controller,
   required bool validateAudioMedia,
 }) async {
+  FocusManager.instance.primaryFocus?.unfocus();
   await tester.tap(find.byKey(const Key('primary-tab-scenes')));
-  await _waitUntil(
-    tester,
-    () =>
-        find.byKey(const Key('scene-self-introduction')).evaluate().isNotEmpty,
-    const Duration(seconds: 5),
+  await tester.pump();
+  final scenario = find.byKey(
+    const Key('catalog-scenario-scn_programmer_interview'),
   );
-  await tester.tap(find.byKey(const Key('scene-self-introduction')));
-  await _waitUntil(
+  await _waitForPreparationTarget(
     tester,
-    () =>
-        find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty ||
-        find.byKey(const Key('scene-operation-error')).evaluate().isNotEmpty,
-    const Duration(seconds: 30),
+    target: scenario,
+    operation: 'load the formal preparation catalog',
+    timeout: const Duration(seconds: 30),
   );
-  if (find.byKey(const Key('scene-operation-error')).evaluate().isNotEmpty) {
-    fail('The real service could not start the selected voice scene.');
-  }
+  await _scrollPreparationIntoView(tester, scenario);
+  await tester.tap(scenario);
+  await tester.pump();
 
-  await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-  await _waitUntil(
+  final role = find.byKey(
+    const Key('preparation-role-role_technical_interviewer'),
+  );
+  await _waitForPreparationTarget(
     tester,
-    () => find.byKey(const Key('practice-page')).evaluate().isNotEmpty,
-    const Duration(seconds: 5),
+    target: role,
+    operation: 'load the technical interview preparation detail',
+    timeout: const Duration(seconds: 30),
+  );
+  await _scrollPreparationIntoView(tester, role);
+  await tester.tap(role);
+  await tester.pump();
+
+  final option = find.byKey(
+    const Key('preparation-option-option_technical_focus'),
+  );
+  await _scrollPreparationIntoView(tester, option);
+  await tester.tap(option);
+  await tester.pump();
+
+  final background = find.byKey(const Key('preparation-background-summary'));
+  await _scrollPreparationIntoView(tester, background);
+  await tester.enterText(
+    background,
+    'Backend engineer preparing for a technical interview. '
+    'Focus on concise spoken explanations of engineering trade-offs.',
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 300));
+
+  final start = find.byKey(const Key('preparation-start-practice'));
+  await _scrollPreparationIntoView(tester, start);
+  await tester.tap(start);
+  await tester.pump();
+  await _waitForPreparationTarget(
+    tester,
+    target: find.byKey(const Key('practice-page')),
+    operation: 'create and open the formal FOCUS Practice Session',
+    timeout: const Duration(seconds: 90),
   );
 
   for (var turn = 1; turn <= 3; turn++) {
@@ -327,6 +376,101 @@ Future<void> _completeRealVoicePractice(
   }
 }
 
+Future<void> _waitForPreparationTarget(
+  WidgetTester tester, {
+  required Finder target,
+  required String operation,
+  required Duration timeout,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final failure = _preparationFailure(tester);
+    if (failure != null) {
+      fail('Failed to $operation: $failure');
+    }
+    if (target.evaluate().isNotEmpty) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+
+  final pending = _preparationPendingState(tester);
+  fail('Timed out waiting to $operation. Current state: $pending.');
+}
+
+Future<void> _scrollPreparationIntoView(
+  WidgetTester tester,
+  Finder target,
+) async {
+  if (target.hitTestable().evaluate().isEmpty) {
+    final scrollable = find.byType(Scrollable).first;
+    if (scrollable.evaluate().isEmpty) {
+      fail('Preparation content has no scrollable surface.');
+    }
+    await tester.scrollUntilVisible(target, 240, scrollable: scrollable);
+  }
+  await tester.ensureVisible(target);
+  await tester.pump(const Duration(milliseconds: 100));
+  if (target.hitTestable().evaluate().isEmpty) {
+    fail('Preparation control $target is not tappable.');
+  }
+}
+
+String? _preparationFailure(WidgetTester tester) {
+  const failures = <(String, String)>[
+    ('preparation-catalog-error', 'catalog request failed'),
+    ('preparation-detail-error', 'scenario detail request failed'),
+    ('preparation-launch-error', 'practice launch failed'),
+  ];
+  for (final (key, fallback) in failures) {
+    final finder = find.byKey(Key(key));
+    if (finder.evaluate().isNotEmpty) {
+      final message = _visibleText(tester, finder);
+      return message.isEmpty ? fallback : '$fallback: $message';
+    }
+  }
+  return null;
+}
+
+String _preparationPendingState(WidgetTester tester) {
+  if (find
+      .byKey(const Key('preparation-launch-progress'))
+      .evaluate()
+      .isNotEmpty) {
+    final stage = _visibleText(
+      tester,
+      find.byKey(const Key('preparation-launch-stage')),
+    );
+    return stage.isEmpty ? 'practice launch is still running' : stage;
+  }
+  if (find
+      .byKey(const Key('preparation-detail-loading'))
+      .evaluate()
+      .isNotEmpty) {
+    return 'scenario detail is still loading';
+  }
+  if (find
+      .byKey(const Key('preparation-catalog-loading'))
+      .evaluate()
+      .isNotEmpty) {
+    return 'preparation catalog is still loading';
+  }
+  return 'the expected preparation control is absent';
+}
+
+String _visibleText(WidgetTester tester, Finder root) {
+  final values = <String>[
+    for (final element in root.evaluate())
+      if (element.widget case final Text text)
+        if ((text.data ?? '').trim().isNotEmpty) text.data!.trim(),
+    for (final text in tester.widgetList<Text>(
+      find.descendant(of: root, matching: find.byType(Text)),
+    ))
+      if ((text.data ?? '').trim().isNotEmpty) text.data!.trim(),
+  ];
+  return values.toSet().join(' ');
+}
+
 Future<void> _validateQuestionTts(AgentController controller) async {
   expect(controller.canPlayQuestionAudio, isTrue);
   await controller.toggleQuestionAudio();
@@ -399,7 +543,7 @@ void _failOnPracticeError(WidgetTester tester, String operation) {
   fail('Failed to $operation: $message');
 }
 
-Future<void> _verifySignedInAccount(
+Future<bool> _signedInAccountMatches(
   WidgetTester tester,
   String expectedEmail,
 ) async {
@@ -410,7 +554,7 @@ Future<void> _verifySignedInAccount(
     const Duration(seconds: 5),
   );
   if (find.text(expectedEmail).evaluate().isEmpty) {
-    fail('The restored E2E Session belongs to a different account.');
+    return false;
   }
   await tester.tap(find.byKey(const Key('primary-tab-agent')));
   await _waitUntil(
@@ -420,6 +564,7 @@ Future<void> _verifySignedInAccount(
         _composerIsReady(tester),
     const Duration(seconds: 20),
   );
+  return true;
 }
 
 Future<void> _signOut(WidgetTester tester) async {

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -10,6 +10,7 @@ import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/main.dart' as app;
 import 'package:speakup/practice/practice_recording.dart';
+import 'package:speakup/review/review_history_controller.dart';
 
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -109,13 +110,14 @@ void main() {
       validateAudioMedia: validateAudioMedia,
     );
     final completedReviewId = dependencies.agentController.review?.id;
-    expect(completedReviewId, isNotNull);
-    await _waitUntil(
+    if (completedReviewId == null) {
+      fail('The completed Practice did not expose its server Review identity.');
+    }
+    await _waitForPersistedReview(
       tester,
-      () => dependencies.reviewHistoryController.items.any(
-        (item) => item.review.id == completedReviewId,
-      ),
-      const Duration(seconds: 15),
+      controller: dependencies.reviewHistoryController,
+      reviewId: completedReviewId,
+      timeout: const Duration(seconds: 15),
     );
     final reviewScreenshot = await binding.takeScreenshot(
       'ios-real-voice-review-e2e',
@@ -125,12 +127,12 @@ void main() {
     await _signOut(tester);
     await _signIn(tester, email: email, password: password);
     await tester.tap(find.byKey(const Key('primary-tab-review')));
-    await _waitUntil(
+    await _waitForPersistedReview(
       tester,
-      () =>
-          dependencies.reviewHistoryController.items.any(
-            (item) => item.review.id == completedReviewId,
-          ) &&
+      controller: dependencies.reviewHistoryController,
+      reviewId: completedReviewId,
+      timeout: const Duration(seconds: 20),
+      additionalCondition: () =>
           find
               .byKey(Key('review-history-$completedReviewId'))
               .evaluate()
@@ -140,7 +142,6 @@ void main() {
               .hitTestable()
               .evaluate()
               .isNotEmpty,
-      const Duration(seconds: 20),
     );
     final restoredReviewScreenshot = await binding.takeScreenshot(
       'ios-real-review-history-restore-e2e',
@@ -167,11 +168,24 @@ Future<void> _registerOrSignIn(
     () => find.text('欢迎回来').evaluate().isNotEmpty,
     const Duration(seconds: 15),
   );
-  await tester.tap(find.text('创建账号'));
-  await tester.pumpAndSettle();
+  final openRegistration = find.widgetWithText(TextButton, '创建账号');
+  await _waitUntil(
+    tester,
+    () => openRegistration.hitTestable().evaluate().length == 1,
+    const Duration(seconds: 5),
+  );
+  await tester.ensureVisible(openRegistration);
+  await tester.tap(openRegistration);
+  await _waitUntil(
+    tester,
+    () =>
+        find.widgetWithText(FilledButton, '创建账号').evaluate().length == 1 &&
+        find.text('返回登录').evaluate().length == 1,
+    const Duration(seconds: 5),
+  );
   await tester.enterText(find.byType(TextFormField).at(0), email);
   await tester.enterText(find.byType(TextFormField).at(1), password);
-  await tester.tap(find.widgetWithText(FilledButton, '创建账号'));
+  await _tapAuthSubmit(tester, '创建账号');
   await _waitUntil(
     tester,
     () =>
@@ -190,7 +204,7 @@ Future<void> _registerOrSignIn(
 
   await tester.enterText(find.byType(TextFormField).at(0), email);
   await tester.enterText(find.byType(TextFormField).at(1), password);
-  await tester.tap(find.text('登录'));
+  await _tapAuthSubmit(tester, '登录');
   await _waitUntil(
     tester,
     () =>
@@ -212,7 +226,7 @@ Future<void> _signIn(
   );
   await tester.enterText(find.byType(TextFormField).at(0), email);
   await tester.enterText(find.byType(TextFormField).at(1), password);
-  await tester.tap(find.text('登录'));
+  await _tapAuthSubmit(tester, '登录');
   await _waitUntil(
     tester,
     () =>
@@ -220,6 +234,21 @@ Future<void> _signIn(
         find.byKey(const Key('primary-tab-review')).evaluate().isNotEmpty,
     const Duration(seconds: 20),
   );
+}
+
+Future<void> _tapAuthSubmit(WidgetTester tester, String label) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 200));
+  final button = find.byType(FilledButton, skipOffstage: false);
+  if (button.evaluate().length != 1) {
+    fail(
+      'Expected one auth submit button for $label, '
+      'found ${button.evaluate().length}.',
+    );
+  }
+  await tester.ensureVisible(button);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tap(button);
 }
 
 Future<void> _completeRealVoicePractice(
@@ -283,12 +312,13 @@ Future<void> _completeRealVoicePractice(
     operation: 'create and open the formal FOCUS Practice Session',
     timeout: const Duration(seconds: 90),
   );
+  await tester.pumpAndSettle();
 
   for (var turn = 1; turn <= 3; turn++) {
     if (validateAudioMedia) {
       await _validateQuestionTts(controller);
     }
-    await tester.tap(find.byKey(const Key('practice-record')));
+    await _tapPracticeControl(tester, const Key('practice-record'));
     await _waitUntil(
       tester,
       () =>
@@ -301,7 +331,7 @@ Future<void> _completeRealVoicePractice(
     );
     _failOnPracticeError(tester, 'start recording for turn $turn');
 
-    await tester.tap(find.byKey(const Key('practice-stop-recording')));
+    await _tapPracticeControl(tester, const Key('practice-stop-recording'));
     await _waitUntil(
       tester,
       () =>
@@ -318,7 +348,7 @@ Future<void> _completeRealVoicePractice(
       isNotEmpty,
     );
 
-    await tester.tap(find.byKey(const Key('practice-confirm-turn')));
+    await _tapPracticeControl(tester, const Key('practice-confirm-turn'));
     await tester.pump();
     if (turn < 3) {
       await _waitUntil(
@@ -374,6 +404,21 @@ Future<void> _completeRealVoicePractice(
       );
     }
   }
+}
+
+Future<void> _tapPracticeControl(WidgetTester tester, Key key) async {
+  final control = find.byKey(key);
+  await _waitUntil(
+    tester,
+    () => control.evaluate().isNotEmpty,
+    const Duration(seconds: 10),
+  );
+  await tester.ensureVisible(control);
+  await tester.pump(const Duration(milliseconds: 100));
+  if (control.hitTestable().evaluate().isEmpty) {
+    fail('Practice control $key is not tappable.');
+  }
+  await tester.tap(control);
 }
 
 Future<void> _waitForPreparationTarget(
@@ -532,6 +577,28 @@ Future<void> _waitForRealReview(WidgetTester tester) async {
   }
   _failOnPracticeError(tester, 'restore the Review');
   fail('The real service did not return a Review after retrying.');
+}
+
+Future<void> _waitForPersistedReview(
+  WidgetTester tester, {
+  required ReviewHistoryController controller,
+  required String reviewId,
+  required Duration timeout,
+  bool Function()? additionalCondition,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final loaded = controller.items.any((item) => item.review.id == reviewId);
+    if (loaded && (additionalCondition?.call() ?? true)) {
+      return;
+    }
+    final error = controller.errorMessage;
+    if (error != null && error.isNotEmpty) {
+      fail('Failed to load persisted Review $reviewId: $error');
+    }
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+  fail('Timed out waiting for persisted Review $reviewId.');
 }
 
 void _failOnPracticeError(WidgetTester tester, String operation) {

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -106,6 +106,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   _AgentRetry? _retry;
   int _completedTurns = 0;
   int _turnLimit = 0;
+  bool _sessionCompleted = false;
   int _epoch = 0;
   int _practiceGeneration = 0;
   bool _initialized = false;
@@ -212,8 +213,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         !_isSessionCompleted;
   }
 
-  bool get _isSessionCompleted =>
-      _turnLimit > 0 && _completedTurns == _turnLimit;
+  bool get _isSessionCompleted => _sessionCompleted;
 
   bool get _practiceRequestInFlight {
     return _recordingState == PracticeRecordingState.transcribing ||
@@ -708,6 +708,120 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     await _selectScene(
       _SceneRetry(scene: scene, clientOperationId: _newClientId('scene')),
     );
+  }
+
+  /// Creates or activates the catalog-backed Matter without starting the
+  /// legacy voice-practice route.
+  Future<AgentMatter> activateMatterForScenario({
+    required String threadId,
+    required AgentScene scene,
+    required String clientOperationId,
+  }) async {
+    final accountFence = _captureOperationFence();
+    await _ensureInitialized();
+    if (!_isOperationCurrent(accountFence) ||
+        _threadId != threadId ||
+        scene.id.trim().isEmpty ||
+        scene.title.trim().isEmpty ||
+        clientOperationId.trim().isEmpty ||
+        isBusy ||
+        hasActivePractice ||
+        _disposed) {
+      throw StateError('The Agent context cannot activate this Matter.');
+    }
+    final current = _activeMatter;
+    if (current != null &&
+        current.scene.id == scene.id &&
+        current.scene.title == scene.title) {
+      return current;
+    }
+    final fence = _captureOperationFence(threadId: threadId);
+    final epoch = fence.epoch;
+    _setBusy(true);
+    try {
+      final selection = await client.startScene(
+        threadId: threadId,
+        scene: scene,
+        clientOperationId: clientOperationId,
+      );
+      if (!_isOperationCurrent(fence)) {
+        throw const AgentClientOperationCancelled();
+      }
+      final matter = selection.activeMatter;
+      if (matter.id.trim().isEmpty ||
+          matter.scene.id != scene.id ||
+          matter.scene.title != scene.title) {
+        throw StateError('Matter activation returned a different scenario.');
+      }
+      _activeMatter = matter;
+      notifyListeners();
+      return matter;
+    } finally {
+      if (_isCurrent(epoch)) {
+        _setBusy(false);
+      }
+    }
+  }
+
+  /// Adopts the exact Session created by the Preparation launch chain.
+  ///
+  /// The voice client resolves by the already trusted Thread, then this method
+  /// requires the returned Session and Matter identities to match the launch
+  /// result. It never starts a second Session or guesses a recent one.
+  Future<void> activateCreatedPractice({
+    required String threadId,
+    required String matterId,
+    required String sessionId,
+    required int turnLimit,
+  }) async {
+    final accountFence = _captureOperationFence();
+    await _ensureInitialized();
+    final practice = practiceClient;
+    final matter = _activeMatter;
+    if (!_isOperationCurrent(accountFence) ||
+        practice == null ||
+        _threadId != threadId ||
+        matter?.id != matterId ||
+        turnLimit < 1 ||
+        turnLimit > 6 ||
+        isBusy ||
+        _disposed) {
+      throw StateError('The Agent context changed before voice activation.');
+    }
+    if (hasActivePractice) {
+      if (_practiceSessionId != sessionId || _turnLimit != turnLimit) {
+        throw StateError(
+          'A different active Practice Session cannot be replaced.',
+        );
+      }
+      return;
+    }
+    final fence = _captureOperationFence(threadId: threadId);
+    final epoch = fence.epoch;
+    _setBusy(true);
+    try {
+      final snapshot = await practice.restorePractice(
+        threadId: threadId,
+        activeMatter: matter,
+      );
+      if (!_isOperationCurrent(fence)) {
+        throw const AgentClientOperationCancelled();
+      }
+      if (snapshot == null ||
+          snapshot.sessionId != sessionId ||
+          (snapshot.threadId != null && snapshot.threadId != threadId) ||
+          snapshot.matter.id != matterId ||
+          snapshot.turnLimit != turnLimit) {
+        throw StateError(
+          'Voice restore did not return the created Practice Session.',
+        );
+      }
+      _applyPracticeSnapshot(snapshot);
+    } finally {
+      if (_isCurrent(epoch)) {
+        _setBusy(false);
+      }
+    }
   }
 
   Future<void> _selectScene(_SceneRetry operation) async {
@@ -1368,6 +1482,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _validateConfirmation(confirmation, candidate);
       _completedTurns = confirmation.completedTurns;
       _turnLimit = confirmation.turnLimit;
+      _sessionCompleted = confirmation.sessionCompleted;
       _currentQuestion = confirmation.nextQuestion;
       _review = confirmation.review;
       final audioAssetId = confirmation.audioAssetId;
@@ -1489,6 +1604,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _retry = null;
     _completedTurns = 0;
     _turnLimit = 0;
+    _sessionCompleted = false;
     _recordings = const <PracticeRecordingReference>[];
     _playingMediaKey = null;
     _loadingMediaKey = null;
@@ -1638,6 +1754,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _activeMatter = null;
       _completedTurns = 0;
       _turnLimit = 0;
+      _sessionCompleted = false;
       _review = null;
       _recordings = const <PracticeRecordingReference>[];
       _recordingState = PracticeRecordingState.idle;
@@ -1651,6 +1768,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _activeMatter = snapshot.matter;
     _completedTurns = snapshot.completedTurns;
     _turnLimit = snapshot.turnLimit;
+    _sessionCompleted = snapshot.sessionCompleted;
     _review = snapshot.review;
     final currentTurn = snapshot.currentTurn;
     final audioAssetId = currentTurn?.audioAssetId;
@@ -2035,9 +2153,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         snapshot.matter.scene.id.trim().isEmpty ||
         snapshot.completedTurns < 0 ||
         snapshot.turnLimit < 1 ||
+        snapshot.turnLimit > 6 ||
         snapshot.completedTurns > snapshot.turnLimit ||
-        snapshot.sessionCompleted !=
-            (snapshot.completedTurns == snapshot.turnLimit) ||
         (!snapshot.sessionCompleted && snapshot.currentQuestion == null) ||
         (snapshot.currentQuestion != null &&
             snapshot.currentQuestion!.sessionId != snapshot.sessionId) ||
@@ -2074,9 +2191,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         confirmation.answer.text != candidate.text ||
         confirmation.completedTurns < 1 ||
         confirmation.turnLimit < 1 ||
+        confirmation.turnLimit > 6 ||
         confirmation.completedTurns > confirmation.turnLimit ||
-        confirmation.sessionCompleted !=
-            (confirmation.completedTurns == confirmation.turnLimit) ||
         (!confirmation.sessionCompleted && confirmation.nextQuestion == null) ||
         (confirmation.nextQuestion != null &&
             confirmation.nextQuestion!.sessionId != confirmation.sessionId) ||

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -328,10 +328,21 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     if (practiceClient case final LegacyAgentPracticeClient legacy) {
       legacy.seedRestoredThread(thread);
     }
-    final practice = await practiceClient?.restorePractice(
-      threadId: thread.threadId,
-      activeMatter: thread.activeMatter,
-    );
+    PracticeSessionSnapshot? practice;
+    try {
+      practice = await practiceClient?.restorePractice(
+        threadId: thread.threadId,
+        activeMatter: thread.activeMatter,
+      );
+    } catch (error) {
+      if (!_isPracticeRestoreAmbiguity(error)) {
+        rethrow;
+      }
+      // Multiple completed Sessions are durable history, but no single one
+      // is the current Practice. Keep the independently restored Agent
+      // context and let Review history present those completed Sessions.
+      practice = null;
+    }
     if (!_isOperationCurrent(fence)) {
       return;
     }
@@ -2015,6 +2026,14 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
 
   bool _isFreeQuotaExhausted(AgentClientException error) {
     return error.errorCode == 'quota_exhausted';
+  }
+
+  bool _isPracticeRestoreAmbiguity(Object error) {
+    return error is AgentClientException &&
+        error.kind == AgentClientFailureKind.conflict &&
+        error.statusCode == 409 &&
+        error.errorCode == 'resource_conflict' &&
+        !error.retryable;
   }
 
   void _setBusy(bool value) {

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -765,14 +765,15 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Adopts the exact Session created by the Preparation launch chain.
   ///
-  /// The voice client resolves by the already trusted Thread, then this method
-  /// requires the returned Session and Matter identities to match the launch
-  /// result. It never starts a second Session or guesses a recent one.
+  /// The voice client activates the formal Session already created for the
+  /// trusted Thread and Matter. This method requires the returned identities
+  /// and frozen Turn budget to match; it never guesses a recent Session.
   Future<void> activateCreatedPractice({
     required String threadId,
     required String matterId,
     required String sessionId,
     required int turnLimit,
+    required String clientOperationId,
   }) async {
     final accountFence = _captureOperationFence();
     await _ensureInitialized();
@@ -784,6 +785,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         matter?.id != matterId ||
         turnLimit < 1 ||
         turnLimit > 6 ||
+        clientOperationId.trim().isEmpty ||
         isBusy ||
         _disposed) {
       throw StateError('The Agent context changed before voice activation.');
@@ -800,20 +802,21 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     final epoch = fence.epoch;
     _setBusy(true);
     try {
-      final snapshot = await practice.restorePractice(
+      final result = await practice.startPractice(
         threadId: threadId,
-        activeMatter: matter,
+        activeMatter: matter!,
+        clientOperationId: clientOperationId,
       );
       if (!_isOperationCurrent(fence)) {
         throw const AgentClientOperationCancelled();
       }
-      if (snapshot == null ||
-          snapshot.sessionId != sessionId ||
-          (snapshot.threadId != null && snapshot.threadId != threadId) ||
+      final snapshot = result.snapshot;
+      if (snapshot.sessionId != sessionId ||
+          snapshot.threadId != threadId ||
           snapshot.matter.id != matterId ||
           snapshot.turnLimit != turnLimit) {
         throw StateError(
-          'Voice restore did not return the created Practice Session.',
+          'Voice activation did not return the created Practice Session.',
         );
       }
       _applyPracticeSnapshot(snapshot);

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -356,6 +356,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       return;
     }
     _applyPracticeSnapshot(practice);
+    if (practice == null) {
+      _activeMatter = thread.activeMatter;
+    }
     _initialized = true;
     _applyRestoredTextState(thread);
   }

--- a/mobile/lib/agent/agent_models.dart
+++ b/mobile/lib/agent/agent_models.dart
@@ -171,12 +171,20 @@ final class AgentMatter {
 final class AgentPracticeSnapshot {
   const AgentPracticeSnapshot({
     required this.completedTurns,
+    this.turnLimit = 3,
+    bool? sessionCompleted,
     this.review,
     this.pendingReviewClientId,
-  }) : assert(completedTurns >= 0 && completedTurns <= 3),
-       assert(review == null || completedTurns == 3);
+  }) : sessionCompleted = sessionCompleted ?? completedTurns == turnLimit,
+       assert(turnLimit >= 1 && turnLimit <= 6),
+       assert(completedTurns >= 0 && completedTurns <= turnLimit),
+       assert(
+         review == null || (sessionCompleted ?? completedTurns == turnLimit),
+       );
 
   final int completedTurns;
+  final int turnLimit;
+  final bool sessionCompleted;
   final AgentReview? review;
   final String? pendingReviewClientId;
 }

--- a/mobile/lib/agent/wire_agent_client.dart
+++ b/mobile/lib/agent/wire_agent_client.dart
@@ -75,6 +75,8 @@ final class WireAgentClient
   final Map<String, _FailedRun> _failedRuns = <String, _FailedRun>{};
   final Set<String> _ambiguousSubmissions = <String>{};
   _AmbiguousThreadCreation? _ambiguousThreadCreation;
+  final Map<_MatterActivationKey, _MatterActivation> _matterActivations =
+      <_MatterActivationKey, _MatterActivation>{};
   Future<void>? _cleanupFuture;
 
   @override
@@ -100,6 +102,7 @@ final class WireAgentClient
     _failedRuns.clear();
     _ambiguousSubmissions.clear();
     _ambiguousThreadCreation = null;
+    _matterActivations.clear();
     final staleOperations = List<Future<void>>.of(_inFlightOperations);
     if (_ownsTransport) {
       (_transport as _IoAgentHttpTransport).close(force: true);
@@ -761,26 +764,29 @@ final class WireAgentClient
       _requireUuid(threadId);
       _requireClientIdentity(clientOperationId);
       _requireContent(scene.title);
-      final listResponse = await _send(
+      final operationKey = (
         generation: generation,
-        method: 'GET',
-        path: '/v1/matters',
+        threadId: threadId,
+        clientOperationId: clientOperationId,
       );
-      _requireStatus(listResponse, const <int>{HttpStatus.ok});
-      final matters = _decodeMatterList(listResponse.body);
-      var matter = matters
-          .where((item) => item.title == scene.title && item.status == 'active')
-          .firstOrNull;
-      if (matter == null) {
-        final createResponse = await _send(
-          generation: generation,
-          method: 'POST',
-          path: '/v1/matters',
-          body: <String, Object?>{'title': scene.title},
+      final existing = _matterActivations[operationKey];
+      final activation =
+          existing ??
+          _MatterActivation(sceneId: scene.id, sceneTitle: scene.title);
+      if (existing == null) {
+        _matterActivations[operationKey] = activation;
+      } else if (existing.sceneId != scene.id ||
+          existing.sceneTitle != scene.title) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.conflict,
+          errorCode: 'idempotency_key_conflict',
         );
-        _requireStatus(createResponse, const <int>{HttpStatus.created});
-        matter = _decodeMatter(createResponse.body);
       }
+      final matter = await _resolveActivationMatter(
+        generation: generation,
+        operationKey: operationKey,
+        activation: activation,
+      );
       final linkResponse = await _send(
         generation: generation,
         method: 'PUT',
@@ -809,6 +815,136 @@ final class WireAgentClient
         ),
       );
     });
+  }
+
+  Future<_WireMatter> _resolveActivationMatter({
+    required int generation,
+    required _MatterActivationKey operationKey,
+    required _MatterActivation activation,
+  }) {
+    final resolved = activation.matter;
+    if (resolved != null) {
+      return Future<_WireMatter>.value(resolved);
+    }
+    final pending = activation.pendingMatter;
+    if (pending != null) {
+      return pending;
+    }
+    late final Future<_WireMatter> operation;
+    operation =
+        _createOrRecoverActivationMatter(
+              generation: generation,
+              operationKey: operationKey,
+              activation: activation,
+            )
+            .then((matter) {
+              _requireMatterActivationCurrent(
+                generation: generation,
+                operationKey: operationKey,
+                activation: activation,
+              );
+              activation.matter = matter;
+              return matter;
+            })
+            .whenComplete(() {
+              if (identical(activation.pendingMatter, operation)) {
+                activation.pendingMatter = null;
+              }
+            });
+    activation.pendingMatter = operation;
+    return operation;
+  }
+
+  Future<_WireMatter> _createOrRecoverActivationMatter({
+    required int generation,
+    required _MatterActivationKey operationKey,
+    required _MatterActivation activation,
+  }) async {
+    if (activation.baselineMatterIds == null) {
+      final matters = await _listMatters(generation);
+      _requireMatterActivationCurrent(
+        generation: generation,
+        operationKey: operationKey,
+        activation: activation,
+      );
+      activation.baselineMatterIds = {
+        for (final matter in matters)
+          if (matter.title == activation.sceneTitle) matter.id,
+      };
+    } else if (activation.createAmbiguous) {
+      final matters = await _listMatters(generation);
+      _requireMatterActivationCurrent(
+        generation: generation,
+        operationKey: operationKey,
+        activation: activation,
+      );
+      final recovered = [
+        for (final matter in matters)
+          if (matter.title == activation.sceneTitle &&
+              matter.status == 'active' &&
+              !activation.baselineMatterIds!.contains(matter.id))
+            matter,
+      ];
+      if (recovered.length > 1) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.conflict,
+          errorCode: 'resource_conflict',
+        );
+      }
+      if (recovered case [final matter]) {
+        return matter;
+      }
+      activation.createAmbiguous = false;
+    }
+
+    try {
+      final createResponse = await _send(
+        generation: generation,
+        method: 'POST',
+        path: '/v1/matters',
+        body: <String, Object?>{'title': activation.sceneTitle},
+      );
+      _requireStatus(createResponse, const <int>{HttpStatus.created});
+      final matter = _decodeMatter(createResponse.body);
+      if (matter.title != activation.sceneTitle || matter.status != 'active') {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.invalidResponse,
+          retryable: true,
+        );
+      }
+      return matter;
+    } on AgentClientException catch (error) {
+      if (error.kind == AgentClientFailureKind.network) {
+        _requireMatterActivationCurrent(
+          generation: generation,
+          operationKey: operationKey,
+          activation: activation,
+        );
+        activation.createAmbiguous = true;
+      }
+      rethrow;
+    }
+  }
+
+  Future<List<_WireMatter>> _listMatters(int generation) async {
+    final response = await _send(
+      generation: generation,
+      method: 'GET',
+      path: '/v1/matters',
+    );
+    _requireStatus(response, const <int>{HttpStatus.ok});
+    return _decodeMatterList(response.body);
+  }
+
+  void _requireMatterActivationCurrent({
+    required int generation,
+    required _MatterActivationKey operationKey,
+    required _MatterActivation activation,
+  }) {
+    _requireCurrentGeneration(generation);
+    if (!identical(_matterActivations[operationKey], activation)) {
+      throw const AgentClientOperationCancelled();
+    }
   }
 
   @override
@@ -1112,6 +1248,23 @@ final class _FailedRun {
   final String threadId;
   final String inputMessageId;
   final String content;
+}
+
+typedef _MatterActivationKey = ({
+  int generation,
+  String threadId,
+  String clientOperationId,
+});
+
+final class _MatterActivation {
+  _MatterActivation({required this.sceneId, required this.sceneTitle});
+
+  final String sceneId;
+  final String sceneTitle;
+  Set<String>? baselineMatterIds;
+  _WireMatter? matter;
+  Future<_WireMatter>? pendingMatter;
+  bool createAmbiguous = false;
 }
 
 final class _WireMatter {

--- a/mobile/lib/agent/wire_agent_client.dart
+++ b/mobile/lib/agent/wire_agent_client.dart
@@ -861,6 +861,10 @@ final class WireAgentClient
     required _MatterActivation activation,
   }) async {
     if (activation.baselineMatterIds == null) {
+      // Every Matter already visible when this client starts the operation is
+      // deliberately treated as unrelated. The frozen API has no durable
+      // client operation identity, so a restarted client must create a fresh
+      // Matter instead of guessing from a same-title result.
       final matters = await _listMatters(generation);
       _requireMatterActivationCurrent(
         generation: generation,
@@ -914,7 +918,8 @@ final class WireAgentClient
       }
       return matter;
     } on AgentClientException catch (error) {
-      if (error.kind == AgentClientFailureKind.network) {
+      if (error.kind == AgentClientFailureKind.network ||
+          error.kind == AgentClientFailureKind.invalidResponse) {
         _requireMatterActivationCurrent(
           generation: generation,
           operationKey: operationKey,

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -6,6 +6,7 @@ import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
 import 'package:speakup/features/review/review.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/auth_gate.dart';
@@ -17,6 +18,7 @@ class SpeakUpApp extends StatelessWidget {
     required AuthController authController,
     required this.agentController,
     required this.preparationController,
+    this.preparationLaunchController,
     this.reviewHistoryController,
     super.key,
   }) : _authentication = (controller: authController),
@@ -25,6 +27,7 @@ class SpeakUpApp extends StatelessWidget {
   const SpeakUpApp.preview({
     this.agentController,
     this.preparationController,
+    this.preparationLaunchController,
     this.reviewHistoryController,
     super.key,
   }) : _authentication = null,
@@ -33,6 +36,7 @@ class SpeakUpApp extends StatelessWidget {
   final ({AuthController controller})? _authentication;
   final AgentController? agentController;
   final PreparationController? preparationController;
+  final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final bool _allowFakePreview;
 
@@ -58,6 +62,7 @@ class SpeakUpApp extends StatelessWidget {
           ? _AuthenticatedNavigator(
               agentController: agentController,
               preparationController: preparationController,
+              preparationLaunchController: preparationLaunchController,
               reviewHistoryController: reviewHistoryController,
               allowFakePreview: _allowFakePreview,
             )
@@ -68,6 +73,7 @@ class SpeakUpApp extends StatelessWidget {
                 authController: controller,
                 agentController: agentController,
                 preparationController: preparationController,
+                preparationLaunchController: preparationLaunchController,
                 reviewHistoryController: reviewHistoryController,
                 allowFakePreview: _allowFakePreview,
               ),
@@ -82,6 +88,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.authController,
     this.agentController,
     this.preparationController,
+    this.preparationLaunchController,
     this.reviewHistoryController,
     required this.allowFakePreview,
   });
@@ -90,6 +97,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final AuthController? authController;
   final AgentController? agentController;
   final PreparationController? preparationController;
+  final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final bool allowFakePreview;
 
@@ -99,6 +107,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
 }
 
 class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
+  final _navigatorKey = GlobalKey<NavigatorState>();
   late final AgentController _agentController;
   late final bool _ownsAgentController;
 
@@ -128,6 +137,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
   @override
   Widget build(BuildContext context) {
     return Navigator(
+      key: _navigatorKey,
       initialRoute: AppRoutes.home,
       onGenerateRoute: (settings) {
         final page = switch (settings.name) {
@@ -137,6 +147,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             authController: widget.authController,
             agentController: _agentController,
             preparationController: widget.preparationController,
+            preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
           ),
           AppRoutes.preparation => PreparationPage(
@@ -144,6 +155,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             previewMode: widget.allowFakePreview,
             agentController: _agentController,
             preparationController: widget.preparationController,
+            launchController: widget.preparationLaunchController,
+            onPracticeStarted: () => _navigatorKey.currentState
+                ?.pushReplacementNamed(AppRoutes.practice),
           ),
           AppRoutes.practice => PracticePage(
             previewMode: widget.allowFakePreview,
@@ -156,6 +170,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             authController: widget.authController,
             agentController: _agentController,
             preparationController: widget.preparationController,
+            preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
           ),
           AppRoutes.review => ReviewPage(

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -9,6 +9,7 @@ import 'package:speakup/app/glass_navigation_bar.dart';
 import 'package:speakup/features/conversation/conversation.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
 import 'package:speakup/features/review/review.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/model/identity_models.dart';
@@ -21,6 +22,7 @@ class SpeakUpShell extends StatefulWidget {
     this.user,
     this.authController,
     this.preparationController,
+    this.preparationLaunchController,
     this.reviewHistoryController,
     required this.agentController,
     super.key,
@@ -32,6 +34,7 @@ class SpeakUpShell extends StatefulWidget {
   final AuthController? authController;
   final AgentController agentController;
   final PreparationController? preparationController;
+  final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
 
   @override
@@ -212,7 +215,9 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         previewMode: widget.previewMode,
         agentController: widget.agentController,
         preparationController: widget.preparationController,
+        launchController: widget.preparationLaunchController,
         onSceneSelected: () => _selectDestination(0),
+        onPracticeStarted: _openPractice,
       ),
       ReviewPage(
         showBackButton: widget.showBackButton,

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -173,26 +173,34 @@ class _PreparationPageState extends State<PreparationPage> {
   @override
   Widget build(BuildContext context) {
     final controller = widget.preparationController;
-    return Scaffold(
-      key: const Key('scenes-page'),
-      backgroundColor: const Color(0xFFF3F3F0),
-      appBar: widget.showBackButton
-          ? AppBar(
-              backgroundColor: const Color(0xFFF3F3F0),
-              surfaceTintColor: Colors.transparent,
-              elevation: 0,
-              scrolledUnderElevation: 0,
-              leading: IconButton(
-                key: const Key('preparation-route-back-button'),
-                tooltip: '返回',
-                onPressed: () => Navigator.of(context).maybePop(),
-                icon: const Icon(Icons.arrow_back_rounded),
-              ),
-            )
-          : null,
-      body: SafeArea(
-        bottom: false,
-        child: controller == null ? _buildPreview() : _buildCatalog(controller),
+    final launchLocked = widget.launchController?.isStarting ?? false;
+    return PopScope<void>(
+      canPop: !launchLocked,
+      child: Scaffold(
+        key: const Key('scenes-page'),
+        backgroundColor: const Color(0xFFF3F3F0),
+        appBar: widget.showBackButton
+            ? AppBar(
+                backgroundColor: const Color(0xFFF3F3F0),
+                surfaceTintColor: Colors.transparent,
+                elevation: 0,
+                scrolledUnderElevation: 0,
+                leading: IconButton(
+                  key: const Key('preparation-route-back-button'),
+                  tooltip: '返回',
+                  onPressed: launchLocked
+                      ? null
+                      : () => Navigator.of(context).maybePop(),
+                  icon: const Icon(Icons.arrow_back_rounded),
+                ),
+              )
+            : null,
+        body: SafeArea(
+          bottom: false,
+          child: controller == null
+              ? _buildPreview()
+              : _buildCatalog(controller),
+        ),
       ),
     );
   }
@@ -324,6 +332,7 @@ class _ScenarioDetailView extends StatelessWidget {
   Widget build(BuildContext context) {
     final detail = controller.detail;
     final selectedRole = controller.selectedRole;
+    final launchLocked = launchController?.isStarting ?? false;
     return ListView(
       key: const Key('preparation-scenario-detail'),
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 140),
@@ -332,10 +341,12 @@ class _ScenarioDetailView extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: TextButton.icon(
             key: const Key('preparation-back-to-catalog'),
-            onPressed: () {
-              launchController?.selectionChanged();
-              controller.showScenarioList();
-            },
+            onPressed: launchLocked
+                ? null
+                : () {
+                    launchController?.selectionChanged();
+                    controller.showScenarioList();
+                  },
             icon: const Icon(Icons.arrow_back_rounded),
             label: const Text('全部场景'),
           ),
@@ -377,10 +388,12 @@ class _ScenarioDetailView extends StatelessWidget {
             _RoleCard(
               role: role,
               selected: selectedRole?.id == role.id,
-              onPressed: () {
-                launchController?.selectionChanged();
-                controller.selectRole(role);
-              },
+              onPressed: launchLocked
+                  ? null
+                  : () {
+                      launchController?.selectionChanged();
+                      controller.selectRole(role);
+                    },
             ),
             const SizedBox(height: 10),
           ],
@@ -400,10 +413,12 @@ class _ScenarioDetailView extends StatelessWidget {
               _OptionCard(
                 option: option,
                 selected: controller.selectedOption?.id == option.id,
-                onPressed: () {
-                  launchController?.selectionChanged();
-                  controller.selectOption(option);
-                },
+                onPressed: launchLocked
+                    ? null
+                    : () {
+                        launchController?.selectionChanged();
+                        controller.selectOption(option);
+                      },
               ),
               const SizedBox(height: 10),
             ],
@@ -602,7 +617,7 @@ class _RoleCard extends StatelessWidget {
 
   final PreparationRole role;
   final bool selected;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -686,7 +701,7 @@ class _OptionCard extends StatelessWidget {
 
   final PreparationOption option;
   final bool selected;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 
 class PreparationPage extends StatefulWidget {
@@ -15,7 +17,9 @@ class PreparationPage extends StatefulWidget {
     this.previewMode = false,
     this.agentController,
     this.preparationController,
+    this.launchController,
     this.onSceneSelected,
+    this.onPracticeStarted,
     super.key,
   });
 
@@ -23,18 +27,24 @@ class PreparationPage extends StatefulWidget {
   final bool previewMode;
   final AgentController? agentController;
   final PreparationController? preparationController;
+  final PreparationLaunchController? launchController;
   final VoidCallback? onSceneSelected;
+  final VoidCallback? onPracticeStarted;
 
   @override
   State<PreparationPage> createState() => _PreparationPageState();
 }
 
 class _PreparationPageState extends State<PreparationPage> {
+  TextEditingController? _backgroundController;
+
   @override
   void initState() {
     super.initState();
     widget.agentController?.addListener(_rebuild);
     widget.preparationController?.addListener(_rebuild);
+    widget.launchController?.addListener(_rebuild);
+    _backgroundController = _newBackgroundController(widget.launchController);
     unawaited(widget.preparationController?.loadIfNeeded());
   }
 
@@ -50,18 +60,79 @@ class _PreparationPageState extends State<PreparationPage> {
       widget.preparationController?.addListener(_rebuild);
       unawaited(widget.preparationController?.loadIfNeeded());
     }
+    if (oldWidget.launchController != widget.launchController) {
+      oldWidget.launchController?.removeListener(_rebuild);
+      widget.launchController?.addListener(_rebuild);
+      _backgroundController?.dispose();
+      _backgroundController = _newBackgroundController(widget.launchController);
+    }
   }
 
   @override
   void dispose() {
     widget.agentController?.removeListener(_rebuild);
     widget.preparationController?.removeListener(_rebuild);
+    widget.launchController?.removeListener(_rebuild);
+    _backgroundController?.dispose();
     super.dispose();
   }
 
   void _rebuild() {
     if (mounted) {
+      final launchBackground = widget.launchController?.backgroundSummary;
+      final textController = _backgroundController;
+      if (launchBackground != null &&
+          textController != null &&
+          textController.text != launchBackground) {
+        textController.value = TextEditingValue(
+          text: launchBackground,
+          selection: TextSelection.collapsed(offset: launchBackground.length),
+        );
+      }
       setState(() {});
+    }
+  }
+
+  TextEditingController? _newBackgroundController(
+    PreparationLaunchController? controller,
+  ) {
+    return controller == null
+        ? null
+        : TextEditingController(text: controller.backgroundSummary);
+  }
+
+  Future<void> _startPractice() async {
+    final catalog = widget.preparationController;
+    final launch = widget.launchController;
+    final scenario = catalog?.selectedScenario;
+    final config = catalog?.detail?.config;
+    final role = catalog?.selectedRole;
+    final option = catalog?.selectedOption;
+    if (catalog == null ||
+        launch == null ||
+        scenario == null ||
+        config == null ||
+        role == null ||
+        option == null) {
+      return;
+    }
+    final started = await launch.start(
+      PreparationLaunchSelection.fromCatalog(
+        scenario: scenario,
+        config: config,
+        role: role,
+        option: option,
+      ),
+    );
+    if (started && mounted) {
+      widget.onPracticeStarted?.call();
+    }
+  }
+
+  Future<void> _retryLaunch() async {
+    final started = await widget.launchController?.retry() ?? false;
+    if (started && mounted) {
+      widget.onPracticeStarted?.call();
     }
   }
 
@@ -132,6 +203,11 @@ class _PreparationPageState extends State<PreparationPage> {
       return _ScenarioDetailView(
         controller: controller,
         scenario: selectedScenario,
+        launchController: widget.launchController,
+        backgroundController: _backgroundController,
+        hasAgentContext: widget.agentController?.threadId != null,
+        onStart: _startPractice,
+        onRetry: _retryLaunch,
       );
     }
     return ListView(
@@ -226,10 +302,23 @@ class _PreparationPageState extends State<PreparationPage> {
 }
 
 class _ScenarioDetailView extends StatelessWidget {
-  const _ScenarioDetailView({required this.controller, required this.scenario});
+  const _ScenarioDetailView({
+    required this.controller,
+    required this.scenario,
+    required this.launchController,
+    required this.backgroundController,
+    required this.hasAgentContext,
+    required this.onStart,
+    required this.onRetry,
+  });
 
   final PreparationController controller;
   final PreparationScenario scenario;
+  final PreparationLaunchController? launchController;
+  final TextEditingController? backgroundController;
+  final bool hasAgentContext;
+  final Future<void> Function() onStart;
+  final Future<void> Function() onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -243,7 +332,10 @@ class _ScenarioDetailView extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: TextButton.icon(
             key: const Key('preparation-back-to-catalog'),
-            onPressed: controller.showScenarioList,
+            onPressed: () {
+              launchController?.selectionChanged();
+              controller.showScenarioList();
+            },
             icon: const Icon(Icons.arrow_back_rounded),
             label: const Text('全部场景'),
           ),
@@ -285,7 +377,10 @@ class _ScenarioDetailView extends StatelessWidget {
             _RoleCard(
               role: role,
               selected: selectedRole?.id == role.id,
-              onPressed: () => controller.selectRole(role),
+              onPressed: () {
+                launchController?.selectionChanged();
+                controller.selectRole(role);
+              },
             ),
             const SizedBox(height: 10),
           ],
@@ -305,14 +400,26 @@ class _ScenarioDetailView extends StatelessWidget {
               _OptionCard(
                 option: option,
                 selected: controller.selectedOption?.id == option.id,
-                onPressed: () => controller.selectOption(option),
+                onPressed: () {
+                  launchController?.selectionChanged();
+                  controller.selectOption(option);
+                },
               ),
               const SizedBox(height: 10),
             ],
           ],
           if (controller.hasCompleteSelection) ...[
             const SizedBox(height: 18),
-            const _ReadOnlySelectionNotice(),
+            if (launchController case final launch?)
+              _LaunchSelectionCard(
+                controller: launch,
+                backgroundController: backgroundController!,
+                hasAgentContext: hasAgentContext,
+                onStart: onStart,
+                onRetry: onRetry,
+              )
+            else
+              const _LaunchUnavailableNotice(),
           ],
         ],
       ],
@@ -643,13 +750,25 @@ class _OptionCard extends StatelessWidget {
   }
 }
 
-class _ReadOnlySelectionNotice extends StatelessWidget {
-  const _ReadOnlySelectionNotice();
+class _LaunchSelectionCard extends StatelessWidget {
+  const _LaunchSelectionCard({
+    required this.controller,
+    required this.backgroundController,
+    required this.hasAgentContext,
+    required this.onStart,
+    required this.onRetry,
+  });
+
+  final PreparationLaunchController controller;
+  final TextEditingController backgroundController;
+  final bool hasAgentContext;
+  final Future<void> Function() onStart;
+  final Future<void> Function() onRetry;
 
   @override
   Widget build(BuildContext context) {
     return Material(
-      key: const Key('preparation-read-only-selection'),
+      key: const Key('preparation-launch-selection'),
       color: const Color(0xFFEDEDEA),
       borderRadius: BorderRadius.circular(18),
       child: Padding(
@@ -657,26 +776,105 @@ class _ReadOnlySelectionNotice extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Text(
-              '目录选择已完成',
-              style: TextStyle(fontWeight: FontWeight.w800),
-            ),
+            const Text('准备开始练习', style: TextStyle(fontWeight: FontWeight.w800)),
             const SizedBox(height: 6),
             const Text(
-              '当前语音练习接口还不能接收这组服务端目录配置，因此本次选择尚未创建练习或写入业务数据。',
+              '请补充真实背景和练习目标。这里只创建本次练习上下文，不会从昵称或历史消息猜测。',
               style: TextStyle(color: Color(0xFF5F6168), height: 1.45),
             ),
             const SizedBox(height: 12),
-            FilledButton(
-              key: Key('preparation-start-unavailable'),
-              onPressed: null,
-              child: Text('练习接线准备中'),
+            TextField(
+              key: const Key('preparation-background-summary'),
+              controller: backgroundController,
+              enabled: !controller.isStarting,
+              minLines: 3,
+              maxLines: 6,
+              maxLength: 4000,
+              textInputAction: TextInputAction.newline,
+              decoration: const InputDecoration(
+                labelText: '你的背景与本次练习目标（必填）',
+                hintText: '例如：你的岗位、经历，以及这次最想练习的表达。',
+                filled: true,
+                fillColor: Colors.white,
+                border: OutlineInputBorder(),
+              ),
+              onChanged: controller.updateBackgroundSummary,
             ),
+            if (!hasAgentContext) ...[
+              const SizedBox(height: 4),
+              const Text(
+                'Agent 对话仍在恢复。无需预先建立事项，恢复完成后可从这里直接开始。',
+                key: Key('preparation-agent-context-missing'),
+                style: TextStyle(color: Color(0xFF6A5B38), height: 1.4),
+              ),
+            ],
+            if (controller.errorMessage case final message?) ...[
+              const SizedBox(height: 8),
+              Text(
+                message,
+                key: const Key('preparation-launch-error'),
+                style: const TextStyle(color: Color(0xFF9A332A), height: 1.4),
+              ),
+            ],
+            if (controller.isStarting) ...[
+              const SizedBox(height: 10),
+              const LinearProgressIndicator(
+                key: Key('preparation-launch-progress'),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                _launchStageLabel(controller.stage),
+                key: const Key('preparation-launch-stage'),
+                style: const TextStyle(color: Color(0xFF5F6168)),
+              ),
+            ],
+            const SizedBox(height: 12),
+            FilledButton(
+              key: const Key('preparation-start-practice'),
+              onPressed: controller.isStarting ? null : onStart,
+              child: Text(controller.isStarting ? '正在创建练习' : '开始语音练习'),
+            ),
+            if (controller.canRetry && !controller.isStarting)
+              TextButton(
+                key: const Key('preparation-retry-launch'),
+                onPressed: onRetry,
+                child: const Text('重试上次启动'),
+              ),
           ],
         ),
       ),
     );
   }
+}
+
+class _LaunchUnavailableNotice extends StatelessWidget {
+  const _LaunchUnavailableNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Material(
+      key: Key('preparation-launch-unavailable'),
+      color: Color(0xFFEDEDEA),
+      borderRadius: BorderRadius.all(Radius.circular(18)),
+      child: Padding(
+        padding: EdgeInsets.all(16),
+        child: Text('正式练习启动服务未注入，当前选择不会写入业务数据。'),
+      ),
+    );
+  }
+}
+
+String _launchStageLabel(PreparationLaunchStage? stage) {
+  return switch (stage) {
+    PreparationLaunchStage.context => '正在确认 Agent 对话与事项',
+    PreparationLaunchStage.matter => '正在创建或激活本次求职事项',
+    PreparationLaunchStage.profile => '正在保存本次背景',
+    PreparationLaunchStage.snapshot => '正在冻结练习背景',
+    PreparationLaunchStage.plan => '正在创建练习计划',
+    PreparationLaunchStage.session => '正在创建练习会话',
+    PreparationLaunchStage.voice => '正在连接第一道语音题目',
+    null => '正在准备练习',
+  };
 }
 
 class _InlineFailure extends StatelessWidget {

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -173,7 +173,7 @@ class _PreparationPageState extends State<PreparationPage> {
   @override
   Widget build(BuildContext context) {
     final controller = widget.preparationController;
-    final launchLocked = widget.launchController?.isStarting ?? false;
+    final launchLocked = widget.launchController?.isSelectionLocked ?? false;
     return PopScope<void>(
       canPop: !launchLocked,
       child: Scaffold(
@@ -332,7 +332,7 @@ class _ScenarioDetailView extends StatelessWidget {
   Widget build(BuildContext context) {
     final detail = controller.detail;
     final selectedRole = controller.selectedRole;
-    final launchLocked = launchController?.isStarting ?? false;
+    final launchLocked = launchController?.isSelectionLocked ?? false;
     return ListView(
       key: const Key('preparation-scenario-detail'),
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 140),
@@ -801,7 +801,7 @@ class _LaunchSelectionCard extends StatelessWidget {
             TextField(
               key: const Key('preparation-background-summary'),
               controller: backgroundController,
-              enabled: !controller.isStarting,
+              enabled: !controller.isSelectionLocked,
               minLines: 3,
               maxLines: 6,
               maxLength: 4000,

--- a/mobile/lib/features/preparation/preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/preparation_launch_client.dart
@@ -1,0 +1,27 @@
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+
+abstract interface class PreparationLaunchClient {
+  Future<PreparationProfile> createProfile({
+    required CreatePreparationProfileInput input,
+    required String idempotencyKey,
+  });
+
+  Future<PreparationSnapshot> createSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  });
+
+  Future<PreparationPracticePlan> createPlan({
+    required CreatePreparationPlanInput input,
+    required String idempotencyKey,
+  });
+
+  Future<PreparationPracticeBootstrap> createSession({
+    required String planId,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  });
+
+  Future<void> clearAccountState();
+}

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -19,6 +19,7 @@ typedef VoicePracticeActivator =
     Future<void> Function({
       required AgentPracticeContext context,
       required PreparationPracticeBootstrap bootstrap,
+      required String clientOperationId,
     });
 
 final class PreparationLaunchController extends ChangeNotifier {
@@ -111,6 +112,7 @@ final class PreparationLaunchController extends ChangeNotifier {
             snapshotKey: _newId('prep-snapshot'),
             planKey: _newId('practice-plan'),
             sessionKey: _newId('practice-session'),
+            voiceKey: _newId('practice-voice'),
           );
     return _run(attempt);
   }
@@ -215,7 +217,11 @@ final class PreparationLaunchController extends ChangeNotifier {
 
       _stage = PreparationLaunchStage.voice;
       notifyListeners();
-      await voiceActivator(context: activeContext, bootstrap: bootstrap);
+      await voiceActivator(
+        context: activeContext,
+        bootstrap: bootstrap,
+        clientOperationId: activeAttempt.voiceKey,
+      );
       _requireCurrent(operationEpoch, activeContext);
 
       _bootstrap = bootstrap;
@@ -330,6 +336,7 @@ final class _LaunchAttempt {
     required this.snapshotKey,
     required this.planKey,
     required this.sessionKey,
+    required this.voiceKey,
   });
 
   final PreparationLaunchSelection selection;
@@ -341,6 +348,7 @@ final class _LaunchAttempt {
   final String snapshotKey;
   final String planKey;
   final String sessionKey;
+  final String voiceKey;
 
   bool matches({
     required PreparationLaunchSelection selection,
@@ -362,6 +370,7 @@ final class _LaunchAttempt {
       snapshotKey: snapshotKey,
       planKey: planKey,
       sessionKey: sessionKey,
+      voiceKey: voiceKey,
     );
   }
 }

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -1,0 +1,414 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:speakup/features/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+
+typedef AgentPracticeContextProvider = AgentPracticeContext? Function();
+typedef AgentThreadIdProvider = String? Function();
+typedef PreparationMatterActivator =
+    Future<AgentPracticeContext> Function({
+      required String threadId,
+      required PreparationLaunchSelection selection,
+      required String clientOperationId,
+    });
+typedef PreparationLaunchIdFactory = String Function(String scope);
+typedef VoicePracticeActivator =
+    Future<void> Function({
+      required AgentPracticeContext context,
+      required PreparationPracticeBootstrap bootstrap,
+    });
+
+final class PreparationLaunchController extends ChangeNotifier {
+  PreparationLaunchController({
+    required this.client,
+    required this.contextProvider,
+    required this.threadIdProvider,
+    required this.matterActivator,
+    required this.voiceActivator,
+    PreparationLaunchIdFactory? idFactory,
+  }) : _idFactory = idFactory ?? _secureLaunchId;
+
+  final PreparationLaunchClient client;
+  final AgentPracticeContextProvider contextProvider;
+  final AgentThreadIdProvider threadIdProvider;
+  final PreparationMatterActivator matterActivator;
+  final VoicePracticeActivator voiceActivator;
+  final PreparationLaunchIdFactory _idFactory;
+
+  String _backgroundSummary = '';
+  String? _errorMessage;
+  PreparationLaunchStage? _stage;
+  PreparationPracticeBootstrap? _bootstrap;
+  _LaunchAttempt? _retry;
+  int _epoch = 0;
+  bool _starting = false;
+  bool _disposed = false;
+
+  String get backgroundSummary => _backgroundSummary;
+  String? get errorMessage => _errorMessage;
+  PreparationLaunchStage? get stage => _stage;
+  PreparationPracticeBootstrap? get bootstrap => _bootstrap;
+  bool get isStarting => _starting;
+  bool get canRetry => _retry != null && !_starting;
+  bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
+
+  void updateBackgroundSummary(String value) {
+    if (_disposed || value == _backgroundSummary) {
+      return;
+    }
+    _backgroundSummary = value;
+    _invalidateAttempt();
+  }
+
+  void selectionChanged() {
+    if (_disposed) {
+      return;
+    }
+    _invalidateAttempt();
+  }
+
+  Future<bool> start(PreparationLaunchSelection selection) {
+    if (_disposed || _starting) {
+      return Future<bool>.value(false);
+    }
+    final background = _backgroundSummary.trim();
+    if (!_validBackground(background)) {
+      _errorMessage = background.isEmpty
+          ? '请先补充你的背景与本次练习目标。'
+          : '背景内容过长，请精简后再开始练习。';
+      _stage = PreparationLaunchStage.profile;
+      _retry = null;
+      notifyListeners();
+      return Future<bool>.value(false);
+    }
+    final threadId = threadIdProvider();
+    if (threadId == null || !_validResourceId(threadId)) {
+      _errorMessage = 'Agent 对话仍在恢复，请稍后再试。你的背景内容会保留在本机当前页面。';
+      _stage = PreparationLaunchStage.context;
+      _retry = null;
+      notifyListeners();
+      return Future<bool>.value(false);
+    }
+    final existing = _retry;
+    final attempt =
+        existing != null &&
+            existing.matches(
+              selection: selection,
+              backgroundSummary: background,
+              threadId: threadId,
+            )
+        ? existing
+        : _LaunchAttempt(
+            selection: selection,
+            backgroundSummary: background,
+            threadId: threadId,
+            context: null,
+            matterKey: _newId('agent-matter'),
+            profileKey: _newId('prep-profile'),
+            snapshotKey: _newId('prep-snapshot'),
+            planKey: _newId('practice-plan'),
+            sessionKey: _newId('practice-session'),
+          );
+    return _run(attempt);
+  }
+
+  Future<bool> retry() {
+    final attempt = _retry;
+    if (_disposed || _starting || attempt == null) {
+      return Future<bool>.value(false);
+    }
+    final threadId = threadIdProvider();
+    if (threadId == null || !_validResourceId(threadId)) {
+      _errorMessage = 'Agent 对话仍在恢复，请稍后再试。你的背景内容会继续保留。';
+      _stage = PreparationLaunchStage.context;
+      notifyListeners();
+      return Future<bool>.value(false);
+    }
+    if (attempt.threadId != threadId) {
+      _errorMessage = '当前 Agent 对话已变化，请重新确认后开始练习。';
+      _stage = PreparationLaunchStage.context;
+      _retry = null;
+      notifyListeners();
+      return Future<bool>.value(false);
+    }
+    return _run(attempt);
+  }
+
+  Future<bool> _run(_LaunchAttempt attempt) async {
+    final operationEpoch = _epoch;
+    _starting = true;
+    _errorMessage = null;
+    _bootstrap = null;
+    _retry = attempt;
+    notifyListeners();
+    try {
+      _requireThreadCurrent(operationEpoch, attempt.threadId);
+      _stage = PreparationLaunchStage.matter;
+      notifyListeners();
+      final activeContext = await matterActivator(
+        threadId: attempt.threadId,
+        selection: attempt.selection,
+        clientOperationId: attempt.matterKey,
+      );
+      if (!_validContext(activeContext) ||
+          activeContext.threadId != attempt.threadId) {
+        throw const PreparationLaunchException(
+          kind: PreparationLaunchFailureKind.invalidResponse,
+          stage: PreparationLaunchStage.matter,
+        );
+      }
+      final activeAttempt = attempt.withContext(activeContext);
+      _retry = activeAttempt;
+      _requireCurrent(operationEpoch, activeContext);
+
+      _stage = PreparationLaunchStage.profile;
+      notifyListeners();
+      final profile = await client.createProfile(
+        input: CreatePreparationProfileInput(
+          backgroundSummary: activeAttempt.backgroundSummary,
+        ),
+        idempotencyKey: activeAttempt.profileKey,
+      );
+      _requireCurrent(operationEpoch, activeContext);
+
+      _stage = PreparationLaunchStage.snapshot;
+      notifyListeners();
+      final snapshot = await client.createSnapshot(
+        profileId: profile.id,
+        sourceVersion: profile.version,
+        idempotencyKey: activeAttempt.snapshotKey,
+      );
+      _requireCurrent(operationEpoch, activeContext);
+
+      _stage = PreparationLaunchStage.plan;
+      notifyListeners();
+      final plan = await client.createPlan(
+        input: CreatePreparationPlanInput(
+          context: activeContext,
+          selection: activeAttempt.selection,
+          preparationProfileId: profile.id,
+          preparationUserId: profile.userId,
+        ),
+        idempotencyKey: activeAttempt.planKey,
+      );
+      _requireCurrent(operationEpoch, activeContext);
+
+      _stage = PreparationLaunchStage.session;
+      notifyListeners();
+      final bootstrap = await client.createSession(
+        planId: plan.id,
+        input: CreatePreparationSessionInput(
+          expectedPlanRevision: plan.revision,
+          preparationSnapshotId: snapshot.id,
+          preparationProfileId: profile.id,
+          preparationProfileVersion: profile.version,
+          preparationUserId: profile.userId,
+          backgroundSummary: profile.backgroundSummary,
+          selection: activeAttempt.selection,
+        ),
+        idempotencyKey: activeAttempt.sessionKey,
+      );
+      _requireCurrent(operationEpoch, activeContext);
+
+      _stage = PreparationLaunchStage.voice;
+      notifyListeners();
+      await voiceActivator(context: activeContext, bootstrap: bootstrap);
+      _requireCurrent(operationEpoch, activeContext);
+
+      _bootstrap = bootstrap;
+      _retry = null;
+      _errorMessage = null;
+      return true;
+    } on PreparationLaunchException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _stage = error.stage ?? _stage;
+        _errorMessage = _messageFor(error);
+        if (!error.retryable &&
+            error.kind != PreparationLaunchFailureKind.contextChanged) {
+          _retry = null;
+        }
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = _stage == PreparationLaunchStage.voice
+            ? '练习已创建，但语音题目暂时无法连接。请重试连接。'
+            : '暂时无法开始练习，请稍后重试。';
+      }
+      return false;
+    } finally {
+      if (_isCurrent(operationEpoch)) {
+        _starting = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> clearPrivateState() async {
+    _epoch++;
+    _backgroundSummary = '';
+    _errorMessage = null;
+    _stage = null;
+    _bootstrap = null;
+    _retry = null;
+    _starting = false;
+    await client.clearAccountState();
+    if (!_disposed) {
+      notifyListeners();
+    }
+  }
+
+  void _invalidateAttempt() {
+    _epoch++;
+    _errorMessage = null;
+    _stage = null;
+    _bootstrap = null;
+    _retry = null;
+    _starting = false;
+    notifyListeners();
+  }
+
+  void _requireCurrent(int epoch, AgentPracticeContext context) {
+    if (!_isCurrent(epoch)) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.superseded,
+      );
+    }
+    if (contextProvider() != context) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.contextChanged,
+        stage: PreparationLaunchStage.context,
+        retryable: true,
+      );
+    }
+  }
+
+  void _requireThreadCurrent(int epoch, String threadId) {
+    if (!_isCurrent(epoch)) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.superseded,
+      );
+    }
+    if (threadIdProvider() != threadId) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.contextChanged,
+        stage: PreparationLaunchStage.context,
+        retryable: true,
+      );
+    }
+  }
+
+  bool _isCurrent(int epoch) => !_disposed && epoch == _epoch;
+
+  String _newId(String scope) {
+    final value = _idFactory(scope);
+    if (value.length < 8 || value.length > 128 || value.trim() != value) {
+      throw StateError('Invalid launch idempotency identity.');
+    }
+    return value;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _epoch++;
+    super.dispose();
+  }
+}
+
+final class _LaunchAttempt {
+  const _LaunchAttempt({
+    required this.selection,
+    required this.backgroundSummary,
+    required this.threadId,
+    required this.context,
+    required this.matterKey,
+    required this.profileKey,
+    required this.snapshotKey,
+    required this.planKey,
+    required this.sessionKey,
+  });
+
+  final PreparationLaunchSelection selection;
+  final String backgroundSummary;
+  final String threadId;
+  final AgentPracticeContext? context;
+  final String matterKey;
+  final String profileKey;
+  final String snapshotKey;
+  final String planKey;
+  final String sessionKey;
+
+  bool matches({
+    required PreparationLaunchSelection selection,
+    required String backgroundSummary,
+    required String threadId,
+  }) =>
+      this.selection == selection &&
+      this.backgroundSummary == backgroundSummary &&
+      this.threadId == threadId;
+
+  _LaunchAttempt withContext(AgentPracticeContext value) {
+    return _LaunchAttempt(
+      selection: selection,
+      backgroundSummary: backgroundSummary,
+      threadId: threadId,
+      context: value,
+      matterKey: matterKey,
+      profileKey: profileKey,
+      snapshotKey: snapshotKey,
+      planKey: planKey,
+      sessionKey: sessionKey,
+    );
+  }
+}
+
+bool _validContext(AgentPracticeContext? context) =>
+    context != null &&
+    _validResourceId(context.threadId) &&
+    _validResourceId(context.matterId);
+
+bool _validResourceId(String value) =>
+    value.isNotEmpty &&
+    value.length <= 128 &&
+    value.trim() == value &&
+    !value.contains('\u0000');
+
+bool _validBackground(String value) =>
+    value.isNotEmpty &&
+    value.trim() == value &&
+    !value.contains('\u0000') &&
+    utf8.encode(value).length <= 64 * 1024;
+
+String _messageFor(PreparationLaunchException error) {
+  return switch (error.kind) {
+    PreparationLaunchFailureKind.contextMissing => 'Agent 对话仍在恢复，请稍后在当前页面重试。',
+    PreparationLaunchFailureKind.contextChanged => '当前 Agent 事项已变化，请重新确认后重试。',
+    PreparationLaunchFailureKind.authenticationRequired => '登录状态已失效，请重新登录后继续。',
+    PreparationLaunchFailureKind.invalidRequest =>
+      '当前练习配置无法提交，请重新确认背景、视角和练习方式。',
+    PreparationLaunchFailureKind.notFound => '练习所需的目录或 Agent 事项已变化，请返回场景页重新选择。',
+    PreparationLaunchFailureKind.conflict =>
+      '当前 Agent 对话已有练习，或配置版本已变化，请先处理现有练习后重试。',
+    PreparationLaunchFailureKind.network => '网络连接不稳定，本次进度已保留，可以重试。',
+    PreparationLaunchFailureKind.server =>
+      error.stage == PreparationLaunchStage.voice
+          ? '练习已创建，但语音题目暂时无法连接。请重试连接。'
+          : '练习服务暂时不可用，本次进度已保留，可以重试。',
+    PreparationLaunchFailureKind.invalidResponse => '练习服务返回了无法识别的数据，请稍后重试。',
+    PreparationLaunchFailureKind.superseded => '',
+  };
+}
+
+final Random _launchRandom = Random.secure();
+
+String _secureLaunchId(String scope) {
+  final value = StringBuffer('${scope}_');
+  for (var index = 0; index < 16; index++) {
+    value.write(_launchRandom.nextInt(256).toRadixString(16).padLeft(2, '0'));
+  }
+  return value.toString();
+}

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -46,6 +46,7 @@ final class PreparationLaunchController extends ChangeNotifier {
   _LaunchAttempt? _retry;
   int _epoch = 0;
   bool _starting = false;
+  bool _commitMayHaveSucceeded = false;
   bool _disposed = false;
 
   String get backgroundSummary => _backgroundSummary;
@@ -53,11 +54,14 @@ final class PreparationLaunchController extends ChangeNotifier {
   PreparationLaunchStage? get stage => _stage;
   PreparationPracticeBootstrap? get bootstrap => _bootstrap;
   bool get isStarting => _starting;
+  bool get isSelectionLocked =>
+      _starting ||
+      (_retry != null && (_bootstrap != null || _commitMayHaveSucceeded));
   bool get canRetry => _retry != null && !_starting;
   bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
 
   void updateBackgroundSummary(String value) {
-    if (_disposed || _starting || value == _backgroundSummary) {
+    if (_disposed || isSelectionLocked || value == _backgroundSummary) {
       return;
     }
     _backgroundSummary = value;
@@ -65,7 +69,7 @@ final class PreparationLaunchController extends ChangeNotifier {
   }
 
   void selectionChanged() {
-    if (_disposed || _starting) {
+    if (_disposed || isSelectionLocked) {
       return;
     }
     _invalidateAttempt();
@@ -81,7 +85,9 @@ final class PreparationLaunchController extends ChangeNotifier {
           ? '请先补充你的背景与本次练习目标。'
           : '背景内容过长，请精简后再开始练习。';
       _stage = PreparationLaunchStage.profile;
-      _retry = null;
+      if (!_hasCommittedOrAmbiguousCreate) {
+        _retry = null;
+      }
       notifyListeners();
       return Future<bool>.value(false);
     }
@@ -89,11 +95,25 @@ final class PreparationLaunchController extends ChangeNotifier {
     if (threadId == null || !_validResourceId(threadId)) {
       _errorMessage = 'Agent 对话仍在恢复，请稍后再试。你的背景内容会保留在本机当前页面。';
       _stage = PreparationLaunchStage.context;
-      _retry = null;
+      if (!_hasCommittedOrAmbiguousCreate) {
+        _retry = null;
+      }
       notifyListeners();
       return Future<bool>.value(false);
     }
     final existing = _retry;
+    if (isSelectionLocked &&
+        (existing == null ||
+            !existing.matches(
+              selection: selection,
+              backgroundSummary: background,
+              threadId: threadId,
+            ))) {
+      _errorMessage = '练习已经创建，请先重试连接原练习。';
+      _stage = PreparationLaunchStage.voice;
+      notifyListeners();
+      return Future<bool>.value(false);
+    }
     final attempt =
         existing != null &&
             existing.matches(
@@ -132,7 +152,9 @@ final class PreparationLaunchController extends ChangeNotifier {
     if (attempt.threadId != threadId) {
       _errorMessage = '当前 Agent 对话已变化，请重新确认后开始练习。';
       _stage = PreparationLaunchStage.context;
-      _retry = null;
+      if (!_hasCommittedOrAmbiguousCreate) {
+        _retry = null;
+      }
       notifyListeners();
       return Future<bool>.value(false);
     }
@@ -141,9 +163,14 @@ final class PreparationLaunchController extends ChangeNotifier {
 
   Future<bool> _run(_LaunchAttempt attempt) async {
     final operationEpoch = _epoch;
+    final preserveCommittedState =
+        identical(_retry, attempt) && _hasCommittedOrAmbiguousCreate;
     _starting = true;
     _errorMessage = null;
-    _bootstrap = null;
+    if (!preserveCommittedState) {
+      _bootstrap = null;
+      _commitMayHaveSucceeded = false;
+    }
     _retry = attempt;
     notifyListeners();
     try {
@@ -226,14 +253,20 @@ final class PreparationLaunchController extends ChangeNotifier {
       _requireCurrent(operationEpoch, activeContext);
 
       _retry = null;
+      _commitMayHaveSucceeded = false;
       _errorMessage = null;
       return true;
     } on PreparationLaunchException catch (error) {
       if (_isCurrent(operationEpoch)) {
         _stage = error.stage ?? _stage;
         _errorMessage = _messageFor(error);
+        if (error.kind == PreparationLaunchFailureKind.invalidResponse &&
+            error.statusCode == 201) {
+          _commitMayHaveSucceeded = true;
+        }
         if (!error.retryable &&
-            error.kind != PreparationLaunchFailureKind.contextChanged) {
+            error.kind != PreparationLaunchFailureKind.contextChanged &&
+            !_hasCommittedOrAmbiguousCreate) {
           _retry = null;
         }
       }
@@ -260,6 +293,7 @@ final class PreparationLaunchController extends ChangeNotifier {
     _stage = null;
     _bootstrap = null;
     _retry = null;
+    _commitMayHaveSucceeded = false;
     _starting = false;
     await client.clearAccountState();
     if (!_disposed) {
@@ -273,6 +307,7 @@ final class PreparationLaunchController extends ChangeNotifier {
     _stage = null;
     _bootstrap = null;
     _retry = null;
+    _commitMayHaveSucceeded = false;
     _starting = false;
     notifyListeners();
   }
@@ -308,6 +343,9 @@ final class PreparationLaunchController extends ChangeNotifier {
   }
 
   bool _isCurrent(int epoch) => !_disposed && epoch == _epoch;
+
+  bool get _hasCommittedOrAmbiguousCreate =>
+      _bootstrap != null || _commitMayHaveSucceeded;
 
   String _newId(String scope) {
     final value = _idFactory(scope);

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -57,7 +57,7 @@ final class PreparationLaunchController extends ChangeNotifier {
   bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
 
   void updateBackgroundSummary(String value) {
-    if (_disposed || value == _backgroundSummary) {
+    if (_disposed || _starting || value == _backgroundSummary) {
       return;
     }
     _backgroundSummary = value;
@@ -65,7 +65,7 @@ final class PreparationLaunchController extends ChangeNotifier {
   }
 
   void selectionChanged() {
-    if (_disposed) {
+    if (_disposed || _starting) {
       return;
     }
     _invalidateAttempt();
@@ -214,6 +214,7 @@ final class PreparationLaunchController extends ChangeNotifier {
         idempotencyKey: activeAttempt.sessionKey,
       );
       _requireCurrent(operationEpoch, activeContext);
+      _bootstrap = bootstrap;
 
       _stage = PreparationLaunchStage.voice;
       notifyListeners();
@@ -224,7 +225,6 @@ final class PreparationLaunchController extends ChangeNotifier {
       );
       _requireCurrent(operationEpoch, activeContext);
 
-      _bootstrap = bootstrap;
       _retry = null;
       _errorMessage = null;
       return true;

--- a/mobile/lib/features/preparation/preparation_launch_models.dart
+++ b/mobile/lib/features/preparation/preparation_launch_models.dart
@@ -1,0 +1,278 @@
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+final class AgentPracticeContext {
+  const AgentPracticeContext({required this.threadId, required this.matterId});
+
+  final String threadId;
+  final String matterId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AgentPracticeContext &&
+      other.threadId == threadId &&
+      other.matterId == matterId;
+
+  @override
+  int get hashCode => Object.hash(threadId, matterId);
+}
+
+final class PreparationLaunchSelection {
+  const PreparationLaunchSelection({
+    required this.scenarioDefinitionId,
+    required this.scenarioDefinitionVersion,
+    required this.scenarioType,
+    required this.scenarioDisplayName,
+    required this.scenarioDescription,
+    required this.scenarioConfigId,
+    required this.scenarioConfigVersion,
+    required this.roleDefinitionId,
+    required this.roleDefinitionVersion,
+    required this.practiceOptionId,
+    required this.practiceOptionType,
+    required this.practiceOptionVersion,
+  });
+
+  factory PreparationLaunchSelection.fromCatalog({
+    required PreparationScenario scenario,
+    required PreparationScenarioConfig config,
+    required PreparationRole role,
+    required PreparationOption option,
+  }) {
+    return PreparationLaunchSelection(
+      scenarioDefinitionId: scenario.id,
+      scenarioDefinitionVersion: scenario.version,
+      scenarioType: scenario.type,
+      scenarioDisplayName: scenario.name,
+      scenarioDescription: '${config.jobTitle}: ${config.jobDescription}',
+      scenarioConfigId: config.id,
+      scenarioConfigVersion: config.version,
+      roleDefinitionId: role.id,
+      roleDefinitionVersion: role.version,
+      practiceOptionId: option.id,
+      practiceOptionType: option.type,
+      practiceOptionVersion: option.version,
+    );
+  }
+
+  final String scenarioDefinitionId;
+  final int scenarioDefinitionVersion;
+  final String scenarioType;
+  final String scenarioDisplayName;
+  final String scenarioDescription;
+  final String scenarioConfigId;
+  final int scenarioConfigVersion;
+  final String roleDefinitionId;
+  final int roleDefinitionVersion;
+  final String practiceOptionId;
+  final PreparationOptionType practiceOptionType;
+  final int practiceOptionVersion;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PreparationLaunchSelection &&
+      other.scenarioDefinitionId == scenarioDefinitionId &&
+      other.scenarioDefinitionVersion == scenarioDefinitionVersion &&
+      other.scenarioType == scenarioType &&
+      other.scenarioDisplayName == scenarioDisplayName &&
+      other.scenarioDescription == scenarioDescription &&
+      other.scenarioConfigId == scenarioConfigId &&
+      other.scenarioConfigVersion == scenarioConfigVersion &&
+      other.roleDefinitionId == roleDefinitionId &&
+      other.roleDefinitionVersion == roleDefinitionVersion &&
+      other.practiceOptionId == practiceOptionId &&
+      other.practiceOptionType == practiceOptionType &&
+      other.practiceOptionVersion == practiceOptionVersion;
+
+  @override
+  int get hashCode => Object.hash(
+    scenarioDefinitionId,
+    scenarioDefinitionVersion,
+    scenarioType,
+    scenarioDisplayName,
+    scenarioDescription,
+    scenarioConfigId,
+    scenarioConfigVersion,
+    roleDefinitionId,
+    roleDefinitionVersion,
+    practiceOptionId,
+    practiceOptionType,
+    practiceOptionVersion,
+  );
+}
+
+final class PreparationProfile {
+  const PreparationProfile({
+    required this.id,
+    required this.userId,
+    required this.backgroundSummary,
+    required this.version,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final String backgroundSummary;
+  final int version;
+  final DateTime updatedAt;
+}
+
+final class PreparationSnapshot {
+  const PreparationSnapshot({
+    required this.id,
+    required this.sourceProfileId,
+    required this.sourceVersion,
+    required this.backgroundSnapshot,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String sourceProfileId;
+  final int sourceVersion;
+  final String backgroundSnapshot;
+  final DateTime createdAt;
+}
+
+final class PreparationPracticePlan {
+  const PreparationPracticePlan({
+    required this.id,
+    required this.userId,
+    required this.context,
+    required this.selection,
+    required this.preparationProfileId,
+    required this.revision,
+    required this.status,
+  });
+
+  final String id;
+  final String userId;
+  final AgentPracticeContext context;
+  final PreparationLaunchSelection selection;
+  final String preparationProfileId;
+  final int revision;
+  final String status;
+}
+
+final class PreparationPracticeSession {
+  const PreparationPracticeSession({
+    required this.id,
+    required this.planId,
+    required this.scenarioType,
+    required this.snapshotId,
+    required this.status,
+    required this.version,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String planId;
+  final String scenarioType;
+  final String snapshotId;
+  final String status;
+  final int version;
+  final DateTime createdAt;
+}
+
+final class PreparationPracticeBootstrap {
+  const PreparationPracticeBootstrap({
+    required this.session,
+    required this.preparationSnapshotId,
+    required this.maxEffectiveTurns,
+  });
+
+  final PreparationPracticeSession session;
+  final String preparationSnapshotId;
+  final int maxEffectiveTurns;
+}
+
+final class CreatePreparationProfileInput {
+  const CreatePreparationProfileInput({required this.backgroundSummary});
+
+  final String backgroundSummary;
+}
+
+final class CreatePreparationPlanInput {
+  const CreatePreparationPlanInput({
+    required this.context,
+    required this.selection,
+    required this.preparationProfileId,
+    required this.preparationUserId,
+  });
+
+  final AgentPracticeContext context;
+  final PreparationLaunchSelection selection;
+  final String preparationProfileId;
+  final String preparationUserId;
+}
+
+final class CreatePreparationSessionInput {
+  const CreatePreparationSessionInput({
+    required this.expectedPlanRevision,
+    required this.preparationSnapshotId,
+    required this.preparationProfileId,
+    required this.preparationProfileVersion,
+    required this.preparationUserId,
+    required this.backgroundSummary,
+    required this.selection,
+  });
+
+  final int expectedPlanRevision;
+  final String preparationSnapshotId;
+  final String preparationProfileId;
+  final int preparationProfileVersion;
+  final String preparationUserId;
+  final String backgroundSummary;
+  final PreparationLaunchSelection selection;
+}
+
+enum PreparationLaunchStage {
+  context,
+  matter,
+  profile,
+  snapshot,
+  plan,
+  session,
+  voice,
+}
+
+enum PreparationLaunchFailureKind {
+  contextMissing,
+  contextChanged,
+  authenticationRequired,
+  invalidRequest,
+  notFound,
+  conflict,
+  network,
+  server,
+  invalidResponse,
+  superseded,
+}
+
+final class PreparationLaunchException implements Exception {
+  const PreparationLaunchException({
+    required this.kind,
+    this.stage,
+    this.statusCode,
+    this.errorCode,
+    this.retryable = false,
+  });
+
+  final PreparationLaunchFailureKind kind;
+  final PreparationLaunchStage? stage;
+  final int? statusCode;
+  final String? errorCode;
+  final bool retryable;
+
+  PreparationLaunchException at(PreparationLaunchStage value) {
+    return PreparationLaunchException(
+      kind: kind,
+      stage: value,
+      statusCode: statusCode,
+      errorCode: errorCode,
+      retryable: retryable,
+    );
+  }
+
+  @override
+  String toString() =>
+      'PreparationLaunchException(kind: ${kind.name}, stage: ${stage?.name})';
+}

--- a/mobile/lib/features/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_launch_client.dart
@@ -58,7 +58,11 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       body: <String, Object?>{'background_summary': input.backgroundSummary},
       stage: PreparationLaunchStage.profile,
     );
-    return _profile(response.body, expectedBackground: input.backgroundSummary);
+    return _decodeCreated(
+      stage: PreparationLaunchStage.profile,
+      decode: () =>
+          _profile(response.body, expectedBackground: input.backgroundSummary),
+    );
   }
 
   @override
@@ -82,10 +86,13 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       body: <String, Object?>{'source_version': sourceVersion},
       stage: PreparationLaunchStage.snapshot,
     );
-    return _snapshot(
-      _decode(response.body),
-      expectedProfileId: profileId,
-      expectedSourceVersion: sourceVersion,
+    return _decodeCreated(
+      stage: PreparationLaunchStage.snapshot,
+      decode: () => _snapshot(
+        _decode(response.body),
+        expectedProfileId: profileId,
+        expectedSourceVersion: sourceVersion,
+      ),
     );
   }
 
@@ -114,7 +121,10 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       },
       stage: PreparationLaunchStage.plan,
     );
-    return _plan(_decode(response.body), expected: input);
+    return _decodeCreated(
+      stage: PreparationLaunchStage.plan,
+      decode: () => _plan(_decode(response.body), expected: input),
+    );
   }
 
   @override
@@ -148,10 +158,13 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       },
       stage: PreparationLaunchStage.session,
     );
-    return _bootstrap(
-      _decode(response.body),
-      expectedPlanId: planId,
-      expected: input,
+    return _decodeCreated(
+      stage: PreparationLaunchStage.session,
+      decode: () => _bootstrap(
+        _decode(response.body),
+        expectedPlanId: planId,
+        expected: input,
+      ),
     );
   }
 
@@ -227,6 +240,8 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
         throw PreparationLaunchException(
           kind: PreparationLaunchFailureKind.invalidResponse,
           stage: stage,
+          statusCode: HttpStatus.created,
+          retryable: true,
         );
       }
       return response;
@@ -277,6 +292,25 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
   @override
   Future<void> clearAccountState() async {
     _accountGeneration++;
+  }
+}
+
+T _decodeCreated<T>({
+  required PreparationLaunchStage stage,
+  required T Function() decode,
+}) {
+  try {
+    return decode();
+  } on PreparationLaunchException catch (error) {
+    if (error.kind != PreparationLaunchFailureKind.invalidResponse) {
+      rethrow;
+    }
+    throw PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidResponse,
+      stage: stage,
+      statusCode: HttpStatus.created,
+      retryable: true,
+    );
   }
 }
 

--- a/mobile/lib/features/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_launch_client.dart
@@ -1,0 +1,950 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:speakup/features/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+final class WirePreparationLaunchClient implements PreparationLaunchClient {
+  factory WirePreparationLaunchClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    IdentityHttpTransport? transport,
+    Duration requestTimeout = const Duration(seconds: 20),
+  }) {
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'requestTimeout');
+    }
+    return WirePreparationLaunchClient._(
+      baseUri,
+      SessionAuthenticatedHttpTransport(
+        transport: transport ?? IoIdentityHttpTransport(),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: baseUri,
+      ),
+      requestTimeout,
+    );
+  }
+
+  WirePreparationLaunchClient._(
+    this._baseUri,
+    this._transport,
+    this._requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  static const _maximumBodyBytes = 1024 * 1024;
+
+  final Uri _baseUri;
+  final IdentityHttpTransport _transport;
+  final Duration _requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  int _accountGeneration = 0;
+
+  @override
+  Future<PreparationProfile> createProfile({
+    required CreatePreparationProfileInput input,
+    required String idempotencyKey,
+  }) async {
+    _requireBackground(input.backgroundSummary);
+    final response = await _post(
+      path: '/v1/preparation-profiles',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'background_summary': input.backgroundSummary},
+      stage: PreparationLaunchStage.profile,
+    );
+    return _profile(response.body, expectedBackground: input.backgroundSummary);
+  }
+
+  @override
+  Future<PreparationSnapshot> createSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(profileId);
+    if (sourceVersion < 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.invalidRequest,
+        stage: PreparationLaunchStage.snapshot,
+      );
+    }
+    final response = await _post(
+      path:
+          '/v1/preparation-profiles/${Uri.encodeComponent(profileId)}'
+          '/snapshots',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'source_version': sourceVersion},
+      stage: PreparationLaunchStage.snapshot,
+    );
+    return _snapshot(
+      _decode(response.body),
+      expectedProfileId: profileId,
+      expectedSourceVersion: sourceVersion,
+    );
+  }
+
+  @override
+  Future<PreparationPracticePlan> createPlan({
+    required CreatePreparationPlanInput input,
+    required String idempotencyKey,
+  }) async {
+    _requireContext(input.context);
+    _requireSelection(input.selection);
+    _requireResourceId(input.preparationProfileId);
+    _requireResourceId(input.preparationUserId);
+    final response = await _post(
+      path: '/v1/practice-plans',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'agent_thread_id': input.context.threadId,
+        'matter_id': input.context.matterId,
+        'scenario_definition_id': input.selection.scenarioDefinitionId,
+        'scenario_definition_version':
+            input.selection.scenarioDefinitionVersion,
+        'scenario_config_id': input.selection.scenarioConfigId,
+        'scenario_config_version': input.selection.scenarioConfigVersion,
+        'preparation_profile_id': input.preparationProfileId,
+        'selected_role_ids': <String>[input.selection.roleDefinitionId],
+      },
+      stage: PreparationLaunchStage.plan,
+    );
+    return _plan(_decode(response.body), expected: input);
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createSession({
+    required String planId,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(planId);
+    _requireSelection(input.selection);
+    _requireResourceId(input.preparationSnapshotId);
+    _requireResourceId(input.preparationProfileId);
+    _requireResourceId(input.preparationUserId);
+    _requireBackground(input.backgroundSummary);
+    if (input.expectedPlanRevision < 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.invalidRequest,
+        stage: PreparationLaunchStage.session,
+      );
+    }
+    final response = await _post(
+      path:
+          '/v1/practice-plans/${Uri.encodeComponent(planId)}'
+          '/practice-sessions',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'expected_plan_revision': input.expectedPlanRevision,
+        'preparation_snapshot_id': input.preparationSnapshotId,
+        'practice_option_id': input.selection.practiceOptionId,
+        'role_definition_ids': <String>[input.selection.roleDefinitionId],
+      },
+      stage: PreparationLaunchStage.session,
+    );
+    return _bootstrap(
+      _decode(response.body),
+      expectedPlanId: planId,
+      expected: input,
+    );
+  }
+
+  Future<IdentityHttpResponse> _post({
+    required String path,
+    required String idempotencyKey,
+    required Map<String, Object?> body,
+    required PreparationLaunchStage stage,
+  }) async {
+    _requireIdempotencyKey(idempotencyKey);
+    final generation = _accountGeneration;
+    final uri = _baseUri.resolve(path);
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(uri);
+    late final IdentityHttpResponse response;
+    try {
+      response = await _transport
+          .send(
+            method: 'POST',
+            uri: uri,
+            headers: <String, String>{
+              HttpHeaders.acceptHeader: ContentType.json.mimeType,
+              HttpHeaders.contentTypeHeader: ContentType.json.mimeType,
+              'Idempotency-Key': idempotencyKey,
+            },
+            body: jsonEncode(body),
+          )
+          .timeout(_requestTimeout);
+    } on AuthSessionSupersededException {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.superseded,
+        stage: stage,
+      );
+    } on StateError {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.authenticationRequired,
+        stage: stage,
+        statusCode: HttpStatus.unauthorized,
+      );
+    } on TimeoutException {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on SocketException {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on HttpException {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on IOException {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    }
+    if (generation != _accountGeneration) {
+      throw PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.superseded,
+        stage: stage,
+      );
+    }
+    if (response.statusCode == HttpStatus.created) {
+      if (utf8.encode(response.body).length > _maximumBodyBytes) {
+        throw PreparationLaunchException(
+          kind: PreparationLaunchFailureKind.invalidResponse,
+          stage: stage,
+        );
+      }
+      return response;
+    }
+    final errorCode = _errorCode(response.body);
+    final exception = switch (response.statusCode) {
+      HttpStatus.badRequest => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.invalidRequest,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.unauthorized => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.authenticationRequired,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.notFound => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.notFound,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.conflict => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.conflict,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      _ when response.statusCode >= 500 => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.server,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+        retryable: true,
+      ),
+      _ => PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.invalidResponse,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+    };
+    throw exception;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+}
+
+PreparationProfile _profile(String body, {required String expectedBackground}) {
+  final object = _object(
+    _decode(body),
+    required: const <String>{
+      'preparation_profile_id',
+      'user_id',
+      'background_summary',
+      'version',
+      'updated_at',
+    },
+    optional: const <String>{'resume_ref', 'job_description_ref'},
+  );
+  if (object['resume_ref'] != null || object['job_description_ref'] != null) {
+    throw _invalidResponse();
+  }
+  final background = _text(object['background_summary'], maxBytes: 64 * 1024);
+  if (background != expectedBackground) {
+    throw _invalidResponse();
+  }
+  return PreparationProfile(
+    id: _resourceId(object['preparation_profile_id']),
+    userId: _resourceId(object['user_id']),
+    backgroundSummary: background,
+    version: _version(object['version']),
+    updatedAt: _dateTime(object['updated_at']),
+  );
+}
+
+PreparationSnapshot _snapshot(
+  Object? value, {
+  required String expectedProfileId,
+  required int expectedSourceVersion,
+}) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'preparation_snapshot_id',
+      'source_profile_id',
+      'source_version',
+      'background_snapshot',
+      'created_at',
+    },
+    optional: const <String>{'resume_snapshot', 'job_description_snapshot'},
+  );
+  final profileId = _resourceId(object['source_profile_id']);
+  final version = _version(object['source_version']);
+  if (profileId != expectedProfileId ||
+      version != expectedSourceVersion ||
+      object['resume_snapshot'] != null ||
+      object['job_description_snapshot'] != null) {
+    throw _invalidResponse();
+  }
+  return PreparationSnapshot(
+    id: _resourceId(object['preparation_snapshot_id']),
+    sourceProfileId: profileId,
+    sourceVersion: version,
+    backgroundSnapshot: _text(
+      object['background_snapshot'],
+      maxBytes: 64 * 1024,
+    ),
+    createdAt: _dateTime(object['created_at']),
+  );
+}
+
+PreparationPracticePlan _plan(
+  Object? value, {
+  required CreatePreparationPlanInput expected,
+}) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'practice_plan_id',
+      'user_id',
+      'agent_thread_id',
+      'matter_id',
+      'scenario_definition_id',
+      'scenario_definition_version',
+      'scenario_type',
+      'scenario_config_id',
+      'scenario_config_version',
+      'preparation_profile_id',
+      'selected_role_ids',
+      'plan_revision',
+      'practice_plan_status',
+      'created_at',
+      'updated_at',
+    },
+  );
+  final context = AgentPracticeContext(
+    threadId: _resourceId(object['agent_thread_id']),
+    matterId: _resourceId(object['matter_id']),
+  );
+  final roles = _resourceIdList(object['selected_role_ids'], min: 1, max: 4);
+  final status = _enumText(object['practice_plan_status'], const {'ready'});
+  if (context != expected.context ||
+      _resourceId(object['user_id']) != expected.preparationUserId ||
+      _resourceId(object['scenario_definition_id']) !=
+          expected.selection.scenarioDefinitionId ||
+      _version(object['scenario_definition_version']) !=
+          expected.selection.scenarioDefinitionVersion ||
+      _enumText(object['scenario_type'], const {'INTERVIEW'}) !=
+          expected.selection.scenarioType ||
+      _resourceId(object['scenario_config_id']) !=
+          expected.selection.scenarioConfigId ||
+      _version(object['scenario_config_version']) !=
+          expected.selection.scenarioConfigVersion ||
+      _resourceId(object['preparation_profile_id']) !=
+          expected.preparationProfileId ||
+      roles.length != 1 ||
+      roles.single != expected.selection.roleDefinitionId) {
+    throw _invalidResponse();
+  }
+  _dateTime(object['created_at']);
+  _dateTime(object['updated_at']);
+  return PreparationPracticePlan(
+    id: _resourceId(object['practice_plan_id']),
+    userId: _resourceId(object['user_id']),
+    context: context,
+    selection: expected.selection,
+    preparationProfileId: expected.preparationProfileId,
+    revision: _version(object['plan_revision']),
+    status: status,
+  );
+}
+
+PreparationPracticeBootstrap _bootstrap(
+  Object? value, {
+  required String expectedPlanId,
+  required CreatePreparationSessionInput expected,
+}) {
+  final root = _object(
+    value,
+    required: const <String>{'practice_session', 'snapshot'},
+  );
+  final sessionObject = _object(
+    root['practice_session'],
+    required: const <String>{
+      'practice_session_id',
+      'practice_plan_id',
+      'scenario_type',
+      'snapshot_id',
+      'practice_session_status',
+      'session_version',
+      'created_at',
+    },
+    optional: const <String>{'started_at', 'ended_at', 'end_reason'},
+  );
+  final sessionId = _resourceId(sessionObject['practice_session_id']);
+  final snapshotId = _resourceId(sessionObject['snapshot_id']);
+  final status = _enumText(sessionObject['practice_session_status'], const {
+    'starting',
+  });
+  final scenarioType = _enumText(sessionObject['scenario_type'], const {
+    'INTERVIEW',
+  });
+  if (_resourceId(sessionObject['practice_plan_id']) != expectedPlanId ||
+      scenarioType != expected.selection.scenarioType ||
+      sessionObject['started_at'] != null ||
+      sessionObject['ended_at'] != null ||
+      sessionObject['end_reason'] != null) {
+    throw _invalidResponse();
+  }
+  final snapshotObject = _object(
+    root['snapshot'],
+    required: const <String>{
+      'snapshot_id',
+      'practice_session_id',
+      'plan_revision',
+      'scenario_type',
+      'scenario_definition_snapshot',
+      'scenario_config_snapshot',
+      'preparation_snapshot',
+      'participants',
+      'practice_option',
+      'session_policy',
+      'practice_focuses',
+      'created_at',
+    },
+  );
+  if (_resourceId(snapshotObject['snapshot_id']) != snapshotId ||
+      _resourceId(snapshotObject['practice_session_id']) != sessionId ||
+      _version(snapshotObject['plan_revision']) !=
+          expected.expectedPlanRevision ||
+      _enumText(snapshotObject['scenario_type'], const {'INTERVIEW'}) !=
+          expected.selection.scenarioType) {
+    throw _invalidResponse();
+  }
+  _validateScenarioSnapshot(
+    snapshotObject['scenario_definition_snapshot'],
+    expected.selection,
+  );
+  _validateConfigSnapshot(
+    snapshotObject['scenario_config_snapshot'],
+    expected.selection,
+  );
+  final preparation = _snapshot(
+    snapshotObject['preparation_snapshot'],
+    expectedProfileId: expected.preparationProfileId,
+    expectedSourceVersion: expected.preparationProfileVersion,
+  );
+  if (preparation.id != expected.preparationSnapshotId ||
+      preparation.backgroundSnapshot != expected.backgroundSummary) {
+    throw _invalidResponse();
+  }
+  _validateParticipants(
+    snapshotObject['participants'],
+    sessionId: sessionId,
+    roleId: expected.selection.roleDefinitionId,
+    roleVersion: expected.selection.roleDefinitionVersion,
+    scenarioId: expected.selection.scenarioDefinitionId,
+    candidateUserId: expected.preparationUserId,
+  );
+  _validatePracticeOption(
+    snapshotObject['practice_option'],
+    expected.selection,
+  );
+  final maxEffectiveTurns = _validateSessionPolicy(
+    snapshotObject['session_policy'],
+    optionType: expected.selection.practiceOptionType,
+  );
+  _validateObjectives(snapshotObject['practice_focuses'], allowEmpty: true);
+  _dateTime(snapshotObject['created_at']);
+  return PreparationPracticeBootstrap(
+    session: PreparationPracticeSession(
+      id: sessionId,
+      planId: expectedPlanId,
+      scenarioType: scenarioType,
+      snapshotId: snapshotId,
+      status: status,
+      version: _version(sessionObject['session_version']),
+      createdAt: _dateTime(sessionObject['created_at']),
+    ),
+    preparationSnapshotId: preparation.id,
+    maxEffectiveTurns: maxEffectiveTurns,
+  );
+}
+
+void _validateScenarioSnapshot(
+  Object? value,
+  PreparationLaunchSelection expected,
+) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'scenario_definition_id',
+      'scenario_type',
+      'name',
+      'version',
+      'status',
+    },
+  );
+  if (_resourceId(object['scenario_definition_id']) !=
+          expected.scenarioDefinitionId ||
+      _enumText(object['scenario_type'], const {'INTERVIEW'}) !=
+          expected.scenarioType ||
+      _version(object['version']) != expected.scenarioDefinitionVersion ||
+      _enumText(object['status'], const {'active'}) != 'active') {
+    throw _invalidResponse();
+  }
+  _text(object['name']);
+}
+
+void _validateConfigSnapshot(
+  Object? value,
+  PreparationLaunchSelection expected,
+) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'scenario_config_id',
+      'scenario_definition_id',
+      'config_type',
+      'version',
+      'job_title',
+      'job_description',
+      'focus_areas',
+    },
+  );
+  if (_resourceId(object['scenario_config_id']) != expected.scenarioConfigId ||
+      _resourceId(object['scenario_definition_id']) !=
+          expected.scenarioDefinitionId ||
+      _enumText(object['config_type'], const {'INTERVIEW'}) !=
+          expected.scenarioType ||
+      _version(object['version']) != expected.scenarioConfigVersion) {
+    throw _invalidResponse();
+  }
+  _text(object['job_title']);
+  _text(object['job_description']);
+  _nonEmptyTextList(object['focus_areas']);
+}
+
+void _validateParticipants(
+  Object? value, {
+  required String sessionId,
+  required String roleId,
+  required int roleVersion,
+  required String scenarioId,
+  required String candidateUserId,
+}) {
+  if (value is! List<Object?> || value.length < 2 || value.length > 16) {
+    throw _invalidResponse();
+  }
+  var selectedRoleCount = 0;
+  var candidateCount = 0;
+  final participantIds = <String>{};
+  final orders = <int>{};
+  for (final raw in value) {
+    final object = _object(
+      raw,
+      required: const <String>{
+        'practice_participant_id',
+        'practice_session_id',
+        'participant_role',
+        'subject_ref',
+        'participant_order',
+      },
+      optional: const <String>{'role_definition_id', 'role_snapshot'},
+    );
+    if (_resourceId(object['practice_session_id']) != sessionId ||
+        !participantIds.add(_resourceId(object['practice_participant_id']))) {
+      throw _invalidResponse();
+    }
+    final order = _version(object['participant_order']);
+    if (!orders.add(order)) {
+      throw _invalidResponse();
+    }
+    final role = _enumText(object['participant_role'], const {
+      'INTERVIEWER',
+      'CANDIDATE',
+    });
+    final subject = _object(
+      object['subject_ref'],
+      required: const <String>{'namespace', 'subject_id'},
+    );
+    final subjectNamespace = _text(subject['namespace']);
+    final subjectId = _resourceId(subject['subject_id']);
+    if (role == 'CANDIDATE') {
+      candidateCount++;
+      if (object['role_definition_id'] != null ||
+          object['role_snapshot'] != null ||
+          subjectNamespace != 'speakup.user' ||
+          subjectId != candidateUserId) {
+        throw _invalidResponse();
+      }
+    } else {
+      if (_resourceId(object['role_definition_id']) != roleId) {
+        throw _invalidResponse();
+      }
+      _validateRoleSnapshot(
+        object['role_snapshot'],
+        roleId: roleId,
+        roleVersion: roleVersion,
+        scenarioId: scenarioId,
+      );
+      selectedRoleCount++;
+    }
+  }
+  if (candidateCount != 1 || selectedRoleCount != 1) {
+    throw _invalidResponse();
+  }
+}
+
+void _validateRoleSnapshot(
+  Object? value, {
+  required String roleId,
+  required int roleVersion,
+  required String scenarioId,
+}) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'role_definition_id',
+      'scenario_definition_id',
+      'role_type',
+      'display_name',
+      'responsibilities',
+      'style',
+      'focus_areas',
+      'version',
+    },
+    optional: const <String>{'voice_config_ref'},
+  );
+  if (_resourceId(object['role_definition_id']) != roleId ||
+      _resourceId(object['scenario_definition_id']) != scenarioId ||
+      _version(object['version']) != roleVersion) {
+    throw _invalidResponse();
+  }
+  _text(object['role_type']);
+  _text(object['display_name']);
+  _text(object['responsibilities']);
+  _text(object['style']);
+  _nonEmptyTextList(object['focus_areas']);
+  if (object['voice_config_ref'] case final value?) {
+    _text(value);
+  }
+}
+
+void _validatePracticeOption(
+  Object? value,
+  PreparationLaunchSelection expected,
+) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'practice_option_id',
+      'scenario_definition_id',
+      'practice_option_type',
+      'display_name',
+      'version',
+    },
+    optional: const <String>{'role_definition_id'},
+  );
+  if (_resourceId(object['practice_option_id']) != expected.practiceOptionId ||
+      _resourceId(object['scenario_definition_id']) !=
+          expected.scenarioDefinitionId ||
+      _enumText(object['practice_option_type'], const {
+            'FULL_SIMULATION',
+            'FOCUS',
+          }) !=
+          expected.practiceOptionType.wireValue ||
+      _version(object['version']) != expected.practiceOptionVersion) {
+    throw _invalidResponse();
+  }
+  if (expected.practiceOptionType == PreparationOptionType.focus) {
+    if (_resourceId(object['role_definition_id']) !=
+        expected.roleDefinitionId) {
+      throw _invalidResponse();
+    }
+  } else if (object['role_definition_id'] != null) {
+    throw _invalidResponse();
+  }
+  _text(object['display_name']);
+}
+
+int _validateSessionPolicy(
+  Object? value, {
+  required PreparationOptionType optionType,
+}) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'suggested_duration_seconds',
+      'min_effective_turns',
+      'max_effective_turns',
+      'coverage_checkpoint_turn',
+      'max_follow_ups_per_question',
+      'target_objectives',
+      'early_completion_rule',
+    },
+  );
+  final minimum = _version(object['min_effective_turns']);
+  final maximum = _version(object['max_effective_turns']);
+  final checkpoint = _version(object['coverage_checkpoint_turn']);
+  final expectedMaximum = switch (optionType) {
+    PreparationOptionType.fullSimulation => 6,
+    PreparationOptionType.focus => 3,
+  };
+  if (_version(object['suggested_duration_seconds']) < 1 ||
+      minimum > checkpoint ||
+      checkpoint > maximum ||
+      maximum != expectedMaximum ||
+      object['max_follow_ups_per_question'] is! int ||
+      (object['max_follow_ups_per_question'] as int) < 0) {
+    throw _invalidResponse();
+  }
+  _validateObjectives(object['target_objectives']);
+  _text(object['early_completion_rule']);
+  return maximum;
+}
+
+void _validateObjectives(Object? value, {bool allowEmpty = false}) {
+  if (value is! List<Object?> ||
+      (!allowEmpty && value.isEmpty) ||
+      value.length > 100) {
+    throw _invalidResponse();
+  }
+  final ids = <String>{};
+  for (final raw in value) {
+    final object = _object(
+      raw,
+      required: const <String>{'objective_id', 'description'},
+    );
+    if (!ids.add(_text(object['objective_id']))) {
+      throw _invalidResponse();
+    }
+    _text(object['description']);
+  }
+}
+
+Object? _decode(String body) {
+  try {
+    return jsonDecode(body);
+  } on FormatException {
+    throw _invalidResponse();
+  }
+}
+
+Map<String, Object?> _object(
+  Object? value, {
+  Set<String> required = const <String>{},
+  Set<String> optional = const <String>{},
+}) {
+  if (value is! Map<String, Object?> ||
+      !value.keys.toSet().containsAll(required) ||
+      value.keys.any(
+        (key) => !required.contains(key) && !optional.contains(key),
+      )) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+String _resourceId(Object? value) {
+  final result = _text(value, maxBytes: 128);
+  if (result.length > 128) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+String _text(Object? value, {int maxBytes = 256 * 1024}) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.trim() != value ||
+      value.contains('\u0000') ||
+      utf8.encode(value).length > maxBytes) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+String _enumText(Object? value, Set<String> allowed) {
+  final result = _text(value, maxBytes: 128);
+  if (!allowed.contains(result)) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+int _version(Object? value) {
+  if (value is! int || value < 1) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+DateTime _dateTime(Object? value) {
+  if (value is! String) {
+    throw _invalidResponse();
+  }
+  final result = DateTime.tryParse(value);
+  if (result == null) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+List<String> _resourceIdList(
+  Object? value, {
+  required int min,
+  required int max,
+}) {
+  if (value is! List<Object?> || value.length < min || value.length > max) {
+    throw _invalidResponse();
+  }
+  final result = value.map(_resourceId).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+List<String> _nonEmptyTextList(Object? value) {
+  if (value is! List<Object?> || value.isEmpty || value.length > 100) {
+    throw _invalidResponse();
+  }
+  final result = value.map(_text).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+String? _errorCode(String body) {
+  try {
+    final root = jsonDecode(body);
+    if (root is! Map<String, Object?> ||
+        root['error'] is! Map<String, Object?>) {
+      return null;
+    }
+    final code = (root['error'] as Map<String, Object?>)['code'];
+    return code is String && code.length <= 128 ? code : null;
+  } on FormatException {
+    return null;
+  }
+}
+
+Never _invalidResponse() => throw const PreparationLaunchException(
+  kind: PreparationLaunchFailureKind.invalidResponse,
+);
+
+void _requireResourceId(String value) {
+  if (value.isEmpty ||
+      value.length > 128 ||
+      value.trim() != value ||
+      value.contains('\u0000')) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireBackground(String value) {
+  if (value.isEmpty ||
+      value.trim() != value ||
+      value.contains('\u0000') ||
+      utf8.encode(value).length > 64 * 1024) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+      stage: PreparationLaunchStage.profile,
+    );
+  }
+}
+
+void _requireContext(AgentPracticeContext context) {
+  _requireResourceId(context.threadId);
+  _requireResourceId(context.matterId);
+}
+
+void _requireSelection(PreparationLaunchSelection value) {
+  _requireResourceId(value.scenarioDefinitionId);
+  _requireResourceId(value.scenarioConfigId);
+  _requireResourceId(value.roleDefinitionId);
+  _requireResourceId(value.practiceOptionId);
+  _requireDisplayText(value.scenarioDisplayName);
+  _requireDisplayText(value.scenarioDescription);
+  if (value.scenarioDefinitionVersion < 1 ||
+      value.scenarioConfigVersion < 1 ||
+      value.roleDefinitionVersion < 1 ||
+      value.practiceOptionVersion < 1 ||
+      value.scenarioType != 'INTERVIEW') {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireDisplayText(String value) {
+  if (value.isEmpty ||
+      value.length > 2048 ||
+      value.trim() != value ||
+      value.contains('\u0000')) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireIdempotencyKey(String value) {
+  if (value.length < 8 ||
+      value.length > 128 ||
+      value.trim() != value ||
+      value.contains('\u0000')) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -198,13 +198,15 @@ ProductionAppDependencies createProductionAppDependencies({
           );
           return AgentPracticeContext(threadId: threadId, matterId: matter.id);
         },
-    voiceActivator: ({required context, required bootstrap}) =>
-        agentController.activateCreatedPractice(
-          threadId: context.threadId,
-          matterId: context.matterId,
-          sessionId: bootstrap.session.id,
-          turnLimit: bootstrap.maxEffectiveTurns,
-        ),
+    voiceActivator:
+        ({required context, required bootstrap, required clientOperationId}) =>
+            agentController.activateCreatedPractice(
+              threadId: context.threadId,
+              matterId: context.matterId,
+              sessionId: bootstrap.session.id,
+              turnLimit: bootstrap.maxEffectiveTurns,
+              clientOperationId: clientOperationId,
+            ),
   );
   authController = AuthController(
     identityClient: WireIdentityClient(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/agent/wire_agent_client.dart';
 import 'package:speakup/agent/wire_agent_voice_client.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/wire_preparation_client.dart';
+import 'package:speakup/features/preparation/wire_preparation_launch_client.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/client/identity_client.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
@@ -32,6 +36,7 @@ void main() {
       authController: dependencies.authController,
       agentController: dependencies.agentController,
       preparationController: dependencies.preparationController,
+      preparationLaunchController: dependencies.preparationLaunchController,
       reviewHistoryController: dependencies.reviewHistoryController,
     ),
   );
@@ -42,12 +47,14 @@ final class ProductionAppDependencies {
     required this.authController,
     required this.agentController,
     required this.preparationController,
+    required this.preparationLaunchController,
     required this.reviewHistoryController,
   });
 
   final AuthController authController;
   final AgentController agentController;
   final PreparationController preparationController;
+  final PreparationLaunchController preparationLaunchController;
   final ReviewHistoryController reviewHistoryController;
 }
 
@@ -58,6 +65,7 @@ ProductionAppDependencies createProductionAppDependencies({
   AgentVoiceWireTransport? agentVoiceTransport,
   AgentVoiceWireTransport? signedAgentVoiceTransport,
   IdentityHttpTransport? preparationTransport,
+  IdentityHttpTransport? preparationLaunchTransport,
   IdentityHttpTransport? reviewHistoryTransport,
   PracticeWireTransport? practiceTransport,
   PracticeMediaWireTransport? practiceMediaTransport,
@@ -151,6 +159,53 @@ ProductionAppDependencies createProductionAppDependencies({
       transport: preparationTransport,
     ),
   );
+  final preparationLaunchController = PreparationLaunchController(
+    client: WirePreparationLaunchClient(
+      baseUri: baseUri,
+      credentialProvider: () => authController.currentCredential,
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) {
+            return authController.invalidateSession(
+              expectedSessionToken: expectedSessionToken,
+              expectedGeneration: expectedGeneration,
+            );
+          },
+      transport: preparationLaunchTransport,
+    ),
+    contextProvider: () {
+      final threadId = agentController.threadId;
+      final matterId = agentController.activeMatter?.id;
+      if (threadId == null || matterId == null) {
+        return null;
+      }
+      return AgentPracticeContext(threadId: threadId, matterId: matterId);
+    },
+    threadIdProvider: () => agentController.threadId,
+    matterActivator:
+        ({
+          required threadId,
+          required selection,
+          required clientOperationId,
+        }) async {
+          final matter = await agentController.activateMatterForScenario(
+            threadId: threadId,
+            scene: AgentScene(
+              id: selection.scenarioDefinitionId,
+              title: selection.scenarioDisplayName,
+              description: selection.scenarioDescription,
+            ),
+            clientOperationId: clientOperationId,
+          );
+          return AgentPracticeContext(threadId: threadId, matterId: matter.id);
+        },
+    voiceActivator: ({required context, required bootstrap}) =>
+        agentController.activateCreatedPractice(
+          threadId: context.threadId,
+          matterId: context.matterId,
+          sessionId: bootstrap.session.id,
+          turnLimit: bootstrap.maxEffectiveTurns,
+        ),
+  );
   authController = AuthController(
     identityClient: WireIdentityClient(
       baseUri: baseUri,
@@ -161,6 +216,7 @@ ProductionAppDependencies createProductionAppDependencies({
       await Future.wait<void>([
         agentController.clearPrivateState(),
         preparationController.clearPrivateState(),
+        preparationLaunchController.clearPrivateState(),
         reviewHistoryController.clearPrivateState(),
       ]);
     },
@@ -169,6 +225,7 @@ ProductionAppDependencies createProductionAppDependencies({
     authController: authController,
     agentController: agentController,
     preparationController: preparationController,
+    preparationLaunchController: preparationLaunchController,
     reviewHistoryController: reviewHistoryController,
   );
 }

--- a/mobile/lib/practice/practice_client.dart
+++ b/mobile/lib/practice/practice_client.dart
@@ -105,20 +105,22 @@ final class LegacyAgentPracticeClient implements PracticeClient {
       return null;
     }
     if (legacy.completedTurns < 0 ||
-        legacy.completedTurns > 3 ||
-        (legacy.review != null && legacy.completedTurns != 3) ||
+        legacy.turnLimit < 1 ||
+        legacy.turnLimit > 6 ||
+        legacy.completedTurns > legacy.turnLimit ||
+        (legacy.review != null && !legacy.sessionCompleted) ||
         (legacy.pendingReviewClientId != null &&
             (legacy.pendingReviewClientId!.trim().isEmpty ||
-                legacy.completedTurns != 3 ||
+                !legacy.sessionCompleted ||
                 legacy.review != null)) ||
-        (legacy.completedTurns == 3 &&
+        (legacy.sessionCompleted &&
             legacy.review == null &&
             legacy.pendingReviewClientId == null)) {
       throw StateError('Invalid legacy Practice snapshot.');
     }
     var review = legacy.review;
     _pendingReviewClientId = legacy.pendingReviewClientId;
-    final completed = legacy.completedTurns == 3;
+    final completed = legacy.sessionCompleted;
     final question = completed
         ? null
         : PracticeQuestion(
@@ -137,7 +139,7 @@ final class LegacyAgentPracticeClient implements PracticeClient {
       sessionId: 'legacy-session-${matter.id}',
       matter: matter,
       completedTurns: legacy.completedTurns,
-      turnLimit: 3,
+      turnLimit: legacy.turnLimit,
       sessionCompleted: completed,
       currentQuestion: question,
       review: review,

--- a/mobile/lib/practice/wire_practice_client.dart
+++ b/mobile/lib/practice/wire_practice_client.dart
@@ -542,8 +542,8 @@ PracticeSessionSnapshot _decodeSessionState(
       sessionVersion < 1 ||
       effectiveTurns < 0 ||
       turnLimit < 1 ||
+      turnLimit > 6 ||
       effectiveTurns > turnLimit ||
-      completed != (effectiveTurns == turnLimit) ||
       (!completed && (question == null || formalReview != null)) ||
       (completed && (question != null || turn == null)) ||
       (question != null && question.sessionId != sessionId) ||

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -14,6 +14,8 @@ import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/client/identity_client.dart';
 import 'package:speakup/identity/model/identity_models.dart';
 import 'package:speakup/identity/session_store.dart';
+import 'package:speakup/review/review_history_client.dart';
+import 'package:speakup/review/review_history_controller.dart';
 
 void main() {
   testWidgets('uses one Agent Thread for text, 3 Practice turns, and Review', (
@@ -312,6 +314,58 @@ void main() {
     },
   );
 
+  testWidgets(
+    'completed Practice refreshes persisted Review history before route exit',
+    (tester) async {
+      final agentController = AgentController(client: FakeAgentClient());
+      await agentController.initialize();
+      await agentController.selectScene(agentScenes.first);
+      final historyClient = _CurrentReviewHistoryClient(agentController);
+      final historyController = ReviewHistoryController(client: historyClient);
+      addTearDown(agentController.dispose);
+      addTearDown(historyController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SpeakUpShell(
+            previewMode: true,
+            agentController: agentController,
+            reviewHistoryController: historyController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final navigatorContext = tester.element(find.byType(SpeakUpShell));
+      Navigator.of(navigatorContext).push(
+        MaterialPageRoute<void>(
+          builder: (_) => PracticePage(agentController: agentController),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(historyClient.listCalls, 0);
+
+      for (var turn = 0; turn < 3; turn++) {
+        await agentController.startRecording();
+        await agentController.stopRecording();
+        await agentController.confirmTranscript();
+        await tester.pump();
+      }
+      await tester.pumpAndSettle();
+
+      final review = agentController.review;
+      expect(review, isNotNull);
+      final reviewId = review!.id;
+      expect(historyClient.listCalls, 1);
+      expect(historyController.items.single.review.id, reviewId);
+      expect(find.byKey(const Key('practice-page')), findsNothing);
+      expect(
+        find.byKey(Key('review-history-$reviewId')).hitTestable(),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgets('completed root Practice route keeps a safe destination', (
     tester,
   ) async {
@@ -393,6 +447,37 @@ void main() {
       findsOneWidget,
     );
   });
+}
+
+final class _CurrentReviewHistoryClient implements ReviewHistoryClient {
+  _CurrentReviewHistoryClient(this.agentController);
+
+  final AgentController agentController;
+  int listCalls = 0;
+
+  @override
+  Future<ReviewHistoryPage> list({String? cursor, int limit = 20}) async {
+    listCalls++;
+    final review = agentController.review;
+    final practiceSessionId = agentController.practiceSessionId;
+    if (review == null || practiceSessionId == null) {
+      throw StateError('Review history refreshed before Practice completed.');
+    }
+    final completedAt = DateTime.utc(2026, 7, 26, 12);
+    return ReviewHistoryPage(
+      items: <ReviewHistoryItem>[
+        ReviewHistoryItem(
+          review: review,
+          practiceSessionId: practiceSessionId,
+          createdAt: completedAt.subtract(const Duration(minutes: 5)),
+          completedAt: completedAt,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
 }
 
 final class _RejectFirstPracticePop extends StatefulWidget {

--- a/mobile/test/agent/formal_practice_activation_test.dart
+++ b/mobile/test/agent/formal_practice_activation_test.dart
@@ -1,0 +1,371 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_client.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/practice/practice_client.dart';
+import 'package:speakup/practice/practice_models.dart';
+
+void main() {
+  test('new user activates a real Matter without legacy voice start', () async {
+    final agent = _ActivationAgentClient(activeMatter: null);
+    final practice = _ActivationPracticeClient(
+      snapshot: _snapshot(turnLimit: 6),
+    );
+    final controller = AgentController(client: agent, practiceClient: practice);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    final matter = await controller.activateMatterForScenario(
+      threadId: _threadId,
+      scene: _matter.scene,
+      clientOperationId: 'matter-stable-operation',
+    );
+
+    expect(matter.id, _matterId);
+    expect(controller.activeMatter?.id, _matterId);
+    expect(agent.sceneStarts, 1);
+    expect(practice.startCalls, 0);
+  });
+
+  test(
+    'does not reuse a same-title Matter from another catalog scene',
+    () async {
+      const staleMatter = AgentMatter(
+        id: 'matter-stale',
+        scene: AgentScene(
+          id: 'another-catalog-scene',
+          title: 'Technical interview',
+          description: 'A different catalog entry with the same title.',
+        ),
+      );
+      final agent = _ActivationAgentClient(activeMatter: staleMatter);
+      final controller = AgentController(client: agent);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      final matter = await controller.activateMatterForScenario(
+        threadId: _threadId,
+        scene: _matter.scene,
+        clientOperationId: 'matter-exact-catalog-match',
+      );
+
+      expect(agent.sceneStarts, 1);
+      expect(matter.scene.id, _matter.scene.id);
+      expect(matter.scene.title, _matter.scene.title);
+    },
+  );
+
+  test('rejects a Matter response for a different catalog scene', () async {
+    const mismatchedMatter = AgentMatter(
+      id: 'matter-other',
+      scene: AgentScene(
+        id: 'other-scene',
+        title: 'Other interview',
+        description: 'Wrong catalog entry.',
+      ),
+    );
+    final agent = _ActivationAgentClient(
+      activeMatter: null,
+      startSceneMatter: mismatchedMatter,
+    );
+    final controller = AgentController(client: agent);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    await expectLater(
+      controller.activateMatterForScenario(
+        threadId: _threadId,
+        scene: _matter.scene,
+        clientOperationId: 'matter-reject-mismatch',
+      ),
+      throwsStateError,
+    );
+    expect(controller.activeMatter, isNull);
+  });
+
+  test(
+    'activates only the exact formal Session with the frozen turn limit',
+    () async {
+      final practice = _ActivationPracticeClient(
+        snapshot: _snapshot(turnLimit: 6),
+      );
+      final controller = AgentController(
+        client: _ActivationAgentClient(),
+        practiceClient: practice,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      await controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _sessionId,
+        turnLimit: 6,
+      );
+
+      expect(controller.practiceSessionId, _sessionId);
+      expect(controller.turnLimit, 6);
+      expect(controller.completedTurns, 0);
+      expect(controller.hasActivePractice, isTrue);
+      expect(practice.restoreCalls, 2);
+    },
+  );
+
+  test(
+    'rejects a voice restore whose limit differs from the formal snapshot',
+    () async {
+      final practice = _ActivationPracticeClient(
+        snapshot: _snapshot(turnLimit: 3),
+      );
+      final controller = AgentController(
+        client: _ActivationAgentClient(),
+        practiceClient: practice,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      await expectLater(
+        controller.activateCreatedPractice(
+          threadId: _threadId,
+          matterId: _matterId,
+          sessionId: _sessionId,
+          turnLimit: 6,
+        ),
+        throwsStateError,
+      );
+      expect(controller.practiceSessionId, isNull);
+    },
+  );
+
+  test('does not replace or relabel an active formal Session', () async {
+    final practice = _ActivationPracticeClient(
+      snapshot: _snapshot(turnLimit: 6),
+    );
+    final controller = AgentController(
+      client: _ActivationAgentClient(),
+      practiceClient: practice,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.activateCreatedPractice(
+      threadId: _threadId,
+      matterId: _matterId,
+      sessionId: _sessionId,
+      turnLimit: 6,
+    );
+
+    await expectLater(
+      controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _sessionId,
+        turnLimit: 3,
+      ),
+      throwsStateError,
+    );
+    await expectLater(
+      controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: 'session-other',
+        turnLimit: 6,
+      ),
+      throwsStateError,
+    );
+    expect(controller.practiceSessionId, _sessionId);
+    expect(controller.turnLimit, 6);
+    expect(practice.restoreCalls, 2);
+  });
+
+  test(
+    'treats server sessionCompleted as authoritative before max turns',
+    () async {
+      final practice = _ActivationPracticeClient(
+        snapshot: PracticeSessionSnapshot(
+          sessionId: _sessionId,
+          planId: 'plan-1',
+          threadId: _threadId,
+          matter: _matter,
+          completedTurns: 4,
+          turnLimit: 6,
+          sessionCompleted: true,
+          review: const AgentReview(
+            id: 'review-1',
+            title: 'Review',
+            summary: 'Covered',
+            strength: 'Clear evidence',
+            nextFocus: 'Concise delivery',
+          ),
+        ),
+      );
+      final controller = AgentController(
+        client: _ActivationAgentClient(),
+        practiceClient: practice,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      await controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _sessionId,
+        turnLimit: 6,
+      );
+
+      expect(controller.completedTurns, 4);
+      expect(controller.turnLimit, 6);
+      expect(controller.hasActivePractice, isFalse);
+      expect(controller.review?.id, 'review-1');
+    },
+  );
+}
+
+PracticeSessionSnapshot _snapshot({required int turnLimit}) {
+  return PracticeSessionSnapshot(
+    sessionId: _sessionId,
+    planId: 'plan-1',
+    threadId: _threadId,
+    matter: _matter,
+    completedTurns: 0,
+    turnLimit: turnLimit,
+    sessionCompleted: false,
+    currentQuestion: const PracticeQuestion(
+      id: 'question-1',
+      sessionId: _sessionId,
+      text: 'Tell me about your experience.',
+    ),
+  );
+}
+
+final class _ActivationPracticeClient implements PracticeClient {
+  _ActivationPracticeClient({required this.snapshot});
+
+  final PracticeSessionSnapshot snapshot;
+  int restoreCalls = 0;
+  int startCalls = 0;
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PracticeSessionSnapshot?> restorePractice({
+    required String threadId,
+    AgentMatter? activeMatter,
+  }) async {
+    restoreCalls++;
+    return restoreCalls == 1 ? null : snapshot;
+  }
+
+  @override
+  Future<PracticeStartResult> startPractice({
+    required String threadId,
+    required AgentMatter activeMatter,
+    required String clientOperationId,
+  }) {
+    startCalls++;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+final class _ActivationAgentClient implements AgentClient {
+  _ActivationAgentClient({this.activeMatter = _matter, this.startSceneMatter});
+
+  final AgentMatter? activeMatter;
+  final AgentMatter? startSceneMatter;
+  int sceneStarts = 0;
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<AgentThreadSnapshot> restoreThread() async {
+    return AgentThreadSnapshot(threadId: _threadId, activeMatter: activeMatter);
+  }
+
+  @override
+  Future<AgentReview> createReview({
+    required String threadId,
+    required AgentScene scene,
+    required String clientReviewId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AgentExchange> sendText({
+    required String threadId,
+    required String text,
+    required String clientMessageId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AgentSceneStart> startScene({
+    required String threadId,
+    required AgentScene scene,
+    required String clientOperationId,
+  }) {
+    sceneStarts++;
+    return Future<AgentSceneStart>.value(
+      AgentSceneStart(
+        activeMatter:
+            startSceneMatter ?? AgentMatter(id: _matterId, scene: scene),
+        assistantMessage: AgentMessage(
+          id: 'matter-$clientOperationId',
+          role: AgentMessageRole.assistant,
+          text: scene.title,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<AgentExchange> submitPracticeTurn({
+    required String threadId,
+    required AgentScene scene,
+    required int turnNumber,
+    required String transcript,
+    required String clientTurnId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> transcribeTurn({
+    required String threadId,
+    required int turnNumber,
+    required String clientTurnId,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+const _threadId = 'thread-1';
+const _matterId = 'matter-1';
+const _sessionId = 'session-1';
+const _matter = AgentMatter(
+  id: _matterId,
+  scene: AgentScene(
+    id: 'technical-interview',
+    title: 'Technical interview',
+    description: 'Practice technical interview answers.',
+  ),
+);

--- a/mobile/test/agent/formal_practice_activation_test.dart
+++ b/mobile/test/agent/formal_practice_activation_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
@@ -101,13 +103,16 @@ void main() {
         matterId: _matterId,
         sessionId: _sessionId,
         turnLimit: 6,
+        clientOperationId: _voiceKey,
       );
 
       expect(controller.practiceSessionId, _sessionId);
       expect(controller.turnLimit, 6);
       expect(controller.completedTurns, 0);
       expect(controller.hasActivePractice, isTrue);
-      expect(practice.restoreCalls, 2);
+      expect(practice.restoreCalls, 1);
+      expect(practice.startCalls, 1);
+      expect(practice.startKeys, [_voiceKey]);
     },
   );
 
@@ -130,12 +135,127 @@ void main() {
           matterId: _matterId,
           sessionId: _sessionId,
           turnLimit: 6,
+          clientOperationId: _voiceKey,
         ),
         throwsStateError,
       );
       expect(controller.practiceSessionId, isNull);
     },
   );
+
+  test('retries formal activation with the same operation key', () async {
+    final practice = _ActivationPracticeClient(
+      snapshot: _snapshot(turnLimit: 6),
+      failFirstStart: true,
+    );
+    final controller = AgentController(
+      client: _ActivationAgentClient(),
+      practiceClient: practice,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    await expectLater(
+      controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _sessionId,
+        turnLimit: 6,
+        clientOperationId: _voiceKey,
+      ),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.network,
+        ),
+      ),
+    );
+    await controller.activateCreatedPractice(
+      threadId: _threadId,
+      matterId: _matterId,
+      sessionId: _sessionId,
+      turnLimit: 6,
+      clientOperationId: _voiceKey,
+    );
+
+    expect(practice.startKeys, [_voiceKey, _voiceKey]);
+    expect(controller.practiceSessionId, _sessionId);
+  });
+
+  test('rejects activation of a different formal Session response', () async {
+    final practice = _ActivationPracticeClient(
+      snapshot: PracticeSessionSnapshot(
+        sessionId: 'session-other',
+        planId: 'plan-1',
+        threadId: _threadId,
+        matter: _matter,
+        completedTurns: 0,
+        turnLimit: 6,
+        sessionCompleted: false,
+        currentQuestion: const PracticeQuestion(
+          id: 'question-other',
+          sessionId: 'session-other',
+          text: 'Wrong session.',
+        ),
+      ),
+    );
+    final controller = AgentController(
+      client: _ActivationAgentClient(),
+      practiceClient: practice,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    await expectLater(
+      controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _sessionId,
+        turnLimit: 6,
+        clientOperationId: _voiceKey,
+      ),
+      throwsStateError,
+    );
+    expect(controller.practiceSessionId, isNull);
+  });
+
+  test('logout fences a late formal activation response', () async {
+    final startCompleter = Completer<PracticeStartResult>();
+    final practice = _ActivationPracticeClient(
+      snapshot: _snapshot(turnLimit: 6),
+      startCompleter: startCompleter,
+    );
+    final controller = AgentController(
+      client: _ActivationAgentClient(),
+      practiceClient: practice,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    final activation = controller.activateCreatedPractice(
+      threadId: _threadId,
+      matterId: _matterId,
+      sessionId: _sessionId,
+      turnLimit: 6,
+      clientOperationId: _voiceKey,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(practice.startCalls, 1);
+
+    await controller.clearPrivateState();
+    startCompleter.complete(
+      PracticeStartResult(snapshot: _snapshot(turnLimit: 6)),
+    );
+
+    await expectLater(
+      activation,
+      throwsA(isA<AgentClientOperationCancelled>()),
+    );
+    expect(controller.threadId, isNull);
+    expect(controller.practiceSessionId, isNull);
+    expect(practice.clearCalls, 1);
+  });
 
   test('does not replace or relabel an active formal Session', () async {
     final practice = _ActivationPracticeClient(
@@ -152,6 +272,7 @@ void main() {
       matterId: _matterId,
       sessionId: _sessionId,
       turnLimit: 6,
+      clientOperationId: _voiceKey,
     );
 
     await expectLater(
@@ -160,6 +281,7 @@ void main() {
         matterId: _matterId,
         sessionId: _sessionId,
         turnLimit: 3,
+        clientOperationId: _voiceKey,
       ),
       throwsStateError,
     );
@@ -169,12 +291,14 @@ void main() {
         matterId: _matterId,
         sessionId: 'session-other',
         turnLimit: 6,
+        clientOperationId: _voiceKey,
       ),
       throwsStateError,
     );
     expect(controller.practiceSessionId, _sessionId);
     expect(controller.turnLimit, 6);
-    expect(practice.restoreCalls, 2);
+    expect(practice.restoreCalls, 1);
+    expect(practice.startCalls, 1);
   });
 
   test(
@@ -210,6 +334,7 @@ void main() {
         matterId: _matterId,
         sessionId: _sessionId,
         turnLimit: 6,
+        clientOperationId: _voiceKey,
       );
 
       expect(controller.completedTurns, 4);
@@ -238,14 +363,24 @@ PracticeSessionSnapshot _snapshot({required int turnLimit}) {
 }
 
 final class _ActivationPracticeClient implements PracticeClient {
-  _ActivationPracticeClient({required this.snapshot});
+  _ActivationPracticeClient({
+    required this.snapshot,
+    this.failFirstStart = false,
+    this.startCompleter,
+  });
 
   final PracticeSessionSnapshot snapshot;
+  final bool failFirstStart;
+  final Completer<PracticeStartResult>? startCompleter;
   int restoreCalls = 0;
   int startCalls = 0;
+  int clearCalls = 0;
+  final startKeys = <String>[];
 
   @override
-  Future<void> clearAccountState() async {}
+  Future<void> clearAccountState() async {
+    clearCalls++;
+  }
 
   @override
   Future<PracticeSessionSnapshot?> restorePractice({
@@ -263,7 +398,20 @@ final class _ActivationPracticeClient implements PracticeClient {
     required String clientOperationId,
   }) {
     startCalls++;
-    throw UnimplementedError();
+    startKeys.add(clientOperationId);
+    if (failFirstStart && startCalls == 1) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
+    }
+    final pending = startCompleter;
+    if (pending != null) {
+      return pending.future;
+    }
+    return Future<PracticeStartResult>.value(
+      PracticeStartResult(snapshot: snapshot),
+    );
   }
 
   @override
@@ -361,6 +509,7 @@ final class _ActivationAgentClient implements AgentClient {
 const _threadId = 'thread-1';
 const _matterId = 'matter-1';
 const _sessionId = 'session-1';
+const _voiceKey = 'formal-voice-activation-key';
 const _matter = AgentMatter(
   id: _matterId,
   scene: AgentScene(

--- a/mobile/test/agent/practice_restore_conflict_test.dart
+++ b/mobile/test/agent/practice_restore_conflict_test.dart
@@ -1,0 +1,373 @@
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_client.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/practice/wire_practice_client.dart';
+import 'package:speakup/review/review_history_client.dart';
+import 'package:speakup/review/review_history_controller.dart';
+
+void main() {
+  test(
+    'two completed Sessions keep Agent usable without guessing a Practice',
+    () async {
+      final transport = _PracticeTransport([
+        _PracticeStep(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/voice-practice-session',
+          response: _errorResponse(
+            statusCode: HttpStatus.conflict,
+            code: 'resource_conflict',
+            retryable: false,
+          ),
+        ),
+        _PracticeStep(
+          method: 'POST',
+          path: '/v1/agent-threads/$_threadId/voice-practice-sessions',
+          response: _jsonResponse(
+            HttpStatus.created,
+            _activeSessionJson(_newSessionId),
+          ),
+        ),
+      ]);
+      final agent = _RestoredAgentClient();
+      final controller = AgentController(
+        client: agent,
+        practiceClient: _wirePracticeClient(transport),
+        clientIdFactory: (scope) => '$scope-stable-id',
+      );
+      final history = ReviewHistoryController(
+        client: _CompletedReviewHistoryClient(),
+      );
+      addTearDown(controller.dispose);
+      addTearDown(history.dispose);
+
+      await controller.initialize();
+
+      expect(controller.threadId, _threadId);
+      expect(controller.activeMatter?.id, _matterId);
+      expect(controller.messages, hasLength(1));
+      expect(controller.practiceSessionId, isNull);
+      expect(controller.hasActivePractice, isFalse);
+      expect(controller.review, isNull);
+      expect(controller.canSelectScene, isTrue);
+      expect(controller.canRetry, isFalse);
+      expect(controller.errorMessage, isNull);
+
+      expect(await controller.sendText('Agent remains available.'), isTrue);
+      expect(agent.sentThreadIds, [_threadId]);
+      expect(controller.messages, hasLength(3));
+
+      await history.refresh();
+      expect(history.items.map((item) => item.practiceSessionId), [
+        _firstCompletedSessionId,
+        _secondCompletedSessionId,
+      ]);
+      expect(controller.review, isNull);
+
+      await controller.activateCreatedPractice(
+        threadId: _threadId,
+        matterId: _matterId,
+        sessionId: _newSessionId,
+        turnLimit: 3,
+        clientOperationId: 'voice-new-practice',
+      );
+
+      expect(controller.practiceSessionId, _newSessionId);
+      expect(controller.hasActivePractice, isTrue);
+      transport.expectDone();
+    },
+  );
+
+  test(
+    'authentication network and in-progress restore failures are not ignored',
+    () async {
+      final cases =
+          <({String name, Object? error, PracticeWireResponse? response})>[
+            (
+              name: 'authentication',
+              error: null,
+              response: _errorResponse(
+                statusCode: HttpStatus.unauthorized,
+                code: 'authentication_required',
+                retryable: false,
+              ),
+            ),
+            (
+              name: 'network',
+              error: const SocketException('offline'),
+              response: null,
+            ),
+            (
+              name: 'in-progress Session',
+              error: null,
+              response: _errorResponse(
+                statusCode: HttpStatus.conflict,
+                code: 'resource_processing',
+                retryable: true,
+              ),
+            ),
+          ];
+
+      for (final testCase in cases) {
+        final transport = _PracticeTransport([
+          _PracticeStep(
+            method: 'GET',
+            path: '/v1/agent-threads/$_threadId/voice-practice-session',
+            response: testCase.response,
+            error: testCase.error,
+          ),
+        ]);
+        final controller = AgentController(
+          client: _RestoredAgentClient(),
+          practiceClient: _wirePracticeClient(transport),
+        );
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+
+        expect(controller.threadId, isNull, reason: testCase.name);
+        expect(controller.activeMatter, isNull, reason: testCase.name);
+        expect(controller.practiceSessionId, isNull, reason: testCase.name);
+        expect(controller.canSelectScene, isFalse, reason: testCase.name);
+        expect(controller.canRetry, isTrue, reason: testCase.name);
+        expect(controller.errorMessage, isNotNull, reason: testCase.name);
+        transport.expectDone();
+      }
+    },
+  );
+}
+
+WirePracticeClient _wirePracticeClient(PracticeWireTransport transport) {
+  return WirePracticeClient(
+    baseUri: Uri.parse('https://api.speak-up.test'),
+    credentialProvider: () => _credential,
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) async {},
+    transport: transport,
+  );
+}
+
+PracticeWireResponse _errorResponse({
+  required int statusCode,
+  required String code,
+  required bool retryable,
+}) {
+  return _jsonResponse(statusCode, {
+    'error': {
+      'code': code,
+      'message': 'Canonical server error.',
+      'retryable': retryable,
+      'correlation_id': 'corr-practice-restore',
+    },
+  });
+}
+
+PracticeWireResponse _jsonResponse(int statusCode, Object body) {
+  return PracticeWireResponse(statusCode: statusCode, body: jsonEncode(body));
+}
+
+Map<String, Object?> _activeSessionJson(String sessionId) {
+  return {
+    'practice_session_id': sessionId,
+    'practice_plan_id': 'plan-new',
+    'thread_id': _threadId,
+    'matter': {
+      'matter_id': _matterId,
+      'title': _matter.scene.title,
+      'status': 'active',
+      'version': 4,
+      'created_at': _timestamp,
+      'updated_at': _timestamp,
+    },
+    'session_version': 2,
+    'effective_turns': 0,
+    'turn_limit': 3,
+    'session_completed': false,
+    'current_question': {
+      'question_id': 'question-new',
+      'practice_session_id': sessionId,
+      'content': 'Tell me about your latest project.',
+      'speaker_participant_id': 'participant-interviewer',
+      'addressee_participant_ids': ['participant-candidate'],
+      'speech_path': '/v1/voice-questions/question-new/speech',
+    },
+  };
+}
+
+final class _RestoredAgentClient implements AgentClient {
+  final List<String> sentThreadIds = <String>[];
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<AgentThreadSnapshot> restoreThread() async {
+    return const AgentThreadSnapshot(
+      threadId: _threadId,
+      activeMatter: _matter,
+      messages: [
+        AgentMessage(
+          id: 'message-restored',
+          role: AgentMessageRole.assistant,
+          text: 'Restored Agent context.',
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<AgentExchange> sendText({
+    required String threadId,
+    required String text,
+    required String clientMessageId,
+  }) async {
+    sentThreadIds.add(threadId);
+    return AgentExchange(
+      userMessage: AgentMessage(
+        id: 'message-user',
+        role: AgentMessageRole.user,
+        text: text,
+      ),
+      assistantMessage: const AgentMessage(
+        id: 'message-assistant',
+        role: AgentMessageRole.assistant,
+        text: 'Agent reply.',
+      ),
+    );
+  }
+
+  @override
+  Future<AgentReview> createReview({
+    required String threadId,
+    required AgentScene scene,
+    required String clientReviewId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AgentSceneStart> startScene({
+    required String threadId,
+    required AgentScene scene,
+    required String clientOperationId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AgentExchange> submitPracticeTurn({
+    required String threadId,
+    required AgentScene scene,
+    required int turnNumber,
+    required String transcript,
+    required String clientTurnId,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> transcribeTurn({
+    required String threadId,
+    required int turnNumber,
+    required String clientTurnId,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+final class _CompletedReviewHistoryClient implements ReviewHistoryClient {
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<ReviewHistoryPage> list({String? cursor, int limit = 20}) async {
+    return ReviewHistoryPage(
+      items: [
+        _historyItem(_firstCompletedSessionId, 'review-first'),
+        _historyItem(_secondCompletedSessionId, 'review-second'),
+      ],
+    );
+  }
+
+  ReviewHistoryItem _historyItem(String sessionId, String reviewId) {
+    final completedAt = DateTime.parse(_timestamp);
+    return ReviewHistoryItem(
+      review: AgentReview(
+        id: reviewId,
+        title: 'Completed review',
+        summary: 'Historical Session remains in Review history.',
+        strength: 'Clear answer',
+        nextFocus: 'Add evidence',
+      ),
+      practiceSessionId: sessionId,
+      createdAt: completedAt.subtract(const Duration(minutes: 5)),
+      completedAt: completedAt,
+    );
+  }
+}
+
+final class _PracticeStep {
+  const _PracticeStep({
+    required this.method,
+    required this.path,
+    this.response,
+    this.error,
+  }) : assert(response != null || error != null);
+
+  final String method;
+  final String path;
+  final PracticeWireResponse? response;
+  final Object? error;
+}
+
+final class _PracticeTransport implements PracticeWireTransport {
+  _PracticeTransport(Iterable<_PracticeStep> steps)
+    : _steps = Queue<_PracticeStep>.of(steps);
+
+  final Queue<_PracticeStep> _steps;
+
+  @override
+  Future<PracticeWireResponse> send(PracticeWireRequest request) async {
+    final step = _steps.removeFirst();
+    expect(request.method, step.method);
+    expect(request.uri.path, step.path);
+    expect(
+      request.headers[HttpHeaders.authorizationHeader],
+      'Bearer sess_practice_restore',
+    );
+    final error = step.error;
+    if (error != null) {
+      throw error;
+    }
+    return step.response!;
+  }
+
+  void expectDone() => expect(_steps, isEmpty);
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _credential = AuthSessionCredential(
+  sessionToken: 'sess_practice_restore',
+  generation: 1,
+);
+const _threadId = '10000000-0000-4000-8000-000000000111';
+const _matterId = '20000000-0000-4000-8000-000000000111';
+const _firstCompletedSessionId = '30000000-0000-4000-8000-000000000111';
+const _secondCompletedSessionId = '30000000-0000-4000-8000-000000000112';
+const _newSessionId = '30000000-0000-4000-8000-000000000113';
+const _timestamp = '2026-07-26T08:00:00Z';
+const _matter = AgentMatter(
+  id: _matterId,
+  scene: AgentScene(
+    id: 'programmer-interview',
+    title: 'Programmer interview',
+    description: 'Formal interview practice.',
+  ),
+);

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -1557,6 +1557,159 @@ void main() {
     transport.expectDone();
   });
 
+  test('recovers a committed Matter after a malformed 201 response', () async {
+    final scene = agentScenes.first;
+    final transport = _ScriptedTransport([
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.ok, {
+          'matters': [_matterJson(id: _matterId, title: scene.title)],
+        }),
+      ),
+      _Step(
+        method: 'POST',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.created, <String, Object?>{}),
+      ),
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.ok, {
+          'matters': [
+            _matterJson(id: _matterId, title: scene.title),
+            _matterJson(id: _matterBId, title: scene.title),
+          ],
+        }),
+      ),
+      _Step(
+        method: 'PUT',
+        path: '/v1/agent-threads/$_threadId/active-matter',
+        verify: (call) {
+          expect(jsonDecode(call.body!), {'matter_id': _matterBId});
+        },
+        response: _jsonResponse(
+          HttpStatus.ok,
+          _matterLinkJson(matterId: _matterBId),
+        ),
+      ),
+    ]);
+    final harness = _Harness(transport);
+    const operationId = 'scene_malformed_201';
+
+    await expectLater(
+      harness.client.startScene(
+        threadId: _threadId,
+        scene: scene,
+        clientOperationId: operationId,
+      ),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.invalidResponse,
+        ),
+      ),
+    );
+    final result = await harness.client.startScene(
+      threadId: _threadId,
+      scene: scene,
+      clientOperationId: operationId,
+    );
+
+    expect(result.activeMatter.id, _matterBId);
+    expect(
+      transport.calls.where(
+        (call) => call.method == 'POST' && call.path == '/v1/matters',
+      ),
+      hasLength(1),
+    );
+    transport.expectDone();
+  });
+
+  test(
+    'after client restart creates fresh Matter instead of guessing a prior commit',
+    () async {
+      final scene = agentScenes.first;
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/matters',
+          response: _jsonResponse(HttpStatus.ok, {
+            'matters': [_matterJson(id: _matterId, title: scene.title)],
+          }),
+        ),
+        _Step(
+          method: 'POST',
+          path: '/v1/matters',
+          response: _jsonResponse(HttpStatus.created, <String, Object?>{}),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/matters',
+          response: _jsonResponse(HttpStatus.ok, {
+            'matters': [
+              _matterJson(id: _matterId, title: scene.title),
+              _matterJson(id: _matterBId, title: scene.title),
+            ],
+          }),
+        ),
+        _Step(
+          method: 'POST',
+          path: '/v1/matters',
+          response: _jsonResponse(
+            HttpStatus.created,
+            _matterJson(id: _matterCId, title: scene.title),
+          ),
+        ),
+        _Step(
+          method: 'PUT',
+          path: '/v1/agent-threads/$_threadId/active-matter',
+          verify: (call) {
+            expect(jsonDecode(call.body!), {'matter_id': _matterCId});
+          },
+          response: _jsonResponse(
+            HttpStatus.ok,
+            _matterLinkJson(matterId: _matterCId),
+          ),
+        ),
+      ]);
+      final firstClient = _Harness(transport);
+      const operationId = 'scene_restart_retry';
+
+      await expectLater(
+        firstClient.client.startScene(
+          threadId: _threadId,
+          scene: scene,
+          clientOperationId: operationId,
+        ),
+        throwsA(
+          isA<AgentClientException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentClientFailureKind.invalidResponse,
+          ),
+        ),
+      );
+
+      final restartedClient = _Harness(transport);
+      final result = await restartedClient.client.startScene(
+        threadId: _threadId,
+        scene: scene,
+        clientOperationId: operationId,
+      );
+
+      expect(result.activeMatter.id, _matterCId);
+      expect(
+        transport.calls.where(
+          (call) => call.method == 'POST' && call.path == '/v1/matters',
+        ),
+        hasLength(2),
+      );
+      transport.expectDone();
+    },
+  );
+
   test('rejects multiple new Matters after an ambiguous create', () async {
     final scene = agentScenes.first;
     final transport = _ScriptedTransport([

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -1437,54 +1437,328 @@ void main() {
     },
   );
 
-  test('scene selection uses Matter and SetActiveMatter HTTP APIs', () async {
+  test(
+    'new catalog activation never reuses an existing same-title Matter',
+    () async {
+      const selectedScene = AgentScene(
+        id: 'catalog-scene-new',
+        title: 'Technical interview',
+        description: 'A distinct catalog scenario with the same title.',
+      );
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/matters',
+          response: _jsonResponse(HttpStatus.ok, {
+            'matters': [_matterJson(id: _matterId, title: selectedScene.title)],
+          }),
+        ),
+        _Step(
+          method: 'POST',
+          path: '/v1/matters',
+          response: _jsonResponse(
+            HttpStatus.created,
+            _matterJson(id: _matterBId, title: selectedScene.title),
+          ),
+        ),
+        _Step(
+          method: 'PUT',
+          path: '/v1/agent-threads/$_threadId/active-matter',
+          verify: (call) {
+            expect(jsonDecode(call.body!), {'matter_id': _matterBId});
+          },
+          response: _jsonResponse(
+            HttpStatus.ok,
+            _matterLinkJson(matterId: _matterBId),
+          ),
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      final result = await harness.client.startScene(
+        threadId: _threadId,
+        scene: selectedScene,
+        clientOperationId: 'scene_select',
+      );
+
+      expect(result.activeMatter.id, _matterBId);
+      expect(result.activeMatter.scene.id, selectedScene.id);
+      transport.expectDone();
+    },
+  );
+
+  test('recovers exactly one Matter after an ambiguous create', () async {
+    final scene = agentScenes.first;
     final transport = _ScriptedTransport([
       _Step(
         method: 'GET',
         path: '/v1/matters',
         response: _jsonResponse(HttpStatus.ok, {
+          'matters': [_matterJson(id: _matterId, title: scene.title)],
+        }),
+      ),
+      _Step(
+        method: 'POST',
+        path: '/v1/matters',
+        error: const SocketException('response lost'),
+      ),
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.ok, {
           'matters': [
-            {
-              'matter_id': _matterId,
-              'title': agentScenes.first.title,
-              'status': 'active',
-              'version': 1,
-              'created_at': '2026-07-25T09:00:00Z',
-              'updated_at': '2026-07-25T09:00:00Z',
-            },
+            _matterJson(id: _matterId, title: scene.title),
+            _matterJson(id: _matterBId, title: scene.title),
           ],
         }),
       ),
       _Step(
         method: 'PUT',
         path: '/v1/agent-threads/$_threadId/active-matter',
+        verify: (call) {
+          expect(jsonDecode(call.body!), {'matter_id': _matterBId});
+        },
+        response: _jsonResponse(
+          HttpStatus.ok,
+          _matterLinkJson(matterId: _matterBId),
+        ),
+      ),
+    ]);
+    final harness = _Harness(transport);
+    const operationId = 'scene_ambiguous';
+
+    await expectLater(
+      harness.client.startScene(
+        threadId: _threadId,
+        scene: scene,
+        clientOperationId: operationId,
+      ),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.network,
+        ),
+      ),
+    );
+    final result = await harness.client.startScene(
+      threadId: _threadId,
+      scene: scene,
+      clientOperationId: operationId,
+    );
+
+    expect(result.activeMatter.id, _matterBId);
+    expect(
+      transport.calls.where(
+        (call) => call.method == 'POST' && call.path == '/v1/matters',
+      ),
+      hasLength(1),
+    );
+    transport.expectDone();
+  });
+
+  test('rejects multiple new Matters after an ambiguous create', () async {
+    final scene = agentScenes.first;
+    final transport = _ScriptedTransport([
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
         response: _jsonResponse(HttpStatus.ok, {
-          'thread_id': _threadId,
-          'matter_id': _matterId,
-          'active': true,
-          'linked_at': '2026-07-25T09:00:00Z',
-          'updated_at': '2026-07-25T09:00:00Z',
+          'matters': [_matterJson(id: _matterId, title: scene.title)],
+        }),
+      ),
+      _Step(
+        method: 'POST',
+        path: '/v1/matters',
+        error: const SocketException('response lost'),
+      ),
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.ok, {
+          'matters': [
+            _matterJson(id: _matterId, title: scene.title),
+            _matterJson(id: _matterBId, title: scene.title),
+            _matterJson(id: _matterCId, title: scene.title),
+          ],
         }),
       ),
     ]);
     final harness = _Harness(transport);
+    const operationId = 'scene_conflict';
 
-    expect(harness.client.supportsPracticeFlow, isFalse);
-    final result = await harness.client.startScene(
-      threadId: _threadId,
-      scene: agentScenes.first,
-      clientOperationId: 'scene_select',
-    );
-    expect(result.activeMatter.id, _matterId);
     await expectLater(
-      harness.client.transcribeTurn(
+      harness.client.startScene(
         threadId: _threadId,
-        turnNumber: 1,
-        clientTurnId: 'turn_unavailable',
+        scene: scene,
+        clientOperationId: operationId,
       ),
-      throwsA(isA<AgentClientException>()),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.network,
+        ),
+      ),
+    );
+    await expectLater(
+      harness.client.startScene(
+        threadId: _threadId,
+        scene: scene,
+        clientOperationId: operationId,
+      ),
+      throwsA(
+        isA<AgentClientException>()
+            .having(
+              (error) => error.kind,
+              'kind',
+              AgentClientFailureKind.conflict,
+            )
+            .having(
+              (error) => error.errorCode,
+              'errorCode',
+              'resource_conflict',
+            ),
+      ),
     );
     transport.expectDone();
+  });
+
+  test('retries the Matter link with the same created Matter ID', () async {
+    final scene = agentScenes.first;
+    final transport = _ScriptedTransport([
+      _Step(
+        method: 'GET',
+        path: '/v1/matters',
+        response: _jsonResponse(HttpStatus.ok, {'matters': <Object?>[]}),
+      ),
+      _Step(
+        method: 'POST',
+        path: '/v1/matters',
+        response: _jsonResponse(
+          HttpStatus.created,
+          _matterJson(id: _matterBId, title: scene.title),
+        ),
+      ),
+      _Step(
+        method: 'PUT',
+        path: '/v1/agent-threads/$_threadId/active-matter',
+        error: const SocketException('link response lost'),
+      ),
+      _Step(
+        method: 'PUT',
+        path: '/v1/agent-threads/$_threadId/active-matter',
+        verify: (call) {
+          expect(jsonDecode(call.body!), {'matter_id': _matterBId});
+        },
+        response: _jsonResponse(
+          HttpStatus.ok,
+          _matterLinkJson(matterId: _matterBId),
+        ),
+      ),
+    ]);
+    final harness = _Harness(transport);
+    const operationId = 'scene_link_retry';
+
+    await expectLater(
+      harness.client.startScene(
+        threadId: _threadId,
+        scene: scene,
+        clientOperationId: operationId,
+      ),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.network,
+        ),
+      ),
+    );
+    final result = await harness.client.startScene(
+      threadId: _threadId,
+      scene: scene,
+      clientOperationId: operationId,
+    );
+
+    expect(result.activeMatter.id, _matterBId);
+    expect(
+      transport.calls.where(
+        (call) => call.method == 'POST' && call.path == '/v1/matters',
+      ),
+      hasLength(1),
+    );
+    transport.expectDone();
+  });
+
+  test('logout fences and clears an in-flight Matter activation', () async {
+    final transport = _ControlledTransport();
+    final initialList = transport.enqueue();
+    final staleCreate = transport.enqueue();
+    final harness = _Harness(transport);
+    final scene = agentScenes.first;
+    const operationId = 'scene_logout_race';
+
+    final staleStart = harness.client.startScene(
+      threadId: _threadId,
+      scene: scene,
+      clientOperationId: operationId,
+    );
+    await transport.waitForCalls(1);
+    initialList.complete(
+      _jsonResponse(HttpStatus.ok, {'matters': <Object?>[]}),
+    );
+    await transport.waitForCalls(2);
+
+    final cleanup = harness.client.clearAccountState();
+    staleCreate.complete(
+      _jsonResponse(
+        HttpStatus.created,
+        _matterJson(id: _matterId, title: scene.title),
+      ),
+    );
+    await expectLater(
+      staleStart,
+      throwsA(isA<AgentClientOperationCancelled>()),
+    );
+    await cleanup;
+
+    harness.credential = const AuthSessionCredential(
+      sessionToken: 'sess_account-b',
+      generation: 2,
+    );
+    final freshList = transport.enqueue();
+    final freshCreate = transport.enqueue();
+    final freshLink = transport.enqueue();
+    final freshStart = harness.client.startScene(
+      threadId: _threadId,
+      scene: scene,
+      clientOperationId: operationId,
+    );
+    await transport.waitForCalls(3);
+    freshList.complete(
+      _jsonResponse(HttpStatus.ok, {
+        'matters': [_matterJson(id: _matterId, title: scene.title)],
+      }),
+    );
+    await transport.waitForCalls(4);
+    freshCreate.complete(
+      _jsonResponse(
+        HttpStatus.created,
+        _matterJson(id: _matterBId, title: scene.title),
+      ),
+    );
+    await transport.waitForCalls(5);
+    freshLink.complete(
+      _jsonResponse(HttpStatus.ok, _matterLinkJson(matterId: _matterBId)),
+    );
+
+    final result = await freshStart;
+    expect(result.activeMatter.id, _matterBId);
+    expect(jsonDecode(transport.calls.last.body!), {'matter_id': _matterBId});
+    expect(
+      transport.calls.last.headers[HttpHeaders.authorizationHeader],
+      'Bearer sess_account-b',
+    );
   });
 }
 
@@ -1689,6 +1963,31 @@ Map<String, Object?> _threadJson({
   };
 }
 
+Map<String, Object?> _matterJson({
+  required String id,
+  required String title,
+  String status = 'active',
+}) {
+  return {
+    'matter_id': id,
+    'title': title,
+    'status': status,
+    'version': 1,
+    'created_at': _createdAt,
+    'updated_at': _updatedAt,
+  };
+}
+
+Map<String, Object?> _matterLinkJson({required String matterId}) {
+  return {
+    'thread_id': _threadId,
+    'matter_id': matterId,
+    'active': true,
+    'linked_at': _createdAt,
+    'updated_at': _updatedAt,
+  };
+}
+
 Map<String, Object?> _messageJson({
   required String id,
   required int sequence,
@@ -1766,6 +2065,8 @@ IdentityHttpResponse _jsonResponse(int statusCode, Object? body) {
 
 const _threadId = '10000000-0000-4000-8000-000000000001';
 const _matterId = '40000000-0000-4000-8000-000000000001';
+const _matterBId = '40000000-0000-4000-8000-000000000002';
+const _matterCId = '40000000-0000-4000-8000-000000000003';
 const _threadBId = '10000000-0000-4000-8000-000000000002';
 const _userMessageId = '20000000-0000-4000-8000-000000000001';
 const _assistantMessageId = '20000000-0000-4000-8000-000000000002';

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -13,6 +13,7 @@ import 'package:speakup/agent/wire_agent_client.dart';
 import 'package:speakup/agent/wire_agent_voice_client.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/preparation/wire_preparation_client.dart';
+import 'package:speakup/features/preparation/wire_preparation_launch_client.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 import 'package:speakup/identity/session_store.dart';
@@ -134,6 +135,7 @@ void main() {
       );
       addTearDown(dependencies.agentController.dispose);
       addTearDown(dependencies.preparationController.dispose);
+      addTearDown(dependencies.preparationLaunchController.dispose);
       addTearDown(dependencies.reviewHistoryController.dispose);
 
       expect(dependencies.agentController.client, isA<WireAgentClient>());
@@ -169,12 +171,17 @@ void main() {
         dependencies.preparationController.client,
         isA<WirePreparationCatalogClient>(),
       );
+      expect(
+        dependencies.preparationLaunchController.client,
+        isA<WirePreparationLaunchClient>(),
+      );
 
       await tester.pumpWidget(
         SpeakUpApp(
           authController: dependencies.authController,
           agentController: dependencies.agentController,
           preparationController: dependencies.preparationController,
+          preparationLaunchController: dependencies.preparationLaunchController,
           reviewHistoryController: dependencies.reviewHistoryController,
         ),
       );

--- a/mobile/test/practice/practice_audio_player_test.dart
+++ b/mobile/test/practice/practice_audio_player_test.dart
@@ -9,6 +9,13 @@ import 'package:speakup/practice/practice_audio_player.dart';
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();
 
+  setUp(() {
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  });
+  tearDown(() {
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  });
+
   test(
     'managed WAV is deleted on stop and caller bytes are untouched',
     () async {
@@ -140,6 +147,9 @@ void main() {
         await _eventually(() async => !await File(native.path!).exists());
 
         expect(completionCount, 1);
+        expect(native.stopCount, 1);
+        expect(native.releaseCount, 1);
+        expect(native.disposeCount, 1);
         expect(await File(native.path!).exists(), isFalse);
       } finally {
         binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);

--- a/mobile/test/practice/wire_practice_client_test.dart
+++ b/mobile/test/practice/wire_practice_client_test.dart
@@ -36,6 +36,48 @@ void main() {
     );
   });
 
+  test(
+    'accepts server-authoritative completion before the frozen max turns',
+    () async {
+      final transport = _Transport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/voice-practice-session',
+          response: _json(HttpStatus.ok, {
+            'practice_session_id': _sessionId,
+            'practice_plan_id': 'plan-1',
+            'thread_id': _threadId,
+            'matter': _matterJson(),
+            'session_version': 5,
+            'effective_turns': 4,
+            'turn_limit': 6,
+            'session_completed': true,
+            'current_turn': {
+              'turn_id': _turnId,
+              'practice_session_id': _sessionId,
+              'question_id': _questionId,
+              'respondent_participant_id': 'participant-user',
+              'candidate_id': _candidateId,
+              'answer_text': 'I explained the trade-off.',
+              'evidence_version': 1,
+              'effective_turns': 4,
+              'session_completed': true,
+            },
+          }),
+        ),
+      ]);
+
+      final snapshot = await _client(
+        transport,
+      ).restorePractice(threadId: _threadId);
+
+      expect(snapshot?.completedTurns, 4);
+      expect(snapshot?.turnLimit, 6);
+      expect(snapshot?.sessionCompleted, isTrue);
+      transport.expectDone();
+    },
+  );
+
   test('uses the frozen #87 empty-body and raw WAV routes', () async {
     final audioFile = await _temporaryAudio();
     addTearDown(() => audioFile.parent.delete(recursive: true));

--- a/mobile/test/practice/wire_practice_client_test.dart
+++ b/mobile/test/practice/wire_practice_client_test.dart
@@ -12,30 +12,6 @@ import 'package:speakup/practice/practice_recording.dart';
 import 'package:speakup/practice/wire_practice_client.dart';
 
 void main() {
-  test('encodes every opaque resource ID as one path segment', () {
-    const endpoints = PracticeWireEndpoints();
-    const opaque = 'resource/part?query#fragment%value';
-    const encoded = 'resource%2Fpart%3Fquery%23fragment%25value';
-
-    expect(
-      endpoints.restorePath(opaque),
-      '/v1/agent-threads/$encoded/voice-practice-session',
-    );
-    expect(
-      endpoints.startPath(opaque),
-      '/v1/agent-threads/$encoded/voice-practice-sessions',
-    );
-    expect(
-      endpoints.transcribePath(opaque, opaque),
-      '/v1/voice-practice-sessions/$encoded/questions/'
-      '$encoded/transcription-candidates',
-    );
-    expect(
-      endpoints.confirmPath(opaque),
-      '/v1/transcription-candidates/$encoded/confirmations',
-    );
-  });
-
   test(
     'accepts server-authoritative completion before the frozen max turns',
     () async {
@@ -77,6 +53,30 @@ void main() {
       transport.expectDone();
     },
   );
+
+  test('encodes every opaque resource ID as one path segment', () {
+    const endpoints = PracticeWireEndpoints();
+    const opaque = 'resource/part?query#fragment%value';
+    const encoded = 'resource%2Fpart%3Fquery%23fragment%25value';
+
+    expect(
+      endpoints.restorePath(opaque),
+      '/v1/agent-threads/$encoded/voice-practice-session',
+    );
+    expect(
+      endpoints.startPath(opaque),
+      '/v1/agent-threads/$encoded/voice-practice-sessions',
+    );
+    expect(
+      endpoints.transcribePath(opaque, opaque),
+      '/v1/voice-practice-sessions/$encoded/questions/'
+      '$encoded/transcription-candidates',
+    );
+    expect(
+      endpoints.confirmPath(opaque),
+      '/v1/transcription-candidates/$encoded/confirmations',
+    );
+  });
 
   test('uses the frozen #87 empty-body and raw WAV routes', () async {
     final audioFile = await _temporaryAudio();

--- a/mobile/test/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/preparation/preparation_launch_controller_test.dart
@@ -26,9 +26,16 @@ void main() {
               matterKeys.add(clientOperationId);
               return _context;
             },
-        voiceActivator: ({required context, required bootstrap}) async {
-          activations.add('${context.threadId}:${bootstrap.session.id}');
-        },
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              activations.add(
+                '${context.threadId}:${bootstrap.session.id}:$clientOperationId',
+              );
+            },
         idFactory: (scope) => '$scope-stable-key',
       );
       addTearDown(controller.dispose);
@@ -53,7 +60,7 @@ void main() {
         'agent-matter-stable-key',
         'agent-matter-stable-key',
       ]);
-      expect(activations, ['$_threadId:$_sessionId']);
+      expect(activations, ['$_threadId:$_sessionId:practice-voice-stable-key']);
       expect(controller.bootstrap?.session.id, _sessionId);
       expect(controller.canRetry, isFalse);
     },
@@ -77,7 +84,12 @@ void main() {
               context = _context;
               return _context;
             },
-        voiceActivator: ({required context, required bootstrap}) async {},
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {},
         idFactory: (scope) => '$scope-recovered-key',
       );
       addTearDown(controller.dispose);
@@ -87,6 +99,52 @@ void main() {
       expect(controller.backgroundSummary, _background);
       expect(client.calls, ['profile', 'snapshot', 'plan', 'session']);
       expect(client.lastPlanInput?.selection, _selection);
+    },
+  );
+
+  test(
+    'reuses the formal voice activation key after a network retry',
+    () async {
+      final voiceKeys = <String>[];
+      final client = _LaunchClient();
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => _context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _context,
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              voiceKeys.add(clientOperationId);
+              if (voiceKeys.length == 1) {
+                throw const PreparationLaunchException(
+                  kind: PreparationLaunchFailureKind.network,
+                  stage: PreparationLaunchStage.voice,
+                  retryable: true,
+                );
+              }
+            },
+        idFactory: (scope) => '$scope-voice-retry-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      expect(await controller.start(_selection), isFalse);
+      expect(controller.canRetry, isTrue);
+      expect(await controller.retry(), isTrue);
+
+      expect(voiceKeys, [
+        'practice-voice-voice-retry-key',
+        'practice-voice-voice-retry-key',
+      ]);
     },
   );
 
@@ -106,7 +164,12 @@ void main() {
               required selection,
               required clientOperationId,
             }) async => context,
-        voiceActivator: ({required context, required bootstrap}) async {},
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {},
         idFactory: (scope) => '$scope-context-key',
       );
       addTearDown(controller.dispose);
@@ -142,9 +205,14 @@ void main() {
               required selection,
               required clientOperationId,
             }) async => _context,
-        voiceActivator: ({required context, required bootstrap}) async {
-          activated = true;
-        },
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              activated = true;
+            },
         idFactory: (scope) => '$scope-logout-key',
       );
       addTearDown(controller.dispose);

--- a/mobile/test/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/preparation/preparation_launch_controller_test.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+void main() {
+  test(
+    'runs the typed launch chain and reuses every key after network failure',
+    () async {
+      final client = _LaunchClient(failFirstSession: true);
+      final activations = <String>[];
+      final matterKeys = <String>[];
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => _context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async {
+              matterKeys.add(clientOperationId);
+              return _context;
+            },
+        voiceActivator: ({required context, required bootstrap}) async {
+          activations.add('${context.threadId}:${bootstrap.session.id}');
+        },
+        idFactory: (scope) => '$scope-stable-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      expect(await controller.start(_selection), isFalse);
+      expect(controller.canRetry, isTrue);
+      expect(controller.errorMessage, contains('进度已保留'));
+      expect(client.calls, ['profile', 'snapshot', 'plan', 'session']);
+
+      expect(await controller.retry(), isTrue);
+      expect(
+        client.calls,
+        ['profile', 'snapshot', 'plan', 'session'] +
+            ['profile', 'snapshot', 'plan', 'session'],
+      );
+      expect(client.profileKeys.toSet(), {'prep-profile-stable-key'});
+      expect(client.snapshotKeys.toSet(), {'prep-snapshot-stable-key'});
+      expect(client.planKeys.toSet(), {'practice-plan-stable-key'});
+      expect(client.sessionKeys.toSet(), {'practice-session-stable-key'});
+      expect(matterKeys, [
+        'agent-matter-stable-key',
+        'agent-matter-stable-key',
+      ]);
+      expect(activations, ['$_threadId:$_sessionId']);
+      expect(controller.bootstrap?.session.id, _sessionId);
+      expect(controller.canRetry, isFalse);
+    },
+  );
+
+  test(
+    'creates a real Matter when a new user has only an Agent Thread',
+    () async {
+      AgentPracticeContext? context;
+      final client = _LaunchClient();
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async {
+              context = _context;
+              return _context;
+            },
+        voiceActivator: ({required context, required bootstrap}) async {},
+        idFactory: (scope) => '$scope-recovered-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      expect(await controller.start(_selection), isTrue);
+      expect(controller.backgroundSummary, _background);
+      expect(client.calls, ['profile', 'snapshot', 'plan', 'session']);
+      expect(client.lastPlanInput?.selection, _selection);
+    },
+  );
+
+  test(
+    'fences a late response after the selected Agent Matter changes',
+    () async {
+      var context = _context;
+      final profile = Completer<PreparationProfile>();
+      final client = _LaunchClient(profileCompleter: profile);
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => context,
+        threadIdProvider: () => context.threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => context,
+        voiceActivator: ({required context, required bootstrap}) async {},
+        idFactory: (scope) => '$scope-context-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      final start = controller.start(_selection);
+      context = const AgentPracticeContext(
+        threadId: _threadId,
+        matterId: 'matter-changed',
+      );
+      profile.complete(_profile);
+
+      expect(await start, isFalse);
+      expect(controller.stage, PreparationLaunchStage.context);
+      expect(controller.errorMessage, contains('已变化'));
+      expect(client.calls, isEmpty);
+    },
+  );
+
+  test(
+    'logout clears input and suppresses an old account completion',
+    () async {
+      final profile = Completer<PreparationProfile>();
+      final client = _LaunchClient(profileCompleter: profile);
+      var activated = false;
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => _context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _context,
+        voiceActivator: ({required context, required bootstrap}) async {
+          activated = true;
+        },
+        idFactory: (scope) => '$scope-logout-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      final start = controller.start(_selection);
+      await controller.clearPrivateState();
+      profile.complete(_profile);
+
+      expect(await start, isFalse);
+      expect(client.clearCalls, 1);
+      expect(controller.backgroundSummary, isEmpty);
+      expect(controller.bootstrap, isNull);
+      expect(controller.errorMessage, isNull);
+      expect(activated, isFalse);
+    },
+  );
+}
+
+final class _LaunchClient implements PreparationLaunchClient {
+  _LaunchClient({this.failFirstSession = false, this.profileCompleter});
+
+  final bool failFirstSession;
+  final Completer<PreparationProfile>? profileCompleter;
+  final calls = <String>[];
+  final profileKeys = <String>[];
+  final snapshotKeys = <String>[];
+  final planKeys = <String>[];
+  final sessionKeys = <String>[];
+  CreatePreparationPlanInput? lastPlanInput;
+  int clearCalls = 0;
+  int _sessionCalls = 0;
+
+  @override
+  Future<PreparationProfile> createProfile({
+    required CreatePreparationProfileInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('profile');
+    profileKeys.add(idempotencyKey);
+    expect(input.backgroundSummary, _background);
+    return profileCompleter?.future ?? _profile;
+  }
+
+  @override
+  Future<PreparationSnapshot> createSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('snapshot');
+    snapshotKeys.add(idempotencyKey);
+    expect(profileId, _profileId);
+    expect(sourceVersion, 1);
+    return _snapshot;
+  }
+
+  @override
+  Future<PreparationPracticePlan> createPlan({
+    required CreatePreparationPlanInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('plan');
+    planKeys.add(idempotencyKey);
+    lastPlanInput = input;
+    expect(input.preparationProfileId, _profileId);
+    expect(input.preparationUserId, _userId);
+    return _plan;
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createSession({
+    required String planId,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('session');
+    sessionKeys.add(idempotencyKey);
+    _sessionCalls++;
+    expect(planId, _planId);
+    expect(input.preparationProfileId, _profileId);
+    expect(input.preparationProfileVersion, 1);
+    expect(input.preparationUserId, _userId);
+    expect(input.backgroundSummary, _background);
+    if (failFirstSession && _sessionCalls == 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: PreparationLaunchStage.session,
+        retryable: true,
+      );
+    }
+    return _bootstrap;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    clearCalls++;
+  }
+}
+
+const _threadId = 'thread-1';
+const _matterId = 'matter-1';
+const _userId = 'user-1';
+const _profileId = 'profile-1';
+const _snapshotId = 'preparation-snapshot-1';
+const _planId = 'plan-1';
+const _sessionId = 'session-1';
+const _background = 'Backend engineer preparing a technical interview.';
+
+const _context = AgentPracticeContext(threadId: _threadId, matterId: _matterId);
+
+const _selection = PreparationLaunchSelection(
+  scenarioDefinitionId: 'scenario-1',
+  scenarioDefinitionVersion: 1,
+  scenarioType: 'INTERVIEW',
+  scenarioDisplayName: 'Technical interview',
+  scenarioDescription: 'Backend engineer: technical interview practice',
+  scenarioConfigId: 'config-1',
+  scenarioConfigVersion: 1,
+  roleDefinitionId: 'role-1',
+  roleDefinitionVersion: 2,
+  practiceOptionId: 'option-1',
+  practiceOptionType: PreparationOptionType.focus,
+  practiceOptionVersion: 1,
+);
+
+final _profile = PreparationProfile(
+  id: _profileId,
+  userId: _userId,
+  backgroundSummary: _background,
+  version: 1,
+  updatedAt: DateTime.utc(2026, 7, 26),
+);
+
+final _snapshot = PreparationSnapshot(
+  id: _snapshotId,
+  sourceProfileId: _profileId,
+  sourceVersion: 1,
+  backgroundSnapshot: _background,
+  createdAt: DateTime.utc(2026, 7, 26),
+);
+
+const _plan = PreparationPracticePlan(
+  id: _planId,
+  userId: _userId,
+  context: _context,
+  selection: _selection,
+  preparationProfileId: _profileId,
+  revision: 1,
+  status: 'ready',
+);
+
+final _bootstrap = PreparationPracticeBootstrap(
+  session: PreparationPracticeSession(
+    id: _sessionId,
+    planId: _planId,
+    scenarioType: 'INTERVIEW',
+    snapshotId: 'session-snapshot-1',
+    status: 'starting',
+    version: 1,
+    createdAt: DateTime.utc(2026, 7, 26),
+  ),
+  preparationSnapshotId: _snapshotId,
+  maxEffectiveTurns: 3,
+);

--- a/mobile/test/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/preparation/preparation_launch_controller_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/preparation/preparation_launch_client.dart';
@@ -103,9 +104,10 @@ void main() {
   );
 
   test(
-    'reuses the formal voice activation key after a network retry',
+    'locks a committed Session and reuses every key after voice failure',
     () async {
       final voiceKeys = <String>[];
+      final matterKeys = <String>[];
       final client = _LaunchClient();
       final controller = PreparationLaunchController(
         client: client,
@@ -116,7 +118,10 @@ void main() {
               required threadId,
               required selection,
               required clientOperationId,
-            }) async => _context,
+            }) async {
+              matterKeys.add(clientOperationId);
+              return _context;
+            },
         voiceActivator:
             ({
               required context,
@@ -126,9 +131,8 @@ void main() {
               voiceKeys.add(clientOperationId);
               if (voiceKeys.length == 1) {
                 throw const PreparationLaunchException(
-                  kind: PreparationLaunchFailureKind.network,
+                  kind: PreparationLaunchFailureKind.invalidResponse,
                   stage: PreparationLaunchStage.voice,
-                  retryable: true,
                 );
               }
             },
@@ -139,12 +143,52 @@ void main() {
 
       expect(await controller.start(_selection), isFalse);
       expect(controller.canRetry, isTrue);
+      expect(controller.isSelectionLocked, isTrue);
+      expect(controller.bootstrap, same(_bootstrap));
+
+      controller.selectionChanged();
+      controller.updateBackgroundSummary('A different background.');
+
+      expect(controller.backgroundSummary, _background);
+      expect(controller.bootstrap, same(_bootstrap));
+      expect(controller.canRetry, isTrue);
       expect(await controller.retry(), isTrue);
 
+      expect(matterKeys, [
+        'agent-matter-voice-retry-key',
+        'agent-matter-voice-retry-key',
+      ]);
+      expect(client.calls, [
+        'profile',
+        'snapshot',
+        'plan',
+        'session',
+        'profile',
+        'snapshot',
+        'plan',
+        'session',
+      ]);
+      expect(client.profileKeys, [
+        'prep-profile-voice-retry-key',
+        'prep-profile-voice-retry-key',
+      ]);
+      expect(client.snapshotKeys, [
+        'prep-snapshot-voice-retry-key',
+        'prep-snapshot-voice-retry-key',
+      ]);
+      expect(client.planKeys, [
+        'practice-plan-voice-retry-key',
+        'practice-plan-voice-retry-key',
+      ]);
+      expect(client.sessionKeys, [
+        'practice-session-voice-retry-key',
+        'practice-session-voice-retry-key',
+      ]);
       expect(voiceKeys, [
         'practice-voice-voice-retry-key',
         'practice-voice-voice-retry-key',
       ]);
+      expect(controller.isSelectionLocked, isFalse);
     },
   );
 
@@ -186,6 +230,56 @@ void main() {
       expect(controller.stage, PreparationLaunchStage.context);
       expect(controller.errorMessage, contains('已变化'));
       expect(client.calls, isEmpty);
+    },
+  );
+
+  test(
+    'retries a malformed 201 Session with the same key before voice',
+    () async {
+      final voiceKeys = <String>[];
+      final client = _LaunchClient(failFirstSessionResponse: true);
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => _context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _context,
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              voiceKeys.add(clientOperationId);
+            },
+        idFactory: (scope) => '$scope-session-201-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      expect(await controller.start(_selection), isFalse);
+      expect(controller.stage, PreparationLaunchStage.session);
+      expect(controller.bootstrap, isNull);
+      expect(controller.canRetry, isTrue);
+      expect(controller.isSelectionLocked, isTrue);
+
+      controller.selectionChanged();
+      controller.updateBackgroundSummary('A different background.');
+
+      expect(controller.backgroundSummary, _background);
+      expect(controller.canRetry, isTrue);
+      expect(await controller.retry(), isTrue);
+      expect(client.sessionKeys, [
+        'practice-session-session-201-key',
+        'practice-session-session-201-key',
+      ]);
+      expect(voiceKeys, ['practice-voice-session-201-key']);
+      expect(controller.bootstrap, same(_bootstrap));
+      expect(controller.isSelectionLocked, isFalse);
     },
   );
 
@@ -287,11 +381,13 @@ void main() {
 final class _LaunchClient implements PreparationLaunchClient {
   _LaunchClient({
     this.failFirstSession = false,
+    this.failFirstSessionResponse = false,
     this.profileCompleter,
     this.sessionCompleter,
   });
 
   final bool failFirstSession;
+  final bool failFirstSessionResponse;
   final Completer<PreparationProfile>? profileCompleter;
   final Completer<PreparationPracticeBootstrap>? sessionCompleter;
   final calls = <String>[];
@@ -358,6 +454,14 @@ final class _LaunchClient implements PreparationLaunchClient {
       throw const PreparationLaunchException(
         kind: PreparationLaunchFailureKind.network,
         stage: PreparationLaunchStage.session,
+        retryable: true,
+      );
+    }
+    if (failFirstSessionResponse && _sessionCalls == 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.invalidResponse,
+        stage: PreparationLaunchStage.session,
+        statusCode: HttpStatus.created,
         retryable: true,
       );
     }

--- a/mobile/test/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/preparation/preparation_launch_controller_test.dart
@@ -230,13 +230,70 @@ void main() {
       expect(activated, isFalse);
     },
   );
+
+  test(
+    'selection changes cannot orphan a Session while launch is pending',
+    () async {
+      final session = Completer<PreparationPracticeBootstrap>();
+      final voice = Completer<void>();
+      final client = _LaunchClient(sessionCompleter: session);
+      final controller = PreparationLaunchController(
+        client: client,
+        contextProvider: () => _context,
+        threadIdProvider: () => _threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _context,
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) => voice.future,
+        idFactory: (scope) => '$scope-selection-lock-key',
+      );
+      addTearDown(controller.dispose);
+      controller.updateBackgroundSummary(_background);
+
+      final start = controller.start(_selection);
+      await Future<void>.delayed(Duration.zero);
+      expect(client.calls, ['profile', 'snapshot', 'plan', 'session']);
+      expect(controller.isStarting, isTrue);
+
+      controller.selectionChanged();
+      controller.updateBackgroundSummary('A stale field callback.');
+
+      expect(controller.isStarting, isTrue);
+      expect(controller.backgroundSummary, _background);
+      session.complete(_bootstrap);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.stage, PreparationLaunchStage.voice);
+      expect(controller.bootstrap, same(_bootstrap));
+      expect(controller.isStarting, isTrue);
+
+      voice.complete();
+
+      expect(await start, isTrue);
+      expect(controller.bootstrap, same(_bootstrap));
+      expect(controller.canRetry, isFalse);
+    },
+  );
 }
 
 final class _LaunchClient implements PreparationLaunchClient {
-  _LaunchClient({this.failFirstSession = false, this.profileCompleter});
+  _LaunchClient({
+    this.failFirstSession = false,
+    this.profileCompleter,
+    this.sessionCompleter,
+  });
 
   final bool failFirstSession;
   final Completer<PreparationProfile>? profileCompleter;
+  final Completer<PreparationPracticeBootstrap>? sessionCompleter;
   final calls = <String>[];
   final profileKeys = <String>[];
   final snapshotKeys = <String>[];
@@ -304,7 +361,7 @@ final class _LaunchClient implements PreparationLaunchClient {
         retryable: true,
       );
     }
-    return _bootstrap;
+    return sessionCompleter?.future ?? _bootstrap;
   }
 
   @override

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -307,7 +307,12 @@ void main() {
               matterId: matter.id,
             );
           },
-      voiceActivator: ({required context, required bootstrap}) async {},
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
       idFactory: (scope) => '$scope-widget-key',
     );
     addTearDown(agentController.dispose);
@@ -378,7 +383,12 @@ void main() {
             }) {
               throw StateError('Matter activation must wait for the Thread.');
             },
-        voiceActivator: ({required context, required bootstrap}) async {},
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {},
         idFactory: (scope) => '$scope-thread-wait-key',
       );
       addTearDown(preparationController.dispose);

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -445,6 +445,146 @@ void main() {
       expect(launchClient.calls, isEmpty);
     },
   );
+
+  testWidgets(
+    'locks roles options and both back paths while Session creation is pending',
+    (tester) async {
+      final session = Completer<PreparationPracticeBootstrap>();
+      final preparationController = PreparationController(
+        client: _FixtureClient(),
+      );
+      final launchClient = _PageLaunchClient(sessionCompleter: session);
+      var navigations = 0;
+      final launchController = PreparationLaunchController(
+        client: launchClient,
+        contextProvider: () => _pageContext,
+        threadIdProvider: () => _pageContext.threadId,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _pageContext,
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {},
+        idFactory: (scope) => '$scope-pending-widget-key',
+      );
+      addTearDown(preparationController.dispose);
+      addTearDown(launchController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            showBackButton: true,
+            preparationController: preparationController,
+            launchController: launchController,
+            onPracticeStarted: () => navigations++,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+      await tester.pumpAndSettle();
+
+      final role = find.byKey(
+        const Key('preparation-role-role_technical_interviewer'),
+      );
+      await tester.ensureVisible(role);
+      await tester.tap(role);
+      await tester.pump();
+      final option = find.byKey(
+        const Key('preparation-option-option_full_simulation'),
+      );
+      await tester.scrollUntilVisible(option, 200);
+      await tester.tap(option);
+      await tester.pump();
+      final background = find
+          .byKey(const Key('preparation-background-summary'))
+          .first;
+      await tester.ensureVisible(background);
+      await tester.enterText(
+        background,
+        'Backend engineer preparing a technical interview.',
+      );
+      final start = find.byKey(const Key('preparation-start-practice'));
+      await tester.ensureVisible(start);
+      await tester.tap(start);
+      await tester.pump();
+
+      expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
+      expect(launchController.isStarting, isTrue);
+      final detailBack = find.byKey(const Key('preparation-back-to-catalog'));
+      await tester.scrollUntilVisible(
+        detailBack,
+        -200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(tester.widget<TextButton>(detailBack).onPressed, isNull);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.byKey(const Key('preparation-route-back-button')),
+            )
+            .onPressed,
+        isNull,
+      );
+      await tester.scrollUntilVisible(
+        role,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(
+        tester
+            .widget<InkWell>(
+              find.descendant(of: role, matching: find.byType(InkWell)),
+            )
+            .onTap,
+        isNull,
+      );
+      await tester.scrollUntilVisible(
+        option,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(
+        tester
+            .widget<InkWell>(
+              find.descendant(of: option, matching: find.byType(InkWell)),
+            )
+            .onTap,
+        isNull,
+      );
+      expect(preparationController.selectedRole?.id, _technicalRole.id);
+      expect(
+        preparationController.selectedOption?.id,
+        'option_full_simulation',
+      );
+
+      session.complete(
+        PreparationPracticeBootstrap(
+          session: PreparationPracticeSession(
+            id: 'session-1',
+            planId: 'plan-1',
+            scenarioType: 'INTERVIEW',
+            snapshotId: 'session-snapshot-1',
+            status: 'starting',
+            version: 1,
+            createdAt: DateTime.utc(2026, 7, 26),
+          ),
+          preparationSnapshotId: 'preparation-snapshot-1',
+          maxEffectiveTurns: 6,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(launchController.isStarting, isFalse);
+      expect(navigations, 1);
+    },
+  );
 }
 
 class _FixtureClient implements PreparationCatalogClient {
@@ -490,6 +630,9 @@ final class _ControlledListClient implements PreparationCatalogClient {
 }
 
 final class _PageLaunchClient implements PreparationLaunchClient {
+  _PageLaunchClient({this.sessionCompleter});
+
+  final Completer<PreparationPracticeBootstrap>? sessionCompleter;
   final calls = <String>[];
 
   @override
@@ -550,7 +693,7 @@ final class _PageLaunchClient implements PreparationLaunchClient {
     required String idempotencyKey,
   }) async {
     calls.add('session');
-    return PreparationPracticeBootstrap(
+    final bootstrap = PreparationPracticeBootstrap(
       session: PreparationPracticeSession(
         id: 'session-1',
         planId: planId,
@@ -563,8 +706,14 @@ final class _PageLaunchClient implements PreparationLaunchClient {
       preparationSnapshotId: input.preparationSnapshotId,
       maxEffectiveTurns: 6,
     );
+    return sessionCompleter?.future ?? bootstrap;
   }
 }
+
+const _pageContext = AgentPracticeContext(
+  threadId: '10000000-0000-4000-8000-000000000001',
+  matterId: '40000000-0000-4000-8000-000000000001',
+);
 
 const _scenarioId = 'scn_programmer_interview';
 

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -430,9 +430,9 @@ void main() {
         findsNothing,
       );
 
-      final background = find
-          .byKey(const Key('preparation-background-summary'))
-          .first;
+      final background = find.byKey(
+        const Key('preparation-background-summary'),
+      );
       await tester.ensureVisible(background);
       await tester.enterText(
         background,
@@ -447,7 +447,7 @@ void main() {
   );
 
   testWidgets(
-    'locks roles options and both back paths while Session creation is pending',
+    'keeps selection locked after Session creation until voice retry succeeds',
     (tester) async {
       final session = Completer<PreparationPracticeBootstrap>();
       final preparationController = PreparationController(
@@ -455,6 +455,7 @@ void main() {
       );
       final launchClient = _PageLaunchClient(sessionCompleter: session);
       var navigations = 0;
+      var voiceCalls = 0;
       final launchController = PreparationLaunchController(
         client: launchClient,
         contextProvider: () => _pageContext,
@@ -470,7 +471,15 @@ void main() {
               required context,
               required bootstrap,
               required clientOperationId,
-            }) async {},
+            }) async {
+              voiceCalls++;
+              if (voiceCalls == 1) {
+                throw const PreparationLaunchException(
+                  kind: PreparationLaunchFailureKind.invalidResponse,
+                  stage: PreparationLaunchStage.voice,
+                );
+              }
+            },
         idFactory: (scope) => '$scope-pending-widget-key',
       );
       addTearDown(preparationController.dispose);
@@ -502,9 +511,9 @@ void main() {
       await tester.scrollUntilVisible(option, 200);
       await tester.tap(option);
       await tester.pump();
-      final background = find
-          .byKey(const Key('preparation-background-summary'))
-          .first;
+      final background = find.byKey(
+        const Key('preparation-background-summary'),
+      );
       await tester.ensureVisible(background);
       await tester.enterText(
         background,
@@ -531,6 +540,10 @@ void main() {
             )
             .onPressed,
         isNull,
+      );
+      expect(
+        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
+        isFalse,
       );
       await tester.scrollUntilVisible(
         role,
@@ -582,6 +595,83 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(launchController.isStarting, isFalse);
+      expect(launchController.isSelectionLocked, isTrue);
+      expect(launchController.bootstrap, isNotNull);
+      expect(launchController.canRetry, isTrue);
+      expect(navigations, 0);
+
+      await tester.scrollUntilVisible(
+        detailBack,
+        -200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(tester.widget<TextButton>(detailBack).onPressed, isNull);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.byKey(const Key('preparation-route-back-button')),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
+        isFalse,
+      );
+      await tester.scrollUntilVisible(
+        role,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(
+        tester
+            .widget<InkWell>(
+              find.descendant(of: role, matching: find.byType(InkWell)),
+            )
+            .onTap,
+        isNull,
+      );
+      await tester.scrollUntilVisible(
+        option,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(
+        tester
+            .widget<InkWell>(
+              find.descendant(of: option, matching: find.byType(InkWell)),
+            )
+            .onTap,
+        isNull,
+      );
+      await tester.scrollUntilVisible(
+        background,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(tester.widget<TextField>(background).enabled, isFalse);
+
+      final retry = find.byKey(const Key('preparation-retry-launch'));
+      await tester.scrollUntilVisible(
+        retry,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(retry);
+      await tester.pumpAndSettle();
+
+      expect(voiceCalls, 2);
+      expect(
+        launchClient.calls,
+        ['profile', 'snapshot', 'plan', 'session'] +
+            ['profile', 'snapshot', 'plan', 'session'],
+      );
+      expect(launchController.isStarting, isFalse);
+      expect(launchController.isSelectionLocked, isFalse);
+      expect(
+        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
+        isTrue,
+      );
       expect(navigations, 1);
     },
   );

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -9,6 +9,9 @@ import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_client.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 
 void main() {
@@ -66,17 +69,13 @@ void main() {
       await tester.tap(fullSimulation);
       await tester.pump();
       final selectionNotice = find.byKey(
-        const Key('preparation-read-only-selection'),
+        const Key('preparation-launch-unavailable'),
       );
       await tester.scrollUntilVisible(selectionNotice, 200);
       await tester.pumpAndSettle();
 
       expect(selectionNotice, findsOneWidget);
-      final startButton = tester.widget<FilledButton>(
-        find.byKey(const Key('preparation-start-unavailable')),
-      );
-      expect(startButton.onPressed, isNull);
-      expect(find.textContaining('尚未创建练习或写入业务数据'), findsOneWidget);
+      expect(find.textContaining('正式练习启动服务未注入'), findsOneWidget);
     },
   );
 
@@ -277,6 +276,165 @@ void main() {
       expect(agentController.activeMatter?.id, originalMatterId);
     },
   );
+
+  testWidgets('starts the real typed chain and reports success to navigation', (
+    tester,
+  ) async {
+    final agentController = AgentController(client: FakeAgentClient());
+    final preparationController = PreparationController(
+      client: _FixtureClient(),
+    );
+    final launchClient = _PageLaunchClient();
+    var navigations = 0;
+    await agentController.initialize();
+    await agentController.selectScene(agentScenes.first);
+    final launchController = PreparationLaunchController(
+      client: launchClient,
+      contextProvider: () => AgentPracticeContext(
+        threadId: agentController.threadId!,
+        matterId: agentController.activeMatter!.id,
+      ),
+      threadIdProvider: () => agentController.threadId,
+      matterActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async {
+            final matter = agentController.activeMatter!;
+            return AgentPracticeContext(
+              threadId: threadId,
+              matterId: matter.id,
+            );
+          },
+      voiceActivator: ({required context, required bootstrap}) async {},
+      idFactory: (scope) => '$scope-widget-key',
+    );
+    addTearDown(agentController.dispose);
+    addTearDown(preparationController.dispose);
+    addTearDown(launchController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          agentController: agentController,
+          preparationController: preparationController,
+          launchController: launchController,
+          onPracticeStarted: () => navigations++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+    await tester.pumpAndSettle();
+    final role = find.byKey(
+      const Key('preparation-role-role_technical_interviewer'),
+    );
+    await tester.ensureVisible(role);
+    await tester.tap(role);
+    await tester.pump();
+    final option = find.byKey(
+      const Key('preparation-option-option_full_simulation'),
+    );
+    await tester.scrollUntilVisible(option, 200);
+    await tester.tap(option);
+    await tester.pump();
+    final background = find
+        .byKey(const Key('preparation-background-summary'))
+        .first;
+    await tester.ensureVisible(background);
+    await tester.enterText(
+      background,
+      'Backend engineer preparing a technical interview.',
+    );
+    final start = find.byKey(const Key('preparation-start-practice'));
+    await tester.ensureVisible(start);
+    await tester.tap(start);
+    await tester.pumpAndSettle();
+
+    expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
+    expect(navigations, 1);
+    expect(agentController.threadId, isNotNull);
+    expect(agentController.activeMatter, isNotNull);
+    expect(launchController.bootstrap?.maxEffectiveTurns, 6);
+  });
+
+  testWidgets(
+    'keeps start on the current page while the Agent Thread restores',
+    (tester) async {
+      final preparationController = PreparationController(
+        client: _FixtureClient(),
+      );
+      final launchClient = _PageLaunchClient();
+      final launchController = PreparationLaunchController(
+        client: launchClient,
+        contextProvider: () => null,
+        threadIdProvider: () => null,
+        matterActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) {
+              throw StateError('Matter activation must wait for the Thread.');
+            },
+        voiceActivator: ({required context, required bootstrap}) async {},
+        idFactory: (scope) => '$scope-thread-wait-key',
+      );
+      addTearDown(preparationController.dispose);
+      addTearDown(launchController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            preparationController: preparationController,
+            launchController: launchController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+      await tester.pumpAndSettle();
+      final role = find.byKey(
+        const Key('preparation-role-role_technical_interviewer'),
+      );
+      await tester.ensureVisible(role);
+      await tester.tap(role);
+      await tester.pump();
+      final option = find.byKey(
+        const Key('preparation-option-option_full_simulation'),
+      );
+      await tester.scrollUntilVisible(option, 200);
+      await tester.tap(option);
+      await tester.pump();
+
+      final startFinder = find.byKey(const Key('preparation-start-practice'));
+      await tester.ensureVisible(startFinder);
+      expect(tester.widget<FilledButton>(startFinder).onPressed, isNotNull);
+      expect(
+        find.byKey(const Key('preparation-agent-context-missing')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('preparation-open-agent-home')),
+        findsNothing,
+      );
+
+      final background = find
+          .byKey(const Key('preparation-background-summary'))
+          .first;
+      await tester.ensureVisible(background);
+      await tester.enterText(
+        background,
+        'Backend engineer preparing a technical interview.',
+      );
+      await tester.tap(startFinder);
+      await tester.pump();
+
+      expect(find.textContaining('Agent 对话仍在恢复'), findsWidgets);
+      expect(launchClient.calls, isEmpty);
+    },
+  );
 }
 
 class _FixtureClient implements PreparationCatalogClient {
@@ -318,6 +476,83 @@ final class _ControlledListClient implements PreparationCatalogClient {
   @override
   Future<List<PreparationRole>> listRoles(String scenarioId) {
     throw UnimplementedError();
+  }
+}
+
+final class _PageLaunchClient implements PreparationLaunchClient {
+  final calls = <String>[];
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PreparationProfile> createProfile({
+    required CreatePreparationProfileInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('profile');
+    return PreparationProfile(
+      id: 'profile-1',
+      userId: 'user-1',
+      backgroundSummary: input.backgroundSummary,
+      version: 1,
+      updatedAt: DateTime.utc(2026, 7, 26),
+    );
+  }
+
+  @override
+  Future<PreparationSnapshot> createSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('snapshot');
+    return PreparationSnapshot(
+      id: 'preparation-snapshot-1',
+      sourceProfileId: profileId,
+      sourceVersion: sourceVersion,
+      backgroundSnapshot: 'Backend engineer preparing a technical interview.',
+      createdAt: DateTime.utc(2026, 7, 26),
+    );
+  }
+
+  @override
+  Future<PreparationPracticePlan> createPlan({
+    required CreatePreparationPlanInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('plan');
+    return PreparationPracticePlan(
+      id: 'plan-1',
+      userId: input.preparationUserId,
+      context: input.context,
+      selection: input.selection,
+      preparationProfileId: input.preparationProfileId,
+      revision: 1,
+      status: 'ready',
+    );
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createSession({
+    required String planId,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('session');
+    return PreparationPracticeBootstrap(
+      session: PreparationPracticeSession(
+        id: 'session-1',
+        planId: planId,
+        scenarioType: 'INTERVIEW',
+        snapshotId: 'session-snapshot-1',
+        status: 'starting',
+        version: 1,
+        createdAt: DateTime.utc(2026, 7, 26),
+      ),
+      preparationSnapshotId: input.preparationSnapshotId,
+      maxEffectiveTurns: 6,
+    );
   }
 }
 

--- a/mobile/test/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_launch_client_test.dart
@@ -1,0 +1,526 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+import 'package:speakup/features/preparation/wire_preparation_launch_client.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+
+void main() {
+  test(
+    'sends the exact authenticated Profile to Session production chain',
+    () async {
+      final transport = _QueueTransport([
+        _response(_profileJson()),
+        _response(_snapshotJson()),
+        _response(_planJson()),
+        _response(_bootstrapJson()),
+      ]);
+      final client = _client(transport);
+
+      final profile = await client.createProfile(
+        input: const CreatePreparationProfileInput(
+          backgroundSummary: _background,
+        ),
+        idempotencyKey: 'profile-key-123',
+      );
+      final snapshot = await client.createSnapshot(
+        profileId: profile.id,
+        sourceVersion: profile.version,
+        idempotencyKey: 'snapshot-key-123',
+      );
+      final plan = await client.createPlan(
+        input: CreatePreparationPlanInput(
+          context: _context,
+          selection: _selection,
+          preparationProfileId: profile.id,
+          preparationUserId: profile.userId,
+        ),
+        idempotencyKey: 'plan-key-123456',
+      );
+      final bootstrap = await client.createSession(
+        planId: plan.id,
+        input: CreatePreparationSessionInput(
+          expectedPlanRevision: plan.revision,
+          preparationSnapshotId: snapshot.id,
+          preparationProfileId: profile.id,
+          preparationProfileVersion: profile.version,
+          preparationUserId: profile.userId,
+          backgroundSummary: profile.backgroundSummary,
+          selection: _selection,
+        ),
+        idempotencyKey: 'session-key-123',
+      );
+
+      expect(bootstrap.session.id, _sessionId);
+      expect(transport.calls.map((call) => call.uri.path), [
+        '/v1/preparation-profiles',
+        '/v1/preparation-profiles/$_profileId/snapshots',
+        '/v1/practice-plans',
+        '/v1/practice-plans/$_planId/practice-sessions',
+      ]);
+      expect(jsonDecode(transport.calls.first.body!), {
+        'background_summary': _background,
+      });
+      expect(jsonDecode(transport.calls[2].body!), {
+        'agent_thread_id': _threadId,
+        'matter_id': _matterId,
+        'scenario_definition_id': _scenarioId,
+        'scenario_definition_version': 1,
+        'scenario_config_id': _configId,
+        'scenario_config_version': 1,
+        'preparation_profile_id': _profileId,
+        'selected_role_ids': [_roleId],
+      });
+      expect(jsonDecode(transport.calls.last.body!), {
+        'expected_plan_revision': 1,
+        'preparation_snapshot_id': _preparationSnapshotId,
+        'practice_option_id': _optionId,
+        'role_definition_ids': [_roleId],
+      });
+      for (final call in transport.calls) {
+        expect(
+          call.headers[HttpHeaders.authorizationHeader],
+          'Bearer sess_account-a',
+        );
+        expect(call.headers[HttpHeaders.contentTypeHeader], 'application/json');
+        expect(call.headers['Idempotency-Key'], isNotEmpty);
+      }
+    },
+  );
+
+  test('rejects a Plan owned by a different user', () async {
+    final response = _planJson()..['user_id'] = 'user-other';
+    final client = _client(_QueueTransport([_response(response)]));
+
+    await expectLater(
+      client.createPlan(
+        input: const CreatePreparationPlanInput(
+          context: _context,
+          selection: _selection,
+          preparationProfileId: _profileId,
+          preparationUserId: _userId,
+        ),
+        idempotencyKey: 'plan-key-123456',
+      ),
+      throwsA(_invalidResponse),
+    );
+  });
+
+  test('rejects a Plan bound to a different Agent Matter', () async {
+    final response = _planJson()..['matter_id'] = 'matter-other';
+    final client = _client(_QueueTransport([_response(response)]));
+
+    await expectLater(
+      client.createPlan(
+        input: const CreatePreparationPlanInput(
+          context: _context,
+          selection: _selection,
+          preparationProfileId: _profileId,
+          preparationUserId: _userId,
+        ),
+        idempotencyKey: 'plan-key-123456',
+      ),
+      throwsA(_invalidResponse),
+    );
+  });
+
+  group('rejects cross-resource Session bootstrap data', () {
+    final cases = <String, void Function(Map<String, Object?>)>{
+      'role version': (root) {
+        _roleSnapshot(root)['version'] = 99;
+      },
+      'role scenario': (root) {
+        _roleSnapshot(root)['scenario_definition_id'] = 'scenario-other';
+      },
+      'background': (root) {
+        _preparationSnapshot(root)['background_snapshot'] = 'Other account';
+      },
+      'source profile': (root) {
+        _preparationSnapshot(root)['source_profile_id'] = 'profile-other';
+      },
+      'source version': (root) {
+        _preparationSnapshot(root)['source_version'] = 2;
+      },
+      'unexpected resume snapshot': (root) {
+        _preparationSnapshot(root)['resume_snapshot'] = 'Unexpected';
+      },
+      'candidate user': (root) {
+        _candidateSubject(root)['subject_id'] = 'user-other';
+      },
+      'option turn budget': (root) {
+        _sessionPolicy(root)['max_effective_turns'] = 6;
+      },
+    };
+
+    for (final entry in cases.entries) {
+      test(entry.key, () async {
+        final response = _bootstrapJson();
+        entry.value(response);
+        final client = _client(_QueueTransport([_response(response)]));
+
+        await expectLater(
+          client.createSession(
+            planId: _planId,
+            input: const CreatePreparationSessionInput(
+              expectedPlanRevision: 1,
+              preparationSnapshotId: _preparationSnapshotId,
+              preparationProfileId: _profileId,
+              preparationProfileVersion: 1,
+              preparationUserId: _userId,
+              backgroundSummary: _background,
+              selection: _selection,
+            ),
+            idempotencyKey: 'session-key-123',
+          ),
+          throwsA(_invalidResponse),
+        );
+      });
+    }
+  });
+
+  test('accepts the frozen six-turn full simulation budget', () async {
+    final response = _bootstrapJson();
+    final snapshot = response['snapshot']! as Map<String, Object?>;
+    final option = snapshot['practice_option']! as Map<String, Object?>;
+    option
+      ..remove('role_definition_id')
+      ..['practice_option_id'] = _fullOptionId
+      ..['practice_option_type'] = 'FULL_SIMULATION'
+      ..['display_name'] = 'Full simulation';
+    final policy = _sessionPolicy(response);
+    policy
+      ..['min_effective_turns'] = 4
+      ..['max_effective_turns'] = 6
+      ..['coverage_checkpoint_turn'] = 4;
+    final client = _client(_QueueTransport([_response(response)]));
+
+    final bootstrap = await client.createSession(
+      planId: _planId,
+      input: const CreatePreparationSessionInput(
+        expectedPlanRevision: 1,
+        preparationSnapshotId: _preparationSnapshotId,
+        preparationProfileId: _profileId,
+        preparationProfileVersion: 1,
+        preparationUserId: _userId,
+        backgroundSummary: _background,
+        selection: _fullSelection,
+      ),
+      idempotencyKey: 'session-full-key',
+    );
+
+    expect(bootstrap.maxEffectiveTurns, 6);
+  });
+
+  test('fences a response that completes after account cleanup', () async {
+    final transport = _CompleterTransport();
+    final client = _client(transport);
+    final operation = client.createProfile(
+      input: const CreatePreparationProfileInput(
+        backgroundSummary: _background,
+      ),
+      idempotencyKey: 'profile-key-123',
+    );
+
+    await client.clearAccountState();
+    transport.complete(_response(_profileJson()));
+
+    await expectLater(
+      operation,
+      throwsA(
+        isA<PreparationLaunchException>().having(
+          (error) => error.kind,
+          'kind',
+          PreparationLaunchFailureKind.superseded,
+        ),
+      ),
+    );
+  });
+}
+
+WirePreparationLaunchClient _client(IdentityHttpTransport transport) {
+  const credential = AuthSessionCredential(
+    sessionToken: 'sess_account-a',
+    generation: 1,
+  );
+  return WirePreparationLaunchClient(
+    baseUri: Uri.parse('https://api.speak-up.top'),
+    credentialProvider: () => credential,
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) async {},
+    transport: transport,
+  );
+}
+
+Matcher get _invalidResponse => isA<PreparationLaunchException>().having(
+  (error) => error.kind,
+  'kind',
+  PreparationLaunchFailureKind.invalidResponse,
+);
+
+final class _TransportCall {
+  const _TransportCall({
+    required this.method,
+    required this.uri,
+    required this.headers,
+    required this.body,
+  });
+
+  final String method;
+  final Uri uri;
+  final Map<String, String> headers;
+  final String? body;
+}
+
+final class _QueueTransport implements IdentityHttpTransport {
+  _QueueTransport(this.responses);
+
+  final List<IdentityHttpResponse> responses;
+  final calls = <_TransportCall>[];
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    calls.add(
+      _TransportCall(
+        method: method,
+        uri: uri,
+        headers: Map<String, String>.of(headers),
+        body: body,
+      ),
+    );
+    return responses.removeAt(0);
+  }
+}
+
+final class _CompleterTransport implements IdentityHttpTransport {
+  final _responseCompleter = Completer<IdentityHttpResponse>();
+
+  void complete(IdentityHttpResponse response) {
+    _responseCompleter.complete(response);
+  }
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) {
+    return _responseCompleter.future;
+  }
+}
+
+IdentityHttpResponse _response(Map<String, Object?> body) {
+  return IdentityHttpResponse(
+    statusCode: HttpStatus.created,
+    body: jsonEncode(body),
+  );
+}
+
+Map<String, Object?> _profileJson() => {
+  'preparation_profile_id': _profileId,
+  'user_id': _userId,
+  'background_summary': _background,
+  'version': 1,
+  'updated_at': _time,
+};
+
+Map<String, Object?> _snapshotJson() => {
+  'preparation_snapshot_id': _preparationSnapshotId,
+  'source_profile_id': _profileId,
+  'source_version': 1,
+  'background_snapshot': _background,
+  'created_at': _time,
+};
+
+Map<String, Object?> _planJson() => {
+  'practice_plan_id': _planId,
+  'user_id': _userId,
+  'agent_thread_id': _threadId,
+  'matter_id': _matterId,
+  'scenario_definition_id': _scenarioId,
+  'scenario_definition_version': 1,
+  'scenario_type': 'INTERVIEW',
+  'scenario_config_id': _configId,
+  'scenario_config_version': 1,
+  'preparation_profile_id': _profileId,
+  'selected_role_ids': [_roleId],
+  'plan_revision': 1,
+  'practice_plan_status': 'ready',
+  'created_at': _time,
+  'updated_at': _time,
+};
+
+Map<String, Object?> _bootstrapJson() => {
+  'practice_session': {
+    'practice_session_id': _sessionId,
+    'practice_plan_id': _planId,
+    'scenario_type': 'INTERVIEW',
+    'snapshot_id': _sessionSnapshotId,
+    'practice_session_status': 'starting',
+    'session_version': 1,
+    'created_at': _time,
+  },
+  'snapshot': {
+    'snapshot_id': _sessionSnapshotId,
+    'practice_session_id': _sessionId,
+    'plan_revision': 1,
+    'scenario_type': 'INTERVIEW',
+    'scenario_definition_snapshot': {
+      'scenario_definition_id': _scenarioId,
+      'scenario_type': 'INTERVIEW',
+      'name': 'Technical interview',
+      'version': 1,
+      'status': 'active',
+    },
+    'scenario_config_snapshot': {
+      'scenario_config_id': _configId,
+      'scenario_definition_id': _scenarioId,
+      'config_type': 'INTERVIEW',
+      'version': 1,
+      'job_title': 'Backend engineer',
+      'job_description': 'Explain engineering decisions.',
+      'focus_areas': ['system_design'],
+    },
+    'preparation_snapshot': _snapshotJson(),
+    'participants': [
+      {
+        'practice_participant_id': 'participant-interviewer',
+        'practice_session_id': _sessionId,
+        'participant_role': 'INTERVIEWER',
+        'subject_ref': {
+          'namespace': 'mock.actor',
+          'subject_id': 'interviewer-technical',
+        },
+        'role_definition_id': _roleId,
+        'role_snapshot': {
+          'role_definition_id': _roleId,
+          'scenario_definition_id': _scenarioId,
+          'role_type': 'TECHNICAL_INTERVIEWER',
+          'display_name': 'Technical interviewer',
+          'responsibilities': 'Probe technical depth.',
+          'style': 'Precise',
+          'focus_areas': ['system_design'],
+          'version': 2,
+        },
+        'participant_order': 1,
+      },
+      {
+        'practice_participant_id': 'participant-candidate',
+        'practice_session_id': _sessionId,
+        'participant_role': 'CANDIDATE',
+        'subject_ref': {'namespace': 'speakup.user', 'subject_id': _userId},
+        'participant_order': 2,
+      },
+    ],
+    'practice_option': {
+      'practice_option_id': _optionId,
+      'scenario_definition_id': _scenarioId,
+      'role_definition_id': _roleId,
+      'practice_option_type': 'FOCUS',
+      'display_name': 'Focused practice',
+      'version': 1,
+    },
+    'session_policy': {
+      'suggested_duration_seconds': 300,
+      'min_effective_turns': 1,
+      'max_effective_turns': 3,
+      'coverage_checkpoint_turn': 1,
+      'max_follow_ups_per_question': 1,
+      'target_objectives': [
+        {
+          'objective_id': 'system_design',
+          'description': 'Explain one design trade-off.',
+        },
+      ],
+      'early_completion_rule': 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+    },
+    'practice_focuses': [
+      {
+        'objective_id': 'system_design',
+        'description': 'Explain one design trade-off.',
+      },
+    ],
+    'created_at': _time,
+  },
+};
+
+Map<String, Object?> _roleSnapshot(Map<String, Object?> root) {
+  final snapshot = root['snapshot']! as Map<String, Object?>;
+  final participants = snapshot['participants']! as List<Object?>;
+  final interviewer = participants.first as Map<String, Object?>;
+  return interviewer['role_snapshot']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _preparationSnapshot(Map<String, Object?> root) {
+  final snapshot = root['snapshot']! as Map<String, Object?>;
+  return snapshot['preparation_snapshot']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _candidateSubject(Map<String, Object?> root) {
+  final snapshot = root['snapshot']! as Map<String, Object?>;
+  final participants = snapshot['participants']! as List<Object?>;
+  final candidate = participants[1] as Map<String, Object?>;
+  return candidate['subject_ref']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _sessionPolicy(Map<String, Object?> root) {
+  final snapshot = root['snapshot']! as Map<String, Object?>;
+  return snapshot['session_policy']! as Map<String, Object?>;
+}
+
+const _time = '2026-07-26T12:00:00Z';
+const _threadId = '20000000-0000-4000-8000-000000000001';
+const _matterId = '10000000-0000-4000-8000-000000000001';
+const _userId = 'user-1';
+const _profileId = 'profile-1';
+const _preparationSnapshotId = 'preparation-snapshot-1';
+const _planId = 'plan-1';
+const _sessionId = 'session-1';
+const _sessionSnapshotId = 'session-snapshot-1';
+const _scenarioId = 'scenario-1';
+const _configId = 'config-1';
+const _roleId = 'role-1';
+const _optionId = 'option-1';
+const _fullOptionId = 'option-full';
+const _background = 'Backend engineer preparing a technical interview.';
+
+const _context = AgentPracticeContext(threadId: _threadId, matterId: _matterId);
+
+const _selection = PreparationLaunchSelection(
+  scenarioDefinitionId: _scenarioId,
+  scenarioDefinitionVersion: 1,
+  scenarioType: 'INTERVIEW',
+  scenarioDisplayName: 'Technical interview',
+  scenarioDescription: 'Backend engineer: technical interview practice',
+  scenarioConfigId: _configId,
+  scenarioConfigVersion: 1,
+  roleDefinitionId: _roleId,
+  roleDefinitionVersion: 2,
+  practiceOptionId: _optionId,
+  practiceOptionType: PreparationOptionType.focus,
+  practiceOptionVersion: 1,
+);
+
+const _fullSelection = PreparationLaunchSelection(
+  scenarioDefinitionId: _scenarioId,
+  scenarioDefinitionVersion: 1,
+  scenarioType: 'INTERVIEW',
+  scenarioDisplayName: 'Technical interview',
+  scenarioDescription: 'Backend engineer: technical interview practice',
+  scenarioConfigId: _configId,
+  scenarioConfigVersion: 1,
+  roleDefinitionId: _roleId,
+  roleDefinitionVersion: 2,
+  practiceOptionId: _fullOptionId,
+  practiceOptionType: PreparationOptionType.fullSimulation,
+  practiceOptionVersion: 1,
+);

--- a/mobile/test/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_launch_client_test.dart
@@ -92,6 +92,141 @@ void main() {
     },
   );
 
+  test(
+    'marks malformed 201 creates ambiguous and retries Session with one key',
+    () async {
+      final transport = _QueueTransport([
+        _rawResponse(HttpStatus.created, '{"truncated":'),
+        _rawResponse(HttpStatus.created, '{"truncated":'),
+        _rawResponse(HttpStatus.created, '{"truncated":'),
+        _rawResponse(HttpStatus.created, '{"truncated":'),
+        _response(_bootstrapJson()),
+      ]);
+      final client = _client(transport);
+      const sessionInput = CreatePreparationSessionInput(
+        expectedPlanRevision: 1,
+        preparationSnapshotId: _preparationSnapshotId,
+        preparationProfileId: _profileId,
+        preparationProfileVersion: 1,
+        preparationUserId: _userId,
+        backgroundSummary: _background,
+        selection: _selection,
+      );
+      final operations =
+          <({PreparationLaunchStage stage, Future<Object?> Function() run})>[
+            (
+              stage: PreparationLaunchStage.profile,
+              run: () => client.createProfile(
+                input: const CreatePreparationProfileInput(
+                  backgroundSummary: _background,
+                ),
+                idempotencyKey: 'profile-malformed-key',
+              ),
+            ),
+            (
+              stage: PreparationLaunchStage.snapshot,
+              run: () => client.createSnapshot(
+                profileId: _profileId,
+                sourceVersion: 1,
+                idempotencyKey: 'snapshot-malformed-key',
+              ),
+            ),
+            (
+              stage: PreparationLaunchStage.plan,
+              run: () => client.createPlan(
+                input: const CreatePreparationPlanInput(
+                  context: _context,
+                  selection: _selection,
+                  preparationProfileId: _profileId,
+                  preparationUserId: _userId,
+                ),
+                idempotencyKey: 'plan-malformed-key',
+              ),
+            ),
+            (
+              stage: PreparationLaunchStage.session,
+              run: () => client.createSession(
+                planId: _planId,
+                input: sessionInput,
+                idempotencyKey: 'session-malformed-key',
+              ),
+            ),
+          ];
+
+      for (final operation in operations) {
+        await expectLater(
+          operation.run(),
+          throwsA(
+            isA<PreparationLaunchException>()
+                .having(
+                  (error) => error.kind,
+                  'kind',
+                  PreparationLaunchFailureKind.invalidResponse,
+                )
+                .having((error) => error.stage, 'stage', operation.stage)
+                .having(
+                  (error) => error.statusCode,
+                  'statusCode',
+                  HttpStatus.created,
+                )
+                .having((error) => error.retryable, 'retryable', isTrue),
+          ),
+        );
+      }
+
+      final bootstrap = await client.createSession(
+        planId: _planId,
+        input: sessionInput,
+        idempotencyKey: 'session-malformed-key',
+      );
+
+      expect(bootstrap.session.id, _sessionId);
+      final sessionCalls = transport.calls.where(
+        (call) => call.uri.path.endsWith('/practice-sessions'),
+      );
+      expect(sessionCalls, hasLength(2));
+      expect(
+        sessionCalls.map((call) => call.headers['Idempotency-Key']),
+        everyElement('session-malformed-key'),
+      );
+    },
+  );
+
+  test(
+    'keeps a definite 400 create validation failure non-retryable',
+    () async {
+      final client = _client(
+        _QueueTransport([
+          _rawResponse(
+            HttpStatus.badRequest,
+            jsonEncode({
+              'error': {'code': 'invalid_request'},
+            }),
+          ),
+        ]),
+      );
+
+      await expectLater(
+        client.createProfile(
+          input: const CreatePreparationProfileInput(
+            backgroundSummary: _background,
+          ),
+          idempotencyKey: 'profile-validation-key',
+        ),
+        throwsA(
+          isA<PreparationLaunchException>()
+              .having(
+                (error) => error.kind,
+                'kind',
+                PreparationLaunchFailureKind.invalidRequest,
+              )
+              .having((error) => error.statusCode, 'statusCode', 400)
+              .having((error) => error.retryable, 'retryable', isFalse),
+        ),
+      );
+    },
+  );
+
   test('rejects a Plan owned by a different user', () async {
     final response = _planJson()..['user_id'] = 'user-other';
     final client = _client(_QueueTransport([_response(response)]));
@@ -323,6 +458,10 @@ IdentityHttpResponse _response(Map<String, Object?> body) {
     statusCode: HttpStatus.created,
     body: jsonEncode(body),
   );
+}
+
+IdentityHttpResponse _rawResponse(int statusCode, String body) {
+  return IdentityHttpResponse(statusCode: statusCode, body: body);
 }
 
 Map<String, Object?> _profileJson() => {


### PR DESCRIPTION
## 产品结果

把 #111 从目录展示推进为真实可用的“AI 英语口语陪练”启动链路。用户在当前场景页选择技术岗位英文面试的视角与练习方式后，可在同一个长期 Agent Thread / Matter 上进入正式语音练习；没有新增第二个 Agent 首页，也没有把面试官角色做成固定关卡。

## 正式链路

`服务端目录 → Matter 激活 → Preparation Profile → 不可变 Snapshot → Practice Plan → Practice Session → 正式 voice session → 三轮 ASR/确认 → Formal Review → 注销登录后历史恢复`

- Flutter 只读取服务端 Scenario / Role / PracticeOption 权威目录。
- 场景页在当前页面完成背景、视角与 FULL/FOCUS 选择并启动。
- Plan 显式锚定当前 AgentThread 与 active Matter，Session 只从 Plan 继承。
- voice POST 只激活并恢复精确正式 Session，不按最近记录猜测。
- FULL 为 6 轮、FOCUS 为 3 轮；完成状态、Review 与历史均以服务端为准。
- 账户切换、注销、旧异步回调、重试与恢复均有 generation / operation fence。

## 审查与联调修复

- 启动期间锁定角色、练习方式、场景返回与系统返回，避免 starting Session 创建后切换配置形成孤儿会话。
- Session 创建成功后立即保留 bootstrap，即使随后语音连接失败也沿同一会话和幂等键重试。
- Matter POST 遇到断网或已提交但 201 无法解析时，按请求前基线恢复唯一新资源；存在歧义时明确冲突，不按同名历史 Matter 猜测。
- 多个已完成 Practice 导致恢复冲突时，只降级为“当前无进行中练习”，长期 Agent Thread、Matter、消息与 Review 历史继续可用。
- 正式引入 #101 的 `GET /v1/formal-reviews`，第三轮完成后自动刷新一次，注销登录后从服务端恢复。
- 修复真实 iOS E2E 的登录、注册、路由动画与练习控件时序；历史接口失败会立即报告精确原因。
- 修复 Flutter CI 中音频生命周期异步清理的固定轮次假设，避免首个失败污染后续测试状态。

## 当前堆叠依赖

- PR #98：千问按轮语音与自动复盘，已保留“按账号当前计费配置调用、额度用尽不在业务层停用”的修订。
- PR #96：OSS / AudioAsset 生命周期与 Migration `000009`。
- PR #107：正式 Review 历史分页接口。
- PR #109：正式 Scenario / Role / PracticeOption 目录。
- PR #113：Preparation / Practice 持久化、Migration `000010` 与精确 voice binding。
- 移动端基线来自 PR #95。

上述刷新后 Head 都已成为本分支祖先；前置 PR 依次进入 `dev` 后，重复差异会自然收敛。

## 已完成验证

- Flutter analyze 通过；全量 Flutter 333 tests 通过。
- 全仓 Go / vet / tests、真实 PostgreSQL 关键历史用例通过。
- OpenAPI 通过：51 operations，6 public、45 Bearer-protected；WebSocket、安全与 Fixture 契约通过。
- Deterministic Smoke 通过。
- 最终正式 Head `230acbb` 在 iOS 18.3 模拟器完成真实全链：注册登录、千问文本 Agent、技术岗位英文面试 FOCUS Session、三轮真实 ASR、正式 Review、注销登录与服务端历史恢复。
- 最新 GitHub CI 正在运行。

## 明确剩余边界

当前冻结的 `POST /v1/matters` 只有 `title`，没有服务端持久化的 `Idempotency-Key` 或 `client_operation_id`。本 PR 已解决同一客户端进程内的提交歧义，且跨重启绝不按同名 Matter 猜测；但在“服务端已创建 Matter、客户端进程随即丢失全部本地操作身份”这一窗口，尚不能证明 exactly-once。

该协议缺口不会在实现中私自扩字段。PR 保持 Draft，等待前置依赖合入及正式增量契约决策，不把未满足的边界描述成已完成。

## 不包含

- 不新增固定 HR → 技术 → 项目 → 管理关卡。
- 不扩展长期记忆、实时语音、多人房间或 Review 评分规则。
- 不改服务端目录稳定 ID、枚举和版本。

Closes #111
