### PR TITLE
feat(http): render canonical unprocessable errors

### DIFF
--- a/server/internal/platform/apperror/apperror.go
+++ b/server/internal/platform/apperror/apperror.go
@@ -11,18 +11,19 @@ import "errors"
 type Category string
 
 const (
-	InvalidArgument    Category = "invalid_argument"
-	Unauthenticated    Category = "unauthenticated"
-	PermissionDenied   Category = "permission_denied"
-	NotFound           Category = "not_found"
-	AlreadyExists      Category = "already_exists"
-	Conflict           Category = "conflict"
-	FailedPrecondition Category = "failed_precondition"
-	ResourceExhausted  Category = "resource_exhausted"
-	DeadlineExceeded   Category = "deadline_exceeded"
-	Unimplemented      Category = "unimplemented"
-	Unavailable        Category = "unavailable"
-	Internal           Category = "internal"
+	InvalidArgument     Category = "invalid_argument"
+	Unauthenticated     Category = "unauthenticated"
+	PermissionDenied    Category = "permission_denied"
+	NotFound            Category = "not_found"
+	AlreadyExists       Category = "already_exists"
+	Conflict            Category = "conflict"
+	FailedPrecondition  Category = "failed_precondition"
+	UnprocessableEntity Category = "unprocessable_entity"
+	ResourceExhausted   Category = "resource_exhausted"
+	DeadlineExceeded    Category = "deadline_exceeded"
+	Unimplemented       Category = "unimplemented"
+	Unavailable         Category = "unavailable"
+	Internal            Category = "internal"
 )
 
 // Valid reports whether category is one of the common categories owned by this
@@ -36,6 +37,7 @@ func (category Category) Valid() bool {
 		AlreadyExists,
 		Conflict,
 		FailedPrecondition,
+		UnprocessableEntity,
 		ResourceExhausted,
 		DeadlineExceeded,
 		Unimplemented,

--- a/server/internal/platform/apperror/apperror_test.go
+++ b/server/internal/platform/apperror/apperror_test.go
@@ -20,6 +20,7 @@ func TestEveryPublicCategoryIsValid(t *testing.T) {
 		apperror.AlreadyExists,
 		apperror.Conflict,
 		apperror.FailedPrecondition,
+		apperror.UnprocessableEntity,
 		apperror.ResourceExhausted,
 		apperror.DeadlineExceeded,
 		apperror.Unimplemented,

--- a/server/internal/platform/httpresponse/contract_test.go
+++ b/server/internal/platform/httpresponse/contract_test.go
@@ -27,6 +27,7 @@ func TestStatusForCategoryMapsEveryCategoryExplicitly(t *testing.T) {
 		{apperror.AlreadyExists, http.StatusConflict},
 		{apperror.Conflict, http.StatusConflict},
 		{apperror.FailedPrecondition, http.StatusPreconditionFailed},
+		{apperror.UnprocessableEntity, http.StatusUnprocessableEntity},
 		{apperror.ResourceExhausted, http.StatusTooManyRequests},
 		{apperror.DeadlineExceeded, http.StatusGatewayTimeout},
 		{apperror.Unimplemented, http.StatusNotImplemented},

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -150,6 +150,8 @@ func statusForCategory(category apperror.Category) (int, bool) {
 		return http.StatusConflict, true
 	case apperror.FailedPrecondition:
 		return http.StatusPreconditionFailed, true
+	case apperror.UnprocessableEntity:
+		return http.StatusUnprocessableEntity, true
 	case apperror.ResourceExhausted:
 		return http.StatusTooManyRequests, true
 	case apperror.DeadlineExceeded:

--- a/server/internal/platform/httpresponse/error_test.go
+++ b/server/internal/platform/httpresponse/error_test.go
@@ -35,6 +35,11 @@ func TestRendererAcceptsMatchingCanonicalCodeStatusPairs(t *testing.T) {
 		{apperror.NotFound, "resource_not_found", http.StatusNotFound},
 		{apperror.AlreadyExists, "account_registration_unavailable", http.StatusConflict},
 		{apperror.Conflict, "resource_conflict", http.StatusConflict},
+		{
+			apperror.UnprocessableEntity,
+			"evaluation_strategy_not_available",
+			http.StatusUnprocessableEntity,
+		},
 		{apperror.ResourceExhausted, "rate_limited", http.StatusTooManyRequests},
 		{apperror.Internal, "internal_error", http.StatusInternalServerError},
 	}


### PR DESCRIPTION
## 功能描述

为共享应用错误与 REST Renderer 补齐 canonical HTTP 422 映射，使已声明的策略/政策拒绝不会误降为 500。

## 实现思路

- 新增 transport-independent `UnprocessableEntity` category。
- 共享 Renderer 映射到 HTTP 422，仍校验 code/status 契约。
- 覆盖 category 完整性、canonical payload 和安全 fallback。

## 可复现验证

```bash
cd server
go test ./internal/platform/apperror ./internal/platform/httpresponse -count=1
go vet ./internal/platform/apperror ./internal/platform/httpresponse
```

Closes #275
Blocks #272