### PR TITLE
fix(identity): 调整登录注册密码长度策略

### DIFF
--- a/api/modules/identity.yaml
+++ b/api/modules/identity.yaml
@@ -293,13 +293,22 @@ components:
       readOnly: true
     Password:
       type: string
-      minLength: 15
+      minLength: 8
       maxLength: 128
       writeOnly: true
       description: |
-        An opaque password string. The service does not trim, case-fold,
-        truncate, or apply Unicode normalization. No character-class
-        composition rule is required.
+        A new opaque password string used during registration. The service
+        does not trim, case-fold, truncate, or apply Unicode normalization.
+        No character-class composition rule is required.
+    LoginPassword:
+      type: string
+      minLength: 1
+      maxLength: 128
+      writeOnly: true
+      description: |
+        An existing opaque password submitted for login. Registration policy
+        is not re-applied during authentication so legacy credentials remain
+        usable. The service never trims, normalizes, or truncates this value.
     User:
       type: object
       additionalProperties: false
@@ -383,7 +392,7 @@ components:
         email:
           $ref: '#/components/schemas/EmailInput'
         password:
-          $ref: '#/components/schemas/Password'
+          $ref: '#/components/schemas/LoginPassword'
     OpaqueSessionToken:
       type: string
       minLength: 6

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -696,8 +696,12 @@ assert.deepEqual(
 assert.equal(updateProfileRequestSchema?.additionalProperties, false);
 const passwordSchema = schemas.Password;
 assert.equal(passwordSchema?.writeOnly, true);
-assert.equal(passwordSchema?.minLength, 15);
+assert.equal(passwordSchema?.minLength, 8);
 assert.equal(passwordSchema?.maxLength, 128);
+const loginPasswordSchema = schemas.LoginPassword;
+assert.equal(loginPasswordSchema?.writeOnly, true);
+assert.equal(loginPasswordSchema?.minLength, 1);
+assert.equal(loginPasswordSchema?.maxLength, 128);
 const emailInputPattern = new RegExp(schemas.EmailInput?.pattern, 'u');
 for (const email of [
   'learner@example.com',

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -29,7 +29,7 @@ void main() {
     const validateAudioMedia = bool.fromEnvironment(
       'SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA',
     );
-    if (email.isEmpty || password.runes.length < 15) {
+    if (email.isEmpty || password.runes.length < 8) {
       fail('A disposable E2E account with a valid password is required.');
     }
     final voiceFixture = _decodeVoiceFixture(voiceWavBase64);

--- a/mobile/lib/identity/auth_controller.dart
+++ b/mobile/lib/identity/auth_controller.dart
@@ -578,7 +578,7 @@ String _registrationMessage(IdentityClientException error) {
   return switch (error.kind) {
     IdentityFailureKind.registrationUnavailable => '无法使用这些信息创建账号。',
     IdentityFailureKind.rateLimited => '尝试次数过多，请稍后重试。',
-    IdentityFailureKind.invalidRequest => '请输入有效邮箱和 15–128 个字符的密码。',
+    IdentityFailureKind.invalidRequest => '请输入有效邮箱和至少 8 个字符的密码。',
     _ => _tryAgainMessage,
   };
 }

--- a/mobile/lib/identity/login_page.dart
+++ b/mobile/lib/identity/login_page.dart
@@ -49,8 +49,7 @@ class _LoginPageState extends State<LoginPage> {
               AuthPasswordField(
                 controller: _passwordController,
                 obscureText: _obscurePassword,
-                minimumLength: 15,
-                helperText: '15–128 个字符',
+                minimumLength: 1,
                 onToggleVisibility: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
                 onSubmitted: (_) => _submit(),
@@ -449,8 +448,14 @@ class AuthPasswordField extends StatelessWidget {
       ),
       validator: (value) {
         final length = value?.runes.length ?? 0;
-        if (length < minimumLength || length > 128) {
-          return '密码长度需为 $minimumLength–128 个字符。';
+        if (length == 0) {
+          return '请输入密码。';
+        }
+        if (length < minimumLength) {
+          return '密码至少需要 $minimumLength 个字符。';
+        }
+        if (length > 128) {
+          return '密码不能超过 128 个字符。';
         }
         return null;
       },

--- a/mobile/lib/identity/register_page.dart
+++ b/mobile/lib/identity/register_page.dart
@@ -65,9 +65,9 @@ class _RegisterPageState extends State<RegisterPage> {
               AuthPasswordField(
                 controller: _passwordController,
                 obscureText: _obscurePassword,
-                minimumLength: 15,
+                minimumLength: 8,
                 autofillHint: AutofillHints.newPassword,
-                helperText: '15–128 个字符',
+                helperText: '至少 8 个字符',
                 onToggleVisibility: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
                 onSubmitted: (_) => _submit(),

--- a/mobile/test/identity/auth_gate_test.dart
+++ b/mobile/test/identity/auth_gate_test.dart
@@ -11,9 +11,9 @@ import 'package:speakup/identity/session_store.dart';
 void main() {
   const user = User(id: 'user-1', email: 'learner@example.com');
 
-  for (final scalarCount in [14, 15, 128, 129]) {
+  for (final scalarCount in [4, 8, 128, 129]) {
     testWidgets(
-      'password validation counts $scalarCount Unicode scalars and preserves input',
+      'login validation accepts $scalarCount Unicode scalars without applying registration minimum',
       (tester) async {
         final client = GateIdentityClient(user: user);
         final controller = AuthController(
@@ -36,13 +36,13 @@ void main() {
         await tester.tap(find.text('登录'));
         await tester.pumpAndSettle();
 
-        if (scalarCount >= 15 && scalarCount <= 128) {
+        if (scalarCount <= 128) {
           expect(client.lastLoginPassword, password);
           expect(client.lastLoginPassword!.codeUnits, password.codeUnits);
-          expect(find.text('密码长度需为 15–128 个字符。'), findsNothing);
+          expect(find.text('密码不能超过 128 个字符。'), findsNothing);
         } else {
           expect(client.lastLoginPassword, isNull);
-          expect(find.text('密码长度需为 15–128 个字符。'), findsOneWidget);
+          expect(find.text('密码不能超过 128 个字符。'), findsOneWidget);
         }
       },
     );
@@ -141,6 +141,47 @@ void main() {
     expect(find.text('账号创建成功，请登录后继续。'), findsOneWidget);
     expect(store.token, isNull);
   });
+
+  for (final scalarCount in [7, 8, 128, 129]) {
+    testWidgets('registration enforces the $scalarCount scalar boundary', (
+      tester,
+    ) async {
+      final client = GateIdentityClient(user: user);
+      final controller = AuthController(
+        identityClient: client,
+        sessionStore: MemorySessionStore(),
+      );
+      final password = scalarPassword(scalarCount);
+
+      await tester.pumpWidget(testApp(controller));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('创建账号'));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const Key('register-display-name')),
+        '小林',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, '邮箱'),
+        'learner@example.com',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, '密码'),
+        password,
+      );
+      await tester.tap(find.widgetWithText(FilledButton, '创建账号'));
+      await tester.pumpAndSettle();
+
+      if (scalarCount >= 8 && scalarCount <= 128) {
+        expect(client.lastRegistrationPassword, password);
+        expect(client.lastRegistrationPassword!.codeUnits, password.codeUnits);
+      } else {
+        expect(client.lastRegistrationPassword, isNull);
+        final message = scalarCount < 8 ? '密码至少需要 8 个字符。' : '密码不能超过 128 个字符。';
+        expect(find.text(message), findsOneWidget);
+      }
+    });
+  }
 
   testWidgets('shows retry without deleting token after a network error', (
     tester,
@@ -325,6 +366,7 @@ final class GateIdentityClient implements IdentityClient {
   final User user;
   IdentityClientException? currentUserError;
   String? lastLoginPassword;
+  String? lastRegistrationPassword;
 
   @override
   Future<User> currentUser({required String sessionToken}) async {
@@ -356,6 +398,7 @@ final class GateIdentityClient implements IdentityClient {
     required String email,
     required String password,
   }) async {
+    lastRegistrationPassword = password;
     return user;
   }
 }

--- a/server/internal/identity/password.go
+++ b/server/internal/identity/password.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	minPasswordCharacters  = 15
+	minPasswordCharacters  = 8
 	maxPasswordCharacters  = 128
 	defaultHashConcurrency = 2
 	defaultHashQueue       = 4
@@ -109,11 +109,19 @@ func NewDefaultArgon2idHasher() (*Argon2idHasher, error) {
 }
 
 func ValidatePassword(password string) error {
+	return validatePasswordLength(password, minPasswordCharacters)
+}
+
+func ValidateLoginPassword(password string) error {
+	return validatePasswordLength(password, 1)
+}
+
+func validatePasswordLength(password string, minimumCharacters int) error {
 	if !utf8.ValidString(password) {
 		return ErrInvalidRequest
 	}
 	characters := utf8.RuneCountInString(password)
-	if characters < minPasswordCharacters || characters > maxPasswordCharacters {
+	if characters < minimumCharacters || characters > maxPasswordCharacters {
 		return ErrInvalidRequest
 	}
 	return nil

--- a/server/internal/identity/password_test.go
+++ b/server/internal/identity/password_test.go
@@ -128,14 +128,26 @@ func TestArgon2idRejectsUnsafeStoredParameters(t *testing.T) {
 }
 
 func TestValidatePasswordUsesCharacterLengthWithoutNormalization(t *testing.T) {
-	if err := ValidatePassword("ééééééééééééééé"); err != nil {
-		t.Fatalf("expected 15-character password to pass: %v", err)
+	if err := ValidatePassword("éééééééé"); err != nil {
+		t.Fatalf("expected 8-character password to pass: %v", err)
 	}
-	if err := ValidatePassword("short password"); err == nil {
-		t.Fatal("expected short password to fail")
+	if err := ValidatePassword("ééééééé"); err == nil {
+		t.Fatal("expected 7-character password to fail")
 	}
 	if err := ValidatePassword(strings.Repeat("a", 129)); err == nil {
 		t.Fatal("expected long password to fail")
+	}
+}
+
+func TestValidateLoginPasswordAcceptsExistingNonEmptyPassword(t *testing.T) {
+	if err := ValidateLoginPassword("x"); err != nil {
+		t.Fatalf("expected non-empty login password to pass: %v", err)
+	}
+	if err := ValidateLoginPassword(""); err == nil {
+		t.Fatal("expected empty login password to fail")
+	}
+	if err := ValidateLoginPassword(strings.Repeat("a", 129)); err == nil {
+		t.Fatal("expected overlong login password to fail")
 	}
 }
 

--- a/server/internal/identity/service.go
+++ b/server/internal/identity/service.go
@@ -147,7 +147,7 @@ func (s *Service) Login(
 	password string,
 ) (LoginResult, error) {
 	canonicalEmail, err := NormalizeEmail(email)
-	if err != nil || ValidatePassword(password) != nil {
+	if err != nil || ValidateLoginPassword(password) != nil {
 		return LoginResult{}, ErrInvalidRequest
 	}
 


### PR DESCRIPTION
## 功能描述

移除登录注册共用的 15 位最低限制：新用户注册改为 8–128 个 Unicode 标量，登录只校验非空和 128 上限，避免旧凭据因新注册规则无法登录。

## 实现思路

- OpenAPI 分离注册密码与登录密码契约。
- 后端分离 `ValidatePassword` 和 `ValidateLoginPassword`。
- Flutter 注册页展示 8 位提示；登录页不展示新密码规则。
- 不增加字符类别组合规则，不修改现有密码哈希。
- 补齐 7/8/128/129 边界和登录兼容测试。

## 测试方式

1. `make check`
2. `go test ./server/internal/identity`
3. `cd mobile && flutter test test/identity/auth_gate_test.dart`
4. 真实后端验证：7 位注册返回 400，8 位注册返回 201，同一账号 8 位密码登录返回 200。

## 相关 Issue / 备注

Closes #164

Depends on #154。当前保持 Draft；#154 合入后重新基于最新 `upstream/dev` 整理，再进入正式 Review。

页面风格变更不在本 PR，见 #159。

## AI 辅助说明

使用 AI 辅助核对 NIST、OWASP 与 Headspace 可见规则，并生成契约、服务端和 Flutter 边界测试。人工确认了产品取舍、真实 HTTP 返回和全部差异。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置