### PR TITLE
feat(practice): 将公共 Practice 页面改造成连续对话气泡流

### DIFF
--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -105,6 +105,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   String? _activeTextAnswer;
   AgentMatter? _activeMatter;
   List<AgentMessage> _messages = const <AgentMessage>[];
+  List<AgentMessage> _practiceMessages = const <AgentMessage>[];
   PracticeRecordingState _recordingState = PracticeRecordingState.idle;
   AgentReview? _review;
   String? _errorMessage;
@@ -156,6 +157,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   AgentMatter? get activeMatter => _activeMatter;
   AgentScene? get scene => _activeMatter?.scene;
   List<AgentMessage> get messages => List.unmodifiable(_messages);
+  List<AgentMessage> get practiceMessages =>
+      List.unmodifiable(_practiceMessages);
   AgentVoiceController? get voiceController => _voiceController;
   bool get supportsAgentVoice => _voiceController != null;
   PracticeRecordingState get recordingState => _recordingState;
@@ -1813,6 +1816,10 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       confirmation.answer,
       ?confirmation.nextQuestion?.presentation,
     ]);
+    _appendPracticeMessages([
+      confirmation.answer,
+      ?confirmation.nextQuestion?.presentation,
+    ]);
     if (confirmation.sessionCompleted) {
       _recordingState = confirmation.review == null
           ? PracticeRecordingState.reviewFailed
@@ -1903,6 +1910,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _activeTextAnswer = null;
     _activeMatter = null;
     _messages = const <AgentMessage>[];
+    _practiceMessages = const <AgentMessage>[];
     _recordingState = PracticeRecordingState.idle;
     _review = null;
     _errorMessage = null;
@@ -2044,6 +2052,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     PracticeSessionSnapshot? snapshot, {
     bool preserveKnownRecordings = false,
   }) {
+    final previousSessionId = _practiceSessionId;
     _cancelRecordingLimit();
     _practiceGeneration++;
     _candidate = null;
@@ -2066,10 +2075,14 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _sessionCompleted = false;
       _review = null;
       _recordings = const <PracticeRecordingReference>[];
+      _practiceMessages = const <AgentMessage>[];
       _recordingState = PracticeRecordingState.idle;
       return;
     }
     _validatePracticeSnapshot(snapshot);
+    if (snapshot.sessionId != previousSessionId) {
+      _practiceMessages = const <AgentMessage>[];
+    }
     final mayPreserveKnownRecordings =
         preserveKnownRecordings && snapshot.sessionId == _practiceSessionId;
     _practiceSessionId = snapshot.sessionId;
@@ -2093,7 +2106,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
               ),
             ];
     }
-    _appendMessages([?snapshot.currentQuestion?.presentation]);
+    final currentQuestion = snapshot.currentQuestion?.presentation;
+    _appendMessages([?currentQuestion]);
+    _appendPracticeMessages([?currentQuestion]);
     _recordingState = snapshot.sessionCompleted
         ? snapshot.review == null
               ? PracticeRecordingState.reviewFailed
@@ -2111,6 +2126,17 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     }
     _messages = messages;
     _voiceController?.syncMessages(_messages);
