### PR TITLE
[后端] 事件驱动唤醒 Agent Memory 提取与索引 Worker

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -150,6 +150,8 @@ func run() int {
 		)
 		return 1
 	}
+	memoryExtractionWakeup := newMemoryWorkerWakeup()
+	memoryIndexWakeup := newMemoryWorkerWakeup()
 
 	var recordingStore objectstore.Store
 	if storageConfig.Enabled {
@@ -167,7 +169,7 @@ func run() int {
 	}
 
 	applicationComposition, err :=
-		bootstrap.NewIdentityAgentAndPracticeComposition(
+		bootstrap.NewIdentityAgentAndPracticeCompositionWithMemoryWakeup(
 			ctx,
 			databasePool.Native(),
 			cfg.TrustedProxyCIDRs,
@@ -181,6 +183,7 @@ func run() int {
 			},
 			memoryIndexComposition.Searcher(),
 			preparationCatalog,
+			memoryExtractionWakeup,
 			bootstrap.VoiceConfiguration{
 				Recognizer:                recognizer,
 				Synthesizer:               synthesizer,
@@ -225,6 +228,8 @@ func run() int {
 	memoryExtraction, err := buildMemoryExtractionWorker(
 		applicationComposition.MemoryExtractionProcessor(),
 		logger,
+		memoryExtractionWakeup.Events(),
+		memoryIndexWakeup,
 	)
 	if err != nil {
 		logger.Error(
@@ -236,6 +241,7 @@ func run() int {
 	memoryIndex, err := buildMemoryIndexWorker(
 		memoryIndexComposition.Processor(),
 		logger,
+		memoryIndexWakeup.Events(),
 	)
 	if err != nil {
 		logger.Error(

--- a/server/cmd/server/memory_extraction.go
+++ b/server/cmd/server/memory_extraction.go
@@ -27,7 +27,11 @@ type memoryExtractionProcessor interface {
 	) (memory.ExtractionSweepResult, error)
 }
 
-type memoryExtractionWaiter func(context.Context, time.Duration) bool
+type memoryExtractionWaiter func(
+	context.Context,
+	time.Duration,
+	<-chan struct{},
+) bool
 
 type memoryExtractionWorker struct {
 	processor    memoryExtractionProcessor
@@ -35,12 +39,16 @@ type memoryExtractionWorker struct {
 	interval     time.Duration
 	sweepTimeout time.Duration
 	claimLimit   int
+	wakeup       <-chan struct{}
+	indexWakeup  interface{ Notify() }
 	wait         memoryExtractionWaiter
 }
 
 func buildMemoryExtractionWorker(
 	processor memoryExtractionProcessor,
 	logger *slog.Logger,
+	wakeup <-chan struct{},
+	indexWakeup interface{ Notify() },
 ) (*memoryExtractionWorker, error) {
 	return newMemoryExtractionWorker(
 		processor,
@@ -48,7 +56,9 @@ func buildMemoryExtractionWorker(
 		memoryExtractionInterval,
 		memoryExtractionSweepTimeout,
 		memoryExtractionClaimLimit,
-		waitForMemoryExtraction,
+		wakeup,
+		indexWakeup,
+		waitForMemoryWork,
 	)
 }
 
@@ -58,6 +68,8 @@ func newMemoryExtractionWorker(
 	interval time.Duration,
 	sweepTimeout time.Duration,
 	claimLimit int,
+	wakeup <-chan struct{},
+	indexWakeup interface{ Notify() },
 	wait memoryExtractionWaiter,
 ) (*memoryExtractionWorker, error) {
 	if nilMemoryExtractionDependency(processor) ||
@@ -76,6 +88,8 @@ func newMemoryExtractionWorker(
 		interval:     interval,
 		sweepTimeout: sweepTimeout,
 		claimLimit:   claimLimit,
+		wakeup:       wakeup,
+		indexWakeup:  indexWakeup,
 		wait:         wait,
 	}, nil
 }
@@ -88,14 +102,16 @@ func (worker *memoryExtractionWorker) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		worker.sweep(ctx)
-		if !worker.wait(ctx, worker.interval) {
+		if worker.sweep(ctx) {
+			continue
+		}
+		if !worker.wait(ctx, worker.interval, worker.wakeup) {
 			return
 		}
 	}
 }
 
-func (worker *memoryExtractionWorker) sweep(parent context.Context) {
+func (worker *memoryExtractionWorker) sweep(parent context.Context) bool {
 	startedAt := time.Now()
 	ctx, cancel := context.WithTimeout(parent, worker.sweepTimeout)
 	defer cancel()
@@ -103,6 +119,9 @@ func (worker *memoryExtractionWorker) sweep(parent context.Context) {
 		ctx,
 		worker.claimLimit,
 	)
+	if result.Completed > 0 && worker.indexWakeup != nil {
+		worker.indexWakeup.Notify()
+	}
 	for _, rejection := range result.Rejections {
 		worker.logger.DebugContext(
 			parent,
@@ -133,7 +152,7 @@ func (worker *memoryExtractionWorker) sweep(parent context.Context) {
 			"memory extraction sweep failed",
 			attributes...,
 		)
-		return
+		return false
 	}
 	if result.Failed > 0 || result.Discarded > 0 {
 		worker.logger.WarnContext(
@@ -141,27 +160,14 @@ func (worker *memoryExtractionWorker) sweep(parent context.Context) {
 			"memory extraction sweep completed with terminal jobs",
 			attributes...,
 		)
-		return
+		return result.Claimed == worker.claimLimit
 	}
 	worker.logger.InfoContext(
 		parent,
 		"memory extraction sweep completed",
 		attributes...,
 	)
-}
-
-func waitForMemoryExtraction(
-	ctx context.Context,
-	interval time.Duration,
-) bool {
-	timer := time.NewTimer(interval)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
+	return result.Claimed == worker.claimLimit
 }
 
 func memoryExtractionErrorKind(err error) string {

--- a/server/cmd/server/memory_extraction_test.go
+++ b/server/cmd/server/memory_extraction_test.go
@@ -33,8 +33,12 @@ func TestMemoryExtractionWorkerRunsImmediatelyAndSanitizesErrors(
 		logger,
 		time.Second,
 		time.Second,
-		1,
-		func(context.Context, time.Duration) bool { return false },
+		2,
+		nil,
+		nil,
+		func(context.Context, time.Duration, <-chan struct{}) bool {
+			return false
+		},
 	)
 	if err != nil {
 		t.Fatalf("newMemoryExtractionWorker: %v", err)
@@ -68,7 +72,9 @@ func TestMemoryExtractionWorkerStopsWithContext(t *testing.T) {
 		time.Second,
 		time.Second,
 		1,
-		waitForMemoryExtraction,
+		nil,
+		nil,
+		waitForMemoryWork,
 	)
 	if err != nil {
 		t.Fatalf("newMemoryExtractionWorker: %v", err)
@@ -113,8 +119,12 @@ func TestMemoryExtractionWorkerLogsSafeCandidateRejection(t *testing.T) {
 		logger,
 		time.Second,
 		time.Second,
-		1,
-		func(context.Context, time.Duration) bool { return false },
+		2,
+		nil,
+		nil,
+		func(context.Context, time.Duration, <-chan struct{}) bool {
+			return false
+		},
 	)
 	if err != nil {
 		t.Fatalf("newMemoryExtractionWorker: %v", err)
@@ -152,6 +162,8 @@ func TestBuildMemoryExtractionWorkerRequiresDependency(t *testing.T) {
 	if _, err := buildMemoryExtractionWorker(
 		nil,
 		slog.Default(),
+		nil,
+		nil,
 	); !errors.Is(err, errMemoryExtractionDependency) {
 		t.Fatalf("build error = %v", err)
 	}

--- a/server/cmd/server/memory_index.go
+++ b/server/cmd/server/memory_index.go
@@ -33,21 +33,48 @@ type memoryIndexWorker struct {
 	interval     time.Duration
 	sweepTimeout time.Duration
 	claimLimit   int
+	wakeup       <-chan struct{}
 }
 
 func buildMemoryIndexWorker(
 	processor memoryIndexProcessor,
 	logger *slog.Logger,
+	wakeup <-chan struct{},
 ) (*memoryIndexWorker, error) {
-	if nilMemoryIndexDependency(processor) || logger == nil {
+	return newMemoryIndexWorker(
+		processor,
+		logger,
+		memoryIndexInterval,
+		memoryIndexSweepTimeout,
+		memoryIndexClaimLimit,
+		wakeup,
+	)
+}
+
+func newMemoryIndexWorker(
+	processor memoryIndexProcessor,
+	logger *slog.Logger,
+	interval time.Duration,
+	sweepTimeout time.Duration,
+	claimLimit int,
+	wakeup <-chan struct{},
+) (*memoryIndexWorker, error) {
+	if nilMemoryIndexDependency(processor) ||
+		logger == nil ||
+		interval <= 0 ||
+		sweepTimeout <= 0 ||
+		sweepTimeout > 5*time.Minute ||
+		claimLimit < 1 ||
+		claimLimit > 20 {
 		return nil, errMemoryIndexDependency
 	}
 	return &memoryIndexWorker{
 		processor:    processor,
 		logger:       logger,
-		interval:     memoryIndexInterval,
-		sweepTimeout: memoryIndexSweepTimeout,
-		claimLimit:   memoryIndexClaimLimit,
+		interval:     interval,
+		sweepTimeout: sweepTimeout,
+		claimLimit:   claimLimit,
+		wakeup:       wakeup,
 	}, nil
 }
 
@@ -59,14 +86,16 @@ func (worker *memoryIndexWorker) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		worker.sweep(ctx)
-		if !waitForMemoryExtraction(ctx, worker.interval) {
+		if worker.sweep(ctx) {
+			continue
+		}
+		if !waitForMemoryWork(ctx, worker.interval, worker.wakeup) {
 			return
 		}
 	}
 }
 
-func (worker *memoryIndexWorker) sweep(parent context.Context) {
+func (worker *memoryIndexWorker) sweep(parent context.Context) bool {
 	startedAt := time.Now()
 	ctx, cancel := context.WithTimeout(parent, worker.sweepTimeout)
 	defer cancel()
@@ -92,7 +121,7 @@ func (worker *memoryIndexWorker) sweep(parent context.Context) {
 			"memory index sweep failed",
 			attributes...,
 		)
-		return
+		return false
 	}
 	if result.Failed > 0 || result.Discarded > 0 {
 		worker.logger.WarnContext(
@@ -100,13 +129,14 @@ func (worker *memoryIndexWorker) sweep(parent context.Context) {
 			"memory index sweep completed with terminal jobs",
 			attributes...,
 		)
-		return
+		return result.Claimed == worker.claimLimit
 	}
 	worker.logger.InfoContext(
 		parent,
 		"memory index sweep completed",
 		attributes...,
 	)
+	return result.Claimed == worker.claimLimit
 }
 
 func memoryIndexErrorKind(err error) string {

--- a/server/cmd/server/memory_wakeup.go
+++ b/server/cmd/server/memory_wakeup.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// memoryWorkerWakeup is an edge-triggered hint only. The database remains the
+// source of truth, so concurrent hints may be safely coalesced.
+type memoryWorkerWakeup struct {
+	events chan struct{}
+}
+
+func newMemoryWorkerWakeup() *memoryWorkerWakeup {
+	return &memoryWorkerWakeup{events: make(chan struct{}, 1)}
+}
+
+func (wakeup *memoryWorkerWakeup) Notify() {
+	if wakeup == nil {
+		return
+	}
+	select {
+	case wakeup.events <- struct{}{}:
+	default:
+	}
+}
+
+func (wakeup *memoryWorkerWakeup) Events() <-chan struct{} {
+	if wakeup == nil {
+		return nil
+	}
+	return wakeup.events
+}
+
+func waitForMemoryWork(
+	ctx context.Context,
+	interval time.Duration,
+	wakeup <-chan struct{},
+) bool {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	case <-wakeup:
+		return true
+	}
+}

--- a/server/cmd/server/memory_wakeup_test.go
+++ b/server/cmd/server/memory_wakeup_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+)
+
+func TestMemoryWorkerWakeupCoalescesWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	wakeup := newMemoryWorkerWakeup()
+	var senders sync.WaitGroup
+	for range 100 {
+		senders.Add(1)
+		go func() {
+			defer senders.Done()
+			wakeup.Notify()
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		senders.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent notifications blocked")
+	}
+	select {
+	case <-wakeup.Events():
+	default:
+		t.Fatal("notification was not retained")
+	}
+	select {
+	case <-wakeup.Events():
+		t.Fatal("burst notifications were not coalesced")
+	default:
+	}
+}
+
+func TestMemoryExtractionWorkerWakesDuringSweepAndNotifiesIndex(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	extractionWakeup := newMemoryWorkerWakeup()
+	indexWakeup := newMemoryWorkerWakeup()
+	firstSweepStarted := make(chan struct{})
+	releaseFirstSweep := make(chan struct{})
+	var calls atomic.Int32
+	processor := memoryExtractionProcessorFunc(func(
+		context.Context,
+		int,
+	) (memory.ExtractionSweepResult, error) {
+		switch calls.Add(1) {
+		case 1:
+			close(firstSweepStarted)
+			<-releaseFirstSweep
+			return memory.ExtractionSweepResult{Completed: 1}, nil
+		default:
+			cancel()
+			return memory.ExtractionSweepResult{}, nil
+		}
+	})
+	worker, err := newMemoryExtractionWorker(
+		processor,
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		time.Hour,
+		time.Second,
+		1,
+		extractionWakeup.Events(),
+		indexWakeup,
+		waitForMemoryWork,
+	)
+	if err != nil {
+		t.Fatalf("newMemoryExtractionWorker: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	<-firstSweepStarted
+	extractionWakeup.Notify()
+	close(releaseFirstSweep)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("notification during sweep did not trigger another sweep")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("processor calls = %d, want 2", got)
+	}
+	select {
+	case <-indexWakeup.Events():
+	default:
+		t.Fatal("completed extraction did not notify index worker")
+	}
+}
+
+func TestMemoryIndexWorkerWakesWithoutWaitingForRecoveryInterval(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wakeup := newMemoryWorkerWakeup()
+	firstSweepDone := make(chan struct{})
+	var calls atomic.Int32
+	processor := memoryIndexProcessorFunc(func(
+		context.Context,
+		int,
+	) (memory.IndexSweepResult, error) {
+		if calls.Add(1) == 1 {
+			close(firstSweepDone)
+		} else {
+			cancel()
+		}
+		return memory.IndexSweepResult{}, nil
+	})
+	worker, err := newMemoryIndexWorker(
+		processor,
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		time.Hour,
+		time.Second,
+		1,
+		wakeup.Events(),
+	)
+	if err != nil {
+		t.Fatalf("newMemoryIndexWorker: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	<-firstSweepDone
+	wakeup.Notify()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("index worker waited for recovery interval")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("processor calls = %d, want 2", got)
+	}
+}
+
+func TestMemoryIndexWorkerKeepsPeriodicRecoverySweep(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var calls atomic.Int32
+	processor := memoryIndexProcessorFunc(func(
+		context.Context,
+		int,
+	) (memory.IndexSweepResult, error) {
+		if calls.Add(1) == 2 {
+			cancel()
+		}
+		return memory.IndexSweepResult{}, nil
+	})
+	worker, err := newMemoryIndexWorker(
+		processor,
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		10*time.Millisecond,
+		time.Second,
+		1,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("newMemoryIndexWorker: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("periodic recovery sweep did not run")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("processor calls = %d, want 2", got)
+	}
+}
+
+func TestMemoryIndexWorkerDrainsFullBatchWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var calls atomic.Int32
+	processor := memoryIndexProcessorFunc(func(
+		context.Context,
+		int,
+	) (memory.IndexSweepResult, error) {
+		if calls.Add(1) == 1 {
+			return memory.IndexSweepResult{Claimed: 1}, nil
+		}
+		cancel()
+		return memory.IndexSweepResult{}, nil
+	})
+	worker, err := newMemoryIndexWorker(
+		processor,
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		time.Hour,
+		time.Second,
+		1,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("newMemoryIndexWorker: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("full batch did not trigger immediate drain sweep")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("processor calls = %d, want 2", got)
+	}
+}
+
+type memoryIndexProcessorFunc func(
+	context.Context,
+	int,
+) (memory.IndexSweepResult, error)
+
+func (function memoryIndexProcessorFunc) ProcessPendingIndexes(
+	ctx context.Context,
+	limit int,
+) (memory.IndexSweepResult, error) {
+	return function(ctx, limit)
+}

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -47,6 +47,7 @@ func NewIdentityAndAgentModules(
 		generator,
 		runConfiguration,
 		memorySearcher,
+		nil,
 		voiceConfigurations...,
 	)
 	if err != nil {
@@ -83,6 +84,7 @@ func buildIdentityAgentComposition(
 	generator ai.TextGenerator,
 	runConfiguration core.RunConfiguration,
 	memorySearcher memory.Searcher,
+	memoryExtractionNotifier interface{ Notify() },
 	voiceConfigurations ...VoiceConfiguration,
 ) (*identityAgentComposition, error) {
 	if ctx == nil || database == nil || generator == nil ||
@@ -128,8 +130,15 @@ func buildIdentityAgentComposition(
 	if err != nil {
 		return nil, err
 	}
+	runRepository := core.RunRepository(agentRepository)
+	if memoryExtractionNotifier != nil {
+		runRepository = &runCompletionNotifyingRepository{
+			RunRepository: agentRepository,
+			notifier:      memoryExtractionNotifier,
+		}
+	}
 	runService, err := agentruntime.NewRunService(
-		agentRepository,
+		runRepository,
 		contextAssembler,
 		generator,
 		runConfiguration,
@@ -243,6 +252,7 @@ func NewIdentityAgentModulesWithVoiceCleanup(
 		generator,
 		runConfiguration,
 		memorySearcher,
+		nil,
 		voiceConfigurations...,
 	)
 	if err != nil {

--- a/server/internal/bootstrap/agent_voice_bootstrap_test.go
+++ b/server/internal/bootstrap/agent_voice_bootstrap_test.go
@@ -98,6 +98,7 @@ func TestAgentVoiceCompositionRequiresCleanupAwareConstructor(t *testing.T) {
 			MaxInputCharacters: 12000,
 		},
 		emptyBootstrapMemorySearcher{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("build composition without Agent voice: %v", err)
@@ -176,6 +177,7 @@ func TestProductionAgentVoiceCompositionRegistersAllRoutes(t *testing.T) {
 			MaxInputCharacters: 12000,
 		},
 		emptyBootstrapMemorySearcher{},
+		nil,
 		configuration,
 	)
 	if err != nil {

--- a/server/internal/bootstrap/memory_wakeup.go
+++ b/server/internal/bootstrap/memory_wakeup.go
@@ -1,0 +1,35 @@
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+type runCompletionNotifyingRepository struct {
+	core.RunRepository
+	notifier interface{ Notify() }
+}
+
+func (repository *runCompletionNotifyingRepository) CompleteRun(
+	ctx context.Context,
+	ownerID string,
+	runID string,
+	workerLeaseToken string,
+	content string,
+	result ai.TextResult,
+) (core.Run, error) {
+	run, err := repository.RunRepository.CompleteRun(
+		ctx,
+		ownerID,
+		runID,
+		workerLeaseToken,
+		content,
+		result,
+	)
+	if err == nil && run.Status == core.RunStatusCompleted {
+		repository.notifier.Notify()
+	}
+	return run, err
+}

--- a/server/internal/bootstrap/memory_wakeup_test.go
+++ b/server/internal/bootstrap/memory_wakeup_test.go
@@ -1,0 +1,80 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+func TestRunCompletionNotifierFiresOnlyAfterSuccessfulCommit(t *testing.T) {
+	t.Parallel()
+
+	completedRun := core.Run{Status: core.RunStatusCompleted}
+	underlying := &completionRepositoryStub{
+		complete: func() (core.Run, error) {
+			return completedRun, nil
+		},
+	}
+	notifier := &countingNotifier{}
+	repository := &runCompletionNotifyingRepository{
+		RunRepository: underlying,
+		notifier:      notifier,
+	}
+	if _, err := repository.CompleteRun(
+		context.Background(),
+		"owner",
+		"run",
+		"lease",
+		"content",
+		ai.TextResult{},
+	); err != nil {
+		t.Fatalf("CompleteRun: %v", err)
+	}
+	if notifier.calls != 1 {
+		t.Fatalf("notifier calls = %d, want 1", notifier.calls)
+	}
+
+	underlying.complete = func() (core.Run, error) {
+		return core.Run{}, errors.New("commit failed")
+	}
+	if _, err := repository.CompleteRun(
+		context.Background(),
+		"owner",
+		"run",
+		"lease",
+		"content",
+		ai.TextResult{},
+	); err == nil {
+		t.Fatal("CompleteRun error = nil")
+	}
+	if notifier.calls != 1 {
+		t.Fatalf("notifier fired before commit: %d calls", notifier.calls)
+	}
+}
+
+type completionRepositoryStub struct {
+	core.RunRepository
+	complete func() (core.Run, error)
+}
+
+func (repository *completionRepositoryStub) CompleteRun(
+	context.Context,
+	string,
+	string,
+	string,
+	string,
+	ai.TextResult,
+) (core.Run, error) {
+	return repository.complete()
+}
+
+type countingNotifier struct {
+	calls int
+}
+
+func (notifier *countingNotifier) Notify() {
+	notifier.calls++
+}

--- a/server/internal/bootstrap/practice_context.go
+++ b/server/internal/bootstrap/practice_context.go
@@ -57,6 +57,60 @@ func NewIdentityAgentAndPracticeComposition(
 	catalog preparation.CatalogReader,
 	voiceConfigurations ...VoiceConfiguration,
 ) (*IdentityAgentPracticeComposition, error) {
+	return newIdentityAgentAndPracticeComposition(
+		ctx,
+		database,
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+		generator,
+		runConfiguration,
+		memorySearcher,
+		catalog,
+		nil,
+		voiceConfigurations...,
+	)
+}
+
+// NewIdentityAgentAndPracticeCompositionWithMemoryWakeup wires a payload-free
+// notification emitted only after a completed Agent Run has been committed.
+func NewIdentityAgentAndPracticeCompositionWithMemoryWakeup(
+	ctx context.Context,
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
+	generator ai.TextGenerator,
+	runConfiguration core.RunConfiguration,
+	memorySearcher memory.Searcher,
+	catalog preparation.CatalogReader,
+	memoryExtractionNotifier interface{ Notify() },
+	voiceConfigurations ...VoiceConfiguration,
+) (*IdentityAgentPracticeComposition, error) {
+	return newIdentityAgentAndPracticeComposition(
+		ctx,
+		database,
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+		generator,
+		runConfiguration,
+		memorySearcher,
+		catalog,
+		memoryExtractionNotifier,
+		voiceConfigurations...,
+	)
+}
+
+func newIdentityAgentAndPracticeComposition(
+	ctx context.Context,
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
+	generator ai.TextGenerator,
+	runConfiguration core.RunConfiguration,
+	memorySearcher memory.Searcher,
+	catalog preparation.CatalogReader,
+	memoryExtractionNotifier interface{ Notify() },
+	voiceConfigurations ...VoiceConfiguration,
+) (*IdentityAgentPracticeComposition, error) {
 	if catalog == nil {
 		return nil, errors.New("bootstrap: Preparation catalog is required")
 	}
@@ -68,6 +122,7 @@ func NewIdentityAgentAndPracticeComposition(
 		generator,
 		runConfiguration,
 		memorySearcher,
+		memoryExtractionNotifier,
 		voiceConfigurations...,
 	)
 	if err != nil {


### PR DESCRIPTION
## 功能描述

- Agent Run 成功提交提取 Job 后，立即唤醒 Memory Extraction Worker；
- 提取事务完成并生成索引 Job 后，立即唤醒 Memory Index Worker；
- 保留 30 秒周期扫描作为启动、信号丢失与异常恢复机制；
- 一次 sweep 取满批次时立即继续排空，避免突发通知合并后剩余 Job 再等一个周期。

数据库 Job 仍是唯一事实来源；唤醒信号为容量 1 的 `chan struct{}`，不携带用户内容、Memory、embedding 或凭证。

## 实现思路

- 增加非阻塞、可合并的进程内 Worker 唤醒器；并发通知只保留一个边沿信号，不阻塞请求，也不创建 goroutine；
- 在 Agent Run 的 `CompleteRun` 成功返回后发送提取唤醒信号，失败事务不通知；
- Extraction sweep 产生已完成任务后发送索引唤醒信号；
- 两个 Worker 启动时立即 sweep，之后同时响应唤醒信号、恢复定时器和 context cancellation；
- 不修改数据库结构、提取协议、Memory Policy、向量模型、召回排序、API、Flutter 或上下文压缩。

## 测试方式

1. `cd server && go test ./internal/memory/... ./internal/bootstrap/... ./cmd/server/...`
2. `cd server && go test ./...`
3. `cd server && go vet ./...`
4. `cd server && go test -race ./cmd/server -run 'TestMemoryWorkerWakeup|TestMemoryExtractionWorkerWakes|TestMemoryIndexWorker' -count=1 -timeout=60s`
5. `cd server && go test -race ./internal/bootstrap -run 'TestRunCompletionNotifier' -count=1 -timeout=60s`

预期：全部通过；测试覆盖并发信号合并、Worker 忙碌期间通知、无需等待恢复周期的提取/索引唤醒、周期恢复扫描、批次排空、取消退出，以及仅在 Run 成功提交后通知。

## 相关 Issue / 备注

Closes #171

依赖现有数据库触发器原子创建 Extraction Job 与 Index Job，本 PR 只缩短 Worker 的调度等待。

## AI 辅助说明

使用 Codex 辅助定位 Job 事务边界、实现并发唤醒器和补充测试；已人工检查信号不承载业务数据、数据库仍为任务事实来源、取消和恢复路径保持有效，并完成全量测试与静态检查。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置