### PR TITLE
feat(memory): add persistent memory repository

### DIFF
--- a/server/internal/memory/model.go
+++ b/server/internal/memory/model.go
@@ -1,0 +1,233 @@
+package memory
+
+import (
+	"crypto/sha256"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	maxCanonicalKeyBytes  = 128
+	maxContentRunes       = 4096
+	maxContentBytes       = 16384
+	maxPolicyVersionBytes = 64
+	maxSourceIDBytes      = 128
+)
+
+var (
+	canonicalKeyPattern = regexp.MustCompile(
+		`^[a-z][a-z0-9._:-]{0,127}$`,
+	)
+	policyVersionPattern = regexp.MustCompile(
+		`^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$`,
+	)
+)
+
+type Type string
+
+const (
+	TypeIdentity   Type = "identity"
+	TypeProfile    Type = "profile"
+	TypePreference Type = "preference"
+	TypeGoal       Type = "goal"
+	TypeInterest   Type = "interest"
+	TypeStrength   Type = "strength"
+	TypeWeakness   Type = "weakness"
+	TypeProgress   Type = "progress"
+	TypeTopic      Type = "topic"
+)
+
+func (memoryType Type) Valid() bool {
+	switch memoryType {
+	case TypeIdentity,
+		TypeProfile,
+		TypePreference,
+		TypeGoal,
+		TypeInterest,
+		TypeStrength,
+		TypeWeakness,
+		TypeProgress,
+		TypeTopic:
+		return true
+	default:
+		return false
+	}
+}
+
+type ScopeType string
+
+const (
+	ScopeUser   ScopeType = "user"
+	ScopeMatter ScopeType = "matter"
+)
+
+func (scope ScopeType) Valid() bool {
+	return scope == ScopeUser || scope == ScopeMatter
+}
+
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusInactive Status = "inactive"
+)
+
+func (status Status) Valid() bool {
+	return status == StatusActive || status == StatusInactive
+}
+
+type SourceType string
+
+const (
+	SourceAgentMessage    SourceType = "agent_message"
+	SourceAgentRun        SourceType = "agent_run"
+	SourceFormalReview    SourceType = "formal_review"
+	SourcePracticeSession SourceType = "practice_session"
+)
+
+func (sourceType SourceType) Valid() bool {
+	switch sourceType {
+	case SourceAgentMessage,
+		SourceAgentRun,
+		SourceFormalReview,
+		SourcePracticeSession:
+		return true
+	default:
+		return false
+	}
+}
+
+type Memory struct {
+	ID            string
+	OwnerID       string
+	Type          Type
+	CanonicalKey  string
+	Content       string
+	Scope         ScopeType
+	MatterID      string
+	Status        Status
+	Version       int64
+	PolicyVersion string
+	ExpiresAt     *time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	InactivatedAt *time.Time
+}
+
+func (item Memory) Valid() bool {
+	return validUUID(item.ID) &&
+		validUUID(item.OwnerID) &&
+		item.Type.Valid() &&
+		validCanonicalKey(item.CanonicalKey) &&
+		validContent(item.Content) &&
+		validScope(item.Scope, item.MatterID) &&
+		item.Status.Valid() &&
+		item.Version > 0 &&
+		validPolicyVersion(item.PolicyVersion) &&
+		validOptionalTime(item.ExpiresAt) &&
+		!item.CreatedAt.IsZero() &&
+		!item.UpdatedAt.IsZero() &&
+		validLifecycle(item)
+}
+
+type Source struct {
+	ID        string
+	OwnerID   string
+	MemoryID  string
+	Type      SourceType
+	SourceID  string
+	Version   int64
+	Checksum  [sha256.Size]byte
+	CreatedAt time.Time
+}
+
+func (source Source) Valid() bool {
+	return validUUID(source.ID) &&
+		validUUID(source.OwnerID) &&
+		validUUID(source.MemoryID) &&
+		source.Input().Valid() &&
+		!source.CreatedAt.IsZero()
+}
+
+type SourceInput struct {
+	Type     SourceType
+	SourceID string
+	Version  int64
+	Checksum [sha256.Size]byte
+}
+
+func (source SourceInput) Valid() bool {
+	return source.Type.Valid() &&
+		validSourceID(source.SourceID) &&
+		source.Version > 0
+}
+
+func (source Source) Input() SourceInput {
+	return SourceInput{
+		Type:     source.Type,
+		SourceID: source.SourceID,
+		Version:  source.Version,
+		Checksum: source.Checksum,
+	}
+}
+
+func validUUID(value string) bool {
+	var identifier pgtype.UUID
+	return identifier.Scan(value) == nil && identifier.Valid
+}
+
+func validCanonicalKey(value string) bool {
+	return len(value) <= maxCanonicalKeyBytes &&
+		canonicalKeyPattern.MatchString(value)
+}
+
+func validContent(value string) bool {
+	return value == strings.TrimSpace(value) &&
+		value != "" &&
+		len([]rune(value)) <= maxContentRunes &&
+		len(value) <= maxContentBytes
+}
+
+func validPolicyVersion(value string) bool {
+	return len(value) <= maxPolicyVersionBytes &&
+		policyVersionPattern.MatchString(value)
+}
+
+func validSourceID(value string) bool {
+	return value == strings.TrimSpace(value) &&
+		value != "" &&
+		len(value) <= maxSourceIDBytes &&
+		!strings.ContainsAny(value, " \t\r\n")
+}
+
+func validScope(scope ScopeType, matterID string) bool {
+	if !scope.Valid() {
+		return false
+	}
+	if scope == ScopeUser {
+		return matterID == ""
+	}
+	return validUUID(matterID)
+}
+
+func validOptionalTime(value *time.Time) bool {
+	return value == nil || !value.IsZero()
+}
+
+func validLifecycle(item Memory) bool {
+	if item.UpdatedAt.Before(item.CreatedAt) {
+		return false
+	}
+	if item.ExpiresAt != nil && !item.ExpiresAt.After(item.CreatedAt) {
+		return false
+	}
+	if item.Status == StatusActive {
+		return item.InactivatedAt == nil
+	}
+	return item.InactivatedAt != nil &&
+		!item.InactivatedAt.Before(item.CreatedAt) &&
+		!item.UpdatedAt.Before(*item.InactivatedAt)
+}

