### PR TITLE
fix(ielts): clarify Part 2 and Part 3 linkage

### DIFF
--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -2321,8 +2321,8 @@ String _ieltsPartNumber(String scenarioId) {
 String _ieltsPartLabel(String scenarioId) {
   return switch (scenarioId) {
     'scn_ielts_speaking_part_1' => '熟悉话题问答',
-    'scn_ielts_speaking_part_2' => '题卡陈述',
-    'scn_ielts_speaking_part_3' => '延伸讨论',
+    'scn_ielts_speaking_part_2' => '题卡陈述 · 可继续 Part 3',
+    'scn_ielts_speaking_part_3' => '承接 Part 2 主题讨论',
     _ => '专项练习',
   };
 }

--- a/mobile/test/preparation/preparation_hub_test.dart
+++ b/mobile/test/preparation/preparation_hub_test.dart
@@ -118,6 +118,8 @@ void main() {
       expect(find.text('IELTS 口语'), findsOneWidget);
       expect(find.text('一次完成三个 Part'), findsOneWidget);
       expect(find.text('Part 1'), findsOneWidget);
+      expect(find.text('题卡陈述 · 可继续 Part 3'), findsOneWidget);
+      expect(find.text('承接 Part 2 主题讨论'), findsOneWidget);
       expect(
         find.byKey(const Key('catalog-scenario-scn_ielts_speaking_part_1')),
         findsOneWidget,
@@ -427,6 +429,24 @@ const _hubScenarios = <PreparationScenario>[
     model: 'EXAM_BASIC_DIALOGUE',
     name: 'IELTS Speaking Part 1',
     summary: '围绕熟悉话题完成简短问答。',
+    version: 1,
+    status: 'active',
+  ),
+  PreparationScenario(
+    id: 'scn_ielts_speaking_part_2',
+    type: 'EXAM',
+    model: 'IELTS_SPEAKING_PART_2',
+    name: 'IELTS Speaking Part 2',
+    summary: '完成题卡陈述，并可继续练习同主题 Part 3。',
+    version: 1,
+    status: 'active',
+  ),
+  PreparationScenario(
+    id: 'scn_ielts_speaking_part_3',
+    type: 'EXAM',
+    model: 'EXAM_BASIC_DIALOGUE',
+    name: 'IELTS Speaking Part 3',
+    summary: '基于对应的 Part 2 主题展开讨论。',
     version: 1,
     status: 'active',
   ),


### PR DESCRIPTION
## 功能说明

- 更新 IELTS 口语分段练习入口文案，明确 Part 2 可继续对应的 Part 3。
- 明确 Part 3 是承接对应 Part 2 主题的讨论练习。
- 其他页面结构、交互与业务流程保持不变。

## 实现思路

- 仅调整 IELTS 训练主页 Part 2、Part 3 卡片的说明文案。
- 扩充分段入口组件测试数据，并增加对应文案断言，防止后续回归。

## 验证方式

在 `mobile` 目录执行：

```bash
dart format lib/features/preparation/preparation.dart test/preparation/preparation_hub_test.dart
flutter analyze --no-pub
flutter test --no-pub test/preparation/preparation_hub_test.dart
```

结果：静态分析通过，目标测试 10 项全部通过；iPhone 模拟器视觉检查通过。

Closes #253
