### PR TITLE
fix(practice): support tap recording

### DIFF
--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -742,6 +742,7 @@ class _RecordingPanelState extends State<_RecordingPanel> {
   bool _pointerActive = false;
   bool _recordingGestureStarted = false;
   bool _cancelArmed = false;
+  bool _tapRecordingActive = false;
   double _voiceHitWidth = double.infinity;
 
   @override
@@ -762,6 +763,7 @@ class _RecordingPanelState extends State<_RecordingPanel> {
       _pointerActive = true;
       _recordingGestureStarted = false;
       _cancelArmed = false;
+      _tapRecordingActive = false;
       _pointerOrigin = event.position;
     });
     _holdTimer = Timer(_holdDelay, () {
@@ -808,6 +810,9 @@ class _RecordingPanelState extends State<_RecordingPanel> {
       _pointerOrigin = null;
     });
     if (!started) {
+      if (!cancel) {
+        _startTapRecording();
+      }
       return;
     }
     if (cancel) {
@@ -820,16 +825,50 @@ class _RecordingPanelState extends State<_RecordingPanel> {
   void _toggleRecordingForAccessibility() {
     final state = widget.controller.recordingState;
     if (state == PracticeRecordingState.idle) {
-      unawaited(widget.controller.startRecording());
+      _startTapRecording();
     } else if (state == PracticeRecordingState.starting ||
         state == PracticeRecordingState.recording) {
-      unawaited(widget.controller.finishRecordingGesture());
+      _finishTapRecording();
     }
+  }
+
+  void _startTapRecording() {
+    if (widget.textMode ||
+        widget.controller.recordingState != PracticeRecordingState.idle) {
+      return;
+    }
+    setState(() => _tapRecordingActive = true);
+    unawaited(HapticFeedback.mediumImpact());
+    unawaited(widget.controller.startRecording());
+  }
+
+  void _finishTapRecording() {
+    final state = widget.controller.recordingState;
+    if (state != PracticeRecordingState.starting &&
+        state != PracticeRecordingState.recording) {
+      return;
+    }
+    setState(() => _tapRecordingActive = false);
+    unawaited(widget.controller.finishRecordingGesture());
+  }
+
+  void _cancelTapRecording() {
+    final state = widget.controller.recordingState;
+    if (state != PracticeRecordingState.starting &&
+        state != PracticeRecordingState.recording) {
+      return;
+    }
+    setState(() => _tapRecordingActive = false);
+    unawaited(widget.controller.cancelRecording());
   }
 
   @override
   Widget build(BuildContext context) {
     final state = widget.controller.recordingState;
+    final tapRecordingActive =
+        _tapRecordingActive &&
+        (state == PracticeRecordingState.starting ||
+            state == PracticeRecordingState.recording);
     final handlesHold =
         !widget.textMode &&
         (state == PracticeRecordingState.idle ||
@@ -849,6 +888,7 @@ class _RecordingPanelState extends State<_RecordingPanel> {
         preparing: state == PracticeRecordingState.starting,
         cancelArmed: _cancelArmed,
         recordingSeconds: widget.recordingSeconds,
+        tapMode: tapRecordingActive,
       ),
       PracticeRecordingState.transcribing => const _WorkingState(
         label: '正在识别英文回答…',
@@ -873,7 +913,38 @@ class _RecordingPanelState extends State<_RecordingPanel> {
         top: false,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
-          child: handlesHold
+          child: tapRecordingActive
+              ? Row(
+                  children: [
+                    Expanded(
+                      child: Semantics(
+                        button: true,
+                        label: state == PracticeRecordingState.starting
+                            ? '正在打开麦克风'
+                            : '结束录音并自动转写',
+                        onTap: _finishTapRecording,
+                        child: ExcludeSemantics(
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: _finishTapRecording,
+                            child: panel,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    IconButton.outlined(
+                      key: const Key('practice-cancel-tap-recording'),
+                      tooltip: '取消录音',
+                      onPressed: _cancelTapRecording,
+                      icon: const Icon(Icons.close_rounded),
+                      style: IconButton.styleFrom(
+                        minimumSize: const Size.square(56),
+                      ),
+                    ),
+                  ],
+                )
+              : handlesHold
               ? LayoutBuilder(
                   builder: (context, constraints) {
                     _voiceHitWidth =
@@ -883,7 +954,7 @@ class _RecordingPanelState extends State<_RecordingPanel> {
                     return Semantics(
                       button: true,
                       label: state == PracticeRecordingState.idle
-                          ? '按住说话'
+                          ? '点击或按住说话'
                           : '正在录音，上滑取消，松开发送',
                       onTap: _toggleRecordingForAccessibility,
                       child: Listener(
@@ -944,12 +1015,16 @@ class _IdleAnswerPanel extends StatelessWidget {
                 children: [
                   Icon(Icons.mic_rounded, color: Colors.white),
                   SizedBox(width: 10),
-                  Text(
-                    '按住说话',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
+                  Flexible(
+                    child: Text(
+                      '点击或按住说话',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
                 ],
@@ -1015,11 +1090,13 @@ class _ActiveRecordingPanel extends StatelessWidget {
     required this.preparing,
     required this.cancelArmed,
     required this.recordingSeconds,
+    required this.tapMode,
   });
 
   final bool preparing;
   final bool cancelArmed;
   final int recordingSeconds;
+  final bool tapMode;
 
   @override
   Widget build(BuildContext context) {
@@ -1028,8 +1105,8 @@ class _ActiveRecordingPanel extends StatelessWidget {
     return AnimatedContainer(
       key: const Key('practice-stop-recording'),
       duration: const Duration(milliseconds: 120),
-      height: 72,
-      padding: const EdgeInsets.symmetric(horizontal: 18),
+      constraints: const BoxConstraints(minHeight: 72),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
       decoration: BoxDecoration(
         color: cancelArmed
             ? SpeakUpDesign.errorMuted
@@ -1056,6 +1133,8 @@ class _ActiveRecordingPanel extends StatelessWidget {
                       ? '松开取消'
                       : preparing
                       ? '正在打开麦克风…'
+                      : tapMode
+                      ? '再次点击结束'
                       : '松开发送',
                   style: SpeakUpDesign.cardTitle.copyWith(
                     color: cancelArmed
@@ -1065,15 +1144,24 @@ class _ActiveRecordingPanel extends StatelessWidget {
                 ),
                 const SizedBox(height: 2),
                 Text(
-                  cancelArmed ? '录音不会保存' : '上滑取消 · $minutes:$seconds',
+                  cancelArmed
+                      ? '录音不会保存'
+                      : tapMode
+                      ? '点击结束并识别 · $minutes:$seconds'
+                      : '上滑取消 · $minutes:$seconds',
                   style: SpeakUpDesign.meta,
                 ),
               ],
             ),
           ),
-          if (!cancelArmed)
+          if (!cancelArmed && !tapMode)
             const Icon(
               Icons.keyboard_arrow_up_rounded,
+              color: SpeakUpDesign.primary,
+            ),
+          if (!cancelArmed && tapMode)
+            const Icon(
+              Icons.stop_circle_outlined,
               color: SpeakUpDesign.primary,
             ),
         ],

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -70,7 +70,27 @@ void main() {
     expect(find.byKey(const Key('practice-page')), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('practice-record')));
-    await tester.pump(const Duration(milliseconds: 220));
+    await tester.pumpAndSettle();
+    expect(agentController.recordingState, PracticeRecordingState.recording);
+    expect(find.text('再次点击结束'), findsOneWidget);
+    expect(
+      find.byKey(const Key('practice-cancel-tap-recording')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('practice-cancel-tap-recording')));
+    await tester.pumpAndSettle();
+    expect(agentController.recordingState, PracticeRecordingState.idle);
+    expect(find.byKey(const Key('practice-transcript')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('practice-record')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('practice-stop-recording')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('practice-rerecord')));
+    await tester.pumpAndSettle();
     expect(agentController.recordingState, PracticeRecordingState.idle);
 
     final cancelledGesture = await tester.startGesture(

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -267,6 +267,80 @@ void main() {
     expect(recorder.cleanupCount, 1);
   });
 
+  test('finishing a starting recording waits and stops exactly once', () async {
+    final recorder = _ControlledStartRecorder();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _TwoTurnPracticeClient(),
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+
+    final start = controller.startRecording();
+    final finish = controller.finishRecordingGesture();
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.recordingState, PracticeRecordingState.starting);
+    expect(recorder.stopCount, 0);
+
+    recorder.startCompleter.complete();
+    await start;
+    await finish;
+
+    expect(recorder.stopCount, 1);
+    expect(
+      controller.recordingState,
+      PracticeRecordingState.awaitingConfirmation,
+    );
+  });
+
+  testWidgets(
+    'tap recording ignores duplicate finish on a narrow large-text screen',
+    (tester) async {
+      tester.view.physicalSize = const Size(320, 780);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final recorder = _ControlledStartRecorder();
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: _TwoTurnPracticeClient(),
+        recorder: recorder,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: MaterialApp(home: PracticePage(agentController: controller)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('practice-record')));
+      await tester.pump();
+      expect(controller.recordingState, PracticeRecordingState.starting);
+      expect(
+        find.byKey(const Key('practice-cancel-tap-recording')),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+
+      final stop = find.byKey(const Key('practice-stop-recording'));
+      await tester.tap(stop);
+      await tester.tap(stop);
+      recorder.startCompleter.complete();
+      await tester.pumpAndSettle();
+
+      expect(recorder.stopCount, 1);
+      expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   test(
     'logout during native stop deletes account A audio without a B upload',
     () async {


### PR DESCRIPTION
## 功能描述

- 训练答题页支持单击开始、再次单击结束并转写。
- 保留长按开始、松开发送、上滑取消的原有交互。
- 点击录音模式提供独立取消按钮，取消后不转写、不提交。
- 统一无障碍语义，并适配窄屏与大字号。

## 实现思路

- 在训练页录音面板内部区分点击模式和长按模式，不改动录音 Controller、API、服务端或数据模型。
- 点击模式复用现有开始、结束和取消链路；原生麦克风仍在启动时，结束操作会等待启动完成。
- 补充点击、取消、长按、连续结束防重以及 320px/2 倍字号回归测试。

## 可复现测试

1. 进入任一训练题目，短点录音按钮，确认显示“再次点击结束”和独立取消按钮。
2. 再点主录音区域，确认进入转写确认态。
3. 重新录音后点取消，确认回到空闲态且不生成转写。
4. 长按超过 180ms 后松开，确认仍可转写；上滑后松开，确认取消。

## 验证结果

- `flutter analyze --no-pub`：通过，0 问题。
- `flutter test --no-pub`：519 项全部通过。
- iOS 26.5 模拟器完整构建并启动通过。
- 真实麦克风、对象存储上传和转写链路通过，候选转写请求返回 201 并展示识别结果。
- 后端 `/health` 与 `/readyz` 通过。

Closes #238