--- a/server/internal/memory/model_test.go
+++ b/server/internal/memory/model_test.go
@@ -1,0 +1,166 @@
+package memory
+
+import (
+	"crypto/sha256"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testOwnerID  = "10000000-0000-4000-8000-000000000001"
+	testMemoryID = "20000000-0000-4000-8000-000000000001"
+	testMatterID = "30000000-0000-4000-8000-000000000001"
+	testSourceID = "40000000-0000-4000-8000-000000000001"
+)
+
+func TestCreateCommandValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := validCreateCommand()
+	tests := []struct {
+		name   string
+		mutate func(*CreateCommand)
+	}{
+		{
+			name: "unknown memory type",
+			mutate: func(command *CreateCommand) {
+				command.Type = Type("personality")
+			},
+		},
+		{
+			name: "invalid canonical key",
+			mutate: func(command *CreateCommand) {
+				command.CanonicalKey = "Career Role"
+			},
+		},
+		{
+			name: "blank content",
+			mutate: func(command *CreateCommand) {
+				command.Content = " "
+			},
+		},
+		{
+			name: "user scope with matter",
+			mutate: func(command *CreateCommand) {
+				command.MatterID = testMatterID
+			},
+		},
+		{
+			name: "matter scope without matter",
+			mutate: func(command *CreateCommand) {
+				command.Scope = ScopeMatter
+			},
+		},
+		{
+			name: "invalid policy version",
+			mutate: func(command *CreateCommand) {
+				command.PolicyVersion = "v1 latest"
+			},
+		},
+		{
+			name: "unknown source type",
+			mutate: func(command *CreateCommand) {
+				command.Source.Type = SourceType("chat")
+			},
+		},
+		{
+			name: "invalid source version",
+			mutate: func(command *CreateCommand) {
+				command.Source.Version = 0
+			},
+		},
+	}
+
+	if !valid.Valid() {
+		t.Fatal("valid CreateCommand was rejected")
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			command := valid
+			test.mutate(&command)
+			if command.Valid() {
+				t.Fatal("invalid CreateCommand was accepted")
+			}
+		})
+	}
+}
+
+func TestMemoryLifecycleValidation(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Now().UTC()
+	item := Memory{
+		ID:            testMemoryID,
+		OwnerID:       testOwnerID,
+		Type:          TypeProfile,
+		CanonicalKey:  "career.role",
+		Content:       "Java backend engineer",
+		Scope:         ScopeUser,
+		Status:        StatusActive,
+		Version:       1,
+		PolicyVersion: "memory-v1",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}
+	if !item.Valid() {
+		t.Fatal("valid active Memory was rejected")
+	}
+
+	inactivatedAt := createdAt.Add(time.Second)
+	item.Status = StatusInactive
+	item.Version = 2
+	item.UpdatedAt = inactivatedAt
+	item.InactivatedAt = &inactivatedAt
+	if !item.Valid() {
+		t.Fatal("valid inactive Memory was rejected")
+	}
+
+	item.Content = strings.Repeat("界", maxContentRunes+1)
+	if item.Valid() {
+		t.Fatal("oversized Memory content was accepted")
+	}
+}
+
+func TestScopeFilterValidation(t *testing.T) {
+	t.Parallel()
+
+	if !(ScopeFilter{Scope: ScopeUser, Limit: 10}).Valid() {
+		t.Fatal("valid user ScopeFilter was rejected")
+	}
+	if !(ScopeFilter{
+		Scope:    ScopeMatter,
+		MatterID: testMatterID,
+		Limit:    100,
+	}).Valid() {
+		t.Fatal("valid matter ScopeFilter was rejected")
+	}
+	for _, filter := range []ScopeFilter{
+		{Scope: ScopeMatter, Limit: 10},
+		{Scope: ScopeUser, MatterID: testMatterID, Limit: 10},
+		{Scope: ScopeUser, Limit: 0},
+		{Scope: ScopeUser, Limit: 101},
+	} {
+		if filter.Valid() {
+			t.Fatalf("invalid ScopeFilter was accepted: %#v", filter)
+		}
+	}
+}
+
+func validCreateCommand() CreateCommand {
+	return CreateCommand{
+		Type:          TypeProfile,
+		CanonicalKey:  "career.role",
+		Content:       "Java backend engineer",
+		Scope:         ScopeUser,
+		PolicyVersion: "memory-v1",
+		Source: SourceInput{
+			Type:     SourceAgentRun,
+			SourceID: testSourceID,
+			Version:  1,
+			Checksum: sha256.Sum256([]byte("source")),
+		},
+	}
+}

