### PR TITLE
fix(preparation): accept scenario policy refs

### DIFF
--- a/mobile/lib/features/preparation/wire_job_preparation_client.dart
+++ b/mobile/lib/features/preparation/wire_job_preparation_client.dart
@@ -1020,6 +1020,8 @@ JobPlanCatalog _jobPlanCatalog(Object? value) {
       'name',
       'version',
       'status',
+      'turn_policy_ref',
+      'session_policy_ref',
     },
   );
   final configObject = _object(
@@ -1060,6 +1062,8 @@ JobPlanCatalog _jobPlanCatalog(Object? value) {
     version: _version(scenarioObject['version']),
     status: _enumText(scenarioObject['status'], const <String>{'active'}),
   );
+  _resourceId(scenarioObject['turn_policy_ref']);
+  _resourceId(scenarioObject['session_policy_ref']);
   final rolesValue = object['selected_roles'];
   if (rolesValue is! List<Object?> || rolesValue.length != 1) {
     throw _invalidResponse();
@@ -1338,8 +1342,12 @@ PreparationScenario _scenarioSnapshot(
       'name',
       'version',
       'status',
+      'turn_policy_ref',
+      'session_policy_ref',
     },
   );
+  _resourceId(object['turn_policy_ref']);
+  _resourceId(object['session_policy_ref']);
   return PreparationScenario(
     id: _resourceId(object['scenario_definition_id']),
     type: _enumText(object['scenario_type'], const <String>{'INTERVIEW'}),

--- a/mobile/lib/features/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_launch_client.dart
@@ -591,6 +591,8 @@ void _validateScenarioSnapshot(
       'name',
       'version',
       'status',
+      'turn_policy_ref',
+      'session_policy_ref',
     },
   );
   if (_resourceId(object['scenario_definition_id']) !=
@@ -604,6 +606,8 @@ void _validateScenarioSnapshot(
     throw _invalidResponse();
   }
   _text(object['name']);
+  _resourceId(object['turn_policy_ref']);
+  _resourceId(object['session_policy_ref']);
 }
 
 void _validateConfigSnapshot(

--- a/mobile/test/preparation/wire_job_preparation_client_test.dart
+++ b/mobile/test/preparation/wire_job_preparation_client_test.dart
@@ -306,6 +306,12 @@ void main() {
         final objectives = policy['target_objectives']! as List<Object?>;
         objectives.add(_clone(objectives.single));
       },
+      'missing turn policy reference': (plan) {
+        final catalog = plan['catalog_snapshot']! as Map<String, Object?>;
+        final scenario =
+            catalog['scenario_definition']! as Map<String, Object?>;
+        scenario.remove('turn_policy_ref');
+      },
     };
 
     for (final entry in cases.entries) {
@@ -355,6 +361,12 @@ void main() {
       'unexpected session field': (root) {
         final session = root['practice_session']! as Map<String, Object?>;
         session['effective_turns'] = 0;
+      },
+      'invalid session policy reference': (root) {
+        final scenario =
+            _sessionSnapshot(root)['scenario_definition_snapshot']!
+                as Map<String, Object?>;
+        scenario['session_policy_ref'] = '';
       },
     };
 
@@ -641,6 +653,8 @@ Map<String, Object?> _scenarioJson() {
     'name': 'Technical interview',
     'version': 1,
     'status': 'active',
+    'turn_policy_ref': 'interview.project_deep_dive.turn.v1',
+    'session_policy_ref': 'interview.project_deep_dive.session.v1',
   };
 }
 

--- a/mobile/test/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_launch_client_test.dart
@@ -290,6 +290,12 @@ void main() {
       'option turn budget': (root) {
         _sessionPolicy(root)['max_effective_turns'] = 6;
       },
+      'missing turn policy reference': (root) {
+        _scenarioDefinitionSnapshot(root).remove('turn_policy_ref');
+      },
+      'invalid session policy reference': (root) {
+        _scenarioDefinitionSnapshot(root)['session_policy_ref'] = '';
+      },
     };
 
     for (final entry in cases.entries) {
@@ -524,6 +530,8 @@ Map<String, Object?> _bootstrapJson() => {
       'name': 'Technical interview',
       'version': 1,
       'status': 'active',
+      'turn_policy_ref': 'interview.project_deep_dive.turn.v1',
+      'session_policy_ref': 'interview.project_deep_dive.session.v1',
     },
     'scenario_config_snapshot': {
       'scenario_config_id': _configId,
@@ -612,6 +620,11 @@ Map<String, Object?> _roleSnapshot(Map<String, Object?> root) {
   final participants = snapshot['participants']! as List<Object?>;
   final interviewer = participants.first as Map<String, Object?>;
   return interviewer['role_snapshot']! as Map<String, Object?>;
+}
+
+Map<String, Object?> _scenarioDefinitionSnapshot(Map<String, Object?> root) {
+  final snapshot = root['snapshot']! as Map<String, Object?>;
+  return snapshot['scenario_definition_snapshot']! as Map<String, Object?>;
 }
 
 Map<String, Object?> _preparationSnapshot(Map<String, Object?> root) {


### PR DESCRIPTION
## 功能描述

修复普通场景与 JD 面试启动链把正式场景快照中的策略引用误判为未知字段，导致前端提示“练习服务返回了无法识别的数据”的回归问题。

## 实现思路

- 普通场景 Session snapshot 接受并严格校验 `turn_policy_ref`、`session_policy_ref`
- JD 面试 Plan catalog 与 Session snapshot 同步接受并校验这两个字段
- 缺失、空值或非法 ResourceId 仍保持严格拒绝
- 不修改 API、服务端、请求内容或领域模型

## 可复现验证

1. 启动本地后端和 iOS App
2. 进入“训练” → “英文面试” → “招聘初筛”
3. 点击开始练习
4. 验证成功进入第 1 题，不再出现“无法识别的数据”

## 验证结果

- 相关解析测试：50 项通过
- 练习切换生命周期测试：1 项通过
- `flutter analyze --no-pub`：通过，无问题
- iOS 26.5 真实 App：招聘初筛成功创建 Agent thread、Matter、Preparation snapshot、Practice plan、Practice session 和 Voice practice session，进入第 1 题

Closes #231
