### PR TITLE
[测试] 补齐新账号真实 iOS 多对话 E2E

### DIFF
--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -205,13 +205,7 @@ Future<void> _registerOrSignIn(
   await tester.enterText(find.byType(TextFormField).at(0), email);
   await tester.enterText(find.byType(TextFormField).at(1), password);
   await _tapAuthSubmit(tester, '登录');
-  await _waitUntil(
-    tester,
-    () =>
-        find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
-        _composerIsReady(tester),
-    const Duration(seconds: 20),
-  );
+  await _ensureFocusedConversation(tester);
 }
 
 Future<void> _signIn(
@@ -624,13 +618,7 @@ Future<bool> _signedInAccountMatches(
     return false;
   }
   await tester.tap(find.byKey(const Key('primary-tab-agent')));
-  await _waitUntil(
-    tester,
-    () =>
-        find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
-        _composerIsReady(tester),
-    const Duration(seconds: 20),
-  );
+  await _ensureFocusedConversation(tester);
   return true;
 }
 
@@ -656,6 +644,30 @@ bool _composerIsReady(WidgetTester tester) {
     return false;
   }
   return tester.widget<TextField>(composer).enabled == true;
+}
+
+Future<void> _ensureFocusedConversation(WidgetTester tester) async {
+  final createConversation = find.byKey(
+    const Key('no-focused-create-conversation'),
+  );
+  await _waitUntil(
+    tester,
+    () =>
+        find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
+        (_composerIsReady(tester) ||
+            createConversation.hitTestable().evaluate().length == 1),
+    const Duration(seconds: 20),
+  );
+  if (_composerIsReady(tester)) {
+    return;
+  }
+
+  await tester.tap(createConversation);
+  await _waitUntil(
+    tester,
+    () => _composerIsReady(tester),
+    const Duration(seconds: 20),
+  );
 }
 
 bool _sendButtonIsEnabled(WidgetTester tester) {


### PR DESCRIPTION
## 功能描述

真实 iOS E2E 现在遵守 #122 已冻结的 focused Thread 规则：新账号登录后如果没有 focused Thread，先等待并显式点击“创建新对话”，再继续 Qianwen 文本与语音练习主链；已有 focused Thread 时直接恢复，不额外创建。

## 实现思路

- 复用 `no-focused-create-conversation` 真实空态 CTA。
- 首次登录与已有登录态回到 Agent 页时，共用一个有界 helper。
- 完成练习后重登仍允许产品自动落到 Review，不强行切回 Agent 页。
- 不修改 AgentController、Wire API 或服务端，不改变“用户显式新建并聚焦”的产品语义。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/agent/agent_controller_test.dart test/speak_up_app_test.dart
```

目标环境真实 Gate 已通过：

```bash
flutter test integration_test/real_agent_e2e_test.dart \
  -d F726FD1C-12E1-4E8A-9741-F6FC98B4520D \
  --dart-define=SPEAKUP_API_BASE_URL=http://127.0.0.1:8081 \
  --dart-define=SPEAKUP_E2E_EMAIL=<disposable-email> \
  --dart-define=SPEAKUP_E2E_PASSWORD=<disposable-password> \
  --dart-define=SPEAKUP_E2E_WAV_BASE64=<private-wav-base64> \
  --dart-define=SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA=true
```

结果：注册/登录、显式创建与聚焦 Thread、真实 Qianwen Agent、三轮 TTS/ASR、OSS 音频播放与删除、FormalReview、退出重登后历史恢复全部通过。

Closes #122
