### PR TITLE
feat(mobile): render assistant messages as markdown

### DIFF
--- a/mobile/lib/agent/agent_voice_widgets.dart
+++ b/mobile/lib/agent/agent_voice_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:speakup/design/speak_up_design.dart';
 
 import 'agent_models.dart';
@@ -110,11 +111,19 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   Widget _buildTextMessage(BuildContext context, Color foreground) {
     final message = widget.message;
     final voice = widget.voiceController;
-    if (message.role == AgentMessageRole.user || voice == null) {
+    if (message.role == AgentMessageRole.user) {
       return Text(
         message.text,
         style: TextStyle(color: foreground, fontSize: 15, height: 1.45),
       );
+    }
+    final markdown = _AssistantMarkdown(
+      key: Key('agent-assistant-text-${message.id}'),
+      data: message.text,
+      foreground: foreground,
+    );
+    if (voice == null) {
+      return markdown;
     }
     final loading = voice.loadingMessageId == message.id;
     final playing = voice.playingMessageId == message.id;
@@ -124,11 +133,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          message.text,
-          key: Key('agent-assistant-text-${message.id}'),
-          style: TextStyle(color: foreground, fontSize: 15, height: 1.48),
-        ),
+        markdown,
         const SizedBox(height: 6),
         Wrap(
           spacing: 4,
@@ -367,6 +372,65 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           ),
         ],
       ],
