### PR TITLE
[P0][API][后端] Evaluation 幂等重放诚实状态

### DIFF
--- a/api/examples/evaluation-contract.json
+++ b/api/examples/evaluation-contract.json
@@ -18,6 +18,13 @@
     "evaluation_status": "QUEUED",
     "status_url": "/v1/evaluations/7b000001-0000-4000-8000-000000000001"
   },
+  "ready_replay": {
+    "evaluation_id": "7b000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "a1000001-0000-4000-8000-000000000001",
+    "revision": 1,
+    "evaluation_status": "READY",
+    "status_url": "/v1/evaluations/7b000001-0000-4000-8000-000000000001"
+  },
   "core_4d_ready": {
     "evaluation_id": "b2000002-0000-4000-8000-000000000002",
     "evaluation_revision_id": "a2000002-0000-4000-8000-000000000002",

--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -36,6 +36,20 @@ paths:
                   pipeline_version: evaluation-pipeline/1.0.0
                   client_request_id: trace_demo_001
       responses:
+        '200':
+          description: |
+            An idempotent replay returned the same logical Evaluation and its
+            honest current non-QUEUED revision state. No work was requeued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationReplay'
+              example:
+                evaluation_id: 7b000001-0000-4000-8000-000000000001
+                evaluation_revision_id: a1000001-0000-4000-8000-000000000001
+                revision: 1
+                evaluation_status: READY
+                status_url: /v1/evaluations/7b000001-0000-4000-8000-000000000001
         '202':
           description: The logical Evaluation exists and is queued.
           content:
@@ -136,6 +150,22 @@ paths:
               pipeline_version: evaluation-pipeline/1.1.0
               client_request_id: trace_demo_reevaluate_001
       responses:
+        '200':
+          description: |
+            An idempotent replay returned the same logical Evaluation and its
+            honest current non-QUEUED revision state. No revision or work was
+            created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationReplay'
+              example:
+                evaluation_id: 7b000001-0000-4000-8000-000000000001
+                evaluation_revision_id: a1000002-0000-4000-8000-000000000002
+                revision: 2
+                supersedes_revision_id: a1000001-0000-4000-8000-000000000001
+                evaluation_status: READY
+                status_url: /v1/evaluations/7b000001-0000-4000-8000-000000000001
         '202':
           description: A replacement immutable revision has been queued.
           content:
@@ -436,6 +466,38 @@ components:
         evaluation_status:
           type: string
           const: QUEUED
+        status_url:
+          type: string
+          pattern: '^/v1/evaluations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+    EvaluationReplay:
+      type: object
+      additionalProperties: false
+      required:
+        - evaluation_id
+        - evaluation_revision_id
+        - revision
+        - evaluation_status
+        - status_url
+      properties:
+        evaluation_id:
+          $ref: '#/components/schemas/EvaluationUUID'
+        evaluation_revision_id:
+          $ref: '#/components/schemas/EvaluationUUID'
+        revision:
+          type: integer
+          minimum: 1
+        supersedes_revision_id:
+          $ref: '#/components/schemas/EvaluationUUID'
+        evaluation_status:
+          type: string
+          enum:
+            - RECEIVED
+            - VALIDATING
+            - RUNNING
+            - PARTIAL_READY
+            - READY
+            - FAILED
+            - SUPERSEDED
         status_url:
           type: string
           pattern: '^/v1/evaluations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -202,6 +202,17 @@ for (const status of ['RUNNING', 'READY', 'FAILED']) {
     replay,
   );
 }
