### PR TITLE
feat(agent): add event-driven thread summary worker

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -164,8 +164,9 @@ func run() int {
 		)
 		return 1
 	}
-	memoryExtractionWakeup := newMemoryWorkerWakeup()
-	memoryIndexWakeup := newMemoryWorkerWakeup()
+	memoryExtractionWakeup := newWorkerWakeup()
+	memoryIndexWakeup := newWorkerWakeup()
+	threadSummaryWakeup := newWorkerWakeup()
 
 	var recordingStore objectstore.Store
 	if storageConfig.Enabled {
@@ -183,7 +184,7 @@ func run() int {
 	}
 
 	applicationComposition, err :=
-		bootstrap.NewIdentityAgentAndPracticeCompositionWithMemoryWakeup(
+		bootstrap.NewIdentityAgentAndPracticeCompositionWithWorkerWakeups(
 			ctx,
 			databasePool.Native(),
 			cfg.TrustedProxyCIDRs,
@@ -197,7 +198,10 @@ func run() int {
 			},
 			memoryIndexComposition.Searcher(),
 			preparationCatalog,
-			memoryExtractionWakeup,
+			bootstrap.AgentWorkerWakeups{
+				MemoryExtraction: memoryExtractionWakeup,
+				ThreadSummary:    threadSummaryWakeup,
+			},
 			bootstrap.VoiceConfiguration{
 				Recognizer:                recognizer,
 				Synthesizer:               synthesizer,
@@ -220,6 +224,18 @@ func run() int {
 		)
 	if err != nil {
 		logger.Error("application startup failed", slog.Any("error", err))
+		return 1
+	}
+	threadSummary, err := buildThreadSummaryWorker(
+		applicationComposition.ThreadSummaryProcessor(),
+		logger,
+		threadSummaryWakeup.Events(),
+	)
+	if err != nil {
+		logger.Error(
+			"thread summary startup failed",
+			slog.String("error_kind", "dependency"),
+		)
 		return 1
 	}
 	contextRoutes, err := applicationComposition.ProtectedRoutes()
@@ -305,6 +321,11 @@ func run() int {
 		defer close(memoryIndexDone)
 		memoryIndex.Run(ctx)
 	}()
+	threadSummaryDone := make(chan struct{})
+	go func() {
+		defer close(threadSummaryDone)
+		threadSummary.Run(ctx)
+	}()
 
 	router := bootstrap.NewRouterWithReadinessAndRoutes(
 		logger,
@@ -387,6 +408,15 @@ func run() int {
 	case <-shutdownCtx.Done():
 		logger.Error(
 			"memory index shutdown failed",
+			slog.String("error_kind", "timeout"),
+		)
+		exitCode = 1
+	}
+	select {
+	case <-threadSummaryDone:
+	case <-shutdownCtx.Done():
+		logger.Error(
+			"thread summary shutdown failed",
 			slog.String("error_kind", "timeout"),
 		)
 		exitCode = 1

--- a/server/cmd/server/memory_extraction.go
+++ b/server/cmd/server/memory_extraction.go
@@ -58,7 +58,7 @@ func buildMemoryExtractionWorker(
 		memoryExtractionClaimLimit,
 		wakeup,
 		indexWakeup,
-		waitForMemoryWork,
+		waitForWorkerWork,
 	)
 }
 

--- a/server/cmd/server/memory_extraction_test.go
+++ b/server/cmd/server/memory_extraction_test.go
@@ -74,7 +74,7 @@ func TestMemoryExtractionWorkerStopsWithContext(t *testing.T) {
 		1,
 		nil,
 		nil,
-		waitForMemoryWork,
+		waitForWorkerWork,
 	)
 	if err != nil {
 		t.Fatalf("newMemoryExtractionWorker: %v", err)

--- a/server/cmd/server/memory_wakeup.go
+++ b/server/cmd/server/memory_wakeup.go
@@ -5,17 +5,17 @@ import (
 	"time"
 )
 
-// memoryWorkerWakeup is an edge-triggered hint only. The database remains the
-// source of truth, so concurrent hints may be safely coalesced.
-type memoryWorkerWakeup struct {
+// workerWakeup is an edge-triggered hint only. The database remains the source
+// of truth, so concurrent hints may be safely coalesced.
+type workerWakeup struct {
 	events chan struct{}
 }
 
-func newMemoryWorkerWakeup() *memoryWorkerWakeup {
-	return &memoryWorkerWakeup{events: make(chan struct{}, 1)}
+func newWorkerWakeup() *workerWakeup {
+	return &workerWakeup{events: make(chan struct{}, 1)}
 }
 
-func (wakeup *memoryWorkerWakeup) Notify() {
+func (wakeup *workerWakeup) Notify() {
 	if wakeup == nil {
 		return
 	}
@@ -25,14 +25,14 @@ func (wakeup *memoryWorkerWakeup) Notify() {
 	}
 }
 
-func (wakeup *memoryWorkerWakeup) Events() <-chan struct{} {
+func (wakeup *workerWakeup) Events() <-chan struct{} {
 	if wakeup == nil {
 		return nil
 	}
 	return wakeup.events
 }
 
-func waitForMemoryWork(
+func waitForWorkerWork(
 	ctx context.Context,
 	interval time.Duration,
 	wakeup <-chan struct{},

--- a/server/cmd/server/memory_wakeup_test.go
+++ b/server/cmd/server/memory_wakeup_test.go
@@ -15,7 +15,7 @@ import (
 func TestMemoryWorkerWakeupCoalescesWithoutBlocking(t *testing.T) {
 	t.Parallel()
 
-	wakeup := newMemoryWorkerWakeup()
+	wakeup := newWorkerWakeup()
 	var senders sync.WaitGroup
 	for range 100 {
 		senders.Add(1)
@@ -53,8 +53,8 @@ func TestMemoryExtractionWorkerWakesDuringSweepAndNotifiesIndex(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	extractionWakeup := newMemoryWorkerWakeup()
-	indexWakeup := newMemoryWorkerWakeup()
+	extractionWakeup := newWorkerWakeup()
+	indexWakeup := newWorkerWakeup()
 	firstSweepStarted := make(chan struct{})
 	releaseFirstSweep := make(chan struct{})
 	var calls atomic.Int32
@@ -80,7 +80,7 @@ func TestMemoryExtractionWorkerWakesDuringSweepAndNotifiesIndex(
 		1,
 		extractionWakeup.Events(),
 		indexWakeup,
-		waitForMemoryWork,
+		waitForWorkerWork,
 	)
 	if err != nil {
 		t.Fatalf("newMemoryExtractionWorker: %v", err)
@@ -115,7 +115,7 @@ func TestMemoryIndexWorkerWakesWithoutWaitingForRecoveryInterval(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wakeup := newMemoryWorkerWakeup()
+	wakeup := newWorkerWakeup()
 	firstSweepDone := make(chan struct{})
 	var calls atomic.Int32
 	processor := memoryIndexProcessorFunc(func(

--- a/server/cmd/server/thread_summary.go
+++ b/server/cmd/server/thread_summary.go
@@ -7,28 +7,29 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
 )
 
 const (
-	memoryIndexInterval     = 30 * time.Second
-	memoryIndexSweepTimeout = 90 * time.Second
-	memoryIndexClaimLimit   = 4
+	threadSummaryInterval     = 30 * time.Second
+	threadSummarySweepTimeout = 90 * time.Second
+	threadSummaryClaimLimit   = 4
 )
 
-var errMemoryIndexDependency = errors.New(
-	"memory index dependency is required",
+var errThreadSummaryDependency = errors.New(
+	"thread summary dependency is required",
 )
 
-type memoryIndexProcessor interface {
-	ProcessPendingIndexes(
+type threadSummaryProcessor interface {
+	ProcessPending(
 		context.Context,
 		int,
-	) (memory.IndexSweepResult, error)
+	) (agentsummary.SweepResult, error)
 }
 
-type memoryIndexWorker struct {
-	processor    memoryIndexProcessor
+type threadSummaryWorker struct {
+	processor    threadSummaryProcessor
 	logger       *slog.Logger
 	interval     time.Duration
 	sweepTimeout time.Duration
@@ -36,39 +37,39 @@ type memoryIndexWorker struct {
 	wakeup       <-chan struct{}
 }
 
-func buildMemoryIndexWorker(
-	processor memoryIndexProcessor,
+func buildThreadSummaryWorker(
+	processor threadSummaryProcessor,
 	logger *slog.Logger,
 	wakeup <-chan struct{},
-) (*memoryIndexWorker, error) {
-	return newMemoryIndexWorker(
+) (*threadSummaryWorker, error) {
+	return newThreadSummaryWorker(
 		processor,
 		logger,
-		memoryIndexInterval,
-		memoryIndexSweepTimeout,
-		memoryIndexClaimLimit,
+		threadSummaryInterval,
+		threadSummarySweepTimeout,
+		threadSummaryClaimLimit,
 		wakeup,
 	)
 }
 
-func newMemoryIndexWorker(
-	processor memoryIndexProcessor,
+func newThreadSummaryWorker(
+	processor threadSummaryProcessor,
 	logger *slog.Logger,
 	interval time.Duration,
 	sweepTimeout time.Duration,
 	claimLimit int,
 	wakeup <-chan struct{},
-) (*memoryIndexWorker, error) {
-	if nilMemoryIndexDependency(processor) ||
+) (*threadSummaryWorker, error) {
+	if nilThreadSummaryDependency(processor) ||
 		logger == nil ||
 		interval <= 0 ||
 		sweepTimeout <= 0 ||
 		sweepTimeout > 5*time.Minute ||
 		claimLimit < 1 ||
 		claimLimit > 20 {
-		return nil, errMemoryIndexDependency
+		return nil, errThreadSummaryDependency
 	}
-	return &memoryIndexWorker{
+	return &threadSummaryWorker{
 		processor:    processor,
 		logger:       logger,
 		interval:     interval,
@@ -78,7 +79,7 @@ func newMemoryIndexWorker(
 	}, nil
 }
 
-func (worker *memoryIndexWorker) Run(ctx context.Context) {
+func (worker *threadSummaryWorker) Run(ctx context.Context) {
 	if ctx == nil {
 		return
 	}
@@ -95,11 +96,11 @@ func (worker *memoryIndexWorker) Run(ctx context.Context) {
 	}
 }
 
-func (worker *memoryIndexWorker) sweep(parent context.Context) bool {
+func (worker *threadSummaryWorker) sweep(parent context.Context) bool {
 	startedAt := time.Now()
 	ctx, cancel := context.WithTimeout(parent, worker.sweepTimeout)
 	defer cancel()
-	result, err := worker.processor.ProcessPendingIndexes(
+	result, err := worker.processor.ProcessPending(
 		ctx,
 		worker.claimLimit,
 	)
@@ -107,64 +108,70 @@ func (worker *memoryIndexWorker) sweep(parent context.Context) bool {
 		slog.Int("claimed", result.Claimed),
 		slog.Int("completed", result.Completed),
 		slog.Int("retried", result.Retried),
+		slog.Int("skipped", result.Skipped),
+		slog.Int("superseded", result.Superseded),
 		slog.Int("failed", result.Failed),
-		slog.Int("discarded", result.Discarded),
 		slog.Int64("duration_ms", time.Since(startedAt).Milliseconds()),
 	}
 	if err != nil {
 		attributes = append(
 			attributes,
-			slog.String("error_kind", memoryIndexErrorKind(err)),
+			slog.String("error_kind", threadSummaryErrorKind(err)),
 		)
 		worker.logger.WarnContext(
 			parent,
-			"memory index sweep failed",
+			"thread summary sweep failed",
 			attributes...,
 		)
 		return false
 	}
-	if result.Failed > 0 || result.Discarded > 0 {
+	if result.Failed > 0 {
 		worker.logger.WarnContext(
 			parent,
-			"memory index sweep completed with terminal jobs",
+			"thread summary sweep completed with terminal jobs",
 			attributes...,
 		)
 		return result.Claimed == worker.claimLimit
 	}
 	worker.logger.InfoContext(
 		parent,
-		"memory index sweep completed",
+		"thread summary sweep completed",
 		attributes...,
 	)
 	return result.Claimed == worker.claimLimit
 }
 
-func memoryIndexErrorKind(err error) string {
+func threadSummaryErrorKind(err error) string {
 	switch {
 	case errors.Is(err, context.Canceled):
 		return "canceled"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "deadline_exceeded"
-	case errors.Is(err, memory.ErrConflict):
+	case errors.Is(err, core.ErrConflict):
 		return "concurrent_update"
-	case errors.Is(err, memory.ErrInvalidArgument):
-		return "invalid_state"
-	case errors.Is(err, memory.ErrRepository):
-		return "repository"
+	case errors.Is(err, agentsummary.ErrInvalidArgument),
+		errors.Is(err, core.ErrInvalidRequest):
+		return "invalid_argument"
 	default:
 		return "dependency"
 	}
 }
 
-func nilMemoryIndexDependency(value any) bool {
-	if value == nil {
+func nilThreadSummaryDependency(
+	processor threadSummaryProcessor,
+) bool {
+	if processor == nil {
 		return true
 	}
-	reflected := reflect.ValueOf(value)
-	switch reflected.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
-		reflect.Pointer, reflect.Slice:
-		return reflected.IsNil()
+	value := reflect.ValueOf(processor)
+	switch value.Kind() {
+	case reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Pointer,
+		reflect.Slice:
+		return value.IsNil()
 	default:
 		return false
 	}

--- a/server/cmd/server/thread_summary_test.go
+++ b/server/cmd/server/thread_summary_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
+)
+
+func TestThreadSummaryWorkerWakesWithoutWaitingForRecoveryInterval(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	wakeup := newWorkerWakeup()
+	firstSweepDone := make(chan struct{})
+	wokenSweepDone := make(chan struct{})
+	var calls atomic.Int32
+	processor := threadSummaryProcessorFunc(func(
+		context.Context,
+		int,
+	) (agentsummary.SweepResult, error) {
+		switch calls.Add(1) {
+		case 1:
+			close(firstSweepDone)
+		case 2:
+			close(wokenSweepDone)
+		}
+		return agentsummary.SweepResult{}, nil
+	})
+	worker, err := newThreadSummaryWorker(
+		processor,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		time.Hour,
+		time.Second,
+		1,
+		wakeup.Events(),
+	)
+	if err != nil {
+		t.Fatalf("newThreadSummaryWorker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	<-firstSweepDone
+	wakeup.Notify()
+	select {
+	case <-wokenSweepDone:
+	case <-time.After(time.Second):
+		t.Fatal("Summary Worker did not respond to wakeup")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Summary Worker did not stop after cancellation")
+	}
+}
+
+func TestThreadSummaryWorkerDrainsFullBatchWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	secondSweep := make(chan struct{})
+	var calls atomic.Int32
+	processor := threadSummaryProcessorFunc(func(
+		context.Context,
+		int,
+	) (agentsummary.SweepResult, error) {
+		if calls.Add(1) == 1 {
+			return agentsummary.SweepResult{Claimed: 1}, nil
+		}
+		close(secondSweep)
+		return agentsummary.SweepResult{}, nil
+	})
+	worker, err := newThreadSummaryWorker(
+		processor,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		time.Hour,
+		time.Second,
+		1,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("newThreadSummaryWorker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	select {
+	case <-secondSweep:
+	case <-time.After(time.Second):
+		t.Fatal("Summary Worker waited after a full batch")
+	}
+	cancel()
+	<-done
+}
+
+type threadSummaryProcessorFunc func(
+	context.Context,
+	int,
+) (agentsummary.SweepResult, error)
+
+func (process threadSummaryProcessorFunc) ProcessPending(
+	ctx context.Context,
+	limit int,
+) (agentsummary.SweepResult, error) {
+	return process(ctx, limit)
+}

--- a/server/internal/agent/persistence/summary_job_postgres.go
+++ b/server/internal/agent/persistence/summary_job_postgres.go
@@ -1,0 +1,389 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"time"
+
+	. "github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (r *PostgresRepository) ClaimSummaryJob(
+	ctx context.Context,
+	configuration agentsummary.WorkerConfiguration,
+) (agentsummary.JobClaim, bool, error) {
+	if ctx == nil || !configuration.Valid() {
+		return agentsummary.JobClaim{}, false, ErrInvalidRequest
+	}
+	leaseToken, err := r.ids.NewID()
+	if err != nil {
+		return agentsummary.JobClaim{}, false, ErrRepository
+	}
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return agentsummary.JobClaim{}, false, ErrRepository
+	}
+	defer rollback(tx)
+
+	if _, err := tx.Exec(ctx, `
+UPDATE agent_thread_summary_jobs
+SET
+    status = 'failed',
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    outcome_reason = 'attempts_exhausted',
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE status = 'running'
+  AND lease_expires_at <= clock_timestamp()
+  AND attempt_count >= $1`,
+		configuration.MaxAttempts,
+	); err != nil {
+		return agentsummary.JobClaim{}, false, mapPostgresError(err)
+	}
+
+	job, err := scanSummaryJob(tx.QueryRow(ctx, `
+WITH next_job AS (
+    SELECT jobs.source_run_id
+    FROM agent_thread_summary_jobs AS jobs
+    INNER JOIN agent_threads AS threads
+        ON threads.id = jobs.source_thread_id
+       AND threads.owner_user_id = jobs.owner_user_id
+    WHERE (
+        (
+                jobs.status = 'pending'
+                AND jobs.next_attempt_at <= transaction_timestamp()
+            )
+            OR (
+                jobs.status = 'running'
+                AND jobs.lease_expires_at <= clock_timestamp()
+                AND jobs.attempt_count < $1
+            )
+        )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM agent_thread_summary_jobs AS active
+        WHERE active.owner_user_id = jobs.owner_user_id
+          AND active.source_thread_id = jobs.source_thread_id
+          AND active.source_run_id <> jobs.source_run_id
+          AND active.status = 'running'
+          AND active.lease_expires_at > clock_timestamp()
+    )
+    ORDER BY
+        CASE WHEN jobs.status = 'running' THEN 0 ELSE 1 END,
+        jobs.next_attempt_at,
+        jobs.source_completed_at,
+        jobs.source_run_id
+    FOR UPDATE OF jobs, threads SKIP LOCKED
+    LIMIT 1
+)
+UPDATE agent_thread_summary_jobs AS jobs
+SET
+    status = 'running',
+    attempt_count = jobs.attempt_count + 1,
+    lease_token = $2,
+    lease_expires_at =
+        transaction_timestamp() + make_interval(secs => $3),
+    trigger_policy_version = $4,
+    summary_policy_version = $5,
+    prompt_version = $6,
+    provider = $7,
+    model = $8,
+    target_covered_through_sequence = NULL,
+    outcome_reason = NULL,
+    updated_at = transaction_timestamp()
+FROM next_job
+WHERE jobs.source_run_id = next_job.source_run_id
+RETURNING `+summaryJobColumns("jobs"),
+		configuration.MaxAttempts,
+		leaseToken,
+		configuration.LeaseDuration.Seconds(),
+		configuration.TriggerPolicyVersion,
+		configuration.Summary.PolicyVersion,
+		configuration.Summary.PromptVersion,
+		configuration.Summary.Provider,
+		configuration.Summary.Model,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		if commitErr := tx.Commit(ctx); commitErr != nil {
+			return agentsummary.JobClaim{}, false, ErrRepository
+		}
+		return agentsummary.JobClaim{}, false, nil
+	}
+	if err != nil {
+		return agentsummary.JobClaim{}, false, mapPostgresError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return agentsummary.JobClaim{}, false, ErrRepository
+	}
+	claim := agentsummary.JobClaim{Job: job}
+	if !claim.Valid() {
+		return agentsummary.JobClaim{}, false, ErrRepository
+	}
+	return claim, true, nil
+}
+
+func (r *PostgresRepository) CompleteSummaryJob(
+	ctx context.Context,
+	claim agentsummary.JobClaim,
+	targetCoveredThrough int64,
+	checkpoint ThreadSummaryCheckpoint,
+) (agentsummary.Job, error) {
+	if ctx == nil ||
+		!claim.Valid() ||
+		targetCoveredThrough < 1 ||
+		!checkpoint.Valid() ||
+		checkpoint.OwnerID != claim.OwnerID ||
+		checkpoint.ThreadID != claim.ThreadID ||
+		checkpoint.CoveredThroughSequence != targetCoveredThrough {
+		return agentsummary.Job{}, ErrInvalidRequest
+	}
+	job, err := scanSummaryJob(r.database.QueryRow(ctx, `
+UPDATE agent_thread_summary_jobs
+SET
+    status = 'completed',
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    target_covered_through_sequence = $4,
+    checkpoint_id = $5,
+    outcome_reason = NULL,
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE source_run_id = $1
+  AND owner_user_id = $2
+  AND status = 'running'
+  AND lease_token = $3
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+summaryJobColumns("agent_thread_summary_jobs"),
+		claim.SourceRunID,
+		claim.OwnerID,
+		claim.LeaseToken,
+		targetCoveredThrough,
+		checkpoint.ID,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return agentsummary.Job{}, ErrConflict
+	}
+	if err != nil {
+		return agentsummary.Job{}, mapPostgresError(err)
+	}
+	return job, nil
+}
+
+func (r *PostgresRepository) FinishSummaryJob(
+	ctx context.Context,
+	claim agentsummary.JobClaim,
+	status agentsummary.JobStatus,
+	targetCoveredThrough int64,
+	reason string,
+) (agentsummary.Job, error) {
+	validTarget := status == agentsummary.JobSkipped &&
+		targetCoveredThrough == 0 ||
+		status == agentsummary.JobSuperseded &&
+			targetCoveredThrough >= 1
+	if ctx == nil ||
+		!claim.Valid() ||
+		!validTarget ||
+		!summaryJobReasonPattern.MatchString(reason) {
+		return agentsummary.Job{}, ErrInvalidRequest
+	}
+	var target any
+	if targetCoveredThrough > 0 {
+		target = targetCoveredThrough
+	}
+	job, err := scanSummaryJob(r.database.QueryRow(ctx, `
+UPDATE agent_thread_summary_jobs
+SET
+    status = $4,
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    target_covered_through_sequence = $5,
+    checkpoint_id = NULL,
+    outcome_reason = $6,
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE source_run_id = $1
+  AND owner_user_id = $2
+  AND status = 'running'
+  AND lease_token = $3
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+summaryJobColumns("agent_thread_summary_jobs"),
+		claim.SourceRunID,
+		claim.OwnerID,
+		claim.LeaseToken,
+		status,
+		target,
+		reason,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return agentsummary.Job{}, ErrConflict
+	}
+	if err != nil {
+		return agentsummary.Job{}, mapPostgresError(err)
+	}
+	return job, nil
+}
+
+func (r *PostgresRepository) FailSummaryJob(
+	ctx context.Context,
+	claim agentsummary.JobClaim,
+	targetCoveredThrough int64,
+	failureKind string,
+	retryable bool,
+	configuration agentsummary.WorkerConfiguration,
+) (agentsummary.Job, error) {
+	if ctx == nil ||
+		!claim.Valid() ||
+		targetCoveredThrough < 0 ||
+		!summaryJobReasonPattern.MatchString(failureKind) ||
+		!configuration.Valid() {
+		return agentsummary.Job{}, ErrInvalidRequest
+	}
+	status := agentsummary.JobFailed
+	if retryable && claim.AttemptCount < configuration.MaxAttempts {
+		status = agentsummary.JobPending
+	}
+	var target any
+	if targetCoveredThrough > 0 {
+		target = targetCoveredThrough
+	}
+	backoff := summaryJobBackoff(claim.AttemptCount)
+	job, err := scanSummaryJob(r.database.QueryRow(ctx, `
+UPDATE agent_thread_summary_jobs
+SET
+    status = $4,
+    lease_token = NULL,
+    lease_expires_at = NULL,
+    next_attempt_at = CASE
+        WHEN $4 = 'pending'
+        THEN transaction_timestamp() + make_interval(secs => $5)
+        ELSE next_attempt_at
+    END,
+    target_covered_through_sequence = $6,
+    checkpoint_id = NULL,
+    outcome_reason = $7,
+    updated_at = transaction_timestamp(),
+    completed_at = CASE
+        WHEN $4 = 'pending' THEN NULL
+        ELSE transaction_timestamp()
+    END
+WHERE source_run_id = $1
+  AND owner_user_id = $2
+  AND status = 'running'
+  AND lease_token = $3
+  AND lease_expires_at > clock_timestamp()
+RETURNING `+summaryJobColumns("agent_thread_summary_jobs"),
+		claim.SourceRunID,
+		claim.OwnerID,
+		claim.LeaseToken,
+		status,
+		backoff.Seconds(),
+		target,
+		failureKind,
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return agentsummary.Job{}, ErrConflict
+	}
+	if err != nil {
+		return agentsummary.Job{}, mapPostgresError(err)
+	}
+	return job, nil
+}
+
+func summaryJobBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		return time.Second
+	}
+	backoff := time.Second << min(attempt-1, 8)
+	if backoff > 5*time.Minute {
+		return 5 * time.Minute
+	}
+	return backoff
+}
+
+func summaryJobColumns(alias string) string {
+	return `
+    ` + alias + `.source_run_id::text,
+    ` + alias + `.owner_user_id::text,
+    ` + alias + `.source_thread_id::text,
+    ` + alias + `.observed_through_sequence,
+    ` + alias + `.source_completed_at,
+    ` + alias + `.status,
+    ` + alias + `.attempt_count,
+    COALESCE(` + alias + `.lease_token::text, ''),
+    ` + alias + `.lease_expires_at,
+    ` + alias + `.next_attempt_at,
+    COALESCE(` + alias + `.trigger_policy_version, ''),
+    COALESCE(` + alias + `.summary_policy_version, ''),
+    COALESCE(` + alias + `.prompt_version, ''),
+    COALESCE(` + alias + `.provider, ''),
+    COALESCE(` + alias + `.model, ''),
+    COALESCE(` + alias + `.target_covered_through_sequence, 0),
+    COALESCE(` + alias + `.checkpoint_id::text, ''),
+    COALESCE(` + alias + `.outcome_reason, ''),
+    ` + alias + `.created_at,
+    ` + alias + `.updated_at,
+    ` + alias + `.completed_at`
+}
+
+func scanSummaryJob(row rowScanner) (agentsummary.Job, error) {
+	var job agentsummary.Job
+	var status string
+	var leaseExpiresAt pgtype.Timestamptz
+	var completedAt pgtype.Timestamptz
+	if err := row.Scan(
+		&job.SourceRunID,
+		&job.OwnerID,
+		&job.ThreadID,
+		&job.ObservedThroughSequence,
+		&job.SourceCompletedAt,
+		&status,
+		&job.AttemptCount,
+		&job.LeaseToken,
+		&leaseExpiresAt,
+		&job.NextAttemptAt,
+		&job.TriggerPolicyVersion,
+		&job.SummaryPolicyVersion,
+		&job.PromptVersion,
+		&job.Provider,
+		&job.Model,
+		&job.TargetCoveredThrough,
+		&job.CheckpointID,
+		&job.OutcomeReason,
+		&job.CreatedAt,
+		&job.UpdatedAt,
+		&completedAt,
+	); err != nil {
+		return agentsummary.Job{}, err
+	}
+	job.Status = agentsummary.JobStatus(status)
+	job.SourceCompletedAt = job.SourceCompletedAt.UTC()
+	job.NextAttemptAt = job.NextAttemptAt.UTC()
+	job.CreatedAt = job.CreatedAt.UTC()
+	job.UpdatedAt = job.UpdatedAt.UTC()
+	if leaseExpiresAt.Valid {
+		job.LeaseExpiresAt = leaseExpiresAt.Time.UTC()
+	}
+	if completedAt.Valid {
+		job.CompletedAt = completedAt.Time.UTC()
+	}
+	if !job.Status.Valid() ||
+		!ValidUUID(job.SourceRunID) ||
+		!ValidUUID(job.OwnerID) ||
+		!ValidUUID(job.ThreadID) ||
+		job.ObservedThroughSequence < 1 ||
+		job.SourceCompletedAt.IsZero() ||
+		job.AttemptCount < 0 {
+		return agentsummary.Job{}, ErrRepository
+	}
+	return job, nil
+}
+
+var (
+	summaryJobReasonPattern                            = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
+	_                       agentsummary.JobRepository = (*PostgresRepository)(nil)
+)

--- a/server/internal/agent/summary/job.go
+++ b/server/internal/agent/summary/job.go
@@ -1,0 +1,159 @@
+package summary
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+)
+
+const (
+	TriggerPolicyV1          = "summary-trigger-v1"
+	DefaultTriggerMessages   = int64(40)
+	DefaultRetainedMessages  = int64(12)
+	DefaultWorkerMaxAttempts = 3
+)
+
+var summaryJobFailurePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
+
+type JobStatus string
+
+const (
+	JobPending    JobStatus = "pending"
+	JobRunning    JobStatus = "running"
+	JobCompleted  JobStatus = "completed"
+	JobSkipped    JobStatus = "skipped"
+	JobSuperseded JobStatus = "superseded"
+	JobFailed     JobStatus = "failed"
+)
+
+func (status JobStatus) Valid() bool {
+	switch status {
+	case JobPending,
+		JobRunning,
+		JobCompleted,
+		JobSkipped,
+		JobSuperseded,
+		JobFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+type WorkerConfiguration struct {
+	TriggerPolicyVersion string
+	TriggerMessages      int64
+	RetainRecentMessages int64
+	LeaseDuration        time.Duration
+	MaxAttempts          int
+	Summary              Configuration
+}
+
+func (configuration WorkerConfiguration) Valid() bool {
+	return core.ValidSummaryVersion(configuration.TriggerPolicyVersion) &&
+		configuration.TriggerMessages > configuration.RetainRecentMessages &&
+		configuration.TriggerMessages <= 1000 &&
+		configuration.RetainRecentMessages >= 1 &&
+		configuration.RetainRecentMessages <
+			int64(core.MaxSummarySourceMessages) &&
+		configuration.LeaseDuration >= time.Second &&
+		configuration.LeaseDuration <= 10*time.Minute &&
+		configuration.MaxAttempts >= 1 &&
+		configuration.MaxAttempts <= 10 &&
+		configuration.Summary.Valid()
+}
+
+type Job struct {
+	SourceRunID             string
+	OwnerID                 string
+	ThreadID                string
+	ObservedThroughSequence int64
+	SourceCompletedAt       time.Time
+	Status                  JobStatus
+	AttemptCount            int
+	LeaseToken              string
+	LeaseExpiresAt          time.Time
+	NextAttemptAt           time.Time
+	TriggerPolicyVersion    string
+	SummaryPolicyVersion    string
+	PromptVersion           string
+	Provider                string
+	Model                   string
+	TargetCoveredThrough    int64
+	CheckpointID            string
+	OutcomeReason           string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	CompletedAt             time.Time
+}
+
+type JobClaim struct {
+	Job
+}
+
+func (claim JobClaim) Valid() bool {
+	return core.ValidUUID(claim.SourceRunID) &&
+		core.ValidUUID(claim.OwnerID) &&
+		core.ValidUUID(claim.ThreadID) &&
+		claim.ObservedThroughSequence >= 1 &&
+		!claim.SourceCompletedAt.IsZero() &&
+		claim.Status == JobRunning &&
+		claim.AttemptCount > 0 &&
+		core.ValidUUID(claim.LeaseToken) &&
+		!claim.LeaseExpiresAt.IsZero() &&
+		core.ValidSummaryVersion(claim.TriggerPolicyVersion) &&
+		core.ValidSummaryVersion(claim.SummaryPolicyVersion) &&
+		core.ValidSummaryVersion(claim.PromptVersion) &&
+		core.ValidProviderID(claim.Provider) &&
+		core.ValidModelID(claim.Model)
+}
+
+type JobRepository interface {
+	ClaimSummaryJob(
+		context.Context,
+		WorkerConfiguration,
+	) (JobClaim, bool, error)
+	CompleteSummaryJob(
+		context.Context,
+		JobClaim,
+		int64,
+		core.ThreadSummaryCheckpoint,
+	) (Job, error)
+	FinishSummaryJob(
+		context.Context,
+		JobClaim,
+		JobStatus,
+		int64,
+		string,
+	) (Job, error)
+	FailSummaryJob(
+		context.Context,
+		JobClaim,
+		int64,
+		string,
+		bool,
+		WorkerConfiguration,
+	) (Job, error)
+}
+
+type CheckpointGenerator interface {
+	GenerateCheckpoint(
+		context.Context,
+		GenerateCheckpointCommand,
+	) (core.ThreadSummaryCheckpoint, error)
+}
+
+type SweepResult struct {
+	Claimed    int
+	Completed  int
+	Retried    int
+	Skipped    int
+	Superseded int
+	Failed     int
+}
+
+type Processor interface {
+	ProcessPending(context.Context, int) (SweepResult, error)
+}

--- a/server/internal/agent/summary/service.go
+++ b/server/internal/agent/summary/service.go
@@ -129,8 +129,8 @@ func (service *Service) GenerateCheckpoint(
 		sourceFromSequence = previous.CoveredThroughSequence + 1
 		previousCheckpointID = previous.ID
 	}
-	if command.CoveredThroughSequence-sourceFromSequence+1 >
-		core.MaxSummarySourceMessages {
+	if command.CoveredThroughSequence-sourceFromSequence >=
+		int64(core.MaxSummarySourceMessages) {
 		return core.ThreadSummaryCheckpoint{}, ErrInvalidArgument
 	}
 	messages, err := service.repository.ListMessagesForSummary(

--- a/server/internal/agent/summary/worker.go
+++ b/server/internal/agent/summary/worker.go
@@ -1,0 +1,274 @@
+package summary
+
+import (
+	"context"
+	"errors"
+	"math"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+const maxSummarySweepLimit = 20
+
+type Worker struct {
+	jobs          JobRepository
+	checkpoints   core.ThreadSummaryCheckpointRepository
+	generator     CheckpointGenerator
+	configuration WorkerConfiguration
+}
+
+func NewWorker(
+	jobs JobRepository,
+	checkpoints core.ThreadSummaryCheckpointRepository,
+	generator CheckpointGenerator,
+	configuration WorkerConfiguration,
+) (*Worker, error) {
+	if jobs == nil ||
+		checkpoints == nil ||
+		generator == nil ||
+		!configuration.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	return &Worker{
+		jobs:          jobs,
+		checkpoints:   checkpoints,
+		generator:     generator,
+		configuration: configuration,
+	}, nil
+}
+
+func (worker *Worker) ProcessPending(
+	ctx context.Context,
+	limit int,
+) (SweepResult, error) {
+	if ctx == nil || limit < 1 || limit > maxSummarySweepLimit {
+		return SweepResult{}, ErrInvalidArgument
+	}
+	var result SweepResult
+	for result.Claimed < limit {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		claim, acquired, err := worker.jobs.ClaimSummaryJob(
+			ctx,
+			worker.configuration,
+		)
+		if err != nil {
+			return result, err
+		}
+		if !acquired {
+			return result, nil
+		}
+		result.Claimed++
+		status, err := worker.processClaim(ctx, claim)
+		if err != nil {
+			return result, err
+		}
+		switch status {
+		case JobCompleted:
+			result.Completed++
+		case JobPending:
+			result.Retried++
+		case JobSkipped:
+			result.Skipped++
+		case JobSuperseded:
+			result.Superseded++
+		case JobFailed:
+			result.Failed++
+		default:
+			return result, core.ErrRepository
+		}
+	}
+	return result, nil
+}
+
+func (worker *Worker) processClaim(
+	ctx context.Context,
+	claim JobClaim,
+) (JobStatus, error) {
+	previous, err := worker.checkpoints.FindLatestSummaryCheckpoint(
+		ctx,
+		claim.OwnerID,
+		claim.ThreadID,
+		math.MaxInt64,
+	)
+	hasPrevious := err == nil
+	if err != nil && !errors.Is(err, core.ErrNotFound) {
+		return worker.recordFailure(ctx, claim, 0, err)
+	}
+	previousCoverage := int64(0)
+	if hasPrevious {
+		previousCoverage = previous.CoveredThroughSequence
+	}
+	if previousCoverage >= claim.ObservedThroughSequence {
+		return worker.finish(
+			ctx,
+			claim,
+			JobSuperseded,
+			claim.ObservedThroughSequence,
+			"already_covered",
+		)
+	}
+	uncoveredMessages := claim.ObservedThroughSequence - previousCoverage
+	if uncoveredMessages < worker.configuration.TriggerMessages {
+		return worker.finish(
+			ctx,
+			claim,
+			JobSkipped,
+			0,
+			"below_threshold",
+		)
+	}
+
+	target := claim.ObservedThroughSequence -
+		worker.configuration.RetainRecentMessages
+	maxTarget := int64(math.MaxInt64)
+	if previousCoverage <=
+		math.MaxInt64-int64(core.MaxSummarySourceMessages) {
+		maxTarget = previousCoverage +
+			int64(core.MaxSummarySourceMessages)
+	}
+	if target > maxTarget {
+		target = maxTarget
+	}
+	if target <= previousCoverage {
+		return worker.finish(
+			ctx,
+			claim,
+			JobSuperseded,
+			target,
+			"no_new_coverage",
+		)
+	}
+
+	checkpoint, err := worker.generator.GenerateCheckpoint(
+		ctx,
+		GenerateCheckpointCommand{
+			OwnerID:                claim.OwnerID,
+			ThreadID:               claim.ThreadID,
+			CoveredThroughSequence: target,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, core.ErrConflict) {
+			latest, latestErr := worker.checkpoints.FindLatestSummaryCheckpoint(
+				ctx,
+				claim.OwnerID,
+				claim.ThreadID,
+				math.MaxInt64,
+			)
+			if latestErr == nil &&
+				latest.CoveredThroughSequence >= target {
+				return worker.finish(
+					ctx,
+					claim,
+					JobSuperseded,
+					target,
+					"concurrently_covered",
+				)
+			}
+			if latestErr != nil &&
+				!errors.Is(latestErr, core.ErrNotFound) {
+				return worker.recordFailure(
+					ctx,
+					claim,
+					target,
+					latestErr,
+				)
+			}
+		}
+		return worker.recordFailure(ctx, claim, target, err)
+	}
+	if !checkpoint.Valid() ||
+		checkpoint.OwnerID != claim.OwnerID ||
+		checkpoint.ThreadID != claim.ThreadID ||
+		checkpoint.CoveredThroughSequence != target {
+		return worker.recordFailure(
+			ctx,
+			claim,
+			target,
+			ErrInvalidResponse,
+		)
+	}
+	job, err := worker.jobs.CompleteSummaryJob(
+		ctx,
+		claim,
+		target,
+		checkpoint,
+	)
+	if err != nil {
+		return "", err
+	}
+	return job.Status, nil
+}
+
+func (worker *Worker) finish(
+	ctx context.Context,
+	claim JobClaim,
+	status JobStatus,
+	target int64,
+	reason string,
+) (JobStatus, error) {
+	job, err := worker.jobs.FinishSummaryJob(
+		ctx,
+		claim,
+		status,
+		target,
+		reason,
+	)
+	if err != nil {
+		return "", err
+	}
+	return job.Status, nil
+}
+
+func (worker *Worker) recordFailure(
+	ctx context.Context,
+	claim JobClaim,
+	target int64,
+	cause error,
+) (JobStatus, error) {
+	kind, retryable := summaryJobFailure(cause)
+	job, err := worker.jobs.FailSummaryJob(
+		ctx,
+		claim,
+		target,
+		kind,
+		retryable,
+		worker.configuration,
+	)
+	if err != nil {
+		return "", err
+	}
+	return job.Status, nil
+}
+
+func summaryJobFailure(cause error) (string, bool) {
+	switch {
+	case errors.Is(cause, context.Canceled):
+		return "canceled", true
+	case errors.Is(cause, context.DeadlineExceeded):
+		return "timeout", true
+	case errors.Is(cause, ErrInvalidArgument),
+		errors.Is(cause, core.ErrInvalidRequest):
+		return "invalid_argument", false
+	case errors.Is(cause, ErrInvalidResponse):
+		return "invalid_response", false
+	case errors.Is(cause, core.ErrNotFound):
+		return "source_not_found", false
+	case errors.Is(cause, core.ErrConflict):
+		return "concurrent_update", true
+	}
+	var generationError *ai.GenerationError
+	if errors.As(cause, &generationError) {
+		kind := generationError.StableCategory()
+		if !summaryJobFailurePattern.MatchString(kind) {
+			kind = "provider_error"
+		}
+		return kind, generationError.Retryable()
+	}
+	return "dependency", true
+}
+
+var _ Processor = (*Worker)(nil)

--- a/server/internal/agent/summary/worker_test.go
+++ b/server/internal/agent/summary/worker_test.go
@@ -1,0 +1,401 @@
+package summary
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+)
+
+func TestWorkerSkipsBelowThresholdWithoutGeneration(t *testing.T) {
+	t.Parallel()
+
+	jobs := &jobRepositoryStub{claim: jobClaimFixture(39)}
+	checkpoints := &checkpointRepositoryStub{
+		findErr: core.ErrNotFound,
+	}
+	generator := &checkpointGeneratorStub{}
+	worker := newWorkerForTest(t, jobs, checkpoints, generator)
+
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if result.Skipped != 1 || generator.calls != 0 {
+		t.Fatalf("result = %#v generator calls = %d", result, generator.calls)
+	}
+	if jobs.finishedStatus != JobSkipped ||
+		jobs.finishedTarget != 0 ||
+		jobs.finishedReason != "below_threshold" {
+		t.Fatalf("unexpected finish: %#v", jobs)
+	}
+}
+
+func TestWorkerRetainsRecentMessagesAndCompletes(t *testing.T) {
+	t.Parallel()
+
+	claim := jobClaimFixture(40)
+	jobs := &jobRepositoryStub{claim: claim}
+	checkpoints := &checkpointRepositoryStub{findErr: core.ErrNotFound}
+	generator := &checkpointGeneratorStub{}
+	generator.generate = func(
+		command GenerateCheckpointCommand,
+	) (core.ThreadSummaryCheckpoint, error) {
+		if command.CoveredThroughSequence != 28 {
+			t.Fatalf(
+				"covered through = %d, want 28",
+				command.CoveredThroughSequence,
+			)
+		}
+		return checkpointForTarget(claim, 28), nil
+	}
+	worker := newWorkerForTest(t, jobs, checkpoints, generator)
+
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if result.Completed != 1 || generator.calls != 1 {
+		t.Fatalf("result = %#v generator calls = %d", result, generator.calls)
+	}
+	if jobs.completedTarget != 28 ||
+		jobs.completedCheckpoint.CoveredThroughSequence != 28 {
+		t.Fatalf("unexpected completion: %#v", jobs)
+	}
+}
+
+func TestWorkerCapsBacklogAtSummarySourceLimit(t *testing.T) {
+	t.Parallel()
+
+	claim := jobClaimFixture(200)
+	jobs := &jobRepositoryStub{claim: claim}
+	previous := checkpointForTarget(claim, 20)
+	checkpoints := &checkpointRepositoryStub{latest: previous}
+	generator := &checkpointGeneratorStub{}
+	generator.generate = func(
+		command GenerateCheckpointCommand,
+	) (core.ThreadSummaryCheckpoint, error) {
+		if command.CoveredThroughSequence != 120 {
+			t.Fatalf(
+				"covered through = %d, want 120",
+				command.CoveredThroughSequence,
+			)
+		}
+		return checkpointForTarget(claim, 120), nil
+	}
+	worker := newWorkerForTest(t, jobs, checkpoints, generator)
+
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if result.Completed != 1 || jobs.completedTarget != 120 {
+		t.Fatalf("unexpected result = %#v jobs = %#v", result, jobs)
+	}
+}
+
+func TestWorkerSupersedesAlreadyCoveredJob(t *testing.T) {
+	t.Parallel()
+
+	claim := jobClaimFixture(40)
+	jobs := &jobRepositoryStub{claim: claim}
+	checkpoints := &checkpointRepositoryStub{
+		latest: checkpointForTarget(claim, 40),
+	}
+	generator := &checkpointGeneratorStub{}
+	worker := newWorkerForTest(t, jobs, checkpoints, generator)
+
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if result.Superseded != 1 ||
+		generator.calls != 0 ||
+		jobs.finishedReason != "already_covered" {
+		t.Fatalf(
+			"result = %#v generator calls = %d jobs = %#v",
+			result,
+			generator.calls,
+			jobs,
+		)
+	}
+}
+
+func TestWorkerRecordsRetryableAndTerminalFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		generation error
+		wantStatus JobStatus
+		wantReason string
+	}{
+		{
+			name: "retryable provider",
+			generation: ai.NewGenerationError(
+				ai.ErrorProviderUnavailable,
+				503,
+				"",
+				"",
+				errors.New("provider unavailable"),
+			),
+			wantStatus: JobPending,
+			wantReason: "provider_unavailable",
+		},
+		{
+			name:       "invalid response",
+			generation: ErrInvalidResponse,
+			wantStatus: JobFailed,
+			wantReason: "invalid_response",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			jobs := &jobRepositoryStub{
+				claim:      jobClaimFixture(40),
+				failedWith: test.wantStatus,
+			}
+			checkpoints := &checkpointRepositoryStub{
+				findErr: core.ErrNotFound,
+			}
+			generator := &checkpointGeneratorStub{
+				generate: func(
+					GenerateCheckpointCommand,
+				) (core.ThreadSummaryCheckpoint, error) {
+					return core.ThreadSummaryCheckpoint{}, test.generation
+				},
+			}
+			worker := newWorkerForTest(
+				t,
+				jobs,
+				checkpoints,
+				generator,
+			)
+
+			result, err := worker.ProcessPending(
+				context.Background(),
+				1,
+			)
+			if err != nil {
+				t.Fatalf("ProcessPending: %v", err)
+			}
+			if jobs.failureReason != test.wantReason ||
+				jobs.failureRetryable !=
+					(test.wantStatus == JobPending) {
+				t.Fatalf("unexpected failure recording: %#v", jobs)
+			}
+			if test.wantStatus == JobPending && result.Retried != 1 {
+				t.Fatalf("result = %#v", result)
+			}
+			if test.wantStatus == JobFailed && result.Failed != 1 {
+				t.Fatalf("result = %#v", result)
+			}
+		})
+	}
+}
+
+func newWorkerForTest(
+	t *testing.T,
+	jobs JobRepository,
+	checkpoints core.ThreadSummaryCheckpointRepository,
+	generator CheckpointGenerator,
+) *Worker {
+	t.Helper()
+
+	worker, err := NewWorker(
+		jobs,
+		checkpoints,
+		generator,
+		workerConfigurationFixture(),
+	)
+	if err != nil {
+		t.Fatalf("NewWorker: %v", err)
+	}
+	return worker
+}
+
+func workerConfigurationFixture() WorkerConfiguration {
+	return WorkerConfiguration{
+		TriggerPolicyVersion: TriggerPolicyV1,
+		TriggerMessages:      DefaultTriggerMessages,
+		RetainRecentMessages: DefaultRetainedMessages,
+		LeaseDuration:        time.Minute,
+		MaxAttempts:          DefaultWorkerMaxAttempts,
+		Summary: Configuration{
+			PolicyVersion: "summary-policy-v1",
+			PromptVersion: "summary-prompt-v1",
+			Provider:      "fake",
+			Model:         "fake-model",
+		},
+	}
+}
+
+func jobClaimFixture(observedThrough int64) JobClaim {
+	return JobClaim{Job: Job{
+		SourceRunID:             "11111111-1111-4111-8111-111111111111",
+		OwnerID:                 "22222222-2222-4222-8222-222222222222",
+		ThreadID:                "33333333-3333-4333-8333-333333333333",
+		ObservedThroughSequence: observedThrough,
+		SourceCompletedAt:       time.Unix(1, 0).UTC(),
+		Status:                  JobRunning,
+		AttemptCount:            1,
+		LeaseToken:              "44444444-4444-4444-8444-444444444444",
+		LeaseExpiresAt:          time.Now().Add(time.Minute),
+		TriggerPolicyVersion:    TriggerPolicyV1,
+		SummaryPolicyVersion:    "summary-policy-v1",
+		PromptVersion:           "summary-prompt-v1",
+		Provider:                "fake",
+		Model:                   "fake-model",
+	}}
+}
+
+func checkpointForTarget(
+	claim JobClaim,
+	target int64,
+) core.ThreadSummaryCheckpoint {
+	sourceFrom := int64(1)
+	previousID := ""
+	if target > 40 {
+		sourceFrom = 21
+		previousID = "55555555-5555-4555-8555-555555555555"
+	}
+	return core.ThreadSummaryCheckpoint{
+		ID:                     "66666666-6666-4666-8666-666666666666",
+		OwnerID:                claim.OwnerID,
+		ThreadID:               claim.ThreadID,
+		PreviousCheckpointID:   previousID,
+		SourceFromSequence:     sourceFrom,
+		CoveredThroughSequence: target,
+		Content: core.ThreadSummaryContent{
+			Goals:         []string{"Continue the conversation"},
+			Background:    []string{},
+			Progress:      []string{},
+			Decisions:     []string{},
+			OpenQuestions: []string{},
+			NextSteps:     []string{},
+		},
+		PolicyVersion:  "summary-policy-v1",
+		PromptVersion:  "summary-prompt-v1",
+		Provider:       "fake",
+		Model:          "fake-model",
+		SourceChecksum: sha256.Sum256([]byte("source")),
+		CreatedAt:      time.Now(),
+	}
+}
+
+type jobRepositoryStub struct {
+	claim               JobClaim
+	claimed             bool
+	completedTarget     int64
+	completedCheckpoint core.ThreadSummaryCheckpoint
+	finishedStatus      JobStatus
+	finishedTarget      int64
+	finishedReason      string
+	failedWith          JobStatus
+	failureTarget       int64
+	failureReason       string
+	failureRetryable    bool
+}
+
+func (repository *jobRepositoryStub) ClaimSummaryJob(
+	context.Context,
+	WorkerConfiguration,
+) (JobClaim, bool, error) {
+	if repository.claimed {
+		return JobClaim{}, false, nil
+	}
+	repository.claimed = true
+	return repository.claim, true, nil
+}
+
+func (repository *jobRepositoryStub) CompleteSummaryJob(
+	_ context.Context,
+	claim JobClaim,
+	target int64,
+	checkpoint core.ThreadSummaryCheckpoint,
+) (Job, error) {
+	repository.completedTarget = target
+	repository.completedCheckpoint = checkpoint
+	job := claim.Job
+	job.Status = JobCompleted
+	return job, nil
+}
+
+func (repository *jobRepositoryStub) FinishSummaryJob(
+	_ context.Context,
+	claim JobClaim,
+	status JobStatus,
+	target int64,
+	reason string,
+) (Job, error) {
+	repository.finishedStatus = status
+	repository.finishedTarget = target
+	repository.finishedReason = reason
+	job := claim.Job
+	job.Status = status
+	return job, nil
+}
+
+func (repository *jobRepositoryStub) FailSummaryJob(
+	_ context.Context,
+	claim JobClaim,
+	target int64,
+	reason string,
+	retryable bool,
+	_ WorkerConfiguration,
+) (Job, error) {
+	repository.failureTarget = target
+	repository.failureReason = reason
+	repository.failureRetryable = retryable
+	job := claim.Job
+	job.Status = repository.failedWith
+	return job, nil
+}
+
+type checkpointRepositoryStub struct {
+	latest  core.ThreadSummaryCheckpoint
+	findErr error
+}
+
+func (*checkpointRepositoryStub) CreateSummaryCheckpoint(
+	context.Context,
+	core.CreateThreadSummaryCheckpointCommand,
+) (core.ThreadSummaryCheckpoint, error) {
+	return core.ThreadSummaryCheckpoint{}, errors.New("unexpected create")
+}
+
+func (repository *checkpointRepositoryStub) FindLatestSummaryCheckpoint(
+	context.Context,
+	string,
+	string,
+	int64,
+) (core.ThreadSummaryCheckpoint, error) {
+	return repository.latest, repository.findErr
+}
+
+type checkpointGeneratorStub struct {
+	calls    int
+	generate func(
+		GenerateCheckpointCommand,
+	) (core.ThreadSummaryCheckpoint, error)
+}
+
+func (generator *checkpointGeneratorStub) GenerateCheckpoint(
+	_ context.Context,
+	command GenerateCheckpointCommand,
+) (core.ThreadSummaryCheckpoint, error) {
+	generator.calls++
+	if generator.generate == nil {
+		return core.ThreadSummaryCheckpoint{}, errors.New(
+			"unexpected generation",
+		)
+	}
+	return generator.generate(command)
+}

--- a/server/internal/agent/summary_job_postgres_integration_test.go
+++ b/server/internal/agent/summary_job_postgres_integration_test.go
@@ -1,0 +1,486 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai/fake"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestCompletedRunQueuesAndProcessesThreadSummaryJob(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	_, dataService, runService, repository := newAgentRunServices(
+		t,
+		database.pool,
+		fake.NewTextGenerator(successfulTextResult()),
+		testRunConfiguration,
+	)
+	thread, err := dataService.CreateThread(
+		context.Background(),
+		testActorA(),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("create Thread: %v", err)
+	}
+	for index := range 19 {
+		seedSummarySourceMessages(
+			t,
+			database.pool,
+			thread.ID,
+			fmt.Sprintf("summary-job-source-%d", index),
+		)
+	}
+	submission, err := runService.SubmitText(
+		context.Background(),
+		testActorA(),
+		thread.ID,
+		"summary-job-trigger",
+		"Create a checkpoint after this reply.",
+	)
+	if err != nil {
+		t.Fatalf("complete triggering Run: %v", err)
+	}
+	if submission.Run.Status != RunStatusCompleted {
+		t.Fatalf("Run status = %s", submission.Run.Status)
+	}
+	assertSummaryJobRow(
+		t,
+		database.pool,
+		submission.Run.ID,
+		"pending",
+		40,
+		0,
+		"",
+	)
+
+	summaryGenerator := &recordingTextGenerator{
+		result: ai.TextResult{
+			ID:           "summary-completion-1",
+			Provider:     "fake",
+			Model:        "configured-model",
+			Content:      summaryJobValidJSON(),
+			FinishReason: "stop",
+		},
+	}
+	summaryService, err := agentsummary.NewService(
+		repository,
+		summaryGenerator,
+		agentsummary.Configuration{
+			PolicyVersion: "summary-policy-v1",
+			PromptVersion: "summary-prompt-v1",
+			Provider:      "fake",
+			Model:         "configured-model",
+		},
+	)
+	if err != nil {
+		t.Fatalf("new Summary service: %v", err)
+	}
+	worker, err := agentsummary.NewWorker(
+		repository,
+		repository,
+		summaryService,
+		summaryWorkerConfiguration(),
+	)
+	if err != nil {
+		t.Fatalf("new Summary worker: %v", err)
+	}
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("process Summary Job: %v", err)
+	}
+	if result.Completed != 1 || summaryGenerator.CallCount() != 1 {
+		t.Fatalf(
+			"result = %#v generator calls = %d",
+			result,
+			summaryGenerator.CallCount(),
+		)
+	}
+	checkpoint, err := repository.FindLatestSummaryCheckpoint(
+		context.Background(),
+		agentTestUserA,
+		thread.ID,
+		40,
+	)
+	if err != nil {
+		t.Fatalf("find generated Checkpoint: %v", err)
+	}
+	if checkpoint.CoveredThroughSequence != 28 ||
+		checkpoint.SourceFromSequence != 1 {
+		t.Fatalf("unexpected Checkpoint: %#v", checkpoint)
+	}
+	assertSummaryJobRow(
+		t,
+		database.pool,
+		submission.Run.ID,
+		"completed",
+		40,
+		28,
+		checkpoint.ID,
+	)
+
+	replay, err := runService.SubmitText(
+		context.Background(),
+		testActorA(),
+		thread.ID,
+		"summary-job-trigger",
+		"Create a checkpoint after this reply.",
+	)
+	if err != nil {
+		t.Fatalf("replay triggering Run: %v", err)
+	}
+	if replay.Created || replay.Run.ID != submission.Run.ID {
+		t.Fatalf("unexpected replay: %#v", replay)
+	}
+	var jobCount int
+	if err := database.pool.QueryRow(
+		context.Background(),
+		`SELECT count(*) FROM agent_thread_summary_jobs
+WHERE source_run_id = $1`,
+		submission.Run.ID,
+	).Scan(&jobCount); err != nil {
+		t.Fatalf("count Summary Jobs: %v", err)
+	}
+	if jobCount != 1 {
+		t.Fatalf("Summary Job count = %d, want 1", jobCount)
+	}
+}
+
+func TestThreadSummaryJobSkipsBelowThresholdAndSerializesThreadClaims(
+	t *testing.T,
+) {
+	database := newAgentTestDatabase(t)
+	_, dataService, runService, repository := newAgentRunServices(
+		t,
+		database.pool,
+		fake.NewTextGenerator(successfulTextResult()),
+		testRunConfiguration,
+	)
+	thread, err := dataService.CreateThread(
+		context.Background(),
+		testActorA(),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("create Thread: %v", err)
+	}
+	first, err := runService.SubmitText(
+		context.Background(),
+		testActorA(),
+		thread.ID,
+		"summary-job-small-1",
+		"First short exchange.",
+	)
+	if err != nil {
+		t.Fatalf("complete first Run: %v", err)
+	}
+	second, err := runService.SubmitText(
+		context.Background(),
+		testActorA(),
+		thread.ID,
+		"summary-job-small-2",
+		"Second short exchange.",
+	)
+	if err != nil {
+		t.Fatalf("complete second Run: %v", err)
+	}
+
+	configuration := summaryWorkerConfiguration()
+	type claimResult struct {
+		claim    agentsummary.JobClaim
+		acquired bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan claimResult, 2)
+	var wait sync.WaitGroup
+	for range 2 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			claim, acquired, claimErr := repository.ClaimSummaryJob(
+				context.Background(),
+				configuration,
+			)
+			results <- claimResult{
+				claim:    claim,
+				acquired: acquired,
+				err:      claimErr,
+			}
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	var firstClaim agentsummary.JobClaim
+	acquiredCount := 0
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("concurrent ClaimSummaryJob: %v", result.err)
+		}
+		if result.acquired {
+			acquiredCount++
+			firstClaim = result.claim
+		}
+	}
+	if acquiredCount != 1 || firstClaim.ThreadID != thread.ID {
+		t.Fatalf(
+			"acquired count = %d claim = %#v",
+			acquiredCount,
+			firstClaim,
+		)
+	}
+	if _, err := repository.FinishSummaryJob(
+		context.Background(),
+		firstClaim,
+		agentsummary.JobSkipped,
+		0,
+		"below_threshold",
+	); err != nil {
+		t.Fatalf("finish first Job: %v", err)
+	}
+
+	generator := &recordingTextGenerator{
+		result: ai.TextResult{
+			ID:           "summary-unused",
+			Provider:     "fake",
+			Model:        "configured-model",
+			Content:      summaryJobValidJSON(),
+			FinishReason: "stop",
+		},
+	}
+	service, err := agentsummary.NewService(
+		repository,
+		generator,
+		configuration.Summary,
+	)
+	if err != nil {
+		t.Fatalf("new Summary service: %v", err)
+	}
+	worker, err := agentsummary.NewWorker(
+		repository,
+		repository,
+		service,
+		configuration,
+	)
+	if err != nil {
+		t.Fatalf("new Summary worker: %v", err)
+	}
+	result, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("process second Job: %v", err)
+	}
+	if result.Skipped != 1 || generator.CallCount() != 0 {
+		t.Fatalf(
+			"result = %#v generator calls = %d",
+			result,
+			generator.CallCount(),
+		)
+	}
+	assertSummaryJobRow(
+		t,
+		database.pool,
+		first.Run.ID,
+		"skipped",
+		2,
+		0,
+		"",
+	)
+	assertSummaryJobRow(
+		t,
+		database.pool,
+		second.Run.ID,
+		"skipped",
+		4,
+		0,
+		"",
+	)
+}
+
+func TestThreadSummaryJobRecoversExpiredLeaseAndExhaustsRetries(
+	t *testing.T,
+) {
+	database := newAgentTestDatabase(t)
+	_, dataService, runService, repository := newAgentRunServices(
+		t,
+		database.pool,
+		fake.NewTextGenerator(successfulTextResult()),
+		testRunConfiguration,
+	)
+	thread, err := dataService.CreateThread(
+		context.Background(),
+		testActorA(),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("create Thread: %v", err)
+	}
+	submission, err := runService.SubmitText(
+		context.Background(),
+		testActorA(),
+		thread.ID,
+		"summary-job-recovery",
+		"Create a recoverable Summary Job.",
+	)
+	if err != nil {
+		t.Fatalf("complete Run: %v", err)
+	}
+	configuration := summaryWorkerConfiguration()
+	firstClaim, acquired, err := repository.ClaimSummaryJob(
+		context.Background(),
+		configuration,
+	)
+	if err != nil || !acquired {
+		t.Fatalf("claim first lease: acquired=%t err=%v", acquired, err)
+	}
+	if _, err := database.pool.Exec(
+		context.Background(),
+		`UPDATE agent_thread_summary_jobs
+SET
+    updated_at = created_at,
+    lease_expires_at = created_at + INTERVAL '1 microsecond'
+WHERE source_run_id = $1`,
+		submission.Run.ID,
+	); err != nil {
+		t.Fatalf("expire first lease: %v", err)
+	}
+	recovered, acquired, err := repository.ClaimSummaryJob(
+		context.Background(),
+		configuration,
+	)
+	if err != nil || !acquired {
+		t.Fatalf("recover expired lease: acquired=%t err=%v", acquired, err)
+	}
+	if recovered.AttemptCount != 2 ||
+		recovered.LeaseToken == firstClaim.LeaseToken {
+		t.Fatalf("unexpected recovered claim: %#v", recovered)
+	}
+	retried, err := repository.FailSummaryJob(
+		context.Background(),
+		recovered,
+		0,
+		"dependency",
+		true,
+		configuration,
+	)
+	if err != nil {
+		t.Fatalf("requeue recovered Job: %v", err)
+	}
+	if retried.Status != agentsummary.JobPending ||
+		retried.OutcomeReason != "dependency" {
+		t.Fatalf("unexpected retried Job: %#v", retried)
+	}
+	if _, err := database.pool.Exec(
+		context.Background(),
+		`UPDATE agent_thread_summary_jobs
+SET next_attempt_at = created_at
+WHERE source_run_id = $1`,
+		submission.Run.ID,
+	); err != nil {
+		t.Fatalf("make retry due: %v", err)
+	}
+	finalClaim, acquired, err := repository.ClaimSummaryJob(
+		context.Background(),
+		configuration,
+	)
+	if err != nil || !acquired {
+		t.Fatalf("claim final attempt: acquired=%t err=%v", acquired, err)
+	}
+	if finalClaim.AttemptCount != configuration.MaxAttempts {
+		t.Fatalf(
+			"attempt count = %d, want %d",
+			finalClaim.AttemptCount,
+			configuration.MaxAttempts,
+		)
+	}
+	failed, err := repository.FailSummaryJob(
+		context.Background(),
+		finalClaim,
+		0,
+		"dependency",
+		true,
+		configuration,
+	)
+	if err != nil {
+		t.Fatalf("exhaust retry: %v", err)
+	}
+	if failed.Status != agentsummary.JobFailed ||
+		failed.CompletedAt.IsZero() ||
+		failed.OutcomeReason != "dependency" {
+		t.Fatalf("unexpected failed Job: %#v", failed)
+	}
+}
+
+func summaryWorkerConfiguration() agentsummary.WorkerConfiguration {
+	return agentsummary.WorkerConfiguration{
+		TriggerPolicyVersion: agentsummary.TriggerPolicyV1,
+		TriggerMessages:      agentsummary.DefaultTriggerMessages,
+		RetainRecentMessages: agentsummary.DefaultRetainedMessages,
+		LeaseDuration:        time.Minute,
+		MaxAttempts:          agentsummary.DefaultWorkerMaxAttempts,
+		Summary: agentsummary.Configuration{
+			PolicyVersion: "summary-policy-v1",
+			PromptVersion: "summary-prompt-v1",
+			Provider:      "fake",
+			Model:         "configured-model",
+		},
+	}
+}
+
+func summaryJobValidJSON() string {
+	return `{"goals":["Continue the conversation"],"background":[],"progress":[],"decisions":[],"open_questions":[],"next_steps":[]}`
+}
+
+func assertSummaryJobRow(
+	t *testing.T,
+	database *pgxpool.Pool,
+	runID string,
+	wantStatus string,
+	wantObserved int64,
+	wantTarget int64,
+	wantCheckpointID string,
+) {
+	t.Helper()
+
+	var status string
+	var observed int64
+	var target int64
+	var checkpointID string
+	if err := database.QueryRow(
+		context.Background(),
+		`SELECT
+    status,
+    observed_through_sequence,
+    COALESCE(target_covered_through_sequence, 0),
+    COALESCE(checkpoint_id::text, '')
+FROM agent_thread_summary_jobs
+WHERE source_run_id = $1`,
+		runID,
+	).Scan(
+		&status,
+		&observed,
+		&target,
+		&checkpointID,
+	); err != nil {
+		t.Fatalf("read Summary Job: %v", err)
+	}
+	if status != wantStatus ||
+		observed != wantObserved ||
+		target != wantTarget ||
+		checkpointID != wantCheckpointID {
+		t.Fatalf(
+			"Summary Job = status:%s observed:%d target:%d checkpoint:%s",
+			status,
+			observed,
+			target,
+			checkpointID,
+		)
+	}
+}

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	agentapp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/app"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	agentpersistence "github.com/1024XEngineer/XE3-ESL/server/internal/agent/persistence"
 	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
 	agenttransport "github.com/1024XEngineer/XE3-ESL/server/internal/agent/transport"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/voice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
@@ -48,6 +50,7 @@ func NewIdentityAndAgentModules(
 		runConfiguration,
 		memorySearcher,
 		nil,
+		nil,
 		voiceConfigurations...,
 	)
 	if err != nil {
@@ -63,6 +66,7 @@ type identityAgentComposition struct {
 	agentVoiceReclaimer AgentVoiceObjectReclaimer
 	matterService       *matter.Service
 	memoryExtraction    memory.ExtractionProcessor
+	summaryProcessor    agentsummary.Processor
 	ids                 *identity.UUIDv4Generator
 }
 
@@ -85,6 +89,7 @@ func buildIdentityAgentComposition(
 	runConfiguration core.RunConfiguration,
 	memorySearcher memory.Searcher,
 	memoryExtractionNotifier interface{ Notify() },
+	summaryNotifier interface{ Notify() },
 	voiceConfigurations ...VoiceConfiguration,
 ) (*identityAgentComposition, error) {
 	if ctx == nil || database == nil || generator == nil ||
@@ -135,10 +140,17 @@ func buildIdentityAgentComposition(
 		return nil, err
 	}
 	runRepository := core.RunRepository(agentRepository)
+	notifiers := make([]interface{ Notify() }, 0, 2)
 	if memoryExtractionNotifier != nil {
+		notifiers = append(notifiers, memoryExtractionNotifier)
+	}
+	if summaryNotifier != nil {
+		notifiers = append(notifiers, summaryNotifier)
+	}
+	if len(notifiers) > 0 {
 		runRepository = &runCompletionNotifyingRepository{
 			RunRepository: agentRepository,
-			notifier:      memoryExtractionNotifier,
+			notifiers:     notifiers,
 		}
 	}
 	runService, err := agentruntime.NewRunService(
@@ -160,6 +172,40 @@ func buildIdentityAgentComposition(
 		agentRepository,
 		generator,
 		runConfiguration,
+	)
+	if err != nil {
+		return nil, err
+	}
+	summaryService, err := agentsummary.NewService(
+		agentRepository,
+		generator,
+		agentsummary.Configuration{
+			PolicyVersion: "summary-policy-v1",
+			PromptVersion: "summary-prompt-v1",
+			Provider:      runConfiguration.Provider,
+			Model:         runConfiguration.Model,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	summaryProcessor, err := agentsummary.NewWorker(
+		agentRepository,
+		agentRepository,
+		summaryService,
+		agentsummary.WorkerConfiguration{
+			TriggerPolicyVersion: agentsummary.TriggerPolicyV1,
+			TriggerMessages:      agentsummary.DefaultTriggerMessages,
+			RetainRecentMessages: agentsummary.DefaultRetainedMessages,
+			LeaseDuration:        2 * time.Minute,
+			MaxAttempts:          agentsummary.DefaultWorkerMaxAttempts,
+			Summary: agentsummary.Configuration{
+				PolicyVersion: "summary-policy-v1",
+				PromptVersion: "summary-prompt-v1",
+				Provider:      runConfiguration.Provider,
+				Model:         runConfiguration.Model,
+			},
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -228,6 +274,7 @@ func buildIdentityAgentComposition(
 		agentVoiceReclaimer: agentVoiceReclaimer,
 		matterService:       matterService,
 		memoryExtraction:    memoryExtraction,
+		summaryProcessor:    summaryProcessor,
 		ids:                 ids,
 	}, nil
 }
@@ -257,6 +304,7 @@ func NewIdentityAgentModulesWithVoiceCleanup(
 		generator,
 		runConfiguration,
 		memorySearcher,
+		nil,
 		nil,
 		voiceConfigurations...,
 	)

--- a/server/internal/bootstrap/agent_voice_bootstrap_test.go
+++ b/server/internal/bootstrap/agent_voice_bootstrap_test.go
@@ -99,6 +99,7 @@ func TestAgentVoiceCompositionRequiresCleanupAwareConstructor(t *testing.T) {
 		},
 		emptyBootstrapMemorySearcher{},
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("build composition without Agent voice: %v", err)
@@ -177,6 +178,7 @@ func TestProductionAgentVoiceCompositionRegistersAllRoutes(t *testing.T) {
 			MaxInputCharacters: 12000,
 		},
 		emptyBootstrapMemorySearcher{},
+		nil,
 		nil,
 		configuration,
 	)

--- a/server/internal/bootstrap/memory_wakeup.go
+++ b/server/internal/bootstrap/memory_wakeup.go
@@ -9,7 +9,7 @@ import (
 
 type runCompletionNotifyingRepository struct {
 	core.RunRepository
-	notifier interface{ Notify() }
+	notifiers []interface{ Notify() }
 }
 
 func (repository *runCompletionNotifyingRepository) CompleteRun(
@@ -29,7 +29,11 @@ func (repository *runCompletionNotifyingRepository) CompleteRun(
 		result,
 	)
 	if err == nil && run.Status == core.RunStatusCompleted {
-		repository.notifier.Notify()
+		for _, notifier := range repository.notifiers {
+			if notifier != nil {
+				notifier.Notify()
+			}
+		}
 	}
 	return run, err
 }

--- a/server/internal/bootstrap/memory_wakeup_test.go
+++ b/server/internal/bootstrap/memory_wakeup_test.go
@@ -21,7 +21,7 @@ func TestRunCompletionNotifierFiresOnlyAfterSuccessfulCommit(t *testing.T) {
 	notifier := &countingNotifier{}
 	repository := &runCompletionNotifyingRepository{
 		RunRepository: underlying,
-		notifier:      notifier,
+		notifiers:     []interface{ Notify() }{notifier},
 	}
 	if _, err := repository.CompleteRun(
 		context.Background(),
@@ -52,6 +52,38 @@ func TestRunCompletionNotifierFiresOnlyAfterSuccessfulCommit(t *testing.T) {
 	}
 	if notifier.calls != 1 {
 		t.Fatalf("notifier fired before commit: %d calls", notifier.calls)
+	}
+}
+
+func TestRunCompletionNotifierFansOutPayloadFreeWakeups(t *testing.T) {
+	t.Parallel()
+
+	first := &countingNotifier{}
+	second := &countingNotifier{}
+	repository := &runCompletionNotifyingRepository{
+		RunRepository: &completionRepositoryStub{
+			complete: func() (core.Run, error) {
+				return core.Run{Status: core.RunStatusCompleted}, nil
+			},
+		},
+		notifiers: []interface{ Notify() }{first, second},
+	}
+	if _, err := repository.CompleteRun(
+		context.Background(),
+		"owner",
+		"run",
+		"lease",
+		"content",
+		ai.TextResult{},
+	); err != nil {
+		t.Fatalf("CompleteRun: %v", err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf(
+			"notifier calls = %d/%d, want 1/1",
+			first.calls,
+			second.calls,
+		)
 	}
 }
 

--- a/server/internal/bootstrap/practice_context.go
+++ b/server/internal/bootstrap/practice_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/matter"
@@ -34,6 +35,7 @@ type IdentityAgentPracticeComposition struct {
 	agentModule            RouteRegistrar
 	agentVoiceReclaimer    AgentVoiceObjectReclaimer
 	memoryExtraction       memory.ExtractionProcessor
+	summaryProcessor       agentsummary.Processor
 	identityHTTP           *identity.HTTPHandler
 	preparationApplication *preparation.PersistenceService
 	preparationHTTP        *preparation.ProfileHTTPHandler
@@ -67,6 +69,7 @@ func NewIdentityAgentAndPracticeComposition(
 		memorySearcher,
 		catalog,
 		nil,
+		nil,
 		voiceConfigurations...,
 	)
 }
@@ -95,6 +98,39 @@ func NewIdentityAgentAndPracticeCompositionWithMemoryWakeup(
 		memorySearcher,
 		catalog,
 		memoryExtractionNotifier,
+		nil,
+		voiceConfigurations...,
+	)
+}
+
+type AgentWorkerWakeups struct {
+	MemoryExtraction interface{ Notify() }
+	ThreadSummary    interface{ Notify() }
+}
+
+func NewIdentityAgentAndPracticeCompositionWithWorkerWakeups(
+	ctx context.Context,
+	database *pgxpool.Pool,
+	trustedProxyCIDRs []string,
+	trustedProxyHeader string,
+	generator ai.TextGenerator,
+	runConfiguration core.RunConfiguration,
+	memorySearcher memory.Searcher,
+	catalog preparation.CatalogReader,
+	wakeups AgentWorkerWakeups,
+	voiceConfigurations ...VoiceConfiguration,
+) (*IdentityAgentPracticeComposition, error) {
+	return newIdentityAgentAndPracticeComposition(
+		ctx,
+		database,
+		trustedProxyCIDRs,
+		trustedProxyHeader,
+		generator,
+		runConfiguration,
+		memorySearcher,
+		catalog,
+		wakeups.MemoryExtraction,
+		wakeups.ThreadSummary,
 		voiceConfigurations...,
 	)
 }
@@ -109,6 +145,7 @@ func newIdentityAgentAndPracticeComposition(
 	memorySearcher memory.Searcher,
 	catalog preparation.CatalogReader,
 	memoryExtractionNotifier interface{ Notify() },
+	summaryNotifier interface{ Notify() },
 	voiceConfigurations ...VoiceConfiguration,
 ) (*IdentityAgentPracticeComposition, error) {
 	if catalog == nil {
@@ -123,6 +160,7 @@ func newIdentityAgentAndPracticeComposition(
 		runConfiguration,
 		memorySearcher,
 		memoryExtractionNotifier,
+		summaryNotifier,
 		voiceConfigurations...,
 	)
 	if err != nil {
@@ -203,6 +241,7 @@ func newIdentityAgentAndPracticeComposition(
 		agentModule:            base.agentModule,
 		agentVoiceReclaimer:    base.agentVoiceReclaimer,
 		memoryExtraction:       base.memoryExtraction,
+		summaryProcessor:       base.summaryProcessor,
 		identityHTTP:           base.identity.handler,
 		preparationApplication: preparationApplication,
 		preparationHTTP:        preparationHTTP,
@@ -243,6 +282,13 @@ func (c *IdentityAgentPracticeComposition) MemoryExtractionProcessor() memory.Ex
 		return nil
 	}
 	return c.memoryExtraction
+}
+
+func (c *IdentityAgentPracticeComposition) ThreadSummaryProcessor() agentsummary.Processor {
+	if c == nil {
+		return nil
+	}
+	return c.summaryProcessor
 }
 
 func (c *IdentityAgentPracticeComposition) PreparationApplication() *preparation.PersistenceService {

--- a/server/migrations/000026_agent_thread_summary_jobs.down.sql
+++ b/server/migrations/000026_agent_thread_summary_jobs.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TRIGGER agent_runs_enqueue_thread_summary ON agent_runs;
+DROP FUNCTION enqueue_agent_thread_summary_job();
+DROP TABLE agent_thread_summary_jobs;
+
+COMMIT;

--- a/server/migrations/000026_agent_thread_summary_jobs.up.sql
+++ b/server/migrations/000026_agent_thread_summary_jobs.up.sql
@@ -1,0 +1,262 @@
+BEGIN;
+
+CREATE TABLE agent_thread_summary_jobs (
+    source_run_id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    source_thread_id uuid NOT NULL,
+    observed_through_sequence bigint NOT NULL,
+    source_completed_at timestamptz NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+    attempt_count integer NOT NULL DEFAULT 0,
+    lease_token uuid,
+    lease_expires_at timestamptz,
+    next_attempt_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    trigger_policy_version text COLLATE "C",
+    summary_policy_version text COLLATE "C",
+    prompt_version text COLLATE "C",
+    provider text,
+    model text,
+    target_covered_through_sequence bigint,
+    checkpoint_id uuid,
+    outcome_reason text,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    completed_at timestamptz,
+    CONSTRAINT agent_thread_summary_jobs_run_owner_fkey
+        FOREIGN KEY (
+            source_run_id,
+            owner_user_id,
+            source_thread_id
+        )
+        REFERENCES agent_runs (id, owner_user_id, thread_id)
+        ON DELETE CASCADE,
+    CONSTRAINT agent_thread_summary_jobs_checkpoint_owner_fkey
+        FOREIGN KEY (
+            checkpoint_id,
+            owner_user_id,
+            source_thread_id
+        )
+        REFERENCES agent_thread_summary_checkpoints (
+            id,
+            owner_user_id,
+            thread_id
+        )
+        ON DELETE CASCADE,
+    CONSTRAINT agent_thread_summary_jobs_status_check
+        CHECK (
+            status IN (
+                'pending',
+                'running',
+                'completed',
+                'skipped',
+                'superseded',
+                'failed'
+            )
+        ),
+    CONSTRAINT agent_thread_summary_jobs_sequence_check
+        CHECK (
+            observed_through_sequence >= 1
+            AND (
+                target_covered_through_sequence IS NULL
+                OR (
+                    target_covered_through_sequence >= 1
+                    AND target_covered_through_sequence
+                        <= observed_through_sequence
+                )
+            )
+        ),
+    CONSTRAINT agent_thread_summary_jobs_attempt_check
+        CHECK (attempt_count >= 0),
+    CONSTRAINT agent_thread_summary_jobs_versions_check
+        CHECK (
+            (
+                trigger_policy_version IS NULL
+                AND summary_policy_version IS NULL
+                AND prompt_version IS NULL
+                AND provider IS NULL
+                AND model IS NULL
+            )
+            OR
+            (
+                trigger_policy_version IS NOT NULL
+                AND summary_policy_version IS NOT NULL
+                AND prompt_version IS NOT NULL
+                AND provider IS NOT NULL
+                AND model IS NOT NULL
+                AND trigger_policy_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+                AND summary_policy_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+                AND prompt_version
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$'
+                AND provider ~ '^[a-z][a-z0-9_-]{0,63}$'
+                AND model
+                    ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+            )
+        ),
+    CONSTRAINT agent_thread_summary_jobs_reason_check
+        CHECK (
+            outcome_reason IS NULL
+            OR outcome_reason ~ '^[a-z][a-z0-9_]{0,63}$'
+        ),
+    CONSTRAINT agent_thread_summary_jobs_state_shape_check
+        CHECK (
+            (
+                status = 'pending'
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND checkpoint_id IS NULL
+                AND completed_at IS NULL
+            )
+            OR
+            (
+                status = 'running'
+                AND attempt_count > 0
+                AND lease_token IS NOT NULL
+                AND lease_expires_at IS NOT NULL
+                AND checkpoint_id IS NULL
+                AND outcome_reason IS NULL
+                AND completed_at IS NULL
+            )
+            OR
+            (
+                status = 'completed'
+                AND attempt_count > 0
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND target_covered_through_sequence IS NOT NULL
+                AND checkpoint_id IS NOT NULL
+                AND outcome_reason IS NULL
+                AND completed_at IS NOT NULL
+            )
+            OR
+            (
+                status = 'skipped'
+                AND attempt_count > 0
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND target_covered_through_sequence IS NULL
+                AND checkpoint_id IS NULL
+                AND outcome_reason IS NOT NULL
+                AND completed_at IS NOT NULL
+            )
+            OR
+            (
+                status = 'superseded'
+                AND attempt_count > 0
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND target_covered_through_sequence IS NOT NULL
+                AND checkpoint_id IS NULL
+                AND outcome_reason IS NOT NULL
+                AND completed_at IS NOT NULL
+            )
+            OR
+            (
+                status = 'failed'
+                AND attempt_count > 0
+                AND lease_token IS NULL
+                AND lease_expires_at IS NULL
+                AND checkpoint_id IS NULL
+                AND outcome_reason IS NOT NULL
+                AND completed_at IS NOT NULL
+            )
+        ),
+    CONSTRAINT agent_thread_summary_jobs_timestamps_check
+        CHECK (
+            source_completed_at <= created_at
+            AND updated_at >= created_at
+            AND next_attempt_at >= created_at
+            AND (
+                lease_expires_at IS NULL
+                OR lease_expires_at > updated_at
+            )
+            AND (
+                completed_at IS NULL
+                OR completed_at >= created_at
+            )
+        )
+);
+
+CREATE INDEX agent_thread_summary_jobs_claim_idx
+    ON agent_thread_summary_jobs (
+        next_attempt_at,
+        source_completed_at,
+        source_run_id
+    )
+    WHERE status = 'pending';
+
+CREATE INDEX agent_thread_summary_jobs_recovery_idx
+    ON agent_thread_summary_jobs (
+        lease_expires_at,
+        source_run_id
+    )
+    WHERE status = 'running';
+
+CREATE INDEX agent_thread_summary_jobs_owner_thread_idx
+    ON agent_thread_summary_jobs (
+        owner_user_id,
+        source_thread_id,
+        observed_through_sequence,
+        source_run_id
+    );
+
+CREATE UNIQUE INDEX agent_thread_summary_jobs_one_running_per_thread_idx
+    ON agent_thread_summary_jobs (
+        owner_user_id,
+        source_thread_id
+    )
+    WHERE status = 'running';
+
+CREATE FUNCTION enqueue_agent_thread_summary_job()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    observed_sequence bigint;
+BEGIN
+    SELECT sequence_no
+    INTO STRICT observed_sequence
+    FROM agent_messages
+    WHERE id = NEW.assistant_message_id
+      AND owner_user_id = NEW.owner_user_id
+      AND thread_id = NEW.thread_id;
+
+    INSERT INTO agent_thread_summary_jobs (
+        source_run_id,
+        owner_user_id,
+        source_thread_id,
+        observed_through_sequence,
+        source_completed_at,
+        status,
+        attempt_count,
+        next_attempt_at,
+        created_at,
+        updated_at
+    ) VALUES (
+        NEW.id,
+        NEW.owner_user_id,
+        NEW.thread_id,
+        observed_sequence,
+        NEW.completed_at,
+        'pending',
+        0,
+        transaction_timestamp(),
+        transaction_timestamp(),
+        transaction_timestamp()
+    )
+    ON CONFLICT (source_run_id) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER agent_runs_enqueue_thread_summary
+AFTER UPDATE OF status ON agent_runs
+FOR EACH ROW
+WHEN (
+    NEW.status = 'completed'
+    AND OLD.status IS DISTINCT FROM NEW.status
+)
+EXECUTE FUNCTION enqueue_agent_thread_summary_job();
+
+COMMIT;


### PR DESCRIPTION
## 功能描述

- 在 AgentRun 完成事务中创建 Thread Summary Job
- 使用事件驱动唤醒 Summary Worker，并保留周期恢复扫描
- 按 `summary-trigger-v1` 在累计 40 条未覆盖消息后生成 checkpoint，保留最新 12 条原始消息
- 提供租约、并发互斥、幂等、有限重试及稳定错误分类
- 本 PR 只生成 checkpoint，不修改 ContextAssembler 的注入策略

## 实现思路

- 新增 `agent_thread_summary_jobs` 表、索引和 AgentRun 完成触发器
- 新增 Summary Job Repository、Processor 与 Worker
- 复用已有 Summary Service 生成 checkpoint
- Bootstrap 注入 payload-free wakeup，Server 启动事件驱动 worker 与 30 秒恢复扫描
- 对同一 thread 使用数据库行锁与部分唯一索引避免并发重复生成

## 验证方式

```bash
cd server
TEST_DATABASE_URL="$DATABASE_URL" go test -count=1 ./internal/agent -run "TestPostgresSummaryJob|TestThreadSummary"
go test -count=1 ./internal/agent/summary ./internal/bootstrap ./cmd/server
go test -count=1 ./...
go vet ./...
go test -race ./internal/agent/summary ./cmd/server ./internal/bootstrap
docker compose config --quiet
GOTOOLCHAIN=go1.26.5 govulncheck ./...
```

迁移已验证 up、重复 up、down-one、重新 up，最终版本为 26 且 dirty=false。

Closes #197