### PR TITLE
[功能] 增加 Agent 工具注册与命令路由骨架

### DIFF
--- a/server/internal/agent/commands/builtin.go
+++ b/server/internal/agent/commands/builtin.go
@@ -6,8 +6,6 @@ const (
 	ToolScenarioCreate = "scenario.create.v1"
 	ToolScenarioSearch = "scenario.search.v1"
 	ToolReviewSearch   = "review.search.v1"
-	ToolMistakeSearch  = "mistake.search.v1"
-	ToolMaterialSearch = "material.search.v1"
 )
 
 // Builtins 返回 Agent 首批支持的用户可见斜杠命令。
@@ -51,24 +49,6 @@ func Builtins() []Definition {
 			Aliases:     []string{"评价", "查上次评价"},
 			Description: "查询历史 Review 或面试评价",
 			ToolName:    ToolReviewSearch,
-			BuildInput: func(args string) (json.RawMessage, error) {
-				return JSONObjectInput(map[string]any{"query": args})
-			},
-		},
-		{
-			Name:        "查错题",
-			Aliases:     []string{"错题"},
-			Description: "查询历史错题或学习问题",
-			ToolName:    ToolMistakeSearch,
-			BuildInput: func(args string) (json.RawMessage, error) {
-				return JSONObjectInput(map[string]any{"query": args})
-			},
-		},
-		{
-			Name:        "解析简历",
-			Aliases:     []string{"简历"},
-			Description: "检索或解析简历和材料",
-			ToolName:    ToolMaterialSearch,
 			BuildInput: func(args string) (json.RawMessage, error) {
 				return JSONObjectInput(map[string]any{"query": args})
 			},

--- a/server/internal/agent/commands/builtin.go
+++ b/server/internal/agent/commands/builtin.go
@@ -1,0 +1,76 @@
+package commands
+
+import "encoding/json"
+
+const (
+	ToolScenarioCreate = "scenario.create.v1"
+	ToolScenarioSearch = "scenario.search.v1"
+	ToolReviewSearch   = "review.search.v1"
+	ToolMistakeSearch  = "mistake.search.v1"
+	ToolMaterialSearch = "material.search.v1"
+)
+
+func Builtins() []Definition {
+	return []Definition{
+		{
+			Name:        "创建面试",
+			Aliases:     []string{"面试", "准备面试"},
+			Description: "创建或补全面试准备场景",
+			ToolName:    ToolScenarioCreate,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{
+					"type":  "interview",
+					"title": args,
+				})
+			},
+		},
+		{
+			Name:        "创建口语场景",
+			Aliases:     []string{"口语场景", "新建场景"},
+			Description: "创建职业英语口语场景",
+			ToolName:    ToolScenarioCreate,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{
+					"type":  "speaking",
+					"title": args,
+				})
+			},
+		},
+		{
+			Name:        "继续场景",
+			Aliases:     []string{"继续"},
+			Description: "搜索并恢复相关的历史场景",
+			ToolName:    ToolScenarioSearch,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{"query": args})
+			},
+		},
+		{
+			Name:        "查评价",
+			Aliases:     []string{"评价", "查上次评价"},
+			Description: "查询历史 Review 或面试评价",
+			ToolName:    ToolReviewSearch,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{"query": args})
+			},
+		},
+		{
+			Name:        "查错题",
+			Aliases:     []string{"错题"},
+			Description: "查询历史错题或学习问题",
+			ToolName:    ToolMistakeSearch,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{"query": args})
+			},
+		},
+		{
+			Name:        "解析简历",
+			Aliases:     []string{"简历"},
+			Description: "检索或解析简历和材料",
+			ToolName:    ToolMaterialSearch,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(map[string]any{"query": args})
+			},
+		},
+	}
+}

--- a/server/internal/agent/commands/builtin.go
+++ b/server/internal/agent/commands/builtin.go
@@ -10,6 +10,7 @@ const (
 	ToolMaterialSearch = "material.search.v1"
 )
 