+const laterRevisionReplay = structuredClone(fixture.ready_replay);
+laterRevisionReplay.evaluation_revision_id =
+  'a1000002-0000-4000-8000-000000000002';
+laterRevisionReplay.revision = 2;
+laterRevisionReplay.supersedes_revision_id =
+  'a1000001-0000-4000-8000-000000000001';
+assertValid(
+  'later current revision idempotent replay',
+  'EvaluationReplay',
+  laterRevisionReplay,
+);
 assertValid('Core 4D ready', 'Evaluation', fixture.core_4d_ready);
 assert.match(
   fixture.core_4d_ready.evaluation_id,

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -143,6 +143,7 @@ const validators = Object.fromEntries(
   [
     'CreateEvaluationRequest',
     'EvaluationAccepted',
+    'EvaluationReplay',
     'Evaluation',
     'SceneEvaluationResult',
     'CoreAbilityObservation',
@@ -187,6 +188,20 @@ assert.match(
   /^[0-9]/,
   'queued fixture must cover a digit-leading Evaluation UUID',
 );
+assertValid(
+  'ready idempotent replay',
+  'EvaluationReplay',
+  fixture.ready_replay,
+);
+for (const status of ['RUNNING', 'READY', 'FAILED']) {
+  const replay = structuredClone(fixture.ready_replay);
+  replay.evaluation_status = status;
+  assertValid(
+    `${status} idempotent replay`,
+    'EvaluationReplay',
+    replay,
+  );
+}
 assertValid('Core 4D ready', 'Evaluation', fixture.core_4d_ready);
 assert.match(
   fixture.core_4d_ready.evaluation_id,
@@ -214,6 +229,22 @@ assertValid(
   'replacement revision queued',
   'EvaluationAccepted',
   fixture.revision_queued,
+);
+
+const replayDisguisedAsQueued = structuredClone(fixture.ready_replay);
+replayDisguisedAsQueued.evaluation_status = 'QUEUED';
+assertSchemaRejected(
+  'idempotent replay disguised as queued',
+  'EvaluationReplay',
+  replayDisguisedAsQueued,
+);
+
+const freshAcceptedDisguisedAsReady = structuredClone(fixture.queued);
+freshAcceptedDisguisedAsReady.evaluation_status = 'READY';
+assertSchemaRejected(
+  'fresh accepted response disguised as ready',
+  'EvaluationAccepted',
+  freshAcceptedDisguisedAsReady,
 );
 
 const scoreFields = [

--- a/server/internal/evaluation/postgres_integration_test.go
+++ b/server/internal/evaluation/postgres_integration_test.go
@@ -132,6 +132,26 @@ func TestPostgresLedgerRevisionIdempotencyAndIsolation(t *testing.T) {
 		)
 	}
 
+	request.ClientRequestID = "create-retry-after-reevaluation"
+	createReplayAfterReevaluation, replayed, err := service.Create(
+		ctx,
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("replay Create after re-evaluation: %v", err)
+	}
+	if !replayed ||
+		createReplayAfterReevaluation.ID != created.ID ||
+		createReplayAfterReevaluation.Revision.ID != revisionTwo.Revision.ID ||
+		createReplayAfterReevaluation.Revision.Number != 2 {
+		t.Fatalf(
+			"create replay after re-evaluation = %#v, replayed = %v",
+			createReplayAfterReevaluation,
+			replayed,
+		)
+	}
+
 	assertEvaluationCounts(t, pool, created.ID, 2, 4)
 	var oldStatus string
 	if err := pool.QueryRow(ctx, `

--- a/server/internal/evaluation/transport/http.go
+++ b/server/internal/evaluation/transport/http.go
@@ -45,14 +45,16 @@ type Application interface {
 	) (EvaluationAccepted, error)
 }
 
-// EvaluationAccepted is the immutable revision identity returned by a fresh
-// write. The transport accepts only genuinely queued revisions.
+// EvaluationAccepted is the immutable revision identity returned by a write.
+// Fresh writes must be genuinely QUEUED. Idempotent replays may expose the
+// persisted current state without requeuing work.
 type EvaluationAccepted struct {
 	EvaluationID         string
 	EvaluationRevisionID string
 	Revision             int
 	SupersedesRevisionID string
 	EvaluationStatus     evaluation.Status
+	Replayed             bool `json:"-"`
 }
 
 type ScoreabilityStatus string
@@ -179,11 +181,11 @@ func (h *HTTPHandler) create(c *gin.Context) {
 		h.writeApplicationError(c, err)
 		return
 	}
-	if !accepted.valid() || accepted.Revision != 1 {
+	if !accepted.valid() || (!accepted.Replayed && accepted.Revision != 1) {
 		h.errors.Write(c, errInvalidApplicationProjection)
 		return
 	}
-	c.JSON(http.StatusAccepted, accepted.response())
+	c.JSON(accepted.responseStatus(), accepted.response())
 }
 
 func (h *HTTPHandler) get(c *gin.Context) {
@@ -248,7 +250,7 @@ func (h *HTTPHandler) reevaluate(c *gin.Context) {
 		h.errors.Write(c, errInvalidApplicationProjection)
 		return
 	}
-	c.JSON(http.StatusAccepted, accepted.response())
+	c.JSON(accepted.responseStatus(), accepted.response())
 }
 
 type optionalString struct {
@@ -357,8 +359,14 @@ type evaluationAcceptedResponse struct {
 func (accepted EvaluationAccepted) valid() bool {
 	if !validEvaluationID(accepted.EvaluationID) ||
 		!validEvaluationID(accepted.EvaluationRevisionID) ||
-		accepted.Revision < 1 ||
-		accepted.EvaluationStatus != evaluation.StatusQueued {
+		accepted.Revision < 1 {
+		return false
+	}
+	if accepted.Replayed {
+		if !validEvaluationStatus(accepted.EvaluationStatus) {
+			return false
+		}
+	} else if accepted.EvaluationStatus != evaluation.StatusQueued {
 		return false
 	}
 	if accepted.Revision == 1 {
@@ -366,6 +374,14 @@ func (accepted EvaluationAccepted) valid() bool {
 	}
 	return validEvaluationID(accepted.SupersedesRevisionID) &&
 		accepted.SupersedesRevisionID != accepted.EvaluationRevisionID
+}
+
+func (accepted EvaluationAccepted) responseStatus() int {
+	if accepted.Replayed &&
+		accepted.EvaluationStatus != evaluation.StatusQueued {
+		return http.StatusOK
+	}
+	return http.StatusAccepted
 }
 
 func (accepted EvaluationAccepted) response() evaluationAcceptedResponse {

--- a/server/internal/evaluation/transport/http_test.go
+++ b/server/internal/evaluation/transport/http_test.go
@@ -194,6 +194,83 @@ func TestReevaluateUsesTrustedActorAndReturnsReplacementIdentity(t *testing.T) {
 	})
 }
 
+func TestWriteEndpointsReturnIdempotentReplayStateHonestly(t *testing.T) {
+	statuses := []struct {
+		status     evaluation.Status
+		wantStatus int
+	}{
+		{status: evaluation.StatusQueued, wantStatus: http.StatusAccepted},
+		{status: evaluation.StatusRunning, wantStatus: http.StatusOK},
+		{status: evaluation.StatusReady, wantStatus: http.StatusOK},
+		{status: evaluation.StatusFailed, wantStatus: http.StatusOK},
+	}
+
+	for _, endpoint := range []string{"create", "re-evaluate"} {
+		for _, status := range statuses {
+			t.Run(endpoint+" "+string(status.status), func(t *testing.T) {
+				var (
+					accepted EvaluationAccepted
+					path     string
+					body     string
+					app      applicationStub
+				)
+				if endpoint == "create" {
+					accepted = queuedAccepted()
+					// A create replay may expose a later current revision
+					// after the logical Evaluation has been re-evaluated.
+					accepted.EvaluationRevisionID = testOtherID
+					accepted.Revision = 3
+					accepted.SupersedesRevisionID = testNextRevision
+					path = "/v1/evaluations"
+					body = validCreateBody()
+				} else {
+					accepted = queuedReevaluation()
+					path = "/v1/evaluations/" + testEvaluationID +
+						"/re-evaluate"
+					body = validReevaluateBody()
+				}
+				accepted.EvaluationStatus = status.status
+				accepted.Replayed = true
+				if endpoint == "create" {
+					app.create = fixedCreate(accepted)
+				} else {
+					app.reevaluate = fixedReevaluation(accepted)
+				}
+
+				router := newTestRouter(t, app, &testActor)
+				response := performRequest(
+					router,
+					http.MethodPost,
+					path,
+					body,
+					"application/json",
+				)
+
+				if response.Code != status.wantStatus {
+					t.Fatalf(
+						"status = %d, want %d, body = %s",
+						response.Code,
+						status.wantStatus,
+						response.Body,
+					)
+				}
+				assertPrivateResponse(t, response)
+				assertJSONEquals(t, response.Body.String(), map[string]any{
+					"evaluation_id": accepted.EvaluationID,
+					"evaluation_revision_id": accepted.
+						EvaluationRevisionID,
+					"revision": float64(accepted.Revision),
+					"supersedes_revision_id": accepted.
+						SupersedesRevisionID,
+					"evaluation_status": string(status.status),
+					"status_url": "/v1/evaluations/" +
+						accepted.EvaluationID,
+				})
+			})
+		}
+	}
+}
+
 func TestGetPublishesEveryLifecycleStateHonestly(t *testing.T) {
 	statuses := []evaluation.Status{
 		evaluation.StatusReceived,
@@ -943,16 +1020,28 @@ func TestInvalidApplicationResourceProjectionsFailClosed(t *testing.T) {
 	}
 }
 
-func TestWriteEndpointsAcceptOnlyFreshQueuedLineage(t *testing.T) {
+func TestWriteEndpointsRejectInvalidFreshAndReplayProjections(t *testing.T) {
 	createRunning := queuedAccepted()
 	createRunning.EvaluationStatus = evaluation.StatusRunning
 
 	createRevisionTwo := queuedAccepted()
+	createRevisionTwo.EvaluationRevisionID = testNextRevision
 	createRevisionTwo.Revision = 2
 	createRevisionTwo.SupersedesRevisionID = testRevisionID
 
+	createReplayMissingParent := createRevisionTwo
+	createReplayMissingParent.Replayed = true
+	createReplayMissingParent.SupersedesRevisionID = ""
+
+	createReplaySupersedesItself := createRevisionTwo
+	createReplaySupersedesItself.Replayed = true
+	createReplaySupersedesItself.SupersedesRevisionID =
+		createReplaySupersedesItself.EvaluationRevisionID
+
 	reevaluateRunning := queuedReevaluation()
 	reevaluateRunning.EvaluationStatus = evaluation.StatusRunning
+
+	reevaluateRevisionOne := queuedAccepted()
 
 	reevaluateMissingParent := queuedReevaluation()
 	reevaluateMissingParent.SupersedesRevisionID = ""
@@ -963,6 +1052,18 @@ func TestWriteEndpointsAcceptOnlyFreshQueuedLineage(t *testing.T) {
 	reevaluateSupersedesItself := queuedReevaluation()
 	reevaluateSupersedesItself.SupersedesRevisionID =
 		reevaluateSupersedesItself.EvaluationRevisionID
+
+	reevaluateReplayRevisionOne := reevaluateRevisionOne
+	reevaluateReplayRevisionOne.Replayed = true
+
+	reevaluateReplayMissingParent := reevaluateMissingParent
+	reevaluateReplayMissingParent.Replayed = true
+
+	reevaluateReplayWrongID := reevaluateWrongID
+	reevaluateReplayWrongID.Replayed = true
+
+	reevaluateReplaySupersedesItself := reevaluateSupersedesItself
+	reevaluateReplaySupersedesItself.Replayed = true
 
 	tests := []struct {
 		name        string
@@ -987,11 +1088,35 @@ func TestWriteEndpointsAcceptOnlyFreshQueuedLineage(t *testing.T) {
 			},
 		},
 		{
+			name: "create replay omitted immutable lineage",
+			path: "/v1/evaluations",
+			body: validCreateBody(),
+			application: applicationStub{
+				create: fixedCreate(createReplayMissingParent),
+			},
+		},
+		{
+			name: "create replay revision supersedes itself",
+			path: "/v1/evaluations",
+			body: validCreateBody(),
+			application: applicationStub{
+				create: fixedCreate(createReplaySupersedesItself),
+			},
+		},
+		{
 			name: "re-evaluate returned RUNNING",
 			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
 			body: validReevaluateBody(),
 			application: applicationStub{
 				reevaluate: fixedReevaluation(reevaluateRunning),
+			},
+		},
+		{
+			name: "re-evaluate returned revision one",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(reevaluateRevisionOne),
 			},
 		},
 		{
@@ -1016,6 +1141,46 @@ func TestWriteEndpointsAcceptOnlyFreshQueuedLineage(t *testing.T) {
 			body: validReevaluateBody(),
 			application: applicationStub{
 				reevaluate: fixedReevaluation(reevaluateSupersedesItself),
+			},
+		},
+		{
+			name: "re-evaluate replay returned revision one",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(
+					reevaluateReplayRevisionOne,
+				),
+			},
+		},
+		{
+			name: "re-evaluate replay omitted immutable lineage",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(
+					reevaluateReplayMissingParent,
+				),
+			},
+		},
+		{
+			name: "re-evaluate replay returned another evaluation",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(
+					reevaluateReplayWrongID,
+				),
+			},
+		},
+		{
+			name: "re-evaluate replay revision supersedes itself",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(
+					reevaluateReplaySupersedesItself,
+				),
 			},
 		},
 	}


### PR DESCRIPTION
## 功能描述

为 Evaluation create 与 re-evaluate 写接口补充诚实的幂等重放响应：

- fresh write：继续返回 `202 + QUEUED`
- replay 且仍为 `QUEUED`：返回 `202`
- replay 且当前状态为非 `QUEUED`：返回 `200` 和真实状态

写响应只返回 logical Evaluation/current revision identity，不复制结果 payload，也不重新排队任务。

## 实现思路

- OpenAPI 新增最小 `EvaluationReplay` schema，并为 create/re-evaluate 声明 `200` 响应；`QUEUED` 仍只属于现有 `EvaluationAccepted`。
- `EvaluationAccepted.Replayed` 仅由服务端 application projection 设置，不进入 JSON，也不能由客户端提交。
- fresh create 仍只能是 revision 1；create replay 可诚实返回后续 current revision。
- re-evaluate 无论 fresh 或 replay 都必须满足 revision ≥ 2、返回 ID 等于路径 ID、父 revision 合法且不自引用。
- 保留 #291 已合入的可信 Actor、严格请求解析、固定安全错误映射、私密响应头和 GET fail-closed 边界。
- Postgres 集成断言证明：revision 2 创建后再次调用原 Create 会重放 current revision 2，revision/outbox 数量不增加。

## 测试方式

1. 在 `api` 目录执行：
   `npm run check`
2. 在 `server` 目录执行：
   `go test -count=1 ./internal/evaluation/transport`
3. 执行：
   `go test -race -count=1 ./internal/evaluation/transport`
4. 执行：
   `go vet ./internal/evaluation/transport`
5. 执行：
   `go test -count=1 ./internal/evaluation/...`
6. CI 使用隔离 PostgreSQL 验证迁移与 ledger/outbox 集成断言。

预期：API、Go、竞态、静态检查、数据库 readiness 全部通过；fresh 非 QUEUED、错误路径或错误 lineage 均安全失败。

## 相关 Issue / 备注

Closes #277

- Evaluation HTTP transport 基础层 #290 / PR #291 已合入。
- 本 PR 不修改数据库 schema、幂等键、revision/outbox 状态机、Worker、Provider 或场景业务。
- Interview Shadow 生产 application 会在 #272 的独立 PR 中消费该服务端 replay 标记。

## AI 辅助说明

使用 AI 将旧草稿分支重建到最新 `dev`，只迁移 replay 契约并在 #291 transport 上补充最小状态分流、测试和安全复审。提交前已逐项确认：

- 无 Shadow、报告、Provider、bootstrap 或 migration 扩域。
- `200/202` 只由服务端 replay 结论与真实状态决定。
- #291 的错误清洗、路径校验和 lineage fail-closed 未回退。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
