### PR TITLE
feat(voice): unify mobile capture controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,8 +85,8 @@ QIANWEN_TTS_LIVE_TEST=0
 # WORKPLACE or DAILY Practice Session. Flutter receives App/Avatar IDs and that
 # short-lived token, never the API key. The console endpoint must match Region.
 SPATIUS_ENABLED=0
-SPATIUS_REGION=cn-beijing
-SPATIUS_CONSOLE_BASE_URL=https://console.cn-beijing.spatialwalk.top/v1/console
+SPATIUS_REGION=ap-northeast
+SPATIUS_CONSOLE_BASE_URL=https://console.ap-northeast.spatialwalk.cloud/v1/console
 SPATIUS_APP_ID=
 SPATIUS_AVATAR_ID=
 SPATIUS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,19 @@ QIANWEN_ASR_LIVE_TEST=0
 QIANWEN_ASR_LIVE_TEST_AUDIO=
 QIANWEN_TTS_LIVE_TEST=0
 
+# Spatius Direct Mode. The server exchanges SPATIUS_API_KEY for a short-lived
+# Session Token only after verifying the authenticated user owns an interactive
+# WORKPLACE or DAILY Practice Session. Flutter receives App/Avatar IDs and that
+# short-lived token, never the API key. The console endpoint must match Region.
+SPATIUS_ENABLED=0
+SPATIUS_REGION=cn-beijing
+SPATIUS_CONSOLE_BASE_URL=https://console.cn-beijing.spatialwalk.top/v1/console
+SPATIUS_APP_ID=
+SPATIUS_AVATAR_ID=
+SPATIUS_API_KEY=
+SPATIUS_TOKEN_TTL=10m
+SPATIUS_TIMEOUT=5s
+
 # Server-only private audio storage. Production defaults to a refreshable ECS
 # RAM-role provider. OSS_RAM_ROLE_NAME is optional; when empty, the SDK asks
 # the ECS metadata service for the attached role. Local/CI may explicitly set

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ SHELL := /bin/bash
 	check-api \
 	check-api-dependencies \
 	check-api-contracts \
-	check-smoke
+	check-smoke \
+	dev-android
 
 help:
 	@printf '%s\n' \
@@ -28,7 +29,8 @@ help:
 		'  make check-go       Run Go format, vet, and test checks' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
-		'  make check-smoke    Run the deterministic Mock main flow'
+		'  make check-smoke    Run the deterministic Mock main flow' \
+		'  make dev-android    Start the backend and run the App on an Android device'
 
 check: check-flutter check-go check-api check-smoke
 
@@ -109,3 +111,6 @@ check-smoke:
 		exit 1; \
 	fi
 	cd server && go test -count=1 -run '^TestDeterministicMainFlow$$' ./internal/smoke
+
+dev-android:
+	./tools/android-dev/run.sh

--- a/api/modules/avatar.yaml
+++ b/api/modules/avatar.yaml
@@ -1,0 +1,114 @@
+paths:
+  /v1/practice-sessions/{practice_session_id}/avatar-session-token:
+    post:
+      tags:
+        - Avatar
+      summary: Mint a short-lived avatar provider Session Token
+      description: |
+        Verifies that the current Bearer actor owns the requested formal
+        Practice Session and that it is a starting or in-progress WORKPLACE or
+        DAILY session. The server exchanges its private provider API key for a
+        short-lived Session Token. The API key is never returned to the client.
+
+        The operation accepts an empty request body. Paused, terminal, and
+        unsupported scenario sessions must resume or continue without avatar
+        rendering before another Token can be requested.
+      operationId: createAvatarSessionToken
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: |
+            Short-lived provider credentials and the exact audio contract
+            required by the configured avatar renderer.
+          headers:
+            Cache-Control:
+              description: Prevents storage of the short-lived credential.
+              required: true
+              schema:
+                type: string
+                const: no-store
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvatarSessionToken'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        '503':
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+components:
+  parameters:
+    PracticeSessionId:
+      name: practice_session_id
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 128
+  schemas:
+    AvatarSessionToken:
+      type: object
+      additionalProperties: false
+      required:
+        - app_id
+        - avatar_id
+        - session_token
+        - region
+        - expires_at
+        - audio_format
+      properties:
+        app_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        avatar_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        session_token:
+          type: string
+          minLength: 8
+          maxLength: 8192
+          pattern: '^[\x21-\x7E]+$'
+          readOnly: true
+          description: |
+            Short-lived provider Session Token. Keep it only in process memory;
+            never persist it or place it in URLs, logs, or telemetry.
+        region:
+          type: string
+          enum:
+            - cn-beijing
+            - ap-northeast
+            - us-west
+        expires_at:
+          type: string
+          format: date-time
+          description: RFC 3339 UTC expiration instant.
+        audio_format:
+          $ref: '#/components/schemas/AvatarAudioFormat'
+    AvatarAudioFormat:
+      type: object
+      additionalProperties: false
+      required:
+        - encoding
+        - sample_rate_hz
+        - channels
+      properties:
+        encoding:
+          type: string
+          const: PCM_S16LE
+        sample_rate_hz:
+          type: integer
+          const: 24000
+        channels:
+          type: integer
+          const: 1

--- a/api/modules/avatar.yaml
+++ b/api/modules/avatar.yaml
@@ -86,7 +86,6 @@ components:
         region:
           type: string
           enum:
-            - cn-beijing
             - ap-northeast
             - us-west
         expires_at:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -41,6 +41,8 @@ tags:
     description: Analysis, evidence feedback, same-question retry, and history projections.
   - name: Evaluation
     description: Versioned Scene and Core 4D evaluation facts, gates, evidence, and revisions.
+  - name: Avatar
+    description: Short-lived avatar rendering credentials for owned interactive practice sessions.
 paths:
   /health:
     get:
@@ -163,6 +165,8 @@ paths:
     $ref: ./modules/practice.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1practice-start-confirmations
   /v1/practice-sessions/{practice_session_id}:
     $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}
+  /v1/practice-sessions/{practice_session_id}/avatar-session-token:
+    $ref: ./modules/avatar.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1avatar-session-token
   /v1/practice-sessions/{practice_session_id}/snapshot:
     $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1snapshot
   /v1/practice-sessions/{practice_session_id}/pause:

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -942,6 +942,7 @@ for (const { key, operation, pathParameters } of operations) {
 }
 assert.deepEqual(sorted(tokenResponseLocations), [
   'POST /v1/auth/login 200 session_token',
+  'POST /v1/practice-sessions/{practice_session_id}/avatar-session-token 200 session_token',
 ]);
 
 const websocket = requireOperation(

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -10,3 +10,17 @@ dart format --output=none --set-exit-if-changed lib test
 flutter analyze
 flutter test
 ```
+
+## Android 真机调试
+
+在仓库根目录执行：
+
+```shell
+make dev-android
+```
+
+命令会启动 PostgreSQL 和本地后端、配置 USB 端口映射，并在已授权的
+Android 真机上运行 App。连接多台设备时，可通过
+`ANDROID_DEVICE_ID=<设备 ID> make dev-android` 指定设备。
+本地调试后端默认使用 `18080` 端口，可通过
+`SPEAKUP_DEV_PORT=<端口> make dev-android` 覆盖。

--- a/mobile/android/.gitignore
+++ b/mobile/android/.gitignore
@@ -1,5 +1,6 @@
 gradle-wrapper.jar
 /.gradle
+/.kotlin
 /captures/
 /gradlew
 /gradlew.bat

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -20,10 +20,19 @@ android {
         applicationId = "com.xengineer.speakup"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 24
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
+    }
+
+    packaging {
+        jniLibs {
+            excludes += listOf("lib/armeabi-v7a/**", "lib/x86/**", "lib/x86_64/**")
+        }
     }
 
     buildTypes {

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Local API traffic is carried through adb reverse during development. -->
+    <application android:usesCleartextTraffic="true"/>
 </manifest>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:label="speakup"
         android:name="${applicationName}"

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,0 +1,42 @@
+platform :ios, '16.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - avatar_kit (1.0.0-beta.44):
+    - Flutter
+  - Flutter (1.0.0)
+
+DEPENDENCIES:
+  - avatar_kit (from `.symlinks/plugins/avatar_kit/ios`)
+  - Flutter (from `Flutter`)
+
+EXTERNAL SOURCES:
+  avatar_kit:
+    :path: ".symlinks/plugins/avatar_kit/ios"
+  Flutter:
+    :path: Flutter
+
+SPEC CHECKSUMS:
+  avatar_kit: 78d33738d6a8bb5180c7a99a9c4aa7b22b4d1c23
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+
+PODFILE CHECKSUM: bd29822c3d5baf6b44b726f00ea3293a19339ef2
+
+COCOAPODS: 1.17.0

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		42273D8143A96AA2E06F69F3 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D8DC8DD3911AC4850FCB306 /* Pods_RunnerTests.framework */; };
+		4AE7CB3AC4003A0C21279553 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E291B1183F8BBE70B6FC8214 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -47,13 +49,18 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		6792D48E9CF882CC8C6D8F6D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		6D8DC8DD3911AC4850FCB306 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		74CFB7A9816CF6D47F7334D4 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		81A100012E00000000000001 /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		81A100022E00000000000002 /* Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
-		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		89DBB02192C15FDB85853BD5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		8BDA7E9E13910C0138CB9939 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -61,14 +68,26 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A7C557BE4162C3DE5C64D7B6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		DE650ED816922B5B94F42733 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		E291B1183F8BBE70B6FC8214 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		237BEC2B1D5D340CD772B5BB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42273D8143A96AA2E06F69F3 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				4AE7CB3AC4003A0C21279553 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,6 +121,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				F1A9F4B02F829FA70240C152 /* Pods */,
+				A02E41E8915A032C6397D5C7 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -132,6 +153,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		A02E41E8915A032C6397D5C7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E291B1183F8BBE70B6FC8214 /* Pods_Runner.framework */,
+				6D8DC8DD3911AC4850FCB306 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F1A9F4B02F829FA70240C152 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A7C557BE4162C3DE5C64D7B6 /* Pods-Runner.debug.xcconfig */,
+				DE650ED816922B5B94F42733 /* Pods-Runner.release.xcconfig */,
+				8BDA7E9E13910C0138CB9939 /* Pods-Runner.profile.xcconfig */,
+				74CFB7A9816CF6D47F7334D4 /* Pods-RunnerTests.debug.xcconfig */,
+				89DBB02192C15FDB85853BD5 /* Pods-RunnerTests.release.xcconfig */,
+				6792D48E9CF882CC8C6D8F6D /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -139,8 +183,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				F890CB353FB4A15B8EE0DC23 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				237BEC2B1D5D340CD772B5BB /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -156,12 +202,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				5143AC80FDAC2885CA79BCA8 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				2812CB6D4CE26C8590D82AD9 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -205,7 +253,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -239,6 +287,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2812CB6D4CE26C8590D82AD9 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -255,6 +320,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		5143AC80FDAC2885CA79BCA8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -269,6 +356,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		F890CB353FB4A15B8EE0DC23 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -364,7 +473,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -397,6 +506,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74CFB7A9816CF6D47F7334D4 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -414,6 +524,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 89DBB02192C15FDB85853BD5 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -429,6 +540,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6792D48E9CF882CC8C6D8F6D /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -491,7 +603,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -542,7 +654,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -634,7 +746,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/mobile/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/mobile/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -152,6 +152,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   bool get isLoadingEarlierMessages => _loadingEarlierMessages;
   String? get practiceSessionId => _practiceSessionId;
   int? get practiceSessionVersion => _practiceSessionVersion;
+  PracticeQuestion? get currentQuestion => _currentQuestion;
   String? get questionId => _currentQuestion?.id;
   String? get candidateId => _candidate?.id;
   AgentMatter? get activeMatter => _activeMatter;

--- a/mobile/lib/agent/agent_models.dart
+++ b/mobile/lib/agent/agent_models.dart
@@ -73,16 +73,24 @@ enum PracticeRecordingState {
   completed,
 }
 
+/// Selects the product presentation without coupling navigation to a scene
+/// title or a concrete avatar vendor.
+enum AgentScenePresentationMode { standard, immersiveRoleplay }
+
 final class AgentScene {
   const AgentScene({
     required this.id,
     required this.title,
     required this.description,
+    this.scenarioType,
+    this.presentationMode = AgentScenePresentationMode.standard,
   });
 
   final String id;
   final String title;
   final String description;
+  final String? scenarioType;
+  final AgentScenePresentationMode presentationMode;
 }
 
 final class AgentMessage {

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -3,9 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/design/speak_up_theme.dart';
+import 'package:speakup/features/practice/immersive_roleplay.dart';
+import 'package:speakup/features/practice/immersive_roleplay_session.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/preparation/job_preparation_wizard.dart';
@@ -26,6 +29,7 @@ class SpeakUpApp extends StatelessWidget {
     this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
+    this.avatarControllerFactory,
     super.key,
   }) : _authentication = (controller: authController),
        _allowFakePreview = false;
@@ -36,6 +40,7 @@ class SpeakUpApp extends StatelessWidget {
     this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
+    this.avatarControllerFactory,
     super.key,
   }) : _authentication = null,
        _allowFakePreview = true;
@@ -46,6 +51,7 @@ class SpeakUpApp extends StatelessWidget {
   final JobPreparationController? jobPreparationController;
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
+  final AvatarControllerFactory? avatarControllerFactory;
   final bool _allowFakePreview;
 
   @override
@@ -62,6 +68,7 @@ class SpeakUpApp extends StatelessWidget {
               jobPreparationController: jobPreparationController,
               preparationLaunchController: preparationLaunchController,
               reviewHistoryController: reviewHistoryController,
+              avatarControllerFactory: avatarControllerFactory,
               allowFakePreview: _allowFakePreview,
             )
           : AuthGate(
@@ -74,6 +81,7 @@ class SpeakUpApp extends StatelessWidget {
                 jobPreparationController: jobPreparationController,
                 preparationLaunchController: preparationLaunchController,
                 reviewHistoryController: reviewHistoryController,
+                avatarControllerFactory: avatarControllerFactory,
                 allowFakePreview: _allowFakePreview,
               ),
             ),
@@ -90,6 +98,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.jobPreparationController,
     this.preparationLaunchController,
     this.reviewHistoryController,
+    this.avatarControllerFactory,
     required this.allowFakePreview,
   });
 
@@ -100,6 +109,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final JobPreparationController? jobPreparationController;
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
+  final AvatarControllerFactory? avatarControllerFactory;
   final bool allowFakePreview;
 
   @override
@@ -200,12 +210,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
               onPracticeStarted: () => _navigatorKey.currentState
                   ?.pushReplacementNamed(AppRoutes.practice),
             ),
-          AppRoutes.practice => PracticePage(
-            previewMode: widget.allowFakePreview,
-            agentController: _agentController,
-            onExitRequested:
-                widget.preparationLaunchController?.parkCurrentPractice,
-          ),
+          AppRoutes.practice => _buildPracticePage(),
           AppRoutes.conversation => SpeakUpShell(
             showBackButton: true,
             previewMode: widget.allowFakePreview,
@@ -234,6 +239,34 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
           builder: (_) => page,
         );
       },
+    );
+  }
+
+  Widget _buildPracticePage() {
+    final launchController = widget.preparationLaunchController;
+    final presentationMode = launchController?.hasResumablePractice ?? false
+        ? launchController!.resumablePresentationMode
+        : _agentController.scene?.presentationMode ??
+              AgentScenePresentationMode.standard;
+    if (presentationMode == AgentScenePresentationMode.immersiveRoleplay) {
+      final factory = widget.avatarControllerFactory;
+      if (factory != null) {
+        return ImmersiveRoleplaySession(
+          agentController: _agentController,
+          avatarControllerFactory: factory,
+          onExitRequested: launchController?.parkCurrentPractice,
+        );
+      }
+      return ImmersiveRoleplayPage(
+        previewMode: widget.allowFakePreview,
+        agentController: _agentController,
+        onExitRequested: launchController?.parkCurrentPractice,
+      );
+    }
+    return PracticePage(
+      previewMode: widget.allowFakePreview,
+      agentController: _agentController,
+      onExitRequested: launchController?.parkCurrentPractice,
     );
   }
 }

--- a/mobile/lib/design/voice_capture_control.dart
+++ b/mobile/lib/design/voice_capture_control.dart
@@ -1,0 +1,303 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+enum VoiceCapturePhase { idle, starting, recording, busy }
+
+enum VoiceCaptureMode { pressAndHold, tapToToggle }
+
+typedef VoiceCaptureAction = FutureOr<void> Function();
+
+typedef VoiceCaptureTargetBuilder =
+    Widget Function({
+      Key? key,
+      required Widget child,
+      required String semanticsLabel,
+    });
+
+typedef VoiceCaptureBuilder =
+    Widget Function(BuildContext context, VoiceCaptureView view);
+
+@immutable
+class VoiceCaptureView {
+  const VoiceCaptureView({
+    required this.pressed,
+    required this.cancelArmed,
+    required this.tapMode,
+    required this.wrapTarget,
+    required this.finishTapCapture,
+    required this.cancelTapCapture,
+  });
+
+  final bool pressed;
+  final bool cancelArmed;
+  final bool tapMode;
+  final VoiceCaptureTargetBuilder wrapTarget;
+  final VoidCallback finishTapCapture;
+  final VoidCallback cancelTapCapture;
+}
+
+class VoiceCaptureControl extends StatefulWidget {
+  const VoiceCaptureControl({
+    required this.phase,
+    required this.onStart,
+    required this.onFinish,
+    required this.onCancel,
+    required this.builder,
+    this.onBeforeStart,
+    this.enabled = true,
+    this.mode = VoiceCaptureMode.pressAndHold,
+    this.holdDelay = const Duration(milliseconds: 180),
+    this.cancelDistance = 72,
+    super.key,
+  });
+
+  final VoiceCapturePhase phase;
+  final VoiceCaptureAction onStart;
+  final VoiceCaptureAction? onBeforeStart;
+  final VoiceCaptureAction onFinish;
+  final VoiceCaptureAction onCancel;
+  final VoiceCaptureBuilder builder;
+  final bool enabled;
+  final VoiceCaptureMode mode;
+  final Duration holdDelay;
+  final double cancelDistance;
+
+  @override
+  State<VoiceCaptureControl> createState() => _VoiceCaptureControlState();
+}
+
+enum _PendingCaptureAction { finish, cancel }
+
+class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
+  Timer? _holdTimer;
+  Offset? _pointerOrigin;
+  bool _pointerActive = false;
+  bool _holdStarted = false;
+  bool _cancelArmed = false;
+  bool _tapMode = false;
+  bool _startInFlight = false;
+  int _operationGeneration = 0;
+  _PendingCaptureAction? _pendingAction;
+
+  bool get _isCapturing =>
+      widget.phase == VoiceCapturePhase.starting ||
+      widget.phase == VoiceCapturePhase.recording;
+
+  @override
+  void didUpdateWidget(covariant VoiceCaptureControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.phase == VoiceCapturePhase.busy ||
+        (oldWidget.phase != VoiceCapturePhase.idle &&
+            widget.phase == VoiceCapturePhase.idle &&
+            !_startInFlight)) {
+      _resetInteraction();
+    }
+  }
+
+  @override
+  void dispose() {
+    _holdTimer?.cancel();
+    _operationGeneration++;
+    super.dispose();
+  }
+
+  void _resetInteraction() {
+    _holdTimer?.cancel();
+    _holdTimer = null;
+    _pointerOrigin = null;
+    _pointerActive = false;
+    _holdStarted = false;
+    _cancelArmed = false;
+    _tapMode = false;
+    _pendingAction = null;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!widget.enabled || _pointerActive) {
+      return;
+    }
+    final startingCapture = widget.phase == VoiceCapturePhase.idle;
+    final endingTapCapture = _tapMode && _isCapturing;
+    if (!startingCapture && !endingTapCapture) {
+      return;
+    }
+    _holdTimer?.cancel();
+    setState(() {
+      _pointerActive = true;
+      _holdStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = event.position;
+    });
+    if (!startingCapture || widget.mode == VoiceCaptureMode.tapToToggle) {
+      return;
+    }
+    _holdTimer = Timer(widget.holdDelay, () {
+      if (!mounted ||
+          !_pointerActive ||
+          widget.phase != VoiceCapturePhase.idle) {
+        return;
+      }
+      setState(() => _holdStarted = true);
+      unawaited(HapticFeedback.mediumImpact());
+      unawaited(_beginCapture(tapMode: false));
+    });
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    final origin = _pointerOrigin;
+    if (!_pointerActive || origin == null) {
+      return;
+    }
+    final cancelArmed = event.position.dy <= origin.dy - widget.cancelDistance;
+    if (cancelArmed == _cancelArmed) {
+      return;
+    }
+    setState(() => _cancelArmed = cancelArmed);
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    _finishPointer(cancel: _cancelArmed);
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _finishPointer(cancel: true);
+  }
+
+  void _finishPointer({required bool cancel}) {
+    if (!_pointerActive) {
+      return;
+    }
+    _holdTimer?.cancel();
+    _holdTimer = null;
+    final holdStarted = _holdStarted;
+    final endingTapCapture = _tapMode && _isCapturing;
+    setState(() {
+      _pointerActive = false;
+      _holdStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = null;
+    });
+    if (holdStarted || endingTapCapture) {
+      _requestAction(
+        cancel ? _PendingCaptureAction.cancel : _PendingCaptureAction.finish,
+      );
+      return;
+    }
+    if (!cancel && widget.phase == VoiceCapturePhase.idle) {
+      unawaited(_beginCapture(tapMode: true));
+    }
+  }
+
+  Future<void> _beginCapture({required bool tapMode}) async {
+    if (!widget.enabled ||
+        widget.phase != VoiceCapturePhase.idle ||
+        _startInFlight) {
+      return;
+    }
+    final generation = ++_operationGeneration;
+    setState(() {
+      _tapMode = tapMode;
+      _startInFlight = true;
+      _pendingAction = null;
+    });
+    if (tapMode) {
+      unawaited(HapticFeedback.mediumImpact());
+    }
+    try {
+      await widget.onBeforeStart?.call();
+      if (_pendingAction == _PendingCaptureAction.cancel) {
+        return;
+      }
+      await widget.onStart();
+    } finally {
+      if (mounted && generation == _operationGeneration) {
+        setState(() => _startInFlight = false);
+        final pending = _pendingAction;
+        if (pending != null) {
+          _pendingAction = null;
+          await _runAction(pending, generation);
+        }
+      }
+    }
+  }
+
+  void _requestAction(_PendingCaptureAction action) {
+    if (_startInFlight) {
+      _pendingAction = action;
+      if (mounted) {
+        setState(() {
+          if (action == _PendingCaptureAction.cancel) {
+            _tapMode = false;
+          }
+        });
+      }
+      return;
+    }
+    unawaited(_runAction(action, _operationGeneration));
+  }
+
+  Future<void> _runAction(_PendingCaptureAction action, int generation) async {
+    if (!mounted || generation != _operationGeneration) {
+      return;
+    }
+    setState(() => _tapMode = false);
+    if (action == _PendingCaptureAction.cancel) {
+      await widget.onCancel();
+    } else {
+      await widget.onFinish();
+    }
+  }
+
+  void _handleSemanticTap() {
+    if (!widget.enabled) {
+      return;
+    }
+    if (widget.phase == VoiceCapturePhase.idle) {
+      unawaited(_beginCapture(tapMode: true));
+    } else if (_isCapturing) {
+      _requestAction(_PendingCaptureAction.finish);
+    }
+  }
+
+  Widget _wrapTarget({
+    Key? key,
+    required Widget child,
+    required String semanticsLabel,
+  }) {
+    return Semantics(
+      button: true,
+      enabled: widget.enabled,
+      label: semanticsLabel,
+      onTap: widget.enabled ? _handleSemanticTap : null,
+      child: ExcludeSemantics(
+        child: Listener(
+          key: key,
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: _handlePointerDown,
+          onPointerMove: _handlePointerMove,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: _handlePointerCancel,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(
+      context,
+      VoiceCaptureView(
+        pressed: _pointerActive,
+        cancelArmed: _cancelArmed,
+        tapMode: _tapMode,
+        wrapTarget: _wrapTarget,
+        finishTapCapture: () => _requestAction(_PendingCaptureAction.finish),
+        cancelTapCapture: () => _requestAction(_PendingCaptureAction.cancel),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -10,6 +10,7 @@ import 'package:speakup/agent/agent_voice_controller.dart';
 import 'package:speakup/agent/agent_voice_models.dart';
 import 'package:speakup/agent/agent_voice_widgets.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 
 typedef ConversationVoiceStarter = FutureOr<void> Function();
 
@@ -975,204 +976,218 @@ class _AgentComposerState extends State<_AgentComposer> {
         voiceState == AgentVoiceComposerState.confirming ||
         voiceState == AgentVoiceComposerState.awaitingAssistant;
     final voiceFailure = voiceState == AgentVoiceComposerState.failed;
-    return AnimatedContainer(
-      key: const Key('agent-composer-surface'),
-      duration: const Duration(milliseconds: 180),
-      curve: Curves.easeOut,
-      constraints: BoxConstraints(minHeight: widget.keyboardVisible ? 56 : 58),
-      padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
-      decoration: BoxDecoration(
-        color: SpeakUpDesign.surface,
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-        border: Border.all(color: SpeakUpDesign.border),
-      ),
-      child: recording || voiceProgress || voiceFailure
-          ? Row(
-              children: [
-                if (!voiceSubmissionInFlight) ...[
-                  IconButton(
-                    key: const Key('agent-voice-cancel'),
-                    tooltip: '取消语音输入',
-                    onPressed: _cancelVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.close_rounded, size: 21),
-                  ),
-                  const SizedBox(width: 4),
-                ],
-                if (recording) ...[
-                  const Icon(
-                    Icons.fiber_manual_record_rounded,
-                    size: 12,
-                    color: SpeakUpDesign.error,
-                  ),
-                  const SizedBox(width: 8),
-                ] else if (voiceProgress) ...[
-                  const SizedBox.square(
-                    dimension: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const SizedBox(width: 8),
-                ],
-                Expanded(
-                  child: Text(
-                    recording
-                        ? '正在录音'
-                        : voiceFailure
-                        ? voice?.errorMessage ?? '语音识别失败'
-                        : _composerVoiceStateLabel(voiceState),
-                    key: const Key('agent-voice-state-label'),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: voiceFailure
-                          ? SpeakUpDesign.error
-                          : SpeakUpDesign.secondary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      height: 1.3,
-                    ),
-                  ),
-                ),
-                if (recording) ...[
-                  const SizedBox(width: 8),
-                  Text(
-                    _formatComposerDuration(voice!.recordingElapsed),
-                    key: const Key('agent-voice-recording-duration'),
-                    style: const TextStyle(
-                      color: SpeakUpDesign.secondary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(width: 6),
-                  IconButton.filled(
-                    key: const Key('agent-voice-stop'),
-                    tooltip: '结束录音并自动转写',
-                    onPressed: _stopVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.stop_rounded, size: 20),
-                  ),
-                ] else if (voiceFailure && voice?.canRetry == true)
-                  IconButton(
-                    key: const Key('agent-voice-retry'),
-                    tooltip: '重试',
-                    onPressed: voice?.retry,
-                    icon: const Icon(Icons.refresh_rounded),
-                  ),
-              ],
-            )
-          : Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                if (confirmingText)
-                  IconButton(
-                    key: const Key('agent-voice-cancel'),
-                    tooltip: '取消语音输入',
-                    onPressed: _cancelVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.close_rounded, size: 21),
-                  ),
-                Expanded(
-                  child: TextField(
-                    key: const Key('agent-composer-field'),
-                    controller: _controller,
-                    enabled:
-                        confirmingText || (widget.enabled && !widget.isBusy),
-                    minLines: 1,
-                    maxLines: widget.keyboardVisible ? 3 : 2,
-                    inputFormatters: <TextInputFormatter>[
-                      _agentContentFormatter,
-                    ],
-                    textInputAction: TextInputAction.send,
-                    onSubmitted: (_) => confirmingText
-                        ? widget.voiceController?.confirm()
-                        : _submit(),
-                    style: const TextStyle(
-                      color: SpeakUpDesign.ink,
-                      fontSize: 15,
-                      height: 1.4,
-                    ),
-                    decoration: InputDecoration(
-                      hintText: widget.enabled
-                          ? confirmingText
-                                ? '检查识别文字'
-                                : '问问 SpeakUp'
-                          : '暂时无法开始对话',
-                      hintStyle: const TextStyle(
-                        color: SpeakUpDesign.tertiary,
-                        fontSize: 15,
+    final capturePhase = switch (voiceState) {
+      AgentVoiceComposerState.idle => VoiceCapturePhase.idle,
+      AgentVoiceComposerState.starting => VoiceCapturePhase.starting,
+      AgentVoiceComposerState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
+    return VoiceCaptureControl(
+      phase: capturePhase,
+      enabled: widget.voiceEnabled && widget.onStartVoice != null,
+      onStart: _startVoice,
+      onFinish: _stopVoice,
+      onCancel: _cancelVoice,
+      builder: (context, capture) => AnimatedContainer(
+        key: const Key('agent-composer-surface'),
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOut,
+        constraints: BoxConstraints(
+          minHeight: widget.keyboardVisible ? 56 : 58,
+        ),
+        padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
+        decoration: BoxDecoration(
+          color: SpeakUpDesign.surface,
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+          border: Border.all(color: SpeakUpDesign.border),
+        ),
+        child: recording || voiceProgress || voiceFailure
+            ? Row(
+                children: [
+                  if (!voiceSubmissionInFlight) ...[
+                    IconButton(
+                      key: const Key('agent-voice-cancel'),
+                      tooltip: '取消语音输入',
+                      onPressed: recording
+                          ? capture.cancelTapCapture
+                          : _cancelVoice,
+                      constraints: const BoxConstraints.tightFor(
+                        width: 40,
+                        height: 40,
                       ),
-                      border: InputBorder.none,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
+                      padding: EdgeInsets.zero,
+                      icon: const Icon(Icons.close_rounded, size: 21),
+                    ),
+                    const SizedBox(width: 4),
+                  ],
+                  if (recording) ...[
+                    const Icon(
+                      Icons.fiber_manual_record_rounded,
+                      size: 12,
+                      color: SpeakUpDesign.error,
+                    ),
+                    const SizedBox(width: 8),
+                  ] else if (voiceProgress) ...[
+                    const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                  Expanded(
+                    child: Text(
+                      recording
+                          ? '正在录音'
+                          : voiceFailure
+                          ? voice?.errorMessage ?? '语音识别失败'
+                          : _composerVoiceStateLabel(voiceState),
+                      key: const Key('agent-voice-state-label'),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: voiceFailure
+                            ? SpeakUpDesign.error
+                            : SpeakUpDesign.secondary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        height: 1.3,
+                      ),
                     ),
                   ),
-                ),
-                if (!confirmingText && widget.onStartVoice != null) ...[
-                  Semantics(
-                    key: const Key('agent-mic-placeholder'),
-                    button: true,
-                    enabled: widget.voiceEnabled,
-                    label: '录制 Agent 语音消息',
-                    onTap: widget.voiceEnabled ? _startVoice : null,
-                    child: ExcludeSemantics(
+                  if (recording) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      _formatComposerDuration(voice!.recordingElapsed),
+                      key: const Key('agent-voice-recording-duration'),
+                      style: const TextStyle(
+                        color: SpeakUpDesign.secondary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    IconButton.filled(
+                      key: const Key('agent-voice-stop'),
+                      tooltip: '结束录音并自动转写',
+                      onPressed: capture.finishTapCapture,
+                      constraints: const BoxConstraints.tightFor(
+                        width: 40,
+                        height: 40,
+                      ),
+                      padding: EdgeInsets.zero,
+                      icon: const Icon(Icons.stop_rounded, size: 20),
+                    ),
+                  ] else if (voiceFailure && voice?.canRetry == true)
+                    IconButton(
+                      key: const Key('agent-voice-retry'),
+                      tooltip: '重试',
+                      onPressed: voice?.retry,
+                      icon: const Icon(Icons.refresh_rounded),
+                    ),
+                ],
+              )
+            : Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  if (confirmingText)
+                    IconButton(
+                      key: const Key('agent-voice-cancel'),
+                      tooltip: '取消语音输入',
+                      onPressed: _cancelVoice,
+                      constraints: const BoxConstraints.tightFor(
+                        width: 40,
+                        height: 40,
+                      ),
+                      padding: EdgeInsets.zero,
+                      icon: const Icon(Icons.close_rounded, size: 21),
+                    ),
+                  Expanded(
+                    child: TextField(
+                      key: const Key('agent-composer-field'),
+                      controller: _controller,
+                      enabled:
+                          confirmingText || (widget.enabled && !widget.isBusy),
+                      minLines: 1,
+                      maxLines: widget.keyboardVisible ? 3 : 2,
+                      inputFormatters: <TextInputFormatter>[
+                        _agentContentFormatter,
+                      ],
+                      textInputAction: TextInputAction.send,
+                      onSubmitted: (_) => confirmingText
+                          ? widget.voiceController?.confirm()
+                          : _submit(),
+                      style: const TextStyle(
+                        color: SpeakUpDesign.ink,
+                        fontSize: 15,
+                        height: 1.4,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: widget.enabled
+                            ? confirmingText
+                                  ? '检查识别文字'
+                                  : '问问 SpeakUp'
+                            : '暂时无法开始对话',
+                        hintStyle: const TextStyle(
+                          color: SpeakUpDesign.tertiary,
+                          fontSize: 15,
+                        ),
+                        border: InputBorder.none,
+                        isDense: true,
+                        contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
+                      ),
+                    ),
+                  ),
+                  if (!confirmingText && widget.onStartVoice != null) ...[
+                    capture.wrapTarget(
+                      key: const Key('agent-mic-placeholder'),
+                      semanticsLabel: '录制 Agent 语音消息',
                       child: IconButton(
                         tooltip: '录制 Agent 语音消息',
-                        onPressed: widget.voiceEnabled ? _startVoice : null,
+                        onPressed: null,
                         constraints: const BoxConstraints.tightFor(
                           width: 40,
                           height: 40,
                         ),
                         padding: EdgeInsets.zero,
-                        color: SpeakUpDesign.secondary,
+                        disabledColor: widget.voiceEnabled
+                            ? SpeakUpDesign.secondary
+                            : SpeakUpDesign.tertiary,
                         icon: const Icon(Icons.mic_none_rounded, size: 21),
                       ),
                     ),
+                    const SizedBox(width: 2),
+                  ],
+                  IconButton.filled(
+                    key: Key(
+                      confirmingText
+                          ? 'agent-voice-confirm'
+                          : 'agent-send-button',
+                    ),
+                    tooltip: '发送',
+                    onPressed:
+                        _controller.text.trim().isEmpty ||
+                            (widget.isBusy && !confirmingText) ||
+                            !widget.enabled
+                        ? null
+                        : _textSubmissionInFlight
+                        ? null
+                        : confirmingText
+                        ? voice?.canConfirm == true
+                              ? voice?.confirm
+                              : null
+                        : widget.onSubmitText == null
+                        ? null
+                        : _submit,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 40,
+                    ),
+                    padding: EdgeInsets.zero,
+                    icon: const Icon(Icons.arrow_upward_rounded, size: 20),
                   ),
-                  const SizedBox(width: 2),
                 ],
-                IconButton.filled(
-                  key: Key(
-                    confirmingText
-                        ? 'agent-voice-confirm'
-                        : 'agent-send-button',
-                  ),
-                  tooltip: '发送',
-                  onPressed:
-                      _controller.text.trim().isEmpty ||
-                          (widget.isBusy && !confirmingText) ||
-                          !widget.enabled
-                      ? null
-                      : _textSubmissionInFlight
-                      ? null
-                      : confirmingText
-                      ? voice?.canConfirm == true
-                            ? voice?.confirm
-                            : null
-                      : widget.onSubmitText == null
-                      ? null
-                      : _submit,
-                  constraints: const BoxConstraints.tightFor(
-                    width: 40,
-                    height: 40,
-                  ),
-                  padding: EdgeInsets.zero,
-                  icon: const Icon(Icons.arrow_upward_rounded, size: 20),
-                ),
-              ],
-            ),
+              ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 
 const ieltsSpeakingFullMockScenarioId = 'scn_ielts_speaking_full';
@@ -351,21 +352,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
   }
 
-  Future<void> _toggleShortRecording() async {
-    final state = widget.controller.recordingState;
-    if (state == PracticeRecordingState.idle) {
-      await widget.controller.startRecording();
-      return;
-    }
-    if (state == PracticeRecordingState.starting ||
-        state == PracticeRecordingState.recording) {
-      await widget.controller.finishRecordingGesture();
-      return;
-    }
-    if (state == PracticeRecordingState.awaitingConfirmation) {
-      _confirmPendingTranscript();
-    }
-  }
+  Future<void> _startShortRecording() => widget.controller.startRecording();
+
+  Future<void> _finishShortRecording() =>
+      widget.controller.finishRecordingGesture();
+
+  Future<void> _cancelShortRecording() => widget.controller.cancelRecording();
 
   Future<void> _beginPart3() async {
     final progress = _progress;
@@ -475,7 +467,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                 progress.phase == IeltsMockPhase.part3
             ? _RecorderDock(
                 controller: widget.controller,
-                onTap: _toggleShortRecording,
+                onStart: _startShortRecording,
+                onFinish: _finishShortRecording,
+                onCancel: _cancelShortRecording,
               )
             : null,
       ),
@@ -798,10 +792,17 @@ class _ExamConversation extends StatelessWidget {
 }
 
 class _RecorderDock extends StatelessWidget {
-  const _RecorderDock({required this.controller, required this.onTap});
+  const _RecorderDock({
+    required this.controller,
+    required this.onStart,
+    required this.onFinish,
+    required this.onCancel,
+  });
 
   final AgentController controller;
-  final VoidCallback onTap;
+  final VoiceCaptureAction onStart;
+  final VoiceCaptureAction onFinish;
+  final VoiceCaptureAction onCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -812,6 +813,12 @@ class _RecorderDock extends StatelessWidget {
     final working =
         state == PracticeRecordingState.transcribing ||
         state == PracticeRecordingState.submitting;
+    final capturePhase = switch (state) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
     final label = switch (state) {
       PracticeRecordingState.starting => 'Opening microphone…',
       PracticeRecordingState.recording => 'Listening',
@@ -836,31 +843,40 @@ class _RecorderDock extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: recording ? 'Submit answer' : 'Start recording',
-              child: IconButton.filled(
+            VoiceCaptureControl(
+              phase: capturePhase,
+              mode: VoiceCaptureMode.tapToToggle,
+              enabled: capturePhase != VoiceCapturePhase.busy,
+              onStart: onStart,
+              onFinish: onFinish,
+              onCancel: onCancel,
+              builder: (context, capture) => capture.wrapTarget(
                 key: const Key('ielts-mock-record'),
-                onPressed: working ? null : onTap,
-                style: IconButton.styleFrom(
-                  fixedSize: const Size.square(76),
-                  backgroundColor: recording
-                      ? const Color(0xFF197782)
-                      : SpeakUpDesign.ink,
-                  foregroundColor: Colors.white,
-                ),
-                icon: working
-                    ? const SizedBox.square(
-                        dimension: 25,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2.5,
-                          color: Colors.white,
+                semanticsLabel: recording ? 'Submit answer' : 'Start recording',
+                child: IconButton.filled(
+                  onPressed: () {},
+                  style: IconButton.styleFrom(
+                    fixedSize: const Size.square(76),
+                    backgroundColor: recording
+                        ? const Color(0xFF197782)
+                        : SpeakUpDesign.ink,
+                    foregroundColor: Colors.white,
+                  ),
+                  icon: working
+                      ? const SizedBox.square(
+                          dimension: 25,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
+                            color: Colors.white,
+                          ),
+                        )
+                      : Icon(
+                          recording
+                              ? Icons.stop_rounded
+                              : Icons.mic_none_rounded,
+                          size: 32,
                         ),
-                      )
-                    : Icon(
-                        recording ? Icons.stop_rounded : Icons.mic_none_rounded,
-                        size: 32,
-                      ),
+                ),
               ),
             ),
             const SizedBox(height: 10),

--- a/mobile/lib/features/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/practice/immersive_roleplay.dart
@@ -1,0 +1,1322 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+/// A vendor-neutral surface used by the immersive roleplay shell.
+///
+/// The injected builder may render any avatar implementation. Keeping the
+/// dependency in the composition root lets the product UI survive a vendor
+/// change without importing a provider SDK.
+typedef ImmersiveAvatarSurfaceBuilder = Widget Function(BuildContext context);
+typedef ImmersiveAsyncAction = Future<void> Function();
+
+class ImmersiveRoleplayPage extends StatefulWidget {
+  const ImmersiveRoleplayPage({
+    required this.agentController,
+    this.avatarSurfaceBuilder,
+    this.avatarStatusLabel = '正在准备画面',
+    this.onBeforeStartRecording,
+    this.onBeforeSubmitText,
+    this.onReplayQuestion,
+    this.replayLoading = false,
+    this.replayPlaying = false,
+    this.onExitRequested,
+    this.previewMode = false,
+    super.key,
+  });
+
+  final AgentController agentController;
+  final ImmersiveAvatarSurfaceBuilder? avatarSurfaceBuilder;
+  final String? avatarStatusLabel;
+  final ImmersiveAsyncAction? onBeforeStartRecording;
+  final ImmersiveAsyncAction? onBeforeSubmitText;
+  final ImmersiveAsyncAction? onReplayQuestion;
+  final bool replayLoading;
+  final bool replayPlaying;
+  final Future<bool> Function()? onExitRequested;
+  final bool previewMode;
+
+  @override
+  State<ImmersiveRoleplayPage> createState() => _ImmersiveRoleplayPageState();
+}
+
+class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
+  final _conversationScrollController = ScrollController();
+  final _textController = TextEditingController();
+  final _textFocusNode = FocusNode();
+  Timer? _recordingTicker;
+  DateTime? _recordingStartedAt;
+  int _recordingSeconds = 0;
+  int _observedMessageCount = 0;
+  bool _textMode = false;
+  bool _exitInFlight = false;
+  bool _exitApproved = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _observedMessageCount = widget.agentController.messages.length;
+    widget.agentController.addListener(_handleControllerState);
+    _syncRecordingTimer();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _conversationScrollController.hasClients) {
+        _conversationScrollController.jumpTo(
+          _conversationScrollController.position.maxScrollExtent,
+        );
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant ImmersiveRoleplayPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.agentController == widget.agentController) {
+      return;
+    }
+    oldWidget.agentController.removeListener(_handleControllerState);
+    _observedMessageCount = widget.agentController.messages.length;
+    widget.agentController.addListener(_handleControllerState);
+    _syncRecordingTimer();
+  }
+
+  @override
+  void dispose() {
+    widget.agentController.removeListener(_handleControllerState);
+    _recordingTicker?.cancel();
+    _conversationScrollController.dispose();
+    _textController.dispose();
+    _textFocusNode.dispose();
+    unawaited(widget.agentController.stopPracticeAudio(notify: false));
+    super.dispose();
+  }
+
+  void _handleControllerState() {
+    if (!mounted) {
+      return;
+    }
+    final messageCount = widget.agentController.messages.length;
+    final shouldFollowConversation = messageCount != _observedMessageCount;
+    _observedMessageCount = messageCount;
+    _syncRecordingTimer();
+    setState(() {});
+    if (shouldFollowConversation) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_conversationScrollController.hasClients) {
+          return;
+        }
+        unawaited(
+          _conversationScrollController.animateTo(
+            _conversationScrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 220),
+            curve: Curves.easeOutCubic,
+          ),
+        );
+      });
+    }
+  }
+
+  void _syncRecordingTimer() {
+    final isRecording =
+        widget.agentController.recordingState ==
+        PracticeRecordingState.recording;
+    if (isRecording) {
+      if (_recordingTicker != null) {
+        return;
+      }
+      _recordingStartedAt = DateTime.now();
+      _recordingSeconds = 0;
+      _recordingTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+        final startedAt = _recordingStartedAt;
+        if (!mounted || startedAt == null) {
+          return;
+        }
+        setState(() {
+          _recordingSeconds = DateTime.now().difference(startedAt).inSeconds;
+        });
+      });
+      return;
+    }
+    _recordingTicker?.cancel();
+    _recordingTicker = null;
+    _recordingStartedAt = null;
+    _recordingSeconds = 0;
+    if (widget.agentController.recordingState != PracticeRecordingState.idle) {
+      _textMode = false;
+    }
+  }
+
+  Future<void> _submitText() async {
+    await _runBoundedUserTurnAction(widget.onBeforeSubmitText);
+    if (!mounted) {
+      return;
+    }
+    final submitted = await widget.agentController.submitPracticeText(
+      _textController.text,
+    );
+    if (!mounted || !submitted) {
+      return;
+    }
+    _textController.clear();
+    _textFocusNode.unfocus();
+    setState(() => _textMode = false);
+  }
+
+  void _toggleTextMode() {
+    setState(() => _textMode = !_textMode);
+    if (!_textMode) {
+      _textFocusNode.unfocus();
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _textFocusNode.requestFocus();
+      }
+    });
+  }
+
+  Future<void> _requestExit() async {
+    if (!mounted || _exitInFlight || _exitApproved) {
+      return;
+    }
+    final callback = widget.onExitRequested;
+    if (callback == null) {
+      _exitApproved = true;
+    } else {
+      setState(() => _exitInFlight = true);
+      var approved = false;
+      try {
+        approved = await callback();
+      } on Object {
+        approved = false;
+      }
+      if (!mounted) {
+        return;
+      }
+      _exitInFlight = false;
+      if (!approved) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(const SnackBar(content: Text('当前练习正在保存，请稍后再返回。')));
+        setState(() {});
+        return;
+      }
+      _exitApproved = true;
+    }
+    if (mounted) {
+      setState(() {});
+      await WidgetsBinding.instance.endOfFrame;
+    }
+    if (mounted) {
+      await Navigator.of(context).maybePop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scene = widget.agentController.scene;
+    return PopScope<void>(
+      canPop: widget.onExitRequested == null || _exitApproved,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) {
+          unawaited(_requestExit());
+        }
+      },
+      child: Scaffold(
+        key: const Key('immersive-roleplay-page'),
+        backgroundColor: SpeakUpDesign.canvas,
+        body: SafeArea(
+          child: scene == null
+              ? const Center(child: Text('请先选择一个情景开始对话。'))
+              : LayoutBuilder(
+                  builder: (context, constraints) {
+                    final landscape =
+                        constraints.maxWidth > constraints.maxHeight;
+                    final avatar = _AvatarStage(
+                      scene: scene,
+                      surfaceBuilder: widget.avatarSurfaceBuilder,
+                      statusLabel: widget.avatarStatusLabel,
+                      latestAssistantMessage: _latestAssistantMessage(
+                        widget.agentController.messages,
+                      ),
+                      exitInFlight: _exitInFlight,
+                      onExit: _requestExit,
+                    );
+                    final conversation = _ConversationPanel(
+                      controller: widget.agentController,
+                      scrollController: _conversationScrollController,
+                      textController: _textController,
+                      textFocusNode: _textFocusNode,
+                      textMode: _textMode,
+                      recordingSeconds: _recordingSeconds,
+                      previewMode: widget.previewMode,
+                      onBeforeStartRecording: () => _runBoundedUserTurnAction(
+                        widget.onBeforeStartRecording,
+                      ),
+                      onReplayQuestion: widget.onReplayQuestion,
+                      replayLoading: widget.replayLoading,
+                      replayPlaying: widget.replayPlaying,
+                      onToggleTextMode: _toggleTextMode,
+                      onSubmitText: _submitText,
+                    );
+                    if (landscape) {
+                      return Row(
+                        children: [
+                          SizedBox(
+                            key: const Key('immersive-avatar-region'),
+                            width: constraints.maxWidth * 0.44,
+                            child: avatar,
+                          ),
+                          Expanded(child: conversation),
+                        ],
+                      );
+                    }
+                    return Column(
+                      children: [
+                        SizedBox(
+                          key: const Key('immersive-avatar-region'),
+                          height: constraints.maxHeight * 0.44,
+                          child: avatar,
+                        ),
+                        Expanded(child: conversation),
+                      ],
+                    );
+                  },
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AvatarStage extends StatelessWidget {
+  const _AvatarStage({
+    required this.scene,
+    required this.surfaceBuilder,
+    required this.statusLabel,
+    required this.latestAssistantMessage,
+    required this.exitInFlight,
+    required this.onExit,
+  });
+
+  final AgentScene scene;
+  final ImmersiveAvatarSurfaceBuilder? surfaceBuilder;
+  final String? statusLabel;
+  final AgentMessage? latestAssistantMessage;
+  final bool exitInFlight;
+  final VoidCallback onExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: const Color(0xFFE5E9E5),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (surfaceBuilder case final builder?)
+            builder(context)
+          else
+            const _AvatarPlaceholder(),
+          const Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Color(0x33000000),
+                      Colors.transparent,
+                      Color(0x4D000000),
+                    ],
+                    stops: [0, 0.45, 1],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 12,
+            right: 12,
+            top: 10,
+            child: Row(
+              children: [
+                IconButton.filledTonal(
+                  key: const Key('immersive-exit'),
+                  tooltip: '返回',
+                  onPressed: exitInFlight ? null : onExit,
+                  icon: exitInFlight
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.arrow_back_rounded),
+                  style: IconButton.styleFrom(
+                    backgroundColor: Colors.white.withValues(alpha: 0.9),
+                    foregroundColor: SpeakUpDesign.ink,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    scene.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      shadows: [
+                        Shadow(color: Color(0x66000000), blurRadius: 8),
+                      ],
+                    ),
+                  ),
+                ),
+                if (statusLabel case final label?)
+                  Flexible(
+                    child: Semantics(
+                      liveRegion: true,
+                      child: Container(
+                        key: const Key('immersive-avatar-status'),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 7,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.46),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (latestAssistantMessage case final message?)
+            Positioned(
+              left: 16,
+              right: 16,
+              bottom: 14,
+              child: Container(
+                key: const Key('immersive-live-subtitle'),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 15,
+                  vertical: 11,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.58),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  message.text,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    height: 1.35,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AvatarPlaceholder extends StatelessWidget {
+  const _AvatarPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '情景对话画面',
+      child: const Center(
+        child: Icon(
+          Icons.person_outline_rounded,
+          key: Key('immersive-avatar-placeholder'),
+          size: 84,
+          color: Color(0xFF819087),
+        ),
+      ),
+    );
+  }
+}
+
+class _ConversationPanel extends StatelessWidget {
+  const _ConversationPanel({
+    required this.controller,
+    required this.scrollController,
+    required this.textController,
+    required this.textFocusNode,
+    required this.textMode,
+    required this.recordingSeconds,
+    required this.previewMode,
+    required this.onBeforeStartRecording,
+    required this.onReplayQuestion,
+    required this.replayLoading,
+    required this.replayPlaying,
+    required this.onToggleTextMode,
+    required this.onSubmitText,
+  });
+
+  final AgentController controller;
+  final ScrollController scrollController;
+  final TextEditingController textController;
+  final FocusNode textFocusNode;
+  final bool textMode;
+  final int recordingSeconds;
+  final bool previewMode;
+  final ImmersiveAsyncAction? onBeforeStartRecording;
+  final ImmersiveAsyncAction? onReplayQuestion;
+  final bool replayLoading;
+  final bool replayPlaying;
+  final VoidCallback onToggleTextMode;
+  final VoidCallback onSubmitText;
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = controller.messages;
+    return ColoredBox(
+      color: SpeakUpDesign.surface,
+      child: Column(
+        children: [
+          _ConversationHeader(
+            controller: controller,
+            onReplayQuestion: onReplayQuestion,
+            replayLoading: replayLoading,
+            replayPlaying: replayPlaying,
+          ),
+          Expanded(
+            child: messages.isEmpty
+                ? const _ConversationEmpty()
+                : ListView.separated(
+                    key: const Key('immersive-conversation-history'),
+                    controller: scrollController,
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                    itemCount:
+                        messages.length +
+                        (controller.errorMessage == null ? 0 : 1) +
+                        (controller.mediaErrorMessage == null ? 0 : 1) +
+                        (previewMode ? 1 : 0),
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, index) {
+                      if (index < messages.length) {
+                        return _MessageBubble(message: messages[index]);
+                      }
+                      var extraIndex = index - messages.length;
+                      if (controller.errorMessage case final error?) {
+                        if (extraIndex == 0) {
+                          return _InlineError(message: error);
+                        }
+                        extraIndex--;
+                      }
+                      if (controller.mediaErrorMessage case final error?) {
+                        if (extraIndex == 0) {
+                          return _InlineError(message: error);
+                        }
+                        extraIndex--;
+                      }
+                      return const Text(
+                        '当前为预览模式，语音服务可能不可用。',
+                        textAlign: TextAlign.center,
+                        style: SpeakUpDesign.meta,
+                      );
+                    },
+                  ),
+          ),
+          _ImmersiveComposer(
+            controller: controller,
+            textController: textController,
+            textFocusNode: textFocusNode,
+            textMode: textMode,
+            recordingSeconds: recordingSeconds,
+            onBeforeStartRecording: onBeforeStartRecording,
+            onToggleTextMode: onToggleTextMode,
+            onSubmitText: onSubmitText,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConversationHeader extends StatelessWidget {
+  const _ConversationHeader({
+    required this.controller,
+    required this.onReplayQuestion,
+    required this.replayLoading,
+    required this.replayPlaying,
+  });
+
+  final AgentController controller;
+  final ImmersiveAsyncAction? onReplayQuestion;
+  final bool replayLoading;
+  final bool replayPlaying;
+
+  @override
+  Widget build(BuildContext context) {
+    final current = (controller.completedTurns + 1).clamp(
+      1,
+      controller.turnLimit,
+    );
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: SpeakUpDesign.border)),
+      ),
+      child: Row(
+        children: [
+          const Expanded(child: Text('对话', style: SpeakUpDesign.cardTitle)),
+          Flexible(
+            child: Text(
+              '第 $current 轮 · 共 ${controller.turnLimit} 轮',
+              key: const Key('immersive-turn-progress'),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.end,
+              style: SpeakUpDesign.meta,
+            ),
+          ),
+          if (onReplayQuestion != null || controller.canPlayQuestionAudio) ...[
+            const SizedBox(width: 6),
+            IconButton(
+              key: const Key('immersive-replay-question'),
+              tooltip:
+                  (onReplayQuestion != null
+                      ? replayPlaying
+                      : controller.isQuestionAudioPlaying)
+                  ? '停止播放'
+                  : '重听对方',
+              onPressed: onReplayQuestion != null
+                  ? replayLoading || !_canTriggerImmersiveReplay(controller)
+                        ? null
+                        : () => unawaited(onReplayQuestion!())
+                  : controller.canUsePracticeAudio
+                  ? controller.toggleQuestionAudio
+                  : null,
+              visualDensity: VisualDensity.compact,
+              icon:
+                  (onReplayQuestion != null
+                      ? replayLoading
+                      : controller.isQuestionAudioLoading)
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      (onReplayQuestion != null
+                              ? replayPlaying
+                              : controller.isQuestionAudioPlaying)
+                          ? Icons.stop_circle_outlined
+                          : Icons.volume_up_outlined,
+                    ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ConversationEmpty extends StatelessWidget {
+  const _ConversationEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Text(
+          '对方正在准备开场，请稍候。',
+          textAlign: TextAlign.center,
+          style: SpeakUpDesign.body,
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({required this.message});
+
+  final AgentMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = message.role == AgentMessageRole.user;
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Semantics(
+        label: '${isUser ? '你' : '对话伙伴'}：${message.text}',
+        child: Container(
+          key: Key('immersive-message-${message.id}'),
+          constraints: const BoxConstraints(maxWidth: 520),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: isUser ? SpeakUpDesign.primary : SpeakUpDesign.surfaceMuted,
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(16),
+              topRight: const Radius.circular(16),
+              bottomLeft: Radius.circular(isUser ? 16 : 4),
+              bottomRight: Radius.circular(isUser ? 4 : 16),
+            ),
+          ),
+          child: Text(
+            message.text,
+            style: TextStyle(
+              color: isUser ? Colors.white : SpeakUpDesign.ink,
+              fontSize: 15,
+              height: 1.42,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineError extends StatelessWidget {
+  const _InlineError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      message,
+      textAlign: TextAlign.center,
+      style: const TextStyle(color: SpeakUpDesign.error, fontSize: 13),
+    );
+  }
+}
+
+class _ImmersiveComposer extends StatefulWidget {
+  const _ImmersiveComposer({
+    required this.controller,
+    required this.textController,
+    required this.textFocusNode,
+    required this.textMode,
+    required this.recordingSeconds,
+    required this.onBeforeStartRecording,
+    required this.onToggleTextMode,
+    required this.onSubmitText,
+  });
+
+  final AgentController controller;
+  final TextEditingController textController;
+  final FocusNode textFocusNode;
+  final bool textMode;
+  final int recordingSeconds;
+  final ImmersiveAsyncAction? onBeforeStartRecording;
+  final VoidCallback onToggleTextMode;
+  final VoidCallback onSubmitText;
+
+  @override
+  State<_ImmersiveComposer> createState() => _ImmersiveComposerState();
+}
+
+class _ImmersiveComposerState extends State<_ImmersiveComposer> {
+  static const _holdDelay = Duration(milliseconds: 180);
+  static const _cancelDistance = 72.0;
+
+  Timer? _holdTimer;
+  Offset? _pointerOrigin;
+  bool _pointerActive = false;
+  bool _holdRecordingStarted = false;
+  bool _cancelArmed = false;
+  bool _tapRecordingActive = false;
+  bool _recordingStartInFlight = false;
+  int _recordingStartGeneration = 0;
+
+  @override
+  void dispose() {
+    _holdTimer?.cancel();
+    super.dispose();
+  }
+
+  void _pointerDown(PointerDownEvent event) {
+    if (_pointerActive ||
+        _recordingStartInFlight ||
+        widget.textMode ||
+        widget.controller.recordingState != PracticeRecordingState.idle) {
+      return;
+    }
+    _holdTimer?.cancel();
+    setState(() {
+      _pointerActive = true;
+      _holdRecordingStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = event.position;
+    });
+    _holdTimer = Timer(_holdDelay, () {
+      if (!mounted || !_pointerActive) {
+        return;
+      }
+      setState(() => _holdRecordingStarted = true);
+      unawaited(HapticFeedback.mediumImpact());
+      unawaited(_beginRecording(tapMode: false));
+    });
+  }
+
+  void _pointerMove(PointerMoveEvent event) {
+    final origin = _pointerOrigin;
+    if (!_pointerActive || origin == null) {
+      return;
+    }
+    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
+    if (cancelArmed == _cancelArmed) {
+      return;
+    }
+    setState(() => _cancelArmed = cancelArmed);
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  void _pointerUp(PointerUpEvent event) => _finishPointer(cancel: _cancelArmed);
+
+  void _pointerCancel(PointerCancelEvent event) => _finishPointer(cancel: true);
+
+  void _finishPointer({required bool cancel}) {
+    if (!_pointerActive) {
+      return;
+    }
+    _holdTimer?.cancel();
+    final started = _holdRecordingStarted;
+    if (started) {
+      _recordingStartGeneration++;
+      _recordingStartInFlight = false;
+    }
+    setState(() {
+      _pointerActive = false;
+      _holdRecordingStarted = false;
+      _cancelArmed = false;
+      _pointerOrigin = null;
+    });
+    if (!started) {
+      if (!cancel) {
+        _startTapRecording();
+      }
+      return;
+    }
+    unawaited(
+      cancel
+          ? widget.controller.cancelRecording()
+          : widget.controller.finishRecordingGesture(),
+    );
+  }
+
+  void _startTapRecording() {
+    if (widget.textMode ||
+        _recordingStartInFlight ||
+        widget.controller.recordingState != PracticeRecordingState.idle) {
+      return;
+    }
+    setState(() => _tapRecordingActive = true);
+    unawaited(HapticFeedback.mediumImpact());
+    unawaited(_beginRecording(tapMode: true));
+  }
+
+  Future<void> _beginRecording({required bool tapMode}) async {
+    final generation = ++_recordingStartGeneration;
+    setState(() => _recordingStartInFlight = true);
+    try {
+      try {
+        await widget.onBeforeStartRecording?.call();
+      } on Object {
+        // Avatar interruption is best-effort; microphone access must remain
+        // available when the visual provider is degraded.
+      }
+      final intentStillActive = tapMode ? _tapRecordingActive : _pointerActive;
+      if (!mounted ||
+          generation != _recordingStartGeneration ||
+          !intentStillActive ||
+          widget.controller.recordingState != PracticeRecordingState.idle) {
+        return;
+      }
+      await widget.controller.startRecording();
+    } finally {
+      if (mounted && generation == _recordingStartGeneration) {
+        setState(() => _recordingStartInFlight = false);
+      }
+    }
+  }
+
+  void _finishTapRecording() {
+    final state = widget.controller.recordingState;
+    if (state != PracticeRecordingState.starting &&
+        state != PracticeRecordingState.recording) {
+      return;
+    }
+    setState(() => _tapRecordingActive = false);
+    _recordingStartGeneration++;
+    _recordingStartInFlight = false;
+    unawaited(widget.controller.finishRecordingGesture());
+  }
+
+  void _cancelTapRecording() {
+    final state = widget.controller.recordingState;
+    if (state != PracticeRecordingState.starting &&
+        state != PracticeRecordingState.recording) {
+      return;
+    }
+    setState(() => _tapRecordingActive = false);
+    _recordingStartGeneration++;
+    _recordingStartInFlight = false;
+    unawaited(widget.controller.cancelRecording());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = widget.controller.recordingState;
+    final tapRecording =
+        _tapRecordingActive &&
+        (state == PracticeRecordingState.starting ||
+            state == PracticeRecordingState.recording);
+    return Material(
+      color: SpeakUpDesign.surface,
+      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+          child: switch (state) {
+            PracticeRecordingState.idle => _IdleComposer(
+              textController: widget.textController,
+              textFocusNode: widget.textFocusNode,
+              textMode: widget.textMode,
+              pressed: _pointerActive,
+              onToggleTextMode: widget.onToggleTextMode,
+              onSubmitText: widget.onSubmitText,
+              onPointerDown: _pointerDown,
+              onPointerMove: _pointerMove,
+              onPointerUp: _pointerUp,
+              onPointerCancel: _pointerCancel,
+              onSemanticTap: _startTapRecording,
+            ),
+            PracticeRecordingState.starting ||
+            PracticeRecordingState.recording => _RecordingComposer(
+              preparing: state == PracticeRecordingState.starting,
+              tapMode: tapRecording,
+              cancelArmed: _cancelArmed,
+              seconds: widget.recordingSeconds,
+              onFinish: _finishTapRecording,
+              onCancel: _cancelTapRecording,
+              onPointerMove: _pointerMove,
+              onPointerUp: _pointerUp,
+              onPointerCancel: _pointerCancel,
+            ),
+            PracticeRecordingState.transcribing => const _ComposerProgress(
+              label: '正在识别你的回答…',
+            ),
+            PracticeRecordingState.awaitingConfirmation => _TranscriptComposer(
+              controller: widget.controller,
+            ),
+            PracticeRecordingState.submitting => const _ComposerProgress(
+              label: '正在发送并准备下一轮…',
+            ),
+            PracticeRecordingState.reviewFailed => _ComposerAction(
+              label: '本轮已完成，暂时无法保存结果。',
+              actionLabel: '重试',
+              onPressed: widget.controller.retryReview,
+            ),
+            PracticeRecordingState.completed => const _ComposerProgress(
+              label: '本轮对话已完成',
+              showProgress: false,
+            ),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _IdleComposer extends StatelessWidget {
+  const _IdleComposer({
+    required this.textController,
+    required this.textFocusNode,
+    required this.textMode,
+    required this.pressed,
+    required this.onToggleTextMode,
+    required this.onSubmitText,
+    required this.onPointerDown,
+    required this.onPointerMove,
+    required this.onPointerUp,
+    required this.onPointerCancel,
+    required this.onSemanticTap,
+  });
+
+  final TextEditingController textController;
+  final FocusNode textFocusNode;
+  final bool textMode;
+  final bool pressed;
+  final VoidCallback onToggleTextMode;
+  final VoidCallback onSubmitText;
+  final PointerDownEventListener onPointerDown;
+  final PointerMoveEventListener onPointerMove;
+  final PointerUpEventListener onPointerUp;
+  final PointerCancelEventListener onPointerCancel;
+  final VoidCallback onSemanticTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (textMode) {
+      return Row(
+        children: [
+          IconButton.outlined(
+            key: const Key('immersive-return-to-voice'),
+            tooltip: '切换到语音',
+            onPressed: onToggleTextMode,
+            icon: const Icon(Icons.mic_none_rounded),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              key: const Key('immersive-text-answer'),
+              controller: textController,
+              focusNode: textFocusNode,
+              minLines: 1,
+              maxLines: 2,
+              maxLength: 8000,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                hintText: 'Type your reply…',
+                counterText: '',
+                isDense: true,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.filled(
+            key: const Key('immersive-submit-text'),
+            tooltip: '发送',
+            onPressed: onSubmitText,
+            icon: const Icon(Icons.arrow_upward_rounded),
+          ),
+        ],
+      );
+    }
+    return Row(
+      children: [
+        Expanded(
+          child: Semantics(
+            button: true,
+            label: '点击或按住说话',
+            onTap: onSemanticTap,
+            child: Listener(
+              key: const Key('immersive-record'),
+              behavior: HitTestBehavior.opaque,
+              onPointerDown: onPointerDown,
+              onPointerMove: onPointerMove,
+              onPointerUp: onPointerUp,
+              onPointerCancel: onPointerCancel,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 100),
+                height: 52,
+                decoration: BoxDecoration(
+                  color: pressed
+                      ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                      : SpeakUpDesign.primary,
+                  borderRadius: BorderRadius.circular(
+                    SpeakUpDesign.radiusControl,
+                  ),
+                ),
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.mic_rounded, color: Colors.white),
+                    SizedBox(width: 8),
+                    Flexible(
+                      child: Text(
+                        '点击或按住说话',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton.outlined(
+          key: const Key('immersive-open-keyboard'),
+          tooltip: '键盘输入',
+          onPressed: onToggleTextMode,
+          icon: const Icon(Icons.keyboard_alt_outlined),
+          style: IconButton.styleFrom(minimumSize: const Size.square(52)),
+        ),
+      ],
+    );
+  }
+}
+
+class _RecordingComposer extends StatelessWidget {
+  const _RecordingComposer({
+    required this.preparing,
+    required this.tapMode,
+    required this.cancelArmed,
+    required this.seconds,
+    required this.onFinish,
+    required this.onCancel,
+    required this.onPointerMove,
+    required this.onPointerUp,
+    required this.onPointerCancel,
+  });
+
+  final bool preparing;
+  final bool tapMode;
+  final bool cancelArmed;
+  final int seconds;
+  final VoidCallback onFinish;
+  final VoidCallback onCancel;
+  final PointerMoveEventListener onPointerMove;
+  final PointerUpEventListener onPointerUp;
+  final PointerCancelEventListener onPointerCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final minutesText = (seconds ~/ 60).toString().padLeft(2, '0');
+    final secondsText = (seconds % 60).toString().padLeft(2, '0');
+    final control = Container(
+      key: const Key('immersive-stop-recording'),
+      height: 58,
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      decoration: BoxDecoration(
+        color: cancelArmed
+            ? SpeakUpDesign.errorMuted
+            : SpeakUpDesign.primaryMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            cancelArmed ? Icons.delete_outline_rounded : Icons.mic_rounded,
+            color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              cancelArmed
+                  ? '松开取消'
+                  : preparing
+                  ? '正在打开麦克风…'
+                  : tapMode
+                  ? '再次点击结束 · $minutesText:$secondsText'
+                  : '松开发送 · $minutesText:$secondsText',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: SpeakUpDesign.label.copyWith(
+                color: cancelArmed
+                    ? SpeakUpDesign.error
+                    : SpeakUpDesign.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (tapMode) {
+      return Row(
+        children: [
+          Expanded(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onFinish,
+              child: control,
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.outlined(
+            key: const Key('immersive-cancel-tap-recording'),
+            tooltip: '取消录音',
+            onPressed: onCancel,
+            icon: const Icon(Icons.close_rounded),
+            style: IconButton.styleFrom(minimumSize: const Size.square(52)),
+          ),
+        ],
+      );
+    }
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerMove: onPointerMove,
+      onPointerUp: onPointerUp,
+      onPointerCancel: onPointerCancel,
+      child: control,
+    );
+  }
+}
+
+class _TranscriptComposer extends StatelessWidget {
+  const _TranscriptComposer({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          controller.transcript ?? '',
+          key: const Key('immersive-transcript'),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: SpeakUpDesign.body,
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('immersive-rerecord'),
+                onPressed: controller.rerecord,
+                child: const Text('重录'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: FilledButton(
+                key: const Key('immersive-confirm-turn'),
+                onPressed: controller.confirmTranscript,
+                child: const Text('发送'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ComposerProgress extends StatelessWidget {
+  const _ComposerProgress({required this.label, this.showProgress = true});
+
+  final String label;
+  final bool showProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 52,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (showProgress) ...[
+            const SizedBox.square(
+              dimension: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: 10),
+          ],
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: SpeakUpDesign.body,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ComposerAction extends StatelessWidget {
+  const _ComposerAction({
+    required this.label,
+    required this.actionLabel,
+    required this.onPressed,
+  });
+
+  final String label;
+  final String actionLabel;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: SpeakUpDesign.body,
+          ),
+        ),
+        const SizedBox(width: 8),
+        FilledButton(onPressed: onPressed, child: Text(actionLabel)),
+      ],
+    );
+  }
+}
+
+AgentMessage? _latestAssistantMessage(List<AgentMessage> messages) {
+  for (final message in messages.reversed) {
+    if (message.role == AgentMessageRole.assistant) {
+      return message;
+    }
+  }
+  return null;
+}
+
+bool _canTriggerImmersiveReplay(AgentController controller) {
+  if (controller.isBusy) {
+    return false;
+  }
+  return switch (controller.recordingState) {
+    PracticeRecordingState.idle ||
+    PracticeRecordingState.awaitingConfirmation ||
+    PracticeRecordingState.reviewFailed ||
+    PracticeRecordingState.completed => true,
+    PracticeRecordingState.starting ||
+    PracticeRecordingState.recording ||
+    PracticeRecordingState.transcribing ||
+    PracticeRecordingState.submitting => false,
+  };
+}
+
+Future<void> _runBoundedUserTurnAction(ImmersiveAsyncAction? action) async {
+  if (action == null) {
+    return;
+  }
+  Future<void> guardedAction() async {
+    try {
+      await action();
+    } on Object {
+      // User input remains available when avatar interruption degrades.
+    }
+  }
+
+  final timeout = Completer<void>();
+  final timer = Timer(const Duration(milliseconds: 500), timeout.complete);
+  try {
+    await Future.any<void>([guardedAction(), timeout.future]);
+  } finally {
+    timer.cancel();
+  }
+}

--- a/mobile/lib/features/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/practice/immersive_roleplay.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 
 /// A vendor-neutral surface used by the immersive roleplay shell.
 ///
@@ -733,215 +733,82 @@ class _ImmersiveComposer extends StatefulWidget {
 }
 
 class _ImmersiveComposerState extends State<_ImmersiveComposer> {
-  static const _holdDelay = Duration(milliseconds: 180);
-  static const _cancelDistance = 72.0;
-
-  Timer? _holdTimer;
-  Offset? _pointerOrigin;
-  bool _pointerActive = false;
-  bool _holdRecordingStarted = false;
-  bool _cancelArmed = false;
-  bool _tapRecordingActive = false;
-  bool _recordingStartInFlight = false;
-  int _recordingStartGeneration = 0;
-
-  @override
-  void dispose() {
-    _holdTimer?.cancel();
-    super.dispose();
-  }
-
-  void _pointerDown(PointerDownEvent event) {
-    if (_pointerActive ||
-        _recordingStartInFlight ||
-        widget.textMode ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
-    }
-    _holdTimer?.cancel();
-    setState(() {
-      _pointerActive = true;
-      _holdRecordingStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = event.position;
-    });
-    _holdTimer = Timer(_holdDelay, () {
-      if (!mounted || !_pointerActive) {
-        return;
-      }
-      setState(() => _holdRecordingStarted = true);
-      unawaited(HapticFeedback.mediumImpact());
-      unawaited(_beginRecording(tapMode: false));
-    });
-  }
-
-  void _pointerMove(PointerMoveEvent event) {
-    final origin = _pointerOrigin;
-    if (!_pointerActive || origin == null) {
-      return;
-    }
-    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
-    if (cancelArmed == _cancelArmed) {
-      return;
-    }
-    setState(() => _cancelArmed = cancelArmed);
-    unawaited(HapticFeedback.selectionClick());
-  }
-
-  void _pointerUp(PointerUpEvent event) => _finishPointer(cancel: _cancelArmed);
-
-  void _pointerCancel(PointerCancelEvent event) => _finishPointer(cancel: true);
-
-  void _finishPointer({required bool cancel}) {
-    if (!_pointerActive) {
-      return;
-    }
-    _holdTimer?.cancel();
-    final started = _holdRecordingStarted;
-    if (started) {
-      _recordingStartGeneration++;
-      _recordingStartInFlight = false;
-    }
-    setState(() {
-      _pointerActive = false;
-      _holdRecordingStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = null;
-    });
-    if (!started) {
-      if (!cancel) {
-        _startTapRecording();
-      }
-      return;
-    }
-    unawaited(
-      cancel
-          ? widget.controller.cancelRecording()
-          : widget.controller.finishRecordingGesture(),
-    );
-  }
-
-  void _startTapRecording() {
-    if (widget.textMode ||
-        _recordingStartInFlight ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
-    }
-    setState(() => _tapRecordingActive = true);
-    unawaited(HapticFeedback.mediumImpact());
-    unawaited(_beginRecording(tapMode: true));
-  }
-
-  Future<void> _beginRecording({required bool tapMode}) async {
-    final generation = ++_recordingStartGeneration;
-    setState(() => _recordingStartInFlight = true);
+  Future<void> _prepareRecording() async {
     try {
-      try {
-        await widget.onBeforeStartRecording?.call();
-      } on Object {
-        // Avatar interruption is best-effort; microphone access must remain
-        // available when the visual provider is degraded.
-      }
-      final intentStillActive = tapMode ? _tapRecordingActive : _pointerActive;
-      if (!mounted ||
-          generation != _recordingStartGeneration ||
-          !intentStillActive ||
-          widget.controller.recordingState != PracticeRecordingState.idle) {
-        return;
-      }
-      await widget.controller.startRecording();
-    } finally {
-      if (mounted && generation == _recordingStartGeneration) {
-        setState(() => _recordingStartInFlight = false);
-      }
+      await widget.onBeforeStartRecording?.call();
+    } on Object {
+      // Avatar interruption is best-effort. Recording remains available when
+      // the visual provider is degraded.
     }
-  }
-
-  void _finishTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    _recordingStartGeneration++;
-    _recordingStartInFlight = false;
-    unawaited(widget.controller.finishRecordingGesture());
-  }
-
-  void _cancelTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    _recordingStartGeneration++;
-    _recordingStartInFlight = false;
-    unawaited(widget.controller.cancelRecording());
   }
 
   @override
   Widget build(BuildContext context) {
-    final state = widget.controller.recordingState;
-    final tapRecording =
-        _tapRecordingActive &&
-        (state == PracticeRecordingState.starting ||
-            state == PracticeRecordingState.recording);
-    return Material(
-      color: SpeakUpDesign.surface,
-      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
-          child: switch (state) {
-            PracticeRecordingState.idle => _IdleComposer(
-              textController: widget.textController,
-              textFocusNode: widget.textFocusNode,
-              textMode: widget.textMode,
-              pressed: _pointerActive,
-              onToggleTextMode: widget.onToggleTextMode,
-              onSubmitText: widget.onSubmitText,
-              onPointerDown: _pointerDown,
-              onPointerMove: _pointerMove,
-              onPointerUp: _pointerUp,
-              onPointerCancel: _pointerCancel,
-              onSemanticTap: _startTapRecording,
+    final recordingState = widget.controller.recordingState;
+    final phase = switch (recordingState) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
+    return VoiceCaptureControl(
+      phase: phase,
+      enabled: !widget.textMode,
+      onBeforeStart: _prepareRecording,
+      onStart: widget.controller.startRecording,
+      onFinish: widget.controller.finishRecordingGesture,
+      onCancel: widget.controller.cancelRecording,
+      builder: (context, capture) {
+        final tapRecording =
+            capture.tapMode &&
+            (recordingState == PracticeRecordingState.starting ||
+                recordingState == PracticeRecordingState.recording);
+        return Material(
+          color: SpeakUpDesign.surface,
+          shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+              child: switch (recordingState) {
+                PracticeRecordingState.idle => _IdleComposer(
+                  textController: widget.textController,
+                  textFocusNode: widget.textFocusNode,
+                  textMode: widget.textMode,
+                  capture: capture,
+                  onToggleTextMode: widget.onToggleTextMode,
+                  onSubmitText: widget.onSubmitText,
+                ),
+                PracticeRecordingState.starting ||
+                PracticeRecordingState.recording => _RecordingComposer(
+                  preparing: recordingState == PracticeRecordingState.starting,
+                  tapMode: tapRecording,
+                  cancelArmed: capture.cancelArmed,
+                  seconds: widget.recordingSeconds,
+                  capture: capture,
+                ),
+                PracticeRecordingState.transcribing => const _ComposerProgress(
+                  label: '正在识别你的回答…',
+                ),
+                PracticeRecordingState.awaitingConfirmation =>
+                  _TranscriptComposer(controller: widget.controller),
+                PracticeRecordingState.submitting => const _ComposerProgress(
+                  label: '正在发送并准备下一轮…',
+                ),
+                PracticeRecordingState.reviewFailed => _ComposerAction(
+                  label: '本轮已完成，暂时无法保存结果。',
+                  actionLabel: '重试',
+                  onPressed: widget.controller.retryReview,
+                ),
+                PracticeRecordingState.completed => const _ComposerProgress(
+                  label: '本轮对话已完成',
+                  showProgress: false,
+                ),
+              },
             ),
-            PracticeRecordingState.starting ||
-            PracticeRecordingState.recording => _RecordingComposer(
-              preparing: state == PracticeRecordingState.starting,
-              tapMode: tapRecording,
-              cancelArmed: _cancelArmed,
-              seconds: widget.recordingSeconds,
-              onFinish: _finishTapRecording,
-              onCancel: _cancelTapRecording,
-              onPointerMove: _pointerMove,
-              onPointerUp: _pointerUp,
-              onPointerCancel: _pointerCancel,
-            ),
-            PracticeRecordingState.transcribing => const _ComposerProgress(
-              label: '正在识别你的回答…',
-            ),
-            PracticeRecordingState.awaitingConfirmation => _TranscriptComposer(
-              controller: widget.controller,
-            ),
-            PracticeRecordingState.submitting => const _ComposerProgress(
-              label: '正在发送并准备下一轮…',
-            ),
-            PracticeRecordingState.reviewFailed => _ComposerAction(
-              label: '本轮已完成，暂时无法保存结果。',
-              actionLabel: '重试',
-              onPressed: widget.controller.retryReview,
-            ),
-            PracticeRecordingState.completed => const _ComposerProgress(
-              label: '本轮对话已完成',
-              showProgress: false,
-            ),
-          },
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }
@@ -951,27 +818,17 @@ class _IdleComposer extends StatelessWidget {
     required this.textController,
     required this.textFocusNode,
     required this.textMode,
-    required this.pressed,
+    required this.capture,
     required this.onToggleTextMode,
     required this.onSubmitText,
-    required this.onPointerDown,
-    required this.onPointerMove,
-    required this.onPointerUp,
-    required this.onPointerCancel,
-    required this.onSemanticTap,
   });
 
   final TextEditingController textController;
   final FocusNode textFocusNode;
   final bool textMode;
-  final bool pressed;
+  final VoiceCaptureView capture;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
-  final PointerDownEventListener onPointerDown;
-  final PointerMoveEventListener onPointerMove;
-  final PointerUpEventListener onPointerUp;
-  final PointerCancelEventListener onPointerCancel;
-  final VoidCallback onSemanticTap;
 
   @override
   Widget build(BuildContext context) {
@@ -1014,47 +871,38 @@ class _IdleComposer extends StatelessWidget {
     return Row(
       children: [
         Expanded(
-          child: Semantics(
-            button: true,
-            label: '点击或按住说话',
-            onTap: onSemanticTap,
-            child: Listener(
-              key: const Key('immersive-record'),
-              behavior: HitTestBehavior.opaque,
-              onPointerDown: onPointerDown,
-              onPointerMove: onPointerMove,
-              onPointerUp: onPointerUp,
-              onPointerCancel: onPointerCancel,
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 100),
-                height: 52,
-                decoration: BoxDecoration(
-                  color: pressed
-                      ? SpeakUpDesign.primary.withValues(alpha: 0.82)
-                      : SpeakUpDesign.primary,
-                  borderRadius: BorderRadius.circular(
-                    SpeakUpDesign.radiusControl,
-                  ),
+          child: capture.wrapTarget(
+            key: const Key('immersive-record'),
+            semanticsLabel: '点击或按住说话',
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 100),
+              height: 52,
+              decoration: BoxDecoration(
+                color: capture.pressed
+                    ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                    : SpeakUpDesign.primary,
+                borderRadius: BorderRadius.circular(
+                  SpeakUpDesign.radiusControl,
                 ),
-                child: const Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(Icons.mic_rounded, color: Colors.white),
-                    SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        '点击或按住说话',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w700,
-                        ),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.mic_rounded, color: Colors.white),
+                  SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      '点击或按住说话',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -1078,22 +926,14 @@ class _RecordingComposer extends StatelessWidget {
     required this.tapMode,
     required this.cancelArmed,
     required this.seconds,
-    required this.onFinish,
-    required this.onCancel,
-    required this.onPointerMove,
-    required this.onPointerUp,
-    required this.onPointerCancel,
+    required this.capture,
   });
 
   final bool preparing;
   final bool tapMode;
   final bool cancelArmed;
   final int seconds;
-  final VoidCallback onFinish;
-  final VoidCallback onCancel;
-  final PointerMoveEventListener onPointerMove;
-  final PointerUpEventListener onPointerUp;
-  final PointerCancelEventListener onPointerCancel;
+  final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
@@ -1124,7 +964,7 @@ class _RecordingComposer extends StatelessWidget {
                   ? '正在打开麦克风…'
                   : tapMode
                   ? '再次点击结束 · $minutesText:$secondsText'
-                  : '松开发送 · $minutesText:$secondsText',
+                  : '松开完成 · $minutesText:$secondsText',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: SpeakUpDesign.label.copyWith(
@@ -1141,9 +981,8 @@ class _RecordingComposer extends StatelessWidget {
       return Row(
         children: [
           Expanded(
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: onFinish,
+            child: capture.wrapTarget(
+              semanticsLabel: preparing ? '正在打开麦克风' : '结束录音并自动转写',
               child: control,
             ),
           ),
@@ -1151,18 +990,15 @@ class _RecordingComposer extends StatelessWidget {
           IconButton.outlined(
             key: const Key('immersive-cancel-tap-recording'),
             tooltip: '取消录音',
-            onPressed: onCancel,
+            onPressed: capture.cancelTapCapture,
             icon: const Icon(Icons.close_rounded),
             style: IconButton.styleFrom(minimumSize: const Size.square(52)),
           ),
         ],
       );
     }
-    return Listener(
-      behavior: HitTestBehavior.opaque,
-      onPointerMove: onPointerMove,
-      onPointerUp: onPointerUp,
-      onPointerCancel: onPointerCancel,
+    return capture.wrapTarget(
+      semanticsLabel: '正在录音，上滑取消，松开完成录音',
       child: control,
     );
   }

--- a/mobile/lib/features/practice/immersive_roleplay_session.dart
+++ b/mobile/lib/features/practice/immersive_roleplay_session.dart
@@ -1,0 +1,615 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/features/practice/immersive_roleplay.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+import 'package:speakup/practice/practice_models.dart';
+
+typedef AvatarControllerFactory = AvatarController Function();
+
+/// Owns one avatar connection for one immersive practice route.
+///
+/// The product shell remains vendor-neutral: this coordinator only knows the
+/// AvatarController boundary, while the composition root chooses Spatius (or a
+/// future provider).
+class ImmersiveRoleplaySession extends StatefulWidget {
+  const ImmersiveRoleplaySession({
+    required this.agentController,
+    required this.avatarControllerFactory,
+    this.onExitRequested,
+    super.key,
+  });
+
+  final AgentController agentController;
+  final AvatarControllerFactory avatarControllerFactory;
+  final Future<bool> Function()? onExitRequested;
+
+  @override
+  State<ImmersiveRoleplaySession> createState() =>
+      _ImmersiveRoleplaySessionState();
+}
+
+class _ImmersiveRoleplaySessionState extends State<ImmersiveRoleplaySession>
+    with WidgetsBindingObserver {
+  static const _avatarReadinessTimeout = Duration(seconds: 15);
+  static const _userTurnInterruptBudget = Duration(milliseconds: 500);
+  static const _maximumConnectionAttempts = 3;
+
+  late AvatarController _avatarController;
+  Timer? _readinessTimer;
+  Timer? _reconnectTimer;
+  String? _connectionAttemptedSessionId;
+  String? _autoHandledQuestionId;
+  String? _observedQuestionId;
+  bool _readinessExpired = false;
+  bool _connectionInFlight = false;
+  bool _speechInFlight = false;
+  bool _replayLoading = false;
+  bool _syncInFlight = false;
+  bool _syncAgain = false;
+  bool _foreground = true;
+  bool _hasLiveAvatarController = true;
+  bool _disposed = false;
+  int _connectionAttempts = 0;
+  int _connectionOperationId = 0;
+  int _generation = 0;
+  Future<void> _lifecycleTail = Future<void>.value();
+  Future<void> _controllerReplacementTail = Future<void>.value();
+
+  @override
+  void initState() {
+    super.initState();
+    _avatarController = widget.avatarControllerFactory();
+    _observedQuestionId = widget.agentController.questionId;
+    widget.agentController.addListener(_handleAgentState);
+    _avatarController.addListener(_handleAvatarState);
+    WidgetsBinding.instance.addObserver(this);
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    _foreground = lifecycle == null || lifecycle == AppLifecycleState.resumed;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_foreground) {
+        _scheduleSync();
+      } else {
+        _queueLifecycleReconciliation();
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant ImmersiveRoleplaySession oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.agentController == widget.agentController) {
+      return;
+    }
+    oldWidget.agentController.removeListener(_handleAgentState);
+    widget.agentController.addListener(_handleAgentState);
+    _observedQuestionId = widget.agentController.questionId;
+    _autoHandledQuestionId = null;
+    _generation++;
+    _scheduleSync();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _foreground = state == AppLifecycleState.resumed;
+    _generation++;
+    _cancelConnectionTimers();
+    if (!_foreground) {
+      // Never replay an interrupted question just because the App resumes.
+      _autoHandledQuestionId = widget.agentController.questionId;
+    }
+    _queueLifecycleReconciliation();
+  }
+
+  void _queueLifecycleReconciliation() {
+    final previous = _lifecycleTail;
+    final operation = previous
+        .catchError((_) {})
+        .then((_) => _reconcileLifecycle());
+    _lifecycleTail = operation;
+    unawaited(operation);
+  }
+
+  Future<void> _reconcileLifecycle() async {
+    if (_disposed) {
+      return;
+    }
+    if (!_foreground || !_hasLiveAvatarController) {
+      await _replaceAvatarController(resetConnectionAttempts: true);
+    }
+    if (!_disposed && _foreground && _hasLiveAvatarController) {
+      _scheduleSync();
+    }
+  }
+
+  void _cancelConnectionTimers() {
+    _readinessTimer?.cancel();
+    _readinessTimer = null;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+  }
+
+  Future<void> _replaceAvatarController({
+    required bool resetConnectionAttempts,
+  }) {
+    final previous = _controllerReplacementTail;
+    final operation = previous.catchError((_) {}).then((_) async {
+      if (_disposed) {
+        return;
+      }
+      _cancelConnectionTimers();
+      _connectionOperationId++;
+      _connectionInFlight = false;
+      _connectionAttemptedSessionId = null;
+      _readinessExpired = false;
+      if (resetConnectionAttempts) {
+        _connectionAttempts = 0;
+      }
+
+      if (_hasLiveAvatarController) {
+        final previousController = _avatarController;
+        _hasLiveAvatarController = false;
+        previousController.removeListener(_handleAvatarState);
+        await _bestEffort(previousController.close);
+      }
+
+      if (_disposed || !_foreground) {
+        if (mounted) {
+          setState(() {});
+        }
+        return;
+      }
+
+      final replacement = widget.avatarControllerFactory();
+      if (_disposed || !_foreground) {
+        await _bestEffort(replacement.close);
+        return;
+      }
+      _avatarController = replacement;
+      _hasLiveAvatarController = true;
+      replacement.addListener(_handleAvatarState);
+      if (mounted) {
+        setState(() {});
+      }
+    });
+    _controllerReplacementTail = operation;
+    return operation;
+  }
+
+  void _handleAgentState() {
+    final questionId = widget.agentController.questionId;
+    if (questionId != _observedQuestionId) {
+      _observedQuestionId = questionId;
+      _autoHandledQuestionId = null;
+      _generation++;
+      if (_hasLiveAvatarController) {
+        unawaited(_avatarController.interrupt());
+      }
+    }
+    if (mounted) {
+      setState(() {});
+    }
+    _scheduleSync();
+  }
+
+  void _handleAvatarState() {
+    if (!_hasLiveAvatarController) {
+      return;
+    }
+    if (_avatarController.state.canUseAvatar) {
+      _connectionAttempts = 0;
+      _readinessTimer?.cancel();
+      _readinessTimer = null;
+    }
+    final sessionId = widget.agentController.practiceSessionId;
+    if (sessionId != null &&
+        !_connectionInFlight &&
+        _isRetryableAvatarFailure(_avatarController.state.failure)) {
+      _scheduleReconnect(sessionId);
+    }
+    if (mounted) {
+      setState(() {});
+    }
+    _scheduleSync();
+  }
+
+  void _scheduleSync() {
+    if (_disposed || !_foreground) {
+      return;
+    }
+    if (_syncInFlight) {
+      _syncAgain = true;
+      return;
+    }
+    unawaited(_runSyncLoop());
+  }
+
+  Future<void> _runSyncLoop() async {
+    if (_syncInFlight || _disposed) {
+      return;
+    }
+    _syncInFlight = true;
+    try {
+      do {
+        _syncAgain = false;
+        await _synchronize();
+      } while (_syncAgain && !_disposed && _foreground);
+    } finally {
+      _syncInFlight = false;
+    }
+  }
+
+  Future<void> _synchronize() async {
+    final sessionId = widget.agentController.practiceSessionId;
+    if (sessionId == null || sessionId.isEmpty) {
+      return;
+    }
+    if (!_hasLiveAvatarController) {
+      _queueLifecycleReconciliation();
+      return;
+    }
+    if (_connectionAttemptedSessionId != sessionId && !_connectionInFlight) {
+      await _connect(sessionId);
+    }
+    if (_disposed || !_foreground || !_hasLiveAvatarController) {
+      return;
+    }
+    final question = widget.agentController.currentQuestion;
+    if (question == null ||
+        _speechInFlight ||
+        question.id == _autoHandledQuestionId ||
+        !_canSpeakNow(widget.agentController)) {
+      return;
+    }
+    final phase = _avatarController.state.phase;
+    final retrying =
+        _isRetryableAvatarFailure(_avatarController.state.failure) &&
+        _connectionAttempts < _maximumConnectionAttempts &&
+        (_connectionInFlight || _reconnectTimer != null);
+    if (retrying) {
+      return;
+    }
+    final readyForQuestion =
+        _avatarController.state.canUseAvatar ||
+        phase == AvatarControllerPhase.failed ||
+        _readinessExpired;
+    if (!readyForQuestion) {
+      return;
+    }
+    _autoHandledQuestionId = question.id;
+    await _speakQuestion(question);
+  }
+
+  Future<void> _connect(String sessionId) async {
+    if (!_hasLiveAvatarController || _disposed || !_foreground) {
+      return;
+    }
+    final controller = _avatarController;
+    final operationId = ++_connectionOperationId;
+    _connectionInFlight = true;
+    _connectionAttemptedSessionId = sessionId;
+    _connectionAttempts++;
+    _readinessExpired = false;
+    _readinessTimer?.cancel();
+    _readinessTimer = null;
+    var retry = false;
+    try {
+      final connected = await controller.connect(practiceSessionId: sessionId);
+      if (!_connectionFenceMatches(
+        controller: controller,
+        operationId: operationId,
+        sessionId: sessionId,
+      )) {
+        return;
+      }
+      if (!connected) {
+        retry = _isRetryableAvatarFailure(controller.state.failure);
+        _readinessExpired = !retry;
+        return;
+      }
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
+      if (controller.state.canUseAvatar) {
+        return;
+      }
+      _readinessTimer = Timer(_avatarReadinessTimeout, () {
+        if (!_connectionFenceMatches(
+              controller: controller,
+              operationId: operationId,
+              sessionId: sessionId,
+            ) ||
+            controller.state.canUseAvatar) {
+          return;
+        }
+        _readinessExpired = true;
+        _scheduleSync();
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    } catch (_) {
+      if (_connectionFenceMatches(
+        controller: controller,
+        operationId: operationId,
+        sessionId: sessionId,
+      )) {
+        retry = true;
+        _readinessExpired = false;
+      }
+    } finally {
+      if (operationId == _connectionOperationId) {
+        _connectionInFlight = false;
+        if (retry) {
+          _scheduleReconnect(sessionId);
+        }
+        if (mounted) {
+          setState(() {});
+        }
+      }
+    }
+  }
+
+  bool _connectionFenceMatches({
+    required AvatarController controller,
+    required int operationId,
+    required String sessionId,
+  }) {
+    return !_disposed &&
+        _foreground &&
+        _hasLiveAvatarController &&
+        identical(_avatarController, controller) &&
+        operationId == _connectionOperationId &&
+        widget.agentController.practiceSessionId == sessionId;
+  }
+
+  bool _isRetryableAvatarFailure(AvatarRendererFailure? failure) {
+    return failure == AvatarRendererFailure.network ||
+        failure == AvatarRendererFailure.sessionExpired ||
+        failure == AvatarRendererFailure.rendering ||
+        failure == AvatarRendererFailure.unavailable;
+  }
+
+  void _scheduleReconnect(String sessionId) {
+    if (_disposed ||
+        !_foreground ||
+        !_hasLiveAvatarController ||
+        _reconnectTimer != null ||
+        _connectionAttempts >= _maximumConnectionAttempts ||
+        widget.agentController.practiceSessionId != sessionId) {
+      return;
+    }
+    final delay = Duration(milliseconds: 500 * (_connectionAttempts + 1));
+    _reconnectTimer = Timer(delay, () async {
+      _reconnectTimer = null;
+      if (_disposed ||
+          !_foreground ||
+          widget.agentController.practiceSessionId != sessionId) {
+        return;
+      }
+      await _replaceAvatarController(resetConnectionAttempts: false);
+      if (_disposed ||
+          !_foreground ||
+          !_hasLiveAvatarController ||
+          widget.agentController.practiceSessionId != sessionId) {
+        return;
+      }
+      _connectionAttemptedSessionId = null;
+      _scheduleSync();
+    });
+  }
+
+  Future<void> _speakQuestion(
+    PracticeQuestion question, {
+    bool replay = false,
+  }) async {
+    if (!_hasLiveAvatarController) {
+      return;
+    }
+    final avatarController = _avatarController;
+    final mediaClient = widget.agentController.mediaClient;
+    final speechPath = question.speechPath;
+    if (_speechInFlight || mediaClient == null || speechPath == null) {
+      return;
+    }
+    final sessionId = widget.agentController.practiceSessionId;
+    if (sessionId == null || question.sessionId != sessionId) {
+      return;
+    }
+    final generation = ++_generation;
+    _speechInFlight = true;
+    if (replay) {
+      _replayLoading = true;
+    }
+    if (mounted) {
+      setState(() {});
+    }
+
+    Uint8List? bytes;
+    try {
+      await widget.agentController.stopPracticeAudio(notify: false);
+      bytes = await mediaClient.loadQuestionSpeech(speechPath);
+      if (!_speechFenceMatches(
+        generation: generation,
+        sessionId: sessionId,
+        questionId: question.id,
+        speechPath: speechPath,
+        avatarController: avatarController,
+      )) {
+        return;
+      }
+      _replayLoading = false;
+      if (mounted) {
+        setState(() {});
+      }
+      await avatarController.speakWav(bytes);
+    } catch (_) {
+      // The roleplay remains usable through text/recording when media or the
+      // provider is unavailable. A replay tap can retry the same question.
+    } finally {
+      if (bytes != null) {
+        try {
+          bytes.fillRange(0, bytes.length, 0);
+        } catch (_) {
+          // Production media clients return an owned mutable byte buffer.
+        }
+      }
+      _speechInFlight = false;
+      _replayLoading = false;
+      if (mounted) {
+        setState(() {});
+      }
+      _scheduleSync();
+    }
+  }
+
+  bool _speechFenceMatches({
+    required int generation,
+    required String sessionId,
+    required String questionId,
+    required String speechPath,
+    required AvatarController avatarController,
+  }) {
+    final current = widget.agentController.currentQuestion;
+    return !_disposed &&
+        _foreground &&
+        _hasLiveAvatarController &&
+        identical(_avatarController, avatarController) &&
+        generation == _generation &&
+        widget.agentController.practiceSessionId == sessionId &&
+        current?.id == questionId &&
+        current?.speechPath == speechPath;
+  }
+
+  Future<void> _replayQuestion() async {
+    if (_replayLoading || !_canSpeakNow(widget.agentController)) {
+      return;
+    }
+    if (_isAvatarSpeaking) {
+      await _interruptForUserTurn();
+      return;
+    }
+    final question = widget.agentController.currentQuestion;
+    if (question != null) {
+      await _speakQuestion(question, replay: true);
+    }
+  }
+
+  Future<void> _interruptForUserTurn() async {
+    _generation++;
+    final operations = <Future<void>>[
+      _bestEffort(
+        () => widget.agentController.stopPracticeAudio(notify: false),
+      ),
+    ];
+    if (_hasLiveAvatarController) {
+      operations.add(_bestEffort(_avatarController.interrupt));
+    }
+    final interruption = Future.wait<void>(operations);
+    await _waitAtMost(interruption, _userTurnInterruptBudget);
+  }
+
+  bool get _isAvatarSpeaking {
+    if (!_hasLiveAvatarController) {
+      return false;
+    }
+    final state = _avatarController.state;
+    return state.phase == AvatarControllerPhase.speaking ||
+        state.phase == AvatarControllerPhase.fallback ||
+        state.renderer.conversation == AvatarRendererConversation.playing;
+  }
+
+  String? get _avatarStatusLabel {
+    if (!_hasLiveAvatarController) {
+      return _foreground ? '正在重新连接情景角色' : '情景角色已暂停';
+    }
+    final state = _avatarController.state;
+    if (state.phase == AvatarControllerPhase.idle ||
+        state.phase == AvatarControllerPhase.preparing) {
+      return _readinessExpired ? '画面暂不可用，语音仍可继续' : '正在准备情景角色';
+    }
+    if (state.phase == AvatarControllerPhase.failed ||
+        state.failure != null && !state.canUseAvatar) {
+      return '画面暂不可用，语音仍可继续';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ImmersiveRoleplayPage(
+      agentController: widget.agentController,
+      avatarSurfaceBuilder: (_) => _hasLiveAvatarController
+          ? _avatarController.buildSurface(
+              key: const Key('immersive-avatar-surface'),
+            )
+          : const SizedBox.expand(key: Key('immersive-avatar-surface')),
+      avatarStatusLabel: _avatarStatusLabel,
+      onBeforeStartRecording: _interruptForUserTurn,
+      onBeforeSubmitText: _interruptForUserTurn,
+      onReplayQuestion:
+          widget.agentController.currentQuestion?.speechPath == null
+          ? null
+          : _replayQuestion,
+      replayLoading: _replayLoading,
+      replayPlaying: _isAvatarSpeaking,
+      onExitRequested: widget.onExitRequested,
+    );
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _generation++;
+    _connectionOperationId++;
+    _cancelConnectionTimers();
+    WidgetsBinding.instance.removeObserver(this);
+    widget.agentController.removeListener(_handleAgentState);
+    if (_hasLiveAvatarController) {
+      final controller = _avatarController;
+      _hasLiveAvatarController = false;
+      controller.removeListener(_handleAvatarState);
+      unawaited(_bestEffort(controller.close));
+    }
+    super.dispose();
+  }
+}
+
+bool _canSpeakNow(AgentController controller) {
+  if (controller.isBusy) {
+    return false;
+  }
+  return switch (controller.recordingState) {
+    PracticeRecordingState.idle ||
+    PracticeRecordingState.awaitingConfirmation ||
+    PracticeRecordingState.reviewFailed ||
+    PracticeRecordingState.completed => true,
+    PracticeRecordingState.starting ||
+    PracticeRecordingState.recording ||
+    PracticeRecordingState.transcribing ||
+    PracticeRecordingState.submitting => false,
+  };
+}
+
+Future<void> _bestEffort(Future<void> Function() operation) async {
+  try {
+    await operation();
+  } catch (_) {
+    // Lifecycle and user-turn interruption remain best-effort.
+  }
+}
+
+Future<void> _waitAtMost(
+  Future<void> operation,
+  Duration timeoutDuration,
+) async {
+  final timeout = Completer<void>();
+  final timer = Timer(timeoutDuration, timeout.complete);
+  try {
+    await Future.any<void>([operation, timeout.future]);
+  } finally {
+    timer.cancel();
+  }
+}

--- a/mobile/lib/features/practice/immersive_roleplay_session.dart
+++ b/mobile/lib/features/practice/immersive_roleplay_session.dart
@@ -297,7 +297,9 @@ class _ImmersiveRoleplaySessionState extends State<ImmersiveRoleplaySession>
     _readinessTimer = null;
     var retry = false;
     try {
-      final connected = await controller.connect(practiceSessionId: sessionId);
+      final connected = await controller
+          .connect(practiceSessionId: sessionId)
+          .timeout(_avatarReadinessTimeout);
       if (!_connectionFenceMatches(
         controller: controller,
         operationId: operationId,
@@ -330,6 +332,14 @@ class _ImmersiveRoleplaySessionState extends State<ImmersiveRoleplaySession>
           setState(() {});
         }
       });
+    } on TimeoutException {
+      if (_connectionFenceMatches(
+        controller: controller,
+        operationId: operationId,
+        sessionId: sessionId,
+      )) {
+        _readinessExpired = true;
+      }
     } catch (_) {
       if (_connectionFenceMatches(
         controller: controller,

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -4,10 +4,10 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/practice/ielts_mock_practice.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/practice/practice_recordings.dart';
@@ -776,244 +776,93 @@ class _RecordingPanel extends StatefulWidget {
 }
 
 class _RecordingPanelState extends State<_RecordingPanel> {
-  static const _holdDelay = Duration(milliseconds: 180);
-  static const _cancelDistance = 72.0;
-
-  Timer? _holdTimer;
-  Offset? _pointerOrigin;
-  bool _pointerActive = false;
-  bool _recordingGestureStarted = false;
-  bool _cancelArmed = false;
-  bool _tapRecordingActive = false;
-  double _voiceHitWidth = double.infinity;
-
-  @override
-  void dispose() {
-    _holdTimer?.cancel();
-    super.dispose();
-  }
-
-  void _handlePointerDown(PointerDownEvent event) {
-    if (_pointerActive ||
-        widget.textMode ||
-        event.localPosition.dx > _voiceHitWidth ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
-    }
-    _holdTimer?.cancel();
-    setState(() {
-      _pointerActive = true;
-      _recordingGestureStarted = false;
-      _cancelArmed = false;
-      _tapRecordingActive = false;
-      _pointerOrigin = event.position;
-    });
-    _holdTimer = Timer(_holdDelay, () {
-      if (!mounted || !_pointerActive) {
-        return;
-      }
-      setState(() => _recordingGestureStarted = true);
-      unawaited(HapticFeedback.mediumImpact());
-      unawaited(widget.controller.startRecording());
-    });
-  }
-
-  void _handlePointerMove(PointerMoveEvent event) {
-    final origin = _pointerOrigin;
-    if (!_pointerActive || origin == null) {
-      return;
-    }
-    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
-    if (cancelArmed == _cancelArmed) {
-      return;
-    }
-    setState(() => _cancelArmed = cancelArmed);
-    unawaited(HapticFeedback.selectionClick());
-  }
-
-  void _handlePointerUp(PointerUpEvent event) {
-    _finishGesture(cancel: _cancelArmed);
-  }
-
-  void _handlePointerCancel(PointerCancelEvent event) {
-    _finishGesture(cancel: true);
-  }
-
-  void _finishGesture({required bool cancel}) {
-    if (!_pointerActive) {
-      return;
-    }
-    _holdTimer?.cancel();
-    final started = _recordingGestureStarted;
-    setState(() {
-      _pointerActive = false;
-      _recordingGestureStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = null;
-    });
-    if (!started) {
-      if (!cancel) {
-        _startTapRecording();
-      }
-      return;
-    }
-    if (cancel) {
-      unawaited(widget.controller.cancelRecording());
-    } else {
-      unawaited(widget.controller.finishRecordingGesture());
-    }
-  }
-
-  void _toggleRecordingForAccessibility() {
-    final state = widget.controller.recordingState;
-    if (state == PracticeRecordingState.idle) {
-      _startTapRecording();
-    } else if (state == PracticeRecordingState.starting ||
-        state == PracticeRecordingState.recording) {
-      _finishTapRecording();
-    }
-  }
-
-  void _startTapRecording() {
-    if (widget.textMode ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
-    }
-    setState(() => _tapRecordingActive = true);
-    unawaited(HapticFeedback.mediumImpact());
-    unawaited(widget.controller.startRecording());
-  }
-
-  void _finishTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    unawaited(widget.controller.finishRecordingGesture());
-  }
-
-  void _cancelTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    unawaited(widget.controller.cancelRecording());
-  }
-
   @override
   Widget build(BuildContext context) {
     final state = widget.controller.recordingState;
-    final tapRecordingActive =
-        _tapRecordingActive &&
-        (state == PracticeRecordingState.starting ||
-            state == PracticeRecordingState.recording);
-    final handlesHold =
-        !widget.textMode &&
-        (state == PracticeRecordingState.idle ||
-            state == PracticeRecordingState.starting ||
-            state == PracticeRecordingState.recording);
-    final panel = switch (state) {
-      PracticeRecordingState.idle => _IdleAnswerPanel(
-        textController: widget.textController,
-        textFocusNode: widget.textFocusNode,
-        onSubmitText: widget.onSubmitText,
-        textMode: widget.textMode,
-        onToggleTextMode: widget.onToggleTextMode,
-        pressed: _pointerActive,
-      ),
-      PracticeRecordingState.starting ||
-      PracticeRecordingState.recording => _ActiveRecordingPanel(
-        preparing: state == PracticeRecordingState.starting,
-        cancelArmed: _cancelArmed,
-        recordingSeconds: widget.recordingSeconds,
-        tapMode: tapRecordingActive,
-      ),
-      PracticeRecordingState.transcribing => const _WorkingState(
-        label: '正在识别英文回答…',
-      ),
-      PracticeRecordingState.awaitingConfirmation => _TranscriptConfirmation(
-        controller: widget.controller,
-      ),
-      PracticeRecordingState.submitting => const _WorkingState(
-        label: '回答已发送，正在准备下一题…',
-      ),
-      PracticeRecordingState.reviewFailed => _ReviewRetry(
-        onPressed: widget.controller.retryReview,
-      ),
-      PracticeRecordingState.completed => const _WorkingState(
-        label: '复盘已生成，正在打开',
-      ),
+    final phase = switch (state) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
     };
-    return Material(
-      color: SpeakUpDesign.surface,
-      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
-          child: tapRecordingActive
-              ? Row(
-                  children: [
-                    Expanded(
-                      child: Semantics(
-                        button: true,
-                        label: state == PracticeRecordingState.starting
-                            ? '正在打开麦克风'
-                            : '结束录音并自动转写',
-                        onTap: _finishTapRecording,
-                        child: ExcludeSemantics(
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: _finishTapRecording,
-                            child: panel,
+    return VoiceCaptureControl(
+      phase: phase,
+      enabled: !widget.textMode,
+      onStart: widget.controller.startRecording,
+      onFinish: widget.controller.finishRecordingGesture,
+      onCancel: widget.controller.cancelRecording,
+      builder: (context, capture) {
+        final tapRecordingActive =
+            capture.tapMode &&
+            (state == PracticeRecordingState.starting ||
+                state == PracticeRecordingState.recording);
+        final panel = switch (state) {
+          PracticeRecordingState.idle => _IdleAnswerPanel(
+            textController: widget.textController,
+            textFocusNode: widget.textFocusNode,
+            onSubmitText: widget.onSubmitText,
+            textMode: widget.textMode,
+            onToggleTextMode: widget.onToggleTextMode,
+            capture: capture,
+          ),
+          PracticeRecordingState.starting ||
+          PracticeRecordingState.recording => capture.wrapTarget(
+            key: const Key('practice-record'),
+            semanticsLabel: state == PracticeRecordingState.starting
+                ? '正在打开麦克风'
+                : tapRecordingActive
+                ? '结束录音并自动转写'
+                : '正在录音，上滑取消，松开完成录音',
+            child: _ActiveRecordingPanel(
+              preparing: state == PracticeRecordingState.starting,
+              cancelArmed: capture.cancelArmed,
+              recordingSeconds: widget.recordingSeconds,
+              tapMode: tapRecordingActive,
+            ),
+          ),
+          PracticeRecordingState.transcribing => const _WorkingState(
+            label: '正在识别英文回答…',
+          ),
+          PracticeRecordingState.awaitingConfirmation =>
+            _TranscriptConfirmation(controller: widget.controller),
+          PracticeRecordingState.submitting => const _WorkingState(
+            label: '回答已发送，正在准备下一题…',
+          ),
+          PracticeRecordingState.reviewFailed => _ReviewRetry(
+            onPressed: widget.controller.retryReview,
+          ),
+          PracticeRecordingState.completed => const _WorkingState(
+            label: '复盘已生成，正在打开',
+          ),
+        };
+        return Material(
+          color: SpeakUpDesign.surface,
+          shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
+              child: tapRecordingActive
+                  ? Row(
+                      children: [
+                        Expanded(child: panel),
+                        const SizedBox(width: 10),
+                        IconButton.outlined(
+                          key: const Key('practice-cancel-tap-recording'),
+                          tooltip: '取消录音',
+                          onPressed: capture.cancelTapCapture,
+                          icon: const Icon(Icons.close_rounded),
+                          style: IconButton.styleFrom(
+                            minimumSize: const Size.square(56),
                           ),
                         ),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    IconButton.outlined(
-                      key: const Key('practice-cancel-tap-recording'),
-                      tooltip: '取消录音',
-                      onPressed: _cancelTapRecording,
-                      icon: const Icon(Icons.close_rounded),
-                      style: IconButton.styleFrom(
-                        minimumSize: const Size.square(56),
-                      ),
-                    ),
-                  ],
-                )
-              : handlesHold
-              ? LayoutBuilder(
-                  builder: (context, constraints) {
-                    _voiceHitWidth =
-                        state == PracticeRecordingState.idle && !widget.textMode
-                        ? constraints.maxWidth - 66
-                        : constraints.maxWidth;
-                    return Semantics(
-                      button: true,
-                      label: state == PracticeRecordingState.idle
-                          ? '点击或按住说话'
-                          : '正在录音，上滑取消，松开发送',
-                      onTap: _toggleRecordingForAccessibility,
-                      child: Listener(
-                        key: const Key('practice-record'),
-                        behavior: HitTestBehavior.opaque,
-                        onPointerDown: _handlePointerDown,
-                        onPointerMove: _handlePointerMove,
-                        onPointerUp: _handlePointerUp,
-                        onPointerCancel: _handlePointerCancel,
-                        child: panel,
-                      ),
-                    );
-                  },
-                )
-              : panel,
-        ),
-      ),
+                      ],
+                    )
+                  : panel,
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -1025,7 +874,7 @@ class _IdleAnswerPanel extends StatelessWidget {
     required this.onSubmitText,
     required this.textMode,
     required this.onToggleTextMode,
-    required this.pressed,
+    required this.capture,
   });
 
   final TextEditingController textController;
@@ -1033,7 +882,7 @@ class _IdleAnswerPanel extends StatelessWidget {
   final VoidCallback onSubmitText;
   final bool textMode;
   final VoidCallback onToggleTextMode;
-  final bool pressed;
+  final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
@@ -1041,35 +890,39 @@ class _IdleAnswerPanel extends StatelessWidget {
       return Row(
         children: [
           Expanded(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 100),
-              height: 56,
-              decoration: BoxDecoration(
-                color: pressed
-                    ? SpeakUpDesign.primary.withValues(alpha: 0.82)
-                    : SpeakUpDesign.primary,
-                borderRadius: BorderRadius.circular(
-                  SpeakUpDesign.radiusControl,
+            child: capture.wrapTarget(
+              key: const Key('practice-record'),
+              semanticsLabel: '点击或按住说话',
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 100),
+                height: 56,
+                decoration: BoxDecoration(
+                  color: capture.pressed
+                      ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                      : SpeakUpDesign.primary,
+                  borderRadius: BorderRadius.circular(
+                    SpeakUpDesign.radiusControl,
+                  ),
                 ),
-              ),
-              child: const Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.mic_rounded, color: Colors.white),
-                  SizedBox(width: 10),
-                  Flexible(
-                    child: Text(
-                      '点击或按住说话',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.mic_rounded, color: Colors.white),
+                    SizedBox(width: 10),
+                    Flexible(
+                      child: Text(
+                        '点击或按住说话',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -1177,7 +1030,7 @@ class _ActiveRecordingPanel extends StatelessWidget {
                       ? '正在打开麦克风…'
                       : tapMode
                       ? '再次点击结束'
-                      : '松开发送',
+                      : '松开完成',
                   style: SpeakUpDesign.cardTitle.copyWith(
                     color: cancelArmed
                         ? SpeakUpDesign.error

--- a/mobile/lib/features/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/preparation/practice_workspace_controller.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/features/preparation/practice_launch_record_store.dart';
 
 final class PracticeWorkspaceLease {
@@ -71,6 +72,9 @@ final class PracticeWorkspaceController extends ChangeNotifier {
   String? get currentMatterId => _current?.matterId;
   String? get currentSessionId => _current?.sessionId;
   String? get currentScenarioId => _current?.scenarioId;
+  String? get currentScenarioType => _current?.scenarioType;
+  AgentScenePresentationMode get currentPresentationMode =>
+      _current?.presentationMode ?? AgentScenePresentationMode.standard;
 
   Future<void> activateAccount(String accountId) async {
     await _activeOperationDone?.future;
@@ -264,12 +268,16 @@ final class PracticeWorkspaceController extends ChangeNotifier {
     required String sessionId,
     required String scenarioId,
     required String scenarioTitle,
+    String? scenarioType,
+    AgentScenePresentationMode presentationMode =
+        AgentScenePresentationMode.standard,
   }) async {
     if (!_canStartOperation() ||
         !_validOpaqueId(matterId) ||
         !_validOpaqueId(sessionId) ||
         !_validOpaqueId(scenarioId) ||
-        !_validTitle(scenarioTitle)) {
+        !_validTitle(scenarioTitle) ||
+        !_validScenePresentation(scenarioType, presentationMode)) {
       if (!_busy) {
         _setError('练习记录不完整，暂时无法保存。');
       }
@@ -293,6 +301,8 @@ final class PracticeWorkspaceController extends ChangeNotifier {
         sessionId: sessionId,
         scenarioId: scenarioId,
         scenarioTitle: scenarioTitle,
+        scenarioType: scenarioType,
+        presentationMode: presentationMode,
       );
       _current = committed;
       notifyListeners();
@@ -701,6 +711,8 @@ final class PracticeWorkspaceController extends ChangeNotifier {
       sessionId: sessionId,
       scenarioId: matter.scene.id,
       scenarioTitle: matter.scene.title,
+      scenarioType: matter.scene.scenarioType,
+      presentationMode: matter.scene.presentationMode,
     );
   }
 
@@ -973,6 +985,8 @@ final class _StoredPracticeWorkspace {
     required this.sessionId,
     required this.scenarioId,
     required this.scenarioTitle,
+    required this.scenarioType,
+    required this.presentationMode,
   });
 
   factory _StoredPracticeWorkspace.pending({
@@ -990,10 +1004,12 @@ final class _StoredPracticeWorkspace {
       sessionId: null,
       scenarioId: null,
       scenarioTitle: null,
+      scenarioType: null,
+      presentationMode: AgentScenePresentationMode.standard,
     );
   }
 
-  static const schemaVersion = 1;
+  static const schemaVersion = 2;
 
   final String accountId;
   final String operationId;
@@ -1003,6 +1019,8 @@ final class _StoredPracticeWorkspace {
   final String? sessionId;
   final String? scenarioId;
   final String? scenarioTitle;
+  final String? scenarioType;
+  final AgentScenePresentationMode presentationMode;
 
   bool get isCommitted =>
       matterId != null &&
@@ -1021,6 +1039,9 @@ final class _StoredPracticeWorkspace {
     required String sessionId,
     required String scenarioId,
     required String scenarioTitle,
+    String? scenarioType,
+    AgentScenePresentationMode presentationMode =
+        AgentScenePresentationMode.standard,
   }) {
     return _StoredPracticeWorkspace(
       accountId: accountId,
@@ -1031,6 +1052,8 @@ final class _StoredPracticeWorkspace {
       sessionId: sessionId,
       scenarioId: scenarioId,
       scenarioTitle: scenarioTitle,
+      scenarioType: scenarioType,
+      presentationMode: presentationMode,
     );
   }
 
@@ -1044,6 +1067,8 @@ final class _StoredPracticeWorkspace {
       sessionId: sessionId,
       scenarioId: scenarioId,
       scenarioTitle: scenarioTitle,
+      scenarioType: scenarioType,
+      presentationMode: presentationMode,
     );
   }
 
@@ -1058,6 +1083,8 @@ final class _StoredPracticeWorkspace {
       'practice_session_id': sessionId,
       'scenario_definition_id': scenarioId,
       'scenario_title': scenarioTitle,
+      'scenario_type': scenarioType,
+      'presentation_mode': presentationMode.name,
     });
   }
 
@@ -1067,19 +1094,37 @@ final class _StoredPracticeWorkspace {
   }) {
     try {
       final decoded = jsonDecode(encoded);
-      if (decoded is! Map<String, Object?> ||
-          !setEquals(decoded.keys.toSet(), const <String>{
-            'schema_version',
-            'account_id',
-            'operation_id',
-            'practice_thread_id',
-            'return_thread_id',
-            'matter_id',
-            'practice_session_id',
-            'scenario_definition_id',
-            'scenario_title',
-          }) ||
-          decoded['schema_version'] != schemaVersion ||
+      if (decoded is! Map<String, Object?>) {
+        return null;
+      }
+      final version = decoded['schema_version'];
+      final expectedKeys = version == 1
+          ? const <String>{
+              'schema_version',
+              'account_id',
+              'operation_id',
+              'practice_thread_id',
+              'return_thread_id',
+              'matter_id',
+              'practice_session_id',
+              'scenario_definition_id',
+              'scenario_title',
+            }
+          : const <String>{
+              'schema_version',
+              'account_id',
+              'operation_id',
+              'practice_thread_id',
+              'return_thread_id',
+              'matter_id',
+              'practice_session_id',
+              'scenario_definition_id',
+              'scenario_title',
+              'scenario_type',
+              'presentation_mode',
+            };
+      if (!setEquals(decoded.keys.toSet(), expectedKeys) ||
+          (version != 1 && version != schemaVersion) ||
           decoded['account_id'] != expectedAccountId) {
         return null;
       }
@@ -1091,6 +1136,13 @@ final class _StoredPracticeWorkspace {
       final sessionId = decoded['practice_session_id'];
       final scenarioId = decoded['scenario_definition_id'];
       final scenarioTitle = decoded['scenario_title'];
+      final scenarioType = version == 1 ? null : decoded['scenario_type'];
+      final presentationModeName = version == 1
+          ? AgentScenePresentationMode.standard.name
+          : decoded['presentation_mode'];
+      final presentationMode = AgentScenePresentationMode.values
+          .where((value) => value.name == presentationModeName)
+          .firstOrNull;
       if (accountId is! String ||
           operationId is! String ||
           practiceThreadId is! String ||
@@ -1099,6 +1151,8 @@ final class _StoredPracticeWorkspace {
           (sessionId != null && sessionId is! String) ||
           (scenarioId != null && scenarioId is! String) ||
           (scenarioTitle != null && scenarioTitle is! String) ||
+          (scenarioType != null && scenarioType is! String) ||
+          presentationMode == null ||
           !_validOpaqueId(accountId) ||
           !_validOperationId(operationId) ||
           !_validOpaqueId(practiceThreadId) ||
@@ -1121,7 +1175,11 @@ final class _StoredPracticeWorkspace {
           (!_validOpaqueId(matterId! as String) ||
               !_validOpaqueId(sessionId! as String) ||
               !_validOpaqueId(scenarioId! as String) ||
-              !_validTitle(scenarioTitle! as String))) {
+              !_validTitle(scenarioTitle! as String) ||
+              !_validScenePresentation(
+                scenarioType as String?,
+                presentationMode,
+              ))) {
         return null;
       }
       return _StoredPracticeWorkspace(
@@ -1133,11 +1191,29 @@ final class _StoredPracticeWorkspace {
         sessionId: sessionId as String?,
         scenarioId: scenarioId as String?,
         scenarioTitle: scenarioTitle as String?,
+        scenarioType: scenarioType as String?,
+        presentationMode: presentationMode,
       );
     } on Object {
       return null;
     }
   }
+}
+
+bool _validScenePresentation(
+  String? scenarioType,
+  AgentScenePresentationMode presentationMode,
+) {
+  if (scenarioType != null &&
+      (scenarioType.isEmpty ||
+          scenarioType.length > 32 ||
+          scenarioType.trim() != scenarioType ||
+          !RegExp(r'^[A-Z][A-Z0-9_]*$').hasMatch(scenarioType))) {
+    return false;
+  }
+  return presentationMode != AgentScenePresentationMode.immersiveRoleplay ||
+      scenarioType == 'WORKPLACE' ||
+      scenarioType == 'DAILY';
 }
 
 bool _validOpaqueId(String value) {

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -524,8 +524,8 @@ class _PreparationPageState extends State<PreparationPage> {
           const SizedBox(height: 12),
           _PracticeHubEntry(
             key: const Key('practice-hub-roleplay'),
-            title: 'AI 数字人陪练',
-            description: '工作、旅行与日常真实对话',
+            title: '情景对话',
+            description: '工作、旅行与日常英语实战',
             icon: Icons.record_voice_over_outlined,
             accentColor: PreparationDesign.roleplay,
             tintColor: PreparationDesign.roleplayTint,
@@ -705,8 +705,8 @@ class _PreparationPageState extends State<PreparationPage> {
         const SizedBox(height: 12),
         _PracticeHubEntry(
           key: const Key('practice-hub-roleplay'),
-          title: 'AI 数字人陪练',
-          description: '工作、旅行与日常真实对话',
+          title: '情景对话',
+          description: '工作、旅行与日常英语实战',
           icon: Icons.record_voice_over_outlined,
           accentColor: PreparationDesign.roleplay,
           tintColor: PreparationDesign.roleplayTint,
@@ -1504,7 +1504,7 @@ class _RoleplayModuleHeader extends StatelessWidget {
                 header: true,
                 container: true,
                 child: const Text(
-                  'AI 数字人陪练',
+                  '情景对话',
                   key: Key('practice-hub-title-roleplay'),
                   style: PreparationDesign.pageTitle,
                 ),
@@ -2276,7 +2276,7 @@ String _practiceHubLabel(_PracticeHub hub) {
   return switch (hub) {
     _PracticeHub.interview => '英文面试',
     _PracticeHub.ielts => 'IELTS 口语',
-    _PracticeHub.roleplay => 'AI 数字人陪练',
+    _PracticeHub.roleplay => '情景对话',
   };
 }
 

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/features/preparation/preparation_launch_client.dart';
 import 'package:speakup/features/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/preparation/practice_workspace_controller.dart';
@@ -70,6 +71,10 @@ final class PreparationLaunchController extends ChangeNotifier {
   bool get hasResumablePractice => workspaceController?.hasResumable ?? false;
   String? get resumablePracticeTitle => workspaceController?.currentTitle;
   String? get resumableScenarioId => workspaceController?.currentScenarioId;
+  String? get resumableScenarioType => workspaceController?.currentScenarioType;
+  AgentScenePresentationMode get resumablePresentationMode =>
+      workspaceController?.currentPresentationMode ??
+      AgentScenePresentationMode.standard;
   String? get workspaceErrorMessage => workspaceController?.errorMessage;
   bool get canRetryWorkspaceActivation =>
       workspaceController?.canRetryActivation ?? false;
@@ -328,6 +333,12 @@ final class PreparationLaunchController extends ChangeNotifier {
           sessionId: bootstrap.session.id,
           scenarioId: activeAttempt.selection.scenarioDefinitionId,
           scenarioTitle: activeAttempt.selection.scenarioDisplayName,
+          scenarioType: activeAttempt.selection.scenarioType,
+          presentationMode:
+              activeAttempt.selection.scenarioType == 'WORKPLACE' ||
+                  activeAttempt.selection.scenarioType == 'DAILY'
+              ? AgentScenePresentationMode.immersiveRoleplay
+              : AgentScenePresentationMode.standard,
         );
         if (!committed) {
           throw const PreparationLaunchException(

--- a/mobile/lib/features/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_launch_client.dart
@@ -419,6 +419,10 @@ PreparationPracticePlan _plan(
       'scenario_config_version',
       'preparation_profile_id',
       'selected_role_ids',
+      'preparation_snapshot',
+      'catalog_snapshot',
+      'session_policy',
+      'practice_focuses',
       'plan_revision',
       'practice_plan_status',
       'created_at',
@@ -449,6 +453,12 @@ PreparationPracticePlan _plan(
           expected.preparationProfileId ||
       roles.length != 1 ||
       roles.single != expected.selection.roleDefinitionId) {
+    throw _invalidResponse();
+  }
+  if (object['preparation_snapshot'] is! Map<String, Object?> ||
+      object['catalog_snapshot'] is! Map<String, Object?> ||
+      object['session_policy'] is! Map<String, Object?> ||
+      object['practice_focuses'] is! List<Object?>) {
     throw _invalidResponse();
   }
   _dateTime(object['created_at']);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
@@ -5,6 +7,7 @@ import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/agent/wire_agent_client.dart';
 import 'package:speakup/agent/wire_agent_voice_client.dart';
 import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/practice/immersive_roleplay_session.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/preparation/job_preparation_draft_store.dart';
@@ -20,6 +23,7 @@ import 'package:speakup/identity/client/identity_client.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 import 'package:speakup/identity/session_store.dart';
 import 'package:speakup/practice/ios_practice_recorder.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
 import 'package:speakup/practice/practice_audio_player.dart';
 import 'package:speakup/practice/practice_media.dart';
 import 'package:speakup/practice/practice_recording.dart';
@@ -44,6 +48,7 @@ void main() {
       jobPreparationController: dependencies.jobPreparationController,
       preparationLaunchController: dependencies.preparationLaunchController,
       reviewHistoryController: dependencies.reviewHistoryController,
+      avatarControllerFactory: dependencies.avatarControllerFactory,
     ),
   );
 }
@@ -56,6 +61,7 @@ final class ProductionAppDependencies {
     required this.jobPreparationController,
     required this.preparationLaunchController,
     required this.reviewHistoryController,
+    required this.avatarControllerFactory,
   });
 
   final AuthController authController;
@@ -64,6 +70,7 @@ final class ProductionAppDependencies {
   final JobPreparationController jobPreparationController;
   final PreparationLaunchController preparationLaunchController;
   final ReviewHistoryController reviewHistoryController;
+  final AvatarControllerFactory avatarControllerFactory;
 }
 
 ProductionAppDependencies createProductionAppDependencies({
@@ -84,6 +91,8 @@ ProductionAppDependencies createProductionAppDependencies({
   AgentVoiceAudioPlayer? agentVoiceAudioPlayer,
   PracticeMediaClient? practiceMediaClient,
   PracticeAudioPlayer? practiceAudioPlayer,
+  AvatarSessionTokenClient? avatarSessionTokenClient,
+  AvatarControllerFactory? avatarControllerFactory,
   JobPreparationDraftStore? jobPreparationDraftStore,
   PracticeLaunchRecordStore? practiceLaunchRecordStore,
   SessionStore? sessionStore,
@@ -114,6 +123,49 @@ ProductionAppDependencies createProductionAppDependencies({
     apiTransport: agentVoiceTransport,
     signedAudioTransport: signedAgentVoiceTransport,
   );
+  final resolvedPracticeAudioPlayer =
+      practiceAudioPlayer ?? AudioplayersPracticeAudioPlayer();
+  final resolvedAvatarSessionTokenClient =
+      avatarSessionTokenClient ??
+      WireAvatarSessionTokenClient(
+        baseUri: baseUri,
+        credentialProvider: () => authController.currentCredential,
+        invalidateSession:
+            ({required expectedSessionToken, required expectedGeneration}) {
+              return authController.invalidateSession(
+                expectedSessionToken: expectedSessionToken,
+                expectedGeneration: expectedGeneration,
+              );
+            },
+      );
+  final activeAvatarControllers = <AvatarController>{};
+  final accountAvatarControllers = <AvatarController>{};
+  AvatarController createAvatarController() {
+    for (final active in activeAvatarControllers.toList(growable: false)) {
+      unawaited(active.close().catchError((_) {}));
+    }
+    final controller =
+        avatarControllerFactory?.call() ??
+        AvatarController(
+          renderer: SpatiusAvatarRenderer(),
+          tokenClient: resolvedAvatarSessionTokenClient,
+          fallbackPlayback: resolvedPracticeAudioPlayer.playWav,
+          fallbackStop: resolvedPracticeAudioPlayer.stop,
+        );
+    activeAvatarControllers.add(controller);
+    accountAvatarControllers.add(controller);
+    late final void Function() removeClosedController;
+    removeClosedController = () {
+      if (controller.state.phase != AvatarControllerPhase.closed) {
+        return;
+      }
+      controller.removeListener(removeClosedController);
+      activeAvatarControllers.remove(controller);
+    };
+    controller.addListener(removeClosedController);
+    return controller;
+  }
+
   final agentController = AgentController(
     client: agentClient,
     voiceClient: agentVoiceClient,
@@ -148,7 +200,7 @@ ProductionAppDependencies createProductionAppDependencies({
           apiTransport: practiceMediaTransport,
           signedAudioTransport: signedAudioTransport,
         ),
-    audioPlayer: practiceAudioPlayer ?? AudioplayersPracticeAudioPlayer(),
+    audioPlayer: resolvedPracticeAudioPlayer,
   );
   final reviewHistoryController = ReviewHistoryController(
     client: WireReviewHistoryClient(
@@ -210,6 +262,12 @@ ProductionAppDependencies createProductionAppDependencies({
               id: selection.scenarioDefinitionId,
               title: selection.scenarioDisplayName,
               description: selection.scenarioDescription,
+              scenarioType: selection.scenarioType,
+              presentationMode:
+                  selection.scenarioType == 'WORKPLACE' ||
+                      selection.scenarioType == 'DAILY'
+                  ? AgentScenePresentationMode.immersiveRoleplay
+                  : AgentScenePresentationMode.standard,
             ),
             clientOperationId: clientOperationId,
           );
@@ -273,12 +331,24 @@ ProductionAppDependencies createProductionAppDependencies({
     baseUri: baseUri,
     transport: identityTransport,
   );
+  Future<void> clearAvatarPrivateState() async {
+    final controllers = accountAvatarControllers.toList(growable: false);
+    activeAvatarControllers.clear();
+    accountAvatarControllers.clear();
+    await Future.wait<void>([
+      for (final controller in controllers)
+        controller.clearAccountState().catchError((_) {}),
+    ]);
+    await resolvedAvatarSessionTokenClient.clearAccountState();
+  }
+
   authController = AuthController(
     identityClient: identityClient,
     profileClient: identityClient,
     sessionStore: sessionStore ?? const IosKeychainSessionStore(),
     clearPrivateState: () async {
       await preparationLaunchController.clearPrivateState();
+      await clearAvatarPrivateState();
       await Future.wait<void>([
         agentController.clearPrivateState(),
         preparationController.clearPrivateState(),
@@ -294,5 +364,6 @@ ProductionAppDependencies createProductionAppDependencies({
     jobPreparationController: jobPreparationController,
     preparationLaunchController: preparationLaunchController,
     reviewHistoryController: reviewHistoryController,
+    avatarControllerFactory: createAvatarController,
   );
 }

--- a/mobile/lib/practice/avatar/avatar.dart
+++ b/mobile/lib/practice/avatar/avatar.dart
@@ -1,0 +1,7 @@
+export 'avatar_audio.dart';
+export 'avatar_controller.dart';
+export 'avatar_models.dart';
+export 'avatar_renderer.dart';
+export 'avatar_session_token_client.dart';
+export 'spatius_avatar_renderer.dart';
+export 'wire_avatar_session_token_client.dart';

--- a/mobile/lib/practice/avatar/avatar_audio.dart
+++ b/mobile/lib/practice/avatar/avatar_audio.dart
@@ -1,0 +1,152 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'avatar_models.dart';
+
+final class AvatarAudioException implements Exception {
+  const AvatarAudioException();
+
+  @override
+  String toString() => 'Avatar audio is not supported PCM WAV.';
+}
+
+final class AvatarPcmAudio {
+  const AvatarPcmAudio({required this.bytes, required this.format});
+
+  final Uint8List bytes;
+  final AvatarAudioFormat format;
+}
+
+/// Strictly extracts one PCM16, 24 kHz, mono `data` chunk from RIFF/WAVE.
+///
+/// Unknown RIFF chunks are skipped, including their required padding byte.
+/// Truncated, trailing, duplicate, compressed, stereo, or mismatched audio is
+/// rejected before any bytes reach a native SDK.
+AvatarPcmAudio parseAvatarPcmWave(
+  Uint8List wavBytes, {
+  AvatarAudioFormat expectedFormat = AvatarAudioFormat.pcmS16le24kMono,
+}) {
+  if (!expectedFormat.isSupported || wavBytes.length < 44) {
+    throw const AvatarAudioException();
+  }
+  final data = ByteData.sublistView(wavBytes);
+  if (!_matchesAscii(wavBytes, 0, 'RIFF') ||
+      !_matchesAscii(wavBytes, 8, 'WAVE')) {
+    throw const AvatarAudioException();
+  }
+
+  final riffPayloadSize = data.getUint32(4, Endian.little);
+  if (riffPayloadSize != wavBytes.length - 8) {
+    throw const AvatarAudioException();
+  }
+
+  _WaveFormat? waveFormat;
+  Uint8List? pcm;
+  var offset = 12;
+  while (offset < wavBytes.length) {
+    if (wavBytes.length - offset < 8) {
+      throw const AvatarAudioException();
+    }
+    final chunkId = String.fromCharCodes(wavBytes.sublist(offset, offset + 4));
+    final chunkSize = data.getUint32(offset + 4, Endian.little);
+    final payloadStart = offset + 8;
+    final payloadEnd = payloadStart + chunkSize;
+    if (payloadEnd < payloadStart || payloadEnd > wavBytes.length) {
+      throw const AvatarAudioException();
+    }
+
+    if (chunkId == 'fmt ') {
+      if (waveFormat != null || chunkSize < 16) {
+        throw const AvatarAudioException();
+      }
+      waveFormat = _WaveFormat(
+        encoding: data.getUint16(payloadStart, Endian.little),
+        channels: data.getUint16(payloadStart + 2, Endian.little),
+        sampleRate: data.getUint32(payloadStart + 4, Endian.little),
+        byteRate: data.getUint32(payloadStart + 8, Endian.little),
+        blockAlign: data.getUint16(payloadStart + 12, Endian.little),
+        bitsPerSample: data.getUint16(payloadStart + 14, Endian.little),
+      );
+    } else if (chunkId == 'data') {
+      if (pcm != null || chunkSize == 0 || chunkSize.isOdd) {
+        throw const AvatarAudioException();
+      }
+      pcm = Uint8List.fromList(wavBytes.sublist(payloadStart, payloadEnd));
+    }
+
+    final paddedEnd = payloadEnd + (chunkSize.isOdd ? 1 : 0);
+    if (paddedEnd > wavBytes.length) {
+      throw const AvatarAudioException();
+    }
+    offset = paddedEnd;
+  }
+
+  final format = waveFormat;
+  if (offset != wavBytes.length ||
+      format == null ||
+      pcm == null ||
+      format.encoding != 1 ||
+      format.channels != expectedFormat.channels ||
+      format.sampleRate != expectedFormat.sampleRateHz ||
+      format.bitsPerSample != 16 ||
+      format.blockAlign != expectedFormat.channels * 2 ||
+      format.byteRate != expectedFormat.bytesPerSecond ||
+      pcm.length % format.blockAlign != 0) {
+    throw const AvatarAudioException();
+  }
+
+  return AvatarPcmAudio(bytes: pcm, format: expectedFormat);
+}
+
+Iterable<Uint8List> chunkAvatarPcm(
+  AvatarPcmAudio audio, {
+  Duration chunkDuration = const Duration(seconds: 1),
+}) sync* {
+  if (audio.bytes.isEmpty ||
+      !audio.format.isSupported ||
+      chunkDuration <= Duration.zero) {
+    throw const AvatarAudioException();
+  }
+  final rawChunkSize =
+      (audio.format.bytesPerSecond * chunkDuration.inMicroseconds) ~/
+      Duration.microsecondsPerSecond;
+  final alignedChunkSize = rawChunkSize - (rawChunkSize % 2);
+  if (alignedChunkSize <= 0) {
+    throw const AvatarAudioException();
+  }
+  for (var offset = 0; offset < audio.bytes.length;) {
+    final end = math.min(offset + alignedChunkSize, audio.bytes.length);
+    yield Uint8List.sublistView(audio.bytes, offset, end);
+    offset = end;
+  }
+}
+
+bool _matchesAscii(Uint8List bytes, int offset, String value) {
+  if (offset < 0 || offset + value.length > bytes.length) {
+    return false;
+  }
+  for (var index = 0; index < value.length; index += 1) {
+    if (bytes[offset + index] != value.codeUnitAt(index)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+final class _WaveFormat {
+  const _WaveFormat({
+    required this.encoding,
+    required this.channels,
+    required this.sampleRate,
+    required this.byteRate,
+    required this.blockAlign,
+    required this.bitsPerSample,
+  });
+
+  final int encoding;
+  final int channels;
+  final int sampleRate;
+  final int byteRate;
+  final int blockAlign;
+  final int bitsPerSample;
+}

--- a/mobile/lib/practice/avatar/avatar_controller.dart
+++ b/mobile/lib/practice/avatar/avatar_controller.dart
@@ -1,0 +1,453 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'avatar_audio.dart';
+import 'avatar_models.dart';
+import 'avatar_renderer.dart';
+import 'avatar_session_token_client.dart';
+
+/// Coordinates the short-lived capability, renderer lifecycle, and exclusive
+/// avatar audio playback for one practice page.
+final class AvatarController extends ChangeNotifier {
+  AvatarController({
+    required AvatarRenderer renderer,
+    required this._tokenClient,
+    required this._fallbackPlayback,
+    required this._fallbackStop,
+    AvatarDelay? delay,
+    this.chunkDuration = const Duration(seconds: 1),
+    this.interChunkDelay = const Duration(milliseconds: 100),
+  }) : _renderer = renderer,
+       _delay = delay ?? Future<void>.delayed,
+       _state = AvatarControllerState(
+         phase: AvatarControllerPhase.idle,
+         renderer: renderer.state,
+       ) {
+    if (chunkDuration <= Duration.zero || interChunkDelay < Duration.zero) {
+      throw ArgumentError('Avatar audio pacing must not be negative.');
+    }
+    _rendererSubscription = renderer.states.listen(_onRendererState);
+  }
+
+  final AvatarRenderer _renderer;
+  final AvatarSessionTokenClient _tokenClient;
+  final AvatarFallbackPlayback _fallbackPlayback;
+  final AvatarFallbackStop _fallbackStop;
+  final AvatarDelay _delay;
+  final Duration chunkDuration;
+  final Duration interChunkDelay;
+
+  late final StreamSubscription<AvatarRendererState> _rendererSubscription;
+  AvatarControllerState _state;
+  int _generation = 0;
+  bool _closed = false;
+  bool _disposed = false;
+  Future<void>? _interruptFuture;
+  Future<void>? _closeFuture;
+
+  AvatarControllerState get state => _state;
+
+  Widget buildSurface({Key? key}) {
+    if (_closed) {
+      return SizedBox.shrink(key: key);
+    }
+    return _renderer.buildSurface(key: key);
+  }
+
+  /// Mints a capability and prepares the renderer without exposing the token.
+  ///
+  /// `true` means the visual surface can be built. The renderer may still be
+  /// connecting, so callers should use [state] to decide when audio is ready.
+  Future<bool> connect({required String practiceSessionId}) async {
+    _ensureOpen();
+    final generation = ++_generation;
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.preparing,
+        renderer: _renderer.state,
+      ),
+    );
+    try {
+      final grant = await _tokenClient.createSession(
+        practiceSessionId: practiceSessionId,
+      );
+      if (!_isCurrent(generation)) {
+        return false;
+      }
+      await _renderer.prepare(grant);
+      if (!_isCurrent(generation)) {
+        await _renderer.close();
+        return false;
+      }
+      _setState(
+        AvatarControllerState(
+          phase: _renderer.state.canAcceptAudio
+              ? AvatarControllerPhase.ready
+              : AvatarControllerPhase.preparing,
+          renderer: _renderer.state,
+        ),
+      );
+      return true;
+    } on AvatarRendererException catch (error) {
+      if (_isCurrent(generation)) {
+        _setState(
+          AvatarControllerState(
+            phase: AvatarControllerPhase.failed,
+            renderer: _renderer.state,
+            failure: error.failure,
+          ),
+        );
+      }
+      return false;
+    } on AvatarSessionTokenException catch (error) {
+      if (_isCurrent(generation)) {
+        _setState(
+          AvatarControllerState(
+            phase: AvatarControllerPhase.failed,
+            renderer: _renderer.state,
+            failure: _mapTokenFailure(error.failure),
+          ),
+        );
+      }
+      return false;
+    } catch (_) {
+      if (_isCurrent(generation)) {
+        _setState(
+          AvatarControllerState(
+            phase: AvatarControllerPhase.failed,
+            renderer: _renderer.state,
+            failure: AvatarRendererFailure.unavailable,
+          ),
+        );
+      }
+      return false;
+    }
+  }
+
+  /// Sends the owned WAV to the avatar, or exclusively invokes the existing
+  /// audio player when avatar playback is unavailable.
+  Future<AvatarSpeechResult> speakWav(Uint8List wavBytes) async {
+    _ensureOpen();
+
+    // A fresh utterance always fences and interrupts the previous native send.
+    await interrupt();
+    if (_closed) {
+      return AvatarSpeechResult.interrupted;
+    }
+    final generation = ++_generation;
+
+    late final AvatarPcmAudio audio;
+    try {
+      audio = parseAvatarPcmWave(wavBytes);
+    } on AvatarAudioException {
+      return _playFallback(
+        wavBytes,
+        generation,
+        AvatarRendererFailure.invalidConfiguration,
+      );
+    }
+
+    if (!_renderer.state.canAcceptAudio) {
+      return _playFallback(
+        wavBytes,
+        generation,
+        _renderer.state.failure ?? AvatarRendererFailure.unavailable,
+      );
+    }
+
+    final chunks = chunkAvatarPcm(
+      audio,
+      chunkDuration: chunkDuration,
+    ).toList(growable: false);
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.speaking,
+        renderer: _renderer.state,
+      ),
+    );
+
+    try {
+      for (var index = 0; index < chunks.length; index += 1) {
+        if (!_isCurrent(generation)) {
+          return AvatarSpeechResult.interrupted;
+        }
+        final isLast = index == chunks.length - 1;
+        await _renderer.sendPcm(chunks[index], end: isLast);
+        if (!_isCurrent(generation)) {
+          return AvatarSpeechResult.interrupted;
+        }
+        if (!isLast && interChunkDelay > Duration.zero) {
+          await _delay(interChunkDelay);
+        }
+      }
+      if (!_isCurrent(generation)) {
+        return AvatarSpeechResult.interrupted;
+      }
+      _setState(
+        AvatarControllerState(
+          phase: AvatarControllerPhase.ready,
+          renderer: _renderer.state,
+        ),
+      );
+      return AvatarSpeechResult.avatar;
+    } catch (_) {
+      if (!_isCurrent(generation)) {
+        return AvatarSpeechResult.interrupted;
+      }
+      if (!await _stopRendererForFallback()) {
+        if (_isCurrent(generation)) {
+          _setState(
+            AvatarControllerState(
+              phase: AvatarControllerPhase.failed,
+              renderer: _renderer.state,
+              failure: AvatarRendererFailure.rendering,
+            ),
+          );
+        }
+        return AvatarSpeechResult.interrupted;
+      }
+      return _playFallback(
+        wavBytes,
+        generation,
+        _renderer.state.failure ?? AvatarRendererFailure.unavailable,
+      );
+    }
+  }
+
+  Future<void> interrupt() {
+    if (_closed) {
+      return Future<void>.value();
+    }
+    _generation++;
+    final existing = _interruptFuture;
+    if (existing != null) {
+      return existing;
+    }
+    final operation = _performInterrupt();
+    _interruptFuture = operation;
+    return operation.whenComplete(() {
+      if (identical(_interruptFuture, operation)) {
+        _interruptFuture = null;
+      }
+    });
+  }
+
+  Future<void> _performInterrupt() async {
+    try {
+      await _fallbackStop();
+    } catch (_) {
+      // The renderer still needs interruption when local stop has failed.
+    }
+    try {
+      await _renderer.interrupt();
+    } catch (_) {
+      // Interruption is best-effort; the generation fence rejects late sends.
+    }
+    if (_closed) {
+      return;
+    }
+    _setState(
+      AvatarControllerState(
+        phase:
+            _renderer.state.failure != null ||
+                _renderer.state.connection == AvatarRendererConnection.failed
+            ? AvatarControllerPhase.failed
+            : _renderer.state.canAcceptAudio
+            ? AvatarControllerPhase.ready
+            : AvatarControllerPhase.preparing,
+        renderer: _renderer.state,
+        failure: _renderer.state.failure,
+      ),
+    );
+  }
+
+  Future<void> pauseRendering() async {
+    if (!_closed) {
+      await _renderer.pauseRendering();
+    }
+  }
+
+  Future<void> resumeRendering() async {
+    if (!_closed) {
+      await _renderer.resumeRendering();
+    }
+  }
+
+  /// Used on logout or account switch to fence all old-account work.
+  Future<void> clearAccountState() async {
+    try {
+      await close();
+    } finally {
+      await _tokenClient.clearAccountState();
+    }
+  }
+
+  Future<void> close() {
+    final existing = _closeFuture;
+    if (existing != null) {
+      return existing;
+    }
+    if (_closed) {
+      return Future<void>.value();
+    }
+    _closed = true;
+    _generation++;
+    final completion = _performClose();
+    _closeFuture = completion;
+    return completion;
+  }
+
+  Future<void> _performClose() async {
+    await _rendererSubscription.cancel();
+    try {
+      final pendingInterrupt = _interruptFuture;
+      if (pendingInterrupt != null) {
+        try {
+          await pendingInterrupt;
+        } catch (_) {
+          // Renderer close below is the final interruption boundary.
+        }
+      }
+      try {
+        await _fallbackStop();
+      } catch (_) {
+        // Continue native teardown even if local playback is already gone.
+      }
+      await _renderer.close();
+    } finally {
+      _setState(
+        AvatarControllerState(
+          phase: AvatarControllerPhase.closed,
+          renderer: const AvatarRendererState(
+            connection: AvatarRendererConnection.closed,
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<bool> _stopRendererForFallback() async {
+    try {
+      await _renderer.interrupt();
+      return true;
+    } catch (_) {
+      try {
+        await _renderer.close();
+        return true;
+      } catch (_) {
+        return false;
+      }
+    }
+  }
+
+  Future<AvatarSpeechResult> _playFallback(
+    Uint8List wavBytes,
+    int generation,
+    AvatarRendererFailure failure,
+  ) async {
+    if (!_isCurrent(generation)) {
+      return AvatarSpeechResult.interrupted;
+    }
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.fallback,
+        renderer: _renderer.state,
+        failure: failure,
+      ),
+    );
+    try {
+      await _fallbackPlayback(Uint8List.fromList(wavBytes));
+    } catch (_) {
+      if (_isCurrent(generation)) {
+        _setState(
+          AvatarControllerState(
+            phase: AvatarControllerPhase.failed,
+            renderer: _renderer.state,
+            failure: AvatarRendererFailure.unavailable,
+          ),
+        );
+      }
+      rethrow;
+    }
+    if (!_isCurrent(generation)) {
+      return AvatarSpeechResult.interrupted;
+    }
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.ready,
+        renderer: _renderer.state,
+        failure: failure,
+      ),
+    );
+    return AvatarSpeechResult.fallback;
+  }
+
+  void _onRendererState(AvatarRendererState rendererState) {
+    if (_closed) {
+      return;
+    }
+    final phase = switch (rendererState.connection) {
+      AvatarRendererConnection.connected =>
+        _state.phase == AvatarControllerPhase.speaking
+            ? AvatarControllerPhase.speaking
+            : AvatarControllerPhase.ready,
+      AvatarRendererConnection.failed => AvatarControllerPhase.failed,
+      AvatarRendererConnection.closed => AvatarControllerPhase.failed,
+      _ =>
+        _state.phase == AvatarControllerPhase.fallback
+            ? AvatarControllerPhase.fallback
+            : AvatarControllerPhase.preparing,
+    };
+    _setState(
+      AvatarControllerState(
+        phase: phase,
+        renderer: rendererState,
+        failure: rendererState.failure ?? _state.failure,
+      ),
+    );
+  }
+
+  bool _isCurrent(int generation) => !_closed && generation == _generation;
+
+  void _ensureOpen() {
+    if (_closed || _disposed) {
+      throw StateError('Avatar controller is closed.');
+    }
+  }
+
+  void _setState(AvatarControllerState next) {
+    _state = next;
+    if (!_disposed) {
+      notifyListeners();
+    }
+  }
+
+  static AvatarRendererFailure _mapTokenFailure(
+    AvatarSessionTokenFailure failure,
+  ) {
+    return switch (failure) {
+      AvatarSessionTokenFailure.authenticationRequired ||
+      AvatarSessionTokenFailure.forbidden =>
+        AvatarRendererFailure.authentication,
+      AvatarSessionTokenFailure.notFound ||
+      AvatarSessionTokenFailure.invalidResponse =>
+        AvatarRendererFailure.invalidConfiguration,
+      AvatarSessionTokenFailure.conflict => AvatarRendererFailure.sessionLimit,
+      AvatarSessionTokenFailure.network ||
+      AvatarSessionTokenFailure.unavailable => AvatarRendererFailure.network,
+      AvatarSessionTokenFailure.cancelled => AvatarRendererFailure.unavailable,
+    };
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    unawaited(close().catchError((_) {}));
+    super.dispose();
+  }
+}

--- a/mobile/lib/practice/avatar/avatar_models.dart
+++ b/mobile/lib/practice/avatar/avatar_models.dart
@@ -1,0 +1,182 @@
+import 'dart:typed_data';
+
+enum AvatarRegion {
+  usWest('us-west'),
+  apNortheast('ap-northeast'),
+  cnBeijing('cn-beijing');
+
+  const AvatarRegion(this.wireName);
+
+  final String wireName;
+
+  static AvatarRegion? fromWireName(String value) {
+    for (final region in values) {
+      if (region.wireName == value) {
+        return region;
+      }
+    }
+    return null;
+  }
+}
+
+final class AvatarAudioFormat {
+  const AvatarAudioFormat({
+    required this.encoding,
+    required this.sampleRateHz,
+    required this.channels,
+  });
+
+  static const pcmS16le24kMono = AvatarAudioFormat(
+    encoding: 'PCM_S16LE',
+    sampleRateHz: 24000,
+    channels: 1,
+  );
+
+  final String encoding;
+  final int sampleRateHz;
+  final int channels;
+
+  bool get isSupported =>
+      encoding == pcmS16le24kMono.encoding &&
+      sampleRateHz == pcmS16le24kMono.sampleRateHz &&
+      channels == pcmS16le24kMono.channels;
+
+  int get bytesPerSecond => sampleRateHz * channels * 2;
+}
+
+/// A short-lived, server-minted capability for one avatar session.
+///
+/// [toString] deliberately excludes every credential-shaped value.
+final class AvatarSessionGrant {
+  const AvatarSessionGrant({
+    required this.appId,
+    required this.avatarId,
+    required this.sessionToken,
+    required this.region,
+    required this.expiresAt,
+    required this.audioFormat,
+  });
+
+  final String appId;
+  final String avatarId;
+  final String sessionToken;
+  final AvatarRegion region;
+  final DateTime expiresAt;
+  final AvatarAudioFormat audioFormat;
+
+  @override
+  String toString() =>
+      'AvatarSessionGrant(region: ${region.wireName}, '
+      'expiresAt: $expiresAt, audioFormat: ${audioFormat.encoding}/'
+      '${audioFormat.sampleRateHz}/${audioFormat.channels})';
+}
+
+enum AvatarRendererConnection {
+  idle,
+  preparing,
+  surfaceReady,
+  connecting,
+  connected,
+  failed,
+  closed,
+}
+
+enum AvatarRendererConversation { idle, playing }
+
+enum AvatarRendererFailure {
+  unsupportedDevice,
+  invalidConfiguration,
+  authentication,
+  insufficientBalance,
+  sessionLimit,
+  sessionExpired,
+  network,
+  rendering,
+  unavailable,
+}
+
+final class AvatarRendererState {
+  const AvatarRendererState({
+    this.connection = AvatarRendererConnection.idle,
+    this.conversation = AvatarRendererConversation.idle,
+    this.failure,
+  });
+
+  final AvatarRendererConnection connection;
+  final AvatarRendererConversation conversation;
+  final AvatarRendererFailure? failure;
+
+  bool get canAcceptAudio =>
+      connection == AvatarRendererConnection.connected && failure == null;
+
+  AvatarRendererState copyWith({
+    AvatarRendererConnection? connection,
+    AvatarRendererConversation? conversation,
+    AvatarRendererFailure? failure,
+    bool clearFailure = false,
+  }) {
+    return AvatarRendererState(
+      connection: connection ?? this.connection,
+      conversation: conversation ?? this.conversation,
+      failure: clearFailure ? null : failure ?? this.failure,
+    );
+  }
+}
+
+final class AvatarRendererException implements Exception {
+  const AvatarRendererException(this.failure);
+
+  final AvatarRendererFailure failure;
+
+  @override
+  String toString() => 'Avatar rendering is unavailable (${failure.name}).';
+}
+
+enum AvatarControllerPhase {
+  idle,
+  preparing,
+  ready,
+  speaking,
+  fallback,
+  failed,
+  closed,
+}
+
+final class AvatarControllerState {
+  const AvatarControllerState({
+    required this.phase,
+    required this.renderer,
+    this.failure,
+  });
+
+  const AvatarControllerState.idle()
+    : phase = AvatarControllerPhase.idle,
+      renderer = const AvatarRendererState(),
+      failure = null;
+
+  final AvatarControllerPhase phase;
+  final AvatarRendererState renderer;
+  final AvatarRendererFailure? failure;
+
+  bool get canUseAvatar =>
+      phase != AvatarControllerPhase.closed && renderer.canAcceptAudio;
+
+  AvatarControllerState copyWith({
+    AvatarControllerPhase? phase,
+    AvatarRendererState? renderer,
+    AvatarRendererFailure? failure,
+    bool clearFailure = false,
+  }) {
+    return AvatarControllerState(
+      phase: phase ?? this.phase,
+      renderer: renderer ?? this.renderer,
+      failure: clearFailure ? null : failure ?? this.failure,
+    );
+  }
+}
+
+enum AvatarSpeechResult { avatar, fallback, interrupted }
+
+typedef AvatarFallbackPlayback = Future<void> Function(Uint8List wavBytes);
+typedef AvatarFallbackStop = Future<void> Function();
+typedef AvatarDelay = Future<void> Function(Duration duration);

--- a/mobile/lib/practice/avatar/avatar_models.dart
+++ b/mobile/lib/practice/avatar/avatar_models.dart
@@ -2,8 +2,7 @@ import 'dart:typed_data';
 
 enum AvatarRegion {
   usWest('us-west'),
-  apNortheast('ap-northeast'),
-  cnBeijing('cn-beijing');
+  apNortheast('ap-northeast');
 
   const AvatarRegion(this.wireName);
 

--- a/mobile/lib/practice/avatar/avatar_renderer.dart
+++ b/mobile/lib/practice/avatar/avatar_renderer.dart
@@ -1,0 +1,29 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+
+import 'avatar_models.dart';
+
+/// The only vendor-neutral boundary used by practice UI and orchestration.
+///
+/// A renderer owns visual playback. Callers must not start a second audio
+/// player after [sendPcm] succeeds.
+abstract interface class AvatarRenderer {
+  AvatarRendererState get state;
+
+  Stream<AvatarRendererState> get states;
+
+  Future<void> prepare(AvatarSessionGrant grant);
+
+  Widget buildSurface({Key? key});
+
+  Future<void> sendPcm(Uint8List pcmBytes, {required bool end});
+
+  Future<void> interrupt();
+
+  Future<void> pauseRendering();
+
+  Future<void> resumeRendering();
+
+  Future<void> close();
+}

--- a/mobile/lib/practice/avatar/avatar_session_token_client.dart
+++ b/mobile/lib/practice/avatar/avatar_session_token_client.dart
@@ -1,0 +1,37 @@
+import 'avatar_models.dart';
+
+abstract interface class AvatarSessionTokenClient {
+  Future<AvatarSessionGrant> createSession({required String practiceSessionId});
+
+  Future<void> clearAccountState();
+
+  Future<void> dispose();
+}
+
+enum AvatarSessionTokenFailure {
+  authenticationRequired,
+  forbidden,
+  notFound,
+  conflict,
+  unavailable,
+  invalidResponse,
+  network,
+  cancelled,
+}
+
+final class AvatarSessionTokenException implements Exception {
+  const AvatarSessionTokenException({
+    required this.failure,
+    this.statusCode,
+    this.retryable = false,
+  });
+
+  final AvatarSessionTokenFailure failure;
+  final int? statusCode;
+  final bool retryable;
+
+  @override
+  String toString() =>
+      'Avatar session is unavailable (${failure.name}, '
+      'status: ${statusCode ?? 'none'}).';
+}

--- a/mobile/lib/practice/avatar/spatius_avatar_renderer.dart
+++ b/mobile/lib/practice/avatar/spatius_avatar_renderer.dart
@@ -17,6 +17,9 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
         sync: true,
       );
 
+  static const _avatarLoadTimeout = Duration(seconds: 15);
+  static const _cancelLoadingTimeout = Duration(seconds: 1);
+
   final StreamController<AvatarRendererState> _stateController;
 
   static int _nextTokenLease = 0;
@@ -70,9 +73,20 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
         await _clearSdkTokenIfOwned();
         throw const AvatarRendererException(AvatarRendererFailure.unavailable);
       }
-      _loadingAvatarId = grant.avatarId;
-      _avatar = await kit.AvatarManager.shared.load(id: grant.avatarId);
-      _loadingAvatarId = null;
+      final avatarId = grant.avatarId;
+      _loadingAvatarId = avatarId;
+      try {
+        _avatar = await kit.AvatarManager.shared
+            .load(id: avatarId)
+            .timeout(_avatarLoadTimeout);
+      } on TimeoutException {
+        await _cancelLoadingBestEffort(avatarId);
+        throw const AvatarRendererException(AvatarRendererFailure.network);
+      } finally {
+        if (_loadingAvatarId == avatarId) {
+          _loadingAvatarId = null;
+        }
+      }
       if (_closed) {
         await _clearSdkTokenIfOwned();
         throw const AvatarRendererException(AvatarRendererFailure.unavailable);
@@ -86,6 +100,11 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       await _cleanupFailedPrepare();
       _fail(error.failure);
       rethrow;
+    } on kit.AvatarError catch (error) {
+      await _cleanupFailedPrepare();
+      final failure = _mapError(error);
+      _fail(failure);
+      throw AvatarRendererException(failure);
     } catch (_) {
       await _cleanupFailedPrepare();
       _fail(AvatarRendererFailure.unavailable);
@@ -266,11 +285,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
     final loadingAvatarId = _loadingAvatarId;
     _loadingAvatarId = null;
     if (loadingAvatarId != null) {
-      try {
-        await kit.AvatarManager.shared.cancelLoading(id: loadingAvatarId);
-      } catch (_) {
-        // Cancellation is best-effort during teardown.
-      }
+      await _cancelLoadingBestEffort(loadingAvatarId);
     }
     final controller = _controller;
     _controller = null;
@@ -321,9 +336,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       await kit.AvatarSDK.initialize(
         appID: grant.appId,
         configuration: kit.Configuration(
-          environment: grant.region == AvatarRegion.cnBeijing
-              ? kit.Environment.cn
-              : kit.Environment.intl,
+          environment: kit.Environment.intl,
           audioFormat: kit.AudioFormat(
             sampleRate: grant.audioFormat.sampleRateHz,
           ),
@@ -348,14 +361,20 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
     final loadingAvatarId = _loadingAvatarId;
     _loadingAvatarId = null;
     if (loadingAvatarId != null) {
-      try {
-        await kit.AvatarManager.shared.cancelLoading(id: loadingAvatarId);
-      } catch (_) {
-        // Failed preparation still releases the session token below.
-      }
+      await _cancelLoadingBestEffort(loadingAvatarId);
     }
     _avatar = null;
     await _clearSdkTokenIfOwned();
+  }
+
+  Future<void> _cancelLoadingBestEffort(String avatarId) async {
+    try {
+      await kit.AvatarManager.shared
+          .cancelLoading(id: avatarId)
+          .timeout(_cancelLoadingTimeout);
+    } catch (_) {
+      // beta SDKs may cancel natively without completing the Flutter call.
+    }
   }
 
   Future<void> _clearSdkTokenIfOwned() async {

--- a/mobile/lib/practice/avatar/spatius_avatar_renderer.dart
+++ b/mobile/lib/practice/avatar/spatius_avatar_renderer.dart
@@ -1,0 +1,448 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:avatar_kit/avatar_kit.dart' as kit;
+import 'package:flutter/widgets.dart';
+
+import 'avatar_models.dart';
+import 'avatar_renderer.dart';
+
+/// The only file allowed to depend on the temporary Spatius/AvatarKit SDK.
+///
+/// Replacing the beta package later does not change practice UI, orchestration,
+/// token transport, or audio parsing.
+final class SpatiusAvatarRenderer implements AvatarRenderer {
+  SpatiusAvatarRenderer()
+    : _stateController = StreamController<AvatarRendererState>.broadcast(
+        sync: true,
+      );
+
+  final StreamController<AvatarRendererState> _stateController;
+
+  static int _nextTokenLease = 0;
+  static int _activeTokenLease = 0;
+  static Future<void> _tokenLeaseTail = Future<void>.value();
+
+  AvatarRendererState _state = const AvatarRendererState();
+  kit.Avatar? _avatar;
+  kit.AvatarController? _controller;
+  String? _loadingAvatarId;
+  bool _closed = false;
+  bool _prepared = false;
+  int? _tokenLease;
+  Completer<void>? _tokenLeaseRelease;
+  Future<void>? _sdkConfigurationFuture;
+  Future<void>? _closeFuture;
+
+  @override
+  AvatarRendererState get state => _state;
+
+  @override
+  Stream<AvatarRendererState> get states => _stateController.stream;
+
+  @override
+  Future<void> prepare(AvatarSessionGrant grant) async {
+    if (_closed || _prepared || !grant.audioFormat.isSupported) {
+      throw const AvatarRendererException(
+        AvatarRendererFailure.invalidConfiguration,
+      );
+    }
+    _prepared = true;
+    _setState(
+      const AvatarRendererState(connection: AvatarRendererConnection.preparing),
+    );
+    try {
+      if (!await kit.AvatarSDK.isDeviceSupported()) {
+        throw const AvatarRendererException(
+          AvatarRendererFailure.unsupportedDevice,
+        );
+      }
+      final configuration = _configureSdk(grant);
+      _sdkConfigurationFuture = configuration;
+      try {
+        await configuration;
+      } finally {
+        if (identical(_sdkConfigurationFuture, configuration)) {
+          _sdkConfigurationFuture = null;
+        }
+      }
+      if (_closed) {
+        await _clearSdkTokenIfOwned();
+        throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+      }
+      _loadingAvatarId = grant.avatarId;
+      _avatar = await kit.AvatarManager.shared.load(id: grant.avatarId);
+      _loadingAvatarId = null;
+      if (_closed) {
+        await _clearSdkTokenIfOwned();
+        throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+      }
+      _setState(
+        const AvatarRendererState(
+          connection: AvatarRendererConnection.surfaceReady,
+        ),
+      );
+    } on AvatarRendererException catch (error) {
+      await _cleanupFailedPrepare();
+      _fail(error.failure);
+      rethrow;
+    } catch (_) {
+      await _cleanupFailedPrepare();
+      _fail(AvatarRendererFailure.unavailable);
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+  }
+
+  @override
+  Widget buildSurface({Key? key}) {
+    final avatar = _avatar;
+    if (_closed || avatar == null) {
+      return SizedBox.expand(key: key);
+    }
+    return _AvatarSurfaceHost(
+      key: key,
+      avatar: avatar,
+      onController: _attachController,
+    );
+  }
+
+  void _attachController(kit.AvatarController controller) {
+    if (_closed) {
+      unawaited(controller.close().catchError((_) {}));
+      return;
+    }
+    final previous = _controller;
+    if (previous != null && !identical(previous, controller)) {
+      unawaited(previous.close().catchError((_) {}));
+    }
+    _controller = controller;
+    controller.onFirstRendering = () {
+      if (!_closed && _state.connection == AvatarRendererConnection.preparing) {
+        _setState(
+          _state.copyWith(
+            connection: AvatarRendererConnection.surfaceReady,
+            clearFailure: true,
+          ),
+        );
+      }
+    };
+    controller.onConnectionState = (connection, _) {
+      if (_closed || !identical(_controller, controller)) {
+        return;
+      }
+      switch (connection) {
+        case kit.ConnectionState.disconnected:
+          _setState(
+            const AvatarRendererState(
+              connection: AvatarRendererConnection.surfaceReady,
+            ),
+          );
+        case kit.ConnectionState.connecting:
+          _setState(
+            const AvatarRendererState(
+              connection: AvatarRendererConnection.connecting,
+            ),
+          );
+        case kit.ConnectionState.connected:
+          _setState(
+            const AvatarRendererState(
+              connection: AvatarRendererConnection.connected,
+            ),
+          );
+        case kit.ConnectionState.failed:
+          _fail(AvatarRendererFailure.network);
+      }
+    };
+    controller.onConversationState = (conversation) {
+      if (_closed || !identical(_controller, controller)) {
+        return;
+      }
+      final mapped = switch (conversation) {
+        kit.ConversationState.playing => AvatarRendererConversation.playing,
+        kit.ConversationState.idle ||
+        kit.ConversationState.paused => AvatarRendererConversation.idle,
+      };
+      _setState(_state.copyWith(conversation: mapped));
+    };
+    controller.onError = (error) {
+      if (!_closed && identical(_controller, controller)) {
+        _fail(_mapError(error));
+      }
+    };
+    _setState(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.connecting,
+      ),
+    );
+    unawaited(_start(controller));
+  }
+
+  Future<void> _start(kit.AvatarController controller) async {
+    try {
+      await controller.start();
+    } catch (_) {
+      if (!_closed && identical(_controller, controller)) {
+        _fail(AvatarRendererFailure.network);
+      }
+    }
+  }
+
+  @override
+  Future<void> sendPcm(Uint8List pcmBytes, {required bool end}) async {
+    final controller = _controller;
+    if (_closed ||
+        controller == null ||
+        !_state.canAcceptAudio ||
+        pcmBytes.isEmpty ||
+        pcmBytes.length.isOdd) {
+      throw AvatarRendererException(
+        _state.failure ?? AvatarRendererFailure.unavailable,
+      );
+    }
+    try {
+      await controller.send(pcmBytes, end: end);
+    } catch (_) {
+      _fail(AvatarRendererFailure.network);
+      throw const AvatarRendererException(AvatarRendererFailure.network);
+    }
+  }
+
+  @override
+  Future<void> interrupt() async {
+    final controller = _controller;
+    if (_closed || controller == null) {
+      return;
+    }
+    try {
+      await controller.interrupt();
+      if (!_closed) {
+        _setState(
+          _state.copyWith(conversation: AvatarRendererConversation.idle),
+        );
+      }
+    } catch (_) {
+      _fail(AvatarRendererFailure.rendering);
+      throw const AvatarRendererException(AvatarRendererFailure.rendering);
+    }
+  }
+
+  @override
+  Future<void> pauseRendering() async {
+    final controller = _controller;
+    if (!_closed && controller != null) {
+      await controller.pauseRendering();
+    }
+  }
+
+  @override
+  Future<void> resumeRendering() async {
+    final controller = _controller;
+    if (!_closed && controller != null) {
+      await controller.resumeRendering();
+    }
+  }
+
+  @override
+  Future<void> close() {
+    final existing = _closeFuture;
+    if (existing != null) {
+      return existing;
+    }
+    _closed = true;
+    final completion = _performClose();
+    _closeFuture = completion;
+    return completion;
+  }
+
+  Future<void> _performClose() async {
+    final configuration = _sdkConfigurationFuture;
+    if (configuration != null) {
+      try {
+        await configuration;
+      } catch (_) {
+        // Failed/cancelled configuration releases its global SDK lease.
+      }
+    }
+    final loadingAvatarId = _loadingAvatarId;
+    _loadingAvatarId = null;
+    if (loadingAvatarId != null) {
+      try {
+        await kit.AvatarManager.shared.cancelLoading(id: loadingAvatarId);
+      } catch (_) {
+        // Cancellation is best-effort during teardown.
+      }
+    }
+    final controller = _controller;
+    _controller = null;
+    var nativeCloseFailed = false;
+    if (controller != null) {
+      controller.onFirstRendering = null;
+      controller.onConnectionState = null;
+      controller.onConversationState = null;
+      controller.onError = null;
+      controller.onFrameRateInfo = null;
+      try {
+        await controller.interrupt();
+      } catch (_) {
+        // Continue closing even if the native session is already gone.
+      }
+      try {
+        await controller.close();
+      } catch (_) {
+        nativeCloseFailed = true;
+      }
+    }
+    _avatar = null;
+    await _clearSdkTokenIfOwned();
+    _setState(
+      const AvatarRendererState(connection: AvatarRendererConnection.closed),
+    );
+    await _stateController.close();
+    if (nativeCloseFailed) {
+      throw const AvatarRendererException(AvatarRendererFailure.rendering);
+    }
+  }
+
+  Future<void> _configureSdk(AvatarSessionGrant grant) async {
+    final previousLease = _tokenLeaseTail.catchError((_) {});
+    final release = Completer<void>();
+    _tokenLeaseTail = previousLease.then((_) => release.future);
+    await previousLease;
+    if (_closed) {
+      release.complete();
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+
+    final lease = ++_nextTokenLease;
+    _activeTokenLease = lease;
+    _tokenLease = lease;
+    _tokenLeaseRelease = release;
+    try {
+      await kit.AvatarSDK.initialize(
+        appID: grant.appId,
+        configuration: kit.Configuration(
+          environment: grant.region == AvatarRegion.cnBeijing
+              ? kit.Environment.cn
+              : kit.Environment.intl,
+          audioFormat: kit.AudioFormat(
+            sampleRate: grant.audioFormat.sampleRateHz,
+          ),
+          drivingServiceMode: kit.DrivingServiceMode.sdk,
+          logLevel: kit.LogLevel.off,
+        ),
+      );
+      if (_closed || _activeTokenLease != lease) {
+        throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+      }
+      await kit.AvatarSDK.setSessionToken(grant.sessionToken);
+      if (_closed || _activeTokenLease != lease) {
+        throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+      }
+    } catch (_) {
+      await _clearSdkTokenIfOwned();
+      rethrow;
+    }
+  }
+
+  Future<void> _cleanupFailedPrepare() async {
+    final loadingAvatarId = _loadingAvatarId;
+    _loadingAvatarId = null;
+    if (loadingAvatarId != null) {
+      try {
+        await kit.AvatarManager.shared.cancelLoading(id: loadingAvatarId);
+      } catch (_) {
+        // Failed preparation still releases the session token below.
+      }
+    }
+    _avatar = null;
+    await _clearSdkTokenIfOwned();
+  }
+
+  Future<void> _clearSdkTokenIfOwned() async {
+    final lease = _tokenLease;
+    final release = _tokenLeaseRelease;
+    _tokenLease = null;
+    _tokenLeaseRelease = null;
+    if (lease == null) {
+      if (release != null && !release.isCompleted) {
+        release.complete();
+      }
+      return;
+    }
+    try {
+      if (_activeTokenLease == lease) {
+        try {
+          await kit.AvatarSDK.setSessionToken('');
+        } catch (_) {
+          // Some native versions reject an empty token after shutdown.
+        }
+        if (_activeTokenLease == lease) {
+          _activeTokenLease = 0;
+        }
+      }
+    } finally {
+      if (release != null && !release.isCompleted) {
+        release.complete();
+      }
+    }
+  }
+
+  void _fail(AvatarRendererFailure failure) {
+    if (_closed) {
+      return;
+    }
+    _setState(
+      AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: failure,
+      ),
+    );
+  }
+
+  void _setState(AvatarRendererState next) {
+    _state = next;
+    if (!_stateController.isClosed) {
+      _stateController.add(next);
+    }
+  }
+
+  static AvatarRendererFailure _mapError(kit.AvatarError error) {
+    return switch (error) {
+      kit.AvatarError.appIDUnrecognized ||
+      kit.AvatarError.avatarIDUnrecognized ||
+      kit.AvatarError.avatarAssetMissing =>
+        AvatarRendererFailure.invalidConfiguration,
+      kit.AvatarError.sessionTokenInvalid =>
+        AvatarRendererFailure.authentication,
+      kit.AvatarError.sessionTokenExpired ||
+      kit.AvatarError.sessionTimeout => AvatarRendererFailure.sessionExpired,
+      kit.AvatarError.insufficientBalance =>
+        AvatarRendererFailure.insufficientBalance,
+      kit.AvatarError.concurrentLimitExceeded =>
+        AvatarRendererFailure.sessionLimit,
+      kit.AvatarError.failedToFetchAvatarMetadata ||
+      kit.AvatarError.failedToDownloadAvatarAssets ||
+      kit.AvatarError.serverError => AvatarRendererFailure.network,
+    };
+  }
+}
+
+/// Keeps the SDK-specific controller type out of the vendor-neutral boundary.
+final class _AvatarSurfaceHost extends StatelessWidget {
+  const _AvatarSurfaceHost({
+    super.key,
+    required this.avatar,
+    required this.onController,
+  });
+
+  final kit.Avatar avatar;
+  final ValueChanged<kit.AvatarController> onController;
+
+  @override
+  Widget build(BuildContext context) {
+    return kit.AvatarWidget(
+      avatar: avatar,
+      onPlatformViewCreated: onController,
+    );
+  }
+}

--- a/mobile/lib/practice/avatar/wire_avatar_session_token_client.dart
+++ b/mobile/lib/practice/avatar/wire_avatar_session_token_client.dart
@@ -1,0 +1,495 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/bearer_authentication.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+import 'avatar_models.dart';
+import 'avatar_session_token_client.dart';
+
+final class AvatarSessionWireRequest {
+  const AvatarSessionWireRequest({
+    required this.method,
+    required this.uri,
+    required this.headers,
+    required this.maximumResponseBytes,
+  });
+
+  final String method;
+  final Uri uri;
+  final Map<String, String> headers;
+  final int maximumResponseBytes;
+}
+
+final class AvatarSessionWireResponse {
+  const AvatarSessionWireResponse({
+    required this.statusCode,
+    required this.body,
+    this.headers = const <String, String>{},
+  });
+
+  final int statusCode;
+  final Uint8List body;
+  final Map<String, String> headers;
+}
+
+abstract interface class AvatarSessionWireTransport {
+  Future<AvatarSessionWireResponse> send(AvatarSessionWireRequest request);
+
+  void close({bool force = false});
+}
+
+typedef AvatarSessionWireTransportFactory =
+    AvatarSessionWireTransport Function();
+typedef AvatarSessionClock = DateTime Function();
+
+final class WireAvatarSessionTokenClient implements AvatarSessionTokenClient {
+  factory WireAvatarSessionTokenClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    AvatarSessionWireTransport? transport,
+    AvatarSessionWireTransportFactory? transportFactory,
+    AvatarSessionClock? clock,
+    Duration timeout = const Duration(seconds: 30),
+  }) {
+    if (timeout <= Duration.zero ||
+        (transport != null && transportFactory != null)) {
+      throw ArgumentError('Avatar session transport configuration is invalid.');
+    }
+    final createTransport =
+        transportFactory ??
+        () => IoAvatarSessionWireTransport(timeout: timeout);
+    return WireAvatarSessionTokenClient._(
+      baseUri,
+      TrustedIdentityHttpOrigin(baseUri),
+      credentialProvider,
+      invalidateSession,
+      transport ?? createTransport(),
+      transport == null,
+      createTransport,
+      clock ?? _utcNow,
+      timeout,
+    );
+  }
+
+  WireAvatarSessionTokenClient._(
+    this._baseUri,
+    this._trustedOrigin,
+    this._credentialProvider,
+    this._invalidateSession,
+    this._transport,
+    this._ownsTransport,
+    this._transportFactory,
+    this._clock,
+    this._timeout,
+  );
+
+  static const _maximumJsonBytes = 32 * 1024;
+  static const _maximumGrantLifetime = Duration(minutes: 10);
+  static const _clockSkew = Duration(seconds: 30);
+  static final _resourceIdPattern = RegExp(
+    r'^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$',
+  );
+  static final _rfc3339UtcPattern = RegExp(
+    r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+    r'(?:\.\d+)?[Zz]$',
+  );
+
+  final Uri _baseUri;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  final AuthSessionCredentialProvider _credentialProvider;
+  final AuthSessionInvalidator _invalidateSession;
+  AvatarSessionWireTransport _transport;
+  final bool _ownsTransport;
+  final AvatarSessionWireTransportFactory _transportFactory;
+  final AvatarSessionClock _clock;
+  final Duration _timeout;
+
+  int _accountGeneration = 0;
+  bool _disposed = false;
+  Future<void>? _cleanupFuture;
+  final Set<Future<void>> _inFlight = <Future<void>>{};
+
+  @override
+  Future<AvatarSessionGrant> createSession({
+    required String practiceSessionId,
+  }) {
+    if (!_resourceIdPattern.hasMatch(practiceSessionId)) {
+      return Future<AvatarSessionGrant>.error(
+        const AvatarSessionTokenException(
+          failure: AvatarSessionTokenFailure.invalidResponse,
+        ),
+      );
+    }
+    return _run((generation) async {
+      final credential = _requireCredential();
+      final path =
+          '/v1/practice-sessions/'
+          '${Uri.encodeComponent(practiceSessionId)}/avatar-session-token';
+      final uri = _baseUri.resolve(path);
+      _trustedOrigin.validateResourceUri(uri);
+      validateNoSessionCredentialInUri(
+        uri,
+        sessionToken: credential.sessionToken,
+      );
+
+      late final AvatarSessionWireResponse response;
+      try {
+        response = await _transport
+            .send(
+              AvatarSessionWireRequest(
+                method: 'POST',
+                uri: uri,
+                headers: <String, String>{
+                  HttpHeaders.acceptHeader: ContentType.json.mimeType,
+                  HttpHeaders.authorizationHeader: bearerAuthorizationValue(
+                    credential.sessionToken,
+                  ),
+                  HttpHeaders.cacheControlHeader: 'no-store',
+                },
+                maximumResponseBytes: _maximumJsonBytes,
+              ),
+            )
+            .timeout(_timeout);
+      } on AvatarSessionTokenException {
+        rethrow;
+      } on TimeoutException {
+        throw const AvatarSessionTokenException(
+          failure: AvatarSessionTokenFailure.network,
+          retryable: true,
+        );
+      } on IOException {
+        throw const AvatarSessionTokenException(
+          failure: AvatarSessionTokenFailure.network,
+          retryable: true,
+        );
+      } catch (_) {
+        throw const AvatarSessionTokenException(
+          failure: AvatarSessionTokenFailure.network,
+          retryable: true,
+        );
+      }
+
+      try {
+        _requireGeneration(generation);
+        if (!isSameAuthSessionCredential(_credentialProvider(), credential)) {
+          throw const AvatarSessionTokenException(
+            failure: AvatarSessionTokenFailure.cancelled,
+          );
+        }
+        if (response.statusCode == HttpStatus.unauthorized) {
+          await _invalidateSession(
+            expectedSessionToken: credential.sessionToken,
+            expectedGeneration: credential.generation,
+          );
+        }
+        _requireStatus(response);
+        final contentType = _header(
+          response.headers,
+          HttpHeaders.contentTypeHeader,
+        );
+        if (_header(response.headers, HttpHeaders.cacheControlHeader) !=
+                'no-store' ||
+            contentType == null ||
+            contentType.split(';').first.trim().toLowerCase() !=
+                ContentType.json.mimeType) {
+          throw const AvatarSessionTokenException(
+            failure: AvatarSessionTokenFailure.invalidResponse,
+          );
+        }
+        return _decodeGrant(response.body);
+      } finally {
+        _zero(response.body);
+      }
+    });
+  }
+
+  @override
+  Future<void> clearAccountState() {
+    final existing = _cleanupFuture;
+    if (existing != null) {
+      return existing;
+    }
+    final cleanup = _performCleanup();
+    _cleanupFuture = cleanup;
+    return cleanup.whenComplete(() {
+      if (identical(_cleanupFuture, cleanup)) {
+        _cleanupFuture = null;
+      }
+    });
+  }
+
+  Future<void> _performCleanup() async {
+    if (_disposed) {
+      return;
+    }
+    final cleanupGeneration = ++_accountGeneration;
+    if (_ownsTransport) {
+      _transport.close(force: true);
+    }
+    await Future.wait(List<Future<void>>.of(_inFlight));
+    if (_disposed || cleanupGeneration != _accountGeneration) {
+      return;
+    }
+    if (_ownsTransport) {
+      _transport = _transportFactory();
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _accountGeneration++;
+    if (_ownsTransport) {
+      _transport.close(force: true);
+    }
+    await Future.wait(List<Future<void>>.of(_inFlight));
+  }
+
+  Future<T> _run<T>(Future<T> Function(int generation) operation) async {
+    final cleanup = _cleanupFuture;
+    if (cleanup != null) {
+      await cleanup;
+    }
+    if (_disposed) {
+      throw const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.cancelled,
+      );
+    }
+    final generation = _accountGeneration;
+    final completion = Completer<void>();
+    final marker = completion.future;
+    _inFlight.add(marker);
+    try {
+      return await operation(generation);
+    } finally {
+      _inFlight.remove(marker);
+      completion.complete();
+    }
+  }
+
+  AuthSessionCredential _requireCredential() {
+    final credential = _credentialProvider();
+    if (credential == null) {
+      throw const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.authenticationRequired,
+        statusCode: HttpStatus.unauthorized,
+      );
+    }
+    return credential;
+  }
+
+  void _requireGeneration(int generation) {
+    if (_disposed || generation != _accountGeneration) {
+      throw const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.cancelled,
+      );
+    }
+  }
+
+  AvatarSessionGrant _decodeGrant(Uint8List bytes) {
+    try {
+      final decoded = jsonDecode(utf8.decode(bytes));
+      if (decoded is! Map<String, Object?> ||
+          !_hasExactKeys(decoded, const {
+            'app_id',
+            'avatar_id',
+            'session_token',
+            'region',
+            'expires_at',
+            'audio_format',
+          })) {
+        throw const FormatException();
+      }
+      final appId = _strictResourceId(decoded['app_id']);
+      final avatarId = _strictResourceId(decoded['avatar_id']);
+      final sessionToken = _strictSecret(decoded['session_token']);
+      final rawRegion = decoded['region'];
+      final rawExpiresAt = decoded['expires_at'];
+      final rawAudioFormat = decoded['audio_format'];
+      if (rawRegion is! String ||
+          rawExpiresAt is! String ||
+          rawAudioFormat is! Map<String, Object?> ||
+          !_hasExactKeys(rawAudioFormat, const {
+            'encoding',
+            'sample_rate_hz',
+            'channels',
+          })) {
+        throw const FormatException();
+      }
+      final region = AvatarRegion.fromWireName(rawRegion);
+      if (region == null ||
+          !_rfc3339UtcPattern.hasMatch(rawExpiresAt) ||
+          rawAudioFormat['encoding'] !=
+              AvatarAudioFormat.pcmS16le24kMono.encoding ||
+          rawAudioFormat['sample_rate_hz'] !=
+              AvatarAudioFormat.pcmS16le24kMono.sampleRateHz ||
+          rawAudioFormat['channels'] !=
+              AvatarAudioFormat.pcmS16le24kMono.channels) {
+        throw const FormatException();
+      }
+      final expiresAt = DateTime.parse(rawExpiresAt);
+      if (!expiresAt.isUtc) {
+        throw const FormatException();
+      }
+      final remaining = expiresAt.difference(_clock().toUtc());
+      if (remaining <= Duration.zero ||
+          remaining > _maximumGrantLifetime + _clockSkew) {
+        throw const FormatException();
+      }
+      return AvatarSessionGrant(
+        appId: appId,
+        avatarId: avatarId,
+        sessionToken: sessionToken,
+        region: region,
+        expiresAt: expiresAt,
+        audioFormat: AvatarAudioFormat.pcmS16le24kMono,
+      );
+    } catch (error) {
+      if (error is AvatarSessionTokenException) {
+        rethrow;
+      }
+      throw const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.invalidResponse,
+      );
+    }
+  }
+
+  void _requireStatus(AvatarSessionWireResponse response) {
+    if (response.statusCode == HttpStatus.ok) {
+      return;
+    }
+    final failure =
+        response.statusCode >= HttpStatus.internalServerError &&
+            response.statusCode <= 599
+        ? AvatarSessionTokenFailure.unavailable
+        : switch (response.statusCode) {
+            HttpStatus.unauthorized =>
+              AvatarSessionTokenFailure.authenticationRequired,
+            HttpStatus.forbidden => AvatarSessionTokenFailure.forbidden,
+            HttpStatus.notFound => AvatarSessionTokenFailure.notFound,
+            HttpStatus.conflict => AvatarSessionTokenFailure.conflict,
+            HttpStatus.tooManyRequests => AvatarSessionTokenFailure.unavailable,
+            _ => AvatarSessionTokenFailure.invalidResponse,
+          };
+    throw AvatarSessionTokenException(
+      failure: failure,
+      statusCode: response.statusCode,
+      retryable:
+          failure == AvatarSessionTokenFailure.unavailable ||
+          response.statusCode >= 500,
+    );
+  }
+
+  static bool _hasExactKeys(Map<String, Object?> object, Set<String> expected) {
+    return object.length == expected.length &&
+        expected.every(object.containsKey);
+  }
+
+  static String _strictResourceId(Object? value) {
+    if (value is! String || !_resourceIdPattern.hasMatch(value)) {
+      throw const FormatException();
+    }
+    return value;
+  }
+
+  static String _strictSecret(Object? value) {
+    if (value is! String ||
+        value.isEmpty ||
+        value.length > 8192 ||
+        value.trim() != value ||
+        value.codeUnits.any((unit) => unit <= 0x20 || unit > 0x7e)) {
+      throw const FormatException();
+    }
+    return value;
+  }
+}
+
+final class IoAvatarSessionWireTransport implements AvatarSessionWireTransport {
+  IoAvatarSessionWireTransport({required Duration timeout})
+    : _timeout = timeout,
+      _client = HttpClient()..connectionTimeout = timeout;
+
+  final Duration _timeout;
+  final HttpClient _client;
+
+  @override
+  Future<AvatarSessionWireResponse> send(
+    AvatarSessionWireRequest request,
+  ) async {
+    HttpClientRequest? nativeRequest;
+    try {
+      nativeRequest = await _client
+          .openUrl(request.method, request.uri)
+          .timeout(_timeout);
+      nativeRequest.followRedirects = false;
+      request.headers.forEach(nativeRequest.headers.set);
+      nativeRequest.contentLength = 0;
+      final response = await nativeRequest.close().timeout(
+        _timeout,
+        onTimeout: () {
+          nativeRequest?.abort();
+          throw TimeoutException('Avatar session response timed out.');
+        },
+      );
+      if (response.contentLength > request.maximumResponseBytes) {
+        nativeRequest.abort();
+        throw const AvatarSessionTokenException(
+          failure: AvatarSessionTokenFailure.invalidResponse,
+        );
+      }
+      final builder = BytesBuilder(copy: false);
+      var length = 0;
+      await for (final chunk in response.timeout(_timeout)) {
+        length += chunk.length;
+        if (length > request.maximumResponseBytes) {
+          nativeRequest.abort();
+          throw const AvatarSessionTokenException(
+            failure: AvatarSessionTokenFailure.invalidResponse,
+          );
+        }
+        builder.add(chunk);
+      }
+      final headers = <String, String>{};
+      response.headers.forEach((name, values) {
+        headers[name.toLowerCase()] = values.join(',');
+      });
+      return AvatarSessionWireResponse(
+        statusCode: response.statusCode,
+        body: builder.takeBytes(),
+        headers: headers,
+      );
+    } on TimeoutException {
+      nativeRequest?.abort();
+      rethrow;
+    }
+  }
+
+  @override
+  void close({bool force = false}) {
+    _client.close(force: force);
+  }
+}
+
+String? _header(Map<String, String> headers, String name) {
+  final lowerName = name.toLowerCase();
+  for (final entry in headers.entries) {
+    if (entry.key.toLowerCase() == lowerName) {
+      return entry.value.trim().toLowerCase();
+    }
+  }
+  return null;
+}
+
+void _zero(Uint8List bytes) {
+  bytes.fillRange(0, bytes.length, 0);
+}
+
+DateTime _utcNow() => DateTime.now().toUtc();

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.4.1"
+  avatar_kit:
+    dependency: "direct main"
+    description:
+      name: avatar_kit
+      sha256: "4cdc65eec4defca29401c1d522b9a925413c3c475018d1243651426511a658ae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.44"
   boolean_selector:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.12.2
 
 dependencies:
+  avatar_kit: 1.0.0-beta.44
   audioplayers: ^6.8.1
   flutter:
     sdk: flutter

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -200,6 +200,72 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('long press starts Agent recording and release uploads it', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      clientIdFactory: _sequentialIdFactory(),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
+    await tester.pumpAndSettle();
+    final voiceController = controller.voiceController!;
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('agent-mic-placeholder'))),
+    );
+    await tester.pump(const Duration(milliseconds: 179));
+    expect(voiceController.state, AgentVoiceComposerState.idle);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(voiceController.state, AgentVoiceComposerState.recording);
+
+    await gesture.up();
+    await _pumpVoiceOperation(tester);
+
+    expect(voiceController.state, AgentVoiceComposerState.awaitingConfirmation);
+    expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
+  });
+
+  testWidgets('upward release cancels Agent recording', (tester) async {
+    final voiceController = AgentVoiceController(
+      client: FakeAgentClient(),
+      recorder: FakeAgentVoiceRecorder(),
+      audioPlayer: FakeAgentVoiceAudioPlayer(),
+      onMessagesCommitted: (_) {},
+      onMessageAudioDeleted: (_, _) {},
+      idFactory: (scope) => '${scope}_1',
+    );
+    addTearDown(voiceController.dispose);
+    await voiceController.bindThread('thread-a');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ConversationPage(
+          onStartVoice: voiceController.startRecording,
+          voiceController: voiceController,
+          onSubmitText: (_) async => true,
+        ),
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('agent-mic-placeholder'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    expect(voiceController.state, AgentVoiceComposerState.recording);
+
+    await gesture.moveBy(const Offset(0, -80));
+    await tester.pump();
+    await gesture.up();
+    await _pumpVoiceOperation(tester);
+
+    expect(voiceController.state, AgentVoiceComposerState.idle);
+    expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
+  });
+
   testWidgets('composer drafts cannot cross the Thread boundary', (
     tester,
   ) async {

--- a/mobile/test/design/voice_capture_control_test.dart
+++ b/mobile/test/design/voice_capture_control_test.dart
@@ -1,0 +1,231 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/voice_capture_control.dart';
+
+void main() {
+  testWidgets('quick tap starts and second tap finishes once', (tester) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 0);
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 1);
+  });
+
+  testWidgets('long press starts and release finishes once', (tester) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 0);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 1);
+  });
+
+  testWidgets('swipe up and release cancels the capture', (tester) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.moveBy(const Offset(0, -80));
+    await tester.pump();
+
+    expect(find.text('cancel armed'), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 0);
+    expect(harness.currentState?.cancels, 1);
+  });
+
+  testWidgets('pointer cancel does not start after a quick press', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.cancel();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(harness.currentState?.starts, 0);
+    expect(harness.currentState?.finishes, 0);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('release waits for an asynchronous microphone start', (
+    tester,
+  ) async {
+    final startCompleter = Completer<void>();
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, startCompleter: startCompleter),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+    expect(harness.currentState?.finishes, 0);
+
+    startCompleter.complete();
+    await tester.pump();
+
+    expect(harness.currentState?.finishes, 1);
+  });
+
+  testWidgets('cancel during preparation never starts the microphone', (
+    tester,
+  ) async {
+    final beforeStartCompleter = Completer<void>();
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(
+        key: harness,
+        beforeStartCompleter: beforeStartCompleter,
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.moveBy(const Offset(0, -80));
+    await gesture.up();
+    await tester.pump();
+
+    beforeStartCompleter.complete();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 0);
+    expect(harness.currentState?.finishes, 0);
+    expect(harness.currentState?.cancels, 1);
+  });
+
+  testWidgets('tap-to-toggle mode does not start during a hold', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, mode: VoiceCaptureMode.tapToToggle),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(harness.currentState?.starts, 0);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 1);
+  });
+}
+
+class _VoiceCaptureHarness extends StatefulWidget {
+  const _VoiceCaptureHarness({
+    required super.key,
+    this.startCompleter,
+    this.beforeStartCompleter,
+    this.mode = VoiceCaptureMode.pressAndHold,
+  });
+
+  final Completer<void>? startCompleter;
+  final Completer<void>? beforeStartCompleter;
+  final VoiceCaptureMode mode;
+
+  @override
+  State<_VoiceCaptureHarness> createState() => _VoiceCaptureHarnessState();
+}
+
+class _VoiceCaptureHarnessState extends State<_VoiceCaptureHarness> {
+  VoiceCapturePhase phase = VoiceCapturePhase.idle;
+  int starts = 0;
+  int finishes = 0;
+  int cancels = 0;
+
+  Future<void> _start() async {
+    starts++;
+    setState(() => phase = VoiceCapturePhase.starting);
+    await widget.startCompleter?.future;
+    if (mounted) {
+      setState(() => phase = VoiceCapturePhase.recording);
+    }
+  }
+
+  void _finish() {
+    finishes++;
+    setState(() => phase = VoiceCapturePhase.busy);
+  }
+
+  void _cancel() {
+    cancels++;
+    setState(() => phase = VoiceCapturePhase.idle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: VoiceCaptureControl(
+            phase: phase,
+            mode: widget.mode,
+            onBeforeStart: () async {
+              await widget.beforeStartCompleter?.future;
+            },
+            onStart: _start,
+            onFinish: _finish,
+            onCancel: _cancel,
+            builder: (context, view) => view.wrapTarget(
+              key: const Key('voice-capture-target'),
+              semanticsLabel: phase == VoiceCapturePhase.idle ? '开始录音' : '结束录音',
+              child: SizedBox(
+                width: 180,
+                height: 64,
+                child: Center(
+                  child: Text(
+                    view.cancelArmed ? 'cancel armed' : 'voice capture',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/practice/avatar/avatar_audio_test.dart
+++ b/mobile/test/practice/avatar/avatar_audio_test.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+
+import 'avatar_test_fakes.dart';
+
+void main() {
+  group('parseAvatarPcmWave', () {
+    test('extracts strict 24 kHz mono PCM across padded unknown chunks', () {
+      final pcm = Uint8List.fromList(List<int>.generate(32, (index) => index));
+      final wav = buildPcmWave(
+        pcm: pcm,
+        beforeFormat: [
+          (id: 'JUNK', bytes: Uint8List.fromList([1, 2, 3])),
+        ],
+        betweenFormatAndData: [
+          (id: 'LIST', bytes: Uint8List.fromList([4, 5, 6, 7])),
+        ],
+      );
+
+      final parsed = parseAvatarPcmWave(wav);
+
+      expect(parsed.bytes, pcm);
+      expect(parsed.format, same(AvatarAudioFormat.pcmS16le24kMono));
+    });
+
+    test('rejects stereo, wrong rate, compressed, and inconsistent fmt', () {
+      for (final wav in [
+        buildPcmWave(channels: 2),
+        buildPcmWave(sampleRate: 16000),
+        buildPcmWave(audioEncoding: 3),
+        buildPcmWave(byteRate: 1234),
+        buildPcmWave(blockAlign: 4),
+      ]) {
+        expect(
+          () => parseAvatarPcmWave(wav),
+          throwsA(isA<AvatarAudioException>()),
+        );
+      }
+    });
+
+    test('rejects truncated, trailing, duplicate, and odd PCM payloads', () {
+      final valid = buildPcmWave(pcm: Uint8List(32));
+      final truncated = Uint8List.fromList(valid.sublist(0, valid.length - 1));
+      final trailing = Uint8List.fromList([...valid, 0]);
+      final duplicateData = buildPcmWave(
+        pcm: Uint8List(32),
+        afterData: [(id: 'data', bytes: Uint8List(2))],
+      );
+      final oddPcm = buildPcmWave(pcm: Uint8List(3));
+
+      for (final wav in [truncated, trailing, duplicateData, oddPcm]) {
+        expect(
+          () => parseAvatarPcmWave(wav),
+          throwsA(isA<AvatarAudioException>()),
+        );
+      }
+    });
+  });
+
+  test('chunks on PCM16 frame boundaries without dropping bytes', () {
+    final pcm = Uint8List.fromList(
+      List<int>.generate(100000, (index) => index % 256),
+    );
+    final chunks = chunkAvatarPcm(
+      AvatarPcmAudio(bytes: pcm, format: AvatarAudioFormat.pcmS16le24kMono),
+    ).toList();
+
+    expect(chunks.map((chunk) => chunk.length), [48000, 48000, 4000]);
+    expect(chunks.expand((chunk) => chunk), pcm);
+    expect(chunks.every((chunk) => chunk.length.isEven), isTrue);
+  });
+}

--- a/mobile/test/practice/avatar/avatar_controller_test.dart
+++ b/mobile/test/practice/avatar/avatar_controller_test.dart
@@ -1,0 +1,298 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+
+import 'avatar_test_fakes.dart';
+
+void main() {
+  test(
+    'connect keeps the session capability inside the renderer boundary',
+    () async {
+      final renderer = FakeAvatarRenderer();
+      final tokenClient = FakeAvatarSessionTokenClient();
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: tokenClient,
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      addTearDown(controller.close);
+
+      expect(await controller.connect(practiceSessionId: 'practice-1'), isTrue);
+
+      expect(tokenClient.requestedSessionIds, ['practice-1']);
+      expect(renderer.preparedGrant, same(testAvatarGrant));
+      expect(controller.state.phase, AvatarControllerPhase.ready);
+      expect(controller.state.canUseAvatar, isTrue);
+      expect(controller.buildSurface(), isNotNull);
+    },
+  );
+
+  test('avatar owns WAV playback and marks end exactly once', () async {
+    final renderer = FakeAvatarRenderer();
+    var fallbackCount = 0;
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async => fallbackCount++,
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    addTearDown(controller.close);
+    await controller.connect(practiceSessionId: 'practice-1');
+    final wav = buildPcmWave(pcm: Uint8List(100000));
+
+    final result = await controller.speakWav(wav);
+
+    expect(result, AvatarSpeechResult.avatar);
+    expect(fallbackCount, 0);
+    expect(renderer.sends.map((send) => send.bytes.length), [
+      48000,
+      48000,
+      4000,
+    ]);
+    expect(renderer.sends.map((send) => send.end), [false, false, true]);
+    expect(renderer.sends.where((send) => send.end), hasLength(1));
+  });
+
+  test('invalid WAV exclusively falls back without sending PCM', () async {
+    final renderer = FakeAvatarRenderer();
+    final fallbackWaves = <Uint8List>[];
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (bytes) async => fallbackWaves.add(bytes),
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    addTearDown(controller.close);
+    await controller.connect(practiceSessionId: 'practice-1');
+    final invalid = buildPcmWave(sampleRate: 16000);
+
+    final result = await controller.speakWav(invalid);
+
+    expect(result, AvatarSpeechResult.fallback);
+    expect(renderer.sends, isEmpty);
+    expect(fallbackWaves, [invalid]);
+  });
+
+  test('native send failure interrupts and falls back once', () async {
+    final renderer = FakeAvatarRenderer()..failSendAt = 1;
+    var fallbackCount = 0;
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async => fallbackCount++,
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    addTearDown(controller.close);
+    await controller.connect(practiceSessionId: 'practice-1');
+
+    final result = await controller.speakWav(
+      buildPcmWave(pcm: Uint8List(100000)),
+    );
+
+    expect(result, AvatarSpeechResult.fallback);
+    expect(renderer.sends, hasLength(2));
+    expect(renderer.sends.where((send) => send.end), isEmpty);
+    expect(renderer.interruptCount, greaterThanOrEqualTo(2));
+    expect(fallbackCount, 1);
+  });
+
+  test(
+    'interrupt fences an in-flight send and prevents late fallback',
+    () async {
+      final renderer = FakeAvatarRenderer()..holdSends = true;
+      var fallbackCount = 0;
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async => fallbackCount++,
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      addTearDown(controller.close);
+      await controller.connect(practiceSessionId: 'practice-1');
+
+      final speech = controller.speakWav(buildPcmWave(pcm: Uint8List(96000)));
+      await _until(() => renderer.pendingSends.isNotEmpty);
+      await controller.interrupt();
+      renderer.pendingSends.single.complete();
+
+      expect(await speech, AvatarSpeechResult.interrupted);
+      expect(renderer.sends, hasLength(1));
+      expect(renderer.sends.single.end, isFalse);
+      expect(fallbackCount, 0);
+    },
+  );
+
+  test('a fresh utterance waits for one coalesced interrupt', () async {
+    final gate = Completer<void>();
+    final renderer = FakeAvatarRenderer()..interruptGate = gate;
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async {},
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    addTearDown(controller.close);
+    await controller.connect(practiceSessionId: 'practice-1');
+
+    final firstInterrupt = controller.interrupt();
+    await _until(() => renderer.interruptCount == 1);
+    final speech = controller.speakWav(buildPcmWave(pcm: Uint8List(48000)));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(renderer.interruptCount, 1);
+    expect(renderer.sends, isEmpty);
+
+    gate.complete();
+    await firstInterrupt;
+
+    expect(await speech, AvatarSpeechResult.avatar);
+    expect(renderer.interruptCount, 1);
+    expect(renderer.actions.last, 'send');
+  });
+
+  test('partial native send is stopped before local fallback starts', () async {
+    final renderer = FakeAvatarRenderer()
+      ..failSendAt = 1
+      ..interruptError = StateError('native interrupt failed');
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async => renderer.actions.add('fallback'),
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    addTearDown(controller.close);
+    await controller.connect(practiceSessionId: 'practice-1');
+
+    final result = await controller.speakWav(
+      buildPcmWave(pcm: Uint8List(100000)),
+    );
+
+    expect(result, AvatarSpeechResult.fallback);
+    expect(renderer.actions, containsAllInOrder(['send', 'close', 'fallback']));
+    expect(
+      renderer.actions.lastIndexOf('close'),
+      lessThan(renderer.actions.indexOf('fallback')),
+    );
+  });
+
+  test(
+    'never starts local fallback when native playback cannot be stopped',
+    () async {
+      final renderer = FakeAvatarRenderer()
+        ..failSendAt = 0
+        ..interruptError = StateError('native interrupt failed')
+        ..closeError = StateError('native close failed');
+      var fallbackCount = 0;
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async => fallbackCount++,
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      await controller.connect(practiceSessionId: 'practice-1');
+
+      final result = await controller.speakWav(
+        buildPcmWave(pcm: Uint8List(48000)),
+      );
+
+      expect(result, AvatarSpeechResult.interrupted);
+      expect(fallbackCount, 0);
+      renderer
+        ..interruptError = null
+        ..closeError = null;
+      await controller.close();
+    },
+  );
+
+  test('close and account cleanup are idempotent', () async {
+    final renderer = FakeAvatarRenderer();
+    final tokenClient = FakeAvatarSessionTokenClient();
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: tokenClient,
+      fallbackPlayback: (_) async {},
+      fallbackStop: () async {},
+    );
+
+    await Future.wait([controller.clearAccountState(), controller.close()]);
+    await controller.close();
+
+    expect(renderer.closeCount, 1);
+    expect(tokenClient.clearCount, 1);
+    expect(controller.state.phase, AvatarControllerPhase.closed);
+  });
+
+  test(
+    'account cleanup still clears token state when native close fails',
+    () async {
+      final renderer = FakeAvatarRenderer()
+        ..closeError = StateError('native close failed');
+      final tokenClient = FakeAvatarSessionTokenClient();
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: tokenClient,
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+      );
+      await controller.connect(practiceSessionId: 'practice-1');
+
+      await expectLater(controller.clearAccountState(), throwsStateError);
+
+      expect(tokenClient.clearCount, 1);
+      expect(controller.state.phase, AvatarControllerPhase.closed);
+    },
+  );
+
+  test('interrupt and close stop fallback playback', () async {
+    final renderer = FakeAvatarRenderer();
+    final fallbackStarted = Completer<void>();
+    final fallbackFinished = Completer<void>();
+    var stopCount = 0;
+    final controller = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async {
+        fallbackStarted.complete();
+        await fallbackFinished.future;
+      },
+      fallbackStop: () async {
+        stopCount++;
+        if (!fallbackFinished.isCompleted) {
+          fallbackFinished.complete();
+        }
+      },
+    );
+    await controller.connect(practiceSessionId: 'practice-1');
+    final speech = controller.speakWav(buildPcmWave(sampleRate: 16000));
+    await fallbackStarted.future;
+
+    await controller.interrupt();
+
+    expect(await speech, AvatarSpeechResult.interrupted);
+    expect(stopCount, greaterThanOrEqualTo(2));
+
+    await controller.close();
+    expect(stopCount, greaterThanOrEqualTo(3));
+  });
+}
+
+Future<void> _until(bool Function() condition) async {
+  for (var attempts = 0; attempts < 50; attempts += 1) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Condition was not reached.');
+}

--- a/mobile/test/practice/avatar/avatar_test_fakes.dart
+++ b/mobile/test/practice/avatar/avatar_test_fakes.dart
@@ -5,10 +5,15 @@ import 'package:flutter/widgets.dart';
 import 'package:speakup/practice/avatar/avatar.dart';
 
 final class FakeAvatarRenderer implements AvatarRenderer {
-  FakeAvatarRenderer({this.connectOnPrepare = true, this.prepareFailure});
+  FakeAvatarRenderer({
+    this.connectOnPrepare = true,
+    this.prepareFailure,
+    this.prepareGate,
+  });
 
   final bool connectOnPrepare;
   final AvatarRendererFailure? prepareFailure;
+  final Completer<void>? prepareGate;
   final StreamController<AvatarRendererState> _states =
       StreamController<AvatarRendererState>.broadcast(sync: true);
 
@@ -36,6 +41,10 @@ final class FakeAvatarRenderer implements AvatarRenderer {
   @override
   Future<void> prepare(AvatarSessionGrant grant) async {
     preparedGrant = grant;
+    final gate = prepareGate;
+    if (gate != null) {
+      await gate.future;
+    }
     final failure = prepareFailure;
     if (failure != null) {
       emit(
@@ -154,7 +163,7 @@ final testAvatarGrant = AvatarSessionGrant(
   appId: 'app-1',
   avatarId: 'avatar-1',
   sessionToken: 'private-avatar-token',
-  region: AvatarRegion.cnBeijing,
+  region: AvatarRegion.apNortheast,
   expiresAt: DateTime.utc(2030),
   audioFormat: AvatarAudioFormat.pcmS16le24kMono,
 );

--- a/mobile/test/practice/avatar/avatar_test_fakes.dart
+++ b/mobile/test/practice/avatar/avatar_test_fakes.dart
@@ -1,0 +1,212 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+
+final class FakeAvatarRenderer implements AvatarRenderer {
+  FakeAvatarRenderer({this.connectOnPrepare = true, this.prepareFailure});
+
+  final bool connectOnPrepare;
+  final AvatarRendererFailure? prepareFailure;
+  final StreamController<AvatarRendererState> _states =
+      StreamController<AvatarRendererState>.broadcast(sync: true);
+
+  AvatarRendererState _state = const AvatarRendererState();
+  AvatarSessionGrant? preparedGrant;
+  final List<({Uint8List bytes, bool end})> sends = [];
+  final List<Completer<void>> pendingSends = [];
+  final List<String> actions = [];
+  int interruptCount = 0;
+  int pauseCount = 0;
+  int resumeCount = 0;
+  int closeCount = 0;
+  int? failSendAt;
+  bool holdSends = false;
+  Completer<void>? interruptGate;
+  Object? interruptError;
+  Object? closeError;
+
+  @override
+  AvatarRendererState get state => _state;
+
+  @override
+  Stream<AvatarRendererState> get states => _states.stream;
+
+  @override
+  Future<void> prepare(AvatarSessionGrant grant) async {
+    preparedGrant = grant;
+    final failure = prepareFailure;
+    if (failure != null) {
+      emit(
+        AvatarRendererState(
+          connection: AvatarRendererConnection.failed,
+          failure: failure,
+        ),
+      );
+      throw AvatarRendererException(failure);
+    }
+    emit(
+      AvatarRendererState(
+        connection: connectOnPrepare
+            ? AvatarRendererConnection.connected
+            : AvatarRendererConnection.surfaceReady,
+      ),
+    );
+  }
+
+  @override
+  Widget buildSurface({Key? key}) => SizedBox(key: key);
+
+  @override
+  Future<void> sendPcm(Uint8List pcmBytes, {required bool end}) async {
+    actions.add('send');
+    sends.add((bytes: Uint8List.fromList(pcmBytes), end: end));
+    if (failSendAt == sends.length - 1) {
+      throw const AvatarRendererException(AvatarRendererFailure.network);
+    }
+    if (holdSends) {
+      final completer = Completer<void>();
+      pendingSends.add(completer);
+      await completer.future;
+    }
+  }
+
+  @override
+  Future<void> interrupt() async {
+    interruptCount++;
+    actions.add('interrupt');
+    final gate = interruptGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    final error = interruptError;
+    if (error != null) {
+      throw error;
+    }
+  }
+
+  @override
+  Future<void> pauseRendering() async {
+    pauseCount++;
+  }
+
+  @override
+  Future<void> resumeRendering() async {
+    resumeCount++;
+  }
+
+  @override
+  Future<void> close() async {
+    closeCount++;
+    actions.add('close');
+    final error = closeError;
+    if (error != null) {
+      throw error;
+    }
+    emit(
+      const AvatarRendererState(connection: AvatarRendererConnection.closed),
+    );
+    await _states.close();
+  }
+
+  void emit(AvatarRendererState state) {
+    _state = state;
+    if (!_states.isClosed) {
+      _states.add(state);
+    }
+  }
+}
+
+final class FakeAvatarSessionTokenClient implements AvatarSessionTokenClient {
+  FakeAvatarSessionTokenClient({AvatarSessionGrant? grant, this.error})
+    : grant = grant ?? testAvatarGrant;
+
+  final AvatarSessionGrant grant;
+  final Object? error;
+  final List<String> requestedSessionIds = [];
+  int clearCount = 0;
+  int disposeCount = 0;
+
+  @override
+  Future<AvatarSessionGrant> createSession({
+    required String practiceSessionId,
+  }) async {
+    requestedSessionIds.add(practiceSessionId);
+    if (error case final error?) {
+      throw error;
+    }
+    return grant;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    clearCount++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCount++;
+  }
+}
+
+final testAvatarGrant = AvatarSessionGrant(
+  appId: 'app-1',
+  avatarId: 'avatar-1',
+  sessionToken: 'private-avatar-token',
+  region: AvatarRegion.cnBeijing,
+  expiresAt: DateTime.utc(2030),
+  audioFormat: AvatarAudioFormat.pcmS16le24kMono,
+);
+
+Uint8List buildPcmWave({
+  int channels = 1,
+  int sampleRate = 24000,
+  int bitsPerSample = 16,
+  int? byteRate,
+  int? blockAlign,
+  int audioEncoding = 1,
+  Uint8List? pcm,
+  List<({String id, Uint8List bytes})> beforeFormat = const [],
+  List<({String id, Uint8List bytes})> betweenFormatAndData = const [],
+  List<({String id, Uint8List bytes})> afterData = const [],
+}) {
+  final resolvedPcm = pcm ?? Uint8List(96000);
+  final resolvedBlockAlign = blockAlign ?? channels * (bitsPerSample ~/ 8);
+  final resolvedByteRate = byteRate ?? sampleRate * resolvedBlockAlign;
+  final fmt = ByteData(16)
+    ..setUint16(0, audioEncoding, Endian.little)
+    ..setUint16(2, channels, Endian.little)
+    ..setUint32(4, sampleRate, Endian.little)
+    ..setUint32(8, resolvedByteRate, Endian.little)
+    ..setUint16(12, resolvedBlockAlign, Endian.little)
+    ..setUint16(14, bitsPerSample, Endian.little);
+  final chunks = <({String id, Uint8List bytes})>[
+    ...beforeFormat,
+    (id: 'fmt ', bytes: fmt.buffer.asUint8List()),
+    ...betweenFormatAndData,
+    (id: 'data', bytes: resolvedPcm),
+    ...afterData,
+  ];
+  final payloadLength = chunks.fold<int>(
+    4,
+    (total, chunk) => total + 8 + chunk.bytes.length + chunk.bytes.length % 2,
+  );
+  final result = Uint8List(8 + payloadLength);
+  final view = ByteData.sublistView(result);
+  _writeAscii(result, 0, 'RIFF');
+  view.setUint32(4, payloadLength, Endian.little);
+  _writeAscii(result, 8, 'WAVE');
+  var offset = 12;
+  for (final chunk in chunks) {
+    _writeAscii(result, offset, chunk.id);
+    view.setUint32(offset + 4, chunk.bytes.length, Endian.little);
+    result.setRange(offset + 8, offset + 8 + chunk.bytes.length, chunk.bytes);
+    offset += 8 + chunk.bytes.length + chunk.bytes.length % 2;
+  }
+  return result;
+}
+
+void _writeAscii(Uint8List target, int offset, String value) {
+  target.setRange(offset, offset + value.length, value.codeUnits);
+}

--- a/mobile/test/practice/avatar/wire_avatar_session_token_client_test.dart
+++ b/mobile/test/practice/avatar/wire_avatar_session_token_client_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(grant.appId, 'app-1');
       expect(grant.avatarId, 'avatar-1');
       expect(grant.sessionToken, 'private-avatar-token');
-      expect(grant.region, AvatarRegion.cnBeijing);
+      expect(grant.region, AvatarRegion.apNortheast);
       expect(grant.audioFormat.isSupported, isTrue);
       expect(responseBody, everyElement(0));
       expect(grant.toString(), isNot(contains('private-avatar-token')));
@@ -337,7 +337,7 @@ Map<String, Object?> _grantJson(DateTime now, {DateTime? expiresAt}) {
     'app_id': 'app-1',
     'avatar_id': 'avatar-1',
     'session_token': 'private-avatar-token',
-    'region': 'cn-beijing',
+    'region': 'ap-northeast',
     'expires_at': (expiresAt ?? now.add(const Duration(minutes: 10)))
         .toIso8601String(),
     'audio_format': {

--- a/mobile/test/practice/avatar/wire_avatar_session_token_client_test.dart
+++ b/mobile/test/practice/avatar/wire_avatar_session_token_client_test.dart
@@ -1,0 +1,398 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 7, 29, 10);
+
+  test(
+    'uses Bearer/no-store and decodes the exact six-field contract',
+    () async {
+      final responseBody = _jsonBytes(_grantJson(now));
+      final transport = _Transport(
+        AvatarSessionWireResponse(
+          statusCode: HttpStatus.ok,
+          body: responseBody,
+          headers: const {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Cache-Control': 'no-store',
+          },
+        ),
+      );
+      final client = _client(transport, now: now);
+
+      final grant = await client.createSession(
+        practiceSessionId: 'practice-session-1',
+      );
+
+      final request = transport.request!;
+      expect(request.method, 'POST');
+      expect(
+        request.uri.path,
+        '/v1/practice-sessions/practice-session-1/avatar-session-token',
+      );
+      expect(request.uri.query, isEmpty);
+      expect(
+        request.headers[HttpHeaders.authorizationHeader],
+        'Bearer sess_test',
+      );
+      expect(request.headers[HttpHeaders.acceptHeader], 'application/json');
+      expect(request.headers[HttpHeaders.cacheControlHeader], 'no-store');
+      expect(request.headers, isNot(contains(HttpHeaders.contentTypeHeader)));
+      expect(grant.appId, 'app-1');
+      expect(grant.avatarId, 'avatar-1');
+      expect(grant.sessionToken, 'private-avatar-token');
+      expect(grant.region, AvatarRegion.cnBeijing);
+      expect(grant.audioFormat.isSupported, isTrue);
+      expect(responseBody, everyElement(0));
+      expect(grant.toString(), isNot(contains('private-avatar-token')));
+      expect(grant.toString(), isNot(contains('app-1')));
+      expect(grant.toString(), isNot(contains('avatar-1')));
+    },
+  );
+
+  test('rejects extra, missing, and mismatched audio fields', () async {
+    final invalidBodies = <Map<String, Object?>>[
+      {..._grantJson(now), 'unexpected': true},
+      {..._grantJson(now)}..remove('avatar_id'),
+      {
+        ..._grantJson(now),
+        'audio_format': {
+          'encoding': 'PCM_S16LE',
+          'sample_rate_hz': 16000,
+          'channels': 1,
+        },
+      },
+      {
+        ..._grantJson(now),
+        'audio_format': {
+          'encoding': 'PCM_S16LE',
+          'sample_rate_hz': 24000,
+          'channels': 1,
+          'extra': false,
+        },
+      },
+    ];
+
+    for (final json in invalidBodies) {
+      final client = _client(_Transport(_success(json)), now: now);
+      await expectLater(
+        client.createSession(practiceSessionId: 'practice-1'),
+        throwsA(
+          isA<AvatarSessionTokenException>().having(
+            (error) => error.failure,
+            'failure',
+            AvatarSessionTokenFailure.invalidResponse,
+          ),
+        ),
+      );
+    }
+  });
+
+  test('requires JSON content type, no-store, future UTC expiry', () async {
+    final scenarios = [
+      AvatarSessionWireResponse(
+        statusCode: HttpStatus.ok,
+        body: _jsonBytes(_grantJson(now)),
+        headers: const {
+          'content-type': 'application/json',
+          'cache-control': 'private, no-store',
+        },
+      ),
+      AvatarSessionWireResponse(
+        statusCode: HttpStatus.ok,
+        body: _jsonBytes(_grantJson(now)),
+        headers: const {
+          'content-type': 'text/plain',
+          'cache-control': 'no-store',
+        },
+      ),
+      _success(
+        _grantJson(now, expiresAt: now.subtract(const Duration(seconds: 1))),
+      ),
+      _success({..._grantJson(now), 'expires_at': '2026-07-29T18:10:00+08:00'}),
+    ];
+
+    for (final response in scenarios) {
+      final client = _client(_Transport(response), now: now);
+      await expectLater(
+        client.createSession(practiceSessionId: 'practice-1'),
+        throwsA(isA<AvatarSessionTokenException>()),
+      );
+    }
+  });
+
+  test('invalidates exactly the captured app session on 401', () async {
+    String? invalidatedToken;
+    int? invalidatedGeneration;
+    final client = WireAvatarSessionTokenClient(
+      baseUri: Uri.parse('http://localhost:8080'),
+      credentialProvider: () =>
+          const AuthSessionCredential(sessionToken: 'sess_test', generation: 7),
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) async {
+            invalidatedToken = expectedSessionToken;
+            invalidatedGeneration = expectedGeneration;
+          },
+      transport: _Transport(
+        AvatarSessionWireResponse(
+          statusCode: HttpStatus.unauthorized,
+          body: Uint8List(0),
+        ),
+      ),
+      clock: () => now,
+    );
+
+    await expectLater(
+      client.createSession(practiceSessionId: 'practice-1'),
+      throwsA(
+        isA<AvatarSessionTokenException>().having(
+          (error) => error.failure,
+          'failure',
+          AvatarSessionTokenFailure.authenticationRequired,
+        ),
+      ),
+    );
+
+    expect(invalidatedToken, 'sess_test');
+    expect(invalidatedGeneration, 7);
+  });
+
+  test('discards a response completed after account switch', () async {
+    var credential = const AuthSessionCredential(
+      sessionToken: 'sess_first',
+      generation: 1,
+    );
+    final body = _jsonBytes(_grantJson(now));
+    final transport = _PendingTransport();
+    final client = WireAvatarSessionTokenClient(
+      baseUri: Uri.parse('http://localhost:8080'),
+      credentialProvider: () => credential,
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: transport,
+      clock: () => now,
+    );
+
+    final pending = client.createSession(practiceSessionId: 'practice-1');
+    await Future<void>.delayed(Duration.zero);
+    credential = const AuthSessionCredential(
+      sessionToken: 'sess_second',
+      generation: 2,
+    );
+    transport.complete(
+      AvatarSessionWireResponse(
+        statusCode: HttpStatus.ok,
+        body: body,
+        headers: const {
+          'content-type': 'application/json',
+          'cache-control': 'no-store',
+        },
+      ),
+    );
+
+    await expectLater(
+      pending,
+      throwsA(
+        isA<AvatarSessionTokenException>().having(
+          (error) => error.failure,
+          'failure',
+          AvatarSessionTokenFailure.cancelled,
+        ),
+      ),
+    );
+    expect(body, everyElement(0));
+  });
+
+  test('zeros a response completed during account cleanup', () async {
+    final body = _jsonBytes(_grantJson(now));
+    final transport = _PendingTransport();
+    final client = _client(transport, now: now);
+
+    final pending = client.createSession(practiceSessionId: 'practice-1');
+    await Future<void>.delayed(Duration.zero);
+    final cleanup = client.clearAccountState();
+    await Future<void>.delayed(Duration.zero);
+    transport.complete(
+      AvatarSessionWireResponse(
+        statusCode: HttpStatus.ok,
+        body: body,
+        headers: const {
+          'content-type': 'application/json',
+          'cache-control': 'no-store',
+        },
+      ),
+    );
+
+    await expectLater(
+      pending,
+      throwsA(
+        isA<AvatarSessionTokenException>().having(
+          (error) => error.failure,
+          'failure',
+          AvatarSessionTokenFailure.cancelled,
+        ),
+      ),
+    );
+    await cleanup;
+    expect(body, everyElement(0));
+  });
+
+  test(
+    'maps every provider-side 5xx response to retryable unavailable',
+    () async {
+      for (final statusCode in [
+        HttpStatus.internalServerError,
+        HttpStatus.notImplemented,
+        HttpStatus.badGateway,
+      ]) {
+        final client = _client(
+          _Transport(
+            AvatarSessionWireResponse(
+              statusCode: statusCode,
+              body: Uint8List(0),
+            ),
+          ),
+          now: now,
+        );
+        await expectLater(
+          client.createSession(practiceSessionId: 'practice-1'),
+          throwsA(
+            isA<AvatarSessionTokenException>()
+                .having(
+                  (error) => error.failure,
+                  'failure',
+                  AvatarSessionTokenFailure.unavailable,
+                )
+                .having((error) => error.retryable, 'retryable', isTrue),
+          ),
+        );
+      }
+    },
+  );
+
+  test('IO transport sends POST with an explicit zero-length body', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final observed = Completer<({int contentLength, bool chunked})>();
+    server.listen((request) async {
+      observed.complete((
+        contentLength: request.contentLength,
+        chunked: request.headers.chunkedTransferEncoding,
+      ));
+      await request.drain<void>();
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..headers.set(HttpHeaders.cacheControlHeader, 'no-store')
+        ..write(jsonEncode(_grantJson(now)));
+      await request.response.close();
+    });
+    final transport = IoAvatarSessionWireTransport(
+      timeout: const Duration(seconds: 5),
+    );
+    addTearDown(transport.close);
+
+    final response = await transport.send(
+      AvatarSessionWireRequest(
+        method: 'POST',
+        uri: Uri.parse(
+          'http://${server.address.address}:${server.port}/avatar-token',
+        ),
+        headers: const {HttpHeaders.acceptHeader: 'application/json'},
+        maximumResponseBytes: 32 * 1024,
+      ),
+    );
+
+    expect(await observed.future, (contentLength: 0, chunked: false));
+    expect(response.statusCode, HttpStatus.ok);
+  });
+}
+
+WireAvatarSessionTokenClient _client(
+  AvatarSessionWireTransport transport, {
+  required DateTime now,
+}) {
+  return WireAvatarSessionTokenClient(
+    baseUri: Uri.parse('http://localhost:8080'),
+    credentialProvider: () =>
+        const AuthSessionCredential(sessionToken: 'sess_test', generation: 1),
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) async {},
+    transport: transport,
+    clock: () => now,
+  );
+}
+
+Map<String, Object?> _grantJson(DateTime now, {DateTime? expiresAt}) {
+  return {
+    'app_id': 'app-1',
+    'avatar_id': 'avatar-1',
+    'session_token': 'private-avatar-token',
+    'region': 'cn-beijing',
+    'expires_at': (expiresAt ?? now.add(const Duration(minutes: 10)))
+        .toIso8601String(),
+    'audio_format': {
+      'encoding': 'PCM_S16LE',
+      'sample_rate_hz': 24000,
+      'channels': 1,
+    },
+  };
+}
+
+AvatarSessionWireResponse _success(Map<String, Object?> body) {
+  return AvatarSessionWireResponse(
+    statusCode: HttpStatus.ok,
+    body: _jsonBytes(body),
+    headers: const {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  );
+}
+
+Uint8List _jsonBytes(Map<String, Object?> json) {
+  return Uint8List.fromList(utf8.encode(jsonEncode(json)));
+}
+
+final class _Transport implements AvatarSessionWireTransport {
+  _Transport(this.response);
+
+  final AvatarSessionWireResponse response;
+  AvatarSessionWireRequest? request;
+
+  @override
+  Future<AvatarSessionWireResponse> send(
+    AvatarSessionWireRequest request,
+  ) async {
+    this.request = request;
+    return response;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+final class _PendingTransport implements AvatarSessionWireTransport {
+  final _completer = Completer<AvatarSessionWireResponse>();
+
+  void complete(AvatarSessionWireResponse response) {
+    _completer.complete(response);
+  }
+
+  @override
+  Future<AvatarSessionWireResponse> send(AvatarSessionWireRequest request) {
+    return _completer.future;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/practice/ielts_mock_practice.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
@@ -11,6 +12,44 @@ import 'package:speakup/practice/practice_models.dart';
 import 'package:speakup/practice/practice_recording.dart';
 
 void main() {
+  testWidgets('short-answer recorder uses tap-to-toggle voice capture', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _IeltsPracticeClient(initialCompleted: 0),
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final capture = tester.widget<VoiceCaptureControl>(
+      find.byType(VoiceCaptureControl),
+    );
+    expect(capture.mode, VoiceCaptureMode.tapToToggle);
+    expect(find.byKey(const Key('ielts-mock-record')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    await tester.pump();
+
+    expect(controller.recordingState, PracticeRecordingState.recording);
+
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    await tester.pump();
+    await tester.pump();
+  });
+
   testWidgets(
     'Part 1 boundary enters prep, keeps notes, and submits the Part 2 long turn',
     (tester) async {

--- a/mobile/test/practice/immersive_roleplay_session_test.dart
+++ b/mobile/test/practice/immersive_roleplay_session_test.dart
@@ -165,6 +165,41 @@ void main() {
     expect(tokenClient.requestedSessionIds, hasLength(2));
   });
 
+  testWidgets('falls back when avatar preparation does not finish in time', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final prepareGate = Completer<void>();
+    final renderer = FakeAvatarRenderer(prepareGate: prepareGate);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () => AvatarController(
+            renderer: renderer,
+            tokenClient: FakeAvatarSessionTokenClient(),
+            fallbackPlayback: (_) async {},
+            fallbackStop: () async {},
+            delay: (_) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('正在准备情景角色'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 15));
+    await tester.pump();
+
+    expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
+
+    prepareGate.complete();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('waits for a retry before loading assistant fallback audio', (
     tester,
   ) async {

--- a/mobile/test/practice/immersive_roleplay_session_test.dart
+++ b/mobile/test/practice/immersive_roleplay_session_test.dart
@@ -1,0 +1,522 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_client.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/app/app_routes.dart';
+import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/app/speak_up_shell.dart';
+import 'package:speakup/features/practice/immersive_roleplay_session.dart';
+import 'package:speakup/practice/avatar/avatar.dart';
+import 'package:speakup/practice/practice_audio_player.dart';
+import 'package:speakup/practice/practice_client.dart';
+import 'package:speakup/practice/practice_media.dart';
+import 'package:speakup/practice/practice_models.dart';
+
+import 'avatar/avatar_test_fakes.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('owns one avatar connection and fences app lifecycle', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final tokenClient = FakeAvatarSessionTokenClient();
+    final renderers = <FakeAvatarRenderer>[];
+    AvatarController createAvatarController() {
+      final renderer = FakeAvatarRenderer();
+      renderers.add(renderer);
+      return AvatarController(
+        renderer: renderer,
+        tokenClient: tokenClient,
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: createAvatarController,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tokenClient.requestedSessionIds, [
+      agentController.practiceSessionId,
+    ]);
+    expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
+    expect(find.byKey(const Key('immersive-avatar-surface')), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await _pumpUntil(tester, () => renderers.first.closeCount == 1);
+    expect(renderers, hasLength(1));
+    expect(renderers.first.closeCount, 1);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await _pumpUntil(tester, () => renderers.length == 2);
+    expect(renderers, hasLength(2));
+    expect(tokenClient.requestedSessionIds, hasLength(2));
+
+    final resumedRenderer = renderers.last;
+    await tester.pumpWidget(const SizedBox.shrink());
+    await _pumpUntil(tester, () => resumedRenderer.closeCount == 1);
+    expect(renderers, hasLength(2));
+    expect(resumedRenderer.closeCount, 1);
+  });
+
+  testWidgets('retries a transient session failure with a fresh renderer', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final failedTokenClient = FakeAvatarSessionTokenClient(
+      error: const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.unavailable,
+        statusCode: 503,
+        retryable: true,
+      ),
+    );
+    final readyTokenClient = FakeAvatarSessionTokenClient();
+    final renderers = <FakeAvatarRenderer>[];
+    var factoryCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () {
+            final renderer = FakeAvatarRenderer();
+            renderers.add(renderer);
+            final tokenClient = factoryCalls++ == 0
+                ? failedTokenClient
+                : readyTokenClient;
+            return AvatarController(
+              renderer: renderer,
+              tokenClient: tokenClient,
+              fallbackPlayback: (_) async {},
+              fallbackStop: () async {},
+              delay: (_) async {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(failedTokenClient.requestedSessionIds, hasLength(1));
+    expect(factoryCalls, 1);
+
+    await tester.pump(const Duration(seconds: 1));
+    await _pumpUntil(tester, () => factoryCalls == 2);
+
+    expect(factoryCalls, 2);
+    expect(renderers.first.closeCount, 1);
+    expect(readyTokenClient.requestedSessionIds, hasLength(1));
+  });
+
+  testWidgets('reconnects after a live renderer network failure', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final tokenClient = FakeAvatarSessionTokenClient();
+    final renderers = <FakeAvatarRenderer>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () {
+            final renderer = FakeAvatarRenderer();
+            renderers.add(renderer);
+            return AvatarController(
+              renderer: renderer,
+              tokenClient: tokenClient,
+              fallbackPlayback: (_) async {},
+              fallbackStop: () async {},
+              delay: (_) async {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    renderers.single.emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
+    await _pumpUntil(tester, () => renderers.length == 2);
+
+    expect(renderers, hasLength(2));
+    expect(renderers.first.closeCount, 1);
+    expect(tokenClient.requestedSessionIds, hasLength(2));
+  });
+
+  testWidgets('waits for a retry before loading assistant fallback audio', (
+    tester,
+  ) async {
+    const scene = AgentScene(
+      id: 'daily-retry',
+      title: '旅行对话',
+      description: '练习旅行中的真实交流。',
+      scenarioType: 'DAILY',
+      presentationMode: AgentScenePresentationMode.immersiveRoleplay,
+    );
+    final snapshot = PracticeSessionSnapshot(
+      sessionId: 'session-retry-1',
+      matter: const AgentMatter(id: 'matter-retry-1', scene: scene),
+      completedTurns: 0,
+      turnLimit: 3,
+      sessionCompleted: false,
+      currentQuestion: const PracticeQuestion(
+        id: 'question-retry-1',
+        sessionId: 'session-retry-1',
+        text: 'Where would you like to go?',
+        speechPath: '/v1/voice-questions/question-retry-1/speech',
+      ),
+    );
+    final media = _QuestionMediaClient();
+    final fallbackPlayer = _FallbackPlayer();
+    final agentController = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _SnapshotPracticeClient(snapshot),
+      mediaClient: media,
+      audioPlayer: fallbackPlayer,
+    );
+    addTearDown(agentController.dispose);
+    await agentController.initialize();
+    await agentController.selectScene(scene);
+    final failedTokenClient = FakeAvatarSessionTokenClient(
+      error: const AvatarSessionTokenException(
+        failure: AvatarSessionTokenFailure.unavailable,
+        statusCode: 503,
+        retryable: true,
+      ),
+    );
+    final readyTokenClient = FakeAvatarSessionTokenClient();
+    final renderers = <FakeAvatarRenderer>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () {
+            final renderer = FakeAvatarRenderer();
+            renderers.add(renderer);
+            return AvatarController(
+              renderer: renderer,
+              tokenClient: renderers.length == 1
+                  ? failedTokenClient
+                  : readyTokenClient,
+              fallbackPlayback: fallbackPlayer.playWav,
+              fallbackStop: fallbackPlayer.stop,
+              delay: (_) async {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(media.questionLoadCount, 0);
+    expect(fallbackPlayer.playCount, 0);
+
+    await tester.pump(const Duration(seconds: 1));
+    await _pumpUntil(
+      tester,
+      () => renderers.length == 2 && media.questionLoadCount == 1,
+    );
+
+    expect(renderers.last.sends, hasLength(1));
+    expect(fallbackPlayer.playCount, 0);
+  });
+
+  testWidgets('caps repeated surface connection failures at three attempts', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final tokenClient = FakeAvatarSessionTokenClient();
+    final renderers = <FakeAvatarRenderer>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () {
+            final renderer = FakeAvatarRenderer(connectOnPrepare: false);
+            renderers.add(renderer);
+            return AvatarController(
+              renderer: renderer,
+              tokenClient: tokenClient,
+              fallbackPlayback: (_) async {},
+              fallbackStop: () async {},
+              delay: (_) async {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    renderers[0].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await _pumpUntil(tester, () => renderers.length == 2);
+
+    renderers[1].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 1500));
+    await _pumpUntil(tester, () => renderers.length == 3);
+
+    renderers[2].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump(const Duration(seconds: 3));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+
+    expect(renderers, hasLength(3));
+    expect(tokenClient.requestedSessionIds, hasLength(3));
+  });
+
+  testWidgets('routes an immersive scene through the avatar coordinator', (
+    tester,
+  ) async {
+    final agentController = await _immersiveAgentController();
+    addTearDown(agentController.dispose);
+    final renderer = FakeAvatarRenderer();
+    final tokenClient = FakeAvatarSessionTokenClient();
+    var factoryCalls = 0;
+
+    await tester.pumpWidget(
+      SpeakUpApp.preview(
+        agentController: agentController,
+        avatarControllerFactory: () {
+          factoryCalls++;
+          return AvatarController(
+            renderer: renderer,
+            tokenClient: tokenClient,
+            fallbackPlayback: (_) async {},
+            fallbackStop: () async {},
+            delay: (_) async {},
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Navigator.of(
+      tester.element(find.byType(SpeakUpShell)),
+    ).pushNamed(AppRoutes.practice);
+    await tester.pumpAndSettle();
+
+    expect(factoryCalls, 1);
+    expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
+    expect(find.byKey(const Key('practice-page')), findsNothing);
+  });
+
+  testWidgets('loads each assistant WAV once and sends it only to the avatar', (
+    tester,
+  ) async {
+    const scene = AgentScene(
+      id: 'daily-travel',
+      title: '旅行对话',
+      description: '练习旅行中的真实交流。',
+      scenarioType: 'DAILY',
+      presentationMode: AgentScenePresentationMode.immersiveRoleplay,
+    );
+    final snapshot = PracticeSessionSnapshot(
+      sessionId: 'session-avatar-1',
+      matter: const AgentMatter(id: 'matter-avatar-1', scene: scene),
+      completedTurns: 0,
+      turnLimit: 3,
+      sessionCompleted: false,
+      currentQuestion: const PracticeQuestion(
+        id: 'question-avatar-1',
+        sessionId: 'session-avatar-1',
+        text: 'Where would you like to go?',
+        speechPath: '/v1/voice-questions/question-avatar-1/speech',
+      ),
+    );
+    final media = _QuestionMediaClient();
+    final fallbackPlayer = _FallbackPlayer();
+    final agentController = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _SnapshotPracticeClient(snapshot),
+      mediaClient: media,
+      audioPlayer: fallbackPlayer,
+    );
+    addTearDown(agentController.dispose);
+    await agentController.initialize();
+    await agentController.selectScene(scene);
+    final renderer = FakeAvatarRenderer();
+    final avatarController = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: fallbackPlayer.playWav,
+      fallbackStop: fallbackPlayer.stop,
+      delay: (_) async {},
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplaySession(
+          agentController: agentController,
+          avatarControllerFactory: () => avatarController,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(media.questionLoadCount, 1);
+    expect(renderer.sends, hasLength(1));
+    expect(renderer.sends.single.end, isTrue);
+    expect(fallbackPlayer.playCount, 0);
+  });
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempts = 0; attempts < 50; attempts += 1) {
+    if (condition()) {
+      return;
+    }
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 1));
+  }
+  fail('Condition was not reached.');
+}
+
+Future<AgentController> _immersiveAgentController() async {
+  final controller = AgentController(client: FakeAgentClient());
+  await controller.initialize();
+  await controller.selectScene(
+    const AgentScene(
+      id: 'daily-travel',
+      title: '旅行对话',
+      description: '练习旅行中的真实交流。',
+      scenarioType: 'DAILY',
+      presentationMode: AgentScenePresentationMode.immersiveRoleplay,
+    ),
+  );
+  return controller;
+}
+
+final class _SnapshotPracticeClient implements PracticeClient {
+  _SnapshotPracticeClient(this.snapshot);
+
+  final PracticeSessionSnapshot snapshot;
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PracticeSessionSnapshot?> restorePractice({
+    required String threadId,
+    AgentMatter? activeMatter,
+  }) async => null;
+
+  @override
+  Future<PracticeStartResult> startPractice({
+    required String threadId,
+    required AgentMatter activeMatter,
+    required String clientOperationId,
+  }) async => PracticeStartResult(snapshot: snapshot);
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PracticeTurnConfirmation> submitText({
+    required String sessionId,
+    required String questionId,
+    required String answerText,
+    required String idempotencyKey,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+}
+
+final class _QuestionMediaClient implements PracticeMediaClient {
+  int questionLoadCount = 0;
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) async {
+    questionLoadCount++;
+    return buildPcmWave(pcm: Uint8List(48000));
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) {
+    throw UnimplementedError();
+  }
+}
+
+final class _FallbackPlayer implements PracticeAudioPlayer {
+  final StreamController<void> _completions =
+      StreamController<void>.broadcast();
+  int playCount = 0;
+
+  @override
+  Stream<void> get onComplete => _completions.stream;
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {
+    playCount++;
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() => _completions.close();
+}

--- a/mobile/test/practice/immersive_roleplay_test.dart
+++ b/mobile/test/practice/immersive_roleplay_test.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_client.dart';
+import 'package:speakup/agent/agent_controller.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/features/practice/immersive_roleplay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows an injected avatar above the live conversation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          avatarStatusLabel: '画面已连接',
+          avatarSurfaceBuilder: (_) => const ColoredBox(
+            key: Key('test-avatar-surface'),
+            color: Colors.green,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.text('画面已连接'), findsOneWidget);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const Key('immersive-avatar-region'))).height,
+      closeTo(844 * 0.44, 0.1),
+    );
+    expect(find.byKey(const Key('immersive-conversation-history')), findsOne);
+    expect(find.textContaining('评分'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('keeps the existing typed-answer flow in the immersive shell', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    var interruptedBeforeSubmit = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onBeforeSubmitText: () async {
+            interruptedBeforeSubmit = true;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('immersive-open-keyboard')));
+    await tester.pump();
+    const answer = 'Could I change my reservation to tomorrow morning?';
+    await tester.enterText(
+      find.byKey(const Key('immersive-text-answer')),
+      answer,
+    );
+    await tester.tap(find.byKey(const Key('immersive-submit-text')));
+    await tester.pumpAndSettle();
+
+    expect(
+      controller.messages.any(
+        (message) =>
+            message.role == AgentMessageRole.user && message.text == answer,
+      ),
+      isTrue,
+    );
+    expect(find.text(answer), findsOneWidget);
+    expect(controller.completedTurns, 1);
+    expect(interruptedBeforeSubmit, isTrue);
+  });
+
+  testWidgets('bounds avatar interruption before opening the microphone', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    final neverCompletes = Completer<void>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onBeforeStartRecording: () => neverCompletes.future,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('immersive-record')));
+    await tester.pump(const Duration(milliseconds: 499));
+    expect(controller.recordingState, PracticeRecordingState.idle);
+
+    await tester.pump(const Duration(milliseconds: 2));
+    await tester.pump();
+    expect(controller.recordingState, PracticeRecordingState.recording);
+    await controller.cancelRecording();
+  });
+
+  testWidgets('interrupts the avatar before tap and hold recording starts', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    final tapInterrupt = Completer<void>();
+    var interruptCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onBeforeStartRecording: () {
+            interruptCalls++;
+            return tapInterrupt.future;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('immersive-record')));
+    await tester.pump();
+    expect(interruptCalls, 1);
+    expect(controller.recordingState, PracticeRecordingState.idle);
+
+    tapInterrupt.complete();
+    await tester.pumpAndSettle();
+    expect(controller.recordingState, PracticeRecordingState.recording);
+    await tester.tap(find.byKey(const Key('immersive-stop-recording')));
+    await tester.pumpAndSettle();
+    controller.rerecord();
+    await tester.pump();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onBeforeStartRecording: () async {
+            interruptCalls++;
+          },
+        ),
+      ),
+    );
+    final hold = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('immersive-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(interruptCalls, 2);
+    expect(controller.recordingState, PracticeRecordingState.recording);
+    await hold.up();
+    await tester.pumpAndSettle();
+    expect(
+      controller.recordingState,
+      PracticeRecordingState.awaitingConfirmation,
+    );
+  });
+
+  testWidgets('prefers the injected avatar replay action over audio playback', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    var replayCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onReplayQuestion: () async {
+            replayCalls++;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('immersive-replay-question')));
+    await tester.pump();
+
+    expect(replayCalls, 1);
+  });
+
+  testWidgets('disables injected replay while the microphone is recording', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    await controller.startRecording();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ImmersiveRoleplayPage(
+          agentController: controller,
+          onReplayQuestion: () async {},
+        ),
+      ),
+    );
+
+    final button = tester.widget<IconButton>(
+      find.byKey(const Key('immersive-replay-question')),
+    );
+    expect(button.onPressed, isNull);
+    await controller.cancelRecording();
+  });
+
+  testWidgets('fits a compact phone with large text and landscape layout', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(320, 568),
+            textScaler: TextScaler.linear(2),
+          ),
+          child: ImmersiveRoleplayPage(agentController: controller),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key('immersive-record')), findsOneWidget);
+
+    tester.view.physicalSize = const Size(844, 390);
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(agentController: controller)),
+    );
+    await tester.pump();
+
+    expect(
+      tester.getSize(find.byKey(const Key('immersive-avatar-region'))).width,
+      closeTo(844 * 0.44, 0.1),
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<AgentController> _roleplayController() async {
+  final controller = AgentController(client: FakeAgentClient());
+  await controller.initialize();
+  await controller.selectScene(
+    const AgentScene(
+      id: 'daily-hotel',
+      title: '酒店入住',
+      description: '练习办理入住与需求沟通。',
+      scenarioType: 'DAILY',
+      presentationMode: AgentScenePresentationMode.immersiveRoleplay,
+    ),
+  );
+  return controller;
+}

--- a/mobile/test/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/preparation/practice_lifecycle_flow_test.dart
@@ -119,7 +119,7 @@ void main() {
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
       await _openScenario(tester, _progressScenario.id);
 
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       final firstPracticeThreadId = agentController.threadId!;
       final firstSessionId = agentController.practiceSessionId!;
       expect(firstPracticeThreadId, isNot(homeThreadId));
@@ -132,13 +132,13 @@ void main() {
 
       await _tapVisible(
         tester,
-        find.byKey(const Key('practice-open-keyboard')),
+        find.byKey(const Key('immersive-open-keyboard')),
       );
       await tester.enterText(
-        find.byKey(const Key('practice-text-answer')),
+        find.byKey(const Key('immersive-text-answer')),
         'The migration is on schedule, and I have isolated the main risk.',
       );
-      await _tapVisible(tester, find.byKey(const Key('practice-submit-text')));
+      await _tapVisible(tester, find.byKey(const Key('immersive-submit-text')));
 
       expect(agentController.completedTurns, 1);
       expect(agentController.practiceSessionVersion, 2);
@@ -149,7 +149,7 @@ void main() {
 
       await _leavePractice(tester);
 
-      expect(find.byKey(const Key('practice-page')), findsNothing);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsNothing);
       expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
       expect(agentController.threadId, homeThreadId);
       expect(agentController.hasActivePractice, isFalse);
@@ -166,7 +166,10 @@ void main() {
       practiceClient.releaseRestore();
       for (var attempt = 0; attempt < 100; attempt++) {
         await tester.pump(const Duration(milliseconds: 20));
-        if (find.byKey(const Key('practice-page')).evaluate().isNotEmpty) {
+        if (find
+            .byKey(const Key('immersive-roleplay-page'))
+            .evaluate()
+            .isNotEmpty) {
           break;
         }
       }
@@ -174,7 +177,7 @@ void main() {
       expect(agentController.threadId, firstPracticeThreadId);
       expect(agentController.hasActivePractice, isTrue);
       expect(workspaceController.errorMessage, isNull);
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(workspaceController.hasResumable, isTrue);
 
       await _leavePractice(tester);
@@ -184,7 +187,7 @@ void main() {
         find.byKey(const Key('quick-action-continue-practice')),
       );
 
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(agentController.threadId, firstPracticeThreadId);
       expect(agentController.practiceSessionId, firstSessionId);
       expect(agentController.completedTurns, 1);
@@ -221,7 +224,7 @@ void main() {
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
       await _tapVisible(tester, find.byKey(const Key('practice-continuation')));
 
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(agentController.threadId, firstPracticeThreadId);
       expect(agentController.threadId, isNot(unrelatedPracticeThreadId));
       expect(agentController.practiceSessionId, firstSessionId);
@@ -234,7 +237,7 @@ void main() {
       expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
       await _openScenario(tester, _progressScenario.id);
 
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(find.text('开始新的练习？'), findsNothing);
       expect(agentController.practiceSessionId, firstSessionId);
       expect(agentController.completedTurns, 1);
@@ -254,7 +257,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
-      expect(find.byKey(const Key('practice-page')), findsOneWidget);
+      expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(practiceClient.endedSessionIds, [firstSessionId]);
       expect(practiceClient.snapshotFor(firstPracticeThreadId), isNull);
       expect(agentController.threadId, isNot(firstPracticeThreadId));
@@ -282,8 +285,8 @@ Future<void> _openScenario(WidgetTester tester, String scenarioId) async {
 
 Future<void> _leavePractice(WidgetTester tester) async {
   final backButton = find.descendant(
-    of: find.byKey(const Key('practice-page')),
-    matching: find.byType(BackButton),
+    of: find.byKey(const Key('immersive-roleplay-page')),
+    matching: find.byKey(const Key('immersive-exit')),
   );
   expect(backButton, findsOneWidget);
   await tester.tap(backButton);

--- a/mobile/test/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/preparation/practice_workspace_controller_test.dart
@@ -48,7 +48,7 @@ void main() {
         containsPair('practice_thread_id', retried?.practiceThreadId),
       );
       expect(record, containsPair('return_thread_id', homeThreadId));
-      expect(record, containsPair('schema_version', 1));
+      expect(record, containsPair('schema_version', 2));
 
       final replacement = await workspace.acquireThread(
         'different-operation-2',
@@ -106,6 +106,55 @@ void main() {
       expect(harness.agent.hasActivePractice, isTrue);
       expect(await restoredWorkspace.parkCurrentPractice(), isTrue);
       expect(harness.agent.threadId, newerHomeThreadId);
+    },
+  );
+
+  test(
+    'roleplay presentation survives parking and cold workspace restore',
+    () async {
+      final store = _InspectableRecordStore();
+      final harness = await _createHarness();
+      final firstWorkspace = PracticeWorkspaceController(
+        agentController: harness.agent,
+        recordStore: store,
+      );
+      addTearDown(harness.agent.dispose);
+      await firstWorkspace.activateAccount('account-1');
+      await _launchPractice(
+        harness: harness,
+        workspace: firstWorkspace,
+        operationId: 'launch-roleplay-operation',
+        scenarioId: 'daily-hotel',
+        scenarioTitle: '酒店入住',
+        sessionId: 'practice-roleplay-session',
+        scenarioType: 'DAILY',
+        presentationMode: AgentScenePresentationMode.immersiveRoleplay,
+      );
+      expect(firstWorkspace.currentScenarioType, 'DAILY');
+      expect(
+        firstWorkspace.currentPresentationMode,
+        AgentScenePresentationMode.immersiveRoleplay,
+      );
+      expect(await firstWorkspace.parkCurrentPractice(), isTrue);
+      firstWorkspace.dispose();
+
+      final restoredWorkspace = PracticeWorkspaceController(
+        agentController: harness.agent,
+        recordStore: store,
+      );
+      addTearDown(restoredWorkspace.dispose);
+      await restoredWorkspace.activateAccount('account-1');
+
+      expect(restoredWorkspace.currentScenarioType, 'DAILY');
+      expect(
+        restoredWorkspace.currentPresentationMode,
+        AgentScenePresentationMode.immersiveRoleplay,
+      );
+      final record = jsonDecode((await store.read('account-1'))!);
+      expect(record, containsPair('scenario_type', 'DAILY'));
+      expect(record, containsPair('presentation_mode', 'immersiveRoleplay'));
+      expect(await restoredWorkspace.resumeCurrentPractice(), isTrue);
+      expect(restoredWorkspace.currentScenarioId, 'daily-hotel');
     },
   );
 
@@ -837,6 +886,9 @@ Future<_LaunchedPractice> _launchPractice({
   required String scenarioId,
   required String scenarioTitle,
   required String sessionId,
+  String? scenarioType,
+  AgentScenePresentationMode presentationMode =
+      AgentScenePresentationMode.standard,
 }) async {
   final lease = await workspace.acquireThread(operationId);
   expect(lease, isNotNull);
@@ -844,6 +896,8 @@ Future<_LaunchedPractice> _launchPractice({
     id: scenarioId,
     title: scenarioTitle,
     description: 'Test practice scenario.',
+    scenarioType: scenarioType,
+    presentationMode: presentationMode,
   );
   final matter = await harness.agent.activateMatterForScenario(
     threadId: lease!.practiceThreadId,
@@ -857,6 +911,8 @@ Future<_LaunchedPractice> _launchPractice({
       sessionId: sessionId,
       scenarioId: scenarioId,
       scenarioTitle: scenarioTitle,
+      scenarioType: scenarioType,
+      presentationMode: presentationMode,
     ),
     isTrue,
   );

--- a/mobile/test/preparation/preparation_hub_test.dart
+++ b/mobile/test/preparation/preparation_hub_test.dart
@@ -138,7 +138,7 @@ void main() {
 
     await _openModule(tester, const Key('practice-hub-roleplay'));
 
-    expect(find.text('AI 数字人陪练'), findsOneWidget);
+    expect(find.text('情景对话'), findsOneWidget);
     expect(find.text('进度与风险汇报'), findsOneWidget);
     expect(find.text('酒店入住与问题处理'), findsOneWidget);
     expect(find.byKey(const Key('roleplay-filter-workplace')), findsOneWidget);
@@ -166,7 +166,7 @@ void main() {
     for (final entryData in const [
       (key: Key('practice-hub-interview'), title: '英文面试'),
       (key: Key('practice-hub-exam'), title: 'IELTS 口语'),
-      (key: Key('practice-hub-roleplay'), title: 'AI 数字人陪练'),
+      (key: Key('practice-hub-roleplay'), title: '情景对话'),
     ]) {
       final entry = find.byKey(entryData.key);
       await tester.scrollUntilVisible(
@@ -330,7 +330,7 @@ void main() {
       for (final entryData in const [
         (key: Key('practice-hub-interview'), label: '英文面试。模拟面试与轮次专项练习'),
         (key: Key('practice-hub-exam'), label: 'IELTS 口语。Part 1、2、3 与完整模考'),
-        (key: Key('practice-hub-roleplay'), label: 'AI 数字人陪练。工作、旅行与日常真实对话'),
+        (key: Key('practice-hub-roleplay'), label: '情景对话。工作、旅行与日常英语实战'),
       ]) {
         final entry = find.byKey(entryData.key);
         await tester.scrollUntilVisible(

--- a/mobile/test/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_launch_client_test.dart
@@ -272,6 +272,25 @@ void main() {
     );
   });
 
+  test('rejects an unknown Plan response field', () async {
+    final response = _planJson()..['unexpected_field'] = true;
+    final client = _client(_QueueTransport([_response(response)]));
+
+    await expectLater(
+      client.createPlan(
+        input: const CreatePreparationPlanInput(
+          context: _context,
+          selection: _selection,
+          preparationProfileId: _profileId,
+          preparationSnapshotId: _preparationSnapshotId,
+          preparationUserId: _userId,
+        ),
+        idempotencyKey: 'plan-key-123456',
+      ),
+      throwsA(_invalidResponse),
+    );
+  });
+
   group('rejects cross-resource Session bootstrap data', () {
     final cases = <String, void Function(Map<String, Object?>)>{
       'role version': (root) {
@@ -565,24 +584,38 @@ Map<String, Object?> _snapshotJson() => {
   'created_at': _time,
 };
 
-Map<String, Object?> _planJson() => {
-  'practice_plan_id': _planId,
-  'user_id': _userId,
-  'agent_thread_id': _threadId,
-  'matter_id': _matterId,
-  'scenario_definition_id': _scenarioId,
-  'scenario_definition_version': 1,
-  'scenario_type': 'INTERVIEW',
-  'scenario_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
-  'scenario_config_id': _configId,
-  'scenario_config_version': 1,
-  'preparation_profile_id': _profileId,
-  'selected_role_ids': [_roleId],
-  'plan_revision': 1,
-  'practice_plan_status': 'ready',
-  'created_at': _time,
-  'updated_at': _time,
-};
+Map<String, Object?> _planJson() {
+  final snapshot = _bootstrapJson()['snapshot']! as Map<String, Object?>;
+  final participants = snapshot['participants']! as List<Object?>;
+  final facilitator = participants.first as Map<String, Object?>;
+  return {
+    'practice_plan_id': _planId,
+    'user_id': _userId,
+    'agent_thread_id': _threadId,
+    'matter_id': _matterId,
+    'scenario_definition_id': _scenarioId,
+    'scenario_definition_version': 1,
+    'scenario_type': 'INTERVIEW',
+    'scenario_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+    'scenario_config_id': _configId,
+    'scenario_config_version': 1,
+    'preparation_profile_id': _profileId,
+    'selected_role_ids': [_roleId],
+    'preparation_snapshot': snapshot['preparation_snapshot'],
+    'catalog_snapshot': {
+      'scenario_definition': snapshot['scenario_definition_snapshot'],
+      'scenario_config': snapshot['scenario_config_snapshot'],
+      'selected_roles': [facilitator['role_snapshot']],
+      'practice_option': snapshot['practice_option'],
+    },
+    'session_policy': snapshot['session_policy'],
+    'practice_focuses': snapshot['practice_focuses'],
+    'plan_revision': 1,
+    'practice_plan_status': 'ready',
+    'created_at': _time,
+    'updated_at': _time,
+  };
+}
 
 Map<String, Object?> _bootstrapJson() => {
   'practice_session': {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	agent "github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/avatar"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/bootstrap"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
@@ -94,6 +95,14 @@ func run() int {
 	reviewHistoryConfig, err := config.LoadReviewHistory()
 	if err != nil {
 		logger.Error("Review history configuration failed")
+		return 1
+	}
+	spatiusConfig, err := config.LoadSpatius()
+	if err != nil {
+		logger.Error(
+			"avatar provider configuration failed",
+			slog.String("error_kind", "configuration"),
+		)
 		return 1
 	}
 	audioVault, err := platformmedia.NewTemporaryAudioVault(
@@ -238,7 +247,44 @@ func run() int {
 		)
 		return 1
 	}
-	contextRoutes, err := applicationComposition.ProtectedRoutes()
+	var avatarProvider avatar.TokenProvider
+	if spatiusConfig.Enabled {
+		avatarProvider, err = avatar.NewSpatiusClient(spatiusConfig)
+		if err != nil {
+			logger.Error(
+				"avatar provider startup failed",
+				slog.String("error_kind", "dependency"),
+			)
+			return 1
+		}
+	}
+	avatarService, err := avatar.NewService(
+		avatar.ServiceConfiguration{
+			Enabled:  spatiusConfig.Enabled,
+			AppID:    spatiusConfig.AppID,
+			AvatarID: spatiusConfig.AvatarID,
+			Region:   spatiusConfig.Region,
+			TokenTTL: spatiusConfig.TokenTTL,
+		},
+		applicationComposition.PracticeApplication(),
+		avatarProvider,
+	)
+	if err != nil {
+		logger.Error(
+			"avatar service startup failed",
+			slog.String("error_kind", "dependency"),
+		)
+		return 1
+	}
+	avatarHTTP, err := avatar.NewHTTPHandler(avatarService)
+	if err != nil {
+		logger.Error(
+			"avatar HTTP startup failed",
+			slog.String("error_kind", "dependency"),
+		)
+		return 1
+	}
+	contextRoutes, err := applicationComposition.ProtectedRoutes(avatarHTTP)
 	if err != nil {
 		logger.Error("context route startup failed", slog.Any("error", err))
 		return 1

--- a/server/internal/avatar/http.go
+++ b/server/internal/avatar/http.go
@@ -1,0 +1,70 @@
+package avatar
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type HTTPHandler struct {
+	application *Service
+	errors      *httpresponse.Renderer
+}
+
+func NewHTTPHandler(application *Service) (*HTTPHandler, error) {
+	if application == nil {
+		return nil, apperror.New(
+			apperror.Internal,
+			"internal_error",
+			"Internal server error.",
+		)
+	}
+	return &HTTPHandler{
+		application: application,
+		errors:      httpresponse.NewRenderer(nil),
+	}, nil
+}
+
+func (handler *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
+	routes.POST(
+		"/v1/practice-sessions/:practice_session_id/avatar-session-token",
+		handler.issueSessionToken,
+	)
+}
+
+func (handler *HTTPHandler) issueSessionToken(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+	if c.Request.ContentLength != 0 ||
+		len(c.Request.TransferEncoding) != 0 {
+		handler.errors.Write(c, apperror.New(
+			apperror.InvalidArgument,
+			"invalid_request",
+			"Request validation failed.",
+		))
+		return
+	}
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		c.Header("WWW-Authenticate", "Bearer")
+		handler.errors.Write(c, apperror.New(
+			apperror.Unauthenticated,
+			"authentication_required",
+			"Authentication is required.",
+		))
+		return
+	}
+	result, err := handler.application.IssueSessionToken(
+		c.Request.Context(),
+		actor,
+		c.Param("practice_session_id"),
+	)
+	if err != nil {
+		handler.errors.Write(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}

--- a/server/internal/avatar/http_test.go
+++ b/server/internal/avatar/http_test.go
@@ -1,0 +1,181 @@
+package avatar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestHTTPHandlerReturnsStrictNoStoreSessionTokenContract(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	service := newTestService(
+		t,
+		contextSessionReaderStub{session: interactiveSession()},
+		&tokenProviderStub{token: ProviderSessionToken{
+			Value:     "provider-session-token",
+			ExpiresAt: now.Add(10 * time.Minute),
+		}},
+	)
+	service.now = func() time.Time { return now }
+	router := avatarTestRouter(t, service, true)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/practice-sessions/practice-session-1/avatar-session-token",
+		nil,
+	)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Cache-Control", "no-store")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	if response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf(
+			"Cache-Control = %q",
+			response.Header().Get("Cache-Control"),
+		)
+	}
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", contentType)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	expectedKeys := []string{
+		"app_id",
+		"avatar_id",
+		"session_token",
+		"region",
+		"expires_at",
+		"audio_format",
+	}
+	if len(document) != len(expectedKeys) {
+		t.Fatalf("response keys = %v", document)
+	}
+	for _, key := range expectedKeys {
+		if _, exists := document[key]; !exists {
+			t.Fatalf("response is missing %q", key)
+		}
+	}
+	var format AudioFormat
+	if err := json.Unmarshal(document["audio_format"], &format); err != nil {
+		t.Fatalf("decode audio format: %v", err)
+	}
+	if format != (AudioFormat{
+		Encoding:     "PCM_S16LE",
+		SampleRateHz: 24000,
+		Channels:     1,
+	}) {
+		t.Fatalf("audio format = %#v", format)
+	}
+	if strings.Contains(response.Body.String(), "server-only") {
+		t.Fatal("response exposed server-only material")
+	}
+}
+
+func TestHTTPHandlerRequiresTrustedActorAndEmptyBody(t *testing.T) {
+	service := newTestService(
+		t,
+		contextSessionReaderStub{session: interactiveSession()},
+		&tokenProviderStub{},
+	)
+	tests := []struct {
+		name      string
+		withActor bool
+		body      string
+		status    int
+		errorCode string
+	}{
+		{
+			name:      "missing actor",
+			status:    http.StatusUnauthorized,
+			errorCode: "authentication_required",
+		},
+		{
+			name:      "unexpected body",
+			withActor: true,
+			body:      `{}`,
+			status:    http.StatusBadRequest,
+			errorCode: "invalid_request",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := avatarTestRouter(t, service, test.withActor)
+			var body *strings.Reader
+			if test.body == "" {
+				body = strings.NewReader("")
+			} else {
+				body = strings.NewReader(test.body)
+			}
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/v1/practice-sessions/practice-session-1/avatar-session-token",
+				body,
+			)
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != test.status {
+				t.Fatalf(
+					"status = %d, body = %s",
+					response.Code,
+					response.Body,
+				)
+			}
+			var document struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if document.Error.Code != test.errorCode {
+				t.Fatalf("error code = %q", document.Error.Code)
+			}
+			if response.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf(
+					"Cache-Control = %q",
+					response.Header().Get("Cache-Control"),
+				)
+			}
+		})
+	}
+}
+
+func avatarTestRouter(
+	t *testing.T,
+	service *Service,
+	withActor bool,
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	if withActor {
+		router.Use(func(c *gin.Context) {
+			c.Request = c.Request.WithContext(requestcontext.WithActor(
+				context.Background(),
+				testActor(),
+			))
+			c.Next()
+		})
+	}
+	handler, err := NewHTTPHandler(service)
+	if err != nil {
+		t.Fatalf("NewHTTPHandler() error = %v", err)
+	}
+	handler.RegisterRoutes(router)
+	return router
+}

--- a/server/internal/avatar/session.go
+++ b/server/internal/avatar/session.go
@@ -1,0 +1,223 @@
+package avatar
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice/persistence"
+)
+
+const (
+	audioEncoding          = "PCM_S16LE"
+	audioSampleRate        = 24000
+	audioChannels          = 1
+	maximumSessionTokenTTL = 10 * time.Minute
+)
+
+type SessionReader interface {
+	GetSession(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (persistence.ContextSession, error)
+}
+
+type TokenProvider interface {
+	CreateSessionToken(
+		context.Context,
+		string,
+		time.Time,
+	) (ProviderSessionToken, error)
+}
+
+type ProviderSessionToken struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+type ServiceConfiguration struct {
+	Enabled  bool
+	AppID    string
+	AvatarID string
+	Region   string
+	TokenTTL time.Duration
+}
+
+type Service struct {
+	configuration ServiceConfiguration
+	sessions      SessionReader
+	provider      TokenProvider
+	now           func() time.Time
+}
+
+type AudioFormat struct {
+	Encoding     string `json:"encoding"`
+	SampleRateHz int    `json:"sample_rate_hz"`
+	Channels     int    `json:"channels"`
+}
+
+type SessionToken struct {
+	AppID        string      `json:"app_id"`
+	AvatarID     string      `json:"avatar_id"`
+	SessionToken string      `json:"session_token"`
+	Region       string      `json:"region"`
+	ExpiresAt    string      `json:"expires_at"`
+	AudioFormat  AudioFormat `json:"audio_format"`
+}
+
+func NewService(
+	configuration ServiceConfiguration,
+	sessions SessionReader,
+	provider TokenProvider,
+) (*Service, error) {
+	if sessions == nil ||
+		configuration.TokenTTL <= 0 ||
+		configuration.TokenTTL > maximumSessionTokenTTL {
+		return nil, errors.New("avatar: service dependency is required")
+	}
+	if configuration.Enabled &&
+		(provider == nil ||
+			strings.TrimSpace(configuration.AppID) == "" ||
+			strings.TrimSpace(configuration.AvatarID) == "" ||
+			strings.TrimSpace(configuration.Region) == "") {
+		return nil, errors.New(
+			"avatar: enabled provider configuration is required",
+		)
+	}
+	return &Service{
+		configuration: configuration,
+		sessions:      sessions,
+		provider:      provider,
+		now:           time.Now,
+	}, nil
+}
+
+func (service *Service) IssueSessionToken(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	practiceSessionID string,
+) (SessionToken, error) {
+	if service == nil || service.sessions == nil || ctx == nil ||
+		!actor.Valid() || !validResourceID(practiceSessionID) {
+		return SessionToken{}, sessionNotFoundError(nil)
+	}
+	session, err := service.sessions.GetSession(
+		ctx,
+		actor,
+		practiceSessionID,
+	)
+	if err != nil {
+		if errors.Is(err, persistence.ErrNotFound) ||
+			errors.Is(err, persistence.ErrInvalidArgument) {
+			return SessionToken{}, sessionNotFoundError(err)
+		}
+		return SessionToken{}, apperror.New(
+			apperror.Internal,
+			"internal_error",
+			"Internal server error.",
+			apperror.WithCause(err),
+		)
+	}
+	if session.ID != practiceSessionID ||
+		(session.ScenarioType != persistence.ScenarioFamilyWorkplace &&
+			session.ScenarioType != persistence.ScenarioFamilyDaily) ||
+		(session.Status != persistence.ContextSessionStarting &&
+			session.Status != persistence.ContextSessionProgress) {
+		return SessionToken{}, apperror.New(
+			apperror.Conflict,
+			"resource_conflict",
+			"The practice session cannot start an avatar connection.",
+		)
+	}
+	if !service.configuration.Enabled || service.provider == nil {
+		return SessionToken{}, providerUnavailableError(nil)
+	}
+
+	now := service.now().UTC()
+	requestedExpiry := now.Add(service.configuration.TokenTTL).
+		Truncate(time.Second)
+	providerToken, err := service.provider.CreateSessionToken(
+		ctx,
+		service.configuration.AppID,
+		requestedExpiry,
+	)
+	if err != nil {
+		if errors.Is(err, ErrProviderQuotaExhausted) {
+			return SessionToken{}, apperror.New(
+				apperror.Unavailable,
+				"quota_exhausted",
+				"Avatar capacity is temporarily unavailable.",
+				apperror.WithRetryable(true),
+				apperror.WithCause(err),
+			)
+		}
+		return SessionToken{}, providerUnavailableError(err)
+	}
+	if !validSessionToken(providerToken.Value) ||
+		providerToken.ExpiresAt.Before(now.Add(15*time.Second)) ||
+		providerToken.ExpiresAt.After(requestedExpiry) {
+		return SessionToken{}, providerUnavailableError(
+			ErrInvalidProviderResponse,
+		)
+	}
+	return SessionToken{
+		AppID:        service.configuration.AppID,
+		AvatarID:     service.configuration.AvatarID,
+		SessionToken: providerToken.Value,
+		Region:       service.configuration.Region,
+		ExpiresAt: providerToken.ExpiresAt.UTC().
+			Truncate(time.Second).
+			Format(time.RFC3339),
+		AudioFormat: AudioFormat{
+			Encoding:     audioEncoding,
+			SampleRateHz: audioSampleRate,
+			Channels:     audioChannels,
+		},
+	}, nil
+}
+
+func sessionNotFoundError(cause error) error {
+	options := make([]apperror.Option, 0, 1)
+	if cause != nil {
+		options = append(options, apperror.WithCause(cause))
+	}
+	return apperror.New(
+		apperror.NotFound,
+		"practice_session_not_found",
+		"Practice session was not found.",
+		options...,
+	)
+}
+
+func providerUnavailableError(cause error) error {
+	options := []apperror.Option{apperror.WithRetryable(true)}
+	if cause != nil {
+		options = append(options, apperror.WithCause(cause))
+	}
+	return apperror.New(
+		apperror.Unavailable,
+		"provider_unavailable",
+		"Avatar service is temporarily unavailable.",
+		options...,
+	)
+}
+
+func validResourceID(value string) bool {
+	return value != "" &&
+		len(value) <= 128 &&
+		strings.TrimSpace(value) == value &&
+		!strings.ContainsRune(value, '\x00')
+}
+
+func validSessionToken(value string) bool {
+	if len(value) < 8 || len(value) > 8192 {
+		return false
+	}
+	return strings.IndexFunc(value, func(character rune) bool {
+		return character <= 0x20 || character > 0x7e
+	}) < 0
+}

--- a/server/internal/avatar/session_test.go
+++ b/server/internal/avatar/session_test.go
@@ -39,7 +39,7 @@ func TestServiceIssuesFrozenClientContractForOwnedInteractiveSession(
 	if result.AppID != "app-1" ||
 		result.AvatarID != "avatar-1" ||
 		result.SessionToken != "provider-session-token" ||
-		result.Region != "cn-beijing" ||
+		result.Region != "ap-northeast" ||
 		result.ExpiresAt != "2026-07-29T10:10:00Z" ||
 		result.AudioFormat != (AudioFormat{
 			Encoding:     "PCM_S16LE",
@@ -191,7 +191,7 @@ func TestNewServiceRejectsTokenTTLAboveHardLimit(t *testing.T) {
 			Enabled:  true,
 			AppID:    "app-1",
 			AvatarID: "avatar-1",
-			Region:   "cn-beijing",
+			Region:   "ap-northeast",
 			TokenTTL: maximumSessionTokenTTL + time.Nanosecond,
 		},
 		contextSessionReaderStub{},
@@ -241,7 +241,7 @@ func newTestService(
 			Enabled:  true,
 			AppID:    "app-1",
 			AvatarID: "avatar-1",
-			Region:   "cn-beijing",
+			Region:   "ap-northeast",
 			TokenTTL: 10 * time.Minute,
 		},
 		sessions,

--- a/server/internal/avatar/session_test.go
+++ b/server/internal/avatar/session_test.go
@@ -1,0 +1,301 @@
+package avatar
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/practice/persistence"
+)
+
+func TestServiceIssuesFrozenClientContractForOwnedInteractiveSession(
+	t *testing.T,
+) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	provider := &tokenProviderStub{
+		token: ProviderSessionToken{
+			Value:     "provider-session-token",
+			ExpiresAt: now.Add(10 * time.Minute),
+		},
+	}
+	service := newTestService(
+		t,
+		contextSessionReaderStub{session: interactiveSession()},
+		provider,
+	)
+	service.now = func() time.Time { return now }
+
+	result, err := service.IssueSessionToken(
+		context.Background(),
+		testActor(),
+		"practice-session-1",
+	)
+	if err != nil {
+		t.Fatalf("IssueSessionToken() error = %v", err)
+	}
+	if result.AppID != "app-1" ||
+		result.AvatarID != "avatar-1" ||
+		result.SessionToken != "provider-session-token" ||
+		result.Region != "cn-beijing" ||
+		result.ExpiresAt != "2026-07-29T10:10:00Z" ||
+		result.AudioFormat != (AudioFormat{
+			Encoding:     "PCM_S16LE",
+			SampleRateHz: 24000,
+			Channels:     1,
+		}) {
+		t.Fatalf("result = %#v", result)
+	}
+	if provider.appID != "app-1" ||
+		!provider.expiresAt.Equal(now.Add(10*time.Minute)) {
+		t.Fatalf(
+			"provider request = app %q, expiry %s",
+			provider.appID,
+			provider.expiresAt,
+		)
+	}
+}
+
+func TestServiceRejectsUnownedAndNonInteractiveSessionsBeforeProvider(
+	t *testing.T,
+) {
+	tests := []struct {
+		name         string
+		reader       contextSessionReaderStub
+		expected     apperror.Category
+		expectedCode string
+	}{
+		{
+			name: "unowned",
+			reader: contextSessionReaderStub{
+				err: persistence.ErrNotFound,
+			},
+			expected:     apperror.NotFound,
+			expectedCode: "practice_session_not_found",
+		},
+		{
+			name: "paused",
+			reader: contextSessionReaderStub{
+				session: func() persistence.ContextSession {
+					session := interactiveSession()
+					session.Status = persistence.ContextSessionPaused
+					return session
+				}(),
+			},
+			expected:     apperror.Conflict,
+			expectedCode: "resource_conflict",
+		},
+		{
+			name: "terminal",
+			reader: contextSessionReaderStub{
+				session: func() persistence.ContextSession {
+					session := interactiveSession()
+					session.Status = persistence.ContextSessionCompleted
+					return session
+				}(),
+			},
+			expected:     apperror.Conflict,
+			expectedCode: "resource_conflict",
+		},
+		{
+			name: "unsupported scenario",
+			reader: contextSessionReaderStub{
+				session: func() persistence.ContextSession {
+					session := interactiveSession()
+					session.ScenarioType =
+						persistence.ScenarioFamilyInterview
+					return session
+				}(),
+			},
+			expected:     apperror.Conflict,
+			expectedCode: "resource_conflict",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &tokenProviderStub{
+				token: ProviderSessionToken{
+					Value:     "provider-session-token",
+					ExpiresAt: time.Now().Add(5 * time.Minute),
+				},
+			}
+			service := newTestService(t, test.reader, provider)
+			_, err := service.IssueSessionToken(
+				context.Background(),
+				testActor(),
+				"practice-session-1",
+			)
+			appError, ok := apperror.From(err)
+			if !ok ||
+				appError.Category() != test.expected ||
+				appError.Code() != test.expectedCode {
+				t.Fatalf("error = %#v", err)
+			}
+			if provider.calls != 0 {
+				t.Fatalf("provider calls = %d, want 0", provider.calls)
+			}
+		})
+	}
+}
+
+func TestServiceMapsProviderFailuresWithoutExposingProviderDetails(
+	t *testing.T,
+) {
+	tests := []struct {
+		name          string
+		providerError error
+		expectedCode  string
+	}{
+		{
+			name:          "unavailable",
+			providerError: ErrProviderUnavailable,
+			expectedCode:  "provider_unavailable",
+		},
+		{
+			name:          "quota",
+			providerError: ErrProviderQuotaExhausted,
+			expectedCode:  "quota_exhausted",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestService(
+				t,
+				contextSessionReaderStub{session: interactiveSession()},
+				&tokenProviderStub{err: test.providerError},
+			)
+			_, err := service.IssueSessionToken(
+				context.Background(),
+				testActor(),
+				"practice-session-1",
+			)
+			appError, ok := apperror.From(err)
+			if !ok ||
+				appError.Category() != apperror.Unavailable ||
+				appError.Code() != test.expectedCode ||
+				!appError.Retryable() {
+				t.Fatalf("error = %#v", err)
+			}
+			if errors.Is(err, test.providerError) == false {
+				t.Fatal("provider cause was not preserved")
+			}
+		})
+	}
+}
+
+func TestNewServiceRejectsTokenTTLAboveHardLimit(t *testing.T) {
+	_, err := NewService(
+		ServiceConfiguration{
+			Enabled:  true,
+			AppID:    "app-1",
+			AvatarID: "avatar-1",
+			Region:   "cn-beijing",
+			TokenTTL: maximumSessionTokenTTL + time.Nanosecond,
+		},
+		contextSessionReaderStub{},
+		&tokenProviderStub{},
+	)
+	if err == nil {
+		t.Fatal("NewService() error = nil")
+	}
+}
+
+func TestServiceRejectsProviderExpiryBeyondRequestedHardLimit(t *testing.T) {
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	service := newTestService(
+		t,
+		contextSessionReaderStub{session: interactiveSession()},
+		&tokenProviderStub{
+			token: ProviderSessionToken{
+				Value:     "provider-session-token",
+				ExpiresAt: now.Add(maximumSessionTokenTTL + time.Second),
+			},
+		},
+	)
+	service.now = func() time.Time { return now }
+
+	_, err := service.IssueSessionToken(
+		context.Background(),
+		testActor(),
+		"practice-session-1",
+	)
+	appError, ok := apperror.From(err)
+	if !ok ||
+		appError.Category() != apperror.Unavailable ||
+		appError.Code() != "provider_unavailable" ||
+		!errors.Is(err, ErrInvalidProviderResponse) {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func newTestService(
+	t *testing.T,
+	sessions SessionReader,
+	provider TokenProvider,
+) *Service {
+	t.Helper()
+	service, err := NewService(
+		ServiceConfiguration{
+			Enabled:  true,
+			AppID:    "app-1",
+			AvatarID: "avatar-1",
+			Region:   "cn-beijing",
+			TokenTTL: 10 * time.Minute,
+		},
+		sessions,
+		provider,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	return service
+}
+
+func interactiveSession() persistence.ContextSession {
+	return persistence.ContextSession{
+		ID:           "practice-session-1",
+		ScenarioType: persistence.ScenarioFamilyWorkplace,
+		Status:       persistence.ContextSessionProgress,
+	}
+}
+
+func testActor() requestcontext.Actor {
+	return requestcontext.Actor{
+		UserID:    "user-1",
+		SessionID: "identity-session-1",
+	}
+}
+
+type contextSessionReaderStub struct {
+	session persistence.ContextSession
+	err     error
+}
+
+func (stub contextSessionReaderStub) GetSession(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (persistence.ContextSession, error) {
+	return stub.session, stub.err
+}
+
+type tokenProviderStub struct {
+	token     ProviderSessionToken
+	err       error
+	appID     string
+	expiresAt time.Time
+	calls     int
+}
+
+func (stub *tokenProviderStub) CreateSessionToken(
+	_ context.Context,
+	appID string,
+	expiresAt time.Time,
+) (ProviderSessionToken, error) {
+	stub.calls++
+	stub.appID = appID
+	stub.expiresAt = expiresAt
+	return stub.token, stub.err
+}

--- a/server/internal/avatar/spatius_client.go
+++ b/server/internal/avatar/spatius_client.go
@@ -1,0 +1,237 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+)
+
+const maxSpatiusResponseBody = 64 * 1024
+
+var (
+	ErrProviderUnavailable     = errors.New("avatar provider unavailable")
+	ErrProviderQuotaExhausted  = errors.New("avatar provider quota exhausted")
+	ErrInvalidProviderResponse = errors.New("invalid avatar provider response")
+)
+
+type SpatiusClient struct {
+	endpoint string
+	apiKey   config.Secret
+	client   *http.Client
+}
+
+func NewSpatiusClient(
+	configuration config.SpatiusConfig,
+) (*SpatiusClient, error) {
+	return newSpatiusClient(configuration, nil)
+}
+
+func newSpatiusClient(
+	configuration config.SpatiusConfig,
+	client *http.Client,
+) (*SpatiusClient, error) {
+	if !configuration.Enabled {
+		return nil, errors.New("avatar: Spatius provider is disabled")
+	}
+	if strings.TrimSpace(configuration.ConsoleBaseURL) == "" ||
+		strings.TrimSpace(configuration.AppID) == "" ||
+		configuration.APIKey.Reveal() == "" ||
+		configuration.Timeout <= 0 {
+		return nil, errors.New("avatar: Spatius client configuration is required")
+	}
+	if client == nil {
+		client = &http.Client{}
+	}
+	client.Timeout = configuration.Timeout
+	client.CheckRedirect = func(
+		_ *http.Request,
+		_ []*http.Request,
+	) error {
+		return http.ErrUseLastResponse
+	}
+	return &SpatiusClient{
+		endpoint: strings.TrimSuffix(
+			configuration.ConsoleBaseURL,
+			"/",
+		) + "/session-tokens",
+		apiKey: configuration.APIKey,
+		client: client,
+	}, nil
+}
+
+func (client *SpatiusClient) CreateSessionToken(
+	ctx context.Context,
+	appID string,
+	expiresAt time.Time,
+) (ProviderSessionToken, error) {
+	if client == nil || client.client == nil || ctx == nil ||
+		strings.TrimSpace(appID) == "" ||
+		!expiresAt.After(time.Now().UTC()) {
+		return ProviderSessionToken{}, ErrProviderUnavailable
+	}
+	payload, err := json.Marshal(struct {
+		AppID    string `json:"appId"`
+		ExpireAt int64  `json:"expireAt"`
+	}{
+		AppID:    appID,
+		ExpireAt: expiresAt.UTC().Unix(),
+	})
+	if err != nil {
+		return ProviderSessionToken{}, ErrProviderUnavailable
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		client.endpoint,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return ProviderSessionToken{}, ErrProviderUnavailable
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Api-Key", client.apiKey.Reveal())
+
+	response, err := client.client.Do(request)
+	if err != nil {
+		return ProviderSessionToken{}, fmt.Errorf(
+			"create avatar provider session token: %w",
+			ErrProviderUnavailable,
+		)
+	}
+	defer response.Body.Close()
+
+	switch {
+	case response.StatusCode == http.StatusTooManyRequests ||
+		response.StatusCode == http.StatusPaymentRequired:
+		discardSpatiusResponse(response.Body)
+		return ProviderSessionToken{}, ErrProviderQuotaExhausted
+	case response.StatusCode < http.StatusOK ||
+		response.StatusCode >= http.StatusMultipleChoices:
+		discardSpatiusResponse(response.Body)
+		return ProviderSessionToken{}, ErrProviderUnavailable
+	}
+	if !spatiusJSONContentType(response.Header.Get("Content-Type")) {
+		discardSpatiusResponse(response.Body)
+		return ProviderSessionToken{}, ErrInvalidProviderResponse
+	}
+	body, err := io.ReadAll(io.LimitReader(
+		response.Body,
+		maxSpatiusResponseBody+1,
+	))
+	if err != nil || len(body) == 0 || len(body) > maxSpatiusResponseBody {
+		return ProviderSessionToken{}, ErrInvalidProviderResponse
+	}
+	token, providerExpiry, err := decodeSpatiusSessionToken(body)
+	if err != nil {
+		return ProviderSessionToken{}, ErrInvalidProviderResponse
+	}
+	if providerExpiry.IsZero() {
+		providerExpiry = expiresAt.UTC().Truncate(time.Second)
+	}
+	return ProviderSessionToken{
+		Value:     token,
+		ExpiresAt: providerExpiry.UTC(),
+	}, nil
+}
+
+func decodeSpatiusSessionToken(
+	body []byte,
+) (string, time.Time, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var document map[string]any
+	if err := decoder.Decode(&document); err != nil {
+		return "", time.Time{}, err
+	}
+	var trailing any
+	if !errors.Is(decoder.Decode(&trailing), io.EOF) {
+		return "", time.Time{}, ErrInvalidProviderResponse
+	}
+	token := spatiusTokenValue(document)
+	if token != "" {
+		expiry, err := spatiusExpiryValue(document)
+		if err != nil || !validSessionToken(token) {
+			return "", time.Time{}, ErrInvalidProviderResponse
+		}
+		return token, expiry, nil
+	}
+	data, ok := document["data"].(map[string]any)
+	if !ok {
+		return "", time.Time{}, ErrInvalidProviderResponse
+	}
+	token = spatiusTokenValue(data)
+	if !validSessionToken(token) {
+		return "", time.Time{}, ErrInvalidProviderResponse
+	}
+	expiry, err := spatiusExpiryValue(data)
+	if err != nil {
+		return "", time.Time{}, ErrInvalidProviderResponse
+	}
+	if expiry.IsZero() {
+		expiry, err = spatiusExpiryValue(document)
+	}
+	return token, expiry, err
+}
+
+func spatiusTokenValue(document map[string]any) string {
+	for _, key := range []string{"sessionToken", "sessionKey", "token"} {
+		if value, ok := document[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func spatiusExpiryValue(document map[string]any) (time.Time, error) {
+	for _, key := range []string{
+		"expireAt",
+		"expiresAt",
+		"expires_at",
+	} {
+		value, exists := document[key]
+		if !exists {
+			continue
+		}
+		switch typed := value.(type) {
+		case json.Number:
+			seconds, err := typed.Int64()
+			if err != nil || seconds <= 0 {
+				return time.Time{}, ErrInvalidProviderResponse
+			}
+			return time.Unix(seconds, 0).UTC(), nil
+		case string:
+			if seconds, err := strconv.ParseInt(typed, 10, 64); err == nil &&
+				seconds > 0 {
+				return time.Unix(seconds, 0).UTC(), nil
+			}
+			parsed, err := time.Parse(time.RFC3339, typed)
+			if err != nil {
+				return time.Time{}, ErrInvalidProviderResponse
+			}
+			return parsed.UTC(), nil
+		default:
+			return time.Time{}, ErrInvalidProviderResponse
+		}
+	}
+	return time.Time{}, nil
+}
+
+func spatiusJSONContentType(raw string) bool {
+	mediaType, _, err := mime.ParseMediaType(raw)
+	return err == nil && strings.EqualFold(mediaType, "application/json")
+}
+
+func discardSpatiusResponse(body io.Reader) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxSpatiusResponseBody))
+}

--- a/server/internal/avatar/spatius_client.go
+++ b/server/internal/avatar/spatius_client.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -80,10 +79,8 @@ func (client *SpatiusClient) CreateSessionToken(
 		return ProviderSessionToken{}, ErrProviderUnavailable
 	}
 	payload, err := json.Marshal(struct {
-		AppID    string `json:"appId"`
-		ExpireAt int64  `json:"expireAt"`
+		ExpireAt int64 `json:"expireAt"`
 	}{
-		AppID:    appID,
 		ExpireAt: expiresAt.UTC().Unix(),
 	})
 	if err != nil {
@@ -132,99 +129,44 @@ func (client *SpatiusClient) CreateSessionToken(
 	if err != nil || len(body) == 0 || len(body) > maxSpatiusResponseBody {
 		return ProviderSessionToken{}, ErrInvalidProviderResponse
 	}
-	token, providerExpiry, err := decodeSpatiusSessionToken(body)
+	token, err := decodeSpatiusSessionToken(body)
 	if err != nil {
-		return ProviderSessionToken{}, ErrInvalidProviderResponse
-	}
-	if providerExpiry.IsZero() {
-		providerExpiry = expiresAt.UTC().Truncate(time.Second)
+		return ProviderSessionToken{}, err
 	}
 	return ProviderSessionToken{
 		Value:     token,
-		ExpiresAt: providerExpiry.UTC(),
+		ExpiresAt: expiresAt.UTC().Truncate(time.Second),
 	}, nil
 }
 
-func decodeSpatiusSessionToken(
-	body []byte,
-) (string, time.Time, error) {
+func decodeSpatiusSessionToken(body []byte) (string, error) {
 	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	var document map[string]any
+	var document struct {
+		SessionToken string `json:"sessionToken"`
+		Errors       []struct {
+			Status int `json:"status"`
+		} `json:"errors"`
+	}
 	if err := decoder.Decode(&document); err != nil {
-		return "", time.Time{}, err
+		return "", ErrInvalidProviderResponse
 	}
 	var trailing any
 	if !errors.Is(decoder.Decode(&trailing), io.EOF) {
-		return "", time.Time{}, ErrInvalidProviderResponse
+		return "", ErrInvalidProviderResponse
 	}
-	token := spatiusTokenValue(document)
-	if token != "" {
-		expiry, err := spatiusExpiryValue(document)
-		if err != nil || !validSessionToken(token) {
-			return "", time.Time{}, ErrInvalidProviderResponse
-		}
-		return token, expiry, nil
-	}
-	data, ok := document["data"].(map[string]any)
-	if !ok {
-		return "", time.Time{}, ErrInvalidProviderResponse
-	}
-	token = spatiusTokenValue(data)
-	if !validSessionToken(token) {
-		return "", time.Time{}, ErrInvalidProviderResponse
-	}
-	expiry, err := spatiusExpiryValue(data)
-	if err != nil {
-		return "", time.Time{}, ErrInvalidProviderResponse
-	}
-	if expiry.IsZero() {
-		expiry, err = spatiusExpiryValue(document)
-	}
-	return token, expiry, err
-}
-
-func spatiusTokenValue(document map[string]any) string {
-	for _, key := range []string{"sessionToken", "sessionKey", "token"} {
-		if value, ok := document[key].(string); ok {
-			return value
+	for _, providerError := range document.Errors {
+		if providerError.Status == http.StatusPaymentRequired ||
+			providerError.Status == http.StatusTooManyRequests {
+			return "", ErrProviderQuotaExhausted
 		}
 	}
-	return ""
-}
-
-func spatiusExpiryValue(document map[string]any) (time.Time, error) {
-	for _, key := range []string{
-		"expireAt",
-		"expiresAt",
-		"expires_at",
-	} {
-		value, exists := document[key]
-		if !exists {
-			continue
-		}
-		switch typed := value.(type) {
-		case json.Number:
-			seconds, err := typed.Int64()
-			if err != nil || seconds <= 0 {
-				return time.Time{}, ErrInvalidProviderResponse
-			}
-			return time.Unix(seconds, 0).UTC(), nil
-		case string:
-			if seconds, err := strconv.ParseInt(typed, 10, 64); err == nil &&
-				seconds > 0 {
-				return time.Unix(seconds, 0).UTC(), nil
-			}
-			parsed, err := time.Parse(time.RFC3339, typed)
-			if err != nil {
-				return time.Time{}, ErrInvalidProviderResponse
-			}
-			return parsed.UTC(), nil
-		default:
-			return time.Time{}, ErrInvalidProviderResponse
-		}
+	if len(document.Errors) > 0 {
+		return "", ErrProviderUnavailable
 	}
-	return time.Time{}, nil
+	if !validSessionToken(document.SessionToken) {
+		return "", ErrInvalidProviderResponse
+	}
+	return document.SessionToken, nil
 }
 
 func spatiusJSONContentType(raw string) bool {

--- a/server/internal/avatar/spatius_client_test.go
+++ b/server/internal/avatar/spatius_client_test.go
@@ -1,0 +1,214 @@
+package avatar
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+)
+
+func TestSpatiusClientSendsServerCredentialAndParsesNestedResponse(
+	t *testing.T,
+) {
+	expiry := time.Now().UTC().Add(10 * time.Minute).Truncate(time.Second)
+	server := httptest.NewTLSServer(http.HandlerFunc(
+		func(response http.ResponseWriter, request *http.Request) {
+			if request.Method != http.MethodPost ||
+				request.URL.Path != "/v1/console/session-tokens" ||
+				request.Header.Get("X-Api-Key") != "server-only-key" ||
+				request.Header.Get("Accept") != "application/json" ||
+				request.Header.Get("Content-Type") != "application/json" {
+				t.Fatalf("unexpected request: %#v", request)
+			}
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			var payload struct {
+				AppID    string `json:"appId"`
+				ExpireAt int64  `json:"expireAt"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if payload.AppID != "app-1" ||
+				payload.ExpireAt != expiry.Unix() {
+				t.Fatalf("payload = %#v", payload)
+			}
+			response.Header().Set("Content-Type", "application/json")
+			_, _ = response.Write([]byte(
+				`{"data":{"sessionKey":"provider-session-token","expireAt":` +
+					jsonNumber(expiry.Unix()) + `}}`,
+			))
+		},
+	))
+	defer server.Close()
+	configuration := spatiusClientTestConfiguration(t)
+	configuration.ConsoleBaseURL = server.URL + "/v1/console"
+	client, err := newSpatiusClient(configuration, server.Client())
+	if err != nil {
+		t.Fatalf("newSpatiusClient() error = %v", err)
+	}
+
+	result, err := client.CreateSessionToken(
+		t.Context(),
+		"app-1",
+		expiry,
+	)
+	if err != nil {
+		t.Fatalf("CreateSessionToken() error = %v", err)
+	}
+	if result.Value != "provider-session-token" ||
+		!result.ExpiresAt.Equal(expiry) {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestSpatiusClientDoesNotFollowRedirects(t *testing.T) {
+	var redirected atomic.Int32
+	target := httptest.NewTLSServer(http.HandlerFunc(
+		func(http.ResponseWriter, *http.Request) {
+			redirected.Add(1)
+		},
+	))
+	defer target.Close()
+	source := httptest.NewTLSServer(http.HandlerFunc(
+		func(response http.ResponseWriter, _ *http.Request) {
+			response.Header().Set("Location", target.URL)
+			response.WriteHeader(http.StatusTemporaryRedirect)
+		},
+	))
+	defer source.Close()
+	configuration := spatiusClientTestConfiguration(t)
+	configuration.ConsoleBaseURL = source.URL
+	client, err := newSpatiusClient(configuration, source.Client())
+	if err != nil {
+		t.Fatalf("newSpatiusClient() error = %v", err)
+	}
+
+	_, err = client.CreateSessionToken(
+		t.Context(),
+		"app-1",
+		time.Now().Add(5*time.Minute),
+	)
+	if !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("error = %v", err)
+	}
+	if redirected.Load() != 0 {
+		t.Fatalf("redirect target requests = %d", redirected.Load())
+	}
+}
+
+func TestSpatiusClientRejectsUnsafeProviderResponses(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		expected    error
+	}{
+		{
+			name:        "quota",
+			status:      http.StatusTooManyRequests,
+			contentType: "application/json",
+			body:        `{"error":"secret diagnostics"}`,
+			expected:    ErrProviderQuotaExhausted,
+		},
+		{
+			name:        "wrong content type",
+			status:      http.StatusOK,
+			contentType: "text/html",
+			body:        `<p>provider-session-token</p>`,
+			expected:    ErrInvalidProviderResponse,
+		},
+		{
+			name:        "missing token",
+			status:      http.StatusOK,
+			contentType: "application/json",
+			body:        `{"data":{}}`,
+			expected:    ErrInvalidProviderResponse,
+		},
+		{
+			name:        "oversized",
+			status:      http.StatusOK,
+			contentType: "application/json",
+			body:        strings.Repeat("x", maxSpatiusResponseBody+1),
+			expected:    ErrInvalidProviderResponse,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(
+				func(response http.ResponseWriter, _ *http.Request) {
+					response.Header().Set("Content-Type", test.contentType)
+					response.WriteHeader(test.status)
+					_, _ = response.Write([]byte(test.body))
+				},
+			))
+			defer server.Close()
+			configuration := spatiusClientTestConfiguration(t)
+			configuration.ConsoleBaseURL = server.URL
+			client, err := newSpatiusClient(
+				configuration,
+				server.Client(),
+			)
+			if err != nil {
+				t.Fatalf("newSpatiusClient() error = %v", err)
+			}
+			_, err = client.CreateSessionToken(
+				t.Context(),
+				"app-1",
+				time.Now().Add(5*time.Minute),
+			)
+			if !errors.Is(err, test.expected) {
+				t.Fatalf("error = %v, want %v", err, test.expected)
+			}
+			if strings.Contains(
+				err.Error(),
+				"server-only-key",
+			) {
+				t.Fatal("error exposed the API key")
+			}
+		})
+	}
+}
+
+func spatiusClientTestConfiguration(
+	t *testing.T,
+) config.SpatiusConfig {
+	t.Helper()
+	t.Setenv("SPATIUS_ENABLED", "true")
+	t.Setenv("SPATIUS_REGION", "cn-beijing")
+	t.Setenv("SPATIUS_CONSOLE_BASE_URL", "")
+	t.Setenv("SPATIUS_APP_ID", "app-1")
+	t.Setenv("SPATIUS_AVATAR_ID", "avatar-1")
+	t.Setenv("SPATIUS_API_KEY", "server-only-key")
+	t.Setenv("SPATIUS_TOKEN_TTL", "10m")
+	t.Setenv("SPATIUS_TIMEOUT", "5s")
+	configuration, err := config.LoadSpatius()
+	if err != nil {
+		t.Fatalf("LoadSpatius() error = %v", err)
+	}
+	return configuration
+}
+
+func jsonNumber(value int64) string {
+	return strings.TrimSpace(
+		string(mustJSONMarshal(value)),
+	)
+}
+
+func mustJSONMarshal(value any) []byte {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}

--- a/server/internal/avatar/spatius_client_test.go
+++ b/server/internal/avatar/spatius_client_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 )
 
-func TestSpatiusClientSendsServerCredentialAndParsesNestedResponse(
+func TestSpatiusClientSendsServerCredentialAndParsesResponse(
 	t *testing.T,
 ) {
 	expiry := time.Now().UTC().Add(10 * time.Minute).Truncate(time.Second)
@@ -31,21 +31,23 @@ func TestSpatiusClientSendsServerCredentialAndParsesNestedResponse(
 			if err != nil {
 				t.Fatalf("read body: %v", err)
 			}
-			var payload struct {
-				AppID    string `json:"appId"`
-				ExpireAt int64  `json:"expireAt"`
-			}
+			var payload map[string]json.RawMessage
 			if err := json.Unmarshal(body, &payload); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if payload.AppID != "app-1" ||
-				payload.ExpireAt != expiry.Unix() {
+			if len(payload) != 1 {
 				t.Fatalf("payload = %#v", payload)
+			}
+			var expireAt int64
+			if err := json.Unmarshal(payload["expireAt"], &expireAt); err != nil {
+				t.Fatalf("decode expireAt: %v", err)
+			}
+			if expireAt != expiry.Unix() {
+				t.Fatalf("expireAt = %d", expireAt)
 			}
 			response.Header().Set("Content-Type", "application/json")
 			_, _ = response.Write([]byte(
-				`{"data":{"sessionKey":"provider-session-token","expireAt":` +
-					jsonNumber(expiry.Unix()) + `}}`,
+				`{"sessionToken":"provider-session-token"}`,
 			))
 		},
 	))
@@ -136,6 +138,20 @@ func TestSpatiusClientRejectsUnsafeProviderResponses(t *testing.T) {
 			expected:    ErrInvalidProviderResponse,
 		},
 		{
+			name:        "provider error",
+			status:      http.StatusOK,
+			contentType: "application/json",
+			body:        `{"errors":[{"status":400,"detail":"invalid api key"}]}`,
+			expected:    ErrProviderUnavailable,
+		},
+		{
+			name:        "provider quota error",
+			status:      http.StatusOK,
+			contentType: "application/json",
+			body:        `{"errors":[{"status":429,"detail":"secret diagnostics"}]}`,
+			expected:    ErrProviderQuotaExhausted,
+		},
+		{
 			name:        "oversized",
 			status:      http.StatusOK,
 			contentType: "application/json",
@@ -185,7 +201,7 @@ func spatiusClientTestConfiguration(
 ) config.SpatiusConfig {
 	t.Helper()
 	t.Setenv("SPATIUS_ENABLED", "true")
-	t.Setenv("SPATIUS_REGION", "cn-beijing")
+	t.Setenv("SPATIUS_REGION", "ap-northeast")
 	t.Setenv("SPATIUS_CONSOLE_BASE_URL", "")
 	t.Setenv("SPATIUS_APP_ID", "app-1")
 	t.Setenv("SPATIUS_AVATAR_ID", "avatar-1")
@@ -197,18 +213,4 @@ func spatiusClientTestConfiguration(
 		t.Fatalf("LoadSpatius() error = %v", err)
 	}
 	return configuration
-}
-
-func jsonNumber(value int64) string {
-	return strings.TrimSpace(
-		string(mustJSONMarshal(value)),
-	)
-}
-
-func mustJSONMarshal(value any) []byte {
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		panic(err)
-	}
-	return encoded
 }

--- a/server/internal/platform/config/spatius.go
+++ b/server/internal/platform/config/spatius.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	SpatiusRegionChinaBeijing = "cn-beijing"
+	SpatiusRegionAPNortheast  = "ap-northeast"
+	SpatiusRegionUSWest       = "us-west"
+	defaultSpatiusRegion      = SpatiusRegionChinaBeijing
+	defaultSpatiusTokenTTL    = 10 * time.Minute
+	defaultSpatiusTimeout     = 5 * time.Second
+	minimumSpatiusTokenTTL    = time.Minute
+	maximumSpatiusTokenTTL    = 10 * time.Minute
+	maximumSpatiusHTTPTimeout = 30 * time.Second
+)
+
+var spatiusConsoleBaseURLs = map[string]string{
+	SpatiusRegionChinaBeijing: "https://console.cn-beijing.spatialwalk.top/v1/console",
+	SpatiusRegionAPNortheast:  "https://console.ap-northeast.spatius.ai/v1/console",
+	SpatiusRegionUSWest:       "https://console.us-west.spatius.ai/v1/console",
+}
+
+type SpatiusConfig struct {
+	Enabled        bool
+	ConsoleBaseURL string
+	AppID          string
+	AvatarID       string
+	Region         string
+	APIKey         Secret
+	TokenTTL       time.Duration
+	Timeout        time.Duration
+}
+
+// LoadSpatius validates the server-only avatar provider configuration. When
+// disabled, public metadata and credentials are optional so the existing
+// voice/text experience can start without the provider.
+func LoadSpatius() (SpatiusConfig, error) {
+	enabled, err := parseSpatiusEnabled(os.Getenv("SPATIUS_ENABLED"))
+	if err != nil {
+		return SpatiusConfig{}, err
+	}
+	if !enabled {
+		return SpatiusConfig{
+			Enabled:        false,
+			ConsoleBaseURL: spatiusConsoleBaseURLs[defaultSpatiusRegion],
+			Region:         defaultSpatiusRegion,
+			TokenTTL:       defaultSpatiusTokenTTL,
+			Timeout:        defaultSpatiusTimeout,
+		}, nil
+	}
+	region := strings.ToLower(strings.TrimSpace(os.Getenv("SPATIUS_REGION")))
+	if region == "" {
+		region = defaultSpatiusRegion
+	}
+	defaultBaseURL, regionSupported := spatiusConsoleBaseURLs[region]
+	if !regionSupported {
+		return SpatiusConfig{}, errors.New("SPATIUS_REGION is not supported")
+	}
+	baseURL := strings.TrimSpace(os.Getenv("SPATIUS_CONSOLE_BASE_URL"))
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	if !validSpatiusConsoleBaseURL(baseURL, defaultBaseURL) {
+		return SpatiusConfig{}, errors.New(
+			"SPATIUS_CONSOLE_BASE_URL does not match SPATIUS_REGION",
+		)
+	}
+	tokenTTL, err := durationOrDefault(
+		"SPATIUS_TOKEN_TTL",
+		defaultSpatiusTokenTTL,
+	)
+	if err != nil {
+		return SpatiusConfig{}, err
+	}
+	if tokenTTL < minimumSpatiusTokenTTL ||
+		tokenTTL > maximumSpatiusTokenTTL {
+		return SpatiusConfig{}, fmt.Errorf(
+			"SPATIUS_TOKEN_TTL must be between %s and %s",
+			minimumSpatiusTokenTTL,
+			maximumSpatiusTokenTTL,
+		)
+	}
+	timeout, err := durationOrDefault(
+		"SPATIUS_TIMEOUT",
+		defaultSpatiusTimeout,
+	)
+	if err != nil {
+		return SpatiusConfig{}, err
+	}
+	if timeout <= 0 || timeout > maximumSpatiusHTTPTimeout {
+		return SpatiusConfig{}, fmt.Errorf(
+			"SPATIUS_TIMEOUT must be greater than zero and at most %s",
+			maximumSpatiusHTTPTimeout,
+		)
+	}
+
+	appID := strings.TrimSpace(os.Getenv("SPATIUS_APP_ID"))
+	avatarID := strings.TrimSpace(os.Getenv("SPATIUS_AVATAR_ID"))
+	rawAPIKey := strings.TrimSpace(os.Getenv("SPATIUS_API_KEY"))
+	if enabled {
+		switch {
+		case !validSpatiusIdentifier(appID):
+			return SpatiusConfig{}, errors.New(
+				"SPATIUS_APP_ID is required and must be a valid identifier",
+			)
+		case !validSpatiusIdentifier(avatarID):
+			return SpatiusConfig{}, errors.New(
+				"SPATIUS_AVATAR_ID is required and must be a valid identifier",
+			)
+		case !validSpatiusSecret(rawAPIKey):
+			return SpatiusConfig{}, errors.New(
+				"SPATIUS_API_KEY is required and contains an invalid character",
+			)
+		}
+	}
+	return SpatiusConfig{
+		Enabled:        enabled,
+		ConsoleBaseURL: baseURL,
+		AppID:          appID,
+		AvatarID:       avatarID,
+		Region:         region,
+		APIKey:         Secret{value: rawAPIKey},
+		TokenTTL:       tokenTTL,
+		Timeout:        timeout,
+	}, nil
+}
+
+func parseSpatiusEnabled(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "0", "false", "disabled":
+		return false, nil
+	case "1", "true", "enabled":
+		return true, nil
+	default:
+		return false, errors.New("SPATIUS_ENABLED must be a boolean")
+	}
+}
+
+func validSpatiusConsoleBaseURL(value string, expected string) bool {
+	parsed, err := url.Parse(value)
+	if err != nil ||
+		parsed.Scheme != "https" ||
+		parsed.User != nil ||
+		parsed.RawQuery != "" ||
+		parsed.Fragment != "" ||
+		parsed.String() != value {
+		return false
+	}
+	return value == expected
+}
+
+func validSpatiusIdentifier(value string) bool {
+	if len(value) < 1 || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z',
+			character >= 'A' && character <= 'Z',
+			character >= '0' && character <= '9',
+			character == '-',
+			character == '_',
+			character == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validSpatiusSecret(value string) bool {
+	if len(value) < 8 || len(value) > 4096 {
+		return false
+	}
+	return strings.IndexFunc(value, func(character rune) bool {
+		return character < 0x21 || character > 0x7e
+	}) < 0
+}

--- a/server/internal/platform/config/spatius.go
+++ b/server/internal/platform/config/spatius.go
@@ -10,10 +10,9 @@ import (
 )
 
 const (
-	SpatiusRegionChinaBeijing = "cn-beijing"
 	SpatiusRegionAPNortheast  = "ap-northeast"
 	SpatiusRegionUSWest       = "us-west"
-	defaultSpatiusRegion      = SpatiusRegionChinaBeijing
+	defaultSpatiusRegion      = SpatiusRegionAPNortheast
 	defaultSpatiusTokenTTL    = 10 * time.Minute
 	defaultSpatiusTimeout     = 5 * time.Second
 	minimumSpatiusTokenTTL    = time.Minute
@@ -22,9 +21,8 @@ const (
 )
 
 var spatiusConsoleBaseURLs = map[string]string{
-	SpatiusRegionChinaBeijing: "https://console.cn-beijing.spatialwalk.top/v1/console",
-	SpatiusRegionAPNortheast:  "https://console.ap-northeast.spatius.ai/v1/console",
-	SpatiusRegionUSWest:       "https://console.us-west.spatius.ai/v1/console",
+	SpatiusRegionAPNortheast: "https://console.ap-northeast.spatialwalk.cloud/v1/console",
+	SpatiusRegionUSWest:      "https://console.us-west.spatialwalk.cloud/v1/console",
 }
 
 type SpatiusConfig struct {

--- a/server/internal/platform/config/spatius_test.go
+++ b/server/internal/platform/config/spatius_test.go
@@ -14,9 +14,9 @@ func TestLoadSpatiusUsesDisabledSafeDefaults(t *testing.T) {
 		t.Fatalf("LoadSpatius() error = %v", err)
 	}
 	if configuration.Enabled ||
-		configuration.Region != SpatiusRegionChinaBeijing ||
+		configuration.Region != SpatiusRegionAPNortheast ||
 		configuration.ConsoleBaseURL !=
-			"https://console.cn-beijing.spatialwalk.top/v1/console" ||
+			"https://console.ap-northeast.spatialwalk.cloud/v1/console" ||
 		configuration.TokenTTL != 10*time.Minute ||
 		configuration.Timeout != 5*time.Second ||
 		configuration.APIKey.Reveal() != "" {
@@ -30,7 +30,7 @@ func TestLoadSpatiusReadsEnabledConfiguration(t *testing.T) {
 	t.Setenv("SPATIUS_REGION", SpatiusRegionAPNortheast)
 	t.Setenv(
 		"SPATIUS_CONSOLE_BASE_URL",
-		"https://console.ap-northeast.spatius.ai/v1/console",
+		"https://console.ap-northeast.spatialwalk.cloud/v1/console",
 	)
 	t.Setenv("SPATIUS_APP_ID", "app-test_1")
 	t.Setenv("SPATIUS_AVATAR_ID", "avatar-test_1")
@@ -70,12 +70,12 @@ func TestLoadSpatiusRejectsUnsafeConfiguration(t *testing.T) {
 		{
 			name:  "region endpoint mismatch",
 			key:   "SPATIUS_CONSOLE_BASE_URL",
-			value: "https://console.us-west.spatius.ai/v1/console",
+			value: "https://console.us-west.spatialwalk.cloud/v1/console",
 		},
 		{
 			name:  "endpoint query",
 			key:   "SPATIUS_CONSOLE_BASE_URL",
-			value: "https://console.cn-beijing.spatialwalk.top/v1/console?redirect=1",
+			value: "https://console.ap-northeast.spatialwalk.cloud/v1/console?redirect=1",
 		},
 		{name: "short token ttl", key: "SPATIUS_TOKEN_TTL", value: "30s"},
 		{name: "long token ttl", key: "SPATIUS_TOKEN_TTL", value: "11m"},
@@ -109,7 +109,7 @@ func TestLoadSpatiusDisabledIgnoresStaleProviderOverrides(t *testing.T) {
 		t.Fatalf("LoadSpatius() error = %v", err)
 	}
 	if configuration.Enabled ||
-		configuration.Region != SpatiusRegionChinaBeijing ||
+		configuration.Region != SpatiusRegionAPNortheast ||
 		configuration.TokenTTL != defaultSpatiusTokenTTL ||
 		configuration.Timeout != defaultSpatiusTimeout ||
 		configuration.APIKey.Reveal() != "" {
@@ -137,10 +137,10 @@ func setRequiredSpatiusEnvironment(t *testing.T) {
 	t.Helper()
 	clearSpatiusEnvironment(t)
 	t.Setenv("SPATIUS_ENABLED", "true")
-	t.Setenv("SPATIUS_REGION", SpatiusRegionChinaBeijing)
+	t.Setenv("SPATIUS_REGION", SpatiusRegionAPNortheast)
 	t.Setenv(
 		"SPATIUS_CONSOLE_BASE_URL",
-		"https://console.cn-beijing.spatialwalk.top/v1/console",
+		"https://console.ap-northeast.spatialwalk.cloud/v1/console",
 	)
 	t.Setenv("SPATIUS_APP_ID", "app-test")
 	t.Setenv("SPATIUS_AVATAR_ID", "avatar-test")

--- a/server/internal/platform/config/spatius_test.go
+++ b/server/internal/platform/config/spatius_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadSpatiusUsesDisabledSafeDefaults(t *testing.T) {
+	clearSpatiusEnvironment(t)
+
+	configuration, err := LoadSpatius()
+	if err != nil {
+		t.Fatalf("LoadSpatius() error = %v", err)
+	}
+	if configuration.Enabled ||
+		configuration.Region != SpatiusRegionChinaBeijing ||
+		configuration.ConsoleBaseURL !=
+			"https://console.cn-beijing.spatialwalk.top/v1/console" ||
+		configuration.TokenTTL != 10*time.Minute ||
+		configuration.Timeout != 5*time.Second ||
+		configuration.APIKey.Reveal() != "" {
+		t.Fatalf("unexpected defaults: %#v", configuration)
+	}
+}
+
+func TestLoadSpatiusReadsEnabledConfiguration(t *testing.T) {
+	clearSpatiusEnvironment(t)
+	t.Setenv("SPATIUS_ENABLED", "true")
+	t.Setenv("SPATIUS_REGION", SpatiusRegionAPNortheast)
+	t.Setenv(
+		"SPATIUS_CONSOLE_BASE_URL",
+		"https://console.ap-northeast.spatius.ai/v1/console",
+	)
+	t.Setenv("SPATIUS_APP_ID", "app-test_1")
+	t.Setenv("SPATIUS_AVATAR_ID", "avatar-test_1")
+	t.Setenv("SPATIUS_API_KEY", "server-only-key")
+	t.Setenv("SPATIUS_TOKEN_TTL", "8m")
+	t.Setenv("SPATIUS_TIMEOUT", "8s")
+
+	configuration, err := LoadSpatius()
+	if err != nil {
+		t.Fatalf("LoadSpatius() error = %v", err)
+	}
+	if !configuration.Enabled ||
+		configuration.Region != SpatiusRegionAPNortheast ||
+		configuration.AppID != "app-test_1" ||
+		configuration.AvatarID != "avatar-test_1" ||
+		configuration.APIKey.Reveal() != "server-only-key" ||
+		configuration.TokenTTL != 8*time.Minute ||
+		configuration.Timeout != 8*time.Second {
+		t.Fatalf("unexpected configuration: %#v", configuration)
+	}
+	if strings.Contains(
+		configuration.APIKey.String(),
+		configuration.APIKey.Reveal(),
+	) {
+		t.Fatal("formatted API key exposed its value")
+	}
+}
+
+func TestLoadSpatiusRejectsUnsafeConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "enabled flag", key: "SPATIUS_ENABLED", value: "maybe"},
+		{name: "region", key: "SPATIUS_REGION", value: "eu-central"},
+		{
+			name:  "region endpoint mismatch",
+			key:   "SPATIUS_CONSOLE_BASE_URL",
+			value: "https://console.us-west.spatius.ai/v1/console",
+		},
+		{
+			name:  "endpoint query",
+			key:   "SPATIUS_CONSOLE_BASE_URL",
+			value: "https://console.cn-beijing.spatialwalk.top/v1/console?redirect=1",
+		},
+		{name: "short token ttl", key: "SPATIUS_TOKEN_TTL", value: "30s"},
+		{name: "long token ttl", key: "SPATIUS_TOKEN_TTL", value: "11m"},
+		{name: "long timeout", key: "SPATIUS_TIMEOUT", value: "31s"},
+		{name: "app identifier", key: "SPATIUS_APP_ID", value: "bad/app"},
+		{name: "avatar identifier", key: "SPATIUS_AVATAR_ID", value: "bad avatar"},
+		{name: "api key whitespace", key: "SPATIUS_API_KEY", value: "bad key value"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setRequiredSpatiusEnvironment(t)
+			t.Setenv(test.key, test.value)
+			if _, err := LoadSpatius(); err == nil {
+				t.Fatal("expected configuration error")
+			}
+		})
+	}
+}
+
+func TestLoadSpatiusDisabledIgnoresStaleProviderOverrides(t *testing.T) {
+	clearSpatiusEnvironment(t)
+	t.Setenv("SPATIUS_ENABLED", "false")
+	t.Setenv("SPATIUS_REGION", "stale-invalid-region")
+	t.Setenv("SPATIUS_CONSOLE_BASE_URL", "http://unsafe.example.test")
+	t.Setenv("SPATIUS_TOKEN_TTL", "24h")
+	t.Setenv("SPATIUS_TIMEOUT", "2m")
+	t.Setenv("SPATIUS_API_KEY", "stale secret with spaces")
+
+	configuration, err := LoadSpatius()
+	if err != nil {
+		t.Fatalf("LoadSpatius() error = %v", err)
+	}
+	if configuration.Enabled ||
+		configuration.Region != SpatiusRegionChinaBeijing ||
+		configuration.TokenTTL != defaultSpatiusTokenTTL ||
+		configuration.Timeout != defaultSpatiusTimeout ||
+		configuration.APIKey.Reveal() != "" {
+		t.Fatalf("unexpected disabled configuration: %#v", configuration)
+	}
+}
+
+func clearSpatiusEnvironment(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"SPATIUS_ENABLED",
+		"SPATIUS_CONSOLE_BASE_URL",
+		"SPATIUS_APP_ID",
+		"SPATIUS_AVATAR_ID",
+		"SPATIUS_REGION",
+		"SPATIUS_API_KEY",
+		"SPATIUS_TOKEN_TTL",
+		"SPATIUS_TIMEOUT",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func setRequiredSpatiusEnvironment(t *testing.T) {
+	t.Helper()
+	clearSpatiusEnvironment(t)
+	t.Setenv("SPATIUS_ENABLED", "true")
+	t.Setenv("SPATIUS_REGION", SpatiusRegionChinaBeijing)
+	t.Setenv(
+		"SPATIUS_CONSOLE_BASE_URL",
+		"https://console.cn-beijing.spatialwalk.top/v1/console",
+	)
+	t.Setenv("SPATIUS_APP_ID", "app-test")
+	t.Setenv("SPATIUS_AVATAR_ID", "avatar-test")
+	t.Setenv("SPATIUS_API_KEY", "server-only-key")
+}

--- a/tools/android-dev/run.sh
+++ b/tools/android-dev/run.sh
@@ -1,0 +1,143 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+tool_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "$tool_dir/../.." && pwd)"
+server_dir="$repo_dir/server"
+mobile_dir="$repo_dir/mobile"
+server_port="${SPEAKUP_DEV_PORT:-18080}"
+base_url="http://127.0.0.1:$server_port"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/xe3-android-dev.XXXXXX")"
+server_binary="$run_dir/server"
+server_log="$run_dir/server.log"
+server_pid=""
+device_id=""
+reverse_added=0
+
+cleanup() {
+  if [[ -n "$device_id" && "$reverse_added" == "1" ]]; then
+    adb -s "$device_id" reverse --remove "tcp:$server_port" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$run_dir"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command_name in adb curl docker flutter go; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    print -u2 "缺少命令：$command_name"
+    exit 1
+  fi
+done
+
+if [[ ! -f "$repo_dir/.env" ]]; then
+  print -u2 "缺少 $repo_dir/.env，无法启动真实后端。"
+  exit 1
+fi
+
+adb start-server >/dev/null
+
+if [[ -n "${ANDROID_DEVICE_ID:-}" ]]; then
+  device_id="$ANDROID_DEVICE_ID"
+  if [[ "$(adb -s "$device_id" get-state 2>/dev/null || true)" != "device" ]]; then
+    print -u2 "ANDROID_DEVICE_ID 指定的设备未连接或尚未授权：$device_id"
+    exit 1
+  fi
+else
+  connected_devices="$(
+    adb devices |
+      awk 'NR > 1 && $2 == "device" && $1 !~ /^emulator-/ {print $1}'
+  )"
+  device_count="$(
+    print -r -- "$connected_devices" |
+      sed '/^[[:space:]]*$/d' |
+      wc -l |
+      tr -d ' '
+  )"
+  if [[ "$device_count" == "0" ]]; then
+    if adb devices | awk 'NR > 1 && $2 == "unauthorized" {found=1} END {exit !found}'; then
+      print -u2 "手机尚未授权。请解锁手机并允许这台 Mac 进行 USB 调试。"
+    else
+      print -u2 "没有检测到已授权的 Android 真机。"
+    fi
+    exit 1
+  fi
+  if [[ "$device_count" != "1" ]]; then
+    print -u2 "检测到多台 Android 真机，请设置 ANDROID_DEVICE_ID 后重试。"
+    exit 1
+  fi
+  device_id="$(print -r -- "$connected_devices" | head -n 1)"
+fi
+
+abi_list="$(adb -s "$device_id" shell getprop ro.product.cpu.abilist | tr -d '\r')"
+if [[ "$abi_list" != *"arm64-v8a"* ]]; then
+  print -u2 "当前设备不支持 AvatarKit 所需的 arm64-v8a：$abi_list"
+  exit 1
+fi
+
+device_model="$(
+  adb -s "$device_id" shell getprop ro.product.model |
+    tr -d '\r'
+)"
+print "使用 Android 真机：$device_model"
+
+print "启动 PostgreSQL..."
+docker compose -f "$repo_dir/compose.yaml" up -d --wait postgres
+
+print "执行数据库迁移..."
+(cd "$server_dir" && go run ./cmd/migrate up)
+
+print "构建并启动本地后端..."
+(cd "$server_dir" && go build -o "$server_binary" ./cmd/server)
+(
+  cd "$server_dir"
+  SERVER_HOST=127.0.0.1 \
+  SERVER_PORT="$server_port" \
+  "$server_binary"
+) >"$server_log" 2>&1 &
+server_pid=$!
+
+ready=0
+for _ in {1..120}; do
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    print -u2 "后端启动失败："
+    tail -80 "$server_log" >&2
+    exit 1
+  fi
+  if curl --silent --fail --max-time 2 "$base_url/readyz" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$ready" != "1" ]]; then
+  print -u2 "等待后端就绪超时："
+  tail -80 "$server_log" >&2
+  exit 1
+fi
+
+adb -s "$device_id" reverse "tcp:$server_port" "tcp:$server_port"
+reverse_added=1
+
+print "启动 SpeakUp；按 q 退出，修改代码后按 r 热重载。"
+cd "$mobile_dir"
+flutter build apk \
+  --debug \
+  --target-platform android-arm64 \
+  --dart-define="SPEAKUP_API_BASE_URL=$base_url" \
+  "$@"
+adb -s "$device_id" install \
+  --no-streaming \
+  -t \
+  -r \
+  "$mobile_dir/build/app/outputs/flutter-apk/app-debug.apk"
+adb -s "$device_id" shell am start \
+  -S \
+  -n com.xengineer.speakup/.MainActivity
+flutter attach -d "$device_id"


### PR DESCRIPTION
## 功能描述

- 新增统一的 Flutter `VoiceCaptureControl`，统一按住说话、上滑取消和点击录音状态。
- 情景练习、沉浸式情景、Agent 首页和 IELTS 共用同一交互控件。
- 保留各业务既有录音、转写、人工确认、120 秒限制和数字人打断流程。

## 实现思路

- 公共层只管理手势与展示状态，不接管各页面的业务状态机。
- 按住 180ms 开始录音，上滑 72px 取消；IELTS 保留点击开始/停止模式。
- 本次不修改后端、对象存储、评分接口或数字人供应商。

## 验证

```bash
cd mobile
dart format --output=none --set-exit-if-changed lib/design/voice_capture_control.dart lib/features/conversation/conversation.dart lib/features/practice/practice.dart lib/features/practice/immersive_roleplay.dart lib/features/practice/ielts_mock_practice.dart test/design/voice_capture_control_test.dart test/agent/agent_voice_flow_test.dart test/practice/ielts_mock_practice_test.dart
flutter analyze --no-pub lib/design/voice_capture_control.dart lib/features/conversation/conversation.dart lib/features/practice/practice.dart lib/features/practice/immersive_roleplay.dart lib/features/practice/ielts_mock_practice.dart test/design/voice_capture_control_test.dart test/agent/agent_voice_flow_test.dart test/practice/ielts_mock_practice_test.dart
flutter test --no-pub test/design/voice_capture_control_test.dart test/agent/agent_flow_test.dart test/agent/agent_voice_flow_test.dart test/practice/immersive_roleplay_test.dart test/practice/ielts_mock_practice_test.dart test/main_wiring_test.dart test/practice/practice_controller_contract_test.dart
```

针对性检查通过：Flutter Analyze 无问题，相关 64 个测试通过。

### Android 真机烟测

- Android 16 / ARM64 实体机编译、安装和启动通过。
- USB `adb reverse` 访问本地 `18080` 后端，登录、场景与 Agent 接口均返回成功。
- Agent 首页长按进入录音、松开进入转写；上滑取消后未产生转写请求。
- 静音录音按既有业务规则返回可重试的转写失败提示。

## 依赖

- 本 PR 叠加在 #256 之上；#256 合入 `dev` 后，本 PR 将只保留统一语音输入控件的差异。

Closes #259
