### PR TITLE
[功能] 实现 Flutter JD-first 面试准备向导

### DIFF
--- a/mobile/lib/app/app_routes.dart
+++ b/mobile/lib/app/app_routes.dart
@@ -1,6 +1,7 @@
 abstract final class AppRoutes {
   static const home = '/';
   static const preparation = '/preparation';
+  static const jobPreparation = '/preparation/job';
   static const practice = '/practice';
   static const conversation = '/conversation';
   static const review = '/review';

--- a/mobile/lib/app/glass_navigation_bar.dart
+++ b/mobile/lib/app/glass_navigation_bar.dart
@@ -22,8 +22,8 @@ class GlassNavigationBar extends StatelessWidget {
     super.key,
   });
 
-  static const height = 74.0;
-  static const minimumBottomInset = 12.0;
+  static const height = 64.0;
+  static const minimumBottomInset = 10.0;
   static const _maximumLabelScale = 1.5;
 
   final List<GlassNavigationDestination> destinations;
@@ -59,32 +59,32 @@ class GlassNavigationBar extends StatelessWidget {
       ),
       child: DecoratedBox(
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(32),
+          borderRadius: BorderRadius.circular(24),
           boxShadow: const [
             BoxShadow(
-              color: Color(0x1C000000),
-              blurRadius: 34,
-              offset: Offset(0, 12),
+              color: Color(0x12000000),
+              blurRadius: 18,
+              offset: Offset(0, 6),
             ),
           ],
         ),
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(32),
+          borderRadius: BorderRadius.circular(24),
           child: BackdropFilter(
-            filter: ui.ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+            filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
             child: Container(
               key: const Key('primary-navigation'),
               height: navigationHeight,
-              padding: const EdgeInsets.all(6),
+              padding: const EdgeInsets.all(4),
               decoration: BoxDecoration(
                 color: highContrast
                     ? const Color(0xFFF8F8F6)
                     : const Color(0xDEFFFFFF),
-                borderRadius: BorderRadius.circular(32),
+                borderRadius: BorderRadius.circular(24),
                 border: Border.all(
                   color: highContrast
                       ? const Color(0xFFD8DAE2)
-                      : const Color(0xD9FFFFFF),
+                      : const Color(0xBFFFFFFF),
                 ),
               ),
               child: Semantics(
@@ -139,7 +139,7 @@ class _NavigationItem extends StatelessWidget {
         child: Material(
           color: Colors.transparent,
           child: InkWell(
-            borderRadius: BorderRadius.circular(26),
+            borderRadius: BorderRadius.circular(20),
             onTap: onTap,
             child: AnimatedContainer(
               duration: reduceMotion
@@ -148,7 +148,7 @@ class _NavigationItem extends StatelessWidget {
               curve: Curves.easeOutCubic,
               decoration: BoxDecoration(
                 color: selected ? const Color(0xD9E8E8E5) : Colors.transparent,
-                borderRadius: BorderRadius.circular(26),
+                borderRadius: BorderRadius.circular(20),
                 border: selected
                     ? Border.all(color: const Color(0xCFFFFFFF))
                     : null,
@@ -158,12 +158,12 @@ class _NavigationItem extends StatelessWidget {
                 children: [
                   Icon(
                     destination.icon,
-                    size: 23,
+                    size: 21,
                     color: selected
                         ? const Color(0xFF111217)
                         : const Color(0xFF686A72),
                   ),
-                  const SizedBox(height: 3),
+                  const SizedBox(height: 2),
                   FittedBox(
                     fit: BoxFit.scaleDown,
                     child: Text(

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/practice/practice.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_wizard.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/preparation/preparation_launch_controller.dart';
@@ -18,6 +22,7 @@ class SpeakUpApp extends StatelessWidget {
     required AuthController authController,
     required this.agentController,
     required this.preparationController,
+    this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
     super.key,
@@ -27,6 +32,7 @@ class SpeakUpApp extends StatelessWidget {
   const SpeakUpApp.preview({
     this.agentController,
     this.preparationController,
+    this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
     super.key,
@@ -36,6 +42,7 @@ class SpeakUpApp extends StatelessWidget {
   final ({AuthController controller})? _authentication;
   final AgentController? agentController;
   final PreparationController? preparationController;
+  final JobPreparationController? jobPreparationController;
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final bool _allowFakePreview;
@@ -62,6 +69,7 @@ class SpeakUpApp extends StatelessWidget {
           ? _AuthenticatedNavigator(
               agentController: agentController,
               preparationController: preparationController,
+              jobPreparationController: jobPreparationController,
               preparationLaunchController: preparationLaunchController,
               reviewHistoryController: reviewHistoryController,
               allowFakePreview: _allowFakePreview,
@@ -73,6 +81,7 @@ class SpeakUpApp extends StatelessWidget {
                 authController: controller,
                 agentController: agentController,
                 preparationController: preparationController,
+                jobPreparationController: jobPreparationController,
                 preparationLaunchController: preparationLaunchController,
                 reviewHistoryController: reviewHistoryController,
                 allowFakePreview: _allowFakePreview,
@@ -88,6 +97,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.authController,
     this.agentController,
     this.preparationController,
+    this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
     required this.allowFakePreview,
@@ -97,6 +107,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final AuthController? authController;
   final AgentController? agentController;
   final PreparationController? preparationController;
+  final JobPreparationController? jobPreparationController;
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final bool allowFakePreview;
@@ -124,6 +135,22 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     _agentController =
         injectedController ?? AgentController(client: FakeAgentClient());
     _agentController.initialize();
+    final user = widget.user;
+    if (user != null) {
+      unawaited(widget.jobPreparationController?.activateAccount(user.id));
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _AuthenticatedNavigator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.user?.id != widget.user?.id ||
+        oldWidget.jobPreparationController != widget.jobPreparationController) {
+      final user = widget.user;
+      if (user != null) {
+        unawaited(widget.jobPreparationController?.activateAccount(user.id));
+      }
+    }
   }
 
   @override
@@ -147,6 +174,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             authController: widget.authController,
             agentController: _agentController,
             preparationController: widget.preparationController,
+            jobPreparationController: widget.jobPreparationController,
             preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
           ),
@@ -159,6 +187,14 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             onPracticeStarted: () => _navigatorKey.currentState
                 ?.pushReplacementNamed(AppRoutes.practice),
           ),
+          AppRoutes.jobPreparation
+              when widget.jobPreparationController != null =>
+            JobPreparationWizard(
+              controller: widget.jobPreparationController!,
+              catalogController: widget.preparationController,
+              onPracticeStarted: () => _navigatorKey.currentState
+                  ?.pushReplacementNamed(AppRoutes.practice),
+            ),
           AppRoutes.practice => PracticePage(
             previewMode: widget.allowFakePreview,
             agentController: _agentController,
@@ -170,6 +206,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             authController: widget.authController,
             agentController: _agentController,
             preparationController: widget.preparationController,
+            jobPreparationController: widget.jobPreparationController,
             preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
           ),

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -7,6 +7,7 @@ import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/glass_navigation_bar.dart';
 import 'package:speakup/features/conversation/conversation.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/preparation/preparation_launch_controller.dart';
@@ -23,6 +24,7 @@ class SpeakUpShell extends StatefulWidget {
     this.authController,
     this.preparationController,
     this.preparationLaunchController,
+    this.jobPreparationController,
     this.reviewHistoryController,
     required this.agentController,
     super.key,
@@ -35,6 +37,7 @@ class SpeakUpShell extends StatefulWidget {
   final AgentController agentController;
   final PreparationController? preparationController;
   final PreparationLaunchController? preparationLaunchController;
+  final JobPreparationController? jobPreparationController;
   final ReviewHistoryController? reviewHistoryController;
 
   @override
@@ -49,7 +52,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       key: Key('primary-tab-agent'),
     ),
     GlassNavigationDestination(
-      label: '场景',
+      label: '训练',
       icon: Icons.grid_view_rounded,
       key: Key('primary-tab-scenes'),
     ),
@@ -99,6 +102,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   }
 
   void _selectDestination(int index) {
+    if (index == 1 && widget.jobPreparationController != null) {
+      _openJobPreparation();
+      return;
+    }
     if (_selectedIndex == index) {
       if (index == 2) {
         unawaited(widget.reviewHistoryController?.refresh());
@@ -110,6 +117,14 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       unawaited(widget.reviewHistoryController?.refresh());
     }
     setState(() => _selectedIndex = index);
+  }
+
+  void _openJobPreparation() {
+    if (widget.jobPreparationController == null) {
+      _showMockNotice('岗位准备流程尚未连接');
+      return;
+    }
+    Navigator.of(context).pushNamed(AppRoutes.jobPreparation);
   }
 
   void _showMockNotice(String message) {
@@ -175,7 +190,9 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onNavigateBack: widget.showBackButton
             ? () => Navigator.of(context).maybePop()
             : null,
-        onCreatePlan: () => _selectDestination(1),
+        onCreatePlan: widget.jobPreparationController == null
+            ? () => _selectDestination(1)
+            : _openJobPreparation,
         onContinuePractice: _openPractice,
         onOpenReview: () => _selectDestination(2),
         onStartVoice: widget.agentController.supportsAgentVoice

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -102,10 +102,6 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   }
 
   void _selectDestination(int index) {
-    if (index == 1 && widget.jobPreparationController != null) {
-      _openJobPreparation();
-      return;
-    }
     if (_selectedIndex == index) {
       if (index == 2) {
         unawaited(widget.reviewHistoryController?.refresh());
@@ -190,9 +186,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onNavigateBack: widget.showBackButton
             ? () => Navigator.of(context).maybePop()
             : null,
-        onCreatePlan: widget.jobPreparationController == null
-            ? () => _selectDestination(1)
-            : _openJobPreparation,
+        onCreatePlan: () => _selectDestination(1),
         onContinuePractice: _openPractice,
         onOpenReview: () => _selectDestination(2),
         onStartVoice: widget.agentController.supportsAgentVoice
@@ -233,6 +227,9 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         agentController: widget.agentController,
         preparationController: widget.preparationController,
         launchController: widget.preparationLaunchController,
+        onOpenJobPreparation: widget.jobPreparationController == null
+            ? null
+            : _openJobPreparation,
         onSceneSelected: () => _selectDestination(0),
         onPracticeStarted: _openPractice,
       ),

--- a/mobile/lib/features/preparation/job_preparation_client.dart
+++ b/mobile/lib/features/preparation/job_preparation_client.dart
@@ -1,0 +1,76 @@
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+
+abstract interface class JobPreparationClient {
+  Future<JobTarget> createJobTarget({
+    required JobTargetInput input,
+    required String idempotencyKey,
+  });
+
+  Future<JobTarget> getJobTarget(String jobTargetId);
+
+  Future<JobTarget> updateJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required JobTargetInput input,
+    required String idempotencyKey,
+  });
+
+  Future<JobTarget> analyzeJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  });
+
+  Future<JobTarget> confirmJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required int expectedAnalysisVersion,
+    required JobTargetCandidate candidate,
+    required String idempotencyKey,
+  });
+
+  Future<JobTarget> discardJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  });
+
+  Future<JobPreparationProfile> createProfileForJobTarget({
+    required String backgroundSummary,
+    required String jobTargetId,
+    required int jobTargetConfirmationVersion,
+    required String idempotencyKey,
+  });
+
+  Future<JobPreparationSnapshot> createJobPreparationSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  });
+
+  Future<JobPracticePlanPreview> createJobPracticePlan({
+    required AgentPracticeContext context,
+    required String preparationSnapshotId,
+    required String idempotencyKey,
+  });
+
+  Future<JobPracticePlanPreview> getJobPracticePlan(String planId);
+
+  Future<JobPracticePlanPreview> reviseJobPracticePlan({
+    required String planId,
+    required int expectedPlanRevision,
+    required String roleDefinitionId,
+    required String practiceOptionId,
+    required int practiceOptionVersion,
+    required int maxEffectiveTurns,
+    required String idempotencyKey,
+  });
+
+  Future<PreparationPracticeBootstrap> createJobPracticeSession({
+    required JobPracticePlanPreview plan,
+    required String idempotencyKey,
+  });
+
+  Future<void> clearAccountState();
+}

--- a/mobile/lib/features/preparation/job_preparation_controller.dart
+++ b/mobile/lib/features/preparation/job_preparation_controller.dart
@@ -1,0 +1,1496 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:speakup/features/preparation/job_preparation_client.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+
+typedef JobPreparationIdFactory = String Function(String scope);
+typedef JobPreparationThreadIdProvider = String? Function();
+typedef JobPreparationMatterActivator =
+    Future<AgentPracticeContext> Function({
+      required String threadId,
+      required JobTargetCandidate candidate,
+      required String clientOperationId,
+    });
+typedef JobPreparationVoiceActivator =
+    Future<void> Function({
+      required AgentPracticeContext context,
+      required PreparationPracticeBootstrap bootstrap,
+      required String clientOperationId,
+    });
+
+enum JobPreparationStep { input, confirmation, setup, preview }
+
+final class JobPreparationController extends ChangeNotifier {
+  JobPreparationController({
+    required this.client,
+    required this.threadIdProvider,
+    required this.matterActivator,
+    required this.voiceActivator,
+    JobPreparationDraftStore? draftStore,
+    JobPreparationIdFactory? idFactory,
+    this.analysisPollInterval = const Duration(seconds: 1),
+    this.maxAnalysisPollAttempts = 75,
+  }) : draftStore = draftStore ?? const NullJobPreparationDraftStore(),
+       _idFactory = idFactory ?? _secureJobPreparationId {
+    if (analysisPollInterval.isNegative || maxAnalysisPollAttempts < 1) {
+      throw ArgumentError('Invalid JobTarget polling configuration.');
+    }
+  }
+
+  final JobPreparationClient client;
+  final JobPreparationDraftStore draftStore;
+  final JobPreparationThreadIdProvider threadIdProvider;
+  final JobPreparationMatterActivator matterActivator;
+  final JobPreparationVoiceActivator voiceActivator;
+  final JobPreparationIdFactory _idFactory;
+  final Duration analysisPollInterval;
+  final int maxAnalysisPollAttempts;
+
+  JobTargetInput _input = const JobTargetInput(
+    source: JobTargetSource.jobDescription,
+  );
+  JobTarget? _target;
+  JobTargetCandidate? _candidate;
+  JobPracticePlanPreview? _plan;
+  PreparationPracticeBootstrap? _bootstrap;
+  JobPreparationStep _step = JobPreparationStep.input;
+  JobPreparationOperationStage? _operationStage;
+  String? _errorMessage;
+  bool _busy = false;
+  bool _initializingDraft = false;
+  bool _draftCompleted = false;
+  bool _disposed = false;
+  int _epoch = 0;
+  int _accountGeneration = 0;
+  String? _accountId;
+  String? _loadedDraftAccountId;
+  String? _agentIntentPrefill;
+  _StoredJobPreparationDraft? _restorableDraft;
+  Future<void> _draftWriteTail = Future<void>.value();
+
+  String? _createTargetKey;
+  String? _updateTargetKey;
+  String? _analysisKey;
+  String? _confirmationKey;
+  String? _discardTargetKey;
+  String? _matterKey;
+  String? _profileKey;
+  String? _snapshotKey;
+  String? _planKey;
+  String? _planRevisionKey;
+  String? _sessionKey;
+  String? _voiceKey;
+
+  JobTargetInput get input => _input;
+  JobTarget? get target => _target;
+  JobTargetCandidate? get candidate => _candidate;
+  JobPracticePlanPreview? get plan => _plan;
+  PreparationPracticeBootstrap? get bootstrap => _bootstrap;
+  JobPreparationStep get step => _step;
+  JobPreparationOperationStage? get operationStage => _operationStage;
+  String? get errorMessage => _errorMessage;
+  bool get isBusy => _busy;
+  bool get isInitializingDraft => _initializingDraft;
+  bool get hasRestorableDraft => _restorableDraft != null;
+  bool get canRetry => _errorMessage != null && !_busy;
+  bool get isQuickStart => _input.source == JobTargetSource.quickStart;
+  String? get agentIntentPrefill => _agentIntentPrefill;
+
+  void offerAgentIntent(String? value) {
+    final normalized = value?.trim();
+    if (_disposed ||
+        _target != null ||
+        _step != JobPreparationStep.input ||
+        normalized == null ||
+        normalized.isEmpty ||
+        utf8.encode(normalized).length > 64 * 1024) {
+      return;
+    }
+    _agentIntentPrefill = normalized;
+    notifyListeners();
+  }
+
+  void applyAgentIntentPrefill() {
+    final value = _agentIntentPrefill;
+    if (_disposed || value == null || _target != null) {
+      return;
+    }
+    _agentIntentPrefill = null;
+    updateInput(
+      JobTargetInput(
+        source: JobTargetSource.jobDescription,
+        jobDescription: value,
+        company: _input.company,
+        seniority: _input.seniority,
+        candidateBackground: _input.candidateBackground,
+        resumeRef: _input.resumeRef,
+        practiceFocus: _input.practiceFocus,
+      ),
+    );
+  }
+
+  void dismissAgentIntentPrefill() {
+    if (_disposed || _agentIntentPrefill == null) {
+      return;
+    }
+    _agentIntentPrefill = null;
+    notifyListeners();
+  }
+
+  Future<void> activateAccount(String accountId) async {
+    if (_disposed ||
+        !_validResourceId(accountId) ||
+        (_accountId == accountId &&
+            (_initializingDraft || _loadedDraftAccountId == accountId))) {
+      return;
+    }
+    final generation = ++_accountGeneration;
+    _epoch++;
+    _accountId = accountId;
+    _loadedDraftAccountId = null;
+    _restorableDraft = null;
+    _agentIntentPrefill = null;
+    _resetPresentation();
+    _initializingDraft = true;
+    notifyListeners();
+    try {
+      final encoded = await draftStore.read(accountId);
+      if (!_isCurrentAccount(generation, accountId) || encoded == null) {
+        return;
+      }
+      final draft = _StoredJobPreparationDraft.tryDecode(encoded);
+      if (draft == null) {
+        await draftStore.delete(accountId);
+        return;
+      }
+      if (!_isCurrentAccount(generation, accountId)) {
+        return;
+      }
+      _restorableDraft = draft;
+    } on Object {
+      if (_isCurrentAccount(generation, accountId)) {
+        _errorMessage = '无法安全读取本机草稿，你仍可以重新开始。';
+      }
+    } finally {
+      if (_isCurrentAccount(generation, accountId)) {
+        _loadedDraftAccountId = accountId;
+        _initializingDraft = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<bool> resumeDraft() async {
+    final accountId = _accountId;
+    final draft = _restorableDraft;
+    if (_disposed || _busy || accountId == null || draft == null) {
+      return false;
+    }
+    final operationEpoch = ++_epoch;
+    _applyStoredDraft(draft);
+    _restorableDraft = null;
+    _begin(JobPreparationOperationStage.target);
+    try {
+      final targetId = draft.targetId;
+      if (targetId == null) {
+        _step = JobPreparationStep.input;
+        _errorMessage = null;
+        return true;
+      }
+      final target = await client.getJobTarget(targetId);
+      _requireCurrent(operationEpoch, _input);
+      if (target.userId != accountId || target.input != _input) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.target,
+        );
+      }
+      _target = target;
+      _applyTargetStage(target, storedCandidate: draft.candidate);
+      final planId = draft.planId;
+      if (target.stage == JobTargetStage.confirmed && planId != null) {
+        _operationStage = JobPreparationOperationStage.plan;
+        notifyListeners();
+        final plan = await client.getJobPracticePlan(planId);
+        _requireCurrent(operationEpoch, _input);
+        if (plan.userId != accountId ||
+            plan.preparationSnapshot.sourceJobTargetId != target.id ||
+            plan.preparationSnapshot.sourceJobTargetConfirmationVersion !=
+                target.confirmation?.confirmationVersion) {
+          throw const JobPreparationException(
+            kind: JobPreparationFailureKind.invalidResponse,
+            stage: JobPreparationOperationStage.plan,
+          );
+        }
+        if (threadIdProvider() == plan.context.threadId) {
+          _plan = plan;
+          _step = JobPreparationStep.preview;
+        } else {
+          _clearPreviewAttempt();
+          _step = JobPreparationStep.setup;
+        }
+      }
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _operationStage = error.stage ?? _operationStage;
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法恢复草稿，请检查网络后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<bool> discardDraft() async {
+    final accountId = _accountId;
+    final draft = _restorableDraft;
+    if (_disposed || _busy || accountId == null || draft == null) {
+      return false;
+    }
+    final operationEpoch = _epoch;
+    _begin(JobPreparationOperationStage.target);
+    try {
+      JobTarget? target;
+      if (draft.targetId != null) {
+        try {
+          target = await client.getJobTarget(draft.targetId!);
+        } on JobPreparationException catch (error) {
+          if (error.kind != JobPreparationFailureKind.notFound) {
+            rethrow;
+          }
+        }
+      } else if (draft.createTargetKey != null) {
+        target = await client.createJobTarget(
+          input: draft.input,
+          idempotencyKey: draft.createTargetKey!,
+        );
+      }
+      if (!_isCurrent(operationEpoch)) {
+        return false;
+      }
+      if (target != null &&
+          target.userId == accountId &&
+          target.stage != JobTargetStage.confirmed &&
+          target.stage != JobTargetStage.discarded) {
+        await client.discardJobTarget(
+          jobTargetId: target.id,
+          expectedInputVersion: target.inputVersion,
+          idempotencyKey:
+              draft.discardTargetKey ??
+              (_discardTargetKey ??= _newId('job-target-discard')),
+        );
+      }
+      await _draftWriteTail;
+      await draftStore.delete(accountId);
+      if (!_isCurrent(operationEpoch)) {
+        return false;
+      }
+      _restorableDraft = null;
+      _resetPresentation();
+      _draftCompleted = true;
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法丢弃草稿，请检查网络后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  void updateInput(JobTargetInput value) {
+    if (_disposed || value == _input) {
+      return;
+    }
+    _epoch++;
+    _input = value;
+    _draftCompleted = false;
+    _candidate = null;
+    _plan = null;
+    _bootstrap = null;
+    _step = JobPreparationStep.input;
+    _operationStage = null;
+    _errorMessage = null;
+    _busy = false;
+    _updateTargetKey = null;
+    _analysisKey = null;
+    _confirmationKey = null;
+    _clearPreviewAttempt();
+    notifyListeners();
+    _queueDraftWrite();
+  }
+
+  void updateCandidate(JobTargetCandidate value) {
+    if (_disposed || _busy || _step != JobPreparationStep.confirmation) {
+      return;
+    }
+    _epoch++;
+    _candidate = value;
+    _confirmationKey = null;
+    _errorMessage = null;
+    _operationStage = null;
+    notifyListeners();
+    _queueDraftWrite();
+  }
+
+  void returnToInput() {
+    if (_disposed || _busy) {
+      return;
+    }
+    _step = JobPreparationStep.input;
+    _errorMessage = null;
+    _operationStage = null;
+    notifyListeners();
+    _queueDraftWrite();
+  }
+
+  void returnToSetup() {
+    if (_disposed || _busy || _target?.stage != JobTargetStage.confirmed) {
+      return;
+    }
+    _step = JobPreparationStep.setup;
+    _errorMessage = null;
+    _operationStage = null;
+    notifyListeners();
+    _queueDraftWrite();
+  }
+
+  Future<bool> analyze() async {
+    if (_disposed || _busy) {
+      return false;
+    }
+    final input = _input;
+    if (!_validJobTargetInput(input)) {
+      _errorMessage = input.source == JobTargetSource.jobDescription
+          ? '请粘贴完整职位描述后再分析。'
+          : '请填写目标岗位后再开始。';
+      _operationStage = JobPreparationOperationStage.target;
+      notifyListeners();
+      return false;
+    }
+
+    final current = _target;
+    if (current != null && current.input == input) {
+      if (current.stage == JobTargetStage.confirmed &&
+          current.confirmation != null) {
+        _candidate = current.confirmation!.candidate;
+        _step = JobPreparationStep.setup;
+        _errorMessage = null;
+        notifyListeners();
+        _queueDraftWrite();
+        return true;
+      }
+      if (current.stage == JobTargetStage.awaitingConfirmation &&
+          current.analysis?.candidate != null) {
+        _candidate = current.analysis!.candidate;
+        _step = JobPreparationStep.confirmation;
+        _errorMessage = null;
+        notifyListeners();
+        _queueDraftWrite();
+        return true;
+      }
+    }
+
+    final operationEpoch = _epoch;
+    _begin(JobPreparationOperationStage.target);
+    try {
+      var target = current;
+      if (target == null) {
+        target = await client.createJobTarget(
+          input: input,
+          idempotencyKey: _createTargetKey ??= _newId('job-target'),
+        );
+      } else if (target.input != input) {
+        target = await client.updateJobTarget(
+          jobTargetId: target.id,
+          expectedInputVersion: target.inputVersion,
+          input: input,
+          idempotencyKey: _updateTargetKey ??= _newId('job-target-update'),
+        );
+      }
+      _requireCurrent(operationEpoch, input);
+      if (target.input != input || target.stage == JobTargetStage.discarded) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.target,
+        );
+      }
+      _target = target;
+
+      if (target.stage == JobTargetStage.confirmed &&
+          target.confirmation != null) {
+        _candidate = target.confirmation!.candidate;
+        _step = JobPreparationStep.setup;
+        return true;
+      }
+      if (target.stage == JobTargetStage.awaitingConfirmation &&
+          target.analysis?.candidate != null) {
+        _candidate = target.analysis!.candidate;
+        _step = JobPreparationStep.confirmation;
+        return true;
+      }
+      if (target.stage == JobTargetStage.analysisFailed) {
+        _analysisKey = null;
+      }
+
+      _operationStage = JobPreparationOperationStage.analysis;
+      notifyListeners();
+      target = await client.analyzeJobTarget(
+        jobTargetId: target.id,
+        expectedInputVersion: target.inputVersion,
+        idempotencyKey: _analysisKey ??= _newId('job-target-analysis'),
+      );
+      _requireCurrent(operationEpoch, input);
+      target = await _pollAnalysis(
+        target,
+        operationEpoch: operationEpoch,
+        expectedInput: input,
+      );
+      _requireCurrent(operationEpoch, input);
+      _target = target;
+      final candidate = target.analysis?.candidate;
+      if (target.stage != JobTargetStage.awaitingConfirmation ||
+          candidate == null) {
+        if (target.stage == JobTargetStage.analysisFailed) {
+          _analysisKey = null;
+          throw const JobPreparationException(
+            kind: JobPreparationFailureKind.server,
+            stage: JobPreparationOperationStage.analysis,
+            errorCode: 'job_target_analysis_failed',
+            retryable: true,
+          );
+        }
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.analysis,
+        );
+      }
+      _candidate = candidate;
+      _step = JobPreparationStep.confirmation;
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _operationStage = error.stage ?? _operationStage;
+        if (error.stage == JobPreparationOperationStage.analysis &&
+            error.errorCode == 'job_target_analysis_failed') {
+          // A terminal parser failure is durably tied to the previous
+          // idempotency intent. A user retry must claim a new parser attempt.
+          _analysisKey = null;
+        }
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法分析岗位信息，请稍后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<JobTarget> _pollAnalysis(
+    JobTarget initial, {
+    required int operationEpoch,
+    required JobTargetInput expectedInput,
+  }) async {
+    var target = initial;
+    for (
+      var attempt = 0;
+      target.stage == JobTargetStage.parsing &&
+          attempt < maxAnalysisPollAttempts;
+      attempt++
+    ) {
+      if (analysisPollInterval != Duration.zero) {
+        await Future<void>.delayed(analysisPollInterval);
+      }
+      _requireCurrent(operationEpoch, expectedInput);
+      target = await client.getJobTarget(target.id);
+      _requireCurrent(operationEpoch, expectedInput);
+    }
+    if (target.stage == JobTargetStage.parsing) {
+      throw const JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: JobPreparationOperationStage.analysis,
+        retryable: true,
+      );
+    }
+    return target;
+  }
+
+  Future<bool> confirm() async {
+    if (_disposed || _busy) {
+      return false;
+    }
+    final target = _target;
+    final candidate = _candidate;
+    final analysis = target?.analysis;
+    if (target == null ||
+        candidate == null ||
+        analysis == null ||
+        target.input != _input ||
+        target.stage != JobTargetStage.awaitingConfirmation ||
+        analysis.status != JobTargetAnalysisStatus.succeeded ||
+        candidate.source != _input.source) {
+      _errorMessage = '当前分析已失效，请返回并重新分析岗位信息。';
+      _operationStage = JobPreparationOperationStage.confirmation;
+      notifyListeners();
+      return false;
+    }
+    final operationEpoch = _epoch;
+    _begin(JobPreparationOperationStage.confirmation);
+    try {
+      final confirmed = await client.confirmJobTarget(
+        jobTargetId: target.id,
+        expectedInputVersion: target.inputVersion,
+        expectedAnalysisVersion: analysis.analysisVersion,
+        candidate: candidate,
+        idempotencyKey: _confirmationKey ??= _newId('job-target-confirmation'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (confirmed.stage != JobTargetStage.confirmed ||
+          confirmed.input != _input ||
+          confirmed.confirmation?.candidate.source != candidate.source) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.confirmation,
+        );
+      }
+      _target = confirmed;
+      _candidate = confirmed.confirmation!.candidate;
+      _step = JobPreparationStep.setup;
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法确认岗位分析，请稍后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<bool> createPreview() async {
+    if (_disposed || _busy) {
+      return false;
+    }
+    final target = _target;
+    final confirmation = target?.confirmation;
+    final candidate = confirmation?.candidate;
+    final background = _input.candidateBackground;
+    final threadId = threadIdProvider();
+    if (target == null ||
+        confirmation == null ||
+        candidate == null ||
+        target.input != _input ||
+        target.stage != JobTargetStage.confirmed) {
+      _errorMessage = '岗位信息尚未确认，请先完成分析与确认。';
+      _operationStage = JobPreparationOperationStage.confirmation;
+      notifyListeners();
+      return false;
+    }
+    if (background == null || background.isEmpty) {
+      _errorMessage = '请先补充你的相关背景，再生成练习预览。';
+      _operationStage = JobPreparationOperationStage.profile;
+      notifyListeners();
+      return false;
+    }
+    if (threadId == null || !_validResourceId(threadId)) {
+      _errorMessage = 'Agent 对话仍在恢复，请稍后重试。';
+      _operationStage = JobPreparationOperationStage.matter;
+      notifyListeners();
+      return false;
+    }
+
+    final operationEpoch = _epoch;
+    _begin(JobPreparationOperationStage.matter);
+    try {
+      final context = await matterActivator(
+        threadId: threadId,
+        candidate: candidate,
+        clientOperationId: _matterKey ??= _newId('job-target-matter'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (context.threadId != threadId || !_validResourceId(context.matterId)) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.matter,
+        );
+      }
+
+      _operationStage = JobPreparationOperationStage.profile;
+      notifyListeners();
+      final profile = await client.createProfileForJobTarget(
+        backgroundSummary: background,
+        jobTargetId: target.id,
+        jobTargetConfirmationVersion: confirmation.confirmationVersion,
+        idempotencyKey: _profileKey ??= _newId('job-target-profile'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (profile.userId != target.userId) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.profile,
+        );
+      }
+
+      _operationStage = JobPreparationOperationStage.snapshot;
+      notifyListeners();
+      final snapshot = await client.createJobPreparationSnapshot(
+        profileId: profile.id,
+        sourceVersion: profile.version,
+        idempotencyKey: _snapshotKey ??= _newId('job-target-snapshot'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (snapshot.sourceJobTargetId != target.id ||
+          snapshot.sourceJobTargetConfirmationVersion !=
+              confirmation.confirmationVersion ||
+          snapshot.jobTargetInput != _input ||
+          !_sameJobTargetCandidate(
+            snapshot.jobTargetCandidate,
+            confirmation.candidate,
+          )) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.snapshot,
+        );
+      }
+
+      _operationStage = JobPreparationOperationStage.plan;
+      notifyListeners();
+      final plan = await client.createJobPracticePlan(
+        context: context,
+        preparationSnapshotId: snapshot.id,
+        idempotencyKey: _planKey ??= _newId('job-target-plan'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (plan.userId != target.userId ||
+          plan.context != context ||
+          plan.preparationSnapshot.sourceJobTargetId != target.id ||
+          plan.preparationSnapshot.sourceJobTargetConfirmationVersion !=
+              confirmation.confirmationVersion) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.plan,
+        );
+      }
+      _plan = plan;
+      _bootstrap = null;
+      _sessionKey = null;
+      _voiceKey = null;
+      _step = JobPreparationStep.preview;
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _operationStage = error.stage ?? _operationStage;
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法生成练习预览，请稍后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<bool> revisePreview({
+    required String roleDefinitionId,
+    required String practiceOptionId,
+    required int practiceOptionVersion,
+    required int maxEffectiveTurns,
+  }) async {
+    final plan = _plan;
+    if (_disposed || _busy || plan == null) {
+      return false;
+    }
+    final operationEpoch = _epoch;
+    _begin(JobPreparationOperationStage.plan);
+    try {
+      final revised = await client.reviseJobPracticePlan(
+        planId: plan.id,
+        expectedPlanRevision: plan.revision,
+        roleDefinitionId: roleDefinitionId,
+        practiceOptionId: practiceOptionId,
+        practiceOptionVersion: practiceOptionVersion,
+        maxEffectiveTurns: maxEffectiveTurns,
+        idempotencyKey: _planRevisionKey ??= _newId('job-target-plan-revision'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      if (revised.context != plan.context ||
+          revised.preparationSnapshot.id != plan.preparationSnapshot.id) {
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: JobPreparationOperationStage.plan,
+        );
+      }
+      _plan = revised;
+      _planRevisionKey = null;
+      _bootstrap = null;
+      _sessionKey = null;
+      _voiceKey = null;
+      _errorMessage = null;
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = '暂时无法更新练习预览，请稍后重试。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<bool> startPractice() async {
+    final plan = _plan;
+    if (_disposed || _busy || plan == null) {
+      return false;
+    }
+    final operationEpoch = _epoch;
+    _begin(
+      _bootstrap == null
+          ? JobPreparationOperationStage.session
+          : JobPreparationOperationStage.voice,
+    );
+    try {
+      final bootstrap =
+          _bootstrap ??
+          await client.createJobPracticeSession(
+            plan: plan,
+            idempotencyKey: _sessionKey ??= _newId('job-target-session'),
+          );
+      _requireCurrent(operationEpoch, _input);
+      _bootstrap = bootstrap;
+
+      _operationStage = JobPreparationOperationStage.voice;
+      notifyListeners();
+      await voiceActivator(
+        context: plan.context,
+        bootstrap: bootstrap,
+        clientOperationId: _voiceKey ??= _newId('job-target-voice'),
+      );
+      _requireCurrent(operationEpoch, _input);
+      _errorMessage = null;
+      _draftCompleted = true;
+      await _deleteActiveDraft();
+      _requireCurrent(operationEpoch, _input);
+      return true;
+    } on JobPreparationException catch (error) {
+      if (_isCurrent(operationEpoch)) {
+        _operationStage = error.stage ?? _operationStage;
+        _errorMessage = _messageFor(error);
+      }
+      return false;
+    } on Object {
+      if (_isCurrent(operationEpoch)) {
+        _errorMessage = _bootstrap == null
+            ? '暂时无法创建练习，本次预览已保留，可以重试。'
+            : '练习已创建，但语音题目暂时无法连接。请重试连接。';
+      }
+      return false;
+    } finally {
+      _finish(operationEpoch);
+    }
+  }
+
+  Future<bool> retry() {
+    return switch (_operationStage) {
+      JobPreparationOperationStage.target ||
+      JobPreparationOperationStage.analysis => analyze(),
+      JobPreparationOperationStage.confirmation => confirm(),
+      JobPreparationOperationStage.profile ||
+      JobPreparationOperationStage.snapshot ||
+      JobPreparationOperationStage.matter => createPreview(),
+      JobPreparationOperationStage.plan
+          when _step != JobPreparationStep.preview =>
+        createPreview(),
+      JobPreparationOperationStage.plan => Future<bool>.value(false),
+      JobPreparationOperationStage.session ||
+      JobPreparationOperationStage.voice => startPractice(),
+      null => Future<bool>.value(false),
+    };
+  }
+
+  Future<void> clearPrivateState() async {
+    final accountId = _accountId;
+    _accountGeneration++;
+    _epoch++;
+    _accountId = null;
+    _loadedDraftAccountId = null;
+    _restorableDraft = null;
+    _initializingDraft = false;
+    _resetPresentation();
+    await client.clearAccountState();
+    await _draftWriteTail;
+    if (accountId != null) {
+      await draftStore.delete(accountId);
+    }
+    if (!_disposed) {
+      notifyListeners();
+    }
+  }
+
+  void _applyStoredDraft(_StoredJobPreparationDraft draft) {
+    _input = draft.input;
+    _target = null;
+    _candidate = draft.candidate;
+    _plan = null;
+    _bootstrap = null;
+    _step = JobPreparationStep.input;
+    _operationStage = null;
+    _errorMessage = null;
+    _draftCompleted = false;
+    _createTargetKey = draft.createTargetKey;
+    _updateTargetKey = draft.updateTargetKey;
+    _analysisKey = draft.analysisKey;
+    _confirmationKey = draft.confirmationKey;
+    _discardTargetKey = draft.discardTargetKey;
+    _matterKey = draft.matterKey;
+    _profileKey = draft.profileKey;
+    _snapshotKey = draft.snapshotKey;
+    _planKey = draft.planKey;
+    _planRevisionKey = null;
+    _sessionKey = draft.sessionKey;
+    _voiceKey = draft.voiceKey;
+  }
+
+  void _applyTargetStage(
+    JobTarget target, {
+    JobTargetCandidate? storedCandidate,
+  }) {
+    switch (target.stage) {
+      case JobTargetStage.awaitingConfirmation:
+        final serverCandidate = target.analysis?.candidate;
+        _candidate = storedCandidate?.source == serverCandidate?.source
+            ? storedCandidate
+            : serverCandidate;
+        _step = JobPreparationStep.confirmation;
+      case JobTargetStage.confirmed:
+        _candidate = target.confirmation?.candidate;
+        _step = JobPreparationStep.setup;
+      case JobTargetStage.draft ||
+          JobTargetStage.parsing ||
+          JobTargetStage.analysisFailed:
+        _candidate = null;
+        _step = JobPreparationStep.input;
+      case JobTargetStage.discarded:
+        throw const JobPreparationException(
+          kind: JobPreparationFailureKind.notFound,
+          stage: JobPreparationOperationStage.target,
+        );
+    }
+  }
+
+  void _resetPresentation() {
+    _input = const JobTargetInput(source: JobTargetSource.jobDescription);
+    _agentIntentPrefill = null;
+    _target = null;
+    _candidate = null;
+    _plan = null;
+    _bootstrap = null;
+    _step = JobPreparationStep.input;
+    _operationStage = null;
+    _errorMessage = null;
+    _busy = false;
+    _draftCompleted = false;
+    _createTargetKey = null;
+    _updateTargetKey = null;
+    _analysisKey = null;
+    _confirmationKey = null;
+    _discardTargetKey = null;
+    _clearPreviewAttempt();
+  }
+
+  void _queueDraftWrite() {
+    final accountId = _accountId;
+    if (_disposed ||
+        accountId == null ||
+        _restorableDraft != null ||
+        _draftCompleted) {
+      return;
+    }
+    final encoded = _StoredJobPreparationDraft(
+      input: _input,
+      targetId: _target?.id,
+      candidate: _candidate,
+      planId: _plan?.id,
+      createTargetKey: _createTargetKey,
+      updateTargetKey: _updateTargetKey,
+      analysisKey: _analysisKey,
+      confirmationKey: _confirmationKey,
+      discardTargetKey: _discardTargetKey,
+      matterKey: _matterKey,
+      profileKey: _profileKey,
+      snapshotKey: _snapshotKey,
+      planKey: _planKey,
+      sessionKey: _sessionKey,
+      voiceKey: _voiceKey,
+    ).encode();
+    _draftWriteTail = _draftWriteTail
+        .then((_) => draftStore.write(accountId, encoded))
+        .catchError((Object _) {});
+  }
+
+  Future<void> _deleteActiveDraft() async {
+    final accountId = _accountId;
+    if (accountId == null) {
+      return;
+    }
+    await _draftWriteTail;
+    await draftStore.delete(accountId);
+  }
+
+  void _clearPreviewAttempt() {
+    _matterKey = null;
+    _profileKey = null;
+    _snapshotKey = null;
+    _planKey = null;
+    _planRevisionKey = null;
+    _sessionKey = null;
+    _voiceKey = null;
+  }
+
+  void _begin(JobPreparationOperationStage stage) {
+    _busy = true;
+    _operationStage = stage;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  void _finish(int operationEpoch) {
+    if (_isCurrent(operationEpoch)) {
+      _busy = false;
+      notifyListeners();
+      _queueDraftWrite();
+    }
+  }
+
+  void _requireCurrent(int operationEpoch, JobTargetInput expectedInput) {
+    if (!_isCurrent(operationEpoch) || _input != expectedInput) {
+      throw const JobPreparationException(
+        kind: JobPreparationFailureKind.superseded,
+      );
+    }
+  }
+
+  bool _isCurrent(int operationEpoch) {
+    return !_disposed && operationEpoch == _epoch;
+  }
+
+  bool _isCurrentAccount(int generation, String accountId) {
+    return !_disposed &&
+        generation == _accountGeneration &&
+        accountId == _accountId;
+  }
+
+  String _newId(String scope) {
+    final value = _idFactory(scope);
+    if (value.length < 8 ||
+        value.length > 128 ||
+        value.trim() != value ||
+        value.contains('\u0000')) {
+      throw StateError('Invalid Job preparation idempotency identity.');
+    }
+    return value;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _epoch++;
+    super.dispose();
+  }
+}
+
+final class _StoredJobPreparationDraft {
+  const _StoredJobPreparationDraft({
+    required this.input,
+    this.targetId,
+    this.candidate,
+    this.planId,
+    this.createTargetKey,
+    this.updateTargetKey,
+    this.analysisKey,
+    this.confirmationKey,
+    this.discardTargetKey,
+    this.matterKey,
+    this.profileKey,
+    this.snapshotKey,
+    this.planKey,
+    this.sessionKey,
+    this.voiceKey,
+  });
+
+  final JobTargetInput input;
+  final String? targetId;
+  final JobTargetCandidate? candidate;
+  final String? planId;
+  final String? createTargetKey;
+  final String? updateTargetKey;
+  final String? analysisKey;
+  final String? confirmationKey;
+  final String? discardTargetKey;
+  final String? matterKey;
+  final String? profileKey;
+  final String? snapshotKey;
+  final String? planKey;
+  final String? sessionKey;
+  final String? voiceKey;
+
+  String encode() {
+    return jsonEncode(<String, Object?>{
+      'schema_version': 1,
+      'input': _storedInputJson(input),
+      'target_id': ?targetId,
+      'candidate': ?(candidate == null
+          ? null
+          : _storedCandidateJson(candidate!)),
+      'plan_id': ?planId,
+      'create_target_key': ?createTargetKey,
+      'update_target_key': ?updateTargetKey,
+      'analysis_key': ?analysisKey,
+      'confirmation_key': ?confirmationKey,
+      'discard_target_key': ?discardTargetKey,
+      'matter_key': ?matterKey,
+      'profile_key': ?profileKey,
+      'snapshot_key': ?snapshotKey,
+      'plan_key': ?planKey,
+      'session_key': ?sessionKey,
+      'voice_key': ?voiceKey,
+    });
+  }
+
+  static _StoredJobPreparationDraft? tryDecode(String encoded) {
+    try {
+      if (utf8.encode(encoded).length > 256 * 1024) {
+        return null;
+      }
+      final value = jsonDecode(encoded);
+      if (value is! Map<String, Object?> ||
+          value['schema_version'] != 1 ||
+          !value.containsKey('input') ||
+          value.keys.any(
+            (key) => !const <String>{
+              'schema_version',
+              'input',
+              'target_id',
+              'candidate',
+              'plan_id',
+              'create_target_key',
+              'update_target_key',
+              'analysis_key',
+              'confirmation_key',
+              'discard_target_key',
+              'matter_key',
+              'profile_key',
+              'snapshot_key',
+              'plan_key',
+              'session_key',
+              'voice_key',
+            }.contains(key),
+          )) {
+        return null;
+      }
+      final input = _storedInput(value['input']);
+      final candidate = value.containsKey('candidate')
+          ? _storedCandidate(value['candidate'])
+          : null;
+      final targetId = _storedOptionalId(value, 'target_id');
+      final planId = _storedOptionalId(value, 'plan_id');
+      if ((candidate != null && candidate.source != input.source) ||
+          (planId != null && targetId == null)) {
+        return null;
+      }
+      return _StoredJobPreparationDraft(
+        input: input,
+        targetId: targetId,
+        candidate: candidate,
+        planId: planId,
+        createTargetKey: _storedOptionalKey(value, 'create_target_key'),
+        updateTargetKey: _storedOptionalKey(value, 'update_target_key'),
+        analysisKey: _storedOptionalKey(value, 'analysis_key'),
+        confirmationKey: _storedOptionalKey(value, 'confirmation_key'),
+        discardTargetKey: _storedOptionalKey(value, 'discard_target_key'),
+        matterKey: _storedOptionalKey(value, 'matter_key'),
+        profileKey: _storedOptionalKey(value, 'profile_key'),
+        snapshotKey: _storedOptionalKey(value, 'snapshot_key'),
+        planKey: _storedOptionalKey(value, 'plan_key'),
+        sessionKey: _storedOptionalKey(value, 'session_key'),
+        voiceKey: _storedOptionalKey(value, 'voice_key'),
+      );
+    } on Object {
+      return null;
+    }
+  }
+}
+
+Map<String, Object?> _storedInputJson(JobTargetInput input) {
+  return <String, Object?>{
+    'source': input.source.wireValue,
+    'job_title': ?input.jobTitle,
+    'job_description': ?input.jobDescription,
+    'company': ?input.company,
+    'seniority': ?input.seniority,
+    'candidate_background': ?input.candidateBackground,
+    'resume_ref': ?input.resumeRef,
+    'practice_focus': ?input.practiceFocus,
+  };
+}
+
+JobTargetInput _storedInput(Object? value) {
+  if (value is! Map<String, Object?> ||
+      value['source'] is! String ||
+      value.keys.any(
+        (key) => !const <String>{
+          'source',
+          'job_title',
+          'job_description',
+          'company',
+          'seniority',
+          'candidate_background',
+          'resume_ref',
+          'practice_focus',
+        }.contains(key),
+      )) {
+    throw const FormatException('Invalid stored JobTarget input.');
+  }
+  final source = switch (value['source']) {
+    'job_description' => JobTargetSource.jobDescription,
+    'quick_start' => JobTargetSource.quickStart,
+    _ => throw const FormatException('Invalid stored JobTarget source.'),
+  };
+  final input = JobTargetInput(
+    source: source,
+    jobTitle: _storedOptionalInputText(value, 'job_title', 512),
+    jobDescription: _storedOptionalInputText(
+      value,
+      'job_description',
+      64 * 1024,
+    ),
+    company: _storedOptionalInputText(value, 'company', 512),
+    seniority: _storedOptionalInputText(value, 'seniority', 256),
+    candidateBackground: _storedOptionalInputText(
+      value,
+      'candidate_background',
+      16 * 1024,
+    ),
+    resumeRef: _storedOptionalInputText(value, 'resume_ref', 16 * 1024),
+    practiceFocus: _storedOptionalInputText(value, 'practice_focus', 8 * 1024),
+  );
+  if (!_validPartialJobTargetInput(input)) {
+    throw const FormatException('Invalid stored JobTarget input.');
+  }
+  return input;
+}
+
+Map<String, Object?> _storedCandidateJson(JobTargetCandidate candidate) {
+  return <String, Object?>{
+    'source': candidate.source.wireValue,
+    'general_advice_only': candidate.generalAdviceOnly,
+    'job_title': candidate.jobTitle,
+    'seniority': candidate.seniority,
+    'responsibilities': candidate.responsibilities,
+    'core_skills': candidate.coreSkills,
+    'communication_focus': candidate.communicationFocus,
+    'practice_goals': candidate.practiceGoals,
+    'scope_notice': candidate.scopeNotice,
+    'catalog_recommendation': <String, Object?>{
+      'scenario_definition_id':
+          candidate.catalogRecommendation.scenarioDefinitionId,
+      'scenario_definition_version':
+          candidate.catalogRecommendation.scenarioDefinitionVersion,
+      'selected_role_ids': candidate.catalogRecommendation.selectedRoleIds,
+      'practice_option_id': candidate.catalogRecommendation.practiceOptionId,
+      'practice_option_version':
+          candidate.catalogRecommendation.practiceOptionVersion,
+    },
+  };
+}
+
+JobTargetCandidate _storedCandidate(Object? value) {
+  if (value is! Map<String, Object?> ||
+      value.keys.toSet().difference(const <String>{
+        'source',
+        'general_advice_only',
+        'job_title',
+        'seniority',
+        'responsibilities',
+        'core_skills',
+        'communication_focus',
+        'practice_goals',
+        'scope_notice',
+        'catalog_recommendation',
+      }).isNotEmpty ||
+      value.length != 10) {
+    throw const FormatException('Invalid stored JobTarget candidate.');
+  }
+  final source = switch (value['source']) {
+    'job_description' => JobTargetSource.jobDescription,
+    'quick_start' => JobTargetSource.quickStart,
+    _ => throw const FormatException('Invalid stored JobTarget source.'),
+  };
+  final recommendation = value['catalog_recommendation'];
+  if (recommendation is! Map<String, Object?> ||
+      recommendation.length != 5 ||
+      recommendation.keys.toSet().difference(const <String>{
+        'scenario_definition_id',
+        'scenario_definition_version',
+        'selected_role_ids',
+        'practice_option_id',
+        'practice_option_version',
+      }).isNotEmpty) {
+    throw const FormatException('Invalid stored catalog recommendation.');
+  }
+  final roles = _storedStringList(
+    recommendation['selected_role_ids'],
+    maxItems: 1,
+    maxBytes: 128,
+  );
+  final candidate = JobTargetCandidate(
+    source: source,
+    generalAdviceOnly: value['general_advice_only'] as bool,
+    jobTitle: _storedText(value['job_title'], 512),
+    seniority: _storedText(value['seniority'], 256),
+    responsibilities: _storedStringList(value['responsibilities']),
+    coreSkills: _storedStringList(value['core_skills']),
+    communicationFocus: _storedStringList(value['communication_focus']),
+    practiceGoals: _storedStringList(value['practice_goals']),
+    scopeNotice: _storedText(value['scope_notice'], 2048),
+    catalogRecommendation: JobTargetCatalogRecommendation(
+      scenarioDefinitionId: _storedId(recommendation['scenario_definition_id']),
+      scenarioDefinitionVersion: _storedVersion(
+        recommendation['scenario_definition_version'],
+      ),
+      selectedRoleIds: roles,
+      practiceOptionId: _storedId(recommendation['practice_option_id']),
+      practiceOptionVersion: _storedVersion(
+        recommendation['practice_option_version'],
+      ),
+    ),
+  );
+  if (candidate.generalAdviceOnly !=
+      (candidate.source == JobTargetSource.quickStart)) {
+    throw const FormatException('Invalid stored JobTarget advice scope.');
+  }
+  return candidate;
+}
+
+String? _storedOptionalId(Map<String, Object?> value, String key) {
+  return value.containsKey(key) ? _storedId(value[key]) : null;
+}
+
+String _storedId(Object? value) {
+  final result = _storedText(value, 128);
+  if (!_validResourceId(result)) {
+    throw const FormatException('Invalid stored resource identity.');
+  }
+  return result;
+}
+
+String? _storedOptionalKey(Map<String, Object?> value, String key) {
+  if (!value.containsKey(key)) {
+    return null;
+  }
+  final result = _storedText(value[key], 128);
+  if (result.length < 8) {
+    throw const FormatException('Invalid stored idempotency identity.');
+  }
+  return result;
+}
+
+String? _storedOptionalInputText(
+  Map<String, Object?> value,
+  String key,
+  int maxBytes,
+) {
+  if (!value.containsKey(key)) {
+    return null;
+  }
+  final result = value[key];
+  if (result is! String ||
+      result.isEmpty ||
+      result.contains('\u0000') ||
+      utf8.encode(result).length > maxBytes) {
+    throw const FormatException('Invalid stored input text.');
+  }
+  return result;
+}
+
+String _storedText(Object? value, int maxBytes) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.trim() != value ||
+      value.contains('\u0000') ||
+      utf8.encode(value).length > maxBytes) {
+    throw const FormatException('Invalid stored text.');
+  }
+  return value;
+}
+
+int _storedVersion(Object? value) {
+  if (value is! int || value < 1) {
+    throw const FormatException('Invalid stored version.');
+  }
+  return value;
+}
+
+List<String> _storedStringList(
+  Object? value, {
+  int maxItems = 20,
+  int maxBytes = 8 * 1024,
+}) {
+  if (value is! List<Object?> || value.isEmpty || value.length > maxItems) {
+    throw const FormatException('Invalid stored list.');
+  }
+  final result = value
+      .map((item) => _storedText(item, maxBytes))
+      .toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw const FormatException('Invalid stored list.');
+  }
+  return List<String>.unmodifiable(result);
+}
+
+bool _validPartialJobTargetInput(JobTargetInput input) {
+  bool valid(String? value, int maxBytes) {
+    return value == null ||
+        (value.isNotEmpty &&
+            !value.contains('\u0000') &&
+            utf8.encode(value).length <= maxBytes);
+  }
+
+  return valid(input.jobTitle, 512) &&
+      valid(input.jobDescription, 64 * 1024) &&
+      valid(input.company, 512) &&
+      valid(input.seniority, 256) &&
+      valid(input.candidateBackground, 16 * 1024) &&
+      valid(input.resumeRef, 16 * 1024) &&
+      valid(input.practiceFocus, 8 * 1024) &&
+      !(input.source == JobTargetSource.quickStart &&
+          input.jobDescription != null);
+}
+
+bool _sameJobTargetCandidate(
+  JobTargetCandidate left,
+  JobTargetCandidate right,
+) {
+  final leftRecommendation = left.catalogRecommendation;
+  final rightRecommendation = right.catalogRecommendation;
+  return left.source == right.source &&
+      left.generalAdviceOnly == right.generalAdviceOnly &&
+      left.jobTitle == right.jobTitle &&
+      left.seniority == right.seniority &&
+      listEquals(left.responsibilities, right.responsibilities) &&
+      listEquals(left.coreSkills, right.coreSkills) &&
+      listEquals(left.communicationFocus, right.communicationFocus) &&
+      listEquals(left.practiceGoals, right.practiceGoals) &&
+      left.scopeNotice == right.scopeNotice &&
+      leftRecommendation.scenarioDefinitionId ==
+          rightRecommendation.scenarioDefinitionId &&
+      leftRecommendation.scenarioDefinitionVersion ==
+          rightRecommendation.scenarioDefinitionVersion &&
+      listEquals(
+        leftRecommendation.selectedRoleIds,
+        rightRecommendation.selectedRoleIds,
+      ) &&
+      leftRecommendation.practiceOptionId ==
+          rightRecommendation.practiceOptionId &&
+      leftRecommendation.practiceOptionVersion ==
+          rightRecommendation.practiceOptionVersion;
+}
+
+bool _validJobTargetInput(JobTargetInput input) {
+  bool valid(String? value, int maxBytes) {
+    return value == null ||
+        (value.isNotEmpty &&
+            value.trim() == value &&
+            !value.contains('\u0000') &&
+            utf8.encode(value).length <= maxBytes);
+  }
+
+  return valid(input.jobTitle, 512) &&
+      valid(input.jobDescription, 64 * 1024) &&
+      valid(input.company, 512) &&
+      valid(input.seniority, 256) &&
+      valid(input.candidateBackground, 16 * 1024) &&
+      valid(input.resumeRef, 16 * 1024) &&
+      valid(input.practiceFocus, 8 * 1024) &&
+      switch (input.source) {
+        JobTargetSource.jobDescription => input.jobDescription != null,
+        JobTargetSource.quickStart =>
+          input.jobTitle != null && input.jobDescription == null,
+      };
+}
+
+bool _validResourceId(String value) {
+  return value.isNotEmpty &&
+      value.length <= 128 &&
+      value.trim() == value &&
+      !value.contains('\u0000');
+}
+
+String _messageFor(JobPreparationException error) {
+  return switch (error.kind) {
+    JobPreparationFailureKind.authenticationRequired => '登录状态已失效，请重新登录后继续。',
+    JobPreparationFailureKind.invalidRequest =>
+      error.stage == JobPreparationOperationStage.confirmation
+          ? '确认内容无法提交，请检查每一项后重试。'
+          : '当前信息无法提交，请检查填写内容后重试。',
+    JobPreparationFailureKind.notFound => '这份准备草稿已不存在，请重新开始。',
+    JobPreparationFailureKind.conflict => '服务端版本已变化，请恢复最新草稿后再继续。',
+    JobPreparationFailureKind.network => '网络连接不稳定，本次进度已保留，可以重试。',
+    JobPreparationFailureKind.server =>
+      error.stage == JobPreparationOperationStage.analysis
+          ? '岗位分析暂时失败，可以重试；已填写内容不会丢失。'
+          : '准备服务暂时不可用，本次进度已保留，可以重试。',
+    JobPreparationFailureKind.invalidResponse => '准备服务返回了无法识别的数据，请稍后重试。',
+    JobPreparationFailureKind.superseded => '',
+  };
+}
+
+final Random _jobPreparationRandom = Random.secure();
+
+String _secureJobPreparationId(String scope) {
+  final value = StringBuffer('${scope}_');
+  for (var index = 0; index < 16; index++) {
+    value.write(
+      _jobPreparationRandom.nextInt(256).toRadixString(16).padLeft(2, '0'),
+    );
+  }
+  return value.toString();
+}

--- a/mobile/lib/features/preparation/job_preparation_draft_store.dart
+++ b/mobile/lib/features/preparation/job_preparation_draft_store.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:speakup/identity/session_store.dart';
+
+abstract interface class JobPreparationDraftStore {
+  Future<String?> read(String accountId);
+
+  Future<void> write(String accountId, String value);
+
+  Future<void> delete(String accountId);
+}
+
+final class SecureJobPreparationDraftStore implements JobPreparationDraftStore {
+  const SecureJobPreparationDraftStore([
+    this._storage = const FlutterSecureStorageAdapter(),
+  ]);
+
+  final SecureStorageAdapter _storage;
+
+  @override
+  Future<String?> read(String accountId) {
+    return _storage.read(_key(accountId));
+  }
+
+  @override
+  Future<void> write(String accountId, String value) {
+    return _storage.write(_key(accountId), value);
+  }
+
+  @override
+  Future<void> delete(String accountId) {
+    return _storage.delete(_key(accountId));
+  }
+
+  String _key(String accountId) {
+    final encoded = base64Url
+        .encode(utf8.encode(accountId))
+        .replaceAll('=', '');
+    return 'job_preparation_draft_v1_$encoded';
+  }
+}
+
+final class MemoryJobPreparationDraftStore implements JobPreparationDraftStore {
+  final Map<String, String> _values = <String, String>{};
+
+  @override
+  Future<String?> read(String accountId) async => _values[accountId];
+
+  @override
+  Future<void> write(String accountId, String value) async {
+    _values[accountId] = value;
+  }
+
+  @override
+  Future<void> delete(String accountId) async {
+    _values.remove(accountId);
+  }
+}
+
+final class NullJobPreparationDraftStore implements JobPreparationDraftStore {
+  const NullJobPreparationDraftStore();
+
+  @override
+  Future<String?> read(String accountId) async => null;
+
+  @override
+  Future<void> write(String accountId, String value) async {}
+
+  @override
+  Future<void> delete(String accountId) async {}
+}

--- a/mobile/lib/features/preparation/job_preparation_models.dart
+++ b/mobile/lib/features/preparation/job_preparation_models.dart
@@ -1,0 +1,345 @@
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+enum JobTargetSource {
+  jobDescription('job_description'),
+  quickStart('quick_start');
+
+  const JobTargetSource(this.wireValue);
+
+  final String wireValue;
+}
+
+enum JobTargetStage {
+  draft('draft'),
+  parsing('parsing'),
+  analysisFailed('analysis_failed'),
+  awaitingConfirmation('awaiting_confirmation'),
+  confirmed('confirmed'),
+  discarded('discarded');
+
+  const JobTargetStage(this.wireValue);
+
+  final String wireValue;
+}
+
+enum JobTargetAnalysisStatus {
+  running('running'),
+  succeeded('succeeded'),
+  failed('failed');
+
+  const JobTargetAnalysisStatus(this.wireValue);
+
+  final String wireValue;
+}
+
+final class JobTargetInput {
+  const JobTargetInput({
+    required this.source,
+    this.jobTitle,
+    this.jobDescription,
+    this.company,
+    this.seniority,
+    this.candidateBackground,
+    this.resumeRef,
+    this.practiceFocus,
+  });
+
+  final JobTargetSource source;
+  final String? jobTitle;
+  final String? jobDescription;
+  final String? company;
+  final String? seniority;
+  final String? candidateBackground;
+  final String? resumeRef;
+  final String? practiceFocus;
+
+  @override
+  bool operator ==(Object other) {
+    return other is JobTargetInput &&
+        other.source == source &&
+        other.jobTitle == jobTitle &&
+        other.jobDescription == jobDescription &&
+        other.company == company &&
+        other.seniority == seniority &&
+        other.candidateBackground == candidateBackground &&
+        other.resumeRef == resumeRef &&
+        other.practiceFocus == practiceFocus;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    source,
+    jobTitle,
+    jobDescription,
+    company,
+    seniority,
+    candidateBackground,
+    resumeRef,
+    practiceFocus,
+  );
+}
+
+final class JobTargetCatalogRecommendation {
+  const JobTargetCatalogRecommendation({
+    required this.scenarioDefinitionId,
+    required this.scenarioDefinitionVersion,
+    required this.selectedRoleIds,
+    required this.practiceOptionId,
+    required this.practiceOptionVersion,
+  });
+
+  final String scenarioDefinitionId;
+  final int scenarioDefinitionVersion;
+  final List<String> selectedRoleIds;
+  final String practiceOptionId;
+  final int practiceOptionVersion;
+}
+
+final class JobTargetCandidate {
+  const JobTargetCandidate({
+    required this.source,
+    required this.generalAdviceOnly,
+    required this.jobTitle,
+    required this.seniority,
+    required this.responsibilities,
+    required this.coreSkills,
+    required this.communicationFocus,
+    required this.practiceGoals,
+    required this.scopeNotice,
+    required this.catalogRecommendation,
+  });
+
+  final JobTargetSource source;
+  final bool generalAdviceOnly;
+  final String jobTitle;
+  final String seniority;
+  final List<String> responsibilities;
+  final List<String> coreSkills;
+  final List<String> communicationFocus;
+  final List<String> practiceGoals;
+  final String scopeNotice;
+  final JobTargetCatalogRecommendation catalogRecommendation;
+}
+
+final class JobTargetAnalysis {
+  const JobTargetAnalysis({
+    required this.inputVersion,
+    required this.analysisVersion,
+    required this.attempt,
+    required this.status,
+    required this.startedAt,
+    this.candidate,
+    this.stableErrorCategory,
+    this.finishedAt,
+  });
+
+  final int inputVersion;
+  final int analysisVersion;
+  final int attempt;
+  final JobTargetAnalysisStatus status;
+  final JobTargetCandidate? candidate;
+  final String? stableErrorCategory;
+  final DateTime startedAt;
+  final DateTime? finishedAt;
+}
+
+final class JobTargetConfirmation {
+  const JobTargetConfirmation({
+    required this.inputVersion,
+    required this.analysisVersion,
+    required this.confirmationVersion,
+    required this.candidate,
+    required this.confirmedAt,
+  });
+
+  final int inputVersion;
+  final int analysisVersion;
+  final int confirmationVersion;
+  final JobTargetCandidate candidate;
+  final DateTime confirmedAt;
+}
+
+final class JobTarget {
+  const JobTarget({
+    required this.id,
+    required this.userId,
+    required this.input,
+    required this.inputVersion,
+    required this.stage,
+    required this.createdAt,
+    required this.updatedAt,
+    this.analysis,
+    this.confirmation,
+  });
+
+  final String id;
+  final String userId;
+  final JobTargetInput input;
+  final int inputVersion;
+  final JobTargetStage stage;
+  final JobTargetAnalysis? analysis;
+  final JobTargetConfirmation? confirmation;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+final class JobPreparationProfile {
+  const JobPreparationProfile({
+    required this.id,
+    required this.userId,
+    required this.backgroundSummary,
+    required this.jobTargetId,
+    required this.jobTargetConfirmationVersion,
+    required this.version,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final String backgroundSummary;
+  final String jobTargetId;
+  final int jobTargetConfirmationVersion;
+  final int version;
+  final DateTime updatedAt;
+}
+
+final class JobPreparationSnapshot {
+  const JobPreparationSnapshot({
+    required this.id,
+    required this.sourceProfileId,
+    required this.sourceVersion,
+    required this.sourceJobTargetId,
+    required this.sourceJobTargetConfirmationVersion,
+    required this.jobTargetInput,
+    required this.jobTargetCandidate,
+    required this.backgroundSnapshot,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String sourceProfileId;
+  final int sourceVersion;
+  final String sourceJobTargetId;
+  final int sourceJobTargetConfirmationVersion;
+  final JobTargetInput jobTargetInput;
+  final JobTargetCandidate jobTargetCandidate;
+  final String backgroundSnapshot;
+  final DateTime createdAt;
+}
+
+final class JobPracticeObjective {
+  const JobPracticeObjective({required this.id, required this.description});
+
+  final String id;
+  final String description;
+}
+
+final class JobSessionPolicy {
+  const JobSessionPolicy({
+    required this.suggestedDurationSeconds,
+    required this.minEffectiveTurns,
+    required this.maxEffectiveTurns,
+    required this.coverageCheckpointTurn,
+    required this.maxFollowUpsPerQuestion,
+    required this.targetObjectives,
+    required this.earlyCompletionRule,
+  });
+
+  final int suggestedDurationSeconds;
+  final int minEffectiveTurns;
+  final int maxEffectiveTurns;
+  final int coverageCheckpointTurn;
+  final int maxFollowUpsPerQuestion;
+  final List<JobPracticeObjective> targetObjectives;
+  final String earlyCompletionRule;
+}
+
+final class JobPlanCatalog {
+  const JobPlanCatalog({
+    required this.scenario,
+    required this.config,
+    required this.selectedRole,
+    required this.practiceOption,
+  });
+
+  final PreparationScenario scenario;
+  final PreparationScenarioConfig config;
+  final PreparationRole selectedRole;
+  final PreparationOption practiceOption;
+}
+
+final class JobPracticePlanPreview {
+  const JobPracticePlanPreview({
+    required this.id,
+    required this.userId,
+    required this.context,
+    required this.preparationProfileId,
+    required this.preparationSnapshot,
+    required this.catalog,
+    required this.sessionPolicy,
+    required this.practiceFocuses,
+    required this.revision,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final AgentPracticeContext context;
+  final String preparationProfileId;
+  final JobPreparationSnapshot preparationSnapshot;
+  final JobPlanCatalog catalog;
+  final JobSessionPolicy sessionPolicy;
+  final List<JobPracticeObjective> practiceFocuses;
+  final int revision;
+  final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+enum JobPreparationOperationStage {
+  target,
+  analysis,
+  confirmation,
+  profile,
+  snapshot,
+  matter,
+  plan,
+  session,
+  voice,
+}
+
+enum JobPreparationFailureKind {
+  authenticationRequired,
+  invalidRequest,
+  notFound,
+  conflict,
+  network,
+  server,
+  invalidResponse,
+  superseded,
+}
+
+final class JobPreparationException implements Exception {
+  const JobPreparationException({
+    required this.kind,
+    this.stage,
+    this.statusCode,
+    this.errorCode,
+    this.retryable = false,
+  });
+
+  final JobPreparationFailureKind kind;
+  final JobPreparationOperationStage? stage;
+  final int? statusCode;
+  final String? errorCode;
+  final bool retryable;
+
+  @override
+  String toString() {
+    return 'JobPreparationException(kind: ${kind.name}, '
+        'stage: ${stage?.name})';
+  }
+}

--- a/mobile/lib/features/preparation/job_preparation_wizard.dart
+++ b/mobile/lib/features/preparation/job_preparation_wizard.dart
@@ -1,0 +1,1140 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+class JobPreparationWizard extends StatefulWidget {
+  const JobPreparationWizard({
+    required this.controller,
+    this.catalogController,
+    this.onPracticeStarted,
+    super.key,
+  });
+
+  final JobPreparationController controller;
+  final PreparationController? catalogController;
+  final VoidCallback? onPracticeStarted;
+
+  @override
+  State<JobPreparationWizard> createState() => _JobPreparationWizardState();
+}
+
+class _JobPreparationWizardState extends State<JobPreparationWizard> {
+  late final TextEditingController _jd;
+  late final TextEditingController _title;
+  late final TextEditingController _company;
+  late final TextEditingController _seniority;
+  late final TextEditingController _background;
+  late final TextEditingController _focus;
+  late final TextEditingController _candidateTitle;
+  late final TextEditingController _candidateSeniority;
+  late final TextEditingController _responsibilities;
+  late final TextEditingController _skills;
+  late final TextEditingController _communication;
+  late final TextEditingController _goals;
+  JobTargetCandidate? _shownCandidate;
+  int? _shownPlanRevision;
+  int? _selectedTurnLimit;
+  bool _catalogSyncing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final input = widget.controller.input;
+    _jd = TextEditingController(text: input.jobDescription);
+    _title = TextEditingController(text: input.jobTitle);
+    _company = TextEditingController(text: input.company);
+    _seniority = TextEditingController(text: input.seniority);
+    _background = TextEditingController(text: input.candidateBackground);
+    _focus = TextEditingController(text: input.practiceFocus);
+    _candidateTitle = TextEditingController();
+    _candidateSeniority = TextEditingController();
+    _responsibilities = TextEditingController();
+    _skills = TextEditingController();
+    _communication = TextEditingController();
+    _goals = TextEditingController();
+    widget.controller.addListener(_rebuild);
+    widget.catalogController?.addListener(_rebuild);
+    _syncCandidate();
+    unawaited(_prepareCatalog());
+  }
+
+  @override
+  void didUpdateWidget(covariant JobPreparationWizard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) {
+      if (oldWidget.catalogController != widget.catalogController) {
+        oldWidget.catalogController?.removeListener(_rebuild);
+        widget.catalogController?.addListener(_rebuild);
+        unawaited(_prepareCatalog());
+      }
+      return;
+    }
+    oldWidget.controller.removeListener(_rebuild);
+    widget.controller.addListener(_rebuild);
+    if (oldWidget.catalogController != widget.catalogController) {
+      oldWidget.catalogController?.removeListener(_rebuild);
+      widget.catalogController?.addListener(_rebuild);
+    }
+    _syncInput();
+    _syncCandidate();
+    unawaited(_prepareCatalog());
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_rebuild);
+    widget.catalogController?.removeListener(_rebuild);
+    for (final controller in <TextEditingController>[
+      _jd,
+      _title,
+      _company,
+      _seniority,
+      _background,
+      _focus,
+      _candidateTitle,
+      _candidateSeniority,
+      _responsibilities,
+      _skills,
+      _communication,
+      _goals,
+    ]) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _rebuild() {
+    if (!mounted) {
+      return;
+    }
+    _syncCandidate();
+    unawaited(_prepareCatalog());
+    setState(() {});
+  }
+
+  void _syncInput() {
+    final input = widget.controller.input;
+    _replaceText(_jd, input.jobDescription);
+    _replaceText(_title, input.jobTitle);
+    _replaceText(_company, input.company);
+    _replaceText(_seniority, input.seniority);
+    _replaceText(_background, input.candidateBackground);
+    _replaceText(_focus, input.practiceFocus);
+  }
+
+  void _syncCandidate() {
+    final plan = widget.controller.plan;
+    if (plan != null && plan.revision != _shownPlanRevision) {
+      _shownPlanRevision = plan.revision;
+      _selectedTurnLimit = plan.sessionPolicy.maxEffectiveTurns;
+    }
+    final candidate = widget.controller.candidate;
+    if (candidate == null || identical(candidate, _shownCandidate)) {
+      return;
+    }
+    _shownCandidate = candidate;
+    _replaceText(_candidateTitle, candidate.jobTitle);
+    _replaceText(_candidateSeniority, candidate.seniority);
+    _replaceText(_responsibilities, candidate.responsibilities.join('\n'));
+    _replaceText(_skills, candidate.coreSkills.join('\n'));
+    _replaceText(_communication, candidate.communicationFocus.join('\n'));
+    _replaceText(_goals, candidate.practiceGoals.join('\n'));
+  }
+
+  Future<void> _prepareCatalog() async {
+    final catalog = widget.catalogController;
+    final candidate = widget.controller.candidate;
+    if (!mounted || catalog == null || candidate == null || _catalogSyncing) {
+      return;
+    }
+    _catalogSyncing = true;
+    try {
+      await catalog.loadIfNeeded();
+      if (!mounted || widget.controller.candidate != candidate) {
+        return;
+      }
+      final scenarioId = candidate.catalogRecommendation.scenarioDefinitionId;
+      final scenario = catalog.scenarios
+          .where((item) => item.id == scenarioId)
+          .firstOrNull;
+      if (scenario == null) {
+        return;
+      }
+      if (catalog.selectedScenario?.id != scenario.id ||
+          catalog.detail == null) {
+        await catalog.selectScenario(scenario);
+      }
+      if (!mounted || widget.controller.candidate != candidate) {
+        return;
+      }
+      final plan = widget.controller.plan;
+      final roleId =
+          plan?.catalog.selectedRole.id ??
+          candidate.catalogRecommendation.selectedRoleIds.firstOrNull;
+      final role = catalog.roles.where((item) => item.id == roleId).firstOrNull;
+      if (role != null && catalog.selectedRole?.id != role.id) {
+        catalog.selectRole(role);
+      }
+      final optionId =
+          plan?.catalog.practiceOption.id ??
+          candidate.catalogRecommendation.practiceOptionId;
+      final option = catalog.availableOptions
+          .where((item) => item.id == optionId)
+          .firstOrNull;
+      if (option != null && catalog.selectedOption?.id != option.id) {
+        catalog.selectOption(option);
+      }
+    } finally {
+      _catalogSyncing = false;
+    }
+  }
+
+  void _replaceText(TextEditingController controller, String? value) {
+    final next = value ?? '';
+    if (controller.text == next) {
+      return;
+    }
+    controller.value = TextEditingValue(
+      text: next,
+      selection: TextSelection.collapsed(offset: next.length),
+    );
+  }
+
+  JobTargetInput _currentInput({JobTargetSource? source}) {
+    String? normalized(String value) {
+      final result = value.trim();
+      return result.isEmpty ? null : result;
+    }
+
+    final resolvedSource = source ?? widget.controller.input.source;
+    return JobTargetInput(
+      source: resolvedSource,
+      jobTitle: resolvedSource == JobTargetSource.quickStart
+          ? normalized(_title.text)
+          : null,
+      jobDescription: resolvedSource == JobTargetSource.jobDescription
+          ? normalized(_jd.text)
+          : null,
+      company: normalized(_company.text),
+      seniority: normalized(_seniority.text),
+      candidateBackground: normalized(_background.text),
+      practiceFocus: normalized(_focus.text),
+    );
+  }
+
+  void _commitInput() {
+    widget.controller.updateInput(_currentInput());
+  }
+
+  JobTargetCandidate _editedCandidate(JobTargetCandidate original) {
+    List<String> lines(TextEditingController controller) => controller.text
+        .split('\n')
+        .map((item) => item.trim())
+        .where((item) => item.isNotEmpty)
+        .toList(growable: false);
+
+    return JobTargetCandidate(
+      source: original.source,
+      generalAdviceOnly: original.generalAdviceOnly,
+      jobTitle: _candidateTitle.text.trim(),
+      seniority: _candidateSeniority.text.trim(),
+      responsibilities: lines(_responsibilities),
+      coreSkills: lines(_skills),
+      communicationFocus: lines(_communication),
+      practiceGoals: lines(_goals),
+      scopeNotice: original.scopeNotice,
+      catalogRecommendation: original.catalogRecommendation,
+    );
+  }
+
+  Future<void> _startPractice() async {
+    final started = await widget.controller.startPractice();
+    if (started && mounted) {
+      widget.onPracticeStarted?.call();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = widget.controller;
+    return PopScope<void>(
+      canPop: !controller.isBusy,
+      child: Scaffold(
+        key: const Key('job-preparation-wizard'),
+        backgroundColor: const Color(0xFFF3F3F0),
+        appBar: AppBar(
+          title: const Text('准备英文面试'),
+          backgroundColor: const Color(0xFFF3F3F0),
+          surfaceTintColor: Colors.transparent,
+          leading: IconButton(
+            key: const Key('job-wizard-close'),
+            tooltip: '关闭准备流程',
+            onPressed: controller.isBusy
+                ? null
+                : () => Navigator.of(context).maybePop(),
+            icon: const Icon(Icons.close_rounded),
+          ),
+        ),
+        body: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              _StepProgress(step: controller.step),
+              if (controller.isBusy)
+                LinearProgressIndicator(
+                  key: const Key('job-wizard-progress'),
+                  minHeight: 2,
+                  semanticsLabel: _busyLabel(controller.operationStage),
+                ),
+              if (controller.isBusy)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      _busyLabel(controller.operationStage),
+                      key: const Key('job-wizard-progress-label'),
+                      style: const TextStyle(
+                        color: Color(0xFF686A72),
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ),
+              Expanded(
+                child: switch (controller.step) {
+                  JobPreparationStep.input => _buildInput(controller),
+                  JobPreparationStep.confirmation => _buildConfirmation(
+                    controller,
+                  ),
+                  JobPreparationStep.setup => _buildSetup(controller),
+                  JobPreparationStep.preview => _buildPreview(controller),
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInput(JobPreparationController controller) {
+    final source = controller.input.source;
+    return ListView(
+      key: const Key('job-wizard-input-step'),
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      children: [
+        Text(
+          '先告诉我你要准备什么岗位',
+          style: Theme.of(
+            context,
+          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          '优先粘贴真实 JD。没有 JD 也可以只填岗位快速开始。',
+          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
+        ),
+        const SizedBox(height: 20),
+        SegmentedButton<JobTargetSource>(
+          key: const Key('job-source-selector'),
+          segments: const [
+            ButtonSegment(
+              value: JobTargetSource.jobDescription,
+              label: Text('粘贴 JD'),
+              icon: Icon(Icons.description_outlined),
+            ),
+            ButtonSegment(
+              value: JobTargetSource.quickStart,
+              label: Text('岗位快速开始'),
+              icon: Icon(Icons.bolt_outlined),
+            ),
+          ],
+          selected: {source},
+          onSelectionChanged: controller.isBusy
+              ? null
+              : (selection) {
+                  FocusManager.instance.primaryFocus?.unfocus();
+                  widget.controller.updateInput(
+                    _currentInput(source: selection.single),
+                  );
+                },
+        ),
+        const SizedBox(height: 18),
+        if (source == JobTargetSource.jobDescription)
+          _Field(
+            key: const Key('job-description-field'),
+            controller: _jd,
+            label: '职位描述（JD）',
+            hint: '粘贴岗位职责、要求和英语使用场景',
+            maxLines: 8,
+            onChanged: (_) => _commitInput(),
+          )
+        else ...[
+          Semantics(
+            key: const Key('quick-start-notice'),
+            liveRegion: true,
+            child: const _Notice(
+              icon: Icons.info_outline_rounded,
+              text: '快速开始不会基于真实 JD，只会提供通用岗位建议。',
+            ),
+          ),
+          const SizedBox(height: 14),
+          _Field(
+            key: const Key('job-title-field'),
+            controller: _title,
+            label: '目标岗位',
+            hint: '例如：后端工程师',
+            onChanged: (_) => _commitInput(),
+          ),
+        ],
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('job-company-field'),
+          controller: _company,
+          label: '公司（可选）',
+          hint: '例如：跨国科技公司',
+          onChanged: (_) => _commitInput(),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('job-seniority-field'),
+          controller: _seniority,
+          label: '职级（可选）',
+          hint: '例如：Senior / 资深',
+          onChanged: (_) => _commitInput(),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('job-background-field'),
+          controller: _background,
+          label: '你的相关背景',
+          hint: '简要描述经历、项目和想重点表达的成果',
+          maxLines: 4,
+          onChanged: (_) => _commitInput(),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('job-goal-field'),
+          controller: _focus,
+          label: '本次目标（可选）',
+          hint: '例如：练习系统设计取舍的英文表达',
+          maxLines: 3,
+          onChanged: (_) => _commitInput(),
+        ),
+        if (controller.agentIntentPrefill case final prefill?) ...[
+          const SizedBox(height: 14),
+          _AgentIntentCard(
+            text: prefill,
+            onApply: controller.applyAgentIntentPrefill,
+            onDismiss: controller.dismissAgentIntentPrefill,
+          ),
+        ],
+        if (controller.target != null && controller.candidate == null) ...[
+          const SizedBox(height: 14),
+          const _Notice(
+            icon: Icons.refresh_rounded,
+            text: '岗位信息已修改，之前的分析、确认和计划预览已失效，需要重新分析。',
+          ),
+        ],
+        if (controller.hasRestorableDraft) ...[
+          const SizedBox(height: 14),
+          _DraftCard(
+            onResume: controller.isBusy ? null : controller.resumeDraft,
+            onDiscard: controller.isBusy ? null : controller.discardDraft,
+          ),
+        ],
+        if (controller.errorMessage case final message?)
+          _ErrorCard(
+            message: message,
+            onRetry: controller.canRetry ? controller.retry : null,
+          ),
+        const SizedBox(height: 24),
+        FilledButton.icon(
+          key: const Key('analyze-job-button'),
+          onPressed: controller.isBusy
+              ? null
+              : () {
+                  _commitInput();
+                  unawaited(controller.analyze());
+                },
+          icon: const Icon(Icons.auto_awesome_outlined),
+          label: Text(
+            source == JobTargetSource.jobDescription ? '分析岗位信息' : '生成通用岗位建议',
+          ),
+          style: _primaryButtonStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildConfirmation(JobPreparationController controller) {
+    final candidate = controller.candidate;
+    if (candidate == null) {
+      return const Center(child: Text('分析结果已失效，请返回重试。'));
+    }
+    return ListView(
+      key: const Key('job-wizard-confirmation-step'),
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      children: [
+        Text(
+          '确认 AI 提取结果',
+          style: Theme.of(
+            context,
+          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          candidate.scopeNotice,
+          key: const Key('job-analysis-scope-notice'),
+          style: const TextStyle(color: Color(0xFF686A72), height: 1.45),
+        ),
+        const SizedBox(height: 18),
+        _Field(
+          key: const Key('candidate-title-field'),
+          controller: _candidateTitle,
+          label: '岗位',
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('candidate-seniority-field'),
+          controller: _candidateSeniority,
+          label: '职级',
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('candidate-responsibilities-field'),
+          controller: _responsibilities,
+          label: '核心职责（每行一项）',
+          maxLines: 4,
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('candidate-skills-field'),
+          controller: _skills,
+          label: '核心能力（每行一项）',
+          maxLines: 4,
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('candidate-communication-field'),
+          controller: _communication,
+          label: '英语沟通重点（每行一项）',
+          maxLines: 4,
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        const SizedBox(height: 14),
+        _Field(
+          key: const Key('candidate-goals-field'),
+          controller: _goals,
+          label: '建议训练重点（每行一项）',
+          maxLines: 4,
+          onChanged: (_) =>
+              controller.updateCandidate(_editedCandidate(candidate)),
+        ),
+        if (controller.errorMessage case final message?)
+          _ErrorCard(
+            message: message,
+            onRetry: controller.canRetry ? controller.retry : null,
+          ),
+        const SizedBox(height: 24),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('edit-job-input-button'),
+                onPressed: controller.isBusy ? null : controller.returnToInput,
+                style: _secondaryButtonStyle,
+                child: const Text('修改原始信息'),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: FilledButton(
+                key: const Key('confirm-job-analysis-button'),
+                onPressed: controller.isBusy
+                    ? null
+                    : () => unawaited(controller.confirm()),
+                style: _primaryButtonStyle,
+                child: const Text('确认分析'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSetup(JobPreparationController controller) {
+    final candidate = controller.candidate;
+    return ListView(
+      key: const Key('job-wizard-setup-step'),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      children: [
+        Text(
+          '生成练习计划',
+          style: Theme.of(
+            context,
+          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          '系统会根据已确认的岗位信息、服务端训练目录和练习策略生成不可变预览，不会立即创建练习。',
+          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
+        ),
+        const SizedBox(height: 18),
+        _SummaryCard(
+          title: candidate?.jobTitle ?? '目标岗位',
+          subtitle: candidate?.seniority ?? '',
+          rows: [
+            ('训练重点', candidate?.practiceGoals.join('、') ?? '由服务端推荐'),
+            ('个人背景', controller.input.candidateBackground ?? '尚未填写'),
+          ],
+        ),
+        if (controller.errorMessage case final message?)
+          _ErrorCard(
+            message: message,
+            onRetry: controller.canRetry ? controller.retry : null,
+          ),
+        const SizedBox(height: 24),
+        OutlinedButton(
+          key: const Key('back-to-confirmation-button'),
+          onPressed: controller.isBusy ? null : controller.returnToInput,
+          style: _secondaryButtonStyle,
+          child: const Text('重新填写岗位信息'),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.icon(
+          key: const Key('create-plan-preview-button'),
+          onPressed: controller.isBusy
+              ? null
+              : () => unawaited(controller.createPreview()),
+          icon: const Icon(Icons.event_note_outlined),
+          label: const Text('生成计划预览'),
+          style: _primaryButtonStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreview(JobPreparationController controller) {
+    final plan = controller.plan;
+    if (plan == null) {
+      return const Center(child: Text('计划预览已失效，请重新生成。'));
+    }
+    final minutes = (plan.sessionPolicy.suggestedDurationSeconds / 60).ceil();
+    return ListView(
+      key: const Key('job-wizard-preview-step'),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      children: [
+        Text(
+          '确认本次练习',
+          style: Theme.of(
+            context,
+          ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          '计划已冻结。只有点击“开始练习”才会创建正式 Session。',
+          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
+        ),
+        const SizedBox(height: 18),
+        _SummaryCard(
+          key: const Key('job-plan-summary'),
+          title: plan.catalog.scenario.name,
+          subtitle: plan.catalog.practiceOption.displayName,
+          rows: [
+            ('岗位', plan.preparationSnapshot.jobTargetCandidate.jobTitle),
+            ('预计时长', '约 $minutes 分钟'),
+            (
+              '有效轮次',
+              '${plan.sessionPolicy.minEffectiveTurns}–'
+                  '${plan.sessionPolicy.maxEffectiveTurns} 轮',
+            ),
+            ('训练视角', plan.catalog.selectedRole.displayName),
+            (
+              '重点',
+              plan.practiceFocuses.map((item) => item.description).join('、'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        ExpansionTile(
+          key: const Key('job-plan-advanced-settings'),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 4),
+          title: const Text('高级设置'),
+          subtitle: const Text('面试官视角由服务端按岗位推荐'),
+          children: [_buildAdvancedSettings(controller, plan)],
+        ),
+        if (controller.errorMessage case final message?)
+          _ErrorCard(
+            key: const Key('job-preview-error'),
+            message: message,
+            onRetry: controller.canRetry ? controller.retry : null,
+          ),
+        const SizedBox(height: 24),
+        OutlinedButton(
+          key: const Key('revise-job-plan-button'),
+          onPressed: controller.isBusy ? null : controller.returnToSetup,
+          style: _secondaryButtonStyle,
+          child: const Text('返回调整'),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.icon(
+          key: const Key('start-job-practice-button'),
+          onPressed: controller.isBusy ? null : _startPractice,
+          icon: const Icon(Icons.mic_none_rounded),
+          label: Text(controller.bootstrap == null ? '开始练习' : '重新连接语音练习'),
+          style: _primaryButtonStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAdvancedSettings(
+    JobPreparationController controller,
+    JobPracticePlanPreview plan,
+  ) {
+    final catalog = widget.catalogController;
+    final roles = catalog?.roles ?? const <PreparationRole>[];
+    final options = catalog?.availableOptions ?? const <PreparationOption>[];
+    final selectedRole = catalog?.selectedRole;
+    final selectedOption = catalog?.selectedOption;
+    final minTurns = plan.sessionPolicy.minEffectiveTurns;
+    final maxTurns = plan.sessionPolicy.maxEffectiveTurns < 6
+        ? 6
+        : plan.sessionPolicy.maxEffectiveTurns;
+    final selectedTurns = (_selectedTurnLimit ?? maxTurns)
+        .clamp(minTurns, maxTurns)
+        .toInt();
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (roles.isEmpty)
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('当前视角'),
+              subtitle: Text(plan.catalog.selectedRole.displayName),
+            )
+          else
+            DropdownButtonFormField<String>(
+              key: const Key('job-plan-role-selector'),
+              initialValue: selectedRole?.id,
+              decoration: const InputDecoration(labelText: '面试官视角'),
+              items: [
+                for (final role in roles)
+                  DropdownMenuItem(
+                    value: role.id,
+                    child: Text(role.displayName),
+                  ),
+              ],
+              onChanged: controller.isBusy
+                  ? null
+                  : (id) {
+                      final role = roles
+                          .where((item) => item.id == id)
+                          .firstOrNull;
+                      if (role != null) {
+                        catalog?.selectRole(role);
+                      }
+                    },
+            ),
+          const SizedBox(height: 12),
+          if (options.isEmpty)
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('练习方式'),
+              subtitle: Text(plan.catalog.practiceOption.displayName),
+            )
+          else
+            DropdownButtonFormField<String>(
+              key: const Key('job-plan-option-selector'),
+              initialValue: selectedOption?.id,
+              decoration: const InputDecoration(labelText: '训练重点'),
+              items: [
+                for (final option in options)
+                  DropdownMenuItem(
+                    value: option.id,
+                    child: Text(option.displayName),
+                  ),
+              ],
+              onChanged: controller.isBusy
+                  ? null
+                  : (id) {
+                      final option = options
+                          .where((item) => item.id == id)
+                          .firstOrNull;
+                      if (option != null) {
+                        catalog?.selectOption(option);
+                      }
+                    },
+            ),
+          const SizedBox(height: 12),
+          Text('最多 $selectedTurns 个有效轮次'),
+          Slider(
+            key: const Key('job-plan-turn-limit'),
+            value: selectedTurns.toDouble(),
+            min: minTurns.toDouble(),
+            max: maxTurns.toDouble(),
+            divisions: maxTurns - minTurns,
+            label: '$selectedTurns 轮',
+            onChanged: controller.isBusy
+                ? null
+                : (value) => setState(() => _selectedTurnLimit = value.round()),
+          ),
+          FilledButton.tonal(
+            key: const Key('save-job-plan-revision'),
+            onPressed:
+                controller.isBusy ||
+                    selectedRole == null ||
+                    selectedOption == null
+                ? null
+                : () => unawaited(
+                    controller.revisePreview(
+                      roleDefinitionId: selectedRole.id,
+                      practiceOptionId: selectedOption.id,
+                      practiceOptionVersion: selectedOption.version,
+                      maxEffectiveTurns: selectedTurns,
+                    ),
+                  ),
+            child: const Text('保存高级设置'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepProgress extends StatelessWidget {
+  const _StepProgress({required this.step});
+
+  final JobPreparationStep step;
+
+  @override
+  Widget build(BuildContext context) {
+    final index = switch (step) {
+      JobPreparationStep.input => 0,
+      JobPreparationStep.confirmation => 1,
+      JobPreparationStep.setup => 2,
+      JobPreparationStep.preview => 3,
+    };
+    return Semantics(
+      label: '准备进度，第 ${index + 1} 步，共 4 步',
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+        child: Row(
+          children: List.generate(
+            4,
+            (item) => Expanded(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                height: 4,
+                margin: EdgeInsets.only(right: item == 3 ? 0 : 6),
+                decoration: BoxDecoration(
+                  color: item <= index
+                      ? const Color(0xFF27282C)
+                      : const Color(0xFFD7D7D2),
+                  borderRadius: BorderRadius.circular(99),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({
+    required this.controller,
+    required this.label,
+    this.hint,
+    this.maxLines = 1,
+    this.onChanged,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String? hint;
+  final int maxLines;
+  final ValueChanged<String>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      maxLines: maxLines,
+      minLines: maxLines > 1 ? 2 : 1,
+      textInputAction: maxLines > 1
+          ? TextInputAction.newline
+          : TextInputAction.next,
+      onChanged: onChanged,
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        alignLabelWithHint: maxLines > 1,
+        filled: true,
+        fillColor: Colors.white.withValues(alpha: 0.82),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(18),
+          borderSide: const BorderSide(color: Color(0xFFD8D8D3)),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(18),
+          borderSide: const BorderSide(color: Color(0xFFD8D8D3)),
+        ),
+      ),
+    );
+  }
+}
+
+class _Notice extends StatelessWidget {
+  const _Notice({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFE9E9E5),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20),
+          const SizedBox(width: 10),
+          Expanded(child: Text(text, style: const TextStyle(height: 1.4))),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorCard extends StatelessWidget {
+  const _ErrorCard({required this.message, required this.onRetry, super.key});
+
+  final String message;
+  final Future<bool> Function()? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Semantics(
+        liveRegion: true,
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFECE8),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Row(
+            children: [
+              const Icon(Icons.error_outline_rounded),
+              const SizedBox(width: 10),
+              Expanded(child: Text(message)),
+              if (onRetry != null)
+                TextButton(
+                  key: const Key('job-wizard-retry-button'),
+                  onPressed: () => unawaited(onRetry!()),
+                  child: const Text('重试'),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentIntentCard extends StatelessWidget {
+  const _AgentIntentCard({
+    required this.text,
+    required this.onApply,
+    required this.onDismiss,
+  });
+
+  final String text;
+  final VoidCallback onApply;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('agent-intent-prefill-card'),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '从 Agent 对话带入',
+              style: TextStyle(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 6),
+            Text(text, maxLines: 3, overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(onPressed: onDismiss, child: const Text('忽略')),
+                FilledButton.tonal(
+                  onPressed: onApply,
+                  child: const Text('填入 JD'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DraftCard extends StatelessWidget {
+  const _DraftCard({required this.onResume, required this.onDiscard});
+
+  final Future<bool> Function()? onResume;
+  final Future<bool> Function()? onDiscard;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('job-draft-card'),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              '发现未完成的准备草稿',
+              style: TextStyle(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            const Text('草稿只属于当前账号。你可以继续，或安全丢弃后重新开始。'),
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  key: const Key('discard-job-draft-button'),
+                  onPressed: onDiscard == null
+                      ? null
+                      : () => unawaited(onDiscard!()),
+                  child: const Text('丢弃'),
+                ),
+                FilledButton.tonal(
+                  key: const Key('resume-job-draft-button'),
+                  onPressed: onResume == null
+                      ? null
+                      : () => unawaited(onResume!()),
+                  child: const Text('继续'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.title,
+    required this.subtitle,
+    required this.rows,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<(String, String)> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.85),
+        border: Border.all(color: const Color(0xFFD8D8D3)),
+        borderRadius: BorderRadius.circular(22),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+          ),
+          if (subtitle.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(subtitle, style: const TextStyle(color: Color(0xFF686A72))),
+          ],
+          const SizedBox(height: 14),
+          for (final row in rows) ...[
+            Text(
+              row.$1,
+              style: const TextStyle(
+                color: Color(0xFF777983),
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 3),
+            Text(row.$2.isEmpty ? '—' : row.$2),
+            const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+String _busyLabel(JobPreparationOperationStage? stage) {
+  return switch (stage) {
+    JobPreparationOperationStage.target => '正在保存岗位信息',
+    JobPreparationOperationStage.analysis => '正在分析岗位信息',
+    JobPreparationOperationStage.confirmation => '正在确认岗位分析',
+    JobPreparationOperationStage.matter => '正在准备练习事项',
+    JobPreparationOperationStage.profile => '正在保存个人背景',
+    JobPreparationOperationStage.snapshot => '正在冻结练习资料',
+    JobPreparationOperationStage.plan => '正在生成练习计划',
+    JobPreparationOperationStage.session => '正在创建练习',
+    JobPreparationOperationStage.voice => '正在连接语音练习',
+    null => '正在处理',
+  };
+}
+
+final ButtonStyle _primaryButtonStyle = FilledButton.styleFrom(
+  minimumSize: const Size.fromHeight(52),
+  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+);
+
+final ButtonStyle _secondaryButtonStyle = OutlinedButton.styleFrom(
+  minimumSize: const Size.fromHeight(52),
+  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+);

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -18,6 +18,7 @@ class PreparationPage extends StatefulWidget {
     this.agentController,
     this.preparationController,
     this.launchController,
+    this.onOpenJobPreparation,
     this.onSceneSelected,
     this.onPracticeStarted,
     super.key,
@@ -28,6 +29,7 @@ class PreparationPage extends StatefulWidget {
   final AgentController? agentController;
   final PreparationController? preparationController;
   final PreparationLaunchController? launchController;
+  final VoidCallback? onOpenJobPreparation;
   final VoidCallback? onSceneSelected;
   final VoidCallback? onPracticeStarted;
 
@@ -220,22 +222,30 @@ class _PreparationPageState extends State<PreparationPage> {
     }
     return ListView(
       key: const Key('preparation-catalog-list'),
-      padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 112),
       children: [
-        const Text(
-          '场景',
-          style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
+        const Row(
+          children: [
+            Expanded(
+              child: Text(
+                '练习中心',
+                key: Key('training-center-title'),
+                style: TextStyle(fontSize: 28, fontWeight: FontWeight.w800),
+              ),
+            ),
+            _TrainingCatalogStatus(),
+          ],
         ),
         const SizedBox(height: 8),
         const Text(
-          'SpeakUp 是你的通用职业英语 Agent。首发内容包聚焦技术岗位英文面试。',
+          '按目标选择训练专题。当前先把英文面试做深，后续专题会沿用同一套练习与复盘能力。',
           style: TextStyle(
             color: Color(0xFF696B73),
-            fontSize: 15,
+            fontSize: 14,
             height: 1.45,
           ),
         ),
-        const SizedBox(height: 28),
+        const SizedBox(height: 22),
         if (controller.isLoadingScenarios)
           const _CatalogLoading(key: Key('preparation-catalog-loading'))
         else if (controller.errorMessage case final message?)
@@ -250,7 +260,9 @@ class _PreparationPageState extends State<PreparationPage> {
           for (final scenario in controller.scenarios) ...[
             _CatalogScenarioCard(
               scenario: scenario,
-              onPressed: () => controller.selectScenario(scenario),
+              onPressed: widget.onOpenJobPreparation == null
+                  ? () => controller.selectScenario(scenario)
+                  : widget.onOpenJobPreparation!,
             ),
             const SizedBox(height: 12),
           ],
@@ -265,8 +277,8 @@ class _PreparationPageState extends State<PreparationPage> {
       padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
       children: [
         const Text(
-          '场景',
-          style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
+          '练习中心',
+          style: TextStyle(fontSize: 28, fontWeight: FontWeight.w800),
         ),
         const SizedBox(height: 8),
         Text(
@@ -454,8 +466,35 @@ class _CatalogLoading extends StatelessWidget {
           children: [
             CircularProgressIndicator(),
             SizedBox(height: 14),
-            Text('正在读取服务端练习目录'),
+            Text('正在加载练习专题'),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TrainingCatalogStatus extends StatelessWidget {
+  const _TrainingCatalogStatus();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '练习专题目录',
+      child: Container(
+        key: const Key('training-catalog-status'),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: const Color(0xFFE7E7E3),
+          borderRadius: BorderRadius.circular(99),
+        ),
+        child: const Text(
+          '持续更新',
+          style: TextStyle(
+            color: Color(0xFF55575E),
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+          ),
         ),
       ),
     );
@@ -521,26 +560,26 @@ class _CatalogScenarioCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: 0,
-      color: Colors.white,
+      color: const Color(0xFFFAFAF8),
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
-        side: const BorderSide(color: Color(0xFFE8E8E4)),
+        borderRadius: BorderRadius.circular(18),
+        side: const BorderSide(color: Color(0xFFDEDEDA)),
       ),
       child: InkWell(
         key: Key('catalog-scenario-${scenario.id}'),
         onTap: onPressed,
         child: Padding(
-          padding: const EdgeInsets.all(18),
+          padding: const EdgeInsets.all(16),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Container(
-                width: 48,
-                height: 48,
+                width: 40,
+                height: 40,
                 decoration: BoxDecoration(
-                  color: const Color(0xFFE8E8E5),
-                  borderRadius: BorderRadius.circular(15),
+                  color: const Color(0xFFE9E9E5),
+                  borderRadius: BorderRadius.circular(12),
                 ),
                 child: const Icon(
                   Icons.work_outline_rounded,
@@ -561,14 +600,48 @@ class _CatalogScenarioCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 5),
                     const Text(
-                      '查看可选面试官视角与练习方式',
+                      '从岗位与 JD 开始，生成专属练习计划',
                       style: TextStyle(color: Color(0xFF696B73), height: 1.4),
                     ),
+                    const SizedBox(height: 9),
+                    const _AvailableTopicLabel(),
                   ],
                 ),
               ),
-              const Icon(Icons.arrow_forward_ios_rounded, size: 16),
+              const Icon(
+                Icons.arrow_forward_ios_rounded,
+                size: 15,
+                color: Color(0xFF777980),
+              ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AvailableTopicLabel extends StatelessWidget {
+  const _AvailableTopicLabel();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Align(
+      alignment: Alignment.centerLeft,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Color(0xFFE7ECE6),
+          borderRadius: BorderRadius.all(Radius.circular(99)),
+        ),
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 9, vertical: 4),
+          child: Text(
+            '可用',
+            style: TextStyle(
+              color: Color(0xFF405846),
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -11,6 +11,8 @@ import 'package:speakup/features/preparation/preparation_launch_controller.dart'
 import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 
+const _jobInterviewScenarioId = 'scn_programmer_interview';
+
 class PreparationPage extends StatefulWidget {
   const PreparationPage({
     this.showBackButton = false,
@@ -260,7 +262,12 @@ class _PreparationPageState extends State<PreparationPage> {
           for (final scenario in controller.scenarios) ...[
             _CatalogScenarioCard(
               scenario: scenario,
-              onPressed: widget.onOpenJobPreparation == null
+              jdFirstAvailable:
+                  widget.onOpenJobPreparation != null &&
+                  scenario.id == _jobInterviewScenarioId,
+              onPressed:
+                  widget.onOpenJobPreparation == null ||
+                      scenario.id != _jobInterviewScenarioId
                   ? () => controller.selectScenario(scenario)
                   : widget.onOpenJobPreparation!,
             ),
@@ -284,9 +291,9 @@ class _PreparationPageState extends State<PreparationPage> {
         Text(
           practiceAvailable
               ? widget.previewMode
-                    ? '本地 UI Mock；练习结果不会写入正式服务。'
-                    : '练习目录未注入，当前页面不可用于正式运行。'
-              : '服务端场景与语音契约尚未开放，当前仅提供 Agent 文本对话。',
+                    ? '预览练习专题与进入流程。'
+                    : '练习内容暂时无法加载，请稍后重试。'
+              : '练习功能正在准备中，目前可以先使用文字陪练。',
           key: const Key('practice-availability-message'),
           style: const TextStyle(color: Color(0xFF696B73), fontSize: 15),
         ),
@@ -551,9 +558,14 @@ class _CatalogEmpty extends StatelessWidget {
 }
 
 class _CatalogScenarioCard extends StatelessWidget {
-  const _CatalogScenarioCard({required this.scenario, required this.onPressed});
+  const _CatalogScenarioCard({
+    required this.scenario,
+    required this.jdFirstAvailable,
+    required this.onPressed,
+  });
 
   final PreparationScenario scenario;
+  final bool jdFirstAvailable;
   final VoidCallback onPressed;
 
   @override
@@ -599,12 +611,17 @@ class _CatalogScenarioCard extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 5),
-                    const Text(
-                      '从岗位与 JD 开始，生成专属练习计划',
-                      style: TextStyle(color: Color(0xFF696B73), height: 1.4),
+                    Text(
+                      jdFirstAvailable ? '从岗位与 JD 开始，生成专属练习计划' : '查看练习方式与训练重点',
+                      style: const TextStyle(
+                        color: Color(0xFF696B73),
+                        height: 1.4,
+                      ),
                     ),
-                    const SizedBox(height: 9),
-                    const _AvailableTopicLabel(),
+                    if (jdFirstAvailable) ...[
+                      const SizedBox(height: 9),
+                      const _AvailableTopicLabel(),
+                    ],
                   ],
                 ),
               ),

--- a/mobile/lib/features/preparation/wire_job_preparation_client.dart
+++ b/mobile/lib/features/preparation/wire_job_preparation_client.dart
@@ -1,0 +1,1851 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:speakup/features/preparation/job_preparation_client.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+final class WireJobPreparationClient implements JobPreparationClient {
+  factory WireJobPreparationClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    IdentityHttpTransport? transport,
+    Duration requestTimeout = const Duration(seconds: 75),
+  }) {
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'requestTimeout');
+    }
+    return WireJobPreparationClient._(
+      baseUri,
+      SessionAuthenticatedHttpTransport(
+        transport: transport ?? IoIdentityHttpTransport(),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: baseUri,
+      ),
+      requestTimeout,
+    );
+  }
+
+  WireJobPreparationClient._(
+    this._baseUri,
+    this._transport,
+    this._requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  static const _maximumBodyBytes = 1024 * 1024;
+
+  final Uri _baseUri;
+  final IdentityHttpTransport _transport;
+  final Duration _requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  int _accountGeneration = 0;
+
+  @override
+  Future<JobTarget> createJobTarget({
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    _requireJobTargetInput(input);
+    final response = await _request(
+      method: 'POST',
+      path: '/v1/job-targets',
+      idempotencyKey: idempotencyKey,
+      body: _jobTargetInputJson(input),
+      acceptedStatuses: const <int>{HttpStatus.created},
+      stage: JobPreparationOperationStage.target,
+    );
+    return _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.target,
+      decode: _decodeJobTarget,
+    );
+  }
+
+  @override
+  Future<JobTarget> getJobTarget(String jobTargetId) async {
+    _requireResourceId(jobTargetId);
+    final response = await _request(
+      method: 'GET',
+      path: '/v1/job-targets/${Uri.encodeComponent(jobTargetId)}',
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.target,
+    );
+    final target = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.target,
+      decode: _decodeJobTarget,
+    );
+    if (target.id != jobTargetId) {
+      throw _invalidResponse(JobPreparationOperationStage.target);
+    }
+    return target;
+  }
+
+  @override
+  Future<JobTarget> updateJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(jobTargetId);
+    _requireVersion(expectedInputVersion);
+    _requireJobTargetInput(input);
+    final response = await _request(
+      method: 'PUT',
+      path: '/v1/job-targets/${Uri.encodeComponent(jobTargetId)}',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'expected_input_version': expectedInputVersion,
+        ..._jobTargetInputJson(input),
+      },
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.target,
+    );
+    final target = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.target,
+      decode: _decodeJobTarget,
+    );
+    if (target.id != jobTargetId || target.input != input) {
+      throw _invalidResponse(JobPreparationOperationStage.target);
+    }
+    return target;
+  }
+
+  @override
+  Future<JobTarget> analyzeJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(jobTargetId);
+    _requireVersion(expectedInputVersion);
+    final response = await _request(
+      method: 'POST',
+      path: '/v1/job-targets/${Uri.encodeComponent(jobTargetId)}/analyses',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'expected_input_version': expectedInputVersion},
+      acceptedStatuses: const <int>{HttpStatus.ok, HttpStatus.accepted},
+      stage: JobPreparationOperationStage.analysis,
+    );
+    final target = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.analysis,
+      decode: _decodeJobTarget,
+    );
+    if (target.id != jobTargetId ||
+        target.inputVersion != expectedInputVersion ||
+        (response.statusCode == HttpStatus.accepted &&
+            target.stage != JobTargetStage.parsing) ||
+        (response.statusCode == HttpStatus.ok &&
+            target.stage == JobTargetStage.parsing)) {
+      throw _invalidResponse(JobPreparationOperationStage.analysis);
+    }
+    return target;
+  }
+
+  @override
+  Future<JobTarget> confirmJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required int expectedAnalysisVersion,
+    required JobTargetCandidate candidate,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(jobTargetId);
+    _requireVersion(expectedInputVersion);
+    _requireVersion(expectedAnalysisVersion);
+    _requireJobTargetCandidate(candidate);
+    final response = await _request(
+      method: 'POST',
+      path:
+          '/v1/job-targets/${Uri.encodeComponent(jobTargetId)}'
+          '/confirmations',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'expected_input_version': expectedInputVersion,
+        'expected_analysis_version': expectedAnalysisVersion,
+        'candidate': _jobTargetCandidateJson(candidate),
+      },
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.confirmation,
+    );
+    final target = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.confirmation,
+      decode: _decodeJobTarget,
+    );
+    if (target.id != jobTargetId ||
+        target.inputVersion != expectedInputVersion ||
+        target.stage != JobTargetStage.confirmed ||
+        target.confirmation?.analysisVersion != expectedAnalysisVersion) {
+      throw _invalidResponse(JobPreparationOperationStage.confirmation);
+    }
+    return target;
+  }
+
+  @override
+  Future<JobTarget> discardJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(jobTargetId);
+    _requireVersion(expectedInputVersion);
+    final response = await _request(
+      method: 'POST',
+      path: '/v1/job-targets/${Uri.encodeComponent(jobTargetId)}/discard',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'expected_input_version': expectedInputVersion},
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.target,
+    );
+    final target = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.target,
+      decode: _decodeJobTarget,
+    );
+    if (target.id != jobTargetId ||
+        target.inputVersion != expectedInputVersion ||
+        target.stage != JobTargetStage.discarded) {
+      throw _invalidResponse(JobPreparationOperationStage.target);
+    }
+    return target;
+  }
+
+  @override
+  Future<JobPreparationProfile> createProfileForJobTarget({
+    required String backgroundSummary,
+    required String jobTargetId,
+    required int jobTargetConfirmationVersion,
+    required String idempotencyKey,
+  }) async {
+    _requireText(backgroundSummary, maxBytes: 64 * 1024);
+    _requireResourceId(jobTargetId);
+    _requireVersion(jobTargetConfirmationVersion);
+    final response = await _request(
+      method: 'POST',
+      path: '/v1/preparation-profiles',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'background_summary': backgroundSummary,
+        'job_target_id': jobTargetId,
+        'job_target_confirmation_version': jobTargetConfirmationVersion,
+      },
+      acceptedStatuses: const <int>{HttpStatus.created},
+      stage: JobPreparationOperationStage.profile,
+    );
+    return _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.profile,
+      decode: (body) => _decodeJobPreparationProfile(
+        body,
+        expectedBackground: backgroundSummary,
+        expectedJobTargetId: jobTargetId,
+        expectedConfirmationVersion: jobTargetConfirmationVersion,
+      ),
+    );
+  }
+
+  @override
+  Future<JobPreparationSnapshot> createJobPreparationSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(profileId);
+    _requireVersion(sourceVersion);
+    final response = await _request(
+      method: 'POST',
+      path:
+          '/v1/preparation-profiles/${Uri.encodeComponent(profileId)}'
+          '/snapshots',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'source_version': sourceVersion},
+      acceptedStatuses: const <int>{HttpStatus.created},
+      stage: JobPreparationOperationStage.snapshot,
+    );
+    final snapshot = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.snapshot,
+      decode: _decodeJobPreparationSnapshot,
+    );
+    if (snapshot.sourceProfileId != profileId ||
+        snapshot.sourceVersion != sourceVersion) {
+      throw _invalidResponse(JobPreparationOperationStage.snapshot);
+    }
+    return snapshot;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> createJobPracticePlan({
+    required AgentPracticeContext context,
+    required String preparationSnapshotId,
+    required String idempotencyKey,
+  }) async {
+    _requireContext(context);
+    _requireResourceId(preparationSnapshotId);
+    final response = await _request(
+      method: 'POST',
+      path: '/v1/practice-plans',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'agent_thread_id': context.threadId,
+        'matter_id': context.matterId,
+        'preparation_snapshot_id': preparationSnapshotId,
+      },
+      acceptedStatuses: const <int>{HttpStatus.created},
+      stage: JobPreparationOperationStage.plan,
+    );
+    final plan = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.plan,
+      decode: _decodeJobPracticePlan,
+    );
+    if (plan.context != context ||
+        plan.preparationSnapshot.id != preparationSnapshotId) {
+      throw _invalidResponse(JobPreparationOperationStage.plan);
+    }
+    return plan;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> getJobPracticePlan(String planId) async {
+    _requireResourceId(planId);
+    final response = await _request(
+      method: 'GET',
+      path: '/v1/practice-plans/${Uri.encodeComponent(planId)}',
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.plan,
+    );
+    final plan = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.plan,
+      decode: _decodeJobPracticePlan,
+    );
+    if (plan.id != planId) {
+      throw _invalidResponse(JobPreparationOperationStage.plan);
+    }
+    return plan;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> reviseJobPracticePlan({
+    required String planId,
+    required int expectedPlanRevision,
+    required String roleDefinitionId,
+    required String practiceOptionId,
+    required int practiceOptionVersion,
+    required int maxEffectiveTurns,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(planId);
+    _requireVersion(expectedPlanRevision);
+    _requireResourceId(roleDefinitionId);
+    _requireResourceId(practiceOptionId);
+    _requireVersion(practiceOptionVersion);
+    _requireVersion(maxEffectiveTurns);
+    final response = await _request(
+      method: 'PUT',
+      path: '/v1/practice-plans/${Uri.encodeComponent(planId)}',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{
+        'expected_plan_revision': expectedPlanRevision,
+        'selected_role_ids': <String>[roleDefinitionId],
+        'practice_option_id': practiceOptionId,
+        'practice_option_version': practiceOptionVersion,
+        'max_effective_turns': maxEffectiveTurns,
+      },
+      acceptedStatuses: const <int>{HttpStatus.ok},
+      stage: JobPreparationOperationStage.plan,
+    );
+    final plan = _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.plan,
+      decode: _decodeJobPracticePlan,
+    );
+    if (plan.id != planId ||
+        plan.revision <= expectedPlanRevision ||
+        plan.catalog.selectedRole.id != roleDefinitionId ||
+        plan.catalog.practiceOption.id != practiceOptionId ||
+        plan.catalog.practiceOption.version != practiceOptionVersion ||
+        plan.sessionPolicy.maxEffectiveTurns != maxEffectiveTurns) {
+      throw _invalidResponse(JobPreparationOperationStage.plan);
+    }
+    return plan;
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createJobPracticeSession({
+    required JobPracticePlanPreview plan,
+    required String idempotencyKey,
+  }) async {
+    _requireResourceId(plan.id);
+    _requireVersion(plan.revision);
+    final response = await _request(
+      method: 'POST',
+      path:
+          '/v1/practice-plans/${Uri.encodeComponent(plan.id)}'
+          '/practice-sessions',
+      idempotencyKey: idempotencyKey,
+      body: <String, Object?>{'expected_plan_revision': plan.revision},
+      acceptedStatuses: const <int>{HttpStatus.created},
+      stage: JobPreparationOperationStage.session,
+    );
+    return _decodeResponse(
+      response,
+      stage: JobPreparationOperationStage.session,
+      decode: (body) => _decodeJobPracticeBootstrap(body, expectedPlan: plan),
+    );
+  }
+
+  Future<IdentityHttpResponse> _request({
+    required String method,
+    required String path,
+    required Set<int> acceptedStatuses,
+    required JobPreparationOperationStage stage,
+    String? idempotencyKey,
+    Map<String, Object?>? body,
+  }) async {
+    if ((method == 'GET') != (body == null) ||
+        (method == 'GET') != (idempotencyKey == null)) {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.invalidRequest,
+        stage: stage,
+      );
+    }
+    if (idempotencyKey != null) {
+      _requireIdempotencyKey(idempotencyKey);
+    }
+    final generation = _accountGeneration;
+    final uri = _baseUri.resolve(path);
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(uri);
+    late final IdentityHttpResponse response;
+    try {
+      response = await _transport
+          .send(
+            method: method,
+            uri: uri,
+            headers: <String, String>{
+              HttpHeaders.acceptHeader: ContentType.json.mimeType,
+              if (body != null)
+                HttpHeaders.contentTypeHeader: ContentType.json.mimeType,
+              'Idempotency-Key': ?idempotencyKey,
+            },
+            body: body == null ? null : jsonEncode(body),
+          )
+          .timeout(_requestTimeout);
+    } on AuthSessionSupersededException {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.superseded,
+        stage: stage,
+      );
+    } on StateError {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.authenticationRequired,
+        stage: stage,
+        statusCode: HttpStatus.unauthorized,
+      );
+    } on TimeoutException {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on SocketException {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on HttpException {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    } on IOException {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: stage,
+        retryable: true,
+      );
+    }
+    if (generation != _accountGeneration) {
+      throw JobPreparationException(
+        kind: JobPreparationFailureKind.superseded,
+        stage: stage,
+      );
+    }
+    if (acceptedStatuses.contains(response.statusCode)) {
+      if (utf8.encode(response.body).length > _maximumBodyBytes) {
+        throw JobPreparationException(
+          kind: JobPreparationFailureKind.invalidResponse,
+          stage: stage,
+          statusCode: response.statusCode,
+          retryable: method != 'GET',
+        );
+      }
+      return response;
+    }
+    final errorCode = _decodeErrorCode(response.body);
+    throw switch (response.statusCode) {
+      HttpStatus.badRequest => JobPreparationException(
+        kind: JobPreparationFailureKind.invalidRequest,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.unauthorized => JobPreparationException(
+        kind: JobPreparationFailureKind.authenticationRequired,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.notFound => JobPreparationException(
+        kind: JobPreparationFailureKind.notFound,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+      HttpStatus.conflict => JobPreparationException(
+        kind: JobPreparationFailureKind.conflict,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+        retryable:
+            errorCode == 'job_target_analysis_claim_lost' ||
+            errorCode == 'resource_conflict',
+      ),
+      _ when response.statusCode >= 500 => JobPreparationException(
+        kind: JobPreparationFailureKind.server,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+        retryable: true,
+      ),
+      _ => JobPreparationException(
+        kind: JobPreparationFailureKind.invalidResponse,
+        stage: stage,
+        statusCode: response.statusCode,
+        errorCode: errorCode,
+      ),
+    };
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+}
+
+T _decodeResponse<T>(
+  IdentityHttpResponse response, {
+  required JobPreparationOperationStage stage,
+  required T Function(String body) decode,
+}) {
+  try {
+    return decode(response.body);
+  } on JobPreparationException catch (error) {
+    if (error.kind != JobPreparationFailureKind.invalidResponse) {
+      rethrow;
+    }
+    throw JobPreparationException(
+      kind: JobPreparationFailureKind.invalidResponse,
+      stage: stage,
+      statusCode: response.statusCode,
+      retryable: response.statusCode == HttpStatus.created,
+    );
+  } on Object {
+    throw JobPreparationException(
+      kind: JobPreparationFailureKind.invalidResponse,
+      stage: stage,
+      statusCode: response.statusCode,
+      retryable: response.statusCode == HttpStatus.created,
+    );
+  }
+}
+
+JobTarget _decodeJobTarget(String body) {
+  return _jobTarget(_decodeJson(body));
+}
+
+JobTarget _jobTarget(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'job_target_id',
+      'user_id',
+      'input',
+      'input_version',
+      'stage',
+      'created_at',
+      'updated_at',
+    },
+    optional: const <String>{'analysis', 'confirmation'},
+  );
+  final input = _jobTargetInput(object['input']);
+  final inputVersion = _version(object['input_version']);
+  final stage = _jobTargetStage(object['stage']);
+  final analysis = object.containsKey('analysis')
+      ? _jobTargetAnalysis(object['analysis'])
+      : null;
+  final confirmation = object.containsKey('confirmation')
+      ? _jobTargetConfirmation(object['confirmation'])
+      : null;
+  final createdAt = _dateTime(object['created_at']);
+  final updatedAt = _dateTime(object['updated_at']);
+  if (updatedAt.isBefore(createdAt) ||
+      (analysis != null && analysis.inputVersion != inputVersion)) {
+    throw _invalidResponse();
+  }
+  switch (stage) {
+    case JobTargetStage.draft:
+      if (analysis != null || confirmation != null) {
+        throw _invalidResponse();
+      }
+    case JobTargetStage.parsing:
+      if (analysis?.status != JobTargetAnalysisStatus.running ||
+          confirmation != null) {
+        throw _invalidResponse();
+      }
+    case JobTargetStage.analysisFailed:
+      if (analysis?.status != JobTargetAnalysisStatus.failed ||
+          confirmation != null) {
+        throw _invalidResponse();
+      }
+    case JobTargetStage.awaitingConfirmation:
+      if (analysis?.status != JobTargetAnalysisStatus.succeeded ||
+          analysis?.candidate == null ||
+          confirmation != null) {
+        throw _invalidResponse();
+      }
+    case JobTargetStage.confirmed:
+      if (analysis?.status != JobTargetAnalysisStatus.succeeded ||
+          analysis?.candidate == null ||
+          confirmation == null ||
+          confirmation.inputVersion != inputVersion ||
+          confirmation.analysisVersion != analysis?.analysisVersion ||
+          confirmation.candidate.source != input.source) {
+        throw _invalidResponse();
+      }
+    case JobTargetStage.discarded:
+      if (confirmation != null) {
+        throw _invalidResponse();
+      }
+  }
+  return JobTarget(
+    id: _resourceId(object['job_target_id']),
+    userId: _resourceId(object['user_id']),
+    input: input,
+    inputVersion: inputVersion,
+    stage: stage,
+    analysis: analysis,
+    confirmation: confirmation,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+  );
+}
+
+JobTargetInput _jobTargetInput(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{'source'},
+    optional: const <String>{
+      'job_title',
+      'job_description',
+      'company',
+      'seniority',
+      'candidate_background',
+      'resume_ref',
+      'practice_focus',
+    },
+  );
+  final input = JobTargetInput(
+    source: _jobTargetSource(object['source']),
+    jobTitle: _optionalText(object, 'job_title', maxBytes: 512),
+    jobDescription: _optionalText(
+      object,
+      'job_description',
+      maxBytes: 64 * 1024,
+    ),
+    company: _optionalText(object, 'company', maxBytes: 512),
+    seniority: _optionalText(object, 'seniority', maxBytes: 256),
+    candidateBackground: _optionalText(
+      object,
+      'candidate_background',
+      maxBytes: 16 * 1024,
+    ),
+    resumeRef: _optionalText(object, 'resume_ref', maxBytes: 16 * 1024),
+    practiceFocus: _optionalText(object, 'practice_focus', maxBytes: 8 * 1024),
+  );
+  _requireJobTargetInput(input, invalidResponse: true);
+  return input;
+}
+
+JobTargetAnalysis _jobTargetAnalysis(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'input_version',
+      'analysis_version',
+      'attempt',
+      'status',
+      'started_at',
+    },
+    optional: const <String>{
+      'candidate',
+      'stable_error_category',
+      'finished_at',
+    },
+  );
+  final status = _jobTargetAnalysisStatus(object['status']);
+  final candidate = object.containsKey('candidate')
+      ? _jobTargetCandidate(object['candidate'])
+      : null;
+  final stableError = _optionalPatternText(
+    object,
+    'stable_error_category',
+    RegExp(r'^[a-z][a-z0-9_]{0,63}$'),
+  );
+  final finishedAt = object.containsKey('finished_at')
+      ? _dateTime(object['finished_at'])
+      : null;
+  if (switch (status) {
+    JobTargetAnalysisStatus.running =>
+      candidate != null || stableError != null || finishedAt != null,
+    JobTargetAnalysisStatus.succeeded =>
+      candidate == null || stableError != null || finishedAt == null,
+    JobTargetAnalysisStatus.failed =>
+      candidate != null || stableError == null || finishedAt == null,
+  }) {
+    throw _invalidResponse();
+  }
+  final startedAt = _dateTime(object['started_at']);
+  if (finishedAt != null && finishedAt.isBefore(startedAt)) {
+    throw _invalidResponse();
+  }
+  return JobTargetAnalysis(
+    inputVersion: _version(object['input_version']),
+    analysisVersion: _version(object['analysis_version']),
+    attempt: _version(object['attempt']),
+    status: status,
+    candidate: candidate,
+    stableErrorCategory: stableError,
+    startedAt: startedAt,
+    finishedAt: finishedAt,
+  );
+}
+
+JobTargetConfirmation _jobTargetConfirmation(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'input_version',
+      'analysis_version',
+      'confirmation_version',
+      'candidate',
+      'confirmed_at',
+    },
+  );
+  return JobTargetConfirmation(
+    inputVersion: _version(object['input_version']),
+    analysisVersion: _version(object['analysis_version']),
+    confirmationVersion: _version(object['confirmation_version']),
+    candidate: _jobTargetCandidate(object['candidate']),
+    confirmedAt: _dateTime(object['confirmed_at']),
+  );
+}
+
+JobTargetCandidate _jobTargetCandidate(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'source',
+      'general_advice_only',
+      'job_title',
+      'seniority',
+      'responsibilities',
+      'core_skills',
+      'communication_focus',
+      'practice_goals',
+      'scope_notice',
+      'catalog_recommendation',
+    },
+  );
+  if (utf8.encode(jsonEncode(object)).length > 64 * 1024) {
+    throw _invalidResponse();
+  }
+  final source = _jobTargetSource(object['source']);
+  final generalAdviceOnly = object['general_advice_only'];
+  if (generalAdviceOnly is! bool ||
+      generalAdviceOnly != (source == JobTargetSource.quickStart)) {
+    throw _invalidResponse();
+  }
+  final recommendationObject = _object(
+    object['catalog_recommendation'],
+    required: const <String>{
+      'scenario_definition_id',
+      'scenario_definition_version',
+      'selected_role_ids',
+      'practice_option_id',
+      'practice_option_version',
+    },
+  );
+  final selectedRoleIds = _resourceIdList(
+    recommendationObject['selected_role_ids'],
+    min: 1,
+    max: 1,
+  );
+  return JobTargetCandidate(
+    source: source,
+    generalAdviceOnly: generalAdviceOnly,
+    jobTitle: _text(object['job_title'], maxBytes: 512),
+    seniority: _text(object['seniority'], maxBytes: 256),
+    responsibilities: _candidateItems(object['responsibilities']),
+    coreSkills: _candidateItems(object['core_skills']),
+    communicationFocus: _candidateItems(object['communication_focus']),
+    practiceGoals: _candidateItems(object['practice_goals']),
+    scopeNotice: _text(object['scope_notice'], maxBytes: 2048),
+    catalogRecommendation: JobTargetCatalogRecommendation(
+      scenarioDefinitionId: _resourceId(
+        recommendationObject['scenario_definition_id'],
+      ),
+      scenarioDefinitionVersion: _version(
+        recommendationObject['scenario_definition_version'],
+      ),
+      selectedRoleIds: selectedRoleIds,
+      practiceOptionId: _resourceId(recommendationObject['practice_option_id']),
+      practiceOptionVersion: _version(
+        recommendationObject['practice_option_version'],
+      ),
+    ),
+  );
+}
+
+JobPreparationProfile _decodeJobPreparationProfile(
+  String body, {
+  required String expectedBackground,
+  required String expectedJobTargetId,
+  required int expectedConfirmationVersion,
+}) {
+  final object = _object(
+    _decodeJson(body),
+    required: const <String>{
+      'preparation_profile_id',
+      'user_id',
+      'background_summary',
+      'job_target_id',
+      'job_target_confirmation_version',
+      'version',
+      'updated_at',
+    },
+    optional: const <String>{'resume_ref', 'job_description_ref'},
+  );
+  final background = _text(object['background_summary'], maxBytes: 64 * 1024);
+  final targetId = _resourceId(object['job_target_id']);
+  final confirmationVersion = _version(
+    object['job_target_confirmation_version'],
+  );
+  if (background != expectedBackground ||
+      targetId != expectedJobTargetId ||
+      confirmationVersion != expectedConfirmationVersion ||
+      object.containsKey('resume_ref') ||
+      object.containsKey('job_description_ref')) {
+    throw _invalidResponse();
+  }
+  return JobPreparationProfile(
+    id: _resourceId(object['preparation_profile_id']),
+    userId: _resourceId(object['user_id']),
+    backgroundSummary: background,
+    jobTargetId: targetId,
+    jobTargetConfirmationVersion: confirmationVersion,
+    version: _version(object['version']),
+    updatedAt: _dateTime(object['updated_at']),
+  );
+}
+
+JobPreparationSnapshot _decodeJobPreparationSnapshot(String body) {
+  return _jobPreparationSnapshot(_decodeJson(body));
+}
+
+JobPreparationSnapshot _jobPreparationSnapshot(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'preparation_snapshot_id',
+      'source_profile_id',
+      'source_version',
+      'source_job_target_id',
+      'source_job_target_confirmation_version',
+      'job_target_input_snapshot',
+      'job_target_candidate_snapshot',
+      'background_snapshot',
+      'created_at',
+    },
+    optional: const <String>{'resume_snapshot', 'job_description_snapshot'},
+  );
+  if (object.containsKey('resume_snapshot') ||
+      object.containsKey('job_description_snapshot')) {
+    throw _invalidResponse();
+  }
+  final input = _jobTargetInput(object['job_target_input_snapshot']);
+  final candidate = _jobTargetCandidate(
+    object['job_target_candidate_snapshot'],
+  );
+  if (input.source != candidate.source) {
+    throw _invalidResponse();
+  }
+  return JobPreparationSnapshot(
+    id: _resourceId(object['preparation_snapshot_id']),
+    sourceProfileId: _resourceId(object['source_profile_id']),
+    sourceVersion: _version(object['source_version']),
+    sourceJobTargetId: _resourceId(object['source_job_target_id']),
+    sourceJobTargetConfirmationVersion: _version(
+      object['source_job_target_confirmation_version'],
+    ),
+    jobTargetInput: input,
+    jobTargetCandidate: candidate,
+    backgroundSnapshot: _text(
+      object['background_snapshot'],
+      maxBytes: 64 * 1024,
+    ),
+    createdAt: _dateTime(object['created_at']),
+  );
+}
+
+JobPracticePlanPreview _decodeJobPracticePlan(String body) {
+  final object = _object(
+    _decodeJson(body),
+    required: const <String>{
+      'practice_plan_id',
+      'user_id',
+      'agent_thread_id',
+      'matter_id',
+      'scenario_definition_id',
+      'scenario_definition_version',
+      'scenario_type',
+      'scenario_config_id',
+      'scenario_config_version',
+      'preparation_profile_id',
+      'selected_role_ids',
+      'preparation_snapshot',
+      'catalog_snapshot',
+      'session_policy',
+      'practice_focuses',
+      'plan_revision',
+      'practice_plan_status',
+      'created_at',
+      'updated_at',
+    },
+  );
+  final catalog = _jobPlanCatalog(object['catalog_snapshot']);
+  final selectedRoleIds = _resourceIdList(
+    object['selected_role_ids'],
+    min: 1,
+    max: 1,
+  );
+  final preparationSnapshot = _jobPreparationSnapshot(
+    object['preparation_snapshot'],
+  );
+  final policy = _jobSessionPolicy(object['session_policy']);
+  final createdAt = _dateTime(object['created_at']);
+  final updatedAt = _dateTime(object['updated_at']);
+  if (_resourceId(object['scenario_definition_id']) != catalog.scenario.id ||
+      _version(object['scenario_definition_version']) !=
+          catalog.scenario.version ||
+      _enumText(object['scenario_type'], const <String>{'INTERVIEW'}) !=
+          catalog.scenario.type ||
+      _resourceId(object['scenario_config_id']) != catalog.config.id ||
+      _version(object['scenario_config_version']) != catalog.config.version ||
+      _resourceId(object['preparation_profile_id']) !=
+          preparationSnapshot.sourceProfileId ||
+      selectedRoleIds.single != catalog.selectedRole.id ||
+      catalog.practiceOption.scenarioId != catalog.scenario.id ||
+      updatedAt.isBefore(createdAt)) {
+    throw _invalidResponse();
+  }
+  return JobPracticePlanPreview(
+    id: _resourceId(object['practice_plan_id']),
+    userId: _resourceId(object['user_id']),
+    context: AgentPracticeContext(
+      threadId: _resourceId(object['agent_thread_id']),
+      matterId: _resourceId(object['matter_id']),
+    ),
+    preparationProfileId: preparationSnapshot.sourceProfileId,
+    preparationSnapshot: preparationSnapshot,
+    catalog: catalog,
+    sessionPolicy: policy,
+    practiceFocuses: _jobObjectives(object['practice_focuses']),
+    revision: _version(object['plan_revision']),
+    status: _enumText(object['practice_plan_status'], const <String>{'ready'}),
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+  );
+}
+
+JobPlanCatalog _jobPlanCatalog(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'scenario_definition',
+      'scenario_config',
+      'selected_roles',
+      'practice_option',
+    },
+  );
+  final scenarioObject = _object(
+    object['scenario_definition'],
+    required: const <String>{
+      'scenario_definition_id',
+      'scenario_type',
+      'name',
+      'version',
+      'status',
+    },
+  );
+  final scenario = PreparationScenario(
+    id: _resourceId(scenarioObject['scenario_definition_id']),
+    type: _enumText(scenarioObject['scenario_type'], const <String>{
+      'INTERVIEW',
+    }),
+    name: _text(scenarioObject['name']),
+    version: _version(scenarioObject['version']),
+    status: _enumText(scenarioObject['status'], const <String>{'active'}),
+  );
+  final configObject = _object(
+    object['scenario_config'],
+    required: const <String>{
+      'scenario_config_id',
+      'scenario_definition_id',
+      'config_type',
+      'version',
+      'job_title',
+      'job_description',
+      'focus_areas',
+    },
+  );
+  final config = PreparationScenarioConfig(
+    id: _resourceId(configObject['scenario_config_id']),
+    scenarioId: _resourceId(configObject['scenario_definition_id']),
+    type: _enumText(configObject['config_type'], const <String>{'INTERVIEW'}),
+    version: _version(configObject['version']),
+    jobTitle: _text(configObject['job_title']),
+    jobDescription: _text(configObject['job_description']),
+    focusAreas: _nonEmptyTextList(configObject['focus_areas'], max: 100),
+  );
+  final rolesValue = object['selected_roles'];
+  if (rolesValue is! List<Object?> || rolesValue.length != 1) {
+    throw _invalidResponse();
+  }
+  final role = _preparationRole(rolesValue.single);
+  final option = _preparationOption(object['practice_option']);
+  if (config.scenarioId != scenario.id ||
+      config.type != scenario.type ||
+      role.scenarioId != scenario.id ||
+      option.scenarioId != scenario.id ||
+      (option.type == PreparationOptionType.focus &&
+          option.roleId != role.id) ||
+      (option.type == PreparationOptionType.fullSimulation &&
+          option.roleId != null)) {
+    throw _invalidResponse();
+  }
+  return JobPlanCatalog(
+    scenario: scenario,
+    config: config,
+    selectedRole: role,
+    practiceOption: option,
+  );
+}
+
+PreparationRole _preparationRole(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'role_definition_id',
+      'scenario_definition_id',
+      'role_type',
+      'display_name',
+      'responsibilities',
+      'style',
+      'focus_areas',
+      'version',
+    },
+    optional: const <String>{'voice_config_ref'},
+  );
+  return PreparationRole(
+    id: _resourceId(object['role_definition_id']),
+    scenarioId: _resourceId(object['scenario_definition_id']),
+    type: _text(object['role_type'], maxBytes: 128),
+    displayName: _text(object['display_name']),
+    responsibilities: _text(object['responsibilities']),
+    style: _text(object['style']),
+    focusAreas: _nonEmptyTextList(object['focus_areas'], max: 100),
+    version: _version(object['version']),
+    voiceConfigRef: _optionalText(object, 'voice_config_ref'),
+  );
+}
+
+PreparationOption _preparationOption(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'practice_option_id',
+      'scenario_definition_id',
+      'practice_option_type',
+      'display_name',
+      'version',
+    },
+    optional: const <String>{'role_definition_id'},
+  );
+  final type = switch (_enumText(object['practice_option_type'], const <String>{
+    'FULL_SIMULATION',
+    'FOCUS',
+  })) {
+    'FULL_SIMULATION' => PreparationOptionType.fullSimulation,
+    'FOCUS' => PreparationOptionType.focus,
+    _ => throw _invalidResponse(),
+  };
+  final roleId = _optionalResourceId(object, 'role_definition_id');
+  if ((type == PreparationOptionType.focus) != (roleId != null)) {
+    throw _invalidResponse();
+  }
+  return PreparationOption(
+    id: _resourceId(object['practice_option_id']),
+    scenarioId: _resourceId(object['scenario_definition_id']),
+    type: type,
+    displayName: _text(object['display_name']),
+    version: _version(object['version']),
+    roleId: roleId,
+  );
+}
+
+JobSessionPolicy _jobSessionPolicy(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'suggested_duration_seconds',
+      'min_effective_turns',
+      'max_effective_turns',
+      'coverage_checkpoint_turn',
+      'max_follow_ups_per_question',
+      'target_objectives',
+      'early_completion_rule',
+    },
+  );
+  final duration = _version(object['suggested_duration_seconds']);
+  final minimum = _version(object['min_effective_turns']);
+  final maximum = _version(object['max_effective_turns']);
+  final checkpoint = _version(object['coverage_checkpoint_turn']);
+  final followUps = object['max_follow_ups_per_question'];
+  if (minimum > checkpoint ||
+      checkpoint > maximum ||
+      followUps is! int ||
+      followUps < 0) {
+    throw _invalidResponse();
+  }
+  return JobSessionPolicy(
+    suggestedDurationSeconds: duration,
+    minEffectiveTurns: minimum,
+    maxEffectiveTurns: maximum,
+    coverageCheckpointTurn: checkpoint,
+    maxFollowUpsPerQuestion: followUps,
+    targetObjectives: _jobObjectives(object['target_objectives']),
+    earlyCompletionRule: _patternText(
+      object['early_completion_rule'],
+      RegExp(r'^[A-Z][A-Z0-9_]*$'),
+    ),
+  );
+}
+
+List<JobPracticeObjective> _jobObjectives(Object? value) {
+  if (value is! List<Object?> || value.isEmpty || value.length > 100) {
+    throw _invalidResponse();
+  }
+  final ids = <String>{};
+  return List<JobPracticeObjective>.unmodifiable(
+    value.map((raw) {
+      final object = _object(
+        raw,
+        required: const <String>{'objective_id', 'description'},
+      );
+      final id = _patternText(
+        object['objective_id'],
+        RegExp(r'^[a-z][a-z0-9_]*$'),
+      );
+      if (!ids.add(id)) {
+        throw _invalidResponse();
+      }
+      return JobPracticeObjective(
+        id: id,
+        description: _text(object['description']),
+      );
+    }),
+  );
+}
+
+PreparationPracticeBootstrap _decodeJobPracticeBootstrap(
+  String body, {
+  required JobPracticePlanPreview expectedPlan,
+}) {
+  final root = _object(
+    _decodeJson(body),
+    required: const <String>{'practice_session', 'snapshot'},
+  );
+  final sessionObject = _object(
+    root['practice_session'],
+    required: const <String>{
+      'practice_session_id',
+      'practice_plan_id',
+      'scenario_type',
+      'snapshot_id',
+      'practice_session_status',
+      'session_version',
+      'created_at',
+    },
+    optional: const <String>{'started_at', 'ended_at', 'end_reason'},
+  );
+  final sessionId = _resourceId(sessionObject['practice_session_id']);
+  final snapshotId = _resourceId(sessionObject['snapshot_id']);
+  final scenarioType = _enumText(sessionObject['scenario_type'], const <String>{
+    'INTERVIEW',
+  });
+  if (_resourceId(sessionObject['practice_plan_id']) != expectedPlan.id ||
+      scenarioType != expectedPlan.catalog.scenario.type ||
+      _enumText(sessionObject['practice_session_status'], const <String>{
+            'starting',
+          }) !=
+          'starting' ||
+      sessionObject.containsKey('started_at') ||
+      sessionObject.containsKey('ended_at') ||
+      sessionObject.containsKey('end_reason')) {
+    throw _invalidResponse();
+  }
+
+  final snapshotObject = _object(
+    root['snapshot'],
+    required: const <String>{
+      'snapshot_id',
+      'practice_session_id',
+      'plan_revision',
+      'scenario_type',
+      'scenario_definition_snapshot',
+      'scenario_config_snapshot',
+      'preparation_snapshot',
+      'participants',
+      'practice_option',
+      'session_policy',
+      'practice_focuses',
+      'created_at',
+    },
+  );
+  final scenario = _scenarioSnapshot(
+    snapshotObject['scenario_definition_snapshot'],
+  );
+  final config = _configSnapshot(snapshotObject['scenario_config_snapshot']);
+  final preparation = _jobPreparationSnapshot(
+    snapshotObject['preparation_snapshot'],
+  );
+  final option = _preparationOption(snapshotObject['practice_option']);
+  final policy = _jobSessionPolicy(snapshotObject['session_policy']);
+  final focuses = _jobObjectives(snapshotObject['practice_focuses']);
+  if (_resourceId(snapshotObject['snapshot_id']) != snapshotId ||
+      _resourceId(snapshotObject['practice_session_id']) != sessionId ||
+      _version(snapshotObject['plan_revision']) != expectedPlan.revision ||
+      _enumText(snapshotObject['scenario_type'], const <String>{'INTERVIEW'}) !=
+          scenarioType ||
+      !_sameScenario(scenario, expectedPlan.catalog.scenario) ||
+      !_sameConfig(config, expectedPlan.catalog.config) ||
+      !_samePreparationSnapshot(
+        preparation,
+        expectedPlan.preparationSnapshot,
+      ) ||
+      !_sameOption(option, expectedPlan.catalog.practiceOption) ||
+      !_samePolicy(policy, expectedPlan.sessionPolicy) ||
+      !_sameObjectives(focuses, expectedPlan.practiceFocuses)) {
+    throw _invalidResponse();
+  }
+  _validateParticipants(
+    snapshotObject['participants'],
+    sessionId: sessionId,
+    expectedPlan: expectedPlan,
+  );
+  return PreparationPracticeBootstrap(
+    session: PreparationPracticeSession(
+      id: sessionId,
+      planId: expectedPlan.id,
+      scenarioType: scenarioType,
+      snapshotId: snapshotId,
+      status: 'starting',
+      version: _version(sessionObject['session_version']),
+      createdAt: _dateTime(sessionObject['created_at']),
+    ),
+    preparationSnapshotId: preparation.id,
+    maxEffectiveTurns: policy.maxEffectiveTurns,
+  );
+}
+
+PreparationScenario _scenarioSnapshot(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'scenario_definition_id',
+      'scenario_type',
+      'name',
+      'version',
+      'status',
+    },
+  );
+  return PreparationScenario(
+    id: _resourceId(object['scenario_definition_id']),
+    type: _enumText(object['scenario_type'], const <String>{'INTERVIEW'}),
+    name: _text(object['name']),
+    version: _version(object['version']),
+    status: _enumText(object['status'], const <String>{'active'}),
+  );
+}
+
+PreparationScenarioConfig _configSnapshot(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'scenario_config_id',
+      'scenario_definition_id',
+      'config_type',
+      'version',
+      'job_title',
+      'job_description',
+      'focus_areas',
+    },
+  );
+  return PreparationScenarioConfig(
+    id: _resourceId(object['scenario_config_id']),
+    scenarioId: _resourceId(object['scenario_definition_id']),
+    type: _enumText(object['config_type'], const <String>{'INTERVIEW'}),
+    version: _version(object['version']),
+    jobTitle: _text(object['job_title']),
+    jobDescription: _text(object['job_description']),
+    focusAreas: _nonEmptyTextList(object['focus_areas'], max: 100),
+  );
+}
+
+void _validateParticipants(
+  Object? value, {
+  required String sessionId,
+  required JobPracticePlanPreview expectedPlan,
+}) {
+  if (value is! List<Object?> || value.length < 2 || value.length > 16) {
+    throw _invalidResponse();
+  }
+  final participantIds = <String>{};
+  final orders = <int>{};
+  var interviewerCount = 0;
+  var candidateCount = 0;
+  for (final raw in value) {
+    final object = _object(
+      raw,
+      required: const <String>{
+        'practice_participant_id',
+        'practice_session_id',
+        'participant_role',
+        'subject_ref',
+        'participant_order',
+      },
+      optional: const <String>{'role_definition_id', 'role_snapshot'},
+    );
+    if (_resourceId(object['practice_session_id']) != sessionId ||
+        !participantIds.add(_resourceId(object['practice_participant_id'])) ||
+        !orders.add(_version(object['participant_order']))) {
+      throw _invalidResponse();
+    }
+    final subject = _object(
+      object['subject_ref'],
+      required: const <String>{'namespace', 'subject_id'},
+    );
+    final participantRole = _enumText(
+      object['participant_role'],
+      const <String>{'INTERVIEWER', 'CANDIDATE'},
+    );
+    if (participantRole == 'CANDIDATE') {
+      candidateCount++;
+      if (object.containsKey('role_definition_id') ||
+          object.containsKey('role_snapshot') ||
+          _text(subject['namespace']) != 'speakup.user' ||
+          _resourceId(subject['subject_id']) != expectedPlan.userId) {
+        throw _invalidResponse();
+      }
+      continue;
+    }
+    interviewerCount++;
+    final role = _preparationRole(object['role_snapshot']);
+    if (_resourceId(object['role_definition_id']) !=
+            expectedPlan.catalog.selectedRole.id ||
+        !_sameRole(role, expectedPlan.catalog.selectedRole)) {
+      throw _invalidResponse();
+    }
+    _text(subject['namespace']);
+    _resourceId(subject['subject_id']);
+  }
+  if (interviewerCount != 1 || candidateCount != 1) {
+    throw _invalidResponse();
+  }
+}
+
+bool _sameScenario(PreparationScenario left, PreparationScenario right) {
+  return left.id == right.id &&
+      left.type == right.type &&
+      left.name == right.name &&
+      left.version == right.version &&
+      left.status == right.status;
+}
+
+bool _sameConfig(
+  PreparationScenarioConfig left,
+  PreparationScenarioConfig right,
+) {
+  return left.id == right.id &&
+      left.scenarioId == right.scenarioId &&
+      left.type == right.type &&
+      left.version == right.version &&
+      left.jobTitle == right.jobTitle &&
+      left.jobDescription == right.jobDescription &&
+      _sameStrings(left.focusAreas, right.focusAreas);
+}
+
+bool _sameRole(PreparationRole left, PreparationRole right) {
+  return left.id == right.id &&
+      left.scenarioId == right.scenarioId &&
+      left.type == right.type &&
+      left.displayName == right.displayName &&
+      left.responsibilities == right.responsibilities &&
+      left.style == right.style &&
+      left.version == right.version &&
+      left.voiceConfigRef == right.voiceConfigRef &&
+      _sameStrings(left.focusAreas, right.focusAreas);
+}
+
+bool _sameOption(PreparationOption left, PreparationOption right) {
+  return left.id == right.id &&
+      left.scenarioId == right.scenarioId &&
+      left.type == right.type &&
+      left.displayName == right.displayName &&
+      left.version == right.version &&
+      left.roleId == right.roleId;
+}
+
+bool _samePreparationSnapshot(
+  JobPreparationSnapshot left,
+  JobPreparationSnapshot right,
+) {
+  return left.id == right.id &&
+      left.sourceProfileId == right.sourceProfileId &&
+      left.sourceVersion == right.sourceVersion &&
+      left.sourceJobTargetId == right.sourceJobTargetId &&
+      left.sourceJobTargetConfirmationVersion ==
+          right.sourceJobTargetConfirmationVersion &&
+      left.backgroundSnapshot == right.backgroundSnapshot &&
+      left.createdAt == right.createdAt &&
+      left.jobTargetInput == right.jobTargetInput &&
+      _sameCandidate(left.jobTargetCandidate, right.jobTargetCandidate);
+}
+
+bool _sameCandidate(JobTargetCandidate left, JobTargetCandidate right) {
+  final leftRecommendation = left.catalogRecommendation;
+  final rightRecommendation = right.catalogRecommendation;
+  return left.source == right.source &&
+      left.generalAdviceOnly == right.generalAdviceOnly &&
+      left.jobTitle == right.jobTitle &&
+      left.seniority == right.seniority &&
+      _sameStrings(left.responsibilities, right.responsibilities) &&
+      _sameStrings(left.coreSkills, right.coreSkills) &&
+      _sameStrings(left.communicationFocus, right.communicationFocus) &&
+      _sameStrings(left.practiceGoals, right.practiceGoals) &&
+      left.scopeNotice == right.scopeNotice &&
+      leftRecommendation.scenarioDefinitionId ==
+          rightRecommendation.scenarioDefinitionId &&
+      leftRecommendation.scenarioDefinitionVersion ==
+          rightRecommendation.scenarioDefinitionVersion &&
+      _sameStrings(
+        leftRecommendation.selectedRoleIds,
+        rightRecommendation.selectedRoleIds,
+      ) &&
+      leftRecommendation.practiceOptionId ==
+          rightRecommendation.practiceOptionId &&
+      leftRecommendation.practiceOptionVersion ==
+          rightRecommendation.practiceOptionVersion;
+}
+
+bool _samePolicy(JobSessionPolicy left, JobSessionPolicy right) {
+  return left.suggestedDurationSeconds == right.suggestedDurationSeconds &&
+      left.minEffectiveTurns == right.minEffectiveTurns &&
+      left.maxEffectiveTurns == right.maxEffectiveTurns &&
+      left.coverageCheckpointTurn == right.coverageCheckpointTurn &&
+      left.maxFollowUpsPerQuestion == right.maxFollowUpsPerQuestion &&
+      left.earlyCompletionRule == right.earlyCompletionRule &&
+      _sameObjectives(left.targetObjectives, right.targetObjectives);
+}
+
+bool _sameObjectives(
+  List<JobPracticeObjective> left,
+  List<JobPracticeObjective> right,
+) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index].id != right[index].id ||
+        left[index].description != right[index].description) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _sameStrings(List<String> left, List<String> right) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Object? _decodeJson(String body) {
+  try {
+    return jsonDecode(body);
+  } on FormatException {
+    throw _invalidResponse();
+  }
+}
+
+Map<String, Object?> _object(
+  Object? value, {
+  Set<String> required = const <String>{},
+  Set<String> optional = const <String>{},
+}) {
+  if (value is! Map<String, Object?> ||
+      !value.keys.toSet().containsAll(required) ||
+      value.keys.any(
+        (key) => !required.contains(key) && !optional.contains(key),
+      )) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+JobTargetSource _jobTargetSource(Object? value) {
+  return switch (_enumText(value, const <String>{
+    'job_description',
+    'quick_start',
+  })) {
+    'job_description' => JobTargetSource.jobDescription,
+    'quick_start' => JobTargetSource.quickStart,
+    _ => throw _invalidResponse(),
+  };
+}
+
+JobTargetStage _jobTargetStage(Object? value) {
+  final wire = _enumText(value, const <String>{
+    'draft',
+    'parsing',
+    'analysis_failed',
+    'awaiting_confirmation',
+    'confirmed',
+    'discarded',
+  });
+  return JobTargetStage.values.singleWhere(
+    (candidate) => candidate.wireValue == wire,
+  );
+}
+
+JobTargetAnalysisStatus _jobTargetAnalysisStatus(Object? value) {
+  final wire = _enumText(value, const <String>{
+    'running',
+    'succeeded',
+    'failed',
+  });
+  return JobTargetAnalysisStatus.values.singleWhere(
+    (candidate) => candidate.wireValue == wire,
+  );
+}
+
+String _resourceId(Object? value) {
+  return _text(value, maxBytes: 128);
+}
+
+String? _optionalResourceId(Map<String, Object?> object, String key) {
+  return object.containsKey(key) ? _resourceId(object[key]) : null;
+}
+
+String _text(Object? value, {int maxBytes = 256 * 1024}) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.trim() != value ||
+      value.contains('\u0000') ||
+      utf8.encode(value).length > maxBytes) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+String? _optionalText(
+  Map<String, Object?> object,
+  String key, {
+  int maxBytes = 256 * 1024,
+}) {
+  return object.containsKey(key)
+      ? _text(object[key], maxBytes: maxBytes)
+      : null;
+}
+
+String _patternText(Object? value, RegExp pattern) {
+  final result = _text(value, maxBytes: 2048);
+  if (!pattern.hasMatch(result)) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+String? _optionalPatternText(
+  Map<String, Object?> object,
+  String key,
+  RegExp pattern,
+) {
+  return object.containsKey(key) ? _patternText(object[key], pattern) : null;
+}
+
+String _enumText(Object? value, Set<String> allowed) {
+  final result = _text(value, maxBytes: 128);
+  if (!allowed.contains(result)) {
+    throw _invalidResponse();
+  }
+  return result;
+}
+
+int _version(Object? value) {
+  if (value is! int || value < 1) {
+    throw _invalidResponse();
+  }
+  return value;
+}
+
+DateTime _dateTime(Object? value) {
+  if (value is! String) {
+    throw _invalidResponse();
+  }
+  final parsed = DateTime.tryParse(value);
+  if (parsed == null) {
+    throw _invalidResponse();
+  }
+  return parsed;
+}
+
+List<String> _resourceIdList(
+  Object? value, {
+  required int min,
+  required int max,
+}) {
+  if (value is! List<Object?> || value.length < min || value.length > max) {
+    throw _invalidResponse();
+  }
+  final result = value.map(_resourceId).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw _invalidResponse();
+  }
+  return List<String>.unmodifiable(result);
+}
+
+List<String> _candidateItems(Object? value) {
+  if (value is! List<Object?> || value.isEmpty || value.length > 20) {
+    throw _invalidResponse();
+  }
+  final result = value
+      .map((item) {
+        final text = _text(item, maxBytes: 8 * 1024);
+        if (text.runes.length > 2048) {
+          throw _invalidResponse();
+        }
+        return text;
+      })
+      .toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw _invalidResponse();
+  }
+  return List<String>.unmodifiable(result);
+}
+
+List<String> _nonEmptyTextList(Object? value, {required int max}) {
+  if (value is! List<Object?> || value.isEmpty || value.length > max) {
+    throw _invalidResponse();
+  }
+  final result = value.map(_text).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw _invalidResponse();
+  }
+  return List<String>.unmodifiable(result);
+}
+
+Map<String, Object?> _jobTargetInputJson(JobTargetInput input) {
+  return <String, Object?>{
+    'source': input.source.wireValue,
+    if (input.jobTitle != null) 'job_title': input.jobTitle,
+    if (input.jobDescription != null) 'job_description': input.jobDescription,
+    if (input.company != null) 'company': input.company,
+    if (input.seniority != null) 'seniority': input.seniority,
+    if (input.candidateBackground != null)
+      'candidate_background': input.candidateBackground,
+    if (input.resumeRef != null) 'resume_ref': input.resumeRef,
+    if (input.practiceFocus != null) 'practice_focus': input.practiceFocus,
+  };
+}
+
+Map<String, Object?> _jobTargetCandidateJson(JobTargetCandidate candidate) {
+  return <String, Object?>{
+    'source': candidate.source.wireValue,
+    'general_advice_only': candidate.generalAdviceOnly,
+    'job_title': candidate.jobTitle,
+    'seniority': candidate.seniority,
+    'responsibilities': candidate.responsibilities,
+    'core_skills': candidate.coreSkills,
+    'communication_focus': candidate.communicationFocus,
+    'practice_goals': candidate.practiceGoals,
+    'scope_notice': candidate.scopeNotice,
+    'catalog_recommendation': <String, Object?>{
+      'scenario_definition_id':
+          candidate.catalogRecommendation.scenarioDefinitionId,
+      'scenario_definition_version':
+          candidate.catalogRecommendation.scenarioDefinitionVersion,
+      'selected_role_ids': candidate.catalogRecommendation.selectedRoleIds,
+      'practice_option_id': candidate.catalogRecommendation.practiceOptionId,
+      'practice_option_version':
+          candidate.catalogRecommendation.practiceOptionVersion,
+    },
+  };
+}
+
+String? _decodeErrorCode(String body) {
+  try {
+    final root = jsonDecode(body);
+    if (root is! Map<String, Object?> ||
+        root['error'] is! Map<String, Object?>) {
+      return null;
+    }
+    final value = (root['error'] as Map<String, Object?>)['code'];
+    return value is String && value.length <= 128 ? value : null;
+  } on FormatException {
+    return null;
+  }
+}
+
+Never _invalidResponse([JobPreparationOperationStage? stage]) {
+  throw JobPreparationException(
+    kind: JobPreparationFailureKind.invalidResponse,
+    stage: stage,
+  );
+}
+
+void _requireContext(AgentPracticeContext context) {
+  _requireResourceId(context.threadId);
+  _requireResourceId(context.matterId);
+}
+
+void _requireVersion(int value) {
+  if (value < 1) {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireResourceId(String value) {
+  if (value.isEmpty ||
+      value.length > 128 ||
+      value.trim() != value ||
+      value.contains('\u0000')) {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireText(String value, {required int maxBytes}) {
+  if (value.isEmpty ||
+      value.trim() != value ||
+      value.contains('\u0000') ||
+      utf8.encode(value).length > maxBytes) {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+    );
+  }
+}
+
+void _requireJobTargetInput(
+  JobTargetInput input, {
+  bool invalidResponse = false,
+}) {
+  void invalid() {
+    if (invalidResponse) {
+      throw _invalidResponse();
+    }
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+      stage: JobPreparationOperationStage.target,
+    );
+  }
+
+  bool validOptional(String? value, int maxBytes) {
+    return value == null ||
+        (value.isNotEmpty &&
+            value.trim() == value &&
+            !value.contains('\u0000') &&
+            utf8.encode(value).length <= maxBytes);
+  }
+
+  if (!validOptional(input.jobTitle, 512) ||
+      !validOptional(input.jobDescription, 64 * 1024) ||
+      !validOptional(input.company, 512) ||
+      !validOptional(input.seniority, 256) ||
+      !validOptional(input.candidateBackground, 16 * 1024) ||
+      !validOptional(input.resumeRef, 16 * 1024) ||
+      !validOptional(input.practiceFocus, 8 * 1024) ||
+      (input.source == JobTargetSource.jobDescription &&
+          input.jobDescription == null) ||
+      (input.source == JobTargetSource.quickStart &&
+          (input.jobTitle == null || input.jobDescription != null))) {
+    invalid();
+  }
+}
+
+void _requireJobTargetCandidate(JobTargetCandidate candidate) {
+  try {
+    _jobTargetCandidate(_jobTargetCandidateJson(candidate));
+  } on JobPreparationException {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+      stage: JobPreparationOperationStage.confirmation,
+    );
+  }
+}
+
+void _requireIdempotencyKey(String value) {
+  if (value.length < 8 ||
+      value.length > 128 ||
+      value.trim() != value ||
+      value.contains('\u0000')) {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,9 +6,12 @@ import 'package:speakup/agent/wire_agent_client.dart';
 import 'package:speakup/agent/wire_agent_voice_client.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
 import 'package:speakup/features/preparation/preparation_launch_controller.dart';
 import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/wire_preparation_client.dart';
+import 'package:speakup/features/preparation/wire_job_preparation_client.dart';
 import 'package:speakup/features/preparation/wire_preparation_launch_client.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/client/identity_client.dart';
@@ -36,6 +39,7 @@ void main() {
       authController: dependencies.authController,
       agentController: dependencies.agentController,
       preparationController: dependencies.preparationController,
+      jobPreparationController: dependencies.jobPreparationController,
       preparationLaunchController: dependencies.preparationLaunchController,
       reviewHistoryController: dependencies.reviewHistoryController,
     ),
@@ -47,6 +51,7 @@ final class ProductionAppDependencies {
     required this.authController,
     required this.agentController,
     required this.preparationController,
+    required this.jobPreparationController,
     required this.preparationLaunchController,
     required this.reviewHistoryController,
   });
@@ -54,6 +59,7 @@ final class ProductionAppDependencies {
   final AuthController authController;
   final AgentController agentController;
   final PreparationController preparationController;
+  final JobPreparationController jobPreparationController;
   final PreparationLaunchController preparationLaunchController;
   final ReviewHistoryController reviewHistoryController;
 }
@@ -65,6 +71,7 @@ ProductionAppDependencies createProductionAppDependencies({
   AgentVoiceWireTransport? agentVoiceTransport,
   AgentVoiceWireTransport? signedAgentVoiceTransport,
   IdentityHttpTransport? preparationTransport,
+  IdentityHttpTransport? jobPreparationTransport,
   IdentityHttpTransport? preparationLaunchTransport,
   IdentityHttpTransport? reviewHistoryTransport,
   PracticeWireTransport? practiceTransport,
@@ -75,6 +82,7 @@ ProductionAppDependencies createProductionAppDependencies({
   AgentVoiceAudioPlayer? agentVoiceAudioPlayer,
   PracticeMediaClient? practiceMediaClient,
   PracticeAudioPlayer? practiceAudioPlayer,
+  JobPreparationDraftStore? jobPreparationDraftStore,
   SessionStore? sessionStore,
 }) {
   late final AuthController authController;
@@ -208,6 +216,49 @@ ProductionAppDependencies createProductionAppDependencies({
               clientOperationId: clientOperationId,
             ),
   );
+  final jobPreparationController = JobPreparationController(
+    client: WireJobPreparationClient(
+      baseUri: baseUri,
+      credentialProvider: () => authController.currentCredential,
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) {
+            return authController.invalidateSession(
+              expectedSessionToken: expectedSessionToken,
+              expectedGeneration: expectedGeneration,
+            );
+          },
+      transport: jobPreparationTransport,
+    ),
+    draftStore:
+        jobPreparationDraftStore ?? const SecureJobPreparationDraftStore(),
+    threadIdProvider: () => agentController.threadId,
+    matterActivator:
+        ({
+          required threadId,
+          required candidate,
+          required clientOperationId,
+        }) async {
+          final matter = await agentController.activateMatterForScenario(
+            threadId: threadId,
+            scene: AgentScene(
+              id: candidate.catalogRecommendation.scenarioDefinitionId,
+              title: '${candidate.jobTitle}英文面试',
+              description: candidate.scopeNotice,
+            ),
+            clientOperationId: clientOperationId,
+          );
+          return AgentPracticeContext(threadId: threadId, matterId: matter.id);
+        },
+    voiceActivator:
+        ({required context, required bootstrap, required clientOperationId}) =>
+            agentController.activateCreatedPractice(
+              threadId: context.threadId,
+              matterId: context.matterId,
+              sessionId: bootstrap.session.id,
+              turnLimit: bootstrap.maxEffectiveTurns,
+              clientOperationId: clientOperationId,
+            ),
+  );
   authController = AuthController(
     identityClient: WireIdentityClient(
       baseUri: baseUri,
@@ -219,6 +270,7 @@ ProductionAppDependencies createProductionAppDependencies({
         agentController.clearPrivateState(),
         preparationController.clearPrivateState(),
         preparationLaunchController.clearPrivateState(),
+        jobPreparationController.clearPrivateState(),
         reviewHistoryController.clearPrivateState(),
       ]);
     },
@@ -227,6 +279,7 @@ ProductionAppDependencies createProductionAppDependencies({
     authController: authController,
     agentController: agentController,
     preparationController: preparationController,
+    jobPreparationController: jobPreparationController,
     preparationLaunchController: preparationLaunchController,
     reviewHistoryController: reviewHistoryController,
   );

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -12,6 +12,8 @@ import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/agent/wire_agent_client.dart';
 import 'package:speakup/agent/wire_agent_voice_client.dart';
 import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
+import 'package:speakup/features/preparation/wire_job_preparation_client.dart';
 import 'package:speakup/features/preparation/wire_preparation_client.dart';
 import 'package:speakup/features/preparation/wire_preparation_launch_client.dart';
 import 'package:speakup/identity/auth_state.dart';
@@ -131,11 +133,13 @@ void main() {
         agentVoiceAudioPlayer: agentVoiceAudioPlayer,
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
+        jobPreparationDraftStore: MemoryJobPreparationDraftStore(),
         sessionStore: _MemorySessionStore('sess_main-wiring'),
       );
       addTearDown(dependencies.agentController.dispose);
       addTearDown(dependencies.preparationController.dispose);
       addTearDown(dependencies.preparationLaunchController.dispose);
+      addTearDown(dependencies.jobPreparationController.dispose);
       addTearDown(dependencies.reviewHistoryController.dispose);
 
       expect(dependencies.agentController.client, isA<WireAgentClient>());
@@ -175,12 +179,17 @@ void main() {
         dependencies.preparationLaunchController.client,
         isA<WirePreparationLaunchClient>(),
       );
+      expect(
+        dependencies.jobPreparationController.client,
+        isA<WireJobPreparationClient>(),
+      );
 
       await tester.pumpWidget(
         SpeakUpApp(
           authController: dependencies.authController,
           agentController: dependencies.agentController,
           preparationController: dependencies.preparationController,
+          jobPreparationController: dependencies.jobPreparationController,
           preparationLaunchController: dependencies.preparationLaunchController,
           reviewHistoryController: dependencies.reviewHistoryController,
         ),
@@ -219,12 +228,11 @@ void main() {
 
       await tester.tap(find.byKey(const Key('primary-tab-scenes')));
       await tester.pumpAndSettle();
-      expect(find.text('服务端场景与语音契约尚未开放，当前仅提供 Agent 文本对话。'), findsNothing);
-      final scene = tester.widget<InkWell>(
-        find.byKey(const Key('catalog-scenario-scn_programmer_interview')),
-      );
-      expect(scene.onTap, isNotNull);
-      expect(preparationTransport.calls.single.authorization, isNull);
+      expect(find.byKey(const Key('job-preparation-wizard')), findsOneWidget);
+      expect(find.byKey(const Key('job-description-field')), findsOneWidget);
+      expect(find.byKey(const Key('primary-tab-review')), findsNothing);
+      await tester.tap(find.byKey(const Key('job-wizard-close')));
+      await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('primary-tab-review')));
       await tester.pump();
@@ -241,6 +249,8 @@ void main() {
       expect(dependencies.reviewHistoryController.isLoading, isFalse);
       expect(dependencies.preparationController.scenarios, isEmpty);
       expect(dependencies.preparationController.selectedScenario, isNull);
+      expect(dependencies.jobPreparationController.target, isNull);
+      expect(dependencies.jobPreparationController.plan, isNull);
       expect(dependencies.agentController.threadId, isNull);
       expect(dependencies.agentController.messages, isEmpty);
       expect(practiceRecorder.clearCount, 1);

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -228,9 +228,16 @@ void main() {
 
       await tester.tap(find.byKey(const Key('primary-tab-scenes')));
       await tester.pumpAndSettle();
+      expect(find.byKey(const Key('scenes-page')), findsOneWidget);
+      expect(find.byKey(const Key('training-center-title')), findsOneWidget);
+      expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+      await tester.tap(
+        find.byKey(const Key('catalog-scenario-scn_programmer_interview')),
+      );
+      await tester.pumpAndSettle();
       expect(find.byKey(const Key('job-preparation-wizard')), findsOneWidget);
       expect(find.byKey(const Key('job-description-field')), findsOneWidget);
-      expect(find.byKey(const Key('primary-tab-review')), findsNothing);
+      expect(find.byKey(const Key('primary-navigation')), findsNothing);
       await tester.tap(find.byKey(const Key('job-wizard-close')));
       await tester.pumpAndSettle();
 

--- a/mobile/test/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/preparation/job_preparation_controller_test.dart
@@ -1,0 +1,737 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/job_preparation_client.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+void main() {
+  test(
+    'runs JD confirmation and preview before explicit Session start',
+    () async {
+      final client = _FakeJobPreparationClient();
+      final voiceKeys = <String>[];
+      final controller = _controller(
+        client,
+        voiceActivator:
+            ({
+              required context,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              voiceKeys.add(clientOperationId);
+            },
+      );
+      addTearDown(controller.dispose);
+      controller.updateInput(_input);
+
+      expect(await controller.analyze(), isTrue);
+      expect(controller.step, JobPreparationStep.confirmation);
+      expect(controller.candidate, isNotNull);
+      expect(await controller.confirm(), isTrue);
+      expect(controller.step, JobPreparationStep.setup);
+      expect(await controller.createPreview(), isTrue);
+      expect(controller.step, JobPreparationStep.preview);
+      expect(client.calls, <String>[
+        'create-target',
+        'analyze-target',
+        'confirm-target',
+        'profile',
+        'snapshot',
+        'plan',
+      ]);
+      expect(client.sessionKeys, isEmpty);
+
+      expect(await controller.startPractice(), isTrue);
+      expect(client.calls.last, 'session');
+      expect(client.sessionKeys, hasLength(1));
+      expect(voiceKeys, hasLength(1));
+    },
+  );
+
+  test('double start creates exactly one Session', () async {
+    final session = Completer<PreparationPracticeBootstrap>();
+    final client = _FakeJobPreparationClient(sessionCompleter: session);
+    final controller = _controller(client);
+    addTearDown(controller.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+    await controller.confirm();
+    await controller.createPreview();
+
+    final first = controller.startPractice();
+    final second = controller.startPractice();
+    expect(await second, isFalse);
+    expect(client.sessionKeys, hasLength(1));
+    session.complete(_bootstrap);
+
+    expect(await first, isTrue);
+    expect(client.sessionKeys, hasLength(1));
+  });
+
+  test('voice retry never creates a second committed Session', () async {
+    final client = _FakeJobPreparationClient();
+    var voiceCalls = 0;
+    final voiceKeys = <String>[];
+    final controller = _controller(
+      client,
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {
+            voiceCalls++;
+            voiceKeys.add(clientOperationId);
+            if (voiceCalls == 1) {
+              throw StateError('voice unavailable');
+            }
+          },
+    );
+    addTearDown(controller.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+    await controller.confirm();
+    await controller.createPreview();
+
+    expect(await controller.startPractice(), isFalse);
+    expect(controller.bootstrap, same(_bootstrap));
+    expect(await controller.retry(), isTrue);
+
+    expect(client.sessionKeys, hasLength(1));
+    expect(voiceKeys, <String>[
+      'job-target-voice-stable-key',
+      'job-target-voice-stable-key',
+    ]);
+  });
+
+  test('network retry keeps the same JobTarget analysis identity', () async {
+    final client = _FakeJobPreparationClient(failFirstAnalysis: true);
+    final controller = _controller(client);
+    addTearDown(controller.dispose);
+    controller.updateInput(_input);
+
+    expect(await controller.analyze(), isFalse);
+    expect(controller.canRetry, isTrue);
+    expect(await controller.retry(), isTrue);
+
+    expect(client.analysisKeys, <String>[
+      'job-target-analysis-stable-key',
+      'job-target-analysis-stable-key',
+    ]);
+    expect(client.createTargetKeys, <String>['job-target-stable-key']);
+  });
+
+  test(
+    'editing input immediately invalidates analysis and late response',
+    () async {
+      final analysis = Completer<JobTarget>();
+      final client = _FakeJobPreparationClient(analysisCompleter: analysis);
+      final controller = _controller(client);
+      addTearDown(controller.dispose);
+      controller.updateInput(_input);
+
+      final operation = controller.analyze();
+      await _flush();
+      controller.updateInput(_quickInput);
+      analysis.complete(_target(JobTargetStage.awaitingConfirmation));
+
+      expect(await operation, isFalse);
+      expect(controller.input, _quickInput);
+      expect(controller.candidate, isNull);
+      expect(controller.plan, isNull);
+      expect(controller.step, JobPreparationStep.input);
+    },
+  );
+
+  test(
+    'editing confirmed input invalidates confirmation and preview',
+    () async {
+      final client = _FakeJobPreparationClient();
+      final controller = _controller(client);
+      addTearDown(controller.dispose);
+      controller.updateInput(_input);
+      await controller.analyze();
+      await controller.confirm();
+      await controller.createPreview();
+      expect(controller.plan, isNotNull);
+
+      controller.updateInput(
+        const JobTargetInput(
+          source: JobTargetSource.jobDescription,
+          jobDescription: 'A materially changed JD.',
+          candidateBackground: _background,
+        ),
+      );
+
+      expect(controller.candidate, isNull);
+      expect(controller.plan, isNull);
+      expect(controller.bootstrap, isNull);
+      expect(controller.step, JobPreparationStep.input);
+    },
+  );
+
+  test(
+    'analysis polling accepts only the current terminal projection',
+    () async {
+      final client = _FakeJobPreparationClient(
+        analyzeAsParsing: true,
+        restoredTarget: _target(JobTargetStage.awaitingConfirmation),
+      );
+      final controller = _controller(client);
+      addTearDown(controller.dispose);
+      controller.updateInput(_input);
+
+      expect(await controller.analyze(), isTrue);
+      expect(
+        client.calls,
+        containsAllInOrder(<String>[
+          'create-target',
+          'analyze-target',
+          'get-target',
+        ]),
+      );
+      expect(controller.step, JobPreparationStep.confirmation);
+    },
+  );
+
+  test(
+    'draft survives controller restart and remains account isolated',
+    () async {
+      final store = MemoryJobPreparationDraftStore();
+      final first = _controller(_FakeJobPreparationClient(), draftStore: store);
+      await first.activateAccount(_userId);
+      first.updateInput(_input);
+      await _flush();
+      first.dispose();
+
+      final restored = _controller(
+        _FakeJobPreparationClient(),
+        draftStore: store,
+      );
+      addTearDown(restored.dispose);
+      await restored.activateAccount(_userId);
+      expect(restored.hasRestorableDraft, isTrue);
+      expect(await restored.resumeDraft(), isTrue);
+      expect(restored.input, _input);
+
+      final otherAccount = _controller(
+        _FakeJobPreparationClient(),
+        draftStore: store,
+      );
+      addTearDown(otherAccount.dispose);
+      await otherAccount.activateAccount('user-2');
+      expect(otherAccount.hasRestorableDraft, isFalse);
+    },
+  );
+
+  test(
+    'logout clears the current account draft and fences late work',
+    () async {
+      final store = MemoryJobPreparationDraftStore();
+      final analysis = Completer<JobTarget>();
+      final client = _FakeJobPreparationClient(analysisCompleter: analysis);
+      final controller = _controller(client, draftStore: store);
+      addTearDown(controller.dispose);
+      await controller.activateAccount(_userId);
+      controller.updateInput(_input);
+      final operation = controller.analyze();
+      await _flush();
+
+      final cleanup = controller.clearPrivateState();
+      analysis.complete(_target(JobTargetStage.awaitingConfirmation));
+      await cleanup;
+
+      expect(await operation, isFalse);
+      expect(client.clearCount, 1);
+      final replacement = _controller(
+        _FakeJobPreparationClient(),
+        draftStore: store,
+      );
+      addTearDown(replacement.dispose);
+      await replacement.activateAccount(_userId);
+      expect(replacement.hasRestorableDraft, isFalse);
+    },
+  );
+
+  test(
+    'discard recovers an ambiguous create key before server discard',
+    () async {
+      final store = MemoryJobPreparationDraftStore();
+      final firstClient = _FakeJobPreparationClient(failFirstCreate: true);
+      final first = _controller(firstClient, draftStore: store);
+      await first.activateAccount(_userId);
+      first.updateInput(_input);
+      expect(await first.analyze(), isFalse);
+      await _flush();
+      first.dispose();
+
+      final client = _FakeJobPreparationClient();
+      final restored = _controller(client, draftStore: store);
+      addTearDown(restored.dispose);
+      await restored.activateAccount(_userId);
+      expect(restored.hasRestorableDraft, isTrue);
+
+      expect(await restored.discardDraft(), isTrue);
+      expect(client.calls, <String>['create-target', 'discard-target']);
+      expect(client.createTargetKeys, <String>['job-target-stable-key']);
+    },
+  );
+
+  test(
+    'Agent intent is only offered until the user explicitly applies it',
+    () async {
+      final client = _FakeJobPreparationClient();
+      final controller = _controller(client);
+      addTearDown(controller.dispose);
+
+      controller.offerAgentIntent('A pasted role from the Agent conversation');
+      expect(controller.agentIntentPrefill, isNotNull);
+      expect(controller.input.jobDescription, isNull);
+      expect(client.calls, isEmpty);
+
+      controller.applyAgentIntentPrefill();
+      expect(
+        controller.input.jobDescription,
+        'A pasted role from the Agent conversation',
+      );
+      expect(client.calls, isEmpty);
+    },
+  );
+}
+
+JobPreparationController _controller(
+  _FakeJobPreparationClient client, {
+  JobPreparationDraftStore? draftStore,
+  JobPreparationVoiceActivator? voiceActivator,
+}) {
+  return JobPreparationController(
+    client: client,
+    draftStore: draftStore,
+    threadIdProvider: () => _threadId,
+    matterActivator:
+        ({
+          required threadId,
+          required candidate,
+          required clientOperationId,
+        }) async => _context,
+    voiceActivator:
+        voiceActivator ??
+        ({
+          required context,
+          required bootstrap,
+          required clientOperationId,
+        }) async {},
+    idFactory: (scope) => '$scope-stable-key',
+    analysisPollInterval: Duration.zero,
+    maxAnalysisPollAttempts: 2,
+  );
+}
+
+Future<void> _flush() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+final class _FakeJobPreparationClient implements JobPreparationClient {
+  _FakeJobPreparationClient({
+    this.analysisCompleter,
+    this.sessionCompleter,
+    this.failFirstCreate = false,
+    this.failFirstAnalysis = false,
+    this.analyzeAsParsing = false,
+    JobTarget? restoredTarget,
+  }) : restoredTarget =
+           restoredTarget ?? _target(JobTargetStage.awaitingConfirmation);
+
+  final Completer<JobTarget>? analysisCompleter;
+  final Completer<PreparationPracticeBootstrap>? sessionCompleter;
+  final bool failFirstCreate;
+  final bool failFirstAnalysis;
+  final bool analyzeAsParsing;
+  final JobTarget restoredTarget;
+
+  final List<String> calls = <String>[];
+  final List<String> createTargetKeys = <String>[];
+  final List<String> analysisKeys = <String>[];
+  final List<String> sessionKeys = <String>[];
+  int clearCount = 0;
+  int _createAttempts = 0;
+  int _analysisAttempts = 0;
+
+  @override
+  Future<JobTarget> createJobTarget({
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('create-target');
+    createTargetKeys.add(idempotencyKey);
+    _createAttempts++;
+    if (failFirstCreate && _createAttempts == 1) {
+      throw const JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: JobPreparationOperationStage.target,
+        retryable: true,
+      );
+    }
+    return _target(JobTargetStage.draft, input: input);
+  }
+
+  @override
+  Future<JobTarget> getJobTarget(String jobTargetId) async {
+    calls.add('get-target');
+    return restoredTarget;
+  }
+
+  @override
+  Future<JobTarget> updateJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    calls.add('update-target');
+    return _target(JobTargetStage.draft, input: input);
+  }
+
+  @override
+  Future<JobTarget> analyzeJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('analyze-target');
+    analysisKeys.add(idempotencyKey);
+    _analysisAttempts++;
+    if (failFirstAnalysis && _analysisAttempts == 1) {
+      throw const JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: JobPreparationOperationStage.analysis,
+        retryable: true,
+      );
+    }
+    if (analysisCompleter != null) {
+      return analysisCompleter!.future;
+    }
+    return analyzeAsParsing
+        ? _target(JobTargetStage.parsing)
+        : _target(JobTargetStage.awaitingConfirmation);
+  }
+
+  @override
+  Future<JobTarget> confirmJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required int expectedAnalysisVersion,
+    required JobTargetCandidate candidate,
+    required String idempotencyKey,
+  }) async {
+    calls.add('confirm-target');
+    return _target(JobTargetStage.confirmed, confirmedCandidate: candidate);
+  }
+
+  @override
+  Future<JobTarget> discardJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('discard-target');
+    return _target(JobTargetStage.discarded);
+  }
+
+  @override
+  Future<JobPreparationProfile> createProfileForJobTarget({
+    required String backgroundSummary,
+    required String jobTargetId,
+    required int jobTargetConfirmationVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('profile');
+    return _profile;
+  }
+
+  @override
+  Future<JobPreparationSnapshot> createJobPreparationSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    calls.add('snapshot');
+    return _snapshot;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> createJobPracticePlan({
+    required AgentPracticeContext context,
+    required String preparationSnapshotId,
+    required String idempotencyKey,
+  }) async {
+    calls.add('plan');
+    return _plan;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> getJobPracticePlan(String planId) async {
+    calls.add('get-plan');
+    return _plan;
+  }
+
+  @override
+  Future<JobPracticePlanPreview> reviseJobPracticePlan({
+    required String planId,
+    required int expectedPlanRevision,
+    required String roleDefinitionId,
+    required String practiceOptionId,
+    required int practiceOptionVersion,
+    required int maxEffectiveTurns,
+    required String idempotencyKey,
+  }) async {
+    calls.add('revise-plan');
+    return _planWithRevision(expectedPlanRevision + 1);
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createJobPracticeSession({
+    required JobPracticePlanPreview plan,
+    required String idempotencyKey,
+  }) async {
+    calls.add('session');
+    sessionKeys.add(idempotencyKey);
+    final pending = sessionCompleter;
+    if (pending != null) {
+      return pending.future;
+    }
+    return _bootstrap;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    clearCount++;
+  }
+}
+
+JobTarget _target(
+  JobTargetStage stage, {
+  JobTargetInput input = _input,
+  JobTargetCandidate? confirmedCandidate,
+}) {
+  final now = DateTime.utc(2026, 7, 26, 12);
+  final analysis = switch (stage) {
+    JobTargetStage.parsing => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.running,
+      startedAt: now,
+    ),
+    JobTargetStage.awaitingConfirmation ||
+    JobTargetStage.confirmed => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.succeeded,
+      candidate: _candidate,
+      startedAt: now,
+      finishedAt: now,
+    ),
+    JobTargetStage.analysisFailed => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.failed,
+      stableErrorCategory: 'provider_unavailable',
+      startedAt: now,
+      finishedAt: now,
+    ),
+    JobTargetStage.draft || JobTargetStage.discarded => null,
+  };
+  return JobTarget(
+    id: _targetId,
+    userId: _userId,
+    input: input,
+    inputVersion: 1,
+    stage: stage,
+    analysis: analysis,
+    confirmation: stage == JobTargetStage.confirmed
+        ? JobTargetConfirmation(
+            inputVersion: 1,
+            analysisVersion: 1,
+            confirmationVersion: 1,
+            candidate: confirmedCandidate ?? _candidate,
+            confirmedAt: now,
+          )
+        : null,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+JobPracticePlanPreview _planWithRevision(int revision) {
+  return JobPracticePlanPreview(
+    id: _planId,
+    userId: _userId,
+    context: _context,
+    preparationProfileId: _profileId,
+    preparationSnapshot: _snapshot,
+    catalog: _catalog,
+    sessionPolicy: _policy,
+    practiceFocuses: _objectives,
+    revision: revision,
+    status: 'ready',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+final DateTime _now = DateTime.utc(2026, 7, 26, 12);
+
+const _input = JobTargetInput(
+  source: JobTargetSource.jobDescription,
+  jobDescription: 'Build reliable APIs and explain trade-offs.',
+  candidateBackground: _background,
+  practiceFocus: 'System design',
+);
+
+const _quickInput = JobTargetInput(
+  source: JobTargetSource.quickStart,
+  jobTitle: 'Backend engineer',
+  candidateBackground: _background,
+);
+
+const _candidate = JobTargetCandidate(
+  source: JobTargetSource.jobDescription,
+  generalAdviceOnly: false,
+  jobTitle: 'Backend engineer',
+  seniority: 'Senior',
+  responsibilities: <String>['Build reliable APIs'],
+  coreSkills: <String>['Go services'],
+  communicationFocus: <String>['Explain trade-offs'],
+  practiceGoals: <String>['Practice system design'],
+  scopeNotice: 'Based on the supplied JD.',
+  catalogRecommendation: JobTargetCatalogRecommendation(
+    scenarioDefinitionId: _scenarioId,
+    scenarioDefinitionVersion: 1,
+    selectedRoleIds: <String>[_roleId],
+    practiceOptionId: _optionId,
+    practiceOptionVersion: 1,
+  ),
+);
+
+final JobPreparationProfile _profile = JobPreparationProfile(
+  id: _profileId,
+  userId: _userId,
+  backgroundSummary: _background,
+  jobTargetId: _targetId,
+  jobTargetConfirmationVersion: 1,
+  version: 1,
+  updatedAt: _now,
+);
+
+final JobPreparationSnapshot _snapshot = JobPreparationSnapshot(
+  id: _snapshotId,
+  sourceProfileId: _profileId,
+  sourceVersion: 1,
+  sourceJobTargetId: _targetId,
+  sourceJobTargetConfirmationVersion: 1,
+  jobTargetInput: _input,
+  jobTargetCandidate: _candidate,
+  backgroundSnapshot: _background,
+  createdAt: _now,
+);
+
+const _scenario = PreparationScenario(
+  id: _scenarioId,
+  type: 'INTERVIEW',
+  name: 'Technical interview',
+  version: 1,
+  status: 'active',
+);
+
+const _config = PreparationScenarioConfig(
+  id: 'config-1',
+  scenarioId: _scenarioId,
+  type: 'INTERVIEW',
+  version: 1,
+  jobTitle: 'Backend engineer',
+  jobDescription: 'Explain trade-offs.',
+  focusAreas: <String>['system_design'],
+);
+
+const _role = PreparationRole(
+  id: _roleId,
+  scenarioId: _scenarioId,
+  type: 'TECHNICAL_INTERVIEWER',
+  displayName: 'Technical interviewer',
+  responsibilities: 'Probe technical depth.',
+  style: 'Precise',
+  focusAreas: <String>['system_design'],
+  version: 1,
+);
+
+const _option = PreparationOption(
+  id: _optionId,
+  scenarioId: _scenarioId,
+  type: PreparationOptionType.focus,
+  displayName: 'System design focus',
+  version: 1,
+  roleId: _roleId,
+);
+
+const _catalog = JobPlanCatalog(
+  scenario: _scenario,
+  config: _config,
+  selectedRole: _role,
+  practiceOption: _option,
+);
+
+const _objectives = <JobPracticeObjective>[
+  JobPracticeObjective(
+    id: 'system_design',
+    description: 'Explain one design trade-off.',
+  ),
+];
+
+const _policy = JobSessionPolicy(
+  suggestedDurationSeconds: 720,
+  minEffectiveTurns: 2,
+  maxEffectiveTurns: 5,
+  coverageCheckpointTurn: 3,
+  maxFollowUpsPerQuestion: 2,
+  targetObjectives: _objectives,
+  earlyCompletionRule: 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+);
+
+final JobPracticePlanPreview _plan = _planWithRevision(1);
+
+final PreparationPracticeBootstrap _bootstrap = PreparationPracticeBootstrap(
+  session: PreparationPracticeSession(
+    id: _sessionId,
+    planId: _planId,
+    scenarioType: 'INTERVIEW',
+    snapshotId: 'session-snapshot-1',
+    status: 'starting',
+    version: 1,
+    createdAt: _now,
+  ),
+  preparationSnapshotId: _snapshotId,
+  maxEffectiveTurns: 5,
+);
+
+const _context = AgentPracticeContext(threadId: _threadId, matterId: _matterId);
+
+const _userId = 'user-1';
+const _targetId = 'target-1';
+const _profileId = 'profile-1';
+const _snapshotId = 'snapshot-1';
+const _planId = 'plan-1';
+const _sessionId = 'session-1';
+const _threadId = 'thread-1';
+const _matterId = 'matter-1';
+const _scenarioId = 'scenario-1';
+const _roleId = 'role-1';
+const _optionId = 'option-1';
+const _background = 'Built reliable Go services for three years.';

--- a/mobile/test/preparation/job_preparation_draft_store_test.dart
+++ b/mobile/test/preparation/job_preparation_draft_store_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
+import 'package:speakup/identity/session_store.dart';
+
+void main() {
+  test('secure draft keys and values stay isolated by account', () async {
+    final adapter = _MemorySecureStorageAdapter();
+    final store = SecureJobPreparationDraftStore(adapter);
+
+    await store.write('user-1', '{"draft":1}');
+    await store.write('user:2', '{"draft":2}');
+
+    expect(await store.read('user-1'), '{"draft":1}');
+    expect(await store.read('user:2'), '{"draft":2}');
+    expect(adapter.values, hasLength(2));
+    expect(adapter.values.keys.toSet(), hasLength(2));
+    expect(
+      adapter.values.keys,
+      everyElement(startsWith('job_preparation_draft_v1_')),
+    );
+    expect(adapter.values.keys.join(' '), isNot(contains('user-1')));
+  });
+
+  test('deleting one account never removes another account draft', () async {
+    final adapter = _MemorySecureStorageAdapter();
+    final store = SecureJobPreparationDraftStore(adapter);
+    await store.write('user-1', 'first');
+    await store.write('user-2', 'second');
+
+    await store.delete('user-1');
+
+    expect(await store.read('user-1'), isNull);
+    expect(await store.read('user-2'), 'second');
+  });
+
+  test(
+    'memory store supports deterministic restart and logout tests',
+    () async {
+      final store = MemoryJobPreparationDraftStore();
+
+      await store.write('user-1', 'draft');
+      expect(await store.read('user-1'), 'draft');
+      expect(await store.read('user-2'), isNull);
+
+      await store.delete('user-1');
+      expect(await store.read('user-1'), isNull);
+    },
+  );
+}
+
+final class _MemorySecureStorageAdapter implements SecureStorageAdapter {
+  final Map<String, String> values = <String, String>{};
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    values.remove(key);
+  }
+}

--- a/mobile/test/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/preparation/job_preparation_wizard_test.dart
@@ -1,0 +1,630 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/job_preparation_client.dart';
+import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/job_preparation_wizard.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/preparation_models.dart';
+
+void main() {
+  testWidgets('starts with JD-first input and labels quick start honestly', (
+    tester,
+  ) async {
+    final controller = JobPreparationController(
+      client: _WizardClient(),
+      threadIdProvider: () => 'thread-1',
+      matterActivator:
+          ({
+            required threadId,
+            required candidate,
+            required clientOperationId,
+          }) async =>
+              AgentPracticeContext(threadId: threadId, matterId: 'matter-1'),
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: JobPreparationWizard(controller: controller)),
+    );
+
+    expect(find.byKey(const Key('job-wizard-input-step')), findsOneWidget);
+    expect(find.byKey(const Key('job-description-field')), findsOneWidget);
+    expect(find.byKey(const Key('job-title-field')), findsNothing);
+
+    await tester.tap(find.text('岗位快速开始'));
+    await tester.pump();
+
+    expect(find.byKey(const Key('job-title-field')), findsOneWidget);
+    expect(find.text('快速开始不会基于真实 JD，只会提供通用岗位建议。'), findsOneWidget);
+  });
+
+  testWidgets('runs confirmation and preview before one explicit start', (
+    tester,
+  ) async {
+    final pendingSession = Completer<PreparationPracticeBootstrap>();
+    final client = _WizardClient(sessionCompleter: pendingSession);
+    var voiceCalls = 0;
+    var opened = 0;
+    final controller = _controller(
+      client,
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {
+            voiceCalls++;
+          },
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: JobPreparationWizard(
+          controller: controller,
+          onPracticeStarted: () => opened++,
+        ),
+      ),
+    );
+    await tester.enterText(
+      find.byKey(const Key('job-description-field')),
+      'Build reliable Go APIs and explain system design trade-offs.',
+    );
+    await tester.enterText(
+      find.byKey(const Key('job-background-field')),
+      _background,
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('analyze-job-button'),
+      scrollable: const Key('job-wizard-input-step'),
+    );
+    await tester.tap(find.byKey(const Key('analyze-job-button')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('job-wizard-confirmation-step')),
+      findsOneWidget,
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('confirm-job-analysis-button'),
+      scrollable: const Key('job-wizard-confirmation-step'),
+    );
+    await tester.tap(find.byKey(const Key('confirm-job-analysis-button')));
+    await tester.pump();
+    expect(find.byKey(const Key('job-wizard-setup-step')), findsOneWidget);
+
+    await _scrollTo(
+      tester,
+      target: const Key('create-plan-preview-button'),
+      scrollable: const Key('job-wizard-setup-step'),
+    );
+    await tester.tap(find.byKey(const Key('create-plan-preview-button')));
+    await tester.pump();
+    expect(find.byKey(const Key('job-wizard-preview-step')), findsOneWidget);
+    expect(client.sessionCalls, 0);
+
+    await _scrollTo(
+      tester,
+      target: const Key('start-job-practice-button'),
+      scrollable: const Key('job-wizard-preview-step'),
+    );
+    await tester.tap(find.byKey(const Key('start-job-practice-button')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('start-job-practice-button')));
+    expect(client.sessionCalls, 1);
+    pendingSession.complete(_bootstrap);
+    await tester.pump();
+    await tester.pump();
+
+    expect(voiceCalls, 1);
+    expect(opened, 1);
+  });
+
+  testWidgets('voice retry reuses committed Session', (tester) async {
+    final client = _WizardClient();
+    var voiceCalls = 0;
+    final controller = _controller(
+      client,
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {
+            voiceCalls++;
+            if (voiceCalls == 1) {
+              throw StateError('voice unavailable');
+            }
+          },
+    );
+    addTearDown(controller.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+    await controller.confirm();
+    await controller.createPreview();
+
+    await tester.pumpWidget(
+      MaterialApp(home: JobPreparationWizard(controller: controller)),
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('start-job-practice-button'),
+      scrollable: const Key('job-wizard-preview-step'),
+    );
+    await tester.tap(find.byKey(const Key('start-job-practice-button')));
+    await tester.pumpAndSettle();
+    await _scrollTo(
+      tester,
+      target: const Key('start-job-practice-button'),
+      scrollable: const Key('job-wizard-preview-step'),
+    );
+    expect(find.text('重新连接语音练习'), findsOneWidget);
+    expect(find.byKey(const Key('job-preview-error')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('start-job-practice-button')));
+    await tester.pump();
+
+    expect(client.sessionCalls, 1);
+    expect(voiceCalls, 2);
+  });
+
+  testWidgets('narrow screen, keyboard and 2x text remain usable', (
+    tester,
+  ) async {
+    final controller = _controller(_WizardClient());
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: Size(320, 640),
+          textScaler: TextScaler.linear(2),
+        ),
+        child: MaterialApp(home: JobPreparationWizard(controller: controller)),
+      ),
+    );
+    await tester.tap(find.text('岗位快速开始'));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('job-title-field')));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    final semantics = tester.getSemantics(
+      find.byKey(const Key('quick-start-notice')),
+    );
+    expect(semantics.label, contains('快速开始不会基于真实 JD'));
+    await _scrollTo(
+      tester,
+      target: const Key('analyze-job-button'),
+      scrollable: const Key('job-wizard-input-step'),
+    );
+    expect(find.byKey(const Key('analyze-job-button')), findsOneWidget);
+  });
+}
+
+Future<void> _scrollTo(
+  WidgetTester tester, {
+  required Key target,
+  required Key scrollable,
+}) async {
+  await tester.scrollUntilVisible(
+    find.byKey(target),
+    260,
+    scrollable: find
+        .descendant(
+          of: find.byKey(scrollable),
+          matching: find.byType(Scrollable),
+        )
+        .first,
+    maxScrolls: 12,
+  );
+  await tester.pump();
+}
+
+JobPreparationController _controller(
+  _WizardClient client, {
+  JobPreparationVoiceActivator? voiceActivator,
+}) {
+  var sequence = 0;
+  return JobPreparationController(
+    client: client,
+    threadIdProvider: () => _threadId,
+    matterActivator:
+        ({
+          required threadId,
+          required candidate,
+          required clientOperationId,
+        }) async =>
+            AgentPracticeContext(threadId: threadId, matterId: _matterId),
+    voiceActivator:
+        voiceActivator ??
+        ({
+          required context,
+          required bootstrap,
+          required clientOperationId,
+        }) async {},
+    idFactory: (scope) => '$scope-widget-${++sequence}',
+    analysisPollInterval: Duration.zero,
+  );
+}
+
+final class _WizardClient implements JobPreparationClient {
+  _WizardClient({this.sessionCompleter});
+
+  final Completer<PreparationPracticeBootstrap>? sessionCompleter;
+  JobTarget? _target;
+  JobPreparationSnapshot? _snapshotValue;
+  JobPracticePlanPreview? _planValue;
+  int sessionCalls = 0;
+
+  @override
+  Future<JobTarget> analyzeJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async {
+    _target = _targetFor(
+      JobTargetStage.awaitingConfirmation,
+      input: _target?.input ?? _input,
+    );
+    return _target!;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<JobTarget> confirmJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required int expectedAnalysisVersion,
+    required JobTargetCandidate candidate,
+    required String idempotencyKey,
+  }) async {
+    _target = _targetFor(
+      JobTargetStage.confirmed,
+      input: _target?.input ?? _input,
+      confirmedCandidate: candidate,
+    );
+    return _target!;
+  }
+
+  @override
+  Future<JobPreparationProfile> createProfileForJobTarget({
+    required String backgroundSummary,
+    required String jobTargetId,
+    required int jobTargetConfirmationVersion,
+    required String idempotencyKey,
+  }) async => _profile;
+
+  @override
+  Future<JobPracticePlanPreview> createJobPracticePlan({
+    required AgentPracticeContext context,
+    required String preparationSnapshotId,
+    required String idempotencyKey,
+  }) async {
+    final snapshot = _snapshotValue ?? _snapshot;
+    _planValue = _planFrom(snapshot: snapshot, context: context, revision: 1);
+    return _planValue!;
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createJobPracticeSession({
+    required JobPracticePlanPreview plan,
+    required String idempotencyKey,
+  }) async {
+    sessionCalls++;
+    return sessionCompleter?.future ?? _bootstrap;
+  }
+
+  @override
+  Future<JobPreparationSnapshot> createJobPreparationSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    final target = _target ?? _targetFor(JobTargetStage.confirmed);
+    final candidate =
+        target.confirmation?.candidate ?? _candidateFor(target.input.source);
+    _snapshotValue = JobPreparationSnapshot(
+      id: _snapshotId,
+      sourceProfileId: _profileId,
+      sourceVersion: 1,
+      sourceJobTargetId: target.id,
+      sourceJobTargetConfirmationVersion: 1,
+      jobTargetInput: target.input,
+      jobTargetCandidate: candidate,
+      backgroundSnapshot: target.input.candidateBackground ?? _background,
+      createdAt: _now,
+    );
+    return _snapshotValue!;
+  }
+
+  @override
+  Future<JobTarget> createJobTarget({
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    _target = _targetFor(JobTargetStage.draft, input: input);
+    return _target!;
+  }
+
+  @override
+  Future<JobTarget> discardJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required String idempotencyKey,
+  }) async =>
+      _targetFor(JobTargetStage.discarded, input: _target?.input ?? _input);
+
+  @override
+  Future<JobPracticePlanPreview> getJobPracticePlan(String planId) async =>
+      _planValue ?? _plan;
+
+  @override
+  Future<JobTarget> getJobTarget(String jobTargetId) async =>
+      _target ?? _targetFor(JobTargetStage.awaitingConfirmation);
+
+  @override
+  Future<JobPracticePlanPreview> reviseJobPracticePlan({
+    required String planId,
+    required int expectedPlanRevision,
+    required String roleDefinitionId,
+    required String practiceOptionId,
+    required int practiceOptionVersion,
+    required int maxEffectiveTurns,
+    required String idempotencyKey,
+  }) async {
+    final current = _planValue ?? _plan;
+    _planValue = _planFrom(
+      snapshot: current.preparationSnapshot,
+      context: current.context,
+      revision: expectedPlanRevision + 1,
+    );
+    return _planValue!;
+  }
+
+  @override
+  Future<JobTarget> updateJobTarget({
+    required String jobTargetId,
+    required int expectedInputVersion,
+    required JobTargetInput input,
+    required String idempotencyKey,
+  }) async {
+    _target = _targetFor(JobTargetStage.draft, input: input);
+    return _target!;
+  }
+}
+
+JobTarget _targetFor(
+  JobTargetStage stage, {
+  JobTargetInput input = _input,
+  JobTargetCandidate? confirmedCandidate,
+}) {
+  final analysis = switch (stage) {
+    JobTargetStage.parsing => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.running,
+      startedAt: _now,
+    ),
+    JobTargetStage.awaitingConfirmation ||
+    JobTargetStage.confirmed => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.succeeded,
+      candidate: _candidateFor(input.source),
+      startedAt: _now,
+      finishedAt: _now,
+    ),
+    JobTargetStage.analysisFailed => JobTargetAnalysis(
+      inputVersion: 1,
+      analysisVersion: 1,
+      attempt: 1,
+      status: JobTargetAnalysisStatus.failed,
+      stableErrorCategory: 'provider_unavailable',
+      startedAt: _now,
+      finishedAt: _now,
+    ),
+    JobTargetStage.draft || JobTargetStage.discarded => null,
+  };
+  return JobTarget(
+    id: _targetId,
+    userId: _userId,
+    input: input,
+    inputVersion: 1,
+    stage: stage,
+    analysis: analysis,
+    confirmation: stage == JobTargetStage.confirmed
+        ? JobTargetConfirmation(
+            inputVersion: 1,
+            analysisVersion: 1,
+            confirmationVersion: 1,
+            candidate: confirmedCandidate ?? _candidateFor(input.source),
+            confirmedAt: _now,
+          )
+        : null,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+JobTargetCandidate _candidateFor(JobTargetSource source) => JobTargetCandidate(
+  source: source,
+  generalAdviceOnly: source == JobTargetSource.quickStart,
+  jobTitle: 'Backend engineer',
+  seniority: 'Senior',
+  responsibilities: const ['Build reliable APIs'],
+  coreSkills: const ['Go services'],
+  communicationFocus: const ['Explain trade-offs'],
+  practiceGoals: const ['System design'],
+  scopeNotice: source == JobTargetSource.quickStart
+      ? 'Not based on a real JD.'
+      : 'Based on the supplied JD.',
+  catalogRecommendation: const JobTargetCatalogRecommendation(
+    scenarioDefinitionId: _scenarioId,
+    scenarioDefinitionVersion: 1,
+    selectedRoleIds: [_roleId],
+    practiceOptionId: _optionId,
+    practiceOptionVersion: 1,
+  ),
+);
+
+JobPracticePlanPreview _planWithRevision(int revision) => _planFrom(
+  snapshot: _snapshot,
+  context: const AgentPracticeContext(threadId: _threadId, matterId: _matterId),
+  revision: revision,
+);
+
+JobPracticePlanPreview _planFrom({
+  required JobPreparationSnapshot snapshot,
+  required AgentPracticeContext context,
+  required int revision,
+}) => JobPracticePlanPreview(
+  id: _planId,
+  userId: _userId,
+  context: context,
+  preparationProfileId: _profileId,
+  preparationSnapshot: snapshot,
+  catalog: _catalog,
+  sessionPolicy: _policy,
+  practiceFocuses: _objectives,
+  revision: revision,
+  status: 'ready',
+  createdAt: _now,
+  updatedAt: _now,
+);
+
+final _now = DateTime.utc(2026, 7, 26, 12);
+
+const _input = JobTargetInput(
+  source: JobTargetSource.jobDescription,
+  jobDescription: 'Build reliable APIs and explain trade-offs.',
+  candidateBackground: _background,
+);
+
+final _profile = JobPreparationProfile(
+  id: _profileId,
+  userId: _userId,
+  backgroundSummary: _background,
+  jobTargetId: _targetId,
+  jobTargetConfirmationVersion: 1,
+  version: 1,
+  updatedAt: _now,
+);
+
+final _snapshot = JobPreparationSnapshot(
+  id: _snapshotId,
+  sourceProfileId: _profileId,
+  sourceVersion: 1,
+  sourceJobTargetId: _targetId,
+  sourceJobTargetConfirmationVersion: 1,
+  jobTargetInput: _input,
+  jobTargetCandidate: _candidateFor(JobTargetSource.jobDescription),
+  backgroundSnapshot: _background,
+  createdAt: _now,
+);
+
+const _scenario = PreparationScenario(
+  id: _scenarioId,
+  type: 'INTERVIEW',
+  name: 'Technical interview',
+  version: 1,
+  status: 'active',
+);
+
+const _config = PreparationScenarioConfig(
+  id: 'config-1',
+  scenarioId: _scenarioId,
+  type: 'INTERVIEW',
+  version: 1,
+  jobTitle: 'Backend engineer',
+  jobDescription: 'Explain trade-offs.',
+  focusAreas: ['system_design'],
+);
+
+const _role = PreparationRole(
+  id: _roleId,
+  scenarioId: _scenarioId,
+  type: 'TECHNICAL_INTERVIEWER',
+  displayName: 'Technical interviewer',
+  responsibilities: 'Probe technical depth.',
+  style: 'Precise',
+  focusAreas: ['system_design'],
+  version: 1,
+);
+
+const _option = PreparationOption(
+  id: _optionId,
+  scenarioId: _scenarioId,
+  type: PreparationOptionType.focus,
+  displayName: 'System design focus',
+  version: 1,
+  roleId: _roleId,
+);
+
+const _catalog = JobPlanCatalog(
+  scenario: _scenario,
+  config: _config,
+  selectedRole: _role,
+  practiceOption: _option,
+);
+
+const _objectives = [
+  JobPracticeObjective(
+    id: 'system_design',
+    description: 'Explain one design trade-off.',
+  ),
+];
+
+const _policy = JobSessionPolicy(
+  suggestedDurationSeconds: 720,
+  minEffectiveTurns: 2,
+  maxEffectiveTurns: 5,
+  coverageCheckpointTurn: 3,
+  maxFollowUpsPerQuestion: 2,
+  targetObjectives: _objectives,
+  earlyCompletionRule: 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+);
+
+final _plan = _planWithRevision(1);
+
+final _bootstrap = PreparationPracticeBootstrap(
+  session: PreparationPracticeSession(
+    id: _sessionId,
+    planId: _planId,
+    scenarioType: 'INTERVIEW',
+    snapshotId: _snapshotId,
+    status: 'starting',
+    version: 1,
+    createdAt: _now,
+  ),
+  preparationSnapshotId: _snapshotId,
+  maxEffectiveTurns: 5,
+);
+
+const _background = 'Built reliable Go services for three years.';
+const _userId = 'user-1';
+const _targetId = 'target-1';
+const _profileId = 'profile-1';
+const _snapshotId = 'snapshot-1';
+const _planId = 'plan-1';
+const _sessionId = 'session-1';
+const _threadId = 'thread-1';
+const _matterId = 'matter-1';
+const _scenarioId = 'scenario-1';
+const _roleId = 'role-1';
+const _optionId = 'option-1';

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -49,6 +49,33 @@ void main() {
     },
   );
 
+  testWidgets('only the interview topic opens JD-first when catalog grows', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _MultiScenarioClient());
+    addTearDown(controller.dispose);
+    var opens = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: controller,
+          onOpenJobPreparation: () => opens++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('catalog-scenario-scn_general_speaking')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(opens, 0);
+    expect(controller.selectedScenario?.id, 'scn_general_speaking');
+    expect(find.text('General speaking practice'), findsOneWidget);
+  });
+
   testWidgets(
     'loads the server catalog and keeps perspectives independent of stages',
     (tester) async {
@@ -726,6 +753,25 @@ class _FixtureClient implements PreparationCatalogClient {
   Future<List<PreparationRole>> listRoles(String scenarioId) async => _roles;
 }
 
+final class _MultiScenarioClient implements PreparationCatalogClient {
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PreparationScenarioDetail> getScenario(String scenarioId) async =>
+      scenarioId == _scenarioId ? _detail : _otherDetail;
+
+  @override
+  Future<List<PreparationScenario>> listScenarios() async => const [
+    _scenario,
+    _otherScenario,
+  ];
+
+  @override
+  Future<List<PreparationRole>> listRoles(String scenarioId) async =>
+      scenarioId == _scenarioId ? _roles : const [_otherRole];
+}
+
 final class _ControlledListClient implements PreparationCatalogClient {
   final Completer<List<PreparationScenario>> first =
       Completer<List<PreparationScenario>>();
@@ -847,6 +893,55 @@ const _scenario = PreparationScenario(
   name: 'English interview for technical roles',
   version: 1,
   status: 'active',
+);
+
+const _otherScenario = PreparationScenario(
+  id: 'scn_general_speaking',
+  type: 'GENERAL',
+  name: 'General speaking practice',
+  version: 1,
+  status: 'active',
+);
+
+const _otherRole = PreparationRole(
+  id: 'role_general_coach',
+  scenarioId: 'scn_general_speaking',
+  type: 'COACH',
+  displayName: 'Speaking coach',
+  responsibilities: 'Guide a focused conversation.',
+  style: 'Supportive.',
+  focusAreas: ['fluency'],
+  version: 1,
+);
+
+const _otherDetail = PreparationScenarioDetail(
+  scenario: _otherScenario,
+  config: PreparationScenarioConfig(
+    id: 'scfg_general_speaking',
+    scenarioId: 'scn_general_speaking',
+    type: 'GENERAL',
+    version: 1,
+    jobTitle: 'General speaking',
+    jobDescription: 'Practice everyday spoken English.',
+    focusAreas: ['fluency'],
+  ),
+  options: [
+    PreparationOption(
+      id: 'option_general_full',
+      scenarioId: 'scn_general_speaking',
+      type: PreparationOptionType.fullSimulation,
+      displayName: 'Full practice',
+      version: 1,
+    ),
+    PreparationOption(
+      id: 'option_general_focus',
+      scenarioId: 'scn_general_speaking',
+      roleId: 'role_general_coach',
+      type: PreparationOptionType.focus,
+      displayName: 'Fluency focus',
+      version: 1,
+    ),
+  ],
 );
 
 const _config = PreparationScenarioConfig(

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -16,6 +16,40 @@ import 'package:speakup/features/preparation/preparation_models.dart';
 
 void main() {
   testWidgets(
+    'product training center shows server topic before opening JD-first',
+    (tester) async {
+      final controller = PreparationController(client: _FixtureClient());
+      addTearDown(controller.dispose);
+      var opens = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            preparationController: controller,
+            onOpenJobPreparation: () => opens++,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('training-center-title')), findsOneWidget);
+      expect(find.text('练习中心'), findsOneWidget);
+      expect(find.byKey(const Key('training-catalog-status')), findsOneWidget);
+      expect(find.text('可用'), findsOneWidget);
+      expect(
+        find.text('English interview for technical roles'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+      await tester.pump();
+
+      expect(opens, 1);
+      expect(controller.selectedScenario, isNull);
+    },
+  );
+
+  testWidgets(
     'loads the server catalog and keeps perspectives independent of stages',
     (tester) async {
       final controller = PreparationController(client: _FixtureClient());
@@ -26,8 +60,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('通用职业英语 Agent'), findsOneWidget);
-      expect(find.textContaining('技术岗位英文面试'), findsOneWidget);
+      expect(find.text('练习中心'), findsOneWidget);
+      expect(find.textContaining('当前先把英文面试做深'), findsOneWidget);
       await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
       await tester.pumpAndSettle();
 

--- a/mobile/test/preparation/wire_job_preparation_client_test.dart
+++ b/mobile/test/preparation/wire_job_preparation_client_test.dart
@@ -1,0 +1,840 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/preparation/job_preparation_models.dart';
+import 'package:speakup/features/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/preparation/wire_job_preparation_client.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+
+void main() {
+  test(
+    'runs the exact JD-first wire chain without creating Session early',
+    () async {
+      final transport = _QueueTransport(<IdentityHttpResponse>[
+        _response(HttpStatus.created, _targetJson(JobTargetStage.draft)),
+        _response(
+          HttpStatus.ok,
+          _targetJson(JobTargetStage.awaitingConfirmation),
+        ),
+        _response(HttpStatus.ok, _targetJson(JobTargetStage.confirmed)),
+        _response(HttpStatus.created, _profileJson()),
+        _response(HttpStatus.created, _preparationSnapshotJson()),
+        _response(HttpStatus.created, _planJson()),
+        _response(HttpStatus.created, _bootstrapJson()),
+      ]);
+      final client = _client(transport);
+
+      final draft = await client.createJobTarget(
+        input: _input,
+        idempotencyKey: 'target-create-key',
+      );
+      final analyzed = await client.analyzeJobTarget(
+        jobTargetId: draft.id,
+        expectedInputVersion: draft.inputVersion,
+        idempotencyKey: 'target-analysis-key',
+      );
+      final confirmed = await client.confirmJobTarget(
+        jobTargetId: analyzed.id,
+        expectedInputVersion: analyzed.inputVersion,
+        expectedAnalysisVersion: analyzed.analysis!.analysisVersion,
+        candidate: analyzed.analysis!.candidate!,
+        idempotencyKey: 'target-confirm-key',
+      );
+      final profile = await client.createProfileForJobTarget(
+        backgroundSummary: _background,
+        jobTargetId: confirmed.id,
+        jobTargetConfirmationVersion:
+            confirmed.confirmation!.confirmationVersion,
+        idempotencyKey: 'target-profile-key',
+      );
+      final snapshot = await client.createJobPreparationSnapshot(
+        profileId: profile.id,
+        sourceVersion: profile.version,
+        idempotencyKey: 'target-snapshot-key',
+      );
+      final plan = await client.createJobPracticePlan(
+        context: _context,
+        preparationSnapshotId: snapshot.id,
+        idempotencyKey: 'target-plan-key',
+      );
+
+      expect(transport.calls, hasLength(6));
+      expect(
+        transport.calls.where(
+          (call) => call.uri.path.endsWith('/practice-sessions'),
+        ),
+        isEmpty,
+      );
+      expect(plan.sessionPolicy.maxEffectiveTurns, 5);
+      expect(jsonDecode(transport.calls[3].body!), <String, Object?>{
+        'background_summary': _background,
+        'job_target_id': _targetId,
+        'job_target_confirmation_version': 1,
+      });
+      expect(jsonDecode(transport.calls[5].body!), <String, Object?>{
+        'agent_thread_id': _threadId,
+        'matter_id': _matterId,
+        'preparation_snapshot_id': _preparationSnapshotId,
+      });
+
+      final bootstrap = await client.createJobPracticeSession(
+        plan: plan,
+        idempotencyKey: 'target-session-key',
+      );
+
+      expect(bootstrap.session.id, _sessionId);
+      expect(transport.calls, hasLength(7));
+      expect(jsonDecode(transport.calls.last.body!), <String, Object?>{
+        'expected_plan_revision': 1,
+      });
+      expect(
+        transport.calls.last.body,
+        isNot(
+          anyOf(
+            contains('role_definition_ids'),
+            contains('practice_option_id'),
+          ),
+        ),
+      );
+      for (final call in transport.calls) {
+        expect(
+          call.headers[HttpHeaders.authorizationHeader],
+          'Bearer sess_account-a',
+        );
+        if (call.method != 'GET') {
+          expect(call.headers['Idempotency-Key'], isNotEmpty);
+        }
+      }
+    },
+  );
+
+  test('quick-start sends no invented job description', () async {
+    final response = _targetJson(JobTargetStage.draft, input: _quickInput);
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.created, response),
+    ]);
+    final client = _client(transport);
+
+    await client.createJobTarget(
+      input: _quickInput,
+      idempotencyKey: 'quick-target-key',
+    );
+
+    expect(jsonDecode(transport.calls.single.body!), <String, Object?>{
+      'source': 'quick_start',
+      'job_title': 'Backend engineer',
+      'candidate_background': _background,
+    });
+  });
+
+  test('accepts 202 only for a parsing projection and polls by GET', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.accepted, _targetJson(JobTargetStage.parsing)),
+      _response(
+        HttpStatus.ok,
+        _targetJson(JobTargetStage.awaitingConfirmation),
+      ),
+    ]);
+    final client = _client(transport);
+
+    final parsing = await client.analyzeJobTarget(
+      jobTargetId: _targetId,
+      expectedInputVersion: 1,
+      idempotencyKey: 'analysis-poll-key',
+    );
+    final completed = await client.getJobTarget(parsing.id);
+
+    expect(parsing.stage, JobTargetStage.parsing);
+    expect(completed.stage, JobTargetStage.awaitingConfirmation);
+    expect(transport.calls.last.method, 'GET');
+    expect(transport.calls.last.headers['Idempotency-Key'], isNull);
+  });
+
+  test(
+    'revises only server catalog identities and server turn budget',
+    () async {
+      final revised = _planJson()..['plan_revision'] = 2;
+      final transport = _QueueTransport(<IdentityHttpResponse>[
+        _response(HttpStatus.ok, revised),
+      ]);
+      final client = _client(transport);
+
+      final plan = await client.reviseJobPracticePlan(
+        planId: _planId,
+        expectedPlanRevision: 1,
+        roleDefinitionId: _roleId,
+        practiceOptionId: _optionId,
+        practiceOptionVersion: 1,
+        maxEffectiveTurns: 5,
+        idempotencyKey: 'plan-revision-key',
+      );
+
+      expect(plan.revision, 2);
+      expect(jsonDecode(transport.calls.single.body!), <String, Object?>{
+        'expected_plan_revision': 1,
+        'selected_role_ids': <String>[_roleId],
+        'practice_option_id': _optionId,
+        'practice_option_version': 1,
+        'max_effective_turns': 5,
+      });
+    },
+  );
+
+  group('strict JobTarget decoder', () {
+    final cases = <String, void Function(Map<String, Object?>)>{
+      'unknown root field': (target) => target['invented'] = true,
+      'draft analysis': (target) {
+        target['analysis'] = _analysisJson(JobTargetAnalysisStatus.running);
+      },
+      'parsing without running analysis': (target) {
+        target
+          ..['stage'] = 'parsing'
+          ..remove('analysis');
+      },
+      'succeeded analysis without candidate': (target) {
+        target['stage'] = 'awaiting_confirmation';
+        target['analysis'] = _analysisJson(JobTargetAnalysisStatus.succeeded)
+          ..remove('candidate');
+      },
+      'confirmation version mismatch': (target) {
+        target['confirmation'] = _confirmationJson()..['analysis_version'] = 2;
+      },
+      'candidate source mismatch': (target) {
+        final confirmation = target['confirmation']! as Map<String, Object?>;
+        final candidate = confirmation['candidate']! as Map<String, Object?>;
+        candidate
+          ..['source'] = 'quick_start'
+          ..['general_advice_only'] = true;
+      },
+    };
+
+    for (final entry in cases.entries) {
+      test(entry.key, () async {
+        final value = _targetJson(JobTargetStage.confirmed);
+        entry.value(value);
+        final client = _client(
+          _QueueTransport(<IdentityHttpResponse>[
+            _response(HttpStatus.ok, value),
+          ]),
+        );
+
+        await expectLater(
+          client.getJobTarget(_targetId),
+          throwsA(_invalidResponse),
+        );
+      });
+    }
+  });
+
+  group('strict targeted Profile and Snapshot decoder', () {
+    final cases = <String, Map<String, Object?> Function()>{
+      'profile missing confirmation pair': () =>
+          _profileJson()..remove('job_target_confirmation_version'),
+      'profile accepts no legacy resume field': () =>
+          _profileJson()..['resume_ref'] = 'resume-local',
+      'snapshot missing candidate snapshot': () =>
+          _preparationSnapshotJson()..remove('job_target_candidate_snapshot'),
+      'snapshot candidate source mismatch': () {
+        final value = _preparationSnapshotJson();
+        final candidate =
+            value['job_target_candidate_snapshot']! as Map<String, Object?>;
+        candidate
+          ..['source'] = 'quick_start'
+          ..['general_advice_only'] = true;
+        return value;
+      },
+      'snapshot accepts no legacy JD snapshot': () =>
+          _preparationSnapshotJson()
+            ..['job_description_snapshot'] = 'Legacy value',
+    };
+
+    for (final entry in cases.entries) {
+      test(entry.key, () async {
+        final isProfile = entry.key.startsWith('profile');
+        final client = _client(
+          _QueueTransport(<IdentityHttpResponse>[
+            _response(HttpStatus.created, entry.value()),
+          ]),
+        );
+
+        final operation = isProfile
+            ? client.createProfileForJobTarget(
+                backgroundSummary: _background,
+                jobTargetId: _targetId,
+                jobTargetConfirmationVersion: 1,
+                idempotencyKey: 'invalid-profile-key',
+              )
+            : client.createJobPreparationSnapshot(
+                profileId: _profileId,
+                sourceVersion: 1,
+                idempotencyKey: 'invalid-snapshot-key',
+              );
+        await expectLater(operation, throwsA(_invalidResponse));
+      });
+    }
+  });
+
+  group('strict targeted Plan decoder', () {
+    final cases = <String, void Function(Map<String, Object?>)>{
+      'missing targeted optional group': (plan) {
+        plan.remove('session_policy');
+      },
+      'selected role differs from catalog': (plan) {
+        plan['selected_role_ids'] = <String>['role-other'];
+      },
+      'scenario differs from catalog': (plan) {
+        plan['scenario_definition_id'] = 'scenario-other';
+      },
+      'profile differs from snapshot': (plan) {
+        plan['preparation_profile_id'] = 'profile-other';
+      },
+      'focus option differs from selected role': (plan) {
+        final catalog = plan['catalog_snapshot']! as Map<String, Object?>;
+        final option = catalog['practice_option']! as Map<String, Object?>;
+        option['role_definition_id'] = 'role-other';
+      },
+      'policy checkpoint exceeds max': (plan) {
+        final policy = plan['session_policy']! as Map<String, Object?>;
+        policy['coverage_checkpoint_turn'] = 6;
+      },
+      'duplicate objective identity': (plan) {
+        final policy = plan['session_policy']! as Map<String, Object?>;
+        final objectives = policy['target_objectives']! as List<Object?>;
+        objectives.add(_clone(objectives.single));
+      },
+    };
+
+    for (final entry in cases.entries) {
+      test(entry.key, () async {
+        final value = _planJson();
+        entry.value(value);
+        final client = _client(
+          _QueueTransport(<IdentityHttpResponse>[
+            _response(HttpStatus.created, value),
+          ]),
+        );
+
+        await expectLater(
+          client.createJobPracticePlan(
+            context: _context,
+            preparationSnapshotId: _preparationSnapshotId,
+            idempotencyKey: 'invalid-plan-key',
+          ),
+          throwsA(_invalidResponse),
+        );
+      });
+    }
+  });
+
+  group('strict targeted Session decoder', () {
+    final cases = <String, void Function(Map<String, Object?>)>{
+      'plan revision mismatch': (root) {
+        _sessionSnapshot(root)['plan_revision'] = 2;
+      },
+      'candidate account mismatch': (root) {
+        _candidateSubject(root)['subject_id'] = 'user-other';
+      },
+      'role version mismatch': (root) {
+        _sessionRole(root)['version'] = 2;
+      },
+      'preparation confirmation mismatch': (root) {
+        _sessionPreparation(root)['source_job_target_confirmation_version'] = 2;
+      },
+      'policy content mismatch': (root) {
+        _sessionPolicy(root)['suggested_duration_seconds'] = 999;
+      },
+      'focus content mismatch': (root) {
+        final focuses =
+            _sessionSnapshot(root)['practice_focuses']! as List<Object?>;
+        (focuses.single as Map<String, Object?>)['description'] = 'Changed';
+      },
+      'unexpected session field': (root) {
+        final session = root['practice_session']! as Map<String, Object?>;
+        session['effective_turns'] = 0;
+      },
+    };
+
+    for (final entry in cases.entries) {
+      test(entry.key, () async {
+        final bootstrap = _bootstrapJson();
+        entry.value(bootstrap);
+        final transport = _QueueTransport(<IdentityHttpResponse>[
+          _response(HttpStatus.created, _planJson()),
+          _response(HttpStatus.created, bootstrap),
+        ]);
+        final client = _client(transport);
+        final plan = await client.createJobPracticePlan(
+          context: _context,
+          preparationSnapshotId: _preparationSnapshotId,
+          idempotencyKey: 'valid-plan-key',
+        );
+
+        await expectLater(
+          client.createJobPracticeSession(
+            plan: plan,
+            idempotencyKey: 'invalid-session-key',
+          ),
+          throwsA(_invalidResponse),
+        );
+      });
+    }
+  });
+
+  test('marks malformed 201 create responses retryable with stage', () async {
+    final client = _client(
+      _QueueTransport(<IdentityHttpResponse>[
+        IdentityHttpResponse(
+          statusCode: HttpStatus.created,
+          body: '{"truncated":',
+        ),
+      ]),
+    );
+
+    await expectLater(
+      client.createJobTarget(
+        input: _input,
+        idempotencyKey: 'ambiguous-create-key',
+      ),
+      throwsA(
+        isA<JobPreparationException>()
+            .having(
+              (error) => error.kind,
+              'kind',
+              JobPreparationFailureKind.invalidResponse,
+            )
+            .having(
+              (error) => error.stage,
+              'stage',
+              JobPreparationOperationStage.target,
+            )
+            .having((error) => error.statusCode, 'status', 201)
+            .having((error) => error.retryable, 'retryable', isTrue),
+      ),
+    );
+  });
+
+  test('fences a response arriving after account cleanup', () async {
+    final transport = _CompleterTransport();
+    final client = _client(transport);
+    final operation = client.createJobTarget(
+      input: _input,
+      idempotencyKey: 'late-target-key',
+    );
+
+    await client.clearAccountState();
+    transport.complete(
+      _response(HttpStatus.created, _targetJson(JobTargetStage.draft)),
+    );
+
+    await expectLater(
+      operation,
+      throwsA(
+        isA<JobPreparationException>().having(
+          (error) => error.kind,
+          'kind',
+          JobPreparationFailureKind.superseded,
+        ),
+      ),
+    );
+  });
+}
+
+WireJobPreparationClient _client(IdentityHttpTransport transport) {
+  const credential = AuthSessionCredential(
+    sessionToken: 'sess_account-a',
+    generation: 1,
+  );
+  return WireJobPreparationClient(
+    baseUri: Uri.parse('https://api.speak-up.top'),
+    credentialProvider: () => credential,
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) async {},
+    transport: transport,
+  );
+}
+
+Matcher get _invalidResponse => isA<JobPreparationException>().having(
+  (error) => error.kind,
+  'kind',
+  JobPreparationFailureKind.invalidResponse,
+);
+
+final class _Call {
+  const _Call({
+    required this.method,
+    required this.uri,
+    required this.headers,
+    this.body,
+  });
+
+  final String method;
+  final Uri uri;
+  final Map<String, String> headers;
+  final String? body;
+}
+
+final class _QueueTransport implements IdentityHttpTransport {
+  _QueueTransport(this.responses);
+
+  final List<IdentityHttpResponse> responses;
+  final List<_Call> calls = <_Call>[];
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    calls.add(
+      _Call(
+        method: method,
+        uri: uri,
+        headers: Map<String, String>.of(headers),
+        body: body,
+      ),
+    );
+    return responses.removeAt(0);
+  }
+}
+
+final class _CompleterTransport implements IdentityHttpTransport {
+  final Completer<IdentityHttpResponse> _completer =
+      Completer<IdentityHttpResponse>();
+
+  void complete(IdentityHttpResponse response) {
+    _completer.complete(response);
+  }
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) {
+    return _completer.future;
+  }
+}
+
+IdentityHttpResponse _response(int status, Map<String, Object?> body) {
+  return IdentityHttpResponse(statusCode: status, body: jsonEncode(body));
+}
+
+Map<String, Object?> _targetJson(
+  JobTargetStage stage, {
+  JobTargetInput input = _input,
+}) {
+  return <String, Object?>{
+    'job_target_id': _targetId,
+    'user_id': _userId,
+    'input': _inputJson(input),
+    'input_version': 1,
+    'stage': stage.wireValue,
+    if (stage == JobTargetStage.parsing)
+      'analysis': _analysisJson(JobTargetAnalysisStatus.running),
+    if (stage == JobTargetStage.analysisFailed)
+      'analysis': _analysisJson(JobTargetAnalysisStatus.failed),
+    if (stage == JobTargetStage.awaitingConfirmation ||
+        stage == JobTargetStage.confirmed)
+      'analysis': _analysisJson(JobTargetAnalysisStatus.succeeded),
+    if (stage == JobTargetStage.confirmed) 'confirmation': _confirmationJson(),
+    'created_at': _time,
+    'updated_at': _time,
+  };
+}
+
+Map<String, Object?> _inputJson(JobTargetInput input) {
+  return <String, Object?>{
+    'source': input.source.wireValue,
+    'job_title': ?input.jobTitle,
+    'job_description': ?input.jobDescription,
+    'company': ?input.company,
+    'seniority': ?input.seniority,
+    'candidate_background': ?input.candidateBackground,
+    'resume_ref': ?input.resumeRef,
+    'practice_focus': ?input.practiceFocus,
+  };
+}
+
+Map<String, Object?> _analysisJson(JobTargetAnalysisStatus status) {
+  return <String, Object?>{
+    'input_version': 1,
+    'analysis_version': 1,
+    'attempt': 1,
+    'status': status.wireValue,
+    if (status == JobTargetAnalysisStatus.succeeded)
+      'candidate': _candidateJson(),
+    if (status == JobTargetAnalysisStatus.failed)
+      'stable_error_category': 'provider_unavailable',
+    'started_at': _time,
+    if (status != JobTargetAnalysisStatus.running) 'finished_at': _time,
+  };
+}
+
+Map<String, Object?> _confirmationJson() {
+  return <String, Object?>{
+    'input_version': 1,
+    'analysis_version': 1,
+    'confirmation_version': 1,
+    'candidate': _candidateJson(),
+    'confirmed_at': _time,
+  };
+}
+
+Map<String, Object?> _candidateJson() {
+  return <String, Object?>{
+    'source': 'job_description',
+    'general_advice_only': false,
+    'job_title': 'Backend engineer',
+    'seniority': 'Senior',
+    'responsibilities': <String>['Build reliable APIs'],
+    'core_skills': <String>['Go services'],
+    'communication_focus': <String>['Explain trade-offs'],
+    'practice_goals': <String>['Practice a system design answer'],
+    'scope_notice': 'Based on the supplied job description.',
+    'catalog_recommendation': <String, Object?>{
+      'scenario_definition_id': _scenarioId,
+      'scenario_definition_version': 1,
+      'selected_role_ids': <String>[_roleId],
+      'practice_option_id': _optionId,
+      'practice_option_version': 1,
+    },
+  };
+}
+
+Map<String, Object?> _profileJson() {
+  return <String, Object?>{
+    'preparation_profile_id': _profileId,
+    'user_id': _userId,
+    'background_summary': _background,
+    'job_target_id': _targetId,
+    'job_target_confirmation_version': 1,
+    'version': 1,
+    'updated_at': _time,
+  };
+}
+
+Map<String, Object?> _preparationSnapshotJson() {
+  return <String, Object?>{
+    'preparation_snapshot_id': _preparationSnapshotId,
+    'source_profile_id': _profileId,
+    'source_version': 1,
+    'source_job_target_id': _targetId,
+    'source_job_target_confirmation_version': 1,
+    'job_target_input_snapshot': _inputJson(_input),
+    'job_target_candidate_snapshot': _candidateJson(),
+    'background_snapshot': _background,
+    'created_at': _time,
+  };
+}
+
+Map<String, Object?> _scenarioJson() {
+  return <String, Object?>{
+    'scenario_definition_id': _scenarioId,
+    'scenario_type': 'INTERVIEW',
+    'name': 'Technical interview',
+    'version': 1,
+    'status': 'active',
+  };
+}
+
+Map<String, Object?> _configJson() {
+  return <String, Object?>{
+    'scenario_config_id': _configId,
+    'scenario_definition_id': _scenarioId,
+    'config_type': 'INTERVIEW',
+    'version': 1,
+    'job_title': 'Backend engineer',
+    'job_description': 'Explain engineering decisions.',
+    'focus_areas': <String>['system_design'],
+  };
+}
+
+Map<String, Object?> _roleJson() {
+  return <String, Object?>{
+    'role_definition_id': _roleId,
+    'scenario_definition_id': _scenarioId,
+    'role_type': 'TECHNICAL_INTERVIEWER',
+    'display_name': 'Technical interviewer',
+    'responsibilities': 'Probe technical depth.',
+    'style': 'Precise',
+    'focus_areas': <String>['system_design'],
+    'version': 1,
+  };
+}
+
+Map<String, Object?> _optionJson() {
+  return <String, Object?>{
+    'practice_option_id': _optionId,
+    'scenario_definition_id': _scenarioId,
+    'role_definition_id': _roleId,
+    'practice_option_type': 'FOCUS',
+    'display_name': 'System design focus',
+    'version': 1,
+  };
+}
+
+Map<String, Object?> _policyJson() {
+  return <String, Object?>{
+    'suggested_duration_seconds': 720,
+    'min_effective_turns': 2,
+    'max_effective_turns': 5,
+    'coverage_checkpoint_turn': 3,
+    'max_follow_ups_per_question': 2,
+    'target_objectives': <Object?>[_objectiveJson()],
+    'early_completion_rule': 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+  };
+}
+
+Map<String, Object?> _objectiveJson() {
+  return <String, Object?>{
+    'objective_id': 'system_design',
+    'description': 'Explain one design trade-off.',
+  };
+}
+
+Map<String, Object?> _planJson() {
+  return <String, Object?>{
+    'practice_plan_id': _planId,
+    'user_id': _userId,
+    'agent_thread_id': _threadId,
+    'matter_id': _matterId,
+    'scenario_definition_id': _scenarioId,
+    'scenario_definition_version': 1,
+    'scenario_type': 'INTERVIEW',
+    'scenario_config_id': _configId,
+    'scenario_config_version': 1,
+    'preparation_profile_id': _profileId,
+    'selected_role_ids': <String>[_roleId],
+    'preparation_snapshot': _preparationSnapshotJson(),
+    'catalog_snapshot': <String, Object?>{
+      'scenario_definition': _scenarioJson(),
+      'scenario_config': _configJson(),
+      'selected_roles': <Object?>[_roleJson()],
+      'practice_option': _optionJson(),
+    },
+    'session_policy': _policyJson(),
+    'practice_focuses': <Object?>[_objectiveJson()],
+    'plan_revision': 1,
+    'practice_plan_status': 'ready',
+    'created_at': _time,
+    'updated_at': _time,
+  };
+}
+
+Map<String, Object?> _bootstrapJson() {
+  return <String, Object?>{
+    'practice_session': <String, Object?>{
+      'practice_session_id': _sessionId,
+      'practice_plan_id': _planId,
+      'scenario_type': 'INTERVIEW',
+      'snapshot_id': _sessionSnapshotId,
+      'practice_session_status': 'starting',
+      'session_version': 1,
+      'created_at': _time,
+    },
+    'snapshot': <String, Object?>{
+      'snapshot_id': _sessionSnapshotId,
+      'practice_session_id': _sessionId,
+      'plan_revision': 1,
+      'scenario_type': 'INTERVIEW',
+      'scenario_definition_snapshot': _scenarioJson(),
+      'scenario_config_snapshot': _configJson(),
+      'preparation_snapshot': _preparationSnapshotJson(),
+      'participants': <Object?>[
+        <String, Object?>{
+          'practice_participant_id': 'participant-interviewer',
+          'practice_session_id': _sessionId,
+          'participant_role': 'INTERVIEWER',
+          'subject_ref': <String, Object?>{
+            'namespace': 'mock.actor',
+            'subject_id': 'interviewer-technical',
+          },
+          'role_definition_id': _roleId,
+          'role_snapshot': _roleJson(),
+          'participant_order': 1,
+        },
+        <String, Object?>{
+          'practice_participant_id': 'participant-candidate',
+          'practice_session_id': _sessionId,
+          'participant_role': 'CANDIDATE',
+          'subject_ref': <String, Object?>{
+            'namespace': 'speakup.user',
+            'subject_id': _userId,
+          },
+          'participant_order': 2,
+        },
+      ],
+      'practice_option': _optionJson(),
+      'session_policy': _policyJson(),
+      'practice_focuses': <Object?>[_objectiveJson()],
+      'created_at': _time,
+    },
+  };
+}
+
+Map<String, Object?> _sessionSnapshot(Map<String, Object?> root) {
+  return root['snapshot']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _sessionPreparation(Map<String, Object?> root) {
+  return _sessionSnapshot(root)['preparation_snapshot']!
+      as Map<String, Object?>;
+}
+
+Map<String, Object?> _sessionPolicy(Map<String, Object?> root) {
+  return _sessionSnapshot(root)['session_policy']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _sessionRole(Map<String, Object?> root) {
+  final participants = _sessionSnapshot(root)['participants']! as List<Object?>;
+  final interviewer = participants.first as Map<String, Object?>;
+  return interviewer['role_snapshot']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _candidateSubject(Map<String, Object?> root) {
+  final participants = _sessionSnapshot(root)['participants']! as List<Object?>;
+  final candidate = participants.last as Map<String, Object?>;
+  return candidate['subject_ref']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _clone(Object? value) {
+  return jsonDecode(jsonEncode(value))! as Map<String, Object?>;
+}
+
+const _input = JobTargetInput(
+  source: JobTargetSource.jobDescription,
+  jobDescription: 'Build reliable APIs and explain engineering trade-offs.',
+  company: 'Example Co',
+  seniority: 'Senior',
+  candidateBackground: _background,
+  practiceFocus: 'System design communication',
+);
+
+const _quickInput = JobTargetInput(
+  source: JobTargetSource.quickStart,
+  jobTitle: 'Backend engineer',
+  candidateBackground: _background,
+);
+
+const _context = AgentPracticeContext(threadId: _threadId, matterId: _matterId);
+
+const _time = '2026-07-26T12:00:00Z';
+const _userId = 'user-1';
+const _targetId = 'target-1';
+const _profileId = 'profile-1';
+const _preparationSnapshotId = 'preparation-snapshot-1';
+const _planId = 'plan-1';
+const _sessionId = 'session-1';
+const _sessionSnapshotId = 'session-snapshot-1';
+const _threadId = 'thread-1';
+const _matterId = 'matter-1';
+const _scenarioId = 'scenario-1';
+const _configId = 'config-1';
+const _roleId = 'role-1';
+const _optionId = 'option-1';
+const _background = 'Built reliable Go services for three years.';

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -5,6 +5,7 @@ import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/app/app_routes.dart';
+import 'package:speakup/app/glass_navigation_bar.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/conversation/conversation.dart';
@@ -45,6 +46,7 @@ void main() {
       find.byKey(const Key('agent-composer-surface')),
     );
     final navigationRect = tester.getRect(navigation);
+    expect(navigationRect.height, closeTo(GlassNavigationBar.height, 0.1));
     expect(navigationRect.top - composerRect.bottom, closeTo(10, 1));
     expect(navigationRect.left, closeTo(composerRect.left, 1));
     expect(navigationRect.right, closeTo(composerRect.right, 1));

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -465,7 +465,7 @@ void main() {
 
     await _tapVisible(tester, 'quick-action-create-plan');
     expect(find.byKey(const Key('scenes-page')), findsOneWidget);
-    expect(find.text('本地 UI Mock；练习结果不会写入正式服务。'), findsOneWidget);
+    expect(find.text('预览练习专题与进入流程。'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('primary-tab-agent')));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 功能说明

实现 Issue #121 的 Flutter JD-first 面试准备向导，并把入口收敛到可扩展的训练中心：

- 首次流程按 `JD/岗位 → 解析 → 确认 → 设置 → Plan 预览 → 显式开始` 推进。
- 支持粘贴真实 JD，以及明确标注“未基于真实 JD”的岗位快速开始。
- 修改输入后使旧分析、确认与预览失效，避免使用过期方案创建练习。
- 训练底栏先进入训练中心；“英文求职面试”再打开既有 JD-first 向导。
- 训练中心为 IELTS、托福及后续专题保留扩展位置，但本 PR 不实现未冻结业务。
- 保留 #121 分支原有的 Agent Thread、语音 Practice 与 Review 接线，不引入 #118 的通用语音消息改动。

## 实现思路

- Flutter 只负责渐进式填写、状态展示和用户确认；岗位解析、目录与 Plan 仍由服务端返回。
- 浏览训练中心或返回修改不会创建 Session，只有用户在 Plan 预览后显式开始才进入既有 Practice。
- 训练页使用统一专题卡片状态；未开放专题明确展示“即将开放”，不会伪装成可用入口。
- 调整底部导航的文字与选中态层级，使首页、训练、复盘和我的保持同一套产品外壳。

## 本次定向验证

```bash
cd mobile
flutter analyze --no-pub
flutter test --no-pub \
  test/preparation/preparation_page_test.dart \
  test/preparation/job_preparation_wizard_test.dart \
  test/speak_up_app_test.dart \
  test/main_wiring_test.dart
git diff --check
```

结果：

- Flutter 静态分析通过，无问题。
- 31 条 Preparation、JD 向导、App Shell 与正式装配定向测试全部通过。
- 分支差异检查通过。

## 依赖与合入顺序

- 已接受 MiniSpec：#116。
- 后端前置：#119、#120。
- 协调：#88 / PR #95、#111 / PR #114。
- 当前 PR 保持 Draft；待前置任务进入 `dev` 后，从最新 `upstream/dev` 去栈并完成完整 Flutter、iOS Simulator 与真实链路验收，再转为 Ready。

### 当前 Database CI 阻塞

- Migration 定义、追加历史和完整升降级检查均已通过，不是迁移缺失或编号冲突。
- Database Job 稳定失败于 #120 引入的
  `TestContextRepositoryPersistsPreviewRevisionAndExplicitStart`：
  Plan 首次从 PostgreSQL 返回后使用本机时区表示时间，而幂等记录经 JSON
  重放后使用 UTC；测试使用 `reflect.DeepEqual` 比较整个 Plan，UTC Runner
  因 `time.Location` 不同而失败。
- 本地使用 `TZ=UTC` 定向运行可稳定复现；默认 Asia/Shanghai 下定向运行通过。
- 该问题属于 #120 的 PostgreSQL Repository/测试边界。#121 不复制或修改
  后端迁移与 Repository；待 #120 在自身分支统一时间表示并通过 Database CI
  后，再同步前置分支。

## 明确不做

- 不新增本地权威训练目录、后端接口或数据库字段。
- 不实现 IELTS、托福、实时语音或 Android。
- 不合入 #118 的通用 Agent 异步语音消息范围。

Closes #121
