### PR TITLE
feat(memory): add deterministic stable profile reader

### DIFF
--- a/server/internal/agent/runtime/stable_profile.go
+++ b/server/internal/agent/runtime/stable_profile.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+var stableProfileCanonicalKeyPattern = regexp.MustCompile(
+	`^[a-z][a-z0-9._:-]{0,127}$`,
+)
+
+type StableProfileReadRequest struct {
+	Actor requestcontext.Actor
+}
+
+func (request StableProfileReadRequest) Valid() bool {
+	return request.Actor.Valid()
+}
+
+type StableProfileMemory struct {
+	MemoryID      string
+	MemoryVersion int64
+	CanonicalKey  string
+	Type          string
+	Content       string
+	Scope         string
+}
+
+func (item StableProfileMemory) Valid() bool {
+	return core.ValidUUID(item.MemoryID) &&
+		item.MemoryVersion > 0 &&
+		stableProfileCanonicalKeyPattern.MatchString(item.CanonicalKey) &&
+		item.Type != "" &&
+		item.Type == strings.TrimSpace(item.Type) &&
+		len(item.Type) <= 32 &&
+		item.Content != "" &&
+		item.Content == strings.TrimSpace(item.Content) &&
+		len(item.Content) <= 16384 &&
+		item.Scope == memoryScopeUser
+}
+
+type StableProfileReader interface {
+	ReadStableProfile(
+		context.Context,
+		StableProfileReadRequest,
+	) ([]StableProfileMemory, error)
+}

--- a/server/internal/bootstrap/stable_profile.go
+++ b/server/internal/bootstrap/stable_profile.go
@@ -1,0 +1,63 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+)
+
+type agentStableProfileReader struct {
+	reader memory.StableProfileReader
+}
+
+func newAgentStableProfileReader(
+	reader memory.StableProfileReader,
+) (*agentStableProfileReader, error) {
+	if reader == nil {
+		return nil, errors.New(
+			"bootstrap: Stable Profile read dependency is required",
+		)
+	}
+	return &agentStableProfileReader{reader: reader}, nil
+}
+
+func (reader *agentStableProfileReader) ReadStableProfile(
+	ctx context.Context,
+	request agentruntime.StableProfileReadRequest,
+) ([]agentruntime.StableProfileMemory, error) {
+	if reader == nil || reader.reader == nil {
+		return nil, errors.New(
+			"bootstrap: Stable Profile read dependency is required",
+		)
+	}
+	if ctx == nil || !request.Valid() {
+		return nil, memory.ErrInvalidArgument
+	}
+	items, err := reader.reader.ListStableProfile(ctx, request.Actor)
+	if err != nil {
+		return nil, err
+	}
+	if !memory.ValidStableProfileMemories(items, request.Actor.UserID) {
+		return nil, memory.ErrRepository
+	}
+	result := make([]agentruntime.StableProfileMemory, 0, len(items))
+	for _, item := range items {
+		mapped := agentruntime.StableProfileMemory{
+			MemoryID:      item.ID,
+			MemoryVersion: item.Version,
+			CanonicalKey:  item.CanonicalKey,
+			Type:          string(item.Type),
+			Content:       item.Content,
+			Scope:         string(item.Scope),
+		}
+		if !mapped.Valid() {
+			return nil, memory.ErrRepository
+		}
+		result = append(result, mapped)
+	}
+	return result, nil
+}
+
+var _ agentruntime.StableProfileReader = (*agentStableProfileReader)(nil)

