### PR TITLE
fix(ielts): stabilize full mock lifecycle

### DIFF
--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -8,10 +8,12 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 
 const ieltsSpeakingFullMockScenarioId = 'scn_ielts_speaking_full';
+const _ieltsSpeakingFullMockTitle = 'IELTS 口语完整模拟';
 
 bool isIeltsSpeakingFullMockSession(AgentController controller) =>
-    controller.scene?.id == ieltsSpeakingFullMockScenarioId &&
-    controller.turnLimit == 14;
+    controller.turnLimit == 14 &&
+    (controller.scene?.id == ieltsSpeakingFullMockScenarioId ||
+        controller.scene?.title == _ieltsSpeakingFullMockTitle);
 
 class IeltsSpeakingMockPage extends StatefulWidget {
   const IeltsSpeakingMockPage({

--- a/mobile/lib/features/preparation/preparation_controller.dart
+++ b/mobile/lib/features/preparation/preparation_controller.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:speakup/features/preparation/preparation_client.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 
+const _ieltsSpeakingFullMockScenarioId = 'scn_ielts_speaking_full';
+
 final class PreparationController extends ChangeNotifier {
   PreparationController({required this.client});
 
@@ -248,20 +250,19 @@ final class PreparationController extends ChangeNotifier {
               option.roleId == role.id,
         )
         .toList(growable: false);
-    _selectedOption =
-        compatibleOptions
-            .where(
-              (option) =>
-                  option.type == PreparationOptionType.focus &&
-                  option.roleId == role.id,
-            )
-            .firstOrNull ??
-        compatibleOptions
-            .where(
-              (option) => option.type == PreparationOptionType.fullSimulation,
-            )
-            .firstOrNull ??
-        compatibleOptions.firstOrNull;
+    final fullSimulation = compatibleOptions
+        .where((option) => option.type == PreparationOptionType.fullSimulation)
+        .firstOrNull;
+    final roleFocus = compatibleOptions
+        .where(
+          (option) =>
+              option.type == PreparationOptionType.focus &&
+              option.roleId == role.id,
+        )
+        .firstOrNull;
+    _selectedOption = _selectedScenario!.id == _ieltsSpeakingFullMockScenarioId
+        ? fullSimulation ?? roleFocus ?? compatibleOptions.firstOrNull
+        : roleFocus ?? fullSimulation ?? compatibleOptions.firstOrNull;
     notifyListeners();
     return hasCompleteSelection;
   }

--- a/mobile/lib/features/preparation/wire_preparation_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_client.dart
@@ -330,7 +330,10 @@ PreparationScenarioPrompt _scenarioPrompt(Object? value) {
     aiRole: _string(object['ai_role']),
     personaSummary: _string(object['persona_summary']),
     focusAreas: _stringList(object['focus_areas']),
-    turnBlueprints: _stringList(object['turn_blueprints']),
+    turnBlueprints: _stringList(
+      object['turn_blueprints'],
+      maximumItemBytes: 4096,
+    ),
     suggestedDurationSeconds: duration,
   );
 }
@@ -441,14 +444,14 @@ String _string(Object? value, {int maximumBytes = 4096}) {
   return value;
 }
 
-List<String> _stringList(Object? value) {
+List<String> _stringList(Object? value, {int maximumItemBytes = 128}) {
   if (value is! List<Object?> || value.isEmpty || value.length > 50) {
     throw _invalidResponse();
   }
   final seen = <String>{};
   final result = <String>[];
   for (final item in value) {
-    final text = _string(item, maximumBytes: 128);
+    final text = _string(item, maximumBytes: maximumItemBytes);
     if (!seen.add(text)) {
       throw _invalidResponse();
     }

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -152,6 +152,92 @@ void main() {
     expect(find.textContaining('OVERALL BAND'), findsNothing);
     expect(find.byKey(const Key('practice-page')), findsNothing);
   });
+
+  testWidgets('restored matter identity still opens the three-part mock flow', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(
+      initialCompleted: 8,
+      snapshotScene: const AgentScene(
+        id: 'matter-restored',
+        title: 'IELTS 口语完整模拟',
+        description: '恢复的练习场景',
+      ),
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticePage(
+          agentController: controller,
+          ieltsMockProgressStore: _MemoryProgressStore(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('ielts-mock-part-1-complete')), findsOneWidget);
+    expect(find.byKey(const Key('practice-page')), findsNothing);
+  });
+
+  testWidgets('save and exit returns from an in-progress full mock', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 0);
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+    var parkCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              key: const Key('open-mock'),
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => IeltsSpeakingMockPage(
+                    controller: controller,
+                    progressStore: _MemoryProgressStore(),
+                    onExitRequested: () async {
+                      parkCalls++;
+                      return true;
+                    },
+                  ),
+                ),
+              ),
+              child: const Text('Open mock'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-mock')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
+    await tester.pumpAndSettle();
+    expect(find.text('Exit mock test?'), findsOneWidget);
+    await tester.tap(find.text('Save & exit'));
+    await tester.pumpAndSettle();
+
+    expect(parkCalls, 1);
+    expect(find.byKey(const Key('open-mock')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-page')), findsNothing);
+  });
 }
 
 final class _MemoryProgressStore implements IeltsMockProgressStore {
@@ -178,10 +264,11 @@ final class _MemoryProgressStore implements IeltsMockProgressStore {
 }
 
 final class _IeltsPracticeClient implements PracticeClient {
-  _IeltsPracticeClient({required this.initialCompleted})
+  _IeltsPracticeClient({required this.initialCompleted, this.snapshotScene})
     : completed = initialCompleted;
 
   final int initialCompleted;
+  final AgentScene? snapshotScene;
   int completed;
   final List<String> confirmedQuestionIds = [];
 
@@ -204,7 +291,9 @@ final class _IeltsPracticeClient implements PracticeClient {
     return PracticeStartResult(
       snapshot: PracticeSessionSnapshot(
         sessionId: _sessionId,
-        matter: activeMatter,
+        matter: snapshotScene == null
+            ? activeMatter
+            : AgentMatter(id: activeMatter.id, scene: snapshotScene!),
         completedTurns: completed,
         turnLimit: 14,
         sessionCompleted: done,

--- a/mobile/test/preparation/preparation_controller_test.dart
+++ b/mobile/test/preparation/preparation_controller_test.dart
@@ -52,6 +52,21 @@ void main() {
     },
   );
 
+  test(
+    'keeps the IELTS full mock entry on the full simulation option',
+    () async {
+      final controller = PreparationController(client: _IeltsCatalogClient());
+      addTearDown(controller.dispose);
+
+      await controller.loadIfNeeded();
+      await controller.selectScenario(_ieltsScenario);
+
+      expect(controller.selectRecommendedConfiguration(), isTrue);
+      expect(controller.selectedRole, _ieltsRole);
+      expect(controller.selectedOption, _ieltsFullOption);
+    },
+  );
+
   test('retries the failed directory request', () async {
     final client = _FailOnceCatalogClient();
     final controller = PreparationController(client: client);
@@ -168,6 +183,25 @@ final class _ControlledCatalogClient implements PreparationCatalogClient {
   }
 }
 
+final class _IeltsCatalogClient implements PreparationCatalogClient {
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PreparationScenarioDetail> getScenario(String scenarioId) async =>
+      _ieltsDetail;
+
+  @override
+  Future<List<PreparationScenario>> listScenarios() async => const [
+    _ieltsScenario,
+  ];
+
+  @override
+  Future<List<PreparationRole>> listRoles(String scenarioId) async => const [
+    _ieltsRole,
+  ];
+}
+
 const _scenarioId = 'scn_programmer_interview';
 
 const _scenario = PreparationScenario(
@@ -254,4 +288,61 @@ const _detail = PreparationScenarioDetail(
   scenario: _scenario,
   config: _config,
   options: [_fullOption, _technicalFocus, _recruiterFocus],
+);
+
+const _ieltsScenarioId = 'scn_ielts_speaking_full';
+
+const _ieltsScenario = PreparationScenario(
+  id: _ieltsScenarioId,
+  type: 'EXAM',
+  model: 'IELTS_SPEAKING_FULL_MOCK',
+  name: 'IELTS 口语完整模拟',
+  summary: '按 Part 1、Part 2、Part 3 完成一轮练习。',
+  version: 2,
+  status: 'active',
+);
+
+const _ieltsConfig = PreparationScenarioConfig(
+  id: 'scfg_ielts_speaking_full',
+  scenarioId: _ieltsScenarioId,
+  type: 'EXAM',
+  model: 'IELTS_SPEAKING_FULL_MOCK',
+  version: 2,
+  jobTitle: null,
+  jobDescription: null,
+  prompt: _prompt,
+);
+
+const _ieltsRole = PreparationRole(
+  id: 'role_ielts_examiner',
+  scenarioId: _ieltsScenarioId,
+  type: 'IELTS_EXAMINER',
+  displayName: 'IELTS 口语考官',
+  responsibilities: 'Run the complete mock test.',
+  style: 'Neutral and concise.',
+  focusAreas: ['part_1', 'part_2', 'part_3'],
+  version: 2,
+);
+
+const _ieltsFullOption = PreparationOption(
+  id: 'option_ielts_speaking_full_full',
+  scenarioId: _ieltsScenarioId,
+  type: PreparationOptionType.fullSimulation,
+  displayName: '完整模考',
+  version: 2,
+);
+
+const _ieltsFocusOption = PreparationOption(
+  id: 'option_ielts_speaking_full_focus',
+  scenarioId: _ieltsScenarioId,
+  roleId: 'role_ielts_examiner',
+  type: PreparationOptionType.focus,
+  displayName: '专项练习',
+  version: 2,
+);
+
+const _ieltsDetail = PreparationScenarioDetail(
+  scenario: _ieltsScenario,
+  config: _ieltsConfig,
+  options: [_ieltsFullOption, _ieltsFocusOption],
 );

--- a/mobile/test/preparation/wire_preparation_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_client_test.dart
@@ -88,6 +88,34 @@ void main() {
     transport.expectDone();
   });
 
+  test('accepts a complete IELTS cue card as one turn blueprint', () async {
+    const cueCard =
+        'Part 2 cue card: Describe a skill you would like to learn.\n'
+        'You should say:\n'
+        '• What the skill is\n'
+        '• Why you want to learn it\n'
+        '• How you would learn it\n'
+        '• And explain how learning this skill would benefit you';
+    final config = <String, Object?>{
+      ..._configJson,
+      'prompt_model': <String, Object?>{
+        ..._configJson['prompt_model']! as Map<String, Object?>,
+        'turn_blueprints': [cueCard],
+      },
+    };
+    final client = WirePreparationCatalogClient(
+      baseUri: Uri.parse('https://api.speak-up.test'),
+      transport: _QueueTransport([
+        _response(<String, Object?>{..._detailJson, 'scenario_config': config}),
+      ]),
+    );
+
+    final detail = await client.getScenario(_scenarioId);
+
+    expect(detail.config.prompt.turnBlueprints, [cueCard]);
+    expect(utf8.encode(cueCard).length, greaterThan(128));
+  });
+
   test('accepts the four supported scenario family and model pairs', () async {
     final scenarios = <Map<String, Object?>>[
       _scenarioJson,

--- a/server/internal/agent/transport/voice_test_helpers_test.go
+++ b/server/internal/agent/transport/voice_test_helpers_test.go
@@ -330,6 +330,17 @@ func (practice *agentVoicePractice) ApplyEffectiveTurn(
 	return result, nil
 }
 
+func (practice *agentVoicePractice) RequiresSessionReview(
+	_ context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+) (bool, error) {
+	if actor.UserID != "user-a" || sessionID != "session-1" {
+		return false, conversation.ErrVoiceRoundNotFound
+	}
+	return true, nil
+}
+
 var errAgentVoiceLostAcknowledgement = errors.New(
 	"review acknowledgement lost",
 )

--- a/server/internal/agent/voice/round.go
+++ b/server/internal/agent/voice/round.go
@@ -76,6 +76,11 @@ type VoicePracticePort interface {
 		string,
 		string,
 	) (VoiceTurnProgress, error)
+	RequiresSessionReview(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (bool, error)
 }
 
 type VoiceTurnProgress struct {
@@ -270,6 +275,17 @@ func (orchestrator *VoiceRoundOrchestrator) finishTurn(
 		}
 	}
 	if !turn.SessionCompleted {
+		return turn, nil
+	}
+	reviewRequired, err := orchestrator.practice.RequiresSessionReview(
+		ctx,
+		actor,
+		turn.SessionID,
+	)
+	if err != nil {
+		return conversation.ConfirmedVoiceTurn{}, err
+	}
+	if !reviewRequired {
 		return turn, nil
 	}
 

--- a/server/internal/agent/voice/round_test.go
+++ b/server/internal/agent/voice/round_test.go
@@ -157,6 +157,41 @@ func TestVoiceRoundOrchestratorOwnsThreeTurnReviewSaga(t *testing.T) {
 	}
 }
 
+func TestVoiceRoundOrchestratorCompletesWhenReviewIsDeferred(t *testing.T) {
+	conversations := newAgentVoiceConversation(1)
+	practice := newAgentVoicePractice(2)
+	practice.skipReview = true
+	reviews := newAgentVoiceReview()
+	orchestrator := newAgentVoiceOrchestrator(
+		t,
+		conversations,
+		practice,
+		reviews,
+	)
+
+	result, err := orchestrator.Confirm(
+		context.Background(),
+		agentVoiceActor("a"),
+		conversation.ConfirmVoiceTurnCommand{
+			CandidateID:    "candidate-1",
+			IdempotencyKey: "confirm-candidate-1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	if !result.SessionCompleted || result.ReviewID != "" {
+		t.Fatalf("completed result = %#v", result)
+	}
+	if reviews.creations != 0 || conversations.reviewSaves != 0 {
+		t.Fatalf(
+			"deferred review generated: reviews=%d saves=%d",
+			reviews.creations,
+			conversations.reviewSaves,
+		)
+	}
+}
+
 func TestVoiceRoundOrchestratorConcurrentThirdTurnCreatesOneReview(t *testing.T) {
 	conversations := newAgentVoiceConversation(1)
 	practice := newAgentVoicePractice(2)
@@ -558,6 +593,7 @@ type agentVoicePractice struct {
 	mu             sync.Mutex
 	turns          map[string]VoiceTurnProgress
 	effectiveTurns int
+	skipReview     bool
 }
 
 func newAgentVoicePractice(effectiveTurns int) *agentVoicePractice {
@@ -601,6 +637,17 @@ func (practice *agentVoicePractice) ApplyEffectiveTurn(
 	}
 	practice.turns[turnID] = result
 	return result, nil
+}
+
+func (practice *agentVoicePractice) RequiresSessionReview(
+	_ context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+) (bool, error) {
+	if actor.UserID != "user-a" || sessionID != "session-1" {
+		return false, conversation.ErrVoiceRoundNotFound
+	}
+	return !practice.skipReview, nil
 }
 
 var errAgentVoiceLostAcknowledgement = errors.New(

--- a/server/internal/agent/voice/session.go
+++ b/server/internal/agent/voice/session.go
@@ -21,6 +21,7 @@ const (
 	maxVoiceReviewConclusions       = 8
 	maxVoiceReviewLabelUTF8Bytes    = 64
 	maxVoiceReviewTextUTF8Bytes     = 2048
+	ieltsSpeakingFullMockModel      = "IELTS_SPEAKING_FULL_MOCK"
 )
 
 // VoicePracticeSession is the Agent application view of Practice state. It
@@ -502,7 +503,8 @@ func (application *VoiceSessionApplication) state(
 		state.Turn = &latest
 	}
 	if found && (latest.EffectiveTurns == 0 ||
-		(latest.SessionCompleted && latest.ReviewID == "")) {
+		(latest.SessionCompleted && latest.ReviewID == "" &&
+			requiresSynchronousSessionReview(session))) {
 		recovered, recoveryErr := application.orchestrator.Confirm(
 			ctx,
 			actor,
@@ -559,7 +561,9 @@ func (application *VoiceSessionApplication) state(
 		return VoiceSessionState{}, ErrInvalidContext
 	}
 	if state.Session.Completed {
-		if state.Turn == nil || state.Review == nil {
+		if state.Turn == nil ||
+			(requiresSynchronousSessionReview(session) &&
+				state.Review == nil) {
 			return VoiceSessionState{}, ErrInvalidContext
 		}
 		return state, nil
@@ -588,6 +592,10 @@ func (application *VoiceSessionApplication) state(
 		return VoiceSessionState{}, ErrInvalidContext
 	}
 	return state, nil
+}
+
+func requiresSynchronousSessionReview(session VoicePracticeSession) bool {
+	return session.ScenarioModel != ieltsSpeakingFullMockModel
 }
 
 func validVoiceScenarioPrompt(session VoicePracticeSession) bool {

--- a/server/internal/agent/voice/session_test.go
+++ b/server/internal/agent/voice/session_test.go
@@ -528,6 +528,65 @@ func TestVoiceSessionRestoresFormalEarlyCompletionBeforeMaximum(t *testing.T) {
 	}
 }
 
+func TestVoiceSessionRestoresCompletedIELTSFullMockWithoutReview(
+	t *testing.T,
+) {
+	session := VoicePracticeSession{
+		ID:                       "session-ielts-full",
+		PlanID:                   "plan-ielts-full",
+		ThreadID:                 "thread-1",
+		MatterID:                 "matter-1",
+		ScenarioType:             "EXAM",
+		ScenarioModel:            ieltsSpeakingFullMockModel,
+		PromptModel:              voiceSessionTestPrompt(),
+		SessionVersion:           15,
+		EffectiveTurns:           14,
+		TurnLimit:                14,
+		Completed:                true,
+		Status:                   "completed",
+		InterviewerParticipantID: "participant-interviewer",
+		CandidateParticipantID:   "participant-a",
+	}
+	turn := conversation.ConfirmedVoiceTurn{
+		ID:               "turn-14",
+		SessionID:        session.ID,
+		EffectiveTurns:   session.EffectiveTurns,
+		SessionCompleted: true,
+	}
+	application, err := NewVoiceSessionApplication(
+		fixedVoiceSessionPort{session: session},
+		voiceSessionTestQuestions{},
+		fixedVoiceCheckpoint{turn: turn},
+		newAgentVoiceOrchestrator(
+			t,
+			newAgentVoiceConversation(14),
+			newAgentVoicePractice(14),
+			newAgentVoiceReview(),
+		),
+		voiceSessionTestReviews{reviews: newAgentVoiceReview()},
+		voiceSessionTestMatters{},
+	)
+	if err != nil {
+		t.Fatalf("NewVoiceSessionApplication: %v", err)
+	}
+
+	state, err := application.Resume(
+		context.Background(),
+		agentVoiceActor("a"),
+		session.ThreadID,
+		session.MatterID,
+	)
+	if err != nil {
+		t.Fatalf("Resume completed IELTS full mock: %v", err)
+	}
+	if !state.Session.Completed ||
+		state.Turn == nil ||
+		state.Question != nil ||
+		state.Review != nil {
+		t.Fatalf("completed IELTS full mock state = %#v", state)
+	}
+}
+
 func newVoiceSessionTestApplication(
 	t *testing.T,
 	conversations *agentVoiceConversation,

--- a/server/internal/bootstrap/practice_context_test.go
+++ b/server/internal/bootstrap/practice_context_test.go
@@ -283,6 +283,52 @@ func TestPracticeCatalogContextReaderRejectsStaleAndForgedSelections(
 	}
 }
 
+func TestPracticeCatalogContextReaderAcceptsIELTSFullMockSelection(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	catalog, err := preparation.NewBuiltinCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := newPracticeCatalogContextReader(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail, err := catalog.GetScenarioDetail(
+		preparation.IELTSSpeakingFullMockScenarioID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles, err := catalog.ListRoles(
+		preparation.IELTSSpeakingFullMockScenarioID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("IELTS full mock roles = %d, want 1", len(roles))
+	}
+
+	selection, err := reader.ReadPlanCatalog(practice.PlanCatalogRequest{
+		ScenarioDefinitionID:      detail.ScenarioDefinition.ID,
+		ScenarioDefinitionVersion: detail.ScenarioDefinition.Version,
+		ScenarioConfigID:          detail.ScenarioConfig.ID,
+		ScenarioConfigVersion:     detail.ScenarioConfig.Version,
+		SelectedRoleIDs:           []string{roles[0].ID},
+	})
+	if err != nil {
+		t.Fatalf("ReadPlanCatalog: %v", err)
+	}
+	if selection.ScenarioDefinition.ID !=
+		preparation.IELTSSpeakingFullMockScenarioID ||
+		selection.PracticeOption.Type != "FULL_SIMULATION" {
+		t.Fatalf("selection = %+v", selection)
+	}
+}
+
 type agentThreadReaderStub struct {
 	thread agent.Thread
 	err    error

--- a/server/internal/bootstrap/voice_practice.go
+++ b/server/internal/bootstrap/voice_practice.go
@@ -25,6 +25,11 @@ type PracticeVoiceApplication interface {
 		string,
 		string,
 	) (practice.VoiceTurnProgress, error)
+	RequiresSessionReview(
+		context.Context,
+		persistence.Actor,
+		string,
+	) (bool, error)
 }
 
 type practiceVoicePort struct {
@@ -88,6 +93,21 @@ func (p *practiceVoicePort) ApplyEffectiveTurn(
 		TurnLimit:        progress.TurnLimit,
 		SessionCompleted: progress.SessionCompleted,
 	}, nil
+}
+
+func (p *practiceVoicePort) RequiresSessionReview(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+) (bool, error) {
+	if p == nil || p.application == nil || ctx == nil || !actor.Valid() {
+		return false, persistence.ErrInvalidArgument
+	}
+	return p.application.RequiresSessionReview(
+		ctx,
+		practiceVoiceActor(actor),
+		sessionID,
+	)
 }
 
 func practiceVoiceActor(actor requestcontext.Actor) persistence.Actor {

--- a/server/internal/bootstrap/voice_practice_test.go
+++ b/server/internal/bootstrap/voice_practice_test.go
@@ -61,6 +61,14 @@ func TestPracticeVoicePortMapsTrustedActorAndProgress(t *testing.T) {
 	}) {
 		t.Fatalf("mapped actor = %#v", application.actor)
 	}
+	required, err := port.RequiresSessionReview(
+		context.Background(),
+		actor,
+		"practice-session",
+	)
+	if err != nil || !required {
+		t.Fatalf("RequiresSessionReview = %t, %v", required, err)
+	}
 }
 
 func TestPracticeVoicePortPropagatesPracticeFailure(t *testing.T) {
@@ -157,6 +165,15 @@ func (s *practiceVoiceApplicationStub) ApplyEffectiveTurn(
 ) (practice.VoiceTurnProgress, error) {
 	s.actor = actor
 	return s.progress, s.err
+}
+
+func (s *practiceVoiceApplicationStub) RequiresSessionReview(
+	_ context.Context,
+	actor persistence.Actor,
+	_ string,
+) (bool, error) {
+	s.actor = actor
+	return true, s.err
 }
 
 var _ PracticeVoiceApplication = (*practiceVoiceApplicationStub)(nil)

--- a/server/internal/practice/voice.go
+++ b/server/internal/practice/voice.go
@@ -39,6 +39,29 @@ type VoiceTurnProgress struct {
 	SessionCompleted bool
 }
 
+// RequiresSessionReview reports whether completing this frozen Session must
+// synchronously create a formal Review. IELTS full mock reports are delivered
+// separately, so their speaking flow must not depend on Review generation.
+func (a *VoiceApplication) RequiresSessionReview(
+	ctx context.Context,
+	actor persistence.Actor,
+	sessionID string,
+) (bool, error) {
+	if a == nil || a.repository == nil || ctx == nil ||
+		sessionID == "" || sessionID != strings.TrimSpace(sessionID) {
+		return false, persistence.ErrInvalidArgument
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	session, err := a.repository.GetContextSession(ctx, actor, sessionID)
+	if err != nil {
+		return false, err
+	}
+	return session.ScenarioModel !=
+		persistence.ScenarioModelIELTSSpeakingFullMock, nil
+}
+
 // VoiceApplication exposes Practice capabilities without leaking its
 // Repository to Agent or Conversation. actorSubjectNamespace is supplied by
 // composition because Practice treats SubjectRef namespaces as opaque.

--- a/server/migrations/000032_ielts_speaking_full_mock_model.down.sql
+++ b/server/migrations/000032_ielts_speaking_full_mock_model.down.sql
@@ -1,0 +1,79 @@
+BEGIN;
+
+ALTER TABLE practice_sessions
+    DROP CONSTRAINT practice_sessions_scenario_model_check,
+    ADD CONSTRAINT practice_sessions_scenario_model_check
+        CHECK (
+            context_plan_id IS NULL
+            OR
+            (
+                scenario_type = 'INTERVIEW'
+                AND scenario_model IN (
+                    'PROJECT_EXPERIENCE_DEEP_DIVE',
+                    'INTERVIEW_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'EXAM'
+                AND scenario_model IN (
+                    'IELTS_SPEAKING_PART_2',
+                    'EXAM_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'WORKPLACE'
+                AND scenario_model IN (
+                    'PROGRESS_AND_RISK_UPDATE',
+                    'WORKPLACE_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'DAILY'
+                AND scenario_model IN (
+                    'HOTEL_CHECKIN_AND_ISSUE_HANDLING',
+                    'DAILY_BASIC_DIALOGUE'
+                )
+            )
+        );
+
+ALTER TABLE practice_plans
+    DROP CONSTRAINT practice_plans_scenario_model_check,
+    ADD CONSTRAINT practice_plans_scenario_model_check
+        CHECK (
+            (
+                scenario_type = 'INTERVIEW'
+                AND scenario_model IN (
+                    'PROJECT_EXPERIENCE_DEEP_DIVE',
+                    'INTERVIEW_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'EXAM'
+                AND scenario_model IN (
+                    'IELTS_SPEAKING_PART_2',
+                    'EXAM_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'WORKPLACE'
+                AND scenario_model IN (
+                    'PROGRESS_AND_RISK_UPDATE',
+                    'WORKPLACE_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'DAILY'
+                AND scenario_model IN (
+                    'HOTEL_CHECKIN_AND_ISSUE_HANDLING',
+                    'DAILY_BASIC_DIALOGUE'
+                )
+            )
+        );
+
+COMMIT;

--- a/server/migrations/000032_ielts_speaking_full_mock_model.up.sql
+++ b/server/migrations/000032_ielts_speaking_full_mock_model.up.sql
@@ -1,0 +1,81 @@
+BEGIN;
+
+ALTER TABLE practice_plans
+    DROP CONSTRAINT practice_plans_scenario_model_check,
+    ADD CONSTRAINT practice_plans_scenario_model_check
+        CHECK (
+            (
+                scenario_type = 'INTERVIEW'
+                AND scenario_model IN (
+                    'PROJECT_EXPERIENCE_DEEP_DIVE',
+                    'INTERVIEW_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'EXAM'
+                AND scenario_model IN (
+                    'IELTS_SPEAKING_PART_2',
+                    'IELTS_SPEAKING_FULL_MOCK',
+                    'EXAM_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'WORKPLACE'
+                AND scenario_model IN (
+                    'PROGRESS_AND_RISK_UPDATE',
+                    'WORKPLACE_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'DAILY'
+                AND scenario_model IN (
+                    'HOTEL_CHECKIN_AND_ISSUE_HANDLING',
+                    'DAILY_BASIC_DIALOGUE'
+                )
+            )
+        );
+
+ALTER TABLE practice_sessions
+    DROP CONSTRAINT practice_sessions_scenario_model_check,
+    ADD CONSTRAINT practice_sessions_scenario_model_check
+        CHECK (
+            context_plan_id IS NULL
+            OR
+            (
+                scenario_type = 'INTERVIEW'
+                AND scenario_model IN (
+                    'PROJECT_EXPERIENCE_DEEP_DIVE',
+                    'INTERVIEW_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'EXAM'
+                AND scenario_model IN (
+                    'IELTS_SPEAKING_PART_2',
+                    'IELTS_SPEAKING_FULL_MOCK',
+                    'EXAM_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'WORKPLACE'
+                AND scenario_model IN (
+                    'PROGRESS_AND_RISK_UPDATE',
+                    'WORKPLACE_BASIC_DIALOGUE'
+                )
+            )
+            OR
+            (
+                scenario_type = 'DAILY'
+                AND scenario_model IN (
+                    'HOTEL_CHECKIN_AND_ISSUE_HANDLING',
+                    'DAILY_BASIC_DIALOGUE'
+                )
+            )
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -17,4 +17,5 @@ import "embed"
 //go:embed 000029_agent_stable_profile_context_manifest.*.sql
 //go:embed 000030_agent_tool_routing_cleanup.*.sql
 //go:embed 000031_agent_memory_extraction_barrier.*.sql
+//go:embed 000032_ielts_speaking_full_mock_model.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能说明

修复 IELTS 口语三段式完整模考在真实联调中的启动、恢复、完成与退出阻塞问题。

- 支持目录中的完整 Part 2 长题卡内容，避免误报目录响应无法识别。
- 增加迁移 000032，使 Practice Plan 与 Session 接受 IELTS_SPEAKING_FULL_MOCK。
- 会话恢复为 Matter 作用域标识后仍进入专用 Part 1/2/3 模考界面。
- 完整模考 14/14 后直接完成，不再同步依赖暂未交付的报告生成；其他练习的 Review 流程保持不变。
- 保持进行中保存退出与完成后返回训练路径可用。

## 实现思路

移动端使用冻结的完整模考标题与 14 轮策略共同识别恢复会话，并只放宽 turn_blueprints 的解析上限。服务端通过可回滚迁移扩展场景约束，并由 Practice 权威场景模型决定完成时是否需要同步 Review。IELTS 完整模考延后 Review，其他场景继续执行原有 Review saga。

## 验证方式

- iPhone 16 Pro 模拟器实机走通：Part 1 八题 → Part 2 准备与录音 → Part 3 五题 → Mock Test Complete → 返回训练。
- 最终转写确认接口返回 200。
- cd mobile && flutter analyze --no-pub：通过。
- cd mobile && flutter test --no-pub：532 项全部通过。
- cd server && go test -count=1 ./...：全部通过。
- git diff --check upstream/dev...HEAD：通过。

Closes #247