### PR TITLE
fix(agent): open home as a conversation draft

### DIFF
--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -90,6 +90,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   String? _nextMessageCursor;
   String? _threadHistoryErrorMessage;
   _ThreadHistoryRecovery? _threadHistoryRecovery;
+  String? _pendingFocusThreadId;
+  int _draftThreadRecoveryGeneration = 0;
   bool _loadingMoreThreads = false;
   bool _loadingEarlierMessages = false;
   bool _threadTransitionInFlight = false;
@@ -141,6 +143,10 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   bool get isLoadingMoreThreads => _loadingMoreThreads;
   String? get threadHistoryErrorMessage => _threadHistoryErrorMessage;
   bool get canRetryThreadHistory => _threadHistoryRecovery != null;
+  bool get hasPendingThreadCreationRecovery =>
+      _pendingFocusThreadId != null ||
+      _threadHistoryRecovery == _ThreadHistoryRecovery.create;
+  int get draftThreadRecoveryGeneration => _draftThreadRecoveryGeneration;
   bool get hasEarlierMessages => _nextMessageCursor != null;
   bool get isLoadingEarlierMessages => _loadingEarlierMessages;
   String? get practiceSessionId => _practiceSessionId;
@@ -393,6 +399,29 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     if (client is! AgentThreadHistoryClient || _disposed) {
       return false;
     }