--- a/server/internal/bootstrap/stable_profile_test.go
+++ b/server/internal/bootstrap/stable_profile_test.go
@@ -1,0 +1,155 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/memory"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestAgentStableProfileReaderPreservesFields(t *testing.T) {
+	t.Parallel()
+	actor := stableProfileActor()
+	now := time.Now().UTC()
+	delegate := &recordingStableProfileReader{
+		items: []memory.Memory{{
+			ID:            "10000000-0000-4000-8000-000000000001",
+			OwnerID:       actor.UserID,
+			Type:          memory.TypeProfile,
+			CanonicalKey:  memory.CanonicalProfilePreferredName,
+			Content:       "小花",
+			Scope:         memory.ScopeUser,
+			Status:        memory.StatusActive,
+			Version:       3,
+			PolicyVersion: "memory-policy-v2",
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}},
+	}
+	adapter, err := newAgentStableProfileReader(delegate)
+	if err != nil {
+		t.Fatalf("newAgentStableProfileReader: %v", err)
+	}
+	request := agentruntime.StableProfileReadRequest{Actor: actor}
+	items, err := adapter.ReadStableProfile(context.Background(), request)
+	if err != nil {
+		t.Fatalf("ReadStableProfile: %v", err)
+	}
+	if delegate.actor != actor {
+		t.Fatalf("domain actor = %#v", delegate.actor)
+	}
+	if len(items) != 1 ||
+		items[0].MemoryID != delegate.items[0].ID ||
+		items[0].MemoryVersion != delegate.items[0].Version ||
+		items[0].CanonicalKey != delegate.items[0].CanonicalKey ||
+		items[0].Type != string(delegate.items[0].Type) ||
+		items[0].Content != delegate.items[0].Content ||
+		items[0].Scope != string(delegate.items[0].Scope) ||
+		!items[0].Valid() {
+		t.Fatalf("Agent Stable Profile = %#v", items)
+	}
+}
+
+func TestAgentStableProfileReaderAcceptsEmptyProfile(t *testing.T) {
+	t.Parallel()
+	adapter, err := newAgentStableProfileReader(
+		&recordingStableProfileReader{items: []memory.Memory{}},
+	)
+	if err != nil {
+		t.Fatalf("newAgentStableProfileReader: %v", err)
+	}
+	items, err := adapter.ReadStableProfile(
+		context.Background(),
+		agentruntime.StableProfileReadRequest{Actor: stableProfileActor()},
+	)
+	if err != nil {
+		t.Fatalf("ReadStableProfile: %v", err)
+	}
+	if items == nil || len(items) != 0 {
+		t.Fatalf("empty Stable Profile = %#v", items)
+	}
+}
+
+func TestAgentStableProfileReaderRejectsInvalidDomainResult(t *testing.T) {
+	t.Parallel()
+	actor := stableProfileActor()
+	now := time.Now().UTC()
+	adapter, err := newAgentStableProfileReader(
+		&recordingStableProfileReader{items: []memory.Memory{{
+			ID:            "10000000-0000-4000-8000-000000000001",
+			OwnerID:       actor.UserID,
+			Type:          memory.TypeProfile,
+			CanonicalKey:  "profile.unapproved",
+			Content:       "must not pass",
+			Scope:         memory.ScopeUser,
+			Status:        memory.StatusActive,
+			Version:       1,
+			PolicyVersion: "memory-policy-v2",
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}}},
+	)
+	if err != nil {
+		t.Fatalf("newAgentStableProfileReader: %v", err)
+	}
+	if _, err := adapter.ReadStableProfile(
+		context.Background(),
+		agentruntime.StableProfileReadRequest{Actor: actor},
+	); !errors.Is(err, memory.ErrRepository) {
+		t.Fatalf("invalid domain result error = %v", err)
+	}
+}
+
+func TestAgentStableProfileReaderRequiresDependencyAndPropagatesFailure(
+	t *testing.T,
+) {
+	t.Parallel()
+	if adapter, err := newAgentStableProfileReader(nil); err == nil ||
+		adapter != nil {
+		t.Fatalf("nil adapter = %#v, %v", adapter, err)
+	}
+	dependencyError := errors.New("profile database unavailable")
+	adapter, err := newAgentStableProfileReader(
+		&recordingStableProfileReader{err: dependencyError},
+	)
+	if err != nil {
+		t.Fatalf("newAgentStableProfileReader: %v", err)
+	}
+	if _, err := adapter.ReadStableProfile(
+		context.Background(),
+		agentruntime.StableProfileReadRequest{Actor: stableProfileActor()},
+	); !errors.Is(err, dependencyError) {
+		t.Fatalf("ReadStableProfile error = %v", err)
+	}
+	if _, err := adapter.ReadStableProfile(
+		context.Background(),
+		agentruntime.StableProfileReadRequest{},
+	); !errors.Is(err, memory.ErrInvalidArgument) {
+		t.Fatalf("invalid request error = %v", err)
+	}
+}
+
+type recordingStableProfileReader struct {
+	actor requestcontext.Actor
+	items []memory.Memory
+	err   error
+}
+
+func (reader *recordingStableProfileReader) ListStableProfile(
+	_ context.Context,
+	actor requestcontext.Actor,
+) ([]memory.Memory, error) {
+	reader.actor = actor
+	return append([]memory.Memory(nil), reader.items...), reader.err
+}
+
+func stableProfileActor() requestcontext.Actor {
+	return requestcontext.Actor{
+		UserID:    "20000000-0000-4000-8000-000000000001",
+		SessionID: "30000000-0000-4000-8000-000000000001",
+	}
+}

