### PR TITLE
feat(identity): 重建移动端登录注册页风格

### DIFF
--- a/mobile/lib/identity/login_page.dart
+++ b/mobile/lib/identity/login_page.dart
@@ -30,43 +30,46 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return AuthFormScaffold(
       title: '欢迎回来',
-      subtitle: '登录后继续使用 SpeakUp。',
+      subtitle: '继续你的英语表达练习。',
+      switchPrompt: '第一次使用 SpeakUp？',
+      switchActionLabel: '创建账号',
+      onSwitch: widget.state.isSubmitting
+          ? null
+          : widget.controller.showRegister,
       message: widget.state.noticeMessage,
       errorMessage: widget.state.errorMessage,
-      child: Form(
-        key: _formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            AuthEmailField(controller: _emailController),
-            const SizedBox(height: 16),
-            AuthPasswordField(
-              controller: _passwordController,
-              obscureText: _obscurePassword,
-              onToggleVisibility: () =>
-                  setState(() => _obscurePassword = !_obscurePassword),
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: widget.state.isSubmitting ? null : _submit,
-              child: widget.state.isSubmitting
-                  ? const AuthButtonProgress()
-                  : const Text('登录'),
-            ),
-            const SizedBox(height: 12),
-            TextButton(
-              onPressed: widget.state.isSubmitting
-                  ? null
-                  : widget.controller.showRegister,
-              child: const Text('创建账号'),
-            ),
-          ],
+      child: AutofillGroup(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              AuthEmailField(controller: _emailController),
+              const SizedBox(height: 14),
+              AuthPasswordField(
+                controller: _passwordController,
+                obscureText: _obscurePassword,
+                minimumLength: 15,
+                helperText: '15–128 个字符',
+                onToggleVisibility: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 28),
+              AuthPrimaryButton(
+                label: '登录',
+                isSubmitting: widget.state.isSubmitting,
+                onPressed: widget.state.isSubmitting ? null : _submit,
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 
   void _submit() {
+    FocusManager.instance.primaryFocus?.unfocus();
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }
@@ -81,6 +84,9 @@ class AuthFormScaffold extends StatelessWidget {
   const AuthFormScaffold({
     required this.title,
     required this.subtitle,
+    required this.switchPrompt,
+    required this.switchActionLabel,
+    required this.onSwitch,
     required this.child,
     this.message,
     this.errorMessage,
@@ -89,61 +95,284 @@ class AuthFormScaffold extends StatelessWidget {
 
   final String title;
   final String subtitle;
+  final String switchPrompt;
+  final String switchActionLabel;
+  final VoidCallback? onSwitch;
   final String? message;
   final String? errorMessage;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
     return Scaffold(
-      backgroundColor: colors.surface,
+      backgroundColor: AuthPalette.background,
       body: SafeArea(
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 440),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Icon(
-                    Icons.record_voice_over_outlined,
-                    size: 40,
-                    color: colors.primary,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final minHeight = constraints.maxHeight > 48
+                ? constraints.maxHeight - 48
+                : 0.0;
+            return SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              padding: const EdgeInsets.fromLTRB(24, 30, 24, 18),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: minHeight,
+                    maxWidth: 440,
                   ),
-                  const SizedBox(height: 20),
-                  Text(
-                    title,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const Align(
+                        alignment: Alignment.center,
+                        child: AuthWordmark(),
+                      ),
+                      const SizedBox(height: 38),
+                      Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: AuthPalette.ink,
+                          fontSize: 27,
+                          height: 1.1,
+                          letterSpacing: -0.5,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        subtitle,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: AuthPalette.muted,
+                          fontSize: 15,
+                          height: 1.5,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      AuthSwitchPrompt(
+                        prompt: switchPrompt,
+                        actionLabel: switchActionLabel,
+                        onPressed: onSwitch,
+                      ),
+                      if (message != null) ...[
+                        const SizedBox(height: 18),
+                        AuthMessage(message: message!),
+                      ],
+                      if (errorMessage != null) ...[
+                        const SizedBox(height: 18),
+                        AuthMessage(message: errorMessage!, isError: true),
+                      ],
+                      const SizedBox(height: 44),
+                      child,
+                    ],
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    subtitle,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: colors.onSurfaceVariant,
-                    ),
-                  ),
-                  if (message != null) ...[
-                    const SizedBox(height: 20),
-                    AuthMessage(message: message!),
-                  ],
-                  if (errorMessage != null) ...[
-                    const SizedBox(height: 20),
-                    AuthMessage(message: errorMessage!, isError: true),
-                  ],
-                  const SizedBox(height: 28),
-                  child,
-                ],
+                ),
               ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class AuthSwitchPrompt extends StatelessWidget {
+  const AuthSwitchPrompt({
+    required this.prompt,
+    required this.actionLabel,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String prompt;
+  final String actionLabel;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final promptText = Text(
+      prompt,
+      textAlign: TextAlign.center,
+      style: const TextStyle(color: AuthPalette.muted, fontSize: 14),
+    );
+    final action = TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        foregroundColor: AuthPalette.link,
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 7),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        textStyle: const TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          decoration: TextDecoration.underline,
+          decorationThickness: 1,
+        ),
+      ),
+      child: Text(actionLabel),
+    );
+    if (MediaQuery.textScalerOf(context).scale(1) > 1.6) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [promptText, action],
+      );
+    }
+    return Wrap(
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [promptText, action],
+    );
+  }
+}
+
+abstract final class AuthPalette {
+  static const background = Color(0xFFFFFBF6);
+  static const field = Color(0xFFFFFFFF);
+  static const ink = Color(0xFF202628);
+  static const muted = Color(0xFF666D70);
+  static const border = Color(0xFFD9D6D1);
+  static const focusedBorder = Color(0xFF516C74);
+  static const primary = Color(0xFF183F49);
+  static const disabled = Color(0xFFD8D6D2);
+  static const link = Color(0xFF246B87);
+  static const noticeBackground = Color(0xFFEAF3EF);
+  static const noticeForeground = Color(0xFF285443);
+  static const errorBackground = Color(0xFFFFEDE8);
+  static const errorForeground = Color(0xFF8A2D21);
+}
+
+class AuthWordmark extends StatelessWidget {
+  const AuthWordmark({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'SpeakUp',
+      image: true,
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: 1.5,
+        child: ExcludeSemantics(
+          child: SizedBox(
+            height: 30,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                const Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(text: 'speak'),
+                      TextSpan(
+                        text: 'up',
+                        style: TextStyle(
+                          color: AuthPalette.primary,
+                          fontStyle: FontStyle.italic,
+                        ),
+                      ),
+                    ],
+                  ),
+                  style: TextStyle(
+                    color: AuthPalette.ink,
+                    fontSize: 23,
+                    height: 1,
+                    letterSpacing: -1.2,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                Positioned(
+                  right: 1,
+                  bottom: 0,
+                  child: Transform.rotate(
+                    angle: -0.08,
+                    child: Container(
+                      width: 28,
+                      height: 2.5,
+                      decoration: BoxDecoration(
+                        color: AuthPalette.primary,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+InputDecoration authFieldDecoration({
+  required String label,
+  String? helperText,
+  Widget? suffixIcon,
+}) {
+  const borderRadius = BorderRadius.all(Radius.circular(11));
+  return InputDecoration(
+    hintText: label,
+    hintStyle: const TextStyle(color: AuthPalette.muted, fontSize: 16),
+    helperText: helperText,
+    helperStyle: const TextStyle(
+      color: AuthPalette.muted,
+      fontSize: 12,
+      height: 1.3,
+    ),
+    filled: true,
+    fillColor: AuthPalette.field,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+    suffixIcon: suffixIcon,
+    border: const OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: AuthPalette.border),
+    ),
+    enabledBorder: const OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: AuthPalette.border),
+    ),
+    focusedBorder: const OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: AuthPalette.focusedBorder, width: 1.5),
+    ),
+    errorBorder: const OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: AuthPalette.errorForeground),
+    ),
+    focusedErrorBorder: const OutlineInputBorder(
+      borderRadius: borderRadius,
+      borderSide: BorderSide(color: AuthPalette.errorForeground, width: 1.5),
+    ),
+  );
+}
+
+class AuthPrimaryButton extends StatelessWidget {
+  const AuthPrimaryButton({
+    required this.label,
+    required this.isSubmitting,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String label;
+  final bool isSubmitting;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(
+      onPressed: onPressed,
+      style: FilledButton.styleFrom(
+        backgroundColor: AuthPalette.primary,
+        foregroundColor: Colors.white,
+        disabledBackgroundColor: AuthPalette.disabled,
+        disabledForegroundColor: AuthPalette.muted,
+        minimumSize: const Size.fromHeight(54),
+        shape: const StadiumBorder(),
+        elevation: 0,
+        textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+      ),
+      child: isSubmitting ? const AuthButtonProgress() : Text(label),
     );
   }
 }
@@ -161,10 +390,8 @@ class AuthEmailField extends StatelessWidget {
       autofillHints: const [AutofillHints.email],
       autocorrect: false,
       textInputAction: TextInputAction.next,
-      decoration: const InputDecoration(
-        labelText: '邮箱',
-        border: OutlineInputBorder(),
-      ),
+      onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+      decoration: authFieldDecoration(label: '邮箱'),
       validator: (value) {
         if (!isValidIdentityEmailInput(value ?? '')) {
           return '请输入有效的邮箱地址。';
@@ -179,29 +406,40 @@ class AuthPasswordField extends StatelessWidget {
   const AuthPasswordField({
     required this.controller,
     required this.obscureText,
+    required this.minimumLength,
     required this.onToggleVisibility,
+    this.autofillHint = AutofillHints.password,
+    this.helperText,
+    this.onSubmitted,
     super.key,
   });
 
   final TextEditingController controller;
   final bool obscureText;
+  final int minimumLength;
   final VoidCallback onToggleVisibility;
+  final String autofillHint;
+  final String? helperText;
+  final ValueChanged<String>? onSubmitted;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
       obscureText: obscureText,
-      autofillHints: const [AutofillHints.password],
+      autofillHints: [autofillHint],
       enableSuggestions: false,
       autocorrect: false,
-      decoration: InputDecoration(
-        labelText: '密码',
-        helperText: '15–128 个字符',
-        border: const OutlineInputBorder(),
+      textInputAction: TextInputAction.done,
+      onFieldSubmitted: onSubmitted,
+      onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+      decoration: authFieldDecoration(
+        label: '密码',
+        helperText: helperText,
         suffixIcon: IconButton(
           onPressed: onToggleVisibility,
           tooltip: obscureText ? '显示密码' : '隐藏密码',
+          color: AuthPalette.muted,
           icon: Icon(
             obscureText
                 ? Icons.visibility_outlined
@@ -211,8 +449,8 @@ class AuthPasswordField extends StatelessWidget {
       ),
       validator: (value) {
         final length = value?.runes.length ?? 0;
-        if (length < 15 || length > 128) {
-          return '密码长度需为 15–128 个字符。';
+        if (length < minimumLength || length > 128) {
+          return '密码长度需为 $minimumLength–128 个字符。';
         }
         return null;
       },
@@ -227,7 +465,7 @@ class AuthButtonProgress extends StatelessWidget {
   Widget build(BuildContext context) {
     return const SizedBox.square(
       dimension: 20,
-      child: CircularProgressIndicator(strokeWidth: 2),
+      child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
     );
   }
 }
@@ -240,21 +478,24 @@ class AuthMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
     return Semantics(
       liveRegion: true,
       child: Container(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
         decoration: BoxDecoration(
-          color: isError ? colors.errorContainer : colors.secondaryContainer,
-          borderRadius: BorderRadius.circular(12),
+          color: isError
+              ? AuthPalette.errorBackground
+              : AuthPalette.noticeBackground,
+          borderRadius: BorderRadius.circular(10),
         ),
         child: Text(
           message,
           style: TextStyle(
             color: isError
-                ? colors.onErrorContainer
-                : colors.onSecondaryContainer,
+                ? AuthPalette.errorForeground
+                : AuthPalette.noticeForeground,
+            fontSize: 14,
+            height: 1.4,
           ),
         ),
       ),

--- a/mobile/lib/identity/register_page.dart
+++ b/mobile/lib/identity/register_page.dart
@@ -37,55 +37,56 @@ class _RegisterPageState extends State<RegisterPage> {
   Widget build(BuildContext context) {
     return AuthFormScaffold(
       title: '创建账号',
-      subtitle: '使用邮箱和安全密码开始使用 SpeakUp。',
+      subtitle: '从一次更自在的开口开始。',
+      switchPrompt: '已经有账号？',
+      switchActionLabel: '返回登录',
+      onSwitch: widget.state.isSubmitting ? null : widget.controller.showLogin,
       errorMessage: widget.state.errorMessage,
-      child: Form(
-        key: _formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            TextFormField(
-              key: const Key('register-display-name'),
-              controller: _displayNameController,
-              textInputAction: TextInputAction.next,
-              autofillHints: const [AutofillHints.name],
-              decoration: const InputDecoration(
-                labelText: '昵称',
-                hintText: '希望 SpeakUp 如何称呼你',
-                border: OutlineInputBorder(),
+      child: AutofillGroup(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                key: const Key('register-display-name'),
+                controller: _displayNameController,
+                textInputAction: TextInputAction.next,
+                autofillHints: const [AutofillHints.name],
+                textCapitalization: TextCapitalization.words,
+                onTapOutside: (_) =>
+                    FocusManager.instance.primaryFocus?.unfocus(),
+                decoration: authFieldDecoration(label: '昵称'),
+                validator: validateDisplayNameInput,
               ),
-              validator: validateDisplayNameInput,
-            ),
-            const SizedBox(height: 16),
-            AuthEmailField(controller: _emailController),
-            const SizedBox(height: 16),
-            AuthPasswordField(
-              controller: _passwordController,
-              obscureText: _obscurePassword,
-              onToggleVisibility: () =>
-                  setState(() => _obscurePassword = !_obscurePassword),
-            ),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: widget.state.isSubmitting ? null : _submit,
-              child: widget.state.isSubmitting
-                  ? const AuthButtonProgress()
-                  : const Text('创建账号'),
-            ),
-            const SizedBox(height: 12),
-            TextButton(
-              onPressed: widget.state.isSubmitting
-                  ? null
-                  : widget.controller.showLogin,
-              child: const Text('返回登录'),
-            ),
-          ],
+              const SizedBox(height: 14),
+              AuthEmailField(controller: _emailController),
+              const SizedBox(height: 14),
+              AuthPasswordField(
+                controller: _passwordController,
+                obscureText: _obscurePassword,
+                minimumLength: 15,
+                autofillHint: AutofillHints.newPassword,
+                helperText: '15–128 个字符',
+                onToggleVisibility: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 28),
+              AuthPrimaryButton(
+                label: '创建账号',
+                isSubmitting: widget.state.isSubmitting,
+                onPressed: widget.state.isSubmitting ? null : _submit,
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 
   void _submit() {
+    FocusManager.instance.primaryFocus?.unfocus();
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }

--- a/mobile/test/identity/auth_gate_test.dart
+++ b/mobile/test/identity/auth_gate_test.dart
@@ -82,6 +82,33 @@ void main() {
     expect(find.text('欢迎回来'), findsOneWidget);
   });
 
+  testWidgets('signed-out pages expose only supported authentication actions', (
+    tester,
+  ) async {
+    final controller = AuthController(
+      identityClient: GateIdentityClient(user: user),
+      sessionStore: MemorySessionStore(),
+    );
+
+    await tester.pumpWidget(testApp(controller));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('SpeakUp'), findsOneWidget);
+    expect(find.text('Google'), findsNothing);
+    expect(find.text('Facebook'), findsNothing);
+    expect(find.text('Apple'), findsNothing);
+    expect(find.text('忘记密码'), findsNothing);
+    expect(find.text('SSO'), findsNothing);
+    expect(find.widgetWithText(TextButton, '创建账号'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(TextButton, '创建账号'));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('SpeakUp'), findsOneWidget);
+    expect(find.byKey(const Key('register-display-name')), findsOneWidget);
+    expect(find.widgetWithText(TextButton, '返回登录'), findsOneWidget);
+  });
+
   testWidgets('registration returns to login and does not authenticate', (
     tester,
   ) async {
@@ -216,6 +243,40 @@ void main() {
     await tester.ensureVisible(createAccount);
     await tester.pumpAndSettle();
     expect(createAccount.hitTestable(), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('registration remains usable at 320pt with 3x text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    final controller = AuthController(
+      identityClient: GateIdentityClient(user: user),
+      sessionStore: MemorySessionStore(),
+    );
+    await tester.pumpWidget(testApp(controller));
+    await tester.pumpAndSettle();
+    final createAccount = find.widgetWithText(TextButton, '创建账号');
+    await tester.ensureVisible(createAccount);
+    await tester.pumpAndSettle();
+    await tester.tap(createAccount);
+    await tester.pumpAndSettle();
+
+    final displayName = find.byKey(const Key('register-display-name'));
+    await tester.ensureVisible(displayName);
+    await tester.pumpAndSettle();
+    expect(displayName.hitTestable(), findsOneWidget);
+
+    final submit = find.widgetWithText(FilledButton, '创建账号');
+    await tester.ensureVisible(submit);
+    await tester.pumpAndSettle();
+    expect(submit.hitTestable(), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
## 功能描述

重建移动端登录与注册页视觉层级：移除品牌左侧橙色图标，增加 speakup 文字标识，整体下移表单区域，并保留当前真实邮箱认证能力。

## 实现思路

- 使用 Flutter 原生组件实现文字标识，不新增字体或图片依赖。
- 使用暖白背景、单一深青主色、白色输入框和胶囊主按钮。
- 登录与注册共用页面骨架、字段样式和状态反馈。
- 不增加第三方登录、忘记密码等尚未实现的占位入口。
- 增加窄屏、3 倍字体和键盘遮挡回归测试。

## 测试方式

1. `cd mobile && flutter analyze`
2. `cd mobile && flutter test test/identity/auth_gate_test.dart`
3. 在 iPhone 16 Pro Max 模拟器检查登录、注册切换、键盘滚动和提交按钮可达性。

## 相关 Issue / 备注

Closes #159

Depends on #154。当前保持 Draft；#154 合入后重新基于最新 `upstream/dev` 整理，再进入正式 Review。

密码策略变更不在本 PR，见 #164。

## AI 辅助说明

使用 AI 辅助参考 Headspace 的信息层级，并依据项目 `ai-design-smell` 规则检查卡片嵌套、渐变、装饰入口和可访问性。人工确认了最终页面、字段、跳转和模拟器截图。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置