### PR TITLE
fix(api): align Evaluation IDs with UUID ledger

### DIFF
--- a/api/examples/evaluation-contract.json
+++ b/api/examples/evaluation-contract.json
@@ -12,15 +12,15 @@
     "client_request_id": "trace_eval_001"
   },
   "queued": {
-    "evaluation_id": "evaluation_001",
-    "evaluation_revision_id": "evaluation_revision_001",
+    "evaluation_id": "7b000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "a1000001-0000-4000-8000-000000000001",
     "revision": 1,
     "evaluation_status": "QUEUED",
-    "status_url": "/v1/evaluations/evaluation_001"
+    "status_url": "/v1/evaluations/7b000001-0000-4000-8000-000000000001"
   },
   "core_4d_ready": {
-    "evaluation_id": "evaluation_002",
-    "evaluation_revision_id": "evaluation_revision_002",
+    "evaluation_id": "b2000002-0000-4000-8000-000000000002",
+    "evaluation_revision_id": "a2000002-0000-4000-8000-000000000002",
     "revision": 1,
     "practice_session_id": "session_eval_002",
     "input_snapshot_id": "snapshot_eval_002",
@@ -197,8 +197,8 @@
     "completed_at": "2026-07-28T12:00:10Z"
   },
   "short_sample_blocked": {
-    "evaluation_id": "evaluation_003",
-    "evaluation_revision_id": "evaluation_revision_003",
+    "evaluation_id": "c3000003-0000-4000-8000-000000000003",
+    "evaluation_revision_id": "a3000003-0000-4000-8000-000000000003",
     "revision": 1,
     "practice_session_id": "session_eval_003",
     "input_snapshot_id": "snapshot_eval_003",
@@ -239,8 +239,8 @@
     "completed_at": "2026-07-28T12:01:01Z"
   },
   "low_asr_feedback_only": {
-    "evaluation_id": "evaluation_004",
-    "evaluation_revision_id": "evaluation_revision_004",
+    "evaluation_id": "d4000004-0000-4000-8000-000000000004",
+    "evaluation_revision_id": "a4000004-0000-4000-8000-000000000004",
     "revision": 1,
     "practice_session_id": "session_eval_004",
     "input_snapshot_id": "snapshot_eval_004",
@@ -281,8 +281,8 @@
     "completed_at": "2026-07-28T12:02:01Z"
   },
   "ielts_ready": {
-    "evaluation_id": "evaluation_005",
-    "evaluation_revision_id": "evaluation_revision_005",
+    "evaluation_id": "e5000005-0000-4000-8000-000000000005",
+    "evaluation_revision_id": "a5000005-0000-4000-8000-000000000005",
     "revision": 1,
     "practice_session_id": "session_eval_005",
     "input_snapshot_id": "snapshot_eval_005",
@@ -439,8 +439,8 @@
     "completed_at": "2026-07-28T12:03:10Z"
   },
   "interview_missing_opportunity": {
-    "evaluation_id": "evaluation_006",
-    "evaluation_revision_id": "evaluation_revision_006",
+    "evaluation_id": "f6000006-0000-4000-8000-000000000006",
+    "evaluation_revision_id": "a6000006-0000-4000-8000-000000000006",
     "revision": 1,
     "practice_session_id": "session_eval_006",
     "input_snapshot_id": "snapshot_eval_006",
@@ -645,8 +645,8 @@
     "completed_at": "2026-07-28T12:04:10Z"
   },
   "failed": {
-    "evaluation_id": "evaluation_007",
-    "evaluation_revision_id": "evaluation_revision_007",
+    "evaluation_id": "17000007-0000-4000-8000-000000000007",
+    "evaluation_revision_id": "a7000007-0000-4000-8000-000000000007",
     "revision": 1,
     "practice_session_id": "session_eval_007",
     "input_snapshot_id": "snapshot_eval_007",
@@ -673,11 +673,11 @@
     "completed_at": "2026-07-28T12:05:01Z"
   },
   "revision_queued": {
-    "evaluation_id": "evaluation_001",
-    "evaluation_revision_id": "evaluation_revision_008",
+    "evaluation_id": "7b000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "a8000008-0000-4000-8000-000000000008",
     "revision": 2,
-    "supersedes_revision_id": "evaluation_revision_001",
+    "supersedes_revision_id": "a1000001-0000-4000-8000-000000000001",
     "evaluation_status": "QUEUED",
-    "status_url": "/v1/evaluations/evaluation_001"
+    "status_url": "/v1/evaluations/7b000001-0000-4000-8000-000000000001"
   }
 }

--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -43,11 +43,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/EvaluationAccepted'
               example:
-                evaluation_id: evaluation_demo_001
-                evaluation_revision_id: evaluation_revision_demo_001
+                evaluation_id: 7b000001-0000-4000-8000-000000000001
+                evaluation_revision_id: a1000001-0000-4000-8000-000000000001
                 revision: 1
                 evaluation_status: QUEUED