--- a/server/internal/memory/extractor.go
+++ b/server/internal/memory/extractor.go
@@ -266,22 +266,22 @@ func mapProfileUpdate(
 	switch update.Field {
 	case profilePreferredName:
 		candidate.Type = TypeProfile
-		candidate.CanonicalKey = "profile.preferred_name"
+		candidate.CanonicalKey = CanonicalProfilePreferredName
 	case profileFormOfAddress:
 		candidate.Type = TypePreference
-		candidate.CanonicalKey = "preference.form_of_address"
+		candidate.CanonicalKey = CanonicalPreferenceFormOfAddress
 	case profileGender:
 		candidate.Type = TypeProfile
-		candidate.CanonicalKey = "profile.gender"
+		candidate.CanonicalKey = CanonicalProfileGender
 	case profileOccupation:
 		candidate.Type = TypeProfile
-		candidate.CanonicalKey = "career.occupation"
+		candidate.CanonicalKey = CanonicalCareerOccupation
 	case profileExperience:
 		candidate.Type = TypeProfile
-		candidate.CanonicalKey = "career.experience_years"
+		candidate.CanonicalKey = CanonicalCareerExperienceYears
 	case profileCoachingStyle:
 		candidate.Type = TypePreference
-		candidate.CanonicalKey = "coaching.style"
+		candidate.CanonicalKey = CanonicalCoachingStyle
 	case profileCurrentGoal:
 		candidate.Type = TypeGoal
 		candidate.CanonicalKey = "goal.current"

--- a/server/internal/memory/postgres.go
+++ b/server/internal/memory/postgres.go
@@ -254,6 +254,88 @@ LIMIT $3`
 	return items, nil
 }
 
+func (repository *PostgresRepository) ListStableProfile(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) ([]Memory, error) {
+	if ctx == nil || !validActor(actor) {
+		return nil, ErrInvalidArgument
+	}
+	fields := StableProfileV1Fields()
+	canonicalKeys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		canonicalKeys = append(canonicalKeys, field.CanonicalKey)
+	}
+	rows, err := repository.database.Query(ctx, `
+SELECT
+    memories.id::text,
+    memories.owner_user_id::text,
+    memories.memory_type,
+    memories.canonical_key,
+    memories.content,
+    memories.scope_type,
+    coalesce(memories.matter_id::text, ''),
+    memories.status,
+    memories.version,
+    memories.policy_version,
+    memories.expires_at,
+    memories.created_at,
+    memories.updated_at,
+    memories.inactivated_at
+FROM agent_memories AS memories
+JOIN identity_users AS users
+  ON users.id = memories.owner_user_id
+ AND users.account_status = 'active'
+WHERE memories.owner_user_id = $1
+  AND memories.scope_type = 'user'
+  AND memories.matter_id IS NULL
+  AND memories.status = 'active'
+  AND (memories.expires_at IS NULL OR memories.expires_at > CURRENT_TIMESTAMP)
+  AND memories.canonical_key = ANY($2::text[])`,
+		actor.UserID,
+		canonicalKeys,
+	)
+	if err != nil {
+		return nil, ErrRepository
+	}
+	defer rows.Close()
+
+	byCanonicalKey := make(map[string]Memory, len(fields))
+	for rows.Next() {
+		item, scanErr := scanMemory(rows)
+		if scanErr != nil {
+			return nil, ErrRepository
+		}
+		field, found := stableProfileField(item.CanonicalKey)
+		if !found ||
+			field.Type != item.Type ||
+			item.OwnerID != actor.UserID ||
+			item.Scope != ScopeUser ||
+			item.MatterID != "" ||
+			item.Status != StatusActive {
+			return nil, ErrRepository
+		}
+		if _, duplicate := byCanonicalKey[item.CanonicalKey]; duplicate {
+			return nil, ErrRepository
+		}
+		byCanonicalKey[item.CanonicalKey] = item
+	}
+	if rows.Err() != nil {
+		return nil, ErrRepository
+	}
+
+	items := make([]Memory, 0, len(byCanonicalKey))
+	for _, field := range fields {
+		if item, found := byCanonicalKey[field.CanonicalKey]; found {
+			items = append(items, item)
+		}
+	}
+	if !ValidStableProfileMemories(items, actor.UserID) {
+		return nil, ErrRepository
+	}
+	return items, nil
+}
+
 func (repository *PostgresRepository) ListSources(
 	ctx context.Context,
 	actor requestcontext.Actor,

--- a/server/internal/memory/repository.go
+++ b/server/internal/memory/repository.go
@@ -135,6 +135,13 @@ type Repository interface {
 	DeleteOwnerData(context.Context, DeleteOwnerCommand) error
 }
 
+type StableProfileReader interface {
+	ListStableProfile(
+		context.Context,
+		requestcontext.Actor,
+	) ([]Memory, error)
+}
+
 type IDGenerator interface {
 	NewID() (string, error)
 }

--- a/server/internal/memory/stable_profile.go
+++ b/server/internal/memory/stable_profile.go
@@ -1,0 +1,92 @@
+package memory
+
+const (
+	CanonicalProfilePreferredName    = "profile.preferred_name"
+	CanonicalPreferenceFormOfAddress = "preference.form_of_address"
+	CanonicalProfileGender           = "profile.gender"
+	CanonicalCareerOccupation        = "career.occupation"
+	CanonicalCareerExperienceYears   = "career.experience_years"
+	CanonicalCoachingStyle           = "coaching.style"
+)
+
+type StableProfileField struct {
+	CanonicalKey string
+	Type         Type
+}
+
+var stableProfileV1Fields = [...]StableProfileField{
+	{
+		CanonicalKey: CanonicalProfilePreferredName,
+		Type:         TypeProfile,
+	},
+	{
+		CanonicalKey: CanonicalPreferenceFormOfAddress,
+		Type:         TypePreference,
+	},
+	{
+		CanonicalKey: CanonicalProfileGender,
+		Type:         TypeProfile,
+	},
+	{
+		CanonicalKey: CanonicalCareerOccupation,
+		Type:         TypeProfile,
+	},
+	{
+		CanonicalKey: CanonicalCareerExperienceYears,
+		Type:         TypeProfile,
+	},
+	{
+		CanonicalKey: CanonicalCoachingStyle,
+		Type:         TypePreference,
+	},
+}
+
+func StableProfileV1Fields() []StableProfileField {
+	fields := make([]StableProfileField, len(stableProfileV1Fields))
+	copy(fields, stableProfileV1Fields[:])
+	return fields
+}
+
+func stableProfileField(canonicalKey string) (StableProfileField, bool) {
+	for _, field := range stableProfileV1Fields {
+		if field.CanonicalKey == canonicalKey {
+			return field, true
+		}
+	}
+	return StableProfileField{}, false
+}
+
+func ValidStableProfileMemories(items []Memory, ownerID string) bool {
+	if !validUUID(ownerID) || len(items) > len(stableProfileV1Fields) {
+		return false
+	}
+	previousPosition := -1
+	for _, item := range items {
+		if !item.Valid() ||
+			item.OwnerID != ownerID ||
+			item.Scope != ScopeUser ||
+			item.MatterID != "" ||
+			item.Status != StatusActive {
+			return false
+		}
+		field, found := stableProfileField(item.CanonicalKey)
+		if !found || field.Type != item.Type {
+			return false
+		}
+		position := stableProfilePosition(item.CanonicalKey)
+		if position <= previousPosition {
+			return false
+		}
+		previousPosition = position
+	}
+	return true
+}
+
+func stableProfilePosition(canonicalKey string) int {
+	for position, field := range stableProfileV1Fields {
+		if field.CanonicalKey == canonicalKey {
+			return position
+		}
+	}
+	return -1
+}

--- a/server/internal/memory/stable_profile_postgres_integration_test.go
+++ b/server/internal/memory/stable_profile_postgres_integration_test.go
@@ -1,0 +1,207 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestPostgresRepositoryListsStableProfileDeterministically(
+	t *testing.T,
+) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	ctx := context.Background()
+	actorA := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	actorB := requestcontext.Actor{
+		UserID:    integrationUserB,
+		SessionID: integrationSessionB,
+	}
+
+	create := func(
+		actor requestcontext.Actor,
+		memoryType Type,
+		key string,
+		content string,
+	) Memory {
+		t.Helper()
+		command := createCommand(key, content)
+		command.Type = memoryType
+		item, createErr := repository.Create(ctx, actor, command)
+		if createErr != nil {
+			t.Fatalf("Create %s: %v", key, createErr)
+		}
+		return item
+	}
+
+	occupation := create(
+		actorA,
+		TypeProfile,
+		CanonicalCareerOccupation,
+		"Java 后端工程师",
+	)
+	preferredName := create(
+		actorA,
+		TypeProfile,
+		CanonicalProfilePreferredName,
+		"小花",
+	)
+	formOfAddress := create(
+		actorA,
+		TypePreference,
+		CanonicalPreferenceFormOfAddress,
+		"花花",
+	)
+	experience := create(
+		actorA,
+		TypeProfile,
+		CanonicalCareerExperienceYears,
+		"5 年",
+	)
+	gender := create(
+		actorA,
+		TypeProfile,
+		CanonicalProfileGender,
+		"女性",
+	)
+	coachingStyle := create(
+		actorA,
+		TypePreference,
+		CanonicalCoachingStyle,
+		"回答简短，先给修改稿",
+	)
+	create(actorA, TypeInterest, "interest.running", "喜欢跑步")
+	foreignName := create(
+		actorB,
+		TypeProfile,
+		CanonicalProfilePreferredName,
+		"小雨",
+	)
+
+	matterCommand := createCommand(
+		CanonicalProfilePreferredName,
+		"Matter 中的错误姓名",
+	)
+	matterCommand.Scope = ScopeMatter
+	matterCommand.MatterID = integrationMatterA
+	matterCommand.Source = evidence(
+		SourceAgentMessage,
+		"matter-profile-name",
+		1,
+		"matter profile name",
+	)
+	if _, err := repository.Create(
+		ctx,
+		actorA,
+		matterCommand,
+	); err != nil {
+		t.Fatalf("Create Matter-scoped profile: %v", err)
+	}
+	if _, err := repository.Inactivate(ctx, actorA, InactivateCommand{
+		MemoryID:        gender.ID,
+		ExpectedVersion: gender.Version,
+		Source: evidence(
+			SourceAgentMessage,
+			"forget-profile-gender",
+			1,
+			"forget profile gender",
+		),
+	}); err != nil {
+		t.Fatalf("Inactivate gender: %v", err)
+	}
+	if _, err := database.Exec(ctx, `
+UPDATE agent_memories
+SET expires_at = created_at + INTERVAL '1 microsecond'
+WHERE id = $1`,
+		coachingStyle.ID,
+	); err != nil {
+		t.Fatalf("expire coaching style: %v", err)
+	}
+
+	items, err := repository.ListStableProfile(ctx, actorA)
+	if err != nil {
+		t.Fatalf("ListStableProfile actor A: %v", err)
+	}
+	expectedIDs := []string{
+		preferredName.ID,
+		formOfAddress.ID,
+		occupation.ID,
+		experience.ID,
+	}
+	if len(items) != len(expectedIDs) {
+		t.Fatalf("Stable Profile actor A = %#v", items)
+	}
+	for index, expectedID := range expectedIDs {
+		if items[index].ID != expectedID {
+			t.Fatalf(
+				"Stable Profile actor A item %d = %#v",
+				index,
+				items[index],
+			)
+		}
+	}
+
+	foreignItems, err := repository.ListStableProfile(ctx, actorB)
+	if err != nil {
+		t.Fatalf("ListStableProfile actor B: %v", err)
+	}
+	if len(foreignItems) != 1 || foreignItems[0].ID != foreignName.ID {
+		t.Fatalf("Stable Profile actor B = %#v", foreignItems)
+	}
+
+	if _, err := database.Exec(ctx, `
+UPDATE identity_users
+SET account_status = 'deleting'
+WHERE id = $1`,
+		actorB.UserID,
+	); err != nil {
+		t.Fatalf("disable actor B: %v", err)
+	}
+	disabledItems, err := repository.ListStableProfile(ctx, actorB)
+	if err != nil {
+		t.Fatalf("ListStableProfile disabled actor B: %v", err)
+	}
+	if len(disabledItems) != 0 {
+		t.Fatalf("disabled actor Stable Profile = %#v", disabledItems)
+	}
+
+	if _, err := repository.ListStableProfile(ctx, requestcontext.Actor{}); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("invalid actor error = %v", err)
+	}
+}
+
+func TestPostgresRepositoryListsEmptyStableProfile(t *testing.T) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	items, err := repository.ListStableProfile(
+		context.Background(),
+		requestcontext.Actor{
+			UserID:    integrationUserA,
+			SessionID: integrationSessionA,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ListStableProfile: %v", err)
+	}
+	if items == nil || len(items) != 0 {
+		t.Fatalf("empty Stable Profile = %#v", items)
+	}
+}

--- a/server/internal/memory/stable_profile_test.go
+++ b/server/internal/memory/stable_profile_test.go
@@ -1,0 +1,126 @@
+package memory
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStableProfileV1FieldsAreFixedAndCopied(t *testing.T) {
+	t.Parallel()
+	fields := StableProfileV1Fields()
+	expected := []StableProfileField{
+		{CanonicalKey: CanonicalProfilePreferredName, Type: TypeProfile},
+		{
+			CanonicalKey: CanonicalPreferenceFormOfAddress,
+			Type:         TypePreference,
+		},
+		{CanonicalKey: CanonicalProfileGender, Type: TypeProfile},
+		{CanonicalKey: CanonicalCareerOccupation, Type: TypeProfile},
+		{CanonicalKey: CanonicalCareerExperienceYears, Type: TypeProfile},
+		{CanonicalKey: CanonicalCoachingStyle, Type: TypePreference},
+	}
+	if len(fields) != len(expected) {
+		t.Fatalf("Stable Profile field count = %d", len(fields))
+	}
+	for index := range expected {
+		if fields[index] != expected[index] {
+			t.Fatalf("Stable Profile field %d = %#v", index, fields[index])
+		}
+	}
+	fields[0].CanonicalKey = "profile.mutated"
+	if StableProfileV1Fields()[0].CanonicalKey !=
+		CanonicalProfilePreferredName {
+		t.Fatal("Stable Profile fields exposed mutable policy state")
+	}
+}
+
+func TestValidStableProfileMemoriesRequiresWhitelistAndOrder(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	ownerID := "10000000-0000-4000-8000-000000000001"
+	preferredName := stableProfileMemory(
+		"20000000-0000-4000-8000-000000000001",
+		ownerID,
+		TypeProfile,
+		CanonicalProfilePreferredName,
+		"小花",
+		now,
+	)
+	occupation := stableProfileMemory(
+		"20000000-0000-4000-8000-000000000002",
+		ownerID,
+		TypeProfile,
+		CanonicalCareerOccupation,
+		"Java 后端工程师",
+		now,
+	)
+	if !ValidStableProfileMemories(
+		[]Memory{preferredName, occupation},
+		ownerID,
+	) {
+		t.Fatal("valid Stable Profile was rejected")
+	}
+	for name, mutate := range map[string]func([]Memory) []Memory{
+		"reordered": func(items []Memory) []Memory {
+			return []Memory{items[1], items[0]}
+		},
+		"duplicate": func(items []Memory) []Memory {
+			return []Memory{items[0], items[0]}
+		},
+		"unknown key": func(items []Memory) []Memory {
+			items[0].CanonicalKey = "profile.unapproved"
+			return items
+		},
+		"incompatible type": func(items []Memory) []Memory {
+			items[0].Type = TypePreference
+			return items
+		},
+		"wrong owner": func(items []Memory) []Memory {
+			items[0].OwnerID = "30000000-0000-4000-8000-000000000001"
+			return items
+		},
+		"matter scope": func(items []Memory) []Memory {
+			items[0].Scope = ScopeMatter
+			items[0].MatterID = "40000000-0000-4000-8000-000000000001"
+			return items
+		},
+		"inactive": func(items []Memory) []Memory {
+			inactivatedAt := now.Add(time.Second)
+			items[0].Status = StatusInactive
+			items[0].Version++
+			items[0].UpdatedAt = inactivatedAt
+			items[0].InactivatedAt = &inactivatedAt
+			return items
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			items := []Memory{preferredName, occupation}
+			if ValidStableProfileMemories(mutate(items), ownerID) {
+				t.Fatalf("%s Stable Profile was accepted", name)
+			}
+		})
+	}
+}
+
+func stableProfileMemory(
+	id string,
+	ownerID string,
+	memoryType Type,
+	canonicalKey string,
+	content string,
+	now time.Time,
+) Memory {
+	return Memory{
+		ID:            id,
+		OwnerID:       ownerID,
+		Type:          memoryType,
+		CanonicalKey:  canonicalKey,
+		Content:       content,
+		Scope:         ScopeUser,
+		Status:        StatusActive,
+		Version:       1,
+		PolicyVersion: "memory-v1",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}


### PR DESCRIPTION
## 功能描述

实现 #221 冻结的双路记忆架构中的第一步：为少量稳定用户资料提供不依赖 query、Embedding、相似度阈值或 Top-K 的确定性读取端口。

本 PR 只交付 Stable Profile 精确读取和 Agent adapter，不把资料注入 provider request，也不修改现有向量 Search、ContextManifest 或 HTTP API。

## 实现思路

- 冻结 Stable Profile V1 六个 canonical key 及顺序：
  - `profile.preferred_name`
  - `preference.form_of_address`
  - `profile.gender`
  - `career.occupation`
  - `career.experience_years`
  - `coaching.style`
- 让现有固定提取协议复用上述 canonical key 常量，避免写入和读取白名单漂移。
- 在 Memory 领域新增窄 `StableProfileReader`，继续复用 `agent_memories`。
- PostgreSQL 按可信 actor owner、user scope、active、未过期和固定 key 集合精确读取，不访问向量表。
- 在应用层按冻结字段顺序重组结果，并对重复 key、未知 key、类型不兼容和非法 Memory 显式失败。
- 新增 Agent runtime 中立读取模型和 bootstrap adapter，保留后续注入与审计所需的 ID、version、canonical key、type、scope 和 content。
- 合法空 Profile 返回空集合；依赖、请求或结果非法时不回退为向量 Search 或合法空结果。

## 测试方式

在仓库根目录执行：

```bash
cd server
go test ./internal/memory/... ./internal/bootstrap/... ./internal/agent/runtime/...
go test -race ./internal/memory/... ./internal/bootstrap/... ./internal/agent/runtime/...
cd ..
make check-go
git diff --check upstream/dev...HEAD
```

使用本地 Docker PostgreSQL 额外执行：

```bash
cd server
TEST_DATABASE_URL='<local test database>' \
  go test ./internal/platform/migration \
  -run '^TestRunnerAppliesIdempotentlyAndRevertsLatestMigration$' \
  -count=1 -v
TEST_DATABASE_URL='<local test database>' \
  go test ./internal/memory \
  -run 'TestPostgresRepositoryLists(StableProfileDeterministically|EmptyStableProfile)$' \
  -count=1 -v
```

验证结果：

- 聚焦单元测试通过；
- Race Detector 通过；
- PR #224 修复后的完整迁移链集成测试通过；
- Stable Profile PostgreSQL 集成测试通过，覆盖固定顺序、owner 隔离、Matter 排除、inactive、expired、非 active 账号和空结果；
- `make check-go` 通过。

## 非目标

- 不注入 `<stable_user_profile>`；
- 不排除向量 Search 中的重复 Profile key；
- 不扩展 ContextManifest 或 HTTP 审计；
- 不修改提取 Worker、写入一致性或 Flutter UI；
- 不引入第三方记忆 SDK。

## 关联

Closes #222

- 增量架构：#221
- Memory V1：#65
- 相关记忆 Context 注入：#161
- 固定提取协议：#169
- 显式失败：#150

## AI 辅助说明

- 关键 Prompt：基于已接受的 #221，从最新 `upstream/dev` 实现 Stable Profile 精确读取和 Agent adapter，不提前接入 Context。
- 人工 Review 要点：确认白名单没有按前缀扩大；确认查询不依赖向量索引；确认空结果与依赖失败严格区分；确认 PR 不包含 Prompt、Manifest、API、迁移或其他 Issue 的改动。
