### PR TITLE
[后端] 定义统一 Evaluation API、状态与结果契约

### DIFF
--- a/api/common/errors.yaml
+++ b/api/common/errors.yaml
@@ -94,6 +94,11 @@ components:
         - retry_request_not_found
         - retry_request_conflict
         - transcript_unavailable
+        - evaluation_not_found
+        - evaluation_strategy_not_available
+        - evaluation_version_conflict
+        - evaluation_policy_violation
+        - evaluation_retryable_failure
         - unsupported_message
         - internal_error
       x-http-status-map:
@@ -138,6 +143,11 @@ components:
         turn_analysis_conflict: 409
         retry_request_conflict: 409
         transcript_unavailable: 422
+        evaluation_not_found: 404
+        evaluation_strategy_not_available: 422
+        evaluation_version_conflict: 409
+        evaluation_policy_violation: 422
+        evaluation_retryable_failure: 503
         rate_limited: 429
         provider_unavailable: 503
         quota_exhausted: 503

--- a/api/examples/evaluation-contract.json
+++ b/api/examples/evaluation-contract.json
@@ -1,0 +1,683 @@
+{
+  "create_dual_channel": {
+    "practice_session_id": "session_eval_001",
+    "input_snapshot_id": "snapshot_eval_001",
+    "input_revision": 1,
+    "scope": "SESSION",
+    "scene_type": "INTERVIEW",
+    "channels": ["SCENE", "CORE_4D"],
+    "scene_strategy_ref": "interview/project-deep-dive/1.0.0",
+    "core_4d_strategy_ref": "speaking-core4d/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "client_request_id": "trace_eval_001"
+  },
+  "queued": {
+    "evaluation_id": "evaluation_001",
+    "evaluation_revision_id": "evaluation_revision_001",
+    "revision": 1,
+    "evaluation_status": "QUEUED",
+    "status_url": "/v1/evaluations/evaluation_001"
+  },
+  "core_4d_ready": {
+    "evaluation_id": "evaluation_002",
+    "evaluation_revision_id": "evaluation_revision_002",
+    "revision": 1,
+    "practice_session_id": "session_eval_002",
+    "input_snapshot_id": "snapshot_eval_002",
+    "input_revision": 1,
+    "scope": "SESSION",
+    "scene_type": "INTERVIEW",
+    "channels": ["CORE_4D"],
+    "core_4d_strategy_ref": "speaking-core4d/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "READY",
+    "scoreability_status": "RELIABLE",
+    "gate_status": "PASS",
+    "module_statuses": {
+      "core_4d": "READY"
+    },
+    "core_4d_observations": [
+      {
+        "observation_id": "observation_pronunciation_001",
+        "dimension": "PRONUNCIATION",
+        "weights": [{"key": "intelligibility", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.86,
+        "coverage": 0.91,
+        "gate_status": "PASS",
+        "reason_codes": [],
+        "evidence_refs": [
+          {
+            "evidence_ref_id": "evidence_pronunciation_001",
+            "snapshot_id": "snapshot_eval_002",
+            "turn_id": "turn_eval_001",
+            "speaker": "USER",
+            "audio_span": {
+              "audio_asset_id": "audio_eval_001",
+              "start_ms": 1200,
+              "end_ms": 4800
+            },
+            "quality": {
+              "audio": 0.93,
+              "alignment": 0.9
+            },
+            "lineage": {
+              "feature_artifact": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        ],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "raw_score": 78.4,
+        "display_score": 78,
+        "interval": [72, 84]
+      },
+      {
+        "observation_id": "observation_fluency_001",
+        "dimension": "FLUENCY",
+        "weights": [{"key": "continuity", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.84,
+        "coverage": 0.9,
+        "gate_status": "PASS",
+        "reason_codes": [],
+        "evidence_refs": [
+          {
+            "evidence_ref_id": "evidence_fluency_001",
+            "snapshot_id": "snapshot_eval_002",
+            "turn_id": "turn_eval_001",
+            "speaker": "USER",
+            "audio_span": {
+              "audio_asset_id": "audio_eval_001",
+              "start_ms": 1200,
+              "end_ms": 6800
+            },
+            "quality": {
+              "audio": 0.93,
+              "alignment": 0.9
+            },
+            "lineage": {
+              "feature_artifact": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        ],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "raw_score": 74.2,
+        "display_score": 74,
+        "interval": [68, 80]
+      },
+      {
+        "observation_id": "observation_vocabulary_001",
+        "dimension": "VOCABULARY",
+        "weights": [{"key": "accuracy", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.82,
+        "coverage": 0.88,
+        "gate_status": "PASS",
+        "reason_codes": [],
+        "evidence_refs": [
+          {
+            "evidence_ref_id": "evidence_vocabulary_001",
+            "snapshot_id": "snapshot_eval_002",
+            "turn_id": "turn_eval_001",
+            "speaker": "USER",
+            "transcript_span": {
+              "start_utf8_byte": 0,
+              "end_utf8_byte": 48,
+              "token_ids": ["token_eval_001", "token_eval_002"]
+            },
+            "quality": {
+              "asr": 0.92,
+              "alignment": 0.9
+            },
+            "lineage": {
+              "asr_artifact": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            }
+          }
+        ],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "raw_score": 76.8,
+        "display_score": 77,
+        "interval": [70, 82]
+      },
+      {
+        "observation_id": "observation_grammar_001",
+        "dimension": "GRAMMAR",
+        "weights": [{"key": "accuracy", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.8,
+        "coverage": 0.86,
+        "gate_status": "PASS",
+        "reason_codes": [],
+        "evidence_refs": [
+          {
+            "evidence_ref_id": "evidence_grammar_001",
+            "snapshot_id": "snapshot_eval_002",
+            "turn_id": "turn_eval_001",
+            "speaker": "USER",
+            "transcript_span": {
+              "start_utf8_byte": 49,
+              "end_utf8_byte": 96,
+              "token_ids": ["token_eval_003", "token_eval_004"]
+            },
+            "quality": {
+              "asr": 0.92,
+              "alignment": 0.9
+            },
+            "lineage": {
+              "asr_artifact": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            }
+          }
+        ],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "raw_score": 72.5,
+        "display_score": 73,
+        "interval": [66, 79]
+      }
+    ],
+    "is_final": true,
+    "created_at": "2026-07-28T12:00:00Z",
+    "updated_at": "2026-07-28T12:00:10Z",
+    "completed_at": "2026-07-28T12:00:10Z"
+  },
+  "short_sample_blocked": {
+    "evaluation_id": "evaluation_003",
+    "evaluation_revision_id": "evaluation_revision_003",
+    "revision": 1,
+    "practice_session_id": "session_eval_003",
+    "input_snapshot_id": "snapshot_eval_003",
+    "input_revision": 1,
+    "scope": "TURN",
+    "scene_type": "INTERVIEW",
+    "channels": ["CORE_4D"],
+    "core_4d_strategy_ref": "speaking-core4d/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "READY",
+    "scoreability_status": "INSUFFICIENT",
+    "gate_status": "BLOCKED",
+    "module_statuses": {
+      "core_4d": "READY"
+    },
+    "core_4d_observations": [
+      {
+        "observation_id": "observation_fluency_002",
+        "dimension": "FLUENCY",
+        "weights": [{"key": "continuity", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.1,
+        "coverage": 0.02,
+        "gate_status": "BLOCKED",
+        "reason_codes": ["INSUFFICIENT_EVIDENCE"],
+        "evidence_refs": [],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      }
+    ],
+    "is_final": true,
+    "created_at": "2026-07-28T12:01:00Z",
+    "updated_at": "2026-07-28T12:01:01Z",
+    "completed_at": "2026-07-28T12:01:01Z"
+  },
+  "low_asr_feedback_only": {
+    "evaluation_id": "evaluation_004",
+    "evaluation_revision_id": "evaluation_revision_004",
+    "revision": 1,
+    "practice_session_id": "session_eval_004",
+    "input_snapshot_id": "snapshot_eval_004",
+    "input_revision": 1,
+    "scope": "TURN",
+    "scene_type": "INTERVIEW",
+    "channels": ["CORE_4D"],
+    "core_4d_strategy_ref": "speaking-core4d/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "READY",
+    "scoreability_status": "PROVISIONAL",
+    "gate_status": "FEEDBACK_ONLY",
+    "module_statuses": {
+      "core_4d": "READY"
+    },
+    "core_4d_observations": [
+      {
+        "observation_id": "observation_vocabulary_002",
+        "dimension": "VOCABULARY",
+        "weights": [{"key": "accuracy", "value": 1}],
+        "rounding_rule": "HALF_UP_TO_INTEGER",
+        "confidence": 0.3,
+        "coverage": 0.7,
+        "gate_status": "FEEDBACK_ONLY",
+        "reason_codes": ["ASR_LOW_CONFIDENCE"],
+        "evidence_refs": [],
+        "profile_update_eligible": false,
+        "strategy_ref": "speaking-core4d/1.0.0",
+        "aggregation_version": "core4d-aggregation/1.0.0",
+        "calibration_version": "NOT_CONFIGURED",
+        "full_config_hash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      }
+    ],
+    "is_final": false,
+    "created_at": "2026-07-28T12:02:00Z",
+    "updated_at": "2026-07-28T12:02:01Z",
+    "completed_at": "2026-07-28T12:02:01Z"
+  },
+  "ielts_ready": {
+    "evaluation_id": "evaluation_005",
+    "evaluation_revision_id": "evaluation_revision_005",
+    "revision": 1,
+    "practice_session_id": "session_eval_005",
+    "input_snapshot_id": "snapshot_eval_005",
+    "input_revision": 1,
+    "scope": "SESSION",
+    "scene_type": "IELTS_SPEAKING",
+    "channels": ["SCENE"],
+    "scene_strategy_ref": "ielts-speaking/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "READY",
+    "scoreability_status": "RELIABLE",
+    "gate_status": "PASS",
+    "module_statuses": {
+      "scene": "READY"
+    },
+    "scene_result": {
+      "scene_type": "IELTS_SPEAKING",
+      "dimensions": [
+        {
+          "dimension_id": "IELTS_FC",
+          "rounding_rule": "HALF_UP_TO_0_5",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.84,
+          "coverage": 0.9,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_ielts_fc_001",
+              "snapshot_id": "snapshot_eval_005",
+              "turn_id": "turn_ielts_001",
+              "speaker": "USER",
+              "audio_span": {
+                "audio_asset_id": "audio_ielts_001",
+                "start_ms": 1000,
+                "end_ms": 8000
+              },
+              "quality": {"audio": 0.93, "alignment": 0.9},
+              "lineage": {
+                "feature_artifact": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+              }
+            }
+          ],
+          "raw": 7,
+          "display": 7,
+          "interval": [6.5, 7.5]
+        },
+        {
+          "dimension_id": "IELTS_LR",
+          "rounding_rule": "HALF_UP_TO_0_5",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.82,
+          "coverage": 0.88,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_ielts_lr_001",
+              "snapshot_id": "snapshot_eval_005",
+              "turn_id": "turn_ielts_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 0,
+                "end_utf8_byte": 60
+              },
+              "quality": {"asr": 0.92, "alignment": 0.9},
+              "lineage": {
+                "asr_artifact": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+              }
+            }
+          ],
+          "raw": 7,
+          "display": 7,
+          "interval": [6.5, 7.5]
+        },
+        {
+          "dimension_id": "IELTS_GRA",
+          "rounding_rule": "HALF_UP_TO_0_5",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.8,
+          "coverage": 0.86,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_ielts_gra_001",
+              "snapshot_id": "snapshot_eval_005",
+              "turn_id": "turn_ielts_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 61,
+                "end_utf8_byte": 120
+              },
+              "quality": {"asr": 0.92, "alignment": 0.9},
+              "lineage": {
+                "asr_artifact": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+              }
+            }
+          ],
+          "raw": 6,
+          "display": 6,
+          "interval": [5.5, 6.5]
+        },
+        {
+          "dimension_id": "IELTS_PR",
+          "rounding_rule": "HALF_UP_TO_0_5",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.83,
+          "coverage": 0.89,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_ielts_pr_001",
+              "snapshot_id": "snapshot_eval_005",
+              "turn_id": "turn_ielts_001",
+              "speaker": "USER",
+              "audio_span": {
+                "audio_asset_id": "audio_ielts_001",
+                "start_ms": 1000,
+                "end_ms": 8000
+              },
+              "quality": {"audio": 0.93, "alignment": 0.9},
+              "lineage": {
+                "feature_artifact": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+              }
+            }
+          ],
+          "raw": 7,
+          "display": 7,
+          "interval": [6.5, 7.5]
+        }
+      ],
+      "task_results": [],
+      "question_results": [],
+      "core4_observation_refs": [],
+      "evaluation_status": "READY",
+      "scoreability_status": "RELIABLE",
+      "gate_status": "PASS",
+      "module_statuses": {"scene": "READY"},
+      "strategy_ref": "ielts-speaking/1.0.0",
+      "aggregation_version": "ielts-aggregation/1.0.0",
+      "calibration_version": "NOT_CONFIGURED",
+      "full_config_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "is_final": true,
+      "overall_raw": 6.75,
+      "overall_display": 7,
+      "overall_rounding_rule": "HALF_UP_TO_0_5"
+    },
+    "is_final": true,
+    "created_at": "2026-07-28T12:03:00Z",
+    "updated_at": "2026-07-28T12:03:10Z",
+    "completed_at": "2026-07-28T12:03:10Z"
+  },
+  "interview_missing_opportunity": {
+    "evaluation_id": "evaluation_006",
+    "evaluation_revision_id": "evaluation_revision_006",
+    "revision": 1,
+    "practice_session_id": "session_eval_006",
+    "input_snapshot_id": "snapshot_eval_006",
+    "input_revision": 1,
+    "scope": "SESSION",
+    "scene_type": "INTERVIEW",
+    "channels": ["SCENE"],
+    "scene_strategy_ref": "interview/project-deep-dive/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "READY",
+    "scoreability_status": "INSUFFICIENT",
+    "gate_status": "BLOCKED",
+    "module_statuses": {
+      "scene": "READY"
+    },
+    "scene_result": {
+      "scene_type": "INTERVIEW",
+      "dimensions": [
+        {
+          "dimension_id": "INTERVIEW_RELEVANCE",
+          "rounding_rule": "HALF_UP_TO_INTEGER",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.82,
+          "coverage": 0.9,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_interview_001",
+              "snapshot_id": "snapshot_eval_006",
+              "turn_id": "turn_interview_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 0,
+                "end_utf8_byte": 80
+              },
+              "quality": {"asr": 0.93, "alignment": 0.91},
+              "lineage": {
+                "asr_artifact": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+              }
+            }
+          ],
+          "raw": 78.4,
+          "display": 78,
+          "interval": [72, 84]
+        },
+        {
+          "dimension_id": "INTERVIEW_STRUCTURE",
+          "rounding_rule": "HALF_UP_TO_INTEGER",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.8,
+          "coverage": 0.88,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_interview_002",
+              "snapshot_id": "snapshot_eval_006",
+              "turn_id": "turn_interview_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 0,
+                "end_utf8_byte": 80
+              },
+              "quality": {"asr": 0.93, "alignment": 0.91},
+              "lineage": {
+                "asr_artifact": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+              }
+            }
+          ],
+          "raw": 74.1,
+          "display": 74,
+          "interval": [68, 80]
+        },
+        {
+          "dimension_id": "INTERVIEW_EVIDENCE",
+          "rounding_rule": "HALF_UP_TO_INTEGER",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.79,
+          "coverage": 0.84,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_interview_003",
+              "snapshot_id": "snapshot_eval_006",
+              "turn_id": "turn_interview_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 20,
+                "end_utf8_byte": 80
+              },
+              "quality": {"asr": 0.93, "alignment": 0.91},
+              "lineage": {
+                "asr_artifact": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+              }
+            }
+          ],
+          "raw": 69.3,
+          "display": 69,
+          "interval": [62, 76]
+        },
+        {
+          "dimension_id": "INTERVIEW_PROFESSIONAL",
+          "rounding_rule": "HALF_UP_TO_INTEGER",
+          "scoreability_status": "RELIABLE",
+          "gate_status": "PASS",
+          "confidence": 0.83,
+          "coverage": 0.9,
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_interview_004",
+              "snapshot_id": "snapshot_eval_006",
+              "turn_id": "turn_interview_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 0,
+                "end_utf8_byte": 80
+              },
+              "quality": {"asr": 0.93, "alignment": 0.91},
+              "lineage": {
+                "asr_artifact": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+              }
+            }
+          ],
+          "raw": 80.6,
+          "display": 81,
+          "interval": [75, 86]
+        },
+        {
+          "dimension_id": "INTERVIEW_INTERACTION",
+          "rounding_rule": "HALF_UP_TO_INTEGER",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "confidence": 0,
+          "coverage": 0,
+          "reason_codes": ["OPPORTUNITY_NOT_PROVIDED"],
+          "evidence_refs": []
+        }
+      ],
+      "task_results": [
+        {
+          "task_blueprint_ref": "interview/project-deep-dive/task/1.0.0",
+          "opportunity_status": "PROVIDED",
+          "outcome_status": "PARTIAL",
+          "reason_codes": [],
+          "evidence_refs": [
+            {
+              "evidence_ref_id": "evidence_interview_task_001",
+              "snapshot_id": "snapshot_eval_006",
+              "turn_id": "turn_interview_001",
+              "speaker": "USER",
+              "transcript_span": {
+                "start_utf8_byte": 0,
+                "end_utf8_byte": 80
+              },
+              "quality": {"asr": 0.93, "alignment": 0.91},
+              "lineage": {
+                "asr_artifact": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+              }
+            }
+          ]
+        }
+      ],
+      "question_results": [
+        {
+          "question_id": "question_interview_followup_001",
+          "opportunity_status": "NOT_PROVIDED",
+          "response_turn_ids": [],
+          "dimension_evidence": [
+            {
+              "dimension_id": "INTERVIEW_INTERACTION",
+              "coverage": 0,
+              "probe_weight": 1,
+              "gate_status": "BLOCKED",
+              "reason_codes": ["OPPORTUNITY_NOT_PROVIDED"],
+              "evidence_refs": []
+            }
+          ],
+          "evidence_refs": [],
+          "confidence": 0,
+          "module_status": "READY"
+        }
+      ],
+      "core4_observation_refs": [],
+      "evaluation_status": "READY",
+      "scoreability_status": "INSUFFICIENT",
+      "gate_status": "BLOCKED",
+      "module_statuses": {"scene": "READY"},
+      "strategy_ref": "interview/project-deep-dive/1.0.0",
+      "aggregation_version": "interview-aggregation/1.0.0",
+      "calibration_version": "NOT_CONFIGURED",
+      "full_config_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "is_final": true,
+      "readiness_level": "NOT_ASSESSED"
+    },
+    "is_final": true,
+    "created_at": "2026-07-28T12:04:00Z",
+    "updated_at": "2026-07-28T12:04:10Z",
+    "completed_at": "2026-07-28T12:04:10Z"
+  },
+  "failed": {
+    "evaluation_id": "evaluation_007",
+    "evaluation_revision_id": "evaluation_revision_007",
+    "revision": 1,
+    "practice_session_id": "session_eval_007",
+    "input_snapshot_id": "snapshot_eval_007",
+    "input_revision": 1,
+    "scope": "SESSION",
+    "scene_type": "INTERVIEW",
+    "channels": ["SCENE", "CORE_4D"],
+    "scene_strategy_ref": "interview/project-deep-dive/1.0.0",
+    "core_4d_strategy_ref": "speaking-core4d/1.0.0",
+    "pipeline_version": "evaluation-pipeline/1.0.0",
+    "schema_version": "evaluation-schema/1.0.0",
+    "evaluation_status": "FAILED",
+    "module_statuses": {
+      "scene": "FAILED",
+      "core_4d": "SKIPPED"
+    },
+    "stable_failure": {
+      "reason_code": "INTERNAL_RETRYABLE",
+      "retryable": true
+    },
+    "is_final": true,
+    "created_at": "2026-07-28T12:05:00Z",
+    "updated_at": "2026-07-28T12:05:01Z",
+    "completed_at": "2026-07-28T12:05:01Z"
+  },
+  "revision_queued": {
+    "evaluation_id": "evaluation_001",
+    "evaluation_revision_id": "evaluation_revision_008",
+    "revision": 2,
+    "supersedes_revision_id": "evaluation_revision_001",
+    "evaluation_status": "QUEUED",
+    "status_url": "/v1/evaluations/evaluation_001"
+  }
+}

