### PR TITLE
feat(memory): add extraction barrier snapshot reader

### DIFF
--- a/server/internal/memory/extraction_barrier.go
+++ b/server/internal/memory/extraction_barrier.go
@@ -1,0 +1,86 @@
+package memory
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type ExtractionBarrierRequest struct {
+	Actor  requestcontext.Actor
+	Cutoff time.Time
+}
+
+func (request ExtractionBarrierRequest) Valid() bool {
+	return request.Actor.Valid() &&
+		!request.Cutoff.IsZero() &&
+		request.Cutoff.Location() == time.UTC
+}
+
+type ExtractionBarrierSnapshot struct {
+	Cutoff                               time.Time
+	JobCount                             int64
+	PendingCount                         int64
+	RunningCount                         int64
+	CompletedCount                       int64
+	FailedCount                          int64
+	DiscardedCount                       int64
+	LatestSourceCompletedAt              time.Time
+	EarliestNonTerminalSourceCompletedAt time.Time
+}
+
+func (snapshot ExtractionBarrierSnapshot) Valid() bool {
+	if snapshot.Cutoff.IsZero() ||
+		snapshot.Cutoff.Location() != time.UTC ||
+		snapshot.JobCount < 0 ||
+		snapshot.PendingCount < 0 ||
+		snapshot.RunningCount < 0 ||
+		snapshot.CompletedCount < 0 ||
+		snapshot.FailedCount < 0 ||
+		snapshot.DiscardedCount < 0 ||
+		snapshot.JobCount != snapshot.PendingCount+
+			snapshot.RunningCount+
+			snapshot.CompletedCount+
+			snapshot.FailedCount+
+			snapshot.DiscardedCount {
+		return false
+	}
+	if snapshot.JobCount == 0 {
+		return snapshot.LatestSourceCompletedAt.IsZero() &&
+			snapshot.EarliestNonTerminalSourceCompletedAt.IsZero()
+	}
+	if !validBarrierTimestamp(
+		snapshot.LatestSourceCompletedAt,
+		snapshot.Cutoff,
+	) {
+		return false
+	}
+	nonTerminalCount := snapshot.PendingCount + snapshot.RunningCount
+	if nonTerminalCount == 0 {
+		return snapshot.EarliestNonTerminalSourceCompletedAt.IsZero()
+	}
+	return validBarrierTimestamp(
+		snapshot.EarliestNonTerminalSourceCompletedAt,
+		snapshot.LatestSourceCompletedAt,
+	)
+}
+
+func (snapshot ExtractionBarrierSnapshot) Ready() bool {
+	return snapshot.Valid() &&
+		snapshot.PendingCount == 0 &&
+		snapshot.RunningCount == 0
+}
+
+func validBarrierTimestamp(value time.Time, maximum time.Time) bool {
+	return !value.IsZero() &&
+		value.Location() == time.UTC &&
+		!value.After(maximum)
+}
+
+type ExtractionBarrierReader interface {
+	ReadExtractionBarrier(
+		context.Context,
+		ExtractionBarrierRequest,
+	) (ExtractionBarrierSnapshot, error)
+}

