### PR TITLE
[后端] 实现 Agent Memory 向量索引、隔离检索与重排

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ QIANWEN_MAX_OUTPUT_TOKENS=512
 AGENT_CONTEXT_MAX_CHARACTERS=12000
 DASHSCOPE_API_KEY=
 
+# Required Agent Memory semantic index. Uses the same server-only API key.
+EMBEDDING_PROVIDER=qianwen
+QIANWEN_EMBEDDING_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+QIANWEN_EMBEDDING_MODEL=text-embedding-v4
+QIANWEN_EMBEDDING_DIMENSIONS=1024
+QIANWEN_EMBEDDING_TIMEOUT=60s
+
 # Stable, server-only HMAC key for Review history cursors. Generate exactly
 # 32 random bytes and encode them as unpadded base64url. Keep the same value
 # across restarts and replicas; rotating it invalidates outstanding cursors.

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -35,7 +35,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:18.4-bookworm@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296
+        image: pgvector/pgvector:pg18-bookworm@sha256:12a379b47ad65289572ea0756efc11b7c241a6662833e8af7038cd3b73d647e0
         env:
           POSTGRES_DB: xe3_esl
           POSTGRES_USER: xe3_esl
@@ -119,6 +119,10 @@ jobs:
           TEXT_GENERATION_PROVIDER: qianwen
           QIANWEN_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           QIANWEN_MODEL: qwen-ci-readiness-not-invoked
+          EMBEDDING_PROVIDER: qianwen
+          QIANWEN_EMBEDDING_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
+          QIANWEN_EMBEDDING_MODEL: text-embedding-v4
+          QIANWEN_EMBEDDING_DIMENSIONS: "1024"
           SPEECH_RECOGNITION_PROVIDER: qianwen
           QIANWEN_ASR_BASE_URL: https://dashscope.aliyuncs.com/api/v1
           QIANWEN_ASR_MODEL: fun-asr-flash-2026-06-15

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:18.4-bookworm@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296
+    image: pgvector/pgvector:pg18-bookworm@sha256:12a379b47ad65289572ea0756efc11b7c241a6662833e8af7038cd3b73d647e0
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-xe3_esl}
       POSTGRES_USER: ${POSTGRES_USER:-xe3_esl}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -42,6 +42,16 @@ func run() int {
 		logger.Error("text generation startup failed")
 		return 1
 	}
+	embeddingConfig, err := config.LoadEmbedding()
+	if err != nil {
+		logger.Error("embedding configuration failed")
+		return 1
+	}
+	embedder, err := bootstrap.NewEmbedder(embeddingConfig)
+	if err != nil {
+		logger.Error("embedding startup failed")
+		return 1
+	}
 	asrConfig, err := config.LoadSpeechRecognition()
 	if err != nil {
 		logger.Error("speech recognition configuration failed")
@@ -128,6 +138,19 @@ func run() int {
 	}
 	defer databasePool.Close()
 
+	memoryIndexComposition, err := bootstrap.NewMemoryIndexComposition(
+		databasePool.Native(),
+		embedder,
+		embeddingConfig,
+	)
+	if err != nil {
+		logger.Error(
+			"memory index composition failed",
+			slog.String("error_kind", "dependency"),
+		)
+		return 1
+	}
+
 	var recordingStore objectstore.Store
 	if storageConfig.Enabled {
 		recordingStore, err = productionAudioCleanupFactories.newStore(
@@ -209,6 +232,17 @@ func run() int {
 		)
 		return 1
 	}
+	memoryIndex, err := buildMemoryIndexWorker(
+		memoryIndexComposition.Processor(),
+		logger,
+	)
+	if err != nil {
+		logger.Error(
+			"memory index startup failed",
+			slog.String("error_kind", "dependency"),
+		)
+		return 1
+	}
 
 	cleanupWorker, err := buildAudioCleanupWorker(
 		ctx,
@@ -244,6 +278,11 @@ func run() int {
 	go func() {
 		defer close(memoryExtractionDone)
 		memoryExtraction.Run(ctx)
+	}()
+	memoryIndexDone := make(chan struct{})
+	go func() {
+		defer close(memoryIndexDone)
+		memoryIndex.Run(ctx)
 	}()
 
 	router := bootstrap.NewRouterWithReadinessAndRoutes(
@@ -318,6 +357,15 @@ func run() int {
 	case <-shutdownCtx.Done():
 		logger.Error(
 			"memory extraction shutdown failed",
+			slog.String("error_kind", "timeout"),
+		)
+		exitCode = 1
+	}
+	select {
+	case <-memoryIndexDone:
+	case <-shutdownCtx.Done():
+		logger.Error(
+			"memory index shutdown failed",
 			slog.String("error_kind", "timeout"),
 		)
 		exitCode = 1

--- a/server/cmd/server/memory_index.go
+++ b/server/cmd/server/memory_index.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+)
+
+const (
+	memoryIndexInterval     = 30 * time.Second
+	memoryIndexSweepTimeout = 90 * time.Second
+	memoryIndexClaimLimit   = 4
+)
+
+var errMemoryIndexDependency = errors.New(
+	"memory index dependency is required",
+)
+
+type memoryIndexProcessor interface {
+	ProcessPendingIndexes(
+		context.Context,
+		int,
+	) (memory.IndexSweepResult, error)
+}
+
+type memoryIndexWorker struct {
+	processor    memoryIndexProcessor
+	logger       *slog.Logger
+	interval     time.Duration
+	sweepTimeout time.Duration
+	claimLimit   int
+}
+
+func buildMemoryIndexWorker(
+	processor memoryIndexProcessor,
+	logger *slog.Logger,
+) (*memoryIndexWorker, error) {
+	if nilMemoryIndexDependency(processor) || logger == nil {
+		return nil, errMemoryIndexDependency
+	}
+	return &memoryIndexWorker{
+		processor:    processor,
+		logger:       logger,
+		interval:     memoryIndexInterval,
+		sweepTimeout: memoryIndexSweepTimeout,
+		claimLimit:   memoryIndexClaimLimit,
+	}, nil
+}
+
+func (worker *memoryIndexWorker) Run(ctx context.Context) {
+	if ctx == nil {
+		return
+	}
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		worker.sweep(ctx)
+		if !waitForMemoryExtraction(ctx, worker.interval) {
+			return
+		}
+	}
+}
+
+func (worker *memoryIndexWorker) sweep(parent context.Context) {
+	startedAt := time.Now()
+	ctx, cancel := context.WithTimeout(parent, worker.sweepTimeout)
+	defer cancel()
+	result, err := worker.processor.ProcessPendingIndexes(
+		ctx,
+		worker.claimLimit,
+	)
+	attributes := []any{
+		slog.Int("claimed", result.Claimed),
+		slog.Int("completed", result.Completed),
+		slog.Int("retried", result.Retried),
+		slog.Int("failed", result.Failed),
+		slog.Int("discarded", result.Discarded),
+		slog.Int64("duration_ms", time.Since(startedAt).Milliseconds()),
+	}
+	if err != nil {
+		attributes = append(
+			attributes,
+			slog.String("error_kind", memoryIndexErrorKind(err)),
+		)
+		worker.logger.WarnContext(
+			parent,
+			"memory index sweep failed",
+			attributes...,
+		)
+		return
+	}
+	if result.Failed > 0 || result.Discarded > 0 {
+		worker.logger.WarnContext(
+			parent,
+			"memory index sweep completed with terminal jobs",
+			attributes...,
+		)
+		return
+	}
+	worker.logger.InfoContext(
+		parent,
+		"memory index sweep completed",
+		attributes...,
+	)
+}
+
+func memoryIndexErrorKind(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, memory.ErrConflict):
+		return "concurrent_update"
+	case errors.Is(err, memory.ErrInvalidArgument):
+		return "invalid_state"
+	case errors.Is(err, memory.ErrRepository):
+		return "repository"
+	default:
+		return "dependency"
+	}
+}
+
+func nilMemoryIndexDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/server/internal/ai/embedding.go
+++ b/server/internal/ai/embedding.go
@@ -1,0 +1,146 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+const (
+	MaxEmbeddingInputs     = 10
+	MaxEmbeddingInputBytes = 16 * 1024
+	MaxEmbeddingDimensions = 2048
+)
+
+// Embedder is the application-facing boundary for one bounded embedding
+// batch. Implementations must preserve input order and must not retry calls
+// implicitly.
+type Embedder interface {
+	Embed(context.Context, EmbeddingRequest) (EmbeddingResult, error)
+}
+
+type EmbeddingRequest struct {
+	Inputs     []string
+	Dimensions int
+}
+
+type EmbeddingResult struct {
+	Provider    string
+	Model       string
+	Dimensions  int
+	Vectors     [][]float32
+	InputTokens int
+	TotalTokens int
+}
+
+func ValidateEmbeddingRequest(request EmbeddingRequest) error {
+	if len(request.Inputs) < 1 || len(request.Inputs) > MaxEmbeddingInputs {
+		return fmt.Errorf(
+			"embedding requires between 1 and %d inputs",
+			MaxEmbeddingInputs,
+		)
+	}
+	if request.Dimensions < 1 ||
+		request.Dimensions > MaxEmbeddingDimensions {
+		return fmt.Errorf(
+			"embedding dimensions must be between 1 and %d",
+			MaxEmbeddingDimensions,
+		)
+	}
+	for index, input := range request.Inputs {
+		if input == "" || input != strings.TrimSpace(input) {
+			return fmt.Errorf("embedding input %d is empty or untrimmed", index)
+		}
+		if len(input) > MaxEmbeddingInputBytes {
+			return fmt.Errorf("embedding input %d exceeds the byte limit", index)
+		}
+	}
+	return nil
+}
+
+func ValidateEmbeddingResult(
+	request EmbeddingRequest,
+	result EmbeddingResult,
+) error {
+	if err := ValidateEmbeddingRequest(request); err != nil {
+		return err
+	}
+	if result.Provider == "" ||
+		result.Model == "" ||
+		result.Dimensions != request.Dimensions ||
+		len(result.Vectors) != len(request.Inputs) ||
+		result.InputTokens < 0 ||
+		result.TotalTokens < result.InputTokens {
+		return errors.New("embedding result metadata is invalid")
+	}
+	for _, vector := range result.Vectors {
+		if len(vector) != result.Dimensions {
+			return errors.New("embedding result dimension is invalid")
+		}
+		nonZero := false
+		for _, value := range vector {
+			if math.IsNaN(float64(value)) ||
+				math.IsInf(float64(value), 0) {
+				return errors.New("embedding result contains a non-finite value")
+			}
+			nonZero = nonZero || value != 0
+		}
+		if !nonZero {
+			return errors.New("embedding result contains a zero vector")
+		}
+	}
+	return nil
+}
+
+// EmbeddingError exposes stable failure semantics without carrying provider
+// payloads, user inputs, vectors, or credentials.
+type EmbeddingError struct {
+	Kind         ErrorKind
+	StatusCode   int
+	ProviderCode string
+	RequestID    string
+	cause        error
+}
+
+func NewEmbeddingError(
+	kind ErrorKind,
+	statusCode int,
+	providerCode string,
+	requestID string,
+	cause error,
+) *EmbeddingError {
+	return &EmbeddingError{
+		Kind:         kind,
+		StatusCode:   statusCode,
+		ProviderCode: providerCode,
+		RequestID:    requestID,
+		cause:        cause,
+	}
+}
+
+func (e *EmbeddingError) Error() string {
+	if e == nil {
+		return "embedding failed"
+	}
+	return "embedding failed: " + string(e.Kind)
+}
+
+func (e *EmbeddingError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *EmbeddingError) Retryable() bool {
+	return e != nil && e.Kind.Retryable()
+}
+
+func (e *EmbeddingError) StableCategory() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Kind)
+}

