### PR TITLE
feat(agent): derive server-owned thread titles

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -832,12 +832,20 @@ components:
       additionalProperties: false
       required:
         - thread_id
+        - title
         - created_at
         - updated_at
       properties:
         thread_id:
           type: string
           format: uuid
+          readOnly: true
+        title:
+          type:
+            - string
+            - "null"
+          minLength: 1
+          maxLength: 25
           readOnly: true
         active_matter_id:
           type: string

--- a/mobile/lib/agent/agent_client.dart
+++ b/mobile/lib/agent/agent_client.dart
@@ -783,6 +783,7 @@ final class FakeAgentClient
     final thread = _threads[threadId]!;
     return AgentThreadSnapshot(
       threadId: thread.id,
+      title: thread.title,
       activeMatter: _threadMatters[threadId],
       messages: List<AgentMessage>.unmodifiable(
         _threadMessages[threadId] ?? const <AgentMessage>[],
@@ -807,6 +808,7 @@ final class FakeAgentClient
     final now = DateTime.now().toUtc();
     _threads[threadId] = AgentThreadSummary(
       id: thread.id,
+      title: thread.title,
       activeMatterId: _threadMatters[threadId]?.id,
       createdAt: thread.createdAt,
       updatedAt: now.isBefore(thread.updatedAt) ? thread.updatedAt : now,

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -2016,6 +2016,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     }
     return AgentThreadSummary(
       id: snapshot.threadId,
+      title: snapshot.title,
       activeMatterId: snapshot.activeMatter?.id,
       createdAt: createdAt,
       updatedAt: updatedAt,
@@ -2122,6 +2123,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       final now = DateTime.now().toUtc();
       final updated = AgentThreadSummary(
         id: current.id,
+        title: current.title,
         activeMatterId: current.activeMatterId,
         createdAt: current.createdAt,
         updatedAt: now.isBefore(current.updatedAt) ? current.updatedAt : now,
@@ -2130,6 +2132,19 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _mergeThreadSummary(updated, placeFirst: true);
     }
     notifyListeners();
+    if (client case final AgentThreadHistoryClient historyClient) {
+      final threadId = _threadId;
+      if (threadId != null) {
+        final fence = _captureOperationFence(threadId: threadId);
+        unawaited(
+          _refreshAuthoritativeThreadPage(
+            historyClient,
+            fence: fence,
+            failureMessage: '语音消息已发送，但对话标题暂时无法刷新。请重试。',
+          ),
+        );
+      }
+    }
   }
 
   void _markVoiceMessageAudioDeleted(

--- a/mobile/lib/agent/agent_models.dart
+++ b/mobile/lib/agent/agent_models.dart
@@ -106,17 +106,19 @@ final class AgentMessage {
 
 /// One durable Agent Thread as returned by the bounded history endpoint.
 ///
-/// Threads deliberately have no client-invented title, summary, archive, or
-/// unread state. The Drawer presents the server-owned update time instead.
+/// Thread titles are server-owned and may be absent until the first committed
+/// user Message. Clients never infer a title from local Message content.
 final class AgentThreadSummary {
   const AgentThreadSummary({
     required this.id,
     required this.createdAt,
     required this.updatedAt,
+    this.title,
     this.activeMatterId,
   });
 
   final String id;
+  final String? title;
   final String? activeMatterId;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -192,6 +194,7 @@ final class AgentPracticeSnapshot {
 final class AgentThreadSnapshot {
   const AgentThreadSnapshot({
     required this.threadId,
+    this.title,
     this.activeMatter,
     this.practice,
     this.textRecovery,
@@ -202,6 +205,7 @@ final class AgentThreadSnapshot {
   }) : assert(practice == null || activeMatter != null);
 
   final String threadId;
+  final String? title;
   final AgentMatter? activeMatter;
   final AgentPracticeSnapshot? practice;
   final AgentTextRecovery? textRecovery;

--- a/mobile/lib/agent/wire_agent_client.dart
+++ b/mobile/lib/agent/wire_agent_client.dart
@@ -265,6 +265,7 @@ final class WireAgentClient
     );
     return AgentThreadSnapshot(
       threadId: thread.id,
+      title: thread.title,
       activeMatter: activeMatter,
       textRecovery: recovery.failure,
       messages: <AgentMessage>[
@@ -1295,16 +1296,19 @@ final class _WireThread {
     required this.id,
     required this.createdAt,
     required this.updatedAt,
+    this.title,
     this.activeMatterId,
   });
 
   final String id;
+  final String? title;
   final String? activeMatterId;
   final DateTime createdAt;
   final DateTime updatedAt;
 
   AgentThreadSummary get presentation => AgentThreadSummary(
     id: id,
+    title: title,
     activeMatterId: activeMatterId,
     createdAt: createdAt,
     updatedAt: updatedAt,
@@ -1551,13 +1555,18 @@ _WireThread _decodeThreadObject(Object? value) {
     value,
     allowed: const <String>{
       'thread_id',
+      'title',
       'active_matter_id',
       'created_at',
       'updated_at',
     },
-    required: const <String>{'thread_id', 'created_at', 'updated_at'},
+    required: const <String>{'thread_id', 'title', 'created_at', 'updated_at'},
   );
   final id = _strictUuid(object['thread_id']);
+  final titleValue = object['title'];
+  final title = titleValue == null
+      ? null
+      : _strictString(titleValue, minLength: 1, maxLength: 25);
   final activeMatterId = _absentOnlyOptional(
     object,
     'active_matter_id',
@@ -1570,6 +1579,7 @@ _WireThread _decodeThreadObject(Object? value) {
   }
   return _WireThread(
     id: id,
+    title: title,
     activeMatterId: activeMatterId,
     createdAt: createdAt,
     updatedAt: updatedAt,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -454,6 +454,7 @@ class _ConversationDrawer extends StatelessWidget {
             else
               _ConversationThreadTile(
                 threadId: currentThreadId,
+                title: current?.title,
                 updatedAt: current?.updatedAt,
                 selected: true,
                 enabled: !controller.isBusy,
@@ -475,6 +476,7 @@ class _ConversationDrawer extends StatelessWidget {
               for (final thread in recentThreads)
                 _ConversationThreadTile(
                   threadId: thread.id,
+                  title: thread.title,
                   updatedAt: thread.updatedAt,
                   selected: false,
                   enabled: !controller.isBusy,
@@ -514,6 +516,7 @@ class _ConversationDrawer extends StatelessWidget {
 class _ConversationThreadTile extends StatelessWidget {
   const _ConversationThreadTile({
     required this.threadId,
+    required this.title,
     required this.updatedAt,
     required this.selected,
     required this.enabled,
@@ -521,6 +524,7 @@ class _ConversationThreadTile extends StatelessWidget {
   });
 
   final String threadId;
+  final String? title;
   final DateTime? updatedAt;
   final bool selected;
   final bool enabled;
@@ -529,10 +533,11 @@ class _ConversationThreadTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final lastUpdatedAt = updatedAt;
+    final displayTitle = title ?? '新对话';
     return Semantics(
       selected: selected,
       button: true,
-      label: selected ? '当前 Agent 对话' : 'Agent 对话',
+      label: selected ? '当前对话：$displayTitle' : displayTitle,
       child: ListTile(
         key: Key('conversation-thread-$threadId'),
         contentPadding: const EdgeInsets.symmetric(horizontal: 8),
@@ -542,7 +547,7 @@ class _ConversationThreadTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
         ),
         leading: const Icon(Icons.chat_bubble_outline_rounded),
-        title: const Text('Agent 对话'),
+        title: Text(displayTitle, maxLines: 1, overflow: TextOverflow.ellipsis),
         subtitle: lastUpdatedAt == null
             ? null
             : Text('更新于 ${_formatThreadUpdatedAt(lastUpdatedAt)}'),

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -18,7 +18,7 @@ void main() {
           method: 'GET',
           path: '/v1/agent-threads',
           response: _jsonResponse(HttpStatus.ok, {
-            'threads': [_threadJson()],
+            'threads': [_threadJson(title: '英文面试准备')],
           }),
         ),
         _Step(
@@ -49,6 +49,7 @@ void main() {
       final snapshot = await harness.client.restoreThread();
 
       expect(snapshot.threadId, _threadId);
+      expect(snapshot.title, '英文面试准备');
       expect(snapshot.messages, hasLength(2));
       expect(snapshot.messages.first.text, 'Help me explain this.');
       expect(snapshot.messages.last.role, AgentMessageRole.assistant);
@@ -248,6 +249,60 @@ void main() {
           path: '/v1/agent-threads',
           response: _jsonResponse(HttpStatus.ok, {
             'threads': [malformedThread],
+          }),
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      await expectLater(
+        harness.client.restoreThread(),
+        throwsA(
+          isA<AgentClientException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentClientFailureKind.invalidResponse,
+          ),
+        ),
+      );
+      transport.expectDone();
+    });
+
+    test(
+      'rejects a Thread response that omits the required title field',
+      () async {
+        final malformedThread = _threadJson()..remove('title');
+        final transport = _ScriptedTransport([
+          _Step(
+            method: 'GET',
+            path: '/v1/agent-threads',
+            response: _jsonResponse(HttpStatus.ok, {
+              'threads': [malformedThread],
+            }),
+          ),
+        ]);
+        final harness = _Harness(transport);
+
+        await expectLater(
+          harness.client.restoreThread(),
+          throwsA(
+            isA<AgentClientException>().having(
+              (error) => error.kind,
+              'kind',
+              AgentClientFailureKind.invalidResponse,
+            ),
+          ),
+        );
+        transport.expectDone();
+      },
+    );
+
+    test('rejects a Thread title beyond the server contract limit', () async {
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads',
+          response: _jsonResponse(HttpStatus.ok, {
+            'threads': [_threadJson(title: List.filled(26, '一').join())],
           }),
         ),
       ]);
@@ -2106,10 +2161,12 @@ Map<String, Object?> _threadJson({
   String id = _threadId,
   String createdAt = _createdAt,
   String updatedAt = _updatedAt,
+  String? title,
   String? activeMatterId,
 }) {
   return {
     'thread_id': id,
+    'title': title,
     'active_matter_id': ?activeMatterId,
     'created_at': createdAt,
     'updated_at': updatedAt,

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -73,6 +73,7 @@ void main() {
             'threads': [
               {
                 'thread_id': _threadId,
+                'title': '英文面试准备',
                 'created_at': _timestamp,
                 'updated_at': _timestamp,
               },
@@ -86,6 +87,7 @@ void main() {
           statusCode: HttpStatus.ok,
           body: {
             'thread_id': _threadId,
+            'title': '英文面试准备',
             'created_at': _timestamp,
             'updated_at': _timestamp,
           },
@@ -218,6 +220,18 @@ void main() {
       expect(find.byKey(const Key('agent-preview-label')), findsNothing);
       expect(find.byKey(const Key('quick-action-create-plan')), findsOneWidget);
       expect(dependencies.agentController.threadId, _threadId);
+      expect(
+        dependencies.agentController.currentThreadSummary?.title,
+        '英文面试准备',
+      );
+      await tester.tap(find.byKey(const Key('conversation-menu-button')));
+      await tester.pumpAndSettle();
+      expect(
+        find.descendant(of: find.byType(Drawer), matching: find.text('英文面试准备')),
+        findsOneWidget,
+      );
+      await tester.tap(find.byTooltip('关闭对话菜单'));
+      await tester.pumpAndSettle();
       expect(dependencies.authController.state, isA<AuthAuthenticated>());
       expect(
         identityTransport.calls.first.authorization,

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -576,7 +576,7 @@ void main() {
     );
     expect(
       find.descendant(of: drawer, matching: find.text('新对话')),
-      findsOneWidget,
+      findsNWidgets(2),
     );
     expect(
       find.descendant(of: drawer, matching: find.text('当前对话')),

--- a/server/internal/agent/core/model.go
+++ b/server/internal/agent/core/model.go
@@ -34,6 +34,7 @@ const (
 type Thread struct {
 	ID             string
 	OwnerID        string
+	Title          string
 	ActiveMatterID string
 	NextMessageSeq int64
 	CreatedAt      time.Time

--- a/server/internal/agent/core/thread_title.go
+++ b/server/internal/agent/core/thread_title.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const ThreadTitleContentLimit = 24
+
+func DeriveThreadTitle(firstUserMessage string) string {
+	normalized := strings.Join(strings.Fields(firstUserMessage), " ")
+	if normalized == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(normalized) <= ThreadTitleContentLimit {
+		return normalized
+	}
+	runes := []rune(normalized)
+	return string(runes[:ThreadTitleContentLimit]) + "…"
+}

--- a/server/internal/agent/core/thread_title_test.go
+++ b/server/internal/agent/core/thread_title_test.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestDeriveThreadTitle(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		input string
+		want  string
+	}{
+		"empty": {
+			input: " \n\t ",
+			want:  "",
+		},
+		"collapse whitespace": {
+			input: "  Help me\nprepare\tEnglish  ",
+			want:  "Help me prepare English",
+		},
+		"short Unicode": {
+			input: "我想练习英文自我介绍",
+			want:  "我想练习英文自我介绍",
+		},
+		"truncate Unicode": {
+			input: strings.Repeat("面", ThreadTitleContentLimit+1),
+			want:  strings.Repeat("面", ThreadTitleContentLimit) + "…",
+		},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := DeriveThreadTitle(testCase.input)
+			if got != testCase.want {
+				t.Fatalf("DeriveThreadTitle(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+			if utf8.RuneCountInString(got) > ThreadTitleContentLimit+1 {
+				t.Fatalf("title length = %d", utf8.RuneCountInString(got))
+			}
+		})
+	}
+}

--- a/server/internal/agent/persistence/postgres.go
+++ b/server/internal/agent/persistence/postgres.go
@@ -118,6 +118,7 @@ func (r *PostgresRepository) ListThreads(
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -127,6 +128,15 @@ LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
  AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true
 WHERE threads.owner_user_id = $1
 ORDER BY threads.updated_at DESC, threads.id DESC`,
 		ownerID,
@@ -142,6 +152,7 @@ ORDER BY threads.updated_at DESC, threads.id DESC`,
 		if err := rows.Scan(
 			&item.ID,
 			&item.OwnerID,
+			&item.Title,
 			&item.ActiveMatterID,
 			&item.NextMessageSeq,
 			&item.CreatedAt,
@@ -149,6 +160,7 @@ ORDER BY threads.updated_at DESC, threads.id DESC`,
 		); err != nil {
 			return nil, ErrRepository
 		}
+		item.Title = DeriveThreadTitle(item.Title)
 		result = append(result, item)
 	}
 	if rows.Err() != nil {
@@ -167,6 +179,7 @@ func (r *PostgresRepository) PageThreads(
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -176,6 +189,15 @@ LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
  AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true
 WHERE threads.owner_user_id = $1
 ORDER BY threads.updated_at DESC, threads.id DESC
 LIMIT $2`
@@ -185,6 +207,7 @@ LIMIT $2`
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -194,6 +217,15 @@ LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
  AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true
 WHERE threads.owner_user_id = $1
   AND (threads.updated_at, threads.id) < ($2, $3)
 ORDER BY threads.updated_at DESC, threads.id DESC
@@ -217,6 +249,7 @@ LIMIT $4`
 		if err := rows.Scan(
 			&item.ID,
 			&item.OwnerID,
+			&item.Title,
 			&item.ActiveMatterID,
 			&item.NextMessageSeq,
 			&item.CreatedAt,
@@ -224,6 +257,7 @@ LIMIT $4`
 		); err != nil {
 			return nil, ErrRepository
 		}
+		item.Title = DeriveThreadTitle(item.Title)
 		result = append(result, item)
 	}
 	if rows.Err() != nil {
@@ -242,6 +276,7 @@ func (r *PostgresRepository) FindThread(
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -251,12 +286,22 @@ LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
  AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true
 WHERE threads.id = $1 AND threads.owner_user_id = $2`,
 		threadID,
 		ownerID,
 	).Scan(
 		&result.ID,
 		&result.OwnerID,
+		&result.Title,
 		&result.ActiveMatterID,
 		&result.NextMessageSeq,
 		&result.CreatedAt,
@@ -265,6 +310,7 @@ WHERE threads.id = $1 AND threads.owner_user_id = $2`,
 	if err != nil {
 		return Thread{}, mapPostgresError(err)
 	}
+	result.Title = DeriveThreadTitle(result.Title)
 	return result, nil
 }
 
@@ -277,6 +323,7 @@ func (r *PostgresRepository) FindFocusedThread(
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -289,11 +336,21 @@ LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
  AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true
 WHERE focus.owner_user_id = $1`,
 		ownerID,
 	).Scan(
 		&result.ID,
 		&result.OwnerID,
+		&result.Title,
 		&result.ActiveMatterID,
 		&result.NextMessageSeq,
 		&result.CreatedAt,
@@ -305,6 +362,7 @@ WHERE focus.owner_user_id = $1`,
 	if err != nil {
 		return Thread{}, false, mapPostgresError(err)
 	}
+	result.Title = DeriveThreadTitle(result.Title)
 	return result, true, nil
 }
 
@@ -344,6 +402,7 @@ selected AS (
 SELECT
     threads.id::text,
     threads.owner_user_id::text,
+    COALESCE(first_user.content, ''),
     COALESCE(active_link.matter_id::text, ''),
     threads.next_message_sequence,
     threads.created_at,
@@ -355,12 +414,22 @@ JOIN agent_threads AS threads
 LEFT JOIN agent_thread_matter_links AS active_link
   ON active_link.thread_id = threads.id
  AND active_link.owner_user_id = threads.owner_user_id
- AND active_link.is_active`,
+ AND active_link.is_active
+LEFT JOIN LATERAL (
+    SELECT messages.content
+    FROM agent_messages AS messages
+    WHERE messages.owner_user_id = threads.owner_user_id
+      AND messages.thread_id = threads.id
+      AND messages.role = 'user'
+    ORDER BY messages.sequence_no
+    LIMIT 1
+) AS first_user ON true`,
 		threadID,
 		ownerID,
 	).Scan(
 		&result.ID,
 		&result.OwnerID,
+		&result.Title,
 		&result.ActiveMatterID,
 		&result.NextMessageSeq,
 		&result.CreatedAt,
@@ -369,6 +438,7 @@ LEFT JOIN agent_thread_matter_links AS active_link
 	if err != nil {
 		return Thread{}, mapPostgresError(err)
 	}
+	result.Title = DeriveThreadTitle(result.Title)
 	return result, nil
 }
 

--- a/server/internal/agent/thread_title_postgres_integration_test.go
+++ b/server/internal/agent/thread_title_postgres_integration_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestPostgresThreadTitlesAreDerivedFromFirstOwnedUserMessage(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	_, service := newAgentDataServices(t, database.pool)
+	ctx := context.Background()
+	actorA := requestcontext.Actor{
+		UserID:    agentTestUserA,
+		SessionID: "20000000-0000-4000-8000-000000000001",
+	}
+	actorB := requestcontext.Actor{
+		UserID:    agentTestUserB,
+		SessionID: "20000000-0000-4000-8000-000000000002",
+	}
+
+	empty, err := service.CreateThread(ctx, actorA, "")
+	if err != nil {
+		t.Fatalf("create empty Thread: %v", err)
+	}
+	if empty.Title != "" {
+		t.Fatalf("new Thread title = %q", empty.Title)
+	}
+
+	titled, err := service.CreateThread(ctx, actorA, "")
+	if err != nil {
+		t.Fatalf("create titled Thread: %v", err)
+	}
+	if _, err := service.AppendUserMessage(
+		ctx,
+		actorA,
+		titled.ID,
+		"title-message-1",
+		"  我想\n练习\t英文自我介绍  ",
+	); err != nil {
+		t.Fatalf("append first user Message: %v", err)
+	}
+	if _, err := service.AppendUserMessage(
+		ctx,
+		actorA,
+		titled.ID,
+		"title-message-2",
+		"第二条消息不能覆盖标题",
+	); err != nil {
+		t.Fatalf("append second user Message: %v", err)
+	}
+
+	foreign, err := service.CreateThread(ctx, actorB, "")
+	if err != nil {
+		t.Fatalf("create foreign Thread: %v", err)
+	}
+	if _, err := service.AppendUserMessage(
+		ctx,
+		actorB,
+		foreign.ID,
+		"foreign-title-message",
+		"另一个用户的私密标题",
+	); err != nil {
+		t.Fatalf("append foreign user Message: %v", err)
+	}
+
+	long, err := service.CreateThread(ctx, actorA, "")
+	if err != nil {
+		t.Fatalf("create long-title Thread: %v", err)
+	}
+	if _, err := service.AppendUserMessage(
+		ctx,
+		actorA,
+		long.ID,
+		"long-title-message",
+		strings.Repeat("面", core.ThreadTitleContentLimit+1),
+	); err != nil {
+		t.Fatalf("append long title Message: %v", err)
+	}
+
+	found, err := service.GetThread(ctx, actorA, titled.ID)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if found.Title != "我想 练习 英文自我介绍" {
+		t.Fatalf("GetThread title = %q", found.Title)
+	}
+
+	page, err := service.PageThreads(ctx, actorA, 20, "")
+	if err != nil {
+		t.Fatalf("PageThreads: %v", err)
+	}
+	titles := make(map[string]string, len(page.Threads))
+	for _, thread := range page.Threads {
+		titles[thread.ID] = thread.Title
+	}
+	if len(titles) != 3 {
+		t.Fatalf("owner A Thread count = %d, want 3", len(titles))
+	}
+	if _, visible := titles[foreign.ID]; visible {
+		t.Fatal("foreign Thread was visible in owner A page")
+	}
+	if titles[empty.ID] != "" ||
+		titles[titled.ID] != "我想 练习 英文自我介绍" ||
+		titles[long.ID] !=
+			strings.Repeat("面", core.ThreadTitleContentLimit)+"…" {
+		t.Fatalf("PageThreads titles = %#v", titles)
+	}
+
+	focused, err := service.SetFocusedThread(ctx, actorA, titled.ID)
+	if err != nil {
+		t.Fatalf("SetFocusedThread: %v", err)
+	}
+	if focused.Title != "我想 练习 英文自我介绍" {
+		t.Fatalf("focused title = %q", focused.Title)
+	}
+	restored, present, err := service.GetFocusedThread(ctx, actorA)
+	if err != nil {
+		t.Fatalf("GetFocusedThread: %v", err)
+	}
+	if !present || restored.Title != focused.Title {
+		t.Fatalf("restored focused Thread = %#v, present = %t", restored, present)
+	}
+}

--- a/server/internal/agent/transport/http.go
+++ b/server/internal/agent/transport/http.go
@@ -1812,8 +1812,12 @@ func matterResponse(item matter.Matter) gin.H {
 func threadResponse(thread Thread) gin.H {
 	result := gin.H{
 		"thread_id":  thread.ID,
+		"title":      nil,
 		"created_at": thread.CreatedAt.UTC().Format(time.RFC3339Nano),
 		"updated_at": thread.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if thread.Title != "" {
+		result["title"] = thread.Title
 	}
 	if thread.ActiveMatterID != "" {
 		result["active_matter_id"] = thread.ActiveMatterID

--- a/server/internal/agent/transport/thread_title_test.go
+++ b/server/internal/agent/transport/thread_title_test.go
@@ -1,0 +1,33 @@
+package transport
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+)
+
+func TestThreadResponseIncludesRequiredNullableTitle(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC)
+	withoutTitle := threadResponse(core.Thread{
+		ID:        "10000000-0000-4000-8000-000000000001",
+		OwnerID:   "20000000-0000-4000-8000-000000000001",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if value, present := withoutTitle["title"]; !present || value != nil {
+		t.Fatalf("empty Thread title = %#v, present = %t", value, present)
+	}
+
+	withTitle := threadResponse(core.Thread{
+		ID:        "10000000-0000-4000-8000-000000000002",
+		OwnerID:   "20000000-0000-4000-8000-000000000001",
+		Title:     "英文自我介绍",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if withTitle["title"] != "英文自我介绍" {
+		t.Fatalf("Thread title = %#v", withTitle["title"])
+	}
+}


### PR DESCRIPTION
## 功能描述

- 从每个 Thread 的首条已提交用户消息确定性生成标题
- 空会话返回 null，移动端显示「新对话」
- 侧边栏展示不同会话标题，并保留更新时间与选中态
- 文本和语音提交后均刷新服务端权威 Thread 列表

## 实现思路

- PostgreSQL 读取 Thread 时通过 owner-safe LATERAL 子查询取得首条 user Message，无 N+1、无数据库迁移
- 服务端折叠空白并按 Unicode 截取 24 个内容字符，超长追加省略号
- API 将 title 定义为必填的 string/null 只读字段
- Flutter 严格解析服务端 title，禁止根据本地消息自行推断

## 可复现测试

- make check-api
- TEST_DATABASE_URL=... make check-go
- make check-flutter
- flutter run -d C3F00DDB-A017-4A12-ABB7-234CB16B2037 --debug
- 打开会话侧边栏，确认历史会话显示各自首条用户消息标题，空会话显示「新对话」

Closes #240