--- a/server/internal/memory/extraction_barrier_postgres.go
+++ b/server/internal/memory/extraction_barrier_postgres.go
@@ -1,0 +1,63 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (repository *PostgresRepository) ReadExtractionBarrier(
+	ctx context.Context,
+	request ExtractionBarrierRequest,
+) (ExtractionBarrierSnapshot, error) {
+	if ctx == nil || !request.Valid() {
+		return ExtractionBarrierSnapshot{}, ErrInvalidArgument
+	}
+	snapshot := ExtractionBarrierSnapshot{Cutoff: request.Cutoff}
+	var latestSourceCompletedAt pgtype.Timestamptz
+	var earliestNonTerminalSourceCompletedAt pgtype.Timestamptz
+	err := repository.database.QueryRow(ctx, `
+SELECT
+    count(*),
+    count(*) FILTER (WHERE status = 'pending'),
+    count(*) FILTER (WHERE status = 'running'),
+    count(*) FILTER (WHERE status = 'completed'),
+    count(*) FILTER (WHERE status = 'failed'),
+    count(*) FILTER (WHERE status = 'discarded'),
+    max(source_completed_at),
+    min(source_completed_at) FILTER (
+        WHERE status IN ('pending', 'running')
+    )
+FROM agent_memory_extraction_jobs
+WHERE owner_user_id = $1
+  AND source_completed_at <= $2`,
+		request.Actor.UserID,
+		request.Cutoff,
+	).Scan(
+		&snapshot.JobCount,
+		&snapshot.PendingCount,
+		&snapshot.RunningCount,
+		&snapshot.CompletedCount,
+		&snapshot.FailedCount,
+		&snapshot.DiscardedCount,
+		&latestSourceCompletedAt,
+		&earliestNonTerminalSourceCompletedAt,
+	)
+	if err != nil {
+		return ExtractionBarrierSnapshot{}, ErrRepository
+	}
+	if latestSourceCompletedAt.Valid {
+		snapshot.LatestSourceCompletedAt =
+			latestSourceCompletedAt.Time.UTC()
+	}
+	if earliestNonTerminalSourceCompletedAt.Valid {
+		snapshot.EarliestNonTerminalSourceCompletedAt =
+			earliestNonTerminalSourceCompletedAt.Time.UTC()
+	}
+	if !snapshot.Valid() {
+		return ExtractionBarrierSnapshot{}, ErrRepository
+	}
+	return snapshot, nil
+}
+
+var _ ExtractionBarrierReader = (*PostgresRepository)(nil)

