### PR TITLE
refactor(practice): formalize domain application contracts

### DIFF
--- a/server/internal/practice/contract_test.go
+++ b/server/internal/practice/contract_test.go
@@ -1,0 +1,123 @@
+package practice_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
+)
+
+func TestContractValues(t *testing.T) {
+	tests := map[string]string{
+		"scenario interview":        string(practice.ScenarioTypeInterview),
+		"plan configuring":          string(practice.PracticePlanConfiguring),
+		"plan configuration failed": string(practice.PracticePlanConfigurationFailed),
+		"plan ready":                string(practice.PracticePlanReady),
+		"plan archived":             string(practice.PracticePlanArchived),
+		"session starting":          string(practice.PracticeSessionStarting),
+		"session in progress":       string(practice.PracticeSessionInProgress),
+		"session paused":            string(practice.PracticeSessionPaused),
+		"session completed":         string(practice.PracticeSessionCompleted),
+		"session ended early":       string(practice.PracticeSessionEndedEarly),
+		"full simulation":           string(practice.PracticeModeFullSimulation),
+		"focused practice":          string(practice.PracticeModeFocusedPractice),
+		"coverage covered":          string(practice.CoverageCovered),
+		"coverage partial":          string(practice.CoveragePartial),
+		"coverage uncovered":        string(practice.CoverageUncovered),
+		"objectives covered":        string(practice.EarlyCompletionObjectivesCovered),
+		"coverage after checkpoint": string(practice.EarlyCompletionCoverageSatisfiedAfterCheckpoint),
+		"coverage end reason":       string(practice.PracticeSessionEndCoverageSatisfiedAtCheckpoint),
+		"follow up current":         string(practice.NextActionFollowUpCurrent),
+		"move to next objective":    string(practice.NextActionMoveToNextObjective),
+		"complete session":          string(practice.NextActionCompleteSession),
+	}
+	want := map[string]string{
+		"scenario interview":        "INTERVIEW",
+		"plan configuring":          "configuring",
+		"plan configuration failed": "configuration_failed",
+		"plan ready":                "ready",
+		"plan archived":             "archived",
+		"session starting":          "starting",
+		"session in progress":       "in_progress",
+		"session paused":            "paused",
+		"session completed":         "completed",
+		"session ended early":       "ended_early",
+		"full simulation":           "full_simulation",
+		"focused practice":          "focused_practice",
+		"coverage covered":          "covered",
+		"coverage partial":          "partial",
+		"coverage uncovered":        "uncovered",
+		"objectives covered":        "objectives_covered",
+		"coverage after checkpoint": "COVERAGE_SATISFIED_AFTER_CHECKPOINT",
+		"coverage end reason":       "COVERAGE_SATISFIED_AT_CHECKPOINT",
+		"follow up current":         "FOLLOW_UP_CURRENT",
+		"move to next objective":    "MOVE_TO_NEXT_OBJECTIVE",
+		"complete session":          "COMPLETE_SESSION",
+	}
+	for name, value := range tests {
+		if value != want[name] {
+			t.Errorf("%s = %q, want %q", name, value, want[name])
+		}
+	}
+}
+
+func TestCrossModuleContractsExposeRequiredFields(t *testing.T) {
+	createdAt := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	contracts := []any{
+		practice.PracticePlan{
+			ID:       "plan-1",
+			UserID:   "user-1",
+			Revision: 1,
+			Status:   practice.PracticePlanReady,
+		},
+		practice.PracticeSession{
+			ID:        "session-1",
+			PlanID:    "plan-1",
+			StartedAt: &createdAt,
+		},
+		practice.PracticeParticipant{
+			ID:               "participant-1",
+			SessionID:        "session-1",
+			ParticipantRole:  "CANDIDATE",
+			SubjectRef:       practice.SubjectRef{Namespace: "user", SubjectID: "user-1"},
+			RoleDefinitionID: "role-1",
+		},
+		practice.PracticeSessionPolicy{
+			Mode: practice.PracticeModeFullSimulation,
+			TargetObjectives: []practice.PracticeObjective{{
+				ID:          "objective-1",
+				Description: "Explain the trade-off.",
+			}},
+		},
+		practice.TurnOutcome{
+			TurnID:      "turn-1",
+			SessionID:   "session-1",
+			AnswerValid: true,
+		},
+		practice.PracticeSessionSnapshot{
+			ID:        "snapshot-1",
+			SessionID: "session-1",
+			CreatedAt: createdAt,
+		},
+	}
+	if len(contracts) != 6 {
+		t.Fatalf("contracts = %d, want 6", len(contracts))
+	}
+}
+
+var (
+	_ func(*practice.Service, practice.CreatePracticePlanCommand) (practice.PracticePlan, error)                   = (*practice.Service).CreatePracticePlan
+	_ func(*practice.Service, practice.PracticePlanExistsQuery) bool                                               = (*practice.Service).PracticePlanExists
+	_ func(*practice.Service, practice.CreatePracticeSessionCommand) (practice.CreatePracticeSessionResult, error) = (*practice.Service).CreatePracticeSession
+	_ func(*practice.Service, practice.GetPracticeSessionQuery) (practice.PracticeSession, bool)                   = (*practice.Service).GetPracticeSession
+	_ func(*practice.Service, practice.GetPracticeSessionSnapshotQuery) (practice.PracticeSessionSnapshot, bool)   = (*practice.Service).GetPracticeSessionSnapshot
+	_ func(*practice.Service, practice.StartPracticeSessionCommand) (practice.StartPracticeSessionResult, error)   = (*practice.Service).StartPracticeSession
+	_ func(*practice.Service, practice.AuthorizePracticeTurnCommand) error                                         = (*practice.Service).AuthorizePracticeTurn
+	_ func(*practice.Service, practice.ApplyTurnOutcomeCommand) (practice.ApplyTurnOutcomeResult, error)           = (*practice.Service).ApplyTurnOutcome
+)
+
+func TestModuleRegistration(t *testing.T) {
+	if got := practice.New().Name(); got != "practice" {
+		t.Fatalf("Name() = %q, want practice", got)
+	}
+}

--- a/server/internal/practice/errors.go
+++ b/server/internal/practice/errors.go
@@ -1,0 +1,20 @@
+package practice
+
+import "errors"
+
+var (
+	ErrPracticeCommandInvalid              = errors.New("practice_command_invalid")
+	ErrPracticePlanNotFound                = errors.New("practice_plan_not_found")
+	ErrPracticePlanNotReady                = errors.New("practice_plan_not_ready")
+	ErrPracticePlanArchived                = errors.New("practice_plan_archived")
+	ErrPracticePlanHasActiveSession        = errors.New("practice_plan_has_active_session")
+	ErrPracticePlanRevisionConflict        = errors.New("practice_plan_revision_conflict")
+	ErrPracticeSessionNotFound             = errors.New("practice_session_not_found")
+	ErrPracticeSessionTransitionNotAllowed = errors.New("practice_session_transition_not_allowed")
+	ErrPracticeSessionAlreadyTerminal      = errors.New("practice_session_already_terminal")
+	ErrPracticeParticipantInvalid          = errors.New("practice_participant_invalid")
+	ErrPracticeOptionInvalid               = errors.New("practice_option_invalid")
+	ErrTurnOutcomeSessionMismatch          = errors.New("turn_outcome_session_mismatch")
+	ErrPracticeIdempotencyConflict         = errors.New("practice_idempotency_conflict")
+	ErrPracticeResourceForbidden           = errors.New("practice_resource_forbidden")
+)