+// Builtins returns the first set of user-facing slash commands supported by Agent.
 func Builtins() []Definition {
 	return []Definition{
 		{

--- a/server/internal/agent/commands/builtin.go
+++ b/server/internal/agent/commands/builtin.go
@@ -10,7 +10,7 @@ const (
 	ToolMaterialSearch = "material.search.v1"
 )
 
-// Builtins returns the first set of user-facing slash commands supported by Agent.
+// Builtins 返回 Agent 首批支持的用户可见斜杠命令。
 func Builtins() []Definition {
 	return []Definition{
 		{

--- a/server/internal/agent/commands/invocation.go
+++ b/server/internal/agent/commands/invocation.go
@@ -6,6 +6,7 @@ import (
 	agenttools "github.com/1024XEngineer/XE3-ESL/server/internal/agent/tools"
 )
 
+// agentInvocation wraps a parsed command target as an Agent tool invocation.
 func agentInvocation(name string, input json.RawMessage) agenttools.Invocation {
 	return agenttools.Invocation{Name: name, Input: input}
 }

--- a/server/internal/agent/commands/invocation.go
+++ b/server/internal/agent/commands/invocation.go
@@ -6,7 +6,7 @@ import (
 	agenttools "github.com/1024XEngineer/XE3-ESL/server/internal/agent/tools"
 )
 
-// agentInvocation wraps a parsed command target as an Agent tool invocation.
+// agentInvocation 把解析出的命令目标包装成 Agent 工具调用。
 func agentInvocation(name string, input json.RawMessage) agenttools.Invocation {
 	return agenttools.Invocation{Name: name, Input: input}
 }

--- a/server/internal/agent/commands/invocation.go
+++ b/server/internal/agent/commands/invocation.go
@@ -1,0 +1,11 @@
+package commands
+
+import (
+	"encoding/json"
+
+	agenttools "github.com/1024XEngineer/XE3-ESL/server/internal/agent/tools"
+)
+
+func agentInvocation(name string, input json.RawMessage) agenttools.Invocation {
+	return agenttools.Invocation{Name: name, Input: input}
+}

--- a/server/internal/agent/commands/registry.go
+++ b/server/internal/agent/commands/registry.go
@@ -1,0 +1,66 @@
+package commands
+
+import "sort"
+
+type Registry struct {
+	commands map[string]Definition
+}
+
+func NewRegistry(definitions ...Definition) (*Registry, error) {
+	registry := &Registry{commands: make(map[string]Definition)}
+	for _, definition := range definitions {
+		if err := registry.Register(definition); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+func (registry *Registry) Register(definition Definition) error {
+	if registry == nil {
+		return ErrInvalidDefinition
+	}
+	if err := ValidateDefinition(definition); err != nil {
+		return err
+	}
+	if registry.commands == nil {
+		registry.commands = make(map[string]Definition)
+	}
+	names := append([]string{definition.Name}, definition.Aliases...)
+	for _, name := range names {
+		if _, exists := registry.commands[name]; exists {
+			return ErrDuplicateCommand
+		}
+	}
+	for _, name := range names {
+		registry.commands[name] = definition
+	}
+	return nil
+}
+
+func (registry *Registry) Get(name string) (Definition, bool) {
+	if registry == nil {
+		return Definition{}, false
+	}
+	definition, ok := registry.commands[name]
+	return definition, ok
+}
+
+func (registry *Registry) Definitions() []Definition {
+	if registry == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	definitions := make([]Definition, 0)
+	for _, definition := range registry.commands {
+		if _, exists := seen[definition.Name]; exists {
+			continue
+		}
+		seen[definition.Name] = struct{}{}
+		definitions = append(definitions, definition)
+	}
+	sort.Slice(definitions, func(left, right int) bool {
+		return definitions[left].Name < definitions[right].Name
+	})
+	return definitions
+}

--- a/server/internal/agent/commands/registry.go
+++ b/server/internal/agent/commands/registry.go
@@ -6,7 +6,7 @@ type Registry struct {
 	commands map[string]Definition
 }
 
-// NewRegistry builds a command registry and registers the provided definitions.
+// NewRegistry 创建命令注册表，并注册传入的命令定义。
 func NewRegistry(definitions ...Definition) (*Registry, error) {
 	registry := &Registry{commands: make(map[string]Definition)}
 	for _, definition := range definitions {
@@ -17,7 +17,7 @@ func NewRegistry(definitions ...Definition) (*Registry, error) {
 	return registry, nil
 }
 
-// Register adds one command definition and all of its aliases to the registry.
+// Register 把一个命令定义及其别名加入注册表。
 func (registry *Registry) Register(definition Definition) error {
 	if registry == nil {
 		return ErrInvalidDefinition
@@ -40,7 +40,7 @@ func (registry *Registry) Register(definition Definition) error {
 	return nil
 }
 
-// Get finds a command definition by canonical name or alias.
+// Get 按命令名或别名查找命令定义。
 func (registry *Registry) Get(name string) (Definition, bool) {
 	if registry == nil {
 		return Definition{}, false
@@ -49,7 +49,7 @@ func (registry *Registry) Get(name string) (Definition, bool) {
 	return definition, ok
 }
 
-// Definitions returns unique canonical command definitions in stable name order.
+// Definitions 按稳定顺序返回去重后的主命令定义。
 func (registry *Registry) Definitions() []Definition {
 	if registry == nil {
 		return nil

--- a/server/internal/agent/commands/registry.go
+++ b/server/internal/agent/commands/registry.go
@@ -6,6 +6,7 @@ type Registry struct {
 	commands map[string]Definition
 }
 
+// NewRegistry builds a command registry and registers the provided definitions.
 func NewRegistry(definitions ...Definition) (*Registry, error) {
 	registry := &Registry{commands: make(map[string]Definition)}
 	for _, definition := range definitions {
@@ -16,6 +17,7 @@ func NewRegistry(definitions ...Definition) (*Registry, error) {
 	return registry, nil
 }
 
+// Register adds one command definition and all of its aliases to the registry.
 func (registry *Registry) Register(definition Definition) error {
 	if registry == nil {
 		return ErrInvalidDefinition
@@ -38,6 +40,7 @@ func (registry *Registry) Register(definition Definition) error {
 	return nil
 }
 
+// Get finds a command definition by canonical name or alias.
 func (registry *Registry) Get(name string) (Definition, bool) {
 	if registry == nil {
 		return Definition{}, false
@@ -46,6 +49,7 @@ func (registry *Registry) Get(name string) (Definition, bool) {
 	return definition, ok
 }
 
+// Definitions returns unique canonical command definitions in stable name order.
 func (registry *Registry) Definitions() []Definition {
 	if registry == nil {
 		return nil

--- a/server/internal/agent/commands/registry_test.go
+++ b/server/internal/agent/commands/registry_test.go
@@ -74,6 +74,19 @@ func TestRouterParsesBuiltinCommand(t *testing.T) {
 	}
 }
 
+func TestBuiltinsOnlyReferenceImplementedTools(t *testing.T) {
+	implemented := map[string]struct{}{
+		ToolScenarioCreate: {},
+		ToolScenarioSearch: {},
+		ToolReviewSearch:   {},
+	}
+	for _, definition := range Builtins() {
+		if _, ok := implemented[definition.ToolName]; !ok {
+			t.Fatalf("builtin %q references unimplemented tool %q", definition.Name, definition.ToolName)
+		}
+	}
+}
+
 func TestRouterIgnoresNonCommand(t *testing.T) {
 	registry, err := NewRegistry(Builtins()...)
 	if err != nil {

--- a/server/internal/agent/commands/registry_test.go
+++ b/server/internal/agent/commands/registry_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestRegistryMatchesAliases(t *testing.T) {
+	registry, err := NewRegistry(Definition{
+		Name:        "创建面试",
+		Aliases:     []string{"面试"},
+		Description: "Create interview scenario.",
+		ToolName:    ToolScenarioCreate,
+		BuildInput: func(args string) (json.RawMessage, error) {
+			return JSONObjectInput(map[string]any{"title": args})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	definition, ok := registry.Get("面试")
+	if !ok {
+		t.Fatal("Get(alias) ok = false, want true")
+	}
+	if got, want := definition.Name, "创建面试"; got != want {
+		t.Fatalf("definition.Name = %q, want %q", got, want)
+	}
+}
+
+func TestRegistryRejectsDuplicateAlias(t *testing.T) {
+	_, err := NewRegistry(
+		Definition{
+			Name:        "创建面试",
+			Aliases:     []string{"面试"},
+			Description: "Create interview scenario.",
+			ToolName:    ToolScenarioCreate,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(nil)
+			},
+		},
+		Definition{
+			Name:        "创建口语场景",
+			Aliases:     []string{"面试"},
+			Description: "Create speaking scenario.",
+			ToolName:    ToolScenarioCreate,
+			BuildInput: func(args string) (json.RawMessage, error) {
+				return JSONObjectInput(nil)
+			},
+		},
+	)
+	if !errors.Is(err, ErrDuplicateCommand) {
+		t.Fatalf("NewRegistry() error = %v, want %v", err, ErrDuplicateCommand)
+	}
+}
+
+func TestRouterParsesBuiltinCommand(t *testing.T) {
+	registry, err := NewRegistry(Builtins()...)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	parsed, matched, err := NewRouter(registry).Parse("/创建面试 产品经理 一面")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("Parse() matched = false, want true")
+	}
+	if got, want := parsed.Invocation.Name, ToolScenarioCreate; got != want {
+		t.Fatalf("tool name = %q, want %q", got, want)
+	}
+	if got, want := parsed.Args, "产品经理 一面"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func TestRouterIgnoresNonCommand(t *testing.T) {
+	registry, err := NewRegistry(Builtins()...)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	_, matched, err := NewRouter(registry).Parse("帮我润色这句话")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if matched {
+		t.Fatal("Parse() matched = true, want false")
+	}
+}

--- a/server/internal/agent/commands/router.go
+++ b/server/internal/agent/commands/router.go
@@ -6,10 +6,12 @@ type Router struct {
 	registry *Registry
 }
 
+// NewRouter creates a router that parses slash commands with the given registry.
 func NewRouter(registry *Registry) *Router {
 	return &Router{registry: registry}
 }
 
+// Parse converts a slash command into a tool invocation and ignores non-command input.
 func (router *Router) Parse(input string) (Parsed, bool, error) {
 	text := strings.TrimSpace(input)
 	if !strings.HasPrefix(text, "/") {
@@ -35,6 +37,7 @@ func (router *Router) Parse(input string) (Parsed, bool, error) {
 	}, true, nil
 }
 
+// splitCommand separates a slash-command body into command name and raw arguments.
 func splitCommand(body string) (string, string) {
 	parts := strings.Fields(body)
 	if len(parts) == 0 {

--- a/server/internal/agent/commands/router.go
+++ b/server/internal/agent/commands/router.go
@@ -6,12 +6,12 @@ type Router struct {
 	registry *Registry
 }
 
-// NewRouter creates a router that parses slash commands with the given registry.
+// NewRouter 创建使用指定注册表的斜杠命令路由器。
 func NewRouter(registry *Registry) *Router {
 	return &Router{registry: registry}
 }
 
-// Parse converts a slash command into a tool invocation and ignores non-command input.
+// Parse 把斜杠命令转换成工具调用，并忽略普通自然语言输入。
 func (router *Router) Parse(input string) (Parsed, bool, error) {
 	text := strings.TrimSpace(input)
 	if !strings.HasPrefix(text, "/") {
@@ -37,7 +37,7 @@ func (router *Router) Parse(input string) (Parsed, bool, error) {
 	}, true, nil
 }
 
-// splitCommand separates a slash-command body into command name and raw arguments.
+// splitCommand 把命令正文拆成命令名和原始参数。
 func splitCommand(body string) (string, string) {
 	parts := strings.Fields(body)
 	if len(parts) == 0 {

--- a/server/internal/agent/commands/router.go
+++ b/server/internal/agent/commands/router.go
@@ -1,0 +1,46 @@
+package commands
+
+import "strings"
+
+type Router struct {
+	registry *Registry
+}
+
+func NewRouter(registry *Registry) *Router {
+	return &Router{registry: registry}
+}
+
+func (router *Router) Parse(input string) (Parsed, bool, error) {
+	text := strings.TrimSpace(input)
+	if !strings.HasPrefix(text, "/") {
+		return Parsed{}, false, nil
+	}
+	body := strings.TrimSpace(strings.TrimPrefix(text, "/"))
+	if body == "" {
+		return Parsed{}, true, ErrInvalidCommand
+	}
+	name, args := splitCommand(body)
+	definition, ok := router.registry.Get(name)
+	if !ok {
+		return Parsed{}, true, ErrUnknownCommand
+	}
+	raw, err := definition.BuildInput(args)
+	if err != nil {
+		return Parsed{}, true, err
+	}
+	return Parsed{
+		CommandName: definition.Name,
+		Args:        args,
+		Invocation:  agentInvocation(definition.ToolName, raw),
+	}, true, nil
+}
+
+func splitCommand(body string) (string, string) {
+	parts := strings.Fields(body)
+	if len(parts) == 0 {
+		return "", ""
+	}
+	name := parts[0]
+	args := strings.TrimSpace(strings.TrimPrefix(body, name))
+	return name, args
+}

--- a/server/internal/agent/commands/schema.go
+++ b/server/internal/agent/commands/schema.go
@@ -1,4 +1,4 @@
-// Package commands maps explicit slash commands to Agent tool invocations.
+// Package commands 把显式斜杠命令映射成 Agent 工具调用。
 package commands
 
 import (
@@ -32,7 +32,7 @@ type Parsed struct {
 	Invocation  agenttools.Invocation
 }
 
-// ValidateDefinition checks whether a command definition is complete enough to register.
+// ValidateDefinition 检查命令定义是否完整，能否注册。
 func ValidateDefinition(definition Definition) error {
 	if strings.TrimSpace(definition.Name) == "" ||
 		strings.TrimSpace(definition.Description) == "" ||
@@ -48,7 +48,7 @@ func ValidateDefinition(definition Definition) error {
 	return nil
 }
 
-// JSONObjectInput encodes command arguments as the JSON object expected by a tool invocation.
+// JSONObjectInput 把命令参数编码成工具调用需要的 JSON 对象。
 func JSONObjectInput(fields map[string]any) (json.RawMessage, error) {
 	if fields == nil {
 		fields = map[string]any{}

--- a/server/internal/agent/commands/schema.go
+++ b/server/internal/agent/commands/schema.go
@@ -1,0 +1,55 @@
+// Package commands maps explicit slash commands to Agent tool invocations.
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	agenttools "github.com/1024XEngineer/XE3-ESL/server/internal/agent/tools"
+)
+
+var (
+	ErrInvalidDefinition = errors.New("agent command: invalid definition")
+	ErrDuplicateCommand  = errors.New("agent command: duplicate command")
+	ErrUnknownCommand    = errors.New("agent command: unknown command")
+	ErrInvalidCommand    = errors.New("agent command: invalid command")
+)
+
+type InputBuilder func(args string) (json.RawMessage, error)
+
+type Definition struct {
+	Name        string
+	Aliases     []string
+	Description string
+	ToolName    string
+	BuildInput  InputBuilder
+}
+
+type Parsed struct {
+	CommandName string
+	Args        string
+	Invocation  agenttools.Invocation
+}
+
+func ValidateDefinition(definition Definition) error {
+	if strings.TrimSpace(definition.Name) == "" ||
+		strings.TrimSpace(definition.Description) == "" ||
+		strings.TrimSpace(definition.ToolName) == "" ||
+		definition.BuildInput == nil {
+		return ErrInvalidDefinition
+	}
+	for _, alias := range definition.Aliases {
+		if strings.TrimSpace(alias) == "" {
+			return ErrInvalidDefinition
+		}
+	}
+	return nil
+}
+
+func JSONObjectInput(fields map[string]any) (json.RawMessage, error) {
+	if fields == nil {
+		fields = map[string]any{}
+	}
+	return json.Marshal(fields)
+}

--- a/server/internal/agent/commands/schema.go
+++ b/server/internal/agent/commands/schema.go
@@ -32,6 +32,7 @@ type Parsed struct {
 	Invocation  agenttools.Invocation
 }
 
+// ValidateDefinition checks whether a command definition is complete enough to register.
 func ValidateDefinition(definition Definition) error {
 	if strings.TrimSpace(definition.Name) == "" ||
 		strings.TrimSpace(definition.Description) == "" ||
@@ -47,6 +48,7 @@ func ValidateDefinition(definition Definition) error {
 	return nil
 }
 
+// JSONObjectInput encodes command arguments as the JSON object expected by a tool invocation.
 func JSONObjectInput(fields map[string]any) (json.RawMessage, error) {
 	if fields == nil {
 		fields = map[string]any{}

--- a/server/internal/agent/tools/executor.go
+++ b/server/internal/agent/tools/executor.go
@@ -9,10 +9,12 @@ type Executor struct {
 	registry *Registry
 }
 
+// NewExecutor creates a tool executor backed by the provided registry.
 func NewExecutor(registry *Registry) *Executor {
 	return &Executor{registry: registry}
 }
 
+// Execute validates a tool invocation, resolves its tool, and runs it with trusted context.
 func (executor *Executor) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -43,6 +45,7 @@ func (executor *Executor) Execute(
 	return result, nil
 }
 
+// MarshalInput encodes a typed value into the raw JSON payload used by tool invocations.
 func MarshalInput(value any) (json.RawMessage, error) {
 	raw, err := json.Marshal(value)
 	if err != nil {

--- a/server/internal/agent/tools/executor.go
+++ b/server/internal/agent/tools/executor.go
@@ -19,6 +19,7 @@ func (executor *Executor) Execute(
 	ctx context.Context,
 	call CallContext,
 	invocation Invocation,
+	policy Policy,
 ) (Result, error) {
 	if executor == nil || executor.registry == nil {
 		return Result{}, ErrUnknownTool
@@ -27,13 +28,17 @@ func (executor *Executor) Execute(
 	if !ok {
 		return Result{}, ErrUnknownTool
 	}
-	if err := ValidateJSONObject(invocation.Input); err != nil {
-		return Result{}, err
+	definition := tool.Definition()
+	if !policy.Allows(definition) {
+		return Result{}, ErrToolRejected
 	}
 	if !call.Actor.Valid() || call.ThreadID == "" ||
 		call.RunID == "" || call.ToolCallID == "" ||
 		call.RequestID == "" {
 		return Result{}, ErrToolRejected
+	}
+	if err := ValidateInput(definition.InputSchema, invocation.Input); err != nil {
+		return Result{}, err
 	}
 	result, err := tool.Execute(ctx, call, invocation.Input)
 	if err != nil {

--- a/server/internal/agent/tools/executor.go
+++ b/server/internal/agent/tools/executor.go
@@ -9,12 +9,12 @@ type Executor struct {
 	registry *Registry
 }
 
-// NewExecutor creates a tool executor backed by the provided registry.
+// NewExecutor 基于工具注册表创建统一工具执行器。
 func NewExecutor(registry *Registry) *Executor {
 	return &Executor{registry: registry}
 }
 
-// Execute validates a tool invocation, resolves its tool, and runs it with trusted context.
+// Execute 校验工具调用，查找对应工具，并带着可信上下文执行它。
 func (executor *Executor) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -45,7 +45,7 @@ func (executor *Executor) Execute(
 	return result, nil
 }
 
-// MarshalInput encodes a typed value into the raw JSON payload used by tool invocations.
+// MarshalInput 把结构化值编码成工具调用使用的原始 JSON 入参。
 func MarshalInput(value any) (json.RawMessage, error) {
 	raw, err := json.Marshal(value)
 	if err != nil {

--- a/server/internal/agent/tools/executor.go
+++ b/server/internal/agent/tools/executor.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type Executor struct {
+	registry *Registry
+}
+
+func NewExecutor(registry *Registry) *Executor {
+	return &Executor{registry: registry}
+}
+
+func (executor *Executor) Execute(
+	ctx context.Context,
+	call CallContext,
+	invocation Invocation,
+) (Result, error) {
+	if executor == nil || executor.registry == nil {
+		return Result{}, ErrUnknownTool
+	}
+	tool, ok := executor.registry.Get(invocation.Name)
+	if !ok {
+		return Result{}, ErrUnknownTool
+	}
+	if err := ValidateJSONObject(invocation.Input); err != nil {
+		return Result{}, err
+	}
+	if !call.Actor.Valid() || call.ThreadID == "" ||
+		call.RunID == "" || call.ToolCallID == "" ||
+		call.RequestID == "" {
+		return Result{}, ErrToolRejected
+	}
+	result, err := tool.Execute(ctx, call, invocation.Input)
+	if err != nil {
+		return Result{}, err
+	}
+	if result.Content == nil {
+		result.Content = map[string]any{}
+	}
+	return result, nil
+}
+
+func MarshalInput(value any) (json.RawMessage, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/server/internal/agent/tools/policy.go
+++ b/server/internal/agent/tools/policy.go
@@ -5,7 +5,7 @@ type Policy struct {
 	AllowWrites  bool
 }
 
-// Select returns the tool definitions allowed for the current Agent run.
+// Select 返回当前 Agent Run 允许暴露的工具定义。
 func (policy Policy) Select(registry *Registry) ([]Definition, error) {
 	if registry == nil {
 		return nil, nil
@@ -28,7 +28,7 @@ func (policy Policy) Select(registry *Registry) ([]Definition, error) {
 	return definitions, nil
 }
 
-// selectFromDefinitions filters definitions by write permission while preserving order.
+// selectFromDefinitions 按写权限过滤工具定义，并保持原有顺序。
 func selectFromDefinitions(definitions []Definition, allowWrites bool) []Definition {
 	selected := make([]Definition, 0, len(definitions))
 	for _, definition := range definitions {

--- a/server/internal/agent/tools/policy.go
+++ b/server/internal/agent/tools/policy.go
@@ -5,6 +5,22 @@ type Policy struct {
 	AllowWrites  bool
 }
 
+// Allows 判断某个工具定义在当前策略下是否允许执行。
+func (policy Policy) Allows(definition Definition) bool {
+	if !policy.AllowWrites && !definition.ReadOnly {
+		return false
+	}
+	if len(policy.AllowedNames) == 0 {
+		return true
+	}
+	for _, name := range policy.AllowedNames {
+		if name == definition.Name {
+			return true
+		}
+	}
+	return false
+}
+
 // Select 返回当前 Agent Run 允许暴露的工具定义。
 func (policy Policy) Select(registry *Registry) ([]Definition, error) {
 	if registry == nil {

--- a/server/internal/agent/tools/policy.go
+++ b/server/internal/agent/tools/policy.go
@@ -5,6 +5,7 @@ type Policy struct {
 	AllowWrites  bool
 }
 
+// Select returns the tool definitions allowed for the current Agent run.
 func (policy Policy) Select(registry *Registry) ([]Definition, error) {
 	if registry == nil {
 		return nil, nil
@@ -27,6 +28,7 @@ func (policy Policy) Select(registry *Registry) ([]Definition, error) {
 	return definitions, nil
 }
 
+// selectFromDefinitions filters definitions by write permission while preserving order.
 func selectFromDefinitions(definitions []Definition, allowWrites bool) []Definition {
 	selected := make([]Definition, 0, len(definitions))
 	for _, definition := range definitions {

--- a/server/internal/agent/tools/policy.go
+++ b/server/internal/agent/tools/policy.go
@@ -1,0 +1,38 @@
+package tools
+
+type Policy struct {
+	AllowedNames []string
+	AllowWrites  bool
+}
+
+func (policy Policy) Select(registry *Registry) ([]Definition, error) {
+	if registry == nil {
+		return nil, nil
+	}
+	if len(policy.AllowedNames) == 0 {
+		return selectFromDefinitions(registry.Definitions(), policy.AllowWrites), nil
+	}
+	definitions := make([]Definition, 0, len(policy.AllowedNames))
+	for _, name := range policy.AllowedNames {
+		tool, ok := registry.Get(name)
+		if !ok {
+			return nil, ErrUnknownTool
+		}
+		definition := tool.Definition()
+		if !policy.AllowWrites && !definition.ReadOnly {
+			continue
+		}
+		definitions = append(definitions, definition)
+	}
+	return definitions, nil
+}
+
+func selectFromDefinitions(definitions []Definition, allowWrites bool) []Definition {
+	selected := make([]Definition, 0, len(definitions))
+	for _, definition := range definitions {
+		if allowWrites || definition.ReadOnly {
+			selected = append(selected, definition)
+		}
+	}
+	return selected
+}

--- a/server/internal/agent/tools/registry.go
+++ b/server/internal/agent/tools/registry.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"errors"
+	"sort"
+)
+
+var ErrDuplicateTool = errors.New("agent tool: duplicate tool")
+
+type Registry struct {
+	tools map[string]Tool
+}
+
+func NewRegistry(items ...Tool) (*Registry, error) {
+	registry := &Registry{tools: make(map[string]Tool, len(items))}
+	for _, item := range items {
+		if err := registry.Register(item); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+func (registry *Registry) Register(tool Tool) error {
+	if registry == nil || tool == nil {
+		return ErrInvalidDefinition
+	}
+	definition := tool.Definition()
+	if err := ValidateDefinition(definition); err != nil {
+		return err
+	}
+	if registry.tools == nil {
+		registry.tools = make(map[string]Tool)
+	}
+	if _, exists := registry.tools[definition.Name]; exists {
+		return ErrDuplicateTool
+	}
+	registry.tools[definition.Name] = tool
+	return nil
+}
+
+func (registry *Registry) Get(name string) (Tool, bool) {
+	if registry == nil {
+		return nil, false
+	}
+	tool, ok := registry.tools[name]
+	return tool, ok
+}
+
+func (registry *Registry) Definitions() []Definition {
+	if registry == nil {
+		return nil
+	}
+	definitions := make([]Definition, 0, len(registry.tools))
+	for _, tool := range registry.tools {
+		definitions = append(definitions, tool.Definition())
+	}
+	sort.Slice(definitions, func(left, right int) bool {
+		return definitions[left].Name < definitions[right].Name
+	})
+	return definitions
+}

--- a/server/internal/agent/tools/registry.go
+++ b/server/internal/agent/tools/registry.go
@@ -11,6 +11,7 @@ type Registry struct {
 	tools map[string]Tool
 }
 
+// NewRegistry builds a tool registry and registers the provided tools.
 func NewRegistry(items ...Tool) (*Registry, error) {
 	registry := &Registry{tools: make(map[string]Tool, len(items))}
 	for _, item := range items {
@@ -21,6 +22,7 @@ func NewRegistry(items ...Tool) (*Registry, error) {
 	return registry, nil
 }
 
+// Register adds one tool implementation to the registry after validating its definition.
 func (registry *Registry) Register(tool Tool) error {
 	if registry == nil || tool == nil {
 		return ErrInvalidDefinition
@@ -39,6 +41,7 @@ func (registry *Registry) Register(tool Tool) error {
 	return nil
 }
 
+// Get finds a registered tool by its stable tool name.
 func (registry *Registry) Get(name string) (Tool, bool) {
 	if registry == nil {
 		return nil, false
@@ -47,6 +50,7 @@ func (registry *Registry) Get(name string) (Tool, bool) {
 	return tool, ok
 }
 
+// Definitions returns all tool definitions in stable name order for model exposure.
 func (registry *Registry) Definitions() []Definition {
 	if registry == nil {
 		return nil

--- a/server/internal/agent/tools/registry.go
+++ b/server/internal/agent/tools/registry.go
@@ -11,7 +11,7 @@ type Registry struct {
 	tools map[string]Tool
 }
 
-// NewRegistry builds a tool registry and registers the provided tools.
+// NewRegistry 创建工具注册表，并注册传入的工具。
 func NewRegistry(items ...Tool) (*Registry, error) {
 	registry := &Registry{tools: make(map[string]Tool, len(items))}
 	for _, item := range items {
@@ -22,7 +22,7 @@ func NewRegistry(items ...Tool) (*Registry, error) {
 	return registry, nil
 }
 
-// Register adds one tool implementation to the registry after validating its definition.
+// Register 校验工具定义后，把一个工具实现加入注册表。
 func (registry *Registry) Register(tool Tool) error {
 	if registry == nil || tool == nil {
 		return ErrInvalidDefinition
@@ -41,7 +41,7 @@ func (registry *Registry) Register(tool Tool) error {
 	return nil
 }
 
-// Get finds a registered tool by its stable tool name.
+// Get 按稳定工具名查找已注册工具。
 func (registry *Registry) Get(name string) (Tool, bool) {
 	if registry == nil {
 		return nil, false
@@ -50,7 +50,7 @@ func (registry *Registry) Get(name string) (Tool, bool) {
 	return tool, ok
 }
 
-// Definitions returns all tool definitions in stable name order for model exposure.
+// Definitions 按稳定顺序返回所有工具定义，供模型侧暴露使用。
 func (registry *Registry) Definitions() []Definition {
 	if registry == nil {
 		return nil

--- a/server/internal/agent/tools/registry_test.go
+++ b/server/internal/agent/tools/registry_test.go
@@ -1,0 +1,158 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type stubTool struct {
+	definition Definition
+	result     Result
+	err        error
+	input      json.RawMessage
+}
+
+func (tool *stubTool) Definition() Definition {
+	return tool.definition
+}
+
+func (tool *stubTool) Execute(
+	ctx context.Context,
+	call CallContext,
+	input json.RawMessage,
+) (Result, error) {
+	tool.input = append(json.RawMessage{}, input...)
+	return tool.result, tool.err
+}
+
+func TestRegistryRejectsDuplicateTools(t *testing.T) {
+	tool := &stubTool{definition: readToolDefinition("review.search.v1")}
+	registry, err := NewRegistry(tool)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	if err := registry.Register(tool); !errors.Is(err, ErrDuplicateTool) {
+		t.Fatalf("Register duplicate error = %v, want %v", err, ErrDuplicateTool)
+	}
+}
+
+func TestRegistryDefinitionsAreSorted(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubTool{definition: readToolDefinition("review.search.v1")},
+		&stubTool{definition: readToolDefinition("context.search.v1")},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	definitions := registry.Definitions()
+	if got, want := len(definitions), 2; got != want {
+		t.Fatalf("len(Definitions()) = %d, want %d", got, want)
+	}
+	if got, want := definitions[0].Name, "context.search.v1"; got != want {
+		t.Fatalf("Definitions()[0].Name = %q, want %q", got, want)
+	}
+}
+
+func TestPolicyFiltersWriteTools(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubTool{definition: readToolDefinition("review.search.v1")},
+		&stubTool{definition: writeToolDefinition("scenario.create.v1")},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	definitions, err := (Policy{}).Select(registry)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if got, want := len(definitions), 1; got != want {
+		t.Fatalf("len(Select()) = %d, want %d", got, want)
+	}
+	if got, want := definitions[0].Name, "review.search.v1"; got != want {
+		t.Fatalf("selected tool = %q, want %q", got, want)
+	}
+}
+
+func TestExecutorValidatesAndRunsTool(t *testing.T) {
+	tool := &stubTool{
+		definition: readToolDefinition("review.search.v1"),
+		result: Result{
+			Content: map[string]any{"ok": true},
+		},
+	}
+	registry, err := NewRegistry(tool)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	input := json.RawMessage(`{"query":"last interview"}`)
+	result, err := NewExecutor(registry).Execute(
+		context.Background(),
+		validCallContext(),
+		Invocation{Name: "review.search.v1", Input: input},
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.Content["ok"] != true {
+		t.Fatalf("Execute() content = %#v, want ok", result.Content)
+	}
+	if string(tool.input) != string(input) {
+		t.Fatalf("tool input = %s, want %s", tool.input, input)
+	}
+}
+
+func TestExecutorRejectsInvalidCallContext(t *testing.T) {
+	registry, err := NewRegistry(&stubTool{definition: readToolDefinition("review.search.v1")})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	_, err = NewExecutor(registry).Execute(
+		context.Background(),
+		CallContext{},
+		Invocation{Name: "review.search.v1", Input: json.RawMessage(`{}`)},
+	)
+	if !errors.Is(err, ErrToolRejected) {
+		t.Fatalf("Execute() error = %v, want %v", err, ErrToolRejected)
+	}
+}
+
+func readToolDefinition(name string) Definition {
+	return Definition{
+		Name:        name,
+		Description: "Search data.",
+		InputSchema: objectSchema(map[string]any{
+			"query": stringSchema("Query text."),
+		}, []string{"query"}),
+		ReadOnly: true,
+		Risk:     RiskReadOnly,
+	}
+}
+
+func writeToolDefinition(name string) Definition {
+	return Definition{
+		Name:        name,
+		Description: "Create data.",
+		InputSchema: objectSchema(map[string]any{
+			"title": stringSchema("Title."),
+		}, nil),
+		ReadOnly: false,
+		Risk:     RiskLowRiskWrite,
+	}
+}
+
+func validCallContext() CallContext {
+	return CallContext{
+		Actor: requestcontext.Actor{
+			UserID:    "user-1",
+			SessionID: "session-1",
+		},
+		ThreadID:   "thread-1",
+		RunID:      "run-1",
+		ToolCallID: "tool-call-1",
+		RequestID:  "request-1",
+	}
+}

--- a/server/internal/agent/tools/registry_test.go
+++ b/server/internal/agent/tools/registry_test.go
@@ -14,6 +14,7 @@ type stubTool struct {
 	result     Result
 	err        error
 	input      json.RawMessage
+	calls      int
 }
 
 func (tool *stubTool) Definition() Definition {
@@ -25,6 +26,7 @@ func (tool *stubTool) Execute(
 	call CallContext,
 	input json.RawMessage,
 ) (Result, error) {
+	tool.calls++
 	tool.input = append(json.RawMessage{}, input...)
 	return tool.result, tool.err
 }
@@ -93,6 +95,7 @@ func TestExecutorValidatesAndRunsTool(t *testing.T) {
 		context.Background(),
 		validCallContext(),
 		Invocation{Name: "review.search.v1", Input: input},
+		Policy{AllowedNames: []string{"review.search.v1"}},
 	)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -105,6 +108,26 @@ func TestExecutorValidatesAndRunsTool(t *testing.T) {
 	}
 }
 
+func TestExecutorRejectsToolOutsidePolicy(t *testing.T) {
+	tool := &stubTool{definition: writeToolDefinition("scenario.create.v1")}
+	registry, err := NewRegistry(tool)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	_, err = NewExecutor(registry).Execute(
+		context.Background(),
+		validCallContext(),
+		Invocation{Name: "scenario.create.v1", Input: json.RawMessage(`{"title":"PM interview"}`)},
+		Policy{},
+	)
+	if !errors.Is(err, ErrToolRejected) {
+		t.Fatalf("Execute() error = %v, want %v", err, ErrToolRejected)
+	}
+	if tool.calls != 0 {
+		t.Fatalf("tool calls = %d, want 0", tool.calls)
+	}
+}
+
 func TestExecutorRejectsInvalidCallContext(t *testing.T) {
 	registry, err := NewRegistry(&stubTool{definition: readToolDefinition("review.search.v1")})
 	if err != nil {
@@ -114,9 +137,43 @@ func TestExecutorRejectsInvalidCallContext(t *testing.T) {
 		context.Background(),
 		CallContext{},
 		Invocation{Name: "review.search.v1", Input: json.RawMessage(`{}`)},
+		Policy{AllowedNames: []string{"review.search.v1"}},
 	)
 	if !errors.Is(err, ErrToolRejected) {
 		t.Fatalf("Execute() error = %v, want %v", err, ErrToolRejected)
+	}
+}
+
+func TestExecutorValidatesInputSchema(t *testing.T) {
+	tests := []struct {
+		name  string
+		input json.RawMessage
+	}{
+		{name: "missing required", input: json.RawMessage(`{}`)},
+		{name: "wrong type", input: json.RawMessage(`{"query":123}`)},
+		{name: "extra field", input: json.RawMessage(`{"query":"x","unexpected":true}`)},
+		{name: "null field", input: json.RawMessage(`{"query":null}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &stubTool{definition: readToolDefinition("review.search.v1")}
+			registry, err := NewRegistry(tool)
+			if err != nil {
+				t.Fatalf("NewRegistry() error = %v", err)
+			}
+			_, err = NewExecutor(registry).Execute(
+				context.Background(),
+				validCallContext(),
+				Invocation{Name: "review.search.v1", Input: tt.input},
+				Policy{AllowedNames: []string{"review.search.v1"}},
+			)
+			if !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("Execute() error = %v, want %v", err, ErrInvalidInput)
+			}
+			if tool.calls != 0 {
+				t.Fatalf("tool calls = %d, want 0", tool.calls)
+			}
+		})
 	}
 }
 

--- a/server/internal/agent/tools/review.go
+++ b/server/internal/agent/tools/review.go
@@ -37,10 +37,12 @@ type ReviewSearchTool struct {
 	port ReviewPort
 }
 
+// NewReviewSearchTool creates the adapter for the review search tool.
 func NewReviewSearchTool(port ReviewPort) ReviewSearchTool {
 	return ReviewSearchTool{port: port}
 }
 
+// Definition describes review.search.v1 for model and command exposure.
 func (tool ReviewSearchTool) Definition() Definition {
 	return Definition{
 		Name:        ReviewSearchToolName,
@@ -58,6 +60,7 @@ func (tool ReviewSearchTool) Definition() Definition {
 	}
 }
 
+// Execute validates search input and delegates review lookup to the ReviewPort.
 func (tool ReviewSearchTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -90,10 +93,12 @@ type ReviewGetTool struct {
 	port ReviewPort
 }
 
+// NewReviewGetTool creates the adapter for reading one review.
 func NewReviewGetTool(port ReviewPort) ReviewGetTool {
 	return ReviewGetTool{port: port}
 }
 
+// Definition describes review.get.v1 for model exposure.
 func (tool ReviewGetTool) Definition() Definition {
 	return Definition{
 		Name:        ReviewGetToolName,
@@ -106,6 +111,7 @@ func (tool ReviewGetTool) Definition() Definition {
 	}
 }
 
+// Execute validates get input and delegates review detail loading to the ReviewPort.
 func (tool ReviewGetTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -128,6 +134,7 @@ func (tool ReviewGetTool) Execute(
 	}, nil
 }
 
+// reviewMap returns the compact JSON object exposed back to the model for a review.
 func reviewMap(review ReviewSummary) map[string]any {
 	return map[string]any{
 		"id":          review.ID,

--- a/server/internal/agent/tools/review.go
+++ b/server/internal/agent/tools/review.go
@@ -1,0 +1,138 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+const (
+	ReviewSearchToolName = "review.search.v1"
+	ReviewGetToolName    = "review.get.v1"
+)
+
+type ReviewSearchInput struct {
+	Query      string `json:"query"`
+	ScenarioID string `json:"scenario_id,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+}
+
+type ReviewGetInput struct {
+	ReviewID string `json:"review_id"`
+}
+
+type ReviewSummary struct {
+	ID         string      `json:"id"`
+	Title      string      `json:"title"`
+	Summary    string      `json:"summary"`
+	ScenarioID string      `json:"scenario_id,omitempty"`
+	SourceRefs []SourceRef `json:"source_refs,omitempty"`
+}
+
+type ReviewPort interface {
+	SearchReviews(ctx context.Context, call CallContext, input ReviewSearchInput) ([]ReviewSummary, error)
+	GetReview(ctx context.Context, call CallContext, input ReviewGetInput) (ReviewSummary, error)
+}
+
+type ReviewSearchTool struct {
+	port ReviewPort
+}
+
+func NewReviewSearchTool(port ReviewPort) ReviewSearchTool {
+	return ReviewSearchTool{port: port}
+}
+
+func (tool ReviewSearchTool) Definition() Definition {
+	return Definition{
+		Name:        ReviewSearchToolName,
+		Description: "Search the user's historical practice reviews or interview evaluations.",
+		InputSchema: objectSchema(map[string]any{
+			"query":       stringSchema("What review or evaluation the user wants to find."),
+			"scenario_id": stringSchema("Optional scenario id to restrict the search."),
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of reviews to return.",
+			},
+		}, []string{"query"}),
+		ReadOnly: true,
+		Risk:     RiskReadOnly,
+	}
+}
+
+func (tool ReviewSearchTool) Execute(
+	ctx context.Context,
+	call CallContext,
+	input json.RawMessage,
+) (Result, error) {
+	if tool.port == nil {
+		return Result{}, ErrToolRejected
+	}
+	var parsed ReviewSearchInput
+	if err := json.Unmarshal(input, &parsed); err != nil || parsed.Query == "" {
+		return Result{}, ErrInvalidInput
+	}
+	reviews, err := tool.port.SearchReviews(ctx, call, parsed)
+	if err != nil {
+		return Result{}, err
+	}
+	items := make([]map[string]any, 0, len(reviews))
+	sourceRefs := make([]SourceRef, 0)
+	for _, review := range reviews {
+		items = append(items, reviewMap(review))
+		sourceRefs = append(sourceRefs, review.SourceRefs...)
+	}
+	return Result{
+		Content:    map[string]any{"reviews": items},
+		SourceRefs: sourceRefs,
+	}, nil
+}
+
+type ReviewGetTool struct {
+	port ReviewPort
+}
+
+func NewReviewGetTool(port ReviewPort) ReviewGetTool {
+	return ReviewGetTool{port: port}
+}
+
+func (tool ReviewGetTool) Definition() Definition {
+	return Definition{
+		Name:        ReviewGetToolName,
+		Description: "Read one structured review or interview evaluation by id.",
+		InputSchema: objectSchema(map[string]any{
+			"review_id": stringSchema("Review id to read."),
+		}, []string{"review_id"}),
+		ReadOnly: true,
+		Risk:     RiskReadOnly,
+	}
+}
+
+func (tool ReviewGetTool) Execute(
+	ctx context.Context,
+	call CallContext,
+	input json.RawMessage,
+) (Result, error) {
+	if tool.port == nil {
+		return Result{}, ErrToolRejected
+	}
+	var parsed ReviewGetInput
+	if err := json.Unmarshal(input, &parsed); err != nil || parsed.ReviewID == "" {
+		return Result{}, ErrInvalidInput
+	}
+	review, err := tool.port.GetReview(ctx, call, parsed)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Content:    map[string]any{"review": reviewMap(review)},
+		SourceRefs: review.SourceRefs,
+	}, nil
+}
+
+func reviewMap(review ReviewSummary) map[string]any {
+	return map[string]any{
+		"id":          review.ID,
+		"title":       review.Title,
+		"summary":     review.Summary,
+		"scenario_id": review.ScenarioID,
+	}
+}

--- a/server/internal/agent/tools/review.go
+++ b/server/internal/agent/tools/review.go
@@ -37,12 +37,12 @@ type ReviewSearchTool struct {
 	port ReviewPort
 }
 
-// NewReviewSearchTool creates the adapter for the review search tool.
+// NewReviewSearchTool 创建 Review 搜索工具的适配器。
 func NewReviewSearchTool(port ReviewPort) ReviewSearchTool {
 	return ReviewSearchTool{port: port}
 }
 
-// Definition describes review.search.v1 for model and command exposure.
+// Definition 描述 review.search.v1，供模型和命令入口识别。
 func (tool ReviewSearchTool) Definition() Definition {
 	return Definition{
 		Name:        ReviewSearchToolName,
@@ -60,7 +60,7 @@ func (tool ReviewSearchTool) Definition() Definition {
 	}
 }
 
-// Execute validates search input and delegates review lookup to the ReviewPort.
+// Execute 校验 Review 搜索入参，并委托 ReviewPort 查询 Review。
 func (tool ReviewSearchTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -93,12 +93,12 @@ type ReviewGetTool struct {
 	port ReviewPort
 }
 
-// NewReviewGetTool creates the adapter for reading one review.
+// NewReviewGetTool 创建读取单个 Review 的工具适配器。
 func NewReviewGetTool(port ReviewPort) ReviewGetTool {
 	return ReviewGetTool{port: port}
 }
 
-// Definition describes review.get.v1 for model exposure.
+// Definition 描述 review.get.v1，供模型识别。
 func (tool ReviewGetTool) Definition() Definition {
 	return Definition{
 		Name:        ReviewGetToolName,
@@ -111,7 +111,7 @@ func (tool ReviewGetTool) Definition() Definition {
 	}
 }
 
-// Execute validates get input and delegates review detail loading to the ReviewPort.
+// Execute 校验 Review 读取入参，并委托 ReviewPort 加载详情。
 func (tool ReviewGetTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -134,7 +134,7 @@ func (tool ReviewGetTool) Execute(
 	}, nil
 }
 
-// reviewMap returns the compact JSON object exposed back to the model for a review.
+// reviewMap 返回暴露给模型的精简 Review JSON 对象。
 func reviewMap(review ReviewSummary) map[string]any {
 	return map[string]any{
 		"id":          review.ID,

--- a/server/internal/agent/tools/review_test.go
+++ b/server/internal/agent/tools/review_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fakeReviewPort struct {
+	searchInput ReviewSearchInput
+	getInput    ReviewGetInput
+}
+
+func (port *fakeReviewPort) SearchReviews(
+	ctx context.Context,
+	call CallContext,
+	input ReviewSearchInput,
+) ([]ReviewSummary, error) {
+	port.searchInput = input
+	return []ReviewSummary{{
+		ID:      "review-1",
+		Title:   "Mock interview review",
+		Summary: "Answer was too long.",
+	}}, nil
+}
+
+func (port *fakeReviewPort) GetReview(
+	ctx context.Context,
+	call CallContext,
+	input ReviewGetInput,
+) (ReviewSummary, error) {
+	port.getInput = input
+	return ReviewSummary{
+		ID:      input.ReviewID,
+		Title:   "Mock interview review",
+		Summary: "Answer was too long.",
+	}, nil
+}
+
+func TestReviewSearchToolMapsInput(t *testing.T) {
+	port := &fakeReviewPort{}
+	result, err := NewReviewSearchTool(port).Execute(
+		context.Background(),
+		validCallContext(),
+		json.RawMessage(`{"query":"上次面试评价"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := port.searchInput.Query, "上次面试评价"; got != want {
+		t.Fatalf("searchInput.Query = %q, want %q", got, want)
+	}
+	if result.Content["reviews"] == nil {
+		t.Fatalf("result.Content = %#v, want reviews", result.Content)
+	}
+}
+
+func TestReviewGetToolMapsInput(t *testing.T) {
+	port := &fakeReviewPort{}
+	result, err := NewReviewGetTool(port).Execute(
+		context.Background(),
+		validCallContext(),
+		json.RawMessage(`{"review_id":"review-1"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := port.getInput.ReviewID, "review-1"; got != want {
+		t.Fatalf("getInput.ReviewID = %q, want %q", got, want)
+	}
+	if result.Content["review"] == nil {
+		t.Fatalf("result.Content = %#v, want review", result.Content)
+	}
+}

--- a/server/internal/agent/tools/scenario.go
+++ b/server/internal/agent/tools/scenario.go
@@ -1,0 +1,146 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+const (
+	ScenarioCreateToolName = "scenario.create.v1"
+	ScenarioSearchToolName = "scenario.search.v1"
+)
+
+type ScenarioCreateInput struct {
+	Type  string `json:"type"`
+	Title string `json:"title,omitempty"`
+	Goal  string `json:"goal,omitempty"`
+}
+
+type ScenarioSearchInput struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+type ScenarioResult struct {
+	ID        string      `json:"id"`
+	Title     string      `json:"title"`
+	Type      string      `json:"type"`
+	Status    string      `json:"status"`
+	Summary   string      `json:"summary,omitempty"`
+	SourceRef []SourceRef `json:"source_refs,omitempty"`
+}
+
+type ScenarioPort interface {
+	CreateScenario(ctx context.Context, call CallContext, input ScenarioCreateInput) (ScenarioResult, error)
+	SearchScenarios(ctx context.Context, call CallContext, input ScenarioSearchInput) ([]ScenarioResult, error)
+}
+
+type ScenarioCreateTool struct {
+	port ScenarioPort
+}
+
+func NewScenarioCreateTool(port ScenarioPort) ScenarioCreateTool {
+	return ScenarioCreateTool{port: port}
+}
+
+func (tool ScenarioCreateTool) Definition() Definition {
+	return Definition{
+		Name:        ScenarioCreateToolName,
+		Description: "Create a user's real-world interview, meeting, client, or speaking scenario.",
+		InputSchema: objectSchema(map[string]any{
+			"type":  stringSchema("Scenario type such as interview, meeting, client, presentation, or speaking."),
+			"title": stringSchema("Short user-facing scenario title."),
+			"goal":  stringSchema("What the user wants to prepare or improve."),
+		}, []string{"type"}),
+		ReadOnly: false,
+		Risk:     RiskLowRiskWrite,
+	}
+}
+
+func (tool ScenarioCreateTool) Execute(
+	ctx context.Context,
+	call CallContext,
+	input json.RawMessage,
+) (Result, error) {
+	if tool.port == nil {
+		return Result{}, ErrToolRejected
+	}
+	var parsed ScenarioCreateInput
+	if err := json.Unmarshal(input, &parsed); err != nil || parsed.Type == "" {
+		return Result{}, ErrInvalidInput
+	}
+	result, err := tool.port.CreateScenario(ctx, call, parsed)
+	if err != nil {
+		return Result{}, err
+	}
+	return scenarioToolResult(result), nil
+}
+
+type ScenarioSearchTool struct {
+	port ScenarioPort
+}
+
+func NewScenarioSearchTool(port ScenarioPort) ScenarioSearchTool {
+	return ScenarioSearchTool{port: port}
+}
+
+func (tool ScenarioSearchTool) Definition() Definition {
+	return Definition{
+		Name:        ScenarioSearchToolName,
+		Description: "Search the user's existing scenarios when the current scenario is ambiguous.",
+		InputSchema: objectSchema(map[string]any{
+			"query": stringSchema("User phrase describing the scenario to find."),
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of scenarios to return.",
+			},
+		}, []string{"query"}),
+		ReadOnly: true,
+		Risk:     RiskReadOnly,
+	}
+}
+
+func (tool ScenarioSearchTool) Execute(
+	ctx context.Context,
+	call CallContext,
+	input json.RawMessage,
+) (Result, error) {
+	if tool.port == nil {
+		return Result{}, ErrToolRejected
+	}
+	var parsed ScenarioSearchInput
+	if err := json.Unmarshal(input, &parsed); err != nil || parsed.Query == "" {
+		return Result{}, ErrInvalidInput
+	}
+	results, err := tool.port.SearchScenarios(ctx, call, parsed)
+	if err != nil {
+		return Result{}, err
+	}
+	items := make([]map[string]any, 0, len(results))
+	sourceRefs := make([]SourceRef, 0)
+	for _, result := range results {
+		items = append(items, scenarioMap(result))
+		sourceRefs = append(sourceRefs, result.SourceRef...)
+	}
+	return Result{
+		Content:    map[string]any{"scenarios": items},
+		SourceRefs: sourceRefs,
+	}, nil
+}
+
+func scenarioToolResult(result ScenarioResult) Result {
+	return Result{
+		Content:    map[string]any{"scenario": scenarioMap(result)},
+		SourceRefs: result.SourceRef,
+	}
+}
+
+func scenarioMap(result ScenarioResult) map[string]any {
+	return map[string]any{
+		"id":      result.ID,
+		"title":   result.Title,
+		"type":    result.Type,
+		"status":  result.Status,
+		"summary": result.Summary,
+	}
+}

--- a/server/internal/agent/tools/scenario.go
+++ b/server/internal/agent/tools/scenario.go
@@ -39,12 +39,12 @@ type ScenarioCreateTool struct {
 	port ScenarioPort
 }
 
-// NewScenarioCreateTool creates the adapter for the scenario creation tool.
+// NewScenarioCreateTool 创建场景创建工具的适配器。
 func NewScenarioCreateTool(port ScenarioPort) ScenarioCreateTool {
 	return ScenarioCreateTool{port: port}
 }
 
-// Definition describes scenario.create.v1 for model and command exposure.
+// Definition 描述 scenario.create.v1，供模型和命令入口识别。
 func (tool ScenarioCreateTool) Definition() Definition {
 	return Definition{
 		Name:        ScenarioCreateToolName,
@@ -59,7 +59,7 @@ func (tool ScenarioCreateTool) Definition() Definition {
 	}
 }
 
-// Execute validates create input and delegates scenario creation to the ScenarioPort.
+// Execute 校验创建场景入参，并委托 ScenarioPort 创建场景。
 func (tool ScenarioCreateTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -83,12 +83,12 @@ type ScenarioSearchTool struct {
 	port ScenarioPort
 }
 
-// NewScenarioSearchTool creates the adapter for the scenario search tool.
+// NewScenarioSearchTool 创建场景搜索工具的适配器。
 func NewScenarioSearchTool(port ScenarioPort) ScenarioSearchTool {
 	return ScenarioSearchTool{port: port}
 }
 
-// Definition describes scenario.search.v1 for model and command exposure.
+// Definition 描述 scenario.search.v1，供模型和命令入口识别。
 func (tool ScenarioSearchTool) Definition() Definition {
 	return Definition{
 		Name:        ScenarioSearchToolName,
@@ -105,7 +105,7 @@ func (tool ScenarioSearchTool) Definition() Definition {
 	}
 }
 
-// Execute validates search input and delegates scenario lookup to the ScenarioPort.
+// Execute 校验搜索场景入参，并委托 ScenarioPort 查询场景。
 func (tool ScenarioSearchTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -134,7 +134,7 @@ func (tool ScenarioSearchTool) Execute(
 	}, nil
 }
 
-// scenarioToolResult converts a single scenario domain result into a tool result.
+// scenarioToolResult 把单个场景领域结果转换成工具结果。
 func scenarioToolResult(result ScenarioResult) Result {
 	return Result{
 		Content:    map[string]any{"scenario": scenarioMap(result)},
@@ -142,7 +142,7 @@ func scenarioToolResult(result ScenarioResult) Result {
 	}
 }
 
-// scenarioMap returns the compact JSON object exposed back to the model for a scenario.
+// scenarioMap 返回暴露给模型的精简场景 JSON 对象。
 func scenarioMap(result ScenarioResult) map[string]any {
 	return map[string]any{
 		"id":      result.ID,

--- a/server/internal/agent/tools/scenario.go
+++ b/server/internal/agent/tools/scenario.go
@@ -39,10 +39,12 @@ type ScenarioCreateTool struct {
 	port ScenarioPort
 }
 
+// NewScenarioCreateTool creates the adapter for the scenario creation tool.
 func NewScenarioCreateTool(port ScenarioPort) ScenarioCreateTool {
 	return ScenarioCreateTool{port: port}
 }
 
+// Definition describes scenario.create.v1 for model and command exposure.
 func (tool ScenarioCreateTool) Definition() Definition {
 	return Definition{
 		Name:        ScenarioCreateToolName,
@@ -57,6 +59,7 @@ func (tool ScenarioCreateTool) Definition() Definition {
 	}
 }
 
+// Execute validates create input and delegates scenario creation to the ScenarioPort.
 func (tool ScenarioCreateTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -80,10 +83,12 @@ type ScenarioSearchTool struct {
 	port ScenarioPort
 }
 
+// NewScenarioSearchTool creates the adapter for the scenario search tool.
 func NewScenarioSearchTool(port ScenarioPort) ScenarioSearchTool {
 	return ScenarioSearchTool{port: port}
 }
 
+// Definition describes scenario.search.v1 for model and command exposure.
 func (tool ScenarioSearchTool) Definition() Definition {
 	return Definition{
 		Name:        ScenarioSearchToolName,
@@ -100,6 +105,7 @@ func (tool ScenarioSearchTool) Definition() Definition {
 	}
 }
 
+// Execute validates search input and delegates scenario lookup to the ScenarioPort.
 func (tool ScenarioSearchTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -128,6 +134,7 @@ func (tool ScenarioSearchTool) Execute(
 	}, nil
 }
 
+// scenarioToolResult converts a single scenario domain result into a tool result.
 func scenarioToolResult(result ScenarioResult) Result {
 	return Result{
 		Content:    map[string]any{"scenario": scenarioMap(result)},
@@ -135,6 +142,7 @@ func scenarioToolResult(result ScenarioResult) Result {
 	}
 }
 
+// scenarioMap returns the compact JSON object exposed back to the model for a scenario.
 func scenarioMap(result ScenarioResult) map[string]any {
 	return map[string]any{
 		"id":      result.ID,

--- a/server/internal/agent/tools/scenario_test.go
+++ b/server/internal/agent/tools/scenario_test.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fakeScenarioPort struct {
+	createInput ScenarioCreateInput
+	searchInput ScenarioSearchInput
+}
+
+func (port *fakeScenarioPort) CreateScenario(
+	ctx context.Context,
+	call CallContext,
+	input ScenarioCreateInput,
+) (ScenarioResult, error) {
+	port.createInput = input
+	return ScenarioResult{
+		ID:      "scenario-1",
+		Title:   input.Title,
+		Type:    input.Type,
+		Status:  "active",
+		Summary: input.Goal,
+		SourceRef: []SourceRef{{
+			Type: "scenario",
+			ID:   "scenario-1",
+		}},
+	}, nil
+}
+
+func (port *fakeScenarioPort) SearchScenarios(
+	ctx context.Context,
+	call CallContext,
+	input ScenarioSearchInput,
+) ([]ScenarioResult, error) {
+	port.searchInput = input
+	return []ScenarioResult{{
+		ID:     "scenario-1",
+		Title:  "PM interview",
+		Type:   "interview",
+		Status: "active",
+	}}, nil
+}
+
+func TestScenarioCreateToolMapsInput(t *testing.T) {
+	port := &fakeScenarioPort{}
+	result, err := NewScenarioCreateTool(port).Execute(
+		context.Background(),
+		validCallContext(),
+		json.RawMessage(`{"type":"interview","title":"PM interview","goal":"prepare self introduction"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := port.createInput.Type, "interview"; got != want {
+		t.Fatalf("createInput.Type = %q, want %q", got, want)
+	}
+	if result.Content["scenario"] == nil {
+		t.Fatalf("result.Content = %#v, want scenario", result.Content)
+	}
+}
+
+func TestScenarioSearchToolMapsInput(t *testing.T) {
+	port := &fakeScenarioPort{}
+	result, err := NewScenarioSearchTool(port).Execute(
+		context.Background(),
+		validCallContext(),
+		json.RawMessage(`{"query":"上次面试","limit":3}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := port.searchInput.Query, "上次面试"; got != want {
+		t.Fatalf("searchInput.Query = %q, want %q", got, want)
+	}
+	if result.Content["scenarios"] == nil {
+		t.Fatalf("result.Content = %#v, want scenarios", result.Content)
+	}
+}

--- a/server/internal/agent/tools/schema.go
+++ b/server/internal/agent/tools/schema.go
@@ -1,0 +1,94 @@
+// Package tools contains the Agent tool contract and small adapters that expose
+// domain services to the Agent runtime.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type Risk string
+
+const (
+	RiskReadOnly        Risk = "read_only"
+	RiskLowRiskWrite    Risk = "low_risk_write"
+	RiskRequiresConfirm Risk = "requires_confirm"
+)
+
+var (
+	ErrInvalidDefinition = errors.New("agent tool: invalid definition")
+	ErrInvalidInput      = errors.New("agent tool: invalid input")
+	ErrUnknownTool       = errors.New("agent tool: unknown tool")
+	ErrToolRejected      = errors.New("agent tool: rejected")
+)
+
+type Definition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"input_schema"`
+	ReadOnly    bool           `json:"read_only"`
+	Risk        Risk           `json:"risk"`
+}
+
+type SourceRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type CallContext struct {
+	Actor      requestcontext.Actor
+	ThreadID   string
+	RunID      string
+	ToolCallID string
+	RequestID  string
+}
+
+type Invocation struct {
+	Name  string
+	Input json.RawMessage
+}
+
+type Result struct {
+	Content    map[string]any `json:"content"`
+	SourceRefs []SourceRef    `json:"source_refs,omitempty"`
+}
+
+type Tool interface {
+	Definition() Definition
+	Execute(ctx context.Context, call CallContext, input json.RawMessage) (Result, error)
+}
+
+func ValidateDefinition(definition Definition) error {
+	if strings.TrimSpace(definition.Name) == "" ||
+		strings.TrimSpace(definition.Description) == "" ||
+		definition.InputSchema == nil ||
+		!validRisk(definition.Risk) {
+		return ErrInvalidDefinition
+	}
+	if readOnlyRisk(definition.Risk) != definition.ReadOnly {
+		return ErrInvalidDefinition
+	}
+	return nil
+}
+
+func ValidateJSONObject(input json.RawMessage) error {
+	var value map[string]any
+	if len(input) == 0 || json.Unmarshal(input, &value) != nil {
+		return ErrInvalidInput
+	}
+	return nil
+}
+
+func readOnlyRisk(risk Risk) bool {
+	return risk == RiskReadOnly
+}
+
+func validRisk(risk Risk) bool {
+	return risk == RiskReadOnly ||
+		risk == RiskLowRiskWrite ||
+		risk == RiskRequiresConfirm
+}

--- a/server/internal/agent/tools/schema.go
+++ b/server/internal/agent/tools/schema.go
@@ -1,5 +1,4 @@
-// Package tools contains the Agent tool contract and small adapters that expose
-// domain services to the Agent runtime.
+// Package tools 定义 Agent 工具契约，并把领域服务适配成 Agent 可调用工具。
 package tools
 
 import (
@@ -62,7 +61,7 @@ type Tool interface {
 	Execute(ctx context.Context, call CallContext, input json.RawMessage) (Result, error)
 }
 
-// ValidateDefinition checks whether a tool definition is safe to expose to the model.
+// ValidateDefinition 检查工具定义是否完整，能否安全暴露给模型。
 func ValidateDefinition(definition Definition) error {
 	if strings.TrimSpace(definition.Name) == "" ||
 		strings.TrimSpace(definition.Description) == "" ||
@@ -76,7 +75,7 @@ func ValidateDefinition(definition Definition) error {
 	return nil
 }
 
-// ValidateJSONObject ensures a tool input payload is a non-empty JSON object.
+// ValidateJSONObject 检查工具入参是否为非空 JSON 对象。
 func ValidateJSONObject(input json.RawMessage) error {
 	var value map[string]any
 	if len(input) == 0 || json.Unmarshal(input, &value) != nil {
@@ -85,12 +84,12 @@ func ValidateJSONObject(input json.RawMessage) error {
 	return nil
 }
 
-// readOnlyRisk reports whether the risk level represents a read-only tool.
+// readOnlyRisk 判断风险等级是否代表只读工具。
 func readOnlyRisk(risk Risk) bool {
 	return risk == RiskReadOnly
 }
 
-// validRisk reports whether the risk value is one of the supported tool risk levels.
+// validRisk 判断风险等级是否为当前支持的取值。
 func validRisk(risk Risk) bool {
 	return risk == RiskReadOnly ||
 		risk == RiskLowRiskWrite ||

--- a/server/internal/agent/tools/schema.go
+++ b/server/internal/agent/tools/schema.go
@@ -62,6 +62,7 @@ type Tool interface {
 	Execute(ctx context.Context, call CallContext, input json.RawMessage) (Result, error)
 }
 
+// ValidateDefinition checks whether a tool definition is safe to expose to the model.
 func ValidateDefinition(definition Definition) error {
 	if strings.TrimSpace(definition.Name) == "" ||
 		strings.TrimSpace(definition.Description) == "" ||
@@ -75,6 +76,7 @@ func ValidateDefinition(definition Definition) error {
 	return nil
 }
 
+// ValidateJSONObject ensures a tool input payload is a non-empty JSON object.
 func ValidateJSONObject(input json.RawMessage) error {
 	var value map[string]any
 	if len(input) == 0 || json.Unmarshal(input, &value) != nil {
@@ -83,10 +85,12 @@ func ValidateJSONObject(input json.RawMessage) error {
 	return nil
 }
 
+// readOnlyRisk reports whether the risk level represents a read-only tool.
 func readOnlyRisk(risk Risk) bool {
 	return risk == RiskReadOnly
 }
 
+// validRisk reports whether the risk value is one of the supported tool risk levels.
 func validRisk(risk Risk) bool {
 	return risk == RiskReadOnly ||
 		risk == RiskLowRiskWrite ||

--- a/server/internal/agent/tools/schema.go
+++ b/server/internal/agent/tools/schema.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
@@ -78,8 +79,52 @@ func ValidateDefinition(definition Definition) error {
 // ValidateJSONObject 检查工具入参是否为非空 JSON 对象。
 func ValidateJSONObject(input json.RawMessage) error {
 	var value map[string]any
-	if len(input) == 0 || json.Unmarshal(input, &value) != nil {
+	if len(input) == 0 || json.Unmarshal(input, &value) != nil || value == nil {
 		return ErrInvalidInput
+	}
+	return nil
+}
+
+// ValidateInput 按工具声明的 InputSchema 校验一次工具调用入参。
+func ValidateInput(schema map[string]any, input json.RawMessage) error {
+	if err := ValidateJSONObject(input); err != nil {
+		return err
+	}
+	var value map[string]any
+	if err := json.Unmarshal(input, &value); err != nil {
+		return ErrInvalidInput
+	}
+	if schemaType(schema) != "object" {
+		return ErrInvalidDefinition
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		properties = map[string]any{}
+	}
+	for _, field := range requiredFields(schema) {
+		raw, exists := value[field]
+		if !exists || raw == nil {
+			return ErrInvalidInput
+		}
+	}
+	if additionalPropertiesDisabled(schema) {
+		for field := range value {
+			if _, exists := properties[field]; !exists {
+				return ErrInvalidInput
+			}
+		}
+	}
+	for field, raw := range value {
+		if raw == nil {
+			return ErrInvalidInput
+		}
+		property, ok := properties[field].(map[string]any)
+		if !ok {
+			continue
+		}
+		if !matchesJSONType(raw, schemaType(property)) {
+			return ErrInvalidInput
+		}
 	}
 	return nil
 }
@@ -94,4 +139,63 @@ func validRisk(risk Risk) bool {
 	return risk == RiskReadOnly ||
 		risk == RiskLowRiskWrite ||
 		risk == RiskRequiresConfirm
+}
+
+// schemaType 读取 JSON Schema 的 type 字段。
+func schemaType(schema map[string]any) string {
+	value, _ := schema["type"].(string)
+	return value
+}
+
+// requiredFields 读取 JSON Schema 的 required 字段。
+func requiredFields(schema map[string]any) []string {
+	switch raw := schema["required"].(type) {
+	case []string:
+		return append([]string{}, raw...)
+	case []any:
+		fields := make([]string, 0, len(raw))
+		for _, value := range raw {
+			field, ok := value.(string)
+			if ok {
+				fields = append(fields, field)
+			}
+		}
+		return fields
+	default:
+		return nil
+	}
+}
+
+// additionalPropertiesDisabled 判断 Schema 是否禁止额外字段。
+func additionalPropertiesDisabled(schema map[string]any) bool {
+	value, ok := schema["additionalProperties"].(bool)
+	return ok && !value
+}
+
+// matchesJSONType 判断反序列化后的 JSON 值是否符合声明类型。
+func matchesJSONType(value any, declared string) bool {
+	switch declared {
+	case "":
+		return true
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "integer":
+		number, ok := value.(float64)
+		return ok && math.Trunc(number) == number
+	case "number":
+		_, ok := value.(float64)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	default:
+		return false
+	}
 }

--- a/server/internal/agent/tools/schema_helpers.go
+++ b/server/internal/agent/tools/schema_helpers.go
@@ -1,6 +1,6 @@
 package tools
 
-// objectSchema builds the small JSON schema object used by tool definitions.
+// objectSchema 构造工具定义里使用的简单 JSON Schema 对象。
 func objectSchema(properties map[string]any, required []string) map[string]any {
 	return map[string]any{
 		"type":                 "object",
@@ -10,7 +10,7 @@ func objectSchema(properties map[string]any, required []string) map[string]any {
 	}
 }
 
-// stringSchema builds a string property schema with a human-readable description.
+// stringSchema 构造带说明的字符串字段 Schema。
 func stringSchema(description string) map[string]any {
 	return map[string]any{
 		"type":        "string",

--- a/server/internal/agent/tools/schema_helpers.go
+++ b/server/internal/agent/tools/schema_helpers.go
@@ -1,5 +1,6 @@
 package tools
 
+// objectSchema builds the small JSON schema object used by tool definitions.
 func objectSchema(properties map[string]any, required []string) map[string]any {
 	return map[string]any{
 		"type":                 "object",
@@ -9,6 +10,7 @@ func objectSchema(properties map[string]any, required []string) map[string]any {
 	}
 }
 
+// stringSchema builds a string property schema with a human-readable description.
 func stringSchema(description string) map[string]any {
 	return map[string]any{
 		"type":        "string",

--- a/server/internal/agent/tools/schema_helpers.go
+++ b/server/internal/agent/tools/schema_helpers.go
@@ -1,0 +1,17 @@
+package tools
+
+func objectSchema(properties map[string]any, required []string) map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"required":             required,
+		"additionalProperties": false,
+	}
+}
+
+func stringSchema(description string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}


### PR DESCRIPTION
## 功能描述

Part of #129.

为 Agent 模块新增第一阶段工具与命令运行时骨架，不搬动现有 `server/internal/agent` 平铺文件：

- 新增 `server/internal/agent/tools` 子包，定义 Tool 契约、Registry、Policy、Executor。
- 新增 Scenario / Review 工具适配器骨架，明确领域模块通过 Port 被 Agent 调用。
- 新增 `server/internal/agent/commands` 子包，将 `/创建面试`、`/查评价` 等显式命令解析为内部 Tool Invocation。
- 补充工具注册、策略筛选、执行器、命令解析和适配器映射测试。

## 实现思路

- 工具注册只接收实现 `Tool` 接口的 Agent 适配器，领域模块不需要依赖 Agent 工具接口。
- 命令入口不直接调用领域 Service，而是转成 Tool Invocation，后续复用 Tool Executor 的权限、幂等和审计链路。
- 本 PR 只落骨架和测试，不接真实 LLM function calling、不改数据库、不新增 HTTP API，避免和现有 Agent 主链 PR 冲突。

## 测试方式

```bash
cd server
go test ./internal/agent/...
go test ./...
```

## 明确不做

- 不迁移旧 `service.go` / `run_service.go` / `postgres.go` 到 domain/application/infra。
- 不实现长期记忆晋升、Practice Runtime 或 Review Worker。
- 不引入 MCP。
- 不改动现有语音消息状态机。
