### PR TITLE
feat(practice): streamline launch and mobile answers

### DIFF
--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -1562,6 +1562,35 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     });
   }
 
+  Future<void> finishRecordingGesture() async {
+    if (_recordingState == PracticeRecordingState.starting) {
+      await _recorderStartFuture;
+    }
+    if (_recordingState == PracticeRecordingState.recording) {
+      await stopRecording();
+    }
+  }
+
+  Future<void> cancelRecording() async {
+    if (_recordingState != PracticeRecordingState.starting &&
+        _recordingState != PracticeRecordingState.recording) {
+      return;
+    }
+    _practiceGeneration++;
+    _cancelRecordingLimit();
+    await _recorderStartFuture;
+    if (_disposed) {
+      return;
+    }
+    await recorder.discardCurrent();
+    _candidate = null;
+    _activeConfirmationId = null;
+    _activeTextAnswer = null;
+    _recordingState = PracticeRecordingState.idle;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
   Future<void> _stopRecording({
     required PracticeClient practice,
     required String sessionId,

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
-import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/practice/practice_recordings.dart';
 
@@ -37,11 +36,16 @@ class _PracticePageState extends State<PracticePage> {
   String? _expandedHintQuestionId;
   bool _exitInFlight = false;
   bool _exitApproved = false;
+  bool _textAnswerMode = false;
+  Timer? _recordingTicker;
+  DateTime? _recordingStartedAt;
+  int _recordingSeconds = 0;
 
   @override
   void initState() {
     super.initState();
     widget.agentController?.addListener(_handleState);
+    _syncRecordingTimer();
     _scheduleReviewExitIfNeeded();
   }
 
@@ -61,6 +65,7 @@ class _PracticePageState extends State<PracticePage> {
   void dispose() {
     widget.agentController?.removeListener(_handleState);
     _clearReviewRouteWait();
+    _recordingTicker?.cancel();
     _textAnswerController.dispose();
     unawaited(widget.agentController?.stopPracticeAudio(notify: false));
     super.dispose();
@@ -70,12 +75,44 @@ class _PracticePageState extends State<PracticePage> {
     if (!mounted) {
       return;
     }
+    _syncRecordingTimer();
     setState(() {});
     if (widget.agentController?.review == null) {
       _resetReviewExit();
       return;
     }
     _scheduleReviewExitIfNeeded();
+  }
+
+  void _syncRecordingTimer() {
+    final recording =
+        widget.agentController?.recordingState ==
+        PracticeRecordingState.recording;
+    if (recording) {
+      if (_recordingTicker != null) {
+        return;
+      }
+      _recordingStartedAt = DateTime.now();
+      _recordingSeconds = 0;
+      _recordingTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+        if (!mounted || _recordingStartedAt == null) {
+          return;
+        }
+        setState(() {
+          _recordingSeconds = DateTime.now()
+              .difference(_recordingStartedAt!)
+              .inSeconds;
+        });
+      });
+      return;
+    }
+    _recordingTicker?.cancel();
+    _recordingTicker = null;
+    _recordingStartedAt = null;
+    _recordingSeconds = 0;
+    if (widget.agentController?.recordingState != PracticeRecordingState.idle) {
+      _textAnswerMode = false;
+    }
   }
 
   void _scheduleReviewExitIfNeeded() {
@@ -211,7 +248,44 @@ class _PracticePageState extends State<PracticePage> {
     );
     if (submitted && mounted) {
       _textAnswerController.clear();
+      setState(() => _textAnswerMode = false);
     }
+  }
+
+  void _showPracticeHistory(AgentController controller) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.72,
+        minChildSize: 0.4,
+        maxChildSize: 0.92,
+        builder: (context, scrollController) => ListView(
+          controller: scrollController,
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 32),
+          children: [
+            const Text('本轮记录', style: SpeakUpDesign.sectionTitle),
+            if (controller.recordings.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              PracticeRecordingsCard(controller: controller),
+            ],
+            if (controller.messages.any(
+              (message) => message.id != controller.questionId,
+            )) ...[
+              const SizedBox(height: 20),
+              _ConversationHistory(
+                messages: controller.messages
+                    .where((message) => message.id != controller.questionId)
+                    .toList(growable: false),
+                expandedHintQuestionId: null,
+                onToggleHint: (_) {},
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
   }
 
   Future<void> _requestExit() async {
@@ -264,80 +338,110 @@ class _PracticePageState extends State<PracticePage> {
       },
       child: Scaffold(
         key: const Key('practice-page'),
-        appBar: AppBar(title: const Text('练习')),
+        appBar: AppBar(
+          title: scene == null || controller == null
+              ? const Text('练习')
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(scene.title),
+                    Text(
+                      '第 ${(controller.completedTurns + 1).clamp(1, controller.turnLimit)} 题，共 ${controller.turnLimit} 题',
+                      style: SpeakUpDesign.meta,
+                    ),
+                  ],
+                ),
+          actions:
+              controller == null ||
+                  (controller.recordings.isEmpty &&
+                      !controller.messages.any(
+                        (message) => message.id != controller.questionId,
+                      ))
+              ? null
+              : [
+                  IconButton(
+                    key: const Key('practice-open-history'),
+                    tooltip: '本轮记录',
+                    onPressed:
+                        controller.recordingState == PracticeRecordingState.idle
+                        ? () => _showPracticeHistory(controller)
+                        : null,
+                    icon: const Icon(Icons.more_horiz_rounded),
+                  ),
+                ],
+        ),
         body: SafeArea(
+          bottom: false,
           child: controller == null || scene == null
               ? const _NoScene()
-              : ListView(
-                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+              : Column(
                   children: [
-                    SpeakUpPageHeader(
-                      title: scene.title,
-                      subtitle: '完成 ${controller.turnLimit} 轮有效回答后生成复盘。',
-                    ),
-                    const SizedBox(height: SpeakUpDesign.space24),
-                    _TurnProgress(
-                      completedTurns: controller.completedTurns,
-                      turnLimit: controller.turnLimit,
-                    ),
-                    const SizedBox(height: 22),
-                    _CurrentQuestion(
-                      controller: controller,
-                      expandedHintQuestionId: _expandedHintQuestionId,
-                      onToggleHint: _toggleHint,
-                    ),
-                    if (controller.errorMessage case final message?) ...[
-                      const SizedBox(height: 14),
-                      Text(
-                        message,
-                        key: const Key('practice-error-message'),
-                        style: const TextStyle(color: SpeakUpDesign.error),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+                      child: _TurnProgress(
+                        completedTurns: controller.completedTurns,
+                        turnLimit: controller.turnLimit,
                       ),
-                    ],
-                    if (controller.mediaErrorMessage case final message?) ...[
-                      const SizedBox(height: 14),
-                      Text(
-                        message,
-                        key: const Key('practice-media-error-message'),
-                        style: const TextStyle(color: SpeakUpDesign.error),
-                      ),
-                    ],
-                    const SizedBox(height: 18),
-                    _RecordingPanel(
-                      controller: controller,
-                      textController: _textAnswerController,
-                      onSubmitText: _submitTextAnswer,
                     ),
-                    if (controller.recordings.isNotEmpty) ...[
-                      const SizedBox(height: 18),
-                      PracticeRecordingsCard(controller: controller),
-                    ],
-                    if (controller.messages.any(
-                      (message) => message.id != controller.questionId,
-                    )) ...[
-                      const SizedBox(height: 22),
-                      const Text('本次对话记录', style: SpeakUpDesign.sectionTitle),
-                      const SizedBox(height: 12),
-                      _ConversationHistory(
-                        messages: controller.messages
-                            .where(
-                              (message) => message.id != controller.questionId,
-                            )
-                            .toList(growable: false),
-                        expandedHintQuestionId: _expandedHintQuestionId,
-                        onToggleHint: _toggleHint,
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.fromLTRB(20, 28, 20, 32),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _CurrentQuestion(
+                              controller: controller,
+                              expandedHintQuestionId: _expandedHintQuestionId,
+                              onToggleHint: _toggleHint,
+                            ),
+                            if (controller.errorMessage
+                                case final message?) ...[
+                              const SizedBox(height: 16),
+                              Text(
+                                message,
+                                key: const Key('practice-error-message'),
+                                style: const TextStyle(
+                                  color: SpeakUpDesign.error,
+                                ),
+                              ),
+                            ],
+                            if (controller.mediaErrorMessage
+                                case final message?) ...[
+                              const SizedBox(height: 16),
+                              Text(
+                                message,
+                                key: const Key('practice-media-error-message'),
+                                style: const TextStyle(
+                                  color: SpeakUpDesign.error,
+                                ),
+                              ),
+                            ],
+                            if (widget.previewMode) ...[
+                              const SizedBox(height: 20),
+                              const Text(
+                                '当前页面仅供显式 Fake 预览，不代表生产语音服务已经接入。',
+                                textAlign: TextAlign.center,
+                                style: SpeakUpDesign.meta,
+                              ),
+                            ],
+                          ],
+                        ),
                       ),
-                    ],
-                    const SizedBox(height: 18),
-                    if (widget.previewMode)
-                      const Text(
-                        '当前页面仅供显式 Fake 预览，不代表生产语音服务已经接入。',
-                        textAlign: TextAlign.center,
-                        style: SpeakUpDesign.meta,
-                      ),
+                    ),
                   ],
                 ),
         ),
+        bottomNavigationBar: controller == null || scene == null
+            ? null
+            : _RecordingPanel(
+                controller: controller,
+                textController: _textAnswerController,
+                onSubmitText: _submitTextAnswer,
+                textMode: _textAnswerMode,
+                onToggleTextMode: () =>
+                    setState(() => _textAnswerMode = !_textAnswerMode),
+                recordingSeconds: _recordingSeconds,
+              ),
       ),
     );
   }
@@ -482,63 +586,76 @@ class _CurrentQuestion extends StatelessWidget {
         .firstOrNull;
     final hintExpanded =
         question != null && expandedHintQuestionId == question.id;
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Row(
           children: [
-            Row(
+            CircleAvatar(
+              radius: 22,
+              backgroundColor: SpeakUpDesign.primaryMuted,
+              foregroundColor: SpeakUpDesign.primary,
+              child: Icon(Icons.person_outline_rounded),
+            ),
+            SizedBox(width: 12),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Expanded(child: Text('当前问题', style: SpeakUpDesign.label)),
-                if (question != null)
-                  TextButton.icon(
-                    key: Key('practice-hint-${question.id}'),
-                    onPressed: () => onToggleHint(question.id),
-                    icon: Icon(
-                      hintExpanded
-                          ? Icons.lightbulb_rounded
-                          : Icons.lightbulb_outline_rounded,
-                      size: 19,
-                    ),
-                    label: Text(hintExpanded ? '收起提示' : '提示'),
-                  ),
-                if (controller.canPlayQuestionAudio)
-                  IconButton(
-                    key: const Key('practice-question-audio'),
-                    tooltip: controller.isQuestionAudioPlaying
-                        ? '停止播放'
-                        : '朗读问题',
-                    visualDensity: VisualDensity.compact,
-                    onPressed: controller.canUsePracticeAudio
-                        ? controller.toggleQuestionAudio
-                        : null,
-                    icon: controller.isQuestionAudioLoading
-                        ? const SizedBox.square(
-                            dimension: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(
-                            controller.isQuestionAudioPlaying
-                                ? Icons.stop_circle_outlined
-                                : Icons.volume_up_outlined,
-                          ),
-                  ),
+                Text('AI 面试官', style: SpeakUpDesign.cardTitle),
+                SizedBox(height: 2),
+                Text('请用英文回答', style: SpeakUpDesign.meta),
               ],
             ),
-            const SizedBox(height: 8),
-            Text(
-              question?.text ?? '准备好后开始第一轮。',
-              key: const Key('practice-current-question'),
-              style: SpeakUpDesign.cardTitle,
-            ),
-            if (hintExpanded) ...[
-              const SizedBox(height: 16),
-              const _AnswerHint(),
-            ],
           ],
         ),
-      ),
+        const SizedBox(height: 24),
+        Text(
+          question?.text ?? '准备好后开始第一轮。',
+          key: const Key('practice-current-question'),
+          style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24, height: 1.4),
+        ),
+        const SizedBox(height: 18),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            if (controller.canPlayQuestionAudio)
+              TextButton.icon(
+                key: const Key('practice-question-audio'),
+                onPressed: controller.canUsePracticeAudio
+                    ? controller.toggleQuestionAudio
+                    : null,
+                icon: controller.isQuestionAudioLoading
+                    ? const SizedBox.square(
+                        dimension: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(
+                        controller.isQuestionAudioPlaying
+                            ? Icons.stop_circle_outlined
+                            : Icons.volume_up_outlined,
+                        size: 19,
+                      ),
+                label: Text(
+                  controller.isQuestionAudioPlaying ? '停止播放' : '重听问题',
+                ),
+              ),
+            if (question != null)
+              TextButton.icon(
+                key: Key('practice-hint-${question.id}'),
+                onPressed: () => onToggleHint(question.id),
+                icon: Icon(
+                  hintExpanded
+                      ? Icons.lightbulb_rounded
+                      : Icons.lightbulb_outline_rounded,
+                  size: 19,
+                ),
+                label: Text(hintExpanded ? '收起思路' : '回答思路'),
+              ),
+          ],
+        ),
+        if (hintExpanded) ...[const SizedBox(height: 14), const _AnswerHint()],
+      ],
     );
   }
 }