+  }
+
+  void _appendPracticeMessages(Iterable<AgentMessage> values) {
+    final messages = List<AgentMessage>.from(_practiceMessages);
+    final ids = {for (final message in messages) message.id};
+    for (final message in values) {
+      if (ids.add(message.id)) {
+        messages.add(message);
+      }
+    }
+    _practiceMessages = messages;
   }
 
   void _commitVoiceMessages(Iterable<AgentMessage> values) {

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -30,19 +30,24 @@ class PracticePage extends StatefulWidget {
   State<PracticePage> createState() => _PracticePageState();
 }
 
-class _PracticePageState extends State<PracticePage> {
+class _PracticePageState extends State<PracticePage>
+    with WidgetsBindingObserver {
   static const _maxReviewExitFrameAttempts = 60;
 
   final TextEditingController _textAnswerController = TextEditingController();
   final FocusNode _textAnswerFocusNode = FocusNode();
+  final ScrollController _messageScrollController = ScrollController();
   bool _scheduledReviewExit = false;
   int _reviewExitAttempts = 0;
   Animation<double>? _observedSecondaryAnimation;
   AnimationStatusListener? _reviewRouteStatusListener;
-  String? _expandedHintQuestionId;
   bool _exitInFlight = false;
   bool _exitApproved = false;
   bool _textAnswerMode = false;
+  bool _stickToLatestMessage = true;
+  int _messageCount = 0;
+  String? _lastMessageId;
+  PracticeRecordingState? _lastRecordingState;
   Timer? _recordingTicker;
   DateTime? _recordingStartedAt;
   int _recordingSeconds = 0;
@@ -50,9 +55,13 @@ class _PracticePageState extends State<PracticePage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _messageScrollController.addListener(_handleMessageScroll);
     widget.agentController?.addListener(_handleState);
+    _captureConversationState();
     _syncRecordingTimer();
     _scheduleReviewExitIfNeeded();
+    _scheduleScrollToLatest(animated: false);
   }
 
   @override
@@ -64,14 +73,20 @@ class _PracticePageState extends State<PracticePage> {
     oldWidget.agentController?.removeListener(_handleState);
     _resetReviewExit();
     widget.agentController?.addListener(_handleState);
+    _captureConversationState();
     _scheduleReviewExitIfNeeded();
+    _scheduleScrollToLatest(animated: false);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     widget.agentController?.removeListener(_handleState);
     _clearReviewRouteWait();
     _recordingTicker?.cancel();
+    _messageScrollController
+      ..removeListener(_handleMessageScroll)
+      ..dispose();
     _textAnswerController.dispose();
     _textAnswerFocusNode.dispose();
     unawaited(widget.agentController?.stopPracticeAudio(notify: false));
@@ -82,8 +97,24 @@ class _PracticePageState extends State<PracticePage> {
     if (!mounted) {
       return;
     }
+    final shouldScroll =
+        _stickToLatestMessage || !_messageScrollController.hasClients;
+    final controller = widget.agentController;
+    final messages = controller?.practiceMessages ?? const <AgentMessage>[];
+    final lastMessageId = messages.lastOrNull?.id;
+    final recordingState = controller?.recordingState;
+    final conversationChanged =
+        messages.length != _messageCount ||
+        lastMessageId != _lastMessageId ||
+        recordingState != _lastRecordingState;
+    _messageCount = messages.length;
+    _lastMessageId = lastMessageId;
+    _lastRecordingState = recordingState;
     _syncRecordingTimer();
     setState(() {});
+    if (conversationChanged && shouldScroll) {
+      _scheduleScrollToLatest();
+    }
     if (_isIeltsSpeakingFullMock) {
       _resetReviewExit();
       return;
@@ -93,6 +124,49 @@ class _PracticePageState extends State<PracticePage> {
       return;
     }
     _scheduleReviewExitIfNeeded();
+  }
+
+  @override
+  void didChangeMetrics() {
+    if (_stickToLatestMessage) {
+      _scheduleScrollToLatest();
+    }
+  }
+
+  void _captureConversationState() {
+    final controller = widget.agentController;
+    final messages = controller?.practiceMessages ?? const <AgentMessage>[];
+    _messageCount = messages.length;
+    _lastMessageId = messages.lastOrNull?.id;
+    _lastRecordingState = controller?.recordingState;
+  }
+
+  void _handleMessageScroll() {
+    if (!_messageScrollController.hasClients) {
+      return;
+    }
+    final position = _messageScrollController.position;
+    _stickToLatestMessage = position.maxScrollExtent - position.pixels <= 72;
+  }
+
+  void _scheduleScrollToLatest({bool animated = true}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_messageScrollController.hasClients) {
+        return;
+      }
+      final target = _messageScrollController.position.maxScrollExtent;
+      if (animated) {
+        unawaited(
+          _messageScrollController.animateTo(
+            target,
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOut,
+          ),
+        );
+      } else {
+        _messageScrollController.jumpTo(target);
+      }
+    });
   }
 
   void _syncRecordingTimer() {
@@ -242,14 +316,6 @@ class _PracticePageState extends State<PracticePage> {
     _reviewExitAttempts = 0;
   }
 
-  void _toggleHint(String questionId) {
-    setState(() {
-      _expandedHintQuestionId = _expandedHintQuestionId == questionId
-          ? null
-          : questionId;
-    });
-  }
-
   Future<void> _submitTextAnswer() async {
     final controller = widget.agentController;
     if (controller == null) {
@@ -279,7 +345,7 @@ class _PracticePageState extends State<PracticePage> {
     });
   }
 
-  void _showPracticeHistory(AgentController controller) {
+  void _showPracticeRecordings(AgentController controller) {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
@@ -292,23 +358,9 @@ class _PracticePageState extends State<PracticePage> {
           controller: scrollController,
           padding: const EdgeInsets.fromLTRB(20, 8, 20, 32),
           children: [
-            const Text('本轮记录', style: SpeakUpDesign.sectionTitle),
-            if (controller.recordings.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              PracticeRecordingsCard(controller: controller),
-            ],
-            if (controller.messages.any(
-              (message) => message.id != controller.questionId,
-            )) ...[
-              const SizedBox(height: 20),
-              _ConversationHistory(
-                messages: controller.messages
-                    .where((message) => message.id != controller.questionId)
-                    .toList(growable: false),
-                expandedHintQuestionId: null,
-                onToggleHint: (_) {},
-              ),
-            ],
+            const Text('本轮录音', style: SpeakUpDesign.sectionTitle),
+            const SizedBox(height: 16),
+            PracticeRecordingsCard(controller: controller),
           ],
         ),
       ),
@@ -375,107 +427,45 @@ class _PracticePageState extends State<PracticePage> {
         appBar: AppBar(
           title: scene == null || controller == null
               ? const Text('练习')
-              : Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(scene.title),
-                    Text(
-                      '第 ${(controller.completedTurns + 1).clamp(1, controller.turnLimit)} 题，共 ${controller.turnLimit} 题',
-                      style: SpeakUpDesign.meta,
-                    ),
-                  ],
-                ),
-          actions:
-              controller == null ||
-                  (controller.recordings.isEmpty &&
-                      !controller.messages.any(
-                        (message) => message.id != controller.questionId,
-                      ))
+              : Text(scene.title),
+          actions: controller == null || controller.recordings.isEmpty
               ? null
               : [
                   IconButton(
                     key: const Key('practice-open-history'),
-                    tooltip: '本轮记录',
+                    tooltip: '本轮录音',
                     onPressed:
                         controller.recordingState == PracticeRecordingState.idle
-                        ? () => _showPracticeHistory(controller)
+                        ? () => _showPracticeRecordings(controller)
                         : null,
                     icon: const Icon(Icons.more_horiz_rounded),
                   ),
                 ],
         ),
         body: SafeArea(
-          bottom: false,
           child: controller == null || scene == null
               ? const _NoScene()
               : Column(
                   children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
-                      child: _TurnProgress(
-                        completedTurns: controller.completedTurns,
-                        turnLimit: controller.turnLimit,
+                    Expanded(
+                      child: _SceneConversationMessageList(
+                        controller: controller,
+                        scrollController: _messageScrollController,
+                        previewMode: widget.previewMode,
                       ),
                     ),
-                    Expanded(
-                      child: SingleChildScrollView(
-                        padding: const EdgeInsets.fromLTRB(20, 28, 20, 32),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _CurrentQuestion(
-                              controller: controller,
-                              expandedHintQuestionId: _expandedHintQuestionId,
-                              onToggleHint: _toggleHint,
-                            ),
-                            if (controller.errorMessage
-                                case final message?) ...[
-                              const SizedBox(height: 16),
-                              Text(
-                                message,
-                                key: const Key('practice-error-message'),
-                                style: const TextStyle(
-                                  color: SpeakUpDesign.error,
-                                ),
-                              ),
-                            ],
-                            if (controller.mediaErrorMessage
-                                case final message?) ...[
-                              const SizedBox(height: 16),
-                              Text(
-                                message,
-                                key: const Key('practice-media-error-message'),
-                                style: const TextStyle(
-                                  color: SpeakUpDesign.error,
-                                ),
-                              ),
-                            ],
-                            if (widget.previewMode) ...[
-                              const SizedBox(height: 20),
-                              const Text(
-                                '当前页面仅供显式 Fake 预览，不代表生产语音服务已经接入。',
-                                textAlign: TextAlign.center,
-                                style: SpeakUpDesign.meta,
-                              ),
-                            ],
-                          ],
-                        ),
-                      ),
+                    _RecordingPanel(
+                      controller: controller,
+                      textController: _textAnswerController,
+                      textFocusNode: _textAnswerFocusNode,
+                      onSubmitText: _submitTextAnswer,
+                      textMode: _textAnswerMode,
+                      onToggleTextMode: _toggleTextAnswerMode,
+                      recordingSeconds: _recordingSeconds,
                     ),
                   ],
                 ),
         ),
-        bottomNavigationBar: controller == null || scene == null
-            ? null
-            : _RecordingPanel(
-                controller: controller,
-                textController: _textAnswerController,
-                textFocusNode: _textAnswerFocusNode,
-                onSubmitText: _submitTextAnswer,
-                textMode: _textAnswerMode,
-                onToggleTextMode: _toggleTextAnswerMode,
-                recordingSeconds: _recordingSeconds,
-              ),
       ),
     );
   }
