### PR TITLE
[修复] 生产 OSS 使用可刷新的 RAM Role 凭据

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,11 @@ QIANWEN_ASR_LIVE_TEST=0
 QIANWEN_ASR_LIVE_TEST_AUDIO=
 QIANWEN_TTS_LIVE_TEST=0
 
-# Server-only private audio storage. This file supports explicit local/CI
-# AccessKey or short-lived STS testing only. Production must inject a workload
-# RAM-role CredentialsProvider in code; it does not use these variables.
+# Server-only private audio storage. Production defaults to a refreshable ECS
+# RAM-role provider. OSS_RAM_ROLE_NAME is optional; when empty, the SDK asks
+# the ECS metadata service for the attached role. Local/CI may explicitly set
+# OSS_CREDENTIALS_PROVIDER=environment and then provide the AccessKey or
+# short-lived STS variables below. Production must not select environment.
 # Flutter never receives these values or a permanent object URL.
 # The runtime policy needs object-scoped oss:PutObject, oss:GetObject, and
 # oss:DeleteObject plus bucket-scoped oss:GetBucketAcl and
@@ -74,6 +76,8 @@ OSS_ENABLED=0
 OSS_REGION=
 OSS_ENDPOINT=
 OSS_BUCKET=
+OSS_CREDENTIALS_PROVIDER=ecs_role
+OSS_RAM_ROLE_NAME=
 OSS_ACCESS_KEY_ID=
 OSS_ACCESS_KEY_SECRET=
 OSS_SESSION_TOKEN=

--- a/server/cmd/server/audio_cleanup.go
+++ b/server/cmd/server/audio_cleanup.go
@@ -28,7 +28,11 @@ var productionAudioCleanupFactories = audioCleanupFactories{
 		ctx context.Context,
 		storageConfig config.ObjectStorageConfig,
 	) (objectstore.Store, error) {
-		return ossstore.NewFromEnvironment(ctx, storageConfig)
+		provider, err := ossstore.NewCredentialsProvider(storageConfig)
+		if err != nil {
+			return nil, err
+		}
+		return ossstore.New(ctx, storageConfig, provider)
 	},
 	newRepository: func(
 		pool *pgxpool.Pool,

--- a/server/cmd/server/audio_cleanup_test.go
+++ b/server/cmd/server/audio_cleanup_test.go
@@ -93,3 +93,25 @@ func TestBuildAudioCleanupWorkerFailsEnabledStoreInitialization(t *testing.T) {
 		t.Fatal("repository constructed after storage initialization failed")
 	}
 }
+
+func TestProductionAudioStoreRejectsUnknownCredentialSourceBeforeNetwork(
+	t *testing.T,
+) {
+	t.Setenv("OSS_ACCESS_KEY_ID", "must-not-be-used")
+	t.Setenv("OSS_ACCESS_KEY_SECRET", "must-not-be-used")
+
+	store, err := productionAudioCleanupFactories.newStore(
+		context.Background(),
+		config.ObjectStorageConfig{
+			Enabled:             true,
+			CredentialsProvider: "unknown",
+		},
+	)
+	if store != nil || !errors.Is(err, objectstore.ErrCredentials) {
+		t.Fatalf(
+			"production newStore() = %#v, %v, want nil ErrCredentials",
+			store,
+			err,
+		)
+	}
+}

--- a/server/internal/platform/config/object_storage.go
+++ b/server/internal/platform/config/object_storage.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -15,6 +16,13 @@ const (
 	maxSignedURLTTL            = 2 * time.Minute
 )
 