@@ -561,14 +678,13 @@ class _AnswerHint extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('参考回答', style: TextStyle(fontWeight: FontWeight.w800)),
-            SizedBox(height: 6),
-            Text(
-              'From my perspective, the core responsibility of this role is '
-              'to understand the goal, work closely with the team, and '
-              'deliver reliable results.',
-              style: SpeakUpDesign.body,
-            ),
+            Text('回答框架', style: SpeakUpDesign.cardTitle),
+            SizedBox(height: 10),
+            Text('1. 先直接回答你的核心观点', style: SpeakUpDesign.body),
+            SizedBox(height: 4),
+            Text('2. 用一个具体经历或事实支持', style: SpeakUpDesign.body),
+            SizedBox(height: 4),
+            Text('3. 回到岗位匹配与结果', style: SpeakUpDesign.body),
           ],
         ),
       ),
@@ -581,47 +697,58 @@ class _RecordingPanel extends StatelessWidget {
     required this.controller,
     required this.textController,
     required this.onSubmitText,
+    required this.textMode,
+    required this.onToggleTextMode,
+    required this.recordingSeconds,
   });
 
   final AgentController controller;
   final TextEditingController textController;
   final VoidCallback onSubmitText;
+  final bool textMode;
+  final VoidCallback onToggleTextMode;
+  final int recordingSeconds;
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: switch (controller.recordingState) {
-          PracticeRecordingState.idle => _IdleAnswerPanel(
-            textController: textController,
-            onSubmitText: onSubmitText,
-            onStartRecording: controller.startRecording,
-          ),
-          PracticeRecordingState.starting => const _WorkingState(
-            label: '正在请求麦克风权限',
-          ),
-          PracticeRecordingState.recording => _RecordAction(
-            label: '停止并转写',
-            icon: Icons.stop_rounded,
-            onPressed: controller.stopRecording,
-            emphasized: true,
-          ),
-          PracticeRecordingState.transcribing => const _WorkingState(
-            label: '正在转写这一轮',
-          ),
-          PracticeRecordingState.awaitingConfirmation =>
-            _TranscriptConfirmation(controller: controller),
-          PracticeRecordingState.submitting => const _WorkingState(
-            label: '正在提交并生成下一步',
-          ),
-          PracticeRecordingState.reviewFailed => _ReviewRetry(
-            onPressed: controller.retryReview,
-          ),
-          PracticeRecordingState.completed => const _WorkingState(
-            label: '复盘已生成，正在打开',
-          ),
-        },
+    return Material(
+      color: SpeakUpDesign.surface,
+      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
+          child: switch (controller.recordingState) {
+            PracticeRecordingState.idle => _IdleAnswerPanel(
+              textController: textController,
+              onSubmitText: onSubmitText,
+              onStartRecording: controller.startRecording,
+              textMode: textMode,
+              onToggleTextMode: onToggleTextMode,
+            ),
+            PracticeRecordingState.starting => const _WorkingState(
+              label: '正在准备麦克风…',
+            ),
+            PracticeRecordingState.recording => _RecordAction(
+              onPressed: controller.stopRecording,
+              recordingSeconds: recordingSeconds,
+            ),
+            PracticeRecordingState.transcribing => const _WorkingState(
+              label: '正在整理你的回答…',
+            ),
+            PracticeRecordingState.awaitingConfirmation =>
+              _TranscriptConfirmation(controller: controller),
+            PracticeRecordingState.submitting => const _WorkingState(
+              label: '回答已提交，正在准备下一题…',
+            ),
+            PracticeRecordingState.reviewFailed => _ReviewRetry(
+              onPressed: controller.retryReview,
+            ),
+            PracticeRecordingState.completed => const _WorkingState(
+              label: '复盘已生成，正在打开',
+            ),
+          },
+        ),
       ),
     );
   }
@@ -632,41 +759,57 @@ class _IdleAnswerPanel extends StatelessWidget {
     required this.textController,
     required this.onSubmitText,
     required this.onStartRecording,
+    required this.textMode,
+    required this.onToggleTextMode,
   });
 
   final TextEditingController textController;
   final VoidCallback onSubmitText;
   final VoidCallback onStartRecording;