--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -1,0 +1,1255 @@
+paths:
+  /v1/evaluations:
+    post:
+      tags:
+        - Evaluation
+      summary: Create or return one logical Evaluation
+      description: |
+        Accepts trusted Practice and EvidenceSnapshot references for one Scene,
+        Core 4D, or dual-channel evaluation. The authenticated Actor is derived
+        by the server. Callers cannot submit an owner, tenant, revision number,
+        or server idempotency key.
+
+        The server derives root and per-channel idempotency keys from the
+        canonical request. `client_request_id` is trace-only and has no
+        authority over deduplication.
+      operationId: createEvaluation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEvaluationRequest'
+            examples:
+              dualChannel:
+                value:
+                  practice_session_id: session_demo_001
+                  input_snapshot_id: snapshot_demo_001
+                  input_revision: 1
+                  scope: SESSION
+                  scene_type: INTERVIEW
+                  channels:
+                    - SCENE
+                    - CORE_4D
+                  scene_strategy_ref: interview/project-deep-dive/1.0.0
+                  core_4d_strategy_ref: speaking-core4d/1.0.0
+                  pipeline_version: evaluation-pipeline/1.0.0
+                  client_request_id: trace_demo_001
+      responses:
+        '202':
+          description: The logical Evaluation exists and is queued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationAccepted'
+              example:
+                evaluation_id: evaluation_demo_001
+                evaluation_revision_id: evaluation_revision_demo_001
+                revision: 1
+                evaluation_status: QUEUED
+                status_url: /v1/evaluations/evaluation_demo_001
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: '#/components/responses/EvaluationConflict'
+        '422':
+          $ref: '#/components/responses/EvaluationPolicyRejected'
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/evaluations/{evaluation_id}:
+    get:
+      tags:
+        - Evaluation
+      summary: Get the current publishable Evaluation revision
+      description: |
+        Returns the current publishable immutable revision for one logical
+        Evaluation. Audit and governance readers use a future revision-specific
+        contract; callers must not treat `evaluation_id` as a physical result
+        identifier.
+      operationId: getEvaluation
+      parameters:
+        - $ref: '#/components/parameters/EvaluationId'
+      responses:
+        '200':
+          description: Current Actor-owned Evaluation state and frozen results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Evaluation'
+              example:
+                evaluation_id: evaluation_demo_001
+                evaluation_revision_id: evaluation_revision_demo_001
+                revision: 1
+                practice_session_id: session_demo_001
+                input_snapshot_id: snapshot_demo_001
+                input_revision: 1
+                scope: SESSION
+                scene_type: INTERVIEW
+                channels:
+                  - SCENE
+                  - CORE_4D
+                scene_strategy_ref: interview/project-deep-dive/1.0.0
+                core_4d_strategy_ref: speaking-core4d/1.0.0
+                pipeline_version: evaluation-pipeline/1.0.0
+                schema_version: evaluation-schema/1.0.0
+                evaluation_status: RUNNING
+                module_statuses:
+                  scene: RUNNING
+                  core_4d: PENDING
+                is_final: false
+                created_at: '2026-07-28T12:00:00Z'
+                updated_at: '2026-07-28T12:00:01Z'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: '#/components/responses/EvaluationNotFound'
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/evaluations/{evaluation_id}/re-evaluate:
+    post:
+      tags:
+        - Evaluation
+      summary: Create an immutable replacement Evaluation revision
+      description: |
+        Creates a new revision for the same logical Evaluation. The server
+        assigns the next revision and `supersedes_revision_id`; callers cannot
+        overwrite or select a revision number.
+      operationId: reevaluateEvaluation
+      parameters:
+        - $ref: '#/components/parameters/EvaluationId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReevaluateEvaluationRequest'
+            example:
+              channels:
+                - SCENE
+                - CORE_4D
+              scene_strategy_ref: interview/project-deep-dive/1.1.0
+              core_4d_strategy_ref: speaking-core4d/1.0.0
+              pipeline_version: evaluation-pipeline/1.1.0
+              client_request_id: trace_demo_reevaluate_001
+      responses:
+        '202':
+          description: A replacement immutable revision has been queued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationAccepted'
+              example:
+                evaluation_id: evaluation_demo_001
+                evaluation_revision_id: evaluation_revision_demo_002
+                revision: 2
+                supersedes_revision_id: evaluation_revision_demo_001
+                evaluation_status: QUEUED
+                status_url: /v1/evaluations/evaluation_demo_001
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: '#/components/responses/EvaluationNotFound'
+        '409':
+          $ref: '#/components/responses/EvaluationConflict'
+        '422':
+          $ref: '#/components/responses/EvaluationPolicyRejected'
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+
+components:
+  responses:
+    EvaluationNotFound:
+      description: The logical Evaluation does not exist for the current Actor.
+      content:
+        application/json:
+          schema:
+            $ref: ../common/errors.yaml#/components/schemas/ErrorResponse
+          example:
+            error:
+              code: evaluation_not_found
+              message: Evaluation was not found.
+              retryable: false
+              correlation_id: corr_evaluation_not_found
+    EvaluationConflict:
+      description: The requested Evaluation revision or operation conflicts with current state.
+      content:
+        application/json:
+          schema:
+            $ref: ../common/errors.yaml#/components/schemas/ErrorResponse
+          example:
+            error:
+              code: evaluation_version_conflict
+              message: Evaluation state changed before the operation completed.
+              retryable: false
+              correlation_id: corr_evaluation_version_conflict
+    EvaluationPolicyRejected:
+      description: The requested strategy or policy is unavailable or incompatible.
+      content:
+        application/json:
+          schema:
+            $ref: ../common/errors.yaml#/components/schemas/ErrorResponse
+          example:
+            error:
+              code: evaluation_strategy_not_available
+              message: The requested Evaluation strategy is not available.
+              retryable: false
+              correlation_id: corr_evaluation_strategy_not_available
+  parameters:
+    EvaluationId:
+      name: evaluation_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/StableIdentifier'
+  schemas:
+    StableIdentifier:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: '^[A-Za-z][A-Za-z0-9_-]*$'
+    VersionReference:
+      type: string
+      minLength: 3
+      maxLength: 160
+      pattern: '^[A-Za-z][A-Za-z0-9._:/-]*$'
+    ConfigHash:
+      type: string
+      pattern: '^sha256:[a-f0-9]{64}$'
+    ArtifactDigest:
+      type: string
+      pattern: '^sha256:[a-f0-9]{64}$'
+    EvaluationChannel:
+      type: string
+      enum:
+        - SCENE
+        - CORE_4D
+    EvaluationScope:
+      type: string
+      enum:
+        - TURN
+        - SESSION
+    EvaluationSceneType:
+      type: string
+      enum:
+        - IELTS_SPEAKING
+        - INTERVIEW
+        - OVERSEAS_DAILY_LIFE
+        - OVERSEAS_WORKPLACE
+    EvaluationStatus:
+      type: string
+      enum:
+        - RECEIVED
+        - VALIDATING
+        - QUEUED
+        - RUNNING
+        - PARTIAL_READY
+        - READY
+        - FAILED
+        - SUPERSEDED
+    ScoreabilityStatus:
+      type: string
+      enum:
+        - RELIABLE
+        - PROVISIONAL
+        - INSUFFICIENT
+    GateStatus:
+      type: string
+      enum:
+        - PASS
+        - FEEDBACK_ONLY
+        - BLOCKED
+    ModuleStatus:
+      type: string
+      enum:
+        - PENDING
+        - RUNNING
+        - READY
+        - FAILED
+        - SKIPPED
+    EvaluationReasonCode:
+      type: string
+      enum:
+        - STRATEGY_NOT_AVAILABLE
+        - AUDIO_UNUSABLE
+        - SPEAKER_ATTRIBUTION_FAILED
+        - INSUFFICIENT_EVIDENCE
+        - ASR_LOW_CONFIDENCE
+        - REQUIRED_DIMENSION_MISSING
+        - SCORE_INCONSISTENT
+        - EVIDENCE_REF_INVALID
+        - VERSION_CONFLICT
+        - DUPLICATE_REQUEST
+        - POLICY_VIOLATION
+        - INTERNAL_RETRYABLE
+        - OPPORTUNITY_NOT_PROVIDED
+    RoundingRule:
+      type: string
+      enum:
+        - HALF_UP_TO_INTEGER
+        - HALF_UP_TO_0_5
+    CalibrationVersion:
+      anyOf:
+        - $ref: '#/components/schemas/VersionReference'
+        - type: string
+          const: NOT_CONFIGURED
+    CreateEvaluationRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_session_id
+        - input_snapshot_id
+        - input_revision
+        - scope
+        - scene_type
+        - channels
+        - pipeline_version
+      properties:
+        practice_session_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        input_snapshot_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        input_revision:
+          type: integer
+          minimum: 1
+        scope:
+          $ref: '#/components/schemas/EvaluationScope'
+        scene_type:
+          $ref: '#/components/schemas/EvaluationSceneType'
+        channels:
+          type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationChannel'
+        scene_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        core_4d_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        pipeline_version:
+          $ref: '#/components/schemas/VersionReference'
+        client_request_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9._:-]+$'
+      allOf:
+        - if:
+            properties:
+              channels:
+                type: array
+                contains:
+                  const: SCENE
+            required:
+              - channels
+          then:
+            required:
+              - scene_strategy_ref
+        - if:
+            properties:
+              channels:
+                type: array
+                contains:
+                  const: CORE_4D
+            required:
+              - channels
+          then:
+            required:
+              - core_4d_strategy_ref
+    ReevaluateEvaluationRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - channels
+        - pipeline_version
+      properties:
+        channels:
+          type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationChannel'
+        scene_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        core_4d_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        pipeline_version:
+          $ref: '#/components/schemas/VersionReference'
+        client_request_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9._:-]+$'
+      allOf:
+        - if:
+            properties:
+              channels:
+                type: array
+                contains:
+                  const: SCENE
+            required:
+              - channels
+          then:
+            required:
+              - scene_strategy_ref
+        - if:
+            properties:
+              channels:
+                type: array
+                contains:
+                  const: CORE_4D
+            required:
+              - channels
+          then:
+            required:
+              - core_4d_strategy_ref
+    EvaluationAccepted:
+      type: object
+      additionalProperties: false
+      required:
+        - evaluation_id
+        - evaluation_revision_id
+        - revision
+        - evaluation_status
+        - status_url
+      properties:
+        evaluation_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evaluation_revision_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        revision:
+          type: integer
+          minimum: 1
+        supersedes_revision_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evaluation_status:
+          type: string
+          const: QUEUED
+        status_url:
+          type: string
+          pattern: '^/v1/evaluations/[A-Za-z][A-Za-z0-9_-]*$'
+    Evaluation:
+      $ref: '#/components/schemas/EvaluationCommonProperties'
+    EvaluationCommonProperties:
+      type: object
+      additionalProperties: false
+      required:
+        - evaluation_id
+        - evaluation_revision_id
+        - revision
+        - practice_session_id
+        - input_snapshot_id
+        - input_revision
+        - scope
+        - scene_type
+        - channels
+        - pipeline_version
+        - schema_version
+        - evaluation_status
+        - module_statuses
+        - is_final
+        - created_at
+        - updated_at
+      properties:
+        evaluation_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evaluation_revision_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        revision:
+          type: integer
+          minimum: 1
+        supersedes_revision_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        superseded_by_revision_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        practice_session_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        input_snapshot_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        input_revision:
+          type: integer
+          minimum: 1
+        scope:
+          $ref: '#/components/schemas/EvaluationScope'
+        scene_type:
+          $ref: '#/components/schemas/EvaluationSceneType'
+        channels:
+          type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationChannel'
+        scene_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        core_4d_strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        pipeline_version:
+          $ref: '#/components/schemas/VersionReference'
+        schema_version:
+          $ref: '#/components/schemas/VersionReference'
+        evaluation_status:
+          $ref: '#/components/schemas/EvaluationStatus'
+        scoreability_status:
+          $ref: '#/components/schemas/ScoreabilityStatus'
+        gate_status:
+          $ref: '#/components/schemas/GateStatus'
+        module_statuses:
+          type: object
+          minProperties: 1
+          maxProperties: 32
+          propertyNames:
+            pattern: '^[a-z][a-z0-9_]{0,63}$'
+          additionalProperties:
+            $ref: '#/components/schemas/ModuleStatus'
+        scene_result:
+          $ref: '#/components/schemas/SceneEvaluationResult'
+        core_4d_observations:
+          type: array
+          maxItems: 4
+          items:
+            $ref: '#/components/schemas/CoreAbilityObservation'
+        stable_failure:
+          $ref: '#/components/schemas/EvaluationFailure'
+        is_final:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+      allOf:
+        - if:
+            properties:
+              evaluation_status:
+                type: string
+                const: READY
+            required:
+              - evaluation_status
+          then:
+            required:
+              - scoreability_status
+              - gate_status
+              - completed_at
+            anyOf:
+              - required:
+                  - scene_result
+              - required:
+                  - core_4d_observations
+        - if:
+            properties:
+              evaluation_status:
+                type: string
+                const: FAILED
+            required:
+              - evaluation_status
+          then:
+            required:
+              - stable_failure
+              - completed_at
+            not:
+              anyOf:
+                - required:
+                    - scoreability_status
+                - required:
+                    - gate_status
+                - required:
+                    - scene_result
+                - required:
+                    - core_4d_observations
+        - if:
+            properties:
+              evaluation_status:
+                type: string
+                const: SUPERSEDED
+            required:
+              - evaluation_status
+          then:
+            required:
+              - superseded_by_revision_id
+    EvaluationFailure:
+      type: object
+      additionalProperties: false
+      required:
+        - reason_code
+        - retryable
+      properties:
+        reason_code:
+          $ref: '#/components/schemas/EvaluationReasonCode'
+        retryable:
+          type: boolean
+    SceneEvaluationResult:
+      $ref: '#/components/schemas/SceneResultCommonProperties'
+    SceneResultCommonProperties:
+      type: object
+      additionalProperties: false
+      required:
+        - scene_type
+        - dimensions
+        - task_results
+        - question_results
+        - core4_observation_refs
+        - evaluation_status
+        - scoreability_status
+        - gate_status
+        - module_statuses
+        - strategy_ref
+        - aggregation_version
+        - calibration_version
+        - full_config_hash
+        - is_final
+      properties:
+        scene_type:
+          $ref: '#/components/schemas/EvaluationSceneType'
+        dimensions:
+          type: array
+          minItems: 1
+          maxItems: 5
+          items:
+            $ref: '#/components/schemas/SceneDimension'
+        task_results:
+          type: array
+          maxItems: 64
+          items:
+            $ref: '#/components/schemas/SceneTaskResult'
+        question_results:
+          type: array
+          maxItems: 128
+          items:
+            $ref: '#/components/schemas/QuestionEvaluationResult'
+        core4_observation_refs:
+          type: array
+          maxItems: 4
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+        evaluation_status:
+          type: string
+          enum:
+            - PARTIAL_READY
+            - READY
+        scoreability_status:
+          $ref: '#/components/schemas/ScoreabilityStatus'
+        gate_status:
+          $ref: '#/components/schemas/GateStatus'
+        module_statuses:
+          type: object
+          minProperties: 1
+          maxProperties: 32
+          propertyNames:
+            pattern: '^[a-z][a-z0-9_]{0,63}$'
+          additionalProperties:
+            $ref: '#/components/schemas/ModuleStatus'
+        strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        aggregation_version:
+          $ref: '#/components/schemas/VersionReference'
+        calibration_version:
+          $ref: '#/components/schemas/CalibrationVersion'
+        full_config_hash:
+          $ref: '#/components/schemas/ConfigHash'
+        is_final:
+          type: boolean
+        overall_raw:
+          type: number
+          minimum: 0
+          maximum: 9
+        overall_display:
+          type: number
+          minimum: 0
+          maximum: 9
+          multipleOf: 0.5
+        overall_rounding_rule:
+          type: string
+          const: HALF_UP_TO_0_5
+        readiness_level:
+          type: string
+          enum:
+            - HIGH
+            - MEDIUM
+            - LOW
+            - NOT_ASSESSED
+      allOf:
+        - if:
+            properties:
+              scene_type:
+                type: string
+                const: IELTS_SPEAKING
+            required:
+              - scene_type
+          then:
+            not:
+              required:
+                - readiness_level
+            allOf:
+              - if:
+                  properties:
+                    gate_status:
+                      type: string
+                      const: PASS
+                  required:
+                    - gate_status
+                then:
+                  required:
+                    - overall_raw
+                    - overall_display
+                    - overall_rounding_rule
+                else:
+                  not:
+                    anyOf:
+                      - required:
+                          - overall_raw
+                      - required:
+                          - overall_display
+                      - required:
+                          - overall_rounding_rule
+          else:
+            not:
+              anyOf:
+                - required:
+                    - overall_raw
+                - required:
+                    - overall_display
+                - required:
+                    - overall_rounding_rule
+        - if:
+            properties:
+              scene_type:
+                type: string
+                const: INTERVIEW
+            required:
+              - scene_type
+          then:
+            required:
+              - readiness_level
+          else:
+            not:
+              required:
+                - readiness_level
+    SceneTaskResult:
+      type: object
+      additionalProperties: false
+      required:
+        - task_blueprint_ref
+        - opportunity_status
+        - outcome_status
+        - reason_codes
+        - evidence_refs
+      properties:
+        task_blueprint_ref:
+          $ref: '#/components/schemas/VersionReference'
+        opportunity_status:
+          type: string
+          enum:
+            - PROVIDED
+            - NOT_PROVIDED
+        outcome_status:
+          type: string
+          enum:
+            - ACHIEVED
+            - PARTIAL
+            - NOT_ACHIEVED
+            - NOT_ASSESSED
+        reason_codes:
+          type: array
+          maxItems: 16
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationReasonCode'
+        evidence_refs:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+      allOf:
+        - if:
+            properties:
+              opportunity_status:
+                type: string
+                const: NOT_PROVIDED
+            required:
+              - opportunity_status
+          then:
+            properties:
+              outcome_status:
+                type: string
+                const: NOT_ASSESSED
+              reason_codes:
+                type: array
+                minItems: 1
+    QuestionEvaluationResult:
+      type: object
+      additionalProperties: false
+      required:
+        - question_id
+        - opportunity_status
+        - response_turn_ids
+        - dimension_evidence
+        - evidence_refs
+        - confidence
+        - module_status
+      properties:
+        question_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        opportunity_status:
+          type: string
+          enum:
+            - PROVIDED
+            - NOT_PROVIDED
+        response_turn_ids:
+          type: array
+          maxItems: 32
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+        dimension_evidence:
+          type: array
+          maxItems: 17
+          items:
+            $ref: '#/components/schemas/QuestionDimensionEvidence'
+        evidence_refs:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        module_status:
+          $ref: '#/components/schemas/ModuleStatus'
+    QuestionDimensionEvidence:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension_id
+        - coverage
+        - probe_weight
+        - gate_status
+        - reason_codes
+        - evidence_refs
+      properties:
+        dimension_id:
+          type: string
+          enum:
+            - IELTS_FC
+            - IELTS_LR
+            - IELTS_GRA
+            - IELTS_PR
+            - INTERVIEW_RELEVANCE
+            - INTERVIEW_STRUCTURE
+            - INTERVIEW_EVIDENCE
+            - INTERVIEW_PROFESSIONAL
+            - INTERVIEW_INTERACTION
+            - DAILY_GOAL_ACHIEVEMENT
+            - DAILY_CLARITY_ACCURACY
+            - DAILY_INTERACTION
+            - DAILY_APPROPRIATENESS
+            - WORKPLACE_TASK_PROGRESS
+            - WORKPLACE_CLARITY
+            - WORKPLACE_COLLABORATION
+            - WORKPLACE_PROFESSIONALISM
+        question_score:
+          type: number
+          minimum: 0
+          maximum: 100
+        coverage:
+          type: number
+          minimum: 0
+          maximum: 1
+        probe_weight:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 1
+        gate_status:
+          $ref: '#/components/schemas/GateStatus'
+        reason_codes:
+          type: array
+          maxItems: 16
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationReasonCode'
+        evidence_refs:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+      allOf:
+        - if:
+            properties:
+              gate_status:
+                type: string
+                const: PASS
+            required:
+              - gate_status
+          then:
+            required:
+              - question_score
+            properties:
+              evidence_refs:
+                type: array
+                minItems: 1
+          else:
+            properties:
+              reason_codes:
+                type: array
+                minItems: 1
+            not:
+              required:
+                - question_score
+    SceneDimension:
+      $ref: '#/components/schemas/SceneDimensionCommonProperties'
+    SceneDimensionCommonProperties:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension_id
+        - rounding_rule
+        - scoreability_status
+        - gate_status
+        - confidence
+        - coverage
+        - reason_codes
+        - evidence_refs
+      properties:
+        dimension_id:
+          type: string
+          enum:
+            - IELTS_FC
+            - IELTS_LR
+            - IELTS_GRA
+            - IELTS_PR
+            - INTERVIEW_RELEVANCE
+            - INTERVIEW_STRUCTURE
+            - INTERVIEW_EVIDENCE
+            - INTERVIEW_PROFESSIONAL
+            - INTERVIEW_INTERACTION
+            - DAILY_GOAL_ACHIEVEMENT
+            - DAILY_CLARITY_ACCURACY
+            - DAILY_INTERACTION
+            - DAILY_APPROPRIATENESS
+            - WORKPLACE_TASK_PROGRESS
+            - WORKPLACE_CLARITY
+            - WORKPLACE_COLLABORATION
+            - WORKPLACE_PROFESSIONALISM
+        rounding_rule:
+          $ref: '#/components/schemas/RoundingRule'
+        scoreability_status:
+          $ref: '#/components/schemas/ScoreabilityStatus'
+        gate_status:
+          $ref: '#/components/schemas/GateStatus'
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        coverage:
+          type: number
+          minimum: 0
+          maximum: 1
+        reason_codes:
+          type: array
+          maxItems: 16
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationReasonCode'
+        evidence_refs:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+        raw:
+          type: number
+          minimum: 0
+          maximum: 100
+        display:
+          type: number
+          minimum: 0
+          maximum: 100
+        interval:
+          $ref: '#/components/schemas/ScoreInterval'
+      allOf:
+        - if:
+            properties:
+              gate_status:
+                type: string
+                const: PASS
+            required:
+              - gate_status
+          then:
+            required:
+              - raw
+              - display
+            properties:
+              evidence_refs:
+                type: array
+                minItems: 1
+          else:
+            required:
+              - reason_codes
+            properties:
+              reason_codes:
+                type: array
+                minItems: 1
+            not:
+              anyOf:
+                - required:
+                    - raw
+                - required:
+                    - display
+                - required:
+                    - interval
+    ScoreInterval:
+      type: array
+      minItems: 2
+      maxItems: 2
+      prefixItems:
+        - type: number
+          minimum: 0
+          maximum: 100
+        - type: number
+          minimum: 0
+          maximum: 100
+      items: false
+    CoreAbilityObservation:
+      $ref: '#/components/schemas/CoreAbilityCommonProperties'
+    CoreAbilityCommonProperties:
+      type: object
+      additionalProperties: false
+      required:
+        - observation_id
+        - dimension
+        - weights
+        - rounding_rule
+        - confidence
+        - coverage
+        - gate_status
+        - reason_codes
+        - evidence_refs
+        - profile_update_eligible
+        - strategy_ref
+        - aggregation_version
+        - calibration_version
+        - full_config_hash
+      properties:
+        observation_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        dimension:
+          type: string
+          enum:
+            - PRONUNCIATION
+            - FLUENCY
+            - VOCABULARY
+            - GRAMMAR
+        weights:
+          type: array
+          minItems: 1
+          maxItems: 16
+          items:
+            $ref: '#/components/schemas/NamedWeight'
+        rounding_rule:
+          type: string
+          const: HALF_UP_TO_INTEGER
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        coverage:
+          type: number
+          minimum: 0
+          maximum: 1
+        gate_status:
+          $ref: '#/components/schemas/GateStatus'
+        reason_codes:
+          type: array
+          maxItems: 16
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvaluationReasonCode'
+        evidence_refs:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/EvidenceRef'
+        profile_update_eligible:
+          type: boolean
+        strategy_ref:
+          $ref: '#/components/schemas/VersionReference'
+        aggregation_version:
+          $ref: '#/components/schemas/VersionReference'
+        calibration_version:
+          $ref: '#/components/schemas/CalibrationVersion'
+        full_config_hash:
+          $ref: '#/components/schemas/ConfigHash'
+        raw_score:
+          type: number
+          minimum: 0
+          maximum: 100
+        display_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        interval:
+          $ref: '#/components/schemas/ScoreInterval'
+      allOf:
+        - if:
+            properties:
+              gate_status:
+                type: string
+                const: PASS
+            required:
+              - gate_status
+          then:
+            required:
+              - raw_score
+              - display_score
+            properties:
+              evidence_refs:
+                type: array
+                minItems: 1
+          else:
+            required:
+              - reason_codes
+              - profile_update_eligible
+            properties:
+              reason_codes:
+                type: array
+                minItems: 1
+              profile_update_eligible:
+                type: boolean
+                const: false
+            not:
+              anyOf:
+                - required:
+                    - raw_score
+                - required:
+                    - display_score
+                - required:
+                    - interval
+    NamedWeight:
+      type: object
+      additionalProperties: false
+      required:
+        - key
+        - value
+      properties:
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: '^[a-z][a-z0-9_]*$'
+        value:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 1
+    EvidenceRef:
+      type: object
+      additionalProperties: false
+      required:
+        - evidence_ref_id
+        - snapshot_id
+        - turn_id
+        - speaker
+        - quality
+        - lineage
+      properties:
+        evidence_ref_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        snapshot_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        turn_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        speaker:
+          type: string
+          enum:
+            - USER
+            - FACILITATOR
+        transcript_span:
+          $ref: '#/components/schemas/TranscriptSpan'
+        audio_span:
+          $ref: '#/components/schemas/AudioSpan'
+        quality:
+          $ref: '#/components/schemas/EvidenceQuality'
+        lineage:
+          $ref: '#/components/schemas/EvidenceLineage'
+      anyOf:
+        - required:
+            - transcript_span
+        - required:
+            - audio_span
+    TranscriptSpan:
+      type: object
+      additionalProperties: false
+      required:
+        - start_utf8_byte
+        - end_utf8_byte
+      properties:
+        start_utf8_byte:
+          type: integer
+          minimum: 0
+        end_utf8_byte:
+          type: integer
+          minimum: 1
+        token_ids:
+          type: array
+          maxItems: 256
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+    AudioSpan:
+      type: object
+      additionalProperties: false
+      required:
+        - audio_asset_id
+        - start_ms
+        - end_ms
+      properties:
+        audio_asset_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        start_ms:
+          type: integer
+          minimum: 0
+        end_ms:
+          type: integer
+          minimum: 1
+    EvidenceQuality:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        audio:
+          type: number
+          minimum: 0
+          maximum: 1
+        asr:
+          type: number
+          minimum: 0
+          maximum: 1
+        alignment:
+          type: number
+          minimum: 0
+          maximum: 1
+    EvidenceLineage:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        asr_artifact:
+          $ref: '#/components/schemas/ArtifactDigest'
+        feature_artifact:
+          $ref: '#/components/schemas/ArtifactDigest'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39,6 +39,8 @@ tags:
     description: Questions, effective Turns, and ordered session events.
   - name: Review
     description: Analysis, evidence feedback, same-question retry, and history projections.
