### PR TITLE
feat(practice): unify preparation and review surfaces

### DIFF
--- a/mobile/lib/agent/agent_voice_widgets.dart
+++ b/mobile/lib/agent/agent_voice_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 
 import 'agent_models.dart';
 import 'agent_voice_controller.dart';
@@ -84,7 +85,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   Widget build(BuildContext context) {
     final message = widget.message;
     final isUser = message.role == AgentMessageRole.user;
-    const foreground = Color(0xFF25262A);
+    const foreground = SpeakUpDesign.ink;
     return Align(
       alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
@@ -95,9 +96,9 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
             ? const EdgeInsets.fromLTRB(14, 11, 12, 11)
             : const EdgeInsets.fromLTRB(2, 7, 12, 9),
         decoration: BoxDecoration(
-          color: isUser ? const Color(0xFFE7E7E3) : Colors.transparent,
-          borderRadius: BorderRadius.circular(18),
-          border: isUser ? Border.all(color: const Color(0xFFDCDCD7)) : null,
+          color: isUser ? SpeakUpDesign.primaryMuted : Colors.transparent,
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+          border: isUser ? Border.all(color: SpeakUpDesign.border) : null,
         ),
         child: message.modality == AgentMessageModality.voice
             ? _buildUserVoice(context, foreground)
@@ -138,8 +139,8 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
               key: Key('agent-assistant-tts-${message.id}'),
               onPressed: () => voice.toggleMessagePlayback(message),
               style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF55575E),
-                backgroundColor: const Color(0xFFE8E8E4),
+                foregroundColor: SpeakUpDesign.primary,
+                backgroundColor: SpeakUpDesign.surfaceMuted,
                 minimumSize: const Size(0, 32),
                 padding: const EdgeInsets.symmetric(horizontal: 10),
                 visualDensity: VisualDensity.compact,
@@ -171,7 +172,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
               key: Key('agent-assistant-speed-${message.id}'),
               onPressed: voice.cycleSpeechSpeed,
               style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF66686F),
+                foregroundColor: SpeakUpDesign.secondary,
                 minimumSize: const Size(0, 32),
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 visualDensity: VisualDensity.compact,
@@ -190,7 +191,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
             error,
             key: Key('agent-message-media-error-${message.id}'),
             style: const TextStyle(
-              color: Color(0xFF8B2E26),
+              color: SpeakUpDesign.error,
               fontSize: 12,
               height: 1.35,
             ),
@@ -230,10 +231,10 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
                   ? () => voice.toggleMessagePlayback(message)
                   : null,
               style: IconButton.styleFrom(
-                backgroundColor: const Color(0xFFD6D6D1),
+                backgroundColor: SpeakUpDesign.surfaceMuted,
                 foregroundColor: foreground,
-                disabledBackgroundColor: const Color(0xFFDCDCD7),
-                disabledForegroundColor: const Color(0xFF8A8B90),
+                disabledBackgroundColor: SpeakUpDesign.surfaceMuted,
+                disabledForegroundColor: SpeakUpDesign.tertiary,
                 minimumSize: const Size.square(36),
                 maximumSize: const Size.square(36),
                 padding: EdgeInsets.zero,
@@ -243,7 +244,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
                       dimension: 15,
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
-                        color: Color(0xFF55575E),
+                        color: SpeakUpDesign.secondary,
                       ),
                     )
                   : Icon(
@@ -280,7 +281,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
                     : null,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(color: Color(0xFF6B6D73), fontSize: 13),
+                style: SpeakUpDesign.meta,
               ),
             ),
             if (!audio.isReadable) const SizedBox(width: 2),
@@ -298,7 +299,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
                 ),
                 padding: EdgeInsets.zero,
                 visualDensity: VisualDensity.compact,
-                color: const Color(0xFF686A70),
+                color: SpeakUpDesign.secondary,
                 icon: deleting
                     ? const SizedBox.square(
                         dimension: 14,
@@ -315,15 +316,17 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
             value: playing ? progress : 0,
             minHeight: 2,
             borderRadius: BorderRadius.circular(1),
-            backgroundColor: const Color(0xFFCECEC9),
-            valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF55575E)),
+            backgroundColor: SpeakUpDesign.border,
+            valueColor: const AlwaysStoppedAnimation<Color>(
+              SpeakUpDesign.primary,
+            ),
           ),
         ],
         const SizedBox(height: 4),
         TextButton.icon(
           key: Key('agent-user-voice-transcript-toggle-${message.id}'),
           style: TextButton.styleFrom(
-            foregroundColor: const Color(0xFF5F6167),
+            foregroundColor: SpeakUpDesign.secondary,
             minimumSize: const Size(0, 30),
             padding: const EdgeInsets.symmetric(horizontal: 2),
             visualDensity: VisualDensity.compact,
@@ -357,7 +360,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
             error,
             key: Key('agent-message-media-error-${message.id}'),
             style: const TextStyle(
-              color: Color(0xFF8B2E26),
+              color: SpeakUpDesign.error,
               fontSize: 12,
               height: 1.35,
             ),

--- a/mobile/lib/app/glass_navigation_bar.dart
+++ b/mobile/lib/app/glass_navigation_bar.dart
@@ -1,6 +1,5 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 
 class GlassNavigationDestination {
   const GlassNavigationDestination({
@@ -45,7 +44,6 @@ class GlassNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final highContrast = MediaQuery.highContrastOf(context);
     final reduceMotion = MediaQuery.disableAnimationsOf(context);
     final navigationHeight = heightFor(context);
     final horizontalInset = MediaQuery.sizeOf(context).width >= 390
@@ -55,17 +53,11 @@ class GlassNavigationBar extends StatelessWidget {
     final navigation = Container(
       key: const Key('primary-navigation'),
       height: navigationHeight,
-      padding: const EdgeInsets.all(4),
+      padding: const EdgeInsets.all(SpeakUpDesign.space4),
       decoration: BoxDecoration(
-        color: solid || highContrast
-            ? const Color(0xFFF8F8F6)
-            : const Color(0xDEFFFFFF),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(
-          color: solid || highContrast
-              ? const Color(0xFFD8DAE2)
-              : const Color(0xBFFFFFFF),
-        ),
+        color: SpeakUpDesign.surface,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusMedia),
+        border: Border.all(color: SpeakUpDesign.border),
       ),
       child: Semantics(
         container: true,
@@ -85,16 +77,6 @@ class GlassNavigationBar extends StatelessWidget {
         ),
       ),
     );
-    final clippedNavigation = ClipRRect(
-      borderRadius: BorderRadius.circular(24),
-      child: solid
-          ? navigation
-          : BackdropFilter(
-              filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
-              child: navigation,
-            ),
-    );
-
     return SafeArea(
       minimum: EdgeInsets.fromLTRB(
         horizontalInset,
@@ -102,18 +84,9 @@ class GlassNavigationBar extends StatelessWidget {
         horizontalInset,
         minimumBottomInset,
       ),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(24),
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x12000000),
-              blurRadius: 18,
-              offset: Offset(0, 6),
-            ),
-          ],
-        ),
-        child: clippedNavigation,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusMedia),
+        child: navigation,
       ),
     );
   }
