### PR TITLE
fix(agent): 补齐工具审计 PostgreSQL 迁移

### DIFF
--- a/server/migrations/000025_agent_tool_audit.down.sql
+++ b/server/migrations/000025_agent_tool_audit.down.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+DROP TABLE agent_tool_calls;
+
+ALTER TABLE agent_context_manifests
+    DROP CONSTRAINT agent_context_manifests_tool_snapshot_shape_check,
+    DROP CONSTRAINT agent_context_manifests_tool_snapshot_versions_check,
+    DROP CONSTRAINT agent_context_manifests_intent_mode_check,
+    DROP CONSTRAINT agent_context_manifests_tool_schema_hashes_check,
+    DROP CONSTRAINT agent_context_manifests_blocked_tools_check,
+    DROP CONSTRAINT agent_context_manifests_exposed_tools_check,
+    DROP COLUMN tool_schema_hashes,
+    DROP COLUMN tool_policy_version,
+    DROP COLUMN intent_guard_version,
+    DROP COLUMN intent_reason_code,
+    DROP COLUMN intent_mode,
+    DROP COLUMN blocked_tools,
+    DROP COLUMN exposed_tools;
+
+COMMIT;

--- a/server/migrations/000025_agent_tool_audit.up.sql
+++ b/server/migrations/000025_agent_tool_audit.up.sql
@@ -1,0 +1,178 @@
+BEGIN;
+
+ALTER TABLE agent_context_manifests
+    ADD COLUMN exposed_tools jsonb NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN blocked_tools jsonb NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN intent_mode text,
+    ADD COLUMN intent_reason_code text,
+    ADD COLUMN intent_guard_version text,
+    ADD COLUMN tool_policy_version text,
+    ADD COLUMN tool_schema_hashes jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD CONSTRAINT agent_context_manifests_exposed_tools_check
+        CHECK (jsonb_typeof(exposed_tools) = 'array'),
+    ADD CONSTRAINT agent_context_manifests_blocked_tools_check
+        CHECK (jsonb_typeof(blocked_tools) = 'array'),
+    ADD CONSTRAINT agent_context_manifests_tool_schema_hashes_check
+        CHECK (jsonb_typeof(tool_schema_hashes) = 'object'),
+    ADD CONSTRAINT agent_context_manifests_intent_mode_check
+        CHECK (
+            intent_mode IS NULL
+            OR intent_mode IN ('direct_only', 'tool_eligible')
+        ),
+    ADD CONSTRAINT agent_context_manifests_tool_snapshot_versions_check
+        CHECK (
+            (
+                intent_guard_version IS NULL
+                OR intent_guard_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+            )
+            AND (
+                tool_policy_version IS NULL
+                OR tool_policy_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+            )
+        ),
+    ADD CONSTRAINT agent_context_manifests_tool_snapshot_shape_check
+        CHECK (
+            (
+                intent_mode IS NULL
+                AND intent_reason_code IS NULL
+                AND intent_guard_version IS NULL
+                AND tool_policy_version IS NULL
+            )
+            OR
+            (
+                intent_mode IS NOT NULL
+                AND intent_reason_code IS NOT NULL
+                AND intent_guard_version IS NOT NULL
+                AND tool_policy_version IS NOT NULL
+            )
+        );
+
+CREATE TABLE agent_tool_calls (
+    id text COLLATE "C" NOT NULL,
+    run_id uuid NOT NULL,
+    owner_user_id uuid NOT NULL,
+    thread_id uuid NOT NULL,
+    tool_name text COLLATE "C" NOT NULL,
+    schema_version text COLLATE "C" NOT NULL,
+    input jsonb NOT NULL,
+    status text NOT NULL DEFAULT 'proposed',
+    result jsonb,
+    error_category text,
+    request_id text COLLATE "C",
+    source_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+    proposed_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    started_at timestamptz,
+    completed_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT agent_tool_calls_pkey PRIMARY KEY (run_id, id),
+    CONSTRAINT agent_tool_calls_run_owner_fkey
+        FOREIGN KEY (run_id, owner_user_id, thread_id)
+        REFERENCES agent_runs (id, owner_user_id, thread_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_tool_calls_id_check
+        CHECK (
+            octet_length(id) BETWEEN 1 AND 128
+            AND id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        ),
+    CONSTRAINT agent_tool_calls_name_check
+        CHECK (
+            octet_length(tool_name) BETWEEN 1 AND 128
+            AND tool_name ~ '^[a-z][a-z0-9._-]{0,127}$'
+        ),
+    CONSTRAINT agent_tool_calls_schema_version_check
+        CHECK (
+            octet_length(schema_version) BETWEEN 1 AND 64
+            AND schema_version
+                ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+        ),
+    CONSTRAINT agent_tool_calls_status_check
+        CHECK (
+            status IN (
+                'proposed',
+                'running',
+                'succeeded',
+                'failed',
+                'rejected'
+            )
+        ),
+    CONSTRAINT agent_tool_calls_error_category_check
+        CHECK (
+            error_category IS NULL
+            OR (
+                octet_length(error_category) BETWEEN 1 AND 64
+                AND error_category ~ '^[a-z][a-z0-9_]{0,63}$'
+            )
+        ),
+    CONSTRAINT agent_tool_calls_request_id_check
+        CHECK (
+            request_id IS NULL
+            OR (
+                octet_length(request_id) BETWEEN 1 AND 256
+                AND request_id ~
+                    '^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$'
+            )
+        ),
+    CONSTRAINT agent_tool_calls_source_refs_check
+        CHECK (jsonb_typeof(source_refs) = 'array'),
+    CONSTRAINT agent_tool_calls_state_shape_check
+        CHECK (
+            (
+                status = 'proposed'
+                AND result IS NULL
+                AND error_category IS NULL
+                AND request_id IS NULL
+                AND started_at IS NULL
+                AND completed_at IS NULL
+            )
+            OR
+            (
+                status = 'running'
+                AND result IS NULL
+                AND error_category IS NULL
+                AND request_id IS NOT NULL
+                AND started_at IS NOT NULL
+                AND completed_at IS NULL
+            )
+            OR
+            (
+                status = 'succeeded'
+                AND result IS NOT NULL
+                AND error_category IS NULL
+                AND request_id IS NOT NULL
+                AND started_at IS NOT NULL
+                AND completed_at IS NOT NULL
+            )
+            OR
+            (
+                status IN ('failed', 'rejected')
+                AND result IS NULL
+                AND error_category IS NOT NULL
+                AND started_at IS NOT NULL
+                AND completed_at IS NOT NULL
+            )
+        ),
+    CONSTRAINT agent_tool_calls_timestamps_check
+        CHECK (
+            updated_at >= proposed_at
+            AND (started_at IS NULL OR started_at >= proposed_at)
+            AND (
+                completed_at IS NULL
+                OR (
+                    started_at IS NOT NULL
+                    AND completed_at >= started_at
+                )
+            )
+        )
+);
+
+CREATE INDEX agent_tool_calls_owner_run_proposed_idx
+    ON agent_tool_calls (
+        owner_user_id,
+        run_id,
+        proposed_at,
+        id
+    );
+
+COMMIT;


### PR DESCRIPTION
## 功能描述

补齐已合入 Agent Tool Calling 持久化代码所依赖的 PostgreSQL Schema，恢复 `dev` 基线的 Database Workflow。

- 为 `agent_context_manifests` 增加工具暴露、阻断、意图路由、策略版本和 Schema Hash 快照字段。
- 新增 `agent_tool_calls` 审计表，覆盖 proposed、running、succeeded、failed、rejected 生命周期。
- 为 JSON 结构、状态形态、版本格式、时间顺序、Run 所有权和回收边界增加数据库约束。
- 提供成对、事务化、可回滚的 append-only migration。

## 问题原因

Agent PostgreSQL Repository 已读写上述字段和 `agent_tool_calls`，但 `dev` 现有 migration 截止 `000024` 没有创建对应 Schema。`SaveContextManifest` 因此在模型调用前失败并映射为 `internal_error`，并发测试则等待未启动的 generator 直至超时。

## 实现思路

新增 `000025_agent_tool_audit` migration，不修改任何历史 migration：

- 既有 ContextManifest 行通过空数组、空对象和 nullable 路由快照保持兼容。
- 新快照一旦写入，意图模式、原因和策略版本必须成组存在。
- ToolCall 使用 `(run_id, id)` 作为幂等键，并通过复合外键绑定 Run、Owner 和 Thread。
- ToolCall 状态约束与当前 Repository 的状态转换 SQL 保持一致。
- Run 删除时级联清理 ToolCall；Manifest 回滚时移除新增字段。

## 可复现测试

```bash
cd server
set -a
source ../.env
set +a
export TEST_DATABASE_URL="$DATABASE_URL"

go run ./cmd/migrate up
go run ./cmd/migrate status
go run ./cmd/migrate up
go run ./cmd/migrate down-one --local-test-only
go run ./cmd/migrate up
go run ./cmd/migrate status

go test -count=1 ./internal/agent -run "TestPostgresAgentRunSuccessReplayAuditAndOwnership|TestPostgresAgentToolCallAuditReplayAndOwnership|TestPostgresAgentRunConcurrentReplayDoesNotDuplicatePendingWork" -v
go test -count=1 ./internal/memory -run TestCompletedAgentRunQueuesAndAppliesMemoryExtraction -v
go test -count=1 ./...
go vet ./...
GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
```

本地结果：

- migration lifecycle：通过，最终 `version=25 dirty=false`
- 原先失败的四个 PostgreSQL 回归测试：全部通过
- 完整 PostgreSQL Go 测试：通过
- `go vet ./...`：通过
- govulncheck：0 个可达漏洞
- `docker compose config --quiet`：通过

## 范围说明

本 PR 只新增两个 migration 文件，不修改 Thread Summary、Agent 路由、工具执行逻辑或兜底策略。

Closes #194