### PR TITLE
feat(voice): unify capture gestures across practice

### DIFF
--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -82,6 +82,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   final AgentClientIdFactory _clientIdFactory;
   final Duration _recordingLimit;
   AgentVoiceController? _voiceController;
+  Future<void>? _agentVoiceStartFuture;
+  int _agentVoiceStartGeneration = 0;
+  bool _agentDepartureInFlight = false;
   bool _relayedVoiceWorkflowActive = false;
 
   String? _threadId;
@@ -790,31 +793,62 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   /// If the account has no focused Thread, the existing safe Thread creation
   /// path runs first. This microphone is intentionally independent from the
   /// Practice turn recorder.
-  Future<void> startAgentVoiceRecording() async {
+  Future<void> startAgentVoiceRecording() {
     final voice = _voiceController;
-    if (voice == null || _disposed || voice.hasActiveWorkflow) {
-      return;
+    if (voice == null ||
+        _disposed ||
+        voice.hasActiveWorkflow ||
+        _agentDepartureInFlight ||
+        _agentVoiceStartFuture != null) {
+      return Future<void>.value();
     }
+    final generation = ++_agentVoiceStartGeneration;
+    late final Future<void> operation;
+    operation = _startAgentVoiceRecording(voice, generation).whenComplete(() {
+      if (identical(_agentVoiceStartFuture, operation)) {
+        _agentVoiceStartFuture = null;
+      }
+    });
+    _agentVoiceStartFuture = operation;
+    return operation;
+  }
+
+  Future<void> _startAgentVoiceRecording(
+    AgentVoiceController voice,
+    int generation,
+  ) async {
     await _ensureInitialized();
-    if (_disposed) {
+    if (!_isAgentVoiceStartCurrent(voice, generation)) {
       return;
     }
     if (_threadId == null) {
       final created = await createThread();
-      if (!created || _threadId == null || _disposed) {
+      if (!created ||
+          _threadId == null ||
+          !_isAgentVoiceStartCurrent(voice, generation)) {
         return;
       }
     }
     final threadId = _threadId!;
     await voice.bindThread(threadId, messages: _messages);
-    if (_disposed || _threadId != threadId || voice.threadId != threadId) {
+    if (!_isAgentVoiceStartCurrent(voice, generation) ||
+        _threadId != threadId ||
+        voice.threadId != threadId) {
       return;
     }
     await stopPracticeAudio();
-    if (_disposed || _threadId != threadId || voice.threadId != threadId) {
+    if (!_isAgentVoiceStartCurrent(voice, generation) ||
+        _threadId != threadId ||
+        voice.threadId != threadId) {
       return;
     }
     await voice.startRecording();
+  }
+
+  bool _isAgentVoiceStartCurrent(AgentVoiceController voice, int generation) {
+    return !_disposed &&
+        generation == _agentVoiceStartGeneration &&
+        identical(_voiceController, voice);
   }
 
   Future<void> selectScene(AgentScene scene) async {
@@ -1330,26 +1364,36 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   Future<bool> prepareToLeaveAgent() async {
-    if (_disposed || _threadTransitionInFlight) {
+    if (_disposed || _threadTransitionInFlight || _agentDepartureInFlight) {
       return false;
     }
-    final voice = _voiceController;
-    if (voice != null) {
-      switch (voice.state) {
-        case AgentVoiceComposerState.confirming ||
-            AgentVoiceComposerState.awaitingAssistant:
-          return false;
-        case AgentVoiceComposerState.idle:
-          break;
-        default:
-          await voice.cancel();
-      }
-      if (_disposed || voice.hasActiveWorkflow) {
+    _agentDepartureInFlight = true;
+    try {
+      _agentVoiceStartGeneration++;
+      await _agentVoiceStartFuture;
+      if (_disposed || _threadTransitionInFlight) {
         return false;
       }
+      final voice = _voiceController;
+      if (voice != null) {
+        switch (voice.state) {
+          case AgentVoiceComposerState.confirming ||
+              AgentVoiceComposerState.awaitingAssistant:
+            return false;
+          case AgentVoiceComposerState.idle:
+            break;
+          default:
+            await voice.cancel();
+        }
+        if (_disposed || voice.hasActiveWorkflow) {
+          return false;
+        }
+      }
+      await stopPracticeAudio();
+      return !_disposed && !_threadTransitionInFlight;
+    } finally {
+      _agentDepartureInFlight = false;
     }
-    await stopPracticeAudio();
-    return !_disposed && !_threadTransitionInFlight;
   }
 
   Future<bool> prepareToLeavePractice() async {
@@ -1357,6 +1401,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         _practiceRequestInFlight ||
         _threadTransitionInFlight ||
         (_voiceController?.hasActiveWorkflow ?? false)) {
+      return false;
+    }
+    if (_pendingPracticeAudio != null) {
       return false;
     }
     final state = _recordingState;
@@ -1376,12 +1423,6 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _recordingState = PracticeRecordingState.idle;
       _errorMessage = null;
       notifyListeners();
-    }
-    if (_pendingPracticeAudio != null) {
-      await discardPendingPracticeAudio();
-      if (_pendingPracticeAudio != null) {
-        return false;
-      }
     }
     await stopPracticeAudio();
     return !_disposed && !_practiceRequestInFlight;
@@ -2216,6 +2257,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _epoch++;
     _practiceGeneration++;
     _mediaGeneration++;
+    _agentVoiceStartGeneration++;
     _threadTransitionGeneration++;
     _threadTransitionInFlight = false;
     _initializationFuture = null;
@@ -2229,10 +2271,10 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
           try {
             await recorder.discard(pendingPracticeAudio.audio);
           } catch (_) {
-            // The recorder owns its final account-scoped cleanup.
+            // The strict account cleanup below retries all managed recordings.
           }
         }
-        await recorder.discardCurrent();
+        await recorder.clearAccountState();
       }),
     );
     unawaited(_mediaCompletionSubscription?.cancel());

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -7,6 +7,7 @@ import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/agent/agent_voice_client.dart';
 import 'package:speakup/agent/agent_voice_controller.dart';
+import 'package:speakup/agent/agent_voice_models.dart';
 import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/practice/practice_client.dart';
 import 'package:speakup/practice/practice_audio_player.dart';
@@ -101,6 +102,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   String? _endPracticeClientId;
   PracticeQuestion? _currentQuestion;
   TranscriptionCandidate? _candidate;
+  _PendingPracticeAudio? _pendingPracticeAudio;
   String? _activeConfirmationId;
   String? _activeTextAnswer;
   AgentMatter? _activeMatter;
@@ -154,6 +156,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   int? get practiceSessionVersion => _practiceSessionVersion;
   String? get questionId => _currentQuestion?.id;
   String? get candidateId => _candidate?.id;
+  bool get hasPendingPracticeAudio => _pendingPracticeAudio != null;
   AgentMatter? get activeMatter => _activeMatter;
   AgentScene? get scene => _activeMatter?.scene;
   List<AgentMessage> get messages => List.unmodifiable(_messages);
@@ -212,6 +215,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         supportsPracticeFlow &&
         _threadId != null &&
         !_busy &&
+        _pendingPracticeAudio == null &&
         switch (_recordingState) {
           PracticeRecordingState.idle ||
           PracticeRecordingState.reviewFailed ||
@@ -1325,6 +1329,29 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
+  Future<bool> prepareToLeaveAgent() async {
+    if (_disposed || _threadTransitionInFlight) {
+      return false;
+    }
+    final voice = _voiceController;
+    if (voice != null) {
+      switch (voice.state) {
+        case AgentVoiceComposerState.confirming ||
+            AgentVoiceComposerState.awaitingAssistant:
+          return false;
+        case AgentVoiceComposerState.idle:
+          break;
+        default:
+          await voice.cancel();
+      }
+      if (_disposed || voice.hasActiveWorkflow) {
+        return false;
+      }
+    }
+    await stopPracticeAudio();
+    return !_disposed && !_threadTransitionInFlight;
+  }
+
   Future<bool> prepareToLeavePractice() async {
     if (_disposed ||
         _practiceRequestInFlight ||
@@ -1349,6 +1376,12 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _recordingState = PracticeRecordingState.idle;
       _errorMessage = null;
       notifyListeners();
+    }
+    if (_pendingPracticeAudio != null) {
+      await discardPendingPracticeAudio();
+      if (_pendingPracticeAudio != null) {
+        return false;
+      }
     }
     await stopPracticeAudio();
     return !_disposed && !_practiceRequestInFlight;
@@ -1531,6 +1564,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> startRecording({Duration? limit}) {
     if (!hasActivePractice ||
         isBusy ||
+        _pendingPracticeAudio != null ||
         _currentQuestion == null ||
         _recordingState != PracticeRecordingState.idle) {
       return Future<void>.value();
@@ -1689,23 +1723,19 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       if (!_isOperationCurrent(fence)) {
         return;
       }
-      final candidate = await practice.transcribe(
-        PracticeTranscriptionRequest(
-          sessionId: sessionId,
-          questionId: question.id,
-          clientTurnId: clientTurnId,
-          audio: audio,
-        ),
+      final pending = _PendingPracticeAudio(
+        audio: audio,
+        sessionId: sessionId,
+        questionId: question.id,
+        clientTurnId: clientTurnId,
       );
-      if (!_isOperationCurrent(fence)) {
-        return;
-      }
-      _validateCandidate(candidate, sessionId, question.id);
-      _candidate = candidate;
-      _activeConfirmationId = null;
-      _activeTextAnswer = null;
-      _recordingState = PracticeRecordingState.awaitingConfirmation;
-      _errorMessage = null;
+      _pendingPracticeAudio = pending;
+      audio = null;
+      await _transcribePendingPracticeAudio(
+        practice: practice,
+        pending: pending,
+        fence: fence,
+      );
     } catch (error) {
       if (_isOperationCurrent(fence)) {
         _candidate = null;
@@ -1719,6 +1749,146 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         } catch (_) {
           // Account cleanup retries deletion before another user can enter.
         }
+      }
+    }
+    if (_isOperationCurrent(fence)) {
+      notifyListeners();
+    }
+  }
+
+  Future<void> _transcribePendingPracticeAudio({
+    required PracticeClient practice,
+    required _PendingPracticeAudio pending,
+    required _AgentOperationFence fence,
+  }) async {
+    var discardAudio = false;
+    try {
+      final candidate = await practice.transcribe(
+        PracticeTranscriptionRequest(
+          sessionId: pending.sessionId,
+          questionId: pending.questionId,
+          clientTurnId: pending.clientTurnId,
+          audio: pending.audio,
+        ),
+      );
+      if (!_isOperationCurrent(fence) ||
+          !identical(_pendingPracticeAudio, pending)) {
+        return;
+      }
+      _validateCandidate(candidate, pending.sessionId, pending.questionId);
+      _candidate = candidate;
+      _pendingPracticeAudio = null;
+      discardAudio = true;
+      _activeConfirmationId = null;
+      _activeTextAnswer = null;
+      _recordingState = PracticeRecordingState.awaitingConfirmation;
+      _errorMessage = null;
+    } catch (error) {
+      if (_isOperationCurrent(fence) &&
+          identical(_pendingPracticeAudio, pending)) {
+        _candidate = null;
+        _recordingState = PracticeRecordingState.idle;
+        _errorMessage = _transcriptionFailureMessage(error);
+      }
+    } finally {
+      if (discardAudio ||
+          !_isOperationCurrent(fence) ||
+          !identical(_pendingPracticeAudio, pending)) {
+        if (identical(_pendingPracticeAudio, pending)) {
+          _pendingPracticeAudio = null;
+        }
+        try {
+          await recorder.discard(pending.audio);
+        } catch (_) {
+          // Account cleanup retries deletion before another user can enter.
+        }
+      }
+    }
+  }
+
+  Future<void> retryPracticeTranscription() {
+    final practice = practiceClient;
+    final pending = _pendingPracticeAudio;
+    final question = _currentQuestion;
+    final inFlight = _stopRecordingFuture;
+    if (inFlight != null) {
+      return inFlight;
+    }
+    if (practice == null ||
+        pending == null ||
+        question == null ||
+        _disposed ||
+        _recordingState != PracticeRecordingState.idle ||
+        pending.sessionId != _practiceSessionId ||
+        pending.questionId != question.id) {
+      return Future<void>.value();
+    }
+    final fence = _captureOperationFence(
+      threadId: _threadId,
+      practiceGeneration: _practiceGeneration,
+      practiceSessionId: pending.sessionId,
+      questionId: pending.questionId,
+    );
+    _recordingState = PracticeRecordingState.transcribing;
+    _errorMessage = null;
+    notifyListeners();
+    final operation = _transcribePendingPracticeAudio(
+      practice: practice,
+      pending: pending,
+      fence: fence,
+    );
+    _stopRecordingFuture = operation;
+    return operation.whenComplete(() {
+      if (identical(_stopRecordingFuture, operation)) {
+        _stopRecordingFuture = null;
+      }
+      if (_isOperationCurrent(fence)) {
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<void> discardPendingPracticeAudio() {
+    final pending = _pendingPracticeAudio;
+    final inFlight = _stopRecordingFuture;
+    if (inFlight != null) {
+      return inFlight;
+    }
+    if (pending == null ||
+        _disposed ||
+        _recordingState != PracticeRecordingState.idle) {
+      return Future<void>.value();
+    }
+    final fence = _captureOperationFence(
+      threadId: _threadId,
+      practiceGeneration: _practiceGeneration,
+      practiceSessionId: pending.sessionId,
+      questionId: pending.questionId,
+    );
+    final operation = _discardPendingPracticeAudio(pending, fence);
+    _stopRecordingFuture = operation;
+    return operation.whenComplete(() {
+      if (identical(_stopRecordingFuture, operation)) {
+        _stopRecordingFuture = null;
+      }
+    });
+  }
+
+  Future<void> _discardPendingPracticeAudio(
+    _PendingPracticeAudio pending,
+    _AgentOperationFence fence,
+  ) async {
+    try {
+      await recorder.discard(pending.audio);
+      if (_isOperationCurrent(fence) &&
+          identical(_pendingPracticeAudio, pending)) {
+        _pendingPracticeAudio = null;
+        _errorMessage = null;
+      }
+    } catch (_) {
+      if (_isOperationCurrent(fence) &&
+          identical(_pendingPracticeAudio, pending)) {
+        _errorMessage = '暂时无法删除本地录音，请重试。';
       }
     }
     if (_isOperationCurrent(fence)) {
@@ -1799,6 +1969,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         question == null ||
         text.isEmpty ||
         text.length > 8000 ||
+        _pendingPracticeAudio != null ||
         _isSessionCompleted ||
         isBusy ||
         _recordingState != PracticeRecordingState.idle) {
@@ -1954,6 +2125,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _cancelRecordingLimit();
     _epoch++;
     _practiceGeneration++;
+    _pendingPracticeAudio = null;
     _initializationFuture = null;
     _threadId = null;
     _currentThreadSummary = null;
@@ -2033,6 +2205,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
 
   @override
   void dispose() {
+    final pendingPracticeAudio = _pendingPracticeAudio;
+    final practiceAudioOperation = _stopRecordingFuture;
+    _pendingPracticeAudio = null;
     _disposed = true;
     if (mediaClient != null) {
       WidgetsBinding.instance.removeObserver(this);
@@ -2046,7 +2221,20 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     _initializationFuture = null;
     _voiceController?.removeListener(_handleVoiceState);
     _voiceController?.dispose();
-    unawaited(recorder.discardCurrent());
+    unawaited(
+      Future<void>.sync(() async {
+        await _recorderStartFuture;
+        await practiceAudioOperation;
+        if (practiceAudioOperation == null && pendingPracticeAudio != null) {
+          try {
+            await recorder.discard(pendingPracticeAudio.audio);
+          } catch (_) {
+            // The recorder owns its final account-scoped cleanup.
+          }
+        }
+        await recorder.discardCurrent();
+      }),
+    );
     unawaited(_mediaCompletionSubscription?.cancel());
     unawaited(mediaClient?.dispose());
     unawaited(audioPlayer?.dispose());
@@ -2119,6 +2307,11 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
     PracticeSessionSnapshot? snapshot, {
     bool preserveKnownRecordings = false,
   }) {
+    if (_pendingPracticeAudio != null) {
+      throw StateError(
+        'Pending Practice audio must be resolved before replacing its snapshot.',
+      );
+    }
     final previousSessionId = _practiceSessionId;
     _cancelRecordingLimit();
     _practiceGeneration++;
@@ -2381,16 +2574,16 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   String _transcriptionFailureMessage(Object error) {
     if (error is AgentClientException) {
       if (_isFreeQuotaExhausted(error)) {
-        return '今日免费语音额度已用完，本轮未计入进度。';
+        return '今日免费语音额度已用完，录音已保留，本轮未计入进度。';
       }
       if (error.kind == AgentClientFailureKind.network) {
-        return '网络连接不稳定，未能转写；请重新录音。';
+        return '网络连接不稳定，录音已保留；可重试转写或删除。';
       }
       if (error.kind == AgentClientFailureKind.rateLimited) {
-        return '语音请求过于频繁，请稍后重新录音。';
+        return '语音请求过于频繁，录音已保留；请稍后重试转写。';
       }
     }
-    return '没有识别出这一轮，请重新录音。';
+    return '没有识别出这一轮，录音已保留；可重试转写或删除。';
   }
 
   String _confirmationFailureMessage(Object error) {
@@ -2449,7 +2642,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   int? _beginThreadTransition() {
-    if (_disposed || _threadTransitionInFlight) {
+    if (_disposed ||
+        _threadTransitionInFlight ||
+        _pendingPracticeAudio != null) {
       return null;
     }
     _threadTransitionInFlight = true;
@@ -2685,6 +2880,20 @@ final class _AgentOperationFence {
   final String? candidateId;
   final String? questionSpeechPath;
   final String? recordingAudioAssetId;
+}
+
+final class _PendingPracticeAudio {
+  const _PendingPracticeAudio({
+    required this.audio,
+    required this.sessionId,
+    required this.questionId,
+    required this.clientTurnId,
+  });
+
+  final RecordedPracticeAudio audio;
+  final String sessionId;
+  final String questionId;
+  final String clientTurnId;
 }
 
 sealed class _AgentRetry {

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -123,6 +123,16 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       return;
     }
     final navigationGeneration = ++_navigationGeneration;
+    if (_selectedIndex == 0 && index != 0) {
+      final parked = await widget.agentController.prepareToLeaveAgent();
+      if (!mounted || navigationGeneration != _navigationGeneration) {
+        return;
+      }
+      if (!parked) {
+        _showMockNotice('语音正在发送，请完成后再离开');
+        return;
+      }
+    }
     if (_selectedIndex == 1 && index != 1) {
       final launch = widget.preparationLaunchController;
       if (launch?.isStarting ?? false) {

--- a/mobile/lib/design/voice_capture_control.dart
+++ b/mobile/lib/design/voice_capture_control.dart
@@ -1,0 +1,506 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+enum VoiceCapturePhase { idle, starting, recording, busy }
+
+enum VoiceCaptureMode { pressAndHold, tapToToggle }
+
+enum VoiceCaptureReleaseIntent { sendVoice, convertToText, cancel }
+
+typedef VoiceCaptureAction = FutureOr<void> Function();
+
+typedef VoiceCaptureTargetBuilder =
+    Widget Function({
+      Key? key,
+      required Widget child,
+      required String semanticsLabel,
+    });
+
+typedef VoiceCaptureBuilder =
+    Widget Function(BuildContext context, VoiceCaptureView view);
+
+@immutable
+class VoiceCaptureView {
+  const VoiceCaptureView({
+    required this.pressed,
+    required this.holdStarted,
+    required this.cancelArmed,
+    required this.convertArmed,
+    required this.tapMode,
+    required this.releaseIntent,
+    required this.wrapTarget,
+    required this.sendVoiceTapCapture,
+    required this.convertTapCapture,
+    required this.cancelTapCapture,
+  });
+
+  final bool pressed;
+  final bool holdStarted;
+  final bool cancelArmed;
+  final bool convertArmed;
+  final bool tapMode;
+  final VoiceCaptureReleaseIntent releaseIntent;
+  final VoiceCaptureTargetBuilder wrapTarget;
+  final VoidCallback sendVoiceTapCapture;
+  final VoidCallback convertTapCapture;
+  final VoidCallback cancelTapCapture;
+}
+
+class VoiceCaptureControl extends StatefulWidget {
+  const VoiceCaptureControl({
+    required this.phase,
+    required this.onStart,
+    required this.onSendVoice,
+    required this.onConvertToText,
+    required this.onCancel,
+    required this.builder,
+    this.onBeforeStart,
+    this.enabled = true,
+    this.mode = VoiceCaptureMode.pressAndHold,
+    this.holdDelay = const Duration(milliseconds: 180),
+    this.intentDistance = 72,
+    super.key,
+  });
+
+  final VoiceCapturePhase phase;
+  final VoiceCaptureAction onStart;
+  final VoiceCaptureAction? onBeforeStart;
+  final VoiceCaptureAction onSendVoice;
+  final VoiceCaptureAction onConvertToText;
+  final VoiceCaptureAction onCancel;
+  final VoiceCaptureBuilder builder;
+  final bool enabled;
+  final VoiceCaptureMode mode;
+  final Duration holdDelay;
+  final double intentDistance;
+
+  @override
+  State<VoiceCaptureControl> createState() => _VoiceCaptureControlState();
+}
+
+class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
+  Timer? _holdTimer;
+  Offset? _pointerOrigin;
+  Offset? _pointerPosition;
+  int? _activePointer;
+  bool _pointerActive = false;
+  bool _holdStarted = false;
+  bool _tapMode = false;
+  bool _startInFlight = false;
+  bool _actionInFlight = false;
+  int _operationGeneration = 0;
+  VoiceCaptureReleaseIntent _releaseIntent =
+      VoiceCaptureReleaseIntent.sendVoice;
+  VoiceCaptureReleaseIntent? _pendingAction;
+
+  bool get _isCapturing =>
+      widget.phase == VoiceCapturePhase.starting ||
+      widget.phase == VoiceCapturePhase.recording;
+
+  @override
+  void didUpdateWidget(covariant VoiceCaptureControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.phase == VoiceCapturePhase.busy ||
+        (oldWidget.phase != VoiceCapturePhase.idle &&
+            widget.phase == VoiceCapturePhase.idle &&
+            !_startInFlight)) {
+      _resetInteraction();
+    }
+  }
+
+  @override
+  void dispose() {
+    _holdTimer?.cancel();
+    _operationGeneration++;
+    super.dispose();
+  }
+
+  void _resetInteraction() {
+    _holdTimer?.cancel();
+    _holdTimer = null;
+    _pointerOrigin = null;
+    _pointerPosition = null;
+    _activePointer = null;
+    _pointerActive = false;
+    _holdStarted = false;
+    _tapMode = false;
+    _releaseIntent = VoiceCaptureReleaseIntent.sendVoice;
+    _pendingAction = null;
+  }
+
+  void _setReleaseIntent(VoiceCaptureReleaseIntent intent) {
+    if (intent == _releaseIntent) {
+      return;
+    }
+    setState(() => _releaseIntent = intent);
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  VoiceCaptureReleaseIntent _intentForPosition(Offset position) {
+    final origin = _pointerOrigin;
+    if (origin == null) {
+      return VoiceCaptureReleaseIntent.sendVoice;
+    }
+    final horizontalDistance = position.dx - origin.dx;
+    if (horizontalDistance <= -widget.intentDistance) {
+      return VoiceCaptureReleaseIntent.cancel;
+    }
+    if (horizontalDistance >= widget.intentDistance) {
+      return VoiceCaptureReleaseIntent.convertToText;
+    }
+    return VoiceCaptureReleaseIntent.sendVoice;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!widget.enabled || _pointerActive) {
+      return;
+    }
+    final startingCapture = widget.phase == VoiceCapturePhase.idle;
+    final endingTapCapture = _tapMode && _isCapturing;
+    if (!startingCapture && !endingTapCapture) {
+      return;
+    }
+    _holdTimer?.cancel();
+    setState(() {
+      _activePointer = event.pointer;
+      _pointerActive = true;
+      _holdStarted = false;
+      _releaseIntent = VoiceCaptureReleaseIntent.sendVoice;
+      _pointerOrigin = event.position;
+      _pointerPosition = event.position;
+    });
+    if (!startingCapture || widget.mode == VoiceCaptureMode.tapToToggle) {
+      return;
+    }
+    _holdTimer = Timer(widget.holdDelay, () {
+      if (!mounted ||
+          !_pointerActive ||
+          widget.phase != VoiceCapturePhase.idle) {
+        return;
+      }
+      final intent = _intentForPosition(_pointerPosition ?? event.position);
+      setState(() {
+        _holdStarted = true;
+        _releaseIntent = intent;
+      });
+      unawaited(HapticFeedback.mediumImpact());
+      unawaited(_beginCapture(tapMode: false));
+    });
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    if (!mounted ||
+        event.pointer != _activePointer ||
+        !_pointerActive ||
+        _pointerOrigin == null) {
+      return;
+    }
+    _pointerPosition = event.position;
+    if (!_holdStarted) {
+      return;
+    }
+    _setReleaseIntent(_intentForPosition(event.position));
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (event.pointer != _activePointer) {
+      return;
+    }
+    _finishPointer(_releaseIntent);
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    if (event.pointer != _activePointer) {
+      return;
+    }
+    _finishPointer(VoiceCaptureReleaseIntent.cancel);
+  }
+
+  void _finishPointer(VoiceCaptureReleaseIntent intent) {
+    if (!mounted || !_pointerActive) {
+      return;
+    }
+    _holdTimer?.cancel();
+    _holdTimer = null;
+    final holdStarted = _holdStarted;
+    final endingTapCapture = _tapMode && _isCapturing;
+    setState(() {
+      _activePointer = null;
+      _pointerActive = false;
+      _holdStarted = false;
+      _releaseIntent = VoiceCaptureReleaseIntent.sendVoice;
+      _pointerOrigin = null;
+      _pointerPosition = null;
+    });
+    if (holdStarted || endingTapCapture) {
+      _requestAction(intent);
+      return;
+    }
+    if (intent != VoiceCaptureReleaseIntent.cancel &&
+        widget.phase == VoiceCapturePhase.idle) {
+      unawaited(_beginCapture(tapMode: true));
+    }
+  }
+
+  Future<void> _beginCapture({required bool tapMode}) async {
+    if (!widget.enabled ||
+        widget.phase != VoiceCapturePhase.idle ||
+        _startInFlight) {
+      return;
+    }
+    final generation = ++_operationGeneration;
+    setState(() {
+      _tapMode = tapMode;
+      _startInFlight = true;
+      _pendingAction = null;
+    });
+    if (tapMode) {
+      unawaited(HapticFeedback.mediumImpact());
+    }
+    try {
+      await widget.onBeforeStart?.call();
+      if (_pendingAction == VoiceCaptureReleaseIntent.cancel) {
+        return;
+      }
+      await widget.onStart();
+    } finally {
+      if (mounted && generation == _operationGeneration) {
+        setState(() => _startInFlight = false);
+        final pending = _pendingAction;
+        if (pending != null) {
+          _pendingAction = null;
+          await _runAction(pending, generation);
+        }
+      }
+    }
+  }
+
+  void _requestAction(VoiceCaptureReleaseIntent action) {
+    if (_actionInFlight) {
+      return;
+    }
+    if (_startInFlight) {
+      _pendingAction = action;
+      if (mounted && action == VoiceCaptureReleaseIntent.cancel) {
+        setState(() => _tapMode = false);
+      }
+      return;
+    }
+    unawaited(_runAction(action, _operationGeneration));
+  }
+
+  Future<void> _runAction(
+    VoiceCaptureReleaseIntent action,
+    int generation,
+  ) async {
+    if (!mounted || generation != _operationGeneration || _actionInFlight) {
+      return;
+    }
+    setState(() {
+      _tapMode = false;
+      _actionInFlight = true;
+    });
+    try {
+      switch (action) {
+        case VoiceCaptureReleaseIntent.sendVoice:
+          await widget.onSendVoice();
+        case VoiceCaptureReleaseIntent.convertToText:
+          await widget.onConvertToText();
+        case VoiceCaptureReleaseIntent.cancel:
+          await widget.onCancel();
+      }
+    } finally {
+      if (mounted && generation == _operationGeneration) {
+        setState(() => _actionInFlight = false);
+      }
+    }
+  }
+
+  void _handleSemanticTap() {
+    if (!widget.enabled) {
+      return;
+    }
+    if (widget.phase == VoiceCapturePhase.idle) {
+      unawaited(_beginCapture(tapMode: true));
+    } else if (_isCapturing) {
+      _requestAction(VoiceCaptureReleaseIntent.sendVoice);
+    }
+  }
+
+  Widget _wrapTarget({
+    Key? key,
+    required Widget child,
+    required String semanticsLabel,
+  }) {
+    return Semantics(
+      button: true,
+      enabled: widget.enabled,
+      label: semanticsLabel,
+      onTap: widget.enabled ? _handleSemanticTap : null,
+      child: ExcludeSemantics(
+        child: Listener(
+          key: key,
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: _handlePointerDown,
+          onPointerMove: _handlePointerMove,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: _handlePointerCancel,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(
+      context,
+      VoiceCaptureView(
+        pressed: _pointerActive,
+        holdStarted: _holdStarted,
+        cancelArmed: _releaseIntent == VoiceCaptureReleaseIntent.cancel,
+        convertArmed: _releaseIntent == VoiceCaptureReleaseIntent.convertToText,
+        tapMode: _tapMode,
+        releaseIntent: _releaseIntent,
+        wrapTarget: _wrapTarget,
+        sendVoiceTapCapture: () =>
+            _requestAction(VoiceCaptureReleaseIntent.sendVoice),
+        convertTapCapture: () =>
+            _requestAction(VoiceCaptureReleaseIntent.convertToText),
+        cancelTapCapture: () =>
+            _requestAction(VoiceCaptureReleaseIntent.cancel),
+      ),
+    );
+  }
+}
+
+class VoiceCaptureIntentTargets extends StatelessWidget {
+  const VoiceCaptureIntentTargets({
+    required this.capture,
+    required this.elapsed,
+    required this.keyPrefix,
+    this.cancelLabel = '取消',
+    this.convertLabel = '转文字',
+    super.key,
+  });
+
+  final VoiceCaptureView capture;
+  final Duration elapsed;
+  final String keyPrefix;
+  final String cancelLabel;
+  final String convertLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final interactive = capture.tapMode || !capture.pressed;
+    return Column(
+      key: Key('$keyPrefix-voice-targets'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          _formatDuration(elapsed),
+          key: Key('$keyPrefix-voice-target-duration'),
+          style: SpeakUpDesign.meta.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: _VoiceCaptureIntentTarget(
+                key: Key('$keyPrefix-voice-target-cancel'),
+                active: capture.cancelArmed,
+                activeColor: SpeakUpDesign.error,
+                icon: Icons.close_rounded,
+                label: cancelLabel,
+                onPressed: interactive ? capture.cancelTapCapture : null,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: _VoiceCaptureIntentTarget(
+                key: Key('$keyPrefix-voice-target-convert'),
+                active: capture.convertArmed,
+                activeColor: SpeakUpDesign.primary,
+                icon: Icons.text_fields_rounded,
+                label: convertLabel,
+                onPressed: interactive ? capture.convertTapCapture : null,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _VoiceCaptureIntentTarget extends StatelessWidget {
+  const _VoiceCaptureIntentTarget({
+    required this.active,
+    required this.activeColor,
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    super.key,
+  });
+
+  final bool active;
+  final Color activeColor;
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = active ? Colors.white : SpeakUpDesign.ink;
+    final content = AnimatedContainer(
+      duration: const Duration(milliseconds: 100),
+      constraints: const BoxConstraints(minHeight: 56),
+      decoration: BoxDecoration(
+        color: active ? activeColor : SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        border: Border.all(color: active ? activeColor : SpeakUpDesign.border),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, color: foreground, size: 21),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: foreground,
+                fontSize: 15,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (onPressed == null) {
+      return content;
+    }
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        child: content,
+      ),
+    );
+  }
+}
+
+String _formatDuration(Duration value) {
+  final totalSeconds = value.inSeconds.clamp(0, 3599);
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '$minutes:${seconds.toString().padLeft(2, '0')}';
+}

--- a/mobile/lib/features/conversation/conversation.dart
+++ b/mobile/lib/features/conversation/conversation.dart
@@ -10,6 +10,7 @@ import 'package:speakup/agent/agent_voice_controller.dart';
 import 'package:speakup/agent/agent_voice_models.dart';
 import 'package:speakup/agent/agent_voice_widgets.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 
 typedef ConversationVoiceStarter = FutureOr<void> Function();
 
@@ -800,10 +801,12 @@ class _AgentComposer extends StatefulWidget {
 
 class _AgentComposerState extends State<_AgentComposer> {
   final _controller = TextEditingController();
+  final _focusNode = FocusNode();
   bool _suppressControllerNotifications = false;
   bool _textSubmissionInFlight = false;
   bool _draftMaterializationPending = false;
   bool _voiceMaterializationPending = false;
+  bool _textMode = false;
   String _draftBeforeVoice = '';
 
   @override
@@ -835,6 +838,7 @@ class _AgentComposerState extends State<_AgentComposer> {
         _suppressControllerNotifications = true;
         _controller.clear();
         _suppressControllerNotifications = false;
+        _textMode = false;
       }
     }
     if (widget.acceptedUserMessageId != null &&
@@ -852,6 +856,7 @@ class _AgentComposerState extends State<_AgentComposer> {
     _controller
       ..removeListener(_handleTextChanged)
       ..dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -881,6 +886,14 @@ class _AgentComposerState extends State<_AgentComposer> {
       );
       _suppressControllerNotifications = false;
     }
+    if (voice?.state == AgentVoiceComposerState.awaitingConfirmation) {
+      _textMode = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _focusNode.requestFocus();
+        }
+      });
+    }
     setState(() {});
   }
 
@@ -900,7 +913,23 @@ class _AgentComposerState extends State<_AgentComposer> {
     }
   }
 
-  Future<void> _stopVoice() async {
+  Future<void> _sendVoiceMessage() async {
+    final voice = widget.voiceController;
+    if (voice == null) {
+      return;
+    }
+    await voice.stopRecordingAndUpload();
+    if (!mounted || !voice.canConfirm) {
+      return;
+    }
+    await voice.confirm();
+    if (!mounted || voice.editedTranscript.isNotEmpty) {
+      return;
+    }
+    _replaceComposerText(_draftBeforeVoice);
+  }
+
+  Future<void> _convertVoiceToText() async {
     final voice = widget.voiceController;
     if (voice == null) {
       return;
@@ -919,13 +948,63 @@ class _AgentComposerState extends State<_AgentComposer> {
     if (!mounted) {
       return;
     }
+    _replaceComposerText(_draftBeforeVoice);
+  }
+
+  void _replaceComposerText(String value) {
     _suppressControllerNotifications = true;
     _controller.value = TextEditingValue(
-      text: _draftBeforeVoice,
-      selection: TextSelection.collapsed(offset: _draftBeforeVoice.length),
+      text: value,
+      selection: TextSelection.collapsed(offset: value.length),
     );
     _suppressControllerNotifications = false;
-    setState(() {});
+    setState(() => _textMode = value.isNotEmpty);
+    if (value.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _focusNode.requestFocus();
+        }
+      });
+    }
+  }
+
+  void _showTextComposer() {
+    setState(() => _textMode = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _focusNode.requestFocus();
+      }
+    });
+  }
+
+  void _showVoiceComposer() {
+    _focusNode.unfocus();
+    setState(() => _textMode = false);
+  }
+
+  Future<void> _submitConvertedText() async {
+    final voice = widget.voiceController;
+    final text = _controller.text.trim();
+    if (voice == null ||
+        !voice.canConfirm ||
+        text.isEmpty ||
+        _textSubmissionInFlight ||
+        widget.onSubmitText == null) {
+      return;
+    }
+    setState(() => _textSubmissionInFlight = true);
+    try {
+      await voice.cancel();
+      final sent = await widget.onSubmitText!(text);
+      if (mounted && sent) {
+        _controller.clear();
+        setState(() => _textMode = false);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _textSubmissionInFlight = false);
+      }
+    }
   }
 
   Future<void> _submit() async {
@@ -962,11 +1041,11 @@ class _AgentComposerState extends State<_AgentComposer> {
   Widget build(BuildContext context) {
     final voice = widget.voiceController;
     final voiceState = voice?.state ?? AgentVoiceComposerState.idle;
+    final starting = voiceState == AgentVoiceComposerState.starting;
     final recording = voiceState == AgentVoiceComposerState.recording;
     final confirmingText =
         voiceState == AgentVoiceComposerState.awaitingConfirmation;
     final voiceProgress =
-        voiceState == AgentVoiceComposerState.starting ||
         voiceState == AgentVoiceComposerState.uploading ||
         voiceState == AgentVoiceComposerState.transcribing ||
         voiceState == AgentVoiceComposerState.confirming ||
@@ -975,204 +1054,388 @@ class _AgentComposerState extends State<_AgentComposer> {
         voiceState == AgentVoiceComposerState.confirming ||
         voiceState == AgentVoiceComposerState.awaitingAssistant;
     final voiceFailure = voiceState == AgentVoiceComposerState.failed;
-    return AnimatedContainer(
-      key: const Key('agent-composer-surface'),
-      duration: const Duration(milliseconds: 180),
-      curve: Curves.easeOut,
-      constraints: BoxConstraints(minHeight: widget.keyboardVisible ? 56 : 58),
-      padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
-      decoration: BoxDecoration(
-        color: SpeakUpDesign.surface,
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-        border: Border.all(color: SpeakUpDesign.border),
-      ),
-      child: recording || voiceProgress || voiceFailure
-          ? Row(
-              children: [
-                if (!voiceSubmissionInFlight) ...[
-                  IconButton(
-                    key: const Key('agent-voice-cancel'),
-                    tooltip: '取消语音输入',
-                    onPressed: _cancelVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.close_rounded, size: 21),
-                  ),
-                  const SizedBox(width: 4),
-                ],
-                if (recording) ...[
-                  const Icon(
-                    Icons.fiber_manual_record_rounded,
-                    size: 12,
-                    color: SpeakUpDesign.error,
-                  ),
-                  const SizedBox(width: 8),
-                ] else if (voiceProgress) ...[
-                  const SizedBox.square(
-                    dimension: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const SizedBox(width: 8),
-                ],
-                Expanded(
-                  child: Text(
-                    recording
-                        ? '正在录音'
-                        : voiceFailure
-                        ? voice?.errorMessage ?? '语音识别失败'
-                        : _composerVoiceStateLabel(voiceState),
-                    key: const Key('agent-voice-state-label'),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: voiceFailure
-                          ? SpeakUpDesign.error
-                          : SpeakUpDesign.secondary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      height: 1.3,
-                    ),
-                  ),
+    final capturePhase = switch (voiceState) {
+      AgentVoiceComposerState.idle => VoiceCapturePhase.idle,
+      AgentVoiceComposerState.starting => VoiceCapturePhase.starting,
+      AgentVoiceComposerState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
+    final voiceCaptureEnabled =
+        starting ||
+        recording ||
+        (widget.onStartVoice != null &&
+            widget.voiceEnabled &&
+            widget.enabled &&
+            !widget.isBusy);
+    final showTextComposer =
+        confirmingText ||
+        (_textMode &&
+            !starting &&
+            !recording &&
+            !voiceProgress &&
+            !voiceFailure);
+
+    return VoiceCaptureControl(
+      phase: capturePhase,
+      enabled: voiceCaptureEnabled,
+      onStart: _startVoice,
+      onSendVoice: _sendVoiceMessage,
+      onConvertToText: _convertVoiceToText,
+      onCancel: _cancelVoice,
+      builder: (context, capture) {
+        return AnimatedContainer(
+          key: const Key('agent-composer-surface'),
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          constraints: BoxConstraints(
+            minHeight: widget.keyboardVisible ? 56 : 58,
+          ),
+          padding: const EdgeInsets.fromLTRB(8, 7, 7, 7),
+          decoration: BoxDecoration(
+            color: SpeakUpDesign.surface,
+            borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+            border: Border.all(color: SpeakUpDesign.border),
+          ),
+          child: voiceProgress || voiceFailure
+              ? _AgentVoiceStatusDock(
+                  state: voiceState,
+                  message: voiceFailure
+                      ? voice?.errorMessage ?? '语音识别失败'
+                      : _composerVoiceStateLabel(voiceState),
+                  canCancel: !voiceSubmissionInFlight,
+                  canRetry: voiceFailure && voice?.canRetry == true,
+                  onCancel: _cancelVoice,
+                  onRetry: voice?.retry,
+                )
+              : showTextComposer
+              ? _AgentTextDock(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  keyboardVisible: widget.keyboardVisible,
+                  enabled: confirmingText || (widget.enabled && !widget.isBusy),
+                  confirmingConvertedText: confirmingText,
+                  submitting: _textSubmissionInFlight,
+                  canSubmitConvertedText: voice?.canConfirm == true,
+                  canSubmitText:
+                      widget.onSubmitText != null &&
+                      widget.enabled &&
+                      !widget.isBusy,
+                  onReturnToVoice: confirmingText
+                      ? _cancelVoice
+                      : _showVoiceComposer,
+                  onSubmit: confirmingText ? _submitConvertedText : _submit,
+                )
+              : _AgentVoiceDock(
+                  capture: capture,
+                  phase: capturePhase,
+                  elapsed: voice?.recordingElapsed ?? Duration.zero,
+                  enabled: voiceCaptureEnabled,
+                  textEnabled: widget.enabled,
+                  onShowText: _showTextComposer,
                 ),
-                if (recording) ...[
-                  const SizedBox(width: 8),
-                  Text(
-                    _formatComposerDuration(voice!.recordingElapsed),
-                    key: const Key('agent-voice-recording-duration'),
-                    style: const TextStyle(
-                      color: SpeakUpDesign.secondary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(width: 6),
-                  IconButton.filled(
-                    key: const Key('agent-voice-stop'),
-                    tooltip: '结束录音并自动转写',
-                    onPressed: _stopVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.stop_rounded, size: 20),
-                  ),
-                ] else if (voiceFailure && voice?.canRetry == true)
-                  IconButton(
-                    key: const Key('agent-voice-retry'),
-                    tooltip: '重试',
-                    onPressed: voice?.retry,
-                    icon: const Icon(Icons.refresh_rounded),
-                  ),
-              ],
-            )
-          : Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                if (confirmingText)
-                  IconButton(
-                    key: const Key('agent-voice-cancel'),
-                    tooltip: '取消语音输入',
-                    onPressed: _cancelVoice,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 40,
-                      height: 40,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.close_rounded, size: 21),
-                  ),
-                Expanded(
-                  child: TextField(
-                    key: const Key('agent-composer-field'),
-                    controller: _controller,
-                    enabled:
-                        confirmingText || (widget.enabled && !widget.isBusy),
-                    minLines: 1,
-                    maxLines: widget.keyboardVisible ? 3 : 2,
-                    inputFormatters: <TextInputFormatter>[
-                      _agentContentFormatter,
-                    ],
-                    textInputAction: TextInputAction.send,
-                    onSubmitted: (_) => confirmingText
-                        ? widget.voiceController?.confirm()
-                        : _submit(),
-                    style: const TextStyle(
-                      color: SpeakUpDesign.ink,
-                      fontSize: 15,
-                      height: 1.4,
-                    ),
-                    decoration: InputDecoration(
-                      hintText: widget.enabled
-                          ? confirmingText
-                                ? '检查识别文字'
-                                : '问问 SpeakUp'
-                          : '暂时无法开始对话',
-                      hintStyle: const TextStyle(
-                        color: SpeakUpDesign.tertiary,
-                        fontSize: 15,
-                      ),
-                      border: InputBorder.none,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
-                    ),
-                  ),
-                ),
-                if (!confirmingText && widget.onStartVoice != null) ...[
-                  Semantics(
-                    key: const Key('agent-mic-placeholder'),
-                    button: true,
-                    enabled: widget.voiceEnabled,
-                    label: '录制 Agent 语音消息',
-                    onTap: widget.voiceEnabled ? _startVoice : null,
-                    child: ExcludeSemantics(
-                      child: IconButton(
-                        tooltip: '录制 Agent 语音消息',
-                        onPressed: widget.voiceEnabled ? _startVoice : null,
-                        constraints: const BoxConstraints.tightFor(
-                          width: 40,
-                          height: 40,
-                        ),
-                        padding: EdgeInsets.zero,
-                        color: SpeakUpDesign.secondary,
-                        icon: const Icon(Icons.mic_none_rounded, size: 21),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 2),
-                ],
-                IconButton.filled(
-                  key: Key(
-                    confirmingText
-                        ? 'agent-voice-confirm'
-                        : 'agent-send-button',
-                  ),
-                  tooltip: '发送',
-                  onPressed:
-                      _controller.text.trim().isEmpty ||
-                          (widget.isBusy && !confirmingText) ||
-                          !widget.enabled
-                      ? null
-                      : _textSubmissionInFlight
-                      ? null
-                      : confirmingText
-                      ? voice?.canConfirm == true
-                            ? voice?.confirm
-                            : null
-                      : widget.onSubmitText == null
-                      ? null
-                      : _submit,
-                  constraints: const BoxConstraints.tightFor(
-                    width: 40,
-                    height: 40,
-                  ),
-                  padding: EdgeInsets.zero,
-                  icon: const Icon(Icons.arrow_upward_rounded, size: 20),
-                ),
-              ],
+        );
+      },
+    );
+  }
+}
+
+class _AgentVoiceDock extends StatelessWidget {
+  const _AgentVoiceDock({
+    required this.capture,
+    required this.phase,
+    required this.elapsed,
+    required this.enabled,
+    required this.textEnabled,
+    required this.onShowText,
+  });
+
+  final VoiceCaptureView capture;
+  final VoiceCapturePhase phase;
+  final Duration elapsed;
+  final bool enabled;
+  final bool textEnabled;
+  final VoidCallback onShowText;
+
+  @override
+  Widget build(BuildContext context) {
+    final capturing =
+        phase == VoiceCapturePhase.starting ||
+        phase == VoiceCapturePhase.recording;
+    final showTargets = capturing;
+    final label = switch ((phase, capture.releaseIntent, capture.tapMode)) {
+      (VoiceCapturePhase.starting, _, _) => '正在打开麦克风…',
+      (_, VoiceCaptureReleaseIntent.cancel, _) => '松开取消',
+      (_, VoiceCaptureReleaseIntent.convertToText, _) => '松开转成文字',
+      (VoiceCapturePhase.recording, _, true) => '点击发送语音',
+      (VoiceCapturePhase.recording, _, false) => '松开发送语音',
+      _ => enabled ? '点击或按住说话' : '暂时无法录音',
+    };
+    final mainTarget = capture.wrapTarget(
+      key: const Key('agent-mic-placeholder'),
+      semanticsLabel: capturing ? '发送语音' : '开始录音',
+      child: AnimatedContainer(
+        key: capturing ? const Key('agent-voice-stop') : null,
+        duration: const Duration(milliseconds: 100),
+        constraints: const BoxConstraints(minHeight: 56),
+        decoration: BoxDecoration(
+          color: capture.cancelArmed
+              ? SpeakUpDesign.errorMuted
+              : capture.convertArmed
+              ? SpeakUpDesign.primaryMuted
+              : capturing
+              ? SpeakUpDesign.surfaceMuted
+              : SpeakUpDesign.primary,
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+          border: Border.all(
+            color: capture.cancelArmed
+                ? SpeakUpDesign.error
+                : capture.convertArmed
+                ? SpeakUpDesign.primary
+                : capturing
+                ? SpeakUpDesign.border
+                : SpeakUpDesign.primary,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              capturing ? Icons.graphic_eq_rounded : Icons.mic_none_rounded,
+              color: capturing ? SpeakUpDesign.ink : Colors.white,
+              size: 22,
             ),
+            const SizedBox(width: 9),
+            Flexible(
+              child: Text(
+                label,
+                key: const Key('agent-voice-state-label'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: capturing ? SpeakUpDesign.ink : Colors.white,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            if (phase == VoiceCapturePhase.recording) ...[
+              const SizedBox(width: 10),
+              Text(
+                _formatComposerDuration(elapsed),
+                key: const Key('agent-voice-recording-duration'),
+                style: const TextStyle(
+                  color: SpeakUpDesign.secondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (showTargets) ...[
+          VoiceCaptureIntentTargets(
+            capture: capture,
+            elapsed: elapsed,
+            keyPrefix: 'agent',
+          ),
+          const SizedBox(height: 10),
+        ],
+        Row(
+          children: [
+            Expanded(child: mainTarget),
+            if (!capturing) ...[
+              const SizedBox(width: 6),
+              IconButton(
+                key: const Key('agent-show-text-composer'),
+                tooltip: '切换到键盘输入',
+                onPressed: textEnabled ? onShowText : null,
+                constraints: const BoxConstraints.tightFor(
+                  width: 48,
+                  height: 48,
+                ),
+                icon: const Icon(Icons.keyboard_alt_outlined),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentTextDock extends StatelessWidget {
+  const _AgentTextDock({
+    required this.controller,
+    required this.focusNode,
+    required this.keyboardVisible,
+    required this.enabled,
+    required this.confirmingConvertedText,
+    required this.submitting,
+    required this.canSubmitConvertedText,
+    required this.canSubmitText,
+    required this.onReturnToVoice,
+    required this.onSubmit,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool keyboardVisible;
+  final bool enabled;
+  final bool confirmingConvertedText;
+  final bool submitting;
+  final bool canSubmitConvertedText;
+  final bool canSubmitText;
+  final FutureOr<void> Function() onReturnToVoice;
+  final FutureOr<void> Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final canSend =
+        controller.text.trim().isNotEmpty &&
+        !submitting &&
+        (confirmingConvertedText ? canSubmitConvertedText : canSubmitText);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        if (confirmingConvertedText)
+          IconButton(
+            key: const Key('agent-voice-cancel'),
+            tooltip: '取消转文字',
+            onPressed: enabled ? () => onReturnToVoice() : null,
+            constraints: const BoxConstraints.tightFor(width: 44, height: 44),
+            padding: EdgeInsets.zero,
+            icon: const Icon(Icons.close_rounded, size: 21),
+          )
+        else
+          IconButton(
+            key: const Key('agent-show-voice-composer'),
+            tooltip: '切换到语音输入',
+            onPressed: enabled ? () => onReturnToVoice() : null,
+            constraints: const BoxConstraints.tightFor(width: 44, height: 44),
+            padding: EdgeInsets.zero,
+            icon: const Icon(Icons.mic_none_rounded, size: 21),
+          ),
+        Expanded(
+          child: TextField(
+            key: const Key('agent-composer-field'),
+            controller: controller,
+            focusNode: focusNode,
+            enabled: enabled,
+            minLines: 1,
+            maxLines: keyboardVisible ? 3 : 2,
+            inputFormatters: <TextInputFormatter>[_agentContentFormatter],
+            textInputAction: TextInputAction.send,
+            onSubmitted: (_) {
+              if (canSend) {
+                onSubmit();
+              }
+            },
+            style: const TextStyle(
+              color: SpeakUpDesign.ink,
+              fontSize: 15,
+              height: 1.4,
+            ),
+            decoration: InputDecoration(
+              hintText: enabled
+                  ? confirmingConvertedText
+                        ? '编辑识别文字后发送'
+                        : '问问 SpeakUp'
+                  : '暂时无法开始对话',
+              hintStyle: const TextStyle(
+                color: SpeakUpDesign.tertiary,
+                fontSize: 15,
+              ),
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: const EdgeInsets.fromLTRB(7, 9, 6, 8),
+            ),
+          ),
+        ),
+        IconButton.filled(
+          key: Key(
+            confirmingConvertedText
+                ? 'agent-voice-confirm'
+                : 'agent-send-button',
+          ),
+          tooltip: '发送',
+          onPressed: canSend ? () => onSubmit() : null,
+          constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+          padding: EdgeInsets.zero,
+          icon: const Icon(Icons.arrow_upward_rounded, size: 20),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentVoiceStatusDock extends StatelessWidget {
+  const _AgentVoiceStatusDock({
+    required this.state,
+    required this.message,
+    required this.canCancel,
+    required this.canRetry,
+    required this.onCancel,
+    required this.onRetry,
+  });
+
+  final AgentVoiceComposerState state;
+  final String message;
+  final bool canCancel;
+  final bool canRetry;
+  final FutureOr<void> Function() onCancel;
+  final FutureOr<void> Function()? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final failed = state == AgentVoiceComposerState.failed;
+    return Row(
+      children: [
+        if (canCancel) ...[
+          IconButton(
+            key: const Key('agent-voice-cancel'),
+            tooltip: '取消语音输入',
+            onPressed: () => onCancel(),
+            constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+            padding: EdgeInsets.zero,
+            icon: const Icon(Icons.close_rounded, size: 21),
+          ),
+          const SizedBox(width: 4),
+        ],
+        if (!failed) ...[
+          const SizedBox.square(
+            dimension: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 8),
+        ],
+        Expanded(
+          child: Text(
+            message,
+            key: const Key('agent-voice-state-label'),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: failed ? SpeakUpDesign.error : SpeakUpDesign.secondary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              height: 1.3,
+            ),
+          ),
+        ),
+        if (canRetry)
+          IconButton(
+            key: const Key('agent-voice-retry'),
+            tooltip: '重试转文字',
+            onPressed: onRetry == null ? null : () => onRetry?.call(),
+            icon: const Icon(Icons.refresh_rounded),
+          ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 
 const ieltsSpeakingFullMockScenarioId = 'scn_ielts_speaking_full';
@@ -36,12 +37,18 @@ class IeltsSpeakingMockPage extends StatefulWidget {
 class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   late final IeltsMockProgressStore _progressStore;
   final TextEditingController _notesController = TextEditingController();
+  final TextEditingController _convertedAnswerController =
+      TextEditingController();
+  final FocusNode _convertedAnswerFocusNode = FocusNode();
 
   IeltsMockProgress? _progress;
   Timer? _ticker;
   DateTime _now = DateTime.now().toUtc();
   bool _loading = true;
   bool _confirming = false;
+  bool _conversionRequested = false;
+  bool _convertedAnswerMode = false;
+  bool _convertedAnswerSubmitting = false;
   bool _startingPart2Recording = false;
   bool _finishingPart2Recording = false;
   bool _exitApproved = false;
@@ -72,6 +79,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     widget.controller.removeListener(_handleControllerState);
     _notesController.removeListener(_saveNotes);
     _notesController.dispose();
+    _convertedAnswerController.dispose();
+    _convertedAnswerFocusNode.dispose();
     _ticker?.cancel();
     super.dispose();
   }
@@ -142,8 +151,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         IeltsMockPhase.part2Intro ||
         IeltsMockPhase.part2Preparation => value.phase,
         IeltsMockPhase.part2Speaking
-            when widget.controller.recordingState !=
-                PracticeRecordingState.idle =>
+            when widget.controller.hasPendingPracticeAudio ||
+                widget.controller.recordingState !=
+                    PracticeRecordingState.idle =>
           IeltsMockPhase.part2Speaking,
         IeltsMockPhase.part2Speaking => IeltsMockPhase.part2Intro,
         _ => IeltsMockPhase.part1Complete,
@@ -183,6 +193,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   void _confirmPendingTranscript() {
     if (!mounted ||
         _confirming ||
+        _conversionRequested ||
+        _convertedAnswerMode ||
         widget.controller.recordingState !=
             PracticeRecordingState.awaitingConfirmation) {
       return;
@@ -252,7 +264,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     if (progress.phase == IeltsMockPhase.part2Speaking &&
-        _secondsUntil(progress.speakingDeadline) <= 0) {
+        _secondsUntil(progress.speakingDeadline) <= 0 &&
+        !widget.controller.hasPendingPracticeAudio) {
       unawaited(_finishPart2Speaking());
     }
   }
@@ -351,20 +364,83 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
   }
 
-  Future<void> _toggleShortRecording() async {
-    final state = widget.controller.recordingState;
-    if (state == PracticeRecordingState.idle) {
-      await widget.controller.startRecording();
+  Future<void> _startShortRecording() {
+    _conversionRequested = false;
+    return widget.controller.startRecording();
+  }
+
+  Future<void> _sendShortVoice() async {
+    _conversionRequested = false;
+    await widget.controller.finishRecordingGesture();
+    _confirmPendingTranscript();
+  }
+
+  Future<void> _convertShortVoice() async {
+    _conversionRequested = true;
+    await widget.controller.finishRecordingGesture();
+    if (!mounted) {
       return;
     }
-    if (state == PracticeRecordingState.starting ||
-        state == PracticeRecordingState.recording) {
-      await widget.controller.finishRecordingGesture();
+    if (widget.controller.recordingState !=
+        PracticeRecordingState.awaitingConfirmation) {
+      setState(() => _conversionRequested = false);
       return;
     }
-    if (state == PracticeRecordingState.awaitingConfirmation) {
-      _confirmPendingTranscript();
+    final transcript = widget.controller.transcript?.trim() ?? '';
+    widget.controller.rerecord();
+    _convertedAnswerController.value = TextEditingValue(
+      text: transcript,
+      selection: TextSelection.collapsed(offset: transcript.length),
+    );
+    setState(() {
+      _conversionRequested = false;
+      _convertedAnswerMode = true;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _convertedAnswerFocusNode.requestFocus();
+      }
+    });
+  }
+
+  Future<void> _cancelShortVoice() async {
+    _conversionRequested = false;
+    await widget.controller.cancelRecording();
+  }
+
+  Future<void> _submitConvertedAnswer() async {
+    final text = _convertedAnswerController.text.trim();
+    if (text.isEmpty || _convertedAnswerSubmitting) {
+      return;
     }
+    setState(() => _convertedAnswerSubmitting = true);
+    final submitted = await widget.controller.submitPracticeText(text);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _convertedAnswerSubmitting = false;
+      if (submitted) {
+        _convertedAnswerMode = false;
+        _convertedAnswerController.clear();
+        _convertedAnswerFocusNode.unfocus();
+      }
+    });
+  }
+
+  void _cancelConvertedAnswer() {
+    _convertedAnswerController.clear();
+    _convertedAnswerFocusNode.unfocus();
+    setState(() => _convertedAnswerMode = false);
+  }
+
+  void _openTextAnswer() {
+    setState(() => _convertedAnswerMode = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _convertedAnswerFocusNode.requestFocus();
+      }
+    });
   }
 
   Future<void> _beginPart3() async {
@@ -475,7 +551,17 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                 progress.phase == IeltsMockPhase.part3
             ? _RecorderDock(
                 controller: widget.controller,
-                onTap: _toggleShortRecording,
+                convertedAnswerController: _convertedAnswerController,
+                convertedAnswerFocusNode: _convertedAnswerFocusNode,
+                convertedAnswerMode: _convertedAnswerMode,
+                convertedAnswerSubmitting: _convertedAnswerSubmitting,
+                onStart: _startShortRecording,
+                onSendVoice: _sendShortVoice,
+                onConvertToText: _convertShortVoice,
+                onCancelRecording: _cancelShortVoice,
+                onSubmitConvertedAnswer: _submitConvertedAnswer,
+                onCancelConvertedAnswer: _cancelConvertedAnswer,
+                onOpenTextAnswer: _openTextAnswer,
               )
             : null,
       ),
@@ -539,6 +625,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         onPressed: _startPart2Speaking,
       ),
       IeltsMockPhase.part2Speaking => _Part2Speaking(
+        controller: widget.controller,
         secondsRemaining: _secondsUntil(progress.speakingDeadline),
         notes: progress.notes,
         busy:
@@ -798,81 +885,345 @@ class _ExamConversation extends StatelessWidget {
 }
 
 class _RecorderDock extends StatelessWidget {
-  const _RecorderDock({required this.controller, required this.onTap});
+  const _RecorderDock({
+    required this.controller,
+    required this.convertedAnswerController,
+    required this.convertedAnswerFocusNode,
+    required this.convertedAnswerMode,
+    required this.convertedAnswerSubmitting,
+    required this.onStart,
+    required this.onSendVoice,
+    required this.onConvertToText,
+    required this.onCancelRecording,
+    required this.onSubmitConvertedAnswer,
+    required this.onCancelConvertedAnswer,
+    required this.onOpenTextAnswer,
+  });
 
   final AgentController controller;
-  final VoidCallback onTap;
+  final TextEditingController convertedAnswerController;
+  final FocusNode convertedAnswerFocusNode;
+  final bool convertedAnswerMode;
+  final bool convertedAnswerSubmitting;
+  final FutureOr<void> Function() onStart;
+  final FutureOr<void> Function() onSendVoice;
+  final FutureOr<void> Function() onConvertToText;
+  final FutureOr<void> Function() onCancelRecording;
+  final FutureOr<void> Function() onSubmitConvertedAnswer;
+  final VoidCallback onCancelConvertedAnswer;
+  final VoidCallback onOpenTextAnswer;
 
   @override
   Widget build(BuildContext context) {
     final state = controller.recordingState;
-    final recording =
-        state == PracticeRecordingState.starting ||
-        state == PracticeRecordingState.recording;
+    final phase = switch (state) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
     final working =
         state == PracticeRecordingState.transcribing ||
+        state == PracticeRecordingState.awaitingConfirmation ||
         state == PracticeRecordingState.submitting;
+    return VoiceCaptureControl(
+      phase: phase,
+      enabled:
+          !convertedAnswerMode &&
+          !controller.hasPendingPracticeAudio &&
+          !working,
+      onStart: onStart,
+      onSendVoice: onSendVoice,
+      onConvertToText: onConvertToText,
+      onCancel: onCancelRecording,
+      builder: (context, capture) {
+        final content = convertedAnswerMode
+            ? _IeltsConvertedAnswerDock(
+                controller: convertedAnswerController,
+                focusNode: convertedAnswerFocusNode,
+                submitting: convertedAnswerSubmitting,
+                onSubmit: onSubmitConvertedAnswer,
+                onCancel: onCancelConvertedAnswer,
+              )
+            : controller.hasPendingPracticeAudio
+            ? _IeltsPendingAudioDock(controller: controller)
+            : working
+            ? _IeltsRecorderWorkingState(state: state)
+            : _IeltsVoiceCaptureDock(
+                phase: phase,
+                capture: capture,
+                onShowText: onOpenTextAnswer,
+              );
+        return Material(
+          color: SpeakUpDesign.surface,
+          child: SafeArea(
+            top: false,
+            minimum: const EdgeInsets.fromLTRB(20, 12, 20, 14),
+            child: content,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _IeltsVoiceCaptureDock extends StatelessWidget {
+  const _IeltsVoiceCaptureDock({
+    required this.phase,
+    required this.capture,
+    required this.onShowText,
+  });
+
+  final VoiceCapturePhase phase;
+  final VoiceCaptureView capture;
+  final VoidCallback onShowText;
+
+  @override
+  Widget build(BuildContext context) {
+    final recording =
+        phase == VoiceCapturePhase.starting ||
+        phase == VoiceCapturePhase.recording;
+    final showTargets = recording;
+    final label = switch ((phase, capture.releaseIntent, capture.tapMode)) {
+      (VoiceCapturePhase.starting, _, _) => 'Opening microphone…',
+      (_, VoiceCaptureReleaseIntent.cancel, _) => 'Release to cancel',
+      (_, VoiceCaptureReleaseIntent.convertToText, _) =>
+        'Release to convert to text',
+      (VoiceCapturePhase.recording, _, true) => 'Tap to send voice',
+      (VoiceCapturePhase.recording, _, false) => 'Release to send voice',
+      _ => 'Tap or hold to speak',
+    };
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (showTargets) ...[
+          VoiceCaptureIntentTargets(
+            capture: capture,
+            elapsed: Duration.zero,
+            keyPrefix: 'ielts-mock',
+            cancelLabel: 'Cancel',
+            convertLabel: 'Convert to text',
+          ),
+          const SizedBox(height: 10),
+        ],
+        Row(
+          children: [
+            Expanded(
+              child: capture.wrapTarget(
+                key: const Key('ielts-mock-record'),
+                semanticsLabel: recording
+                    ? 'Send voice answer'
+                    : 'Start recording',
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 100),
+                  constraints: const BoxConstraints(minHeight: 64),
+                  decoration: BoxDecoration(
+                    color: capture.cancelArmed
+                        ? SpeakUpDesign.errorMuted
+                        : capture.convertArmed
+                        ? SpeakUpDesign.primaryMuted
+                        : recording
+                        ? const Color(0xFFE2F2F2)
+                        : SpeakUpDesign.ink,
+                    borderRadius: BorderRadius.circular(
+                      SpeakUpDesign.radiusControl,
+                    ),
+                    border: Border.all(
+                      color: capture.cancelArmed
+                          ? SpeakUpDesign.error
+                          : capture.convertArmed
+                          ? SpeakUpDesign.primary
+                          : recording
+                          ? const Color(0xFF197782)
+                          : SpeakUpDesign.ink,
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        recording
+                            ? Icons.graphic_eq_rounded
+                            : Icons.mic_none_rounded,
+                        color: recording
+                            ? const Color(0xFF197782)
+                            : Colors.white,
+                        size: 27,
+                      ),
+                      const SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          label,
+                          key: const Key('ielts-mock-recorder-state'),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: SpeakUpDesign.cardTitle.copyWith(
+                            color: recording
+                                ? const Color(0xFF197782)
+                                : Colors.white,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (!recording) ...[
+              const SizedBox(width: 10),
+              IconButton.outlined(
+                key: const Key('ielts-mock-open-keyboard'),
+                onPressed: onShowText,
+                tooltip: 'Type answer',
+                icon: const Icon(Icons.keyboard_alt_outlined),
+                style: IconButton.styleFrom(minimumSize: const Size.square(56)),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _IeltsRecorderWorkingState extends StatelessWidget {
+  const _IeltsRecorderWorkingState({required this.state});
+
+  final PracticeRecordingState state;
+
+  @override
+  Widget build(BuildContext context) {
     final label = switch (state) {
-      PracticeRecordingState.starting => 'Opening microphone…',
-      PracticeRecordingState.recording => 'Listening',
       PracticeRecordingState.transcribing => 'Transcribing your answer…',
       PracticeRecordingState.awaitingConfirmation => 'Submitting your answer…',
       PracticeRecordingState.submitting => 'Preparing the next question…',
-      _ => 'Ready to speak',
+      _ => 'Working…',
     };
-    return Material(
-      color: SpeakUpDesign.surface,
-      child: SafeArea(
-        top: false,
-        minimum: const EdgeInsets.fromLTRB(20, 12, 20, 14),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
+    return Row(
+      key: const Key('ielts-mock-recorder-working'),
+      children: [
+        const SizedBox.square(
+          dimension: 22,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            label,
+            key: const Key('ielts-mock-recorder-state'),
+            style: SpeakUpDesign.body,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IeltsConvertedAnswerDock extends StatelessWidget {
+  const _IeltsConvertedAnswerDock({
+    required this.controller,
+    required this.focusNode,
+    required this.submitting,
+    required this.onSubmit,
+    required this.onCancel,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool submitting;
+  final FutureOr<void> Function() onSubmit;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: const Key('ielts-mock-converted-answer'),
+      children: [
+        IconButton.outlined(
+          key: const Key('ielts-mock-cancel-converted-answer'),
+          onPressed: submitting ? null : onCancel,
+          tooltip: 'Cancel text draft',
+          icon: const Icon(Icons.close_rounded),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: TextField(
+            key: const Key('ielts-mock-converted-answer-field'),
+            controller: controller,
+            focusNode: focusNode,
+            enabled: !submitting,
+            minLines: 1,
+            maxLines: 3,
+            maxLength: 8000,
+            textInputAction: TextInputAction.newline,
+            decoration: const InputDecoration(
+              hintText: 'Edit the transcript before sending…',
+              counterText: '',
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        ValueListenableBuilder<TextEditingValue>(
+          valueListenable: controller,
+          builder: (context, value, _) => IconButton.filled(
+            key: const Key('ielts-mock-submit-converted-answer'),
+            onPressed: submitting || value.text.trim().isEmpty
+                ? null
+                : () => onSubmit(),
+            tooltip: 'Send text answer',
+            icon: submitting
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Icon(Icons.arrow_upward_rounded),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IeltsPendingAudioDock extends StatelessWidget {
+  const _IeltsPendingAudioDock({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('ielts-mock-pending-audio'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'Recording kept after transcription failed.',
+          style: SpeakUpDesign.cardTitle,
+        ),
+        const SizedBox(height: 10),
+        Row(
           children: [
-            Text(
-              label,
-              key: const Key('ielts-mock-recorder-state'),
-              style: SpeakUpDesign.cardTitle.copyWith(
-                color: recording ? const Color(0xFF197782) : SpeakUpDesign.ink,
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('ielts-mock-delete-pending-audio'),
+                onPressed: controller.discardPendingPracticeAudio,
+                child: const Text('Delete'),
               ),
             ),
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: recording ? 'Submit answer' : 'Start recording',
-              child: IconButton.filled(
-                key: const Key('ielts-mock-record'),
-                onPressed: working ? null : onTap,
-                style: IconButton.styleFrom(
-                  fixedSize: const Size.square(76),
-                  backgroundColor: recording
-                      ? const Color(0xFF197782)
-                      : SpeakUpDesign.ink,
-                  foregroundColor: Colors.white,
-                ),
-                icon: working
-                    ? const SizedBox.square(
-                        dimension: 25,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2.5,
-                          color: Colors.white,
-                        ),
-                      )
-                    : Icon(
-                        recording ? Icons.stop_rounded : Icons.mic_none_rounded,
-                        size: 32,
-                      ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: FilledButton(
+                key: const Key('ielts-mock-retry-transcription'),
+                onPressed: controller.retryPracticeTranscription,
+                child: const Text('Retry transcript'),
               ),
-            ),
-            const SizedBox(height: 10),
-            Text(
-              recording
-                  ? 'Tap again to submit your answer'
-                  : 'Tap to start recording your answer',
-              style: SpeakUpDesign.body.copyWith(fontSize: 13),
             ),
           ],
         ),
-      ),
+      ],
     );
   }
 }
@@ -1060,6 +1411,7 @@ class _Part2Preparation extends StatelessWidget {
 
 class _Part2Speaking extends StatelessWidget {
   const _Part2Speaking({
+    required this.controller,
     required this.secondsRemaining,
     required this.notes,
     required this.busy,
@@ -1067,6 +1419,7 @@ class _Part2Speaking extends StatelessWidget {
     required this.onPressed,
   });
 
+  final AgentController controller;
   final int secondsRemaining;
   final String notes;
   final bool busy;
@@ -1125,24 +1478,27 @@ class _Part2Speaking extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 26),
-          FilledButton(
-            key: const Key('ielts-mock-finish-speaking'),
-            onPressed: busy ? null : onPressed,
-            style: FilledButton.styleFrom(
-              minimumSize: const Size.fromHeight(58),
-              backgroundColor: SpeakUpDesign.ink,
-              foregroundColor: Colors.white,
+          if (controller.hasPendingPracticeAudio)
+            _IeltsPendingAudioDock(controller: controller)
+          else
+            FilledButton(
+              key: const Key('ielts-mock-finish-speaking'),
+              onPressed: busy ? null : onPressed,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(58),
+                backgroundColor: SpeakUpDesign.ink,
+                foregroundColor: Colors.white,
+              ),
+              child: busy
+                  ? const SizedBox.square(
+                      dimension: 22,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2.4,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('Finish Speaking →'),
             ),
-            child: busy
-                ? const SizedBox.square(
-                    dimension: 22,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.4,
-                      color: Colors.white,
-                    ),
-                  )
-                : const Text('Finish Speaking →'),
-          ),
         ],
       ),
     );

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -77,6 +77,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   @override
   void dispose() {
     widget.controller.removeListener(_handleControllerState);
+    unawaited(widget.controller.cancelRecording());
     _notesController.removeListener(_saveNotes);
     _notesController.dispose();
     _convertedAnswerController.dispose();

--- a/mobile/lib/features/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/practice/immersive_roleplay.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 
 /// A vendor-neutral surface used by the immersive roleplay shell.
 ///
@@ -733,213 +733,101 @@ class _ImmersiveComposer extends StatefulWidget {
 }
 
 class _ImmersiveComposerState extends State<_ImmersiveComposer> {
-  static const _holdDelay = Duration(milliseconds: 180);
-  static const _cancelDistance = 72.0;
-
-  Timer? _holdTimer;
-  Offset? _pointerOrigin;
-  bool _pointerActive = false;
-  bool _holdRecordingStarted = false;
-  bool _cancelArmed = false;
-  bool _tapRecordingActive = false;
-  bool _recordingStartInFlight = false;
-  int _recordingStartGeneration = 0;
-
-  @override
-  void dispose() {
-    _holdTimer?.cancel();
-    super.dispose();
+  Future<void> _sendVoice() async {
+    await widget.controller.finishRecordingGesture();
+    if (!mounted ||
+        widget.controller.recordingState !=
+            PracticeRecordingState.awaitingConfirmation) {
+      return;
+    }
+    await widget.controller.confirmTranscript();
   }
 
-  void _pointerDown(PointerDownEvent event) {
-    if (_pointerActive ||
-        _recordingStartInFlight ||
-        widget.textMode ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
+  Future<void> _convertToText() async {
+    await widget.controller.finishRecordingGesture();
+    if (!mounted ||
+        widget.controller.recordingState !=
+            PracticeRecordingState.awaitingConfirmation) {
       return;
     }
-    _holdTimer?.cancel();
-    setState(() {
-      _pointerActive = true;
-      _holdRecordingStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = event.position;
-    });
-    _holdTimer = Timer(_holdDelay, () {
-      if (!mounted || !_pointerActive) {
-        return;
-      }
-      setState(() => _holdRecordingStarted = true);
-      unawaited(HapticFeedback.mediumImpact());
-      unawaited(_beginRecording(tapMode: false));
-    });
-  }
-
-  void _pointerMove(PointerMoveEvent event) {
-    final origin = _pointerOrigin;
-    if (!_pointerActive || origin == null) {
-      return;
-    }
-    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
-    if (cancelArmed == _cancelArmed) {
-      return;
-    }
-    setState(() => _cancelArmed = cancelArmed);
-    unawaited(HapticFeedback.selectionClick());
-  }
-
-  void _pointerUp(PointerUpEvent event) => _finishPointer(cancel: _cancelArmed);
-
-  void _pointerCancel(PointerCancelEvent event) => _finishPointer(cancel: true);
-
-  void _finishPointer({required bool cancel}) {
-    if (!_pointerActive) {
-      return;
-    }
-    _holdTimer?.cancel();
-    final started = _holdRecordingStarted;
-    if (started) {
-      _recordingStartGeneration++;
-      _recordingStartInFlight = false;
-    }
-    setState(() {
-      _pointerActive = false;
-      _holdRecordingStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = null;
-    });
-    if (!started) {
-      if (!cancel) {
-        _startTapRecording();
-      }
-      return;
-    }
-    unawaited(
-      cancel
-          ? widget.controller.cancelRecording()
-          : widget.controller.finishRecordingGesture(),
+    final transcript = widget.controller.transcript?.trim() ?? '';
+    widget.controller.rerecord();
+    widget.textController.value = TextEditingValue(
+      text: transcript,
+      selection: TextSelection.collapsed(offset: transcript.length),
     );
-  }
-
-  void _startTapRecording() {
-    if (widget.textMode ||
-        _recordingStartInFlight ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
+    if (!widget.textMode) {
+      widget.onToggleTextMode();
     }
-    setState(() => _tapRecordingActive = true);
-    unawaited(HapticFeedback.mediumImpact());
-    unawaited(_beginRecording(tapMode: true));
-  }
-
-  Future<void> _beginRecording({required bool tapMode}) async {
-    final generation = ++_recordingStartGeneration;
-    setState(() => _recordingStartInFlight = true);
-    try {
-      try {
-        await widget.onBeforeStartRecording?.call();
-      } on Object {
-        // Avatar interruption is best-effort; microphone access must remain
-        // available when the visual provider is degraded.
-      }
-      final intentStillActive = tapMode ? _tapRecordingActive : _pointerActive;
-      if (!mounted ||
-          generation != _recordingStartGeneration ||
-          !intentStillActive ||
-          widget.controller.recordingState != PracticeRecordingState.idle) {
-        return;
-      }
-      await widget.controller.startRecording();
-    } finally {
-      if (mounted && generation == _recordingStartGeneration) {
-        setState(() => _recordingStartInFlight = false);
-      }
-    }
-  }
-
-  void _finishTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    _recordingStartGeneration++;
-    _recordingStartInFlight = false;
-    unawaited(widget.controller.finishRecordingGesture());
-  }
-
-  void _cancelTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    _recordingStartGeneration++;
-    _recordingStartInFlight = false;
-    unawaited(widget.controller.cancelRecording());
   }
 
   @override
   Widget build(BuildContext context) {
     final state = widget.controller.recordingState;
-    final tapRecording =
-        _tapRecordingActive &&
-        (state == PracticeRecordingState.starting ||
+    final capturePhase = switch (state) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
+    final captureEnabled =
+        !widget.textMode &&
+        !widget.controller.hasPendingPracticeAudio &&
+        (state == PracticeRecordingState.idle ||
+            state == PracticeRecordingState.starting ||
             state == PracticeRecordingState.recording);
-    return Material(
-      color: SpeakUpDesign.surface,
-      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
-          child: switch (state) {
-            PracticeRecordingState.idle => _IdleComposer(
-              textController: widget.textController,
-              textFocusNode: widget.textFocusNode,
-              textMode: widget.textMode,
-              pressed: _pointerActive,
-              onToggleTextMode: widget.onToggleTextMode,
-              onSubmitText: widget.onSubmitText,
-              onPointerDown: _pointerDown,
-              onPointerMove: _pointerMove,
-              onPointerUp: _pointerUp,
-              onPointerCancel: _pointerCancel,
-              onSemanticTap: _startTapRecording,
-            ),
-            PracticeRecordingState.starting ||
-            PracticeRecordingState.recording => _RecordingComposer(
-              preparing: state == PracticeRecordingState.starting,
-              tapMode: tapRecording,
-              cancelArmed: _cancelArmed,
-              seconds: widget.recordingSeconds,
-              onFinish: _finishTapRecording,
-              onCancel: _cancelTapRecording,
-              onPointerMove: _pointerMove,
-              onPointerUp: _pointerUp,
-              onPointerCancel: _pointerCancel,
-            ),
-            PracticeRecordingState.transcribing => const _ComposerProgress(
-              label: '正在识别你的回答…',
-            ),
-            PracticeRecordingState.awaitingConfirmation => _TranscriptComposer(
-              controller: widget.controller,
-            ),
-            PracticeRecordingState.submitting => const _ComposerProgress(
-              label: '正在发送并准备下一轮…',
-            ),
-            PracticeRecordingState.reviewFailed => _ComposerAction(
-              label: '本轮已完成，暂时无法保存结果。',
-              actionLabel: '重试',
-              onPressed: widget.controller.retryReview,
-            ),
-            PracticeRecordingState.completed => const _ComposerProgress(
-              label: '本轮对话已完成',
-              showProgress: false,
-            ),
-          },
+    return VoiceCaptureControl(
+      phase: capturePhase,
+      enabled: captureEnabled,
+      onBeforeStart: widget.onBeforeStartRecording,
+      onStart: widget.controller.startRecording,
+      onSendVoice: _sendVoice,
+      onConvertToText: _convertToText,
+      onCancel: widget.controller.cancelRecording,
+      builder: (context, capture) => Material(
+        color: SpeakUpDesign.surface,
+        shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+            child: switch (state) {
+              PracticeRecordingState.idle =>
+                widget.controller.hasPendingPracticeAudio
+                    ? _PendingImmersiveAudio(controller: widget.controller)
+                    : _IdleComposer(
+                        textController: widget.textController,
+                        textFocusNode: widget.textFocusNode,
+                        textMode: widget.textMode,
+                        onToggleTextMode: widget.onToggleTextMode,
+                        onSubmitText: widget.onSubmitText,
+                        capture: capture,
+                      ),
+              PracticeRecordingState.starting ||
+              PracticeRecordingState.recording => _RecordingComposer(
+                preparing: state == PracticeRecordingState.starting,
+                seconds: widget.recordingSeconds,
+                capture: capture,
+              ),
+              PracticeRecordingState.transcribing => const _ComposerProgress(
+                label: '正在识别你的回答…',
+              ),
+              PracticeRecordingState.awaitingConfirmation =>
+                _TranscriptComposer(controller: widget.controller),
+              PracticeRecordingState.submitting => const _ComposerProgress(
+                label: '正在发送并准备下一轮…',
+              ),
+              PracticeRecordingState.reviewFailed => _ComposerAction(
+                label: '本轮已完成，暂时无法保存结果。',
+                actionLabel: '重试',
+                onPressed: widget.controller.retryReview,
+              ),
+              PracticeRecordingState.completed => const _ComposerProgress(
+                label: '本轮对话已完成',
+                showProgress: false,
+              ),
+            },
+          ),
         ),
       ),
     );
@@ -951,27 +839,17 @@ class _IdleComposer extends StatelessWidget {
     required this.textController,
     required this.textFocusNode,
     required this.textMode,
-    required this.pressed,
     required this.onToggleTextMode,
     required this.onSubmitText,
-    required this.onPointerDown,
-    required this.onPointerMove,
-    required this.onPointerUp,
-    required this.onPointerCancel,
-    required this.onSemanticTap,
+    required this.capture,
   });
 
   final TextEditingController textController;
   final FocusNode textFocusNode;
   final bool textMode;
-  final bool pressed;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
-  final PointerDownEventListener onPointerDown;
-  final PointerMoveEventListener onPointerMove;
-  final PointerUpEventListener onPointerUp;
-  final PointerCancelEventListener onPointerCancel;
-  final VoidCallback onSemanticTap;
+  final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
@@ -1014,47 +892,38 @@ class _IdleComposer extends StatelessWidget {
     return Row(
       children: [
         Expanded(
-          child: Semantics(
-            button: true,
-            label: '点击或按住说话',
-            onTap: onSemanticTap,
-            child: Listener(
-              key: const Key('immersive-record'),
-              behavior: HitTestBehavior.opaque,
-              onPointerDown: onPointerDown,
-              onPointerMove: onPointerMove,
-              onPointerUp: onPointerUp,
-              onPointerCancel: onPointerCancel,
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 100),
-                height: 52,
-                decoration: BoxDecoration(
-                  color: pressed
-                      ? SpeakUpDesign.primary.withValues(alpha: 0.82)
-                      : SpeakUpDesign.primary,
-                  borderRadius: BorderRadius.circular(
-                    SpeakUpDesign.radiusControl,
-                  ),
+          child: capture.wrapTarget(
+            key: const Key('immersive-record'),
+            semanticsLabel: '点击或按住说话',
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 100),
+              height: 52,
+              decoration: BoxDecoration(
+                color: capture.pressed
+                    ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                    : SpeakUpDesign.primary,
+                borderRadius: BorderRadius.circular(
+                  SpeakUpDesign.radiusControl,
                 ),
-                child: const Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(Icons.mic_rounded, color: Colors.white),
-                    SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        '点击或按住说话',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w700,
-                        ),
+              ),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.mic_rounded, color: Colors.white),
+                  SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      '点击或按住说话',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -1075,95 +944,126 @@ class _IdleComposer extends StatelessWidget {
 class _RecordingComposer extends StatelessWidget {
   const _RecordingComposer({
     required this.preparing,
-    required this.tapMode,
-    required this.cancelArmed,
     required this.seconds,
-    required this.onFinish,
-    required this.onCancel,
-    required this.onPointerMove,
-    required this.onPointerUp,
-    required this.onPointerCancel,
+    required this.capture,
   });
 
   final bool preparing;
-  final bool tapMode;
-  final bool cancelArmed;
   final int seconds;
-  final VoidCallback onFinish;
-  final VoidCallback onCancel;
-  final PointerMoveEventListener onPointerMove;
-  final PointerUpEventListener onPointerUp;
-  final PointerCancelEventListener onPointerCancel;
+  final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
     final minutesText = (seconds ~/ 60).toString().padLeft(2, '0');
     final secondsText = (seconds % 60).toString().padLeft(2, '0');
-    final control = Container(
-      key: const Key('immersive-stop-recording'),
-      height: 58,
-      padding: const EdgeInsets.symmetric(horizontal: 14),
-      decoration: BoxDecoration(
-        color: cancelArmed
-            ? SpeakUpDesign.errorMuted
-            : SpeakUpDesign.primaryMuted,
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
-      ),
-      child: Row(
-        children: [
-          Icon(
-            cancelArmed ? Icons.delete_outline_rounded : Icons.mic_rounded,
-            color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
+    final cancelArmed =
+        capture.releaseIntent == VoiceCaptureReleaseIntent.cancel;
+    final convertArmed =
+        capture.releaseIntent == VoiceCaptureReleaseIntent.convertToText;
+    final accent = cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        VoiceCaptureIntentTargets(
+          capture: capture,
+          elapsed: Duration(seconds: seconds),
+          keyPrefix: 'immersive',
+        ),
+        const SizedBox(height: 10),
+        capture.wrapTarget(
+          key: const Key('immersive-record'),
+          semanticsLabel: capture.tapMode ? '发送语音回答' : '录音中，左滑取消，右滑转文字，松开发送',
+          child: AnimatedContainer(
+            key: const Key('immersive-stop-recording'),
+            duration: const Duration(milliseconds: 120),
+            constraints: const BoxConstraints(minHeight: 58),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: cancelArmed
+                  ? SpeakUpDesign.errorMuted
+                  : SpeakUpDesign.primaryMuted,
+              borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+              border: Border.all(color: accent),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  cancelArmed
+                      ? Icons.delete_outline_rounded
+                      : convertArmed
+                      ? Icons.text_fields_rounded
+                      : Icons.graphic_eq_rounded,
+                  color: accent,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    cancelArmed
+                        ? '松开取消'
+                        : convertArmed
+                        ? '松开转成文字'
+                        : preparing
+                        ? '正在打开麦克风…'
+                        : capture.tapMode
+                        ? '点击发送语音 · $minutesText:$secondsText'
+                        : '松开发送语音 · $minutesText:$secondsText',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: SpeakUpDesign.label.copyWith(color: accent),
+                  ),
+                ),
+                if (!cancelArmed && !convertArmed)
+                  Icon(
+                    capture.tapMode
+                        ? Icons.send_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: accent,
+                  ),
+              ],
+            ),
           ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              cancelArmed
-                  ? '松开取消'
-                  : preparing
-                  ? '正在打开麦克风…'
-                  : tapMode
-                  ? '再次点击结束 · $minutesText:$secondsText'
-                  : '松开发送 · $minutesText:$secondsText',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: SpeakUpDesign.label.copyWith(
-                color: cancelArmed
-                    ? SpeakUpDesign.error
-                    : SpeakUpDesign.primary,
+        ),
+      ],
+    );
+  }
+}
+
+class _PendingImmersiveAudio extends StatelessWidget {
+  const _PendingImmersiveAudio({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('immersive-pending-audio'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('这段录音已保留', style: SpeakUpDesign.cardTitle),
+        const SizedBox(height: 4),
+        const Text('刚才没有识别成功，可以重试转文字，或删除后重新录音。', style: SpeakUpDesign.body),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('immersive-delete-pending-audio'),
+                onPressed: controller.discardPendingPracticeAudio,
+                child: const Text('删除录音'),
               ),
             ),
-          ),
-        ],
-      ),
-    );
-    if (tapMode) {
-      return Row(
-        children: [
-          Expanded(
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: onFinish,
-              child: control,
+            const SizedBox(width: 10),
+            Expanded(
+              child: FilledButton(
+                key: const Key('immersive-retry-transcription'),
+                onPressed: controller.retryPracticeTranscription,
+                child: const Text('重试转文字'),
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          IconButton.outlined(
-            key: const Key('immersive-cancel-tap-recording'),
-            tooltip: '取消录音',
-            onPressed: onCancel,
-            icon: const Icon(Icons.close_rounded),
-            style: IconButton.styleFrom(minimumSize: const Size.square(52)),
-          ),
-        ],
-      );
-    }
-    return Listener(
-      behavior: HitTestBehavior.opaque,
-      onPointerMove: onPointerMove,
-      onPointerUp: onPointerUp,
-      onPointerCancel: onPointerCancel,
-      child: control,
+          ],
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -4,10 +4,10 @@ library;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/practice/ielts_mock_practice.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/practice/practice_recordings.dart';
@@ -776,244 +776,123 @@ class _RecordingPanel extends StatefulWidget {
 }
 
 class _RecordingPanelState extends State<_RecordingPanel> {
-  static const _holdDelay = Duration(milliseconds: 180);
-  static const _cancelDistance = 72.0;
-
-  Timer? _holdTimer;
-  Offset? _pointerOrigin;
-  bool _pointerActive = false;
-  bool _recordingGestureStarted = false;
-  bool _cancelArmed = false;
-  bool _tapRecordingActive = false;
-  double _voiceHitWidth = double.infinity;
-
-  @override
-  void dispose() {
-    _holdTimer?.cancel();
-    super.dispose();
-  }
-
-  void _handlePointerDown(PointerDownEvent event) {
-    if (_pointerActive ||
-        widget.textMode ||
-        event.localPosition.dx > _voiceHitWidth ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
+  Future<void> _sendVoice() async {
+    await widget.controller.finishRecordingGesture();
+    if (!mounted ||
+        widget.controller.recordingState !=
+            PracticeRecordingState.awaitingConfirmation) {
       return;
     }
-    _holdTimer?.cancel();
-    setState(() {
-      _pointerActive = true;
-      _recordingGestureStarted = false;
-      _cancelArmed = false;
-      _tapRecordingActive = false;
-      _pointerOrigin = event.position;
-    });
-    _holdTimer = Timer(_holdDelay, () {
-      if (!mounted || !_pointerActive) {
-        return;
-      }
-      setState(() => _recordingGestureStarted = true);
-      unawaited(HapticFeedback.mediumImpact());
-      unawaited(widget.controller.startRecording());
-    });
+    await widget.controller.confirmTranscript();
   }
 
-  void _handlePointerMove(PointerMoveEvent event) {
-    final origin = _pointerOrigin;
-    if (!_pointerActive || origin == null) {
+  Future<void> _convertToText() async {
+    await widget.controller.finishRecordingGesture();
+    if (!mounted ||
+        widget.controller.recordingState !=
+            PracticeRecordingState.awaitingConfirmation) {
       return;
     }
-    final cancelArmed = event.position.dy <= origin.dy - _cancelDistance;
-    if (cancelArmed == _cancelArmed) {
-      return;
-    }
-    setState(() => _cancelArmed = cancelArmed);
-    unawaited(HapticFeedback.selectionClick());
-  }
-
-  void _handlePointerUp(PointerUpEvent event) {
-    _finishGesture(cancel: _cancelArmed);
-  }
-
-  void _handlePointerCancel(PointerCancelEvent event) {
-    _finishGesture(cancel: true);
-  }
-
-  void _finishGesture({required bool cancel}) {
-    if (!_pointerActive) {
-      return;
-    }
-    _holdTimer?.cancel();
-    final started = _recordingGestureStarted;
-    setState(() {
-      _pointerActive = false;
-      _recordingGestureStarted = false;
-      _cancelArmed = false;
-      _pointerOrigin = null;
-    });
-    if (!started) {
-      if (!cancel) {
-        _startTapRecording();
-      }
-      return;
-    }
-    if (cancel) {
-      unawaited(widget.controller.cancelRecording());
-    } else {
-      unawaited(widget.controller.finishRecordingGesture());
+    final transcript = widget.controller.transcript?.trim() ?? '';
+    widget.controller.rerecord();
+    widget.textController.value = TextEditingValue(
+      text: transcript,
+      selection: TextSelection.collapsed(offset: transcript.length),
+    );
+    if (!widget.textMode) {
+      widget.onToggleTextMode();
     }
   }
 
-  void _toggleRecordingForAccessibility() {
-    final state = widget.controller.recordingState;
-    if (state == PracticeRecordingState.idle) {
-      _startTapRecording();
-    } else if (state == PracticeRecordingState.starting ||
-        state == PracticeRecordingState.recording) {
-      _finishTapRecording();
-    }
-  }
-
-  void _startTapRecording() {
-    if (widget.textMode ||
-        widget.controller.recordingState != PracticeRecordingState.idle) {
-      return;
-    }
-    setState(() => _tapRecordingActive = true);
-    unawaited(HapticFeedback.mediumImpact());
-    unawaited(widget.controller.startRecording());
-  }
-
-  void _finishTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    unawaited(widget.controller.finishRecordingGesture());
-  }
-
-  void _cancelTapRecording() {
-    final state = widget.controller.recordingState;
-    if (state != PracticeRecordingState.starting &&
-        state != PracticeRecordingState.recording) {
-      return;
-    }
-    setState(() => _tapRecordingActive = false);
-    unawaited(widget.controller.cancelRecording());
-  }
+  Future<void> _cancel() => widget.controller.cancelRecording();
 
   @override
   Widget build(BuildContext context) {
     final state = widget.controller.recordingState;
-    final tapRecordingActive =
-        _tapRecordingActive &&
-        (state == PracticeRecordingState.starting ||
-            state == PracticeRecordingState.recording);
-    final handlesHold =
+    final capturePhase = switch (state) {
+      PracticeRecordingState.idle => VoiceCapturePhase.idle,
+      PracticeRecordingState.starting => VoiceCapturePhase.starting,
+      PracticeRecordingState.recording => VoiceCapturePhase.recording,
+      _ => VoiceCapturePhase.busy,
+    };
+    final captureEnabled =
         !widget.textMode &&
+        !widget.controller.hasPendingPracticeAudio &&
         (state == PracticeRecordingState.idle ||
             state == PracticeRecordingState.starting ||
             state == PracticeRecordingState.recording);
-    final panel = switch (state) {
-      PracticeRecordingState.idle => _IdleAnswerPanel(
-        textController: widget.textController,
-        textFocusNode: widget.textFocusNode,
-        onSubmitText: widget.onSubmitText,
-        textMode: widget.textMode,
-        onToggleTextMode: widget.onToggleTextMode,
-        pressed: _pointerActive,
-      ),
-      PracticeRecordingState.starting ||
-      PracticeRecordingState.recording => _ActiveRecordingPanel(
-        preparing: state == PracticeRecordingState.starting,
-        cancelArmed: _cancelArmed,
-        recordingSeconds: widget.recordingSeconds,
-        tapMode: tapRecordingActive,
-      ),
-      PracticeRecordingState.transcribing => const _WorkingState(
-        label: '正在识别英文回答…',
-      ),
-      PracticeRecordingState.awaitingConfirmation => _TranscriptConfirmation(
-        controller: widget.controller,
-      ),
-      PracticeRecordingState.submitting => const _WorkingState(
-        label: '回答已发送，正在准备下一题…',
-      ),
-      PracticeRecordingState.reviewFailed => _ReviewRetry(
-        onPressed: widget.controller.retryReview,
-      ),
-      PracticeRecordingState.completed => const _WorkingState(
-        label: '复盘已生成，正在打开',
-      ),
-    };
-    return Material(
-      color: SpeakUpDesign.surface,
-      shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
-          child: tapRecordingActive
-              ? Row(
-                  children: [
-                    Expanded(
-                      child: Semantics(
-                        button: true,
-                        label: state == PracticeRecordingState.starting
-                            ? '正在打开麦克风'
-                            : '结束录音并自动转写',
-                        onTap: _finishTapRecording,
-                        child: ExcludeSemantics(
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: _finishTapRecording,
-                            child: panel,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    IconButton.outlined(
-                      key: const Key('practice-cancel-tap-recording'),
-                      tooltip: '取消录音',
-                      onPressed: _cancelTapRecording,
-                      icon: const Icon(Icons.close_rounded),
-                      style: IconButton.styleFrom(
-                        minimumSize: const Size.square(56),
-                      ),
-                    ),
-                  ],
-                )
-              : handlesHold
-              ? LayoutBuilder(
-                  builder: (context, constraints) {
-                    _voiceHitWidth =
-                        state == PracticeRecordingState.idle && !widget.textMode
-                        ? constraints.maxWidth - 66
-                        : constraints.maxWidth;
-                    return Semantics(
-                      button: true,
-                      label: state == PracticeRecordingState.idle
-                          ? '点击或按住说话'
-                          : '正在录音，上滑取消，松开发送',
-                      onTap: _toggleRecordingForAccessibility,
-                      child: Listener(
-                        key: const Key('practice-record'),
-                        behavior: HitTestBehavior.opaque,
-                        onPointerDown: _handlePointerDown,
-                        onPointerMove: _handlePointerMove,
-                        onPointerUp: _handlePointerUp,
-                        onPointerCancel: _handlePointerCancel,
-                        child: panel,
-                      ),
-                    );
-                  },
-                )
-              : panel,
-        ),
-      ),
+
+    return VoiceCaptureControl(
+      phase: capturePhase,
+      enabled: captureEnabled,
+      onStart: widget.controller.startRecording,
+      onSendVoice: _sendVoice,
+      onConvertToText: _convertToText,
+      onCancel: _cancel,
+      builder: (context, capture) {
+        final panel = switch (state) {
+          PracticeRecordingState.idle =>
+            widget.controller.hasPendingPracticeAudio
+                ? _PendingPracticeAudioPanel(controller: widget.controller)
+                : _IdleAnswerPanel(
+                    textController: widget.textController,
+                    textFocusNode: widget.textFocusNode,
+                    onSubmitText: widget.onSubmitText,
+                    textMode: widget.textMode,
+                    onToggleTextMode: widget.onToggleTextMode,
+                    capture: capture,
+                  ),
+          PracticeRecordingState.starting ||
+          PracticeRecordingState.recording => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              VoiceCaptureIntentTargets(
+                capture: capture,
+                elapsed: Duration(seconds: widget.recordingSeconds),
+                keyPrefix: 'practice',
+              ),
+              const SizedBox(height: 10),
+              capture.wrapTarget(
+                key: const Key('practice-record'),
+                semanticsLabel: capture.tapMode
+                    ? '发送语音回答'
+                    : '录音中，左滑取消，右滑转文字，松开发送',
+                child: _ActiveRecordingPanel(
+                  preparing: state == PracticeRecordingState.starting,
+                  releaseIntent: capture.releaseIntent,
+                  recordingSeconds: widget.recordingSeconds,
+                  tapMode: capture.tapMode,
+                ),
+              ),
+            ],
+          ),
+          PracticeRecordingState.transcribing => const _WorkingState(
+            label: '正在识别英文回答…',
+          ),
+          PracticeRecordingState.awaitingConfirmation =>
+            _TranscriptConfirmation(controller: widget.controller),
+          PracticeRecordingState.submitting => const _WorkingState(
+            label: '回答已发送，正在准备下一题…',
+          ),
+          PracticeRecordingState.reviewFailed => _ReviewRetry(
+            onPressed: widget.controller.retryReview,
+          ),
+          PracticeRecordingState.completed => const _WorkingState(
+            label: '复盘已生成，正在打开',
+          ),
+        };
+        return Material(
+          color: SpeakUpDesign.surface,
+          shape: const Border(top: BorderSide(color: SpeakUpDesign.border)),
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 12),
+              child: panel,
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -1025,7 +904,7 @@ class _IdleAnswerPanel extends StatelessWidget {
     required this.onSubmitText,
     required this.textMode,
     required this.onToggleTextMode,
-    required this.pressed,
+    required this.capture,
   });
 
   final TextEditingController textController;
@@ -1033,7 +912,7 @@ class _IdleAnswerPanel extends StatelessWidget {
   final VoidCallback onSubmitText;
   final bool textMode;
   final VoidCallback onToggleTextMode;
-  final bool pressed;
+  final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
@@ -1041,35 +920,39 @@ class _IdleAnswerPanel extends StatelessWidget {
       return Row(
         children: [
           Expanded(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 100),
-              height: 56,
-              decoration: BoxDecoration(
-                color: pressed
-                    ? SpeakUpDesign.primary.withValues(alpha: 0.82)
-                    : SpeakUpDesign.primary,
-                borderRadius: BorderRadius.circular(
-                  SpeakUpDesign.radiusControl,
+            child: capture.wrapTarget(
+              key: const Key('practice-record'),
+              semanticsLabel: '点击或按住说话',
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 100),
+                height: 56,
+                decoration: BoxDecoration(
+                  color: capture.pressed
+                      ? SpeakUpDesign.primary.withValues(alpha: 0.82)
+                      : SpeakUpDesign.primary,
+                  borderRadius: BorderRadius.circular(
+                    SpeakUpDesign.radiusControl,
+                  ),
                 ),
-              ),
-              child: const Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.mic_rounded, color: Colors.white),
-                  SizedBox(width: 10),
-                  Flexible(
-                    child: Text(
-                      '点击或按住说话',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.mic_rounded, color: Colors.white),
+                    SizedBox(width: 10),
+                    Flexible(
+                      child: Text(
+                        '点击或按住说话',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -1130,13 +1013,13 @@ class _IdleAnswerPanel extends StatelessWidget {
 class _ActiveRecordingPanel extends StatelessWidget {
   const _ActiveRecordingPanel({
     required this.preparing,
-    required this.cancelArmed,
+    required this.releaseIntent,
     required this.recordingSeconds,
     required this.tapMode,
   });
 
   final bool preparing;
-  final bool cancelArmed;
+  final VoiceCaptureReleaseIntent releaseIntent;
   final int recordingSeconds;
   final bool tapMode;
 
@@ -1144,6 +1027,10 @@ class _ActiveRecordingPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final minutes = (recordingSeconds ~/ 60).toString().padLeft(2, '0');
     final seconds = (recordingSeconds % 60).toString().padLeft(2, '0');
+    final cancelArmed = releaseIntent == VoiceCaptureReleaseIntent.cancel;
+    final convertArmed =
+        releaseIntent == VoiceCaptureReleaseIntent.convertToText;
+    final accent = cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary;
     return AnimatedContainer(
       key: const Key('practice-stop-recording'),
       duration: const Duration(milliseconds: 120),
@@ -1154,15 +1041,17 @@ class _ActiveRecordingPanel extends StatelessWidget {
             ? SpeakUpDesign.errorMuted
             : SpeakUpDesign.primaryMuted,
         borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
-        border: Border.all(
-          color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
-        ),
+        border: Border.all(color: accent),
       ),
       child: Row(
         children: [
           Icon(
-            cancelArmed ? Icons.delete_outline_rounded : Icons.mic_rounded,
-            color: cancelArmed ? SpeakUpDesign.error : SpeakUpDesign.primary,
+            cancelArmed
+                ? Icons.delete_outline_rounded
+                : convertArmed
+                ? Icons.text_fields_rounded
+                : Icons.graphic_eq_rounded,
+            color: accent,
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -1173,41 +1062,76 @@ class _ActiveRecordingPanel extends StatelessWidget {
                 Text(
                   cancelArmed
                       ? '松开取消'
+                      : convertArmed
+                      ? '松开转成文字'
                       : preparing
                       ? '正在打开麦克风…'
                       : tapMode
-                      ? '再次点击结束'
-                      : '松开发送',
-                  style: SpeakUpDesign.cardTitle.copyWith(
-                    color: cancelArmed
-                        ? SpeakUpDesign.error
-                        : SpeakUpDesign.primary,
-                  ),
+                      ? '点击发送语音'
+                      : '松开发送语音',
+                  style: SpeakUpDesign.cardTitle.copyWith(color: accent),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   cancelArmed
                       ? '录音不会保存'
+                      : convertArmed
+                      ? '识别后可编辑再发送'
                       : tapMode
-                      ? '点击结束并识别 · $minutes:$seconds'
-                      : '上滑取消 · $minutes:$seconds',
+                      ? '也可点击上方取消或转文字 · $minutes:$seconds'
+                      : '左滑取消 · 右滑转文字 · $minutes:$seconds',
                   style: SpeakUpDesign.meta,
                 ),
               ],
             ),
           ),
-          if (!cancelArmed && !tapMode)
-            const Icon(
-              Icons.keyboard_arrow_up_rounded,
-              color: SpeakUpDesign.primary,
-            ),
-          if (!cancelArmed && tapMode)
-            const Icon(
-              Icons.stop_circle_outlined,
-              color: SpeakUpDesign.primary,
+          if (!cancelArmed && !convertArmed)
+            Icon(
+              tapMode ? Icons.send_rounded : Icons.keyboard_arrow_down_rounded,
+              color: accent,
             ),
         ],
       ),
+    );
+  }
+}
+
+class _PendingPracticeAudioPanel extends StatelessWidget {
+  const _PendingPracticeAudioPanel({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('practice-pending-audio'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('这段录音已保留', style: SpeakUpDesign.cardTitle),
+        const SizedBox(height: 4),
+        const Text('刚才没有识别成功，可以重试转文字，或删除后重新录音。', style: SpeakUpDesign.body),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('practice-delete-pending-audio'),
+                onPressed: controller.discardPendingPracticeAudio,
+                child: const Text('删除录音'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: FilledButton(
+                key: const Key('practice-retry-transcription'),
+                onPressed: controller.retryPracticeTranscription,
+                child: const Text('重试转文字'),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -39,6 +39,8 @@ void main() {
     expect(find.text('英文自我介绍'), findsOneWidget);
 
     const textMessage = 'Please help me make this answer more specific.';
+    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+    await tester.pump();
     await tester.enterText(
       find.byKey(const Key('agent-composer-field')),
       textMessage,
@@ -72,24 +74,31 @@ void main() {
     await tester.tap(find.byKey(const Key('practice-record')));
     await tester.pumpAndSettle();
     expect(agentController.recordingState, PracticeRecordingState.recording);
-    expect(find.text('再次点击结束'), findsOneWidget);
+    expect(find.text('点击发送语音'), findsOneWidget);
     expect(
-      find.byKey(const Key('practice-cancel-tap-recording')),
+      find.byKey(const Key('practice-voice-target-cancel')),
       findsOneWidget,
     );
 
-    await tester.tap(find.byKey(const Key('practice-cancel-tap-recording')));
+    await tester.tap(find.byKey(const Key('practice-voice-target-cancel')));
     await tester.pumpAndSettle();
     expect(agentController.recordingState, PracticeRecordingState.idle);
     expect(find.byKey(const Key('practice-transcript')), findsNothing);
 
     await tester.tap(find.byKey(const Key('practice-record')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('practice-stop-recording')));
+    await tester.tap(find.byKey(const Key('practice-voice-target-convert')));
     await tester.pumpAndSettle();
-    expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
-
-    await tester.tap(find.byKey(const Key('practice-rerecord')));
+    expect(find.byKey(const Key('practice-text-answer')), findsOneWidget);
+    expect(
+      tester
+          .widget<TextField>(find.byKey(const Key('practice-text-answer')))
+          .controller
+          ?.text,
+      isNotEmpty,
+    );
+    expect(agentController.recordingState, PracticeRecordingState.idle);
+    await tester.tap(find.byKey(const Key('practice-return-to-voice')));
     await tester.pumpAndSettle();
     expect(agentController.recordingState, PracticeRecordingState.idle);
 
@@ -97,7 +106,7 @@ void main() {
       tester.getCenter(find.byKey(const Key('practice-record'))),
     );
     await tester.pump(const Duration(milliseconds: 220));
-    await cancelledGesture.moveBy(const Offset(0, -90));
+    await cancelledGesture.moveBy(const Offset(-90, 0));
     await tester.pump();
     expect(find.text('松开取消'), findsOneWidget);
     await cancelledGesture.up();
@@ -106,27 +115,16 @@ void main() {
     expect(agentController.recordingState, PracticeRecordingState.idle);
 
     for (var turn = 1; turn <= 3; turn++) {
-      await _holdAndReleaseAnswer(tester);
-      expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
-      expect(find.text('取消'), findsOneWidget);
       expect(
         find
             .byKey(Key('practice-ai-message-${agentController.questionId}'))
             .hitTestable(),
         findsOneWidget,
       );
-
-      if (turn == 1) {
-        await tester.tap(find.byKey(const Key('practice-rerecord')));
-        await tester.pumpAndSettle();
-        expect(agentController.practiceMessages, hasLength(1));
-        await _holdAndReleaseAnswer(tester);
-      }
-
-      await tester.tap(find.byKey(const Key('practice-confirm-turn')));
-      await tester.pumpAndSettle();
+      await _holdAndReleaseAnswer(tester);
       if (turn < 3) {
         expect(agentController.practiceMessages, hasLength(turn * 2 + 1));
+        expect(agentController.recordingState, PracticeRecordingState.idle);
       }
     }
 

--- a/mobile/test/agent/agent_voice_fence_test.dart
+++ b/mobile/test/agent/agent_voice_fence_test.dart
@@ -268,19 +268,18 @@ void main() {
         ),
       ),
     );
+    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+    await tester.pump();
     await tester.enterText(
       find.byKey(const Key('agent-composer-field')),
       'Unsent text before recording',
     );
+    await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
+    await tester.pump();
     await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
     await tester.pump();
     await tester.tap(find.byKey(const Key('agent-voice-stop')));
     await _pumpVoiceOperation(tester);
-    expect(controller.state, AgentVoiceComposerState.awaitingConfirmation);
-
-    await tester.tap(find.byKey(const Key('agent-voice-confirm')));
-    await tester.pump();
-
     expect(controller.state, AgentVoiceComposerState.confirming);
     expect(find.byKey(const Key('agent-voice-cancel')), findsNothing);
     expect(find.text('Unsent text before recording'), findsNothing);

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -12,7 +12,7 @@ import 'package:speakup/features/conversation/conversation.dart';
 
 void main() {
   testWidgets(
-    'records, confirms, plays, and deletes one ordinary Agent voice Message',
+    'records, directly sends, plays, and deletes one Agent voice Message',
     (tester) async {
       final controller = AgentController(
         client: FakeAgentClient(),
@@ -35,30 +35,12 @@ void main() {
 
       await tester.tap(find.byKey(const Key('agent-voice-stop')));
       await _pumpVoiceOperation(tester);
-      expect(
-        controller.voiceController?.state,
-        AgentVoiceComposerState.awaitingConfirmation,
-      );
+      expect(controller.voiceController?.state, AgentVoiceComposerState.idle);
       expect(find.byKey(const Key('agent-composer-surface')), findsOneWidget);
       expect(find.byKey(const Key('agent-voice-composer-panel')), findsNothing);
       expect(find.text('试听'), findsNothing);
       expect(find.text('重录'), findsNothing);
       expect(find.text('上传并转写'), findsNothing);
-      final transcriptField = find.byKey(const Key('agent-composer-field'));
-      expect(transcriptField, findsOneWidget);
-      await tester.enterText(
-        transcriptField,
-        'I kept the migration safe with staged checks.',
-      );
-      await tester.pump();
-      expect(
-        controller.voiceController?.editedTranscript,
-        'I kept the migration safe with staged checks.',
-      );
-      expect(controller.voiceController?.canConfirm, isTrue);
-
-      await tester.tap(find.byKey(const Key('agent-voice-confirm')));
-      await _pumpVoiceOperation(tester);
 
       final voiceMessages = controller.messages
           .where((message) => message.modality == AgentMessageModality.voice)
@@ -66,7 +48,7 @@ void main() {
       expect(voiceMessages, hasLength(1));
       expect(
         voiceMessages.single.text,
-        'I kept the migration safe with staged checks.',
+        'I explained the problem, the trade-off, and the result clearly.',
       );
       expect(voiceMessages.single.audio?.isReadable, isTrue);
       expect(
@@ -149,6 +131,49 @@ void main() {
     },
   );
 
+  testWidgets('right swipe converts home recording into editable text', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      clientIdFactory: _sequentialIdFactory(),
+    );
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('agent-mic-placeholder'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    await gesture.moveBy(const Offset(90, 0));
+    await tester.pump();
+    expect(find.text('松开转成文字'), findsOneWidget);
+    await gesture.up();
+    await _pumpVoiceOperation(tester);
+
+    final field = find.byKey(const Key('agent-composer-field'));
+    expect(field, findsOneWidget);
+    expect(
+      tester.widget<TextField>(field).controller?.text,
+      'I explained the problem, the trade-off, and the result clearly.',
+    );
+    expect(
+      controller.voiceController?.state,
+      AgentVoiceComposerState.awaitingConfirmation,
+    );
+
+    await tester.enterText(field, 'Edited transcript sent as text.');
+    await tester.tap(find.byKey(const Key('agent-voice-confirm')));
+    await _pumpVoiceOperation(tester);
+
+    final userMessage = controller.messages.lastWhere(
+      (message) => message.role == AgentMessageRole.user,
+    );
+    expect(userMessage.text, 'Edited transcript sent as text.');
+    expect(userMessage.modality, AgentMessageModality.text);
+  });
+
   testWidgets('recording elapsed time updates inside the original composer', (
     tester,
   ) async {
@@ -200,6 +225,38 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('leaving the Agent tab cancels hands-free recording', (
+    tester,
+  ) async {
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      clientIdFactory: _sequentialIdFactory(),
+    );
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await tester.pump();
+    expect(
+      controller.voiceController?.state,
+      AgentVoiceComposerState.recording,
+    );
+
+    await tester.tap(find.byKey(const Key('primary-tab-scenes')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('scenes-page')), findsOneWidget);
+    expect(controller.voiceController?.state, AgentVoiceComposerState.idle);
+    await tester.pump(const Duration(seconds: 60));
+    expect(
+      controller.messages.where(
+        (message) => message.modality == AgentMessageModality.voice,
+      ),
+      isEmpty,
+    );
+  });
+
   testWidgets('composer drafts cannot cross the Thread boundary', (
     tester,
   ) async {
@@ -231,10 +288,14 @@ void main() {
         ),
       ),
     );
+    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+    await tester.pump();
     await tester.enterText(
       find.byKey(const Key('agent-composer-field')),
       'Thread A private draft',
     );
+    await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
+    await tester.pump();
     await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
     await tester.pump();
     expect(voiceController.state, AgentVoiceComposerState.recording);
@@ -245,9 +306,11 @@ void main() {
     await tester.pump();
 
     expect(voiceController.state, AgentVoiceComposerState.recording);
-    await tester.tap(find.byKey(const Key('agent-voice-cancel')));
+    await tester.tap(find.byKey(const Key('agent-voice-target-cancel')));
     await _pumpVoiceOperation(tester);
 
+    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+    await tester.pump();
     final field = find.byKey(const Key('agent-composer-field'));
     expect(field, findsOneWidget);
     expect(tester.widget<TextField>(field).controller?.text, isEmpty);
@@ -273,17 +336,16 @@ void main() {
         find.byKey(const Key('no-focused-conversation-home')),
         findsNothing,
       );
-      expect(
-        tester
-            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
-            .enabled,
-        isTrue,
-      );
+      expect(find.byKey(const Key('agent-show-text-composer')), findsOneWidget);
 
+      await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+      await tester.pump();
       await tester.enterText(
         find.byKey(const Key('agent-composer-field')),
         'Keep this typed draft',
       );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
       await tester.pump();
       await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
       await tester.pump();
@@ -295,6 +357,8 @@ void main() {
         AgentVoiceComposerState.recording,
       );
       await controller.voiceController?.cancel();
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('agent-show-text-composer')));
       await tester.pump();
       expect(
         tester
@@ -346,7 +410,7 @@ void main() {
       );
       expect(tester.takeException(), isNull);
 
-      await tester.tap(find.byKey(const Key('agent-voice-stop')));
+      await tester.tap(find.byKey(const Key('agent-voice-target-convert')));
       await _pumpVoiceOperation(tester);
 
       expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/agent/agent_client.dart';
@@ -9,6 +12,8 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/agent/agent_voice_recording.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/conversation/conversation.dart';
+import 'package:speakup/practice/practice_audio_player.dart';
+import 'package:speakup/practice/practice_media.dart';
 
 void main() {
   testWidgets(
@@ -257,6 +262,36 @@ void main() {
     );
   });
 
+  test(
+    'leaving Agent while playback is stopping fences microphone start',
+    () async {
+      final player = _GatedPracticeAudioPlayer();
+      final recorder = _TrackingAgentVoiceRecorder();
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        mediaClient: _NoopPracticeMediaClient(),
+        audioPlayer: player,
+        voiceRecorder: recorder,
+        voiceAudioPlayer: FakeAgentVoiceAudioPlayer(),
+        clientIdFactory: _sequentialIdFactory(),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      final stop = player.blockNextStop();
+      final start = controller.startAgentVoiceRecording();
+      await stop.entered.future;
+
+      final leave = controller.prepareToLeaveAgent();
+      stop.release.complete();
+
+      await start;
+      expect(await leave, isTrue);
+      expect(recorder.startCalls, 0);
+      expect(controller.voiceController?.state, AgentVoiceComposerState.idle);
+    },
+  );
+
   testWidgets('composer drafts cannot cross the Thread boundary', (
     tester,
   ) async {
@@ -419,6 +454,81 @@ void main() {
       await tester.pump();
     },
   );
+}
+
+final class _TrackingAgentVoiceRecorder implements AgentVoiceRecorder {
+  int startCalls = 0;
+
+  @override
+  Future<void> start() async {
+    startCalls++;
+  }
+
+  @override
+  Future<AgentVoiceLocalRecording> stop() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> discardCurrent() async {}
+
+  @override
+  Future<void> discard(AgentVoiceLocalRecording recording) async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _NoopPracticeMediaClient implements PracticeMediaClient {
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) async => Uint8List(0);
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) async => Uint8List(0);
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+final class _GatedPracticeAudioPlayer implements PracticeAudioPlayer {
+  Completer<void>? _nextStopEntered;
+  Completer<void>? _nextStopGate;
+
+  ({Completer<void> entered, Completer<void> release}) blockNextStop() {
+    final entered = Completer<void>();
+    final release = Completer<void>();
+    _nextStopEntered = entered;
+    _nextStopGate = release;
+    return (entered: entered, release: release);
+  }
+
+  @override
+  Stream<void> get onComplete => const Stream<void>.empty();
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {}
+
+  @override
+  Future<void> stop() async {
+    final entered = _nextStopEntered;
+    final gate = _nextStopGate;
+    _nextStopEntered = null;
+    _nextStopGate = null;
+    entered?.complete();
+    await gate?.future;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 Future<void> _pumpVoiceOperation(WidgetTester tester) async {

--- a/mobile/test/design/voice_capture_control_test.dart
+++ b/mobile/test/design/voice_capture_control_test.dart
@@ -1,0 +1,445 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/voice_capture_control.dart';
+
+void main() {
+  testWidgets('long press neutral release sends voice exactly once', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    expect(harness.currentState?.starts, 1);
+    expect(find.text('send armed'), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 1);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('long press left release cancels', (tester) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.moveBy(const Offset(-80, 0));
+    await tester.pump();
+    expect(find.text('cancel armed'), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 1);
+  });
+
+  testWidgets('long press right release converts to text', (tester) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.moveBy(const Offset(80, 0));
+    await tester.pump();
+    expect(find.text('convert armed'), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 1);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('moving back to the main target restores send intent', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+    final origin = tester.getCenter(
+      find.byKey(const Key('voice-capture-target')),
+    );
+
+    final gesture = await tester.startGesture(origin);
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.moveBy(const Offset(80, -80));
+    await tester.pump();
+    expect(find.text('convert armed'), findsOneWidget);
+
+    await gesture.moveTo(origin);
+    await tester.pump();
+    expect(find.text('send armed'), findsOneWidget);
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 1);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('system pointer cancel never sends an armed action', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.moveBy(const Offset(80, 0));
+    await gesture.cancel();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 1);
+  });
+
+  testWidgets('secondary pointer move and up do not finish active capture', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+    final target = tester.getCenter(
+      find.byKey(const Key('voice-capture-target')),
+    );
+
+    final primary = await tester.startGesture(target, pointer: 1);
+    await tester.pump(const Duration(milliseconds: 180));
+    await primary.moveBy(const Offset(80, 0));
+    await tester.pump();
+    expect(find.text('convert armed'), findsOneWidget);
+
+    final secondary = await tester.startGesture(target, pointer: 2);
+    await secondary.moveBy(const Offset(-160, 0));
+    await secondary.up();
+    await tester.pump();
+
+    expect(find.text('convert armed'), findsOneWidget);
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+
+    await primary.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 1);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('secondary pointer cancel does not cancel active capture', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(_VoiceCaptureHarness(key: harness));
+    final target = tester.getCenter(
+      find.byKey(const Key('voice-capture-target')),
+    );
+
+    final primary = await tester.startGesture(target, pointer: 1);
+    await tester.pump(const Duration(milliseconds: 180));
+    final secondary = await tester.startGesture(target, pointer: 2);
+    await secondary.cancel();
+    await tester.pump();
+
+    expect(find.text('send armed'), findsOneWidget);
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+
+    await primary.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 1);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+  });
+
+  testWidgets('quick tap exposes all three equivalent tap actions', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, showTapActions: true),
+    );
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    expect(harness.currentState?.starts, 1);
+
+    await tester.tap(find.byKey(const Key('voice-convert-action')));
+    await tester.pump();
+    expect(harness.currentState?.converts, 1);
+
+    harness.currentState?.reset();
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('voice-cancel-action')));
+    await tester.pump();
+    expect(harness.currentState?.cancels, 1);
+
+    harness.currentState?.reset();
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    expect(harness.currentState?.sends, 1);
+  });
+
+  testWidgets('release waits for asynchronous microphone start', (
+    tester,
+  ) async {
+    final startCompleter = Completer<void>();
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, startCompleter: startCompleter),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.up();
+    await tester.pump();
+    expect(harness.currentState?.sends, 0);
+
+    startCompleter.complete();
+    await tester.pump();
+    expect(harness.currentState?.sends, 1);
+  });
+
+  testWidgets('one release action fences later taps until it completes', (
+    tester,
+  ) async {
+    final sendCompleter = Completer<void>();
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(
+        key: harness,
+        showTapActions: true,
+        sendCompleter: sendCompleter,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    expect(harness.currentState?.sends, 1);
+
+    await tester.tap(find.byKey(const Key('voice-convert-action')));
+    await tester.tap(find.byKey(const Key('voice-cancel-action')));
+    await tester.pump();
+    expect(harness.currentState?.sends, 1);
+    expect(harness.currentState?.converts, 0);
+    expect(harness.currentState?.cancels, 0);
+
+    sendCompleter.complete();
+    await tester.pump();
+  });
+
+  testWidgets('left release during preparation never starts microphone', (
+    tester,
+  ) async {
+    final beforeStartCompleter = Completer<void>();
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(
+        key: harness,
+        beforeStartCompleter: beforeStartCompleter,
+      ),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+    await gesture.moveBy(const Offset(-80, 0));
+    await gesture.up();
+    await tester.pump();
+
+    beforeStartCompleter.complete();
+    await tester.pump();
+
+    expect(harness.currentState?.starts, 0);
+    expect(harness.currentState?.sends, 0);
+    expect(harness.currentState?.cancels, 1);
+  });
+
+  testWidgets('shared intent targets keep accessible touch sizes', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, showIntentTargets: true),
+    );
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+
+    final cancel = find.byKey(const Key('test-voice-target-cancel'));
+    final convert = find.byKey(const Key('test-voice-target-convert'));
+    expect(cancel.hitTestable(), findsOneWidget);
+    expect(convert.hitTestable(), findsOneWidget);
+    expect(tester.getSize(cancel).height, greaterThanOrEqualTo(48));
+    expect(tester.getSize(convert).height, greaterThanOrEqualTo(48));
+  });
+}
+
+class _VoiceCaptureHarness extends StatefulWidget {
+  const _VoiceCaptureHarness({
+    required super.key,
+    this.startCompleter,
+    this.beforeStartCompleter,
+    this.sendCompleter,
+    this.showTapActions = false,
+    this.showIntentTargets = false,
+  });
+
+  final Completer<void>? startCompleter;
+  final Completer<void>? beforeStartCompleter;
+  final Completer<void>? sendCompleter;
+  final bool showTapActions;
+  final bool showIntentTargets;
+
+  @override
+  State<_VoiceCaptureHarness> createState() => _VoiceCaptureHarnessState();
+}
+
+class _VoiceCaptureHarnessState extends State<_VoiceCaptureHarness> {
+  VoiceCapturePhase phase = VoiceCapturePhase.idle;
+  int starts = 0;
+  int sends = 0;
+  int converts = 0;
+  int cancels = 0;
+
+  Future<void> _start() async {
+    starts++;
+    setState(() => phase = VoiceCapturePhase.starting);
+    await widget.startCompleter?.future;
+    if (mounted) {
+      setState(() => phase = VoiceCapturePhase.recording);
+    }
+  }
+
+  Future<void> _send() async {
+    sends++;
+    await widget.sendCompleter?.future;
+    if (!mounted) {
+      return;
+    }
+    setState(() => phase = VoiceCapturePhase.busy);
+  }
+
+  void _convert() {
+    converts++;
+    setState(() => phase = VoiceCapturePhase.busy);
+  }
+
+  void _cancel() {
+    cancels++;
+    setState(() => phase = VoiceCapturePhase.idle);
+  }
+
+  void reset() {
+    starts = 0;
+    sends = 0;
+    converts = 0;
+    cancels = 0;
+    setState(() => phase = VoiceCapturePhase.idle);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: VoiceCaptureControl(
+            phase: phase,
+            onBeforeStart: () async {
+              await widget.beforeStartCompleter?.future;
+            },
+            onStart: _start,
+            onSendVoice: _send,
+            onConvertToText: _convert,
+            onCancel: _cancel,
+            builder: (context, capture) {
+              final target = capture.wrapTarget(
+                key: const Key('voice-capture-target'),
+                semanticsLabel: phase == VoiceCapturePhase.idle
+                    ? '开始录音'
+                    : '发送语音',
+                child: SizedBox(
+                  width: 180,
+                  height: 64,
+                  child: Center(
+                    child: Text(
+                      capture.cancelArmed
+                          ? 'cancel armed'
+                          : capture.convertArmed
+                          ? 'convert armed'
+                          : capture.holdStarted
+                          ? 'send armed'
+                          : 'voice capture',
+                    ),
+                  ),
+                ),
+              );
+              if (widget.showIntentTargets) {
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    VoiceCaptureIntentTargets(
+                      capture: capture,
+                      elapsed: Duration.zero,
+                      keyPrefix: 'test',
+                    ),
+                    target,
+                  ],
+                );
+              }
+              if (!widget.showTapActions) {
+                return target;
+              }
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  target,
+                  TextButton(
+                    key: const Key('voice-convert-action'),
+                    onPressed: capture.convertTapCapture,
+                    child: const Text('convert'),
+                  ),
+                  TextButton(
+                    key: const Key('voice-cancel-action'),
+                    onPressed: capture.cancelTapCapture,
+                    child: const Text('cancel'),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -123,6 +123,97 @@ void main() {
     expect(find.text('restored note'), findsOneWidget);
   });
 
+  testWidgets('Part 2 keeps failed audio reachable and retries in place', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 8)
+      ..transcribeFailure = StateError('transcription failed');
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-continue')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-start-speaking')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-finish-speaking')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('ielts-mock-part-2-speaking')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-pending-audio')), findsOneWidget);
+    expect(controller.hasPendingPracticeAudio, isTrue);
+
+    practice.transcribeFailure = null;
+    await tester.tap(find.byKey(const Key('ielts-mock-retry-transcription')));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    expect(controller.completedTurns, 9);
+    expect(find.byKey(const Key('ielts-mock-part-2-complete')), findsOneWidget);
+  });
+
+  testWidgets(
+    'Part 1 right-swipe converts to an editable draft without auto-submit',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0);
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(_ieltsScene);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(const Key('ielts-mock-record'))),
+      );
+      await tester.pump(const Duration(milliseconds: 220));
+      await gesture.moveBy(const Offset(90, 0));
+      await tester.pump();
+      expect(find.text('Release to convert to text'), findsOneWidget);
+      await gesture.up();
+      await tester.pump();
+      await tester.pump();
+
+      final field = find.byKey(const Key('ielts-mock-converted-answer-field'));
+      expect(field, findsOneWidget);
+      expect(tester.widget<TextField>(field).controller?.text, 'Answer 1');
+      expect(controller.recordingState, PracticeRecordingState.idle);
+      expect(controller.completedTurns, 0);
+      expect(practice.confirmedQuestionIds, isEmpty);
+    },
+  );
+
   testWidgets('completed full mock remains on completion instead of report', (
     tester,
   ) async {
@@ -269,6 +360,7 @@ final class _IeltsPracticeClient implements PracticeClient {
 
   final int initialCompleted;
   final AgentScene? snapshotScene;
+  Object? transcribeFailure;
   int completed;
   final List<String> confirmedQuestionIds = [];
 
@@ -307,6 +399,10 @@ final class _IeltsPracticeClient implements PracticeClient {
   Future<TranscriptionCandidate> transcribe(
     PracticeTranscriptionRequest request,
   ) async {
+    final failure = transcribeFailure;
+    if (failure != null) {
+      throw failure;
+    }
     return TranscriptionCandidate(
       id: 'candidate-${completed + 1}',
       sessionId: request.sessionId,

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -171,6 +171,44 @@ void main() {
     expect(find.byKey(const Key('ielts-mock-part-2-complete')), findsOneWidget);
   });
 
+  testWidgets('disposing Part 2 cancels recording without an exit callback', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 8);
+    final recorder = _Recorder();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-continue')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-start-speaking')));
+    await tester.pump();
+    expect(recorder.recording, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(recorder.recording, isFalse);
+    expect(controller.recordingState, PracticeRecordingState.idle);
+  });
+
   testWidgets(
     'Part 1 right-swipe converts to an editable draft without auto-submit',
     (tester) async {
@@ -451,11 +489,16 @@ final class _IeltsPracticeClient implements PracticeClient {
 }
 
 final class _Recorder implements PracticeRecorder {
+  bool recording = false;
+
   @override
-  Future<void> start() async {}
+  Future<void> start() async {
+    recording = true;
+  }
 
   @override
   Future<RecordedPracticeAudio> stop() async {
+    recording = false;
     return const RecordedPracticeAudio(
       path: 'ielts.wav',
       contentType: 'audio/wav',
@@ -467,10 +510,14 @@ final class _Recorder implements PracticeRecorder {
   Future<void> discard(RecordedPracticeAudio audio) async {}
 
   @override
-  Future<void> discardCurrent() async {}
+  Future<void> discardCurrent() async {
+    recording = false;
+  }
 
   @override
-  Future<void> clearAccountState() async {}
+  Future<void> clearAccountState() async {
+    recording = false;
+  }
 }
 
 PracticeQuestion _question(int turn) {

--- a/mobile/test/practice/immersive_roleplay_test.dart
+++ b/mobile/test/practice/immersive_roleplay_test.dart
@@ -6,6 +6,8 @@ import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/features/practice/immersive_roleplay.dart';
+import 'package:speakup/practice/practice_client.dart';
+import 'package:speakup/practice/practice_models.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -161,10 +163,104 @@ void main() {
     expect(controller.recordingState, PracticeRecordingState.recording);
     await hold.up();
     await tester.pumpAndSettle();
-    expect(
-      controller.recordingState,
-      PracticeRecordingState.awaitingConfirmation,
+    expect(controller.recordingState, PracticeRecordingState.idle);
+    expect(controller.completedTurns, 2);
+  });
+
+  testWidgets('supports send, left cancel, and right editable text release', (
+    tester,
+  ) async {
+    final controller = await _roleplayController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(agentController: controller)),
     );
+
+    final send = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('immersive-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(find.byKey(const Key('immersive-voice-targets')), findsOneWidget);
+    await send.up();
+    await tester.pumpAndSettle();
+    expect(controller.completedTurns, 1);
+    expect(controller.recordingState, PracticeRecordingState.idle);
+
+    final userTurnsAfterSend = controller.messages
+        .where((message) => message.role == AgentMessageRole.user)
+        .length;
+    final cancel = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('immersive-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    await cancel.moveBy(const Offset(-80, 0));
+    await tester.pump();
+    expect(find.text('松开取消'), findsWidgets);
+    await cancel.up();
+    await tester.pumpAndSettle();
+    expect(controller.completedTurns, 1);
+    expect(
+      controller.messages
+          .where((message) => message.role == AgentMessageRole.user)
+          .length,
+      userTurnsAfterSend,
+    );
+
+    final convert = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('immersive-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    await convert.moveBy(const Offset(80, 0));
+    await tester.pump();
+    expect(find.text('松开转成文字'), findsWidgets);
+    await convert.up();
+    await tester.pumpAndSettle();
+
+    final textField = tester.widget<TextField>(
+      find.byKey(const Key('immersive-text-answer')),
+    );
+    expect(
+      textField.controller?.text,
+      'The main trade-off was delivery speed versus reliability, so I reduced the scope first.',
+    );
+    expect(controller.completedTurns, 1);
+    expect(controller.recordingState, PracticeRecordingState.idle);
+  });
+
+  testWidgets('keeps failed transcription audio for retry or deletion', (
+    tester,
+  ) async {
+    final practiceClient = _FailOncePracticeClient();
+    final controller = await _roleplayController(
+      practiceClient: practiceClient,
+    );
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(agentController: controller)),
+    );
+
+    final send = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('immersive-record'))),
+    );
+    await tester.pump(const Duration(milliseconds: 220));
+    await send.up();
+    await tester.pumpAndSettle();
+
+    expect(controller.hasPendingPracticeAudio, isTrue);
+    expect(find.byKey(const Key('immersive-pending-audio')), findsOneWidget);
+    expect(
+      find.byKey(const Key('immersive-retry-transcription')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('immersive-delete-pending-audio')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('immersive-delete-pending-audio')));
+    await tester.pumpAndSettle();
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    expect(find.byKey(const Key('immersive-record')), findsOneWidget);
   });
 
   testWidgets('prefers the injected avatar replay action over audio playback', (
@@ -251,8 +347,13 @@ void main() {
   });
 }
 
-Future<AgentController> _roleplayController() async {
-  final controller = AgentController(client: FakeAgentClient());
+Future<AgentController> _roleplayController({
+  PracticeClient? practiceClient,
+}) async {
+  final controller = AgentController(
+    client: FakeAgentClient(),
+    practiceClient: practiceClient,
+  );
   await controller.initialize();
   await controller.selectScene(
     const AgentScene(
@@ -264,4 +365,70 @@ Future<AgentController> _roleplayController() async {
     ),
   );
   return controller;
+}
+
+final class _FailOncePracticeClient implements PracticeClient {
+  final _delegate = FakePracticeClient();
+  bool _shouldFail = true;
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<PracticeSessionSnapshot?> restorePractice({
+    required String threadId,
+    AgentMatter? activeMatter,
+  }) =>
+      _delegate.restorePractice(threadId: threadId, activeMatter: activeMatter);
+
+  @override
+  Future<PracticeStartResult> startPractice({
+    required String threadId,
+    required AgentMatter activeMatter,
+    required String clientOperationId,
+  }) => _delegate.startPractice(
+    threadId: threadId,
+    activeMatter: activeMatter,
+    clientOperationId: clientOperationId,
+  );
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) {
+    if (_shouldFail) {
+      _shouldFail = false;
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
+    }
+    return _delegate.transcribe(request);
+  }
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) => _delegate.confirm(
+    sessionId: sessionId,
+    questionId: questionId,
+    candidateId: candidateId,
+    idempotencyKey: idempotencyKey,
+  );
+
+  @override
+  Future<PracticeTurnConfirmation> submitText({
+    required String sessionId,
+    required String questionId,
+    required String answerText,
+    required String idempotencyKey,
+  }) => _delegate.submitText(
+    sessionId: sessionId,
+    questionId: questionId,
+    answerText: answerText,
+    idempotencyKey: idempotencyKey,
+  );
 }

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -171,6 +171,29 @@ void main() {
     expect(recorder.discarded, 0);
   });
 
+  test(
+    'retained transcription audio blocks leaving without deleting it',
+    () async {
+      final practice = _TwoTurnPracticeClient()
+        ..transcribeFailure = StateError('transcription failed');
+      final recorder = _Recorder();
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: recorder,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+      await controller.startRecording();
+      await controller.stopRecording();
+
+      expect(await controller.prepareToLeavePractice(), isFalse);
+      expect(controller.hasPendingPracticeAudio, isTrue);
+      expect(recorder.discarded, 0);
+    },
+  );
+
   test('account cleanup removes retained transcription audio state', () async {
     final practice = _TwoTurnPracticeClient()
       ..transcribeFailure = StateError('transcription failed');
@@ -213,6 +236,37 @@ void main() {
 
     expect(recorder.discarded, 1);
   });
+
+  test(
+    'dispose retries account cleanup after an in-flight delete fails',
+    () async {
+      final practice = _TwoTurnPracticeClient()
+        ..transcribeFailure = StateError('transcription failed');
+      final discardGate = Completer<void>();
+      final cleanupSignal = Completer<void>();
+      final recorder = _Recorder(
+        discardGate: discardGate,
+        cleanupSignal: cleanupSignal,
+      )..discardFailure = StateError('first delete failed');
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: recorder,
+      );
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+      await controller.startRecording();
+      await controller.stopRecording();
+
+      unawaited(controller.discardPendingPracticeAudio());
+      await Future<void>.delayed(Duration.zero);
+      controller.dispose();
+      discardGate.complete();
+      await cleanupSignal.future.timeout(const Duration(seconds: 2));
+
+      expect(recorder.cleanupCount, 1);
+    },
+  );
 
   test(
     'private-state cleanup clears Practice transport and temporary audio',
@@ -1549,9 +1603,11 @@ final class _ControlledStartRecorder implements PracticeRecorder {
 }
 
 final class _Recorder implements PracticeRecorder {
-  _Recorder({this.discardSignal});
+  _Recorder({this.discardSignal, this.discardGate, this.cleanupSignal});
 
   final Completer<void>? discardSignal;
+  final Completer<void>? discardGate;
+  final Completer<void>? cleanupSignal;
   Object? discardFailure;
   int discarded = 0;
   int cleanupCount = 0;
@@ -1574,6 +1630,7 @@ final class _Recorder implements PracticeRecorder {
 
   @override
   Future<void> discard(RecordedPracticeAudio audio) async {
+    await discardGate?.future;
     if (discardFailure case final failure?) {
       throw failure;
     }
@@ -1593,6 +1650,10 @@ final class _Recorder implements PracticeRecorder {
   Future<void> clearAccountState() async {
     cleanupCount++;
     recording = false;
+    final signal = cleanupSignal;
+    if (signal != null && !signal.isCompleted) {
+      signal.complete();
+    }
   }
 }
 

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -47,6 +47,174 @@ void main() {
   });
 
   test(
+    'retains failed transcription audio and retries with one Turn identity',
+    () async {
+      final practice = _TwoTurnPracticeClient()
+        ..transcribeFailure = const AgentClientException(
+          kind: AgentClientFailureKind.network,
+          retryable: true,
+        );
+      final recorder = _Recorder();
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: recorder,
+        clientIdFactory: (scope) => '$scope-stable',
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+
+      await controller.startRecording();
+      await controller.stopRecording();
+
+      expect(controller.recordingState, PracticeRecordingState.idle);
+      expect(controller.hasPendingPracticeAudio, isTrue);
+      expect(recorder.discarded, 0);
+      expect(practice.transcriptionClientTurnIds, <String>['turn-stable']);
+
+      await controller.startRecording();
+      expect(recorder.recording, isFalse);
+
+      practice.transcribeFailure = null;
+      await controller.retryPracticeTranscription();
+
+      expect(
+        controller.recordingState,
+        PracticeRecordingState.awaitingConfirmation,
+      );
+      expect(controller.hasPendingPracticeAudio, isFalse);
+      expect(recorder.discarded, 1);
+      expect(practice.transcriptionClientTurnIds, <String>[
+        'turn-stable',
+        'turn-stable',
+      ]);
+    },
+  );
+
+  test('explicitly deletes retained transcription audio', () async {
+    final practice = _TwoTurnPracticeClient()
+      ..transcribeFailure = StateError('transcription failed');
+    final recorder = _Recorder();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+
+    await controller.discardPendingPracticeAudio();
+
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    expect(recorder.discarded, 1);
+    expect(controller.errorMessage, isNull);
+
+    await controller.startRecording();
+    expect(recorder.recording, isTrue);
+    await controller.cancelRecording();
+  });
+
+  test(
+    'failed local deletion keeps the retained recording addressable',
+    () async {
+      final practice = _TwoTurnPracticeClient()
+        ..transcribeFailure = StateError('transcription failed');
+      final recorder = _Recorder()
+        ..discardFailure = StateError('local delete failed');
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: recorder,
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+      await controller.startRecording();
+      await controller.stopRecording();
+
+      await controller.discardPendingPracticeAudio();
+
+      expect(controller.hasPendingPracticeAudio, isTrue);
+      expect(controller.errorMessage, '暂时无法删除本地录音，请重试。');
+
+      recorder.discardFailure = null;
+      await controller.discardPendingPracticeAudio();
+      expect(controller.hasPendingPracticeAudio, isFalse);
+    },
+  );
+
+  test('retained transcription audio blocks Thread replacement', () async {
+    final practice = _TwoTurnPracticeClient()
+      ..transcribeFailure = StateError('transcription failed');
+    final recorder = _Recorder();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    final threadId = controller.threadId;
+
+    final changed = await controller.createThread();
+
+    expect(changed, isFalse);
+    expect(controller.threadId, threadId);
+    expect(controller.hasPendingPracticeAudio, isTrue);
+    expect(recorder.discarded, 0);
+  });
+
+  test('account cleanup removes retained transcription audio state', () async {
+    final practice = _TwoTurnPracticeClient()
+      ..transcribeFailure = StateError('transcription failed');
+    final recorder = _Recorder();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: recorder,
+    );
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    expect(controller.hasPendingPracticeAudio, isTrue);
+
+    await controller.clearPrivateState();
+
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    expect(recorder.cleanupCount, 1);
+    controller.dispose();
+  });
+
+  test('dispose deletes retained transcription audio', () async {
+    final practice = _TwoTurnPracticeClient()
+      ..transcribeFailure = StateError('transcription failed');
+    final discarded = Completer<void>();
+    final recorder = _Recorder(discardSignal: discarded);
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: recorder,
+    );
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+
+    controller.dispose();
+    await discarded.future.timeout(const Duration(seconds: 2));
+
+    expect(recorder.discarded, 1);
+  });
+
+  test(
     'private-state cleanup clears Practice transport and temporary audio',
     () async {
       final practice = _TwoTurnPracticeClient();
@@ -324,7 +492,7 @@ void main() {
       await tester.pump();
       expect(controller.recordingState, PracticeRecordingState.starting);
       expect(
-        find.byKey(const Key('practice-cancel-tap-recording')),
+        find.byKey(const Key('practice-voice-target-cancel')),
         findsOneWidget,
       );
       expect(tester.takeException(), isNull);
@@ -336,7 +504,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(recorder.stopCount, 1);
-      expect(find.byKey(const Key('practice-transcript')), findsOneWidget);
+      expect(controller.completedTurns, 1);
+      expect(find.byKey(const Key('practice-transcript')), findsNothing);
       expect(tester.takeException(), isNull);
     },
   );
@@ -626,7 +795,15 @@ void main() {
     await controller.stopRecording();
     await tester.pumpAndSettle();
 
-    expect(find.text('今日免费语音额度已用完，本轮未计入进度。'), findsOneWidget);
+    expect(find.text('今日免费语音额度已用完，录音已保留，本轮未计入进度。'), findsOneWidget);
+    expect(
+      find.byKey(const Key('practice-retry-transcription')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('practice-delete-pending-audio')),
+      findsOneWidget,
+    );
     expect(controller.completedTurns, 0);
     expect(controller.recordingState, PracticeRecordingState.idle);
   });
@@ -1055,6 +1232,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
   Object? restoreFailure;
   PracticeSessionSnapshot? restoreResult;
   int transcribeCount = 0;
+  final List<String> transcriptionClientTurnIds = <String>[];
 
   @override
   Future<void> clearAccountState() async {
@@ -1101,6 +1279,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     PracticeTranscriptionRequest request,
   ) async {
     transcribeCount++;
+    transcriptionClientTurnIds.add(request.clientTurnId);
     if (transcribeFailure case final failure?) {
       throw failure;
     }
@@ -1373,6 +1552,7 @@ final class _Recorder implements PracticeRecorder {
   _Recorder({this.discardSignal});
 
   final Completer<void>? discardSignal;
+  Object? discardFailure;
   int discarded = 0;
   int cleanupCount = 0;
   bool recording = false;
@@ -1394,6 +1574,9 @@ final class _Recorder implements PracticeRecorder {
 
   @override
   Future<void> discard(RecordedPracticeAudio audio) async {
+    if (discardFailure case final failure?) {
+      throw failure;
+    }
     discarded++;
     final signal = discardSignal;
     if (signal != null && !signal.isCompleted) {

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -30,7 +30,8 @@ void main() {
       findsNothing,
     );
     expect(find.byKey(const Key('quick-action-recent-review')), findsOneWidget);
-    expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
+    expect(find.byKey(const Key('agent-mic-placeholder')), findsOneWidget);
+    expect(find.byKey(const Key('agent-show-text-composer')), findsOneWidget);
     expect(find.byKey(const Key('agent-preview-label')), findsOneWidget);
 
     for (final key in _primaryTabKeys) {
@@ -131,6 +132,7 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'retry this retained text');
     expect(tester.widget<TextField>(composer).controller?.text, isNotEmpty);
@@ -168,6 +170,7 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'a newer draft');
     update(() {
@@ -209,6 +212,7 @@ void main() {
 
     expect(find.byKey(const Key('no-focused-conversation-home')), findsNothing);
     expect(find.text('你好，今天想练什么？'), findsOneWidget);
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     expect(tester.widget<TextField>(composer).enabled, isTrue);
 
@@ -240,6 +244,7 @@ void main() {
     await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
     await tester.pumpAndSettle();
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'Show the failure');
     await tester.pump();
@@ -277,6 +282,7 @@ void main() {
         ),
       );
 
+      await _openAgentTextInput(tester);
       final composer = find.byKey(const Key('agent-composer-field'));
       await tester.enterText(composer, 'Keep this draft');
       await tester.pump();
@@ -314,6 +320,7 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'Recover this draft');
     update(() {
@@ -349,11 +356,13 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'Private empty-page draft');
     update(() => threadId = 'existing-history-thread');
     await tester.pump();
 
+    await _openAgentTextInput(tester);
     expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
   });
 
@@ -376,11 +385,13 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'Thread A private draft');
     update(() => threadId = 'thread-b');
     await tester.pump();
 
+    await _openAgentTextInput(tester);
     expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
   });
 
@@ -401,6 +412,7 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     await tester.enterText(composer, 'Send once');
     await tester.pump();
@@ -427,6 +439,7 @@ void main() {
       ),
     );
 
+    await _openAgentTextInput(tester);
     final composer = find.byKey(const Key('agent-composer-field'));
     expect(tester.widget<TextField>(composer).enabled, isFalse);
     expect(
@@ -773,6 +786,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('primary-tab-agent')));
     await tester.pumpAndSettle();
+    await _openAgentTextInput(tester);
     tester.view.viewInsets = const FakeViewPadding(bottom: 240);
     await tester.showKeyboard(find.byKey(const Key('agent-composer-field')));
     await tester.pumpAndSettle();
@@ -886,6 +900,11 @@ const _primaryTabKeys = [
   'primary-tab-review',
   'primary-tab-profile',
 ];
+
+Future<void> _openAgentTextInput(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+  await tester.pump();
+}
 
 Future<void> _tapPrimaryDestination(
   WidgetTester tester, {


### PR DESCRIPTION
## 功能说明

统一首页 Agent、普通场景、面试和 IELTS 的语音输入交互：

- 默认按钮支持点击或按住说话。
- 长按后左滑取消、右滑转为可编辑文字、原位松开发语音。
- 轻点进入免按住模式，并提供等价的发送、转文字和取消操作。
- ASR 失败保留本地录音，可重试识别或删除。
- IELTS Part 2 识别失败后保持在当前环节，不再退回并卡死。

## 实现思路

- 新增一个纯 Flutter `VoiceCaptureControl`，集中管理 hold delay、释放意图、多指隔离和重复动作 fence。
- 各业务页面保留自己的录音、上传、转写与确认流程，只复用手势状态机和目标区域。
- 离开 Agent Tab 前对尚未启动或正在录制的麦克风统一加代际围栏，避免隐藏页面继续采集或迟到上传。
- IELTS 离开页面不再静默删除 ASR 失败录音；页面销毁会取消 Part 2 活跃录音，控制器销毁时执行严格账户级临时音频清理。
- Practice snapshot 替换前要求先解决本地 pending audio，删除失败时录音仍可寻址重试。

## 协议边界

当前 Agent/Practice 协议只有真实 transcript 才能创建 Message、Turn、AgentRun 和评分证据；ASR 失败时无法在不改 OpenAPI、Go、数据库及消息模型的前提下直接发送 audio-only 消息。禁止用占位假文本绕过。

## 当前依赖

- 本 PR 已替代 #260/#263 在 Agent、普通练习、面试与 IELTS 中的旧实现。
- 数字人 `immersive_roleplay.dart` 已接到最终 `VoiceCaptureControl`，并保留数字人打断、发送语音、转文字、取消及失败录音恢复。
- 本 PR 合入后关闭 #260/#263，不整体搬运旧实现。
- audio-only 正式消息语义仍由 #268 单独决定，不在本 PR 猜测协议。

## 验证方式

```bash
cd mobile
flutter analyze lib/design/voice_capture_control.dart lib/agent/agent_controller.dart lib/app/speak_up_shell.dart lib/features/conversation/conversation.dart lib/features/practice/practice.dart lib/features/practice/ielts_mock_practice.dart
flutter test test/design/voice_capture_control_test.dart test/agent/agent_flow_test.dart test/agent/agent_voice_fence_test.dart test/agent/agent_voice_flow_test.dart test/practice/ielts_mock_practice_test.dart test/practice/practice_controller_contract_test.dart test/speak_up_app_test.dart
```

结果：完整 Flutter 静态分析通过；统一语音与数字人相关回归去重共 110 项通过；云端 CI 以最新提交结果为准。

Closes #266
Related to #268