+type ObjectStorageCredentialsProvider string
+
+const (
+	ObjectStorageCredentialsECSRole     ObjectStorageCredentialsProvider = "ecs_role"
+	ObjectStorageCredentialsEnvironment ObjectStorageCredentialsProvider = "environment"
+)
+
 var (
 	ErrObjectStorageEnabledInvalid = errors.New("OSS_ENABLED must be 0, 1, false, or true")
 	ErrObjectStorageRegionRequired = errors.New("OSS_REGION is required when object storage is enabled")
@@ -22,18 +30,24 @@ var (
 	ErrObjectStorageBucketRequired = errors.New("OSS_BUCKET is required when object storage is enabled")
 	ErrObjectStoragePrefix         = errors.New("OSS_AUDIO_PREFIX must be audio/v1")
 	ErrObjectStorageSignedURLTTL   = errors.New("OSS_SIGNED_URL_TTL must be positive and no greater than 2m")
+	ErrObjectStorageCredentials    = errors.New("OSS_CREDENTIALS_PROVIDER must be ecs_role or environment")
+	ErrObjectStorageRAMRoleName    = errors.New("OSS_RAM_ROLE_NAME must be a valid RAM role name and is only allowed with ecs_role")
 )
+
+var ramRoleNamePattern = regexp.MustCompile(`\A[A-Za-z0-9.@_-]{1,64}\z`)
 
 // ObjectStorageConfig contains only non-secret object-storage settings.
 // Access credentials stay in the SDK credential provider so Config values can
 // be logged during local debugging without disclosing an AccessKey secret.
 type ObjectStorageConfig struct {
-	Enabled      bool
-	Region       string
-	Endpoint     string
-	Bucket       string
-	AudioPrefix  string
-	SignedURLTTL time.Duration
+	Enabled             bool
+	Region              string
+	Endpoint            string
+	Bucket              string
+	AudioPrefix         string
+	SignedURLTTL        time.Duration
+	CredentialsProvider ObjectStorageCredentialsProvider
+	RAMRoleName         string
 }
 
 // LoadObjectStorage reads and validates the server-only OSS configuration.
@@ -51,6 +65,13 @@ func LoadObjectStorage() (ObjectStorageConfig, error) {
 		Bucket:       strings.TrimSpace(os.Getenv("OSS_BUCKET")),
 		AudioPrefix:  valueOrDefault("OSS_AUDIO_PREFIX", defaultObjectStoragePrefix),
 		SignedURLTTL: defaultSignedURLTTL,
+		CredentialsProvider: ObjectStorageCredentialsProvider(strings.TrimSpace(
+			valueOrDefault(
+				"OSS_CREDENTIALS_PROVIDER",
+				string(ObjectStorageCredentialsECSRole),
+			),
+		)),
+		RAMRoleName: strings.TrimSpace(os.Getenv("OSS_RAM_ROLE_NAME")),
 	}
 
 	if rawTTL := strings.TrimSpace(os.Getenv("OSS_SIGNED_URL_TTL")); rawTTL != "" {
@@ -75,6 +96,20 @@ func LoadObjectStorage() (ObjectStorageConfig, error) {
 	if !config.Enabled {
 		return config, nil
 	}
+	switch config.CredentialsProvider {
+	case ObjectStorageCredentialsECSRole:
+		if config.RAMRoleName != "" &&
+			!ramRoleNamePattern.MatchString(config.RAMRoleName) {
+			return ObjectStorageConfig{}, ErrObjectStorageRAMRoleName
+		}
+	case ObjectStorageCredentialsEnvironment:
+		if config.RAMRoleName != "" {
+			return ObjectStorageConfig{}, ErrObjectStorageRAMRoleName
+		}
+	default:
+		return ObjectStorageConfig{}, ErrObjectStorageCredentials
+	}
+
 	if config.Region == "" {
 		return ObjectStorageConfig{}, ErrObjectStorageRegionRequired
 	}

--- a/server/internal/platform/config/object_storage_test.go
+++ b/server/internal/platform/config/object_storage_test.go
@@ -13,6 +13,8 @@ func TestLoadObjectStorageUsesSafeDefaultsWhenDisabled(t *testing.T) {
 	t.Setenv("OSS_BUCKET", "")
 	t.Setenv("OSS_AUDIO_PREFIX", "")
 	t.Setenv("OSS_SIGNED_URL_TTL", "")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "")
+	t.Setenv("OSS_RAM_ROLE_NAME", "")
 
 	config, err := LoadObjectStorage()
 	if err != nil {
@@ -20,7 +22,9 @@ func TestLoadObjectStorageUsesSafeDefaultsWhenDisabled(t *testing.T) {
 	}
 	if config.Enabled ||
 		config.AudioPrefix != "audio/v1" ||
-		config.SignedURLTTL != 2*time.Minute {
+		config.SignedURLTTL != 2*time.Minute ||
+		config.CredentialsProvider != ObjectStorageCredentialsECSRole ||
+		config.RAMRoleName != "" {
 		t.Fatalf("unexpected disabled config: %#v", config)
 	}
 }
@@ -32,6 +36,8 @@ func TestLoadObjectStorageReadsEnabledConfigurationWithoutSecrets(t *testing.T) 
 	t.Setenv("OSS_BUCKET", "example-private-audio-bucket")
 	t.Setenv("OSS_AUDIO_PREFIX", "audio/v1/")
 	t.Setenv("OSS_SIGNED_URL_TTL", "90s")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "environment")
+	t.Setenv("OSS_RAM_ROLE_NAME", "")
 	t.Setenv("OSS_ACCESS_KEY_ID", "must-not-be-copied")
 	t.Setenv("OSS_ACCESS_KEY_SECRET", "must-not-be-copied")
 
@@ -44,8 +50,27 @@ func TestLoadObjectStorageReadsEnabledConfigurationWithoutSecrets(t *testing.T) 
 		config.Endpoint != "https://oss-cn-shanghai.aliyuncs.com" ||
 		config.Bucket != "example-private-audio-bucket" ||
 		config.AudioPrefix != "audio/v1" ||
-		config.SignedURLTTL != 90*time.Second {
+		config.SignedURLTTL != 90*time.Second ||
+		config.CredentialsProvider != ObjectStorageCredentialsEnvironment {
 		t.Fatalf("unexpected enabled config: %#v", config)
+	}
+}
+
+func TestLoadObjectStorageReadsECSRoleConfiguration(t *testing.T) {
+	t.Setenv("OSS_ENABLED", "1")
+	t.Setenv("OSS_REGION", "cn-shanghai")
+	t.Setenv("OSS_ENDPOINT", "https://oss-cn-shanghai.aliyuncs.com")
+	t.Setenv("OSS_BUCKET", "example-private-audio-bucket")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "ecs_role")
+	t.Setenv("OSS_RAM_ROLE_NAME", "SpeakUp.Audio_Role-1")
+
+	config, err := LoadObjectStorage()
+	if err != nil {
+		t.Fatalf("LoadObjectStorage() error = %v", err)
+	}
+	if config.CredentialsProvider != ObjectStorageCredentialsECSRole ||
+		config.RAMRoleName != "SpeakUp.Audio_Role-1" {
+		t.Fatalf("unexpected ECS role config: %#v", config)
 	}
 }
 
@@ -92,6 +117,18 @@ func TestLoadObjectStorageRejectsUnsafeValues(t *testing.T) {
 			value:    "3m",
 			expected: ErrObjectStorageSignedURLTTL,
 		},
+		{
+			name:     "credentials provider",
+			key:      "OSS_CREDENTIALS_PROVIDER",
+			value:    "automatic",
+			expected: ErrObjectStorageCredentials,
+		},
+		{
+			name:     "RAM role name",
+			key:      "OSS_RAM_ROLE_NAME",
+			value:    "invalid role name",
+			expected: ErrObjectStorageRAMRoleName,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -102,6 +139,8 @@ func TestLoadObjectStorageRejectsUnsafeValues(t *testing.T) {
 			t.Setenv("OSS_BUCKET", "example-bucket")
 			t.Setenv("OSS_AUDIO_PREFIX", "audio/v1")
 			t.Setenv("OSS_SIGNED_URL_TTL", "2m")
+			t.Setenv("OSS_CREDENTIALS_PROVIDER", "ecs_role")
+			t.Setenv("OSS_RAM_ROLE_NAME", "")
 			t.Setenv(testCase.key, testCase.value)
 
 			_, err := LoadObjectStorage()
@@ -112,11 +151,41 @@ func TestLoadObjectStorageRejectsUnsafeValues(t *testing.T) {
 	}
 }
 
+func TestLoadObjectStorageRejectsRAMRoleWithEnvironmentCredentials(t *testing.T) {
+	t.Setenv("OSS_ENABLED", "1")
+	t.Setenv("OSS_REGION", "cn-shanghai")
+	t.Setenv("OSS_ENDPOINT", "https://oss-cn-shanghai.aliyuncs.com")
+	t.Setenv("OSS_BUCKET", "example-private-audio-bucket")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "environment")
+	t.Setenv("OSS_RAM_ROLE_NAME", "unexpected-role")
+
+	_, err := LoadObjectStorage()
+	if !errors.Is(err, ErrObjectStorageRAMRoleName) {
+		t.Fatalf("LoadObjectStorage() error = %v, want %v", err, ErrObjectStorageRAMRoleName)
+	}
+}
+
+func TestLoadObjectStorageDisabledIgnoresUnusedCredentialSettings(t *testing.T) {
+	t.Setenv("OSS_ENABLED", "false")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "unused-provider")
+	t.Setenv("OSS_RAM_ROLE_NAME", "invalid role name")
+
+	config, err := LoadObjectStorage()
+	if err != nil {
+		t.Fatalf("LoadObjectStorage() error = %v", err)
+	}
+	if config.Enabled {
+		t.Fatal("LoadObjectStorage() enabled = true, want false")
+	}
+}
+
 func TestLoadObjectStorageRequiresRemoteSettingsWhenEnabled(t *testing.T) {
 	t.Setenv("OSS_ENABLED", "1")
 	t.Setenv("OSS_REGION", "")
 	t.Setenv("OSS_ENDPOINT", "")
 	t.Setenv("OSS_BUCKET", "")
+	t.Setenv("OSS_CREDENTIALS_PROVIDER", "")
+	t.Setenv("OSS_RAM_ROLE_NAME", "")
 
 	_, err := LoadObjectStorage()
 	if !errors.Is(err, ErrObjectStorageRegionRequired) {

--- a/server/internal/platform/objectstore/ossstore/client.go
+++ b/server/internal/platform/objectstore/ossstore/client.go
@@ -55,6 +55,27 @@ func NewFromEnvironment(
 	)
 }
 
+// NewCredentialsProvider selects the explicitly configured server credential
+// source. ECS RAM role credentials are temporary and refreshed by the SDK.
+// Environment credentials are reserved for explicit local and CI use.
+func NewCredentialsProvider(
+	storageConfig config.ObjectStorageConfig,
+) (credentials.CredentialsProvider, error) {
+	switch storageConfig.CredentialsProvider {
+	case "", config.ObjectStorageCredentialsECSRole:
+		if storageConfig.RAMRoleName == "" {
+			return credentials.NewEcsRoleCredentialsProvider(), nil
+		}
+		return credentials.NewEcsRoleCredentialsProvider(
+			credentials.EcsRamRole(storageConfig.RAMRoleName),
+		), nil
+	case config.ObjectStorageCredentialsEnvironment:
+		return credentials.NewEnvironmentVariableCredentialsProvider(), nil
+	default:
+		return nil, objectstore.ErrCredentials
+	}
+}
+
 // New creates a client with an explicitly selected credentials provider. This
 // is the production boundary for workload RAM role and refreshing providers.
 func New(

--- a/server/internal/platform/objectstore/ossstore/client_test.go
+++ b/server/internal/platform/objectstore/ossstore/client_test.go
@@ -397,6 +397,61 @@ func TestClientCredentialValidationHonorsContext(t *testing.T) {
 	}
 }
 
+func TestNewCredentialsProviderUsesEnvironmentOnlyWhenExplicit(t *testing.T) {
+	t.Setenv("OSS_ACCESS_KEY_ID", "local-access-key")
+	t.Setenv("OSS_ACCESS_KEY_SECRET", "local-secret")
+	t.Setenv("OSS_SESSION_TOKEN", "local-session-token")
+
+	provider, err := NewCredentialsProvider(config.ObjectStorageConfig{
+		CredentialsProvider: config.ObjectStorageCredentialsEnvironment,
+	})
+	if err != nil {
+		t.Fatalf("NewCredentialsProvider() error = %v", err)
+	}
+	credential, err := provider.GetCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("environment provider GetCredentials() error = %v", err)
+	}
+	if credential.AccessKeyID != "local-access-key" ||
+		credential.AccessKeySecret != "local-secret" ||
+		credential.SecurityToken != "local-session-token" {
+		t.Fatal("environment provider returned unexpected credentials")
+	}
+}
+
+func TestNewCredentialsProviderDefaultsToECSRoleWithoutEnvironmentFallback(
+	t *testing.T,
+) {
+	t.Setenv("OSS_ACCESS_KEY_ID", "must-not-be-used")
+	t.Setenv("OSS_ACCESS_KEY_SECRET", "must-not-be-used")
+
+	provider, err := NewCredentialsProvider(config.ObjectStorageConfig{})
+	if err != nil {
+		t.Fatalf("NewCredentialsProvider() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	credential, err := provider.GetCredentials(ctx)
+	if err == nil ||
+		credential.AccessKeyID != "" ||
+		credential.AccessKeySecret != "" {
+		t.Fatalf("default provider used environment credentials: %#v, %v", credential, err)
+	}
+}
+
+func TestNewCredentialsProviderRejectsUnknownSource(t *testing.T) {
+	provider, err := NewCredentialsProvider(config.ObjectStorageConfig{
+		CredentialsProvider: "unknown",
+	})
+	if provider != nil || !errors.Is(err, objectstore.ErrCredentials) {
+		t.Fatalf(
+			"NewCredentialsProvider() = %#v, %v, want nil ErrCredentials",
+			provider,
+			err,
+		)
+	}
+}
+
 func TestClientRejectsCrossPrefixKeyWithoutProviderCall(t *testing.T) {
 	called := false
 	client := newTestClient(t, &http.Client{


### PR DESCRIPTION
## 问题

PR #96 合入后，生产启动路径仍固定读取环境变量 AccessKey。该路径与仓库已经声明的生产部署边界不一致：生产环境应使用可刷新的 ECS RAM Role 凭据，不能依赖静态 AccessKey。

## 实现

- 新增 `OSS_CREDENTIALS_PROVIDER=ecs_role|environment`：
  - OSS 开启时默认 `ecs_role`；
  - `environment` 只用于本地开发和显式 CI。
- 新增可选 `OSS_RAM_ROLE_NAME`；为空时由阿里云 SDK 自动发现实例 RAM Role。
- 生产启动装配显式创建并注入 SDK `CredentialsProvider`，不再调用固定环境变量构造器。
- 不允许 ECS Role 获取失败后静默回退到环境 AccessKey。
- OSS 关闭时不校验未使用的凭据配置，保持本地无 OSS 启动兼容。
- 更新 `.env.example`，不增加 API、Schema 或数据库迁移。

## 验证

- `make check-go check-api check-smoke`
- `go test -race -count=1 ./internal/platform/config ./internal/platform/objectstore/ossstore ./cmd/server`
- 真实 OSS 生命周期：上传、私有签名读取、删除后不可读取，测试对象自动清理
- `git diff --check`

生产 ECS Metadata 只能在具备 RAM Role 的部署环境做最终验证；单元测试已证明默认 ECS 模式不会读取或回退到本地环境 AccessKey。

## 关联

- 修复 PR #96 合入后遗留的生产凭据装配问题
- Closes #131