--- a/server/internal/memory/extraction_barrier_postgres_integration_test.go
+++ b/server/internal/memory/extraction_barrier_postgres_integration_test.go
@@ -1,0 +1,260 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresExtractionBarrierOwnerAndCutoffIsolation(t *testing.T) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	ctx := context.Background()
+	base := time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC)
+	actorA := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	actorB := requestcontext.Actor{
+		UserID:    integrationUserB,
+		SessionID: integrationSessionB,
+	}
+	jobs := []barrierIntegrationJob{
+		{
+			runID:           "aa000000-0000-4000-8000-000000000001",
+			ownerID:         actorA.UserID,
+			status:          "pending",
+			sourceCompleted: base.Add(time.Second),
+		},
+		{
+			runID:           "aa000000-0000-4000-8000-000000000002",
+			ownerID:         actorA.UserID,
+			status:          "running",
+			sourceCompleted: base.Add(2 * time.Second),
+		},
+		{
+			runID:           "aa000000-0000-4000-8000-000000000003",
+			ownerID:         actorA.UserID,
+			status:          "completed",
+			sourceCompleted: base.Add(3 * time.Second),
+		},
+		{
+			runID:           "aa000000-0000-4000-8000-000000000004",
+			ownerID:         actorA.UserID,
+			status:          "failed",
+			sourceCompleted: base.Add(4 * time.Second),
+		},
+		{
+			runID:           "aa000000-0000-4000-8000-000000000005",
+			ownerID:         actorA.UserID,
+			status:          "discarded",
+			sourceCompleted: base.Add(5 * time.Second),
+		},
+		{
+			runID:           "aa000000-0000-4000-8000-000000000006",
+			ownerID:         actorA.UserID,
+			status:          "pending",
+			sourceCompleted: base.Add(7 * time.Second),
+		},
+		{
+			runID:           "bb000000-0000-4000-8000-000000000001",
+			ownerID:         actorB.UserID,
+			status:          "pending",
+			sourceCompleted: base.Add(time.Second),
+		},
+	}
+	for _, job := range jobs {
+		insertBarrierIntegrationJob(t, database, job)
+	}
+
+	cutoff := base.Add(6 * time.Second)
+	snapshot, err := repository.ReadExtractionBarrier(
+		ctx,
+		ExtractionBarrierRequest{Actor: actorA, Cutoff: cutoff},
+	)
+	if err != nil {
+		t.Fatalf("ReadExtractionBarrier actor A: %v", err)
+	}
+	expected := ExtractionBarrierSnapshot{
+		Cutoff:                               cutoff,
+		JobCount:                             5,
+		PendingCount:                         1,
+		RunningCount:                         1,
+		CompletedCount:                       1,
+		FailedCount:                          1,
+		DiscardedCount:                       1,
+		LatestSourceCompletedAt:              base.Add(5 * time.Second),
+		EarliestNonTerminalSourceCompletedAt: base.Add(time.Second),
+	}
+	if snapshot != expected {
+		t.Fatalf("actor A snapshot = %#v, want %#v", snapshot, expected)
+	}
+
+	snapshot, err = repository.ReadExtractionBarrier(
+		ctx,
+		ExtractionBarrierRequest{Actor: actorB, Cutoff: cutoff},
+	)
+	if err != nil {
+		t.Fatalf("ReadExtractionBarrier actor B: %v", err)
+	}
+	if snapshot.JobCount != 1 ||
+		snapshot.PendingCount != 1 ||
+		snapshot.LatestSourceCompletedAt != base.Add(time.Second) {
+		t.Fatalf("actor B snapshot = %#v", snapshot)
+	}
+
+	emptyCutoff := base
+	snapshot, err = repository.ReadExtractionBarrier(
+		ctx,
+		ExtractionBarrierRequest{Actor: actorA, Cutoff: emptyCutoff},
+	)
+	if err != nil {
+		t.Fatalf("ReadExtractionBarrier empty cutoff: %v", err)
+	}
+	if snapshot != (ExtractionBarrierSnapshot{Cutoff: emptyCutoff}) ||
+		!snapshot.Ready() {
+		t.Fatalf("empty snapshot = %#v", snapshot)
+	}
+}
+
+func TestPostgresExtractionBarrierRejectsInvalidRequest(t *testing.T) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	valid := ExtractionBarrierRequest{
+		Actor: requestcontext.Actor{
+			UserID:    integrationUserA,
+			SessionID: integrationSessionA,
+		},
+		Cutoff: time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC),
+	}
+	cases := map[string]ExtractionBarrierRequest{
+		"invalid actor": {
+			Actor:  requestcontext.Actor{},
+			Cutoff: valid.Cutoff,
+		},
+		"zero cutoff": {
+			Actor: valid.Actor,
+		},
+		"non-UTC cutoff": {
+			Actor: valid.Actor,
+			Cutoff: valid.Cutoff.In(
+				time.FixedZone("UTC+8", 8*60*60),
+			),
+		},
+	}
+	for name, request := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := repository.ReadExtractionBarrier(
+				context.Background(),
+				request,
+			)
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("ReadExtractionBarrier error = %v", err)
+			}
+		})
+	}
+}
+
+type barrierIntegrationJob struct {
+	runID           string
+	ownerID         string
+	status          string
+	sourceCompleted time.Time
+}
+
+func insertBarrierIntegrationJob(
+	t *testing.T,
+	database *pgxpool.Pool,
+	job barrierIntegrationJob,
+) {
+	t.Helper()
+	createdAt := job.sourceCompleted.Add(time.Second)
+	attemptCount := 0
+	var leaseToken any
+	var leaseExpiresAt any
+	var candidateCount any
+	var appliedCount any
+	var rejectedCount any
+	var failureKind any
+	var completedAt any
+	switch job.status {
+	case "running":
+		attemptCount = 1
+		leaseToken = "cc000000-0000-4000-8000-000000000001"
+		leaseExpiresAt = createdAt.Add(time.Minute)
+	case "completed":
+		attemptCount = 1
+		candidateCount = 1
+		appliedCount = 1
+		rejectedCount = 0
+		completedAt = createdAt
+	case "failed", "discarded":
+		attemptCount = 1
+		failureKind = "test_failure"
+		completedAt = createdAt
+	}
+	_, err := database.Exec(context.Background(), `
+INSERT INTO agent_memory_extraction_jobs (
+    source_run_id,
+    owner_user_id,
+    source_thread_id,
+    source_input_message_id,
+    source_assistant_message_id,
+    source_attempt,
+    source_completed_at,
+    status,
+    attempt_count,
+    lease_token,
+    lease_expires_at,
+    next_attempt_at,
+    candidate_count,
+    applied_count,
+    rejected_count,
+    failure_kind,
+    created_at,
+    updated_at,
+    completed_at
+) VALUES (
+    $1, $2,
+    'dd000000-0000-4000-8000-000000000001',
+    'ee000000-0000-4000-8000-000000000001',
+    'ff000000-0000-4000-8000-000000000001',
+    1, $3, $4, $5, $6, $7, $8,
+    $9, $10, $11, $12, $13, $13, $14
+)`,
+		job.runID,
+		job.ownerID,
+		job.sourceCompleted,
+		job.status,
+		attemptCount,
+		leaseToken,
+		leaseExpiresAt,
+		createdAt,
+		candidateCount,
+		appliedCount,
+		rejectedCount,
+		failureKind,
+		createdAt,
+		completedAt,
+	)
+	if err != nil {
+		t.Fatalf("insert %s Extraction Barrier job: %v", job.status, err)
+	}
+}