+    );
+  }
+}
+
+class _AssistantMarkdown extends StatelessWidget {
+  const _AssistantMarkdown({
+    required this.data,
+    required this.foreground,
+    super.key,
+  });
+
+  final String data;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    final body = TextStyle(color: foreground, fontSize: 15, height: 1.48);
+    return MarkdownBody(
+      data: data,
+      selectable: true,
+      fitContent: true,
+      styleSheet: MarkdownStyleSheet(
+        a: body,
+        p: body,
+        pPadding: EdgeInsets.zero,
+        em: body.copyWith(fontStyle: FontStyle.italic),
+        strong: body.copyWith(fontWeight: FontWeight.w700),
+        code: body.copyWith(
+          fontFamily: 'monospace',
+          fontSize: 13.5,
+          backgroundColor: SpeakUpDesign.surfaceMuted,
+        ),
+        h1: body.copyWith(fontSize: 20, fontWeight: FontWeight.w700),
+        h2: body.copyWith(fontSize: 18, fontWeight: FontWeight.w700),
+        h3: body.copyWith(fontSize: 16, fontWeight: FontWeight.w700),
+        h4: body.copyWith(fontWeight: FontWeight.w700),
+        h5: body.copyWith(fontWeight: FontWeight.w700),
+        h6: body.copyWith(fontWeight: FontWeight.w700),
+        blockquote: body.copyWith(color: SpeakUpDesign.secondary),
+        listBullet: body,
+        listIndent: 20,
+        blockSpacing: 8,
+        blockquotePadding: const EdgeInsets.fromLTRB(10, 5, 8, 5),
+        blockquoteDecoration: const BoxDecoration(
+          color: SpeakUpDesign.surfaceMuted,
+          border: Border(
+            left: BorderSide(color: SpeakUpDesign.primary, width: 3),
+          ),
+        ),
+        codeblockPadding: const EdgeInsets.all(10),
+        codeblockDecoration: BoxDecoration(
+          color: SpeakUpDesign.surfaceMuted,
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+      imageBuilder: (uri, title, alt) => Text(
+        alt == null || alt.trim().isEmpty ? '[图片已隐藏]' : '[图片：$alt]',
+        style: body.copyWith(color: SpeakUpDesign.secondary),
+      ),
     );
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -179,6 +179,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: fce641d6c2106cc495de1cd603f97a4f9d615a97a64011928ded380dbdade935
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.12"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -327,6 +335,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   audioplayers: ^6.8.1
   flutter:
     sdk: flutter
+  flutter_markdown_plus: ^1.0.12
   flutter_secure_storage: ^10.3.1
   path_provider: ^2.1.5
   record: ^6.1.2

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/agent/agent_voice_widgets.dart';
+
+void main() {
+  testWidgets('renders assistant emphasis instead of Markdown markers', (
+    tester,
+  ) async {
+    await _pumpMessage(
+      tester,
+      const AgentMessage(
+        id: 'assistant-markdown',
+        role: AgentMessageRole.assistant,
+        text: 'You are **Xiaohua**.',
+      ),
+    );
+
+    final selectableText = _messageSelectableText(tester, 'assistant-markdown');
+    expect(
+      selectableText.map(_selectablePlainText).join(),
+      contains('You are Xiaohua.'),
+    );
+    expect(
+      selectableText
+          .expand(
+            (widget) => widget.textSpan == null
+                ? const <TextSpan>[]
+                : _flatten(widget.textSpan!),
+          )
+          .any(
+            (span) =>
+                span.text == 'Xiaohua' &&
+                span.style?.fontWeight == FontWeight.w700,
+          ),
+      isTrue,
+    );
+    expect(
+      selectableText.any(
+        (widget) => _selectablePlainText(widget).contains('**'),
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets('renders assistant block Markdown inside the message bubble', (
+    tester,
+  ) async {
+    await _pumpMessage(
+      tester,
+      const AgentMessage(
+        id: 'assistant-list',
+        role: AgentMessageRole.assistant,
+        text: '## Practice\n\n- First answer\n- Add evidence',
+      ),
+    );
+
+    final text = _messageSelectableText(
+      tester,
+      'assistant-list',
+    ).map(_selectablePlainText).join(' ');
+    expect(text, contains('Practice'));
+    expect(text, contains('First answer'));
+    expect(text, contains('Add evidence'));
+  });
+
+  testWidgets('keeps user Markdown input as literal plain text', (
+    tester,
+  ) async {
+    await _pumpMessage(
+      tester,
+      const AgentMessage(
+        id: 'user-markdown',
+        role: AgentMessageRole.user,
+        text: 'I typed **literal markers**.',
+      ),
+    );
+
+    expect(find.text('I typed **literal markers**.'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('agent-message-user-markdown')),
+        matching: find.byType(SelectableText),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('does not load remote images from assistant Markdown', (
+    tester,
+  ) async {
+    await _pumpMessage(
+      tester,
+      const AgentMessage(
+        id: 'assistant-image',
+        role: AgentMessageRole.assistant,
+        text: '![private diagram](https://example.com/private.png)',
+      ),
+    );
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.text('[图片：private diagram]'), findsOneWidget);
+  });
+}
+
+Future<void> _pumpMessage(WidgetTester tester, AgentMessage message) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: AgentMessageBubble(message: message)),
+    ),
+  );
+  await tester.pump();
+}
+
+Iterable<SelectableText> _messageSelectableText(
+  WidgetTester tester,
+  String messageID,
+) {
+  return tester.widgetList<SelectableText>(
+    find.descendant(
+      of: find.byKey(Key('agent-assistant-text-$messageID')),
+      matching: find.byType(SelectableText),
+    ),
+  );
+}
+
+String _selectablePlainText(SelectableText widget) {
+  return widget.textSpan?.toPlainText() ?? widget.data ?? '';
+}
+
+Iterable<TextSpan> _flatten(InlineSpan span) sync* {
+  if (span is! TextSpan) {
+    return;
+  }
+  yield span;
+  for (final child in span.children ?? const <InlineSpan>[]) {
+    yield* _flatten(child);
+  }
+}


### PR DESCRIPTION
## 功能描述

解决 Agent 助手消息中的 Markdown 标记直接暴露给用户的问题。助手回复现在会在现有对话气泡内渲染常用 Markdown；用户消息仍保持纯文本。

## 实现思路

- 使用维护中的 flutter_markdown_plus 1.0.12 和非滚动 MarkdownBody。
- 仅对 AgentMessageRole.assistant 的文本消息启用 Markdown。
- 为段落、强调、标题、列表、引用与代码设置 SpeakUp 视觉样式。
- 不绑定链接跳转；图片语法由本地占位文本替代，不加载远程资源。
- 朗读仍接收原始 AgentMessage，未修改 TTS、消息模型或后端协议。

## 验证

- flutter analyze：通过。
- flutter test：517 项全部通过。
- flutter build ios --simulator --debug：通过。
- iPhone 17 Pro 模拟器实测：Xiaohua 和 fried eggs 正确加粗，双星号不再显示，朗读按钮和布局正常。

Closes #237