@@ -146,7 +119,7 @@ class _NavigationItem extends StatelessWidget {
         child: Material(
           color: Colors.transparent,
           child: InkWell(
-            borderRadius: BorderRadius.circular(20),
+            borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
             onTap: onTap,
             child: AnimatedContainer(
               duration: reduceMotion
@@ -154,11 +127,10 @@ class _NavigationItem extends StatelessWidget {
                   : const Duration(milliseconds: 180),
               curve: Curves.easeOutCubic,
               decoration: BoxDecoration(
-                color: selected ? const Color(0xD9E8E8E5) : Colors.transparent,
-                borderRadius: BorderRadius.circular(20),
-                border: selected
-                    ? Border.all(color: const Color(0xCFFFFFFF))
-                    : null,
+                color: selected
+                    ? SpeakUpDesign.primaryMuted
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
               ),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -167,8 +139,8 @@ class _NavigationItem extends StatelessWidget {
                     destination.icon,
                     size: 21,
                     color: selected
-                        ? const Color(0xFF111217)
-                        : const Color(0xFF686A72),
+                        ? SpeakUpDesign.primary
+                        : SpeakUpDesign.secondary,
                   ),
                   const SizedBox(height: 2),
                   FittedBox(
@@ -179,8 +151,8 @@ class _NavigationItem extends StatelessWidget {
                       textScaler: TextScaler.linear(labelScale),
                       style: TextStyle(
                         color: selected
-                            ? const Color(0xFF111217)
-                            : const Color(0xFF686A72),
+                            ? SpeakUpDesign.primary
+                            : SpeakUpDesign.secondary,
                         fontSize: 11,
                         fontWeight: selected
                             ? FontWeight.w600

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -6,6 +6,8 @@ import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/glass_navigation_bar.dart';
+import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/conversation/conversation.dart';
 import 'package:speakup/features/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/preparation/preparation.dart';
@@ -334,7 +336,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       extendBody: !practiceSelected,
       resizeToAvoidBottomInset: false,
       backgroundColor: practiceSelected
-          ? const Color(0xFFF6F7FA)
+          ? SpeakUpDesign.canvas
           : Colors.transparent,
       drawer: _ConversationDrawer(
         previewMode: widget.previewMode,
@@ -346,7 +348,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
               ?.currentPracticeThreadId,
         },
       ),
-      drawerScrimColor: const Color(0x330E1120),
+      drawerScrimColor: const Color(0x52000000),
       body: IndexedStack(index: _selectedIndex, children: pages),
       bottomNavigationBar: keyboardVisible
           ? null
@@ -383,7 +385,7 @@ class _ConversationDrawer extends StatelessWidget {
     ];
     return Drawer(
       width: 300,
-      backgroundColor: const Color(0xFFF5F5F2),
+      backgroundColor: SpeakUpDesign.canvas,
       child: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
@@ -391,10 +393,7 @@ class _ConversationDrawer extends StatelessWidget {
             Row(
               children: [
                 const Expanded(
-                  child: Text(
-                    'SpeakUp',
-                    style: TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
-                  ),
+                  child: Text('SpeakUp', style: SpeakUpDesign.sectionTitle),
                 ),
                 IconButton(
                   tooltip: '关闭对话菜单',
@@ -405,7 +404,7 @@ class _ConversationDrawer extends StatelessWidget {
             ),
             Text(
               previewMode ? '本地 Fake 预览，未连接正式账号' : '已连接当前账号',
-              style: const TextStyle(color: Color(0xFF6B6D74), fontSize: 13),
+              style: SpeakUpDesign.meta,
             ),
             const SizedBox(height: 20),
             FilledButton.tonalIcon(
@@ -424,8 +423,8 @@ class _ConversationDrawer extends StatelessWidget {
               style: FilledButton.styleFrom(
                 alignment: Alignment.centerLeft,
                 minimumSize: const Size.fromHeight(48),
-                backgroundColor: const Color(0xFFE8E8E4),
-                foregroundColor: const Color(0xFF202124),
+                backgroundColor: SpeakUpDesign.primaryMuted,
+                foregroundColor: SpeakUpDesign.primary,
               ),
             ),
             if (controller.isBusy) ...[
@@ -436,14 +435,7 @@ class _ConversationDrawer extends StatelessWidget {
               ),
             ],
             const SizedBox(height: 28),
-            const Text(
-              '当前对话',
-              style: TextStyle(
-                color: Color(0xFF777983),
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
+            const Text('当前对话', style: SpeakUpDesign.label),
             const SizedBox(height: 8),
             if (currentThreadId == null)
               const Padding(
@@ -451,7 +443,7 @@ class _ConversationDrawer extends StatelessWidget {
                 child: Text(
                   '尚未选择对话',
                   key: Key('no-focused-conversation'),
-                  style: TextStyle(color: Color(0xFF777983)),
+                  style: SpeakUpDesign.body,
                 ),
               )
             else
@@ -463,14 +455,7 @@ class _ConversationDrawer extends StatelessWidget {
                 onTap: () => Navigator.of(context).pop(),
               ),
             const SizedBox(height: 24),
-            const Text(
-              '近期对话',
-              style: TextStyle(
-                color: Color(0xFF777983),
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
+            const Text('近期对话', style: SpeakUpDesign.label),
             const SizedBox(height: 8),
             if (recentThreads.isEmpty)
               const Padding(
@@ -478,7 +463,7 @@ class _ConversationDrawer extends StatelessWidget {
                 child: Text(
                   '暂无其他对话',
                   key: Key('no-recent-conversations'),
-                  style: TextStyle(color: Color(0xFF777983)),
+                  style: SpeakUpDesign.body,
                 ),
               )
             else
@@ -501,11 +486,7 @@ class _ConversationDrawer extends StatelessWidget {
               Text(
                 message,
                 key: const Key('conversation-history-error'),
-                style: const TextStyle(
-                  color: Color(0xFF9B2C24),
-                  fontSize: 13,
-                  height: 1.35,
-                ),
+                style: SpeakUpDesign.meta.copyWith(color: SpeakUpDesign.error),
               ),
             ],
             if (controller.hasMoreThreads) ...[
@@ -551,8 +532,10 @@ class _ConversationThreadTile extends StatelessWidget {
         key: Key('conversation-thread-$threadId'),
         contentPadding: const EdgeInsets.symmetric(horizontal: 8),
         selected: selected,
-        selectedTileColor: const Color(0xFFE8E8E4),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        selectedTileColor: SpeakUpDesign.primaryMuted,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        ),
         leading: const Icon(Icons.chat_bubble_outline_rounded),
         title: const Text('Agent 对话'),
         subtitle: lastUpdatedAt == null
@@ -601,13 +584,8 @@ class _ProfilePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('profile-page'),
-      backgroundColor: const Color(0xFFF3F3F0),
       appBar: showBackButton
           ? AppBar(
-              backgroundColor: const Color(0xFFF3F3F0),
-              surfaceTintColor: Colors.transparent,
-              elevation: 0,
-              scrolledUnderElevation: 0,
               leading: IconButton(
                 key: const Key('profile-route-back-button'),
                 tooltip: '返回',
@@ -619,25 +597,24 @@ class _ProfilePage extends StatelessWidget {
       body: SafeArea(
         bottom: false,
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 28, 20, 140),
+          padding: EdgeInsets.fromLTRB(
+            SpeakUpDesign.horizontalInset(context),
+            SpeakUpDesign.space24,
+            SpeakUpDesign.horizontalInset(context),
+            140,
+          ),
           children: [
-            const Text(
-              '我的',
-              style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              '当前账号与本机登录状态。',
-              style: TextStyle(color: Color(0xFF696B73), fontSize: 15),
-            ),
-            const SizedBox(height: 28),
+            const SpeakUpPageHeader(title: '我的', subtitle: '管理账号与练习身份。'),
+            const SizedBox(height: SpeakUpDesign.space24),
             Card(
-              elevation: 0,
-              color: Colors.white,
               child: ListTile(
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: SpeakUpDesign.space16,
+                  vertical: SpeakUpDesign.space8,
+                ),
                 leading: CircleAvatar(
-                  backgroundColor: Color(0xFFE8E8E5),
-                  foregroundColor: Color(0xFF35363A),
+                  backgroundColor: SpeakUpDesign.primaryMuted,
+                  foregroundColor: SpeakUpDesign.primary,
                   child: Text(
                     _profileInitial(profile?.displayName),
                     style: const TextStyle(fontWeight: FontWeight.w700),
@@ -660,13 +637,13 @@ class _ProfilePage extends StatelessWidget {
               ),
             ),
             if (profileErrorMessage != null) ...[
-              const SizedBox(height: 8),
+              const SizedBox(height: SpeakUpDesign.space8),
               Text(
                 profileErrorMessage!,
                 style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
             ],
-            const SizedBox(height: 16),
+            const SizedBox(height: SpeakUpDesign.space16),
             OutlinedButton.icon(
               key: const Key('profile-logout-button'),
               onPressed: onLogout,

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -2,14 +2,13 @@
 library;
 
 import 'dart:convert';
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/agent/agent_voice_controller.dart';
 import 'package:speakup/agent/agent_voice_models.dart';
 import 'package:speakup/agent/agent_voice_widgets.dart';
+import 'package:speakup/design/speak_up_design.dart';
 
 class ConversationPage extends StatefulWidget {
   const ConversationPage({
@@ -141,7 +140,7 @@ class ConversationPage extends StatefulWidget {
                                 Text(
                                   '今天想练什么？',
                                   style: TextStyle(
-                                    color: const Color(0xFF0B0B0D),
+                                    color: SpeakUpDesign.ink,
                                     fontSize: titleSize,
                                     fontWeight: FontWeight.w600,
                                     height: 1.12,
@@ -167,7 +166,7 @@ class ConversationPage extends StatefulWidget {
                                     const Text(
                                       '当前场景',
                                       style: TextStyle(
-                                        color: Color(0xFF777980),
+                                        color: SpeakUpDesign.secondary,
                                         fontSize: 13,
                                         fontWeight: FontWeight.w500,
                                       ),
@@ -180,7 +179,7 @@ class ConversationPage extends StatefulWidget {
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
                                         style: const TextStyle(
-                                          color: Color(0xFF34353A),
+                                          color: SpeakUpDesign.ink,
                                           fontSize: 14,
                                           fontWeight: FontWeight.w600,
                                         ),
@@ -420,7 +419,9 @@ class _AgentBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const ExcludeSemantics(child: ColoredBox(color: Color(0xFFF3F3F0)));
+    return const ExcludeSemantics(
+      child: ColoredBox(color: SpeakUpDesign.canvas),
+    );
   }
 }
 
@@ -475,22 +476,14 @@ class _AgentTopBar extends StatelessWidget {
                     const Text(
                       'SpeakUp',
                       key: Key('conversation-fixed-title'),
-                      style: TextStyle(
-                        color: Color(0xFF15161A),
-                        fontSize: 17,
-                        fontWeight: FontWeight.w700,
-                      ),
+                      style: SpeakUpDesign.cardTitle,
                     ),
                     if (previewMode) ...[
                       const SizedBox(width: 8),
                       const Text(
                         'UI Mock',
                         key: Key('agent-preview-label'),
-                        style: TextStyle(
-                          color: Color(0xFF6C6E75),
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                        ),
+                        style: SpeakUpDesign.meta,
                       ),
                     ],
                   ],
@@ -522,7 +515,7 @@ class _PracticeUnavailableNotice extends StatelessWidget {
     return const Text(
       '当前已开放 Agent 文本对话；场景、语音练习与复盘待正式服务契约接入。',
       key: Key('agent-practice-unavailable'),
-      style: TextStyle(color: Color(0xFF6C6E75), height: 1.45),
+      style: SpeakUpDesign.body,
     );
   }
 }
@@ -541,19 +534,15 @@ class _RoundGlassButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipOval(
-      child: BackdropFilter(
-        filter: ui.ImageFilter.blur(sigmaX: 18, sigmaY: 18),
-        child: Material(
-          color: const Color(0xD9FFFFFF),
-          child: IconButton(
-            tooltip: tooltip,
-            onPressed: onPressed,
-            icon: Icon(icon, color: const Color(0xFF15161A)),
-            iconSize: 25,
-            constraints: const BoxConstraints.tightFor(width: 48, height: 48),
-          ),
-        ),
+    return Material(
+      color: SpeakUpDesign.surface,
+      shape: const CircleBorder(side: BorderSide(color: SpeakUpDesign.border)),
+      child: IconButton(
+        tooltip: tooltip,
+        onPressed: onPressed,
+        icon: Icon(icon, color: SpeakUpDesign.ink),
+        iconSize: 24,
+        constraints: const BoxConstraints.tightFor(width: 48, height: 48),
       ),
     );
   }
@@ -568,12 +557,9 @@ class _Greeting extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       displayName == null ? '你好，今天想练什么？' : '你好，$displayName',
-      style: const TextStyle(
-        color: Color(0xFF5F6064),
-        fontSize: 22,
-        fontWeight: FontWeight.w500,
-        height: 1.1,
-        letterSpacing: -0.5,
+      style: SpeakUpDesign.sectionTitle.copyWith(
+        color: SpeakUpDesign.secondary,
+        fontWeight: FontWeight.w600,
       ),
     );
   }
@@ -596,19 +582,9 @@ class _NoFocusedConversation extends StatelessWidget {
       key: const Key('no-focused-conversation-home'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          '选择一个对话',
-          style: TextStyle(
-            color: Color(0xFF0B0B0D),
-            fontSize: 30,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
+        const Text('选择一个对话', style: SpeakUpDesign.pageTitle),
         const SizedBox(height: 10),
-        const Text(
-          '打开近期对话，或创建一个新对话后再开始输入。',
-          style: TextStyle(color: Color(0xFF66686F), height: 1.45),
-        ),
+        const Text('打开近期对话，或创建一个新对话后再开始输入。', style: SpeakUpDesign.body),
         const SizedBox(height: 22),
         if (onCreateConversation != null)
           FilledButton.icon(
@@ -728,47 +704,36 @@ class _QuickActionButton extends StatelessWidget {
       label: label,
       onTap: onPressed,
       excludeSemantics: true,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(18),
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x0D000000),
-              blurRadius: 10,
-              offset: Offset(0, 4),
-            ),
-          ],
+      child: Material(
+        color: SpeakUpDesign.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+          side: const BorderSide(color: SpeakUpDesign.border),
         ),
-        child: Material(
-          color: const Color(0xE8FFFFFF),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
-            side: const BorderSide(color: Color(0xFFE5E5E0)),
-          ),
-          clipBehavior: Clip.antiAlias,
-          child: InkWell(
-            onTap: onPressed,
-            child: Container(
-              constraints: const BoxConstraints(minHeight: 46),
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              child: Row(
-                children: [
-                  Icon(icon, size: 19, color: const Color(0xFF55575E)),
-                  const SizedBox(width: 9),
-                  Expanded(
-                    child: Text(
-                      label,
-                      maxLines: compact ? 2 : 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: Color(0xFF15161A),
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onPressed,
+          child: Container(
+            constraints: const BoxConstraints(
+              minHeight: SpeakUpDesign.minTapTarget,
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: SpeakUpDesign.space12,
+              vertical: SpeakUpDesign.space12,
+            ),
+            child: Row(
+              children: [
+                Icon(icon, size: 19, color: SpeakUpDesign.primary),
+                const SizedBox(width: SpeakUpDesign.space8),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: compact ? 2 : 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: SpeakUpDesign.label,
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),
@@ -807,8 +772,8 @@ class _InlineError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: const Color(0xFFFFF3F1),
-      borderRadius: BorderRadius.circular(16),
+      color: SpeakUpDesign.errorMuted,
+      borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(14, 10, 8, 10),
         child: Row(
@@ -816,7 +781,7 @@ class _InlineError extends StatelessWidget {
             const Icon(
               Icons.error_outline_rounded,
               size: 20,
-              color: Color(0xFF8B2E26),
+              color: SpeakUpDesign.error,
             ),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
@@ -991,216 +956,202 @@ class _AgentComposerState extends State<_AgentComposer> {
         voiceState == AgentVoiceComposerState.confirming ||
         voiceState == AgentVoiceComposerState.awaitingAssistant;
     final voiceFailure = voiceState == AgentVoiceComposerState.failed;
-    return DecoratedBox(
+    return AnimatedContainer(
+      key: const Key('agent-composer-surface'),
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOut,
+      constraints: BoxConstraints(minHeight: widget.keyboardVisible ? 56 : 58),
+      padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(22),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x12000000),
-            blurRadius: 16,
-            offset: Offset(0, 6),
-          ),
-        ],
+        color: SpeakUpDesign.surface,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+        border: Border.all(color: SpeakUpDesign.border),
       ),
-      child: AnimatedContainer(
-        key: const Key('agent-composer-surface'),
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOut,
-        constraints: BoxConstraints(
-          minHeight: widget.keyboardVisible ? 56 : 58,
-        ),
-        padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
-        decoration: BoxDecoration(
-          color: const Color(0xFFFAFAF8),
-          borderRadius: BorderRadius.circular(22),
-          border: Border.all(color: const Color(0xFFDADAD5)),
-        ),
-        child: recording || voiceProgress || voiceFailure
-            ? Row(
-                children: [
-                  if (!voiceSubmissionInFlight) ...[
-                    IconButton(
-                      key: const Key('agent-voice-cancel'),
-                      tooltip: '取消语音输入',
-                      onPressed: _cancelVoice,
-                      constraints: const BoxConstraints.tightFor(
-                        width: 40,
-                        height: 40,
-                      ),
-                      padding: EdgeInsets.zero,
-                      icon: const Icon(Icons.close_rounded, size: 21),
-                    ),
-                    const SizedBox(width: 4),
-                  ],
-                  if (recording) ...[
-                    const Icon(
-                      Icons.fiber_manual_record_rounded,
-                      size: 12,
-                      color: Color(0xFFB63B32),
-                    ),
-                    const SizedBox(width: 8),
-                  ] else if (voiceProgress) ...[
-                    const SizedBox.square(
-                      dimension: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    ),
-                    const SizedBox(width: 8),
-                  ],
-                  Expanded(
-                    child: Text(
-                      recording
-                          ? '正在录音'
-                          : voiceFailure
-                          ? voice?.errorMessage ?? '语音识别失败'
-                          : _composerVoiceStateLabel(voiceState),
-                      key: const Key('agent-voice-state-label'),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        color: voiceFailure
-                            ? const Color(0xFF8B2E26)
-                            : const Color(0xFF4D4F55),
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                      ),
-                    ),
-                  ),
-                  if (recording) ...[
-                    const SizedBox(width: 8),
-                    Text(
-                      _formatComposerDuration(voice!.recordingElapsed),
-                      key: const Key('agent-voice-recording-duration'),
-                      style: const TextStyle(
-                        color: Color(0xFF55575E),
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(width: 6),
-                    IconButton.filled(
-                      key: const Key('agent-voice-stop'),
-                      tooltip: '结束录音并自动转写',
-                      onPressed: _stopVoice,
-                      constraints: const BoxConstraints.tightFor(
-                        width: 40,
-                        height: 40,
-                      ),
-                      padding: EdgeInsets.zero,
-                      icon: const Icon(Icons.stop_rounded, size: 20),
-                    ),
-                  ] else if (voiceFailure && voice?.canRetry == true)
-                    IconButton(
-                      key: const Key('agent-voice-retry'),
-                      tooltip: '重试',
-                      onPressed: voice?.retry,
-                      icon: const Icon(Icons.refresh_rounded),
-                    ),
-                ],
-              )
-            : Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  if (confirmingText)
-                    IconButton(
-                      key: const Key('agent-voice-cancel'),
-                      tooltip: '取消语音输入',
-                      onPressed: _cancelVoice,
-                      constraints: const BoxConstraints.tightFor(
-                        width: 40,
-                        height: 40,
-                      ),
-                      padding: EdgeInsets.zero,
-                      icon: const Icon(Icons.close_rounded, size: 21),
-                    ),
-                  Expanded(
-                    child: TextField(
-                      key: const Key('agent-composer-field'),
-                      controller: _controller,
-                      enabled:
-                          confirmingText || (widget.enabled && !widget.isBusy),
-                      minLines: 1,
-                      maxLines: widget.keyboardVisible ? 3 : 2,
-                      inputFormatters: <TextInputFormatter>[
-                        _agentContentFormatter,
-                      ],
-                      textInputAction: TextInputAction.send,
-                      onSubmitted: (_) => confirmingText
-                          ? widget.voiceController?.confirm()
-                          : _submit(),
-                      style: const TextStyle(
-                        color: Color(0xFF25262A),
-                        fontSize: 15,
-                        height: 1.4,
-                      ),
-                      decoration: InputDecoration(
-                        hintText: widget.enabled
-                            ? confirmingText
-                                  ? '检查识别文字'
-                                  : '问问 SpeakUp'
-                            : '请先选择或创建对话',
-                        hintStyle: const TextStyle(
-                          color: Color(0xFF8A8C92),
-                          fontSize: 15,
-                        ),
-                        border: InputBorder.none,
-                        isDense: true,
-                        contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
-                      ),
-                    ),
-                  ),
-                  if (!confirmingText && widget.onStartVoice != null) ...[
-                    Semantics(
-                      key: const Key('agent-mic-placeholder'),
-                      button: true,
-                      enabled: widget.voiceEnabled,
-                      label: '录制 Agent 语音消息',
-                      onTap: widget.voiceEnabled ? _startVoice : null,
-                      child: ExcludeSemantics(
-                        child: IconButton(
-                          tooltip: '录制 Agent 语音消息',
-                          onPressed: widget.voiceEnabled ? _startVoice : null,
-                          constraints: const BoxConstraints.tightFor(
-                            width: 40,
-                            height: 40,
-                          ),
-                          padding: EdgeInsets.zero,
-                          color: const Color(0xFF55575E),
-                          icon: const Icon(Icons.mic_none_rounded, size: 21),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 2),
-                  ],
-                  IconButton.filled(
-                    key: Key(
-                      confirmingText
-                          ? 'agent-voice-confirm'
-                          : 'agent-send-button',
-                    ),
-                    tooltip: '发送',
-                    onPressed:
-                        _controller.text.trim().isEmpty ||
-                            (widget.isBusy && !confirmingText) ||
-                            !widget.enabled
-                        ? null
-                        : confirmingText
-                        ? voice?.canConfirm == true
-                              ? voice?.confirm
-                              : null
-                        : widget.onSubmitText == null
-                        ? null
-                        : _submit,
+      child: recording || voiceProgress || voiceFailure
+          ? Row(
+              children: [
+                if (!voiceSubmissionInFlight) ...[
+                  IconButton(
+                    key: const Key('agent-voice-cancel'),
+                    tooltip: '取消语音输入',
+                    onPressed: _cancelVoice,
                     constraints: const BoxConstraints.tightFor(
                       width: 40,
                       height: 40,
                     ),
                     padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.arrow_upward_rounded, size: 20),
+                    icon: const Icon(Icons.close_rounded, size: 21),
                   ),
+                  const SizedBox(width: 4),
                 ],
-              ),
-      ),
+                if (recording) ...[
+                  const Icon(
+                    Icons.fiber_manual_record_rounded,
+                    size: 12,
+                    color: SpeakUpDesign.error,
+                  ),
+                  const SizedBox(width: 8),
+                ] else if (voiceProgress) ...[
+                  const SizedBox.square(
+                    dimension: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Expanded(
+                  child: Text(
+                    recording
+                        ? '正在录音'
+                        : voiceFailure
+                        ? voice?.errorMessage ?? '语音识别失败'
+                        : _composerVoiceStateLabel(voiceState),
+                    key: const Key('agent-voice-state-label'),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: voiceFailure
+                          ? SpeakUpDesign.error
+                          : SpeakUpDesign.secondary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      height: 1.3,
+                    ),
+                  ),
+                ),
+                if (recording) ...[
+                  const SizedBox(width: 8),
+                  Text(
+                    _formatComposerDuration(voice!.recordingElapsed),
+                    key: const Key('agent-voice-recording-duration'),
+                    style: const TextStyle(
+                      color: SpeakUpDesign.secondary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  IconButton.filled(
+                    key: const Key('agent-voice-stop'),
+                    tooltip: '结束录音并自动转写',
+                    onPressed: _stopVoice,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 40,
+                    ),
+                    padding: EdgeInsets.zero,
+                    icon: const Icon(Icons.stop_rounded, size: 20),
+                  ),
+                ] else if (voiceFailure && voice?.canRetry == true)
+                  IconButton(
+                    key: const Key('agent-voice-retry'),
+                    tooltip: '重试',
+                    onPressed: voice?.retry,
+                    icon: const Icon(Icons.refresh_rounded),
+                  ),
+              ],
+            )
+          : Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                if (confirmingText)
+                  IconButton(
+                    key: const Key('agent-voice-cancel'),
+                    tooltip: '取消语音输入',
+                    onPressed: _cancelVoice,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 40,
+                    ),
+                    padding: EdgeInsets.zero,
+                    icon: const Icon(Icons.close_rounded, size: 21),
+                  ),
+                Expanded(
+                  child: TextField(
+                    key: const Key('agent-composer-field'),
+                    controller: _controller,
+                    enabled:
+                        confirmingText || (widget.enabled && !widget.isBusy),
+                    minLines: 1,
+                    maxLines: widget.keyboardVisible ? 3 : 2,
+                    inputFormatters: <TextInputFormatter>[
+                      _agentContentFormatter,
+                    ],
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => confirmingText
+                        ? widget.voiceController?.confirm()
+                        : _submit(),
+                    style: const TextStyle(
+                      color: SpeakUpDesign.ink,
+                      fontSize: 15,
+                      height: 1.4,
+                    ),
+                    decoration: InputDecoration(
+                      hintText: widget.enabled
+                          ? confirmingText
+                                ? '检查识别文字'
+                                : '问问 SpeakUp'
+                          : '请先选择或创建对话',
+                      hintStyle: const TextStyle(
+                        color: SpeakUpDesign.tertiary,
+                        fontSize: 15,
+                      ),
+                      border: InputBorder.none,
+                      isDense: true,
+                      contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
+                    ),
+                  ),
+                ),
+                if (!confirmingText && widget.onStartVoice != null) ...[
+                  Semantics(
+                    key: const Key('agent-mic-placeholder'),
+                    button: true,
+                    enabled: widget.voiceEnabled,
+                    label: '录制 Agent 语音消息',
+                    onTap: widget.voiceEnabled ? _startVoice : null,
+                    child: ExcludeSemantics(
+                      child: IconButton(
+                        tooltip: '录制 Agent 语音消息',
+                        onPressed: widget.voiceEnabled ? _startVoice : null,
+                        constraints: const BoxConstraints.tightFor(
+                          width: 40,
+                          height: 40,
+                        ),
+                        padding: EdgeInsets.zero,
+                        color: SpeakUpDesign.secondary,
+                        icon: const Icon(Icons.mic_none_rounded, size: 21),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 2),
+                ],
+                IconButton.filled(
+                  key: Key(
+                    confirmingText
+                        ? 'agent-voice-confirm'
+                        : 'agent-send-button',
+                  ),
+                  tooltip: '发送',
+                  onPressed:
+                      _controller.text.trim().isEmpty ||
+                          (widget.isBusy && !confirmingText) ||
+                          !widget.enabled
+                      ? null
+                      : confirmingText
+                      ? voice?.canConfirm == true
+                            ? voice?.confirm
+                            : null
+                      : widget.onSubmitText == null
+                      ? null
+                      : _submit,
+                  constraints: const BoxConstraints.tightFor(
+                    width: 40,
+                    height: 40,
+                  ),
+                  padding: EdgeInsets.zero,
+                  icon: const Icon(Icons.arrow_upward_rounded, size: 20),
+                ),
+              ],
+            ),
     );
   }
 }

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/practice/practice_recordings.dart';
 
 class PracticePage extends StatefulWidget {
@@ -262,31 +264,18 @@ class _PracticePageState extends State<PracticePage> {
       },
       child: Scaffold(
         key: const Key('practice-page'),
-        backgroundColor: const Color(0xFFF3F3F0),
-        appBar: AppBar(
-          title: const Text('按轮练习'),
-          backgroundColor: const Color(0xFFF3F3F0),
-          surfaceTintColor: Colors.transparent,
-        ),
+        appBar: AppBar(title: const Text('练习')),
         body: SafeArea(
           child: controller == null || scene == null
               ? const _NoScene()
               : ListView(
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
                   children: [
-                    Text(
-                      scene.title,
-                      style: const TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.w800,
-                      ),
+                    SpeakUpPageHeader(
+                      title: scene.title,
+                      subtitle: '完成 ${controller.turnLimit} 轮有效回答后生成复盘。',
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '一问一答，完成 ${controller.turnLimit} 轮有效回答后自动生成复盘。',
-                      style: TextStyle(color: Color(0xFF696B73), height: 1.4),
-                    ),
-                    const SizedBox(height: 22),
+                    const SizedBox(height: SpeakUpDesign.space24),
                     _TurnProgress(
                       completedTurns: controller.completedTurns,
                       turnLimit: controller.turnLimit,
@@ -297,14 +286,12 @@ class _PracticePageState extends State<PracticePage> {
                       expandedHintQuestionId: _expandedHintQuestionId,
                       onToggleHint: _toggleHint,
                     ),
-                    const SizedBox(height: 12),
-                    const _CorrectionIntegrationStatus(),
                     if (controller.errorMessage case final message?) ...[
                       const SizedBox(height: 14),
                       Text(
                         message,
                         key: const Key('practice-error-message'),
-                        style: const TextStyle(color: Color(0xFF8B2E26)),
+                        style: const TextStyle(color: SpeakUpDesign.error),
                       ),
                     ],
                     if (controller.mediaErrorMessage case final message?) ...[
@@ -312,7 +299,7 @@ class _PracticePageState extends State<PracticePage> {
                       Text(
                         message,
                         key: const Key('practice-media-error-message'),
-                        style: const TextStyle(color: Color(0xFF8B2E26)),
+                        style: const TextStyle(color: SpeakUpDesign.error),
                       ),
                     ],
                     const SizedBox(height: 18),
@@ -329,13 +316,7 @@ class _PracticePageState extends State<PracticePage> {
                       (message) => message.id != controller.questionId,
                     )) ...[
                       const SizedBox(height: 22),
-                      const Text(
-                        '本次对话记录',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
+                      const Text('本次对话记录', style: SpeakUpDesign.sectionTitle),
                       const SizedBox(height: 12),
                       _ConversationHistory(
                         messages: controller.messages
@@ -352,10 +333,7 @@ class _PracticePageState extends State<PracticePage> {
                       const Text(
                         '当前页面仅供显式 Fake 预览，不代表生产语音服务已经接入。',
                         textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Color(0xFF85878E),
-                          fontSize: 12,
-                        ),
+                        style: SpeakUpDesign.meta,
                       ),
                   ],
                 ),
@@ -397,8 +375,8 @@ class _TurnProgress extends StatelessWidget {
               height: 7,
               decoration: BoxDecoration(
                 color: index < completedTurns
-                    ? const Color(0xFF2B2C30)
-                    : const Color(0xFFDCDDD9),
+                    ? SpeakUpDesign.primary
+                    : SpeakUpDesign.border,
                 borderRadius: BorderRadius.circular(8),
               ),
             ),
@@ -443,9 +421,12 @@ class _ConversationHistory extends StatelessWidget {
               padding: const EdgeInsets.all(14),
               decoration: BoxDecoration(
                 color: message.role == AgentMessageRole.user
-                    ? const Color(0xFF303136)
-                    : Colors.white,
-                borderRadius: BorderRadius.circular(16),
+                    ? SpeakUpDesign.primary
+                    : SpeakUpDesign.surface,
+                borderRadius: BorderRadius.circular(
+                  SpeakUpDesign.radiusControl,
+                ),
+                border: Border.all(color: SpeakUpDesign.border),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -455,7 +436,7 @@ class _ConversationHistory extends StatelessWidget {
                     style: TextStyle(
                       color: message.role == AgentMessageRole.user
                           ? Colors.white
-                          : const Color(0xFF303136),
+                          : SpeakUpDesign.ink,
                       height: 1.45,
                     ),
                   ),
@@ -502,9 +483,6 @@ class _CurrentQuestion extends StatelessWidget {
     final hintExpanded =
         question != null && expandedHintQuestionId == question.id;
     return Card(
-      elevation: 0,
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(
@@ -512,16 +490,7 @@ class _CurrentQuestion extends StatelessWidget {
           children: [
             Row(
               children: [
-                const Expanded(
-                  child: Text(
-                    '当前问题',
-                    style: TextStyle(
-                      color: Color(0xFF777983),
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
+                const Expanded(child: Text('当前问题', style: SpeakUpDesign.label)),
                 if (question != null)
                   TextButton.icon(
                     key: Key('practice-hint-${question.id}'),
@@ -561,11 +530,7 @@ class _CurrentQuestion extends StatelessWidget {
             Text(
               question?.text ?? '准备好后开始第一轮。',
               key: const Key('practice-current-question'),
-              style: const TextStyle(
-                fontSize: 17,
-                fontWeight: FontWeight.w600,
-                height: 1.45,
-              ),
+              style: SpeakUpDesign.cardTitle,
             ),
             if (hintExpanded) ...[
               const SizedBox(height: 16),
@@ -586,8 +551,10 @@ class _AnswerHint extends StatelessWidget {
     return const DecoratedBox(
       key: Key('practice-answer-hint'),
       decoration: BoxDecoration(
-        color: Color(0xFFF3F3F0),
-        borderRadius: BorderRadius.all(Radius.circular(16)),
+        color: SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.all(
+          Radius.circular(SpeakUpDesign.radiusControl),
+        ),
       ),
       child: Padding(
         padding: EdgeInsets.all(16),
@@ -600,35 +567,7 @@ class _AnswerHint extends StatelessWidget {
               'From my perspective, the core responsibility of this role is '
               'to understand the goal, work closely with the team, and '
               'deliver reliable results.',
-              style: TextStyle(color: Color(0xFF5F6168), height: 1.45),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _CorrectionIntegrationStatus extends StatelessWidget {
-  const _CorrectionIntegrationStatus();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Material(
-      key: Key('practice-correction-status'),
-      color: Color(0xFFE9E9E5),
-      borderRadius: BorderRadius.all(Radius.circular(14)),
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 14, vertical: 11),
-        child: Row(
-          children: [
-            Icon(Icons.fact_check_outlined, size: 19),
-            SizedBox(width: 9),
-            Expanded(
-              child: Text(
-                '逐轮纠错：当前暂无结果（已预留正式接口）',
-                style: TextStyle(fontSize: 13, color: Color(0xFF5F6168)),
-              ),
+              style: SpeakUpDesign.body,
             ),
           ],
         ),
@@ -651,9 +590,6 @@ class _RecordingPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 0,
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: switch (controller.recordingState) {
@@ -723,19 +659,13 @@ class _IdleAnswerPanel extends StatelessWidget {
               Expanded(child: Divider()),
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Text(
-                  '或输入文字',
-                  style: TextStyle(color: Color(0xFF777981)),
-                ),
+                child: Text('或输入文字', style: SpeakUpDesign.meta),
               ),
               Expanded(child: Divider()),
             ],
           ),
         ),
-        const Text(
-          '用英文回答',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-        ),
+        const Text('用英文回答', style: SpeakUpDesign.cardTitle),
         const SizedBox(height: 10),
         TextField(
           key: const Key('practice-text-answer'),
@@ -746,7 +676,6 @@ class _IdleAnswerPanel extends StatelessWidget {
           textCapitalization: TextCapitalization.sentences,
           decoration: const InputDecoration(
             hintText: 'Type your answer in English…',
-            border: OutlineInputBorder(),
             counterText: '',
           ),
         ),
@@ -772,7 +701,11 @@ class _ReviewRetry extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        const Icon(Icons.refresh_rounded, size: 42, color: Color(0xFF303136)),
+        const Icon(
+          Icons.refresh_rounded,
+          size: 36,
+          color: SpeakUpDesign.primary,
+        ),
         const SizedBox(height: 14),
         FilledButton(
           key: const Key('practice-retry-review'),
@@ -805,7 +738,7 @@ class _RecordAction extends StatelessWidget {
         Icon(
           icon,
           size: 42,
-          color: emphasized ? const Color(0xFF8B2E26) : const Color(0xFF303136),
+          color: emphasized ? SpeakUpDesign.error : SpeakUpDesign.primary,
         ),
         const SizedBox(height: 14),
         FilledButton(

--- a/mobile/lib/features/preparation/job_preparation_wizard.dart
+++ b/mobile/lib/features/preparation/job_preparation_wizard.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/preparation/job_preparation_models.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
@@ -356,11 +357,8 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       },
       child: Scaffold(
         key: const Key('job-preparation-wizard'),
-        backgroundColor: const Color(0xFFF3F3F0),
         appBar: AppBar(
           title: const Text('准备英文面试'),
-          backgroundColor: const Color(0xFFF3F3F0),
-          surfaceTintColor: Colors.transparent,
           leading: IconButton(
             key: const Key('job-wizard-close'),
             tooltip: '关闭准备流程',
@@ -389,10 +387,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
                     child: Text(
                       _busyLabel(controller.operationStage),
                       key: const Key('job-wizard-progress-label'),
-                      style: const TextStyle(
-                        color: Color(0xFF686A72),
-                        fontSize: 13,
-                      ),
+                      style: SpeakUpDesign.meta,
                     ),
                   ),
                 ),
@@ -427,10 +422,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
           ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
         ),
         const SizedBox(height: 8),
-        const Text(
-          '优先粘贴真实 JD。没有 JD 也可以只填岗位快速开始。',
-          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
-        ),
+        const Text('优先粘贴真实 JD。没有 JD 也可以只填岗位快速开始。', style: SpeakUpDesign.body),
         const SizedBox(height: 20),
         SegmentedButton<JobTargetSource>(
           key: const Key('job-source-selector'),
@@ -584,7 +576,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
         Text(
           candidate.scopeNotice,
           key: const Key('job-analysis-scope-notice'),
-          style: const TextStyle(color: Color(0xFF686A72), height: 1.45),
+          style: SpeakUpDesign.body,
         ),
         const SizedBox(height: 18),
         _Field(
@@ -686,7 +678,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
         const SizedBox(height: 8),
         const Text(
           '系统会根据已确认的岗位信息、服务端训练目录和练习策略生成不可变预览，不会立即创建练习。',
-          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
+          style: SpeakUpDesign.body,
         ),
         const SizedBox(height: 18),
         _SummaryCard(
@@ -742,7 +734,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
         const SizedBox(height: 8),
         const Text(
           '计划已冻结。只有点击“开始练习”才会创建正式 Session。',
-          style: TextStyle(color: Color(0xFF686A72), height: 1.45),
+          style: SpeakUpDesign.body,
         ),
         const SizedBox(height: 18),
         _SummaryCard(
@@ -940,8 +932,8 @@ class _StepProgress extends StatelessWidget {
                 margin: EdgeInsets.only(right: item == 3 ? 0 : 6),
                 decoration: BoxDecoration(
                   color: item <= index
-                      ? const Color(0xFF27282C)
-                      : const Color(0xFFD7D7D2),
+                      ? SpeakUpDesign.primary
+                      : SpeakUpDesign.border,
                   borderRadius: BorderRadius.circular(99),
                 ),
               ),
@@ -983,16 +975,6 @@ class _Field extends StatelessWidget {
         labelText: label,
         hintText: hint,
         alignLabelWithHint: maxLines > 1,
-        filled: true,
-        fillColor: Colors.white.withValues(alpha: 0.82),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: Color(0xFFD8D8D3)),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: Color(0xFFD8D8D3)),
-        ),
       ),
     );
   }
@@ -1009,8 +991,8 @@ class _Notice extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: const Color(0xFFE9E9E5),
-        borderRadius: BorderRadius.circular(16),
+        color: SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1039,8 +1021,8 @@ class _ErrorCard extends StatelessWidget {
         child: Container(
           padding: const EdgeInsets.all(14),
           decoration: BoxDecoration(
-            color: const Color(0xFFFFECE8),
-            borderRadius: BorderRadius.circular(16),
+            color: SpeakUpDesign.errorMuted,
+            borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
           ),
           child: Row(
             children: [
@@ -1167,39 +1149,26 @@ class _SummaryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.85),
-        border: Border.all(color: const Color(0xFFD8D8D3)),
-        borderRadius: BorderRadius.circular(22),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
-          ),
-          if (subtitle.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text(subtitle, style: const TextStyle(color: Color(0xFF686A72))),
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(SpeakUpDesign.space16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: SpeakUpDesign.sectionTitle),
+            if (subtitle.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(subtitle, style: SpeakUpDesign.body),
+            ],
+            const SizedBox(height: 14),
+            for (final row in rows) ...[
+              Text(row.$1, style: SpeakUpDesign.meta),
+              const SizedBox(height: 3),
+              Text(row.$2.isEmpty ? '—' : row.$2),
+              const SizedBox(height: 12),
+            ],
           ],
-          const SizedBox(height: 14),
-          for (final row in rows) ...[
-            Text(
-              row.$1,
-              style: const TextStyle(
-                color: Color(0xFF777983),
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 3),
-            Text(row.$2.isEmpty ? '—' : row.$2),
-            const SizedBox(height: 12),
-          ],
-        ],
+        ),
       ),
     );
   }
@@ -1222,10 +1191,8 @@ String _busyLabel(JobPreparationOperationStage? stage) {
 
 final ButtonStyle _primaryButtonStyle = FilledButton.styleFrom(
   minimumSize: const Size.fromHeight(52),
-  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
 );
 
 final ButtonStyle _secondaryButtonStyle = OutlinedButton.styleFrom(
   minimumSize: const Size.fromHeight(52),
-  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
 );

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -860,7 +860,7 @@ class _CatalogEmpty extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Material(
       key: Key('preparation-catalog-empty'),
-      color: Colors.white,
+      color: PreparationDesign.surface,
       borderRadius: BorderRadius.all(Radius.circular(20)),
       child: Padding(
         padding: EdgeInsets.all(20),
@@ -873,7 +873,7 @@ class _CatalogEmpty extends StatelessWidget {
             Text(
               '你仍然可以返回 Agent 首页描述自己的职业英语需求。',
               textAlign: TextAlign.center,
-              style: TextStyle(color: Color(0xFF696B73)),
+              style: TextStyle(color: PreparationDesign.inkSecondary),
             ),
           ],
         ),
@@ -911,13 +911,13 @@ class _PracticeContinuation extends StatelessWidget {
             width: 38,
             height: 38,
             decoration: BoxDecoration(
-              color: const Color(0xFFE4E4DF),
+              color: PreparationDesign.surfaceMuted,
               borderRadius: BorderRadius.circular(12),
             ),
             child: const Icon(
               Icons.history_rounded,
               size: 20,
-              color: Color(0xFF4F5054),
+              color: PreparationDesign.inkSecondary,
             ),
           ),
           const SizedBox(width: 12),
@@ -928,7 +928,7 @@ class _PracticeContinuation extends StatelessWidget {
                 Text(
                   label,
                   style: const TextStyle(
-                    color: Color(0xFF696B73),
+                    color: PreparationDesign.inkSecondary,
                     fontSize: 12,
                     fontWeight: FontWeight.w800,
                   ),
@@ -954,7 +954,7 @@ class _PracticeContinuation extends StatelessWidget {
       key: const Key('practice-continuation'),
       decoration: const BoxDecoration(
         border: Border.symmetric(
-          horizontal: BorderSide(color: Color(0xFFD8D8D2)),
+          horizontal: BorderSide(color: PreparationDesign.border),
         ),
       ),
       child: onPressed == null
@@ -2162,14 +2162,17 @@ class _ScenarioPickerSheet extends StatelessWidget {
             const SizedBox(height: 5),
             const Text(
               '选择一个练习',
-              style: TextStyle(color: Color(0xFF696B73), fontSize: 14),
+              style: TextStyle(
+                color: PreparationDesign.inkSecondary,
+                fontSize: 14,
+              ),
             ),
             const SizedBox(height: 12),
             Expanded(
               child: ListView.separated(
                 itemCount: scenarios.length,
                 separatorBuilder: (_, _) =>
-                    const Divider(height: 1, color: Color(0xFFE2E2DE)),
+                    const Divider(height: 1, color: PreparationDesign.border),
                 itemBuilder: (context, index) {
                   final scenario = scenarios[index];
                   return _CatalogScenarioCard(
@@ -2199,7 +2202,7 @@ class _HubEmpty extends StatelessWidget {
         child: Text(
           message,
           textAlign: TextAlign.center,
-          style: const TextStyle(color: Color(0xFF696B73)),
+          style: const TextStyle(color: PreparationDesign.inkSecondary),
         ),
       ),
     );
@@ -2235,7 +2238,7 @@ class _CatalogScenarioCard extends StatelessWidget {
                   child: Icon(
                     _scenarioFamilyIcon(scenario.type),
                     size: 20,
-                    color: const Color(0xFF55575E),
+                    color: PreparationDesign.inkSecondary,
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -2256,7 +2259,7 @@ class _CatalogScenarioCard extends StatelessWidget {
                         maxLines: 3,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
-                          color: Color(0xFF696B73),
+                          color: PreparationDesign.inkSecondary,
                           fontSize: 13,
                           height: 1.4,
                         ),
@@ -2270,7 +2273,7 @@ class _CatalogScenarioCard extends StatelessWidget {
                   child: Icon(
                     Icons.arrow_forward_ios_rounded,
                     size: 15,
-                    color: Color(0xFF777980),
+                    color: PreparationDesign.inkTertiary,
                   ),
                 ),
               ],
@@ -2581,7 +2584,10 @@ class _LaunchSelectionCard extends StatelessWidget {
               const Text(
                 'Agent 对话仍在恢复。无需预先建立事项，恢复完成后可从这里直接开始。',
                 key: Key('preparation-agent-context-missing'),
-                style: TextStyle(color: Color(0xFF6A5B38), height: 1.4),
+                style: TextStyle(
+                  color: PreparationDesign.inkSecondary,
+                  height: 1.4,
+                ),
               ),
             ],
             if (controller.errorMessage ?? controller.workspaceErrorMessage
@@ -2590,7 +2596,10 @@ class _LaunchSelectionCard extends StatelessWidget {
               Text(
                 message,
                 key: const Key('preparation-launch-error'),
-                style: const TextStyle(color: Color(0xFF9A332A), height: 1.4),
+                style: const TextStyle(
+                  color: PreparationDesign.error,
+                  height: 1.4,
+                ),
               ),
               if (controller.canRetryWorkspaceActivation)
                 Align(
@@ -2651,7 +2660,7 @@ class _LaunchUnavailableNotice extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Material(
       key: Key('preparation-launch-unavailable'),
-      color: Color(0xFFEDEDEA),
+      color: PreparationDesign.surfaceMuted,
       borderRadius: BorderRadius.all(Radius.circular(18)),
       child: Padding(
         padding: EdgeInsets.all(16),
@@ -2861,7 +2870,7 @@ class _InlineFailure extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: const Color(0xFFFFF3F1),
+      color: PreparationDesign.errorMuted,
       borderRadius: BorderRadius.circular(16),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(14, 10, 8, 10),
@@ -2870,7 +2879,7 @@ class _InlineFailure extends StatelessWidget {
             const Icon(
               Icons.error_outline_rounded,
               size: 20,
-              color: Color(0xFF8B2E26),
+              color: PreparationDesign.error,
             ),
             const SizedBox(width: 8),
             Expanded(child: Text(message)),
@@ -2904,12 +2913,12 @@ class _PreviewSceneCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: 0,
-      color: Colors.white,
+      color: PreparationDesign.surface,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
         side: BorderSide(
-          color: selected ? const Color(0xFF303136) : const Color(0xFFE8E8E4),
+          color: selected ? PreparationDesign.ink : PreparationDesign.border,
           width: selected ? 1.5 : 1,
         ),
       ),
@@ -2925,12 +2934,12 @@ class _PreviewSceneCard extends StatelessWidget {
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: const Color(0xFFE8E8E5),
+                  color: PreparationDesign.surfaceMuted,
                   borderRadius: BorderRadius.circular(15),
                 ),
                 child: Icon(
                   selected ? Icons.check_rounded : Icons.work_outline_rounded,
-                  color: const Color(0xFF4F5054),
+                  color: PreparationDesign.inkSecondary,
                 ),
               ),
               const SizedBox(width: 14),
@@ -2949,7 +2958,7 @@ class _PreviewSceneCard extends StatelessWidget {
                     Text(
                       scene.description,
                       style: const TextStyle(
-                        color: Color(0xFF696B73),
+                        color: PreparationDesign.inkSecondary,
                         height: 1.4,
                       ),
                     ),

--- a/mobile/lib/features/preparation/preparation_design.dart
+++ b/mobile/lib/features/preparation/preparation_design.dart
@@ -9,11 +9,16 @@ import 'package:speakup/design/speak_up_design.dart';
 abstract final class PreparationDesign {
   static const canvas = SpeakUpDesign.canvas;
   static const surface = SpeakUpDesign.surface;
+  static const surfaceMuted = SpeakUpDesign.surfaceMuted;
   static const ink = SpeakUpDesign.ink;
+  static const inkSecondary = SpeakUpDesign.secondary;
+  static const inkTertiary = SpeakUpDesign.tertiary;
   static const secondary = SpeakUpDesign.secondary;
   static const tertiary = SpeakUpDesign.tertiary;
   static const border = SpeakUpDesign.border;
   static const softSurface = SpeakUpDesign.surfaceMuted;
+  static const error = SpeakUpDesign.error;
+  static const errorMuted = SpeakUpDesign.errorMuted;
 
   static const interview = Color(0xFF20252A);
   static const interviewTint = Color(0xFFE9EAEC);

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/practice/practice_recordings.dart';
 import 'package:speakup/review/review_history_client.dart';
 import 'package:speakup/review/review_history_controller.dart';
@@ -116,13 +118,8 @@ class _ReviewPageState extends State<ReviewPage> {
     final hasEntries = entries.isNotEmpty;
     return Scaffold(
       key: const Key('review-page'),
-      backgroundColor: const Color(0xFFF3F3F0),
       appBar: widget.showBackButton
           ? AppBar(
-              backgroundColor: const Color(0xFFF3F3F0),
-              surfaceTintColor: Colors.transparent,
-              elevation: 0,
-              scrolledUnderElevation: 0,
               leading: IconButton(
                 key: const Key('review-route-back-button'),
                 tooltip: '返回',
@@ -218,20 +215,9 @@ class _ReviewHeader extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            '复盘',
-            style: TextStyle(fontSize: 32, fontWeight: FontWeight.w800),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            previewMode
-                ? '本地 UI Mock；复盘结果不会写入正式服务。'
-                : '查看每次练习的正式结果，并把下一步改进留给下一次练习。',
-            style: const TextStyle(
-              color: Color(0xFF696B73),
-              fontSize: 15,
-              height: 1.45,
-            ),
+          SpeakUpPageHeader(
+            title: '复盘',
+            subtitle: previewMode ? '本地预览；结果不会写入正式服务。' : '查看练习结果，明确下一次要改进的重点。',
           ),
         ],
       ),
@@ -316,13 +302,6 @@ class _ReviewListCard extends StatelessWidget {
               ? 'review-current-${review.id}'
               : 'review-history-${review.id}',
         ),
-        margin: EdgeInsets.zero,
-        elevation: 0,
-        color: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-          side: const BorderSide(color: Color(0xFFE4E4DF)),
-        ),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           key: Key(
@@ -351,11 +330,7 @@ class _ReviewListCard extends StatelessWidget {
                               ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          fontSize: 17,
-                          fontWeight: FontWeight.w700,
-                          height: 1.25,
-                        ),
+                        style: SpeakUpDesign.cardTitle,
                       ),
                       const SizedBox(height: 6),
                       Text(
@@ -363,11 +338,7 @@ class _ReviewListCard extends StatelessWidget {
                         key: Key('review-list-summary-${review.id}'),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: Color(0xFF5F6269),
-                          fontSize: 14,
-                          height: 1.35,
-                        ),
+                        style: SpeakUpDesign.body,
                       ),
                       const SizedBox(height: 8),
                       Wrap(
@@ -376,13 +347,7 @@ class _ReviewListCard extends StatelessWidget {
                         crossAxisAlignment: WrapCrossAlignment.center,
                         children: [
                           if (dateLabel != null)
-                            Text(
-                              dateLabel,
-                              style: const TextStyle(
-                                color: Color(0xFF696B73),
-                                fontSize: 13,
-                              ),
-                            ),
+                            Text(dateLabel, style: SpeakUpDesign.meta),
                           _StatusLabel(
                             key: entry.isCurrent
                                 ? const Key('review-current-label')
@@ -397,7 +362,7 @@ class _ReviewListCard extends StatelessWidget {
                 const SizedBox(width: 10),
                 const Icon(
                   Icons.chevron_right_rounded,
-                  color: Color(0xFF6F7178),
+                  color: SpeakUpDesign.secondary,
                 ),
               ],
             ),
@@ -417,19 +382,12 @@ class _StatusLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: const Color(0xFFF0F1ED),
+        color: SpeakUpDesign.surfaceMuted,
         borderRadius: BorderRadius.circular(999),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        child: Text(
-          label,
-          style: const TextStyle(
-            color: Color(0xFF55585F),
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
+        child: Text(label, style: SpeakUpDesign.meta),
       ),
     );
   }
@@ -460,8 +418,6 @@ class _HistoryFailure extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 0,
-      color: Colors.white,
       child: Padding(
         padding: const EdgeInsets.all(22),
         child: Column(
@@ -470,7 +426,7 @@ class _HistoryFailure extends StatelessWidget {
               message,
               key: const Key('review-history-error'),
               textAlign: TextAlign.center,
-              style: const TextStyle(color: Color(0xFF8B2E26)),
+              style: const TextStyle(color: SpeakUpDesign.error),
             ),
             const SizedBox(height: 12),
             OutlinedButton(
@@ -501,7 +457,7 @@ class _InlineHistoryFailure extends StatelessWidget {
             child: Text(
               message,
               key: const Key('review-history-page-error'),
-              style: const TextStyle(color: Color(0xFF8B2E26)),
+              style: const TextStyle(color: SpeakUpDesign.error),
             ),
           ),
           TextButton(
@@ -563,37 +519,15 @@ class _EmptyReview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 0,
-      color: Colors.white,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 34),
-        child: Column(
-          children: [
-            const Icon(
-              Icons.fact_check_outlined,
-              size: 42,
-              color: Color(0xFF8B8E99),
-            ),
-            const SizedBox(height: 14),
-            Text(
-              practiceAvailable ? '完成本次练习后再来看看' : '复盘功能尚未开放',
-              key: const Key('review-availability-title'),
-              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 6),
-            Text(
-              previewMode
-                  ? '预览模式不会用当前页面状态伪造历史记录。'
-                  : practiceAvailable
-                  ? '完成练习后，正式复盘会保存在当前账号的历史中。'
-                  : '待服务端场景、语音与复盘契约开放后再接入。',
-              textAlign: TextAlign.center,
-              style: const TextStyle(color: Color(0xFF777983)),
-            ),
-          ],
-        ),
-      ),
+    return SpeakUpEmptyState(
+      key: const Key('review-availability-title'),
+      title: practiceAvailable ? '完成练习后查看复盘' : '复盘功能尚未开放',
+      message: previewMode
+          ? '预览模式不会伪造历史记录。'
+          : practiceAvailable
+          ? '练习结束后，结果会保存在当前账号中。'
+          : '正式训练服务开放后可在这里查看结果。',
+      icon: Icons.fact_check_outlined,
     );
   }
 }
@@ -669,12 +603,7 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
     final mediaError = _visibleMediaError;
     return Scaffold(
       key: const Key('review-detail-page'),
-      backgroundColor: const Color(0xFFF3F3F0),
       appBar: AppBar(
-        backgroundColor: const Color(0xFFF3F3F0),
-        surfaceTintColor: Colors.transparent,
-        elevation: 0,
-        scrolledUnderElevation: 0,
         title: const Text('复盘详情'),
         leading: IconButton(
           key: const Key('review-detail-back'),
@@ -717,7 +646,7 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
               Text(
                 mediaError,
                 key: const Key('review-detail-media-error'),
-                style: const TextStyle(color: Color(0xFF8B2E26)),
+                style: const TextStyle(color: SpeakUpDesign.error),
               ),
             ],
           ],
@@ -736,9 +665,7 @@ class _ReviewDetailHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final detailDateLabel = entry.detailDateLabel;
     return Card(
-      elevation: 0,
-      color: const Color(0xFFE9EAE5),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      color: SpeakUpDesign.primaryMuted,
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(
@@ -756,24 +683,14 @@ class _ReviewDetailHeader extends StatelessWidget {
                   label: entry.statusLabel,
                 ),
                 if (detailDateLabel != null)
-                  Text(
-                    detailDateLabel,
-                    style: const TextStyle(
-                      color: Color(0xFF65676E),
-                      fontSize: 13,
-                    ),
-                  ),
+                  Text(detailDateLabel, style: SpeakUpDesign.meta),
               ],
             ),
             const SizedBox(height: 14),
             Text(
               entry.review.title,
               key: const Key('review-detail-title'),
-              style: const TextStyle(
-                fontSize: 24,
-                height: 1.2,
-                fontWeight: FontWeight.w800,
-              ),
+              style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
             ),
           ],
         ),
@@ -795,27 +712,14 @@ class _ReviewDetailSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: EdgeInsets.zero,
-      elevation: 0,
-      color: Colors.white,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(18),
-        side: const BorderSide(color: Color(0xFFE4E4DF)),
-      ),
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              title,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-            ),
+            Text(title, style: SpeakUpDesign.cardTitle),
             const SizedBox(height: 8),
-            Text(
-              body,
-              style: const TextStyle(color: Color(0xFF55575E), height: 1.55),
-            ),
+            Text(body, style: SpeakUpDesign.body),
           ],
         ),
       ),

--- a/mobile/lib/identity/auth_gate.dart
+++ b/mobile/lib/identity/auth_gate.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/auth_input.dart';
@@ -115,65 +117,47 @@ class _ProfileCompletionPageState extends State<_ProfileCompletionPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(28),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 420),
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      '怎么称呼你？',
-                      style: Theme.of(context).textTheme.headlineMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    const Text('设置昵称后，SpeakUp 会在合适的时候用它称呼你。'),
-                    const SizedBox(height: 24),
-                    TextFormField(
-                      key: const Key('complete-profile-display-name'),
-                      controller: _displayNameController,
-                      autofocus: true,
-                      textInputAction: TextInputAction.done,
-                      decoration: const InputDecoration(
-                        labelText: '昵称',
-                        border: OutlineInputBorder(),
-                      ),
-                      validator: validateDisplayNameInput,
-                      onFieldSubmitted: (_) => _save(),
-                    ),
-                    if (_errorMessage != null) ...[
-                      const SizedBox(height: 12),
-                      Text(
-                        _errorMessage!,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.error,
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 20),
-                    FilledButton(
-                      key: const Key('complete-profile-save'),
-                      onPressed: widget.controller.profileSaving ? null : _save,
-                      child: Text(
-                        widget.controller.profileSaving ? '正在保存…' : '保存昵称',
-                      ),
-                    ),
-                    TextButton(
-                      key: const Key('complete-profile-skip'),
-                      onPressed: widget.controller.profileSaving
-                          ? null
-                          : widget.controller.dismissProfilePrompt,
-                      child: const Text('稍后再说'),
-                    ),
-                  ],
-                ),
+      body: SpeakUpPage(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SpeakUpPageHeader(
+                title: '怎么称呼你？',
+                subtitle: '设置昵称后，我们会在练习中用它称呼你。',
               ),
-            ),
+              const SizedBox(height: SpeakUpDesign.space32),
+              TextFormField(
+                key: const Key('complete-profile-display-name'),
+                controller: _displayNameController,
+                autofocus: true,
+                textInputAction: TextInputAction.done,
+                decoration: const InputDecoration(labelText: '昵称'),
+                validator: validateDisplayNameInput,
+                onFieldSubmitted: (_) => _save(),
+              ),
+              if (_errorMessage != null) ...[
+                const SizedBox(height: SpeakUpDesign.space12),
+                Text(
+                  _errorMessage!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ],
+              const SizedBox(height: SpeakUpDesign.space24),
+              FilledButton(
+                key: const Key('complete-profile-save'),
+                onPressed: widget.controller.profileSaving ? null : _save,
+                child: Text(widget.controller.profileSaving ? '正在保存…' : '保存昵称'),
+              ),
+              TextButton(
+                key: const Key('complete-profile-skip'),
+                onPressed: widget.controller.profileSaving
+                    ? null
+                    : widget.controller.dismissProfilePrompt,
+                child: const Text('稍后再说'),
+              ),
+            ],
           ),
         ),
       ),
@@ -223,36 +207,22 @@ class _RetryPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 420),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.cloud_off_outlined, size: 40),
-                  const SizedBox(height: 20),
-                  Text(
-                    '需要网络连接',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(message, textAlign: TextAlign.center),
-                  const SizedBox(height: 24),
-                  FilledButton(onPressed: onRetry, child: const Text('重试')),
-                  if (onSwitchAccount != null) ...[
-                    const SizedBox(height: 8),
-                    TextButton(
-                      key: const Key('auth-switch-account'),
-                      onPressed: onSwitchAccount,
-                      child: const Text('使用其他账号'),
-                    ),
-                  ],
-                ],
-              ),
-            ),
+      body: SpeakUpPage(
+        child: SpeakUpEmptyState(
+          title: '需要网络连接',
+          message: message,
+          icon: Icons.cloud_off_outlined,
+          action: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton(onPressed: onRetry, child: const Text('重试')),
+              if (onSwitchAccount != null)
+                TextButton(
+                  key: const Key('auth-switch-account'),
+                  onPressed: onSwitchAccount,
+                  child: const Text('使用其他账号'),
+                ),
+            ],
           ),
         ),
       ),

--- a/mobile/lib/identity/login_page.dart
+++ b/mobile/lib/identity/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/auth_input.dart';
 import 'package:speakup/identity/auth_state.dart';
@@ -45,7 +46,7 @@ class _LoginPageState extends State<LoginPage> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               AuthEmailField(controller: _emailController),
-              const SizedBox(height: 14),
+              const SizedBox(height: SpeakUpDesign.space16),
               AuthPasswordField(
                 controller: _passwordController,
                 obscureText: _obscurePassword,
@@ -54,7 +55,7 @@ class _LoginPageState extends State<LoginPage> {
                     setState(() => _obscurePassword = !_obscurePassword),
                 onSubmitted: (_) => _submit(),
               ),
-              const SizedBox(height: 28),
+              const SizedBox(height: SpeakUpDesign.space24),
               AuthPrimaryButton(
                 label: '登录',
                 isSubmitting: widget.state.isSubmitting,
@@ -108,12 +109,18 @@ class AuthFormScaffold extends StatelessWidget {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final minHeight = constraints.maxHeight > 48
-                ? constraints.maxHeight - 48
+            final horizontal = SpeakUpDesign.horizontalInset(context);
+            final minHeight = constraints.maxHeight > 40
+                ? constraints.maxHeight - 40
                 : 0.0;
             return SingleChildScrollView(
               keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              padding: const EdgeInsets.fromLTRB(24, 30, 24, 18),
+              padding: EdgeInsets.fromLTRB(
+                horizontal,
+                SpeakUpDesign.space20,
+                horizontal,
+                SpeakUpDesign.space20,
+              ),
               child: Center(
                 child: ConstrainedBox(
                   constraints: BoxConstraints(
@@ -124,46 +131,34 @@ class AuthFormScaffold extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       const Align(
-                        alignment: Alignment.center,
+                        alignment: Alignment.centerLeft,
                         child: AuthWordmark(),
                       ),
-                      const SizedBox(height: 38),
+                      const SizedBox(height: SpeakUpDesign.space32),
                       Text(
                         title,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: AuthPalette.ink,
-                          fontSize: 27,
-                          height: 1.1,
-                          letterSpacing: -0.5,
-                          fontWeight: FontWeight.w700,
-                        ),
+                        style: Theme.of(context).textTheme.headlineLarge,
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: SpeakUpDesign.space8),
                       Text(
                         subtitle,
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: AuthPalette.muted,
-                          fontSize: 15,
-                          height: 1.5,
-                        ),
+                        style: Theme.of(context).textTheme.bodyMedium,
                       ),
-                      const SizedBox(height: 6),
+                      const SizedBox(height: SpeakUpDesign.space4),
                       AuthSwitchPrompt(
                         prompt: switchPrompt,
                         actionLabel: switchActionLabel,
                         onPressed: onSwitch,
                       ),
                       if (message != null) ...[
-                        const SizedBox(height: 18),
+                        const SizedBox(height: SpeakUpDesign.space16),
                         AuthMessage(message: message!),
                       ],
                       if (errorMessage != null) ...[
-                        const SizedBox(height: 18),
+                        const SizedBox(height: SpeakUpDesign.space16),
                         AuthMessage(message: errorMessage!, isError: true),
                       ],
-                      const SizedBox(height: 44),
+                      const SizedBox(height: SpeakUpDesign.space32),
                       child,
                     ],
                   ),
@@ -193,33 +188,23 @@ class AuthSwitchPrompt extends StatelessWidget {
   Widget build(BuildContext context) {
     final promptText = Text(
       prompt,
-      textAlign: TextAlign.center,
-      style: const TextStyle(color: AuthPalette.muted, fontSize: 14),
+      style: Theme.of(context).textTheme.bodyMedium,
     );
     final action = TextButton(
       onPressed: onPressed,
       style: TextButton.styleFrom(
-        foregroundColor: AuthPalette.link,
-        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 7),
-        minimumSize: Size.zero,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        textStyle: const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-          decoration: TextDecoration.underline,
-          decorationThickness: 1,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: 6),
       ),
       child: Text(actionLabel),
     );
     if (MediaQuery.textScalerOf(context).scale(1) > 1.6) {
       return Column(
-        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [promptText, action],
       );
     }
     return Wrap(
-      alignment: WrapAlignment.center,
+      alignment: WrapAlignment.start,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [promptText, action],
     );
@@ -227,19 +212,19 @@ class AuthSwitchPrompt extends StatelessWidget {
 }
 
 abstract final class AuthPalette {
-  static const background = Color(0xFFFFFBF6);
-  static const field = Color(0xFFFFFFFF);
-  static const ink = Color(0xFF202628);
-  static const muted = Color(0xFF666D70);
-  static const border = Color(0xFFD9D6D1);
-  static const focusedBorder = Color(0xFF516C74);
-  static const primary = Color(0xFF183F49);
-  static const disabled = Color(0xFFD8D6D2);
-  static const link = Color(0xFF246B87);
-  static const noticeBackground = Color(0xFFEAF3EF);
-  static const noticeForeground = Color(0xFF285443);
-  static const errorBackground = Color(0xFFFFEDE8);
-  static const errorForeground = Color(0xFF8A2D21);
+  static const background = SpeakUpDesign.canvas;
+  static const field = SpeakUpDesign.surface;
+  static const ink = SpeakUpDesign.ink;
+  static const muted = SpeakUpDesign.secondary;
+  static const border = SpeakUpDesign.border;
+  static const focusedBorder = SpeakUpDesign.primary;
+  static const primary = SpeakUpDesign.primary;
+  static const disabled = SpeakUpDesign.surfaceMuted;
+  static const link = SpeakUpDesign.primary;
+  static const noticeBackground = SpeakUpDesign.successMuted;
+  static const noticeForeground = SpeakUpDesign.success;
+  static const errorBackground = SpeakUpDesign.errorMuted;
+  static const errorForeground = SpeakUpDesign.error;
 }
 
 class AuthWordmark extends StatelessWidget {
@@ -308,19 +293,20 @@ InputDecoration authFieldDecoration({
   String? helperText,
   Widget? suffixIcon,
 }) {
-  const borderRadius = BorderRadius.all(Radius.circular(11));
+  const borderRadius = BorderRadius.all(
+    Radius.circular(SpeakUpDesign.radiusControl),
+  );
   return InputDecoration(
     hintText: label,
-    hintStyle: const TextStyle(color: AuthPalette.muted, fontSize: 16),
+    hintStyle: SpeakUpDesign.body,
     helperText: helperText,
-    helperStyle: const TextStyle(
-      color: AuthPalette.muted,
-      fontSize: 12,
-      height: 1.3,
-    ),
+    helperStyle: SpeakUpDesign.meta,
     filled: true,
     fillColor: AuthPalette.field,
-    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+    contentPadding: const EdgeInsets.symmetric(
+      horizontal: SpeakUpDesign.space16,
+      vertical: SpeakUpDesign.space16,
+    ),
     suffixIcon: suffixIcon,
     border: const OutlineInputBorder(
       borderRadius: borderRadius,
@@ -361,16 +347,7 @@ class AuthPrimaryButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FilledButton(
       onPressed: onPressed,
-      style: FilledButton.styleFrom(
-        backgroundColor: AuthPalette.primary,
-        foregroundColor: Colors.white,
-        disabledBackgroundColor: AuthPalette.disabled,
-        disabledForegroundColor: AuthPalette.muted,
-        minimumSize: const Size.fromHeight(54),
-        shape: const StadiumBorder(),
-        elevation: 0,
-        textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
-      ),
+      style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(52)),
       child: isSubmitting ? const AuthButtonProgress() : Text(label),
     );
   }
@@ -486,12 +463,15 @@ class AuthMessage extends StatelessWidget {
     return Semantics(
       liveRegion: true,
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        padding: const EdgeInsets.symmetric(
+          horizontal: SpeakUpDesign.space16,
+          vertical: SpeakUpDesign.space12,
+        ),
         decoration: BoxDecoration(
           color: isError
               ? AuthPalette.errorBackground
               : AuthPalette.noticeBackground,
-          borderRadius: BorderRadius.circular(10),
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
         ),
         child: Text(
           message,
@@ -499,8 +479,8 @@ class AuthMessage extends StatelessWidget {
             color: isError
                 ? AuthPalette.errorForeground
                 : AuthPalette.noticeForeground,
-            fontSize: 14,
-            height: 1.4,
+            fontSize: SpeakUpDesign.body.fontSize,
+            height: SpeakUpDesign.body.height,
           ),
         ),
       ),

--- a/mobile/lib/identity/register_page.dart
+++ b/mobile/lib/identity/register_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/auth_input.dart';
 import 'package:speakup/identity/auth_state.dart';
@@ -59,9 +60,9 @@ class _RegisterPageState extends State<RegisterPage> {
                 decoration: authFieldDecoration(label: '昵称'),
                 validator: validateDisplayNameInput,
               ),
-              const SizedBox(height: 14),
+              const SizedBox(height: SpeakUpDesign.space16),
               AuthEmailField(controller: _emailController),
-              const SizedBox(height: 14),
+              const SizedBox(height: SpeakUpDesign.space16),
               AuthPasswordField(
                 controller: _passwordController,
                 obscureText: _obscurePassword,
@@ -72,7 +73,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     setState(() => _obscurePassword = !_obscurePassword),
                 onSubmitted: (_) => _submit(),
               ),
-              const SizedBox(height: 28),
+              const SizedBox(height: SpeakUpDesign.space24),
               AuthPrimaryButton(
                 label: '创建账号',
                 isSubmitting: widget.state.isSubmitting,

--- a/mobile/lib/practice/practice_recordings.dart
+++ b/mobile/lib/practice/practice_recordings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/design/speak_up_design.dart';
 
 class PracticeRecordingsCard extends StatelessWidget {
   const PracticeRecordingsCard({
@@ -19,11 +20,13 @@ class PracticeRecordingsCard extends StatelessWidget {
     }
     return Card(
       key: const Key('practice-recordings-card'),
-      elevation: 0,
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(18, 16, 10, 12),
+        padding: const EdgeInsets.fromLTRB(
+          SpeakUpDesign.space16,
+          SpeakUpDesign.space16,
+          SpeakUpDesign.space8,
+          SpeakUpDesign.space12,
+        ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -5,6 +5,7 @@ import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/agent/agent_voice_controller.dart';
 import 'package:speakup/agent/agent_voice_models.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/conversation/conversation.dart';
@@ -100,7 +101,7 @@ void main() {
       final voiceBubble = find.byKey(Key('agent-message-${voiceMessage.id}'));
       final voiceDecoration =
           tester.widget<Container>(voiceBubble).decoration! as BoxDecoration;
-      expect(voiceDecoration.color, const Color(0xFFE7E7E3));
+      expect(voiceDecoration.color, SpeakUpDesign.primaryMuted);
       expect(tester.getSize(voiceBubble).height, lessThan(140));
       expect(
         find.byKey(Key('agent-user-voice-play-${voiceMessage.id}')),

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -491,7 +491,7 @@ void main() {
     await tester.pumpAndSettle();
     await _tapVisible(tester, 'quick-action-recent-review');
     expect(find.byKey(const Key('review-page')), findsOneWidget);
-    expect(find.text('本地 UI Mock；复盘结果不会写入正式服务。'), findsOneWidget);
+    expect(find.text('本地预览；结果不会写入正式服务。'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('primary-tab-agent')));
     await tester.pumpAndSettle();

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -14,7 +14,7 @@ import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/review/review.dart';
 
 void main() {
-  testWidgets('starts on the Agent home with four glass navigation entries', (
+  testWidgets('starts on the Agent home with four primary navigation entries', (
     tester,
   ) async {
     await tester.pumpWidget(const SpeakUpApp.preview());
@@ -39,7 +39,7 @@ void main() {
     expect(navigation, findsOneWidget);
     expect(
       find.ancestor(of: navigation, matching: find.byType(BackdropFilter)),
-      findsOneWidget,
+      findsNothing,
     );
     final composerRect = tester.getRect(
       find.byKey(const Key('agent-composer-surface')),
@@ -101,7 +101,7 @@ void main() {
       key: 'primary-tab-profile',
       expectedPageKey: 'profile-page',
     );
-    expect(find.text('当前账号与本机登录状态。'), findsOneWidget);
+    expect(find.text('管理账号与练习身份。'), findsOneWidget);
     await _tapPrimaryDestination(
       tester,
       key: 'primary-tab-agent',


### PR DESCRIPTION
## 功能描述
统一训练入口、面试与 IELTS 准备、练习过程和复盘页面的视觉层级与移动端布局。

## 实现思路
- 统一训练场景卡片、准备流程、答题区和复盘表面。
- 收敛字体、间距、状态反馈与窄屏表现。
- 保留三类训练入口和既有会话生命周期，不修改服务端 API，不接数字人供应商。

## 验证方式
1. `cd mobile && flutter analyze`
2. `cd mobile && flutter test`
3. `cd mobile && flutter build ios --simulator --debug`

## 依赖
依赖 PR #216，前置合入后转 Ready。

Closes #200