--- a/server/internal/memory/extraction_barrier_test.go
+++ b/server/internal/memory/extraction_barrier_test.go
@@ -1,0 +1,149 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestExtractionBarrierRequestValid(t *testing.T) {
+	t.Parallel()
+	request := ExtractionBarrierRequest{
+		Actor: requestcontext.Actor{
+			UserID:    "10000000-0000-4000-8000-000000000001",
+			SessionID: "20000000-0000-4000-8000-000000000001",
+		},
+		Cutoff: time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC),
+	}
+	if !request.Valid() {
+		t.Fatal("valid Extraction Barrier request was rejected")
+	}
+	request.Cutoff = request.Cutoff.In(time.FixedZone("UTC+8", 8*60*60))
+	if request.Valid() {
+		t.Fatal("non-UTC Extraction Barrier cutoff was accepted")
+	}
+}
+
+func TestExtractionBarrierSnapshotValidAndReady(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC)
+	latest := cutoff.Add(-time.Second)
+	pending := cutoff.Add(-2 * time.Second)
+	snapshot := ExtractionBarrierSnapshot{
+		Cutoff:                               cutoff,
+		JobCount:                             3,
+		PendingCount:                         1,
+		CompletedCount:                       1,
+		FailedCount:                          1,
+		LatestSourceCompletedAt:              latest,
+		EarliestNonTerminalSourceCompletedAt: pending,
+	}
+	if !snapshot.Valid() {
+		t.Fatal("valid Extraction Barrier snapshot was rejected")
+	}
+	if snapshot.Ready() {
+		t.Fatal("snapshot with a pending job reported ready")
+	}
+	snapshot.PendingCount = 0
+	snapshot.CompletedCount = 2
+	snapshot.EarliestNonTerminalSourceCompletedAt = time.Time{}
+	if !snapshot.Ready() {
+		t.Fatal("terminal Extraction Barrier snapshot did not report ready")
+	}
+}
+
+func TestExtractionBarrierSnapshotRejectsInconsistentState(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC)
+	valid := ExtractionBarrierSnapshot{
+		Cutoff:                  cutoff,
+		JobCount:                1,
+		CompletedCount:          1,
+		LatestSourceCompletedAt: cutoff.Add(-time.Second),
+	}
+	cases := map[string]func(ExtractionBarrierSnapshot) ExtractionBarrierSnapshot{
+		"count mismatch": func(snapshot ExtractionBarrierSnapshot) ExtractionBarrierSnapshot {
+			snapshot.JobCount++
+			return snapshot
+		},
+		"missing latest timestamp": func(snapshot ExtractionBarrierSnapshot) ExtractionBarrierSnapshot {
+			snapshot.LatestSourceCompletedAt = time.Time{}
+			return snapshot
+		},
+		"latest after cutoff": func(snapshot ExtractionBarrierSnapshot) ExtractionBarrierSnapshot {
+			snapshot.LatestSourceCompletedAt = cutoff.Add(time.Second)
+			return snapshot
+		},
+		"unexpected non-terminal timestamp": func(snapshot ExtractionBarrierSnapshot) ExtractionBarrierSnapshot {
+			snapshot.EarliestNonTerminalSourceCompletedAt = cutoff.Add(-time.Second)
+			return snapshot
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if mutate(valid).Valid() {
+				t.Fatalf("%s snapshot was accepted", name)
+			}
+		})
+	}
+}
+
+func TestReadExtractionBarrierMapsDatabaseError(t *testing.T) {
+	t.Parallel()
+	repository := &PostgresRepository{database: barrierErrorDatabase{}}
+	_, err := repository.ReadExtractionBarrier(
+		context.Background(),
+		ExtractionBarrierRequest{
+			Actor: requestcontext.Actor{
+				UserID:    "10000000-0000-4000-8000-000000000001",
+				SessionID: "20000000-0000-4000-8000-000000000001",
+			},
+			Cutoff: time.Date(
+				2026,
+				time.July,
+				29,
+				10,
+				0,
+				0,
+				0,
+				time.UTC,
+			),
+		},
+	)
+	if !errors.Is(err, ErrRepository) {
+		t.Fatalf("ReadExtractionBarrier error = %v", err)
+	}
+}
+
+type barrierErrorDatabase struct{}
+
+func (barrierErrorDatabase) Begin(context.Context) (pgx.Tx, error) {
+	return nil, errors.New("unexpected Begin")
+}
+
+func (barrierErrorDatabase) Query(
+	context.Context,
+	string,
+	...any,
+) (pgx.Rows, error) {
+	return nil, errors.New("unexpected Query")
+}
+
+func (barrierErrorDatabase) QueryRow(
+	context.Context,
+	string,
+	...any,
+) pgx.Row {
+	return barrierErrorRow{}
+}
+
+type barrierErrorRow struct{}
+
+func (barrierErrorRow) Scan(...any) error {
+	return errors.New("database unavailable")
+}