+    final pendingFocusThreadId = _pendingFocusThreadId;
+    if (pendingFocusThreadId != null) {
+      return selectThread(pendingFocusThreadId);
+    }
+    return _createNewThread();
+  }
+
+  /// Creates a new Thread for a caller that requires an isolated workspace.
+  ///
+  /// Unlike the ordinary conversation entry point, this never consumes a
+  /// pending Home draft recovery. The caller must let that recovery settle
+  /// before acquiring a dedicated Thread.
+  Future<bool> createIndependentThread() async {
+    if (hasPendingThreadCreationRecovery) {
+      return false;
+    }
+    return _createNewThread();
+  }
+
+  Future<bool> _createNewThread() async {
+    if (client is! AgentThreadHistoryClient || _disposed) {
+      return false;
+    }
     final accountEpoch = _epoch;
     final transitionGeneration = _beginThreadTransition();
     if (transitionGeneration == null) {
@@ -445,6 +474,13 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     String? selectedThreadId,
     required bool createNew,
   }) async {
+    final recoveryAtStart = _threadHistoryRecovery;
+    final pendingFocusAtStart = _pendingFocusThreadId;
+    final recoveringDraftThread =
+        _threadId == null &&
+        ((createNew && recoveryAtStart == _ThreadHistoryRecovery.create) ||
+            (recoveryAtStart == _ThreadHistoryRecovery.focus &&
+                selectedThreadId == pendingFocusAtStart));
     _epoch++;
     _practiceGeneration++;
     _cancelRecordingLimit();
@@ -459,6 +495,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     if (_threadHistoryRecovery != _ThreadHistoryRecovery.create) {
       _threadHistoryErrorMessage = null;
     }
+    AgentThreadSummary? summary;
+    var targetThreadId = selectedThreadId;
     _setBusy(true);
     try {
       await _voiceController?.bindThread(null);
@@ -469,15 +507,14 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       if (!_isOperationCurrent(fence)) {
         return false;
       }
-      AgentThreadSummary? summary;
-      var targetThreadId = selectedThreadId;
       if (createNew) {
         summary = await historyClient.createThread();
         _validateThreadSummary(summary);
         if (!_isOperationCurrent(fence)) {
           return false;
         }
-        _threadHistoryRecovery = null;
+        _pendingFocusThreadId = summary.id;
+        _threadHistoryRecovery = _ThreadHistoryRecovery.focus;
         _mergeThreadSummary(summary, placeFirst: true);
         notifyListeners();
         targetThreadId = summary.id;
@@ -504,7 +541,19 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         _mergeThreadSummary(canonicalSummary, placeFirst: createNew);
         _currentThreadSummary = canonicalSummary;
       }
-      if (_threadHistoryRecovery != _ThreadHistoryRecovery.create) {
+      final resolvedPendingFocus = targetThreadId == _pendingFocusThreadId;
+      if (resolvedPendingFocus) {
+        _pendingFocusThreadId = null;
+      }
+      if (recoveringDraftThread) {
+        _draftThreadRecoveryGeneration++;
+      }
+      if (resolvedPendingFocus ||
+          _threadHistoryRecovery != _ThreadHistoryRecovery.create) {
+        if (_threadHistoryRecovery == _ThreadHistoryRecovery.focus) {
+          _pendingFocusThreadId = null;
+        }
+        _threadHistoryRecovery = null;
         _threadHistoryErrorMessage = null;
       }
       return true;
@@ -513,8 +562,14 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         if (createNew &&
             error is AgentClientException &&
             error.errorCode == 'thread_creation_ambiguous') {
+          _pendingFocusThreadId = null;
           _threadHistoryRecovery = _ThreadHistoryRecovery.create;
           _threadHistoryErrorMessage = '新对话的创建结果尚未确认。请重试恢复；系统不会重复创建。';
+        } else if (targetThreadId != null &&
+            (createNew || targetThreadId == _pendingFocusThreadId)) {
+          _pendingFocusThreadId = targetThreadId;
+          _threadHistoryRecovery = _ThreadHistoryRecovery.focus;
+          _threadHistoryErrorMessage = '新对话已创建，但暂时无法打开。重试不会重复创建。';
         } else if (_threadHistoryRecovery != _ThreadHistoryRecovery.create) {
           _threadHistoryErrorMessage = createNew
               ? '暂时无法创建新对话，请稍后再试。'
@@ -574,6 +629,11 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       await _voiceController?.bindThread(null);
       if (!_isOperationCurrent(fence)) {
         return;
+      }
+      _pendingFocusThreadId = null;
+      if (_threadHistoryRecovery == _ThreadHistoryRecovery.focus) {
+        _threadHistoryRecovery = null;
+        _threadHistoryErrorMessage = null;
       }
       _resetSelectedThreadPresentation();
       _initialized = true;
@@ -906,13 +966,16 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     if (text.isEmpty) {
       return false;
     }
-    final accountFence = _captureOperationFence();
+    final accountEpoch = _epoch;
     await _ensureInitialized();
-    if (!_isOperationCurrent(accountFence) ||
-        _threadId == null ||
-        isBusy ||
-        _disposed) {
+    if (!_isCurrent(accountEpoch) || isBusy || _disposed) {
       return false;
+    }
+    if (_threadId == null) {
+      final created = await createThread();
+      if (!created || _threadId == null || _disposed) {
+        return false;
+      }
     }
     final retry = _retry;
     final operation = retry is _TextRetry && retry.text == text
@@ -979,6 +1042,12 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     switch (_threadHistoryRecovery) {
       case _ThreadHistoryRecovery.create:
         await createThread();
+        return;
+      case _ThreadHistoryRecovery.focus:
+        final threadId = _pendingFocusThreadId;
+        if (threadId != null) {
+          await selectThread(threadId);
+        }
         return;
       case _ThreadHistoryRecovery.refresh:
         await _retryThreadHistoryRefresh();
@@ -1777,6 +1846,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _nextMessageCursor = null;
     _threadHistoryErrorMessage = null;
     _threadHistoryRecovery = null;
+    _pendingFocusThreadId = null;
+    _draftThreadRecoveryGeneration = 0;
     _loadingMoreThreads = false;
     _loadingEarlierMessages = false;
     _threadTransitionGeneration++;
@@ -2470,7 +2541,7 @@ sealed class _AgentRetry {
   const _AgentRetry();
 }
 
-enum _ThreadHistoryRecovery { create, refresh }
+enum _ThreadHistoryRecovery { create, focus, refresh }
 
 final class _RestoreRetry extends _AgentRetry {
   const _RestoreRetry();

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -269,12 +269,14 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onContinuePractice: canContinuePractice ? _openPractice : null,
         onOpenReview: () => _selectDestination(2),
         onStartVoice: widget.agentController.supportsAgentVoice
-            ? () => unawaited(widget.agentController.startAgentVoiceRecording())
+            ? widget.agentController.startAgentVoiceRecording
             : null,
         voiceController: widget.agentController.voiceController,
         onCreateConversation: widget.agentController.supportsThreadHistory
             ? () => unawaited(widget.agentController.createThread())
             : null,
+        draftThreadRecoveryGeneration:
+            widget.agentController.draftThreadRecoveryGeneration,
         messages: widget.agentController.messages,
         activeScene: widget.agentController.scene,
         hasFocusedThread:
@@ -286,9 +288,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         isBusy: widget.agentController.isBusy,
         errorMessage:
             widget.agentController.errorMessage ??
-            (widget.agentController.canRetryThreadHistory
-                ? widget.agentController.threadHistoryErrorMessage
-                : null),
+            widget.agentController.threadHistoryErrorMessage,
         onSubmitText: widget.agentController.sendText,
         onRetryOperation: widget.agentController.canRetry
             ? widget.agentController.retryLastOperation
@@ -441,7 +441,7 @@ class _ConversationDrawer extends StatelessWidget {
               const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 8, vertical: 10),
                 child: Text(
-                  '尚未选择对话',
+                  '新对话 · 未发送',
                   key: Key('no-focused-conversation'),
                   style: SpeakUpDesign.body,
                 ),

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -1,6 +1,7 @@
 /// Conversation module boundary.
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +10,8 @@ import 'package:speakup/agent/agent_voice_controller.dart';
 import 'package:speakup/agent/agent_voice_models.dart';
 import 'package:speakup/agent/agent_voice_widgets.dart';
 import 'package:speakup/design/speak_up_design.dart';
+
+typedef ConversationVoiceStarter = FutureOr<void> Function();
 
 class ConversationPage extends StatefulWidget {
   const ConversationPage({
@@ -22,9 +25,10 @@ class ConversationPage extends StatefulWidget {
     this.onCreatePlan,
     this.onContinuePractice,
     this.onOpenReview,
-    VoidCallback? onStartVoice,
-    VoidCallback? onVoicePlaceholder,
+    ConversationVoiceStarter? onStartVoice,
+    ConversationVoiceStarter? onVoicePlaceholder,
     this.onCreateConversation,
+    this.draftThreadRecoveryGeneration = 0,
     this.messages = const <AgentMessage>[],
     this.activeScene,
     this.hasFocusedThread = true,
@@ -49,8 +53,9 @@ class ConversationPage extends StatefulWidget {
   final VoidCallback? onCreatePlan;
   final VoidCallback? onContinuePractice;
   final VoidCallback? onOpenReview;
-  final VoidCallback? onStartVoice;
+  final ConversationVoiceStarter? onStartVoice;
   final VoidCallback? onCreateConversation;
+  final int draftThreadRecoveryGeneration;
   final List<AgentMessage> messages;
   final AgentScene? activeScene;
   final bool hasFocusedThread;
@@ -78,6 +83,7 @@ class ConversationPage extends StatefulWidget {
     final titleSize = width < 350 ? 28.0 : 32.0;
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
+    final canCompose = hasFocusedThread || onCreateConversation != null;
 
     return Scaffold(
       key: const Key('agent-home-page'),
@@ -127,13 +133,7 @@ class ConversationPage extends StatefulWidget {
                                   ? 16
                                   : 24,
                             ),
-                            if (!hasFocusedThread) ...[
-                              _NoFocusedConversation(
-                                onCreateConversation: onCreateConversation,
-                                onOpenConversations: onOpenMenu,
-                                isBusy: isBusy,
-                              ),
-                            ] else if (messages.isEmpty) ...[
+                            if (messages.isEmpty) ...[
                               _Greeting(displayName: displayName),
                               if (displayName != null) ...[
                                 const SizedBox(height: 5),
@@ -252,7 +252,9 @@ class ConversationPage extends StatefulWidget {
                         0,
                       ),
                       child: _AgentComposer(
-                        key: ValueKey<String?>(threadId),
+                        threadId: threadId,
+                        draftThreadRecoveryGeneration:
+                            draftThreadRecoveryGeneration,
                         keyboardVisible: keyboardVisible,
                         acceptedUserMessageId: acceptedUserMessage?.id,
                         acceptedUserMessageText: acceptedUserMessage?.text,
@@ -260,7 +262,7 @@ class ConversationPage extends StatefulWidget {
                         voiceController: voiceController,
                         voiceEnabled: voiceController != null && !isBusy,
                         onSubmitText: onSubmitText,
-                        enabled: hasFocusedThread,
+                        enabled: canCompose,
                         isBusy: isBusy,
                       ),
                     ),
@@ -565,48 +567,6 @@ class _Greeting extends StatelessWidget {
   }
 }
 
-class _NoFocusedConversation extends StatelessWidget {
-  const _NoFocusedConversation({
-    required this.onCreateConversation,
-    required this.onOpenConversations,
-    required this.isBusy,
-  });
-
-  final VoidCallback? onCreateConversation;
-  final VoidCallback? onOpenConversations;
-  final bool isBusy;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: const Key('no-focused-conversation-home'),
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('选择一个对话', style: SpeakUpDesign.pageTitle),
-        const SizedBox(height: 10),
-        const Text('打开近期对话，或创建一个新对话后再开始输入。', style: SpeakUpDesign.body),
-        const SizedBox(height: 22),
-        if (onCreateConversation != null)
-          FilledButton.icon(
-            key: const Key('no-focused-create-conversation'),
-            onPressed: isBusy ? null : onCreateConversation,
-            icon: const Icon(Icons.add_rounded),
-            label: const Text('创建新对话'),
-          ),
-        if (onOpenConversations != null) ...[
-          const SizedBox(height: 8),
-          TextButton.icon(
-            key: const Key('no-focused-open-conversations'),
-            onPressed: onOpenConversations,
-            icon: const Icon(Icons.chat_bubble_outline_rounded),
-            label: const Text('打开近期对话'),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
 class _QuickActions extends StatelessWidget {
   const _QuickActions({
     required this.compact,
@@ -800,6 +760,8 @@ class _InlineError extends StatelessWidget {
 
 class _AgentComposer extends StatefulWidget {
   const _AgentComposer({
+    required this.threadId,
+    required this.draftThreadRecoveryGeneration,
     required this.keyboardVisible,
     required this.acceptedUserMessageId,
     required this.acceptedUserMessageText,
@@ -809,13 +771,14 @@ class _AgentComposer extends StatefulWidget {
     required this.onSubmitText,
     required this.enabled,
     required this.isBusy,
-    super.key,
   });
 
+  final String? threadId;
+  final int draftThreadRecoveryGeneration;
   final bool keyboardVisible;
   final String? acceptedUserMessageId;
   final String? acceptedUserMessageText;
-  final VoidCallback? onStartVoice;
+  final ConversationVoiceStarter? onStartVoice;
   final AgentVoiceController? voiceController;
   final bool voiceEnabled;
   final Future<bool> Function(String)? onSubmitText;
@@ -829,6 +792,9 @@ class _AgentComposer extends StatefulWidget {
 class _AgentComposerState extends State<_AgentComposer> {
   final _controller = TextEditingController();
   bool _suppressControllerNotifications = false;
+  bool _textSubmissionInFlight = false;
+  bool _draftMaterializationPending = false;
+  bool _voiceMaterializationPending = false;
   String _draftBeforeVoice = '';
 
   @override
@@ -844,6 +810,23 @@ class _AgentComposerState extends State<_AgentComposer> {
     if (oldWidget.voiceController != widget.voiceController) {
       oldWidget.voiceController?.removeListener(_handleVoiceChanged);
       widget.voiceController?.addListener(_handleVoiceChanged);
+    }
+    if (oldWidget.threadId != widget.threadId) {
+      final preserveMaterializedDraft =
+          oldWidget.threadId == null &&
+          widget.threadId != null &&
+          (_draftMaterializationPending ||
+              _voiceMaterializationPending ||
+              oldWidget.draftThreadRecoveryGeneration !=
+                  widget.draftThreadRecoveryGeneration);
+      _draftMaterializationPending = false;
+      _voiceMaterializationPending = false;
+      if (!preserveMaterializedDraft && _controller.text.isNotEmpty) {
+        _draftBeforeVoice = '';
+        _suppressControllerNotifications = true;
+        _controller.clear();
+        _suppressControllerNotifications = false;
+      }
     }
     if (widget.acceptedUserMessageId != null &&
         widget.acceptedUserMessageId != oldWidget.acceptedUserMessageId &&
@@ -892,9 +875,20 @@ class _AgentComposerState extends State<_AgentComposer> {
     setState(() {});
   }
 
-  void _startVoice() {
+  Future<void> _startVoice() async {
     _draftBeforeVoice = _controller.text;
-    widget.onStartVoice?.call();
+    _voiceMaterializationPending = widget.threadId == null;
+    try {
+      await widget.onStartVoice?.call();
+    } finally {
+      if (mounted && _voiceMaterializationPending) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && widget.threadId == null) {
+            _voiceMaterializationPending = false;
+          }
+        });
+      }
+    }
   }
 
   Future<void> _stopVoice() async {
@@ -930,12 +924,28 @@ class _AgentComposerState extends State<_AgentComposer> {
     if (!widget.enabled ||
         text.isEmpty ||
         widget.isBusy ||
+        _textSubmissionInFlight ||
         widget.onSubmitText == null) {
       return;
     }
-    final sent = await widget.onSubmitText!(text);
-    if (mounted && sent) {
-      _controller.clear();
+    setState(() => _textSubmissionInFlight = true);
+    _draftMaterializationPending = widget.threadId == null;
+    try {
+      final sent = await widget.onSubmitText!(text);
+      if (mounted && sent) {
+        _controller.clear();
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _textSubmissionInFlight = false);
+        if (_draftMaterializationPending) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted && widget.threadId == null) {
+              _draftMaterializationPending = false;
+            }
+          });
+        }
+      }
     }
   }
 
@@ -1090,7 +1100,7 @@ class _AgentComposerState extends State<_AgentComposer> {
                           ? confirmingText
                                 ? '检查识别文字'
                                 : '问问 SpeakUp'
-                          : '请先选择或创建对话',
+                          : '暂时无法开始对话',
                       hintStyle: const TextStyle(
                         color: SpeakUpDesign.tertiary,
                         fontSize: 15,
@@ -1135,6 +1145,8 @@ class _AgentComposerState extends State<_AgentComposer> {
                       _controller.text.trim().isEmpty ||
                           (widget.isBusy && !confirmingText) ||
                           !widget.enabled
+                      ? null
+                      : _textSubmissionInFlight
                       ? null
                       : confirmingText
                       ? voice?.canConfirm == true

--- a/mobile/lib/features/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/preparation/practice_workspace_controller.dart
@@ -716,15 +716,23 @@ final class PracticeWorkspaceController extends ChangeNotifier {
       _setError('首页对话状态异常，暂时无法开始练习。');
       return null;
     }
+    if (agentController.hasPendingThreadCreationRecovery) {
+      _setError('有一条新对话仍在恢复，请先回到首页完成恢复，再开始练习。');
+      return null;
+    }
     if (!preparedToLeave && !await _prepareToLeavePractice()) {
       return null;
     }
-    final created = await agentController.createThread();
+    final created = await agentController.createIndependentThread();
     if (!_isCurrentOperation(
       accountGeneration,
       operationGeneration,
       accountId,
     )) {
+      return null;
+    }
+    if (!created && agentController.hasPendingThreadCreationRecovery) {
+      _setError('有一条新对话仍在恢复，请先回到首页完成恢复，再开始练习。');
       return null;
     }
     final practiceThreadId = agentController.threadId;

--- a/mobile/test/agent/agent_controller_test.dart
+++ b/mobile/test/agent/agent_controller_test.dart
@@ -432,9 +432,23 @@ void main() {
   );
 
   test(
-    'keeps an absent focused Thread empty until explicit creation',
+    'first text materializes an absent focused Thread exactly once',
     () async {
-      final client = _HistoryAgentClient(startsWithoutFocus: true);
+      final client = _HistoryAgentClient(
+        startsWithoutFocus: true,
+        textExchange: const AgentExchange(
+          userMessage: AgentMessage(
+            id: 'message_first_user',
+            role: AgentMessageRole.user,
+            text: 'first message',
+          ),
+          assistantMessage: AgentMessage(
+            id: 'message_first_assistant',
+            role: AgentMessageRole.assistant,
+            text: 'first reply',
+          ),
+        ),
+      );
       final controller = AgentController(client: client);
       addTearDown(controller.dispose);
 
@@ -444,9 +458,92 @@ void main() {
       expect(controller.messages, isEmpty);
       expect(controller.threads.single.id, _historyThreadOne);
 
-      expect(await controller.createThread(), isTrue);
+      expect(await controller.sendText('first message'), isTrue);
       expect(controller.threadId, _historyThreadThree);
+      expect(client.createCalls, 1);
       expect(client.focusRequests, <String>[_historyThreadThree]);
+      expect(
+        controller.messages.map((message) => message.id),
+        containsAllInOrder(<String>[
+          'message_first_user',
+          'message_first_assistant',
+        ]),
+      );
+    },
+  );
+
+  test(
+    'lazy text retries the created Thread focus without another POST',
+    () async {
+      final client = _HistoryAgentClient(
+        startsWithoutFocus: true,
+        focusFailuresRemaining: 1,
+        textExchange: const AgentExchange(
+          userMessage: AgentMessage(
+            id: 'message_recovered_user',
+            role: AgentMessageRole.user,
+            text: 'recover this message',
+          ),
+          assistantMessage: AgentMessage(
+            id: 'message_recovered_assistant',
+            role: AgentMessageRole.assistant,
+            text: 'recovered reply',
+          ),
+        ),
+      );
+      final controller = AgentController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      expect(await controller.sendText('recover this message'), isFalse);
+      expect(controller.threadId, isNull);
+      expect(controller.canRetryThreadHistory, isTrue);
+      expect(controller.threadHistoryErrorMessage, contains('不会重复创建'));
+      expect(client.createCalls, 1);
+      expect(client.focusRequests, <String>[_historyThreadThree]);
+
+      expect(await controller.sendText('recover this message'), isTrue);
+
+      expect(controller.threadId, _historyThreadThree);
+      expect(controller.draftThreadRecoveryGeneration, 1);
+      expect(client.createCalls, 1);
+      expect(client.focusRequests, <String>[
+        _historyThreadThree,
+        _historyThreadThree,
+      ]);
+      expect(
+        controller.messages.map((message) => message.id),
+        containsAllInOrder(<String>[
+          'message_recovered_user',
+          'message_recovered_assistant',
+        ]),
+      );
+    },
+  );
+
+  test(
+    'inline Thread recovery focuses the created draft without another POST',
+    () async {
+      final client = _HistoryAgentClient(
+        startsWithoutFocus: true,
+        focusFailuresRemaining: 1,
+      );
+      final controller = AgentController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      expect(await controller.sendText('keep this draft'), isFalse);
+      expect(controller.draftThreadRecoveryGeneration, 0);
+
+      await controller.retryThreadHistory();
+
+      expect(controller.threadId, _historyThreadThree);
+      expect(controller.draftThreadRecoveryGeneration, 1);
+      expect(client.createCalls, 1);
+      expect(client.focusRequests, <String>[
+        _historyThreadThree,
+        _historyThreadThree,
+      ]);
     },
   );
 
@@ -528,6 +625,44 @@ void main() {
       expect(client.focusRequests, <String>[_historyThreadThree]);
     },
   );
+
+  test(
+    'opening history does not treat an ambiguous creation as draft recovery',
+    () async {
+      final client = _HistoryAgentClient(
+        startsWithoutFocus: true,
+        ambiguousCreateFailuresRemaining: 1,
+      );
+      final controller = AgentController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      expect(await controller.createThread(), isFalse);
+      expect(controller.canRetryThreadHistory, isTrue);
+      expect(controller.draftThreadRecoveryGeneration, 0);
+
+      expect(await controller.selectThread(_historyThreadOne), isTrue);
+
+      expect(controller.threadId, _historyThreadOne);
+      expect(controller.draftThreadRecoveryGeneration, 0);
+    },
+  );
+
+  test('surfaces a definite lazy Thread creation failure', () async {
+    final client = _HistoryAgentClient(
+      startsWithoutFocus: true,
+      createFailuresRemaining: 1,
+    );
+    final controller = AgentController(client: client);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    expect(await controller.sendText('show this failure'), isFalse);
+
+    expect(controller.threadId, isNull);
+    expect(controller.canRetryThreadHistory, isFalse);
+    expect(controller.threadHistoryErrorMessage, '暂时无法创建新对话，请稍后再试。');
+  });
 
   test(
     'retains a created Thread when focus fails and retries PUT without POST',
@@ -944,6 +1079,7 @@ final class _HistoryAgentClient extends _DelegatingAgentClient
     this.controlOldSend = false,
     this.startsWithoutFocus = false,
     this.focusFailuresRemaining = 0,
+    this.createFailuresRemaining = 0,
     this.ambiguousCreateFailuresRemaining = 0,
     this.initializationGate,
     this.createGate,
@@ -958,6 +1094,7 @@ final class _HistoryAgentClient extends _DelegatingAgentClient
   final bool controlOldSend;
   final bool startsWithoutFocus;
   int focusFailuresRemaining;
+  int createFailuresRemaining;
   int ambiguousCreateFailuresRemaining;
   final Completer<void>? initializationGate;
   final Completer<void>? createGate;
@@ -1036,6 +1173,10 @@ final class _HistoryAgentClient extends _DelegatingAgentClient
       createStarted.complete();
     }
     await createGate?.future;
+    if (createFailuresRemaining > 0) {
+      createFailuresRemaining--;
+      throw StateError('Definite Thread creation failure.');
+    }
     if (ambiguousCreateFailuresRemaining > 0) {
       ambiguousCreateFailuresRemaining--;
       throw const AgentClientException(

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -271,9 +271,20 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         find.byKey(const Key('no-focused-conversation-home')),
-        findsOneWidget,
+        findsNothing,
+      );
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
+            .enabled,
+        isTrue,
       );
 
+      await tester.enterText(
+        find.byKey(const Key('agent-composer-field')),
+        'Keep this typed draft',
+      );
+      await tester.pump();
       await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
       await tester.pump();
 
@@ -285,6 +296,13 @@ void main() {
       );
       await controller.voiceController?.cancel();
       await tester.pump();
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
+            .controller
+            ?.text,
+        'Keep this typed draft',
+      );
     },
   );
 

--- a/mobile/test/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/preparation/practice_workspace_controller_test.dart
@@ -153,6 +153,52 @@ void main() {
   );
 
   test(
+    'practice does not consume a pending Home draft Thread recovery',
+    () async {
+      final client = _FailingFocusAgentClient();
+      final harness = await _createHarness(client: client);
+      final workspace = PracticeWorkspaceController(
+        agentController: harness.agent,
+        recordStore: _InspectableRecordStore(),
+      );
+      addTearDown(() {
+        workspace.dispose();
+        harness.agent.dispose();
+      });
+      await workspace.activateAccount('account-1');
+      await harness.agent.clearFocusedThread();
+      client.focusFailuresRemaining = 1;
+
+      expect(await harness.agent.sendText('Keep this Home draft'), isFalse);
+      expect(harness.agent.threadId, isNull);
+      expect(harness.agent.hasPendingThreadCreationRecovery, isTrue);
+      final createCallsAfterDraft = client.createCalls;
+
+      expect(
+        await workspace.acquireThread('practice-must-be-independent'),
+        isNull,
+      );
+
+      expect(workspace.errorMessage, contains('先回到首页完成恢复'));
+      expect(client.createCalls, createCallsAfterDraft);
+      expect(harness.agent.threadId, isNull);
+
+      await harness.agent.retryThreadHistory();
+      final recoveredHomeThreadId = harness.agent.threadId;
+      expect(recoveredHomeThreadId, isNotNull);
+
+      final lease = await workspace.acquireThread(
+        'practice-must-be-independent',
+      );
+
+      expect(lease, isNotNull);
+      expect(lease?.returnThreadId, recoveredHomeThreadId);
+      expect(lease?.practiceThreadId, isNot(recoveredHomeThreadId));
+      expect(client.createCalls, createCallsAfterDraft + 1);
+    },
+  );
+
+  test(
     'activation adopts a legacy active Practice and makes it resumable',
     () async {
       final store = _InspectableRecordStore();
@@ -846,6 +892,8 @@ final class _FailingFocusAgentClient
 
   String? failSetFocusedThreadId;
   bool failClearFocusedThread = false;
+  int focusFailuresRemaining = 0;
+  int createCalls = 0;
 
   @override
   Future<void> clearAccountState() => _delegate.clearAccountState();
@@ -862,10 +910,19 @@ final class _FailingFocusAgentClient
       _delegate.getFocusedThread();
 
   @override
-  Future<AgentThreadSummary> createThread() => _delegate.createThread();
+  Future<AgentThreadSummary> createThread() {
+    createCalls++;
+    return _delegate.createThread();
+  }
 
   @override
   Future<AgentThreadSnapshot> setFocusedThread({required String threadId}) {
+    if (focusFailuresRemaining > 0) {
+      focusFailuresRemaining--;
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.unavailable,
+      );
+    }
     if (threadId == failSetFocusedThreadId) {
       throw const AgentClientException(
         kind: AgentClientFailureKind.unavailable,

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -185,84 +187,255 @@ void main() {
     );
   });
 
+  testWidgets('no focused Thread presents a writable new conversation draft', (
+    tester,
+  ) async {
+    var createCalls = 0;
+    var openCalls = 0;
+    final submitted = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ConversationPage(
+          hasFocusedThread: false,
+          onCreateConversation: () => createCalls++,
+          onOpenMenu: () => openCalls++,
+          onSubmitText: (value) async {
+            submitted.add(value);
+            return true;
+          },
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('no-focused-conversation-home')), findsNothing);
+    expect(find.text('你好，今天想练什么？'), findsOneWidget);
+    final composer = find.byKey(const Key('agent-composer-field'));
+    expect(tester.widget<TextField>(composer).enabled, isTrue);
+
+    await tester.enterText(composer, 'Start immediately');
+    await tester.pump();
+    final sendButton = find.byKey(const Key('agent-send-button'));
+    expect(tester.widget<IconButton>(sendButton).onPressed, isNotNull);
+    await tester.tap(sendButton);
+    await tester.pump();
+
+    expect(submitted, <String>['Start immediately']);
+    expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
+
+    await tester.tap(find.byKey(const Key('conversation-create-button')));
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+
+    expect(createCalls, 1);
+    expect(openCalls, 1);
+  });
+
+  testWidgets('home surfaces a definite lazy Thread creation failure', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: _DefiniteCreateFailureAgentClient(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
+    await tester.pumpAndSettle();
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    await tester.enterText(composer, 'Show the failure');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('agent-send-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('暂时无法创建新对话，请稍后再试。'), findsOneWidget);
+    expect(
+      tester.widget<TextField>(composer).controller?.text,
+      'Show the failure',
+    );
+  });
+
   testWidgets(
-    'no focused Thread shows CTAs and disables text and voice input',
+    'materializing a draft Thread preserves text when the first send fails',
     (tester) async {
-      var createCalls = 0;
-      var openCalls = 0;
-      var voiceCalls = 0;
-      var submitCalls = 0;
+      String? threadId;
+      late StateSetter update;
       await tester.pumpWidget(
         MaterialApp(
-          home: ConversationPage(
-            hasFocusedThread: false,
-            onCreateConversation: () => createCalls++,
-            onOpenMenu: () => openCalls++,
-            onVoicePlaceholder: () => voiceCalls++,
-            onSubmitText: (_) async {
-              submitCalls++;
-              return true;
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              update = setState;
+              return ConversationPage(
+                threadId: threadId,
+                hasFocusedThread: threadId != null,
+                onCreateConversation: () {},
+                onSubmitText: (_) async {
+                  update(() => threadId = 'created-from-draft');
+                  return false;
+                },
+              );
             },
           ),
         ),
       );
 
-      expect(
-        find.byKey(const Key('no-focused-conversation-home')),
-        findsOneWidget,
-      );
-      expect(
-        tester
-            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
-            .enabled,
-        isFalse,
-      );
-      expect(
-        tester
-            .widget<IconButton>(find.byKey(const Key('agent-send-button')))
-            .onPressed,
-        isNull,
-      );
-      expect(
-        tester
-            .widget<IconButton>(
-              find.descendant(
-                of: find.byKey(const Key('agent-mic-placeholder')),
-                matching: find.byType(IconButton),
-              ),
-            )
-            .onPressed,
-        isNull,
-      );
+      final composer = find.byKey(const Key('agent-composer-field'));
+      await tester.enterText(composer, 'Keep this draft');
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('agent-send-button')));
+      await tester.pump();
 
-      await tester.tap(find.byKey(const Key('no-focused-create-conversation')));
-      await tester.tap(find.byKey(const Key('no-focused-open-conversations')));
-
-      expect(createCalls, 1);
-      expect(openCalls, 1);
-      expect(voiceCalls, 0);
-      expect(submitCalls, 0);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: ConversationPage(
-            hasFocusedThread: false,
-            isBusy: true,
-            onCreateConversation: () => createCalls++,
-            onOpenMenu: () => openCalls++,
-          ),
-        ),
-      );
+      expect(threadId, 'created-from-draft');
       expect(
-        tester
-            .widget<FilledButton>(
-              find.byKey(const Key('no-focused-create-conversation')),
-            )
-            .onPressed,
-        isNull,
+        tester.widget<TextField>(composer).controller?.text,
+        'Keep this draft',
       );
     },
   );
+
+  testWidgets('inline recovery moves the draft into the recovered Thread', (
+    tester,
+  ) async {
+    String? threadId;
+    var recoveryGeneration = 0;
+    late StateSetter update;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return ConversationPage(
+              threadId: threadId,
+              draftThreadRecoveryGeneration: recoveryGeneration,
+              hasFocusedThread: threadId != null,
+              onCreateConversation: () {},
+              onSubmitText: (_) async => false,
+            );
+          },
+        ),
+      ),
+    );
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    await tester.enterText(composer, 'Recover this draft');
+    update(() {
+      threadId = 'recovered-thread';
+      recoveryGeneration++;
+    });
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(composer).controller?.text,
+      'Recover this draft',
+    );
+  });
+
+  testWidgets('opening existing history does not inherit an empty-page draft', (
+    tester,
+  ) async {
+    String? threadId;
+    late StateSetter update;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return ConversationPage(
+              threadId: threadId,
+              hasFocusedThread: threadId != null,
+              onCreateConversation: () {},
+              onSubmitText: (_) async => false,
+            );
+          },
+        ),
+      ),
+    );
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    await tester.enterText(composer, 'Private empty-page draft');
+    update(() => threadId = 'existing-history-thread');
+    await tester.pump();
+
+    expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
+  });
+
+  testWidgets('switching between existing Threads clears the private draft', (
+    tester,
+  ) async {
+    var threadId = 'thread-a';
+    late StateSetter update;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return ConversationPage(
+              threadId: threadId,
+              onSubmitText: (_) async => false,
+            );
+          },
+        ),
+      ),
+    );
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    await tester.enterText(composer, 'Thread A private draft');
+    update(() => threadId = 'thread-b');
+    await tester.pump();
+
+    expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
+  });
+
+  testWidgets('repeated keyboard submissions share one in-flight send', (
+    tester,
+  ) async {
+    final sendResult = Completer<bool>();
+    var submitCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ConversationPage(
+          threadId: 'thread-a',
+          onSubmitText: (_) {
+            submitCalls++;
+            return sendResult.future;
+          },
+        ),
+      ),
+    );
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    await tester.enterText(composer, 'Send once');
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+
+    expect(submitCalls, 1);
+
+    sendResult.complete(false);
+    await tester.pump();
+    expect(tester.widget<TextField>(composer).controller?.text, 'Send once');
+  });
+
+  testWidgets('a busy empty draft keeps submission disabled', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ConversationPage(
+          hasFocusedThread: false,
+          isBusy: true,
+          onCreateConversation: () {},
+          onSubmitText: (_) async => true,
+        ),
+      ),
+    );
+
+    final composer = find.byKey(const Key('agent-composer-field'));
+    expect(tester.widget<TextField>(composer).enabled, isFalse);
+    expect(
+      tester
+          .widget<IconButton>(find.byKey(const Key('agent-send-button')))
+          .onPressed,
+      isNull,
+    );
+  });
 
   testWidgets('older Message pagination is visible and accessible', (
     tester,
@@ -761,4 +934,112 @@ Future<void> _tapVisible(WidgetTester tester, String key) async {
   await tester.pumpAndSettle();
   await tester.tap(finder);
   await tester.pumpAndSettle();
+}
+
+final class _DefiniteCreateFailureAgentClient
+    implements AgentClient, AgentThreadHistoryClient {
+  final FakeAgentClient _delegate = FakeAgentClient();
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<AgentThreadSnapshot> restoreThread() => _delegate.restoreThread();
+
+  @override
+  Future<AgentThreadPage> listThreads({
+    int pageSize = 20,
+    String? cursor,
+  }) async {
+    final page = await _delegate.listThreads(
+      pageSize: pageSize,
+      cursor: cursor,
+    );
+    return AgentThreadPage(threads: page.threads, nextCursor: page.nextCursor);
+  }
+
+  @override
+  Future<AgentThreadSnapshot?> getFocusedThread() async => null;
+
+  @override
+  Future<AgentThreadSummary> createThread() {
+    throw StateError('Definite Thread creation failure.');
+  }
+
+  @override
+  Future<AgentThreadSnapshot> setFocusedThread({required String threadId}) =>
+      _delegate.setFocusedThread(threadId: threadId);
+
+  @override
+  Future<void> clearFocusedThread() => _delegate.clearFocusedThread();
+
+  @override
+  Future<AgentMessagePage> listMessages({
+    required String threadId,
+    int pageSize = 50,
+    String? cursor,
+  }) => _delegate.listMessages(
+    threadId: threadId,
+    pageSize: pageSize,
+    cursor: cursor,
+  );
+
+  @override
+  Future<AgentSceneStart> startScene({
+    required String threadId,
+    required AgentScene scene,
+    required String clientOperationId,
+  }) => _delegate.startScene(
+    threadId: threadId,
+    scene: scene,
+    clientOperationId: clientOperationId,
+  );
+
+  @override
+  Future<AgentExchange> sendText({
+    required String threadId,
+    required String text,
+    required String clientMessageId,
+  }) => _delegate.sendText(
+    threadId: threadId,
+    text: text,
+    clientMessageId: clientMessageId,
+  );
+
+  @override
+  Future<String> transcribeTurn({
+    required String threadId,
+    required int turnNumber,
+    required String clientTurnId,
+  }) => _delegate.transcribeTurn(
+    threadId: threadId,
+    turnNumber: turnNumber,
+    clientTurnId: clientTurnId,
+  );
+
+  @override
+  Future<AgentExchange> submitPracticeTurn({
+    required String threadId,
+    required AgentScene scene,
+    required int turnNumber,
+    required String transcript,
+    required String clientTurnId,
+  }) => _delegate.submitPracticeTurn(
+    threadId: threadId,
+    scene: scene,
+    turnNumber: turnNumber,
+    transcript: transcript,
+    clientTurnId: clientTurnId,
+  );
+
+  @override
+  Future<AgentReview> createReview({
+    required String threadId,
+    required AgentScene scene,
+    required String clientReviewId,
+  }) => _delegate.createReview(
+    threadId: threadId,
+    scene: scene,
+    clientReviewId: clientReviewId,
+  );
 }


### PR DESCRIPTION
## 功能描述
首页优先恢复已有聚焦对话；没有安全可恢复对话时直接展示可输入的空白对话，首条文字或语音再创建 Thread，不要求用户先点击“新建”。

## 实现思路
- 保留历史抽屉和新建按钮作为次级入口。
- 首次发送懒创建 Thread，并在失败时保留草稿。
- 会话切换继续隔离草稿。
- 训练空间始终创建独立 Thread，不复用首页待恢复会话。

## 验证方式
1. `cd mobile && flutter analyze`
2. `cd mobile && flutter test`
3. `cd mobile && flutter build ios --simulator --debug`
4. 无聚焦 Thread 时直接输入并发送；退出后恢复最近会话；训练仍使用独立会话。

## 依赖
依赖 PR #217，前置合入后转 Ready。

Closes #210