+  final bool textMode;
+  final VoidCallback onToggleTextMode;
 
   @override
   Widget build(BuildContext context) {
+    if (!textMode) {
+      return Row(
+        children: [
+          Expanded(
+            child: FilledButton.icon(
+              key: const Key('practice-record'),
+              onPressed: onStartRecording,
+              icon: const Icon(Icons.mic_rounded),
+              label: const Text('开始回答'),
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(56),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          IconButton.outlined(
+            key: const Key('practice-open-keyboard'),
+            tooltip: '键盘回答',
+            onPressed: onToggleTextMode,
+            icon: const Icon(Icons.keyboard_alt_outlined),
+            style: IconButton.styleFrom(minimumSize: const Size.square(56)),
+          ),
+        ],
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        OutlinedButton.icon(
-          key: const Key('practice-record'),
-          onPressed: onStartRecording,
-          icon: const Icon(Icons.mic_none_rounded),
-          label: const Text('使用语音回答'),
-          style: OutlinedButton.styleFrom(
-            minimumSize: const Size.fromHeight(48),
-          ),
+        Row(
+          children: [
+            const Expanded(child: Text('键盘回答', style: SpeakUpDesign.cardTitle)),
+            IconButton(
+              tooltip: '返回语音回答',
+              onPressed: onToggleTextMode,
+              icon: const Icon(Icons.close_rounded),
+            ),
+          ],
         ),
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 12),
-          child: Row(
-            children: [
-              Expanded(child: Divider()),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Text('或输入文字', style: SpeakUpDesign.meta),
-              ),
-              Expanded(child: Divider()),
-            ],
-          ),
-        ),
-        const Text('用英文回答', style: SpeakUpDesign.cardTitle),
-        const SizedBox(height: 10),
+        const SizedBox(height: 8),
         TextField(
           key: const Key('practice-text-answer'),
           controller: textController,
@@ -720,32 +863,48 @@ class _ReviewRetry extends StatelessWidget {
 
 class _RecordAction extends StatelessWidget {
   const _RecordAction({
-    required this.label,
-    required this.icon,
     required this.onPressed,
-    this.emphasized = false,
+    required this.recordingSeconds,
   });
 
-  final String label;
-  final IconData icon;
   final VoidCallback onPressed;
-  final bool emphasized;
+  final int recordingSeconds;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    final minutes = (recordingSeconds ~/ 60).toString().padLeft(2, '0');
+    final seconds = (recordingSeconds % 60).toString().padLeft(2, '0');
+    return Row(
       children: [
-        Icon(
-          icon,
-          size: 42,
-          color: emphasized ? SpeakUpDesign.error : SpeakUpDesign.primary,
+        const SizedBox(
+          width: 12,
+          height: 28,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: SpeakUpDesign.error,
+              shape: BoxShape.circle,
+            ),
+          ),
         ),
-        const SizedBox(height: 14),
-        FilledButton(
-          key: Key(emphasized ? 'practice-stop-recording' : 'practice-record'),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('正在听你说', style: SpeakUpDesign.cardTitle),
+              Text('$minutes:$seconds', style: SpeakUpDesign.meta),
+            ],
+          ),
+        ),
+        FilledButton.icon(
+          key: const Key('practice-stop-recording'),
           onPressed: onPressed,
-          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
-          child: Text(label),
+          icon: const Icon(Icons.stop_rounded),
+          label: const Text('完成回答'),
+          style: FilledButton.styleFrom(
+            backgroundColor: SpeakUpDesign.error,
+            minimumSize: const Size(0, 52),
+          ),
         ),
       ],
     );
@@ -762,7 +921,7 @@ class _TranscriptConfirmation extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('确认转写', style: TextStyle(fontWeight: FontWeight.w700)),
+        const Text('检查一下识别结果', style: SpeakUpDesign.cardTitle),
         const SizedBox(height: 10),
         Text(
           controller.transcript ?? '',
@@ -784,7 +943,7 @@ class _TranscriptConfirmation extends StatelessWidget {
               child: FilledButton(
                 key: const Key('practice-confirm-turn'),
                 onPressed: controller.confirmTranscript,
-                child: const Text('确认提交'),
+                child: const Text('提交回答'),
               ),
             ),
           ],
@@ -801,11 +960,14 @@ class _WorkingState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return Row(
       children: [
-        const CircularProgressIndicator(),
-        const SizedBox(height: 14),
-        Text(label),
+        const SizedBox.square(
+          dimension: 22,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Expanded(child: Text(label, style: SpeakUpDesign.body)),
       ],
     );
   }

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
@@ -29,6 +30,7 @@ class _PracticePageState extends State<PracticePage> {
   static const _maxReviewExitFrameAttempts = 60;
 
   final TextEditingController _textAnswerController = TextEditingController();
+  final FocusNode _textAnswerFocusNode = FocusNode();
   bool _scheduledReviewExit = false;
   int _reviewExitAttempts = 0;
   Animation<double>? _observedSecondaryAnimation;
@@ -67,6 +69,7 @@ class _PracticePageState extends State<PracticePage> {
     _clearReviewRouteWait();
     _recordingTicker?.cancel();
     _textAnswerController.dispose();
+    _textAnswerFocusNode.dispose();
     unawaited(widget.agentController?.stopPracticeAudio(notify: false));
     super.dispose();
   }
@@ -248,8 +251,23 @@ class _PracticePageState extends State<PracticePage> {
     );
     if (submitted && mounted) {
       _textAnswerController.clear();
+      _textAnswerFocusNode.unfocus();
       setState(() => _textAnswerMode = false);
     }
+  }
+
+  void _toggleTextAnswerMode() {
+    final textMode = !_textAnswerMode;
+    setState(() => _textAnswerMode = textMode);
+    if (!textMode) {
+      _textAnswerFocusNode.unfocus();
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _textAnswerFocusNode.requestFocus();
+      }
+    });
   }
 
   void _showPracticeHistory(AgentController controller) {
@@ -436,10 +454,10 @@ class _PracticePageState extends State<PracticePage> {
             : _RecordingPanel(
                 controller: controller,
                 textController: _textAnswerController,
+                textFocusNode: _textAnswerFocusNode,
                 onSubmitText: _submitTextAnswer,
                 textMode: _textAnswerMode,
-                onToggleTextMode: () =>
-                    setState(() => _textAnswerMode = !_textAnswerMode),
+                onToggleTextMode: _toggleTextAnswerMode,
                 recordingSeconds: _recordingSeconds,
               ),
       ),
@@ -692,10 +710,11 @@ class _AnswerHint extends StatelessWidget {
   }
 }
 
-class _RecordingPanel extends StatelessWidget {
+class _RecordingPanel extends StatefulWidget {
   const _RecordingPanel({
     required this.controller,
     required this.textController,
+    required this.textFocusNode,
     required this.onSubmitText,
     required this.textMode,
     required this.onToggleTextMode,
@@ -704,13 +723,149 @@ class _RecordingPanel extends StatelessWidget {
 
   final AgentController controller;
   final TextEditingController textController;
+  final FocusNode textFocusNode;
   final VoidCallback onSubmitText;
   final bool textMode;
   final VoidCallback onToggleTextMode;
   final int recordingSeconds;
 
   @override
+  State<_RecordingPanel> createState() => _RecordingPanelState();
+}
+
+class _RecordingPanelState extends State<_RecordingPanel> {
+  static const _holdDelay = Duration(milliseconds: 180);
+  static const _cancelDistance = 72.0;
+
+  Timer? _holdTimer;
+  Offset? _pointerOrigin;
+  bool _pointerActive = false;
+  bool _recordingGestureStarted = false;
+  bool _cancelArmed = false;
+  double _voiceHitWidth = double.infinity;
+
+  @override
+  void dispose() {
+    _holdTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (_pointerActive ||
+        widget.textMode ||
+        event.localPosition.dx > _voiceHitWidth ||
+        widget.controller.recordingState != PracticeRecordingState.idle) {
+      return;
+    }
+    _holdTimer?.cancel();
+    setState(() {
+      _pointerActive = true;
+      _recordingGestureStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = event.position;
+    });
+    _holdTimer = Timer(_holdDelay, () {
+      if (!mounted || !_pointerActive) {
+        return;
+      }
+      setState(() => _recordingGestureStarted = true);
+      unawaited(HapticFeedback.mediumImpact());
+      unawaited(widget.controller.startRecording());
+    });
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    final origin = _pointerOrigin;
+    if (!_pointerActive || origin == null) {
+      return;
+    }
+    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
+    if (cancelArmed == _cancelArmed) {
+      return;
+    }
+    setState(() => _cancelArmed = cancelArmed);
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    _finishGesture(cancel: _cancelArmed);
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _finishGesture(cancel: true);
+  }
+
+  void _finishGesture({required bool cancel}) {
+    if (!_pointerActive) {
+      return;
+    }
+    _holdTimer?.cancel();
+    final started = _recordingGestureStarted;
+    setState(() {
+      _pointerActive = false;
+      _recordingGestureStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = null;
+    });
+    if (!started) {
+      return;
+    }
+    if (cancel) {
+      unawaited(widget.controller.cancelRecording());
+    } else {
+      unawaited(widget.controller.finishRecordingGesture());
+    }
+  }
+
+  void _toggleRecordingForAccessibility() {
+    final state = widget.controller.recordingState;
+    if (state == PracticeRecordingState.idle) {
+      unawaited(widget.controller.startRecording());
+    } else if (state == PracticeRecordingState.starting ||
+        state == PracticeRecordingState.recording) {
+      unawaited(widget.controller.finishRecordingGesture());
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = widget.controller.recordingState;
+    final handlesHold =
+        !widget.textMode &&
+        (state == PracticeRecordingState.idle ||
+            state == PracticeRecordingState.starting ||
+            state == PracticeRecordingState.recording);
+    final panel = switch (state) {
+      PracticeRecordingState.idle => _IdleAnswerPanel(
+        textController: widget.textController,
+        textFocusNode: widget.textFocusNode,
+        onSubmitText: widget.onSubmitText,
+        textMode: widget.textMode,
+        onToggleTextMode: widget.onToggleTextMode,
+        pressed: _pointerActive,
+      ),
+      PracticeRecordingState.starting ||
+      PracticeRecordingState.recording => _ActiveRecordingPanel(
+        preparing: state == PracticeRecordingState.starting,
+        cancelArmed: _cancelArmed,
+        recordingSeconds: widget.recordingSeconds,
+      ),
+      PracticeRecordingState.transcribing => const _WorkingState(
+        label: '正在识别英文回答…',
+      ),
+      PracticeRecordingState.awaitingConfirmation => _TranscriptConfirmation(
+        controller: widget.controller,
+      ),
+      PracticeRecordingState.submitting => const _WorkingState(
+        label: '回答已发送，正在准备下一题…',
+      ),
+      PracticeRecordingState.reviewFailed => _ReviewRetry(
+        onPressed: widget.controller.retryReview,
+      ),
+      PracticeRecordingState.completed => const _WorkingState(
+        label: '复盘已生成，正在打开',
+      ),
+    };
     return Material(
       color: SpeakUpDesign.surface,
       shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
@@ -718,36 +873,32 @@ class _RecordingPanel extends StatelessWidget {
         top: false,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
-          child: switch (controller.recordingState) {
-            PracticeRecordingState.idle => _IdleAnswerPanel(
-              textController: textController,
-              onSubmitText: onSubmitText,
-              onStartRecording: controller.startRecording,
-              textMode: textMode,
-              onToggleTextMode: onToggleTextMode,
-            ),
-            PracticeRecordingState.starting => const _WorkingState(
-              label: '正在准备麦克风…',
-            ),
-            PracticeRecordingState.recording => _RecordAction(
-              onPressed: controller.stopRecording,
-              recordingSeconds: recordingSeconds,
-            ),
-            PracticeRecordingState.transcribing => const _WorkingState(
-              label: '正在整理你的回答…',
-            ),
-            PracticeRecordingState.awaitingConfirmation =>
-              _TranscriptConfirmation(controller: controller),
-            PracticeRecordingState.submitting => const _WorkingState(
-              label: '回答已提交，正在准备下一题…',
-            ),
-            PracticeRecordingState.reviewFailed => _ReviewRetry(
-              onPressed: controller.retryReview,
-            ),
-            PracticeRecordingState.completed => const _WorkingState(
-              label: '复盘已生成，正在打开',
-            ),
-          },
+          child: handlesHold
+              ? LayoutBuilder(
+                  builder: (context, constraints) {
+                    _voiceHitWidth =
+                        state == PracticeRecordingState.idle && !widget.textMode
+                        ? constraints.maxWidth - 66
+                        : constraints.maxWidth;
+                    return Semantics(
+                      button: true,
+                      label: state == PracticeRecordingState.idle
+                          ? '按住说话'
+                          : '正在录音，上滑取消，松开发送',
+                      onTap: _toggleRecordingForAccessibility,
+                      child: Listener(
+                        key: const Key('practice-record'),
+                        behavior: HitTestBehavior.opaque,
+                        onPointerDown: _handlePointerDown,
+                        onPointerMove: _handlePointerMove,
+                        onPointerUp: _handlePointerUp,
+                        onPointerCancel: _handlePointerCancel,
+                        child: panel,
+                      ),
+                    );
+                  },
+                )
+              : panel,
         ),
       ),
     );
@@ -757,17 +908,19 @@ class _RecordingPanel extends StatelessWidget {
 class _IdleAnswerPanel extends StatelessWidget {
   const _IdleAnswerPanel({
     required this.textController,
+    required this.textFocusNode,
     required this.onSubmitText,
-    required this.onStartRecording,
     required this.textMode,
     required this.onToggleTextMode,
+    required this.pressed,
   });
 
   final TextEditingController textController;
+  final FocusNode textFocusNode;
   final VoidCallback onSubmitText;
-  final VoidCallback onStartRecording;
   final bool textMode;
   final VoidCallback onToggleTextMode;
+  final bool pressed;
 
   @override
   Widget build(BuildContext context) {
@@ -775,13 +928,31 @@ class _IdleAnswerPanel extends StatelessWidget {
       return Row(
         children: [
           Expanded(
-            child: FilledButton.icon(
-              key: const Key('practice-record'),
-              onPressed: onStartRecording,
-              icon: const Icon(Icons.mic_rounded),
-              label: const Text('开始回答'),
-              style: FilledButton.styleFrom(
-                minimumSize: const Size.fromHeight(56),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 100),
+              height: 56,
+              decoration: BoxDecoration(
+                color: pressed
+                    ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                    : SpeakUpDesign.primary,
+                borderRadius: BorderRadius.circular(
+                  SpeakUpDesign.radiusControl,
+                ),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.mic_rounded, color: Colors.white),
+                  SizedBox(width: 10),
+                  Text(
+                    '按住说话',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -796,41 +967,117 @@ class _IdleAnswerPanel extends StatelessWidget {
         ],
       );
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return Row(
       children: [
-        Row(
-          children: [
-            const Expanded(child: Text('键盘回答', style: SpeakUpDesign.cardTitle)),
-            IconButton(
-              tooltip: '返回语音回答',
-              onPressed: onToggleTextMode,
-              icon: const Icon(Icons.close_rounded),
-            ),
-          ],
+        IconButton.outlined(
+          key: const Key('practice-return-to-voice'),
+          tooltip: '切换到语音回答',
+          onPressed: onToggleTextMode,
+          icon: const Icon(Icons.mic_none_rounded),
+          style: IconButton.styleFrom(minimumSize: const Size.square(52)),
         ),
-        const SizedBox(height: 8),
-        TextField(
-          key: const Key('practice-text-answer'),
-          controller: textController,
-          minLines: 2,
-          maxLines: 4,
-          maxLength: 8000,
-          textCapitalization: TextCapitalization.sentences,
-          decoration: const InputDecoration(
-            hintText: 'Type your answer in English…',
-            counterText: '',
+        const SizedBox(width: 10),
+        Expanded(
+          child: TextField(
+            key: const Key('practice-text-answer'),
+            controller: textController,
+            focusNode: textFocusNode,
+            minLines: 1,
+            maxLines: 3,
+            maxLength: 8000,
+            textCapitalization: TextCapitalization.sentences,
+            textInputAction: TextInputAction.newline,
+            decoration: const InputDecoration(
+              hintText: 'Type your answer…',
+              counterText: '',
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 14,
+                vertical: 13,
+              ),
+            ),
           ),
         ),
-        const SizedBox(height: 10),
-        FilledButton.icon(
+        const SizedBox(width: 10),
+        IconButton.filled(
           key: const Key('practice-submit-text'),
           onPressed: onSubmitText,
-          icon: const Icon(Icons.send_rounded),
-          label: const Text('发送文字回答'),
-          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+          tooltip: '发送文字回答',
+          icon: const Icon(Icons.arrow_upward_rounded),
+          style: IconButton.styleFrom(minimumSize: const Size.square(52)),
         ),
       ],
+    );
+  }
+}
+
+class _ActiveRecordingPanel extends StatelessWidget {
+  const _ActiveRecordingPanel({
+    required this.preparing,
+    required this.cancelArmed,
+    required this.recordingSeconds,
+  });
+
+  final bool preparing;
+  final bool cancelArmed;
+  final int recordingSeconds;
+
+  @override
+  Widget build(BuildContext context) {
+    final minutes = (recordingSeconds ~/ 60).toString().padLeft(2, '0');
+    final seconds = (recordingSeconds % 60).toString().padLeft(2, '0');
+    return AnimatedContainer(
+      key: const Key('practice-stop-recording'),
+      duration: const Duration(milliseconds: 120),
+      height: 72,
+      padding: const EdgeInsets.symmetric(horizontal: 18),
+      decoration: BoxDecoration(
+        color: cancelArmed
+            ? SpeakUpDesign.errorMuted
+            : SpeakUpDesign.primaryMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        border: Border.all(
+          color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            cancelArmed ? Icons.delete_outline_rounded : Icons.mic_rounded,
+            color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  cancelArmed
+                      ? '松开取消'
+                      : preparing
+                      ? '正在打开麦克风…'
+                      : '松开发送',
+                  style: SpeakUpDesign.cardTitle.copyWith(
+                    color: cancelArmed
+                        ? SpeakUpDesign.error
+                        : SpeakUpDesign.primary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  cancelArmed ? '录音不会保存' : '上滑取消 · $minutes:$seconds',
+                  style: SpeakUpDesign.meta,
+                ),
+              ],
+            ),
+          ),
+          if (!cancelArmed)
+            const Icon(
+              Icons.keyboard_arrow_up_rounded,
+              color: SpeakUpDesign.primary,
+            ),
+        ],
+      ),
     );
   }
 }
@@ -855,56 +1102,6 @@ class _ReviewRetry extends StatelessWidget {
           onPressed: onPressed,
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
           child: const Text('刷新复盘'),
-        ),
-      ],
-    );
-  }
-}
-
-class _RecordAction extends StatelessWidget {
-  const _RecordAction({
-    required this.onPressed,
-    required this.recordingSeconds,
-  });
-
-  final VoidCallback onPressed;
-  final int recordingSeconds;
-
-  @override
-  Widget build(BuildContext context) {
-    final minutes = (recordingSeconds ~/ 60).toString().padLeft(2, '0');
-    final seconds = (recordingSeconds % 60).toString().padLeft(2, '0');
-    return Row(
-      children: [
-        const SizedBox(
-          width: 12,
-          height: 28,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: SpeakUpDesign.error,
-              shape: BoxShape.circle,
-            ),
-          ),
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text('正在听你说', style: SpeakUpDesign.cardTitle),
-              Text('$minutes:$seconds', style: SpeakUpDesign.meta),
-            ],
-          ),
-        ),
-        FilledButton.icon(
-          key: const Key('practice-stop-recording'),
-          onPressed: onPressed,
-          icon: const Icon(Icons.stop_rounded),
-          label: const Text('完成回答'),
-          style: FilledButton.styleFrom(
-            backgroundColor: SpeakUpDesign.error,
-            minimumSize: const Size(0, 52),
-          ),
         ),
       ],
     );
@@ -943,7 +1140,7 @@ class _TranscriptConfirmation extends StatelessWidget {
               child: FilledButton(
                 key: const Key('practice-confirm-turn'),
                 onPressed: controller.confirmTranscript,
-                child: const Text('提交回答'),
+                child: const Text('发送回答'),
               ),
             ),
           ],

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -1116,23 +1116,29 @@ class _TranscriptConfirmation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('检查一下识别结果', style: SpeakUpDesign.cardTitle),
-        const SizedBox(height: 10),
-        Text(
-          controller.transcript ?? '',
-          key: const Key('practice-transcript'),
-          style: const TextStyle(height: 1.5),
+        const Text('识别结果', style: SpeakUpDesign.label),
+        const SizedBox(height: 8),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 96),
+          child: SingleChildScrollView(
+            child: Text(
+              controller.transcript ?? '',
+              key: const Key('practice-transcript'),
+              style: const TextStyle(height: 1.45),
+            ),
+          ),
         ),
-        const SizedBox(height: 18),
+        const SizedBox(height: 12),
         Row(
           children: [
             Expanded(
               child: OutlinedButton(
                 key: const Key('practice-rerecord'),
                 onPressed: controller.rerecord,
-                child: const Text('重新录音'),
+                child: const Text('取消'),
               ),
             ),
             const SizedBox(width: 10),

--- a/mobile/lib/features/preparation/job_preparation_wizard.dart
+++ b/mobile/lib/features/preparation/job_preparation_wizard.dart
@@ -1124,6 +1124,9 @@ class _DraftCard extends StatelessWidget {
                   onPressed: onResume == null
                       ? null
                       : () => unawaited(onResume!()),
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size(0, SpeakUpDesign.minTapTarget),
+                  ),
                   child: const Text('继续'),
                 ),
               ],

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -183,6 +183,21 @@ class _PreparationPageState extends State<PreparationPage> {
     }
   }
 
+  Future<void> _startInterviewSpecialty(
+    PreparationController controller,
+    PreparationScenario scenario,
+  ) async {
+    await controller.selectScenario(scenario);
+    if (!mounted || controller.selectedScenario?.id != scenario.id) {
+      return;
+    }
+    final configured = controller.selectRecommendedConfiguration();
+    if (!configured || widget.launchController == null) {
+      return;
+    }
+    await _startPractice();
+  }
+
   Future<_ExistingPracticeAction> _chooseExistingPracticeAction({
     required String? currentTitle,
     required String nextTitle,
@@ -513,7 +528,8 @@ class _PreparationPageState extends State<PreparationPage> {
         if (hub == _PracticeHub.interview)
           _InterviewHub(
             scenarios: scenarios,
-            onScenarioPressed: controller.selectScenario,
+            onScenarioPressed: (scenario) =>
+                unawaited(_startInterviewSpecialty(controller, scenario)),
             onOpenJobPreparation: widget.onOpenJobPreparation,
           )
         else if (hub == _PracticeHub.ielts)

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -30,7 +30,7 @@ const _hiddenCatalogScenarioIds = <String>{
 
 enum _PracticeHub { interview, ielts, roleplay }
 
-enum _ExistingPracticeAction { cancel, continuePractice, replace }
+enum _ExistingPracticeAction { continuePractice, replace }
 
 class PreparationPage extends StatefulWidget {
   const PreparationPage({
@@ -125,7 +125,7 @@ class _PreparationPageState extends State<PreparationPage> {
         : TextEditingController(text: controller.backgroundSummary);
   }
 
-  Future<void> _startPractice() async {
+  Future<void> _startPractice({required bool replaceCurrentPractice}) async {
     final catalog = widget.preparationController;
     final launch = widget.launchController;
     final scenario = catalog?.selectedScenario;
@@ -142,21 +142,6 @@ class _PreparationPageState extends State<PreparationPage> {
     }
     if (launch.backgroundSummary.trim().isEmpty) {
       launch.updateBackgroundSummary('默认示例：${config.prompt.publicSceneBrief}');
-    }
-    var replaceCurrentPractice = false;
-    if (launch.hasResumablePractice) {
-      final action = await _chooseExistingPracticeAction(
-        currentTitle: launch.resumablePracticeTitle,
-        nextTitle: scenario.name,
-      );
-      if (!mounted || action == _ExistingPracticeAction.cancel) {
-        return;
-      }
-      if (action == _ExistingPracticeAction.continuePractice) {
-        await _continueCurrentPractice();
-        return;
-      }
-      replaceCurrentPractice = true;
     }
     final started = await launch.start(
       PreparationLaunchSelection.fromCatalog(
@@ -187,6 +172,26 @@ class _PreparationPageState extends State<PreparationPage> {
     PreparationController controller,
     PreparationScenario scenario,
   ) async {
+    var replaceCurrentPractice = false;
+    final launch = widget.launchController;
+    if (launch?.hasResumablePractice ?? false) {
+      if (launch?.resumableScenarioId == scenario.id) {
+        await _continueCurrentPractice();
+        return;
+      }
+      final action = await _chooseExistingPracticeAction(
+        currentTitle: launch?.resumablePracticeTitle,
+        nextTitle: scenario.name,
+      );
+      if (!mounted || action == null) {
+        return;
+      }
+      if (action == _ExistingPracticeAction.continuePractice) {
+        await _continueCurrentPractice();
+        return;
+      }
+      replaceCurrentPractice = true;
+    }
     await controller.selectScenario(scenario);
     if (!mounted || controller.selectedScenario?.id != scenario.id) {
       return;
@@ -199,44 +204,71 @@ class _PreparationPageState extends State<PreparationPage> {
       controller.showScenarioList();
       return;
     }
-    await _startPractice();
+    await _startPractice(replaceCurrentPractice: replaceCurrentPractice);
   }
 
-  Future<_ExistingPracticeAction> _chooseExistingPracticeAction({
+  Future<_ExistingPracticeAction?> _chooseExistingPracticeAction({
     required String? currentTitle,
     required String nextTitle,
   }) async {
-    return await showDialog<_ExistingPracticeAction>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('你还有一项练习未完成'),
-            content: Text(
-              '当前练习：${currentTitle ?? '上次练习'}\n'
-              '如果开始“$nextTitle”，当前练习会提前结束。',
+    final activeTitle = currentTitle ?? '上次练习';
+    return showModalBottomSheet<_ExistingPracticeAction>(
+      context: context,
+      useSafeArea: true,
+      isScrollControlled: true,
+      builder: (context) => Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '开始新的练习？',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '你正在练“$activeTitle”。开始“$nextTitle”后，'
+                        '当前进度将结束。',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IconButton(
+                  tooltip: '关闭',
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
             ),
-            actions: [
-              TextButton(
-                onPressed: () =>
-                    Navigator.of(context).pop(_ExistingPracticeAction.cancel),
-                child: const Text('取消'),
-              ),
-              TextButton(
-                key: const Key('continue-existing-practice'),
-                onPressed: () => Navigator.of(
-                  context,
-                ).pop(_ExistingPracticeAction.continuePractice),
-                child: const Text('继续上次练习'),
-              ),
-              FilledButton(
-                key: const Key('replace-existing-practice'),
-                onPressed: () =>
-                    Navigator.of(context).pop(_ExistingPracticeAction.replace),
-                child: const Text('结束并开始新的'),
-              ),
-            ],
-          ),
-        ) ??
-        _ExistingPracticeAction.cancel;
+            const SizedBox(height: 24),
+            FilledButton(
+              key: const Key('continue-existing-practice'),
+              onPressed: () => Navigator.of(
+                context,
+              ).pop(_ExistingPracticeAction.continuePractice),
+              child: Text('继续“$activeTitle”'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              key: const Key('replace-existing-practice'),
+              onPressed: () =>
+                  Navigator.of(context).pop(_ExistingPracticeAction.replace),
+              child: Text('开始“$nextTitle”'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Future<void> _selectPreviewScene(AgentScene scene) async {

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -183,7 +183,7 @@ class _PreparationPageState extends State<PreparationPage> {
     }
   }
 
-  Future<void> _startInterviewSpecialty(
+  Future<void> _startScenarioDirectly(
     PreparationController controller,
     PreparationScenario scenario,
   ) async {
@@ -192,7 +192,11 @@ class _PreparationPageState extends State<PreparationPage> {
       return;
     }
     final configured = controller.selectRecommendedConfiguration();
-    if (!configured || widget.launchController == null) {
+    if (!configured) {
+      return;
+    }
+    if (widget.launchController == null) {
+      controller.showScenarioList();
       return;
     }
     await _startPractice();
@@ -370,19 +374,12 @@ class _PreparationPageState extends State<PreparationPage> {
   Widget _buildCatalog(PreparationController controller) {
     final selectedScenario = controller.selectedScenario;
     if (selectedScenario != null) {
-      return _ScenarioDetailView(
+      return _ScenarioLaunchStatus(
         controller: controller,
         scenario: selectedScenario,
-        backLabel: _selectedHub == null
-            ? _scenarioFamilyLabel(selectedScenario.type)
-            : _practiceHubLabel(_selectedHub!),
         launchController: widget.launchController,
-        backgroundController: _backgroundController,
-        hasAgentContext:
-            widget.launchController?.workspaceController != null ||
-            widget.agentController?.threadId != null,
         hasPrimaryNavigation: !widget.showBackButton,
-        onStart: _startPractice,
+        onBack: () => controller.showScenarioList(),
         onRetry: _retryLaunch,
       );
     }
@@ -529,18 +526,20 @@ class _PreparationPageState extends State<PreparationPage> {
           _InterviewHub(
             scenarios: scenarios,
             onScenarioPressed: (scenario) =>
-                unawaited(_startInterviewSpecialty(controller, scenario)),
+                unawaited(_startScenarioDirectly(controller, scenario)),
             onOpenJobPreparation: widget.onOpenJobPreparation,
           )
         else if (hub == _PracticeHub.ielts)
           _IeltsHub(
             scenarios: scenarios,
-            onScenarioPressed: controller.selectScenario,
+            onScenarioPressed: (scenario) =>
+                unawaited(_startScenarioDirectly(controller, scenario)),
           )
         else
           _RoleplayHub(
             scenarios: scenarios,
-            onScenarioPressed: controller.selectScenario,
+            onScenarioPressed: (scenario) =>
+                unawaited(_startScenarioDirectly(controller, scenario)),
           ),
       ],
     );
@@ -681,36 +680,32 @@ class _PreparationPageState extends State<PreparationPage> {
   }
 }
 
-class _ScenarioDetailView extends StatelessWidget {
-  const _ScenarioDetailView({
+class _ScenarioLaunchStatus extends StatelessWidget {
+  const _ScenarioLaunchStatus({
     required this.controller,
     required this.scenario,
-    required this.backLabel,
     required this.launchController,
-    required this.backgroundController,
-    required this.hasAgentContext,
     required this.hasPrimaryNavigation,
-    required this.onStart,
+    required this.onBack,
     required this.onRetry,
   });
 
   final PreparationController controller;
   final PreparationScenario scenario;
-  final String backLabel;
   final PreparationLaunchController? launchController;
-  final TextEditingController? backgroundController;
-  final bool hasAgentContext;
   final bool hasPrimaryNavigation;
-  final Future<void> Function() onStart;
+  final VoidCallback onBack;
   final Future<void> Function() onRetry;
 
   @override
   Widget build(BuildContext context) {
-    final detail = controller.detail;
-    final selectedRole = controller.selectedRole;
     final launchLocked = launchController?.isSelectionLocked ?? false;
+    final message =
+        controller.errorMessage ??
+        launchController?.errorMessage ??
+        launchController?.workspaceErrorMessage;
     return ListView(
-      key: const Key('preparation-scenario-detail'),
+      key: const Key('preparation-scenario-launch-status'),
       primary: false,
       padding: PreparationDesign.pagePadding(
         context,
@@ -722,13 +717,8 @@ class _ScenarioDetailView extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: IconButton(
             key: const Key('preparation-back-to-catalog'),
-            tooltip: '返回$backLabel',
-            onPressed: launchLocked
-                ? null
-                : () {
-                    launchController?.selectionChanged();
-                    controller.showScenarioList();
-                  },
+            tooltip: '取消并返回',
+            onPressed: launchLocked ? null : onBack,
             icon: const Icon(Icons.arrow_back_rounded),
             color: PreparationDesign.ink,
             style: IconButton.styleFrom(
@@ -737,93 +727,32 @@ class _ScenarioDetailView extends StatelessWidget {
             ),
           ),
         ),
-        const SizedBox(height: 12),
-        Text(
-          backLabel,
-          style: PreparationDesign.label.copyWith(
-            color: PreparationDesign.secondary,
-          ),
-        ),
-        const SizedBox(height: 6),
+        const SizedBox(height: 18),
         Text(
           scenario.name,
           key: const Key('preparation-scenario-title'),
           style: PreparationDesign.pageTitle,
         ),
         const SizedBox(height: 8),
-        const Text('确认练习目标与角色后即可开始。', style: PreparationDesign.body),
-        const SizedBox(height: 24),
-        if (controller.isLoadingDetail)
-          const _CatalogLoading(key: Key('preparation-detail-loading'))
-        else if (controller.errorMessage case final message?)
+        Text(
+          message == null ? '正在准备练习…' : '暂时无法开始这项练习。',
+          style: PreparationDesign.body,
+        ),
+        const SizedBox(height: 28),
+        if (message != null)
           _CatalogFailure(
-            key: const Key('preparation-detail-error'),
+            key: const Key('preparation-launch-error'),
             message: message,
-            onRetry: controller.retryLastFailure,
+            onRetry: controller.errorMessage != null
+                ? controller.retryLastFailure
+                : launchController?.canRetry == true
+                ? onRetry
+                : () async => onBack(),
           )
-        else if (detail != null) ...[
-          _ScenarioConfigCard(config: detail.config),
-          if (controller.roles.length > 1) ...[
-            const SizedBox(height: 28),
-            const Text('选择对话角色', style: PreparationDesign.sectionTitle),
-            const SizedBox(height: 6),
-            const Text(
-              'AI 会按所选角色和场景目标推进对话。',
-              key: Key('preparation-role-guidance'),
-              style: PreparationDesign.body,
-            ),
-            const SizedBox(height: 14),
-            for (final role in controller.roles) ...[
-              _RoleCard(
-                role: role,
-                selected: selectedRole?.id == role.id,
-                onPressed: launchLocked
-                    ? null
-                    : () {
-                        launchController?.selectionChanged();
-                        controller.selectRole(role);
-                      },
-              ),
-              const SizedBox(height: 10),
-            ],
-            if (selectedRole != null) ...[
-              const SizedBox(height: 18),
-              const Text('选择练习方式', style: PreparationDesign.sectionTitle),
-              const SizedBox(height: 6),
-              const Text(
-                '完整模拟和专项练习都围绕当前选择的视角进行。',
-                style: PreparationDesign.body,
-              ),
-              const SizedBox(height: 14),
-              for (final option in controller.availableOptions) ...[
-                _OptionCard(
-                  option: option,
-                  selected: controller.selectedOption?.id == option.id,
-                  onPressed: launchLocked
-                      ? null
-                      : () {
-                          launchController?.selectionChanged();
-                          controller.selectOption(option);
-                        },
-                ),
-                const SizedBox(height: 10),
-              ],
-            ],
-          ],
-          if (controller.hasCompleteSelection) ...[
-            const SizedBox(height: 22),
-            if (launchController case final launch?)
-              _LaunchSelectionCard(
-                controller: launch,
-                backgroundController: backgroundController!,
-                hasAgentContext: hasAgentContext,
-                onStart: onStart,
-                onRetry: onRetry,
-              )
-            else
-              const _LaunchUnavailableNotice(),
-          ],
-        ],
+        else
+          const LinearProgressIndicator(
+            key: Key('preparation-launch-progress'),
+          ),
       ],
     );
   }
@@ -2301,413 +2230,6 @@ class _CatalogScenarioCard extends StatelessWidget {
   }
 }
 
-class _ScenarioConfigCard extends StatelessWidget {
-  const _ScenarioConfigCard({required this.config});
-
-  final PreparationScenarioConfig config;
-
-  @override
-  Widget build(BuildContext context) {
-    final prompt = config.prompt;
-    return Material(
-      key: const Key('preparation-scenario-config'),
-      color: PreparationDesign.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(PreparationDesign.radiusMedia),
-        side: const BorderSide(color: PreparationDesign.border),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(18),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('这次会练', style: PreparationDesign.sectionTitle),
-            const SizedBox(height: 8),
-            Text(prompt.publicSceneBrief, style: PreparationDesign.body),
-            const SizedBox(height: 14),
-            Text(prompt.practiceGoal, style: PreparationDesign.cardTitle),
-            const SizedBox(height: 14),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _PreviewLabel(
-                  icon: Icons.person_outline_rounded,
-                  text: '你：${prompt.userRole}',
-                ),
-                _PreviewLabel(
-                  icon: Icons.smart_toy_outlined,
-                  text: 'AI：${prompt.aiRole}',
-                ),
-                _PreviewLabel(
-                  icon: Icons.schedule_rounded,
-                  text:
-                      '约 ${_durationMinutes(prompt.suggestedDurationSeconds)} 分钟',
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PreviewLabel extends StatelessWidget {
-  const _PreviewLabel({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: const BoxDecoration(
-        color: PreparationDesign.softSurface,
-        borderRadius: BorderRadius.all(Radius.circular(12)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: 17, color: PreparationDesign.secondary),
-            const SizedBox(width: 6),
-            Flexible(child: Text(text, style: PreparationDesign.meta)),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RoleCard extends StatelessWidget {
-  const _RoleCard({
-    required this.role,
-    required this.selected,
-    required this.onPressed,
-  });
-
-  final PreparationRole role;
-  final bool selected;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: EdgeInsets.zero,
-      elevation: 0,
-      color: PreparationDesign.surface,
-      clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(PreparationDesign.radiusCard),
-        side: BorderSide(
-          color: selected ? PreparationDesign.ink : PreparationDesign.border,
-          width: selected ? 1.5 : 1,
-        ),
-      ),
-      child: Semantics(
-        key: Key('preparation-role-${role.id}'),
-        container: true,
-        button: true,
-        selected: selected,
-        inMutuallyExclusiveGroup: true,
-        label: '${role.displayName}. ${role.responsibilities} ${role.style}',
-        onTap: onPressed,
-        excludeSemantics: true,
-        child: InkWell(
-          onTap: onPressed,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(
-                  selected
-                      ? Icons.radio_button_checked_rounded
-                      : Icons.radio_button_unchecked_rounded,
-                  color: selected
-                      ? PreparationDesign.ink
-                      : PreparationDesign.tertiary,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        role.displayName,
-                        style: PreparationDesign.cardTitle,
-                      ),
-                      const SizedBox(height: 5),
-                      Text(
-                        role.responsibilities,
-                        style: PreparationDesign.body.copyWith(fontSize: 14),
-                      ),
-                      const SizedBox(height: 5),
-                      Text(role.style, style: PreparationDesign.meta),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _OptionCard extends StatelessWidget {
-  const _OptionCard({
-    required this.option,
-    required this.selected,
-    required this.onPressed,
-  });
-
-  final PreparationOption option;
-  final bool selected;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final typeLabel = switch (option.type) {
-      PreparationOptionType.fullSimulation => '完整模拟',
-      PreparationOptionType.focus => '专项练习',
-    };
-    return Card(
-      margin: EdgeInsets.zero,
-      elevation: 0,
-      color: PreparationDesign.surface,
-      clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(PreparationDesign.radiusCard),
-        side: BorderSide(
-          color: selected ? PreparationDesign.ink : PreparationDesign.border,
-          width: selected ? 1.5 : 1,
-        ),
-      ),
-      child: Semantics(
-        key: Key('preparation-option-${option.id}'),
-        container: true,
-        button: true,
-        selected: selected,
-        inMutuallyExclusiveGroup: true,
-        label: '$typeLabel: ${option.displayName}',
-        onTap: onPressed,
-        excludeSemantics: true,
-        child: InkWell(
-          onTap: onPressed,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              children: [
-                Icon(
-                  selected ? Icons.check_circle_rounded : Icons.circle_outlined,
-                  color: selected
-                      ? PreparationDesign.ink
-                      : PreparationDesign.tertiary,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(typeLabel, style: PreparationDesign.cardTitle),
-                      const SizedBox(height: 4),
-                      Text(option.displayName, style: PreparationDesign.body),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LaunchSelectionCard extends StatelessWidget {
-  const _LaunchSelectionCard({
-    required this.controller,
-    required this.backgroundController,
-    required this.hasAgentContext,
-    required this.onStart,
-    required this.onRetry,
-  });
-
-  final PreparationLaunchController controller;
-  final TextEditingController backgroundController;
-  final bool hasAgentContext;
-  final Future<void> Function() onStart;
-  final Future<void> Function() onRetry;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      key: const Key('preparation-launch-selection'),
-      color: PreparationDesign.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(PreparationDesign.radiusMedia),
-        side: const BorderSide(color: PreparationDesign.border),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(18),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const Text('准备开始', style: PreparationDesign.sectionTitle),
-            const SizedBox(height: 6),
-            const Text('需要更贴近你的情况？可以补充一句背景。', style: PreparationDesign.body),
-            const SizedBox(height: 12),
-            TextField(
-              key: const Key('preparation-background-summary'),
-              controller: backgroundController,
-              enabled: !controller.isSelectionLocked,
-              minLines: 2,
-              maxLines: 4,
-              maxLength: 4000,
-              textInputAction: TextInputAction.newline,
-              decoration: const InputDecoration(
-                labelText: '背景或目标（可选）',
-                hintText: '可留空直接开始',
-                filled: true,
-                fillColor: PreparationDesign.canvas,
-                enabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: PreparationDesign.border),
-                  borderRadius: BorderRadius.all(
-                    Radius.circular(PreparationDesign.radiusControl),
-                  ),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: PreparationDesign.ink),
-                  borderRadius: BorderRadius.all(
-                    Radius.circular(PreparationDesign.radiusControl),
-                  ),
-                ),
-                disabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: PreparationDesign.border),
-                  borderRadius: BorderRadius.all(
-                    Radius.circular(PreparationDesign.radiusControl),
-                  ),
-                ),
-              ),
-              onChanged: controller.updateBackgroundSummary,
-            ),
-            if (!hasAgentContext) ...[
-              const SizedBox(height: 4),
-              const Text(
-                'Agent 对话仍在恢复。无需预先建立事项，恢复完成后可从这里直接开始。',
-                key: Key('preparation-agent-context-missing'),
-                style: TextStyle(
-                  color: PreparationDesign.inkSecondary,
-                  height: 1.4,
-                ),
-              ),
-            ],
-            if (controller.errorMessage ?? controller.workspaceErrorMessage
-                case final message?) ...[
-              const SizedBox(height: 8),
-              Text(
-                message,
-                key: const Key('preparation-launch-error'),
-                style: const TextStyle(
-                  color: PreparationDesign.error,
-                  height: 1.4,
-                ),
-              ),
-              if (controller.canRetryWorkspaceActivation)
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: TextButton(
-                    key: const Key('retry-practice-workspace-detail'),
-                    onPressed: () =>
-                        unawaited(controller.retryWorkspaceActivation()),
-                    child: const Text('重试读取练习记录'),
-                  ),
-                ),
-            ],
-            if (controller.isStarting) ...[
-              const SizedBox(height: 10),
-              const LinearProgressIndicator(
-                key: Key('preparation-launch-progress'),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                _launchStageLabel(controller.stage),
-                key: const Key('preparation-launch-stage'),
-                style: PreparationDesign.meta,
-              ),
-            ],
-            const SizedBox(height: 12),
-            FilledButton(
-              key: const Key('preparation-start-practice'),
-              onPressed: controller.isStarting ? null : onStart,
-              style: FilledButton.styleFrom(
-                minimumSize: const Size.fromHeight(52),
-                backgroundColor: PreparationDesign.ink,
-                foregroundColor: Colors.white,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(
-                    PreparationDesign.radiusControl,
-                  ),
-                ),
-              ),
-              child: Text(controller.isStarting ? '正在创建练习' : '开始练习'),
-            ),
-            if (controller.canRetry && !controller.isStarting)
-              TextButton(
-                key: const Key('preparation-retry-launch'),
-                onPressed: onRetry,
-                child: const Text('重试上次启动'),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _LaunchUnavailableNotice extends StatelessWidget {
-  const _LaunchUnavailableNotice();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Material(
-      key: Key('preparation-launch-unavailable'),
-      color: PreparationDesign.surfaceMuted,
-      borderRadius: BorderRadius.all(Radius.circular(18)),
-      child: Padding(
-        padding: EdgeInsets.all(16),
-        child: Text('正式练习启动服务未注入，当前选择不会写入业务数据。'),
-      ),
-    );
-  }
-}
-
-String _launchStageLabel(PreparationLaunchStage? stage) {
-  return switch (stage) {
-    PreparationLaunchStage.context => '正在准备独立练习空间',
-    PreparationLaunchStage.matter => '正在创建或激活本次求职事项',
-    PreparationLaunchStage.profile => '正在保存本次背景',
-    PreparationLaunchStage.snapshot => '正在冻结练习背景',
-    PreparationLaunchStage.plan => '正在创建练习计划',
-    PreparationLaunchStage.session => '正在创建练习会话',
-    PreparationLaunchStage.voice => '正在连接第一道语音题目',
-    null => '正在准备练习',
-  };
-}
-
-String _scenarioFamilyLabel(String family) {
-  return switch (family) {
-    'INTERVIEW' => '求职面试',
-    'EXAM' => 'IELTS 口语',
-    'WORKPLACE' || 'DAILY' => 'AI 数字人陪练',
-    _ => family,
-  };
-}
-
 String _practiceHubLabel(_PracticeHub hub) {
   return switch (hub) {
     _PracticeHub.interview => '英文面试',
@@ -2868,8 +2390,6 @@ IconData _scenarioFamilyIcon(String family) {
     _ => Icons.record_voice_over_outlined,
   };
 }
-
-int _durationMinutes(int seconds) => (seconds / 60).ceil();
 
 class _InlineFailure extends StatelessWidget {
   const _InlineFailure({

--- a/mobile/lib/features/preparation/preparation_controller.dart
+++ b/mobile/lib/features/preparation/preparation_controller.dart
@@ -222,6 +222,50 @@ final class PreparationController extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool selectRecommendedConfiguration() {
+    if (_disposed ||
+        _selectedScenario == null ||
+        _detail == null ||
+        _roles.isEmpty) {
+      return false;
+    }
+    final preferredRoleType = switch (_selectedScenario!.id) {
+      'scn_interview_recruiter_screening' ||
+      'scn_interview_self_introduction' => 'HR_INTERVIEWER',
+      'scn_interview_behavioral' => 'BEHAVIORAL_INTERVIEWER',
+      'scn_interview_system_design_spoken' => 'SYSTEM_DESIGN_INTERVIEWER',
+      'scn_interview_hiring_manager' => 'HIRING_MANAGER',
+      _ => 'TECHNICAL_INTERVIEWER',
+    };
+    final role =
+        _roles.where((item) => item.type == preferredRoleType).firstOrNull ??
+        _roles.first;
+    _selectedRole = role;
+    final compatibleOptions = _detail!.options
+        .where(
+          (option) =>
+              option.type == PreparationOptionType.fullSimulation ||
+              option.roleId == role.id,
+        )
+        .toList(growable: false);
+    _selectedOption =
+        compatibleOptions
+            .where(
+              (option) =>
+                  option.type == PreparationOptionType.focus &&
+                  option.roleId == role.id,
+            )
+            .firstOrNull ??
+        compatibleOptions
+            .where(
+              (option) => option.type == PreparationOptionType.fullSimulation,
+            )
+            .firstOrNull ??
+        compatibleOptions.firstOrNull;
+    notifyListeners();
+    return hasCompleteSelection;
+  }
+
   void showScenarioList() {
     if (_disposed) {
       return;

--- a/mobile/lib/features/preparation/wire_preparation_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_client.dart
@@ -243,6 +243,8 @@ PreparationScenario _scenario(Object? value, {String? summary}) {
       'name',
       'version',
       'status',
+      'turn_policy_ref',
+      'session_policy_ref',
       if (summary == null) 'summary',
     },
   );
@@ -255,6 +257,8 @@ PreparationScenario _scenario(Object? value, {String? summary}) {
   if (!_validScenarioFamilyModel(type, model)) {
     throw _invalidResponse();
   }
+  _resourceId(object['turn_policy_ref']);
+  _resourceId(object['session_policy_ref']);
   return PreparationScenario(
     id: _resourceId(object['scenario_definition_id']),
     type: type,

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -69,23 +69,31 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('practice-page')), findsOneWidget);
 
-    for (var turn = 1; turn <= 3; turn++) {
-      await tester.tap(find.byKey(const Key('practice-record')));
-      await tester.pump();
-      expect(find.byKey(const Key('practice-stop-recording')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('practice-record')));
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(agentController.recordingState, PracticeRecordingState.idle);
 
-      await tester.tap(find.byKey(const Key('practice-stop-recording')));
-      await tester.pumpAndSettle();
+    final cancelledGesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('practice-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    await cancelledGesture.moveBy(const Offset(0, -90));
+    await tester.pump();
+    expect(find.text('松开取消'), findsOneWidget);
+    await cancelledGesture.up();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('practice-transcript')), findsNothing);
+    expect(agentController.recordingState, PracticeRecordingState.idle);
+
+    for (var turn = 1; turn <= 3; turn++) {
+      await _holdAndReleaseAnswer(tester);
       expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
 
       if (turn == 1) {
         await tester.tap(find.byKey(const Key('practice-rerecord')));
         await tester.pumpAndSettle();
         expect(find.text('0 / 3'), findsOneWidget);
-        await tester.tap(find.byKey(const Key('practice-record')));
-        await tester.pump();
-        await tester.tap(find.byKey(const Key('practice-stop-recording')));
-        await tester.pumpAndSettle();
+        await _holdAndReleaseAnswer(tester);
       }
 
       await tester.tap(find.byKey(const Key('practice-confirm-turn')));
@@ -454,6 +462,15 @@ void main() {
       findsOneWidget,
     );
   });
+}
+
+Future<void> _holdAndReleaseAnswer(WidgetTester tester) async {
+  final holdTarget = find.byKey(const Key('practice-record'));
+  final gesture = await tester.startGesture(tester.getCenter(holdTarget));
+  await tester.pump(const Duration(milliseconds: 220));
+  expect(find.byKey(const Key('practice-stop-recording')), findsOneWidget);
+  await gesture.up();
+  await tester.pumpAndSettle();
 }
 
 final class _CurrentReviewHistoryClient implements ReviewHistoryClient {

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -88,6 +88,11 @@ void main() {
     for (var turn = 1; turn <= 3; turn++) {
       await _holdAndReleaseAnswer(tester);
       expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
+      expect(find.text('取消'), findsOneWidget);
+      expect(
+        find.byKey(const Key('practice-current-question')).hitTestable(),
+        findsOneWidget,
+      );
 
       if (turn == 1) {
         await tester.tap(find.byKey(const Key('practice-rerecord')));

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -113,6 +113,8 @@ void main() {
                 'summary': 'Discuss one backend project.',
                 'version': 1,
                 'status': 'active',
+                'turn_policy_ref': 'interview.project_deep_dive.turn.v1',
+                'session_policy_ref': 'interview.project_deep_dive.session.v1',
               },
             ],
           },

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -575,6 +575,14 @@ void main() {
         'I led the rollout, communicated the risk, and delivered it safely.';
     await tester.tap(find.byKey(const Key('practice-open-keyboard')));
     await tester.pump();
+    expect(find.byKey(const Key('practice-page')), findsOneWidget);
+    expect(
+      Navigator.of(
+        tester.element(find.byKey(const Key('practice-page'))),
+      ).canPop(),
+      isFalse,
+    );
+    expect(find.byKey(const Key('practice-return-to-voice')), findsOneWidget);
     final input = find.byKey(const Key('practice-text-answer'));
     await tester.scrollUntilVisible(
       input,

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -573,6 +573,8 @@ void main() {
 
     const answer =
         'I led the rollout, communicated the risk, and delivered it safely.';
+    await tester.tap(find.byKey(const Key('practice-open-keyboard')));
+    await tester.pump();
     final input = find.byKey(const Key('practice-text-answer'));
     await tester.scrollUntilVisible(
       input,
@@ -591,12 +593,18 @@ void main() {
           .text,
       answer,
     );
+    await tester.tap(find.byKey(const Key('practice-open-history')));
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
       find.text(answer),
       120,
       scrollable: find.byType(Scrollable).first,
     );
     expect(find.text(answer), findsOneWidget);
+    Navigator.of(tester.element(find.text('本轮记录'))).pop();
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('practice-open-keyboard')));
+    await tester.pump();
     expect(tester.widget<TextField>(input).controller?.text, isEmpty);
   });
 

--- a/mobile/test/practice/practice_media_controller_test.dart
+++ b/mobile/test/practice/practice_media_controller_test.dart
@@ -365,6 +365,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('practice-question-audio')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('practice-open-history')));
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
       find.byKey(const Key('practice-recording-play-audio-1')),
       220,
@@ -392,9 +394,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Practice hint shows one concise complete answer', (
-    tester,
-  ) async {
+  testWidgets('Practice hint shows a concise answer framework', (tester) async {
     final controller = _controller(
       snapshot: _activeSnapshot(audioAssetId: 'audio-1'),
       media: _MediaClient(),
@@ -409,18 +409,11 @@ void main() {
     await tester.tap(find.byKey(const Key('practice-hint-question-2')));
     await tester.pump();
 
-    expect(find.text('参考回答'), findsOneWidget);
-    expect(
-      find.text(
-        'From my perspective, the core responsibility of this role is to '
-        'understand the goal, work closely with the team, and deliver '
-        'reliable results.',
-      ),
-      findsOneWidget,
-    );
-    expect(find.text('建议回答结构'), findsNothing);
-    expect(find.text('可用英文表达'), findsNothing);
-    expect(find.textContaining('...'), findsNothing);
+    expect(find.text('回答框架'), findsOneWidget);
+    expect(find.text('1. 先直接回答你的核心观点'), findsOneWidget);
+    expect(find.text('2. 用一个具体经历或事实支持'), findsOneWidget);
+    expect(find.text('3. 回到岗位匹配与结果'), findsOneWidget);
+    expect(find.text('参考回答'), findsNothing);
   });
 
   testWidgets('Practice media buttons are disabled while recording', (
@@ -440,22 +433,19 @@ void main() {
 
     expect(
       tester
-          .widget<IconButton>(find.byKey(const Key('practice-question-audio')))
+          .widget<TextButton>(find.byKey(const Key('practice-question-audio')))
           .onPressed,
       isNull,
-    );
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('practice-recording-play-audio-1')),
-      220,
-      scrollable: find.byType(Scrollable).first,
     );
     expect(
       tester
-          .widget<IconButton>(
-            find.byKey(const Key('practice-recording-play-audio-1')),
-          )
+          .widget<IconButton>(find.byKey(const Key('practice-open-history')))
           .onPressed,
       isNull,
+    );
+    expect(
+      find.byKey(const Key('practice-recording-play-audio-1')),
+      findsNothing,
     );
     await controller.clearPrivateState();
   });

--- a/mobile/test/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/preparation/job_preparation_wizard_test.dart
@@ -2,14 +2,43 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/preparation/job_preparation_client.dart';
 import 'package:speakup/features/preparation/job_preparation_controller.dart';
+import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
 import 'package:speakup/features/preparation/job_preparation_models.dart';
 import 'package:speakup/features/preparation/job_preparation_wizard.dart';
 import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 
 void main() {
+  testWidgets('restorable draft actions fit the shared button theme', (
+    tester,
+  ) async {
+    final store = MemoryJobPreparationDraftStore();
+    final first = _controller(_WizardClient(), draftStore: store);
+    await first.activateAccount('user-1');
+    first.updateInput(_input);
+    await tester.pump();
+    first.dispose();
+
+    final restored = _controller(_WizardClient(), draftStore: store);
+    addTearDown(restored.dispose);
+    await restored.activateAccount('user-1');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: JobPreparationWizard(controller: restored),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('job-draft-card')), findsOneWidget);
+    expect(find.byKey(const Key('resume-job-draft-button')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('starts with JD-first input and labels quick start honestly', (
     tester,
   ) async {
@@ -234,11 +263,13 @@ Future<void> _scrollTo(
 
 JobPreparationController _controller(
   _WizardClient client, {
+  JobPreparationDraftStore? draftStore,
   JobPreparationVoiceActivator? voiceActivator,
 }) {
   var sequence = 0;
   return JobPreparationController(
     client: client,
+    draftStore: draftStore,
     threadIdProvider: () => _threadId,
     matterActivator:
         ({

--- a/mobile/test/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/preparation/job_preparation_wizard_test.dart
@@ -19,7 +19,11 @@ void main() {
     final first = _controller(_WizardClient(), draftStore: store);
     await first.activateAccount('user-1');
     first.updateInput(_input);
-    await tester.pump();
+    await tester.runAsync(() async {
+      while (await store.read('user-1') == null) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+    });
     first.dispose();
 
     final restored = _controller(_WizardClient(), draftStore: store);
@@ -34,6 +38,12 @@ void main() {
     );
     await tester.pump();
 
+    expect(restored.hasRestorableDraft, isTrue);
+    await _scrollTo(
+      tester,
+      target: const Key('job-draft-card'),
+      scrollable: const Key('job-wizard-input-step'),
+    );
     expect(find.byKey(const Key('job-draft-card')), findsOneWidget);
     expect(find.byKey(const Key('resume-job-draft-button')), findsOneWidget);
     expect(tester.takeException(), isNull);

--- a/mobile/test/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/preparation/practice_lifecycle_flow_test.dart
@@ -130,6 +130,10 @@ void main() {
       expect(workspaceController.currentSessionId, firstSessionId);
       expect(agentController.threads, hasLength(2));
 
+      await _tapVisible(
+        tester,
+        find.byKey(const Key('practice-open-keyboard')),
+      );
       await tester.enterText(
         find.byKey(const Key('practice-text-answer')),
         'The migration is on schedule, and I have isolated the main risk.',

--- a/mobile/test/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/preparation/practice_lifecycle_flow_test.dart
@@ -118,10 +118,6 @@ void main() {
 
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
       await _openScenario(tester, _progressScenario.id);
-      await _tapVisible(
-        tester,
-        find.byKey(const Key('preparation-start-practice')),
-      );
 
       expect(find.byKey(const Key('practice-page')), findsOneWidget);
       final firstPracticeThreadId = agentController.threadId!;
@@ -233,19 +229,16 @@ void main() {
 
       expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
       await _openScenario(tester, _hotelScenario.id);
-      await _tapVisible(
-        tester,
-        find.byKey(const Key('preparation-start-practice')),
-      );
 
       expect(find.text('你还有一项练习未完成'), findsOneWidget);
       expect(find.text('结束并开始新的'), findsOneWidget);
       expect(practiceClient.endedSessionIds, isEmpty);
 
-      await _tapVisible(
-        tester,
-        find.byKey(const Key('replace-existing-practice')),
-      );
+      final replace = find.byKey(const Key('replace-existing-practice'));
+      expect(replace, findsOneWidget);
+      await tester.tap(replace);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
 
       expect(find.byKey(const Key('practice-page')), findsOneWidget);
       expect(practiceClient.endedSessionIds, [firstSessionId]);
@@ -264,8 +257,13 @@ void main() {
 
 Future<void> _openScenario(WidgetTester tester, String scenarioId) async {
   await _tapVisible(tester, find.byKey(const Key('practice-hub-roleplay')));
-  await _tapVisible(tester, find.byKey(Key('catalog-scenario-$scenarioId')));
-  expect(find.byKey(const Key('preparation-launch-selection')), findsOneWidget);
+  final scenario = find.byKey(Key('catalog-scenario-$scenarioId'));
+  expect(scenario, findsOneWidget);
+  await tester.ensureVisible(scenario);
+  await tester.pumpAndSettle();
+  await tester.tap(scenario);
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
 }
 
 Future<void> _leavePractice(WidgetTester tester) async {

--- a/mobile/test/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/preparation/practice_lifecycle_flow_test.dart
@@ -232,10 +232,20 @@ void main() {
       expect(agentController.threadId, homeThreadId);
 
       expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
+      await _openScenario(tester, _progressScenario.id);
+
+      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.text('开始新的练习？'), findsNothing);
+      expect(agentController.practiceSessionId, firstSessionId);
+      expect(agentController.completedTurns, 1);
+
+      await _leavePractice(tester);
+      expect(agentController.threadId, homeThreadId);
+
       await _openScenario(tester, _hotelScenario.id);
 
-      expect(find.text('你还有一项练习未完成'), findsOneWidget);
-      expect(find.text('结束并开始新的'), findsOneWidget);
+      expect(find.text('开始新的练习？'), findsOneWidget);
+      expect(find.text('开始“${_hotelScenario.name}”'), findsOneWidget);
       expect(practiceClient.endedSessionIds, isEmpty);
 
       final replace = find.byKey(const Key('replace-existing-practice'));

--- a/mobile/test/preparation/preparation_controller_test.dart
+++ b/mobile/test/preparation/preparation_controller_test.dart
@@ -36,6 +36,22 @@ void main() {
     },
   );
 
+  test(
+    'selects the interview specialty configuration without another prompt',
+    () async {
+      final controller = PreparationController(client: _FixtureCatalogClient());
+      addTearDown(controller.dispose);
+
+      await controller.loadIfNeeded();
+      await controller.selectScenario(_scenario);
+
+      expect(controller.selectRecommendedConfiguration(), isTrue);
+      expect(controller.selectedRole, _technicalRole);
+      expect(controller.selectedOption, _technicalFocus);
+      expect(controller.hasCompleteSelection, isTrue);
+    },
+  );
+
   test('retries the failed directory request', () async {
     final client = _FailOnceCatalogClient();
     final controller = PreparationController(client: client);

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
-import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/preparation/preparation.dart';
 import 'package:speakup/features/preparation/preparation_client.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
@@ -52,7 +51,7 @@ Future<void> _openInterviewScenario(
 
 void main() {
   testWidgets(
-    'product training center previews a topic and keeps JD-first optional',
+    'product training center separates full interview from specialties',
     (tester) async {
       final controller = PreparationController(client: _FixtureClient());
       addTearDown(controller.dispose);
@@ -86,11 +85,12 @@ void main() {
         modeId: 'professional',
       );
 
-      expect(controller.selectedScenario?.id, _scenarioId);
+      expect(controller.selectedScenario, isNull);
       expect(
         find.byKey(const Key('preparation-scenario-config')),
-        findsOneWidget,
+        findsNothing,
       );
+      expect(find.text('选择对话角色'), findsNothing);
     },
   );
 
@@ -118,13 +118,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(opens, 0);
-    expect(controller.selectedScenario?.id, 'scn_general_speaking');
-    expect(
-      tester
-          .widget<Text>(find.byKey(const Key('preparation-scenario-title')))
-          .data,
-      'General speaking practice',
-    );
+    expect(controller.selectedScenario, isNull);
+    expect(find.text('General speaking practice'), findsOneWidget);
+    expect(find.byKey(const Key('preparation-scenario-title')), findsNothing);
   });
 
   testWidgets('subscenes show their own server summaries', (tester) async {
@@ -206,174 +202,6 @@ void main() {
     }
   });
 
-  testWidgets(
-    'loads the server catalog and keeps perspectives independent of stages',
-    (tester) async {
-      final controller = PreparationController(client: _FixtureClient());
-      addTearDown(controller.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(home: PreparationPage(preparationController: controller)),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('场景练习'), findsOneWidget);
-      expect(find.text('今天想练什么？'), findsOneWidget);
-      await _openFamily(tester, 'INTERVIEW');
-      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
-      await tester.pumpAndSettle();
-
-      expect(
-        find.text('English interview for technical roles'),
-        findsOneWidget,
-      );
-      final technical = find.byKey(
-        const Key('preparation-role-role_technical_interviewer'),
-      );
-      expect(controller.roles.take(2).map((role) => role.id), [
-        'role_technical_interviewer',
-        'role_hr_interviewer',
-      ]);
-
-      final guidance = find.byKey(const Key('preparation-role-guidance'));
-      await tester.scrollUntilVisible(guidance, 160);
-      await tester.pumpAndSettle();
-      expect(guidance, findsOneWidget);
-      await tester.scrollUntilVisible(technical, 200);
-      await tester.pumpAndSettle();
-      await tester.tap(technical);
-      await tester.pump();
-      final fullSimulation = find.byKey(
-        const Key('preparation-option-option_full_simulation'),
-      );
-      await tester.scrollUntilVisible(fullSimulation, 200);
-      await tester.pumpAndSettle();
-      expect(fullSimulation, findsOneWidget);
-      expect(
-        find.byKey(const Key('preparation-option-option_technical_focus')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const Key('preparation-option-option_hr_focus')),
-        findsNothing,
-      );
-
-      await tester.tap(fullSimulation);
-      await tester.pump();
-      final selectionNotice = find.byKey(
-        const Key('preparation-launch-unavailable'),
-      );
-      await tester.scrollUntilVisible(selectionNotice, 200);
-      await tester.pumpAndSettle();
-
-      expect(selectionNotice, findsOneWidget);
-      expect(find.textContaining('正式练习启动服务未注入'), findsOneWidget);
-    },
-  );
-
-  testWidgets('role and option cards expose one selectable button node', (
-    tester,
-  ) async {
-    final semantics = tester.ensureSemantics();
-    var semanticsDisposed = false;
-    void disposeSemantics() {
-      if (semanticsDisposed) {
-        return;
-      }
-      semanticsDisposed = true;
-      semantics.dispose();
-    }
-
-    addTearDown(disposeSemantics);
-    final controller = PreparationController(client: _FixtureClient());
-    addTearDown(controller.dispose);
-    try {
-      await tester.pumpWidget(
-        MaterialApp(home: PreparationPage(preparationController: controller)),
-      );
-      await tester.pumpAndSettle();
-      await _openFamily(tester, 'INTERVIEW');
-      await controller.selectScenario(_scenario);
-      await tester.pumpAndSettle();
-
-      const roleLabel =
-          'Technical depth perspective. '
-          'Probe technical depth and decision making. '
-          'Precise and evidence seeking.';
-      final role = find.byKey(
-        const Key('preparation-role-role_technical_interviewer'),
-      );
-      await tester.scrollUntilVisible(
-        role,
-        160,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      expect(
-        tester.getSemantics(role),
-        isSemantics(
-          label: roleLabel,
-          isButton: true,
-          hasSelectedState: true,
-          isSelected: false,
-          isInMutuallyExclusiveGroup: true,
-          hasTapAction: true,
-        ),
-      );
-      expect(find.bySemanticsLabel(roleLabel), findsOneWidget);
-
-      await tester.tap(role);
-      await tester.pump();
-      expect(
-        tester.getSemantics(role),
-        isSemantics(
-          label: roleLabel,
-          isButton: true,
-          hasSelectedState: true,
-          isSelected: true,
-          isInMutuallyExclusiveGroup: true,
-          hasTapAction: true,
-        ),
-      );
-
-      const optionLabel = '完整模拟: Full simulation';
-      final option = find.byKey(
-        const Key('preparation-option-option_full_simulation'),
-      );
-      await tester.scrollUntilVisible(option, 200);
-      await tester.ensureVisible(option);
-      await tester.pumpAndSettle();
-      expect(
-        tester.getSemantics(option),
-        isSemantics(
-          label: optionLabel,
-          isButton: true,
-          hasSelectedState: true,
-          isSelected: false,
-          isInMutuallyExclusiveGroup: true,
-          hasTapAction: true,
-        ),
-      );
-      expect(find.bySemanticsLabel(optionLabel), findsOneWidget);
-
-      await tester.tap(option);
-      await tester.pump();
-      expect(
-        tester.getSemantics(option),
-        isSemantics(
-          label: optionLabel,
-          isButton: true,
-          hasSelectedState: true,
-          isSelected: true,
-          isInMutuallyExclusiveGroup: true,
-          hasTapAction: true,
-        ),
-      );
-    } finally {
-      disposeSemantics();
-    }
-  });
-
   testWidgets('shows loading, failure retry, and empty states', (tester) async {
     final client = _ControlledListClient();
     final controller = PreparationController(client: client);
@@ -403,76 +231,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('preparation-catalog-empty')), findsOneWidget);
   });
-
-  testWidgets('remains usable on a narrow screen with large text', (
-    tester,
-  ) async {
-    tester.view.physicalSize = const Size(320, 568);
-    tester.view.devicePixelRatio = 1;
-    tester.platformDispatcher.textScaleFactorTestValue = 2;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
-    final controller = PreparationController(client: _FixtureClient());
-    addTearDown(controller.dispose);
-
-    await tester.pumpWidget(
-      MaterialApp(home: PreparationPage(preparationController: controller)),
-    );
-    await tester.pumpAndSettle();
-    await _openFamily(tester, 'INTERVIEW');
-    await controller.selectScenario(_scenario);
-    await tester.pumpAndSettle();
-
-    final leadership = find.byKey(
-      const Key('preparation-role-role_executive_interviewer'),
-    );
-    await tester.scrollUntilVisible(
-      leadership,
-      180,
-      scrollable: find.byType(Scrollable).first,
-    );
-    await tester.pumpAndSettle();
-    expect(leadership.hitTestable(), findsOneWidget);
-    expect(tester.takeException(), isNull);
-  });
-
-  testWidgets(
-    'catalog exploration preserves the same Agent Thread and Matter',
-    (tester) async {
-      final agentController = AgentController(client: FakeAgentClient());
-      final preparationController = PreparationController(
-        client: _FixtureClient(),
-      );
-      addTearDown(agentController.dispose);
-      addTearDown(preparationController.dispose);
-      await agentController.initialize();
-      await agentController.selectScene(agentScenes.first);
-      final originalThreadId = agentController.threadId;
-      final originalMatterId = agentController.activeMatter?.id;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SpeakUpShell(
-            agentController: agentController,
-            preparationController: preparationController,
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('primary-tab-scenes')));
-      await tester.pumpAndSettle();
-      await _openFamily(tester, 'INTERVIEW');
-      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('primary-tab-agent')));
-      await tester.pumpAndSettle();
-
-      expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
-      expect(agentController.threadId, originalThreadId);
-      expect(agentController.activeMatter?.id, originalMatterId);
-    },
-  );
 
   testWidgets('starts the real typed chain and reports success to navigation', (
     tester,
@@ -539,319 +297,155 @@ void main() {
     expect(launchController.bootstrap?.maxEffectiveTurns, 6);
   });
 
-  testWidgets(
-    'keeps start on the current page while the Agent Thread restores',
-    (tester) async {
-      final preparationController = PreparationController(
-        client: _FixtureClient(),
-      );
-      final launchClient = _PageLaunchClient();
-      final launchController = PreparationLaunchController(
-        client: launchClient,
-        contextProvider: () => null,
-        threadIdProvider: () => null,
-        matterActivator:
-            ({
-              required threadId,
-              required selection,
-              required clientOperationId,
-            }) {
-              throw StateError('Matter activation must wait for the Thread.');
-            },
-        voiceActivator:
-            ({
-              required context,
-              required bootstrap,
-              required clientOperationId,
-            }) async {},
-        idFactory: (scope) => '$scope-thread-wait-key',
-      );
-      addTearDown(preparationController.dispose);
-      addTearDown(launchController.dispose);
+  testWidgets('direct start reports a missing practice context in place', (
+    tester,
+  ) async {
+    final preparationController = PreparationController(
+      client: _FixtureClient(),
+    );
+    final launchClient = _PageLaunchClient();
+    final launchController = PreparationLaunchController(
+      client: launchClient,
+      contextProvider: () => null,
+      threadIdProvider: () => null,
+      matterActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) {
+            throw StateError('Matter activation must wait for the Thread.');
+          },
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+      idFactory: (scope) => '$scope-thread-wait-key',
+    );
+    addTearDown(preparationController.dispose);
+    addTearDown(launchController.dispose);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PreparationPage(
-            preparationController: preparationController,
-            launchController: launchController,
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: preparationController,
+          launchController: launchController,
         ),
-      );
-      await tester.pumpAndSettle();
-      await _openFamily(tester, 'INTERVIEW');
-      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
-      await tester.pumpAndSettle();
-      final role = find.byKey(
-        const Key('preparation-role-role_technical_interviewer'),
-      );
-      await tester.scrollUntilVisible(role, 200);
-      await tester.pumpAndSettle();
-      await tester.tap(role);
-      await tester.pump();
-      final option = find.byKey(
-        const Key('preparation-option-option_full_simulation'),
-      );
-      await tester.scrollUntilVisible(option, 200);
-      await tester.pumpAndSettle();
-      await tester.tap(option);
-      await tester.pump();
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _openFamily(tester, 'INTERVIEW');
+    await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+    await tester.pumpAndSettle();
 
-      final startFinder = find.byKey(const Key('preparation-start-practice'));
-      await tester.scrollUntilVisible(
-        startFinder,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      expect(tester.widget<FilledButton>(startFinder).onPressed, isNotNull);
-      expect(
-        find.byKey(const Key('preparation-agent-context-missing')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const Key('preparation-open-agent-home')),
-        findsNothing,
-      );
+    expect(
+      find.byKey(const Key('preparation-scenario-launch-status')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('preparation-launch-error')), findsOneWidget);
+    expect(find.text('选择对话角色'), findsNothing);
+    expect(launchClient.calls, isEmpty);
+  });
 
-      final background = find.byKey(
-        const Key('preparation-background-summary'),
-      );
-      await tester.scrollUntilVisible(
-        background,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        background,
-        'Backend engineer preparing a technical interview.',
-      );
-      await tester.tap(startFinder);
-      await tester.pump();
+  testWidgets('direct start stays locked until voice retry succeeds', (
+    tester,
+  ) async {
+    final session = Completer<PreparationPracticeBootstrap>();
+    final preparationController = PreparationController(
+      client: _FixtureClient(),
+    );
+    final launchClient = _PageLaunchClient(sessionCompleter: session);
+    var navigations = 0;
+    var voiceCalls = 0;
+    final launchController = PreparationLaunchController(
+      client: launchClient,
+      contextProvider: () => _pageContext,
+      threadIdProvider: () => _pageContext.threadId,
+      matterActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => _pageContext,
+      voiceActivator:
+          ({
+            required context,
+            required bootstrap,
+            required clientOperationId,
+          }) async {
+            voiceCalls++;
+            if (voiceCalls == 1) {
+              throw const PreparationLaunchException(
+                kind: PreparationLaunchFailureKind.invalidResponse,
+                stage: PreparationLaunchStage.voice,
+              );
+            }
+          },
+      idFactory: (scope) => '$scope-pending-widget-key',
+    );
+    addTearDown(preparationController.dispose);
+    addTearDown(launchController.dispose);
 
-      expect(find.textContaining('Agent 对话仍在恢复'), findsWidgets);
-      expect(launchClient.calls, isEmpty);
-    },
-  );
-
-  testWidgets(
-    'keeps selection locked after Session creation until voice retry succeeds',
-    (tester) async {
-      final session = Completer<PreparationPracticeBootstrap>();
-      final preparationController = PreparationController(
-        client: _FixtureClient(),
-      );
-      final launchClient = _PageLaunchClient(sessionCompleter: session);
-      var navigations = 0;
-      var voiceCalls = 0;
-      final launchController = PreparationLaunchController(
-        client: launchClient,
-        contextProvider: () => _pageContext,
-        threadIdProvider: () => _pageContext.threadId,
-        matterActivator:
-            ({
-              required threadId,
-              required selection,
-              required clientOperationId,
-            }) async => _pageContext,
-        voiceActivator:
-            ({
-              required context,
-              required bootstrap,
-              required clientOperationId,
-            }) async {
-              voiceCalls++;
-              if (voiceCalls == 1) {
-                throw const PreparationLaunchException(
-                  kind: PreparationLaunchFailureKind.invalidResponse,
-                  stage: PreparationLaunchStage.voice,
-                );
-              }
-            },
-        idFactory: (scope) => '$scope-pending-widget-key',
-      );
-      addTearDown(preparationController.dispose);
-      addTearDown(launchController.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PreparationPage(
-            showBackButton: true,
-            preparationController: preparationController,
-            launchController: launchController,
-            onPracticeStarted: () => navigations++,
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          showBackButton: true,
+          preparationController: preparationController,
+          launchController: launchController,
+          onPracticeStarted: () => navigations++,
         ),
-      );
-      await tester.pumpAndSettle();
-      await _openFamily(tester, 'INTERVIEW');
-      await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
-      await tester.pump();
-      await tester.pump();
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _openFamily(tester, 'INTERVIEW');
+    await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
+    await tester.pump();
+    await tester.pump();
 
-      final role = find.byKey(
-        const Key('preparation-role-role_technical_interviewer'),
-      );
-      final option = find.byKey(
-        const Key('preparation-option-option_technical_focus'),
-      );
-      final background = find.byKey(
-        const Key('preparation-background-summary'),
-      );
+    expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
+    expect(launchController.isStarting, isTrue);
+    expect(
+      tester
+          .widget<IconButton>(
+            find.byKey(const Key('preparation-back-to-catalog')),
+          )
+          .onPressed,
+      isNull,
+    );
+    expect(find.text('选择对话角色'), findsNothing);
 
-      expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
-      expect(launchController.isStarting, isTrue);
-      final detailBack = find.byKey(const Key('preparation-back-to-catalog'));
-      await tester.scrollUntilVisible(
-        detailBack,
-        -200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(tester.widget<IconButton>(detailBack).onPressed, isNull);
-      expect(
-        tester
-            .widget<IconButton>(
-              find.byKey(const Key('preparation-route-back-button')),
-            )
-            .onPressed,
-        isNull,
-      );
-      expect(
-        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
-        isFalse,
-      );
-      await tester.scrollUntilVisible(
-        role,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(
-        tester
-            .widget<InkWell>(
-              find.descendant(of: role, matching: find.byType(InkWell)),
-            )
-            .onTap,
-        isNull,
-      );
-      await tester.scrollUntilVisible(
-        option,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(
-        tester
-            .widget<InkWell>(
-              find.descendant(of: option, matching: find.byType(InkWell)),
-            )
-            .onTap,
-        isNull,
-      );
-      expect(preparationController.selectedRole?.id, _technicalRole.id);
-      expect(
-        preparationController.selectedOption?.id,
-        'option_technical_focus',
-      );
-
-      session.complete(
-        PreparationPracticeBootstrap(
-          session: PreparationPracticeSession(
-            id: 'session-1',
-            planId: 'plan-1',
-            scenarioType: 'INTERVIEW',
-            scenarioModel: 'PROJECT_EXPERIENCE_DEEP_DIVE',
-            snapshotId: 'session-snapshot-1',
-            status: 'starting',
-            version: 1,
-            createdAt: DateTime.utc(2026, 7, 26),
-          ),
-          preparationSnapshotId: 'preparation-snapshot-1',
-          maxEffectiveTurns: 6,
+    session.complete(
+      PreparationPracticeBootstrap(
+        session: PreparationPracticeSession(
+          id: 'session-1',
+          planId: 'plan-1',
+          scenarioType: 'INTERVIEW',
+          scenarioModel: 'PROJECT_EXPERIENCE_DEEP_DIVE',
+          snapshotId: 'session-snapshot-1',
+          status: 'starting',
+          version: 1,
+          createdAt: DateTime.utc(2026, 7, 26),
         ),
-      );
-      await tester.pumpAndSettle();
+        preparationSnapshotId: 'preparation-snapshot-1',
+        maxEffectiveTurns: 6,
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      expect(launchController.isStarting, isFalse);
-      expect(launchController.isSelectionLocked, isTrue);
-      expect(launchController.bootstrap, isNotNull);
-      expect(launchController.canRetry, isTrue);
-      expect(navigations, 0);
+    expect(launchController.canRetry, isTrue);
+    expect(navigations, 0);
+    await tester.tap(find.byKey(const Key('preparation-catalog-retry')));
+    await tester.pumpAndSettle();
 
-      await tester.scrollUntilVisible(
-        detailBack,
-        -200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(tester.widget<IconButton>(detailBack).onPressed, isNull);
-      expect(
-        tester
-            .widget<IconButton>(
-              find.byKey(const Key('preparation-route-back-button')),
-            )
-            .onPressed,
-        isNull,
-      );
-      expect(
-        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
-        isFalse,
-      );
-      await tester.scrollUntilVisible(
-        role,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(
-        tester
-            .widget<InkWell>(
-              find.descendant(of: role, matching: find.byType(InkWell)),
-            )
-            .onTap,
-        isNull,
-      );
-      await tester.scrollUntilVisible(
-        option,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(
-        tester
-            .widget<InkWell>(
-              find.descendant(of: option, matching: find.byType(InkWell)),
-            )
-            .onTap,
-        isNull,
-      );
-      await tester.scrollUntilVisible(
-        background,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(tester.widget<TextField>(background).enabled, isFalse);
-
-      final retry = find.byKey(const Key('preparation-retry-launch'));
-      await tester.scrollUntilVisible(
-        retry,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(retry);
-      await tester.pumpAndSettle();
-
-      expect(voiceCalls, 2);
-      expect(
-        launchClient.calls,
-        ['profile', 'snapshot', 'plan', 'session'] +
-            ['profile', 'snapshot', 'plan', 'session'],
-      );
-      expect(launchController.isStarting, isFalse);
-      expect(launchController.isSelectionLocked, isFalse);
-      expect(
-        tester.widget<PopScope<void>>(find.byType(PopScope<void>)).canPop,
-        isTrue,
-      );
-      expect(navigations, 1);
-    },
-  );
+    expect(voiceCalls, 2);
+    expect(navigations, 1);
+    expect(
+      find.byKey(const Key('preparation-scenario-launch-status')),
+      findsNothing,
+    );
+  });
 }
 
 class _FixtureClient implements PreparationCatalogClient {

--- a/mobile/test/preparation/preparation_page_test.dart
+++ b/mobile/test/preparation/preparation_page_test.dart
@@ -530,42 +530,10 @@ void main() {
     await _openFamily(tester, 'INTERVIEW');
     await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
     await tester.pumpAndSettle();
-    final role = find.byKey(
-      const Key('preparation-role-role_technical_interviewer'),
-    );
-    await tester.scrollUntilVisible(role, 200);
-    await tester.pumpAndSettle();
-    await tester.tap(role);
-    await tester.pump();
-    final option = find.byKey(
-      const Key('preparation-option-option_full_simulation'),
-    );
-    await tester.scrollUntilVisible(option, 200);
-    await tester.tap(option);
-    await tester.pump();
-    final background = find.byKey(const Key('preparation-background-summary'));
-    await tester.scrollUntilVisible(
-      background,
-      200,
-      scrollable: find.byType(Scrollable).first,
-    );
-    await tester.pumpAndSettle();
-    await tester.enterText(
-      background,
-      'Backend engineer preparing a technical interview.',
-    );
-    final start = find.byKey(const Key('preparation-start-practice'));
-    await tester.scrollUntilVisible(
-      start,
-      200,
-      scrollable: find.byType(Scrollable).first,
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(start);
-    await tester.pumpAndSettle();
 
     expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
     expect(navigations, 1);
+    expect(find.byKey(const Key('preparation-scenario-detail')), findsNothing);
     expect(agentController.threadId, isNotNull);
     expect(agentController.activeMatter, isNotNull);
     expect(launchController.bootstrap?.maxEffectiveTurns, 6);
@@ -718,49 +686,18 @@ void main() {
       await tester.pumpAndSettle();
       await _openFamily(tester, 'INTERVIEW');
       await tester.tap(find.byKey(const Key('catalog-scenario-$_scenarioId')));
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump();
 
       final role = find.byKey(
         const Key('preparation-role-role_technical_interviewer'),
       );
-      await tester.scrollUntilVisible(role, 200);
-      await tester.pumpAndSettle();
-      await tester.tap(role);
-      await tester.pump();
       final option = find.byKey(
-        const Key('preparation-option-option_full_simulation'),
+        const Key('preparation-option-option_technical_focus'),
       );
-      await tester.scrollUntilVisible(option, 200);
-      await tester.pumpAndSettle();
-      if (option.hitTestable().evaluate().isEmpty) {
-        await tester.drag(find.byType(Scrollable).first, const Offset(0, -80));
-        await tester.pumpAndSettle();
-      }
-      expect(option.hitTestable(), findsOneWidget);
-      await tester.tap(option);
-      await tester.pump();
       final background = find.byKey(
         const Key('preparation-background-summary'),
       );
-      await tester.scrollUntilVisible(
-        background,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        background,
-        'Backend engineer preparing a technical interview.',
-      );
-      final start = find.byKey(const Key('preparation-start-practice'));
-      await tester.scrollUntilVisible(
-        start,
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(start);
-      await tester.pump();
 
       expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
       expect(launchController.isStarting, isTrue);
@@ -812,7 +749,7 @@ void main() {
       expect(preparationController.selectedRole?.id, _technicalRole.id);
       expect(
         preparationController.selectedOption?.id,
-        'option_full_simulation',
+        'option_technical_focus',
       );
 
       session.complete(

--- a/mobile/test/preparation/wire_preparation_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_client_test.dart
@@ -278,6 +278,8 @@ const _scenarioDefinitionJson = <String, Object?>{
   'name': 'English interview for technical roles',
   'version': 1,
   'status': 'active',
+  'turn_policy_ref': 'interview.project_deep_dive.turn.v1',
+  'session_policy_ref': 'interview.project_deep_dive.session.v1',
 };
 
 const _scenarioJson = <String, Object?>{


### PR DESCRIPTION
## 功能描述
简化训练专项启动和移动端答题流程：面试专项点击后直接进入练习，不再展示重复的“这次会练 / 准备开始”确认页，并在练习页内完成按住说话与转写确认。

## 实现思路
- 面试专项直接创建独立、可恢复的练习空间。
- 删除遗留场景设置页和重复切换步骤。
- 将练习页面聚焦到回答阶段。
- 增加页面内按住说话、转写确认和继续作答。
- 修复岗位草稿恢复按钮在窄屏下的约束。
- 保留 #195 的首页/训练会话隔离。

## 验证方式
1. `cd mobile && flutter analyze --no-pub`
2. `cd mobile && flutter test --no-pub test/preparation/preparation_page_test.dart test/preparation/practice_lifecycle_flow_test.dart test/speak_up_app_test.dart`
3. 在模拟器点击招聘初筛等专项，确认不再出现“这次会练 / 准备开始”，可直接进入回答。

## 本地结果
- Flutter analyze：通过。
- 相关测试：32 项通过。

## 依赖
依赖 PR #218，前置合入后转 Ready。

Closes #219