### PR TITLE
[后端] 实现 Evaluation ledger、不可变修订与事务 outbox

### DIFF
--- a/server/internal/evaluation/migration_test.go
+++ b/server/internal/evaluation/migration_test.go
@@ -1,0 +1,42 @@
+package evaluation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+)
+
+func TestEvaluationMigrationFreezesFactsAndMinimizesOutbox(t *testing.T) {
+	content, err := migrations.Files.ReadFile(
+		"000024_evaluation_ledger.up.sql",
+	)
+	if err != nil {
+		t.Fatalf("read Evaluation migration: %v", err)
+	}
+	sql := strings.ToLower(string(content))
+	for _, required := range []string{
+		"create table evaluation_ledgers",
+		"create table evaluation_revisions",
+		"create table evaluation_revision_states",
+		"create table evaluation_outbox",
+		"evaluation_revisions_immutable",
+		"evaluation_assert_revision_chain",
+		"evaluation_outbox_revision_channel_unique",
+		"evaluation_outbox_channel_key_unique",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Errorf("migration is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"transcript",
+		"audio_url",
+		"provider_key",
+		"system_prompt",
+	} {
+		if strings.Contains(sql, forbidden) {
+			t.Errorf("migration contains forbidden sensitive field %q", forbidden)
+		}
+	}
+}

--- a/server/internal/evaluation/model.go
+++ b/server/internal/evaluation/model.go
@@ -1,0 +1,337 @@
+package evaluation
+
+import (
+	"errors"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const SchemaVersion = "evaluation-schema/1.0.0"
+
+var (
+	ErrInvalidRequest      = errors.New("evaluation: invalid request")
+	ErrNotFound            = errors.New("evaluation: not found")
+	ErrIdempotencyConflict = errors.New("evaluation: idempotency conflict")
+	ErrAccountUnavailable  = errors.New("evaluation: account unavailable")
+)
+
+type Channel string
+
+const (
+	ChannelScene  Channel = "SCENE"
+	ChannelCore4D Channel = "CORE_4D"
+)
+
+type Scope string
+
+const (
+	ScopeTurn    Scope = "TURN"
+	ScopeSession Scope = "SESSION"
+)
+
+type SceneType string
+
+const (
+	SceneIELTSSpeaking     SceneType = "IELTS_SPEAKING"
+	SceneInterview         SceneType = "INTERVIEW"
+	SceneOverseasDaily     SceneType = "OVERSEAS_DAILY_LIFE"
+	SceneOverseasWorkplace SceneType = "OVERSEAS_WORKPLACE"
+)
+
+type Status string
+
+const (
+	StatusReceived     Status = "RECEIVED"
+	StatusValidating   Status = "VALIDATING"
+	StatusQueued       Status = "QUEUED"
+	StatusRunning      Status = "RUNNING"
+	StatusPartialReady Status = "PARTIAL_READY"
+	StatusReady        Status = "READY"
+	StatusFailed       Status = "FAILED"
+	StatusSuperseded   Status = "SUPERSEDED"
+)
+
+type CreateRequest struct {
+	PracticeSessionID string
+	InputSnapshotID   string
+	InputRevision     int
+	Scope             Scope
+	SceneType         SceneType
+	Channels          []Channel
+	SceneStrategyRef  string
+	Core4DStrategyRef string
+	PipelineVersion   string
+	ClientRequestID   string
+}
+
+type ReevaluateRequest struct {
+	Channels          []Channel
+	SceneStrategyRef  string
+	Core4DStrategyRef string
+	PipelineVersion   string
+	ClientRequestID   string
+}
+
+type Evaluation struct {
+	ID                string
+	OwnerUserID       string
+	PracticeSessionID string
+	InputSnapshotID   string
+	InputRevision     int
+	Scope             Scope
+	SceneType         SceneType
+	Revision          Revision
+	CreatedAt         time.Time
+}
+
+type Revision struct {
+	ID                   string
+	EvaluationID         string
+	OwnerUserID          string
+	Number               int
+	SupersedesRevisionID string
+	Channels             []Channel
+	SceneStrategyRef     string
+	Core4DStrategyRef    string
+	PipelineVersion      string
+	SchemaVersion        string
+	Status               Status
+	IsFinal              bool
+	ClientRequestID      string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+func (e Evaluation) Valid() bool {
+	return validUUID(e.ID) &&
+		validUUID(e.OwnerUserID) &&
+		validIdentifier(e.PracticeSessionID) &&
+		validIdentifier(e.InputSnapshotID) &&
+		e.InputRevision > 0 &&
+		validScope(e.Scope) &&
+		validSceneType(e.SceneType) &&
+		e.Revision.Valid() &&
+		e.Revision.EvaluationID == e.ID &&
+		e.Revision.OwnerUserID == e.OwnerUserID &&
+		!e.CreatedAt.IsZero()
+}
+
+func (r Revision) Valid() bool {
+	return validUUID(r.ID) &&
+		validUUID(r.EvaluationID) &&
+		validUUID(r.OwnerUserID) &&
+		r.Number > 0 &&
+		((r.Number == 1 && r.SupersedesRevisionID == "") ||
+			(r.Number > 1 && validUUID(r.SupersedesRevisionID))) &&
+		validChannels(r.Channels) &&
+		validStrategies(
+			r.Channels,
+			r.SceneStrategyRef,
+			r.Core4DStrategyRef,
+		) &&
+		validVersion(r.PipelineVersion) &&
+		validVersion(r.SchemaVersion) &&
+		validStatus(r.Status) &&
+		validCompletion(r.Status, r.CompletedAt) &&
+		validClientRequestID(r.ClientRequestID) &&
+		!r.CreatedAt.IsZero() &&
+		!r.UpdatedAt.Before(r.CreatedAt)
+}
+
+type revisionConfig struct {
+	Channels          []Channel `json:"channels"`
+	SceneStrategyRef  string    `json:"scene_strategy_ref,omitempty"`
+	Core4DStrategyRef string    `json:"core_4d_strategy_ref,omitempty"`
+	PipelineVersion   string    `json:"pipeline_version"`
+	SchemaVersion     string    `json:"schema_version"`
+	ClientRequestID   string    `json:"-"`
+}
+
+type createInput struct {
+	PracticeSessionID string         `json:"practice_session_id"`
+	InputSnapshotID   string         `json:"input_snapshot_id"`
+	InputRevision     int            `json:"input_revision"`
+	Scope             Scope          `json:"scope"`
+	SceneType         SceneType      `json:"scene_type"`
+	Config            revisionConfig `json:"config"`
+}
+
+func normalizeCreate(request CreateRequest) (createInput, error) {
+	config, err := normalizeConfig(
+		request.Channels,
+		request.SceneStrategyRef,
+		request.Core4DStrategyRef,
+		request.PipelineVersion,
+		request.ClientRequestID,
+	)
+	if err != nil ||
+		!validIdentifier(request.PracticeSessionID) ||
+		!validIdentifier(request.InputSnapshotID) ||
+		request.InputRevision < 1 ||
+		!validScope(request.Scope) ||
+		!validSceneType(request.SceneType) {
+		return createInput{}, ErrInvalidRequest
+	}
+	return createInput{
+		PracticeSessionID: strings.TrimSpace(request.PracticeSessionID),
+		InputSnapshotID:   strings.TrimSpace(request.InputSnapshotID),
+		InputRevision:     request.InputRevision,
+		Scope:             request.Scope,
+		SceneType:         request.SceneType,
+		Config:            config,
+	}, nil
+}
+
+func normalizeReevaluation(
+	request ReevaluateRequest,
+) (revisionConfig, error) {
+	return normalizeConfig(
+		request.Channels,
+		request.SceneStrategyRef,
+		request.Core4DStrategyRef,
+		request.PipelineVersion,
+		request.ClientRequestID,
+	)
+}
+
+func normalizeConfig(
+	channels []Channel,
+	sceneStrategyRef string,
+	core4DStrategyRef string,
+	pipelineVersion string,
+	clientRequestID string,
+) (revisionConfig, error) {
+	normalizedChannels := slices.Clone(channels)
+	slices.Sort(normalizedChannels)
+	sceneStrategyRef = strings.TrimSpace(sceneStrategyRef)
+	core4DStrategyRef = strings.TrimSpace(core4DStrategyRef)
+	pipelineVersion = strings.TrimSpace(pipelineVersion)
+	clientRequestID = strings.TrimSpace(clientRequestID)
+	if !validChannels(normalizedChannels) ||
+		!validStrategies(
+			normalizedChannels,
+			sceneStrategyRef,
+			core4DStrategyRef,
+		) ||
+		!validVersion(pipelineVersion) ||
+		!validClientRequestID(clientRequestID) {
+		return revisionConfig{}, ErrInvalidRequest
+	}
+	return revisionConfig{
+		Channels:          normalizedChannels,
+		SceneStrategyRef:  sceneStrategyRef,
+		Core4DStrategyRef: core4DStrategyRef,
+		PipelineVersion:   pipelineVersion,
+		SchemaVersion:     SchemaVersion,
+		ClientRequestID:   clientRequestID,
+	}, nil
+}
+
+func validActor(actor requestcontext.Actor) bool {
+	return actor.Valid() && validUUID(actor.UserID)
+}
+
+func validChannels(channels []Channel) bool {
+	if len(channels) < 1 || len(channels) > 2 {
+		return false
+	}
+	seen := make(map[Channel]struct{}, len(channels))
+	for _, channel := range channels {
+		if channel != ChannelScene && channel != ChannelCore4D {
+			return false
+		}
+		if _, exists := seen[channel]; exists {
+			return false
+		}
+		seen[channel] = struct{}{}
+	}
+	return true
+}
+
+func validStrategies(
+	channels []Channel,
+	sceneStrategyRef string,
+	core4DStrategyRef string,
+) bool {
+	hasScene := slices.Contains(channels, ChannelScene)
+	hasCore4D := slices.Contains(channels, ChannelCore4D)
+	return ((hasScene && validVersion(sceneStrategyRef)) ||
+		(!hasScene && sceneStrategyRef == "")) &&
+		((hasCore4D && validVersion(core4DStrategyRef)) ||
+			(!hasCore4D && core4DStrategyRef == ""))
+}
+
+func validScope(scope Scope) bool {
+	return scope == ScopeTurn || scope == ScopeSession
+}
+
+func validSceneType(sceneType SceneType) bool {
+	switch sceneType {
+	case SceneIELTSSpeaking,
+		SceneInterview,
+		SceneOverseasDaily,
+		SceneOverseasWorkplace:
+		return true
+	default:
+		return false
+	}
+}
+
+func validStatus(status Status) bool {
+	switch status {
+	case StatusReceived,
+		StatusValidating,
+		StatusQueued,
+		StatusRunning,
+		StatusPartialReady,
+		StatusReady,
+		StatusFailed,
+		StatusSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+func validCompletion(status Status, completedAt *time.Time) bool {
+	switch status {
+	case StatusReady, StatusFailed, StatusSuperseded:
+		return completedAt != nil && !completedAt.IsZero()
+	default:
+		return completedAt == nil
+	}
+}
+
+var (
+	uuidPattern = regexp.MustCompile(
+		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`,
+	)
+	identifierPattern = regexp.MustCompile(
+		`^[A-Za-z][A-Za-z0-9._:-]{0,127}$`,
+	)
+	versionPattern = regexp.MustCompile(
+		`^[A-Za-z][A-Za-z0-9._:/-]{0,127}$`,
+	)
+	clientRequestPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+)
+
+func validUUID(value string) bool {
+	return uuidPattern.MatchString(value)
+}
+
+func validIdentifier(value string) bool {
+	return identifierPattern.MatchString(strings.TrimSpace(value))
+}
+
+func validVersion(value string) bool {
+	return versionPattern.MatchString(strings.TrimSpace(value))
+}
+
+func validClientRequestID(value string) bool {
+	return value == "" || clientRequestPattern.MatchString(value)
+}

--- a/server/internal/evaluation/model_test.go
+++ b/server/internal/evaluation/model_test.go
@@ -1,0 +1,38 @@
+package evaluation
+
+import "testing"
+
+func TestEvaluationValidityRequiresImmutableRevisionLinkage(t *testing.T) {
+	evaluation := validEvaluation()
+	if !evaluation.Valid() {
+		t.Fatal("valid fixture was rejected")
+	}
+	evaluation.Revision.EvaluationID = testOwnerB
+	if evaluation.Valid() {
+		t.Fatal("cross-Evaluation revision linkage was accepted")
+	}
+}
+
+func TestRevisionValidityRejectsNonFirstRevisionWithoutSupersedes(t *testing.T) {
+	revision := validEvaluation().Revision
+	revision.Number = 2
+	if revision.Valid() {
+		t.Fatal("revision 2 without supersedes was accepted")
+	}
+	revision.SupersedesRevisionID =
+		"60000000-0000-4000-8000-000000000006"
+	if !revision.Valid() {
+		t.Fatal("revision 2 with supersedes was rejected")
+	}
+}
+
+func TestRevisionValidityAllowsCompletedShadowResult(t *testing.T) {
+	revision := validEvaluation().Revision
+	completedAt := revision.UpdatedAt
+	revision.Status = StatusReady
+	revision.IsFinal = false
+	revision.CompletedAt = &completedAt
+	if !revision.Valid() {
+		t.Fatal("completed non-final Shadow revision was rejected")
+	}
+}

--- a/server/internal/evaluation/postgres.go
+++ b/server/internal/evaluation/postgres.go
@@ -1,0 +1,559 @@
+package evaluation
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PostgresRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
+	return &PostgresRepository{pool: pool}
+}
+
+func (r *PostgresRepository) Ensure(
+	ctx context.Context,
+	command EnsureCommand,
+) (Evaluation, bool, error) {
+	if r == nil || r.pool == nil || ctx == nil ||
+		!validEnsureCommand(command) {
+		return Evaluation{}, false, ErrInvalidRequest
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf("begin Evaluation ensure: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := lockActiveOwner(ctx, tx, command.OwnerUserID); err != nil {
+		return Evaluation{}, false, err
+	}
+
+	var evaluationID string
+	err = tx.QueryRow(ctx, `
+		INSERT INTO evaluation_ledgers (
+			owner_user_id,
+			root_idempotency_key,
+			root_request_fingerprint,
+			practice_session_id,
+			input_snapshot_id,
+			input_revision,
+			scope,
+			scene_type
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (owner_user_id, root_idempotency_key) DO NOTHING
+		RETURNING id::text
+	`, command.OwnerUserID, command.RootIdempotencyKey[:],
+		command.RootFingerprint[:], command.Input.PracticeSessionID,
+		command.Input.InputSnapshotID, command.Input.InputRevision,
+		command.Input.Scope, command.Input.SceneType).Scan(&evaluationID)
+	switch {
+	case err == nil:
+		evaluation, insertErr := insertRevision(
+			ctx,
+			tx,
+			evaluationID,
+			command.OwnerUserID,
+			command.RootIdempotencyKey,
+			1,
+			"",
+			command.RevisionFingerprint,
+			command.Input.Config,
+		)
+		if insertErr != nil {
+			return Evaluation{}, false, insertErr
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return Evaluation{}, false, fmt.Errorf(
+				"commit Evaluation ensure: %w",
+				err,
+			)
+		}
+		return evaluation, false, nil
+	case errors.Is(err, pgx.ErrNoRows):
+	default:
+		return Evaluation{}, false, fmt.Errorf(
+			"insert Evaluation ledger: %w",
+			err,
+		)
+	}
+
+	var persistedFingerprint []byte
+	err = tx.QueryRow(ctx, `
+		SELECT id::text, root_request_fingerprint
+		FROM evaluation_ledgers
+		WHERE owner_user_id = $1
+		  AND root_idempotency_key = $2
+		FOR UPDATE
+	`, command.OwnerUserID, command.RootIdempotencyKey[:]).Scan(
+		&evaluationID,
+		&persistedFingerprint,
+	)
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"read Evaluation idempotency replay: %w",
+			err,
+		)
+	}
+	if !bytes.Equal(persistedFingerprint, command.RootFingerprint[:]) {
+		return Evaluation{}, false, ErrIdempotencyConflict
+	}
+	evaluation, err := selectLatest(
+		ctx,
+		tx,
+		command.OwnerUserID,
+		evaluationID,
+	)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"commit Evaluation replay: %w",
+			err,
+		)
+	}
+	return evaluation, true, nil
+}
+
+func (r *PostgresRepository) Reevaluate(
+	ctx context.Context,
+	command ReevaluateCommand,
+) (Evaluation, bool, error) {
+	if r == nil || r.pool == nil || ctx == nil ||
+		!validReevaluateCommand(command) {
+		return Evaluation{}, false, ErrInvalidRequest
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"begin Evaluation re-evaluation: %w",
+			err,
+		)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := lockActiveOwner(ctx, tx, command.OwnerUserID); err != nil {
+		return Evaluation{}, false, err
+	}
+
+	var rootKeyBytes []byte
+	err = tx.QueryRow(ctx, `
+		SELECT root_idempotency_key
+		FROM evaluation_ledgers
+		WHERE id = $1
+		  AND owner_user_id = $2
+		FOR UPDATE
+	`, command.EvaluationID, command.OwnerUserID).Scan(&rootKeyBytes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Evaluation{}, false, ErrNotFound
+	}
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"lock Evaluation ledger: %w",
+			err,
+		)
+	}
+	if len(rootKeyBytes) != sha256.Size {
+		return Evaluation{}, false, ErrInvalidRequest
+	}
+	var rootKey [sha256.Size]byte
+	copy(rootKey[:], rootKeyBytes)
+
+	var latestRevisionID string
+	var latestRevision int
+	var latestFingerprint []byte
+	err = tx.QueryRow(ctx, `
+		SELECT id::text, revision, request_fingerprint
+		FROM evaluation_revisions
+		WHERE evaluation_id = $1
+		  AND owner_user_id = $2
+		ORDER BY revision DESC
+		LIMIT 1
+		FOR UPDATE
+	`, command.EvaluationID, command.OwnerUserID).Scan(
+		&latestRevisionID,
+		&latestRevision,
+		&latestFingerprint,
+	)
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"read latest Evaluation revision: %w",
+			err,
+		)
+	}
+	if bytes.Equal(latestFingerprint, command.RevisionFingerprint[:]) {
+		evaluation, selectErr := selectLatest(
+			ctx,
+			tx,
+			command.OwnerUserID,
+			command.EvaluationID,
+		)
+		if selectErr != nil {
+			return Evaluation{}, false, selectErr
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return Evaluation{}, false, fmt.Errorf(
+				"commit re-evaluation replay: %w",
+				err,
+			)
+		}
+		return evaluation, true, nil
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE evaluation_revision_states
+		SET evaluation_status = 'SUPERSEDED',
+		    updated_at = transaction_timestamp(),
+		    completed_at = transaction_timestamp()
+		WHERE revision_id = $1
+		  AND evaluation_id = $2
+		  AND owner_user_id = $3
+	`, latestRevisionID, command.EvaluationID, command.OwnerUserID)
+	if err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"supersede previous Evaluation revision: %w",
+			err,
+		)
+	}
+
+	evaluation, err := insertRevision(
+		ctx,
+		tx,
+		command.EvaluationID,
+		command.OwnerUserID,
+		rootKey,
+		latestRevision+1,
+		latestRevisionID,
+		command.RevisionFingerprint,
+		command.Config,
+	)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Evaluation{}, false, fmt.Errorf(
+			"commit Evaluation re-evaluation: %w",
+			err,
+		)
+	}
+	return evaluation, false, nil
+}
+
+func (r *PostgresRepository) Get(
+	ctx context.Context,
+	ownerUserID string,
+	evaluationID string,
+) (Evaluation, error) {
+	if r == nil || r.pool == nil || ctx == nil ||
+		!validUUID(ownerUserID) || !validUUID(evaluationID) {
+		return Evaluation{}, ErrInvalidRequest
+	}
+	evaluation, err := selectLatest(
+		ctx,
+		r.pool,
+		ownerUserID,
+		evaluationID,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Evaluation{}, ErrNotFound
+	}
+	return evaluation, err
+}
+
+type queryable interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func selectLatest(
+	ctx context.Context,
+	db queryable,
+	ownerUserID string,
+	evaluationID string,
+) (Evaluation, error) {
+	row := db.QueryRow(ctx, evaluationSelect+`
+		WHERE ledger.id = $1
+		  AND ledger.owner_user_id = $2
+		ORDER BY revision.revision DESC
+		LIMIT 1
+	`, evaluationID, ownerUserID)
+	evaluation, err := scanEvaluation(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Evaluation{}, ErrNotFound
+	}
+	if err != nil {
+		return Evaluation{}, fmt.Errorf("read Evaluation: %w", err)
+	}
+	return evaluation, nil
+}
+
+func insertRevision(
+	ctx context.Context,
+	tx pgx.Tx,
+	evaluationID string,
+	ownerUserID string,
+	rootKey [sha256.Size]byte,
+	revision int,
+	supersedesRevisionID string,
+	fingerprint [sha256.Size]byte,
+	config revisionConfig,
+) (Evaluation, error) {
+	channelStrings := make([]string, len(config.Channels))
+	for index, channel := range config.Channels {
+		channelStrings[index] = string(channel)
+	}
+	var revisionID string
+	err := tx.QueryRow(ctx, `
+		INSERT INTO evaluation_revisions (
+			evaluation_id,
+			owner_user_id,
+			revision,
+			supersedes_revision_id,
+			channels,
+			scene_strategy_ref,
+			core_4d_strategy_ref,
+			pipeline_version,
+			schema_version,
+			request_fingerprint,
+			client_request_id
+		)
+		VALUES (
+			$1, $2, $3, nullif($4, '')::uuid, $5, nullif($6, ''),
+			nullif($7, ''), $8, $9, $10, nullif($11, '')
+		)
+		RETURNING id::text
+	`, evaluationID, ownerUserID, revision, supersedesRevisionID,
+		channelStrings, config.SceneStrategyRef, config.Core4DStrategyRef,
+		config.PipelineVersion, config.SchemaVersion, fingerprint[:],
+		config.ClientRequestID).Scan(&revisionID)
+	if err != nil {
+		return Evaluation{}, fmt.Errorf("insert Evaluation revision: %w", err)
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO evaluation_revision_states (
+			revision_id,
+			evaluation_id,
+			owner_user_id
+		)
+		VALUES ($1, $2, $3)
+	`, revisionID, evaluationID, ownerUserID)
+	if err != nil {
+		return Evaluation{}, fmt.Errorf(
+			"insert Evaluation revision state: %w",
+			err,
+		)
+	}
+	for _, channel := range config.Channels {
+		channelKey := deriveChannelKey(
+			rootKey,
+			revision,
+			channel,
+			strategyForChannel(config, channel),
+		)
+		_, err = tx.Exec(ctx, `
+			INSERT INTO evaluation_outbox (
+				evaluation_id,
+				evaluation_revision_id,
+				owner_user_id,
+				channel,
+				channel_key,
+				event_type,
+				payload
+			)
+			VALUES (
+				$1::uuid,
+				$2::uuid,
+				$3::uuid,
+				$4::text,
+				$5::bytea,
+				'evaluation.revision.queued',
+				jsonb_build_object(
+					'evaluation_id', $1::text,
+					'evaluation_revision_id', $2::text,
+					'revision', $6::integer,
+					'channel', $4::text
+				)
+			)
+		`, evaluationID, revisionID, ownerUserID, channel,
+			channelKey[:], revision)
+		if err != nil {
+			return Evaluation{}, fmt.Errorf(
+				"insert %s Evaluation outbox: %w",
+				channel,
+				err,
+			)
+		}
+	}
+	evaluation, err := selectLatest(ctx, tx, ownerUserID, evaluationID)
+	if err != nil {
+		return Evaluation{}, err
+	}
+	return evaluation, nil
+}
+
+func lockActiveOwner(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerUserID string,
+) error {
+	var status string
+	err := tx.QueryRow(ctx, `
+		SELECT account_status
+		FROM identity_users
+		WHERE id = $1
+		FOR KEY SHARE
+	`, ownerUserID).Scan(&status)
+	if errors.Is(err, pgx.ErrNoRows) || (err == nil && status != "active") {
+		return ErrAccountUnavailable
+	}
+	if err != nil {
+		return fmt.Errorf("lock Evaluation owner: %w", err)
+	}
+	return nil
+}
+
+const evaluationSelect = `
+	SELECT
+		ledger.id::text,
+		ledger.owner_user_id::text,
+		ledger.practice_session_id,
+		ledger.input_snapshot_id,
+		ledger.input_revision,
+		ledger.scope,
+		ledger.scene_type,
+		ledger.created_at,
+		revision.id::text,
+		revision.revision,
+		coalesce(revision.supersedes_revision_id::text, ''),
+		revision.channels,
+		coalesce(revision.scene_strategy_ref, ''),
+		coalesce(revision.core_4d_strategy_ref, ''),
+		revision.pipeline_version,
+		revision.schema_version,
+		coalesce(revision.client_request_id, ''),
+		state.evaluation_status,
+		state.is_final,
+		revision.created_at,
+		state.updated_at,
+		state.completed_at
+	FROM evaluation_ledgers AS ledger
+	JOIN evaluation_revisions AS revision
+	  ON revision.evaluation_id = ledger.id
+	 AND revision.owner_user_id = ledger.owner_user_id
+	JOIN evaluation_revision_states AS state
+	  ON state.revision_id = revision.id
+	 AND state.evaluation_id = ledger.id
+	 AND state.owner_user_id = ledger.owner_user_id
+`
+
+func scanEvaluation(row pgx.Row) (Evaluation, error) {
+	var evaluation Evaluation
+	var channels []string
+	err := row.Scan(
+		&evaluation.ID,
+		&evaluation.OwnerUserID,
+		&evaluation.PracticeSessionID,
+		&evaluation.InputSnapshotID,
+		&evaluation.InputRevision,
+		&evaluation.Scope,
+		&evaluation.SceneType,
+		&evaluation.CreatedAt,
+		&evaluation.Revision.ID,
+		&evaluation.Revision.Number,
+		&evaluation.Revision.SupersedesRevisionID,
+		&channels,
+		&evaluation.Revision.SceneStrategyRef,
+		&evaluation.Revision.Core4DStrategyRef,
+		&evaluation.Revision.PipelineVersion,
+		&evaluation.Revision.SchemaVersion,
+		&evaluation.Revision.ClientRequestID,
+		&evaluation.Revision.Status,
+		&evaluation.Revision.IsFinal,
+		&evaluation.Revision.CreatedAt,
+		&evaluation.Revision.UpdatedAt,
+		&evaluation.Revision.CompletedAt,
+	)
+	if err != nil {
+		return Evaluation{}, err
+	}
+	evaluation.Revision.EvaluationID = evaluation.ID
+	evaluation.Revision.OwnerUserID = evaluation.OwnerUserID
+	evaluation.Revision.Channels = make([]Channel, len(channels))
+	for index, channel := range channels {
+		evaluation.Revision.Channels[index] = Channel(channel)
+	}
+	if !evaluation.Valid() {
+		return Evaluation{}, ErrInvalidRequest
+	}
+	return evaluation, nil
+}
+
+func deriveChannelKey(
+	rootKey [sha256.Size]byte,
+	revision int,
+	channel Channel,
+	strategyRef string,
+) [sha256.Size]byte {
+	hasher := sha256.New()
+	_, _ = hasher.Write([]byte("evaluation-channel:v1\x00"))
+	_, _ = hasher.Write(rootKey[:])
+	var revisionBytes [8]byte
+	binary.BigEndian.PutUint64(revisionBytes[:], uint64(revision))
+	_, _ = hasher.Write(revisionBytes[:])
+	_, _ = hasher.Write([]byte{0})
+	_, _ = hasher.Write([]byte(channel))
+	_, _ = hasher.Write([]byte{0})
+	_, _ = hasher.Write([]byte(strategyRef))
+	var result [sha256.Size]byte
+	copy(result[:], hasher.Sum(nil))
+	return result
+}
+
+func strategyForChannel(config revisionConfig, channel Channel) string {
+	if channel == ChannelScene {
+		return config.SceneStrategyRef
+	}
+	return config.Core4DStrategyRef
+}
+
+func validEnsureCommand(command EnsureCommand) bool {
+	return validUUID(command.OwnerUserID) &&
+		command.Input.PracticeSessionID != "" &&
+		command.Input.InputSnapshotID != "" &&
+		command.Input.InputRevision > 0 &&
+		validScope(command.Input.Scope) &&
+		validSceneType(command.Input.SceneType) &&
+		validChannels(command.Input.Config.Channels) &&
+		validStrategies(
+			command.Input.Config.Channels,
+			command.Input.Config.SceneStrategyRef,
+			command.Input.Config.Core4DStrategyRef,
+		) &&
+		validVersion(command.Input.Config.PipelineVersion) &&
+		command.Input.Config.SchemaVersion == SchemaVersion &&
+		validClientRequestID(command.Input.Config.ClientRequestID)
+}
+
+func validReevaluateCommand(command ReevaluateCommand) bool {
+	return validUUID(command.OwnerUserID) &&
+		validUUID(command.EvaluationID) &&
+		validChannels(command.Config.Channels) &&
+		validStrategies(
+			command.Config.Channels,
+			command.Config.SceneStrategyRef,
+			command.Config.Core4DStrategyRef,
+		) &&
+		validVersion(command.Config.PipelineVersion) &&
+		command.Config.SchemaVersion == SchemaVersion &&
+		validClientRequestID(command.Config.ClientRequestID)
+}

--- a/server/internal/evaluation/postgres_integration_test.go
+++ b/server/internal/evaluation/postgres_integration_test.go
@@ -1,0 +1,454 @@
+package evaluation
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const integrationOwnerB = "20000000-0000-4000-8000-000000000002"
+
+func TestPostgresLedgerRevisionIdempotencyAndIsolation(t *testing.T) {
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA, integrationOwnerB)
+	service := NewService(NewPostgresRepository(pool))
+	ctx := context.Background()
+
+	request := validCreateRequest()
+	request.Channels = []Channel{ChannelScene, ChannelCore4D}
+	request.Core4DStrategyRef = "core4d/v1"
+	created, replayed, err := service.Create(
+		ctx,
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if replayed || !created.Valid() || created.Revision.Number != 1 {
+		t.Fatalf("created Evaluation = %#v, replayed = %v", created, replayed)
+	}
+	request.ClientRequestID = "retry-trace"
+	replay, replayed, err := service.Create(
+		ctx,
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("replay Create: %v", err)
+	}
+	if !replayed || replay.ID != created.ID ||
+		replay.Revision.ID != created.Revision.ID {
+		t.Fatalf("replay = %#v, replayed = %v", replay, replayed)
+	}
+	input, normalizeErr := normalizeCreate(request)
+	if normalizeErr != nil {
+		t.Fatalf("normalize idempotency conflict fixture: %v", normalizeErr)
+	}
+	rootFingerprint, digestErr := digest(struct {
+		OwnerUserID string      `json:"owner_user_id"`
+		Input       createInput `json:"input"`
+	}{
+		OwnerUserID: testOwnerA,
+		Input:       input,
+	})
+	if digestErr != nil {
+		t.Fatalf("digest idempotency conflict fixture: %v", digestErr)
+	}
+	rootKey := sha256.Sum256(append(
+		[]byte("evaluation-root:v1\x00"),
+		rootFingerprint[:]...,
+	))
+	revisionFingerprint, digestErr := digest(input.Config)
+	if digestErr != nil {
+		t.Fatalf("digest revision fixture: %v", digestErr)
+	}
+	conflictingFingerprint := rootFingerprint
+	conflictingFingerprint[0] ^= 0xff
+	_, _, err = NewPostgresRepository(pool).Ensure(ctx, EnsureCommand{
+		OwnerUserID:         testOwnerA,
+		RootIdempotencyKey:  rootKey,
+		RootFingerprint:     conflictingFingerprint,
+		RevisionFingerprint: revisionFingerprint,
+		Input:               input,
+	})
+	if !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("conflicting replay error = %v", err)
+	}
+	if _, err := service.Get(
+		ctx,
+		testActor(integrationOwnerB),
+		created.ID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner Get error = %v", err)
+	}
+
+	revisionTwoRequest := ReevaluateRequest{
+		Channels:          []Channel{ChannelCore4D, ChannelScene},
+		SceneStrategyRef:  "interview/v2",
+		Core4DStrategyRef: "core4d/v1",
+		PipelineVersion:   "pipeline/v2",
+		ClientRequestID:   "reevaluate-2",
+	}
+	revisionTwo, replayed, err := service.Reevaluate(
+		ctx,
+		testActor(testOwnerA),
+		created.ID,
+		revisionTwoRequest,
+	)
+	if err != nil {
+		t.Fatalf("Reevaluate: %v", err)
+	}
+	if replayed || revisionTwo.Revision.Number != 2 ||
+		revisionTwo.Revision.SupersedesRevisionID != created.Revision.ID {
+		t.Fatalf("revision two = %#v, replayed = %v", revisionTwo, replayed)
+	}
+	revisionTwoRequest.ClientRequestID = "reevaluate-2-retry"
+	revisionTwoReplay, replayed, err := service.Reevaluate(
+		ctx,
+		testActor(testOwnerA),
+		created.ID,
+		revisionTwoRequest,
+	)
+	if err != nil {
+		t.Fatalf("replay Reevaluate: %v", err)
+	}
+	if !replayed || revisionTwoReplay.Revision.ID != revisionTwo.Revision.ID {
+		t.Fatalf(
+			"revision replay = %#v, replayed = %v",
+			revisionTwoReplay,
+			replayed,
+		)
+	}
+
+	assertEvaluationCounts(t, pool, created.ID, 2, 4)
+	var oldStatus string
+	if err := pool.QueryRow(ctx, `
+		SELECT evaluation_status
+		FROM evaluation_revision_states
+		WHERE revision_id = $1
+	`, created.Revision.ID).Scan(&oldStatus); err != nil {
+		t.Fatalf("read superseded status: %v", err)
+	}
+	if oldStatus != "SUPERSEDED" {
+		t.Fatalf("old status = %q, want SUPERSEDED", oldStatus)
+	}
+	var oldIsFinal bool
+	if err := pool.QueryRow(ctx, `
+		SELECT is_final
+		FROM evaluation_revision_states
+		WHERE revision_id = $1
+	`, created.Revision.ID).Scan(&oldIsFinal); err != nil {
+		t.Fatalf("read superseded final marker: %v", err)
+	}
+	if oldIsFinal {
+		t.Fatal("superseding a Shadow revision promoted it to final")
+	}
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE evaluation_revisions
+		SET pipeline_version = 'tampered/v9'
+		WHERE id = $1
+	`, revisionTwo.Revision.ID); postgresCode(err) != "55000" {
+		t.Fatalf("immutable update error = %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO evaluation_revisions (
+			evaluation_id,
+			owner_user_id,
+			revision,
+			supersedes_revision_id,
+			channels,
+			scene_strategy_ref,
+			pipeline_version,
+			schema_version,
+			request_fingerprint
+		)
+		VALUES (
+			$1, $2, 4, $3, ARRAY['SCENE'], 'interview/v4',
+			'pipeline/v4', $4, decode(repeat('ab', 32), 'hex')
+		)
+	`, created.ID, testOwnerA, revisionTwo.Revision.ID,
+		SchemaVersion); postgresCode(err) != "23514" {
+		t.Fatalf("non-contiguous revision error = %v", err)
+	}
+}
+
+func TestPostgresConcurrentReevaluationCreatesOneRevision(t *testing.T) {
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA)
+	service := NewService(NewPostgresRepository(pool))
+	created, _, err := service.Create(
+		context.Background(),
+		testActor(testOwnerA),
+		validCreateRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	request := ReevaluateRequest{
+		Channels:         []Channel{ChannelScene},
+		SceneStrategyRef: "interview/v2",
+		PipelineVersion:  "pipeline/v2",
+		ClientRequestID:  "concurrent-trace",
+	}
+
+	const callers = 12
+	start := make(chan struct{})
+	results := make(chan Evaluation, callers)
+	failures := make(chan error, callers)
+	var wait sync.WaitGroup
+	wait.Add(callers)
+	for range callers {
+		go func() {
+			defer wait.Done()
+			<-start
+			evaluation, _, reevaluateErr := service.Reevaluate(
+				context.Background(),
+				testActor(testOwnerA),
+				created.ID,
+				request,
+			)
+			if reevaluateErr != nil {
+				failures <- reevaluateErr
+				return
+			}
+			results <- evaluation
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(failures)
+	for failure := range failures {
+		t.Errorf("concurrent Reevaluate: %v", failure)
+	}
+	var revisionID string
+	for result := range results {
+		if result.Revision.Number != 2 {
+			t.Errorf("revision = %d, want 2", result.Revision.Number)
+		}
+		if revisionID == "" {
+			revisionID = result.Revision.ID
+		} else if result.Revision.ID != revisionID {
+			t.Errorf("revision id = %q, want %q", result.Revision.ID, revisionID)
+		}
+	}
+	assertEvaluationCounts(t, pool, created.ID, 2, 2)
+}
+
+func TestPostgresOutboxFailureRollsBackRevisionAndSupersede(t *testing.T) {
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA)
+	service := NewService(NewPostgresRepository(pool))
+	created, _, err := service.Create(
+		context.Background(),
+		testActor(testOwnerA),
+		validCreateRequest(),
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), `
+		CREATE FUNCTION reject_evaluation_test_outbox()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced outbox failure';
+		END;
+		$$;
+		CREATE TRIGGER reject_evaluation_test_outbox
+		BEFORE INSERT ON evaluation_outbox
+		FOR EACH ROW EXECUTE FUNCTION reject_evaluation_test_outbox();
+	`); err != nil {
+		t.Fatalf("install outbox failure trigger: %v", err)
+	}
+	_, _, err = service.Reevaluate(
+		context.Background(),
+		testActor(testOwnerA),
+		created.ID,
+		ReevaluateRequest{
+			Channels:         []Channel{ChannelScene},
+			SceneStrategyRef: "interview/v2",
+			PipelineVersion:  "pipeline/v2",
+		},
+	)
+	if err == nil {
+		t.Fatal("Reevaluate unexpectedly survived outbox failure")
+	}
+	assertEvaluationCounts(t, pool, created.ID, 1, 1)
+	var status string
+	if err := pool.QueryRow(context.Background(), `
+		SELECT evaluation_status
+		FROM evaluation_revision_states
+		WHERE revision_id = $1
+	`, created.Revision.ID).Scan(&status); err != nil {
+		t.Fatalf("read original state: %v", err)
+	}
+	if status != "QUEUED" {
+		t.Fatalf("rolled-back original status = %q, want QUEUED", status)
+	}
+}
+
+func TestEvaluationMigrationDownRemovesOwnedSchema(t *testing.T) {
+	pool := evaluationDatabase(t)
+	down, err := migrations.Files.ReadFile(
+		"000024_evaluation_ledger.down.sql",
+	)
+	if err != nil {
+		t.Fatalf("read Evaluation down migration: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), string(down)); err != nil {
+		t.Fatalf("apply Evaluation down migration: %v", err)
+	}
+	for _, table := range []string{
+		"evaluation_ledgers",
+		"evaluation_revisions",
+		"evaluation_revision_states",
+		"evaluation_outbox",
+	} {
+		var exists bool
+		if err := pool.QueryRow(context.Background(), `
+			SELECT to_regclass($1) IS NOT NULL
+		`, table).Scan(&exists); err != nil {
+			t.Fatalf("inspect %s: %v", table, err)
+		}
+		if exists {
+			t.Errorf("%s still exists after down migration", table)
+		}
+	}
+}
+
+var evaluationSchemaSequence atomic.Uint64
+
+func evaluationDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open PostgreSQL admin pool: %v", err)
+	}
+	t.Cleanup(admin.Close)
+	schema := fmt.Sprintf(
+		"evaluation_%d_%d",
+		time.Now().UnixNano(),
+		evaluationSchemaSequence.Add(1),
+	)
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatalf("create Evaluation test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(
+			context.Background(),
+			10*time.Second,
+		)
+		defer cleanupCancel()
+		if _, err := admin.Exec(
+			cleanupCtx,
+			"DROP SCHEMA IF EXISTS "+schema+" CASCADE",
+		); err != nil {
+			t.Errorf("drop Evaluation test schema: %v", err)
+		}
+	})
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("parse TEST_DATABASE_URL: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("open isolated Evaluation pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE identity_users (
+			id uuid PRIMARY KEY,
+			account_status text NOT NULL DEFAULT 'active'
+		)
+	`); err != nil {
+		t.Fatalf("create Identity prerequisite: %v", err)
+	}
+	up, err := migrations.Files.ReadFile("000024_evaluation_ledger.up.sql")
+	if err != nil {
+		t.Fatalf("read Evaluation migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(up)); err != nil {
+		t.Fatalf("apply Evaluation migration: %v", err)
+	}
+	return pool
+}
+
+func insertEvaluationUsers(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	userIDs ...string,
+) {
+	t.Helper()
+	for _, userID := range userIDs {
+		if _, err := pool.Exec(context.Background(), `
+			INSERT INTO identity_users (id) VALUES ($1)
+		`, userID); err != nil {
+			t.Fatalf("insert Identity user %s: %v", userID, err)
+		}
+	}
+}
+
+func assertEvaluationCounts(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	evaluationID string,
+	wantRevisions int,
+	wantOutbox int,
+) {
+	t.Helper()
+	var revisions int
+	var outbox int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM evaluation_revisions
+		WHERE evaluation_id = $1
+	`, evaluationID).Scan(&revisions); err != nil {
+		t.Fatalf("count Evaluation revisions: %v", err)
+	}
+	if err := pool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM evaluation_outbox
+		WHERE evaluation_id = $1
+	`, evaluationID).Scan(&outbox); err != nil {
+		t.Fatalf("count Evaluation outbox: %v", err)
+	}
+	if revisions != wantRevisions || outbox != wantOutbox {
+		t.Fatalf(
+			"counts = revisions %d, outbox %d; want %d, %d",
+			revisions,
+			outbox,
+			wantRevisions,
+			wantOutbox,
+		)
+	}
+}
+
+func postgresCode(err error) string {
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		return postgresError.Code
+	}
+	return ""
+}

--- a/server/internal/evaluation/service.go
+++ b/server/internal/evaluation/service.go
@@ -1,0 +1,134 @@
+package evaluation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type EnsureCommand struct {
+	OwnerUserID         string
+	RootIdempotencyKey  [sha256.Size]byte
+	RootFingerprint     [sha256.Size]byte
+	RevisionFingerprint [sha256.Size]byte
+	Input               createInput
+}
+
+type ReevaluateCommand struct {
+	OwnerUserID         string
+	EvaluationID        string
+	RevisionFingerprint [sha256.Size]byte
+	Config              revisionConfig
+}
+
+type Repository interface {
+	Ensure(
+		ctx context.Context,
+		command EnsureCommand,
+	) (Evaluation, bool, error)
+	Reevaluate(
+		ctx context.Context,
+		command ReevaluateCommand,
+	) (Evaluation, bool, error)
+	Get(
+		ctx context.Context,
+		ownerUserID string,
+		evaluationID string,
+	) (Evaluation, error)
+}
+
+type Service struct {
+	repository Repository
+}
+
+func NewService(repository Repository) *Service {
+	return &Service{repository: repository}
+}
+
+func (s *Service) Create(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	request CreateRequest,
+) (Evaluation, bool, error) {
+	if s == nil || s.repository == nil || ctx == nil || !validActor(actor) {
+		return Evaluation{}, false, ErrInvalidRequest
+	}
+	input, err := normalizeCreate(request)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	rootFingerprint, err := digest(struct {
+		OwnerUserID string      `json:"owner_user_id"`
+		Input       createInput `json:"input"`
+	}{
+		OwnerUserID: actor.UserID,
+		Input:       input,
+	})
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	rootKey := sha256.Sum256(append(
+		[]byte("evaluation-root:v1\x00"),
+		rootFingerprint[:]...,
+	))
+	revisionFingerprint, err := digest(input.Config)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	return s.repository.Ensure(ctx, EnsureCommand{
+		OwnerUserID:         actor.UserID,
+		RootIdempotencyKey:  rootKey,
+		RootFingerprint:     rootFingerprint,
+		RevisionFingerprint: revisionFingerprint,
+		Input:               input,
+	})
+}
+
+func (s *Service) Reevaluate(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	evaluationID string,
+	request ReevaluateRequest,
+) (Evaluation, bool, error) {
+	if s == nil || s.repository == nil || ctx == nil ||
+		!validActor(actor) || !validUUID(evaluationID) {
+		return Evaluation{}, false, ErrInvalidRequest
+	}
+	config, err := normalizeReevaluation(request)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	revisionFingerprint, err := digest(config)
+	if err != nil {
+		return Evaluation{}, false, err
+	}
+	return s.repository.Reevaluate(ctx, ReevaluateCommand{
+		OwnerUserID:         actor.UserID,
+		EvaluationID:        evaluationID,
+		RevisionFingerprint: revisionFingerprint,
+		Config:              config,
+	})
+}
+
+func (s *Service) Get(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	evaluationID string,
+) (Evaluation, error) {
+	if s == nil || s.repository == nil || ctx == nil ||
+		!validActor(actor) || !validUUID(evaluationID) {
+		return Evaluation{}, ErrInvalidRequest
+	}
+	return s.repository.Get(ctx, actor.UserID, evaluationID)
+}
+
+func digest(value any) ([sha256.Size]byte, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return [sha256.Size]byte{}, errors.Join(ErrInvalidRequest, err)
+	}
+	return sha256.Sum256(encoded), nil
+}

--- a/server/internal/evaluation/service_test.go
+++ b/server/internal/evaluation/service_test.go
@@ -1,0 +1,256 @@
+package evaluation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	testOwnerA = "10000000-0000-4000-8000-000000000001"
+	testOwnerB = "20000000-0000-4000-8000-000000000002"
+	testEvalID = "30000000-0000-4000-8000-000000000003"
+	testRevID  = "40000000-0000-4000-8000-000000000004"
+)
+
+func TestServiceCreateCanonicalizesAndDerivesServerIdentity(t *testing.T) {
+	repository := &repositoryStub{evaluation: validEvaluation()}
+	service := NewService(repository)
+	request := validCreateRequest()
+	request.Channels = []Channel{ChannelScene, ChannelCore4D}
+	request.Core4DStrategyRef = "core4d/v1"
+
+	_, _, err := service.Create(
+		context.Background(),
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	first := repository.ensureCommands[0]
+	if got := first.Input.Config.Channels; len(got) != 2 ||
+		got[0] != ChannelCore4D || got[1] != ChannelScene {
+		t.Fatalf("canonical channels = %#v", got)
+	}
+	if first.OwnerUserID != testOwnerA {
+		t.Fatalf("owner = %q, want trusted actor", first.OwnerUserID)
+	}
+
+	request.ClientRequestID = "another-trace"
+	_, _, err = service.Create(
+		context.Background(),
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("replayed Create: %v", err)
+	}
+	second := repository.ensureCommands[1]
+	if first.RootIdempotencyKey != second.RootIdempotencyKey ||
+		first.RootFingerprint != second.RootFingerprint ||
+		first.RevisionFingerprint != second.RevisionFingerprint {
+		t.Fatal("client request ID changed server idempotency identity")
+	}
+
+	_, _, err = service.Create(
+		context.Background(),
+		testActor(testOwnerB),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("other-owner Create: %v", err)
+	}
+	third := repository.ensureCommands[2]
+	if first.RootIdempotencyKey == third.RootIdempotencyKey {
+		t.Fatal("root idempotency identity is not owner scoped")
+	}
+}
+
+func TestServiceRejectsInvalidPolicyShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*CreateRequest)
+	}{
+		{
+			name: "duplicate channel",
+			mutate: func(request *CreateRequest) {
+				request.Channels = []Channel{ChannelScene, ChannelScene}
+			},
+		},
+		{
+			name: "missing scene strategy",
+			mutate: func(request *CreateRequest) {
+				request.SceneStrategyRef = ""
+			},
+		},
+		{
+			name: "unexpected core strategy",
+			mutate: func(request *CreateRequest) {
+				request.Core4DStrategyRef = "core/v1"
+			},
+		},
+		{
+			name: "invalid pipeline",
+			mutate: func(request *CreateRequest) {
+				request.PipelineVersion = "invalid pipeline"
+			},
+		},
+		{
+			name: "invalid snapshot",
+			mutate: func(request *CreateRequest) {
+				request.InputSnapshotID = "../snapshot"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := validCreateRequest()
+			test.mutate(&request)
+			_, _, err := NewService(&repositoryStub{}).Create(
+				context.Background(),
+				testActor(testOwnerA),
+				request,
+			)
+			if !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Create error = %v", err)
+			}
+		})
+	}
+}
+
+func TestServiceReevaluateAndGetBindTrustedOwner(t *testing.T) {
+	repository := &repositoryStub{evaluation: validEvaluation()}
+	service := NewService(repository)
+	request := ReevaluateRequest{
+		Channels:         []Channel{ChannelScene},
+		SceneStrategyRef: "interview/v2",
+		PipelineVersion:  "pipeline/v2",
+		ClientRequestID:  "trace-2",
+	}
+	_, _, err := service.Reevaluate(
+		context.Background(),
+		testActor(testOwnerA),
+		testEvalID,
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Reevaluate: %v", err)
+	}
+	if got := repository.reevaluateCommands[0]; got.OwnerUserID != testOwnerA ||
+		got.EvaluationID != testEvalID ||
+		got.Config.ClientRequestID != "trace-2" {
+		t.Fatalf("Reevaluate command = %#v", got)
+	}
+	_, err = service.Get(
+		context.Background(),
+		testActor(testOwnerB),
+		testEvalID,
+	)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if repository.getOwner != testOwnerB {
+		t.Fatalf("Get owner = %q", repository.getOwner)
+	}
+}
+
+func TestChannelKeysAreRevisionChannelAndStrategyScoped(t *testing.T) {
+	var root [32]byte
+	root[0] = 1
+	first := deriveChannelKey(root, 1, ChannelScene, "scene/v1")
+	tests := [][32]byte{
+		deriveChannelKey(root, 2, ChannelScene, "scene/v1"),
+		deriveChannelKey(root, 1, ChannelCore4D, "scene/v1"),
+		deriveChannelKey(root, 1, ChannelScene, "scene/v2"),
+	}
+	for index, candidate := range tests {
+		if candidate == first {
+			t.Fatalf("channel key variant %d collided", index)
+		}
+	}
+}
+
+type repositoryStub struct {
+	evaluation         Evaluation
+	ensureCommands     []EnsureCommand
+	reevaluateCommands []ReevaluateCommand
+	getOwner           string
+}
+
+func (r *repositoryStub) Ensure(
+	_ context.Context,
+	command EnsureCommand,
+) (Evaluation, bool, error) {
+	r.ensureCommands = append(r.ensureCommands, command)
+	return r.evaluation, false, nil
+}
+
+func (r *repositoryStub) Reevaluate(
+	_ context.Context,
+	command ReevaluateCommand,
+) (Evaluation, bool, error) {
+	r.reevaluateCommands = append(r.reevaluateCommands, command)
+	return r.evaluation, false, nil
+}
+
+func (r *repositoryStub) Get(
+	_ context.Context,
+	ownerUserID string,
+	_ string,
+) (Evaluation, error) {
+	r.getOwner = ownerUserID
+	return r.evaluation, nil
+}
+
+func validCreateRequest() CreateRequest {
+	return CreateRequest{
+		PracticeSessionID: "session-1",
+		InputSnapshotID:   "snapshot-1",
+		InputRevision:     1,
+		Scope:             ScopeSession,
+		SceneType:         SceneInterview,
+		Channels:          []Channel{ChannelScene},
+		SceneStrategyRef:  "interview/v1",
+		PipelineVersion:   "pipeline/v1",
+		ClientRequestID:   "trace-1",
+	}
+}
+
+func testActor(owner string) requestcontext.Actor {
+	return requestcontext.Actor{
+		UserID:    owner,
+		SessionID: "50000000-0000-4000-8000-000000000005",
+	}
+}
+
+func validEvaluation() Evaluation {
+	now := time.Now().UTC()
+	return Evaluation{
+		ID:                testEvalID,
+		OwnerUserID:       testOwnerA,
+		PracticeSessionID: "session-1",
+		InputSnapshotID:   "snapshot-1",
+		InputRevision:     1,
+		Scope:             ScopeSession,
+		SceneType:         SceneInterview,
+		CreatedAt:         now,
+		Revision: Revision{
+			ID:               testRevID,
+			EvaluationID:     testEvalID,
+			OwnerUserID:      testOwnerA,
+			Number:           1,
+			Channels:         []Channel{ChannelScene},
+			SceneStrategyRef: "interview/v1",
+			PipelineVersion:  "pipeline/v1",
+			SchemaVersion:    SchemaVersion,
+			Status:           StatusQueued,
+			ClientRequestID:  "trace-1",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+	}
+}

--- a/server/migrations/000024_evaluation_ledger.down.sql
+++ b/server/migrations/000024_evaluation_ledger.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+DROP TABLE IF EXISTS evaluation_outbox;
+DROP TABLE IF EXISTS evaluation_revision_states;
+DROP TRIGGER IF EXISTS evaluation_revisions_immutable
+    ON evaluation_revisions;
+DROP FUNCTION IF EXISTS reject_evaluation_revision_mutation();
+DROP TRIGGER IF EXISTS evaluation_revision_chain
+    ON evaluation_revisions;
+DROP FUNCTION IF EXISTS evaluation_assert_revision_chain();
+DROP TABLE IF EXISTS evaluation_revisions;
+DROP TABLE IF EXISTS evaluation_ledgers;
+
+COMMIT;

--- a/server/migrations/000024_evaluation_ledger.up.sql
+++ b/server/migrations/000024_evaluation_ledger.up.sql
@@ -1,0 +1,289 @@
+BEGIN;
+
+CREATE TABLE evaluation_ledgers (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id uuid NOT NULL,
+    root_idempotency_key bytea NOT NULL,
+    root_request_fingerprint bytea NOT NULL,
+    practice_session_id text COLLATE "C" NOT NULL,
+    input_snapshot_id text COLLATE "C" NOT NULL,
+    input_revision integer NOT NULL,
+    scope text COLLATE "C" NOT NULL,
+    scene_type text COLLATE "C" NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT evaluation_ledgers_owner_fkey
+        FOREIGN KEY (owner_user_id)
+        REFERENCES identity_users (id)
+        ON DELETE RESTRICT,
+    CONSTRAINT evaluation_ledgers_owner_identity_unique
+        UNIQUE (id, owner_user_id),
+    CONSTRAINT evaluation_ledgers_root_key_unique
+        UNIQUE (owner_user_id, root_idempotency_key),
+    CONSTRAINT evaluation_ledgers_root_key_check
+        CHECK (octet_length(root_idempotency_key) = 32),
+    CONSTRAINT evaluation_ledgers_root_fingerprint_check
+        CHECK (octet_length(root_request_fingerprint) = 32),
+    CONSTRAINT evaluation_ledgers_practice_session_check
+        CHECK (practice_session_id ~ '^[A-Za-z][A-Za-z0-9._:-]{0,127}$'),
+    CONSTRAINT evaluation_ledgers_input_snapshot_check
+        CHECK (input_snapshot_id ~ '^[A-Za-z][A-Za-z0-9._:-]{0,127}$'),
+    CONSTRAINT evaluation_ledgers_input_revision_check
+        CHECK (input_revision > 0),
+    CONSTRAINT evaluation_ledgers_scope_check
+        CHECK (scope IN ('TURN', 'SESSION')),
+    CONSTRAINT evaluation_ledgers_scene_type_check
+        CHECK (
+            scene_type IN (
+                'IELTS_SPEAKING',
+                'INTERVIEW',
+                'OVERSEAS_DAILY_LIFE',
+                'OVERSEAS_WORKPLACE'
+            )
+        )
+);
+
+CREATE INDEX evaluation_ledgers_owner_created_idx
+    ON evaluation_ledgers (owner_user_id, created_at DESC, id DESC);
+
+CREATE TABLE evaluation_revisions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    evaluation_id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    revision integer NOT NULL,
+    supersedes_revision_id uuid,
+    channels text[] COLLATE "C" NOT NULL,
+    scene_strategy_ref text COLLATE "C",
+    core_4d_strategy_ref text COLLATE "C",
+    pipeline_version text COLLATE "C" NOT NULL,
+    schema_version text COLLATE "C" NOT NULL,
+    request_fingerprint bytea NOT NULL,
+    client_request_id text COLLATE "C",
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT evaluation_revisions_ledger_fkey
+        FOREIGN KEY (evaluation_id, owner_user_id)
+        REFERENCES evaluation_ledgers (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_revisions_identity_unique
+        UNIQUE (evaluation_id, id),
+    CONSTRAINT evaluation_revisions_number_unique
+        UNIQUE (evaluation_id, revision),
+    CONSTRAINT evaluation_revisions_supersedes_fkey
+        FOREIGN KEY (evaluation_id, supersedes_revision_id)
+        REFERENCES evaluation_revisions (evaluation_id, id)
+        ON DELETE RESTRICT,
+    CONSTRAINT evaluation_revisions_revision_check
+        CHECK (revision > 0),
+    CONSTRAINT evaluation_revisions_supersedes_shape_check
+        CHECK (
+            (revision = 1 AND supersedes_revision_id IS NULL)
+            OR (revision > 1 AND supersedes_revision_id IS NOT NULL)
+        ),
+    CONSTRAINT evaluation_revisions_channels_check
+        CHECK (
+            cardinality(channels) BETWEEN 1 AND 2
+            AND channels <@ ARRAY['SCENE', 'CORE_4D']::text[]
+            AND (
+                cardinality(channels) = 1
+                OR channels[1] <> channels[2]
+            )
+        ),
+    CONSTRAINT evaluation_revisions_scene_strategy_check
+        CHECK (
+            (
+                'SCENE' = ANY(channels)
+                AND scene_strategy_ref ~
+                    '^[A-Za-z][A-Za-z0-9._:/-]{0,127}$'
+            )
+            OR (
+                NOT ('SCENE' = ANY(channels))
+                AND scene_strategy_ref IS NULL
+            )
+        ),
+    CONSTRAINT evaluation_revisions_core_strategy_check
+        CHECK (
+            (
+                'CORE_4D' = ANY(channels)
+                AND core_4d_strategy_ref ~
+                    '^[A-Za-z][A-Za-z0-9._:/-]{0,127}$'
+            )
+            OR (
+                NOT ('CORE_4D' = ANY(channels))
+                AND core_4d_strategy_ref IS NULL
+            )
+        ),
+    CONSTRAINT evaluation_revisions_pipeline_version_check
+        CHECK (
+            pipeline_version ~ '^[A-Za-z][A-Za-z0-9._:/-]{0,127}$'
+        ),
+    CONSTRAINT evaluation_revisions_schema_version_check
+        CHECK (
+            schema_version ~ '^[A-Za-z][A-Za-z0-9._:/-]{0,127}$'
+        ),
+    CONSTRAINT evaluation_revisions_fingerprint_check
+        CHECK (octet_length(request_fingerprint) = 32),
+    CONSTRAINT evaluation_revisions_client_request_check
+        CHECK (
+            client_request_id IS NULL
+            OR client_request_id ~ '^[A-Za-z0-9._:-]{1,128}$'
+        )
+);
+
+CREATE FUNCTION evaluation_assert_revision_chain()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    previous_revision integer;
+BEGIN
+    IF NEW.revision = 1 THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT revision
+      INTO previous_revision
+      FROM evaluation_revisions
+     WHERE evaluation_id = NEW.evaluation_id
+       AND id = NEW.supersedes_revision_id;
+
+    IF previous_revision IS NULL OR previous_revision <> NEW.revision - 1 THEN
+        RAISE EXCEPTION 'evaluation revision must supersede its predecessor'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER evaluation_revision_chain
+BEFORE INSERT ON evaluation_revisions
+FOR EACH ROW
+EXECUTE FUNCTION evaluation_assert_revision_chain();
+
+CREATE FUNCTION reject_evaluation_revision_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'evaluation revisions are immutable'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER evaluation_revisions_immutable
+BEFORE UPDATE ON evaluation_revisions
+FOR EACH ROW
+EXECUTE FUNCTION reject_evaluation_revision_mutation();
+
+CREATE TABLE evaluation_revision_states (
+    revision_id uuid PRIMARY KEY,
+    evaluation_id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    evaluation_status text COLLATE "C" NOT NULL DEFAULT 'QUEUED',
+    is_final boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    completed_at timestamptz,
+    CONSTRAINT evaluation_revision_states_revision_fkey
+        FOREIGN KEY (evaluation_id, revision_id)
+        REFERENCES evaluation_revisions (evaluation_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_revision_states_ledger_fkey
+        FOREIGN KEY (evaluation_id, owner_user_id)
+        REFERENCES evaluation_ledgers (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_revision_states_status_check
+        CHECK (
+            evaluation_status IN (
+                'RECEIVED',
+                'VALIDATING',
+                'QUEUED',
+                'RUNNING',
+                'PARTIAL_READY',
+                'READY',
+                'FAILED',
+                'SUPERSEDED'
+            )
+        ),
+    CONSTRAINT evaluation_revision_states_completion_check
+        CHECK (
+            (
+                evaluation_status IN ('READY', 'FAILED', 'SUPERSEDED')
+                AND completed_at IS NOT NULL
+            )
+            OR (
+                evaluation_status NOT IN ('READY', 'FAILED', 'SUPERSEDED')
+                AND completed_at IS NULL
+            )
+        ),
+    CONSTRAINT evaluation_revision_states_timestamps_check
+        CHECK (
+            updated_at >= created_at
+            AND (completed_at IS NULL OR completed_at >= created_at)
+        )
+);
+
+CREATE TABLE evaluation_outbox (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    evaluation_id uuid NOT NULL,
+    evaluation_revision_id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    channel text COLLATE "C" NOT NULL,
+    channel_key bytea NOT NULL,
+    event_type text COLLATE "C" NOT NULL,
+    payload jsonb NOT NULL,
+    delivery_status text COLLATE "C" NOT NULL DEFAULT 'PENDING',
+    attempt_count integer NOT NULL DEFAULT 0,
+    available_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    delivered_at timestamptz,
+    CONSTRAINT evaluation_outbox_revision_fkey
+        FOREIGN KEY (evaluation_id, evaluation_revision_id)
+        REFERENCES evaluation_revisions (evaluation_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_outbox_ledger_fkey
+        FOREIGN KEY (evaluation_id, owner_user_id)
+        REFERENCES evaluation_ledgers (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_outbox_revision_channel_unique
+        UNIQUE (evaluation_revision_id, channel),
+    CONSTRAINT evaluation_outbox_channel_key_unique
+        UNIQUE (channel_key),
+    CONSTRAINT evaluation_outbox_channel_check
+        CHECK (channel IN ('SCENE', 'CORE_4D')),
+    CONSTRAINT evaluation_outbox_channel_key_check
+        CHECK (octet_length(channel_key) = 32),
+    CONSTRAINT evaluation_outbox_event_type_check
+        CHECK (event_type = 'evaluation.revision.queued'),
+    CONSTRAINT evaluation_outbox_payload_check
+        CHECK (
+            jsonb_typeof(payload) = 'object'
+            AND payload ?& ARRAY[
+                'evaluation_id',
+                'evaluation_revision_id',
+                'revision',
+                'channel'
+            ]
+            AND (
+                payload - ARRAY[
+                    'evaluation_id',
+                    'evaluation_revision_id',
+                    'revision',
+                    'channel'
+                ]
+            ) = '{}'::jsonb
+        ),
+    CONSTRAINT evaluation_outbox_delivery_status_check
+        CHECK (delivery_status IN ('PENDING', 'DELIVERED')),
+    CONSTRAINT evaluation_outbox_attempt_count_check
+        CHECK (attempt_count >= 0),
+    CONSTRAINT evaluation_outbox_delivery_shape_check
+        CHECK (
+            (delivery_status = 'PENDING' AND delivered_at IS NULL)
+            OR (delivery_status = 'DELIVERED' AND delivered_at IS NOT NULL)
+        )
+);
+
+CREATE INDEX evaluation_outbox_pending_idx
+    ON evaluation_outbox (available_at, created_at, id)
+    WHERE delivery_status = 'PENDING';
+
+COMMIT;


### PR DESCRIPTION
## 功能描述

为统一评分平台落地 PostgreSQL 事实账本，使后续 EvidenceSnapshot、质量门禁和双通道 Worker 可以基于同一 logical Evaluation 与不可变 revision 工作。

## 实现思路

- 新增 `evaluation` 领域模型、服务和 Repository 端口。
- 服务端规范化请求并派生 owner-scoped root idempotency key；`client_request_id` 只用于追踪。
- PostgreSQL 分离 logical ledger、immutable revision、可变运行状态和内部 outbox。
- 重评通过锁定 logical Evaluation 追加连续 revision，并记录 `supersedes_revision_id`。
- revision 与每通道 outbox 在同一事务写入；失败时整体回滚。
- 数据库触发器拒绝修改历史 revision，并验证 revision 必须连接直接前序。
- 查询始终绑定可信 owner，跨 owner 返回 not found。
- 补齐 #181 新增 Evaluation 错误码在统一 HTTP 状态快照中的映射，不包含 HTTP handler。

## 数据与安全边界

- outbox 只包含 Evaluation、revision、channel 和版本标识，不持久化完整转写、音频 URL、系统提示或 Provider 密钥。
- Shadow 的 `is_final=false` 与运行终态分离，`READY` 不会被误判为正式发布。
- inactive Identity 无法创建或重评，外键不会产生孤儿 ledger/revision/outbox。

## 可复现测试

- `make check-go`
- `TEST_DATABASE_URL=postgres://... go test -count=1 ./internal/evaluation ./internal/platform/httpresponse ./migrations`

PostgreSQL 集成测试覆盖首建、完全重放、冲突重放、跨 owner 隔离、并发重评、连续 revision、不可变触发器、事务失败回滚、outbox 数量和 migration down。

## 明确不做

- 不实现 Evaluation HTTP handler。
- 不采集 EvidenceSnapshot，不调用评分 Provider。
- 不实现质量门禁、Scene/Core4D 评分、报告投影或生产切换。

Closes #184

关联：#174、#176