--- a/server/internal/memory/postgres.go
+++ b/server/internal/memory/postgres.go
@@ -1,0 +1,896 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const rollbackTimeout = 5 * time.Second
+
+type PostgreSQL interface {
+	Begin(context.Context) (pgx.Tx, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type PostgresRepository struct {
+	database PostgreSQL
+	ids      IDGenerator
+}
+
+func NewPostgresRepository(
+	database PostgreSQL,
+	ids IDGenerator,
+) (*PostgresRepository, error) {
+	if database == nil || ids == nil {
+		return nil, ErrRepository
+	}
+	return &PostgresRepository{database: database, ids: ids}, nil
+}
+
+func (repository *PostgresRepository) Create(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command CreateCommand,
+) (Memory, error) {
+	if ctx == nil || !validActor(actor) || !command.Valid() {
+		return Memory{}, ErrInvalidArgument
+	}
+	memoryID, sourceID, err := repository.newMutationIDs()
+	if err != nil {
+		return Memory{}, err
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return Memory{}, ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := lockActiveOwner(ctx, tx, actor.UserID); err != nil {
+		return Memory{}, err
+	}
+	if command.Scope == ScopeMatter {
+		if err := requireOwnedMatter(
+			ctx,
+			tx,
+			actor.UserID,
+			command.MatterID,
+		); err != nil {
+			return Memory{}, err
+		}
+	}
+
+	item, err := scanMemory(tx.QueryRow(ctx, `
+INSERT INTO agent_memories (
+    id,
+    owner_user_id,
+    memory_type,
+    canonical_key,
+    content,
+    scope_type,
+    matter_id,
+    status,
+    version,
+    policy_version,
+    expires_at,
+    created_at,
+    updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7,
+    'active', 1, $8, $9,
+    transaction_timestamp(),
+    transaction_timestamp()
+)
+RETURNING
+    id::text,
+    owner_user_id::text,
+    memory_type,
+    canonical_key,
+    content,
+    scope_type,
+    coalesce(matter_id::text, ''),
+    status,
+    version,
+    policy_version,
+    expires_at,
+    created_at,
+    updated_at,
+    inactivated_at`,
+		memoryID,
+		actor.UserID,
+		command.Type,
+		command.CanonicalKey,
+		command.Content,
+		command.Scope,
+		nullableUUID(command.MatterID),
+		command.PolicyVersion,
+		command.ExpiresAt,
+	))
+	if err != nil {
+		return Memory{}, mapPostgresError(err)
+	}
+	if err := insertSource(
+		ctx,
+		tx,
+		sourceID,
+		actor.UserID,
+		item.ID,
+		command.Source,
+	); err != nil {
+		return Memory{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Memory{}, ErrRepository
+	}
+	return item, nil
+}
+
+func (repository *PostgresRepository) Find(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	memoryID string,
+) (Memory, error) {
+	if ctx == nil || !validActor(actor) || !validUUID(memoryID) {
+		return Memory{}, ErrInvalidArgument
+	}
+	item, err := scanMemory(repository.database.QueryRow(ctx, `
+SELECT
+    memories.id::text,
+    memories.owner_user_id::text,
+    memories.memory_type,
+    memories.canonical_key,
+    memories.content,
+    memories.scope_type,
+    coalesce(memories.matter_id::text, ''),
+    memories.status,
+    memories.version,
+    memories.policy_version,
+    memories.expires_at,
+    memories.created_at,
+    memories.updated_at,
+    memories.inactivated_at
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.id = $1
+  AND memories.owner_user_id = $2`,
+		memoryID,
+		actor.UserID,
+	))
+	if err != nil {
+		return Memory{}, mapPostgresError(err)
+	}
+	return item, nil
+}
+
+func (repository *PostgresRepository) ListActive(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	filter ScopeFilter,
+) ([]Memory, error) {
+	if ctx == nil || !validActor(actor) || !filter.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	query := `
+SELECT
+    memories.id::text,
+    memories.owner_user_id::text,
+    memories.memory_type,
+    memories.canonical_key,
+    memories.content,
+    memories.scope_type,
+    coalesce(memories.matter_id::text, ''),
+    memories.status,
+    memories.version,
+    memories.policy_version,
+    memories.expires_at,
+    memories.created_at,
+    memories.updated_at,
+    memories.inactivated_at
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.owner_user_id = $1
+  AND memories.scope_type = 'user'
+  AND memories.matter_id IS NULL
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > CURRENT_TIMESTAMP)
+ORDER BY memories.updated_at DESC, memories.id DESC
+LIMIT $2`
+	arguments := []any{actor.UserID, filter.Limit}
+	if filter.Scope == ScopeMatter {
+		query = `
+SELECT
+    memories.id::text,
+    memories.owner_user_id::text,
+    memories.memory_type,
+    memories.canonical_key,
+    memories.content,
+    memories.scope_type,
+    coalesce(memories.matter_id::text, ''),
+    memories.status,
+    memories.version,
+    memories.policy_version,
+    memories.expires_at,
+    memories.created_at,
+    memories.updated_at,
+    memories.inactivated_at
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.owner_user_id = $1
+  AND memories.scope_type = 'matter'
+  AND memories.matter_id = $2
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > CURRENT_TIMESTAMP)
+ORDER BY memories.updated_at DESC, memories.id DESC
+LIMIT $3`
+		arguments = []any{actor.UserID, filter.MatterID, filter.Limit}
+	}
+	rows, err := repository.database.Query(ctx, query, arguments...)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	items := make([]Memory, 0)
+	for rows.Next() {
+		item, scanErr := scanMemory(rows)
+		if scanErr != nil {
+			return nil, ErrRepository
+		}
+		items = append(items, item)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	return items, nil
+}
+
+func (repository *PostgresRepository) ListSources(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	memoryID string,
+) ([]Source, error) {
+	if ctx == nil || !validActor(actor) || !validUUID(memoryID) {
+		return nil, ErrInvalidArgument
+	}
+	rows, err := repository.database.Query(ctx, `
+SELECT
+    sources.id::text,
+    sources.owner_user_id::text,
+    sources.memory_id::text,
+    sources.source_type,
+    sources.source_id,
+    sources.source_version,
+    sources.source_checksum,
+    sources.created_at
+FROM agent_memory_sources AS sources
+JOIN agent_memories AS memories
+  ON memories.id = sources.memory_id
+ AND memories.owner_user_id = sources.owner_user_id
+JOIN identity_users AS users
+  ON users.id = sources.owner_user_id
+ AND users.account_status = 'active'
+WHERE sources.memory_id = $1
+  AND sources.owner_user_id = $2
+ORDER BY sources.created_at, sources.id`,
+		memoryID,
+		actor.UserID,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	items := make([]Source, 0)
+	for rows.Next() {
+		item, scanErr := scanSource(rows)
+		if scanErr != nil {
+			return nil, ErrRepository
+		}
+		items = append(items, item)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	if len(items) == 0 {
+		if _, findErr := repository.Find(
+			ctx,
+			actor,
+			memoryID,
+		); findErr != nil {
+			return nil, findErr
+		}
+	}
+	return items, nil
+}
+
+func (repository *PostgresRepository) Update(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command UpdateCommand,
+) (Memory, error) {
+	if ctx == nil || !validActor(actor) || !command.Valid() {
+		return Memory{}, ErrInvalidArgument
+	}
+	sourceID, err := repository.newID()
+	if err != nil {
+		return Memory{}, err
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return Memory{}, ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := lockActiveOwner(ctx, tx, actor.UserID); err != nil {
+		return Memory{}, err
+	}
+
+	item, err := scanMemory(tx.QueryRow(ctx, `
+UPDATE agent_memories
+SET
+    content = $4,
+    policy_version = $5,
+    expires_at = $6,
+    version = version + 1,
+    updated_at = GREATEST(
+        transaction_timestamp(),
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE id = $1
+  AND owner_user_id = $2
+  AND version = $3
+  AND status = 'active'
+RETURNING
+    id::text,
+    owner_user_id::text,
+    memory_type,
+    canonical_key,
+    content,
+    scope_type,
+    coalesce(matter_id::text, ''),
+    status,
+    version,
+    policy_version,
+    expires_at,
+    created_at,
+    updated_at,
+    inactivated_at`,
+		command.MemoryID,
+		actor.UserID,
+		command.ExpectedVersion,
+		command.Content,
+		command.PolicyVersion,
+		command.ExpiresAt,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Memory{}, classifyMutationMiss(
+			ctx,
+			tx,
+			actor.UserID,
+			command.MemoryID,
+		)
+	}
+	if err != nil {
+		return Memory{}, mapPostgresError(err)
+	}
+	if err := insertSource(
+		ctx,
+		tx,
+		sourceID,
+		actor.UserID,
+		item.ID,
+		command.Source,
+	); err != nil {
+		return Memory{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Memory{}, ErrRepository
+	}
+	return item, nil
+}
+
+func (repository *PostgresRepository) Inactivate(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command InactivateCommand,
+) (Memory, error) {
+	if ctx == nil || !validActor(actor) || !command.Valid() {
+		return Memory{}, ErrInvalidArgument
+	}
+	sourceID, err := repository.newID()
+	if err != nil {
+		return Memory{}, err
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return Memory{}, ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := lockActiveOwner(ctx, tx, actor.UserID); err != nil {
+		return Memory{}, err
+	}
+
+	item, err := scanMemory(tx.QueryRow(ctx, `
+UPDATE agent_memories
+SET
+    status = 'inactive',
+    version = version + 1,
+    inactivated_at = GREATEST(
+        transaction_timestamp(),
+        updated_at + INTERVAL '1 microsecond'
+    ),
+    updated_at = GREATEST(
+        transaction_timestamp(),
+        updated_at + INTERVAL '1 microsecond'
+    )
+WHERE id = $1
+  AND owner_user_id = $2
+  AND version = $3
+  AND status = 'active'
+RETURNING
+    id::text,
+    owner_user_id::text,
+    memory_type,
+    canonical_key,
+    content,
+    scope_type,
+    coalesce(matter_id::text, ''),
+    status,
+    version,
+    policy_version,
+    expires_at,
+    created_at,
+    updated_at,
+    inactivated_at`,
+		command.MemoryID,
+		actor.UserID,
+		command.ExpectedVersion,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Memory{}, classifyMutationMiss(
+			ctx,
+			tx,
+			actor.UserID,
+			command.MemoryID,
+		)
+	}
+	if err != nil {
+		return Memory{}, mapPostgresError(err)
+	}
+	if err := insertSource(
+		ctx,
+		tx,
+		sourceID,
+		actor.UserID,
+		item.ID,
+		command.Source,
+	); err != nil {
+		return Memory{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Memory{}, ErrRepository
+	}
+	return item, nil
+}
+
+func (repository *PostgresRepository) Delete(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	memoryID string,
+) error {
+	if ctx == nil || !validActor(actor) || !validUUID(memoryID) {
+		return ErrInvalidArgument
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := lockActiveOwner(ctx, tx, actor.UserID); err != nil {
+		return err
+	}
+	tag, err := tx.Exec(ctx, `
+DELETE FROM agent_memories
+WHERE id = $1 AND owner_user_id = $2`,
+		memoryID,
+		actor.UserID,
+	)
+	if err != nil {
+		return mapPostgresError(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrRepository
+	}
+	return nil
+}
+
+func (repository *PostgresRepository) DeleteOwnerData(
+	ctx context.Context,
+	command DeleteOwnerCommand,
+) error {
+	if ctx == nil || !command.Valid() {
+		return ErrInvalidArgument
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := lockOwner(ctx, tx, command.UserID); err != nil {
+		return err
+	}
+
+	var accountStatus string
+	err = tx.QueryRow(ctx, `
+SELECT account_status
+FROM identity_users
+WHERE id = $1
+FOR UPDATE`,
+		command.UserID,
+	).Scan(&accountStatus)
+	identityMissing := errors.Is(err, pgx.ErrNoRows)
+	if err != nil && !identityMissing {
+		return ErrRepository
+	}
+
+	var persistedGeneration int64
+	fenceErr := tx.QueryRow(ctx, `
+SELECT deletion_generation
+FROM agent_memory_deletion_fences
+WHERE owner_user_id = $1
+FOR UPDATE`,
+		command.UserID,
+	).Scan(&persistedGeneration)
+	fenceMissing := errors.Is(fenceErr, pgx.ErrNoRows)
+	if fenceErr != nil && !fenceMissing {
+		return ErrRepository
+	}
+	if identityMissing && fenceMissing {
+		return ErrNotFound
+	}
+	if !identityMissing &&
+		accountStatus != "deleting" &&
+		accountStatus != "deleted" {
+		return ErrInvalidArgument
+	}
+	if !fenceMissing && int64(command.Generation) < persistedGeneration {
+		return ErrDeletionGeneration
+	}
+
+	if _, err := tx.Exec(ctx, `
+INSERT INTO agent_memory_deletion_fences (
+    owner_user_id,
+    deletion_generation,
+    created_at,
+    updated_at
+) VALUES (
+    $1, $2, transaction_timestamp(), transaction_timestamp()
+)
+ON CONFLICT (owner_user_id) DO UPDATE
+SET
+    deletion_generation = GREATEST(
+        agent_memory_deletion_fences.deletion_generation,
+        EXCLUDED.deletion_generation
+    ),
+    updated_at = CASE
+        WHEN EXCLUDED.deletion_generation >
+             agent_memory_deletion_fences.deletion_generation
+        THEN transaction_timestamp()
+        ELSE agent_memory_deletion_fences.updated_at
+    END`,
+		command.UserID,
+		command.Generation,
+	); err != nil {
+		return mapPostgresError(err)
+	}
+	if _, err := tx.Exec(ctx, `
+DELETE FROM agent_memories WHERE owner_user_id = $1`,
+		command.UserID,
+	); err != nil {
+		return mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrRepository
+	}
+	return nil
+}
+
+func (repository *PostgresRepository) newMutationIDs() (
+	string,
+	string,
+	error,
+) {
+	memoryID, err := repository.newID()
+	if err != nil {
+		return "", "", err
+	}
+	sourceID, err := repository.newID()
+	if err != nil {
+		return "", "", err
+	}
+	return memoryID, sourceID, nil
+}
+
+func (repository *PostgresRepository) newID() (string, error) {
+	identifier, err := repository.ids.NewID()
+	if err != nil || !validUUID(identifier) {
+		return "", ErrRepository
+	}
+	return identifier, nil
+}
+
+func lockActiveOwner(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+) error {
+	if err := lockOwner(ctx, tx, ownerID); err != nil {
+		return err
+	}
+	var accountStatus string
+	err := tx.QueryRow(ctx, `
+SELECT account_status
+FROM identity_users
+WHERE id = $1
+FOR SHARE`,
+		ownerID,
+	).Scan(&accountStatus)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrAccountDeleted
+	}
+	if err != nil {
+		return ErrRepository
+	}
+	if accountStatus != "active" {
+		return ErrAccountDeleted
+	}
+	var fenceExists bool
+	if err := tx.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM agent_memory_deletion_fences
+    WHERE owner_user_id = $1
+)`,
+		ownerID,
+	).Scan(&fenceExists); err != nil {
+		return ErrRepository
+	}
+	if fenceExists {
+		return ErrAccountDeleted
+	}
+	return nil
+}
+
+func lockOwner(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+) error {
+	if _, err := tx.Exec(ctx, `
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"agent_memory:"+ownerID,
+	); err != nil {
+		return ErrRepository
+	}
+	return nil
+}
+
+func requireOwnedMatter(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+	matterID string,
+) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM matters
+    WHERE id = $1 AND owner_user_id = $2
+)`,
+		matterID,
+		ownerID,
+	).Scan(&exists); err != nil {
+		return ErrRepository
+	}
+	if !exists {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func insertSource(
+	ctx context.Context,
+	tx pgx.Tx,
+	sourceID string,
+	ownerID string,
+	memoryID string,
+	source SourceInput,
+) error {
+	if _, err := tx.Exec(ctx, `
+INSERT INTO agent_memory_sources (
+    id,
+    owner_user_id,
+    memory_id,
+    source_type,
+    source_id,
+    source_version,
+    source_checksum,
+    created_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, transaction_timestamp()
+)
+ON CONFLICT (
+    owner_user_id,
+    memory_id,
+    source_type,
+    source_id,
+    source_version,
+    source_checksum
+) DO NOTHING`,
+		sourceID,
+		ownerID,
+		memoryID,
+		source.Type,
+		source.SourceID,
+		source.Version,
+		source.Checksum[:],
+	); err != nil {
+		return mapPostgresError(err)
+	}
+	return nil
+}
+
+func classifyMutationMiss(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+	memoryID string,
+) error {
+	var version int64
+	if err := tx.QueryRow(ctx, `
+SELECT version
+FROM agent_memories
+WHERE id = $1 AND owner_user_id = $2`,
+		memoryID,
+		ownerID,
+	).Scan(&version); errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	} else if err != nil {
+		return ErrRepository
+	}
+	return ErrConflict
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanMemory(row rowScanner) (Memory, error) {
+	var item Memory
+	var memoryType string
+	var scope string
+	var status string
+	if err := row.Scan(
+		&item.ID,
+		&item.OwnerID,
+		&memoryType,
+		&item.CanonicalKey,
+		&item.Content,
+		&scope,
+		&item.MatterID,
+		&status,
+		&item.Version,
+		&item.PolicyVersion,
+		&item.ExpiresAt,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+		&item.InactivatedAt,
+	); err != nil {
+		return Memory{}, err
+	}
+	item.Type = Type(memoryType)
+	item.Scope = ScopeType(scope)
+	item.Status = Status(status)
+	item.CreatedAt = item.CreatedAt.UTC()
+	item.UpdatedAt = item.UpdatedAt.UTC()
+	normalizeTime(&item.ExpiresAt)
+	normalizeTime(&item.InactivatedAt)
+	if !item.Valid() {
+		return Memory{}, ErrRepository
+	}
+	return item, nil
+}
+
+func scanSource(row rowScanner) (Source, error) {
+	var item Source
+	var sourceType string
+	var checksum []byte
+	if err := row.Scan(
+		&item.ID,
+		&item.OwnerID,
+		&item.MemoryID,
+		&sourceType,
+		&item.SourceID,
+		&item.Version,
+		&checksum,
+		&item.CreatedAt,
+	); err != nil {
+		return Source{}, err
+	}
+	if len(checksum) != len(item.Checksum) {
+		return Source{}, ErrRepository
+	}
+	copy(item.Checksum[:], checksum)
+	item.Type = SourceType(sourceType)
+	item.CreatedAt = item.CreatedAt.UTC()
+	if !item.Valid() {
+		return Source{}, ErrRepository
+	}
+	return item, nil
+}
+
+func normalizeTime(value **time.Time) {
+	if *value == nil {
+		return
+	}
+	normalized := (*value).UTC()
+	*value = &normalized
+}
+
+func nullableUUID(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func validActor(actor requestcontext.Actor) bool {
+	return actor.Valid() &&
+		validUUID(actor.UserID) &&
+		validUUID(actor.SessionID)
+}
+
+func mapPostgresError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		switch postgresError.Code {
+		case "23503":
+			return ErrNotFound
+		case "23505":
+			return ErrConflict
+		case "22001", "22P02", "23514":
+			return ErrInvalidArgument
+		}
+	}
+	return ErrRepository
+}
+
+func rollback(ctx context.Context, tx pgx.Tx) {
+	rollbackContext, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		rollbackTimeout,
+	)
+	defer cancel()
+	_ = tx.Rollback(rollbackContext)
+}
+
+var _ Repository = (*PostgresRepository)(nil)

--- a/server/internal/memory/postgres_integration_test.go
+++ b/server/internal/memory/postgres_integration_test.go
@@ -1,0 +1,473 @@
+package memory
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	integrationUserA    = "a0000000-0000-4000-8000-000000000001"
+	integrationUserB    = "b0000000-0000-4000-8000-000000000001"
+	integrationSessionA = "a1000000-0000-4000-8000-000000000001"
+	integrationSessionB = "b1000000-0000-4000-8000-000000000001"
+	integrationMatterA  = "a2000000-0000-4000-8000-000000000001"
+	integrationMatterB  = "b2000000-0000-4000-8000-000000000001"
+)
+
+func TestPostgresRepositoryLifecycleIsolationAndDeletionFence(
+	t *testing.T,
+) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	ctx := context.Background()
+	actorA := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	actorB := requestcontext.Actor{
+		UserID:    integrationUserB,
+		SessionID: integrationSessionB,
+	}
+
+	userMemory, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("career.role", "Java backend engineer"),
+	)
+	if err != nil {
+		t.Fatalf("Create user Memory: %v", err)
+	}
+	if !userMemory.Valid() || userMemory.Version != 1 {
+		t.Fatalf("created Memory = %#v", userMemory)
+	}
+	if _, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("career.role", "Platform engineer"),
+	); !errors.Is(err, ErrConflict) {
+		t.Fatalf("duplicate active Memory error = %v", err)
+	}
+	if _, err := repository.Find(
+		ctx,
+		actorB,
+		userMemory.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Find error = %v", err)
+	}
+
+	sources, err := repository.ListSources(ctx, actorA, userMemory.ID)
+	if err != nil {
+		t.Fatalf("ListSources after Create: %v", err)
+	}
+	if len(sources) != 1 || sources[0].MemoryID != userMemory.ID {
+		t.Fatalf("sources after Create = %#v", sources)
+	}
+
+	updateSource := evidence(SourceAgentRun, "run-1", 1, "same-source")
+	updated, err := repository.Update(ctx, actorA, UpdateCommand{
+		MemoryID:        userMemory.ID,
+		ExpectedVersion: 1,
+		Content:         "Senior Java backend engineer",
+		PolicyVersion:   "memory-v1",
+		Source:          updateSource,
+	})
+	if err != nil {
+		t.Fatalf("Update Memory: %v", err)
+	}
+	if updated.Version != 2 ||
+		updated.Content != "Senior Java backend engineer" {
+		t.Fatalf("updated Memory = %#v", updated)
+	}
+	updated, err = repository.Update(ctx, actorA, UpdateCommand{
+		MemoryID:        userMemory.ID,
+		ExpectedVersion: 2,
+		Content:         "Senior Java platform engineer",
+		PolicyVersion:   "memory-v1",
+		Source:          updateSource,
+	})
+	if err != nil {
+		t.Fatalf("Update Memory with duplicate source: %v", err)
+	}
+	sources, err = repository.ListSources(ctx, actorA, userMemory.ID)
+	if err != nil {
+		t.Fatalf("ListSources after duplicate source: %v", err)
+	}
+	if len(sources) != 2 {
+		t.Fatalf("source count = %d, want 2", len(sources))
+	}
+	if _, err := repository.Update(ctx, actorA, UpdateCommand{
+		MemoryID:        userMemory.ID,
+		ExpectedVersion: 1,
+		Content:         "stale update",
+		PolicyVersion:   "memory-v1",
+		Source:          evidence(SourceAgentRun, "run-2", 1, "stale"),
+	}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("stale Update error = %v", err)
+	}
+
+	matterCommand := createCommand("goal.current", "Prepare for PM interview")
+	matterCommand.Type = TypeGoal
+	matterCommand.Scope = ScopeMatter
+	matterCommand.MatterID = integrationMatterA
+	matterMemory, err := repository.Create(ctx, actorA, matterCommand)
+	if err != nil {
+		t.Fatalf("Create matter Memory: %v", err)
+	}
+	foreignMatterCommand := matterCommand
+	foreignMatterCommand.CanonicalKey = "goal.foreign"
+	foreignMatterCommand.MatterID = integrationMatterB
+	if _, err := repository.Create(
+		ctx,
+		actorA,
+		foreignMatterCommand,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("foreign Matter Create error = %v", err)
+	}
+
+	userItems, err := repository.ListActive(ctx, actorA, ScopeFilter{
+		Scope: ScopeUser,
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListActive user: %v", err)
+	}
+	if len(userItems) != 1 || userItems[0].ID != userMemory.ID {
+		t.Fatalf("user active Memories = %#v", userItems)
+	}
+	matterItems, err := repository.ListActive(ctx, actorA, ScopeFilter{
+		Scope:    ScopeMatter,
+		MatterID: integrationMatterA,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListActive matter: %v", err)
+	}
+	if len(matterItems) != 1 || matterItems[0].ID != matterMemory.ID {
+		t.Fatalf("matter active Memories = %#v", matterItems)
+	}
+
+	if _, err := database.Exec(ctx, `
+UPDATE agent_memories
+SET expires_at = created_at + INTERVAL '1 microsecond'
+WHERE id = $1`,
+		matterMemory.ID,
+	); err != nil {
+		t.Fatalf("expire matter Memory: %v", err)
+	}
+	matterItems, err = repository.ListActive(ctx, actorA, ScopeFilter{
+		Scope:    ScopeMatter,
+		MatterID: integrationMatterA,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListActive expired matter: %v", err)
+	}
+	if len(matterItems) != 0 {
+		t.Fatalf("expired matter Memories = %#v", matterItems)
+	}
+
+	inactive, err := repository.Inactivate(ctx, actorA, InactivateCommand{
+		MemoryID:        userMemory.ID,
+		ExpectedVersion: updated.Version,
+		Source: evidence(
+			SourceAgentMessage,
+			"message-correction-1",
+			1,
+			"correction",
+		),
+	})
+	if err != nil {
+		t.Fatalf("Inactivate Memory: %v", err)
+	}
+	if inactive.Status != StatusInactive ||
+		inactive.InactivatedAt == nil ||
+		inactive.Version != updated.Version+1 {
+		t.Fatalf("inactive Memory = %#v", inactive)
+	}
+	userItems, err = repository.ListActive(ctx, actorA, ScopeFilter{
+		Scope: ScopeUser,
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListActive after Inactivate: %v", err)
+	}
+	if len(userItems) != 0 {
+		t.Fatalf("inactive Memory returned by ListActive: %#v", userItems)
+	}
+	if err := repository.Delete(
+		ctx,
+		actorB,
+		userMemory.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Delete error = %v", err)
+	}
+	if err := repository.Delete(ctx, actorA, userMemory.ID); err != nil {
+		t.Fatalf("Delete Memory: %v", err)
+	}
+	if _, err := repository.Find(
+		ctx,
+		actorA,
+		userMemory.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Find deleted Memory error = %v", err)
+	}
+
+	deletionMemory, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("interest.running", "Enjoys running"),
+	)
+	if err != nil {
+		t.Fatalf("Create deletion Memory: %v", err)
+	}
+	if _, err := database.Exec(ctx, `
+UPDATE identity_users
+SET account_status = 'deleting', updated_at = transaction_timestamp()
+WHERE id = $1`,
+		integrationUserA,
+	); err != nil {
+		t.Fatalf("mark owner deleting: %v", err)
+	}
+	if err := repository.DeleteOwnerData(ctx, DeleteOwnerCommand{
+		UserID:     integrationUserA,
+		Generation: 2,
+	}); err != nil {
+		t.Fatalf("DeleteOwnerData: %v", err)
+	}
+	if err := repository.DeleteOwnerData(ctx, DeleteOwnerCommand{
+		UserID:     integrationUserA,
+		Generation: 2,
+	}); err != nil {
+		t.Fatalf("repeat DeleteOwnerData: %v", err)
+	}
+	if err := repository.DeleteOwnerData(ctx, DeleteOwnerCommand{
+		UserID:     integrationUserA,
+		Generation: 1,
+	}); !errors.Is(err, ErrDeletionGeneration) {
+		t.Fatalf("stale DeleteOwnerData error = %v", err)
+	}
+	var memoryCount int
+	if err := database.QueryRow(ctx, `
+SELECT count(*) FROM agent_memories WHERE owner_user_id = $1`,
+		integrationUserA,
+	).Scan(&memoryCount); err != nil {
+		t.Fatalf("count deleted Memories: %v", err)
+	}
+	if memoryCount != 0 {
+		t.Fatalf("deleted owner Memory count = %d", memoryCount)
+	}
+	if _, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("late.write", "must be rejected"),
+	); !errors.Is(err, ErrAccountDeleted) {
+		t.Fatalf("late Create error = %v", err)
+	}
+	if _, err := repository.Find(
+		ctx,
+		actorA,
+		deletionMemory.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Find owner-deleted Memory error = %v", err)
+	}
+
+	if _, err := database.Exec(
+		ctx,
+		`DELETE FROM matters WHERE owner_user_id = $1`,
+		integrationUserA,
+	); err != nil {
+		t.Fatalf("delete owner Matters: %v", err)
+	}
+	if _, err := database.Exec(
+		ctx,
+		`DELETE FROM identity_users WHERE id = $1`,
+		integrationUserA,
+	); err != nil {
+		t.Fatalf("physically delete Identity owner: %v", err)
+	}
+	if err := repository.DeleteOwnerData(ctx, DeleteOwnerCommand{
+		UserID:     integrationUserA,
+		Generation: 3,
+	}); err != nil {
+		t.Fatalf("DeleteOwnerData after Identity removal: %v", err)
+	}
+	var fenceGeneration int64
+	if err := database.QueryRow(ctx, `
+SELECT deletion_generation
+FROM agent_memory_deletion_fences
+WHERE owner_user_id = $1`,
+		integrationUserA,
+	).Scan(&fenceGeneration); err != nil {
+		t.Fatalf("read deletion fence: %v", err)
+	}
+	if fenceGeneration != 3 {
+		t.Fatalf("deletion generation = %d, want 3", fenceGeneration)
+	}
+}
+
+func createCommand(key string, content string) CreateCommand {
+	return CreateCommand{
+		Type:          TypeProfile,
+		CanonicalKey:  key,
+		Content:       content,
+		Scope:         ScopeUser,
+		PolicyVersion: "memory-v1",
+		Source: evidence(
+			SourceAgentMessage,
+			"message-"+key,
+			1,
+			key+":"+content,
+		),
+	}
+}
+
+func evidence(
+	sourceType SourceType,
+	sourceID string,
+	version int64,
+	content string,
+) SourceInput {
+	return SourceInput{
+		Type:     sourceType,
+		SourceID: sourceID,
+		Version:  version,
+		Checksum: sha256.Sum256([]byte(content)),
+	}
+}
+
+func newMemoryTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	config, err := pgx.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	admin, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatal("connect to TEST_DATABASE_URL")
+	}
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("generate schema name: %v", err)
+	}
+	schema := "agent_memory_" + hex.EncodeToString(random)
+	identifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(
+		context.Background(),
+		"CREATE SCHEMA "+identifier,
+	); err != nil {
+		t.Fatalf("create test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := admin.Exec(
+			context.Background(),
+			"DROP SCHEMA "+identifier+" CASCADE",
+		); err != nil {
+			t.Errorf("drop test schema: %v", err)
+		}
+	})
+
+	scopedURL, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	query := scopedURL.Query()
+	query.Set("search_path", schema)
+	scopedURL.RawQuery = query.Encode()
+
+	runner, err := migration.Open(scopedURL.String())
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+	if _, err := runner.Up(); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(scopedURL.String())
+	if err != nil {
+		t.Fatal("parse scoped pool config")
+	}
+	pool, err := pgxpool.NewWithConfig(
+		context.Background(),
+		poolConfig,
+	)
+	if err != nil {
+		t.Fatal("open scoped pool")
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Fatal("ping scoped pool")
+	}
+	for _, user := range []struct {
+		id    string
+		email string
+	}{
+		{id: integrationUserA, email: "memory-a@example.com"},
+		{id: integrationUserB, email: "memory-b@example.com"},
+	} {
+		if _, err := pool.Exec(context.Background(), `
+INSERT INTO identity_users (id, canonical_email)
+VALUES ($1, $2)`,
+			user.id,
+			user.email,
+		); err != nil {
+			t.Fatalf("insert Identity user: %v", err)
+		}
+	}
+	for _, item := range []struct {
+		id      string
+		ownerID string
+		title   string
+	}{
+		{
+			id:      integrationMatterA,
+			ownerID: integrationUserA,
+			title:   "User A interview",
+		},
+		{
+			id:      integrationMatterB,
+			ownerID: integrationUserB,
+			title:   "User B interview",
+		},
+	} {
+		if _, err := pool.Exec(context.Background(), `
+INSERT INTO matters (id, owner_user_id, title)
+VALUES ($1, $2, $3)`,
+			item.id,
+			item.ownerID,
+			item.title,
+		); err != nil {
+			t.Fatalf("insert Matter: %v", err)
+		}
+	}
+	return pool
+}

--- a/server/internal/memory/repository.go
+++ b/server/internal/memory/repository.go
@@ -1,0 +1,135 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+var (
+	ErrInvalidArgument    = errors.New("memory: invalid argument")
+	ErrNotFound           = errors.New("memory: not found")
+	ErrConflict           = errors.New("memory: conflict")
+	ErrAccountDeleted     = errors.New("memory: account is not active")
+	ErrDeletionGeneration = errors.New("memory: stale deletion generation")
+	ErrRepository         = errors.New("memory repository: operation failed")
+)
+
+type CreateCommand struct {
+	Type          Type
+	CanonicalKey  string
+	Content       string
+	Scope         ScopeType
+	MatterID      string
+	PolicyVersion string
+	ExpiresAt     *time.Time
+	Source        SourceInput
+}
+
+func (command CreateCommand) Valid() bool {
+	return command.Type.Valid() &&
+		validCanonicalKey(command.CanonicalKey) &&
+		validContent(command.Content) &&
+		validScope(command.Scope, command.MatterID) &&
+		validPolicyVersion(command.PolicyVersion) &&
+		validOptionalTime(command.ExpiresAt) &&
+		command.Source.Valid()
+}
+
+type ScopeFilter struct {
+	Scope    ScopeType
+	MatterID string
+	Limit    int
+}
+
+func (filter ScopeFilter) Valid() bool {
+	return validScope(filter.Scope, filter.MatterID) &&
+		filter.Limit >= 1 &&
+		filter.Limit <= 100
+}
+
+type UpdateCommand struct {
+	MemoryID        string
+	ExpectedVersion int64
+	Content         string
+	PolicyVersion   string
+	ExpiresAt       *time.Time
+	Source          SourceInput
+}
+
+func (command UpdateCommand) Valid() bool {
+	return validUUID(command.MemoryID) &&
+		command.ExpectedVersion > 0 &&
+		validContent(command.Content) &&
+		validPolicyVersion(command.PolicyVersion) &&
+		validOptionalTime(command.ExpiresAt) &&
+		command.Source.Valid()
+}
+
+type InactivateCommand struct {
+	MemoryID        string
+	ExpectedVersion int64
+	Source          SourceInput
+}
+
+func (command InactivateCommand) Valid() bool {
+	return validUUID(command.MemoryID) &&
+		command.ExpectedVersion > 0 &&
+		command.Source.Valid()
+}
+
+type DeleteOwnerCommand struct {
+	UserID     string
+	Generation uint64
+}
+
+func (command DeleteOwnerCommand) Valid() bool {
+	return validUUID(command.UserID) &&
+		command.Generation > 0 &&
+		command.Generation <= uint64(^uint64(0)>>1)
+}
+
+type Repository interface {
+	Create(
+		context.Context,
+		requestcontext.Actor,
+		CreateCommand,
+	) (Memory, error)
+	Find(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (Memory, error)
+	ListActive(
+		context.Context,
+		requestcontext.Actor,
+		ScopeFilter,
+	) ([]Memory, error)
+	ListSources(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) ([]Source, error)
+	Update(
+		context.Context,
+		requestcontext.Actor,
+		UpdateCommand,
+	) (Memory, error)
+	Inactivate(
+		context.Context,
+		requestcontext.Actor,
+		InactivateCommand,
+	) (Memory, error)
+	Delete(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) error
+	DeleteOwnerData(context.Context, DeleteOwnerCommand) error
+}
+
+type IDGenerator interface {
+	NewID() (string, error)
+}

--- a/server/migrations/000017_agent_memory.down.sql
+++ b/server/migrations/000017_agent_memory.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE agent_memory_sources;
+DROP TABLE agent_memories;
+DROP TABLE agent_memory_deletion_fences;
+
+COMMIT;

--- a/server/migrations/000017_agent_memory.up.sql
+++ b/server/migrations/000017_agent_memory.up.sql
@@ -1,0 +1,161 @@
+BEGIN;
+
+CREATE TABLE agent_memory_deletion_fences (
+    -- The tombstone deliberately survives physical Identity deletion.
+    owner_user_id uuid PRIMARY KEY,
+    deletion_generation bigint NOT NULL CHECK (deletion_generation > 0),
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT agent_memory_deletion_fences_timestamps_check
+        CHECK (updated_at >= created_at)
+);
+
+CREATE TABLE agent_memories (
+    id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    memory_type text NOT NULL,
+    canonical_key text COLLATE "C" NOT NULL,
+    content text NOT NULL,
+    scope_type text NOT NULL,
+    matter_id uuid,
+    status text NOT NULL DEFAULT 'active',
+    version bigint NOT NULL DEFAULT 1,
+    policy_version text COLLATE "C" NOT NULL,
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    inactivated_at timestamptz,
+    CONSTRAINT agent_memories_owner_user_id_fkey
+        FOREIGN KEY (owner_user_id)
+        REFERENCES identity_users (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT agent_memories_id_owner_key
+        UNIQUE (id, owner_user_id),
+    CONSTRAINT agent_memories_matter_owner_fkey
+        FOREIGN KEY (matter_id, owner_user_id)
+        REFERENCES matters (id, owner_user_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT agent_memories_type_check
+        CHECK (
+            octet_length(memory_type) BETWEEN 1 AND 32
+            AND memory_type ~ '^[a-z][a-z0-9_]{0,31}$'
+        ),
+    CONSTRAINT agent_memories_key_check
+        CHECK (
+            octet_length(canonical_key) BETWEEN 1 AND 128
+            AND canonical_key ~ '^[a-z][a-z0-9._:-]{0,127}$'
+        ),
+    CONSTRAINT agent_memories_content_check
+        CHECK (
+            char_length(content) BETWEEN 1 AND 4096
+            AND octet_length(content) <= 16384
+            AND content = btrim(content)
+            AND content !~ '^[[:space:]]*$'
+        ),
+    CONSTRAINT agent_memories_scope_check
+        CHECK (
+            (scope_type = 'user' AND matter_id IS NULL)
+            OR (scope_type = 'matter' AND matter_id IS NOT NULL)
+        ),
+    CONSTRAINT agent_memories_status_check
+        CHECK (status IN ('active', 'inactive')),
+    CONSTRAINT agent_memories_version_check CHECK (version > 0),
+    CONSTRAINT agent_memories_policy_version_check
+        CHECK (
+            octet_length(policy_version) BETWEEN 1 AND 64
+            AND policy_version ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+        ),
+    CONSTRAINT agent_memories_lifecycle_check
+        CHECK (
+            updated_at >= created_at
+            AND (expires_at IS NULL OR expires_at > created_at)
+            AND (
+                (status = 'active' AND inactivated_at IS NULL)
+                OR (
+                    status = 'inactive'
+                    AND inactivated_at IS NOT NULL
+                    AND inactivated_at >= created_at
+                    AND updated_at >= inactivated_at
+                )
+            )
+        )
+);
+
+CREATE UNIQUE INDEX agent_memories_one_active_user_key
+    ON agent_memories (
+        owner_user_id,
+        memory_type,
+        canonical_key
+    )
+    WHERE status = 'active' AND scope_type = 'user';
+
+CREATE UNIQUE INDEX agent_memories_one_active_matter_key
+    ON agent_memories (
+        owner_user_id,
+        matter_id,
+        memory_type,
+        canonical_key
+    )
+    WHERE status = 'active' AND scope_type = 'matter';
+
+CREATE INDEX agent_memories_active_user_updated_idx
+    ON agent_memories (owner_user_id, updated_at DESC, id DESC)
+    WHERE status = 'active' AND scope_type = 'user';
+
+CREATE INDEX agent_memories_active_matter_updated_idx
+    ON agent_memories (
+        owner_user_id,
+        matter_id,
+        updated_at DESC,
+        id DESC
+    )
+    WHERE status = 'active' AND scope_type = 'matter';
+
+CREATE TABLE agent_memory_sources (
+    id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    memory_id uuid NOT NULL,
+    source_type text NOT NULL,
+    source_id text COLLATE "C" NOT NULL,
+    source_version bigint NOT NULL,
+    source_checksum bytea NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT agent_memory_sources_memory_owner_fkey
+        FOREIGN KEY (memory_id, owner_user_id)
+        REFERENCES agent_memories (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_memory_sources_type_check
+        CHECK (
+            octet_length(source_type) BETWEEN 1 AND 32
+            AND source_type ~ '^[a-z][a-z0-9_]{0,31}$'
+        ),
+    CONSTRAINT agent_memory_sources_id_check
+        CHECK (
+            octet_length(source_id) BETWEEN 1 AND 128
+            AND source_id = btrim(source_id)
+            AND source_id !~ '[[:space:]]'
+        ),
+    CONSTRAINT agent_memory_sources_version_check
+        CHECK (source_version > 0),
+    CONSTRAINT agent_memory_sources_checksum_check
+        CHECK (octet_length(source_checksum) = 32),
+    CONSTRAINT agent_memory_sources_evidence_key
+        UNIQUE (
+            owner_user_id,
+            memory_id,
+            source_type,
+            source_id,
+            source_version,
+            source_checksum
+        )
+);
+
+CREATE INDEX agent_memory_sources_memory_created_idx
+    ON agent_memory_sources (
+        owner_user_id,
+        memory_id,
+        created_at,
+        id
+    );
+
+COMMIT;


### PR DESCRIPTION
## 功能描述

为已接受提案 #65 建立 Agent Memory V1 的持久化基础：

- 新增 Memory 领域模型与窄 Repository Port；
- 新增 PostgreSQL Repository，支持创建、读取、active 列表、来源查询、乐观更新、失效、单条删除和 owner 全量删除；
- 新增 `agent_memories`、`agent_memory_sources`、`agent_memory_deletion_fences`；
- 落实 user / matter 作用域、active 唯一性、owner 隔离、过期过滤和来源幂等；
- 使用 advisory lock、Identity 状态与 deletion generation fence 阻止删号后的迟到写入。

本 PR 不接入 LLM、Embedding、向量检索、ContextAssembler、Thread Summary、HTTP 或 Flutter。

## 实现思路

- `internal/memory` 独占长期记忆模型和持久化 Port，不依赖 Agent、Review、Practice 或 Preparation Repository；
- Memory 类型由 Go V1 策略校验，数据库只约束安全格式，便于后续增量演进；
- 来源证据采用受约束的多态引用，不建立跨业务模块数据库外键；
- 在线写入在同一事务中锁定 owner 并确认 Identity 为 active；
- owner 删除以 generation fence 保持幂等、防旧请求，并让 tombstone 跨越 Identity 物理删除；
- PostgreSQL 约束保证同 owner/scope/type/key 最多一条 active 记忆。

## 测试

使用本地 `DATABASE_URL` 映射为 `TEST_DATABASE_URL`，每个集成测试创建随机隔离 schema 并自动清理。

```bash
cd server
go vet ./internal/memory/...
go test ./internal/memory/... ./internal/platform/migration/... ./migrations/...
go test ./...
```

验证结果：

- Memory PostgreSQL 生命周期、owner 隔离、来源幂等、过期过滤与删除 fence：通过；
- 完整迁移链 up → down latest → up：通过；
- 后端全部 Go 包：通过。

Closes #144
