### PR TITLE
[修复] 加固 Conversation 删除代际与错误码持久化边界

### DIFF
--- a/server/internal/conversation/postgres/repository.go
+++ b/server/internal/conversation/postgres/repository.go
@@ -1545,7 +1545,8 @@ func validProcessingFailureCode(code string) bool {
 		"provider_timeout",
 		"provider_unavailable",
 		"invalid_response",
-		"cancelled":
+		"cancelled",
+		"legacy_provider_failure":
 		return true
 	default:
 		return false

--- a/server/internal/conversation/postgres/repository.go
+++ b/server/internal/conversation/postgres/repository.go
@@ -486,7 +486,7 @@ func (r *Repository) FailTranscription(
 	failure conversation.ProcessingFailure,
 ) error {
 	if !validJob(job) ||
-		strings.TrimSpace(failure.Code) == "" ||
+		!validProcessingFailureCode(failure.Code) ||
 		failure.Duration < 0 {
 		return conversation.ErrPersistenceInvalid
 	}
@@ -1039,15 +1039,13 @@ func (r *Repository) DeleteUserData(
 		`SELECT account_status FROM identity_users WHERE id = $1 FOR UPDATE`,
 		deletion.OwnerUserID,
 	).Scan(&accountStatus)
-	if errors.Is(err, pgx.ErrNoRows) {
-		// A repeated coordinator call after final Identity removal is complete.
-		// The RESTRICT root foreign key guarantees no Question aggregate remains.
-		return nil
-	}
-	if err != nil {
+	identityMissing := errors.Is(err, pgx.ErrNoRows)
+	if err != nil && !identityMissing {
 		return safeDatabaseError(err)
 	}
-	if accountStatus != "deleting" && accountStatus != "deleted" {
+	if !identityMissing &&
+		accountStatus != "deleting" &&
+		accountStatus != "deleted" {
 		return conversation.ErrPersistenceConflict
 	}
 	now := databaseTime(r.now)
@@ -1533,6 +1531,25 @@ func validJob(job conversation.JobContext) bool {
 
 func validDeletion(deletion conversation.DeletionContext) bool {
 	return deletion.Valid() && validUUID(deletion.OwnerUserID)
+}
+
+func validProcessingFailureCode(code string) bool {
+	switch code {
+	case "invalid_request",
+		"configuration",
+		"authentication",
+		"authorization",
+		"quota_exhausted",
+		"rate_limited",
+		"timeout",
+		"provider_timeout",
+		"provider_unavailable",
+		"invalid_response",
+		"cancelled":
+		return true
+	default:
+		return false
+	}
 }
 
 func validUUID(value string) bool {

--- a/server/internal/conversation/postgres/repository_integration_test.go
+++ b/server/internal/conversation/postgres/repository_integration_test.go
@@ -821,6 +821,65 @@ func TestFailedAttemptCreatesNoTurnAndStoresOnlyNormalizedAudit(t *testing.T) {
 	}
 }
 
+func TestFailureCodeBoundaryRejectsUnnormalizedValues(t *testing.T) {
+	repository, pool := newIntegrationRepository(t)
+	actor := testActor(testUserA)
+	question := saveTestQuestion(
+		t,
+		repository,
+		actor,
+		"question-failure-code",
+		"session-failure-code",
+	)
+	reservation := reserveTestTranscription(
+		t,
+		repository,
+		actor,
+		question,
+		"reserve-failure-code",
+	)
+	job := jobFromReservation(actor.UserID, reservation)
+
+	for _, code := range []string{
+		"",
+		"provider timeout",
+		"Provider_Timeout",
+		"provider_timeout\ncredential",
+		"sk-secret-value",
+		strings.Repeat("a", 65),
+	} {
+		if err := repository.FailTranscription(
+			context.Background(),
+			job,
+			conversation.ProcessingFailure{Code: code, Retryable: true},
+		); !errors.Is(err, conversation.ErrPersistenceInvalid) {
+			t.Fatalf("failure code %q error = %v, want invalid", code, err)
+		}
+	}
+
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE conversation_processing_attempts
+		 SET status = 'failed', error_code = 'raw provider response'
+		 WHERE owner_user_id = $1 AND attempt_id = $2`,
+		actor.UserID,
+		reservation.CurrentAttemptID,
+	); err == nil {
+		t.Fatal("database accepted an unnormalized failure code")
+	}
+
+	if err := repository.FailTranscription(
+		context.Background(),
+		job,
+		conversation.ProcessingFailure{
+			Code:      "provider_timeout",
+			Retryable: true,
+		},
+	); err != nil {
+		t.Fatalf("normalized failure code rejected: %v", err)
+	}
+}
+
 func TestReviewCheckpointCannotBindTwoTurns(t *testing.T) {
 	repository, _ := newIntegrationRepository(t)
 	actor := testActor(testUserA)
@@ -1247,6 +1306,86 @@ func TestMigrationUsesIdentityUUIDOwnershipAndPersistsNoAudio(t *testing.T) {
 	}
 }
 
+func TestDeletionFenceSurvivesPhysicalIdentityRemoval(t *testing.T) {
+	repository, pool := newIntegrationRepository(t)
+	actor := testActor(testUserA)
+	saveTestQuestion(
+		t,
+		repository,
+		actor,
+		"question-durable-fence",
+		"session-durable-fence",
+	)
+	if _, err := pool.Exec(
+		context.Background(),
+		`UPDATE identity_users SET account_status = 'deleting' WHERE id = $1`,
+		actor.UserID,
+	); err != nil {
+		t.Fatalf("start account deletion: %v", err)
+	}
+	deletion := conversation.DeletionContext{
+		OwnerUserID:        actor.UserID,
+		DeletionGeneration: 2,
+	}
+	if err := repository.DeleteUserData(context.Background(), deletion); err != nil {
+		t.Fatalf("delete Conversation data: %v", err)
+	}
+	if _, err := pool.Exec(
+		context.Background(),
+		`DELETE FROM identity_users WHERE id = $1`,
+		actor.UserID,
+	); err != nil {
+		t.Fatalf("physically delete Identity user: %v", err)
+	}
+
+	var generation int64
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT deletion_generation
+		 FROM conversation_deletion_fences
+		 WHERE owner_user_id = $1`,
+		actor.UserID,
+	).Scan(&generation); err != nil {
+		t.Fatalf("restore durable deletion fence: %v", err)
+	}
+	if generation != 2 {
+		t.Fatalf("deletion generation = %d, want 2", generation)
+	}
+	if err := repository.DeleteUserData(
+		context.Background(),
+		conversation.DeletionContext{
+			OwnerUserID:        actor.UserID,
+			DeletionGeneration: 1,
+		},
+	); !errors.Is(err, conversation.ErrPersistenceConflict) {
+		t.Fatalf("stale deletion error = %v, want conflict", err)
+	}
+	if err := repository.DeleteUserData(context.Background(), deletion); err != nil {
+		t.Fatalf("repeat final deletion: %v", err)
+	}
+	if err := repository.DeleteUserData(
+		context.Background(),
+		conversation.DeletionContext{
+			OwnerUserID:        actor.UserID,
+			DeletionGeneration: 3,
+		},
+	); err != nil {
+		t.Fatalf("advance deletion generation: %v", err)
+	}
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT deletion_generation
+		 FROM conversation_deletion_fences
+		 WHERE owner_user_id = $1`,
+		actor.UserID,
+	).Scan(&generation); err != nil {
+		t.Fatalf("restore advanced deletion fence: %v", err)
+	}
+	if generation != 3 {
+		t.Fatalf("advanced deletion generation = %d, want 3", generation)
+	}
+}
+
 func newIntegrationRepository(t *testing.T) (*Repository, *pgxpool.Pool) {
 	t.Helper()
 	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
@@ -1297,14 +1436,20 @@ func newIntegrationRepository(t *testing.T) (*Repository, *pgxpool.Pool) {
 	if _, err := pool.Exec(context.Background(), identityFixture); err != nil {
 		t.Fatalf("create identity dependency fixture: %v", err)
 	}
-	migrationSQL, err := migrations.Files.ReadFile(
+	for _, migrationName := range []string{
 		"000009_conversation_persistence.up.sql",
-	)
-	if err != nil {
-		t.Fatalf("read Conversation migration: %v", err)
-	}
-	if _, err := pool.Exec(context.Background(), string(migrationSQL)); err != nil {
-		t.Fatalf("apply Conversation migration: %v", err)
+		"000010_conversation_persistence_hardening.up.sql",
+	} {
+		migrationSQL, err := migrations.Files.ReadFile(migrationName)
+		if err != nil {
+			t.Fatalf("read Conversation migration %s: %v", migrationName, err)
+		}
+		if _, err := pool.Exec(
+			context.Background(),
+			string(migrationSQL),
+		); err != nil {
+			t.Fatalf("apply Conversation migration %s: %v", migrationName, err)
+		}
 	}
 	for _, userID := range []string{testUserA, testUserB} {
 		if _, err := pool.Exec(

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -106,6 +106,148 @@ func TestRunnerAppliesIdempotentlyAndRevertsLatestMigration(t *testing.T) {
 	}
 }
 
+func TestConversationHardeningNormalizesLegacyFailureCodes(t *testing.T) {
+	migrationConfig, _, _ := isolatedMigrationConfig(t)
+	runner, err := openConfig(migrationConfig)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+
+	if err := runner.migrate.Steps(9); err != nil {
+		t.Fatalf("apply migrations through Conversation v9: %v", err)
+	}
+	status, err := runner.Version()
+	if err != nil {
+		t.Fatalf("read Conversation v9 status: %v", err)
+	}
+	if !status.Present || status.Version != 9 || status.Dirty {
+		t.Fatalf("Conversation migration status = %+v, want clean version 9", status)
+	}
+
+	scoped, err := pgx.ConnectConfig(context.Background(), migrationConfig)
+	if err != nil {
+		t.Fatalf("connect to Conversation v9 schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := scoped.Close(context.Background()); err != nil {
+			t.Errorf("close Conversation v9 schema connection: %v", err)
+		}
+	})
+
+	const userID = "10000000-0000-4000-8000-000000000127"
+	const reservationID = "legacy-reservation"
+	const attemptID = "legacy-attempt"
+	fixtures := []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{
+			name: "Identity user",
+			sql: `INSERT INTO identity_users (id, canonical_email)
+			      VALUES ($1, 'conversation-upgrade@example.com')`,
+			args: []any{userID},
+		},
+		{
+			name: "Conversation question",
+			sql: `INSERT INTO conversation_questions (
+			          owner_user_id, question_id, practice_session_id,
+			          speaker_participant_id, addressee_participant_ids,
+			          objective_id, question_type, content, sequence, created_at
+			      ) VALUES (
+			          $1, 'legacy-question', 'legacy-session',
+			          'interviewer', ARRAY['candidate']::text[],
+			          'legacy-objective', 'PRIMARY', 'Legacy question?', 1, now()
+			      )`,
+			args: []any{userID},
+		},
+		{
+			name: "transcription reservation",
+			sql: `INSERT INTO conversation_transcription_reservations (
+			          owner_user_id, reservation_id, question_id,
+			          practice_session_id, idempotency_key, input_fingerprint,
+			          respondent_participant_id, status, fencing_token,
+			          deletion_generation, lease_expires_at, current_attempt_id,
+			          created_at, updated_at
+			      ) VALUES (
+			          $1, $2, 'legacy-question', 'legacy-session',
+			          'legacy-key', 'legacy-fingerprint', 'candidate',
+			          'failed', 1, 0, now() + interval '1 minute',
+			          $3, now(), now()
+			      )`,
+			args: []any{userID, reservationID, attemptID},
+		},
+		{
+			name: "processing attempt",
+			sql: `INSERT INTO conversation_processing_attempts (
+			          owner_user_id, attempt_id, reservation_id, operation,
+			          fencing_token, status, lease_expires_at, error_code,
+			          retryable, provider_request_id, duration_ms,
+			          started_at, finished_at
+			      ) VALUES (
+			          $1, $3, $2, 'transcription',
+			          1, 'failed', now() + interval '1 minute',
+			          'HTTP 500: upstream secret response',
+			          true, 'legacy-request', 25, now(), now()
+			      )`,
+			args: []any{userID, reservationID, attemptID},
+		},
+	}
+	for _, fixture := range fixtures {
+		if _, err := scoped.Exec(
+			context.Background(),
+			fixture.sql,
+			fixture.args...,
+		); err != nil {
+			t.Fatalf("insert %s fixture: %v", fixture.name, err)
+		}
+	}
+
+	if err := runner.migrate.Steps(1); err != nil {
+		t.Fatalf("upgrade Conversation v9 to v10: %v", err)
+	}
+	status, err = runner.Version()
+	if err != nil {
+		t.Fatalf("read Conversation v10 status: %v", err)
+	}
+	if !status.Present || status.Version != 10 || status.Dirty {
+		t.Fatalf("Conversation migration status = %+v, want clean version 10", status)
+	}
+
+	var errorCode string
+	if err := scoped.QueryRow(
+		context.Background(),
+		`SELECT error_code
+		 FROM conversation_processing_attempts
+		 WHERE owner_user_id = $1 AND attempt_id = $2`,
+		userID,
+		attemptID,
+	).Scan(&errorCode); err != nil {
+		t.Fatalf("restore normalized legacy failure: %v", err)
+	}
+	if errorCode != "legacy_provider_failure" {
+		t.Fatalf(
+			"normalized legacy failure code = %q, want legacy_provider_failure",
+			errorCode,
+		)
+	}
+	if _, err := scoped.Exec(
+		context.Background(),
+		`UPDATE conversation_processing_attempts
+		 SET error_code = 'raw provider response'
+		 WHERE owner_user_id = $1 AND attempt_id = $2`,
+		userID,
+		attemptID,
+	); err == nil {
+		t.Fatal("Conversation v10 accepted an unnormalized failure code")
+	}
+}
+
 func TestAgentDataMigrationUpgradesIdentitySchemaAndReapplies(t *testing.T) {
 	migrationConfig, admin, schema := isolatedMigrationConfig(t)
 	runner, err := openConfig(migrationConfig)

--- a/server/migrations/000010_conversation_persistence_hardening.down.sql
+++ b/server/migrations/000010_conversation_persistence_hardening.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TABLE conversation_processing_attempts
+    DROP CONSTRAINT conversation_processing_attempts_error_code_normalized;
+
+DELETE FROM conversation_deletion_fences AS fence
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM identity_users AS users
+    WHERE users.id = fence.owner_user_id
+);
+
+ALTER TABLE conversation_deletion_fences
+    ADD CONSTRAINT conversation_deletion_fences_owner_user_id_fkey
+    FOREIGN KEY (owner_user_id)
+    REFERENCES identity_users (id)
+    ON DELETE CASCADE;
+
+COMMIT;

--- a/server/migrations/000010_conversation_persistence_hardening.up.sql
+++ b/server/migrations/000010_conversation_persistence_hardening.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+ALTER TABLE conversation_deletion_fences
+    DROP CONSTRAINT conversation_deletion_fences_owner_user_id_fkey;
+
+ALTER TABLE conversation_processing_attempts
+    ADD CONSTRAINT conversation_processing_attempts_error_code_normalized
+    CHECK (
+        (
+            status = 'failed'
+            AND error_code IN (
+                'invalid_request',
+                'configuration',
+                'authentication',
+                'authorization',
+                'quota_exhausted',
+                'rate_limited',
+                'timeout',
+                'provider_timeout',
+                'provider_unavailable',
+                'invalid_response',
+                'cancelled'
+            )
+        )
+        OR
+        (
+            status <> 'failed'
+            AND error_code = ''
+        )
+    );
+
+COMMIT;

--- a/server/migrations/000010_conversation_persistence_hardening.up.sql
+++ b/server/migrations/000010_conversation_persistence_hardening.up.sql
@@ -3,6 +3,29 @@ BEGIN;
 ALTER TABLE conversation_deletion_fences
     DROP CONSTRAINT conversation_deletion_fences_owner_user_id_fkey;
 
+UPDATE conversation_processing_attempts
+SET error_code = 'legacy_provider_failure'
+WHERE status = 'failed'
+  AND error_code NOT IN (
+      'invalid_request',
+      'configuration',
+      'authentication',
+      'authorization',
+      'quota_exhausted',
+      'rate_limited',
+      'timeout',
+      'provider_timeout',
+      'provider_unavailable',
+      'invalid_response',
+      'cancelled',
+      'legacy_provider_failure'
+  );
+
+UPDATE conversation_processing_attempts
+SET error_code = ''
+WHERE status <> 'failed'
+  AND error_code <> '';
+
 ALTER TABLE conversation_processing_attempts
     ADD CONSTRAINT conversation_processing_attempts_error_code_normalized
     CHECK (
@@ -19,7 +42,8 @@ ALTER TABLE conversation_processing_attempts
                 'provider_timeout',
                 'provider_unavailable',
                 'invalid_response',
-                'cancelled'
+                'cancelled',
+                'legacy_provider_failure'
             )
         )
         OR


### PR DESCRIPTION
## 功能说明

修复 PR #99 合入后发现的两个 Conversation 持久化 P1：

- 将 `conversation_deletion_fences` 从 Identity 用户行生命周期中解耦，作为持久 deletion-generation tombstone。
- Identity 行物理删除后，重复、陈旧和更高 generation 的删除协调仍然可以比较并保持单调。
- 将 `ProcessingFailure.Code` 收敛为封闭稳定机器码集合。
- 在 Go Repository 与 PostgreSQL CHECK 两层拒绝自由文本、换行、超长值和疑似凭据。
- v9 中既有的未知自由文本错误码会在添加 CHECK 前归一为 `legacy_provider_failure`，避免历史数据阻断升级。

## 实现思路

- 新增 append-only 迁移 `000010_conversation_persistence_hardening`，不修改已合并的 `000009`。
- Up 迁移移除 fence 对 `identity_users` 的级联外键，并增加失败码 CHECK。
- Up 迁移先归一化 v9 历史失败记录，再验证新的 CHECK；不会因旧自由文本使部署进入 dirty 状态。
- Down 迁移先清理无法重新关联 Identity 的 tombstone，再恢复原外键。
- `DeleteUserData` 在 Identity 行不存在时不再提前返回，而是继续锁定、读取、比较和推进 fence。
- Repository 在开始事务前拒绝非规范失败码，数据库同时防止绕过应用层写入。

## 验证

- 隔离真实 PostgreSQL 迁移 `up → status → up → down-one → up → status`：通过，最终版本 `10`、非 dirty。
- Identity 物理删除后的 fence 保留、陈旧 generation 拒绝、相同 generation 幂等和更高 generation 推进：通过。
- 非法错误码 Repository 拒绝与数据库 CHECK：通过。
- 从含旧自由文本错误码的真实 v9 数据库升级到 v10：通过，历史值归一为 `legacy_provider_failure`。
- 全仓 Go、Conversation/Migration race：通过。
- OpenAPI、安全、WebSocket、Fixture 与 Deterministic Smoke：通过。
- `git diff --check`：通过。

## 明确不做

- 不修改 ASR Provider、Practice、Review、OSS 或 Flutter。
- 不新增用户可见错误类型。
- 不改变 Question、Candidate、Attempt 或 Turn 业务语义。

Closes #127
Refs #90