--- a/server/internal/practice/model.go
+++ b/server/internal/practice/model.go
@@ -1,0 +1,147 @@
+package practice
+
+import "time"
+
+type ScenarioType string
+
+const ScenarioTypeInterview ScenarioType = "INTERVIEW"
+
+type PracticePlanStatus string
+
+const (
+	PracticePlanConfiguring         PracticePlanStatus = "configuring"
+	PracticePlanConfigurationFailed PracticePlanStatus = "configuration_failed"
+	PracticePlanReady               PracticePlanStatus = "ready"
+	PracticePlanArchived            PracticePlanStatus = "archived"
+)
+
+type PracticeSessionStatus string
+
+const (
+	PracticeSessionStarting   PracticeSessionStatus = "starting"
+	PracticeSessionInProgress PracticeSessionStatus = "in_progress"
+	PracticeSessionPaused     PracticeSessionStatus = "paused"
+	PracticeSessionCompleted  PracticeSessionStatus = "completed"
+	PracticeSessionEndedEarly PracticeSessionStatus = "ended_early"
+)
+
+type PracticeSessionEndReason string
+
+const PracticeSessionEndCoverageSatisfiedAtCheckpoint PracticeSessionEndReason = "COVERAGE_SATISFIED_AT_CHECKPOINT"
+
+type PracticePlan struct {
+	ID                        string             `json:"practice_plan_id"`
+	UserID                    string             `json:"user_id"`
+	AgentThreadID             string             `json:"agent_thread_id"`
+	MatterID                  string             `json:"matter_id"`
+	ScenarioDefinitionID      string             `json:"scenario_definition_id"`
+	ScenarioDefinitionVersion int                `json:"scenario_definition_version"`
+	ScenarioType              ScenarioType       `json:"scenario_type"`
+	ScenarioConfigID          string             `json:"scenario_config_id"`
+	ScenarioConfigVersion     int                `json:"scenario_config_version"`
+	PreparationProfileID      string             `json:"preparation_profile_id"`
+	SelectedRoleIDs           []string           `json:"selected_role_ids"`
+	Revision                  int                `json:"plan_revision"`
+	Status                    PracticePlanStatus `json:"practice_plan_status"`
+	CreatedAt                 time.Time          `json:"created_at"`
+	UpdatedAt                 time.Time          `json:"updated_at"`
+}
+
+type PracticeSession struct {
+	ID           string                   `json:"practice_session_id"`
+	PlanID       string                   `json:"practice_plan_id"`
+	ScenarioType ScenarioType             `json:"scenario_type"`
+	SnapshotID   string                   `json:"snapshot_id"`
+	Status       PracticeSessionStatus    `json:"practice_session_status"`
+	Version      int                      `json:"session_version"`
+	CreatedAt    time.Time                `json:"created_at"`
+	StartedAt    *time.Time               `json:"started_at,omitempty"`
+	EndedAt      *time.Time               `json:"ended_at,omitempty"`
+	EndReason    PracticeSessionEndReason `json:"end_reason,omitempty"`
+}
+
+type SubjectRef struct {
+	Namespace string `json:"namespace"`
+	SubjectID string `json:"subject_id"`
+}
+
+type ParticipantRole string
+
+type ScenarioDefinitionSnapshot struct {
+	ID      string       `json:"scenario_definition_id"`
+	Type    ScenarioType `json:"scenario_type"`
+	Name    string       `json:"name"`
+	Version int          `json:"version"`
+	Status  string       `json:"status"`
+}
+
+type ScenarioConfigSnapshot struct {
+	ID                   string       `json:"scenario_config_id"`
+	ScenarioDefinitionID string       `json:"scenario_definition_id"`
+	Type                 ScenarioType `json:"config_type"`
+	Version              int          `json:"version"`
+	JobTitle             string       `json:"job_title"`
+	JobDescription       string       `json:"job_description"`
+	FocusAreas           []string     `json:"focus_areas"`
+}
+
+type PreparationSnapshot struct {
+	ID                     string    `json:"preparation_snapshot_id"`
+	SourceProfileID        string    `json:"source_profile_id"`
+	SourceVersion          int       `json:"source_version"`
+	ResumeSnapshot         string    `json:"resume_snapshot"`
+	JobDescriptionSnapshot string    `json:"job_description_snapshot"`
+	BackgroundSnapshot     string    `json:"background_snapshot"`
+	CreatedAt              time.Time `json:"created_at"`
+}
+
+type RoleSnapshot struct {
+	ID                   string   `json:"role_definition_id"`
+	ScenarioDefinitionID string   `json:"scenario_definition_id"`
+	Type                 string   `json:"role_type"`
+	DisplayName          string   `json:"display_name"`
+	Responsibilities     string   `json:"responsibilities"`
+	Style                string   `json:"style"`
+	FocusAreas           []string `json:"focus_areas"`
+	VoiceConfigRef       string   `json:"voice_config_ref,omitempty"`
+	Version              int      `json:"version"`
+}
+
+type PracticeOptionSnapshot struct {
+	ID                   string `json:"practice_option_id"`
+	ScenarioDefinitionID string `json:"scenario_definition_id"`
+	RoleDefinitionID     string `json:"role_definition_id,omitempty"`
+	Type                 string `json:"practice_option_type"`
+	DisplayName          string `json:"display_name"`
+	Version              int    `json:"version"`
+}
+
+type PracticeParticipant struct {
+	ID               string          `json:"practice_participant_id"`
+	SessionID        string          `json:"practice_session_id"`
+	ParticipantRole  ParticipantRole `json:"participant_role"`
+	SubjectRef       SubjectRef      `json:"subject_ref"`
+	RoleDefinitionID string          `json:"role_definition_id,omitempty"`
+	RoleSnapshot     *RoleSnapshot   `json:"role_snapshot,omitempty"`
+	ParticipantOrder int             `json:"participant_order"`
+}
+
+type PracticeObjective struct {
+	ID          string `json:"objective_id"`
+	Description string `json:"description"`
+}
+
+type PracticeSessionSnapshot struct {
+	ID                 string                     `json:"snapshot_id"`
+	SessionID          string                     `json:"practice_session_id"`
+	PlanRevision       int                        `json:"plan_revision"`
+	ScenarioType       ScenarioType               `json:"scenario_type"`
+	ScenarioDefinition ScenarioDefinitionSnapshot `json:"scenario_definition_snapshot"`
+	ScenarioConfig     ScenarioConfigSnapshot     `json:"scenario_config_snapshot"`
+	Preparation        PreparationSnapshot        `json:"preparation_snapshot"`
+	Participants       []PracticeParticipant      `json:"participants"`
+	PracticeOption     PracticeOptionSnapshot     `json:"practice_option"`
+	SessionPolicy      PracticeSessionPolicy      `json:"session_policy"`
+	PracticeFocuses    []PracticeObjective        `json:"practice_focuses"`
+	CreatedAt          time.Time                  `json:"created_at"`
+}

--- a/server/internal/practice/module.go
+++ b/server/internal/practice/module.go
@@ -34,33 +34,17 @@ type CreateSessionRequest struct {
 	RoleDefinitionIDs     []string `json:"role_definition_ids,omitempty"`
 }
 
-type TurnOutcome struct {
-	SessionID string
-	TurnID    string
-	IsRetry   bool
-}
-
-type TurnDecision struct {
-	EffectiveTurns     int
-	Completed          bool
-	NextQuestionNumber int
-	SessionVersion     int
-	EndReason          string
-}
-
-// Backend is the storage-facing boundary owned by Practice.
 type Backend interface {
-	CreatePlan(CreatePlanRequest) (map[string]any, error)
-	PlanExists(string) bool
-	CreateSession(string, CreateSessionRequest) (map[string]any, error)
-	GetSession(string) (map[string]any, bool)
-	GetSnapshot(string) (map[string]any, bool)
-	StartSession(string) (int, bool, error)
-	AuthorizeTurn(string, bool) error
-	RecordTurnOutcome(TurnOutcome) (TurnDecision, error)
+	CreatePracticePlan(CreatePracticePlanCommand) (PracticePlan, error)
+	PracticePlanExists(PracticePlanExistsQuery) bool
+	CreatePracticeSession(CreatePracticeSessionCommand) (CreatePracticeSessionResult, error)
+	GetPracticeSession(GetPracticeSessionQuery) (PracticeSession, bool)
+	GetPracticeSessionSnapshot(GetPracticeSessionSnapshotQuery) (PracticeSessionSnapshot, bool)
+	StartPracticeSession(StartPracticeSessionCommand) (StartPracticeSessionResult, error)
+	AuthorizePracticeTurn(AuthorizePracticeTurnCommand) error
+	ApplyTurnOutcome(ApplyTurnOutcomeCommand) (ApplyTurnOutcomeResult, error)
 }
 