-                status_url: /v1/evaluations/evaluation_demo_001
+                status_url: /v1/evaluations/7b000001-0000-4000-8000-000000000001
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
         '401':
@@ -81,8 +81,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Evaluation'
               example:
-                evaluation_id: evaluation_demo_001
-                evaluation_revision_id: evaluation_revision_demo_001
+                evaluation_id: 7b000001-0000-4000-8000-000000000001
+                evaluation_revision_id: a1000001-0000-4000-8000-000000000001
                 revision: 1
                 practice_session_id: session_demo_001
                 input_snapshot_id: snapshot_demo_001
@@ -143,12 +143,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/EvaluationAccepted'
               example:
-                evaluation_id: evaluation_demo_001
-                evaluation_revision_id: evaluation_revision_demo_002
+                evaluation_id: 7b000001-0000-4000-8000-000000000001
+                evaluation_revision_id: a1000002-0000-4000-8000-000000000002
                 revision: 2
-                supersedes_revision_id: evaluation_revision_demo_001
+                supersedes_revision_id: a1000001-0000-4000-8000-000000000001
                 evaluation_status: QUEUED
-                status_url: /v1/evaluations/evaluation_demo_001
+                status_url: /v1/evaluations/7b000001-0000-4000-8000-000000000001
         '400':
           $ref: ../common/errors.yaml#/components/responses/BadRequest
         '401':
@@ -206,8 +206,12 @@ components:
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/StableIdentifier'
+        $ref: '#/components/schemas/EvaluationUUID'
   schemas:
+    EvaluationUUID:
+      type: string
+      format: uuid
+      pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
     StableIdentifier:
       type: string
       minLength: 1
@@ -421,20 +425,20 @@ components:
         - status_url
       properties:
         evaluation_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         evaluation_revision_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         revision:
           type: integer
           minimum: 1
         supersedes_revision_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         evaluation_status:
           type: string
           const: QUEUED
         status_url:
           type: string
-          pattern: '^/v1/evaluations/[A-Za-z][A-Za-z0-9_-]*$'
+          pattern: '^/v1/evaluations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
     Evaluation:
       $ref: '#/components/schemas/EvaluationCommonProperties'
     EvaluationCommonProperties:
@@ -459,16 +463,16 @@ components:
         - updated_at
       properties:
         evaluation_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         evaluation_revision_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         revision:
           type: integer
           minimum: 1
         supersedes_revision_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         superseded_by_revision_id:
-          $ref: '#/components/schemas/StableIdentifier'
+          $ref: '#/components/schemas/EvaluationUUID'
         practice_session_id:
           $ref: '#/components/schemas/StableIdentifier'
         input_snapshot_id:

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -182,7 +182,17 @@ assertValid(
   fixture.create_dual_channel,
 );
 assertValid('queued create response', 'EvaluationAccepted', fixture.queued);
+assert.match(
+  fixture.queued.evaluation_id,
+  /^[0-9]/,
+  'queued fixture must cover a digit-leading Evaluation UUID',
+);
 assertValid('Core 4D ready', 'Evaluation', fixture.core_4d_ready);
+assert.match(
+  fixture.core_4d_ready.evaluation_id,
+  /^[A-Fa-f]/,
+  'ready fixture must cover a letter-leading Evaluation UUID',
+);
 assertValid(
   'short sample blocked',
   'Evaluation',
@@ -460,6 +470,14 @@ assertSchemaRejected(
   'caller-supplied owner',
   'CreateEvaluationRequest',
   invalidCreateWithOwner,
+);
+
+const invalidAcceptedEvaluationId = structuredClone(fixture.queued);
+invalidAcceptedEvaluationId.evaluation_id = 'evaluation_not_a_uuid';
+assertSchemaRejected(
+  'non-UUID Evaluation ID',
+  'EvaluationAccepted',
+  invalidAcceptedEvaluationId,
 );
 
 const invalidCreateWithoutSceneStrategy = structuredClone(


### PR DESCRIPTION
## 功能描述

修正 Evaluation API 将 PostgreSQL UUID 误用为字母开头 StableIdentifier 的契约矛盾。数字或字母开头的合法 RFC 4122 UUID 均可用于 Evaluation 与 revision ID，其他业务稳定标识保持不变。

## 实现思路

- 新增 Evaluation 专用 UUID schema，并用于路径、accepted/resource、supersede 字段。
- status URL 与数据库生成 UUID 保持一致。
- 将契约样例替换为合法 UUID，并显式覆盖数字开头、字母开头和非法 UUID。

## 可复现验证

```bash
cd api
npm ci
npm run check
```

本地结果：OpenAPI lint、安全、WebSocket、主流程 fixture、Evaluation schema 全部通过。

Closes #273
Blocks #272