--- a/server/migrations/000031_agent_memory_extraction_barrier.down.sql
+++ b/server/migrations/000031_agent_memory_extraction_barrier.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX agent_memory_extraction_jobs_owner_cutoff_idx;
+
+COMMIT;

--- a/server/migrations/000031_agent_memory_extraction_barrier.up.sql
+++ b/server/migrations/000031_agent_memory_extraction_barrier.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE INDEX agent_memory_extraction_jobs_owner_cutoff_idx
+    ON agent_memory_extraction_jobs (
+        owner_user_id,
+        source_completed_at,
+        source_run_id
+    )
+    INCLUDE (status);
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -16,4 +16,5 @@ import "embed"
 //go:embed 000028_review_scenario_policies.*.sql
 //go:embed 000029_agent_stable_profile_context_manifest.*.sql
 //go:embed 000030_agent_tool_routing_cleanup.*.sql
+//go:embed 000031_agent_memory_extraction_barrier.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

实现 #232 的第一项后端子任务：提供按可信 Actor owner 与 UTC cutoff 隔离的 Memory Extraction Barrier Snapshot Reader。该 PR 只读取持久化提取任务状态，不接入 ContextAssembler、不等待 Worker、不修改 Manifest、HTTP 或 Flutter。

## 实现思路

- 在 Memory domain 增加 ExtractionBarrierRequest、严格校验的 ExtractionBarrierSnapshot 与只读 Reader Port。
- 使用单条 PostgreSQL 聚合查询统计 pending/running/completed/failed/discarded，并返回 latest source completed at 与 earliest non-terminal source completed at。
- 查询仅使用 Actor.UserID，并限制 source_completed_at <= cutoff；数据库错误映射为 ErrRepository。
- 新增可逆迁移 000031，为 owner/cutoff 查询增加 covering index。
- 增加 domain 单元测试和真实 PostgreSQL owner/cutoff/五状态/空历史测试。

## 可复现测试

在 server 目录执行：

1. gofmt -w internal/memory/extraction_barrier*.go migrations/embed.go
2. go vet ./...
3. TEST_DATABASE_URL=本地测试库地址 go test ./... -count=1
4. go run ./cmd/migrate up
5. MIGRATION_ENV=local go run ./cmd/migrate down-one --local-test-only
6. go run ./cmd/migrate up
7. go run ./cmd/migrate version

本地结果：完整 Go 与 PostgreSQL 测试通过；迁移 up/down/up 通过，最终 version=31 dirty=false。

Closes #233