--- a/server/internal/ai/embedding_test.go
+++ b/server/internal/ai/embedding_test.go
@@ -1,0 +1,64 @@
+package ai
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEmbeddingValidationRejectsUnsafeShapes(t *testing.T) {
+	t.Parallel()
+
+	validRequest := EmbeddingRequest{
+		Inputs:     []string{"Java backend interview"},
+		Dimensions: 2,
+	}
+	validResult := EmbeddingResult{
+		Provider:    "qianwen",
+		Model:       "text-embedding-v4",
+		Dimensions:  2,
+		Vectors:     [][]float32{{1, 0.5}},
+		InputTokens: 3,
+		TotalTokens: 3,
+	}
+	if err := ValidateEmbeddingResult(validRequest, validResult); err != nil {
+		t.Fatalf("valid result: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*EmbeddingResult)
+	}{
+		{
+			name: "wrong dimensions",
+			mutate: func(result *EmbeddingResult) {
+				result.Vectors[0] = []float32{1}
+			},
+		},
+		{
+			name: "non finite",
+			mutate: func(result *EmbeddingResult) {
+				result.Vectors[0][0] = float32(math.Inf(1))
+			},
+		},
+		{
+			name: "zero vector",
+			mutate: func(result *EmbeddingResult) {
+				result.Vectors[0] = []float32{0, 0}
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := validResult
+			result.Vectors = [][]float32{append(
+				[]float32(nil),
+				validResult.Vectors[0]...,
+			)}
+			test.mutate(&result)
+			if err := ValidateEmbeddingResult(validRequest, result); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}

--- a/server/internal/ai/fake/embedder.go
+++ b/server/internal/ai/fake/embedder.go
@@ -1,0 +1,36 @@
+package fake
+
+import (
+	"context"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+// Embedder is an explicit deterministic provider for tests.
+type Embedder struct {
+	Result ai.EmbeddingResult
+	Err    error
+}
+
+func (embedder *Embedder) Embed(
+	ctx context.Context,
+	request ai.EmbeddingRequest,
+) (ai.EmbeddingResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ai.EmbeddingResult{}, err
+	}
+	if err := ai.ValidateEmbeddingRequest(request); err != nil {
+		return ai.EmbeddingResult{}, err
+	}
+	if embedder == nil {
+		return ai.EmbeddingResult{}, ai.NewEmbeddingError(
+			ai.ErrorConfiguration, 0, "", "", nil,
+		)
+	}
+	if embedder.Err != nil {
+		return ai.EmbeddingResult{}, embedder.Err
+	}
+	return embedder.Result, nil
+}
+
+var _ ai.Embedder = (*Embedder)(nil)

--- a/server/internal/ai/qianwen/embedding.go
+++ b/server/internal/ai/qianwen/embedding.go
@@ -1,0 +1,328 @@
+package qianwen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+const embeddingsPath = "/embeddings"
+
+type EmbeddingConfig struct {
+	BaseURL    string
+	Model      string
+	Dimensions int
+	Timeout    time.Duration
+}
+
+type EmbeddingClient struct {
+	endpoint   string
+	model      string
+	dimensions int
+	timeout    time.Duration
+	apiKey     providerSecret
+	client     httpDoer
+}
+
+func NewEmbeddingClient(
+	config EmbeddingConfig,
+	apiKey string,
+) (*EmbeddingClient, error) {
+	client := &http.Client{
+		Timeout: config.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return newEmbeddingClientWithHTTP(config, apiKey, client)
+}
+
+func newEmbeddingClientWithHTTP(
+	config EmbeddingConfig,
+	apiKey string,
+	client httpDoer,
+) (*EmbeddingClient, error) {
+	baseURL, err := normalizeBaseURL(config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	model, err := normalizeEmbeddingModel(config.Model)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, err = normalizeAPIKey(apiKey)
+	if err != nil {
+		return nil, err
+	}
+	if config.Dimensions < 64 ||
+		config.Dimensions > ai.MaxEmbeddingDimensions {
+		return nil, fmt.Errorf(
+			"Qianwen embedding dimensions must be between 64 and %d",
+			ai.MaxEmbeddingDimensions,
+		)
+	}
+	if config.Timeout <= 0 || config.Timeout > maxTimeout {
+		return nil, fmt.Errorf(
+			"Qianwen embedding timeout must be greater than zero and at most %s",
+			maxTimeout,
+		)
+	}
+	if client == nil {
+		return nil, errors.New("Qianwen embedding HTTP client is required")
+	}
+	return &EmbeddingClient{
+		endpoint:   baseURL + embeddingsPath,
+		model:      model,
+		dimensions: config.Dimensions,
+		timeout:    config.Timeout,
+		apiKey:     newProviderSecret(apiKey),
+		client:     client,
+	}, nil
+}
+
+func (client *EmbeddingClient) String() string {
+	if client == nil {
+		return "QianwenEmbeddingClient(<nil>)"
+	}
+	return fmt.Sprintf(
+		"QianwenEmbeddingClient(model=%q, dimensions=%d, timeout=%s, api_key=[REDACTED])",
+		client.model,
+		client.dimensions,
+		client.timeout,
+	)
+}
+
+func (client *EmbeddingClient) GoString() string {
+	return client.String()
+}
+
+func (client *EmbeddingClient) Embed(
+	ctx context.Context,
+	request ai.EmbeddingRequest,
+) (ai.EmbeddingResult, error) {
+	if ctx == nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidRequest, 0, "", "",
+			errors.New("embedding context is required"),
+		)
+	}
+	if err := ai.ValidateEmbeddingRequest(request); err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidRequest, 0, "", "", err,
+		)
+	}
+	if request.Dimensions != client.dimensions {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidRequest, 0, "", "",
+			errors.New("embedding request dimension does not match configuration"),
+		)
+	}
+	body, err := json.Marshal(embeddingRequest{
+		Model:          client.model,
+		Input:          request.Inputs,
+		Dimensions:     client.dimensions,
+		EncodingFormat: "float",
+	})
+	if err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidRequest, 0, "", "", err,
+		)
+	}
+	callContext, cancel := context.WithTimeout(ctx, client.timeout)
+	defer cancel()
+	httpRequest, err := http.NewRequestWithContext(
+		callContext,
+		http.MethodPost,
+		client.endpoint,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorConfiguration, 0, "", "", err,
+		)
+	}
+	httpRequest.Header.Set(
+		authorizationHeaderName,
+		"Bearer "+client.apiKey.reveal(),
+	)
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Accept", "application/json")
+
+	response, err := client.client.Do(httpRequest)
+	if err != nil {
+		return ai.EmbeddingResult{}, embeddingTransportError(callContext, err)
+	}
+	if response == nil || response.Body == nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidResponse, 0, "", "",
+			errors.New("Qianwen returned an incomplete embedding response"),
+		)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK ||
+		response.StatusCode >= http.StatusMultipleChoices {
+		generationErr := decodeStatusError(response)
+		var providerErr *ai.GenerationError
+		if errors.As(generationErr, &providerErr) {
+			return ai.EmbeddingResult{}, embeddingError(
+				providerErr.Kind,
+				providerErr.StatusCode,
+				providerErr.ProviderCode,
+				providerErr.RequestID,
+				providerErr,
+			)
+		}
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidResponse,
+			response.StatusCode,
+			"",
+			"",
+			generationErr,
+		)
+	}
+	responseBody, err := readBounded(response.Body, maxResponseBytes)
+	if err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidResponse,
+			response.StatusCode,
+			"",
+			sanitizeIdentifier(response.Header.Get("X-Request-Id")),
+			err,
+		)
+	}
+	var decoded embeddingResponse
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidResponse,
+			response.StatusCode,
+			"",
+			sanitizeIdentifier(response.Header.Get("X-Request-Id")),
+			errors.New("decode Qianwen embedding response"),
+		)
+	}
+	result, err := decoded.result(request, client.model, client.dimensions)
+	if err != nil {
+		return ai.EmbeddingResult{}, embeddingError(
+			ai.ErrorInvalidResponse,
+			response.StatusCode,
+			"",
+			sanitizeIdentifier(response.Header.Get("X-Request-Id")),
+			err,
+		)
+	}
+	return result, nil
+}
+
+type embeddingRequest struct {
+	Model          string   `json:"model"`
+	Input          []string `json:"input"`
+	Dimensions     int      `json:"dimensions"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+type embeddingResponse struct {
+	Model string `json:"model"`
+	Data  []struct {
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+	Usage *struct {
+		PromptTokens *int `json:"prompt_tokens"`
+		TotalTokens  *int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+func (response embeddingResponse) result(
+	request ai.EmbeddingRequest,
+	model string,
+	dimensions int,
+) (ai.EmbeddingResult, error) {
+	if response.Model != model ||
+		response.Usage == nil ||
+		response.Usage.PromptTokens == nil ||
+		response.Usage.TotalTokens == nil ||
+		*response.Usage.PromptTokens < 0 ||
+		*response.Usage.TotalTokens < *response.Usage.PromptTokens ||
+		len(response.Data) != len(request.Inputs) {
+		return ai.EmbeddingResult{}, errors.New(
+			"Qianwen embedding response metadata is invalid",
+		)
+	}
+	vectors := make([][]float32, len(request.Inputs))
+	for _, item := range response.Data {
+		if item.Index < 0 || item.Index >= len(vectors) ||
+			vectors[item.Index] != nil {
+			return ai.EmbeddingResult{}, errors.New(
+				"Qianwen embedding response index is invalid",
+			)
+		}
+		vectors[item.Index] = item.Embedding
+	}
+	result := ai.EmbeddingResult{
+		Provider:    providerName,
+		Model:       model,
+		Dimensions:  dimensions,
+		Vectors:     vectors,
+		InputTokens: *response.Usage.PromptTokens,
+		TotalTokens: *response.Usage.TotalTokens,
+	}
+	if err := ai.ValidateEmbeddingResult(request, result); err != nil {
+		return ai.EmbeddingResult{}, err
+	}
+	return result, nil
+}
+
+func normalizeEmbeddingModel(raw string) (string, error) {
+	model := strings.TrimSpace(raw)
+	if len(model) == 0 || len(model) > maxProviderIdentifier ||
+		!strings.HasPrefix(strings.ToLower(model), "text-embedding-") {
+		return "", errors.New(
+			"Qianwen embedding adapter only accepts text-embedding model IDs",
+		)
+	}
+	for _, value := range model {
+		if !((value >= 'a' && value <= 'z') ||
+			(value >= 'A' && value <= 'Z') ||
+			(value >= '0' && value <= '9') ||
+			value == '-' || value == '_' || value == '.') {
+			return "", errors.New(
+				"Qianwen embedding model contains unsupported characters",
+			)
+		}
+	}
+	return model, nil
+}
+
+func embeddingTransportError(ctx context.Context, cause error) error {
+	generationErr := transportError(ctx, cause)
+	var providerErr *ai.GenerationError
+	if errors.As(generationErr, &providerErr) {
+		return embeddingError(
+			providerErr.Kind,
+			providerErr.StatusCode,
+			providerErr.ProviderCode,
+			providerErr.RequestID,
+			providerErr,
+		)
+	}
+	return embeddingError(ai.ErrorProviderUnavailable, 0, "", "", cause)
+}
+
+func embeddingError(
+	kind ai.ErrorKind,
+	status int,
+	code string,
+	requestID string,
+	cause error,
+) error {
+	return ai.NewEmbeddingError(kind, status, code, requestID, cause)
+}
+
+var _ ai.Embedder = (*EmbeddingClient)(nil)

--- a/server/internal/ai/qianwen/embedding_test.go
+++ b/server/internal/ai/qianwen/embedding_test.go
@@ -1,0 +1,129 @@
+package qianwen
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+func TestEmbeddingClientUsesCompatibleContractAndPreservesOrder(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	vectorA := make([]float32, 1024)
+	vectorB := make([]float32, 1024)
+	vectorA[0] = 1
+	vectorB[1] = 1
+	doer := doerFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() !=
+			"https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings" {
+			t.Fatalf("URL = %s", request.URL)
+		}
+		if request.Header.Get(authorizationHeaderName) != "Bearer test-key" {
+			t.Fatal("missing authorization")
+		}
+		var payload embeddingRequest
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.Model != "text-embedding-v4" ||
+			payload.Dimensions != 1024 ||
+			payload.EncodingFormat != "float" ||
+			len(payload.Input) != 2 {
+			t.Fatalf("payload = %#v", payload)
+		}
+		response, err := json.Marshal(map[string]any{
+			"model": "text-embedding-v4",
+			"data": []map[string]any{
+				{"index": 1, "embedding": vectorB},
+				{"index": 0, "embedding": vectorA},
+			},
+			"usage": map[string]int{
+				"prompt_tokens": 4,
+				"total_tokens":  4,
+			},
+		})
+		if err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+		return jsonResponse(http.StatusOK, string(response)), nil
+	})
+	client, err := newEmbeddingClientWithHTTP(
+		EmbeddingConfig{
+			BaseURL:    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+			Model:      "text-embedding-v4",
+			Dimensions: 1024,
+			Timeout:    time.Second,
+		},
+		"test-key",
+		doer,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	result, err := client.Embed(
+		context.Background(),
+		ai.EmbeddingRequest{
+			Inputs:     []string{"first", "second"},
+			Dimensions: 1024,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if result.Vectors[0][0] != 1 ||
+		result.Vectors[1][1] != 1 ||
+		result.Provider != "qianwen" ||
+		result.Model != "text-embedding-v4" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestEmbeddingClientRejectsDuplicateProviderIndexes(t *testing.T) {
+	t.Parallel()
+
+	vector := make([]float32, 1024)
+	vector[0] = 1
+	response, _ := json.Marshal(map[string]any{
+		"model": "text-embedding-v4",
+		"data": []map[string]any{
+			{"index": 0, "embedding": vector},
+			{"index": 0, "embedding": vector},
+		},
+		"usage": map[string]int{"prompt_tokens": 2, "total_tokens": 2},
+	})
+	client, err := newEmbeddingClientWithHTTP(
+		EmbeddingConfig{
+			BaseURL:    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+			Model:      "text-embedding-v4",
+			Dimensions: 1024,
+			Timeout:    time.Second,
+		},
+		"test-key",
+		doerFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, string(response)), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Embed(
+		context.Background(),
+		ai.EmbeddingRequest{
+			Inputs:     []string{"first", "second"},
+			Dimensions: 1024,
+		},
+	); err == nil {
+		t.Fatal("expected invalid response")
+	}
+}

--- a/server/internal/bootstrap/embedding.go
+++ b/server/internal/bootstrap/embedding.go
@@ -1,0 +1,28 @@
+package bootstrap
+
+import (
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai/qianwen"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+)
+
+func NewEmbedder(configuration config.EmbeddingConfig) (ai.Embedder, error) {
+	switch configuration.Provider {
+	case config.EmbeddingProviderQianwen:
+		return qianwen.NewEmbeddingClient(
+			qianwen.EmbeddingConfig{
+				BaseURL:    configuration.BaseURL,
+				Model:      configuration.Model,
+				Dimensions: configuration.Dimensions,
+				Timeout:    configuration.Timeout,
+			},
+			configuration.APIKey.Reveal(),
+		)
+	default:
+		return nil, errors.New(
+			"bootstrap: embedding provider is not registered",
+		)
+	}
+}

--- a/server/internal/bootstrap/memory_index.go
+++ b/server/internal/bootstrap/memory_index.go
@@ -1,0 +1,96 @@
+package bootstrap
+
+import (
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	memoryEmbeddingPolicyVersion = "memory-embedding-v1"
+	memoryRetrievalPolicyVersion = "memory-retrieval-v1"
+	memoryIndexLease             = 2 * time.Minute
+	memoryIndexRetries           = 3
+	memorySearchCandidateLimit   = 20
+	memoryMinimumSimilarity      = 0.25
+)
+
+type MemoryIndexComposition struct {
+	processor memory.IndexProcessor
+	searcher  memory.Searcher
+}
+
+func NewMemoryIndexComposition(
+	database *pgxpool.Pool,
+	embedder ai.Embedder,
+	configuration config.EmbeddingConfig,
+) (*MemoryIndexComposition, error) {
+	if database == nil || embedder == nil {
+		return nil, errors.New(
+			"bootstrap: Memory index dependencies are required",
+		)
+	}
+	repository, err := memory.NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		return nil, err
+	}
+	indexConfiguration := memory.IndexConfig{
+		Provider:      configuration.Provider,
+		Model:         configuration.Model,
+		Dimensions:    configuration.Dimensions,
+		PolicyVersion: memoryEmbeddingPolicyVersion,
+		LeaseDuration: memoryIndexLease,
+		MaxAttempts:   memoryIndexRetries,
+	}
+	processor, err := memory.NewIndexWorker(
+		repository,
+		embedder,
+		indexConfiguration,
+	)
+	if err != nil {
+		return nil, err
+	}
+	searcher, err := memory.NewSearchService(
+		repository,
+		embedder,
+		memory.SearchConfig{
+			Provider:               configuration.Provider,
+			Model:                  configuration.Model,
+			Dimensions:             configuration.Dimensions,
+			EmbeddingPolicyVersion: memoryEmbeddingPolicyVersion,
+			RetrievalPolicyVersion: memoryRetrievalPolicyVersion,
+			CandidateLimit:         memorySearchCandidateLimit,
+			MinimumSimilarity:      memoryMinimumSimilarity,
+		},
+		time.Now,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &MemoryIndexComposition{
+		processor: processor,
+		searcher:  searcher,
+	}, nil
+}
+
+func (composition *MemoryIndexComposition) Processor() memory.IndexProcessor {
+	if composition == nil {
+		return nil
+	}
+	return composition.processor
+}
+
+func (composition *MemoryIndexComposition) Searcher() memory.Searcher {
+	if composition == nil {
+		return nil
+	}
+	return composition.searcher
+}

--- a/server/internal/memory/index.go
+++ b/server/internal/memory/index.go
@@ -1,0 +1,136 @@
+package memory
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+const MemoryEmbeddingDimensions = 1024
+
+type IndexStatus string
+
+const (
+	IndexPending   IndexStatus = "pending"
+	IndexRunning   IndexStatus = "running"
+	IndexCompleted IndexStatus = "completed"
+	IndexFailed    IndexStatus = "failed"
+	IndexDiscarded IndexStatus = "discarded"
+)
+
+func (status IndexStatus) Valid() bool {
+	switch status {
+	case IndexPending, IndexRunning, IndexCompleted, IndexFailed, IndexDiscarded:
+		return true
+	default:
+		return false
+	}
+}
+
+type IndexConfig struct {
+	Provider      string
+	Model         string
+	Dimensions    int
+	PolicyVersion string
+	LeaseDuration time.Duration
+	MaxAttempts   int
+}
+
+func (configuration IndexConfig) Valid() bool {
+	return providerIdentifierPattern.MatchString(configuration.Provider) &&
+		modelIdentifierPattern.MatchString(configuration.Model) &&
+		configuration.Dimensions == MemoryEmbeddingDimensions &&
+		validPolicyVersion(configuration.PolicyVersion) &&
+		configuration.LeaseDuration >= time.Second &&
+		configuration.LeaseDuration <= 10*time.Minute &&
+		configuration.MaxAttempts >= 1 &&
+		configuration.MaxAttempts <= 10
+}
+
+type IndexJob struct {
+	MemoryID       string
+	OwnerID        string
+	MemoryVersion  int64
+	Status         IndexStatus
+	AttemptCount   int
+	LeaseToken     string
+	LeaseExpiresAt time.Time
+	NextAttemptAt  time.Time
+	PolicyVersion  string
+	Provider       string
+	Model          string
+	Dimensions     int
+	FailureKind    string
+	InputTokens    int
+	TotalTokens    int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	CompletedAt    time.Time
+}
+
+type IndexClaim struct {
+	IndexJob
+}
+
+func (claim IndexClaim) Valid() bool {
+	return validUUID(claim.MemoryID) &&
+		validUUID(claim.OwnerID) &&
+		claim.MemoryVersion > 0 &&
+		claim.Status == IndexRunning &&
+		claim.AttemptCount > 0 &&
+		validUUID(claim.LeaseToken) &&
+		!claim.LeaseExpiresAt.IsZero() &&
+		validPolicyVersion(claim.PolicyVersion) &&
+		providerIdentifierPattern.MatchString(claim.Provider) &&
+		modelIdentifierPattern.MatchString(claim.Model) &&
+		claim.Dimensions == MemoryEmbeddingDimensions
+}
+
+type IndexSource struct {
+	MemoryID string
+	OwnerID  string
+	Version  int64
+	Content  string
+}
+
+func (source IndexSource) Valid() bool {
+	return validUUID(source.MemoryID) &&
+		validUUID(source.OwnerID) &&
+		source.Version > 0 &&
+		validContent(source.Content)
+}
+
+type IndexRepository interface {
+	ClaimIndex(context.Context, IndexConfig) (IndexClaim, bool, error)
+	ReadIndexSource(context.Context, IndexClaim) (IndexSource, error)
+	CompleteIndex(
+		context.Context,
+		IndexClaim,
+		ai.EmbeddingResult,
+	) (IndexJob, error)
+	FailIndex(
+		context.Context,
+		IndexClaim,
+		string,
+		bool,
+		IndexConfig,
+	) (IndexJob, error)
+	DiscardIndex(
+		context.Context,
+		IndexClaim,
+		string,
+	) (IndexJob, error)
+}
+
+type IndexSweepResult struct {
+	Claimed   int
+	Completed int
+	Retried   int
+	Failed    int
+	Discarded int
+}
+
+type IndexProcessor interface {
+	ProcessPendingIndexes(context.Context, int) (IndexSweepResult, error)
+}

--- a/server/internal/memory/index_postgres.go
+++ b/server/internal/memory/index_postgres.go
@@ -1,0 +1,522 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (repository *PostgresRepository) ClaimIndex(
+	ctx context.Context,
+	configuration IndexConfig,
+) (IndexClaim, bool, error) {
+	if ctx == nil || !configuration.Valid() {
+		return IndexClaim{}, false, ErrInvalidArgument
+	}
+	leaseToken, err := repository.newID()
+	if err != nil {
+		return IndexClaim{}, false, err
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return IndexClaim{}, false, ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_memory_index_jobs
+SET
+    status = CASE
+        WHEN attempt_count >= $1 THEN 'failed'
+        ELSE 'pending'
+    END,
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = CASE
+        WHEN attempt_count >= $1 THEN next_attempt_at
+        ELSE transaction_timestamp()
+    END,
+    failure_kind = CASE
+        WHEN attempt_count >= $1 THEN 'attempts_exhausted'
+        ELSE 'lease_expired'
+    END,
+    updated_at = transaction_timestamp(),
+    completed_at = CASE
+        WHEN attempt_count >= $1 THEN transaction_timestamp()
+        ELSE NULL
+    END
+WHERE status = 'running'
+  AND lease_expires_at <= clock_timestamp()`,
+		configuration.MaxAttempts,
+	); err != nil {
+		return IndexClaim{}, false, ErrRepository
+	}
+	job, err := scanIndexJob(tx.QueryRow(ctx, `
+WITH candidate AS (
+    SELECT memory_id, memory_version
+    FROM agent_memory_index_jobs
+    WHERE status = 'pending'
+      AND next_attempt_at <= clock_timestamp()
+    ORDER BY next_attempt_at, created_at, memory_id, memory_version
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+)
+UPDATE agent_memory_index_jobs AS jobs
+SET
+    status = 'running',
+    attempt_count = jobs.attempt_count + 1,
+    lease_token = $1,
+    lease_expires_at = transaction_timestamp() + make_interval(secs => $2),
+    embedding_policy_version = $3,
+    provider = $4,
+    model = $5,
+    dimension = $6,
+    failure_kind = NULL,
+    input_tokens = NULL,
+    total_tokens = NULL,
+    updated_at = transaction_timestamp(),
+    completed_at = NULL
+FROM candidate
+WHERE jobs.memory_id = candidate.memory_id
+  AND jobs.memory_version = candidate.memory_version
+RETURNING `+indexJobColumns("jobs"),
+		leaseToken,
+		configuration.LeaseDuration.Seconds(),
+		configuration.PolicyVersion,
+		configuration.Provider,
+		configuration.Model,
+		configuration.Dimensions,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		if err := tx.Commit(ctx); err != nil {
+			return IndexClaim{}, false, ErrRepository
+		}
+		return IndexClaim{}, false, nil
+	}
+	if err != nil {
+		return IndexClaim{}, false, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return IndexClaim{}, false, ErrRepository
+	}
+	claim := IndexClaim{IndexJob: job}
+	if !claim.Valid() {
+		return IndexClaim{}, false, ErrRepository
+	}
+	return claim, true, nil
+}
+
+func (repository *PostgresRepository) ReadIndexSource(
+	ctx context.Context,
+	claim IndexClaim,
+) (IndexSource, error) {
+	if ctx == nil || !claim.Valid() {
+		return IndexSource{}, ErrInvalidArgument
+	}
+	var accountStatus string
+	if err := repository.database.QueryRow(ctx, `
+SELECT account_status
+FROM identity_users
+WHERE id = $1`,
+		claim.OwnerID,
+	).Scan(&accountStatus); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IndexSource{}, ErrAccountDeleted
+		}
+		return IndexSource{}, ErrRepository
+	}
+	if accountStatus != "active" {
+		return IndexSource{}, ErrAccountDeleted
+	}
+	var source IndexSource
+	if err := repository.database.QueryRow(ctx, `
+SELECT id::text, owner_user_id::text, version, content
+FROM agent_memories
+WHERE id = $1
+  AND owner_user_id = $2
+  AND version = $3
+  AND status = 'active'
+  AND (expires_at IS NULL OR expires_at > clock_timestamp())`,
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+	).Scan(
+		&source.MemoryID,
+		&source.OwnerID,
+		&source.Version,
+		&source.Content,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return IndexSource{}, ErrNotFound
+		}
+		return IndexSource{}, ErrRepository
+	}
+	if !source.Valid() {
+		return IndexSource{}, ErrRepository
+	}
+	return source, nil
+}
+
+func (repository *PostgresRepository) CompleteIndex(
+	ctx context.Context,
+	claim IndexClaim,
+	result ai.EmbeddingResult,
+) (IndexJob, error) {
+	request := ai.EmbeddingRequest{
+		Inputs:     []string{"validated-separately"},
+		Dimensions: claim.Dimensions,
+	}
+	if ctx == nil ||
+		!claim.Valid() ||
+		result.Provider != claim.Provider ||
+		result.Model != claim.Model ||
+		result.Dimensions != claim.Dimensions ||
+		len(result.Vectors) != 1 ||
+		result.InputTokens < 0 ||
+		result.TotalTokens < result.InputTokens {
+		return IndexJob{}, ErrInvalidArgument
+	}
+	// Validate vector shape and numeric safety without retaining the source
+	// content in this persistence boundary.
+	request.Inputs[0] = "memory"
+	if err := ai.ValidateEmbeddingResult(request, result); err != nil {
+		return IndexJob{}, ErrIndexResponse
+	}
+	vector, err := vectorLiteral(result.Vectors[0], claim.Dimensions)
+	if err != nil {
+		return IndexJob{}, err
+	}
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return IndexJob{}, ErrRepository
+	}
+	defer rollback(ctx, tx)
+	if err := verifyIndexClaim(ctx, tx, claim); err != nil {
+		return IndexJob{}, err
+	}
+	commandTag, err := tx.Exec(ctx, `
+INSERT INTO agent_memory_vectors (
+    memory_id,
+    owner_user_id,
+    memory_version,
+    provider,
+    model,
+    dimension,
+    embedding_policy_version,
+    embedding,
+    created_at,
+    updated_at
+)
+SELECT
+    memories.id,
+    memories.owner_user_id,
+    memories.version,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8::public.vector,
+    transaction_timestamp(),
+    transaction_timestamp()
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.id = $1
+  AND memories.owner_user_id = $2
+  AND memories.version = $3
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > clock_timestamp())
+ON CONFLICT (memory_id) DO UPDATE
+SET
+    owner_user_id = EXCLUDED.owner_user_id,
+    memory_version = EXCLUDED.memory_version,
+    provider = EXCLUDED.provider,
+    model = EXCLUDED.model,
+    dimension = EXCLUDED.dimension,
+    embedding_policy_version = EXCLUDED.embedding_policy_version,
+    embedding = EXCLUDED.embedding,
+    updated_at = transaction_timestamp()
+WHERE agent_memory_vectors.owner_user_id = EXCLUDED.owner_user_id
+  AND agent_memory_vectors.memory_version <= EXCLUDED.memory_version`,
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+		claim.Provider,
+		claim.Model,
+		claim.Dimensions,
+		claim.PolicyVersion,
+		vector,
+	)
+	if err != nil {
+		return IndexJob{}, mapPostgresError(err)
+	}
+	if commandTag.RowsAffected() != 1 {
+		return IndexJob{}, ErrNotFound
+	}
+	job, err := scanIndexJob(tx.QueryRow(ctx, `
+UPDATE agent_memory_index_jobs
+SET
+    status = 'completed',
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    failure_kind = NULL,
+    input_tokens = $4,
+    total_tokens = $5,
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE memory_id = $1
+  AND owner_user_id = $2
+  AND memory_version = $3
+  AND status = 'running'
+  AND lease_token = $6
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+indexJobColumns("agent_memory_index_jobs"),
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+		result.InputTokens,
+		result.TotalTokens,
+		claim.LeaseToken,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return IndexJob{}, ErrConflict
+	}
+	if err != nil {
+		return IndexJob{}, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return IndexJob{}, ErrRepository
+	}
+	return job, nil
+}
+
+func (repository *PostgresRepository) FailIndex(
+	ctx context.Context,
+	claim IndexClaim,
+	failureKind string,
+	retryable bool,
+	configuration IndexConfig,
+) (IndexJob, error) {
+	if ctx == nil || !claim.Valid() ||
+		!stableFailurePattern.MatchString(failureKind) ||
+		!configuration.Valid() {
+		return IndexJob{}, ErrInvalidArgument
+	}
+	status := IndexFailed
+	if retryable && claim.AttemptCount < configuration.MaxAttempts {
+		status = IndexPending
+	}
+	job, err := scanIndexJob(repository.database.QueryRow(ctx, `
+UPDATE agent_memory_index_jobs
+SET
+    status = $5,
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = CASE
+        WHEN $5 = 'pending'
+        THEN transaction_timestamp() + make_interval(secs => $6)
+        ELSE next_attempt_at
+    END,
+    failure_kind = $7,
+    updated_at = transaction_timestamp(),
+    completed_at = CASE
+        WHEN $5 = 'pending' THEN NULL
+        ELSE transaction_timestamp()
+    END
+WHERE memory_id = $1
+  AND owner_user_id = $2
+  AND memory_version = $3
+  AND status = 'running'
+  AND lease_token = $4
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+indexJobColumns("agent_memory_index_jobs"),
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+		claim.LeaseToken,
+		status,
+		extractionBackoff(claim.AttemptCount).Seconds(),
+		failureKind,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return IndexJob{}, ErrConflict
+	}
+	if err != nil {
+		return IndexJob{}, mapPostgresError(err)
+	}
+	return job, nil
+}
+
+func (repository *PostgresRepository) DiscardIndex(
+	ctx context.Context,
+	claim IndexClaim,
+	failureKind string,
+) (IndexJob, error) {
+	if ctx == nil || !claim.Valid() ||
+		!stableFailurePattern.MatchString(failureKind) {
+		return IndexJob{}, ErrInvalidArgument
+	}
+	job, err := scanIndexJob(repository.database.QueryRow(ctx, `
+UPDATE agent_memory_index_jobs
+SET
+    status = 'discarded',
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    failure_kind = $5,
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE memory_id = $1
+  AND owner_user_id = $2
+  AND memory_version = $3
+  AND status = 'running'
+  AND lease_token = $4
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+indexJobColumns("agent_memory_index_jobs"),
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+		claim.LeaseToken,
+		failureKind,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return IndexJob{}, ErrConflict
+	}
+	if err != nil {
+		return IndexJob{}, mapPostgresError(err)
+	}
+	return job, nil
+}
+
+func verifyIndexClaim(
+	ctx context.Context,
+	tx pgx.Tx,
+	claim IndexClaim,
+) error {
+	var attempts int
+	if err := tx.QueryRow(ctx, `
+SELECT attempt_count
+FROM agent_memory_index_jobs
+WHERE memory_id = $1
+  AND owner_user_id = $2
+  AND memory_version = $3
+  AND status = 'running'
+  AND lease_token = $4
+  AND lease_expires_at > clock_timestamp()
+FOR UPDATE`,
+		claim.MemoryID,
+		claim.OwnerID,
+		claim.MemoryVersion,
+		claim.LeaseToken,
+	).Scan(&attempts); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrConflict
+		}
+		return ErrRepository
+	}
+	if attempts != claim.AttemptCount {
+		return ErrConflict
+	}
+	return nil
+}
+
+func vectorLiteral(vector []float32, dimensions int) (string, error) {
+	if len(vector) != dimensions ||
+		dimensions != MemoryEmbeddingDimensions {
+		return "", ErrIndexResponse
+	}
+	var builder strings.Builder
+	builder.Grow(dimensions * 12)
+	builder.WriteByte('[')
+	for index, value := range vector {
+		if math.IsNaN(float64(value)) ||
+			math.IsInf(float64(value), 0) {
+			return "", ErrIndexResponse
+		}
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(strconv.FormatFloat(
+			float64(value),
+			'g',
+			-1,
+			32,
+		))
+	}
+	builder.WriteByte(']')
+	return builder.String(), nil
+}
+
+func indexJobColumns(alias string) string {
+	return `
+    ` + alias + `.memory_id::text,
+    ` + alias + `.owner_user_id::text,
+    ` + alias + `.memory_version,
+    ` + alias + `.status,
+    ` + alias + `.attempt_count,
+    coalesce(` + alias + `.lease_token::text, ''),
+    ` + alias + `.lease_expires_at,
+    ` + alias + `.next_attempt_at,
+    coalesce(` + alias + `.embedding_policy_version, ''),
+    coalesce(` + alias + `.provider, ''),
+    coalesce(` + alias + `.model, ''),
+    coalesce(` + alias + `.dimension, 0),
+    coalesce(` + alias + `.failure_kind, ''),
+    coalesce(` + alias + `.input_tokens, 0),
+    coalesce(` + alias + `.total_tokens, 0),
+    ` + alias + `.created_at,
+    ` + alias + `.updated_at,
+    ` + alias + `.completed_at`
+}
+
+func scanIndexJob(row rowScanner) (IndexJob, error) {
+	var job IndexJob
+	var status string
+	var leaseExpiresAt pgtype.Timestamptz
+	var completedAt pgtype.Timestamptz
+	if err := row.Scan(
+		&job.MemoryID,
+		&job.OwnerID,
+		&job.MemoryVersion,
+		&status,
+		&job.AttemptCount,
+		&job.LeaseToken,
+		&leaseExpiresAt,
+		&job.NextAttemptAt,
+		&job.PolicyVersion,
+		&job.Provider,
+		&job.Model,
+		&job.Dimensions,
+		&job.FailureKind,
+		&job.InputTokens,
+		&job.TotalTokens,
+		&job.CreatedAt,
+		&job.UpdatedAt,
+		&completedAt,
+	); err != nil {
+		return IndexJob{}, err
+	}
+	job.Status = IndexStatus(status)
+	job.NextAttemptAt = job.NextAttemptAt.UTC()
+	job.CreatedAt = job.CreatedAt.UTC()
+	job.UpdatedAt = job.UpdatedAt.UTC()
+	if leaseExpiresAt.Valid {
+		job.LeaseExpiresAt = leaseExpiresAt.Time.UTC()
+	}
+	if completedAt.Valid {
+		job.CompletedAt = completedAt.Time.UTC()
+	}
+	if !job.Status.Valid() ||
+		!validUUID(job.MemoryID) ||
+		!validUUID(job.OwnerID) ||
+		job.MemoryVersion < 1 ||
+		job.AttemptCount < 0 {
+		return IndexJob{}, ErrRepository
+	}
+	return job, nil
+}

--- a/server/internal/memory/index_postgres.go
+++ b/server/internal/memory/index_postgres.go
@@ -56,6 +56,50 @@ WHERE status = 'running'
 	); err != nil {
 		return IndexClaim{}, false, ErrRepository
 	}
+	// An embedding rollout does not change the Memory content version. Requeue
+	// non-running jobs whose recorded embedding identity differs so unchanged
+	// active memories cannot silently disappear behind the new search filters.
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_memory_index_jobs AS jobs
+SET
+    status = 'pending',
+    attempt_count = 0,
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = transaction_timestamp(),
+    embedding_policy_version = NULL,
+    provider = NULL,
+    model = NULL,
+    dimension = NULL,
+    failure_kind = NULL,
+    input_tokens = NULL,
+    total_tokens = NULL,
+    updated_at = transaction_timestamp(),
+    completed_at = NULL
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE jobs.memory_id = memories.id
+  AND jobs.owner_user_id = memories.owner_user_id
+  AND jobs.memory_version = memories.version
+  AND jobs.status <> 'running'
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > clock_timestamp())
+  AND jobs.embedding_policy_version IS NOT NULL
+  AND (
+      jobs.embedding_policy_version IS DISTINCT FROM $1
+      OR jobs.provider IS DISTINCT FROM $2
+      OR jobs.model IS DISTINCT FROM $3
+      OR jobs.dimension IS DISTINCT FROM $4
+  )`,
+		configuration.PolicyVersion,
+		configuration.Provider,
+		configuration.Model,
+		configuration.Dimensions,
+	); err != nil {
+		return IndexClaim{}, false, ErrRepository
+	}
 	job, err := scanIndexJob(tx.QueryRow(ctx, `
 WITH candidate AS (
     SELECT memory_id, memory_version

--- a/server/internal/memory/index_postgres_integration_test.go
+++ b/server/internal/memory/index_postgres_integration_test.go
@@ -1,0 +1,176 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	ctx := context.Background()
+	actorA := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	actorB := requestcontext.Actor{
+		UserID:    integrationUserB,
+		SessionID: integrationSessionB,
+	}
+	item, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("career.role", "Java backend engineer"),
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	configuration := testIndexConfig()
+	claim, acquired, err := repository.ClaimIndex(ctx, configuration)
+	if err != nil {
+		t.Fatalf("ClaimIndex: %v", err)
+	}
+	if !acquired ||
+		claim.MemoryID != item.ID ||
+		claim.MemoryVersion != item.Version {
+		t.Fatalf("claim = %#v, acquired=%t", claim, acquired)
+	}
+	source, err := repository.ReadIndexSource(ctx, claim)
+	if err != nil {
+		t.Fatalf("ReadIndexSource: %v", err)
+	}
+	if source.Content != item.Content {
+		t.Fatalf("source = %#v", source)
+	}
+	if _, err := repository.CompleteIndex(
+		ctx,
+		claim,
+		validEmbeddingResult(),
+	); err != nil {
+		t.Fatalf("CompleteIndex: %v", err)
+	}
+
+	candidates, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		validEmbeddingResult().Vectors[0],
+		"",
+		testSearchConfig(),
+	)
+	if err != nil {
+		t.Fatalf("SearchCandidates: %v", err)
+	}
+	if len(candidates) != 1 ||
+		candidates[0].Memory.ID != item.ID ||
+		candidates[0].Similarity < 0.999 {
+		t.Fatalf("candidates = %#v", candidates)
+	}
+	crossOwner, err := repository.SearchCandidates(
+		ctx,
+		actorB,
+		validEmbeddingResult().Vectors[0],
+		"",
+		testSearchConfig(),
+	)
+	if err != nil {
+		t.Fatalf("cross-owner SearchCandidates: %v", err)
+	}
+	if len(crossOwner) != 0 {
+		t.Fatalf("cross-owner candidates = %#v", crossOwner)
+	}
+
+	updated, err := repository.Update(ctx, actorA, UpdateCommand{
+		MemoryID:        item.ID,
+		ExpectedVersion: item.Version,
+		Content:         "Senior Java platform engineer",
+		PolicyVersion:   "memory-policy-v1",
+		Source: evidence(
+			SourceAgentRun,
+			"index-update-run",
+			1,
+			"updated-role",
+		),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	stale, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		validEmbeddingResult().Vectors[0],
+		"",
+		testSearchConfig(),
+	)
+	if err != nil {
+		t.Fatalf("search stale vector: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("stale vector remained searchable: %#v", stale)
+	}
+	nextClaim, acquired, err := repository.ClaimIndex(ctx, configuration)
+	if err != nil {
+		t.Fatalf("ClaimIndex updated: %v", err)
+	}
+	if !acquired || nextClaim.MemoryVersion != updated.Version {
+		t.Fatalf("updated claim = %#v, acquired=%t", nextClaim, acquired)
+	}
+	staleClaim := nextClaim
+	staleClaim.LeaseToken = "f0000000-0000-4000-8000-000000000001"
+	if _, err := repository.CompleteIndex(
+		ctx,
+		staleClaim,
+		validEmbeddingResult(),
+	); err != ErrConflict {
+		t.Fatalf("stale worker CompleteIndex error = %v", err)
+	}
+	if _, err := repository.CompleteIndex(
+		ctx,
+		nextClaim,
+		validEmbeddingResult(),
+	); err != nil {
+		t.Fatalf("CompleteIndex updated: %v", err)
+	}
+	if _, err := repository.Inactivate(ctx, actorA, InactivateCommand{
+		MemoryID:        item.ID,
+		ExpectedVersion: updated.Version,
+		Source: evidence(
+			SourceAgentRun,
+			"index-inactivate-run",
+			1,
+			"forgot-role",
+		),
+	}); err != nil {
+		t.Fatalf("Inactivate: %v", err)
+	}
+	inactive, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		validEmbeddingResult().Vectors[0],
+		"",
+		testSearchConfig(),
+	)
+	if err != nil {
+		t.Fatalf("search inactive: %v", err)
+	}
+	if len(inactive) != 0 {
+		t.Fatalf("inactive Memory remained searchable: %#v", inactive)
+	}
+	if _, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		validEmbeddingResult().Vectors[0],
+		integrationMatterB,
+		testSearchConfig(),
+	); err != ErrNotFound {
+		t.Fatalf("foreign Matter search error = %v", err)
+	}
+}

--- a/server/internal/memory/index_postgres_integration_test.go
+++ b/server/internal/memory/index_postgres_integration_test.go
@@ -291,17 +291,30 @@ INSERT INTO agent_memory_vectors (
 			index+1,
 		)
 		if _, err := database.Exec(ctx, `
-INSERT INTO agent_memories (
-    id,
-    owner_user_id,
-    memory_type,
-    canonical_key,
-    content,
-    scope_type,
-    status,
-    version,
-    policy_version
-) VALUES ($1, $2, 'interest', $3, $4, 'user', 'active', 1, 'memory-policy-v1');
+WITH inserted_memory AS (
+    INSERT INTO agent_memories (
+        id,
+        owner_user_id,
+        memory_type,
+        canonical_key,
+        content,
+        scope_type,
+        status,
+        version,
+        policy_version
+    ) VALUES (
+        $1,
+        $2,
+        'interest',
+        $3,
+        $4,
+        'user',
+        'active',
+        1,
+        'memory-policy-v1'
+    )
+    RETURNING id, owner_user_id, version
+)
 INSERT INTO agent_memory_vectors (
     memory_id,
     owner_user_id,
@@ -311,7 +324,17 @@ INSERT INTO agent_memory_vectors (
     dimension,
     embedding_policy_version,
     embedding
-) VALUES ($1, $2, 1, $5, $6, $7, $8, $9::public.vector)`,
+)
+SELECT
+    inserted_memory.id,
+    inserted_memory.owner_user_id,
+    inserted_memory.version,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9::public.vector
+FROM inserted_memory`,
 			memoryID,
 			integrationUserB,
 			fmt.Sprintf("foreign.interest.%d", index),

--- a/server/internal/memory/index_postgres_integration_test.go
+++ b/server/internal/memory/index_postgres_integration_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
@@ -59,12 +60,13 @@ func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
 		t.Fatalf("CompleteIndex: %v", err)
 	}
 
+	searchConfiguration := testSearchConfig()
 	candidates, err := repository.SearchCandidates(
 		ctx,
 		actorA,
 		validEmbeddingResult().Vectors[0],
 		"",
-		testSearchConfig(),
+		searchConfiguration,
 	)
 	if err != nil {
 		t.Fatalf("SearchCandidates: %v", err)
@@ -74,12 +76,60 @@ func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
 		candidates[0].Similarity < 0.999 {
 		t.Fatalf("candidates = %#v", candidates)
 	}
+	rolloutConfiguration := configuration
+	rolloutConfiguration.PolicyVersion = "memory-embedding-v2"
+	rolloutClaim, acquired, err := repository.ClaimIndex(
+		ctx,
+		rolloutConfiguration,
+	)
+	if err != nil {
+		t.Fatalf("ClaimIndex rollout: %v", err)
+	}
+	if !acquired ||
+		rolloutClaim.MemoryID != item.ID ||
+		rolloutClaim.MemoryVersion != item.Version ||
+		rolloutClaim.PolicyVersion != rolloutConfiguration.PolicyVersion ||
+		rolloutClaim.AttemptCount != 1 {
+		t.Fatalf("rollout claim = %#v, acquired=%t", rolloutClaim, acquired)
+	}
+	if _, err := repository.CompleteIndex(
+		ctx,
+		rolloutClaim,
+		validEmbeddingResult(),
+	); err != nil {
+		t.Fatalf("CompleteIndex rollout: %v", err)
+	}
+	searchConfiguration.EmbeddingPolicyVersion = rolloutConfiguration.PolicyVersion
+	rolledOut, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		validEmbeddingResult().Vectors[0],
+		"",
+		searchConfiguration,
+	)
+	if err != nil {
+		t.Fatalf("SearchCandidates rollout: %v", err)
+	}
+	if len(rolledOut) != 1 || rolledOut[0].Memory.ID != item.ID {
+		t.Fatalf("rolled-out candidates = %#v", rolledOut)
+	}
+	if extra, acquired, err := repository.ClaimIndex(
+		ctx,
+		rolloutConfiguration,
+	); err != nil || acquired {
+		t.Fatalf(
+			"idempotent rollout claim = %#v, acquired=%t, err=%v",
+			extra,
+			acquired,
+			err,
+		)
+	}
 	crossOwner, err := repository.SearchCandidates(
 		ctx,
 		actorB,
 		validEmbeddingResult().Vectors[0],
 		"",
-		testSearchConfig(),
+		searchConfiguration,
 	)
 	if err != nil {
 		t.Fatalf("cross-owner SearchCandidates: %v", err)
@@ -108,7 +158,7 @@ func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
 		actorA,
 		validEmbeddingResult().Vectors[0],
 		"",
-		testSearchConfig(),
+		searchConfiguration,
 	)
 	if err != nil {
 		t.Fatalf("search stale vector: %v", err)
@@ -156,7 +206,7 @@ func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
 		actorA,
 		validEmbeddingResult().Vectors[0],
 		"",
-		testSearchConfig(),
+		searchConfiguration,
 	)
 	if err != nil {
 		t.Fatalf("search inactive: %v", err)
@@ -169,8 +219,124 @@ func TestPostgresMemoryIndexLifecycleAndOwnerIsolation(t *testing.T) {
 		actorA,
 		validEmbeddingResult().Vectors[0],
 		integrationMatterB,
-		testSearchConfig(),
+		searchConfiguration,
 	); err != ErrNotFound {
 		t.Fatalf("foreign Matter search error = %v", err)
+	}
+}
+
+func TestPostgresMemorySearchPrefiltersOwnerBeforeVectorRanking(t *testing.T) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	ctx := context.Background()
+	actorA := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	target, err := repository.Create(
+		ctx,
+		actorA,
+		createCommand("career.target", "Product manager interview"),
+	)
+	if err != nil {
+		t.Fatalf("Create target: %v", err)
+	}
+	targetVector := make([]float32, MemoryEmbeddingDimensions)
+	targetVector[0] = 1
+	foreignVector := make([]float32, MemoryEmbeddingDimensions)
+	foreignVector[0] = 1
+	foreignVector[1] = 0.001
+	targetLiteral, err := vectorLiteral(targetVector, MemoryEmbeddingDimensions)
+	if err != nil {
+		t.Fatalf("target vector: %v", err)
+	}
+	foreignLiteral, err := vectorLiteral(foreignVector, MemoryEmbeddingDimensions)
+	if err != nil {
+		t.Fatalf("foreign vector: %v", err)
+	}
+	configuration := testSearchConfig()
+	if _, err := database.Exec(ctx, `
+INSERT INTO agent_memory_vectors (
+    memory_id,
+    owner_user_id,
+    memory_version,
+    provider,
+    model,
+    dimension,
+    embedding_policy_version,
+    embedding
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::public.vector)`,
+		target.ID,
+		target.OwnerID,
+		target.Version,
+		configuration.Provider,
+		configuration.Model,
+		configuration.Dimensions,
+		configuration.EmbeddingPolicyVersion,
+		targetLiteral,
+	); err != nil {
+		t.Fatalf("insert target vector: %v", err)
+	}
+	// Exceed pgvector's default HNSW ef_search candidate budget with
+	// cross-owner vectors that are almost identical to the query.
+	for index := 0; index < 64; index++ {
+		memoryID := fmt.Sprintf(
+			"c0000000-0000-4000-8000-%012x",
+			index+1,
+		)
+		if _, err := database.Exec(ctx, `
+INSERT INTO agent_memories (
+    id,
+    owner_user_id,
+    memory_type,
+    canonical_key,
+    content,
+    scope_type,
+    status,
+    version,
+    policy_version
+) VALUES ($1, $2, 'interest', $3, $4, 'user', 'active', 1, 'memory-policy-v1');
+INSERT INTO agent_memory_vectors (
+    memory_id,
+    owner_user_id,
+    memory_version,
+    provider,
+    model,
+    dimension,
+    embedding_policy_version,
+    embedding
+) VALUES ($1, $2, 1, $5, $6, $7, $8, $9::public.vector)`,
+			memoryID,
+			integrationUserB,
+			fmt.Sprintf("foreign.interest.%d", index),
+			fmt.Sprintf("Foreign interest %d", index),
+			configuration.Provider,
+			configuration.Model,
+			configuration.Dimensions,
+			configuration.EmbeddingPolicyVersion,
+			foreignLiteral,
+		); err != nil {
+			t.Fatalf("insert foreign vector %d: %v", index, err)
+		}
+	}
+	configuration.CandidateLimit = 1
+	candidates, err := repository.SearchCandidates(
+		ctx,
+		actorA,
+		targetVector,
+		"",
+		configuration,
+	)
+	if err != nil {
+		t.Fatalf("SearchCandidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Memory.ID != target.ID {
+		t.Fatalf("owner-prefiltered candidates = %#v", candidates)
 	}
 }

--- a/server/internal/memory/index_worker.go
+++ b/server/internal/memory/index_worker.go
@@ -1,0 +1,163 @@
+package memory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+const maxIndexSweepLimit = 20
+
+type IndexWorker struct {
+	repository IndexRepository
+	embedder   ai.Embedder
+	config     IndexConfig
+}
+
+func NewIndexWorker(
+	repository IndexRepository,
+	embedder ai.Embedder,
+	configuration IndexConfig,
+) (*IndexWorker, error) {
+	if repository == nil || embedder == nil || !configuration.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	return &IndexWorker{
+		repository: repository,
+		embedder:   embedder,
+		config:     configuration,
+	}, nil
+}
+
+func (worker *IndexWorker) ProcessPendingIndexes(
+	ctx context.Context,
+	limit int,
+) (IndexSweepResult, error) {
+	if ctx == nil || limit < 1 || limit > maxIndexSweepLimit {
+		return IndexSweepResult{}, ErrInvalidArgument
+	}
+	var result IndexSweepResult
+	for result.Claimed < limit {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		claim, acquired, err := worker.repository.ClaimIndex(
+			ctx,
+			worker.config,
+		)
+		if err != nil {
+			return result, err
+		}
+		if !acquired {
+			return result, nil
+		}
+		result.Claimed++
+		outcome, err := worker.processClaim(ctx, claim)
+		if err != nil {
+			return result, err
+		}
+		switch outcome {
+		case IndexCompleted:
+			result.Completed++
+		case IndexPending:
+			result.Retried++
+		case IndexFailed:
+			result.Failed++
+		case IndexDiscarded:
+			result.Discarded++
+		default:
+			return result, ErrRepository
+		}
+	}
+	return result, nil
+}
+
+func (worker *IndexWorker) processClaim(
+	ctx context.Context,
+	claim IndexClaim,
+) (IndexStatus, error) {
+	source, err := worker.repository.ReadIndexSource(ctx, claim)
+	if err != nil {
+		return worker.recordFailure(ctx, claim, err)
+	}
+	result, err := worker.embedder.Embed(ctx, ai.EmbeddingRequest{
+		Inputs:     []string{source.Content},
+		Dimensions: worker.config.Dimensions,
+	})
+	if err != nil {
+		return worker.recordFailure(ctx, claim, err)
+	}
+	if result.Provider != claim.Provider ||
+		result.Model != claim.Model ||
+		result.Dimensions != claim.Dimensions {
+		return worker.recordFailure(ctx, claim, ErrIndexResponse)
+	}
+	job, err := worker.repository.CompleteIndex(ctx, claim, result)
+	if err != nil {
+		return worker.recordFailure(ctx, claim, err)
+	}
+	return job.Status, nil
+}
+
+func (worker *IndexWorker) recordFailure(
+	ctx context.Context,
+	claim IndexClaim,
+	cause error,
+) (IndexStatus, error) {
+	kind, retryable, discard := indexFailure(cause)
+	if discard {
+		job, err := worker.repository.DiscardIndex(ctx, claim, kind)
+		if err != nil {
+			return "", err
+		}
+		return job.Status, nil
+	}
+	job, err := worker.repository.FailIndex(
+		ctx,
+		claim,
+		kind,
+		retryable,
+		worker.config,
+	)
+	if err != nil {
+		return "", err
+	}
+	return job.Status, nil
+}
+
+type stableProviderFailure interface {
+	StableCategory() string
+	Retryable() bool
+}
+
+func indexFailure(cause error) (
+	kind string,
+	retryable bool,
+	discard bool,
+) {
+	switch {
+	case errors.Is(cause, ErrAccountDeleted):
+		return "account_deleted", false, true
+	case errors.Is(cause, ErrNotFound):
+		return "superseded", false, true
+	case errors.Is(cause, ErrIndexResponse),
+		errors.Is(cause, ErrInvalidArgument):
+		return "invalid_response", false, false
+	case errors.Is(cause, context.Canceled):
+		return "canceled", true, false
+	case errors.Is(cause, context.DeadlineExceeded):
+		return "timeout", true, false
+	}
+	var providerError stableProviderFailure
+	if errors.As(cause, &providerError) {
+		kind := providerError.StableCategory()
+		if !stableFailurePattern.MatchString(kind) {
+			kind = "provider_error"
+		}
+		return kind, providerError.Retryable(), false
+	}
+	return "dependency", true, false
+}
+
+var _ IndexProcessor = (*IndexWorker)(nil)

--- a/server/internal/memory/index_worker_test.go
+++ b/server/internal/memory/index_worker_test.go
@@ -1,0 +1,203 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	aifake "github.com/1024XEngineer/XE3-ESL/server/internal/ai/fake"
+)
+
+func TestIndexWorkerCompletesAndRetriesExplicitly(t *testing.T) {
+	t.Parallel()
+
+	claim := validIndexClaim()
+	t.Run("complete", func(t *testing.T) {
+		repository := &fakeIndexRepository{claims: []IndexClaim{claim}}
+		worker, err := NewIndexWorker(
+			repository,
+			&aifake.Embedder{Result: validEmbeddingResult()},
+			testIndexConfig(),
+		)
+		if err != nil {
+			t.Fatalf("NewIndexWorker: %v", err)
+		}
+		result, err := worker.ProcessPendingIndexes(
+			context.Background(),
+			4,
+		)
+		if err != nil {
+			t.Fatalf("ProcessPendingIndexes: %v", err)
+		}
+		if result.Completed != 1 || repository.completed != 1 {
+			t.Fatalf("result=%#v repository=%#v", result, repository)
+		}
+	})
+
+	t.Run("retry provider", func(t *testing.T) {
+		repository := &fakeIndexRepository{claims: []IndexClaim{claim}}
+		worker, _ := NewIndexWorker(
+			repository,
+			&aifake.Embedder{Err: ai.NewEmbeddingError(
+				ai.ErrorRateLimited,
+				429,
+				"",
+				"",
+				nil,
+			)},
+			testIndexConfig(),
+		)
+		result, err := worker.ProcessPendingIndexes(
+			context.Background(),
+			1,
+		)
+		if err != nil {
+			t.Fatalf("ProcessPendingIndexes: %v", err)
+		}
+		if result.Retried != 1 ||
+			repository.failureKind != "rate_limited" ||
+			!repository.retryable {
+			t.Fatalf("result=%#v repository=%#v", result, repository)
+		}
+	})
+
+	t.Run("discard superseded", func(t *testing.T) {
+		repository := &fakeIndexRepository{
+			claims:    []IndexClaim{claim},
+			sourceErr: ErrNotFound,
+		}
+		worker, _ := NewIndexWorker(
+			repository,
+			&aifake.Embedder{Result: validEmbeddingResult()},
+			testIndexConfig(),
+		)
+		result, err := worker.ProcessPendingIndexes(
+			context.Background(),
+			1,
+		)
+		if err != nil {
+			t.Fatalf("ProcessPendingIndexes: %v", err)
+		}
+		if result.Discarded != 1 ||
+			repository.discardKind != "superseded" {
+			t.Fatalf("result=%#v repository=%#v", result, repository)
+		}
+	})
+}
+
+type fakeIndexRepository struct {
+	claims      []IndexClaim
+	sourceErr   error
+	completed   int
+	failureKind string
+	retryable   bool
+	discardKind string
+}
+
+func (repository *fakeIndexRepository) ClaimIndex(
+	context.Context,
+	IndexConfig,
+) (IndexClaim, bool, error) {
+	if len(repository.claims) == 0 {
+		return IndexClaim{}, false, nil
+	}
+	claim := repository.claims[0]
+	repository.claims = repository.claims[1:]
+	return claim, true, nil
+}
+
+func (repository *fakeIndexRepository) ReadIndexSource(
+	context.Context,
+	IndexClaim,
+) (IndexSource, error) {
+	if repository.sourceErr != nil {
+		return IndexSource{}, repository.sourceErr
+	}
+	return IndexSource{
+		MemoryID: validIndexClaim().MemoryID,
+		OwnerID:  validIndexClaim().OwnerID,
+		Version:  1,
+		Content:  "Java backend engineer",
+	}, nil
+}
+
+func (repository *fakeIndexRepository) CompleteIndex(
+	_ context.Context,
+	claim IndexClaim,
+	_ ai.EmbeddingResult,
+) (IndexJob, error) {
+	repository.completed++
+	job := claim.IndexJob
+	job.Status = IndexCompleted
+	return job, nil
+}
+
+func (repository *fakeIndexRepository) FailIndex(
+	_ context.Context,
+	claim IndexClaim,
+	kind string,
+	retryable bool,
+	_ IndexConfig,
+) (IndexJob, error) {
+	repository.failureKind = kind
+	repository.retryable = retryable
+	job := claim.IndexJob
+	job.Status = IndexPending
+	return job, nil
+}
+
+func (repository *fakeIndexRepository) DiscardIndex(
+	_ context.Context,
+	claim IndexClaim,
+	kind string,
+) (IndexJob, error) {
+	repository.discardKind = kind
+	job := claim.IndexJob
+	job.Status = IndexDiscarded
+	return job, nil
+}
+
+func testIndexConfig() IndexConfig {
+	return IndexConfig{
+		Provider:      "qianwen",
+		Model:         "text-embedding-v4",
+		Dimensions:    MemoryEmbeddingDimensions,
+		PolicyVersion: "memory-embedding-v1",
+		LeaseDuration: 2 * time.Minute,
+		MaxAttempts:   3,
+	}
+}
+
+func validIndexClaim() IndexClaim {
+	now := time.Now().UTC()
+	return IndexClaim{IndexJob: IndexJob{
+		MemoryID:       "10000000-0000-4000-8000-000000000001",
+		OwnerID:        integrationUserA,
+		MemoryVersion:  1,
+		Status:         IndexRunning,
+		AttemptCount:   1,
+		LeaseToken:     "20000000-0000-4000-8000-000000000001",
+		LeaseExpiresAt: now.Add(time.Minute),
+		NextAttemptAt:  now,
+		PolicyVersion:  "memory-embedding-v1",
+		Provider:       "qianwen",
+		Model:          "text-embedding-v4",
+		Dimensions:     MemoryEmbeddingDimensions,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}}
+}
+
+func validEmbeddingResult() ai.EmbeddingResult {
+	vector := make([]float32, MemoryEmbeddingDimensions)
+	vector[0] = 1
+	return ai.EmbeddingResult{
+		Provider:    "qianwen",
+		Model:       "text-embedding-v4",
+		Dimensions:  MemoryEmbeddingDimensions,
+		Vectors:     [][]float32{vector},
+		InputTokens: 3,
+		TotalTokens: 3,
+	}
+}

--- a/server/internal/memory/repository.go
+++ b/server/internal/memory/repository.go
@@ -19,6 +19,7 @@ var (
 	ErrExtractionExhausted = errors.New(
 		"memory: extraction attempts exhausted during recovery",
 	)
+	ErrIndexResponse = errors.New("memory: invalid index response")
 )
 
 type CreateCommand struct {

--- a/server/internal/memory/search.go
+++ b/server/internal/memory/search.go
@@ -1,0 +1,240 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	maxSearchResults    = 10
+	maxSearchCandidates = 40
+)
+
+type SearchConfig struct {
+	Provider               string
+	Model                  string
+	Dimensions             int
+	EmbeddingPolicyVersion string
+	RetrievalPolicyVersion string
+	CandidateLimit         int
+	MinimumSimilarity      float64
+}
+
+func (configuration SearchConfig) Valid() bool {
+	return providerIdentifierPattern.MatchString(configuration.Provider) &&
+		modelIdentifierPattern.MatchString(configuration.Model) &&
+		configuration.Dimensions == MemoryEmbeddingDimensions &&
+		validPolicyVersion(configuration.EmbeddingPolicyVersion) &&
+		validPolicyVersion(configuration.RetrievalPolicyVersion) &&
+		configuration.CandidateLimit >= 1 &&
+		configuration.CandidateLimit <= maxSearchCandidates &&
+		configuration.MinimumSimilarity >= -1 &&
+		configuration.MinimumSimilarity <= 1
+}
+
+type SearchRequest struct {
+	Actor    requestcontext.Actor
+	Query    string
+	MatterID string
+	Limit    int
+}
+
+func (request SearchRequest) Valid() bool {
+	return request.Actor.Valid() &&
+		request.Query != "" &&
+		request.Query == strings.TrimSpace(request.Query) &&
+		len(request.Query) <= ai.MaxEmbeddingInputBytes &&
+		(request.MatterID == "" || validUUID(request.MatterID)) &&
+		request.Limit >= 1 &&
+		request.Limit <= maxSearchResults
+}
+
+type SearchCandidate struct {
+	Memory     Memory
+	Similarity float64
+}
+
+type SearchHit struct {
+	MemoryID               string
+	MemoryVersion          int64
+	Type                   Type
+	Content                string
+	Scope                  ScopeType
+	MatterID               string
+	Similarity             float64
+	Score                  float64
+	EmbeddingProvider      string
+	EmbeddingModel         string
+	EmbeddingDimensions    int
+	EmbeddingPolicyVersion string
+	RetrievalPolicyVersion string
+}
+
+type SearchCandidateRepository interface {
+	SearchCandidates(
+		context.Context,
+		requestcontext.Actor,
+		[]float32,
+		string,
+		SearchConfig,
+	) ([]SearchCandidate, error)
+}
+
+type Searcher interface {
+	Search(context.Context, SearchRequest) ([]SearchHit, error)
+}
+
+type SearchService struct {
+	repository SearchCandidateRepository
+	embedder   ai.Embedder
+	config     SearchConfig
+	now        func() time.Time
+}
+
+func NewSearchService(
+	repository SearchCandidateRepository,
+	embedder ai.Embedder,
+	configuration SearchConfig,
+	now func() time.Time,
+) (*SearchService, error) {
+	if repository == nil ||
+		embedder == nil ||
+		!configuration.Valid() ||
+		now == nil {
+		return nil, ErrInvalidArgument
+	}
+	return &SearchService{
+		repository: repository,
+		embedder:   embedder,
+		config:     configuration,
+		now:        now,
+	}, nil
+}
+
+func (service *SearchService) Search(
+	ctx context.Context,
+	request SearchRequest,
+) ([]SearchHit, error) {
+	if ctx == nil || !request.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	embeddingRequest := ai.EmbeddingRequest{
+		Inputs:     []string{request.Query},
+		Dimensions: service.config.Dimensions,
+	}
+	result, err := service.embedder.Embed(ctx, embeddingRequest)
+	if err != nil {
+		return nil, err
+	}
+	if err := ai.ValidateEmbeddingResult(
+		embeddingRequest,
+		result,
+	); err != nil {
+		return nil, ErrIndexResponse
+	}
+	if result.Provider != service.config.Provider ||
+		result.Model != service.config.Model ||
+		result.Dimensions != service.config.Dimensions ||
+		len(result.Vectors) != 1 {
+		return nil, ErrIndexResponse
+	}
+	candidates, err := service.repository.SearchCandidates(
+		ctx,
+		request.Actor,
+		result.Vectors[0],
+		request.MatterID,
+		service.config,
+	)
+	if err != nil {
+		return nil, err
+	}
+	hits := make([]SearchHit, 0, min(request.Limit, len(candidates)))
+	now := service.now().UTC()
+	for _, candidate := range candidates {
+		if !candidate.Memory.Valid() ||
+			candidate.Memory.OwnerID != request.Actor.UserID ||
+			candidate.Similarity < service.config.MinimumSimilarity ||
+			candidate.Similarity < -1 ||
+			candidate.Similarity > 1 {
+			continue
+		}
+		if candidate.Memory.Scope == ScopeMatter &&
+			candidate.Memory.MatterID != request.MatterID {
+			return nil, ErrRepository
+		}
+		hits = append(hits, SearchHit{
+			MemoryID:               candidate.Memory.ID,
+			MemoryVersion:          candidate.Memory.Version,
+			Type:                   candidate.Memory.Type,
+			Content:                candidate.Memory.Content,
+			Scope:                  candidate.Memory.Scope,
+			MatterID:               candidate.Memory.MatterID,
+			Similarity:             candidate.Similarity,
+			Score:                  rerankScore(candidate, request.MatterID, now),
+			EmbeddingProvider:      service.config.Provider,
+			EmbeddingModel:         service.config.Model,
+			EmbeddingDimensions:    service.config.Dimensions,
+			EmbeddingPolicyVersion: service.config.EmbeddingPolicyVersion,
+			RetrievalPolicyVersion: service.config.RetrievalPolicyVersion,
+		})
+	}
+	sort.Slice(hits, func(left, right int) bool {
+		if hits[left].Score != hits[right].Score {
+			return hits[left].Score > hits[right].Score
+		}
+		if hits[left].Similarity != hits[right].Similarity {
+			return hits[left].Similarity > hits[right].Similarity
+		}
+		return hits[left].MemoryID < hits[right].MemoryID
+	})
+	if len(hits) > request.Limit {
+		hits = hits[:request.Limit]
+	}
+	return hits, nil
+}
+
+func rerankScore(
+	candidate SearchCandidate,
+	matterID string,
+	now time.Time,
+) float64 {
+	score := candidate.Similarity * 0.75
+	if candidate.Memory.Scope == ScopeMatter &&
+		candidate.Memory.MatterID == matterID {
+		score += 0.10
+	}
+	score += memoryTypeWeight(candidate.Memory.Type)
+	age := now.Sub(candidate.Memory.UpdatedAt)
+	if age < 0 {
+		age = 0
+	}
+	const recencyWindow = 30 * 24 * time.Hour
+	if age < recencyWindow {
+		score += 0.05 * (1 - float64(age)/float64(recencyWindow))
+	}
+	return score
+}
+
+func memoryTypeWeight(memoryType Type) float64 {
+	switch memoryType {
+	case TypeGoal, TypePreference:
+		return 0.10
+	case TypeIdentity, TypeProfile:
+		return 0.08
+	case TypeStrength, TypeWeakness, TypeProgress:
+		return 0.07
+	case TypeInterest:
+		return 0.05
+	case TypeTopic:
+		return 0.03
+	default:
+		return 0
+	}
+}
+
+var _ Searcher = (*SearchService)(nil)

--- a/server/internal/memory/search_postgres.go
+++ b/server/internal/memory/search_postgres.go
@@ -44,50 +44,75 @@ SELECT EXISTS (
 		}
 	}
 	rows, err := repository.database.Query(ctx, `
-SELECT
-    memories.id::text,
-    memories.owner_user_id::text,
-    memories.memory_type,
-    memories.canonical_key,
-    memories.content,
-    memories.scope_type,
-    coalesce(memories.matter_id::text, ''),
-    memories.status,
-    memories.version,
-    memories.policy_version,
-    memories.expires_at,
-    memories.created_at,
-    memories.updated_at,
-    memories.inactivated_at,
-    1 - (
-        vectors.embedding OPERATOR(public.<=>) $2::public.vector
-    ) AS similarity
-FROM agent_memory_vectors AS vectors
-JOIN agent_memories AS memories
-  ON memories.id = vectors.memory_id
- AND memories.owner_user_id = vectors.owner_user_id
- AND memories.version = vectors.memory_version
-JOIN identity_users AS users
-  ON users.id = memories.owner_user_id
- AND users.account_status = 'active'
-WHERE memories.owner_user_id = $1
-  AND memories.status = 'active'
-  AND (memories.expires_at IS NULL OR memories.expires_at > clock_timestamp())
-  AND vectors.provider = $3
-  AND vectors.model = $4
-  AND vectors.dimension = $5
-  AND vectors.embedding_policy_version = $6
-  AND (
-      (memories.scope_type = 'user' AND memories.matter_id IS NULL)
-      OR (
-          $7::uuid IS NOT NULL
-          AND memories.scope_type = 'matter'
-          AND memories.matter_id = $7::uuid
+WITH eligible AS MATERIALIZED (
+    SELECT
+        memories.id,
+        memories.owner_user_id,
+        memories.memory_type,
+        memories.canonical_key,
+        memories.content,
+        memories.scope_type,
+        memories.matter_id,
+        memories.status,
+        memories.version,
+        memories.policy_version,
+        memories.expires_at,
+        memories.created_at,
+        memories.updated_at,
+        memories.inactivated_at,
+        vectors.embedding
+    FROM agent_memory_vectors AS vectors
+    JOIN agent_memories AS memories
+      ON memories.id = vectors.memory_id
+     AND memories.owner_user_id = vectors.owner_user_id
+     AND memories.version = vectors.memory_version
+    JOIN identity_users AS users
+      ON users.id = memories.owner_user_id
+     AND users.account_status = 'active'
+    WHERE memories.owner_user_id = $1
+      AND memories.status = 'active'
+      AND (
+          memories.expires_at IS NULL
+          OR memories.expires_at > clock_timestamp()
       )
-  )
+      AND vectors.provider = $3
+      AND vectors.model = $4
+      AND vectors.dimension = $5
+      AND vectors.embedding_policy_version = $6
+      AND (
+          (
+              memories.scope_type = 'user'
+              AND memories.matter_id IS NULL
+          )
+          OR (
+              $7::uuid IS NOT NULL
+              AND memories.scope_type = 'matter'
+              AND memories.matter_id = $7::uuid
+          )
+      )
+)
+SELECT
+    eligible.id::text,
+    eligible.owner_user_id::text,
+    eligible.memory_type,
+    eligible.canonical_key,
+    eligible.content,
+    eligible.scope_type,
+    coalesce(eligible.matter_id::text, ''),
+    eligible.status,
+    eligible.version,
+    eligible.policy_version,
+    eligible.expires_at,
+    eligible.created_at,
+    eligible.updated_at,
+    eligible.inactivated_at,
+    1 - (
+        eligible.embedding OPERATOR(public.<=>) $2::public.vector
+    ) AS similarity
+FROM eligible
 ORDER BY
-    vectors.embedding OPERATOR(public.<=>) $2::public.vector,
-    memories.id
+    eligible.embedding OPERATOR(public.<=>) $2::public.vector,
+    eligible.id
 LIMIT $8`,
 		actor.UserID,
 		vector,

--- a/server/internal/memory/search_postgres.go
+++ b/server/internal/memory/search_postgres.go
@@ -1,0 +1,173 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (repository *PostgresRepository) SearchCandidates(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	queryVector []float32,
+	matterID string,
+	configuration SearchConfig,
+) ([]SearchCandidate, error) {
+	if ctx == nil ||
+		!validActor(actor) ||
+		(matterID != "" && !validUUID(matterID)) ||
+		!configuration.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	vector, err := vectorLiteral(queryVector, configuration.Dimensions)
+	if err != nil {
+		return nil, err
+	}
+	if matterID != "" {
+		var owned bool
+		if err := repository.database.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM matters
+    WHERE id = $1
+      AND owner_user_id = $2
+      AND status = 'active'
+)`,
+			matterID,
+			actor.UserID,
+		).Scan(&owned); err != nil {
+			return nil, ErrRepository
+		}
+		if !owned {
+			return nil, ErrNotFound
+		}
+	}
+	rows, err := repository.database.Query(ctx, `
+SELECT
+    memories.id::text,
+    memories.owner_user_id::text,
+    memories.memory_type,
+    memories.canonical_key,
+    memories.content,
+    memories.scope_type,
+    coalesce(memories.matter_id::text, ''),
+    memories.status,
+    memories.version,
+    memories.policy_version,
+    memories.expires_at,
+    memories.created_at,
+    memories.updated_at,
+    memories.inactivated_at,
+    1 - (
+        vectors.embedding OPERATOR(public.<=>) $2::public.vector
+    ) AS similarity
+FROM agent_memory_vectors AS vectors
+JOIN agent_memories AS memories
+  ON memories.id = vectors.memory_id
+ AND memories.owner_user_id = vectors.owner_user_id
+ AND memories.version = vectors.memory_version
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.owner_user_id = $1
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > clock_timestamp())
+  AND vectors.provider = $3
+  AND vectors.model = $4
+  AND vectors.dimension = $5
+  AND vectors.embedding_policy_version = $6
+  AND (
+      (memories.scope_type = 'user' AND memories.matter_id IS NULL)
+      OR (
+          $7::uuid IS NOT NULL
+          AND memories.scope_type = 'matter'
+          AND memories.matter_id = $7::uuid
+      )
+  )
+ORDER BY
+    vectors.embedding OPERATOR(public.<=>) $2::public.vector,
+    memories.id
+LIMIT $8`,
+		actor.UserID,
+		vector,
+		configuration.Provider,
+		configuration.Model,
+		configuration.Dimensions,
+		configuration.EmbeddingPolicyVersion,
+		nullableUUID(matterID),
+		configuration.CandidateLimit,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+	candidates := make([]SearchCandidate, 0)
+	for rows.Next() {
+		var candidate SearchCandidate
+		item, scanErr := scanMemoryWithSimilarity(rows, &candidate.Similarity)
+		if scanErr != nil {
+			return nil, ErrRepository
+		}
+		candidate.Memory = item
+		candidates = append(candidates, candidate)
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+	return candidates, nil
+}
+
+func scanMemoryWithSimilarity(
+	row rowScanner,
+	similarity *float64,
+) (Memory, error) {
+	var item Memory
+	var expiresAt pgtypeTimestamptz
+	var inactivatedAt pgtypeTimestamptz
+	if err := row.Scan(
+		&item.ID,
+		&item.OwnerID,
+		&item.Type,
+		&item.CanonicalKey,
+		&item.Content,
+		&item.Scope,
+		&item.MatterID,
+		&item.Status,
+		&item.Version,
+		&item.PolicyVersion,
+		&expiresAt,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+		&inactivatedAt,
+		similarity,
+	); err != nil {
+		return Memory{}, err
+	}
+	assignOptionalMemoryTimes(&item, expiresAt, inactivatedAt)
+	if !item.Valid() {
+		return Memory{}, ErrRepository
+	}
+	return item, nil
+}
+
+// Keep optional timestamp decoding aligned with scanMemory without exposing
+// pgx implementation types in the search contract.
+type pgtypeTimestamptz = pgtype.Timestamptz
+
+func assignOptionalMemoryTimes(
+	item *Memory,
+	expiresAt pgtypeTimestamptz,
+	inactivatedAt pgtypeTimestamptz,
+) {
+	item.CreatedAt = item.CreatedAt.UTC()
+	item.UpdatedAt = item.UpdatedAt.UTC()
+	if expiresAt.Valid {
+		value := expiresAt.Time.UTC()
+		item.ExpiresAt = &value
+	}
+	if inactivatedAt.Valid {
+		value := inactivatedAt.Time.UTC()
+		item.InactivatedAt = &value
+	}
+}

--- a/server/internal/memory/search_test.go
+++ b/server/internal/memory/search_test.go
@@ -1,0 +1,158 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	aifake "github.com/1024XEngineer/XE3-ESL/server/internal/ai/fake"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestSearchServiceReranksDeterministicallyAndEnforcesMatter(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	actor := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	userMemory := validSearchMemory(
+		"10000000-0000-4000-8000-000000000001",
+		TypeInterest,
+		ScopeUser,
+		"",
+		now.Add(-24*time.Hour),
+	)
+	matterMemory := validSearchMemory(
+		"20000000-0000-4000-8000-000000000001",
+		TypeGoal,
+		ScopeMatter,
+		integrationMatterA,
+		now.Add(-7*24*time.Hour),
+	)
+	repository := &fakeSearchRepository{candidates: []SearchCandidate{
+		{Memory: userMemory, Similarity: 0.90},
+		{Memory: matterMemory, Similarity: 0.82},
+	}}
+	service, err := NewSearchService(
+		repository,
+		&aifake.Embedder{Result: validEmbeddingResult()},
+		testSearchConfig(),
+		func() time.Time { return now },
+	)
+	if err != nil {
+		t.Fatalf("NewSearchService: %v", err)
+	}
+	hits, err := service.Search(context.Background(), SearchRequest{
+		Actor:    actor,
+		Query:    "Help with my interview goal",
+		MatterID: integrationMatterA,
+		Limit:    2,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 2 ||
+		hits[0].MemoryID != matterMemory.ID ||
+		hits[0].RetrievalPolicyVersion != "memory-retrieval-v1" {
+		t.Fatalf("hits = %#v", hits)
+	}
+
+	repository.candidates[1].Memory.MatterID = integrationMatterB
+	if _, err := service.Search(context.Background(), SearchRequest{
+		Actor:    actor,
+		Query:    "Help with my interview goal",
+		MatterID: integrationMatterA,
+		Limit:    2,
+	}); err != ErrRepository {
+		t.Fatalf("cross-Matter error = %v", err)
+	}
+}
+
+func TestSearchServiceDistinguishesNoMatchFromDependencyFailure(t *testing.T) {
+	t.Parallel()
+
+	service, err := NewSearchService(
+		&fakeSearchRepository{},
+		&aifake.Embedder{Result: validEmbeddingResult()},
+		testSearchConfig(),
+		time.Now,
+	)
+	if err != nil {
+		t.Fatalf("NewSearchService: %v", err)
+	}
+	request := SearchRequest{
+		Actor: requestcontext.Actor{
+			UserID:    integrationUserA,
+			SessionID: integrationSessionA,
+		},
+		Query: "unrelated query",
+		Limit: 3,
+	}
+	hits, err := service.Search(context.Background(), request)
+	if err != nil || len(hits) != 0 {
+		t.Fatalf("legitimate empty result = %#v, err=%v", hits, err)
+	}
+
+	expected := ErrRepository
+	service.repository = &fakeSearchRepository{err: expected}
+	if _, err := service.Search(
+		context.Background(),
+		request,
+	); err != expected {
+		t.Fatalf("dependency error = %v", err)
+	}
+}
+
+type fakeSearchRepository struct {
+	candidates []SearchCandidate
+	err        error
+}
+
+func (repository *fakeSearchRepository) SearchCandidates(
+	context.Context,
+	requestcontext.Actor,
+	[]float32,
+	string,
+	SearchConfig,
+) ([]SearchCandidate, error) {
+	return repository.candidates, repository.err
+}
+
+func validSearchMemory(
+	id string,
+	memoryType Type,
+	scope ScopeType,
+	matterID string,
+	updatedAt time.Time,
+) Memory {
+	return Memory{
+		ID:            id,
+		OwnerID:       integrationUserA,
+		Type:          memoryType,
+		CanonicalKey:  "goal.current",
+		Content:       "Prepare for product interview",
+		Scope:         scope,
+		MatterID:      matterID,
+		Status:        StatusActive,
+		Version:       1,
+		PolicyVersion: "memory-policy-v1",
+		CreatedAt:     updatedAt.Add(-time.Hour),
+		UpdatedAt:     updatedAt,
+	}
+}
+
+func testSearchConfig() SearchConfig {
+	return SearchConfig{
+		Provider:               "qianwen",
+		Model:                  "text-embedding-v4",
+		Dimensions:             MemoryEmbeddingDimensions,
+		EmbeddingPolicyVersion: "memory-embedding-v1",
+		RetrievalPolicyVersion: "memory-retrieval-v1",
+		CandidateLimit:         20,
+		MinimumSimilarity:      0.25,
+	}
+}

--- a/server/internal/platform/config/embedding.go
+++ b/server/internal/platform/config/embedding.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	EmbeddingProviderQianwen  = "qianwen"
+	defaultEmbeddingTimeout   = 60 * time.Second
+	defaultEmbeddingDimension = 1024
+	memoryEmbeddingDimension  = 1024
+)
+
+type EmbeddingConfig struct {
+	Provider   string
+	BaseURL    string
+	Model      string
+	Dimensions int
+	Timeout    time.Duration
+	APIKey     Secret
+}
+
+func LoadEmbedding() (EmbeddingConfig, error) {
+	provider := strings.ToLower(strings.TrimSpace(
+		os.Getenv("EMBEDDING_PROVIDER"),
+	))
+	if provider == "" {
+		return EmbeddingConfig{}, errors.New("EMBEDDING_PROVIDER is required")
+	}
+	if provider != EmbeddingProviderQianwen {
+		return EmbeddingConfig{}, errors.New(
+			"EMBEDDING_PROVIDER is not supported",
+		)
+	}
+	baseURL := strings.TrimSpace(os.Getenv("QIANWEN_EMBEDDING_BASE_URL"))
+	if baseURL == "" {
+		return EmbeddingConfig{}, errors.New(
+			"QIANWEN_EMBEDDING_BASE_URL is required",
+		)
+	}
+	model := strings.TrimSpace(os.Getenv("QIANWEN_EMBEDDING_MODEL"))
+	if model == "" {
+		return EmbeddingConfig{}, errors.New(
+			"QIANWEN_EMBEDDING_MODEL is required",
+		)
+	}
+	dimensions, err := positiveIntOrDefault(
+		"QIANWEN_EMBEDDING_DIMENSIONS",
+		defaultEmbeddingDimension,
+	)
+	if err != nil {
+		return EmbeddingConfig{}, err
+	}
+	if dimensions != memoryEmbeddingDimension {
+		return EmbeddingConfig{}, fmt.Errorf(
+			"QIANWEN_EMBEDDING_DIMENSIONS must be %d for the current Memory index",
+			memoryEmbeddingDimension,
+		)
+	}
+	timeout, err := durationOrDefault(
+		"QIANWEN_EMBEDDING_TIMEOUT",
+		defaultEmbeddingTimeout,
+	)
+	if err != nil {
+		return EmbeddingConfig{}, err
+	}
+	if timeout <= 0 || timeout > maximumTextTimeout {
+		return EmbeddingConfig{}, fmt.Errorf(
+			"QIANWEN_EMBEDDING_TIMEOUT must be greater than zero and at most %s",
+			maximumTextTimeout,
+		)
+	}
+	apiKey := strings.TrimSpace(os.Getenv("DASHSCOPE_API_KEY"))
+	if apiKey == "" {
+		return EmbeddingConfig{}, errors.New("DASHSCOPE_API_KEY is required")
+	}
+	if strings.IndexFunc(apiKey, func(r rune) bool {
+		return r < 0x21 || r == 0x7f
+	}) >= 0 {
+		return EmbeddingConfig{}, errors.New(
+			"DASHSCOPE_API_KEY contains whitespace or control characters",
+		)
+	}
+	return EmbeddingConfig{
+		Provider:   provider,
+		BaseURL:    baseURL,
+		Model:      model,
+		Dimensions: dimensions,
+		Timeout:    timeout,
+		APIKey:     Secret{value: apiKey},
+	}, nil
+}

--- a/server/internal/platform/config/embedding_test.go
+++ b/server/internal/platform/config/embedding_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestLoadEmbeddingRequiresExplicitProductionConfiguration(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER", "qianwen")
+	t.Setenv(
+		"QIANWEN_EMBEDDING_BASE_URL",
+		"https://dashscope.aliyuncs.com/compatible-mode/v1",
+	)
+	t.Setenv("QIANWEN_EMBEDDING_MODEL", "text-embedding-v4")
+	t.Setenv("QIANWEN_EMBEDDING_DIMENSIONS", "1024")
+	t.Setenv("QIANWEN_EMBEDDING_TIMEOUT", "45s")
+	t.Setenv("DASHSCOPE_API_KEY", "test-secret")
+
+	configuration, err := LoadEmbedding()
+	if err != nil {
+		t.Fatalf("LoadEmbedding: %v", err)
+	}
+	if configuration.Provider != EmbeddingProviderQianwen ||
+		configuration.Model != "text-embedding-v4" ||
+		configuration.Dimensions != 1024 ||
+		configuration.APIKey.Reveal() != "test-secret" {
+		t.Fatalf("configuration = %#v", configuration)
+	}
+
+	t.Setenv("QIANWEN_EMBEDDING_DIMENSIONS", "768")
+	if _, err = LoadEmbedding(); err == nil {
+		t.Fatal("expected schema dimension mismatch")
+	}
+}
+
+func TestLoadEmbeddingRejectsMissingOrUnsupportedProvider(t *testing.T) {
+	t.Setenv("EMBEDDING_PROVIDER", "")
+	if _, err := LoadEmbedding(); err == nil {
+		t.Fatal("expected missing provider error")
+	}
+	t.Setenv("EMBEDDING_PROVIDER", "fake")
+	if _, err := LoadEmbedding(); err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+}

--- a/server/migrations/000019_agent_memory_vector_index.down.sql
+++ b/server/migrations/000019_agent_memory_vector_index.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP TRIGGER agent_memories_enqueue_vector_index ON agent_memories;
+DROP FUNCTION enqueue_agent_memory_index_job();
+DROP TABLE agent_memory_index_jobs;
+DROP TABLE agent_memory_vectors;
+
+COMMIT;

--- a/server/migrations/000019_agent_memory_vector_index.up.sql
+++ b/server/migrations/000019_agent_memory_vector_index.up.sql
@@ -1,0 +1,263 @@
+BEGIN;
+
+-- Production must provide pgvector. A missing extension or insufficient
+-- privileges intentionally fails this migration instead of silently changing
+-- retrieval semantics.
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
+CREATE TABLE agent_memory_vectors (
+    memory_id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    memory_version bigint NOT NULL,
+    provider text COLLATE "C" NOT NULL,
+    model text COLLATE "C" NOT NULL,
+    dimension integer NOT NULL,
+    embedding_policy_version text COLLATE "C" NOT NULL,
+    embedding public.vector(1024) NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT agent_memory_vectors_memory_owner_fkey
+        FOREIGN KEY (memory_id, owner_user_id)
+        REFERENCES agent_memories (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_memory_vectors_memory_version_check
+        CHECK (memory_version > 0),
+    CONSTRAINT agent_memory_vectors_provider_check
+        CHECK (
+            octet_length(provider) BETWEEN 1 AND 64
+            AND provider ~ '^[a-z][a-z0-9_-]{0,63}$'
+        ),
+    CONSTRAINT agent_memory_vectors_model_check
+        CHECK (
+            octet_length(model) BETWEEN 1 AND 128
+            AND model ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        ),
+    CONSTRAINT agent_memory_vectors_dimension_check
+        CHECK (
+            dimension = 1024
+            AND public.vector_dims(embedding) = dimension
+        ),
+    CONSTRAINT agent_memory_vectors_policy_version_check
+        CHECK (
+            octet_length(embedding_policy_version) BETWEEN 1 AND 64
+            AND embedding_policy_version
+                ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+        ),
+    CONSTRAINT agent_memory_vectors_timestamps_check
+        CHECK (updated_at >= created_at)
+);
+
+CREATE INDEX agent_memory_vectors_owner_version_idx
+    ON agent_memory_vectors (
+        owner_user_id,
+        provider,
+        model,
+        dimension,
+        embedding_policy_version,
+        memory_id
+    );
+
+CREATE INDEX agent_memory_vectors_embedding_hnsw_idx
+    ON agent_memory_vectors
+    USING hnsw (embedding public.vector_cosine_ops);
+
+CREATE TABLE agent_memory_index_jobs (
+    memory_id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    memory_version bigint NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+    attempt_count integer NOT NULL DEFAULT 0,
+    lease_token uuid,
+    lease_expires_at timestamptz,
+    next_attempt_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    embedding_policy_version text COLLATE "C",
+    provider text COLLATE "C",
+    model text COLLATE "C",
+    dimension integer,
+    failure_kind text COLLATE "C",
+    input_tokens integer,
+    total_tokens integer,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    completed_at timestamptz,
+    PRIMARY KEY (memory_id, memory_version),
+    CONSTRAINT agent_memory_index_jobs_memory_owner_fkey
+        FOREIGN KEY (memory_id, owner_user_id)
+        REFERENCES agent_memories (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_memory_index_jobs_memory_version_check
+        CHECK (memory_version > 0),
+    CONSTRAINT agent_memory_index_jobs_status_check
+        CHECK (status IN (
+            'pending',
+            'running',
+            'completed',
+            'failed',
+            'discarded'
+        )),
+    CONSTRAINT agent_memory_index_jobs_attempt_check
+        CHECK (attempt_count BETWEEN 0 AND 10),
+    CONSTRAINT agent_memory_index_jobs_policy_check
+        CHECK (
+            embedding_policy_version IS NULL
+            OR (
+                octet_length(embedding_policy_version) BETWEEN 1 AND 64
+                AND embedding_policy_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_provider_check
+        CHECK (
+            provider IS NULL
+            OR (
+                octet_length(provider) BETWEEN 1 AND 64
+                AND provider ~ '^[a-z][a-z0-9_-]{0,63}$'
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_model_check
+        CHECK (
+            model IS NULL
+            OR (
+                octet_length(model) BETWEEN 1 AND 128
+                AND model ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_dimension_check
+        CHECK (dimension IS NULL OR dimension = 1024),
+    CONSTRAINT agent_memory_index_jobs_failure_check
+        CHECK (
+            failure_kind IS NULL
+            OR (
+                octet_length(failure_kind) BETWEEN 1 AND 64
+                AND failure_kind ~ '^[a-z][a-z0-9_]{0,63}$'
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_usage_check
+        CHECK (
+            (input_tokens IS NULL AND total_tokens IS NULL)
+            OR (
+                input_tokens >= 0
+                AND total_tokens >= input_tokens
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_state_check
+        CHECK (
+            (
+                status = 'pending'
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND completed_at IS NULL
+            )
+            OR (
+                status = 'running'
+                AND lease_token IS NOT NULL
+                AND lease_expires_at IS NOT NULL
+                AND completed_at IS NULL
+                AND embedding_policy_version IS NOT NULL
+                AND provider IS NOT NULL
+                AND model IS NOT NULL
+                AND dimension IS NOT NULL
+            )
+            OR (
+                status = 'completed'
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND completed_at IS NOT NULL
+                AND failure_kind IS NULL
+                AND input_tokens IS NOT NULL
+                AND total_tokens IS NOT NULL
+            )
+            OR (
+                status IN ('failed', 'discarded')
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND completed_at IS NOT NULL
+                AND failure_kind IS NOT NULL
+            )
+        ),
+    CONSTRAINT agent_memory_index_jobs_timestamps_check
+        CHECK (
+            updated_at >= created_at
+            AND next_attempt_at >= created_at
+            AND (
+                lease_expires_at IS NULL
+                OR lease_expires_at > updated_at
+            )
+            AND (
+                completed_at IS NULL
+                OR completed_at >= created_at
+            )
+        )
+);
+
+CREATE INDEX agent_memory_index_jobs_claim_idx
+    ON agent_memory_index_jobs (
+        next_attempt_at,
+        created_at,
+        memory_id,
+        memory_version
+    )
+    WHERE status = 'pending';
+
+CREATE UNIQUE INDEX agent_memory_index_jobs_running_lease_idx
+    ON agent_memory_index_jobs (lease_token)
+    WHERE status = 'running';
+
+CREATE INDEX agent_memory_index_jobs_recovery_idx
+    ON agent_memory_index_jobs (
+        lease_expires_at,
+        memory_id,
+        memory_version
+    )
+    WHERE status = 'running';
+
+CREATE INDEX agent_memory_index_jobs_owner_idx
+    ON agent_memory_index_jobs (
+        owner_user_id,
+        created_at DESC,
+        memory_id,
+        memory_version DESC
+    );
+
+CREATE FUNCTION enqueue_agent_memory_index_job()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.status = 'active'
+       AND (
+           TG_OP = 'INSERT'
+           OR OLD.version IS DISTINCT FROM NEW.version
+       )
+    THEN
+        INSERT INTO agent_memory_index_jobs (
+            memory_id,
+            owner_user_id,
+            memory_version,
+            status,
+            attempt_count,
+            next_attempt_at,
+            created_at,
+            updated_at
+        ) VALUES (
+            NEW.id,
+            NEW.owner_user_id,
+            NEW.version,
+            'pending',
+            0,
+            transaction_timestamp(),
+            transaction_timestamp(),
+            transaction_timestamp()
+        )
+        ON CONFLICT (memory_id, memory_version) DO NOTHING;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER agent_memories_enqueue_vector_index
+AFTER INSERT OR UPDATE OF version, status ON agent_memories
+FOR EACH ROW
+EXECUTE FUNCTION enqueue_agent_memory_index_job();
+
+COMMIT;


### PR DESCRIPTION
## 功能描述

- 增加 provider-neutral Embedding Port 与严格的 Qianwen `text-embedding-v4` Adapter；
- 使用 PostgreSQL pgvector 保存 1024 维 Memory 向量，并以版本化索引任务异步维护；
- Memory 新增或内容版本更新时，在同一事务中原子创建唯一 indexing job；
- Worker 支持 claim/lease、过期恢复、stale worker fence、有界重试、failed/discarded 终态；
- 提供可信 Actor 驱动的 owner / Matter 隔离语义检索；
- 对向量候选执行版本化、确定性的 scope/type/recency 重排；
- 合法无匹配返回空集合，Provider、索引或数据库故障显式返回，不提供关键词或 Fake production fallback。

## 实现思路

- `internal/ai` 只暴露批量 Embedding DTO 和稳定错误语义；Qianwen transport 严格校验输入数量、响应数量、顺序、模型、维度、token usage、有限非零向量；
- migration 000019 要求 pgvector 扩展，新增 `agent_memory_vectors`、`agent_memory_index_jobs` 与 Memory trigger；
- 向量只在 memory version、provider/model/dimension 和 embedding policy 全部匹配时参与检索；
- SQL 先按 owner、scope、active、TTL 和当前版本过滤，再计算 cosine similarity；
- Go 层使用稳定 tie-breaker 重排，并返回 Memory/version/scope/score 与所有策略版本；
- production bootstrap 对 Embedding 配置 fail-closed，并启动独立索引 Worker；检索服务已组装但尚不注入 Agent Context。

## 测试方式

```bash
cd server
go test ./...
go vet ./...
```

数据库 CI 额外验证：

- pgvector migration up/status/idempotent up/down-one/re-up；
- Memory create/update 原子入队；
- 索引完成、旧版本不可命中、inactive 不可命中；
- stale lease token 被拒绝；
- owner 与 Matter 隔离；
- 服务 readiness 与 PostgreSQL 重启恢复。

## 范围边界

- 本 PR 不修改 `ContextAssembler` / `ContextManifest`；
- 不实现 Thread Summary；
- 不增加 HTTP API 或 Flutter 页面；
- 不回扫历史对话；
- 不使用 Mem0 代码或运行时。

Closes #153

关联：#65、#144、#146、#150