@@ -499,233 +489,265 @@ class _NoScene extends StatelessWidget {
   }
 }
 
-class _TurnProgress extends StatelessWidget {
-  const _TurnProgress({required this.completedTurns, required this.turnLimit});
-
-  final int completedTurns;
-  final int turnLimit;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      key: const Key('practice-turn-progress'),
-      children: [
-        for (var index = 0; index < turnLimit; index++) ...[
-          Expanded(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 180),
-              height: 7,
-              decoration: BoxDecoration(
-                color: index < completedTurns
-                    ? SpeakUpDesign.primary
-                    : SpeakUpDesign.border,
-                borderRadius: BorderRadius.circular(8),
-              ),
-            ),
-          ),
-          if (index + 1 != turnLimit) const SizedBox(width: 8),
-        ],
-        const SizedBox(width: 12),
-        Text(
-          '$completedTurns / $turnLimit',
-          key: const Key('practice-turn-count'),
-          style: const TextStyle(fontWeight: FontWeight.w700),
-        ),
-      ],
-    );
-  }
-}
-
-class _ConversationHistory extends StatelessWidget {
-  const _ConversationHistory({
-    required this.messages,
-    required this.expandedHintQuestionId,
-    required this.onToggleHint,
-  });
-
-  final List<AgentMessage> messages;
-  final String? expandedHintQuestionId;
-  final ValueChanged<String> onToggleHint;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: const Key('practice-conversation-history'),
-      children: [
-        for (final message in messages) ...[
-          Align(
-            alignment: message.role == AgentMessageRole.user
-                ? Alignment.centerRight
-                : Alignment.centerLeft,
-            child: Container(
-              key: Key('practice-history-message-${message.id}'),
-              constraints: const BoxConstraints(maxWidth: 560),
-              padding: const EdgeInsets.all(14),
-              decoration: BoxDecoration(
-                color: message.role == AgentMessageRole.user
-                    ? SpeakUpDesign.primary
-                    : SpeakUpDesign.surface,
-                borderRadius: BorderRadius.circular(
-                  SpeakUpDesign.radiusControl,
-                ),
-                border: Border.all(color: SpeakUpDesign.border),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    message.text,
-                    style: TextStyle(
-                      color: message.role == AgentMessageRole.user
-                          ? Colors.white
-                          : SpeakUpDesign.ink,
-                      height: 1.45,
-                    ),
-                  ),
-                  if (message.role == AgentMessageRole.assistant) ...[
-                    const SizedBox(height: 8),
-                    TextButton.icon(
-                      key: Key('practice-history-hint-${message.id}'),
-                      onPressed: () => onToggleHint(message.id),
-                      icon: const Icon(Icons.lightbulb_outline_rounded),
-                      label: Text(
-                        expandedHintQuestionId == message.id ? '收起提示' : '提示',
-                      ),
-                    ),
-                    if (expandedHintQuestionId == message.id)
-                      const _AnswerHint(),
-                  ],
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 10),
-        ],
-      ],
-    );
-  }
-}
-
-class _CurrentQuestion extends StatelessWidget {
-  const _CurrentQuestion({
+class _SceneConversationMessageList extends StatelessWidget {
+  const _SceneConversationMessageList({
     required this.controller,
-    required this.expandedHintQuestionId,
-    required this.onToggleHint,
+    required this.scrollController,
+    required this.previewMode,
   });
 
   final AgentController controller;
-  final String? expandedHintQuestionId;
-  final ValueChanged<String> onToggleHint;
+  final ScrollController scrollController;
+  final bool previewMode;
 
   @override
   Widget build(BuildContext context) {
-    final question = controller.messages.reversed
-        .where((message) => message.role == AgentMessageRole.assistant)
-        .firstOrNull;
-    final hintExpanded =
-        question != null && expandedHintQuestionId == question.id;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Row(
-          children: [
-            CircleAvatar(
-              radius: 22,
-              backgroundColor: SpeakUpDesign.primaryMuted,
-              foregroundColor: SpeakUpDesign.primary,
-              child: Icon(Icons.person_outline_rounded),
-            ),
-            SizedBox(width: 12),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('AI 面试官', style: SpeakUpDesign.cardTitle),
-                SizedBox(height: 2),
-                Text('请用英文回答', style: SpeakUpDesign.meta),
-              ],
-            ),
-          ],
-        ),
-        const SizedBox(height: 24),
-        Text(
-          question?.text ?? '准备好后开始第一轮。',
-          key: const Key('practice-current-question'),
-          style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24, height: 1.4),
-        ),
-        const SizedBox(height: 18),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            if (controller.canPlayQuestionAudio)
-              TextButton.icon(
-                key: const Key('practice-question-audio'),
-                onPressed: controller.canUsePracticeAudio
-                    ? controller.toggleQuestionAudio
+    final messages = controller.practiceMessages;
+    final state = controller.recordingState;
+    final terminal =
+        state == PracticeRecordingState.reviewFailed ||
+        state == PracticeRecordingState.completed;
+    final showThinking =
+        state == PracticeRecordingState.submitting ||
+        (messages.isEmpty && !terminal);
+
+    return SingleChildScrollView(
+      key: const Key('practice-message-list'),
+      controller: scrollController,
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final message in messages) ...[
+            if (message.role == AgentMessageRole.assistant)
+              _SceneAIMessageBubble(
+                key: ValueKey('practice-ai-${message.id}'),
+                message: message,
+                roleName: 'AI 教练',
+                actions:
+                    message.id == controller.questionId &&
+                        controller.canPlayQuestionAudio
+                    ? _QuestionAudioAction(controller: controller)
                     : null,
-                icon: controller.isQuestionAudioLoading
-                    ? const SizedBox.square(
-                        dimension: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : Icon(
-                        controller.isQuestionAudioPlaying
-                            ? Icons.stop_circle_outlined
-                            : Icons.volume_up_outlined,
-                        size: 19,
-                      ),
-                label: Text(
-                  controller.isQuestionAudioPlaying ? '停止播放' : '重听问题',
-                ),
+              )
+            else
+              _SceneUserMessageBubble(
+                key: ValueKey('practice-user-${message.id}'),
+                message: message,
               ),
-            if (question != null)
-              TextButton.icon(
-                key: Key('practice-hint-${question.id}'),
-                onPressed: () => onToggleHint(question.id),
-                icon: Icon(
-                  hintExpanded
-                      ? Icons.lightbulb_rounded
-                      : Icons.lightbulb_outline_rounded,
-                  size: 19,
-                ),
-                label: Text(hintExpanded ? '收起思路' : '回答思路'),
-              ),
+            const SizedBox(height: 14),
           ],
-        ),
-        if (hintExpanded) ...[const SizedBox(height: 14), const _AnswerHint()],
-      ],
+          if (showThinking) ...[
+            _SceneAIThinkingBubble(
+              label: messages.isEmpty ? '正在准备第一轮…' : 'AI 正在思考…',
+            ),
+            const SizedBox(height: 14),
+          ],
+          if (controller.errorMessage case final message?) ...[
+            Text(
+              message,
+              key: const Key('practice-error-message'),
+              style: const TextStyle(color: SpeakUpDesign.error),
+            ),
+            const SizedBox(height: 12),
+          ],
+          if (controller.mediaErrorMessage case final message?) ...[
+            Text(
+              message,
+              key: const Key('practice-media-error-message'),
+              style: const TextStyle(color: SpeakUpDesign.error),
+            ),
+            const SizedBox(height: 12),
+          ],
+          if (previewMode)
+            const Text(
+              '当前页面仅供显式 Fake 预览，不代表生产语音服务已经接入。',
+              textAlign: TextAlign.center,
+              style: SpeakUpDesign.meta,
+            ),
+        ],
+      ),
     );
   }
 }
 