+  - name: Evaluation
+    description: Versioned Scene and Core 4D evaluation facts, gates, evidence, and revisions.
 paths:
   /health:
     get:
@@ -125,6 +127,12 @@ paths:
     $ref: ./modules/review.yaml#/paths/~1v1~1formal-reviews
   /v1/formal-reviews/{review_id}:
     $ref: ./modules/conversation.yaml#/paths/~1v1~1formal-reviews~1{review_id}
+  /v1/evaluations:
+    $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluations
+  /v1/evaluations/{evaluation_id}:
+    $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluations~1{evaluation_id}
+  /v1/evaluations/{evaluation_id}/re-evaluate:
+    $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluations~1{evaluation_id}~1re-evaluate
   /v1/scenario-definitions/{scenario_definition_id}:
     $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}
   /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
@@ -304,6 +312,20 @@ components:
       $ref: ./modules/review.yaml#/components/schemas/RetryRequest
     HistoryRecord:
       $ref: ./modules/review.yaml#/components/schemas/HistoryRecord
+    CreateEvaluationRequest:
+      $ref: ./modules/evaluation.yaml#/components/schemas/CreateEvaluationRequest
+    ReevaluateEvaluationRequest:
+      $ref: ./modules/evaluation.yaml#/components/schemas/ReevaluateEvaluationRequest
+    EvaluationAccepted:
+      $ref: ./modules/evaluation.yaml#/components/schemas/EvaluationAccepted
+    Evaluation:
+      $ref: ./modules/evaluation.yaml#/components/schemas/Evaluation
+    SceneEvaluationResult:
+      $ref: ./modules/evaluation.yaml#/components/schemas/SceneEvaluationResult
+    CoreAbilityObservation:
+      $ref: ./modules/evaluation.yaml#/components/schemas/CoreAbilityObservation
+    EvidenceRef:
+      $ref: ./modules/evaluation.yaml#/components/schemas/EvidenceRef
     ConversationEvent:
       oneOf:
         - $ref: ./websocket/conversation-events.schema.json#/$defs/StreamReadyEvent