-// Service is Practice's formal application-service entry point.
 type Service struct {
 	backend Backend
 }
@@ -69,37 +53,44 @@ func NewService(backend Backend) *Service {
 	return &Service{backend: backend}
 }
 
-func (s *Service) CreatePlan(request CreatePlanRequest) (map[string]any, error) {
-	return s.backend.CreatePlan(request)
+func (s *Service) CreatePracticePlan(command CreatePracticePlanCommand) (PracticePlan, error) {
+	return s.backend.CreatePracticePlan(command)
 }
 
-func (s *Service) PlanExists(id string) bool {
-	return s.backend.PlanExists(id)
+func (s *Service) PracticePlanExists(query PracticePlanExistsQuery) bool {
+	return s.backend.PracticePlanExists(query)
 }
 
-func (s *Service) CreateSession(
-	planID string,
-	request CreateSessionRequest,
-) (map[string]any, error) {
-	return s.backend.CreateSession(planID, request)
+func (s *Service) CreatePracticeSession(
+	command CreatePracticeSessionCommand,
+) (CreatePracticeSessionResult, error) {
+	return s.backend.CreatePracticeSession(command)
 }
 
-func (s *Service) GetSession(id string) (map[string]any, bool) {
-	return s.backend.GetSession(id)
+func (s *Service) GetPracticeSession(
+	query GetPracticeSessionQuery,
+) (PracticeSession, bool) {
+	return s.backend.GetPracticeSession(query)
 }
 
-func (s *Service) GetSnapshot(sessionID string) (map[string]any, bool) {
-	return s.backend.GetSnapshot(sessionID)
+func (s *Service) GetPracticeSessionSnapshot(
+	query GetPracticeSessionSnapshotQuery,
+) (PracticeSessionSnapshot, bool) {
+	return s.backend.GetPracticeSessionSnapshot(query)
 }
 
-func (s *Service) StartSession(sessionID string) (int, bool, error) {
-	return s.backend.StartSession(sessionID)
+func (s *Service) StartPracticeSession(
+	command StartPracticeSessionCommand,
+) (StartPracticeSessionResult, error) {
+	return s.backend.StartPracticeSession(command)
 }
 
-func (s *Service) AuthorizeTurn(sessionID string, retry bool) error {
-	return s.backend.AuthorizeTurn(sessionID, retry)
+func (s *Service) AuthorizePracticeTurn(command AuthorizePracticeTurnCommand) error {
+	return s.backend.AuthorizePracticeTurn(command)
 }
 
-func (s *Service) RecordTurnOutcome(outcome TurnOutcome) (TurnDecision, error) {
-	return s.backend.RecordTurnOutcome(outcome)
+func (s *Service) ApplyTurnOutcome(
+	command ApplyTurnOutcomeCommand,
+) (ApplyTurnOutcomeResult, error) {
+	return s.backend.ApplyTurnOutcome(command)
 }

--- a/server/internal/practice/policy.go
+++ b/server/internal/practice/policy.go
@@ -1,0 +1,58 @@
+package practice
+
+type PracticeMode string
+
+const (
+	PracticeModeFullSimulation  PracticeMode = "full_simulation"
+	PracticeModeFocusedPractice PracticeMode = "focused_practice"
+)
+
+type CoverageLevel string
+
+const (
+	CoverageCovered   CoverageLevel = "covered"
+	CoveragePartial   CoverageLevel = "partial"
+	CoverageUncovered CoverageLevel = "uncovered"
+)
+
+type EarlyCompletionRule string
+
+const (
+	EarlyCompletionObjectivesCovered                EarlyCompletionRule = "objectives_covered"
+	EarlyCompletionCoverageSatisfiedAfterCheckpoint EarlyCompletionRule = "COVERAGE_SATISFIED_AFTER_CHECKPOINT"
+)
+
+type NextAction string
+
+const (
+	NextActionFollowUpCurrent     NextAction = "FOLLOW_UP_CURRENT"
+	NextActionMoveToNextObjective NextAction = "MOVE_TO_NEXT_OBJECTIVE"
+	NextActionCompleteSession     NextAction = "COMPLETE_SESSION"
+)
+
+type PracticeSessionPolicy struct {
+	Mode                     PracticeMode        `json:"mode,omitempty"`
+	SuggestedDurationSeconds int                 `json:"suggested_duration_seconds"`
+	MinEffectiveTurns        int                 `json:"min_effective_turns"`
+	MaxEffectiveTurns        int                 `json:"max_effective_turns"`
+	CoverageCheckpointTurn   int                 `json:"coverage_checkpoint_turn"`
+	MaxFollowUpsPerQuestion  int                 `json:"max_follow_ups_per_question"`
+	TargetObjectives         []PracticeObjective `json:"target_objectives"`
+	EarlyCompletionRule      EarlyCompletionRule `json:"early_completion_rule"`
+}
+
+type ObjectiveCoverage struct {
+	ObjectiveID string        `json:"objective_id"`
+	Level       CoverageLevel `json:"coverage_level"`
+}
+
+type TurnOutcome struct {
+	TurnID                        string
+	SessionID                     string
+	IsRetry                       bool
+	AnswerValid                   bool
+	ObjectiveCoverage             []ObjectiveCoverage
+	FollowUpGap                   bool
+	FollowUpCount                 int
+	CompletedPrimaryQuestionCount int
+}

--- a/server/internal/practice/service.go
+++ b/server/internal/practice/service.go
@@ -1,0 +1,64 @@
+package practice
+
+type CreatePracticePlanCommand struct {
+	AgentThreadID             string   `json:"agent_thread_id"`
+	MatterID                  string   `json:"matter_id"`
+	ScenarioDefinitionID      string   `json:"scenario_definition_id"`
+	ScenarioDefinitionVersion int      `json:"scenario_definition_version"`
+	ScenarioConfigID          string   `json:"scenario_config_id"`
+	ScenarioConfigVersion     int      `json:"scenario_config_version"`
+	PreparationProfileID      string   `json:"preparation_profile_id"`
+	SelectedRoleIDs           []string `json:"selected_role_ids"`
+}
+
+type PracticePlanExistsQuery struct {
+	PracticePlanID string
+}
+
+type CreatePracticeSessionCommand struct {
+	PracticePlanID        string   `json:"-"`
+	ExpectedPlanRevision  int      `json:"expected_plan_revision"`
+	PreparationSnapshotID string   `json:"preparation_snapshot_id"`
+	PracticeOptionID      string   `json:"practice_option_id"`
+	RoleDefinitionIDs     []string `json:"role_definition_ids"`
+}
+
+type CreatePracticeSessionResult struct {
+	Session  PracticeSession         `json:"practice_session"`
+	Snapshot PracticeSessionSnapshot `json:"snapshot"`
+}
+
+type GetPracticeSessionQuery struct {
+	PracticeSessionID string
+}
+
+type GetPracticeSessionSnapshotQuery struct {
+	PracticeSessionID string
+}
+
+type StartPracticeSessionCommand struct {
+	PracticeSessionID string
+}
+
+type StartPracticeSessionResult struct {
+	SessionVersion int
+	Started        bool
+}
+
+type AuthorizePracticeTurnCommand struct {
+	PracticeSessionID string
+	IsRetry           bool
+}
+
+type ApplyTurnOutcomeCommand struct {
+	Outcome TurnOutcome
+}
+
+type ApplyTurnOutcomeResult struct {
+	EffectiveTurns     int
+	Completed          bool
+	NextQuestionNumber int
+	SessionVersion     int
+	EndReason          PracticeSessionEndReason
+	NextAction         NextAction
+}

--- a/server/internal/practice/service.go
+++ b/server/internal/practice/service.go
@@ -3,6 +3,7 @@ package practice
 type CreatePracticePlanCommand struct {
 	AgentThreadID             string   `json:"agent_thread_id"`
 	MatterID                  string   `json:"matter_id"`
+	PreparationSnapshotID     string   `json:"preparation_snapshot_id,omitempty"`
 	ScenarioDefinitionID      string   `json:"scenario_definition_id"`
 	ScenarioDefinitionVersion int      `json:"scenario_definition_version"`
 	ScenarioConfigID          string   `json:"scenario_config_id"`

--- a/server/internal/smoke/application.go
+++ b/server/internal/smoke/application.go
@@ -34,36 +34,41 @@ func NewApplication(
 }
 
 func (a *Application) CreatePlan(
-	request practice.CreatePlanRequest,
-) (map[string]any, error) {
-	if _, err := a.preparation.GetScenarioDetail(request.ScenarioDefinitionID); err != nil {
-		return nil, ErrScenarioNotFound
+	command practice.CreatePracticePlanCommand,
+) (practice.PracticePlan, error) {
+	if _, err := a.preparation.GetScenarioDetail(command.ScenarioDefinitionID); err != nil {
+		return practice.PracticePlan{}, ErrScenarioNotFound
 	}
-	if !a.preparation.ProfileExists(request.PreparationProfileID) {
-		return nil, ErrProfileNotFound
+	if !a.preparation.ProfileExists(command.PreparationProfileID) {
+		return practice.PracticePlan{}, ErrProfileNotFound
 	}
-	return a.practice.CreatePlan(request)
+	return a.practice.CreatePracticePlan(command)
 }
 
 func (a *Application) CreateSession(
-	planID string,
-	request practice.CreateSessionRequest,
-) (map[string]any, error) {
-	if !a.practice.PlanExists(planID) {
-		return nil, ErrPlanNotFound
+	command practice.CreatePracticeSessionCommand,
+) (practice.CreatePracticeSessionResult, error) {
+	if !a.practice.PracticePlanExists(practice.PracticePlanExistsQuery{
+		PracticePlanID: command.PracticePlanID,
+	}) {
+		return practice.CreatePracticeSessionResult{}, ErrPlanNotFound
 	}
-	if !a.preparation.SnapshotExists(request.PreparationSnapshotID) {
-		return nil, ErrSnapshotNotFound
+	if !a.preparation.SnapshotExists(command.PreparationSnapshotID) {
+		return practice.CreatePracticeSessionResult{}, ErrSnapshotNotFound
 	}
-	return a.practice.CreateSession(planID, request)
+	return a.practice.CreatePracticeSession(command)
 }
 
 func (a *Application) Bootstrap(sessionID string) (map[string]any, error) {
-	session, ok := a.practice.GetSession(sessionID)
+	session, ok := a.practice.GetPracticeSession(practice.GetPracticeSessionQuery{
+		PracticeSessionID: sessionID,
+	})
 	if !ok {
 		return nil, ErrSessionNotFound
 	}
-	snapshot, ok := a.practice.GetSnapshot(sessionID)
+	snapshot, ok := a.practice.GetPracticeSessionSnapshot(
+		practice.GetPracticeSessionSnapshotQuery{PracticeSessionID: sessionID},
+	)
 	if !ok {
 		return nil, ErrSessionNotFound
 	}
@@ -77,12 +82,14 @@ func (a *Application) Bootstrap(sessionID string) (map[string]any, error) {
 }
 
 func (a *Application) EnsureCurrentQuestion(sessionID string) (Question, error) {
-	version, started, err := a.practice.StartSession(sessionID)
+	startedSession, err := a.practice.StartPracticeSession(
+		practice.StartPracticeSessionCommand{PracticeSessionID: sessionID},
+	)
 	if err != nil {
 		return Question{}, err
 	}
-	if started {
-		a.conversation.PublishSessionStarted(version)
+	if startedSession.Started {
+		a.conversation.PublishSessionStarted(startedSession.SessionVersion)
 	}
 	return a.conversation.EnsureCurrentQuestion(sessionID)
 }
@@ -96,10 +103,10 @@ func (a *Application) SubmitTurn(
 	if !ok {
 		return Turn{}, ErrQuestionNotFound
 	}
-	if err := a.practice.AuthorizeTurn(
-		question.SessionID,
-		request.RetryRequestID != "",
-	); err != nil {
+	if err := a.practice.AuthorizePracticeTurn(practice.AuthorizePracticeTurnCommand{
+		PracticeSessionID: question.SessionID,
+		IsRetry:           request.RetryRequestID != "",
+	}); err != nil {
 		return Turn{}, err
 	}
 	turn, err := a.conversation.PrepareTurn(questionID, request)
@@ -117,10 +124,12 @@ func (a *Application) SubmitTurn(
 	if err != nil {
 		return Turn{}, err
 	}
-	decision, err := a.practice.RecordTurnOutcome(practice.TurnOutcome{
-		SessionID: turn.SessionID,
-		TurnID:    turn.ID,
-		IsRetry:   turn.IsRetry,
+	decision, err := a.practice.ApplyTurnOutcome(practice.ApplyTurnOutcomeCommand{
+		Outcome: practice.TurnOutcome{
+			SessionID: turn.SessionID,
+			TurnID:    turn.ID,
+			IsRetry:   turn.IsRetry,
+		},
 	})
 	if err != nil {
 		return Turn{}, err
@@ -129,7 +138,7 @@ func (a *Application) SubmitTurn(
 		if decision.Completed {
 			a.conversation.PublishSessionCompleted(
 				decision.SessionVersion,
-				decision.EndReason,
+				string(decision.EndReason),
 			)
 		} else {
 			if _, err := a.conversation.CreateNextQuestion(
@@ -193,7 +202,9 @@ func (a *Application) CreateRetry(feedbackID string) (RetryRequest, error) {
 }
 
 func (a *Application) ListHistory(sessionID string) ([]HistoryRecord, error) {
-	if _, ok := a.practice.GetSession(sessionID); !ok {
+	if _, ok := a.practice.GetPracticeSession(practice.GetPracticeSessionQuery{
+		PracticeSessionID: sessionID,
+	}); !ok {
 		return nil, ErrSessionNotFound
 	}
 	return a.review.ListHistory(sessionID), nil

--- a/server/internal/smoke/http.go
+++ b/server/internal/smoke/http.go
@@ -160,17 +160,17 @@ func (s *Server) createPlan(c *gin.Context) {
 		return
 	}
 	s.executeIdempotent(c, raw, func() apiResponse {
-		var request practice.CreatePlanRequest
-		if err := decodeStrict(raw, &request); err != nil ||
-			!validID(request.ScenarioDefinitionID) ||
-			request.ScenarioDefinitionVersion < 1 ||
-			!validID(request.ScenarioConfigID) ||
-			request.ScenarioConfigVersion < 1 ||
-			!validID(request.PreparationProfileID) ||
-			!validUniqueIDs(request.SelectedRoleIDs) {
+		var command practice.CreatePracticePlanCommand
+		if err := decodeStrict(raw, &command); err != nil ||
+			!validID(command.ScenarioDefinitionID) ||
+			command.ScenarioDefinitionVersion < 1 ||
+			!validID(command.ScenarioConfigID) ||
+			command.ScenarioConfigVersion < 1 ||
+			!validID(command.PreparationProfileID) ||
+			!validUniqueIDs(command.SelectedRoleIDs) {
 			return invalidRequest()
 		}
-		result, err := s.application.CreatePlan(request)
+		result, err := s.application.CreatePlan(command)
 		if err != nil {
 			return serviceError(err)
 		}
@@ -184,15 +184,16 @@ func (s *Server) createSession(c *gin.Context) {
 		return
 	}
 	s.executeIdempotent(c, raw, func() apiResponse {
-		var request practice.CreateSessionRequest
-		if err := decodeStrict(raw, &request); err != nil ||
-			request.ExpectedPlanRevision < 1 ||
-			!validID(request.PreparationSnapshotID) ||
-			!validID(request.PracticeOptionID) ||
-			!validUniqueIDs(request.RoleDefinitionIDs) {
+		var command practice.CreatePracticeSessionCommand
+		if err := decodeStrict(raw, &command); err != nil ||
+			command.ExpectedPlanRevision < 1 ||
+			!validID(command.PreparationSnapshotID) ||
+			!validID(command.PracticeOptionID) ||
+			!validUniqueIDs(command.RoleDefinitionIDs) {
 			return invalidRequest()
 		}
-		result, err := s.application.CreateSession(c.Param("practice_plan_id"), request)
+		command.PracticePlanID = c.Param("practice_plan_id")
+		result, err := s.application.CreateSession(command)
 		if err != nil {
 			return serviceError(err)
 		}
@@ -201,7 +202,9 @@ func (s *Server) createSession(c *gin.Context) {
 }
 
 func (s *Server) getSession(c *gin.Context) {
-	result, ok := s.practice.GetSession(c.Param("practice_session_id"))
+	result, ok := s.practice.GetPracticeSession(practice.GetPracticeSessionQuery{
+		PracticeSessionID: c.Param("practice_session_id"),
+	})
 	if !ok {
 		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
 		return
@@ -210,7 +213,11 @@ func (s *Server) getSession(c *gin.Context) {
 }
 
 func (s *Server) getSessionSnapshot(c *gin.Context) {
-	result, ok := s.practice.GetSnapshot(c.Param("practice_session_id"))
+	result, ok := s.practice.GetPracticeSessionSnapshot(
+		practice.GetPracticeSessionSnapshotQuery{
+			PracticeSessionID: c.Param("practice_session_id"),
+		},
+	)
 	if !ok {
 		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
 		return
@@ -380,7 +387,9 @@ func (s *Server) listHistory(c *gin.Context) {
 
 func (s *Server) streamEvents(c *gin.Context) {
 	sessionID := c.Param("practice_session_id")
-	if _, ok := s.practice.GetSession(sessionID); !ok {
+	if _, ok := s.practice.GetPracticeSession(practice.GetPracticeSessionQuery{
+		PracticeSessionID: sessionID,
+	}); !ok {
 		writeError(c, http.StatusNotFound, "practice_session_not_found", "Practice session was not found.", false)
 		return
 	}

--- a/server/internal/smoke/main_flow_test.go
+++ b/server/internal/smoke/main_flow_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/preparation"
 	"github.com/gorilla/websocket"
 )
@@ -70,14 +71,24 @@ func runMainFlow(t *testing.T) flowTrace {
 	client.expect(t, http.MethodPost, "/v1/preparation-profiles/"+demoPreparationProfile+"/snapshots", map[string]any{
 		"source_version": 1,
 	}, map[string]string{"Idempotency-Key": "snapshot-key-1"}, http.StatusCreated, nil)
+	var createdPlan practice.PracticePlan
 	client.expect(t, http.MethodPost, "/v1/practice-plans", map[string]any{
+		"agent_thread_id":             "agent_thread_demo_001",
+		"matter_id":                   "matter_demo_001",
+		"preparation_snapshot_id":     demoPreparationSnapshot,
 		"scenario_definition_id":      DemoScenarioDefinition,
 		"scenario_definition_version": 1,
 		"scenario_config_id":          preparation.BackendEngineerConfigID,
 		"scenario_config_version":     1,
 		"preparation_profile_id":      demoPreparationProfile,
 		"selected_role_ids":           []string{DemoRoleDefinition},
-	}, map[string]string{"Idempotency-Key": "plan-key-1"}, http.StatusCreated, nil)
+	}, map[string]string{"Idempotency-Key": "plan-key-1"}, http.StatusCreated, &createdPlan)
+	if createdPlan.AgentThreadID != "agent_thread_demo_001" {
+		t.Fatalf("created plan agent thread = %q", createdPlan.AgentThreadID)
+	}
+	if createdPlan.MatterID != "matter_demo_001" {
+		t.Fatalf("created plan matter = %q", createdPlan.MatterID)
+	}
 	var sessionBootstrap struct {
 		Session map[string]any `json:"practice_session"`
 	}

--- a/server/internal/smoke/runtime.go
+++ b/server/internal/smoke/runtime.go
@@ -136,7 +136,7 @@ func (r *Runtime) createSnapshot() (map[string]any, error) {
 	}, nil
 }
 
-func (r *Runtime) createPlan() (practice.PracticePlan, error) {
+func (r *Runtime) createPlan(command practice.CreatePracticePlanCommand) (practice.PracticePlan, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.planCreated = true
@@ -144,6 +144,8 @@ func (r *Runtime) createPlan() (practice.PracticePlan, error) {
 	return practice.PracticePlan{
 		ID:                        demoPracticePlan,
 		UserID:                    DemoUserID,
+		AgentThreadID:             command.AgentThreadID,
+		MatterID:                  command.MatterID,
 		ScenarioDefinitionID:      DemoScenarioDefinition,
 		ScenarioDefinitionVersion: 1,
 		ScenarioType:              practice.ScenarioTypeInterview,

--- a/server/internal/smoke/runtime.go
+++ b/server/internal/smoke/runtime.go
@@ -79,7 +79,7 @@ type Runtime struct {
 
 	retryTurnByRequest     map[string]string
 	retryOriginalByRequest map[string]string
-	turnDecisions          map[string]practice.TurnDecision
+	turnDecisions          map[string]practice.ApplyTurnOutcomeResult
 	subscribers            map[chan Event]struct{}
 }
 
@@ -93,7 +93,7 @@ func NewRuntime() *Runtime {
 		catalog:                catalog,
 		retryTurnByRequest:     make(map[string]string),
 		retryOriginalByRequest: make(map[string]string),
-		turnDecisions:          make(map[string]practice.TurnDecision),
+		turnDecisions:          make(map[string]practice.ApplyTurnOutcomeResult),
 		subscribers:            make(map[chan Event]struct{}),
 		sessionStatus:          "not_started",
 	}
@@ -136,61 +136,64 @@ func (r *Runtime) createSnapshot() (map[string]any, error) {
 	}, nil
 }
 
-func (r *Runtime) createPlan() (map[string]any, error) {
+func (r *Runtime) createPlan() (practice.PracticePlan, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.planCreated = true
-	return map[string]any{
-		"practice_plan_id":            demoPracticePlan,
-		"user_id":                     DemoUserID,
-		"scenario_definition_id":      DemoScenarioDefinition,
-		"scenario_definition_version": 1,
-		"scenario_type":               "INTERVIEW",
-		"scenario_config_id":          preparation.BackendEngineerConfigID,
-		"scenario_config_version":     1,
-		"preparation_profile_id":      demoPreparationProfile,
-		"selected_role_ids":           []string{DemoRoleDefinition},
-		"plan_revision":               1,
-		"practice_plan_status":        "ready",
-		"created_at":                  r.timestamp(3),
-		"updated_at":                  r.timestamp(3),
+	createdAt := r.now.Add(3 * time.Second)
+	return practice.PracticePlan{
+		ID:                        demoPracticePlan,
+		UserID:                    DemoUserID,
+		ScenarioDefinitionID:      DemoScenarioDefinition,
+		ScenarioDefinitionVersion: 1,
+		ScenarioType:              practice.ScenarioTypeInterview,
+		ScenarioConfigID:          preparation.BackendEngineerConfigID,
+		ScenarioConfigVersion:     1,
+		PreparationProfileID:      demoPreparationProfile,
+		SelectedRoleIDs:           []string{DemoRoleDefinition},
+		Revision:                  1,
+		Status:                    practice.PracticePlanReady,
+		CreatedAt:                 createdAt,
+		UpdatedAt:                 createdAt,
 	}, nil
 }
 
-func (r *Runtime) createSession() (map[string]any, error) {
+func (r *Runtime) createSession() (practice.CreatePracticeSessionResult, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.planCreated {
-		return nil, ErrResourceConflict
+		return practice.CreatePracticeSessionResult{}, ErrResourceConflict
 	}
 	if r.sessionCreated {
-		return nil, ErrResourceConflict
+		return practice.CreatePracticeSessionResult{}, ErrResourceConflict
 	}
 	r.sessionCreated = true
-	r.sessionStatus = "starting"
+	r.sessionStatus = string(practice.PracticeSessionStarting)
 	r.sessionVersion = 1
-	return map[string]any{
-		"practice_session": r.sessionLocked(),
-		"snapshot":         r.snapshotLocked(),
+	return practice.CreatePracticeSessionResult{
+		Session:  r.sessionLocked(),
+		Snapshot: r.snapshotLocked(),
 	}, nil
 }
 
-func (r *Runtime) sessionLocked() map[string]any {
-	session := map[string]any{
-		"practice_session_id":     demoPracticeSession,
-		"practice_plan_id":        demoPracticePlan,
-		"scenario_type":           "INTERVIEW",
-		"snapshot_id":             "snapshot_session_demo_001",
-		"practice_session_status": r.sessionStatus,
-		"session_version":         r.sessionVersion,
-		"created_at":              r.timestamp(4),
+func (r *Runtime) sessionLocked() practice.PracticeSession {
+	session := practice.PracticeSession{
+		ID:           demoPracticeSession,
+		PlanID:       demoPracticePlan,
+		ScenarioType: practice.ScenarioTypeInterview,
+		SnapshotID:   "snapshot_session_demo_001",
+		Status:       practice.PracticeSessionStatus(r.sessionStatus),
+		Version:      r.sessionVersion,
+		CreatedAt:    r.now.Add(4 * time.Second),
 	}
-	if r.sessionStatus != "starting" {
-		session["started_at"] = r.timestamp(5)
+	if r.sessionStatus != string(practice.PracticeSessionStarting) {
+		startedAt := r.now.Add(5 * time.Second)
+		session.StartedAt = &startedAt
 	}
-	if r.sessionStatus == "completed" {
-		session["ended_at"] = r.timestamp(80)
-		session["end_reason"] = "COVERAGE_SATISFIED_AT_CHECKPOINT"
+	if r.sessionStatus == string(practice.PracticeSessionCompleted) {
+		endedAt := r.now.Add(80 * time.Second)
+		session.EndedAt = &endedAt
+		session.EndReason = practice.PracticeSessionEndCoverageSatisfiedAtCheckpoint
 	}
 	return session
 }
@@ -468,7 +471,7 @@ func (r *Runtime) lastEventSequenceLocked() int {
 	return last
 }
 
-func (r *Runtime) snapshotLocked() map[string]any {
+func (r *Runtime) snapshotLocked() practice.PracticeSessionSnapshot {
 	catalogSnapshot, err := r.catalog.GetCatalogSnapshot(
 		DemoScenarioDefinition,
 		1,
@@ -479,58 +482,90 @@ func (r *Runtime) snapshotLocked() map[string]any {
 	if err != nil {
 		panic(fmt.Sprintf("resolve deterministic catalog snapshot: %v", err))
 	}
-	objectives := []map[string]any{
-		{"objective_id": "introduction", "description": "Explain current experience clearly."},
-		{"objective_id": "system_design", "description": "Explain a technical design and its trade-offs."},
-		{"objective_id": "project_depth", "description": "Provide evidence of individual contribution."},
-		{"objective_id": "collaboration", "description": "Explain cross-team communication and outcomes."},
+	objectives := []practice.PracticeObjective{
+		{ID: "introduction", Description: "Explain current experience clearly."},
+		{ID: "system_design", Description: "Explain a technical design and its trade-offs."},
+		{ID: "project_depth", Description: "Provide evidence of individual contribution."},
+		{ID: "collaboration", Description: "Explain cross-team communication and outcomes."},
 	}
-	return map[string]any{
-		"snapshot_id":                  "snapshot_session_demo_001",
-		"practice_session_id":          demoPracticeSession,
-		"plan_revision":                1,
-		"scenario_type":                "INTERVIEW",
-		"scenario_definition_snapshot": mustJSONMap(catalogSnapshot.ScenarioDefinition),
-		"scenario_config_snapshot":     mustJSONMap(catalogSnapshot.ScenarioConfig),
-		"preparation_snapshot": map[string]any{
-			"preparation_snapshot_id":  demoPreparationSnapshot,
-			"source_profile_id":        demoPreparationProfile,
-			"source_version":           1,
-			"resume_snapshot":          "Go backend engineer; API reliability project.",
-			"job_description_snapshot": "Build reliable APIs and explain engineering trade-offs.",
-			"background_snapshot":      "Backend engineer preparing for an English technical interview.",
-			"created_at":               r.timestamp(2),
+	roleSnapshot := practice.RoleSnapshot{
+		ID:                   catalogSnapshot.SelectedRoles[0].ID,
+		ScenarioDefinitionID: catalogSnapshot.SelectedRoles[0].ScenarioDefinitionID,
+		Type:                 catalogSnapshot.SelectedRoles[0].Type,
+		DisplayName:          catalogSnapshot.SelectedRoles[0].DisplayName,
+		Responsibilities:     catalogSnapshot.SelectedRoles[0].Responsibilities,
+		Style:                catalogSnapshot.SelectedRoles[0].Style,
+		FocusAreas:           catalogSnapshot.SelectedRoles[0].FocusAreas,
+		VoiceConfigRef:       catalogSnapshot.SelectedRoles[0].VoiceConfigRef,
+		Version:              catalogSnapshot.SelectedRoles[0].Version,
+	}
+	return practice.PracticeSessionSnapshot{
+		ID:           "snapshot_session_demo_001",
+		SessionID:    demoPracticeSession,
+		PlanRevision: 1,
+		ScenarioType: practice.ScenarioTypeInterview,
+		ScenarioDefinition: practice.ScenarioDefinitionSnapshot{
+			ID:      catalogSnapshot.ScenarioDefinition.ID,
+			Type:    practice.ScenarioType(catalogSnapshot.ScenarioDefinition.Type),
+			Name:    catalogSnapshot.ScenarioDefinition.Name,
+			Version: catalogSnapshot.ScenarioDefinition.Version,
+			Status:  string(catalogSnapshot.ScenarioDefinition.Status),
 		},
-		"participants": []map[string]any{
+		ScenarioConfig: practice.ScenarioConfigSnapshot{
+			ID:                   catalogSnapshot.ScenarioConfig.ID,
+			ScenarioDefinitionID: catalogSnapshot.ScenarioConfig.ScenarioDefinitionID,
+			Type:                 practice.ScenarioType(catalogSnapshot.ScenarioConfig.Type),
+			Version:              catalogSnapshot.ScenarioConfig.Version,
+			JobTitle:             catalogSnapshot.ScenarioConfig.JobTitle,
+			JobDescription:       catalogSnapshot.ScenarioConfig.JobDescription,
+			FocusAreas:           catalogSnapshot.ScenarioConfig.FocusAreas,
+		},
+		Preparation: practice.PreparationSnapshot{
+			ID:                     demoPreparationSnapshot,
+			SourceProfileID:        demoPreparationProfile,
+			SourceVersion:          1,
+			ResumeSnapshot:         "Go backend engineer; API reliability project.",
+			JobDescriptionSnapshot: "Build reliable APIs and explain engineering trade-offs.",
+			BackgroundSnapshot:     "Backend engineer preparing for an English technical interview.",
+			CreatedAt:              r.now.Add(2 * time.Second),
+		},
+		Participants: []practice.PracticeParticipant{
 			{
-				"practice_participant_id": demoInterviewerID,
-				"practice_session_id":     demoPracticeSession,
-				"participant_role":        "INTERVIEWER",
-				"subject_ref":             map[string]any{"namespace": "mock.actor", "subject_id": "interviewer_technical"},
-				"role_definition_id":      DemoRoleDefinition,
-				"role_snapshot":           mustJSONMap(catalogSnapshot.SelectedRoles[0]),
-				"participant_order":       1,
+				ID:               demoInterviewerID,
+				SessionID:        demoPracticeSession,
+				ParticipantRole:  "INTERVIEWER",
+				SubjectRef:       practice.SubjectRef{Namespace: "mock.actor", SubjectID: "interviewer_technical"},
+				RoleDefinitionID: DemoRoleDefinition,
+				RoleSnapshot:     &roleSnapshot,
+				ParticipantOrder: 1,
 			},
 			{
-				"practice_participant_id": demoCandidateID,
-				"practice_session_id":     demoPracticeSession,
-				"participant_role":        "CANDIDATE",
-				"subject_ref":             map[string]any{"namespace": "speakup.user", "subject_id": DemoUserID},
-				"participant_order":       2,
+				ID:               demoCandidateID,
+				SessionID:        demoPracticeSession,
+				ParticipantRole:  "CANDIDATE",
+				SubjectRef:       practice.SubjectRef{Namespace: "speakup.user", SubjectID: DemoUserID},
+				ParticipantOrder: 2,
 			},
 		},
-		"practice_option": mustJSONMap(catalogSnapshot.PracticeOption),
-		"session_policy": map[string]any{
-			"suggested_duration_seconds":  900,
-			"min_effective_turns":         4,
-			"max_effective_turns":         6,
-			"coverage_checkpoint_turn":    4,
-			"max_follow_ups_per_question": 1,
-			"target_objectives":           objectives,
-			"early_completion_rule":       "COVERAGE_SATISFIED_AFTER_CHECKPOINT",
+		PracticeOption: practice.PracticeOptionSnapshot{
+			ID:                   catalogSnapshot.PracticeOption.ID,
+			ScenarioDefinitionID: catalogSnapshot.PracticeOption.ScenarioDefinitionID,
+			RoleDefinitionID:     catalogSnapshot.PracticeOption.RoleDefinitionID,
+			Type:                 string(catalogSnapshot.PracticeOption.Type),
+			DisplayName:          catalogSnapshot.PracticeOption.DisplayName,
+			Version:              catalogSnapshot.PracticeOption.Version,
 		},
-		"practice_focuses": objectives,
-		"created_at":       r.timestamp(4),
+		SessionPolicy: practice.PracticeSessionPolicy{
+			SuggestedDurationSeconds: 900,
+			MinEffectiveTurns:        4,
+			MaxEffectiveTurns:        6,
+			CoverageCheckpointTurn:   4,
+			MaxFollowUpsPerQuestion:  1,
+			TargetObjectives:         objectives,
+			EarlyCompletionRule:      practice.EarlyCompletionCoverageSatisfiedAfterCheckpoint,
+		},
+		PracticeFocuses: objectives,
+		CreatedAt:       r.now.Add(4 * time.Second),
 	}
 }
 

--- a/server/internal/smoke/services.go
+++ b/server/internal/smoke/services.go
@@ -62,153 +62,161 @@ type practiceBackend struct {
 	runtime *Runtime
 }
 
-func (b practiceBackend) CreatePlan(
-	request practice.CreatePlanRequest,
-) (map[string]any, error) {
-	if request.PreparationProfileID != demoPreparationProfile {
-		return nil, ErrProfileNotFound
+func (b practiceBackend) CreatePracticePlan(
+	command practice.CreatePracticePlanCommand,
+) (practice.PracticePlan, error) {
+	if command.PreparationProfileID != demoPreparationProfile {
+		return practice.PracticePlan{}, ErrProfileNotFound
 	}
 	catalogSnapshot, err := b.runtime.catalog.GetCatalogSnapshot(
-		request.ScenarioDefinitionID,
-		request.ScenarioDefinitionVersion,
-		request.SelectedRoleIDs,
+		command.ScenarioDefinitionID,
+		command.ScenarioDefinitionVersion,
+		command.SelectedRoleIDs,
 		preparation.FullSimulationOptionID,
 		1,
 	)
 	if err != nil ||
-		catalogSnapshot.ScenarioConfig.ID != request.ScenarioConfigID ||
-		catalogSnapshot.ScenarioConfig.Version != request.ScenarioConfigVersion {
-		return nil, ErrInvalidSelection
+		catalogSnapshot.ScenarioConfig.ID != command.ScenarioConfigID ||
+		catalogSnapshot.ScenarioConfig.Version != command.ScenarioConfigVersion {
+		return practice.PracticePlan{}, ErrInvalidSelection
 	}
 	return b.runtime.createPlan()
 }
 
-func (b practiceBackend) PlanExists(id string) bool {
+func (b practiceBackend) PracticePlanExists(query practice.PracticePlanExistsQuery) bool {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
-	return id == demoPracticePlan && b.runtime.planCreated
+	return query.PracticePlanID == demoPracticePlan && b.runtime.planCreated
 }
 
-func (b practiceBackend) CreateSession(
-	planID string,
-	request practice.CreateSessionRequest,
-) (map[string]any, error) {
-	if planID != demoPracticePlan {
-		return nil, ErrPlanNotFound
+func (b practiceBackend) CreatePracticeSession(
+	command practice.CreatePracticeSessionCommand,
+) (practice.CreatePracticeSessionResult, error) {
+	if command.PracticePlanID != demoPracticePlan {
+		return practice.CreatePracticeSessionResult{}, ErrPlanNotFound
 	}
-	if request.ExpectedPlanRevision != 1 {
-		return nil, ErrVersionConflict
+	if command.ExpectedPlanRevision != 1 {
+		return practice.CreatePracticeSessionResult{}, ErrVersionConflict
 	}
-	if request.PreparationSnapshotID != demoPreparationSnapshot {
-		return nil, ErrInvalidSelection
+	if command.PreparationSnapshotID != demoPreparationSnapshot {
+		return practice.CreatePracticeSessionResult{}, ErrInvalidSelection
 	}
 	if _, err := b.runtime.catalog.GetCatalogSnapshot(
 		DemoScenarioDefinition,
 		1,
-		request.RoleDefinitionIDs,
-		request.PracticeOptionID,
+		command.RoleDefinitionIDs,
+		command.PracticeOptionID,
 		1,
 	); err != nil {
-		return nil, ErrInvalidSelection
+		return practice.CreatePracticeSessionResult{}, ErrInvalidSelection
 	}
 	return b.runtime.createSession()
 }
 
-func (b practiceBackend) GetSession(id string) (map[string]any, bool) {
+func (b practiceBackend) GetPracticeSession(
+	query practice.GetPracticeSessionQuery,
+) (practice.PracticeSession, bool) {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
-	if !b.runtime.sessionCreated || id != demoPracticeSession {
-		return nil, false
+	if !b.runtime.sessionCreated || query.PracticeSessionID != demoPracticeSession {
+		return practice.PracticeSession{}, false
 	}
 	return b.runtime.sessionLocked(), true
 }
 
-func (b practiceBackend) GetSnapshot(sessionID string) (map[string]any, bool) {
+func (b practiceBackend) GetPracticeSessionSnapshot(
+	query practice.GetPracticeSessionSnapshotQuery,
+) (practice.PracticeSessionSnapshot, bool) {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
-	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
-		return nil, false
+	if !b.runtime.sessionCreated || query.PracticeSessionID != demoPracticeSession {
+		return practice.PracticeSessionSnapshot{}, false
 	}
 	return b.runtime.snapshotLocked(), true
 }
 
-func (b practiceBackend) StartSession(sessionID string) (int, bool, error) {
+func (b practiceBackend) StartPracticeSession(
+	command practice.StartPracticeSessionCommand,
+) (practice.StartPracticeSessionResult, error) {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
-	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
-		return 0, false, ErrSessionNotFound
+	if !b.runtime.sessionCreated || command.PracticeSessionID != demoPracticeSession {
+		return practice.StartPracticeSessionResult{}, ErrSessionNotFound
 	}
 	switch b.runtime.sessionStatus {
-	case "starting":
-		b.runtime.sessionStatus = "in_progress"
+	case string(practice.PracticeSessionStarting):
+		b.runtime.sessionStatus = string(practice.PracticeSessionInProgress)
 		b.runtime.sessionVersion = 2
-		return 2, true, nil
-	case "in_progress":
-		return b.runtime.sessionVersion, false, nil
-	case "completed":
-		return b.runtime.sessionVersion, false, nil
+		return practice.StartPracticeSessionResult{SessionVersion: 2, Started: true}, nil
+	case string(practice.PracticeSessionInProgress), string(practice.PracticeSessionCompleted):
+		return practice.StartPracticeSessionResult{SessionVersion: b.runtime.sessionVersion}, nil
 	default:
-		return 0, false, ErrResourceConflict
+		return practice.StartPracticeSessionResult{}, ErrResourceConflict
 	}
 }
 
-func (b practiceBackend) AuthorizeTurn(sessionID string, retry bool) error {
+func (b practiceBackend) AuthorizePracticeTurn(
+	command practice.AuthorizePracticeTurnCommand,
+) error {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
-	if !b.runtime.sessionCreated || sessionID != demoPracticeSession {
+	if !b.runtime.sessionCreated || command.PracticeSessionID != demoPracticeSession {
 		return ErrSessionNotFound
 	}
-	if retry {
+	if command.IsRetry {
 		switch b.runtime.sessionStatus {
-		case "in_progress", "completed":
+		case string(practice.PracticeSessionInProgress), string(practice.PracticeSessionCompleted):
 			return nil
 		default:
 			return ErrResourceConflict
 		}
 	}
-	if b.runtime.sessionStatus != "in_progress" {
+	if b.runtime.sessionStatus != string(practice.PracticeSessionInProgress) {
 		return ErrSessionCompleted
 	}
 	return nil
 }
 
-func (b practiceBackend) RecordTurnOutcome(
-	outcome practice.TurnOutcome,
-) (practice.TurnDecision, error) {
+func (b practiceBackend) ApplyTurnOutcome(
+	command practice.ApplyTurnOutcomeCommand,
+) (practice.ApplyTurnOutcomeResult, error) {
 	b.runtime.mu.Lock()
 	defer b.runtime.mu.Unlock()
+	outcome := command.Outcome
 	if !b.runtime.sessionCreated || outcome.SessionID != demoPracticeSession {
-		return practice.TurnDecision{}, ErrSessionNotFound
+		return practice.ApplyTurnOutcomeResult{}, ErrSessionNotFound
 	}
 	if decision, ok := b.runtime.turnDecisions[outcome.TurnID]; ok {
 		return decision, nil
 	}
 	if outcome.IsRetry {
-		decision := practice.TurnDecision{
+		decision := practice.ApplyTurnOutcomeResult{
 			EffectiveTurns: b.runtime.effectiveTurns,
-			Completed:      b.runtime.sessionStatus == "completed",
+			Completed:      b.runtime.sessionStatus == string(practice.PracticeSessionCompleted),
 			SessionVersion: b.runtime.sessionVersion,
 		}
 		b.runtime.turnDecisions[outcome.TurnID] = decision
 		return decision, nil
 	}
-	if b.runtime.sessionStatus != "in_progress" {
-		return practice.TurnDecision{}, ErrSessionCompleted
+	if b.runtime.sessionStatus != string(practice.PracticeSessionInProgress) {
+		return practice.ApplyTurnOutcomeResult{}, ErrSessionCompleted
 	}
 	b.runtime.effectiveTurns++
 	b.runtime.sessionVersion++
-	decision := practice.TurnDecision{
+	decision := practice.ApplyTurnOutcomeResult{
 		EffectiveTurns:     b.runtime.effectiveTurns,
 		NextQuestionNumber: b.runtime.effectiveTurns + 1,
 		SessionVersion:     b.runtime.sessionVersion,
+		NextAction:         practice.NextActionMoveToNextObjective,
 	}
 	if b.runtime.effectiveTurns == 4 {
-		b.runtime.sessionStatus = "completed"
+		b.runtime.sessionStatus = string(practice.PracticeSessionCompleted)
 		b.runtime.sessionVersion = 6
 		decision.Completed = true
 		decision.NextQuestionNumber = 0
 		decision.SessionVersion = 6
-		decision.EndReason = "COVERAGE_SATISFIED_AT_CHECKPOINT"
+		decision.EndReason = practice.PracticeSessionEndCoverageSatisfiedAtCheckpoint
+		decision.NextAction = practice.NextActionCompleteSession
 	}
 	b.runtime.turnDecisions[outcome.TurnID] = decision
 	return decision, nil

--- a/server/internal/smoke/services.go
+++ b/server/internal/smoke/services.go
@@ -80,7 +80,7 @@ func (b practiceBackend) CreatePracticePlan(
 		catalogSnapshot.ScenarioConfig.Version != command.ScenarioConfigVersion {
 		return practice.PracticePlan{}, ErrInvalidSelection
 	}
-	return b.runtime.createPlan()
+	return b.runtime.createPlan(command)
 }
 
 func (b practiceBackend) PracticePlanExists(query practice.PracticePlanExistsQuery) bool {


### PR DESCRIPTION
## 功能描述

关联并关闭 #125。

将 Practice 模块的应用层边界从松散的 `map[string]any` 和基础参数，收敛为明确的领域模型、Command、Query 与 Result 类型。此次改动为后续场景练习流程提供稳定的内部契约，不新增 Flutter 页面或用户可见功能。

## 实现思路

- 新增 `PracticePlan`、`PracticeSession`、`PracticeParticipant`、`PracticeSessionSnapshot`、`PracticeSessionPolicy` 和 `TurnOutcome` 等领域类型。
- 为创建计划、创建会话、查询会话、启动会话、授权回合和应用回合结果定义类型化的 Service 接口。
- 补充计划状态、会话状态、练习模式、目标覆盖、下一步动作及领域错误常量。
- 将 Smoke 应用层和运行时迁移到新的 Practice 契约，同时保留现有生产 HTTP 请求结构和 API 字段。
- 增加契约测试，固定公开方法签名、必要字段及枚举值。

## 测试方式

在仓库根目录执行：

```bash
cd server
go test ./internal/practice ./internal/smoke
go test -race ./internal/practice ./internal/smoke
cd ..
make check-go
make check-smoke
make check
git diff --check upstream/dev...HEAD
```

本地验证结果：

- Practice 与 Smoke 聚焦测试通过。
- Race Detector 通过。
- Go 检查和确定性 Smoke 通过。
- 完整 `make check` 通过，包括 Flutter format/analyze、436 项 Flutter 测试、Go vet/test、OpenAPI 校验、WebSocket 契约校验及确定性 Smoke 验证。

## 相关 Issue / 备注

Closes #125

非目标范围：

- 不新增或调整 Flutter UI。
- 不改变现有 HTTP/OpenAPI 字段。
- 不包含 #137 的场景模块产品流程实现。

## AI 辅助说明

- 关键 Prompt：基于最新 `upstream/dev` 完成 #125 Practice 领域应用契约重构，保持生产 HTTP/API 兼容，并运行完整项目门禁。
- 人工 Review 要点：确认 Practice Service 公共边界已类型化；确认现有生产请求结构未被窄化；确认四轮有效回答、同题重试和会话完成等确定性行为未改变；确认 PR 未包含 `.env`、密钥、UI 或其他 Issue 的改动。
