### PR TITLE
[后端] 为 Agent Memory 候选拒绝增加安全诊断日志

### DIFF
--- a/server/cmd/server/memory_extraction.go
+++ b/server/cmd/server/memory_extraction.go
@@ -103,6 +103,15 @@ func (worker *memoryExtractionWorker) sweep(parent context.Context) {
 		ctx,
 		worker.claimLimit,
 	)
+	for _, rejection := range result.Rejections {
+		worker.logger.DebugContext(
+			parent,
+			"memory extraction candidate rejected",
+			slog.String("run_id", rejection.RunID),
+			slog.Int("candidate_index", rejection.CandidateIndex),
+			slog.String("reason", string(rejection.Reason)),
+		)
+	}
 	attributes := []any{
 		slog.Int("claimed", result.Claimed),
 		slog.Int("completed", result.Completed),

--- a/server/cmd/server/memory_extraction_test.go
+++ b/server/cmd/server/memory_extraction_test.go
@@ -85,6 +85,67 @@ func TestMemoryExtractionWorkerStopsWithContext(t *testing.T) {
 	}
 }
 
+func TestMemoryExtractionWorkerLogsSafeCandidateRejection(t *testing.T) {
+	t.Parallel()
+
+	const runID = "a3000000-0000-4000-8000-000000000001"
+	processor := memoryExtractionProcessorFunc(func(
+		context.Context,
+		int,
+	) (memory.ExtractionSweepResult, error) {
+		return memory.ExtractionSweepResult{
+			Claimed:   1,
+			Completed: 1,
+			Rejections: []memory.CandidateRejectionEvent{{
+				RunID:          runID,
+				CandidateIndex: 2,
+				Reason:         memory.RejectionEvidenceMismatch,
+			}},
+		}, nil
+	})
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+	worker, err := newMemoryExtractionWorker(
+		processor,
+		logger,
+		time.Second,
+		time.Second,
+		1,
+		func(context.Context, time.Duration) bool { return false },
+	)
+	if err != nil {
+		t.Fatalf("newMemoryExtractionWorker: %v", err)
+	}
+	worker.Run(context.Background())
+	output := logs.String()
+	for _, want := range []string{
+		`"msg":"memory extraction candidate rejected"`,
+		`"run_id":"` + runID + `"`,
+		`"candidate_index":2`,
+		`"reason":"evidence_mismatch"`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("rejection log missing %q: %s", want, output)
+		}
+	}
+	for _, forbidden := range []string{
+		"Private Name",
+		`"query":`,
+		`"content":`,
+		`"evidence":`,
+		`"canonical_key":`,
+		`"api_key":`,
+		"secret",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("rejection log contains %q: %s", forbidden, output)
+		}
+	}
+}
+
 func TestBuildMemoryExtractionWorkerRequiresDependency(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/memory/extraction.go
+++ b/server/internal/memory/extraction.go
@@ -203,13 +203,14 @@ func (decision MemoryDecision) Valid() bool {
 type ExtractionBatch struct {
 	CandidateCount int
 	Decisions      []MemoryDecision
+	Rejections     []CandidateRejection
 	Source         SourceInput
 }
 
 func (batch ExtractionBatch) Valid() bool {
 	if batch.CandidateCount < 0 ||
 		batch.CandidateCount > maxExtractionCandidates ||
-		len(batch.Decisions) > batch.CandidateCount ||
+		len(batch.Decisions)+len(batch.Rejections) != batch.CandidateCount ||
 		!batch.Source.Valid() {
 		return false
 	}
@@ -218,7 +219,68 @@ func (batch ExtractionBatch) Valid() bool {
 			return false
 		}
 	}
+	seenRejectedIndexes := make(map[int]struct{}, len(batch.Rejections))
+	for _, rejection := range batch.Rejections {
+		if !rejection.Valid() ||
+			rejection.CandidateIndex >= batch.CandidateCount {
+			return false
+		}
+		if _, duplicate := seenRejectedIndexes[rejection.CandidateIndex]; duplicate {
+			return false
+		}
+		seenRejectedIndexes[rejection.CandidateIndex] = struct{}{}
+	}
 	return true
+}
+
+type CandidateRejectionReason string
+
+const (
+	RejectionInvalidAction                CandidateRejectionReason = "invalid_action"
+	RejectionUnsupportedType              CandidateRejectionReason = "unsupported_type"
+	RejectionInvalidCanonicalKey          CandidateRejectionReason = "invalid_canonical_key"
+	RejectionIncompatibleKey              CandidateRejectionReason = "incompatible_key"
+	RejectionEvidenceMismatch             CandidateRejectionReason = "evidence_mismatch"
+	RejectionSensitiveCandidate           CandidateRejectionReason = "sensitive_candidate"
+	RejectionGenderInteractionUseRequired CandidateRejectionReason = "gender_interaction_use_required"
+	RejectionMissingMatter                CandidateRejectionReason = "missing_matter"
+	RejectionInvalidScope                 CandidateRejectionReason = "invalid_scope"
+	RejectionInvalidContent               CandidateRejectionReason = "invalid_content"
+	RejectionInactivateContentNotEmpty    CandidateRejectionReason = "inactivate_content_not_empty"
+	RejectionDuplicateCandidate           CandidateRejectionReason = "duplicate_candidate"
+	RejectionInvalidDecision              CandidateRejectionReason = "invalid_decision"
+)
+
+func (reason CandidateRejectionReason) Valid() bool {
+	switch reason {
+	case RejectionInvalidAction,
+		RejectionUnsupportedType,
+		RejectionInvalidCanonicalKey,
+		RejectionIncompatibleKey,
+		RejectionEvidenceMismatch,
+		RejectionSensitiveCandidate,
+		RejectionGenderInteractionUseRequired,
+		RejectionMissingMatter,
+		RejectionInvalidScope,
+		RejectionInvalidContent,
+		RejectionInactivateContentNotEmpty,
+		RejectionDuplicateCandidate,
+		RejectionInvalidDecision:
+		return true
+	default:
+		return false
+	}
+}
+
+type CandidateRejection struct {
+	CandidateIndex int
+	Reason         CandidateRejectionReason
+}
+
+func (rejection CandidateRejection) Valid() bool {
+	return rejection.CandidateIndex >= 0 &&
+		rejection.CandidateIndex < maxExtractionCandidates &&
+		rejection.Reason.Valid()
 }
 
 type ExtractionRepository interface {
@@ -246,11 +308,26 @@ type ExtractionRepository interface {
 }
 
 type ExtractionSweepResult struct {
-	Claimed   int
-	Completed int
-	Retried   int
-	Failed    int
-	Discarded int
+	Claimed    int
+	Completed  int
+	Retried    int
+	Failed     int
+	Discarded  int
+	Rejections []CandidateRejectionEvent
+}
+
+type CandidateRejectionEvent struct {
+	RunID          string
+	CandidateIndex int
+	Reason         CandidateRejectionReason
+}
+
+func (event CandidateRejectionEvent) Valid() bool {
+	return validUUID(event.RunID) &&
+		CandidateRejection{
+			CandidateIndex: event.CandidateIndex,
+			Reason:         event.Reason,
+		}.Valid()
 }
 
 type ExtractionProcessor interface {

--- a/server/internal/memory/extraction_policy.go
+++ b/server/internal/memory/extraction_policy.go
@@ -48,15 +48,24 @@ func (policy *ExtractionPolicy) Decide(
 		return ExtractionBatch{}, ErrInvalidArgument
 	}
 	decisions := make([]MemoryDecision, 0, len(output.Candidates))
+	rejections := make([]CandidateRejection, 0, len(output.Candidates))
 	seen := make(map[string]struct{})
-	for _, candidate := range output.Candidates {
-		decision, accepted := policy.decideCandidate(source, candidate)
-		if !accepted {
+	for index, candidate := range output.Candidates {
+		decision, rejectionReason := policy.decideCandidate(source, candidate)
+		if rejectionReason != "" {
+			rejections = append(rejections, CandidateRejection{
+				CandidateIndex: index,
+				Reason:         rejectionReason,
+			})
 			continue
 		}
 		key := string(decision.Scope) + ":" + decision.MatterID + ":" +
 			string(decision.Type) + ":" + decision.CanonicalKey
 		if _, duplicate := seen[key]; duplicate {
+			rejections = append(rejections, CandidateRejection{
+				CandidateIndex: index,
+				Reason:         RejectionDuplicateCandidate,
+			})
 			continue
 		}
 		seen[key] = struct{}{}
@@ -65,6 +74,7 @@ func (policy *ExtractionPolicy) Decide(
 	return ExtractionBatch{
 		CandidateCount: len(output.Candidates),
 		Decisions:      decisions,
+		Rejections:     rejections,
 		Source: SourceInput{
 			Type:     SourceAgentRun,
 			SourceID: source.RunID,
@@ -77,32 +87,38 @@ func (policy *ExtractionPolicy) Decide(
 func (policy *ExtractionPolicy) decideCandidate(
 	source CompletedRunSource,
 	candidate ExtractedCandidate,
-) (MemoryDecision, bool) {
+) (MemoryDecision, CandidateRejectionReason) {
 	if !candidate.Action.Valid() {
-		return MemoryDecision{}, false
+		return MemoryDecision{}, RejectionInvalidAction
 	}
 	if _, allowed := conversationalTypes[candidate.Type]; !allowed {
-		return MemoryDecision{}, false
+		return MemoryDecision{}, RejectionUnsupportedType
 	}
-	if !validCanonicalKey(candidate.CanonicalKey) ||
-		!compatibleKey(candidate.Type, candidate.CanonicalKey) ||
-		!strings.Contains(source.UserText, candidate.Evidence) ||
-		sensitiveCandidate(candidate) {
-		return MemoryDecision{}, false
+	if !validCanonicalKey(candidate.CanonicalKey) {
+		return MemoryDecision{}, RejectionInvalidCanonicalKey
+	}
+	if !compatibleKey(candidate.Type, candidate.CanonicalKey) {
+		return MemoryDecision{}, RejectionIncompatibleKey
+	}
+	if !strings.Contains(source.UserText, candidate.Evidence) {
+		return MemoryDecision{}, RejectionEvidenceMismatch
+	}
+	if sensitiveCandidate(candidate) {
+		return MemoryDecision{}, RejectionSensitiveCandidate
 	}
 	if candidate.Type == TypeIdentity &&
 		candidate.CanonicalKey == "identity.gender" &&
 		!candidate.InteractionUse {
-		return MemoryDecision{}, false
+		return MemoryDecision{}, RejectionGenderInteractionUseRequired
 	}
 	matterID := ""
 	if candidate.Scope == ScopeMatter {
 		if source.MatterID == "" {
-			return MemoryDecision{}, false
+			return MemoryDecision{}, RejectionMissingMatter
 		}
 		matterID = source.MatterID
 	} else if candidate.Scope != ScopeUser {
-		return MemoryDecision{}, false
+		return MemoryDecision{}, RejectionInvalidScope
 	}
 	decision := MemoryDecision{
 		Action:       candidate.Action,
@@ -113,7 +129,7 @@ func (policy *ExtractionPolicy) decideCandidate(
 	}
 	if candidate.Action == CandidateUpsert {
 		if !validContent(candidate.Content) {
-			return MemoryDecision{}, false
+			return MemoryDecision{}, RejectionInvalidContent
 		}
 		decision.Content = candidate.Content
 		if candidate.Type == TypeTopic {
@@ -121,9 +137,12 @@ func (policy *ExtractionPolicy) decideCandidate(
 			decision.ExpiresAt = &expiresAt
 		}
 	} else if strings.TrimSpace(candidate.Content) != "" {
-		return MemoryDecision{}, false
+		return MemoryDecision{}, RejectionInactivateContentNotEmpty
 	}
-	return decision, decision.Valid()
+	if !decision.Valid() {
+		return MemoryDecision{}, RejectionInvalidDecision
+	}
+	return decision, ""
 }
 
 func compatibleKey(memoryType Type, key string) bool {

--- a/server/internal/memory/extraction_policy_test.go
+++ b/server/internal/memory/extraction_policy_test.go
@@ -68,6 +68,17 @@ func TestExtractionPolicyAcceptsOnlyExplicitSupportedFacts(t *testing.T) {
 	if batch.CandidateCount != 5 || len(batch.Decisions) != 3 {
 		t.Fatalf("batch = %#v", batch)
 	}
+	wantRejections := []CandidateRejection{
+		{CandidateIndex: 3, Reason: RejectionUnsupportedType},
+		{CandidateIndex: 4, Reason: RejectionEvidenceMismatch},
+	}
+	if !equalCandidateRejections(batch.Rejections, wantRejections) {
+		t.Fatalf(
+			"rejections = %#v, want %#v",
+			batch.Rejections,
+			wantRejections,
+		)
+	}
 	topic := batch.Decisions[2]
 	if topic.Type != TypeTopic ||
 		topic.ExpiresAt == nil ||
@@ -129,6 +140,20 @@ func TestExtractionPolicyRequiresMatterAndGenderUse(t *testing.T) {
 		batch.Decisions[0].CanonicalKey != "identity.gender" {
 		t.Fatalf("decisions = %#v", batch.Decisions)
 	}
+	wantRejections := []CandidateRejection{
+		{
+			CandidateIndex: 0,
+			Reason:         RejectionGenderInteractionUseRequired,
+		},
+		{CandidateIndex: 2, Reason: RejectionMissingMatter},
+	}
+	if !equalCandidateRejections(batch.Rejections, wantRejections) {
+		t.Fatalf(
+			"rejections = %#v, want %#v",
+			batch.Rejections,
+			wantRejections,
+		)
+	}
 }
 
 func TestExtractionPolicyRejectsSensitiveEvidence(t *testing.T) {
@@ -160,6 +185,189 @@ func TestExtractionPolicyRejectsSensitiveEvidence(t *testing.T) {
 	if len(batch.Decisions) != 0 {
 		t.Fatalf("sensitive evidence decisions = %#v", batch.Decisions)
 	}
+	if !equalCandidateRejections(
+		batch.Rejections,
+		[]CandidateRejection{{
+			CandidateIndex: 0,
+			Reason:         RejectionSensitiveCandidate,
+		}},
+	) {
+		t.Fatalf("sensitive evidence rejections = %#v", batch.Rejections)
+	}
+}
+
+func TestExtractionPolicyClassifiesEveryCandidateRejection(t *testing.T) {
+	t.Parallel()
+
+	policy, err := NewExtractionPolicy(
+		"memory-policy-v1",
+		30*24*time.Hour,
+		time.Now,
+	)
+	if err != nil {
+		t.Fatalf("NewExtractionPolicy: %v", err)
+	}
+	baseSource := validCompletedRunSource()
+	baseSource.MatterID = ""
+	baseSource.UserText = "Call me Alex."
+	baseCandidate := ExtractedCandidate{
+		Action:       CandidateUpsert,
+		Type:         TypeIdentity,
+		CanonicalKey: "identity.preferred_name",
+		Content:      "Alex",
+		Scope:        ScopeUser,
+		Evidence:     "Call me Alex",
+	}
+	tests := map[string]struct {
+		candidate ExtractedCandidate
+		want      CandidateRejectionReason
+	}{
+		"invalid action": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Action = CandidateAction("replace")
+				return item
+			}(),
+			want: RejectionInvalidAction,
+		},
+		"unsupported type": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Type = TypeWeakness
+				item.CanonicalKey = "weakness.name"
+				return item
+			}(),
+			want: RejectionUnsupportedType,
+		},
+		"invalid canonical key": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.CanonicalKey = "Identity.Name"
+				return item
+			}(),
+			want: RejectionInvalidCanonicalKey,
+		},
+		"incompatible key": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Type = TypeProfile
+				return item
+			}(),
+			want: RejectionIncompatibleKey,
+		},
+		"evidence mismatch": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Evidence = "My name is Alex"
+				return item
+			}(),
+			want: RejectionEvidenceMismatch,
+		},
+		"sensitive candidate": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Content = "secret"
+				return item
+			}(),
+			want: RejectionSensitiveCandidate,
+		},
+		"gender requires interaction use": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.CanonicalKey = "identity.gender"
+				return item
+			}(),
+			want: RejectionGenderInteractionUseRequired,
+		},
+		"missing Matter": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Scope = ScopeMatter
+				return item
+			}(),
+			want: RejectionMissingMatter,
+		},
+		"invalid scope": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Scope = ScopeType("thread")
+				return item
+			}(),
+			want: RejectionInvalidScope,
+		},
+		"invalid content": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Content = " Alex "
+				return item
+			}(),
+			want: RejectionInvalidContent,
+		},
+		"inactivate content not empty": {
+			candidate: func() ExtractedCandidate {
+				item := baseCandidate
+				item.Action = CandidateInactivate
+				return item
+			}(),
+			want: RejectionInactivateContentNotEmpty,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			batch, decideErr := policy.Decide(
+				baseSource,
+				ExtractionOutput{
+					Candidates: []ExtractedCandidate{test.candidate},
+				},
+			)
+			if decideErr != nil {
+				t.Fatalf("Decide: %v", decideErr)
+			}
+			want := []CandidateRejection{{
+				CandidateIndex: 0,
+				Reason:         test.want,
+			}}
+			if !equalCandidateRejections(batch.Rejections, want) {
+				t.Fatalf(
+					"rejections = %#v, want %#v",
+					batch.Rejections,
+					want,
+				)
+			}
+		})
+	}
+
+	duplicates, err := policy.Decide(baseSource, ExtractionOutput{
+		Candidates: []ExtractedCandidate{baseCandidate, baseCandidate},
+	})
+	if err != nil {
+		t.Fatalf("Decide duplicates: %v", err)
+	}
+	if len(duplicates.Decisions) != 1 ||
+		!equalCandidateRejections(
+			duplicates.Rejections,
+			[]CandidateRejection{{
+				CandidateIndex: 1,
+				Reason:         RejectionDuplicateCandidate,
+			}},
+		) {
+		t.Fatalf("duplicate batch = %#v", duplicates)
+	}
+}
+
+func equalCandidateRejections(
+	got []CandidateRejection,
+	want []CandidateRejection,
+) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func validCompletedRunSource() CompletedRunSource {

--- a/server/internal/memory/extraction_worker.go
+++ b/server/internal/memory/extraction_worker.go
@@ -63,7 +63,8 @@ func (worker *Worker) ProcessPending(
 			return result, nil
 		}
 		result.Claimed++
-		outcome, err := worker.processClaim(ctx, claim)
+		outcome, rejections, err := worker.processClaim(ctx, claim)
+		result.Rejections = append(result.Rejections, rejections...)
 		if err != nil {
 			return result, err
 		}
@@ -86,29 +87,33 @@ func (worker *Worker) ProcessPending(
 func (worker *Worker) processClaim(
 	ctx context.Context,
 	claim ExtractionClaim,
-) (ExtractionStatus, error) {
+) (ExtractionStatus, []CandidateRejectionEvent, error) {
 	source, err := worker.sources.ReadCompletedRun(
 		ctx,
 		claim.OwnerID,
 		claim.RunID,
 	)
 	if err != nil {
-		return worker.recordFailure(ctx, claim, err)
+		status, failureErr := worker.recordFailure(ctx, claim, err)
+		return status, nil, failureErr
 	}
 	if !sourceMatchesClaim(source, claim) {
-		return worker.recordFailure(
+		status, failureErr := worker.recordFailure(
 			ctx,
 			claim,
 			ErrExtractionResponse,
 		)
+		return status, nil, failureErr
 	}
 	output, err := worker.extractor.Extract(ctx, source)
 	if err != nil {
-		return worker.recordFailure(ctx, claim, err)
+		status, failureErr := worker.recordFailure(ctx, claim, err)
+		return status, nil, failureErr
 	}
 	batch, err := worker.policy.Decide(source, output)
 	if err != nil {
-		return worker.recordFailure(ctx, claim, err)
+		status, failureErr := worker.recordFailure(ctx, claim, err)
+		return status, nil, failureErr
 	}
 	_, err = worker.repository.CompleteExtraction(ctx, claim, batch)
 	if errors.Is(err, ErrAccountDeleted) {
@@ -118,14 +123,30 @@ func (worker *Worker) processClaim(
 			"account_deleted",
 		)
 		if discardErr != nil {
-			return "", discardErr
+			return "", nil, discardErr
 		}
-		return job.Status, nil
+		return job.Status, nil, nil
 	}
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return ExtractionCompleted, nil
+	rejections := make(
+		[]CandidateRejectionEvent,
+		0,
+		len(batch.Rejections),
+	)
+	for _, rejection := range batch.Rejections {
+		event := CandidateRejectionEvent{
+			RunID:          claim.RunID,
+			CandidateIndex: rejection.CandidateIndex,
+			Reason:         rejection.Reason,
+		}
+		if !event.Valid() {
+			return "", nil, ErrRepository
+		}
+		rejections = append(rejections, event)
+	}
+	return ExtractionCompleted, rejections, nil
 }
 
 func (worker *Worker) recordFailure(

--- a/server/internal/memory/extraction_worker_test.go
+++ b/server/internal/memory/extraction_worker_test.go
@@ -50,6 +50,60 @@ func TestWorkerCompletesAndClassifiesFailures(t *testing.T) {
 	}
 }
 
+func TestWorkerReportsOnlySafePolicyRejectionMetadata(t *testing.T) {
+	t.Parallel()
+
+	source := validCompletedRunSource()
+	source.UserText = "Call me Private Name."
+	claim := validExtractionClaim(source)
+	repository := &fakeExtractionRepository{
+		claims: []ExtractionClaim{claim},
+	}
+	extractor := &fakeCandidateExtractor{
+		output: ExtractionOutput{Candidates: []ExtractedCandidate{{
+			Action:       CandidateUpsert,
+			Type:         TypeIdentity,
+			CanonicalKey: "Private Name",
+			Content:      "Private Name",
+			Scope:        ScopeUser,
+			Evidence:     "Call me Private Name",
+		}}},
+	}
+	policy, _ := NewExtractionPolicy(
+		"memory-policy-v1",
+		testExtractionConfig().TopicTTL,
+		func() time.Time { return source.CompletedAt },
+	)
+	worker, err := NewWorker(
+		repository,
+		fakeCompletedRunReader{source: source},
+		extractor,
+		policy,
+		testExtractionConfig(),
+	)
+	if err != nil {
+		t.Fatalf("NewWorker: %v", err)
+	}
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	want := CandidateRejectionEvent{
+		RunID:          claim.RunID,
+		CandidateIndex: 0,
+		Reason:         RejectionInvalidCanonicalKey,
+	}
+	if len(result.Rejections) != 1 ||
+		result.Rejections[0] != want {
+		t.Fatalf("rejections = %#v, want %#v", result.Rejections, want)
+	}
+	if len(repository.completed) != 1 ||
+		repository.completed[0].CandidateCount != 1 ||
+		len(repository.completed[0].Decisions) != 0 {
+		t.Fatalf("completed batches = %#v", repository.completed)
+	}
+}
+
 func TestWorkerRetriesProviderFailureAndDiscardsMissingSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 功能描述

为 Agent Memory 候选策略拒绝增加稳定、隐私安全的诊断 reason，并在后台 extraction sweep 中输出 Debug 级结构化日志。

Closes #167

## 实现思路

- ExtractionPolicy 为每个策略拒绝或去重舍弃的候选生成稳定 reason code；
- ExtractionBatch 保持 candidate/decision/rejection 数量守恒，不改变原有数据库 applied/rejected 统计；
- Memory Worker 只向服务层传递 run_id、candidate_index 和 reason；
- 服务日志不接收或输出 query、用户消息、content、evidence、canonical key、Embedding payload 或密钥；
- 增加所有拒绝分支、Worker 安全投影和日志隐私测试。

## 可复现测试

```shell
cd server
go test ./internal/memory/... ./cmd/server/...
go test ./...
go vet ./...
```

PostgreSQL/pgvector 隔离集成验证：

```shell
cd server
TEST_DATABASE_URL="$DATABASE_URL" go test ./internal/memory/... ./cmd/server/...
```

以上命令均已在本地通过。