--- a/api/package.json
+++ b/api/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "description": "Validation entrypoint for the SpeakUp REST and WebSocket contracts.",
   "scripts": {
-    "check": "npm run lint:openapi && npm run validate:security && npm run validate:websocket && npm run validate:fixture",
+    "check": "npm run lint:openapi && npm run validate:security && npm run validate:websocket && npm run validate:fixture && npm run validate:evaluation",
     "lint:openapi": "redocly lint openapi.yaml --config redocly.yaml",
     "validate:security": "node scripts/validate-security.mjs",
     "validate:websocket": "node scripts/validate-events.mjs",
-    "validate:fixture": "node scripts/validate-main-flow.mjs"
+    "validate:fixture": "node scripts/validate-main-flow.mjs",
+    "validate:evaluation": "node scripts/validate-evaluation.mjs"
   },
   "devDependencies": {
     "@redocly/cli": "2.40.0",

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -1,0 +1,598 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const execFileAsync = promisify(execFile);
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const fixture = JSON.parse(
+  await readFile(
+    resolve(apiDirectory, 'examples/evaluation-contract.json'),
+    'utf8',
+  ),
+);
+
+const bundleOpenApi = async () => {
+  const temporaryDirectory = await mkdtemp(
+    resolve(tmpdir(), 'speakup-evaluation-bundle-'),
+  );
+  const bundlePath = resolve(temporaryDirectory, 'openapi.bundle.json');
+  const redoclyCliPath = resolve(
+    apiDirectory,
+    'node_modules/@redocly/cli/bin/cli.js',
+  );
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        redoclyCliPath,
+        'bundle',
+        resolve(apiDirectory, 'openapi.yaml'),
+        '--config',
+        resolve(apiDirectory, 'redocly.yaml'),
+        '--output',
+        bundlePath,
+        '--ext',
+        'json',
+      ],
+      {
+        cwd: apiDirectory,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    return JSON.parse(await readFile(bundlePath, 'utf8'));
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+const decodeJsonPointerToken = (token) =>
+  token.replaceAll('~1', '/').replaceAll('~0', '~');
+const encodeJsonPointerToken = (token) =>
+  token.replaceAll('~', '~0').replaceAll('/', '~1');
+const componentReferencePrefix = '#/components/schemas/';
+
+const findComponentReferences = (value, references = new Set()) => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      findComponentReferences(item, references);
+    }
+    return references;
+  }
+  if (value === null || typeof value !== 'object') {
+    return references;
+  }
+  if (
+    typeof value.$ref === 'string' &&
+    value.$ref.startsWith(componentReferencePrefix)
+  ) {
+    references.add(
+      decodeJsonPointerToken(value.$ref.slice(componentReferencePrefix.length)),
+    );
+  }
+  for (const item of Object.values(value)) {
+    findComponentReferences(item, references);
+  }
+  return references;
+};
+
+const rewriteComponentReferences = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(rewriteComponentReferences);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => {
+      if (
+        key === '$ref' &&
+        typeof item === 'string' &&
+        item.startsWith(componentReferencePrefix)
+      ) {
+        const schemaName = decodeJsonPointerToken(
+          item.slice(componentReferencePrefix.length),
+        );
+        return [key, `#/$defs/${encodeJsonPointerToken(schemaName)}`];
+      }
+      return [key, rewriteComponentReferences(item)];
+    }),
+  );
+};
+
+const openApiBundle = await bundleOpenApi();
+const componentSchemas = openApiBundle.components?.schemas;
+assert.ok(componentSchemas, 'Bundled OpenAPI must contain component schemas.');
+
+const buildSchema = (rootSchemaName) => {
+  const definitions = {};
+  const collect = (schemaName) => {
+    if (Object.hasOwn(definitions, schemaName)) {
+      return;
+    }
+    const schema = componentSchemas[schemaName];
+    assert.ok(schema, `Missing bundled ${schemaName} schema.`);
+    definitions[schemaName] = rewriteComponentReferences(schema);
+    for (const dependencyName of findComponentReferences(schema)) {
+      collect(dependencyName);
+    }
+  };
+  collect(rootSchemaName);
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $ref: `#/$defs/${encodeJsonPointerToken(rootSchemaName)}`,
+    $defs: definitions,
+  };
+};
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: true,
+  strictRequired: false,
+});
+addFormats(ajv);
+
+const validators = Object.fromEntries(
+  [
+    'CreateEvaluationRequest',
+    'EvaluationAccepted',
+    'Evaluation',
+    'SceneEvaluationResult',
+    'CoreAbilityObservation',
+    'EvidenceRef',
+  ].map((schemaName) => [schemaName, ajv.compile(buildSchema(schemaName))]),
+);
+
+const validationErrors = (validator) =>
+  (validator.errors ?? [])
+    .map(
+      ({ instancePath, keyword, message }) =>
+        `${instancePath || '/'} ${keyword}: ${message}`,
+    )
+    .join('\n');
+
+const assertValid = (caseName, schemaName, value) => {
+  const validator = validators[schemaName];
+  assert.equal(
+    validator(value),
+    true,
+    `${caseName} violates ${schemaName}:\n${validationErrors(validator)}`,
+  );
+};
+
+const assertSchemaRejected = (caseName, schemaName, value) => {
+  const validator = validators[schemaName];
+  assert.equal(
+    validator(value),
+    false,
+    `${caseName}: invalid ${schemaName} fixture was accepted`,
+  );
+};
+
+assertValid(
+  'dual-channel create',
+  'CreateEvaluationRequest',
+  fixture.create_dual_channel,
+);
+assertValid('queued create response', 'EvaluationAccepted', fixture.queued);
+assertValid('Core 4D ready', 'Evaluation', fixture.core_4d_ready);
+assertValid(
+  'short sample blocked',
+  'Evaluation',
+  fixture.short_sample_blocked,
+);
+assertValid(
+  'low ASR feedback only',
+  'Evaluation',
+  fixture.low_asr_feedback_only,
+);
+assertValid('IELTS ready', 'Evaluation', fixture.ielts_ready);
+assertValid(
+  'Interview missing opportunity',
+  'Evaluation',
+  fixture.interview_missing_opportunity,
+);
+assertValid('technical failure', 'Evaluation', fixture.failed);
+assertValid(
+  'replacement revision queued',
+  'EvaluationAccepted',
+  fixture.revision_queued,
+);
+
+const scoreFields = [
+  'raw',
+  'display',
+  'raw_score',
+  'display_score',
+  'interval',
+];
+const assertNoScores = (value, context) => {
+  for (const field of scoreFields) {
+    assert.equal(
+      value[field],
+      undefined,
+      `${context}: non-PASS result contains ${field}`,
+    );
+  }
+};
+
+const assertEvidenceSemantics = (evidence, context) => {
+  if (evidence.transcript_span !== undefined) {
+    assert.ok(
+      evidence.transcript_span.start_utf8_byte <
+        evidence.transcript_span.end_utf8_byte,
+      `${context}: transcript span must be non-empty`,
+    );
+  }
+  if (evidence.audio_span !== undefined) {
+    assert.ok(
+      evidence.audio_span.start_ms < evidence.audio_span.end_ms,
+      `${context}: audio span must be non-empty`,
+    );
+  }
+};
+
+const assertDimensionSemantics = (dimension, context) => {
+  if (dimension.gate_status !== 'PASS') {
+    assertNoScores(dimension, context);
+    assert.ok(
+      dimension.reason_codes.length > 0,
+      `${context}: unscored result requires a reason`,
+    );
+  } else {
+    assert.ok(
+      dimension.evidence_refs.length > 0,
+      `${context}: scored result requires evidence`,
+    );
+    if (dimension.interval !== undefined) {
+      assert.ok(
+        dimension.interval[0] <= dimension.interval[1],
+        `${context}: interval bounds are reversed`,
+      );
+    }
+  }
+  for (const evidence of dimension.evidence_refs) {
+    assertEvidenceSemantics(evidence, context);
+  }
+};
+
+const assertEvaluationSemantics = (evaluation) => {
+  const hasSceneChannel = evaluation.channels.includes('SCENE');
+  const hasCoreChannel = evaluation.channels.includes('CORE_4D');
+  assert.equal(
+    evaluation.scene_strategy_ref !== undefined,
+    hasSceneChannel,
+    `${evaluation.evaluation_id}: SCENE strategy/channel mismatch`,
+  );
+  assert.equal(
+    evaluation.core_4d_strategy_ref !== undefined,
+    hasCoreChannel,
+    `${evaluation.evaluation_id}: CORE_4D strategy/channel mismatch`,
+  );
+  if (evaluation.scene_result !== undefined) {
+    assert.ok(hasSceneChannel);
+    assert.equal(evaluation.scene_result.scene_type, evaluation.scene_type);
+    assert.equal(
+      evaluation.scene_result.strategy_ref,
+      evaluation.scene_strategy_ref,
+    );
+  }
+  if (evaluation.core_4d_observations !== undefined) {
+    assert.ok(hasCoreChannel);
+    assert.equal(
+      new Set(
+        evaluation.core_4d_observations.map(
+          (observation) => observation.dimension,
+        ),
+      ).size,
+      evaluation.core_4d_observations.length,
+      `${evaluation.evaluation_id}: duplicate Core 4D dimensions`,
+    );
+    assert.ok(
+      evaluation.core_4d_observations.every(
+        (observation) =>
+          observation.strategy_ref === evaluation.core_4d_strategy_ref,
+      ),
+      `${evaluation.evaluation_id}: Core strategy mismatch`,
+    );
+  }
+  if (evaluation.scoreability_status === 'PROVISIONAL') {
+    assert.equal(
+      evaluation.is_final,
+      false,
+      `${evaluation.evaluation_id}: provisional result cannot be final`,
+    );
+  }
+};
+
+for (const evaluation of [
+  fixture.core_4d_ready,
+  fixture.short_sample_blocked,
+  fixture.low_asr_feedback_only,
+  fixture.ielts_ready,
+  fixture.interview_missing_opportunity,
+  fixture.failed,
+]) {
+  assertEvaluationSemantics(evaluation);
+}
+
+const coreDimensions = new Set([
+  'PRONUNCIATION',
+  'FLUENCY',
+  'VOCABULARY',
+  'GRAMMAR',
+]);
+assert.deepEqual(
+  new Set(
+    fixture.core_4d_ready.core_4d_observations.map(
+      (observation) => observation.dimension,
+    ),
+  ),
+  coreDimensions,
+);
+for (const observation of fixture.core_4d_ready.core_4d_observations) {
+  assertDimensionSemantics(
+    observation,
+    `Core 4D ${observation.dimension}`,
+  );
+  const weightSum = observation.weights.reduce(
+    (sum, weight) => sum + weight.value,
+    0,
+  );
+  assert.ok(
+    Math.abs(weightSum - 1) < Number.EPSILON,
+    `${observation.dimension}: weights must sum to one`,
+  );
+  if (observation.dimension === 'PRONUNCIATION') {
+    assert.ok(
+      observation.evidence_refs.every(
+        (evidence) => evidence.audio_span !== undefined,
+      ),
+      'Pronunciation evidence requires audio spans',
+    );
+  }
+}
+
+for (const evaluation of [
+  fixture.short_sample_blocked,
+  fixture.low_asr_feedback_only,
+]) {
+  for (const observation of evaluation.core_4d_observations) {
+    assertDimensionSemantics(
+      observation,
+      `${evaluation.evaluation_id} ${observation.dimension}`,
+    );
+    assert.equal(observation.profile_update_eligible, false);
+  }
+}
+
+const ielts = fixture.ielts_ready.scene_result;
+const ieltsDimensionIds = new Set(
+  ielts.dimensions.map((dimension) => dimension.dimension_id),
+);
+assert.deepEqual(
+  ieltsDimensionIds,
+  new Set(['IELTS_FC', 'IELTS_LR', 'IELTS_GRA', 'IELTS_PR']),
+);
+for (const dimension of ielts.dimensions) {
+  assertDimensionSemantics(dimension, dimension.dimension_id);
+  if (dimension.dimension_id === 'IELTS_PR') {
+    assert.ok(
+      dimension.evidence_refs.every(
+        (evidence) => evidence.audio_span !== undefined,
+      ),
+      'IELTS pronunciation requires audio spans',
+    );
+  }
+}
+const ieltsOverallRaw =
+  ielts.dimensions.reduce((sum, dimension) => sum + dimension.display, 0) /
+  ielts.dimensions.length;
+const ieltsOverallDisplay = Math.floor(ieltsOverallRaw * 2 + 0.5) / 2;
+assert.equal(ieltsOverallRaw, 6.75);
+assert.equal(ielts.overall_raw, ieltsOverallRaw);
+assert.equal(ielts.overall_display, ieltsOverallDisplay);
+assert.equal(ieltsOverallDisplay, 7);
+
+const interview = fixture.interview_missing_opportunity.scene_result;
+assert.equal(interview.overall_raw, undefined);
+assert.equal(interview.overall_display, undefined);
+assert.equal(interview.total_raw, undefined);
+assert.equal(interview.total_display, undefined);
+assert.equal(interview.weights, undefined);
+assert.equal(interview.readiness_level, 'NOT_ASSESSED');
+assert.deepEqual(
+  new Set(interview.dimensions.map((dimension) => dimension.dimension_id)),
+  new Set([
+    'INTERVIEW_RELEVANCE',
+    'INTERVIEW_STRUCTURE',
+    'INTERVIEW_EVIDENCE',
+    'INTERVIEW_PROFESSIONAL',
+    'INTERVIEW_INTERACTION',
+  ]),
+);
+for (const dimension of interview.dimensions) {
+  assertDimensionSemantics(dimension, dimension.dimension_id);
+}
+const interaction = interview.dimensions.find(
+  (dimension) => dimension.dimension_id === 'INTERVIEW_INTERACTION',
+);
+assert.equal(interaction.gate_status, 'BLOCKED');
+assert.deepEqual(interaction.reason_codes, ['OPPORTUNITY_NOT_PROVIDED']);
+assert.equal(interview.task_results.length, 1);
+assert.equal(interview.question_results.length, 1);
+const missingFollowup = interview.question_results[0];
+assert.equal(missingFollowup.opportunity_status, 'NOT_PROVIDED');
+assert.deepEqual(missingFollowup.response_turn_ids, []);
+assert.equal(missingFollowup.dimension_evidence.length, 1);
+assert.equal(
+  missingFollowup.dimension_evidence[0].dimension_id,
+  'INTERVIEW_INTERACTION',
+);
+assert.equal(
+  missingFollowup.dimension_evidence[0].question_score,
+  undefined,
+);
+assert.deepEqual(
+  missingFollowup.dimension_evidence[0].reason_codes,
+  ['OPPORTUNITY_NOT_PROVIDED'],
+);
+
+assert.equal(fixture.failed.scoreability_status, undefined);
+assert.equal(fixture.failed.gate_status, undefined);
+assert.equal(fixture.failed.scene_result, undefined);
+assert.equal(fixture.failed.core_4d_observations, undefined);
+assert.ok(fixture.failed.stable_failure);
+
+assert.ok(fixture.revision_queued.revision > 1);
+assert.ok(fixture.revision_queued.supersedes_revision_id);
+
+const invalidCreateWithOwner = structuredClone(fixture.create_dual_channel);
+invalidCreateWithOwner.owner_user_id = 'user_injected';
+assertSchemaRejected(
+  'caller-supplied owner',
+  'CreateEvaluationRequest',
+  invalidCreateWithOwner,
+);
+
+const invalidCreateWithoutSceneStrategy = structuredClone(
+  fixture.create_dual_channel,
+);
+delete invalidCreateWithoutSceneStrategy.scene_strategy_ref;
+assertSchemaRejected(
+  'SCENE channel without strategy',
+  'CreateEvaluationRequest',
+  invalidCreateWithoutSceneStrategy,
+);
+
+const invalidCreateWithDuplicateChannel = structuredClone(
+  fixture.create_dual_channel,
+);
+invalidCreateWithDuplicateChannel.channels = ['SCENE', 'SCENE'];
+assertSchemaRejected(
+  'duplicate Evaluation channel',
+  'CreateEvaluationRequest',
+  invalidCreateWithDuplicateChannel,
+);
+
+const invalidBlockedWithScore = structuredClone(
+  fixture.short_sample_blocked.core_4d_observations[0],
+);
+invalidBlockedWithScore.raw_score = 0;
+invalidBlockedWithScore.display_score = 0;
+assertSchemaRejected(
+  'non-PASS Core result with zero score',
+  'CoreAbilityObservation',
+  invalidBlockedWithScore,
+);
+
+const invalidInterviewTotal = structuredClone(interview);
+invalidInterviewTotal.overall_raw = 75;
+invalidInterviewTotal.overall_display = 75;
+assertSchemaRejected(
+  'non-IELTS numeric total',
+  'SceneEvaluationResult',
+  invalidInterviewTotal,
+);
+
+const invalidFailedWithGate = structuredClone(fixture.failed);
+invalidFailedWithGate.scoreability_status = 'INSUFFICIENT';
+invalidFailedWithGate.gate_status = 'BLOCKED';
+assertSchemaRejected(
+  'technical failure disguised as unscoreable',
+  'Evaluation',
+  invalidFailedWithGate,
+);
+
+const invalidCoreTotal = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[0],
+);
+invalidCoreTotal.total_display = 78;
+assertSchemaRejected(
+  'Core observation with aggregate total',
+  'CoreAbilityObservation',
+  invalidCoreTotal,
+);
+
+const invalidEvidenceWithoutLocator = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[0].evidence_refs[0],
+);
+delete invalidEvidenceWithoutLocator.audio_span;
+assertSchemaRejected(
+  'EvidenceRef without a transcript or audio locator',
+  'EvidenceRef',
+  invalidEvidenceWithoutLocator,
+);
+
+const invalidEvidenceWithPermanentUrl = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[0].evidence_refs[0],
+);
+invalidEvidenceWithPermanentUrl.audio_url = 'https://storage.example/audio.wav';
+assertSchemaRejected(
+  'EvidenceRef exposing a permanent object URL',
+  'EvidenceRef',
+  invalidEvidenceWithPermanentUrl,
+);
+
+const invalidMissingVersion = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[0],
+);
+delete invalidMissingVersion.aggregation_version;
+assertSchemaRejected(
+  'Core observation missing aggregation version',
+  'CoreAbilityObservation',
+  invalidMissingVersion,
+);
+
+const reversedTranscriptEvidence = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[2].evidence_refs[0],
+);
+reversedTranscriptEvidence.transcript_span.start_utf8_byte = 48;
+reversedTranscriptEvidence.transcript_span.end_utf8_byte = 12;
+assert.throws(
+  () =>
+    assertEvidenceSemantics(
+      reversedTranscriptEvidence,
+      'reversed transcript evidence',
+    ),
+  /transcript span must be non-empty/,
+);
+
+const reversedAudioEvidence = structuredClone(
+  fixture.core_4d_ready.core_4d_observations[0].evidence_refs[0],
+);
+reversedAudioEvidence.audio_span.start_ms = 4800;
+reversedAudioEvidence.audio_span.end_ms = 1200;
+assert.throws(
+  () =>
+    assertEvidenceSemantics(reversedAudioEvidence, 'reversed audio evidence'),
+  /audio span must be non-empty/,
+);
+
+const mismatchedSceneResult = structuredClone(fixture.ielts_ready);
+mismatchedSceneResult.scene_result.scene_type = 'INTERVIEW';
+assert.throws(
+  () => assertEvaluationSemantics(mismatchedSceneResult),
+  /Expected values to be strictly equal/,
+);
+
+const duplicatedCoreDimension = structuredClone(fixture.core_4d_ready);
+duplicatedCoreDimension.core_4d_observations[1].dimension = 'PRONUNCIATION';
+assert.throws(
+  () => assertEvaluationSemantics(duplicatedCoreDimension),
+  /duplicate Core 4D dimensions/,
+);
+
+const provisionalMarkedFinal = structuredClone(fixture.low_asr_feedback_only);
+provisionalMarkedFinal.is_final = true;
+assert.throws(
+  () => assertEvaluationSemantics(provisionalMarkedFinal),
+  /provisional result cannot be final/,
+);


### PR DESCRIPTION
## 功能描述

为统一评分能力定义独立的 Evaluation API 契约，覆盖创建、查询和重评，并明确评分状态、可评分性、门禁、不可评分结果、证据引用、版本与修订语义。

## 实现思路

- 新增 Evaluation OpenAPI 模块并接入主契约。
- Scene 与 Core4D 共享 EvidenceSnapshot，但保持独立结果链。
- 仅 IELTS 输出总分；面试、日常和职场场景禁止根权重与总分。
- 非 PASS 维度禁止输出 0 分或伪分，使用缺失分值与原因码表达。
- 固定正常、短样本、低 ASR、技术失败、重评修订等契约样例。
- 增加自动校验，覆盖结构约束及 IELTS 7/7/6/7 → 7.0 等业务不变量。

## 可复现测试

- `make check-api`
- `git diff --check`

## 范围说明

本 PR 只定义 API/Schema/样例/校验，不包含 Go 运行时、数据库迁移、模型供应商接入或 Flutter 页面。

Closes #176