-class _AnswerHint extends StatelessWidget {
-  const _AnswerHint();
+class _SceneAIMessageBubble extends StatelessWidget {
+  const _SceneAIMessageBubble({
+    required this.message,
+    required this.roleName,
+    this.actions,
+    super.key,
+  });
+
+  final AgentMessage message;
+  final String roleName;
+  final Widget? actions;
 
   @override
   Widget build(BuildContext context) {
-    return const DecoratedBox(
-      key: Key('practice-answer-hint'),
-      decoration: BoxDecoration(
-        color: SpeakUpDesign.surfaceMuted,
-        borderRadius: BorderRadius.all(
-          Radius.circular(SpeakUpDesign.radiusControl),
+    return LayoutBuilder(
+      builder: (context, constraints) => Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const CircleAvatar(
+            radius: 17,
+            backgroundColor: SpeakUpDesign.primaryMuted,
+            foregroundColor: SpeakUpDesign.primary,
+            child: Icon(Icons.person_outline_rounded, size: 20),
+          ),
+          const SizedBox(width: 10),
+          Container(
+            key: Key('practice-ai-message-${message.id}'),
+            constraints: BoxConstraints(maxWidth: constraints.maxWidth * 0.76),
+            padding: const EdgeInsets.fromLTRB(14, 11, 14, 12),
+            decoration: BoxDecoration(
+              color: SpeakUpDesign.surface,
+              borderRadius: const BorderRadius.only(
+                topRight: Radius.circular(SpeakUpDesign.radiusControl),
+                bottomLeft: Radius.circular(SpeakUpDesign.radiusControl),
+                bottomRight: Radius.circular(SpeakUpDesign.radiusControl),
+              ),
+              border: Border.all(color: SpeakUpDesign.border),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  roleName,
+                  style: SpeakUpDesign.meta.copyWith(
+                    color: SpeakUpDesign.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Text(
+                  message.text,
+                  style: SpeakUpDesign.body.copyWith(height: 1.45),
+                ),
+                if (actions != null) ...[const SizedBox(height: 8), actions!],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SceneUserMessageBubble extends StatelessWidget {
+  const _SceneUserMessageBubble({required this.message, super.key});
+
+  final AgentMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) => Align(
+        alignment: Alignment.centerRight,
+        child: Container(
+          key: Key('practice-user-message-${message.id}'),
+          constraints: BoxConstraints(maxWidth: constraints.maxWidth * 0.78),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: const BoxDecoration(
+            color: SpeakUpDesign.primary,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(SpeakUpDesign.radiusControl),
+              bottomLeft: Radius.circular(SpeakUpDesign.radiusControl),
+              bottomRight: Radius.circular(SpeakUpDesign.radiusControl),
+            ),
+          ),
+          child: Text(
+            message.text,
+            style: SpeakUpDesign.body.copyWith(
+              color: Colors.white,
+              height: 1.45,
+            ),
+          ),
         ),
       ),
-      child: Padding(
-        padding: EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('回答框架', style: SpeakUpDesign.cardTitle),
-            SizedBox(height: 10),
-            Text('1. 先直接回答你的核心观点', style: SpeakUpDesign.body),
-            SizedBox(height: 4),
-            Text('2. 用一个具体经历或事实支持', style: SpeakUpDesign.body),
-            SizedBox(height: 4),
-            Text('3. 回到岗位匹配与结果', style: SpeakUpDesign.body),
-          ],
-        ),
+    );
+  }
+}
+
+class _SceneAIThinkingBubble extends StatelessWidget {
+  const _SceneAIThinkingBubble({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Row(
+        key: const Key('practice-ai-thinking'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircleAvatar(
+            radius: 17,
+            backgroundColor: SpeakUpDesign.primaryMuted,
+            foregroundColor: SpeakUpDesign.primary,
+            child: Icon(Icons.person_outline_rounded, size: 20),
+          ),
+          const SizedBox(width: 10),
+          Flexible(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: SpeakUpDesign.surfaceMuted,
+                borderRadius: BorderRadius.circular(
+                  SpeakUpDesign.radiusControl,
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                    const SizedBox(width: 10),
+                    Flexible(child: Text(label, style: SpeakUpDesign.meta)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _QuestionAudioAction extends StatelessWidget {
+  const _QuestionAudioAction({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      key: const Key('practice-question-audio'),
+      onPressed: controller.canUsePracticeAudio
+          ? controller.toggleQuestionAudio
+          : null,
+      icon: controller.isQuestionAudioLoading
+          ? const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Icon(
+              controller.isQuestionAudioPlaying
+                  ? Icons.stop_circle_outlined
+                  : Icons.volume_up_outlined,
+              size: 19,
+            ),
+      label: Text(controller.isQuestionAudioPlaying ? '停止播放' : '重听问题'),
     );
   }
 }

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -110,21 +110,23 @@ void main() {
       expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
       expect(find.text('取消'), findsOneWidget);
       expect(
-        find.byKey(const Key('practice-current-question')).hitTestable(),
+        find
+            .byKey(Key('practice-ai-message-${agentController.questionId}'))
+            .hitTestable(),
         findsOneWidget,
       );
 
       if (turn == 1) {
         await tester.tap(find.byKey(const Key('practice-rerecord')));
         await tester.pumpAndSettle();
-        expect(find.text('0 / 3'), findsOneWidget);
+        expect(agentController.practiceMessages, hasLength(1));
         await _holdAndReleaseAnswer(tester);
       }
 
       await tester.tap(find.byKey(const Key('practice-confirm-turn')));
       await tester.pumpAndSettle();
       if (turn < 3) {
-        expect(find.text('$turn / 3'), findsOneWidget);
+        expect(agentController.practiceMessages, hasLength(turn * 2 + 1));
       }
     }
 

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -631,6 +631,40 @@ void main() {
     expect(controller.recordingState, PracticeRecordingState.idle);
   });
 
+  testWidgets('practice renders the first question as a conversation bubble', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: FakePracticeClient(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes[1]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: PracticePage(agentController: controller)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(agentScenes[1].title), findsOneWidget);
+    expect(
+      find.byKey(const Key('practice-ai-message-question-0-1')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('practice-message-list')), findsOneWidget);
+    expect(find.byKey(const Key('practice-turn-progress')), findsNothing);
+    expect(find.byKey(const Key('practice-turn-count')), findsNothing);
+    expect(find.byKey(const Key('practice-current-question')), findsNothing);
+    expect(find.textContaining('第 1 题'), findsNothing);
+    expect(find.textContaining('共 3 题'), findsNothing);
+
+    final bubble = tester.getRect(
+      find.byKey(const Key('practice-ai-message-question-0-1')),
+    );
+    expect(bubble.center.dx, lessThan(tester.view.physicalSize.width / 2));
+  });
+
   testWidgets('practice submits a typed English answer and advances one turn', (
     tester,
   ) async {
@@ -675,19 +709,105 @@ void main() {
           .text,
       answer,
     );
-    await tester.tap(find.byKey(const Key('practice-open-history')));
-    await tester.pumpAndSettle();
-    await tester.scrollUntilVisible(
-      find.text(answer),
-      120,
-      scrollable: find.byType(Scrollable).first,
+    expect(
+      find.byKey(const Key('practice-ai-message-question-0-1')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('practice-ai-message-question-0-2')),
+      findsOneWidget,
     );
     expect(find.text(answer), findsOneWidget);
-    Navigator.of(tester.element(find.text('本轮记录'))).pop();
+
+    final firstQuestion = tester.getTopLeft(
+      find.byKey(const Key('practice-ai-message-question-0-1')),
+    );
+    final userAnswer = tester.getTopLeft(
+      find.byKey(const Key('practice-user-message-answer-1')),
+    );
+    final secondQuestion = tester.getTopLeft(
+      find.byKey(const Key('practice-ai-message-question-0-2')),
+    );
+    expect(firstQuestion.dy, lessThan(userAnswer.dy));
+    expect(userAnswer.dy, lessThan(secondQuestion.dy));
+
+    await tester.pumpWidget(
+      MaterialApp(home: PracticePage(agentController: controller)),
+    );
     await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsOneWidget,
+    );
     await tester.tap(find.byKey(const Key('practice-open-keyboard')));
     await tester.pump();
     expect(tester.widget<TextField>(input).controller?.text, isEmpty);
+  });
+
+  testWidgets('practice keeps a stable five-message conversation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: FakePracticeClient(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes[1]);
+    await tester.pumpWidget(
+      MaterialApp(home: PracticePage(agentController: controller)),
+    );
+    await tester.pumpAndSettle();
+
+    for (final answer in ['First answer', 'Second answer']) {
+      await tester.tap(find.byKey(const Key('practice-open-keyboard')));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const Key('practice-text-answer')),
+        answer,
+      );
+      await tester.tap(find.byKey(const Key('practice-submit-text')));
+      await tester.pumpAndSettle();
+    }
+
+    const orderedKeys = [
+      'practice-ai-message-question-0-1',
+      'practice-user-message-answer-1',
+      'practice-ai-message-question-0-2',
+      'practice-user-message-answer-2',
+      'practice-ai-message-question-0-3',
+    ];
+    final offsets = <double>[];
+    for (final key in orderedKeys) {
+      final finder = find.byKey(Key(key));
+      expect(finder, findsOneWidget);
+      offsets.add(tester.getTopLeft(finder).dy);
+    }
+    expect(offsets, orderedEquals(offsets.toList()..sort()));
+
+    await tester.pumpWidget(
+      MaterialApp(home: PracticePage(agentController: controller)),
+    );
+    await tester.pumpAndSettle();
+    for (final key in orderedKeys) {
+      expect(find.byKey(Key(key)), findsOneWidget);
+    }
+
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(
+        of: find.byKey(const Key('practice-message-list')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    expect(scrollable.position.maxScrollExtent, greaterThan(0));
   });
 
   testWidgets('practice keeps candidate text after a confirm network error', (
@@ -717,8 +837,163 @@ void main() {
     expect(find.text('网络连接不稳定，这一轮尚未确认，请重试。'), findsOneWidget);
     expect(find.text('Answer 1'), findsOneWidget);
     expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsNothing,
+    );
+    expect(controller.practiceMessages, hasLength(1));
+    expect(
       controller.recordingState,
       PracticeRecordingState.awaitingConfirmation,
+    );
+
+    practice.confirmFailure = null;
+    await tester.tap(find.byKey(const Key('practice-confirm-turn')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsOneWidget,
+    );
+    expect(controller.practiceMessages, hasLength(3));
+  });
+
+  testWidgets('practice does not append a failed typed answer', (tester) async {
+    final practice = _TwoTurnPracticeClient()
+      ..textFailure = const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await tester.pumpWidget(
+      MaterialApp(home: PracticePage(agentController: controller)),
+    );
+
+    await tester.tap(find.byKey(const Key('practice-open-keyboard')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const Key('practice-text-answer')),
+      'This answer must not appear as confirmed.',
+    );
+    await tester.tap(find.byKey(const Key('practice-submit-text')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('网络连接不稳定，这一轮尚未确认，请重试。'), findsOneWidget);
+    expect(controller.practiceMessages, hasLength(1));
+    expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('practice-ai-message-question-1')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('interview and daily scenes share the conversation page', (
+    tester,
+  ) async {
+    const dailyScene = AgentScene(
+      id: 'hotel-check-in',
+      title: '酒店入住',
+      description: '练习办理入住和沟通房间问题。',
+    );
+
+    for (final scene in [agentScenes[1], dailyScene]) {
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: FakePracticeClient(),
+      );
+      await controller.initialize();
+      await controller.selectScene(scene);
+      await tester.pumpWidget(
+        MaterialApp(home: PracticePage(agentController: controller)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(scene.title), findsOneWidget);
+      expect(find.byKey(const Key('practice-message-list')), findsOneWidget);
+      expect(
+        find.byKey(const Key('practice-ai-message-question-0-1')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('practice-record')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('practice-open-keyboard')));
+      await tester.pump();
+      expect(find.byKey(const Key('practice-text-answer')), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      controller.dispose();
+    }
+  });
+
+  testWidgets('long conversation wraps and scrolls on a narrow large-text view', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final practice = _TwoTurnPracticeClient(
+      firstQuestion: List.filled(
+        12,
+        'Please explain the context, your decision, and the measurable result.',
+      ).join(' '),
+      firstAnswer: List.filled(
+        12,
+        'I aligned the team, reduced the risk, and measured the outcome.',
+      ).join(' '),
+      secondQuestion: List.filled(
+        10,
+        'What trade-off would you revisit and why?',
+      ).join(' '),
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    await controller.confirmTranscript();
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+        child: MaterialApp(home: PracticePage(agentController: controller)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const Key('practice-ai-message-question-1')),
+      findsOneWidget,
+    );
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(
+        of: find.byKey(const Key('practice-message-list')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    expect(scrollable.position.maxScrollExtent, greaterThan(0));
+    await tester.drag(
+      find.byKey(const Key('practice-message-list')),
+      const Offset(0, 240),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('practice-user-message-answer-1')),
+      findsOneWidget,
     );
   });
 
@@ -757,9 +1032,17 @@ void main() {
 }
 
 final class _TwoTurnPracticeClient implements PracticeClient {
-  _TwoTurnPracticeClient({this.includeAudioAssets = false});
+  _TwoTurnPracticeClient({
+    this.includeAudioAssets = false,
+    this.firstQuestion = 'First question',
+    this.firstAnswer = 'Answer 1',
+    this.secondQuestion = 'Second question',
+  });
 
   final bool includeAudioAssets;
+  final String firstQuestion;
+  final String firstAnswer;
+  final String secondQuestion;
   int completed = 0;
   int cleanupCount = 0;
   final List<String> confirmedQuestionIds = [];
@@ -768,6 +1051,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
   bool omitReview = false;
   Object? transcribeFailure;
   Object? confirmFailure;
+  Object? textFailure;
   Object? restoreFailure;
   PracticeSessionSnapshot? restoreResult;
   int transcribeCount = 0;
@@ -802,10 +1086,10 @@ final class _TwoTurnPracticeClient implements PracticeClient {
         completedTurns: 0,
         turnLimit: 2,
         sessionCompleted: false,
-        currentQuestion: const PracticeQuestion(
+        currentQuestion: PracticeQuestion(
           id: 'question-1',
           sessionId: _sessionId,
-          text: 'First question',
+          text: firstQuestion,
           speechPath: '/v1/voice-questions/question-1/speech',
         ),
       ),
@@ -824,7 +1108,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
       id: 'candidate-${completed + 1}',
       sessionId: request.sessionId,
       questionId: request.questionId,
-      text: 'Answer ${completed + 1}',
+      text: completed == 0 ? firstAnswer : 'Answer ${completed + 1}',
     );
   }
 
@@ -848,10 +1132,10 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     final done = completed == 2;
     final nextQuestion = done
         ? null
-        : const PracticeQuestion(
+        : PracticeQuestion(
             id: 'question-2',
             sessionId: _sessionId,
-            text: 'Second question',
+            text: secondQuestion,
             speechPath: '/v1/voice-questions/question-2/speech',
           );
     return PracticeTurnConfirmation(
@@ -862,7 +1146,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
       answer: AgentMessage(
         id: 'answer-$completed',
         role: AgentMessageRole.user,
-        text: 'Answer $completed',
+        text: completed == 1 ? firstAnswer : 'Answer $completed',
       ),
       completedTurns: completed,
       turnLimit: 2,
@@ -887,7 +1171,10 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     required String questionId,
     required String answerText,
     required String idempotencyKey,
-  }) {
+  }) async {
+    if (textFailure case final failure?) {
+      throw failure;
+    }
     throw UnimplementedError();
   }
 }

--- a/mobile/test/practice/practice_media_controller_test.dart
+++ b/mobile/test/practice/practice_media_controller_test.dart
@@ -394,7 +394,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Practice hint shows a concise answer framework', (tester) async {
+  testWidgets('Practice hides actions without backed data', (tester) async {
     final controller = _controller(
       snapshot: _activeSnapshot(audioAssetId: 'audio-1'),
       media: _MediaClient(),
@@ -406,13 +406,10 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(home: PracticePage(agentController: controller)),
     );
-    await tester.tap(find.byKey(const Key('practice-hint-question-2')));
-    await tester.pump();
 
-    expect(find.text('回答框架'), findsOneWidget);
-    expect(find.text('1. 先直接回答你的核心观点'), findsOneWidget);
-    expect(find.text('2. 用一个具体经历或事实支持'), findsOneWidget);
-    expect(find.text('3. 回到岗位匹配与结果'), findsOneWidget);
+    expect(find.byKey(const Key('practice-question-audio')), findsOneWidget);
+    expect(find.byKey(const Key('practice-hint-question-2')), findsNothing);
+    expect(find.text('回答框架'), findsNothing);
     expect(find.text('参考回答'), findsNothing);
   });
 


### PR DESCRIPTION
## 功能描述

- 将公共 `PracticePage` 从“只展示当前题”的问答卡改造成连续对话气泡流。
- AI 消息左对齐、用户消息右对齐，并按 `AI1 → User1 → AI2` 持续累积。
- 保留现有真实语音录制、语音候选确认、键盘回答、失败重试与当前题播放能力。
- 不新增后端接口、契约字段或伪造交互。

## 实现思路

- 在当前 Practice Session 内维护 `practiceMessages`，以服务端稳定 ID 去重。
- 首题进入会话流；回答确认成功后追加用户消息，再追加下一道 AI 问题。
- 公共消息列表使用稳定 Key、消息级操作槽和自动滚动，兼容窄屏、键盘与 2x 字号。
- 新建/退出 Practice Session 时清理会话消息，避免跨会话串线。
- 当前恢复接口只提供 `currentQuestion/currentTurn`，因此冷恢复仅能恢复当前题；完整历史恢复不在本 Issue 的接口范围内。

## 测试方式

```bash
cd mobile
dart format --output=none --set-exit-if-changed lib test
flutter analyze
flutter test --no-pub test/practice/
flutter test --no-pub test/agent/
flutter test --no-pub test/preparation/
```

结果：

- 格式检查：110 个文件，0 个变更
- 静态分析：无问题
- Practice：103 项通过
- Agent：121 项通过
- Preparation：138 项通过

新增/调整的覆盖包括首条 AI 气泡、`AI1 → User1 → AI2` 顺序、五条连续消息、语音候选确认、文字提交失败、面试/日常场景复用，以及窄屏和 2x 字号。

## 真实环境验证

已使用登录态走通：`训练 → 英文面试 → 岗位专业面试 → 项目经历深挖`。真实后端成功创建 Agent Thread、Practice Plan/Session、Voice Session，并显示第一条真实 AI 问题及原有语音/键盘入口。

本地环境存在历史数据库漂移，尚未把“双轮生产对话截图”列为已完成：

- `.env` 文件存在；本地启动仍需补充运行时端口、OSS provider 与 review cursor signing key。
- 迁移版本已从 dirty v27/v28 修复并升级为 v31 clean。
- 数据库仍残留旧的 `practice_plans_scenario_family_model_check`，会拒绝 `INTERVIEW_BASIC_DIALOGUE` 等当前模型。
- 后台 sweep 还会报告 `agent_memory_index_jobs` 缺失。

这些问题未通过本前端 Issue 修改后端或 schema。PR 保持 Draft，待环境约束修复后补齐连续两轮真实对话证据。

Closes #249
