### PR TITLE
feat(evaluation): 发布 Interview Shadow 复盘报告

### DIFF
--- a/api/examples/interview-report-contract.json
+++ b/api/examples/interview-report-contract.json
@@ -1,0 +1,497 @@
+{
+  "queued": {
+    "practice_session_id": "session_interview_report_001",
+    "evaluation_id": "81000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "82000001-0000-4000-8000-000000000001",
+    "revision": 1,
+    "evaluation_status": "QUEUED",
+    "is_final": false,
+    "status_url": "/v1/practice-sessions/session_interview_report_001/interview-report"
+  },
+  "running": {
+    "practice_session_id": "session_interview_report_001",
+    "evaluation_id": "81000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "82000001-0000-4000-8000-000000000001",
+    "revision": 1,
+    "evaluation_status": "RUNNING",
+    "is_final": false,
+    "status_url": "/v1/practice-sessions/session_interview_report_001/interview-report"
+  },
+  "ready": {
+    "practice_session_id": "session_interview_report_001",
+    "evaluation_id": "81000001-0000-4000-8000-000000000001",
+    "evaluation_revision_id": "82000001-0000-4000-8000-000000000001",
+    "revision": 1,
+    "evaluation_status": "READY",
+    "is_final": false,
+    "status_url": "/v1/practice-sessions/session_interview_report_001/interview-report",
+    "report": {
+      "schema_version": "interview-report/v1",
+      "scoreability_status": "PROVISIONAL",
+      "gate_status": "FEEDBACK_ONLY",
+      "readiness_level": "NOT_ASSESSED",
+      "readiness_notice": "Practice feedback only; not a hiring decision or probability.",
+      "dimensions": [
+        {
+          "dimension_id": "INTERVIEW_RELEVANCE",
+          "scoreability_status": "PROVISIONAL",
+          "gate_status": "FEEDBACK_ONLY",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "ASR_CONFIDENCE_UNAVAILABLE"
+          ],
+          "evidence_ref_ids": [
+            "evidence_primary_001"
+          ],
+          "strengths": [],
+          "improvements": [
+            {
+              "finding_id": "interview_finding_relevance_001",
+              "message": "The response needs a clearer connection to the question.",
+              "suggestion": "State the answer first, then connect each supporting detail to the question.",
+              "evidence": [
+                {
+                  "evidence_ref_id": "evidence_primary_001",
+                  "turn_id": "turn_primary_001",
+                  "start_utf8_byte": 2,
+                  "end_utf8_byte": 19,
+                  "original_excerpt": "led the migration"
+                }
+              ]
+            }
+          ],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_STRUCTURE",
+          "scoreability_status": "PROVISIONAL",
+          "gate_status": "FEEDBACK_ONLY",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "ASR_CONFIDENCE_UNAVAILABLE"
+          ],
+          "evidence_ref_ids": [
+            "evidence_primary_001"
+          ],
+          "strengths": [],
+          "improvements": [
+            {
+              "finding_id": "interview_finding_structure_001",
+              "message": "The response's main point and support are difficult to follow.",
+              "suggestion": "Use a situation-action-result order and keep one main point per sentence.",
+              "evidence": [
+                {
+                  "evidence_ref_id": "evidence_primary_001",
+                  "turn_id": "turn_primary_001",
+                  "start_utf8_byte": 2,
+                  "end_utf8_byte": 19,
+                  "original_excerpt": "led the migration"
+                }
+              ]
+            }
+          ],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_EVIDENCE",
+          "scoreability_status": "PROVISIONAL",
+          "gate_status": "FEEDBACK_ONLY",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "ASR_CONFIDENCE_UNAVAILABLE"
+          ],
+          "evidence_ref_ids": [
+            "evidence_primary_001"
+          ],
+          "strengths": [],
+          "improvements": [
+            {
+              "finding_id": "interview_finding_evidence_001",
+              "message": "The response needs a more specific example or outcome.",
+              "suggestion": "Name the situation, your action, and the observable outcome.",
+              "evidence": [
+                {
+                  "evidence_ref_id": "evidence_primary_001",
+                  "turn_id": "turn_primary_001",
+                  "start_utf8_byte": 2,
+                  "end_utf8_byte": 19,
+                  "original_excerpt": "led the migration"
+                }
+              ]
+            }
+          ],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_PROFESSIONAL",
+          "scoreability_status": "PROVISIONAL",
+          "gate_status": "FEEDBACK_ONLY",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "ASR_CONFIDENCE_UNAVAILABLE"
+          ],
+          "evidence_ref_ids": [
+            "evidence_primary_001"
+          ],
+          "strengths": [],
+          "improvements": [
+            {
+              "finding_id": "interview_finding_professional_001",
+              "message": "The response could use more precise, professional wording.",
+              "suggestion": "Replace broad claims with specific actions and neutral workplace language.",
+              "evidence": [
+                {
+                  "evidence_ref_id": "evidence_primary_001",
+                  "turn_id": "turn_primary_001",
+                  "start_utf8_byte": 2,
+                  "end_utf8_byte": 19,
+                  "original_excerpt": "led the migration"
+                }
+              ]
+            }
+          ],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_INTERACTION",
+          "scoreability_status": "PROVISIONAL",
+          "gate_status": "FEEDBACK_ONLY",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "ASR_CONFIDENCE_UNAVAILABLE"
+          ],
+          "evidence_ref_ids": [
+            "evidence_followup_001"
+          ],
+          "strengths": [],
+          "improvements": [
+            {
+              "finding_id": "interview_finding_interaction_001",
+              "message": "The response needs to address the follow-up more directly.",
+              "suggestion": "Acknowledge the follow-up, answer it directly, then add one supporting detail.",
+              "evidence": [
+                {
+                  "evidence_ref_id": "evidence_followup_001",
+                  "turn_id": "turn_followup_001",
+                  "start_utf8_byte": 2,
+                  "end_utf8_byte": 21,
+                  "original_excerpt": "measured the result"
+                }
+              ]
+            }
+          ],
+          "recommended_expressions": []
+        }
+      ],
+      "questions": [
+        {
+          "question_id": "question_primary_001",
+          "question_type": "PRIMARY",
+          "opportunity_status": "PROVIDED",
+          "assessment_status": "ASSESSED",
+          "question_text": "Tell me about a project you led.",
+          "confirmed_transcript": "I led the migration and reduced deployment time.",
+          "response_turn_id": "turn_primary_001",
+          "evidence_ref_ids": [
+            "evidence_primary_001"
+          ],
+          "dimension_findings": [
+            {
+              "dimension_id": "INTERVIEW_RELEVANCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [
+                "interview_finding_relevance_001"
+              ],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_STRUCTURE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [
+                "interview_finding_structure_001"
+              ],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_EVIDENCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [
+                "interview_finding_evidence_001"
+              ],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_PROFESSIONAL",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [
+                "interview_finding_professional_001"
+              ],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_INTERACTION",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            }
+          ]
+        },
+        {
+          "question_id": "question_followup_001",
+          "question_type": "FOLLOW_UP",
+          "parent_question_id": "question_primary_001",
+          "opportunity_status": "PROVIDED",
+          "assessment_status": "ASSESSED",
+          "question_text": "How did you measure the result?",
+          "confirmed_transcript": "I measured the result after two weeks.",
+          "response_turn_id": "turn_followup_001",
+          "evidence_ref_ids": [
+            "evidence_followup_001"
+          ],
+          "dimension_findings": [
+            {
+              "dimension_id": "INTERVIEW_RELEVANCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_STRUCTURE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_EVIDENCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_PROFESSIONAL",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_INTERACTION",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [
+                "interview_finding_interaction_001"
+              ],
+              "recommended_expression_finding_ids": []
+            }
+          ]
+        }
+      ],
+      "priority_actions": [
+        {
+          "dimension_id": "INTERVIEW_RELEVANCE",
+          "finding_id": "interview_finding_relevance_001"
+        },
+        {
+          "dimension_id": "INTERVIEW_STRUCTURE",
+          "finding_id": "interview_finding_structure_001"
+        },
+        {
+          "dimension_id": "INTERVIEW_EVIDENCE",
+          "finding_id": "interview_finding_evidence_001"
+        }
+      ]
+    }
+  },
+  "insufficient": {
+    "practice_session_id": "session_interview_report_002",
+    "evaluation_id": "81000002-0000-4000-8000-000000000002",
+    "evaluation_revision_id": "82000002-0000-4000-8000-000000000002",
+    "revision": 1,
+    "evaluation_status": "READY",
+    "is_final": false,
+    "status_url": "/v1/practice-sessions/session_interview_report_002/interview-report",
+    "report": {
+      "schema_version": "interview-report/v1",
+      "scoreability_status": "INSUFFICIENT",
+      "gate_status": "BLOCKED",
+      "readiness_level": "NOT_ASSESSED",
+      "readiness_notice": "Practice feedback only; not a hiring decision or probability.",
+      "dimensions": [
+        {
+          "dimension_id": "INTERVIEW_RELEVANCE",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "INSUFFICIENT_EVIDENCE"
+          ],
+          "evidence_ref_ids": [],
+          "strengths": [],
+          "improvements": [],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_STRUCTURE",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "INSUFFICIENT_EVIDENCE"
+          ],
+          "evidence_ref_ids": [],
+          "strengths": [],
+          "improvements": [],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_EVIDENCE",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "INSUFFICIENT_EVIDENCE"
+          ],
+          "evidence_ref_ids": [],
+          "strengths": [],
+          "improvements": [],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_PROFESSIONAL",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "coverage": 1,
+          "confidence": 0,
+          "reason_codes": [
+            "INSUFFICIENT_EVIDENCE"
+          ],
+          "evidence_ref_ids": [],
+          "strengths": [],
+          "improvements": [],
+          "recommended_expressions": []
+        },
+        {
+          "dimension_id": "INTERVIEW_INTERACTION",
+          "scoreability_status": "INSUFFICIENT",
+          "gate_status": "BLOCKED",
+          "coverage": 0,
+          "confidence": 0,
+          "reason_codes": [
+            "OPPORTUNITY_NOT_PROVIDED"
+          ],
+          "evidence_ref_ids": [],
+          "strengths": [],
+          "improvements": [],
+          "recommended_expressions": []
+        }
+      ],
+      "questions": [
+        {
+          "question_id": "question_short_001",
+          "question_type": "PRIMARY",
+          "opportunity_status": "PROVIDED",
+          "assessment_status": "ASSESSED",
+          "question_text": "Why are you interested in this role?",
+          "confirmed_transcript": "Hi.",
+          "response_turn_id": "turn_short_001",
+          "evidence_ref_ids": [
+            "evidence_short_001"
+          ],
+          "dimension_findings": [
+            {
+              "dimension_id": "INTERVIEW_RELEVANCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_STRUCTURE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_EVIDENCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_PROFESSIONAL",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_INTERACTION",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            }
+          ]
+        },
+        {
+          "question_id": "question_short_followup_001",
+          "question_type": "FOLLOW_UP",
+          "parent_question_id": "question_short_001",
+          "opportunity_status": "NOT_PROVIDED",
+          "assessment_status": "NOT_ASSESSED",
+          "question_text": "Could you give a specific example?",
+          "evidence_ref_ids": [],
+          "dimension_findings": [
+            {
+              "dimension_id": "INTERVIEW_RELEVANCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_STRUCTURE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_EVIDENCE",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_PROFESSIONAL",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            },
+            {
+              "dimension_id": "INTERVIEW_INTERACTION",
+              "strength_finding_ids": [],
+              "improvement_finding_ids": [],
+              "recommended_expression_finding_ids": []
+            }
+          ]
+        }
+      ],
+      "priority_actions": []
+    }
+  },
+  "failed": {
+    "practice_session_id": "session_interview_report_003",
+    "evaluation_id": "81000003-0000-4000-8000-000000000003",
+    "evaluation_revision_id": "82000003-0000-4000-8000-000000000003",
+    "revision": 1,
+    "evaluation_status": "FAILED",
+    "is_final": false,
+    "status_url": "/v1/practice-sessions/session_interview_report_003/interview-report",
+    "stable_failure": {
+      "reason_code": "INTERNAL_RETRYABLE",
+      "retryable": true
+    }
+  }
+}

--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -191,6 +191,49 @@ paths:
           $ref: '#/components/responses/EvaluationPolicyRejected'
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/interview-report:
+    get:
+      tags:
+        - Evaluation
+      summary: Get the current Interview Shadow report
+      description: |
+        Returns the current Actor-owned SESSION + INTERVIEW + SCENE Shadow
+        Evaluation revision projected as a private, qualitative report. A
+        resource owned by another Actor is indistinguishable from a missing
+        resource. This read never freezes evidence, creates or re-evaluates an
+        Evaluation, or invokes a provider.
+
+        The response is private and must not be persisted by intermediaries.
+        Servers must not log report findings, confirmed transcripts, resume
+        context, or evidence excerpts.
+      operationId: getInterviewReport
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: |
+            Current report state. QUEUED and RUNNING are pollable, READY
+            contains a qualitative report, and FAILED contains only a stable
+            technical failure.
+          headers:
+            Cache-Control:
+              required: true
+              description: Prevents shared or private storage of the report.
+              schema:
+                type: string
+                const: private, no-store
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewReportEnvelope'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
 
 components:
   responses:
@@ -237,6 +280,12 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/EvaluationUUID'
+    PracticeSessionId:
+      name: practice_session_id
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/StableIdentifier'
   schemas:
     EvaluationUUID:
       type: string
@@ -321,6 +370,7 @@ components:
         - DUPLICATE_REQUEST
         - POLICY_VIOLATION
         - INTERNAL_RETRYABLE
+        - INTERNAL_NON_RETRYABLE
         - OPPORTUNITY_NOT_PROVIDED
     RoundingRule:
       type: string
@@ -501,6 +551,630 @@ components:
         status_url:
           type: string
           pattern: '^/v1/evaluations/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+    InterviewReportEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - practice_session_id
+        - evaluation_id
+        - evaluation_revision_id
+        - revision
+        - evaluation_status
+        - is_final
+        - status_url
+      properties:
+        practice_session_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evaluation_id:
+          $ref: '#/components/schemas/EvaluationUUID'
+        evaluation_revision_id:
+          $ref: '#/components/schemas/EvaluationUUID'
+        revision:
+          type: integer
+          minimum: 1
+        evaluation_status:
+          type: string
+          enum:
+            - QUEUED
+            - RUNNING
+            - READY
+            - FAILED
+        is_final:
+          type: boolean
+          const: false
+        status_url:
+          type: string
+          maxLength: 167
+          pattern: '^/v1/practice-sessions/[A-Za-z0-9][A-Za-z0-9_-]*/interview-report$'
+        report:
+          $ref: '#/components/schemas/InterviewReport'
+        stable_failure:
+          $ref: '#/components/schemas/InterviewReportFailure'
+      allOf:
+        - if:
+            properties:
+              evaluation_status:
+                const: READY
+            required:
+              - evaluation_status
+          then:
+            required:
+              - report
+            not:
+              required:
+                - stable_failure
+        - if:
+            properties:
+              evaluation_status:
+                const: FAILED
+            required:
+              - evaluation_status
+          then:
+            required:
+              - stable_failure
+            not:
+              required:
+                - report
+        - if:
+            properties:
+              evaluation_status:
+                enum:
+                  - QUEUED
+                  - RUNNING
+            required:
+              - evaluation_status
+          then:
+            not:
+              anyOf:
+                - required:
+                    - report
+                - required:
+                    - stable_failure
+    InterviewReport:
+      type: object
+      additionalProperties: false
+      description: |
+        Versioned qualitative Interview feedback projected from one frozen
+        Shadow revision. It contains no numeric performance score, hiring
+        probability, readiness inference, pronunciation, pace, stress,
+        phoneme, or other acoustic assessment.
+      required:
+        - schema_version
+        - scoreability_status
+        - gate_status
+        - readiness_level
+        - readiness_notice
+        - dimensions
+        - questions
+        - priority_actions
+      properties:
+        schema_version:
+          type: string
+          const: interview-report/v1
+        scoreability_status:
+          $ref: '#/components/schemas/InterviewReportScoreabilityStatus'
+        gate_status:
+          $ref: '#/components/schemas/InterviewReportGateStatus'
+        readiness_level:
+          type: string
+          const: NOT_ASSESSED
+        readiness_notice:
+          type: string
+          const: Practice feedback only; not a hiring decision or probability.
+        dimensions:
+          $ref: '#/components/schemas/InterviewReportDimensions'
+        questions:
+          type: array
+          minItems: 1
+          maxItems: 64
+          items:
+            $ref: '#/components/schemas/InterviewReportQuestion'
+        priority_actions:
+          type: array
+          maxItems: 3
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/InterviewReportPriorityAction'
+      allOf:
+        - if:
+            properties:
+              scoreability_status:
+                const: PROVISIONAL
+            required:
+              - scoreability_status
+          then:
+            properties:
+              gate_status:
+                const: FEEDBACK_ONLY
+        - if:
+            properties:
+              scoreability_status:
+                const: INSUFFICIENT
+            required:
+              - scoreability_status
+          then:
+            properties:
+              gate_status:
+                const: BLOCKED
+    InterviewReportScoreabilityStatus:
+      type: string
+      enum:
+        - PROVISIONAL
+        - INSUFFICIENT
+    InterviewReportGateStatus:
+      type: string
+      enum:
+        - FEEDBACK_ONLY
+        - BLOCKED
+    InterviewReportReasonCode:
+      type: string
+      enum:
+        - ASR_CONFIDENCE_UNAVAILABLE
+        - INSUFFICIENT_EVIDENCE
+        - OPPORTUNITY_NOT_PROVIDED
+    InterviewReportDimensionId:
+      type: string
+      enum:
+        - INTERVIEW_RELEVANCE
+        - INTERVIEW_STRUCTURE
+        - INTERVIEW_EVIDENCE
+        - INTERVIEW_PROFESSIONAL
+        - INTERVIEW_INTERACTION
+    InterviewReportDimensions:
+      type: array
+      minItems: 5
+      maxItems: 5
+      prefixItems:
+        - $ref: '#/components/schemas/InterviewReportRelevanceDimension'
+        - $ref: '#/components/schemas/InterviewReportStructureDimension'
+        - $ref: '#/components/schemas/InterviewReportEvidenceDimension'
+        - $ref: '#/components/schemas/InterviewReportProfessionalDimension'
+        - $ref: '#/components/schemas/InterviewReportInteractionDimension'
+      items: false
+    InterviewReportRelevanceDimension:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_RELEVANCE
+    InterviewReportStructureDimension:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_STRUCTURE
+    InterviewReportEvidenceDimension:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_EVIDENCE
+    InterviewReportProfessionalDimension:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_PROFESSIONAL
+    InterviewReportInteractionDimension:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_INTERACTION
+    InterviewReportDimension:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension_id
+        - scoreability_status
+        - gate_status
+        - coverage
+        - confidence
+        - reason_codes
+        - evidence_ref_ids
+        - strengths
+        - improvements
+        - recommended_expressions
+      properties:
+        dimension_id:
+          $ref: '#/components/schemas/InterviewReportDimensionId'
+        scoreability_status:
+          $ref: '#/components/schemas/InterviewReportScoreabilityStatus'
+        gate_status:
+          $ref: '#/components/schemas/InterviewReportGateStatus'
+        coverage:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Evidence opportunity coverage metadata, not a user score.
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Evidence attribution confidence metadata, not a user score.
+        reason_codes:
+          type: array
+          minItems: 1
+          maxItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/InterviewReportReasonCode'
+        evidence_ref_ids:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+        strengths:
+          $ref: '#/components/schemas/InterviewReportFindings'
+        improvements:
+          $ref: '#/components/schemas/InterviewReportFindings'
+        recommended_expressions:
+          $ref: '#/components/schemas/InterviewReportFindings'
+      allOf:
+        - if:
+            properties:
+              scoreability_status:
+                const: PROVISIONAL
+            required:
+              - scoreability_status
+          then:
+            properties:
+              gate_status:
+                const: FEEDBACK_ONLY
+              reason_codes:
+                type: array
+                items:
+                  const: ASR_CONFIDENCE_UNAVAILABLE
+              evidence_ref_ids:
+                type: array
+                minItems: 1
+            anyOf:
+              - properties:
+                  strengths:
+                    type: array
+                    minItems: 1
+              - properties:
+                  improvements:
+                    type: array
+                    minItems: 1
+        - if:
+            properties:
+              scoreability_status:
+                const: INSUFFICIENT
+            required:
+              - scoreability_status
+          then:
+            properties:
+              gate_status:
+                const: BLOCKED
+              reason_codes:
+                type: array
+                items:
+                  enum:
+                    - INSUFFICIENT_EVIDENCE
+                    - OPPORTUNITY_NOT_PROVIDED
+              evidence_ref_ids:
+                type: array
+                maxItems: 0
+              strengths:
+                type: array
+                maxItems: 0
+              improvements:
+                type: array
+                maxItems: 0
+              recommended_expressions:
+                type: array
+                maxItems: 0
+    InterviewReportFindings:
+      type: array
+      maxItems: 3
+      items:
+        $ref: '#/components/schemas/InterviewReportFinding'
+    InterviewReportFinding:
+      type: object
+      additionalProperties: false
+      required:
+        - finding_id
+        - message
+        - evidence
+      properties:
+        finding_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        message:
+          $ref: '#/components/schemas/InterviewReportText'
+        suggestion:
+          $ref: '#/components/schemas/InterviewReportText'
+        evidence:
+          type: array
+          minItems: 1
+          maxItems: 4
+          items:
+            $ref: '#/components/schemas/InterviewReportEvidence'
+    InterviewReportEvidence:
+      type: object
+      additionalProperties: false
+      required:
+        - evidence_ref_id
+        - turn_id
+        - start_utf8_byte
+        - end_utf8_byte
+        - original_excerpt
+      properties:
+        evidence_ref_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        turn_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        start_utf8_byte:
+          type: integer
+          minimum: 0
+        end_utf8_byte:
+          type: integer
+          minimum: 1
+        original_excerpt:
+          type: string
+          minLength: 1
+          maxLength: 16384
+    InterviewReportQuestion:
+      type: object
+      additionalProperties: false
+      required:
+        - question_id
+        - question_type
+        - opportunity_status
+        - assessment_status
+        - question_text
+        - evidence_ref_ids
+        - dimension_findings
+      properties:
+        question_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        question_type:
+          type: string
+          enum:
+            - PRIMARY
+            - FOLLOW_UP
+        parent_question_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        opportunity_status:
+          type: string
+          enum:
+            - PROVIDED
+            - NOT_PROVIDED
+        assessment_status:
+          type: string
+          enum:
+            - ASSESSED
+            - NOT_ASSESSED
+        question_text:
+          $ref: '#/components/schemas/InterviewReportSourceText'
+        confirmed_transcript:
+          $ref: '#/components/schemas/InterviewReportSourceText'
+        response_turn_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evidence_ref_ids:
+          type: array
+          maxItems: 64
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+        dimension_findings:
+          $ref: '#/components/schemas/InterviewReportQuestionDimensions'
+      allOf:
+        - if:
+            properties:
+              question_type:
+                const: PRIMARY
+            required:
+              - question_type
+          then:
+            not:
+              required:
+                - parent_question_id
+        - if:
+            properties:
+              question_type:
+                const: FOLLOW_UP
+            required:
+              - question_type
+          then:
+            required:
+              - parent_question_id
+        - if:
+            properties:
+              opportunity_status:
+                const: PROVIDED
+            required:
+              - opportunity_status
+          then:
+            required:
+              - confirmed_transcript
+              - response_turn_id
+            properties:
+              assessment_status:
+                const: ASSESSED
+              evidence_ref_ids:
+                type: array
+                minItems: 1
+        - if:
+            properties:
+              opportunity_status:
+                const: NOT_PROVIDED
+            required:
+              - opportunity_status
+          then:
+            properties:
+              assessment_status:
+                const: NOT_ASSESSED
+              evidence_ref_ids:
+                type: array
+                maxItems: 0
+            not:
+              anyOf:
+                - required:
+                    - confirmed_transcript
+                - required:
+                    - response_turn_id
+    InterviewReportQuestionDimensions:
+      type: array
+      minItems: 5
+      maxItems: 5
+      prefixItems:
+        - $ref: '#/components/schemas/InterviewReportQuestionRelevance'
+        - $ref: '#/components/schemas/InterviewReportQuestionStructure'
+        - $ref: '#/components/schemas/InterviewReportQuestionEvidence'
+        - $ref: '#/components/schemas/InterviewReportQuestionProfessional'
+        - $ref: '#/components/schemas/InterviewReportQuestionInteraction'
+      items: false
+    InterviewReportQuestionRelevance:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportQuestionDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_RELEVANCE
+    InterviewReportQuestionStructure:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportQuestionDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_STRUCTURE
+    InterviewReportQuestionEvidence:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportQuestionDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_EVIDENCE
+    InterviewReportQuestionProfessional:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportQuestionDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_PROFESSIONAL
+    InterviewReportQuestionInteraction:
+      allOf:
+        - $ref: '#/components/schemas/InterviewReportQuestionDimension'
+        - type: object
+          required:
+            - dimension_id
+          properties:
+            dimension_id:
+              const: INTERVIEW_INTERACTION
+    InterviewReportQuestionDimension:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension_id
+        - strength_finding_ids
+        - improvement_finding_ids
+        - recommended_expression_finding_ids
+      properties:
+        dimension_id:
+          $ref: '#/components/schemas/InterviewReportDimensionId'
+        strength_finding_ids:
+          $ref: '#/components/schemas/InterviewReportFindingIds'
+        improvement_finding_ids:
+          $ref: '#/components/schemas/InterviewReportFindingIds'
+        recommended_expression_finding_ids:
+          $ref: '#/components/schemas/InterviewReportFindingIds'
+    InterviewReportFindingIds:
+      type: array
+      maxItems: 3
+      uniqueItems: true
+      items:
+        $ref: '#/components/schemas/StableIdentifier'
+    InterviewReportPriorityAction:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension_id
+        - finding_id
+      properties:
+        dimension_id:
+          $ref: '#/components/schemas/InterviewReportDimensionId'
+        finding_id:
+          $ref: '#/components/schemas/StableIdentifier'
+    InterviewReportFailure:
+      type: object
+      additionalProperties: false
+      required:
+        - reason_code
+        - retryable
+      properties:
+        reason_code:
+          type: string
+          enum:
+            - POLICY_VIOLATION
+            - EVIDENCE_REF_INVALID
+            - VERSION_CONFLICT
+            - INTERNAL_RETRYABLE
+            - INTERNAL_NON_RETRYABLE
+        retryable:
+          type: boolean
+      allOf:
+        - if:
+            properties:
+              reason_code:
+                const: INTERNAL_RETRYABLE
+            required:
+              - reason_code
+          then:
+            properties:
+              retryable:
+                const: true
+        - if:
+            properties:
+              reason_code:
+                enum:
+                  - POLICY_VIOLATION
+                  - EVIDENCE_REF_INVALID
+                  - VERSION_CONFLICT
+                  - INTERNAL_NON_RETRYABLE
+            required:
+              - reason_code
+          then:
+            properties:
+              retryable:
+                const: false
+    InterviewReportText:
+      type: string
+      minLength: 1
+      maxLength: 2048
+      pattern: '^\S(?:[\s\S]*\S)?$'
+      description: |
+        Server-controlled feedback template text validated by the frozen
+        Interview Shadow revision; never unvalidated provider prose.
+    InterviewReportSourceText:
+      type: string
+      minLength: 1
+      maxLength: 16384
+      pattern: '^\S(?:[\s\S]*\S)?$'
     Evaluation:
       $ref: '#/components/schemas/EvaluationCommonProperties'
     EvaluationCommonProperties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -143,6 +143,8 @@ paths:
     $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluations~1{evaluation_id}
   /v1/evaluations/{evaluation_id}/re-evaluate:
     $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluations~1{evaluation_id}~1re-evaluate
+  /v1/practice-sessions/{practice_session_id}/interview-report:
+    $ref: ./modules/evaluation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1interview-report
   /v1/scenario-definitions/{scenario_definition_id}:
     $ref: ./modules/preparation.yaml#/paths/~1v1~1scenario-definitions~1{scenario_definition_id}
   /v1/scenario-definitions/{scenario_definition_id}/role-definitions:
@@ -336,6 +338,10 @@ components:
       $ref: ./modules/evaluation.yaml#/components/schemas/ReevaluateEvaluationRequest
     EvaluationAccepted:
       $ref: ./modules/evaluation.yaml#/components/schemas/EvaluationAccepted
+    InterviewReportEnvelope:
+      $ref: ./modules/evaluation.yaml#/components/schemas/InterviewReportEnvelope
+    InterviewReport:
+      $ref: ./modules/evaluation.yaml#/components/schemas/InterviewReport
     Evaluation:
       $ref: ./modules/evaluation.yaml#/components/schemas/Evaluation
     SceneEvaluationResult:

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -17,6 +17,12 @@ const fixture = JSON.parse(
     'utf8',
   ),
 );
+const interviewReportFixture = JSON.parse(
+  await readFile(
+    resolve(apiDirectory, 'examples/interview-report-contract.json'),
+    'utf8',
+  ),
+);
 
 const bundleOpenApi = async () => {
   const temporaryDirectory = await mkdtemp(
@@ -145,6 +151,7 @@ const validators = Object.fromEntries(
     'EvaluationAccepted',
     'EvaluationReplay',
     'Evaluation',
+    'InterviewReportEnvelope',
     'SceneEvaluationResult',
     'CoreAbilityObservation',
     'EvidenceRef',
@@ -665,4 +672,440 @@ provisionalMarkedFinal.is_final = true;
 assert.throws(
   () => assertEvaluationSemantics(provisionalMarkedFinal),
   /provisional result cannot be final/,
+);
+
+const interviewDimensionOrder = [
+  'INTERVIEW_RELEVANCE',
+  'INTERVIEW_STRUCTURE',
+  'INTERVIEW_EVIDENCE',
+  'INTERVIEW_PROFESSIONAL',
+  'INTERVIEW_INTERACTION',
+];
+const interviewFindingKinds = [
+  ['strengths', 'strength_finding_ids'],
+  ['improvements', 'improvement_finding_ids'],
+  ['recommended_expressions', 'recommended_expression_finding_ids'],
+];
+const forbiddenInterviewReportField = new RegExp(
+  String.raw`(^|_)(raw|display|score|overall|total|weight|weights|probe_weight)($|_)`,
+  'u',
+);
+
+const assertNoInterviewScoreFields = (value, path = 'report') => {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNoInterviewScoreFields(item, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+  for (const [field, item] of Object.entries(value)) {
+    assert.doesNotMatch(
+      field,
+      forbiddenInterviewReportField,
+      `${path}.${field} exposes a forbidden numeric score field`,
+    );
+    assertNoInterviewScoreFields(item, `${path}.${field}`);
+  }
+};
+
+const sortedStrings = (values) => [...values].sort();
+
+const assertInterviewReportSemantics = (envelope) => {
+  assert.equal(
+    envelope.status_url,
+    `/v1/practice-sessions/${envelope.practice_session_id}/interview-report`,
+    'Interview report status_url must address the same Practice Session',
+  );
+  if (envelope.evaluation_status !== 'READY') {
+    return;
+  }
+
+  const report = envelope.report;
+  assert.equal(report.schema_version, 'interview-report/v1');
+  assert.equal(report.readiness_level, 'NOT_ASSESSED');
+  assertNoInterviewScoreFields(report);
+  assert.deepEqual(
+    report.dimensions.map((dimension) => dimension.dimension_id),
+    interviewDimensionOrder,
+    'Interview report dimensions must use the canonical order',
+  );
+
+  const questionById = new Map();
+  const questionByTurnId = new Map();
+  for (const question of report.questions) {
+    assert.ok(
+      !questionById.has(question.question_id),
+      `Duplicate question ${question.question_id}`,
+    );
+    questionById.set(question.question_id, question);
+    if (question.response_turn_id !== undefined) {
+      assert.ok(
+        !questionByTurnId.has(question.response_turn_id),
+        `Duplicate response Turn ${question.response_turn_id}`,
+      );
+      questionByTurnId.set(question.response_turn_id, question);
+    }
+    assert.deepEqual(
+      question.dimension_findings.map(
+        (dimension) => dimension.dimension_id,
+      ),
+      interviewDimensionOrder,
+      `${question.question_id}: dimension finding order changed`,
+    );
+    if (question.assessment_status === 'NOT_ASSESSED') {
+      for (const dimension of question.dimension_findings) {
+        for (const [, referenceField] of interviewFindingKinds) {
+          assert.deepEqual(
+            dimension[referenceField],
+            [],
+            `${question.question_id}: unassessed question references findings`,
+          );
+        }
+      }
+    }
+  }
+  for (const question of report.questions) {
+    if (question.question_type === 'FOLLOW_UP') {
+      const parent = questionById.get(question.parent_question_id);
+      assert.ok(parent, `${question.question_id}: parent question is missing`);
+      assert.equal(
+        parent.question_type,
+        'PRIMARY',
+        `${question.question_id}: parent must be PRIMARY`,
+      );
+    }
+  }
+
+  const findingById = new Map();
+  for (const dimension of report.dimensions) {
+    if (report.scoreability_status === 'INSUFFICIENT') {
+      assert.equal(dimension.scoreability_status, 'INSUFFICIENT');
+      assert.equal(dimension.gate_status, 'BLOCKED');
+    } else {
+      assert.ok(
+        (dimension.scoreability_status === 'PROVISIONAL' &&
+          dimension.gate_status === 'FEEDBACK_ONLY') ||
+          (dimension.scoreability_status === 'INSUFFICIENT' &&
+            dimension.gate_status === 'BLOCKED'),
+        `${dimension.dimension_id}: invalid qualitative gate`,
+      );
+    }
+
+    const evidenceRefIds = new Set();
+    for (const [findingField, referenceField] of interviewFindingKinds) {
+      for (const finding of dimension[findingField]) {
+        assert.ok(
+          !findingById.has(finding.finding_id),
+          `Duplicate finding ${finding.finding_id}`,
+        );
+        findingById.set(finding.finding_id, {
+          dimensionId: dimension.dimension_id,
+          findingField,
+          referenceField,
+          finding,
+        });
+        for (const evidence of finding.evidence) {
+          evidenceRefIds.add(evidence.evidence_ref_id);
+          assert.ok(
+            evidence.start_utf8_byte < evidence.end_utf8_byte,
+            `${finding.finding_id}: evidence span must be non-empty`,
+          );
+          const question = questionByTurnId.get(evidence.turn_id);
+          assert.ok(
+            question,
+            `${finding.finding_id}: evidence Turn is not a confirmed response`,
+          );
+          assert.ok(
+            question.evidence_ref_ids.includes(evidence.evidence_ref_id),
+            `${finding.finding_id}: evidence reference is outside its response`,
+          );
+          const transcriptBytes = Buffer.from(
+            question.confirmed_transcript,
+            'utf8',
+          );
+          assert.ok(
+            evidence.end_utf8_byte <= transcriptBytes.length,
+            `${finding.finding_id}: evidence span exceeds its response`,
+          );
+          assert.equal(
+            transcriptBytes
+              .subarray(evidence.start_utf8_byte, evidence.end_utf8_byte)
+              .toString('utf8'),
+            evidence.original_excerpt,
+            `${finding.finding_id}: evidence excerpt does not match its response`,
+          );
+        }
+      }
+    }
+    assert.deepEqual(
+      sortedStrings(dimension.evidence_ref_ids),
+      sortedStrings(evidenceRefIds),
+      `${dimension.dimension_id}: evidence_ref_ids must equal finding evidence`,
+    );
+  }
+
+  for (const question of report.questions) {
+    for (const dimension of question.dimension_findings) {
+      for (const [, referenceField] of interviewFindingKinds) {
+        for (const findingId of dimension[referenceField]) {
+          const target = findingById.get(findingId);
+          assert.ok(
+            target,
+            `${question.question_id}: dangling finding ${findingId}`,
+          );
+          assert.equal(
+            target.dimensionId,
+            dimension.dimension_id,
+            `${question.question_id}: finding dimension mismatch`,
+          );
+          assert.equal(
+            target.referenceField,
+            referenceField,
+            `${question.question_id}: finding category mismatch`,
+          );
+          assert.ok(
+            target.finding.evidence.some((evidence) =>
+              question.evidence_ref_ids.includes(evidence.evidence_ref_id),
+            ),
+            `${question.question_id}: finding is unrelated to its response`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const action of report.priority_actions) {
+    const target = findingById.get(action.finding_id);
+    assert.ok(target, `Priority action ${action.finding_id} is dangling`);
+    assert.equal(
+      target.dimensionId,
+      action.dimension_id,
+      `Priority action ${action.finding_id} has the wrong dimension`,
+    );
+    assert.equal(
+      target.findingField,
+      'improvements',
+      `Priority action ${action.finding_id} must reference an improvement`,
+    );
+  }
+};
+
+for (const [name, value] of Object.entries(interviewReportFixture)) {
+  assertValid(
+    `Interview report ${name}`,
+    'InterviewReportEnvelope',
+    value,
+  );
+  assertInterviewReportSemantics(value);
+}
+
+const digitLeadingInterviewReport = structuredClone(
+  interviewReportFixture.ready,
+);
+digitLeadingInterviewReport.practice_session_id =
+  '20000000-0000-4000-8000-000000000001';
+digitLeadingInterviewReport.status_url =
+  '/v1/practice-sessions/20000000-0000-4000-8000-000000000001/interview-report';
+assertValid(
+  'digit-leading Practice session Interview report',
+  'InterviewReportEnvelope',
+  digitLeadingInterviewReport,
+);
+assertInterviewReportSemantics(digitLeadingInterviewReport);
+
+for (const reasonCode of [
+  'POLICY_VIOLATION',
+  'EVIDENCE_REF_INVALID',
+  'VERSION_CONFLICT',
+]) {
+  const nonRetryableFailure = structuredClone(interviewReportFixture.failed);
+  nonRetryableFailure.stable_failure = {
+    reason_code: reasonCode,
+    retryable: false,
+  };
+  assertValid(
+    `Interview report ${reasonCode} failure`,
+    'InterviewReportEnvelope',
+    nonRetryableFailure,
+  );
+}
+
+const retryablePolicyFailure = structuredClone(interviewReportFixture.failed);
+retryablePolicyFailure.stable_failure = {
+  reason_code: 'POLICY_VIOLATION',
+  retryable: true,
+};
+assertSchemaRejected(
+  'retryable non-transient Interview report failure',
+  'InterviewReportEnvelope',
+  retryablePolicyFailure,
+);
+
+const nonRetryableInternalFailure = structuredClone(
+  interviewReportFixture.failed,
+);
+nonRetryableInternalFailure.stable_failure.retryable = false;
+assertSchemaRejected(
+  'non-retryable INTERNAL_RETRYABLE Interview report failure',
+  'InterviewReportEnvelope',
+  nonRetryableInternalFailure,
+);
+
+const readyWithoutReport = structuredClone(interviewReportFixture.ready);
+delete readyWithoutReport.report;
+assertSchemaRejected(
+  'READY Interview report without report',
+  'InterviewReportEnvelope',
+  readyWithoutReport,
+);
+
+const failedWithReport = structuredClone(interviewReportFixture.failed);
+failedWithReport.report = structuredClone(interviewReportFixture.ready.report);
+assertSchemaRejected(
+  'FAILED Interview report carrying a report',
+  'InterviewReportEnvelope',
+  failedWithReport,
+);
+
+const pendingWithReport = structuredClone(interviewReportFixture.running);
+pendingWithReport.report = structuredClone(interviewReportFixture.ready.report);
+assertSchemaRejected(
+  'pending Interview report carrying a report',
+  'InterviewReportEnvelope',
+  pendingWithReport,
+);
+
+const reportWithUnknownVersion = structuredClone(interviewReportFixture.ready);
+reportWithUnknownVersion.report.schema_version = 'interview-report/v2';
+assertSchemaRejected(
+  'Interview report with unknown schema version',
+  'InterviewReportEnvelope',
+  reportWithUnknownVersion,
+);
+
+for (const [caseName, mutate] of [
+  ['overall score', (value) => (value.report.overall = 75)],
+  ['dimension raw value', (value) => (value.report.dimensions[0].raw = 75)],
+  [
+    'finding display score',
+    (value) =>
+      (value.report.dimensions[0].improvements[0].display_score = 75),
+  ],
+  [
+    'question probe weight',
+    (value) => (value.report.questions[0].probe_weight = 1),
+  ],
+  [
+    'priority action weight',
+    (value) => (value.report.priority_actions[0].weight = 1),
+  ],
+]) {
+  const invalid = structuredClone(interviewReportFixture.ready);
+  mutate(invalid);
+  assertSchemaRejected(
+    `Interview report with ${caseName}`,
+    'InterviewReportEnvelope',
+    invalid,
+  );
+}
+
+const unknownReportReason = structuredClone(interviewReportFixture.ready);
+unknownReportReason.report.dimensions[0].reason_codes = ['UNKNOWN'];
+assertSchemaRejected(
+  'Interview report with free-text reason relationship',
+  'InterviewReportEnvelope',
+  unknownReportReason,
+);
+
+const unknownQuestionType = structuredClone(interviewReportFixture.ready);
+unknownQuestionType.report.questions[0].question_type = 'RELATED';
+assertSchemaRejected(
+  'Interview report with free-text question relationship',
+  'InterviewReportEnvelope',
+  unknownQuestionType,
+);
+
+const unknownParent = structuredClone(interviewReportFixture.ready);
+unknownParent.report.questions[1].parent_question_id = 'question_missing';
+assert.throws(
+  () => assertInterviewReportSemantics(unknownParent),
+  /parent question is missing/,
+);
+
+const danglingQuestionFinding = structuredClone(
+  interviewReportFixture.ready,
+);
+danglingQuestionFinding.report.questions[0].dimension_findings[0]
+  .improvement_finding_ids = ['interview_finding_missing'];
+assertValid(
+  'schema-valid dangling question finding',
+  'InterviewReportEnvelope',
+  danglingQuestionFinding,
+);
+assert.throws(
+  () => assertInterviewReportSemantics(danglingQuestionFinding),
+  /dangling finding/,
+);
+
+const danglingPriorityAction = structuredClone(
+  interviewReportFixture.ready,
+);
+danglingPriorityAction.report.priority_actions[0].finding_id =
+  'interview_finding_missing';
+assertValid(
+  'schema-valid dangling priority action',
+  'InterviewReportEnvelope',
+  danglingPriorityAction,
+);
+assert.throws(
+  () => assertInterviewReportSemantics(danglingPriorityAction),
+  /is dangling/,
+);
+
+const mismatchedFindingCategory = structuredClone(
+  interviewReportFixture.ready,
+);
+mismatchedFindingCategory.report.questions[0].dimension_findings[0]
+  .strength_finding_ids = ['interview_finding_relevance_001'];
+mismatchedFindingCategory.report.questions[0].dimension_findings[0]
+  .improvement_finding_ids = [];
+assertValid(
+  'schema-valid mismatched finding category',
+  'InterviewReportEnvelope',
+  mismatchedFindingCategory,
+);
+assert.throws(
+  () => assertInterviewReportSemantics(mismatchedFindingCategory),
+  /finding category mismatch/,
+);
+
+const forgedInterviewExcerpt = structuredClone(interviewReportFixture.ready);
+forgedInterviewExcerpt.report.dimensions[0].improvements[0].evidence[0]
+  .original_excerpt = 'forged excerpt';
+assertValid(
+  'schema-valid forged Interview excerpt',
+  'InterviewReportEnvelope',
+  forgedInterviewExcerpt,
+);
+assert.throws(
+  () => assertInterviewReportSemantics(forgedInterviewExcerpt),
+  /evidence excerpt does not match/,
+);
+
+const mismatchedReportStatusUrl = structuredClone(
+  interviewReportFixture.running,
+);
+mismatchedReportStatusUrl.status_url =
+  '/v1/practice-sessions/session_other/interview-report';
+assertValid(
+  'schema-valid mismatched Interview status URL',
+  'InterviewReportEnvelope',
+  mismatchedReportStatusUrl,
+);
+assert.throws(
+  () => assertInterviewReportSemantics(mismatchedReportStatusUrl),
+  /same Practice Session/,
 );

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -1024,6 +1024,42 @@ assert.equal(
 );
 assert.equal(websocketParameters.after_sequence?.in, 'query');
 
+const interviewReport = requireOperation(
+  'GET /v1/practice-sessions/{practice_session_id}/interview-report',
+);
+assert.equal(interviewReport.operationId, 'getInterviewReport');
+assert.deepEqual(
+  interviewReport.security ?? openApi.security,
+  bearerSecurity,
+  'Interview reports must derive the Actor from BearerSession.',
+);
+assert.ok(interviewReport.responses?.['200']);
+assert.ok(interviewReport.responses?.['401']);
+assert.ok(interviewReport.responses?.['404']);
+assert.ok(interviewReport.responses?.['409']);
+const interviewReportResponse = resolveLocalReference(
+  interviewReport.responses['200'],
+);
+assert.equal(
+  interviewReportResponse?.headers?.['Cache-Control']?.schema?.const,
+  'private, no-store',
+  'Interview reports must prohibit shared and private caching.',
+);
+assert.equal(
+  getJsonSchema(interviewReportResponse)?.$ref,
+  '#/components/schemas/InterviewReportEnvelope',
+);
+assert.ok(
+  schemas.InterviewReportEnvelope,
+  'The root contract must export InterviewReportEnvelope.',
+);
+assert.ok(
+  schemas.InterviewReport,
+  'The root contract must export InterviewReport.',
+);
+assert.match(interviewReport.description ?? '', /another Actor/i);
+assert.match(interviewReport.description ?? '', /must not log/i);
+
 const formalReviewHistory = requireOperation('GET /v1/formal-reviews');
 const formalReviewHistoryParameters = Object.fromEntries(
   (formalReviewHistory.parameters ?? []).map((parameterValue) => {

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -19,6 +19,7 @@ import 'package:speakup/features/review/review.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/auth_gate.dart';
 import 'package:speakup/identity/model/identity_models.dart';
+import 'package:speakup/review/interview_report_controller.dart';
 import 'package:speakup/review/review_history_controller.dart';
 
 class SpeakUpApp extends StatelessWidget {
@@ -30,6 +31,7 @@ class SpeakUpApp extends StatelessWidget {
     this.preparationLaunchController,
     this.reviewHistoryController,
     this.avatarControllerFactory,
+    this.interviewReportController,
     super.key,
   }) : _authentication = (controller: authController),
        _allowFakePreview = false;
@@ -41,6 +43,7 @@ class SpeakUpApp extends StatelessWidget {
     this.preparationLaunchController,
     this.reviewHistoryController,
     this.avatarControllerFactory,
+    this.interviewReportController,
     super.key,
   }) : _authentication = null,
        _allowFakePreview = true;
@@ -52,6 +55,7 @@ class SpeakUpApp extends StatelessWidget {
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final AvatarControllerFactory? avatarControllerFactory;
+  final InterviewReportController? interviewReportController;
   final bool _allowFakePreview;
 
   @override
@@ -69,6 +73,7 @@ class SpeakUpApp extends StatelessWidget {
               preparationLaunchController: preparationLaunchController,
               reviewHistoryController: reviewHistoryController,
               avatarControllerFactory: avatarControllerFactory,
+              interviewReportController: interviewReportController,
               allowFakePreview: _allowFakePreview,
             )
           : AuthGate(
@@ -82,6 +87,7 @@ class SpeakUpApp extends StatelessWidget {
                 preparationLaunchController: preparationLaunchController,
                 reviewHistoryController: reviewHistoryController,
                 avatarControllerFactory: avatarControllerFactory,
+                interviewReportController: interviewReportController,
                 allowFakePreview: _allowFakePreview,
               ),
             ),
@@ -99,6 +105,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.preparationLaunchController,
     this.reviewHistoryController,
     this.avatarControllerFactory,
+    this.interviewReportController,
     required this.allowFakePreview,
   });
 
@@ -110,6 +117,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final PreparationLaunchController? preparationLaunchController;
   final ReviewHistoryController? reviewHistoryController;
   final AvatarControllerFactory? avatarControllerFactory;
+  final InterviewReportController? interviewReportController;
   final bool allowFakePreview;
 
   @override
@@ -192,6 +200,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             jobPreparationController: widget.jobPreparationController,
             preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
+            interviewReportController: widget.interviewReportController,
           ),
           AppRoutes.preparation => PreparationPage(
             showBackButton: true,
@@ -226,12 +235,14 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             jobPreparationController: widget.jobPreparationController,
             preparationLaunchController: widget.preparationLaunchController,
             reviewHistoryController: widget.reviewHistoryController,
+            interviewReportController: widget.interviewReportController,
           ),
           AppRoutes.review => ReviewPage(
             showBackButton: true,
             previewMode: widget.allowFakePreview,
             practiceAvailable: _agentController.supportsPracticeFlow,
             historyController: widget.reviewHistoryController,
+            interviewReportController: widget.interviewReportController,
             agentController: _agentController,
           ),
           _ => null,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -17,6 +17,7 @@ import 'package:speakup/features/preparation/preparation_launch_controller.dart'
 import 'package:speakup/features/review/review.dart';
 import 'package:speakup/identity/auth_controller.dart';
 import 'package:speakup/identity/model/identity_models.dart';
+import 'package:speakup/review/interview_report_controller.dart';
 import 'package:speakup/review/review_history_controller.dart';
 
 class SpeakUpShell extends StatefulWidget {
@@ -29,6 +30,7 @@ class SpeakUpShell extends StatefulWidget {
     this.preparationLaunchController,
     this.jobPreparationController,
     this.reviewHistoryController,
+    this.interviewReportController,
     required this.agentController,
     super.key,
   });
@@ -42,6 +44,7 @@ class SpeakUpShell extends StatefulWidget {
   final PreparationLaunchController? preparationLaunchController;
   final JobPreparationController? jobPreparationController;
   final ReviewHistoryController? reviewHistoryController;
+  final InterviewReportController? interviewReportController;
 
   @override
   State<SpeakUpShell> createState() => _SpeakUpShellState();
@@ -367,6 +370,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         previewMode: widget.previewMode,
         practiceAvailable: practiceAvailable,
         historyController: widget.reviewHistoryController,
+        interviewReportController: widget.interviewReportController,
         agentController: widget.agentController,
         autoload: false,
       ),

--- a/mobile/lib/features/review/interview_report_view.dart
+++ b/mobile/lib/features/review/interview_report_view.dart
@@ -1,0 +1,465 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_controller.dart';
+
+class InterviewReportPanel extends StatefulWidget {
+  const InterviewReportPanel({required this.controller, super.key});
+
+  final InterviewReportController controller;
+
+  @override
+  State<InterviewReportPanel> createState() => _InterviewReportPanelState();
+}
+
+class _InterviewReportPanelState extends State<InterviewReportPanel> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_rebuild);
+  }
+
+  @override
+  void didUpdateWidget(covariant InterviewReportPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_rebuild);
+      widget.controller.addListener(_rebuild);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_rebuild);
+    super.dispose();
+  }
+
+  void _rebuild() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = widget.controller;
+    final envelope = controller.envelope;
+    final errorMessage = controller.errorMessage;
+    if (envelope == null) {
+      if (errorMessage != null) {
+        return _ReportFailure(
+          message: errorMessage,
+          retryable: controller.canRetry,
+          onRetry: controller.retry,
+        );
+      }
+      return const _GeneratingReport();
+    }
+    return switch (envelope.evaluationStatus) {
+      InterviewReportEvaluationStatus.queued ||
+      InterviewReportEvaluationStatus.running => _GeneratingReport(
+        message: errorMessage,
+        onRetry: controller.canRetry ? controller.retry : null,
+      ),
+      InterviewReportEvaluationStatus.ready => _ReadyInterviewReport(
+        report: envelope.report!,
+      ),
+      InterviewReportEvaluationStatus.failed => _ReportFailure(
+        message: '报告生成遇到技术问题，这不代表你的面试表现较差。',
+        retryable: envelope.stableFailure!.retryable,
+        onRetry: controller.retry,
+      ),
+    };
+  }
+}
+
+class _GeneratingReport extends StatelessWidget {
+  const _GeneratingReport({this.message, this.onRetry});
+
+  final String? message;
+  final Future<void> Function()? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-generating'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            if (message == null)
+              const CircularProgressIndicator(
+                key: Key('interview-report-progress'),
+              ),
+            if (message == null) const SizedBox(height: 14),
+            Text(
+              message ?? '报告生成中',
+              textAlign: TextAlign.center,
+              style: message == null
+                  ? SpeakUpDesign.cardTitle
+                  : const TextStyle(color: SpeakUpDesign.error),
+            ),
+            if (message == null) ...[
+              const SizedBox(height: 6),
+              Text(
+                '正在整理本次面试的文本证据，请稍候。',
+                textAlign: TextAlign.center,
+                style: SpeakUpDesign.body,
+              ),
+            ],
+            if (onRetry != null) ...[
+              const SizedBox(height: 12),
+              OutlinedButton(
+                key: const Key('interview-report-retry'),
+                onPressed: onRetry,
+                child: const Text('重新查询'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReportFailure extends StatelessWidget {
+  const _ReportFailure({
+    required this.message,
+    required this.retryable,
+    required this.onRetry,
+  });
+
+  final String message;
+  final bool retryable;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-failed'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            const Icon(Icons.error_outline_rounded, color: SpeakUpDesign.error),
+            const SizedBox(height: 10),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: SpeakUpDesign.body,
+            ),
+            const SizedBox(height: 6),
+            Text(
+              retryable ? '可以稍后重新查询。' : '请保留本次练习，稍后再试。',
+              textAlign: TextAlign.center,
+              style: SpeakUpDesign.meta,
+            ),
+            if (retryable) ...[
+              const SizedBox(height: 12),
+              OutlinedButton(
+                key: const Key('interview-report-retry'),
+                onPressed: onRetry,
+                child: const Text('重新查询'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReadyInterviewReport extends StatelessWidget {
+  const _ReadyInterviewReport({required this.report});
+
+  final InterviewReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    if (report.scoreabilityStatus ==
+        InterviewReportScoreabilityStatus.insufficient) {
+      return const _InsufficientReport();
+    }
+    return Column(
+      key: const Key('interview-report-ready'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _ReportNotice(),
+        const SizedBox(height: 12),
+        _ReportDimensions(report: report),
+        const SizedBox(height: 12),
+        _ReportQuestions(report: report),
+        if (report.priorityActions.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _PriorityActions(report: report),
+        ],
+      ],
+    );
+  }
+}
+
+class _ReportNotice extends StatelessWidget {
+  const _ReportNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-notice'),
+      color: SpeakUpDesign.primaryMuted,
+      child: const Padding(
+        padding: EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('暂定文本反馈', style: SpeakUpDesign.cardTitle),
+            SizedBox(height: 8),
+            Text(
+              '本报告只基于本次练习中已确认的文字回答，不评估发音、语速或纯声学流利度。',
+              style: SpeakUpDesign.body,
+            ),
+            SizedBox(height: 6),
+            Text(
+              '反馈仅用于练习，不代表录用结论或录用概率。',
+              key: Key('interview-report-readiness-notice'),
+              style: SpeakUpDesign.body,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InsufficientReport extends StatelessWidget {
+  const _InsufficientReport();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-insufficient'),
+      child: const Padding(
+        padding: EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('证据不足', style: SpeakUpDesign.cardTitle),
+            SizedBox(height: 8),
+            Text(
+              '本次已确认的文字回答不足以形成可靠反馈。这里不会显示 0 分，也不会补猜发音、流利度或录用结论。',
+              style: SpeakUpDesign.body,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReportDimensions extends StatelessWidget {
+  const _ReportDimensions({required this.report});
+
+  final InterviewReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-dimensions'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('五维反馈', style: SpeakUpDesign.cardTitle),
+            const SizedBox(height: 14),
+            for (var index = 0; index < report.dimensions.length; index++) ...[
+              if (index > 0) ...[
+                const SizedBox(height: 16),
+                const Divider(height: 1),
+                const SizedBox(height: 16),
+              ],
+              _DimensionFeedback(dimension: report.dimensions[index]),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DimensionFeedback extends StatelessWidget {
+  const _DimensionFeedback({required this.dimension});
+
+  final InterviewReportDimension dimension;
+
+  @override
+  Widget build(BuildContext context) {
+    final findings = <({String label, InterviewReportFinding finding})>[
+      for (final finding in dimension.strengths)
+        (label: '做得好', finding: finding),
+      for (final finding in dimension.improvements)
+        (label: '可改进', finding: finding),
+      for (final finding in dimension.recommendedExpressions)
+        (label: '推荐表达', finding: finding),
+    ];
+    return Column(
+      key: Key('interview-report-dimension-${dimension.id.name}'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(_dimensionLabel(dimension.id), style: SpeakUpDesign.label),
+        if (findings.isEmpty) ...[
+          const SizedBox(height: 6),
+          Text('现有文本证据不足以形成该维度结论。', style: SpeakUpDesign.meta),
+        ],
+        for (final item in findings) ...[
+          const SizedBox(height: 10),
+          Text(item.label, style: SpeakUpDesign.meta),
+          const SizedBox(height: 3),
+          Text(item.finding.message, style: SpeakUpDesign.body),
+          if (item.finding.suggestion case final suggestion?) ...[
+            const SizedBox(height: 3),
+            Text('建议：$suggestion', style: SpeakUpDesign.body),
+          ],
+          for (final evidence in item.finding.evidence) ...[
+            const SizedBox(height: 5),
+            Text('原句：“${evidence.originalExcerpt}”', style: SpeakUpDesign.meta),
+          ],
+        ],
+      ],
+    );
+  }
+}
+
+class _ReportQuestions extends StatelessWidget {
+  const _ReportQuestions({required this.report});
+
+  final InterviewReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-questions'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('逐题复盘', style: SpeakUpDesign.cardTitle),
+            const SizedBox(height: 14),
+            for (var index = 0; index < report.questions.length; index++) ...[
+              if (index > 0) ...[
+                const SizedBox(height: 16),
+                const Divider(height: 1),
+                const SizedBox(height: 16),
+              ],
+              _QuestionFeedback(
+                index: index,
+                question: report.questions[index],
+                report: report,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QuestionFeedback extends StatelessWidget {
+  const _QuestionFeedback({
+    required this.index,
+    required this.question,
+    required this.report,
+  });
+
+  final int index;
+  final InterviewReportQuestion question;
+  final InterviewReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final findingIds = <String>{};
+    for (final result in question.dimensionFindings) {
+      findingIds.addAll(result.strengthFindingIds);
+      findingIds.addAll(result.improvementFindingIds);
+      findingIds.addAll(result.recommendedExpressionFindingIds);
+    }
+    final findings = findingIds
+        .map(report.finding)
+        .whereType<InterviewReportFinding>()
+        .toList(growable: false);
+    return Column(
+      key: Key('interview-report-question-${question.questionId}'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('问题 ${index + 1}', style: SpeakUpDesign.meta),
+        const SizedBox(height: 4),
+        Text(question.questionText, style: SpeakUpDesign.label),
+        const SizedBox(height: 8),
+        if (question.confirmedTranscript case final response?) ...[
+          Text('你的原回答', style: SpeakUpDesign.meta),
+          const SizedBox(height: 3),
+          Text(response, style: SpeakUpDesign.body),
+        ] else
+          Text('本题未提供可确认的回答。', style: SpeakUpDesign.body),
+        for (final finding in findings) ...[
+          const SizedBox(height: 9),
+          Text(finding.message, style: SpeakUpDesign.body),
+          if (finding.suggestion case final suggestion?) ...[
+            const SizedBox(height: 3),
+            Text('建议：$suggestion', style: SpeakUpDesign.body),
+          ],
+        ],
+      ],
+    );
+  }
+}
+
+class _PriorityActions extends StatelessWidget {
+  const _PriorityActions({required this.report});
+
+  final InterviewReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('interview-report-priority-actions'),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('优先改进', style: SpeakUpDesign.cardTitle),
+            const SizedBox(height: 12),
+            for (var index = 0; index < report.priorityActions.length; index++)
+              Padding(
+                padding: EdgeInsets.only(
+                  bottom: index + 1 == report.priorityActions.length ? 0 : 10,
+                ),
+                child: Text(
+                  '${index + 1}. ${_actionText(report, report.priorityActions[index])}',
+                  style: SpeakUpDesign.body,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _actionText(
+  InterviewReport report,
+  InterviewReportPriorityAction action,
+) {
+  final finding = report.finding(action.findingId)!;
+  return finding.suggestion ?? finding.message;
+}
+
+String _dimensionLabel(InterviewReportDimensionId dimension) =>
+    switch (dimension) {
+      InterviewReportDimensionId.relevance => '回答相关性',
+      InterviewReportDimensionId.structure => '表达结构',
+      InterviewReportDimensionId.evidence => '事实与证据',
+      InterviewReportDimensionId.professional => '职业表达',
+      InterviewReportDimensionId.interaction => '追问互动',
+    };

--- a/mobile/lib/features/review/review.dart
+++ b/mobile/lib/features/review/review.dart
@@ -8,8 +8,11 @@ import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/features/review/interview_report_view.dart';
 import 'package:speakup/practice/practice_recordings.dart';
 import 'package:speakup/review/formal_review.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/interview_report_controller.dart';
 import 'package:speakup/review/review_history_client.dart';
 import 'package:speakup/review/review_history_controller.dart';
 
@@ -20,6 +23,7 @@ class ReviewPage extends StatefulWidget {
     this.practiceAvailable = true,
     this.historyController,
     this.agentController,
+    this.interviewReportController,
     this.autoload = true,
     super.key,
   });
@@ -29,6 +33,7 @@ class ReviewPage extends StatefulWidget {
   final bool practiceAvailable;
   final ReviewHistoryController? historyController;
   final AgentController? agentController;
+  final InterviewReportController? interviewReportController;
   final bool autoload;
 
   @override
@@ -81,7 +86,10 @@ class _ReviewPageState extends State<ReviewPage> {
     unawaited(
       Navigator.of(context).push<void>(
         MaterialPageRoute<void>(
-          builder: (_) => _ReviewDetailPage(entry: entry),
+          builder: (_) => _ReviewDetailPage(
+            entry: entry,
+            interviewReportController: widget.interviewReportController,
+          ),
         ),
       ),
     );
@@ -549,9 +557,13 @@ class _EmptyReview extends StatelessWidget {
 }
 
 class _ReviewDetailPage extends StatefulWidget {
-  const _ReviewDetailPage({required this.entry});
+  const _ReviewDetailPage({
+    required this.entry,
+    required this.interviewReportController,
+  });
 
   final _ReviewListEntry entry;
+  final InterviewReportController? interviewReportController;
 
   @override
   State<_ReviewDetailPage> createState() => _ReviewDetailPageState();
@@ -565,7 +577,9 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
   void initState() {
     super.initState();
     widget.entry.agentController?.addListener(_rebuild);
+    widget.interviewReportController?.addListener(_rebuild);
     _ignoredInitialMediaError = _matchingController()?.mediaErrorMessage;
+    _loadInterviewReport();
   }
 
   @override
@@ -575,16 +589,43 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
       oldWidget.entry.agentController?.removeListener(_rebuild);
       widget.entry.agentController?.addListener(_rebuild);
     }
+    if (oldWidget.interviewReportController !=
+        widget.interviewReportController) {
+      oldWidget.interviewReportController?.removeListener(_rebuild);
+      widget.interviewReportController?.addListener(_rebuild);
+    }
     _visibleMediaError = null;
     _ignoredInitialMediaError = _matchingController()?.mediaErrorMessage;
+    if (_interviewSessionId(oldWidget.entry) !=
+            _interviewSessionId(widget.entry) ||
+        oldWidget.interviewReportController !=
+            widget.interviewReportController) {
+      final oldSessionId = _interviewSessionId(oldWidget.entry);
+      if (oldSessionId != null) {
+        oldWidget.interviewReportController?.cancel(oldSessionId);
+      }
+      _loadInterviewReport();
+    }
   }
 
   @override
   void dispose() {
     final attachedController = widget.entry.agentController;
     attachedController?.removeListener(_rebuild);
+    widget.interviewReportController?.removeListener(_rebuild);
     unawaited(_matchingController()?.stopPracticeAudio(notify: false));
+    final sessionId = _interviewSessionId(widget.entry);
+    if (sessionId != null) {
+      widget.interviewReportController?.cancel(sessionId);
+    }
     super.dispose();
+  }
+
+  void _loadInterviewReport() {
+    final sessionId = _interviewSessionId(widget.entry);
+    if (sessionId != null) {
+      unawaited(widget.interviewReportController?.load(sessionId));
+    }
   }
 
   void _rebuild() {
@@ -622,6 +663,13 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
         ? formalReview
         : null;
     final scenarioResult = scenarioReview?.result;
+    final interviewSessionId = _interviewSessionId(entry);
+    final interviewReportController = widget.interviewReportController;
+    final showInterviewReport =
+        interviewSessionId != null &&
+        interviewReportController != null &&
+        interviewReportController.failureKind !=
+            InterviewReportFailureKind.notFound;
     return Scaffold(
       key: const Key('review-detail-page'),
       appBar: AppBar(
@@ -641,44 +689,48 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
           children: [
             _ReviewDetailHeader(entry: entry),
             const SizedBox(height: 12),
-            _ReviewDetailSection(
-              key: const Key('review-detail-summary'),
-              title: '整体表现',
-              body: review.summary,
-            ),
-            if (scenarioReview != null && scenarioResult != null) ...[
-              if (_reviewNotice(scenarioReview) case final notice?) ...[
+            if (showInterviewReport)
+              InterviewReportPanel(controller: interviewReportController)
+            else ...[
+              _ReviewDetailSection(
+                key: const Key('review-detail-summary'),
+                title: '整体表现',
+                body: review.summary,
+              ),
+              if (scenarioReview != null && scenarioResult != null) ...[
+                if (_reviewNotice(scenarioReview) case final notice?) ...[
+                  const SizedBox(height: 12),
+                  _ReviewStatusNotice(
+                    key: const Key('review-detail-status-notice'),
+                    title: notice.title,
+                    message: notice.message,
+                  ),
+                ],
+                if (scenarioResult.dimensions.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _ReviewDimensions(dimensions: scenarioResult.dimensions),
+                ],
+                if (scenarioResult.feedbackItems.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  _ReviewFeedback(
+                    items: scenarioResult.feedbackItems,
+                    priorityRefs: scenarioResult.repracticeSuggestionRefs,
+                  ),
+                ],
+              ] else ...[
                 const SizedBox(height: 12),
-                _ReviewStatusNotice(
-                  key: const Key('review-detail-status-notice'),
-                  title: notice.title,
-                  message: notice.message,
+                _ReviewDetailSection(
+                  key: const Key('review-detail-strength'),
+                  title: '做得好的地方',
+                  body: review.strength,
+                ),
+                const SizedBox(height: 12),
+                _ReviewDetailSection(
+                  key: const Key('review-detail-focus'),
+                  title: '下一次重点',
+                  body: review.nextFocus,
                 ),
               ],
-              if (scenarioResult.dimensions.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                _ReviewDimensions(dimensions: scenarioResult.dimensions),
-              ],
-              if (scenarioResult.feedbackItems.isNotEmpty) ...[
-                const SizedBox(height: 12),
-                _ReviewFeedback(
-                  items: scenarioResult.feedbackItems,
-                  priorityRefs: scenarioResult.repracticeSuggestionRefs,
-                ),
-              ],
-            ] else ...[
-              const SizedBox(height: 12),
-              _ReviewDetailSection(
-                key: const Key('review-detail-strength'),
-                title: '做得好的地方',
-                body: review.strength,
-              ),
-              const SizedBox(height: 12),
-              _ReviewDetailSection(
-                key: const Key('review-detail-focus'),
-                title: '下一次重点',
-                body: review.nextFocus,
-              ),
             ],
             if (hasRecordingControls) ...[
               const SizedBox(height: 12),
@@ -697,6 +749,15 @@ class _ReviewDetailPageState extends State<_ReviewDetailPage> {
       ),
     );
   }
+}
+
+String? _interviewSessionId(_ReviewListEntry entry) {
+  final review = entry.formalReview;
+  if (review?.schema != FormalReviewSchema.scenarioV2 ||
+      review?.contextType != FormalReviewContextType.interviewProjectDeepDive) {
+    return null;
+  }
+  return review!.practiceSessionId;
 }
 
 class _ReviewStatusNotice extends StatelessWidget {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -29,7 +29,9 @@ import 'package:speakup/practice/practice_audio_player.dart';
 import 'package:speakup/practice/practice_media.dart';
 import 'package:speakup/practice/practice_recording.dart';
 import 'package:speakup/practice/wire_practice_client.dart';
+import 'package:speakup/review/interview_report_controller.dart';
 import 'package:speakup/review/review_history_controller.dart';
+import 'package:speakup/review/wire_interview_report_client.dart';
 import 'package:speakup/review/wire_review_history_client.dart';
 
 void main() {
@@ -50,6 +52,7 @@ void main() {
       preparationLaunchController: dependencies.preparationLaunchController,
       reviewHistoryController: dependencies.reviewHistoryController,
       avatarControllerFactory: dependencies.avatarControllerFactory,
+      interviewReportController: dependencies.interviewReportController,
     ),
   );
 }
@@ -63,6 +66,7 @@ final class ProductionAppDependencies {
     required this.preparationLaunchController,
     required this.reviewHistoryController,
     required this.avatarControllerFactory,
+    required this.interviewReportController,
   });
 
   final AuthController authController;
@@ -72,6 +76,7 @@ final class ProductionAppDependencies {
   final PreparationLaunchController preparationLaunchController;
   final ReviewHistoryController reviewHistoryController;
   final AvatarControllerFactory avatarControllerFactory;
+  final InterviewReportController interviewReportController;
 }
 
 ProductionAppDependencies createProductionAppDependencies({
@@ -84,6 +89,7 @@ ProductionAppDependencies createProductionAppDependencies({
   IdentityHttpTransport? jobPreparationTransport,
   IdentityHttpTransport? preparationLaunchTransport,
   IdentityHttpTransport? reviewHistoryTransport,
+  IdentityHttpTransport? interviewReportTransport,
   PracticeWireTransport? practiceTransport,
   PracticeMediaWireTransport? practiceMediaTransport,
   PracticeMediaWireTransport? signedAudioTransport,
@@ -215,6 +221,20 @@ ProductionAppDependencies createProductionAppDependencies({
             );
           },
       transport: reviewHistoryTransport,
+    ),
+  );
+  final interviewReportController = InterviewReportController(
+    client: WireInterviewReportClient(
+      baseUri: baseUri,
+      credentialProvider: () => authController.currentCredential,
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) {
+            return authController.invalidateSession(
+              expectedSessionToken: expectedSessionToken,
+              expectedGeneration: expectedGeneration,
+            );
+          },
+      transport: interviewReportTransport,
     ),
   );
   final preparationCatalogClient = WirePreparationCatalogClient(
@@ -351,14 +371,20 @@ ProductionAppDependencies createProductionAppDependencies({
     profileClient: identityClient,
     sessionStore: sessionStore ?? const IosKeychainSessionStore(),
     clearPrivateState: () async {
-      await preparationLaunchController.clearPrivateState();
-      await clearAvatarPrivateState();
-      await Future.wait<void>([
-        agentController.clearPrivateState(),
-        preparationController.clearPrivateState(),
-        jobPreparationController.clearPrivateState(),
-        reviewHistoryController.clearPrivateState(),
-      ]);
+      final interviewReportCleanup = interviewReportController
+          .clearPrivateState();
+      try {
+        await preparationLaunchController.clearPrivateState();
+        await clearAvatarPrivateState();
+        await Future.wait<void>([
+          agentController.clearPrivateState(),
+          preparationController.clearPrivateState(),
+          jobPreparationController.clearPrivateState(),
+          reviewHistoryController.clearPrivateState(),
+        ]);
+      } finally {
+        await interviewReportCleanup;
+      }
     },
   );
   return ProductionAppDependencies(
@@ -369,5 +395,6 @@ ProductionAppDependencies createProductionAppDependencies({
     preparationLaunchController: preparationLaunchController,
     reviewHistoryController: reviewHistoryController,
     avatarControllerFactory: createAvatarController,
+    interviewReportController: interviewReportController,
   );
 }

--- a/mobile/lib/review/interview_report.dart
+++ b/mobile/lib/review/interview_report.dart
@@ -1,0 +1,198 @@
+enum InterviewReportEvaluationStatus { queued, running, ready, failed }
+
+enum InterviewReportScoreabilityStatus { provisional, insufficient }
+
+enum InterviewReportGateStatus { feedbackOnly, blocked }
+
+enum InterviewReportReadinessLevel { notAssessed }
+
+enum InterviewReportOpportunityStatus { provided, notProvided }
+
+enum InterviewReportAssessmentStatus { assessed, notAssessed }
+
+enum InterviewReportQuestionType { primary, followUp }
+
+enum InterviewReportDimensionId {
+  relevance,
+  structure,
+  evidence,
+  professional,
+  interaction,
+}
+
+final class InterviewReportEnvelope {
+  const InterviewReportEnvelope({
+    required this.practiceSessionId,
+    required this.evaluationId,
+    required this.evaluationRevisionId,
+    required this.revision,
+    required this.evaluationStatus,
+    required this.isFinal,
+    required this.statusUrl,
+    this.report,
+    this.stableFailure,
+  });
+
+  final String practiceSessionId;
+  final String evaluationId;
+  final String evaluationRevisionId;
+  final int revision;
+  final InterviewReportEvaluationStatus evaluationStatus;
+  final bool isFinal;
+  final String statusUrl;
+  final InterviewReport? report;
+  final InterviewReportStableFailure? stableFailure;
+}
+
+final class InterviewReportStableFailure {
+  const InterviewReportStableFailure({
+    required this.reasonCode,
+    required this.retryable,
+  });
+
+  final String reasonCode;
+  final bool retryable;
+}
+
+final class InterviewReport {
+  const InterviewReport({
+    required this.schemaVersion,
+    required this.scoreabilityStatus,
+    required this.gateStatus,
+    required this.readinessLevel,
+    required this.readinessNotice,
+    required this.dimensions,
+    required this.questions,
+    required this.priorityActions,
+  });
+
+  final String schemaVersion;
+  final InterviewReportScoreabilityStatus scoreabilityStatus;
+  final InterviewReportGateStatus gateStatus;
+  final InterviewReportReadinessLevel readinessLevel;
+  final String readinessNotice;
+  final List<InterviewReportDimension> dimensions;
+  final List<InterviewReportQuestion> questions;
+  final List<InterviewReportPriorityAction> priorityActions;
+
+  InterviewReportFinding? finding(String findingId) {
+    for (final dimension in dimensions) {
+      for (final finding in [
+        ...dimension.strengths,
+        ...dimension.improvements,
+        ...dimension.recommendedExpressions,
+      ]) {
+        if (finding.id == findingId) {
+          return finding;
+        }
+      }
+    }
+    return null;
+  }
+}
+
+final class InterviewReportDimension {
+  const InterviewReportDimension({
+    required this.id,
+    required this.scoreabilityStatus,
+    required this.gateStatus,
+    required this.coverage,
+    required this.confidence,
+    required this.reasonCodes,
+    required this.evidenceRefIds,
+    required this.strengths,
+    required this.improvements,
+    required this.recommendedExpressions,
+  });
+
+  final InterviewReportDimensionId id;
+  final InterviewReportScoreabilityStatus scoreabilityStatus;
+  final InterviewReportGateStatus gateStatus;
+  final double coverage;
+  final double confidence;
+  final List<String> reasonCodes;
+  final List<String> evidenceRefIds;
+  final List<InterviewReportFinding> strengths;
+  final List<InterviewReportFinding> improvements;
+  final List<InterviewReportFinding> recommendedExpressions;
+}
+
+final class InterviewReportFinding {
+  const InterviewReportFinding({
+    required this.id,
+    required this.message,
+    required this.evidence,
+    this.suggestion,
+  });
+
+  final String id;
+  final String message;
+  final String? suggestion;
+  final List<InterviewReportEvidence> evidence;
+}
+
+final class InterviewReportEvidence {
+  const InterviewReportEvidence({
+    required this.evidenceRefId,
+    required this.turnId,
+    required this.startUtf8Byte,
+    required this.endUtf8Byte,
+    required this.originalExcerpt,
+  });
+
+  final String evidenceRefId;
+  final String turnId;
+  final int startUtf8Byte;
+  final int endUtf8Byte;
+  final String originalExcerpt;
+}
+
+final class InterviewReportQuestion {
+  const InterviewReportQuestion({
+    required this.questionId,
+    required this.questionType,
+    required this.opportunityStatus,
+    required this.questionText,
+    required this.evidenceRefIds,
+    required this.assessmentStatus,
+    required this.dimensionFindings,
+    this.parentQuestionId,
+    this.responseTurnId,
+    this.confirmedTranscript,
+  });
+
+  final String questionId;
+  final InterviewReportQuestionType questionType;
+  final String? parentQuestionId;
+  final InterviewReportOpportunityStatus opportunityStatus;
+  final InterviewReportAssessmentStatus assessmentStatus;
+  final String questionText;
+  final String? responseTurnId;
+  final String? confirmedTranscript;
+  final List<String> evidenceRefIds;
+  final List<InterviewReportQuestionDimensionFindings> dimensionFindings;
+}
+
+final class InterviewReportQuestionDimensionFindings {
+  const InterviewReportQuestionDimensionFindings({
+    required this.dimensionId,
+    required this.strengthFindingIds,
+    required this.improvementFindingIds,
+    required this.recommendedExpressionFindingIds,
+  });
+
+  final InterviewReportDimensionId dimensionId;
+  final List<String> strengthFindingIds;
+  final List<String> improvementFindingIds;
+  final List<String> recommendedExpressionFindingIds;
+}
+
+final class InterviewReportPriorityAction {
+  const InterviewReportPriorityAction({
+    required this.dimensionId,
+    required this.findingId,
+  });
+
+  final InterviewReportDimensionId dimensionId;
+  final String findingId;
+}

--- a/mobile/lib/review/interview_report_client.dart
+++ b/mobile/lib/review/interview_report_client.dart
@@ -1,0 +1,32 @@
+import 'package:speakup/review/interview_report.dart';
+
+enum InterviewReportFailureKind {
+  authenticationRequired,
+  notFound,
+  conflict,
+  network,
+  server,
+  invalidResponse,
+  superseded,
+}
+
+final class InterviewReportException implements Exception {
+  const InterviewReportException({
+    required this.kind,
+    this.statusCode,
+    this.retryable = false,
+  });
+
+  final InterviewReportFailureKind kind;
+  final int? statusCode;
+  final bool retryable;
+
+  @override
+  String toString() => 'InterviewReportException(kind: ${kind.name})';
+}
+
+abstract interface class InterviewReportClient {
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId);
+
+  Future<void> clearAccountState();
+}

--- a/mobile/lib/review/interview_report_controller.dart
+++ b/mobile/lib/review/interview_report_controller.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+
+final class InterviewReportController extends ChangeNotifier {
+  InterviewReportController({
+    required this.client,
+    this.pollInterval = const Duration(seconds: 2),
+    this.maximumPollAttempts = 8,
+  }) {
+    if (pollInterval < Duration.zero) {
+      throw ArgumentError.value(pollInterval, 'pollInterval');
+    }
+    if (maximumPollAttempts < 1) {
+      throw ArgumentError.value(maximumPollAttempts, 'maximumPollAttempts');
+    }
+  }
+
+  final InterviewReportClient client;
+  final Duration pollInterval;
+  final int maximumPollAttempts;
+
+  String? _practiceSessionId;
+  InterviewReportEnvelope? _envelope;
+  String? _errorMessage;
+  InterviewReportFailureKind? _failureKind;
+  bool _loading = false;
+  bool _canRetry = false;
+  bool _disposed = false;
+  int _requestGeneration = 0;
+
+  String? get practiceSessionId => _practiceSessionId;
+  InterviewReportEnvelope? get envelope => _envelope;
+  String? get errorMessage => _errorMessage;
+  InterviewReportFailureKind? get failureKind => _failureKind;
+  bool get isLoading => _loading;
+  bool get canRetry => _canRetry;
+
+  Future<void> load(String practiceSessionId) async {
+    if (_disposed || practiceSessionId.isEmpty) {
+      return;
+    }
+    final generation = ++_requestGeneration;
+    _practiceSessionId = practiceSessionId;
+    _envelope = null;
+    _errorMessage = null;
+    _failureKind = null;
+    _canRetry = false;
+    _loading = true;
+    notifyListeners();
+
+    for (var attempt = 0; attempt < maximumPollAttempts; attempt++) {
+      try {
+        final envelope = await client.getReport(practiceSessionId);
+        if (!_isCurrent(generation, practiceSessionId)) {
+          return;
+        }
+        _envelope = envelope;
+        _errorMessage = null;
+        _failureKind = null;
+        final pending =
+            envelope.evaluationStatus ==
+                InterviewReportEvaluationStatus.queued ||
+            envelope.evaluationStatus ==
+                InterviewReportEvaluationStatus.running;
+        if (!pending) {
+          _loading = false;
+          _canRetry =
+              envelope.evaluationStatus ==
+                  InterviewReportEvaluationStatus.failed &&
+              (envelope.stableFailure?.retryable ?? false);
+          notifyListeners();
+          return;
+        }
+        notifyListeners();
+        if (attempt + 1 < maximumPollAttempts) {
+          await Future<void>.delayed(pollInterval);
+          if (!_isCurrent(generation, practiceSessionId)) {
+            return;
+          }
+        }
+      } on InterviewReportException catch (error) {
+        if (!_isCurrent(generation, practiceSessionId) ||
+            error.kind == InterviewReportFailureKind.superseded) {
+          return;
+        }
+        _loading = false;
+        _failureKind = error.kind;
+        _canRetry =
+            error.retryable ||
+            error.kind == InterviewReportFailureKind.notFound;
+        _errorMessage = _messageFor(error);
+        notifyListeners();
+        return;
+      } on Object {
+        if (!_isCurrent(generation, practiceSessionId)) {
+          return;
+        }
+        _loading = false;
+        _failureKind = InterviewReportFailureKind.network;
+        _canRetry = true;
+        _errorMessage = '面试报告暂时无法加载，请稍后重试。';
+        notifyListeners();
+        return;
+      }
+    }
+    if (_isCurrent(generation, practiceSessionId)) {
+      _loading = false;
+      _failureKind = InterviewReportFailureKind.network;
+      _canRetry = true;
+      _errorMessage = '报告仍在生成，请稍后重试。';
+      notifyListeners();
+    }
+  }
+
+  Future<void> retry() {
+    final sessionId = _practiceSessionId;
+    return sessionId == null ? Future<void>.value() : load(sessionId);
+  }
+
+  void cancel(String practiceSessionId) {
+    if (_disposed || _practiceSessionId != practiceSessionId) {
+      return;
+    }
+    _requestGeneration++;
+    _reset();
+    notifyListeners();
+  }
+
+  Future<void> clearPrivateState() async {
+    _requestGeneration++;
+    _reset();
+    await client.clearAccountState();
+    if (!_disposed) {
+      notifyListeners();
+    }
+  }
+
+  bool _isCurrent(int generation, String practiceSessionId) =>
+      !_disposed &&
+      generation == _requestGeneration &&
+      practiceSessionId == _practiceSessionId;
+
+  void _reset() {
+    _practiceSessionId = null;
+    _envelope = null;
+    _errorMessage = null;
+    _failureKind = null;
+    _loading = false;
+    _canRetry = false;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _requestGeneration++;
+    _reset();
+    super.dispose();
+  }
+}
+
+String _messageFor(InterviewReportException error) {
+  return switch (error.kind) {
+    InterviewReportFailureKind.authenticationRequired => '登录状态已失效，请重新登录。',
+    InterviewReportFailureKind.notFound => '这次面试的报告尚未生成。',
+    InterviewReportFailureKind.conflict => '这次面试存在多份结果，暂时无法安全展示。',
+    InterviewReportFailureKind.invalidResponse => '面试报告响应无法识别，请稍后重试。',
+    InterviewReportFailureKind.network ||
+    InterviewReportFailureKind.server => '面试报告暂时无法加载，请稍后重试。',
+    InterviewReportFailureKind.superseded => '',
+  };
+}

--- a/mobile/lib/review/interview_report_decoder.dart
+++ b/mobile/lib/review/interview_report_decoder.dart
@@ -1,0 +1,773 @@
+import 'dart:convert';
+
+import 'package:speakup/review/interview_report.dart';
+
+final class InterviewReportDecodeException implements Exception {
+  const InterviewReportDecodeException();
+
+  @override
+  String toString() => 'InterviewReportDecodeException';
+}
+
+InterviewReportEnvelope decodeInterviewReportJson(String body) {
+  try {
+    return decodeInterviewReport(jsonDecode(body));
+  } on FormatException {
+    throw const InterviewReportDecodeException();
+  }
+}
+
+InterviewReportEnvelope decodeInterviewReport(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'practice_session_id',
+      'evaluation_id',
+      'evaluation_revision_id',
+      'revision',
+      'evaluation_status',
+      'is_final',
+      'status_url',
+    },
+    optional: const {'report', 'stable_failure'},
+  );
+  final practiceSessionId = _identifier(root['practice_session_id']);
+  final evaluationId = _uuid(root['evaluation_id']);
+  final evaluationRevisionId = _uuid(root['evaluation_revision_id']);
+  final revision = _positiveInt(root['revision']);
+  final status = _evaluationStatus(root['evaluation_status']);
+  final isFinal = root['is_final'];
+  final statusUrl = root['status_url'];
+  if (isFinal != false ||
+      statusUrl is! String ||
+      statusUrl !=
+          '/v1/practice-sessions/$practiceSessionId/interview-report') {
+    throw const InterviewReportDecodeException();
+  }
+
+  final hasReport = root.containsKey('report');
+  final hasFailure = root.containsKey('stable_failure');
+  if ((hasReport && root['report'] == null) ||
+      (hasFailure && root['stable_failure'] == null)) {
+    throw const InterviewReportDecodeException();
+  }
+  InterviewReport? report;
+  InterviewReportStableFailure? failure;
+  switch (status) {
+    case InterviewReportEvaluationStatus.queued:
+    case InterviewReportEvaluationStatus.running:
+      if (hasReport || hasFailure) {
+        throw const InterviewReportDecodeException();
+      }
+    case InterviewReportEvaluationStatus.ready:
+      if (!hasReport || hasFailure) {
+        throw const InterviewReportDecodeException();
+      }
+      report = _report(root['report']);
+    case InterviewReportEvaluationStatus.failed:
+      if (hasReport || !hasFailure) {
+        throw const InterviewReportDecodeException();
+      }
+      failure = _failure(root['stable_failure']);
+  }
+  return InterviewReportEnvelope(
+    practiceSessionId: practiceSessionId,
+    evaluationId: evaluationId,
+    evaluationRevisionId: evaluationRevisionId,
+    revision: revision,
+    evaluationStatus: status,
+    isFinal: false,
+    statusUrl: statusUrl,
+    report: report,
+    stableFailure: failure,
+  );
+}
+
+InterviewReport _report(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'schema_version',
+      'scoreability_status',
+      'gate_status',
+      'readiness_level',
+      'readiness_notice',
+      'dimensions',
+      'questions',
+      'priority_actions',
+    },
+  );
+  if (root['schema_version'] != 'interview-report/v1') {
+    throw const InterviewReportDecodeException();
+  }
+  final scoreability = _scoreability(root['scoreability_status']);
+  final gate = _gate(root['gate_status']);
+  if ((scoreability == InterviewReportScoreabilityStatus.provisional &&
+          gate != InterviewReportGateStatus.feedbackOnly) ||
+      (scoreability == InterviewReportScoreabilityStatus.insufficient &&
+          gate != InterviewReportGateStatus.blocked)) {
+    throw const InterviewReportDecodeException();
+  }
+  final readinessNotice = _text(root['readiness_notice'], maxBytes: 256);
+  if (readinessNotice != _expectedReadinessNotice) {
+    throw const InterviewReportDecodeException();
+  }
+  final dimensions = _dimensions(root['dimensions']);
+  final findings =
+      <
+        String,
+        ({
+          InterviewReportDimensionId dimension,
+          String kind,
+          InterviewReportFinding finding,
+        })
+      >{};
+  final evidenceTurns = <String, String>{};
+  final evidenceAnchors = <InterviewReportEvidence>[];
+  for (final dimension in dimensions) {
+    if (!_validDimensionGate(
+      rootScoreability: scoreability,
+      rootGate: gate,
+      dimension: dimension,
+    )) {
+      throw const InterviewReportDecodeException();
+    }
+    final dimensionEvidence = <String>{};
+    for (final group in <({String kind, List<InterviewReportFinding> values})>[
+      (kind: 'strength', values: dimension.strengths),
+      (kind: 'improvement', values: dimension.improvements),
+      (
+        kind: 'recommended_expression',
+        values: dimension.recommendedExpressions,
+      ),
+    ]) {
+      for (final finding in group.values) {
+        if (findings.containsKey(finding.id)) {
+          throw const InterviewReportDecodeException();
+        }
+        findings[finding.id] = (
+          dimension: dimension.id,
+          kind: group.kind,
+          finding: finding,
+        );
+        for (final item in finding.evidence) {
+          dimensionEvidence.add(item.evidenceRefId);
+          final existingTurn = evidenceTurns[item.evidenceRefId];
+          if (existingTurn != null && existingTurn != item.turnId) {
+            throw const InterviewReportDecodeException();
+          }
+          evidenceTurns[item.evidenceRefId] = item.turnId;
+          evidenceAnchors.add(item);
+        }
+      }
+    }
+    if (!_sameSet(dimensionEvidence, dimension.evidenceRefIds.toSet())) {
+      throw const InterviewReportDecodeException();
+    }
+  }
+
+  final questions = _questions(root['questions']);
+  final questionIds = questions.map((question) => question.questionId).toSet();
+  if (questionIds.length != questions.length) {
+    throw const InterviewReportDecodeException();
+  }
+  final questionsById = <String, InterviewReportQuestion>{
+    for (final question in questions) question.questionId: question,
+  };
+  final questionsByTurnId = <String, InterviewReportQuestion>{};
+  for (final question in questions) {
+    final parent = question.parentQuestionId;
+    if ((question.questionType == InterviewReportQuestionType.primary &&
+            parent != null) ||
+        (question.questionType == InterviewReportQuestionType.followUp &&
+            (parent == null ||
+                parent == question.questionId ||
+                questionsById[parent]?.questionType !=
+                    InterviewReportQuestionType.primary))) {
+      throw const InterviewReportDecodeException();
+    }
+    final responseTurnId = question.responseTurnId;
+    if (responseTurnId != null &&
+        questionsByTurnId.putIfAbsent(responseTurnId, () => question) !=
+            question) {
+      throw const InterviewReportDecodeException();
+    }
+    for (final ref in question.evidenceRefIds) {
+      final evidenceTurn = evidenceTurns[ref];
+      if (evidenceTurn != null && evidenceTurn != responseTurnId) {
+        throw const InterviewReportDecodeException();
+      }
+    }
+    for (final result in question.dimensionFindings) {
+      for (final group in <({String kind, List<String> ids})>[
+        (kind: 'strength', ids: result.strengthFindingIds),
+        (kind: 'improvement', ids: result.improvementFindingIds),
+        (
+          kind: 'recommended_expression',
+          ids: result.recommendedExpressionFindingIds,
+        ),
+      ]) {
+        for (final id in group.ids) {
+          final resolved = findings[id];
+          if (resolved == null ||
+              resolved.dimension != result.dimensionId ||
+              resolved.kind != group.kind ||
+              !resolved.finding.evidence.any(
+                (item) => question.evidenceRefIds.contains(item.evidenceRefId),
+              )) {
+            throw const InterviewReportDecodeException();
+          }
+        }
+      }
+    }
+  }
+  for (final evidence in evidenceAnchors) {
+    final question = questionsByTurnId[evidence.turnId];
+    if (question == null ||
+        !question.evidenceRefIds.contains(evidence.evidenceRefId) ||
+        question.confirmedTranscript == null ||
+        !_containsExcerpt(question.confirmedTranscript!, evidence)) {
+      throw const InterviewReportDecodeException();
+    }
+  }
+
+  final priorityActions = _priorityActions(root['priority_actions']);
+  for (final action in priorityActions) {
+    final resolved = findings[action.findingId];
+    if (resolved == null ||
+        resolved.dimension != action.dimensionId ||
+        resolved.kind != 'improvement' ||
+        resolved.finding.suggestion == null) {
+      throw const InterviewReportDecodeException();
+    }
+  }
+  if (scoreability == InterviewReportScoreabilityStatus.insufficient &&
+      (priorityActions.isNotEmpty ||
+          dimensions.any(
+            (dimension) =>
+                dimension.strengths.isNotEmpty ||
+                dimension.improvements.isNotEmpty ||
+                dimension.recommendedExpressions.isNotEmpty,
+          ))) {
+    throw const InterviewReportDecodeException();
+  }
+  return InterviewReport(
+    schemaVersion: 'interview-report/v1',
+    scoreabilityStatus: scoreability,
+    gateStatus: gate,
+    readinessLevel: _readiness(root['readiness_level']),
+    readinessNotice: readinessNotice,
+    dimensions: dimensions,
+    questions: questions,
+    priorityActions: priorityActions,
+  );
+}
+
+List<InterviewReportDimension> _dimensions(Object? value) {
+  if (value is! List<Object?> || value.length != _dimensionOrder.length) {
+    throw const InterviewReportDecodeException();
+  }
+  return List<InterviewReportDimension>.unmodifiable([
+    for (var index = 0; index < value.length; index++)
+      _dimension(value[index], expected: _dimensionOrder[index]),
+  ]);
+}
+
+InterviewReportDimension _dimension(
+  Object? value, {
+  required InterviewReportDimensionId expected,
+}) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'dimension_id',
+      'scoreability_status',
+      'gate_status',
+      'coverage',
+      'confidence',
+      'reason_codes',
+      'evidence_ref_ids',
+      'strengths',
+      'improvements',
+      'recommended_expressions',
+    },
+  );
+  final id = _dimensionId(root['dimension_id']);
+  if (id != expected) {
+    throw const InterviewReportDecodeException();
+  }
+  final result = InterviewReportDimension(
+    id: id,
+    scoreabilityStatus: _scoreability(root['scoreability_status']),
+    gateStatus: _gate(root['gate_status']),
+    coverage: _ratio(root['coverage']),
+    confidence: _ratio(root['confidence']),
+    reasonCodes: _reasonCodes(root['reason_codes']),
+    evidenceRefIds: _uniqueIdentifiers(root['evidence_ref_ids']),
+    strengths: _findings(root['strengths']),
+    improvements: _findings(root['improvements']),
+    recommendedExpressions: _findings(root['recommended_expressions']),
+  );
+  if (result.reasonCodes.length != 1) {
+    throw const InterviewReportDecodeException();
+  }
+  if (result.scoreabilityStatus ==
+      InterviewReportScoreabilityStatus.provisional) {
+    if (result.gateStatus != InterviewReportGateStatus.feedbackOnly ||
+        result.reasonCodes.single != 'ASR_CONFIDENCE_UNAVAILABLE' ||
+        result.evidenceRefIds.isEmpty ||
+        (result.strengths.isEmpty && result.improvements.isEmpty)) {
+      throw const InterviewReportDecodeException();
+    }
+  } else if (result.gateStatus != InterviewReportGateStatus.blocked ||
+      !const {
+        'INSUFFICIENT_EVIDENCE',
+        'OPPORTUNITY_NOT_PROVIDED',
+      }.contains(result.reasonCodes.single) ||
+      result.evidenceRefIds.isNotEmpty ||
+      result.strengths.isNotEmpty ||
+      result.improvements.isNotEmpty ||
+      result.recommendedExpressions.isNotEmpty) {
+    throw const InterviewReportDecodeException();
+  }
+  return result;
+}
+
+List<InterviewReportFinding> _findings(Object? value) {
+  if (value is! List<Object?> || value.length > 3) {
+    throw const InterviewReportDecodeException();
+  }
+  return List<InterviewReportFinding>.unmodifiable(
+    value.map((item) {
+      final root = _exactObject(
+        item,
+        required: const {'finding_id', 'message', 'evidence'},
+        optional: const {'suggestion'},
+      );
+      final evidence = root['evidence'];
+      if (evidence is! List<Object?> ||
+          evidence.isEmpty ||
+          evidence.length > 4) {
+        throw const InterviewReportDecodeException();
+      }
+      return InterviewReportFinding(
+        id: _identifier(root['finding_id']),
+        message: _text(root['message'], maxBytes: _maximumFeedbackTextBytes),
+        suggestion: root.containsKey('suggestion')
+            ? _text(root['suggestion'], maxBytes: _maximumFeedbackTextBytes)
+            : null,
+        evidence: List<InterviewReportEvidence>.unmodifiable(
+          evidence.map(_evidence),
+        ),
+      );
+    }),
+  );
+}
+
+InterviewReportEvidence _evidence(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'evidence_ref_id',
+      'turn_id',
+      'start_utf8_byte',
+      'end_utf8_byte',
+      'original_excerpt',
+    },
+  );
+  final start = _nonNegativeInt(root['start_utf8_byte']);
+  final end = _positiveInt(root['end_utf8_byte']);
+  final excerpt = _text(
+    root['original_excerpt'],
+    maxBytes: _maximumSourceTextBytes,
+  );
+  if (end <= start || utf8.encode(excerpt).length != end - start) {
+    throw const InterviewReportDecodeException();
+  }
+  return InterviewReportEvidence(
+    evidenceRefId: _identifier(root['evidence_ref_id']),
+    turnId: _identifier(root['turn_id']),
+    startUtf8Byte: start,
+    endUtf8Byte: end,
+    originalExcerpt: excerpt,
+  );
+}
+
+List<InterviewReportQuestion> _questions(Object? value) {
+  if (value is! List<Object?> || value.isEmpty || value.length > 64) {
+    throw const InterviewReportDecodeException();
+  }
+  return List<InterviewReportQuestion>.unmodifiable(value.map(_question));
+}
+
+InterviewReportQuestion _question(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'question_id',
+      'question_type',
+      'opportunity_status',
+      'assessment_status',
+      'question_text',
+      'evidence_ref_ids',
+      'dimension_findings',
+    },
+    optional: const {
+      'parent_question_id',
+      'response_turn_id',
+      'confirmed_transcript',
+    },
+  );
+  final opportunity = _opportunity(root['opportunity_status']);
+  final assessment = _assessment(root['assessment_status']);
+  final hasResponseTurn = root.containsKey('response_turn_id');
+  final hasTranscript = root.containsKey('confirmed_transcript');
+  final evidenceRefIds = _uniqueIdentifiers(root['evidence_ref_ids']);
+  if (opportunity == InterviewReportOpportunityStatus.provided) {
+    if (assessment != InterviewReportAssessmentStatus.assessed ||
+        !hasResponseTurn ||
+        !hasTranscript ||
+        evidenceRefIds.isEmpty) {
+      throw const InterviewReportDecodeException();
+    }
+  } else if (assessment != InterviewReportAssessmentStatus.notAssessed ||
+      hasResponseTurn ||
+      hasTranscript ||
+      evidenceRefIds.isNotEmpty) {
+    throw const InterviewReportDecodeException();
+  }
+  final dimensions = root['dimension_findings'];
+  if (dimensions is! List<Object?> ||
+      dimensions.length != _dimensionOrder.length) {
+    throw const InterviewReportDecodeException();
+  }
+  final dimensionFindings = <InterviewReportQuestionDimensionFindings>[
+    for (var index = 0; index < dimensions.length; index++)
+      _questionDimensionFindings(
+        dimensions[index],
+        expected: _dimensionOrder[index],
+      ),
+  ];
+  if (opportunity == InterviewReportOpportunityStatus.notProvided &&
+      dimensionFindings.any(
+        (result) =>
+            result.strengthFindingIds.isNotEmpty ||
+            result.improvementFindingIds.isNotEmpty ||
+            result.recommendedExpressionFindingIds.isNotEmpty,
+      )) {
+    throw const InterviewReportDecodeException();
+  }
+  return InterviewReportQuestion(
+    questionId: _identifier(root['question_id']),
+    questionType: _questionType(root['question_type']),
+    parentQuestionId: root.containsKey('parent_question_id')
+        ? _identifier(root['parent_question_id'])
+        : null,
+    opportunityStatus: opportunity,
+    assessmentStatus: assessment,
+    questionText: _text(
+      root['question_text'],
+      maxBytes: _maximumSourceTextBytes,
+    ),
+    responseTurnId: hasResponseTurn
+        ? _identifier(root['response_turn_id'])
+        : null,
+    confirmedTranscript: hasTranscript
+        ? _text(root['confirmed_transcript'], maxBytes: _maximumSourceTextBytes)
+        : null,
+    evidenceRefIds: evidenceRefIds,
+    dimensionFindings:
+        List<InterviewReportQuestionDimensionFindings>.unmodifiable(
+          dimensionFindings,
+        ),
+  );
+}
+
+InterviewReportQuestionDimensionFindings _questionDimensionFindings(
+  Object? value, {
+  required InterviewReportDimensionId expected,
+}) {
+  final root = _exactObject(
+    value,
+    required: const {
+      'dimension_id',
+      'strength_finding_ids',
+      'improvement_finding_ids',
+      'recommended_expression_finding_ids',
+    },
+  );
+  final id = _dimensionId(root['dimension_id']);
+  if (id != expected) {
+    throw const InterviewReportDecodeException();
+  }
+  return InterviewReportQuestionDimensionFindings(
+    dimensionId: id,
+    strengthFindingIds: _uniqueIdentifiers(
+      root['strength_finding_ids'],
+      maximumItems: 3,
+    ),
+    improvementFindingIds: _uniqueIdentifiers(
+      root['improvement_finding_ids'],
+      maximumItems: 3,
+    ),
+    recommendedExpressionFindingIds: _uniqueIdentifiers(
+      root['recommended_expression_finding_ids'],
+      maximumItems: 3,
+    ),
+  );
+}
+
+List<InterviewReportPriorityAction> _priorityActions(Object? value) {
+  if (value is! List<Object?> || value.length > 3) {
+    throw const InterviewReportDecodeException();
+  }
+  final findingIds = <String>{};
+  return List<InterviewReportPriorityAction>.unmodifiable(
+    value.map((item) {
+      final root = _exactObject(
+        item,
+        required: const {'dimension_id', 'finding_id'},
+      );
+      final findingId = _identifier(root['finding_id']);
+      if (!findingIds.add(findingId)) {
+        throw const InterviewReportDecodeException();
+      }
+      return InterviewReportPriorityAction(
+        dimensionId: _dimensionId(root['dimension_id']),
+        findingId: findingId,
+      );
+    }),
+  );
+}
+
+InterviewReportStableFailure _failure(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const {'reason_code', 'retryable'},
+  );
+  final reasonCode = root['reason_code'];
+  final retryable = root['retryable'];
+  if (reasonCode is! String ||
+      !_failureReasonCodes.contains(reasonCode) ||
+      retryable is! bool ||
+      (reasonCode == 'INTERNAL_RETRYABLE') != retryable) {
+    throw const InterviewReportDecodeException();
+  }
+  return InterviewReportStableFailure(
+    reasonCode: reasonCode,
+    retryable: retryable,
+  );
+}
+
+Map<String, Object?> _exactObject(
+  Object? value, {
+  required Set<String> required,
+  Set<String> optional = const {},
+}) {
+  if (value is! Map<String, Object?>) {
+    throw const InterviewReportDecodeException();
+  }
+  final keys = value.keys.toSet();
+  if (!keys.containsAll(required) ||
+      keys.any((key) => !required.contains(key) && !optional.contains(key))) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+String _identifier(Object? value) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.length > 128 ||
+      value != value.trim() ||
+      !RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]*$').hasMatch(value)) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+String _uuid(Object? value) {
+  if (value is! String ||
+      !RegExp(
+        r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
+      ).hasMatch(value)) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+String _text(Object? value, {required int maxBytes}) {
+  if (value is! String ||
+      value.isEmpty ||
+      value != value.trim() ||
+      utf8.encode(value).length > maxBytes) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+int _positiveInt(Object? value) {
+  if (value is! int || value < 1) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+int _nonNegativeInt(Object? value) {
+  if (value is! int || value < 0) {
+    throw const InterviewReportDecodeException();
+  }
+  return value;
+}
+
+double _ratio(Object? value) {
+  if (value is! num || !value.isFinite || value < 0 || value > 1) {
+    throw const InterviewReportDecodeException();
+  }
+  return value.toDouble();
+}
+
+List<String> _uniqueIdentifiers(Object? value, {int maximumItems = 64}) {
+  if (value is! List<Object?> || value.length > maximumItems) {
+    throw const InterviewReportDecodeException();
+  }
+  final seen = <String>{};
+  return List<String>.unmodifiable(
+    value.map((item) {
+      final result = _identifier(item);
+      if (!seen.add(result)) {
+        throw const InterviewReportDecodeException();
+      }
+      return result;
+    }),
+  );
+}
+
+List<String> _reasonCodes(Object? value) {
+  final codes = _uniqueIdentifiers(value);
+  if (codes.any((code) => !_reasonCodesAllowed.contains(code))) {
+    throw const InterviewReportDecodeException();
+  }
+  return codes;
+}
+
+InterviewReportEvaluationStatus _evaluationStatus(Object? value) =>
+    switch (value) {
+      'QUEUED' => InterviewReportEvaluationStatus.queued,
+      'RUNNING' => InterviewReportEvaluationStatus.running,
+      'READY' => InterviewReportEvaluationStatus.ready,
+      'FAILED' => InterviewReportEvaluationStatus.failed,
+      _ => throw const InterviewReportDecodeException(),
+    };
+
+InterviewReportScoreabilityStatus _scoreability(Object? value) =>
+    switch (value) {
+      'PROVISIONAL' => InterviewReportScoreabilityStatus.provisional,
+      'INSUFFICIENT' => InterviewReportScoreabilityStatus.insufficient,
+      _ => throw const InterviewReportDecodeException(),
+    };
+
+InterviewReportGateStatus _gate(Object? value) => switch (value) {
+  'FEEDBACK_ONLY' => InterviewReportGateStatus.feedbackOnly,
+  'BLOCKED' => InterviewReportGateStatus.blocked,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+InterviewReportReadinessLevel _readiness(Object? value) => switch (value) {
+  'NOT_ASSESSED' => InterviewReportReadinessLevel.notAssessed,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+InterviewReportOpportunityStatus _opportunity(Object? value) => switch (value) {
+  'PROVIDED' => InterviewReportOpportunityStatus.provided,
+  'NOT_PROVIDED' => InterviewReportOpportunityStatus.notProvided,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+InterviewReportQuestionType _questionType(Object? value) => switch (value) {
+  'PRIMARY' => InterviewReportQuestionType.primary,
+  'FOLLOW_UP' => InterviewReportQuestionType.followUp,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+InterviewReportAssessmentStatus _assessment(Object? value) => switch (value) {
+  'ASSESSED' => InterviewReportAssessmentStatus.assessed,
+  'NOT_ASSESSED' => InterviewReportAssessmentStatus.notAssessed,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+InterviewReportDimensionId _dimensionId(Object? value) => switch (value) {
+  'INTERVIEW_RELEVANCE' => InterviewReportDimensionId.relevance,
+  'INTERVIEW_STRUCTURE' => InterviewReportDimensionId.structure,
+  'INTERVIEW_EVIDENCE' => InterviewReportDimensionId.evidence,
+  'INTERVIEW_PROFESSIONAL' => InterviewReportDimensionId.professional,
+  'INTERVIEW_INTERACTION' => InterviewReportDimensionId.interaction,
+  _ => throw const InterviewReportDecodeException(),
+};
+
+bool _sameSet(Set<String> left, Set<String> right) =>
+    left.length == right.length && left.containsAll(right);
+
+bool _containsExcerpt(String response, InterviewReportEvidence evidence) {
+  final bytes = utf8.encode(response);
+  if (evidence.endUtf8Byte > bytes.length) {
+    return false;
+  }
+  try {
+    return utf8.decode(
+          bytes.sublist(evidence.startUtf8Byte, evidence.endUtf8Byte),
+          allowMalformed: false,
+        ) ==
+        evidence.originalExcerpt;
+  } on FormatException {
+    return false;
+  }
+}
+
+bool _validDimensionGate({
+  required InterviewReportScoreabilityStatus rootScoreability,
+  required InterviewReportGateStatus rootGate,
+  required InterviewReportDimension dimension,
+}) {
+  if (rootScoreability == InterviewReportScoreabilityStatus.insufficient) {
+    return rootGate == InterviewReportGateStatus.blocked &&
+        dimension.scoreabilityStatus ==
+            InterviewReportScoreabilityStatus.insufficient &&
+        dimension.gateStatus == InterviewReportGateStatus.blocked;
+  }
+  return rootScoreability == InterviewReportScoreabilityStatus.provisional &&
+      rootGate == InterviewReportGateStatus.feedbackOnly &&
+      ((dimension.scoreabilityStatus ==
+                  InterviewReportScoreabilityStatus.provisional &&
+              dimension.gateStatus == InterviewReportGateStatus.feedbackOnly) ||
+          (dimension.scoreabilityStatus ==
+                  InterviewReportScoreabilityStatus.insufficient &&
+              dimension.gateStatus == InterviewReportGateStatus.blocked));
+}
+
+const _dimensionOrder = <InterviewReportDimensionId>[
+  InterviewReportDimensionId.relevance,
+  InterviewReportDimensionId.structure,
+  InterviewReportDimensionId.evidence,
+  InterviewReportDimensionId.professional,
+  InterviewReportDimensionId.interaction,
+];
+
+const _reasonCodesAllowed = <String>{
+  'ASR_CONFIDENCE_UNAVAILABLE',
+  'INSUFFICIENT_EVIDENCE',
+  'OPPORTUNITY_NOT_PROVIDED',
+};
+
+const _failureReasonCodes = <String>{
+  'POLICY_VIOLATION',
+  'EVIDENCE_REF_INVALID',
+  'VERSION_CONFLICT',
+  'INTERNAL_RETRYABLE',
+  'INTERNAL_NON_RETRYABLE',
+};
+
+const _expectedReadinessNotice =
+    'Practice feedback only; not a hiring decision or probability.';
+const _maximumFeedbackTextBytes = 2048;
+const _maximumSourceTextBytes = 16384;

--- a/mobile/lib/review/wire_interview_report_client.dart
+++ b/mobile/lib/review/wire_interview_report_client.dart
@@ -1,0 +1,241 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/interview_report_decoder.dart';
+
+final class WireInterviewReportClient implements InterviewReportClient {
+  factory WireInterviewReportClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    IdentityHttpTransport? transport,
+    Duration requestTimeout = const Duration(seconds: 15),
+  }) {
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'requestTimeout');
+    }
+    final rawTransport =
+        transport ?? _IoInterviewReportHttpTransport(requestTimeout);
+    return WireInterviewReportClient._(
+      baseUri,
+      SessionAuthenticatedHttpTransport(
+        transport: rawTransport,
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: baseUri,
+      ),
+      requestTimeout,
+    );
+  }
+
+  WireInterviewReportClient._(
+    this._baseUri,
+    this._transport,
+    this._requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  final Uri _baseUri;
+  final IdentityHttpTransport _transport;
+  final Duration _requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  int _accountGeneration = 0;
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) async {
+    if (!_validPracticeSessionId(practiceSessionId)) {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.invalidResponse,
+      );
+    }
+    final generation = _accountGeneration;
+    final uri = _baseUri.replace(
+      path:
+          '/v1/practice-sessions/${Uri.encodeComponent(practiceSessionId)}/interview-report',
+      query: null,
+      fragment: null,
+    );
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(uri);
+    late final IdentityHttpResponse response;
+    try {
+      response = await _transport
+          .send(
+            method: 'GET',
+            uri: uri,
+            headers: const <String, String>{
+              HttpHeaders.acceptHeader: 'application/json',
+            },
+          )
+          .timeout(_requestTimeout);
+    } on AuthSessionSupersededException {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.superseded,
+      );
+    } on StateError {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.authenticationRequired,
+        statusCode: HttpStatus.unauthorized,
+      );
+    } on TimeoutException {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.network,
+        retryable: true,
+      );
+    } on SocketException {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.network,
+        retryable: true,
+      );
+    } on HttpException {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.network,
+        retryable: true,
+      );
+    } on IOException {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.network,
+        retryable: true,
+      );
+    }
+    if (generation != _accountGeneration) {
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.superseded,
+      );
+    }
+    switch (response.statusCode) {
+      case HttpStatus.ok:
+        try {
+          final result = decodeInterviewReportJson(response.body);
+          if (result.practiceSessionId != practiceSessionId) {
+            throw const InterviewReportDecodeException();
+          }
+          return result;
+        } on InterviewReportDecodeException {
+          throw const InterviewReportException(
+            kind: InterviewReportFailureKind.invalidResponse,
+          );
+        }
+      case HttpStatus.unauthorized:
+        throw const InterviewReportException(
+          kind: InterviewReportFailureKind.authenticationRequired,
+          statusCode: HttpStatus.unauthorized,
+        );
+      case HttpStatus.notFound:
+        throw const InterviewReportException(
+          kind: InterviewReportFailureKind.notFound,
+          statusCode: HttpStatus.notFound,
+        );
+      case HttpStatus.conflict:
+        throw const InterviewReportException(
+          kind: InterviewReportFailureKind.conflict,
+          statusCode: HttpStatus.conflict,
+        );
+      default:
+        if (response.statusCode >= 500) {
+          throw InterviewReportException(
+            kind: InterviewReportFailureKind.server,
+            statusCode: response.statusCode,
+            retryable: true,
+          );
+        }
+        throw InterviewReportException(
+          kind: InterviewReportFailureKind.invalidResponse,
+          statusCode: response.statusCode,
+        );
+    }
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+}
+
+bool _validPracticeSessionId(String value) =>
+    value.isNotEmpty &&
+    value.length <= 128 &&
+    value == value.trim() &&
+    RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]*$').hasMatch(value);
+
+final class _IoInterviewReportHttpTransport implements IdentityHttpTransport {
+  const _IoInterviewReportHttpTransport(this._requestTimeout);
+
+  final Duration _requestTimeout;
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    final client = HttpClient()..connectionTimeout = _requestTimeout;
+    HttpClientRequest? request;
+    try {
+      final operation = () async {
+        request = await client.openUrl(method, uri);
+        request!.followRedirects = false;
+        headers.forEach(request!.headers.set);
+        if (body != null) {
+          request!.add(utf8.encode(body));
+        }
+        final response = await request!.close();
+        if (response.contentLength > _maximumReportResponseBytes) {
+          request!.abort();
+          throw const InterviewReportException(
+            kind: InterviewReportFailureKind.invalidResponse,
+          );
+        }
+        final bytes = await _readBoundedResponse(response, request!);
+        late final String responseBody;
+        try {
+          responseBody = utf8.decode(bytes, allowMalformed: false);
+        } on FormatException {
+          throw const InterviewReportException(
+            kind: InterviewReportFailureKind.invalidResponse,
+          );
+        }
+        final responseHeaders = <String, String>{};
+        response.headers.forEach((name, values) {
+          responseHeaders[name] = values.join(',');
+        });
+        return IdentityHttpResponse(
+          statusCode: response.statusCode,
+          body: responseBody,
+          headers: responseHeaders,
+        );
+      }();
+      return await operation.timeout(_requestTimeout);
+    } finally {
+      client.close(force: true);
+    }
+  }
+}
+
+Future<Uint8List> _readBoundedResponse(
+  HttpClientResponse response,
+  HttpClientRequest request,
+) async {
+  final builder = BytesBuilder(copy: false);
+  var length = 0;
+  await for (final chunk in response) {
+    length += chunk.length;
+    if (length > _maximumReportResponseBytes) {
+      request.abort();
+      throw const InterviewReportException(
+        kind: InterviewReportFailureKind.invalidResponse,
+      );
+    }
+    builder.add(chunk);
+  }
+  return builder.takeBytes();
+}
+
+const _maximumReportResponseBytes = 1024 * 1024;

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -26,6 +26,7 @@ import 'package:speakup/practice/practice_media.dart';
 import 'package:speakup/practice/practice_recording.dart';
 import 'package:speakup/practice/wire_practice_client.dart';
 import 'package:speakup/review/wire_review_history_client.dart';
+import 'package:speakup/review/wire_interview_report_client.dart';
 
 void main() {
   test('iOS allows local development traffic without a global ATS bypass', () {
@@ -100,6 +101,8 @@ void main() {
         ),
       ]);
       final reviewHistoryTransport = _ControlledReviewHistoryTransport();
+      final interviewReportTransport = _ControlledInterviewReportTransport();
+      final practiceLaunchRecordStore = _BlockingPracticeLaunchRecordStore();
       final preparationTransport = _Transport([
         _Response(
           method: 'GET',
@@ -123,6 +126,8 @@ void main() {
         ),
       ]);
       addTearDown(reviewHistoryTransport.completeEmptyIfPending);
+      addTearDown(interviewReportTransport.completeFailureIfPending);
+      addTearDown(practiceLaunchRecordStore.releaseDelete);
       final practiceRecorder = _TrackingPracticeRecorder();
       final practiceMediaClient = _TrackingPracticeMediaClient();
       final practiceAudioPlayer = _TrackingPracticeAudioPlayer();
@@ -134,6 +139,7 @@ void main() {
         agentTransport: agentTransport,
         preparationTransport: preparationTransport,
         reviewHistoryTransport: reviewHistoryTransport,
+        interviewReportTransport: interviewReportTransport,
         practiceTransport: _PracticeTransport(),
         practiceRecorder: practiceRecorder,
         agentVoiceRecorder: agentVoiceRecorder,
@@ -141,7 +147,7 @@ void main() {
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
         jobPreparationDraftStore: MemoryJobPreparationDraftStore(),
-        practiceLaunchRecordStore: MemoryPracticeLaunchRecordStore(),
+        practiceLaunchRecordStore: practiceLaunchRecordStore,
         sessionStore: _MemorySessionStore('sess_main-wiring'),
       );
       addTearDown(dependencies.agentController.dispose);
@@ -149,6 +155,7 @@ void main() {
       addTearDown(dependencies.preparationLaunchController.dispose);
       addTearDown(dependencies.jobPreparationController.dispose);
       addTearDown(dependencies.reviewHistoryController.dispose);
+      addTearDown(dependencies.interviewReportController.dispose);
 
       expect(dependencies.agentController.client, isA<WireAgentClient>());
       expect(
@@ -180,6 +187,10 @@ void main() {
         isA<WireReviewHistoryClient>(),
       );
       expect(
+        dependencies.interviewReportController.client,
+        isA<WireInterviewReportClient>(),
+      );
+      expect(
         dependencies.preparationController.client,
         isA<WirePreparationCatalogClient>(),
       );
@@ -200,6 +211,7 @@ void main() {
           jobPreparationController: dependencies.jobPreparationController,
           preparationLaunchController: dependencies.preparationLaunchController,
           reviewHistoryController: dependencies.reviewHistoryController,
+          interviewReportController: dependencies.interviewReportController,
         ),
       );
       for (var attempt = 0; attempt < 100; attempt++) {
@@ -269,14 +281,43 @@ void main() {
       expect(reviewHistoryTransport.calls, 1);
       expect(reviewHistoryTransport.authorization, 'Bearer sess_main-wiring');
 
+      await dependencies.preparationLaunchController.activateAccount(
+        'user_fixture',
+      );
+      final pendingReport = dependencies.interviewReportController.load(
+        'session_interview_report_wiring',
+      );
+      await interviewReportTransport.started.future;
+      expect(
+        dependencies.interviewReportController.practiceSessionId,
+        'session_interview_report_wiring',
+      );
+      expect(dependencies.interviewReportController.isLoading, isTrue);
+
       final logout = dependencies.authController.logout();
       await tester.pump();
+      await practiceLaunchRecordStore.deleteStarted.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      expect(dependencies.interviewReportController.envelope, isNull);
+      expect(dependencies.interviewReportController.practiceSessionId, isNull);
+      expect(dependencies.interviewReportController.isLoading, isFalse);
+
+      interviewReportTransport.completeFailureIfPending();
+      await pendingReport.timeout(const Duration(seconds: 1));
+      expect(dependencies.interviewReportController.envelope, isNull);
+      expect(dependencies.interviewReportController.practiceSessionId, isNull);
+
+      practiceLaunchRecordStore.releaseDelete();
       await logout.timeout(const Duration(seconds: 1));
       await tester.pump();
 
       expect(dependencies.reviewHistoryController.items, isEmpty);
       expect(dependencies.reviewHistoryController.errorMessage, isNull);
       expect(dependencies.reviewHistoryController.isLoading, isFalse);
+      expect(dependencies.interviewReportController.envelope, isNull);
+      expect(dependencies.interviewReportController.practiceSessionId, isNull);
       expect(dependencies.preparationController.scenarios, isEmpty);
       expect(dependencies.preparationController.selectedScenario, isNull);
       expect(dependencies.jobPreparationController.target, isNull);
@@ -568,6 +609,86 @@ final class _ControlledReviewHistoryTransport implements IdentityHttpTransport {
         body: jsonEncode({'items': <Object?>[]}),
       ),
     );
+  }
+}
+
+final class _ControlledInterviewReportTransport
+    implements IdentityHttpTransport {
+  final started = Completer<void>();
+  final _response = Completer<IdentityHttpResponse>();
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) {
+    expect(method, 'GET');
+    expect(
+      uri.path,
+      '/v1/practice-sessions/session_interview_report_wiring/interview-report',
+    );
+    expect(headers[HttpHeaders.authorizationHeader], 'Bearer sess_main-wiring');
+    if (!started.isCompleted) {
+      started.complete();
+    }
+    return _response.future;
+  }
+
+  void completeFailureIfPending() {
+    if (_response.isCompleted) {
+      return;
+    }
+    _response.complete(
+      IdentityHttpResponse(
+        statusCode: HttpStatus.ok,
+        body: jsonEncode({
+          'practice_session_id': 'session_interview_report_wiring',
+          'evaluation_id': '81000001-0000-4000-8000-000000000001',
+          'evaluation_revision_id': '82000001-0000-4000-8000-000000000001',
+          'revision': 1,
+          'evaluation_status': 'FAILED',
+          'is_final': false,
+          'status_url':
+              '/v1/practice-sessions/session_interview_report_wiring/interview-report',
+          'stable_failure': {
+            'reason_code': 'INTERNAL_RETRYABLE',
+            'retryable': true,
+          },
+        }),
+      ),
+    );
+  }
+}
+
+final class _BlockingPracticeLaunchRecordStore
+    implements PracticeLaunchRecordStore {
+  final deleteStarted = Completer<void>();
+  final _deleteRelease = Completer<void>();
+  final _values = <String, String>{};
+
+  @override
+  Future<String?> read(String accountId) async => _values[accountId];
+
+  @override
+  Future<void> write(String accountId, String value) async {
+    _values[accountId] = value;
+  }
+
+  @override
+  Future<void> delete(String accountId) async {
+    if (!deleteStarted.isCompleted) {
+      deleteStarted.complete();
+    }
+    await _deleteRelease.future;
+    _values.remove(accountId);
+  }
+
+  void releaseDelete() {
+    if (!_deleteRelease.isCompleted) {
+      _deleteRelease.complete();
+    }
   }
 }
 

--- a/mobile/test/review/interview_report_client_test.dart
+++ b/mobile/test/review/interview_report_client_test.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/wire_interview_report_client.dart';
+
+import 'interview_report_fixture.dart';
+
+void main() {
+  test(
+    'wire client sends Bearer and decodes the exact report resource',
+    () async {
+      final ready = interviewReportContractFixture()['ready']!;
+      final transport = _Transport(
+        IdentityHttpResponse(
+          statusCode: HttpStatus.ok,
+          body: jsonEncode(ready),
+        ),
+      );
+      final client = _client(transport);
+
+      final report = await client.getReport('session_interview_report_001');
+
+      expect(report.evaluationStatus, InterviewReportEvaluationStatus.ready);
+      expect(
+        transport.uri.path,
+        '/v1/practice-sessions/session_interview_report_001/interview-report',
+      );
+      expect(transport.authorization, 'Bearer sess_interview_report');
+      expect(transport.method, 'GET');
+    },
+  );
+
+  test('wire client accepts a digit-leading Practice session UUID', () async {
+    const practiceSessionId = '20000000-0000-4000-8000-000000000001';
+    final ready = cloneInterviewReportFixture(
+      interviewReportContractFixture()['ready'],
+    );
+    ready['practice_session_id'] = practiceSessionId;
+    ready['status_url'] =
+        '/v1/practice-sessions/$practiceSessionId/interview-report';
+    final transport = _Transport(
+      IdentityHttpResponse(statusCode: HttpStatus.ok, body: jsonEncode(ready)),
+    );
+    final client = _client(transport);
+
+    final report = await client.getReport(practiceSessionId);
+
+    expect(report.practiceSessionId, practiceSessionId);
+    expect(
+      transport.uri.path,
+      '/v1/practice-sessions/$practiceSessionId/interview-report',
+    );
+  });
+
+  test(
+    'wire client maps report HTTP failures without fabricating data',
+    () async {
+      for (final testCase
+          in <({int status, InterviewReportFailureKind kind, bool retryable})>[
+            (
+              status: HttpStatus.notFound,
+              kind: InterviewReportFailureKind.notFound,
+              retryable: false,
+            ),
+            (
+              status: HttpStatus.conflict,
+              kind: InterviewReportFailureKind.conflict,
+              retryable: false,
+            ),
+            (
+              status: HttpStatus.serviceUnavailable,
+              kind: InterviewReportFailureKind.server,
+              retryable: true,
+            ),
+          ]) {
+        final client = _client(
+          _Transport(
+            IdentityHttpResponse(
+              statusCode: testCase.status,
+              body: '{"error":{"code":"fixture"}}',
+            ),
+          ),
+        );
+
+        await expectLater(
+          client.getReport('session_interview_report_001'),
+          throwsA(
+            isA<InterviewReportException>()
+                .having((error) => error.kind, 'kind', testCase.kind)
+                .having(
+                  (error) => error.retryable,
+                  'retryable',
+                  testCase.retryable,
+                ),
+          ),
+        );
+      }
+    },
+  );
+
+  test('account clear fences a late report response', () async {
+    final transport = _CompleterTransport();
+    final client = _client(transport);
+    final pending = client.getReport('session_interview_report_001');
+    await transport.started.future;
+
+    await client.clearAccountState();
+    transport.response.complete(
+      IdentityHttpResponse(
+        statusCode: HttpStatus.ok,
+        body: jsonEncode(interviewReportContractFixture()['ready']),
+      ),
+    );
+
+    await expectLater(
+      pending,
+      throwsA(
+        isA<InterviewReportException>().having(
+          (error) => error.kind,
+          'kind',
+          InterviewReportFailureKind.superseded,
+        ),
+      ),
+    );
+  });
+
+  test('wire client rejects a path-unsafe or overlong session identifier', () {
+    final client = _client(
+      _Transport(
+        const IdentityHttpResponse(statusCode: HttpStatus.ok, body: '{}'),
+      ),
+    );
+
+    expect(
+      client.getReport('../other-account'),
+      throwsA(isA<InterviewReportException>()),
+    );
+    expect(
+      client.getReport('s${'a' * 128}'),
+      throwsA(isA<InterviewReportException>()),
+    );
+  });
+}
+
+WireInterviewReportClient _client(IdentityHttpTransport transport) =>
+    WireInterviewReportClient(
+      baseUri: Uri.parse('https://api.speak-up.test'),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_interview_report',
+        generation: 7,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: transport,
+    );
+
+final class _Transport implements IdentityHttpTransport {
+  _Transport(this.response);
+
+  final IdentityHttpResponse response;
+  late Uri uri;
+  late String method;
+  String? authorization;
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    this.method = method;
+    this.uri = uri;
+    authorization = headers[HttpHeaders.authorizationHeader];
+    return response;
+  }
+}
+
+final class _CompleterTransport implements IdentityHttpTransport {
+  final started = Completer<void>();
+  final response = Completer<IdentityHttpResponse>();
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) {
+    started.complete();
+    return response.future;
+  }
+}

--- a/mobile/test/review/interview_report_controller_test.dart
+++ b/mobile/test/review/interview_report_controller_test.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/interview_report_controller.dart';
+import 'package:speakup/review/interview_report_decoder.dart';
+
+import 'interview_report_fixture.dart';
+
+void main() {
+  test('polls QUEUED and RUNNING until READY', () async {
+    final fixture = interviewReportContractFixture();
+    final client = _QueueClient([
+      decodeInterviewReport(fixture['queued']),
+      decodeInterviewReport(fixture['running']),
+      decodeInterviewReport(fixture['ready']),
+    ]);
+    final controller = InterviewReportController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 3,
+    );
+    addTearDown(controller.dispose);
+
+    await controller.load('session_interview_report_001');
+
+    expect(client.calls, 3);
+    expect(
+      controller.envelope?.evaluationStatus,
+      InterviewReportEvaluationStatus.ready,
+    );
+    expect(controller.isLoading, isFalse);
+    expect(controller.errorMessage, isNull);
+  });
+
+  test('bounded polling stops and exposes an explicit retry', () async {
+    final queued = decodeInterviewReport(
+      interviewReportContractFixture()['queued'],
+    );
+    final client = _QueueClient([queued, queued]);
+    final controller = InterviewReportController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 2,
+    );
+    addTearDown(controller.dispose);
+
+    await controller.load('session_interview_report_001');
+
+    expect(client.calls, 2);
+    expect(controller.isLoading, isFalse);
+    expect(controller.canRetry, isTrue);
+    expect(controller.errorMessage, '报告仍在生成，请稍后重试。');
+  });
+
+  test('leaving the detail fences a late response and clears memory', () async {
+    final client = _ControlledClient();
+    final controller = InterviewReportController(client: client);
+    addTearDown(controller.dispose);
+    final pending = controller.load('session_interview_report_001');
+    await client.started.future;
+
+    controller.cancel('session_interview_report_001');
+    client.response.complete(
+      decodeInterviewReport(interviewReportContractFixture()['ready']),
+    );
+    await pending;
+
+    expect(controller.practiceSessionId, isNull);
+    expect(controller.envelope, isNull);
+    expect(controller.errorMessage, isNull);
+  });
+
+  test(
+    'account clear cancels work, clears result, and clears the client',
+    () async {
+      final ready = decodeInterviewReport(
+        interviewReportContractFixture()['ready'],
+      );
+      final client = _QueueClient([ready]);
+      final controller = InterviewReportController(client: client);
+      addTearDown(controller.dispose);
+      await controller.load('session_interview_report_001');
+
+      await controller.clearPrivateState();
+
+      expect(client.clearCalls, 1);
+      expect(controller.practiceSessionId, isNull);
+      expect(controller.envelope, isNull);
+      expect(controller.errorMessage, isNull);
+    },
+  );
+}
+
+final class _QueueClient implements InterviewReportClient {
+  _QueueClient(this.responses);
+
+  final List<InterviewReportEnvelope> responses;
+  int calls = 0;
+  int clearCalls = 0;
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) async {
+    final index = calls++;
+    return responses[index];
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    clearCalls++;
+  }
+}
+
+final class _ControlledClient implements InterviewReportClient {
+  final started = Completer<void>();
+  final response = Completer<InterviewReportEnvelope>();
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) {
+    started.complete();
+    return response.future;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+}

--- a/mobile/test/review/interview_report_decoder_test.dart
+++ b/mobile/test/review/interview_report_decoder_test.dart
@@ -1,0 +1,338 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_decoder.dart';
+
+import 'interview_report_fixture.dart';
+
+void main() {
+  test('decodes every canonical Interview report envelope', () {
+    final contract = interviewReportContractFixture();
+
+    expect(
+      decodeInterviewReport(contract['queued']).evaluationStatus,
+      InterviewReportEvaluationStatus.queued,
+    );
+    expect(
+      decodeInterviewReport(contract['running']).evaluationStatus,
+      InterviewReportEvaluationStatus.running,
+    );
+    final ready = decodeInterviewReport(contract['ready']);
+    expect(ready.evaluationStatus, InterviewReportEvaluationStatus.ready);
+    expect(ready.isFinal, isFalse);
+    expect(ready.report?.dimensions, hasLength(5));
+    expect(ready.report?.questions, hasLength(2));
+    expect(ready.report?.priorityActions, hasLength(3));
+    expect(
+      ready.report?.readinessLevel,
+      InterviewReportReadinessLevel.notAssessed,
+    );
+    final insufficient = decodeInterviewReport(contract['insufficient']);
+    expect(
+      insufficient.report?.scoreabilityStatus,
+      InterviewReportScoreabilityStatus.insufficient,
+    );
+    expect(
+      insufficient.report?.questions.last.assessmentStatus,
+      InterviewReportAssessmentStatus.notAssessed,
+    );
+    final failed = decodeInterviewReport(contract['failed']);
+    expect(failed.evaluationStatus, InterviewReportEvaluationStatus.failed);
+    expect(failed.stableFailure?.retryable, isTrue);
+  });
+
+  test('decodes a report for a digit-leading Practice session UUID', () {
+    final value = cloneInterviewReportFixture(
+      interviewReportContractFixture()['ready'],
+    );
+    const practiceSessionId = '20000000-0000-4000-8000-000000000001';
+    value['practice_session_id'] = practiceSessionId;
+    value['status_url'] =
+        '/v1/practice-sessions/$practiceSessionId/interview-report';
+
+    final decoded = decodeInterviewReport(value);
+
+    expect(decoded.practiceSessionId, practiceSessionId);
+  });
+
+  test(
+    'rejects unknown and numeric scoring fields at every report boundary',
+    () {
+      final contract = interviewReportContractFixture();
+      final rootScore = cloneInterviewReportFixture(contract['ready']);
+      rootScore['overall_score'] = 82;
+      final reportScore = cloneInterviewReportFixture(contract['ready']);
+      (reportScore['report']! as Map<String, Object?>)['display_score'] = 4.5;
+      final dimensionScore = cloneInterviewReportFixture(contract['ready']);
+      (((dimensionScore['report']! as Map<String, Object?>)['dimensions']!
+                      as List<Object?>)
+                  .first
+              as Map<String, Object?>)['raw_score'] =
+          90;
+
+      for (final value in [rootScore, reportScore, dimensionScore]) {
+        expect(
+          () => decodeInterviewReport(value),
+          throwsA(isA<InterviewReportDecodeException>()),
+        );
+      }
+    },
+  );
+
+  test('rejects status payload shape mismatches and a non-report poll URL', () {
+    final contract = interviewReportContractFixture();
+    final queuedWithReport = cloneInterviewReportFixture(contract['queued']);
+    queuedWithReport['report'] = cloneInterviewReportFixture(
+      contract['ready'],
+    )['report'];
+    final readyWithoutReport = cloneInterviewReportFixture(contract['ready'])
+      ..remove('report');
+    final failedWithReport = cloneInterviewReportFixture(contract['failed']);
+    failedWithReport['report'] = cloneInterviewReportFixture(
+      contract['ready'],
+    )['report'];
+    final wrongStatusUrl = cloneInterviewReportFixture(contract['ready']);
+    wrongStatusUrl['status_url'] =
+        '/v1/evaluations/${wrongStatusUrl['evaluation_id']}';
+
+    for (final value in [
+      queuedWithReport,
+      readyWithoutReport,
+      failedWithReport,
+      wrongStatusUrl,
+    ]) {
+      expect(
+        () => decodeInterviewReport(value),
+        throwsA(isA<InterviewReportDecodeException>()),
+      );
+    }
+  });
+
+  test('rejects dangling, cross-kind, and cross-question finding refs', () {
+    final contract = interviewReportContractFixture();
+    final dangling = cloneInterviewReportFixture(contract['ready']);
+    _firstQuestionDimension(dangling)['improvement_finding_ids'] = [
+      'missing_finding',
+    ];
+    final wrongKind = cloneInterviewReportFixture(contract['ready']);
+    final firstDimension = _firstDimension(wrongKind);
+    final improvement =
+        (firstDimension['improvements']! as List<Object?>).single
+            as Map<String, Object?>;
+    firstDimension['strengths'] = [improvement];
+    firstDimension['improvements'] = <Object?>[];
+    final crossQuestion = cloneInterviewReportFixture(contract['ready']);
+    final followupDimensions =
+        (((crossQuestion['report']! as Map<String, Object?>)['questions']!
+                        as List<Object?>)
+                    .last
+                as Map<String, Object?>)['dimension_findings']!
+            as List<Object?>;
+    (followupDimensions.first
+        as Map<String, Object?>)['improvement_finding_ids'] = [
+      'interview_finding_relevance_001',
+    ];
+
+    for (final value in [dangling, wrongKind, crossQuestion]) {
+      expect(
+        () => decodeInterviewReport(value),
+        throwsA(isA<InterviewReportDecodeException>()),
+      );
+    }
+  });
+
+  test('allows a blocked dimension in a provisional report', () {
+    final contract = interviewReportContractFixture();
+    final value = cloneInterviewReportFixture(contract['ready']);
+    (_dimensions(value).last as Map<String, Object?>)
+      ..['scoreability_status'] = 'INSUFFICIENT'
+      ..['gate_status'] = 'BLOCKED'
+      ..['coverage'] = 0
+      ..['confidence'] = 0
+      ..['reason_codes'] = ['OPPORTUNITY_NOT_PROVIDED']
+      ..['evidence_ref_ids'] = <Object?>[]
+      ..['strengths'] = <Object?>[]
+      ..['improvements'] = <Object?>[]
+      ..['recommended_expressions'] = <Object?>[];
+    final questions =
+        ((value['report']! as Map<String, Object?>)['questions']!
+            as List<Object?>);
+    final followupFindings =
+        ((questions.last as Map<String, Object?>)['dimension_findings']!
+            as List<Object?>);
+    (followupFindings.last as Map<String, Object?>)['improvement_finding_ids'] =
+        <Object?>[];
+
+    final decoded = decodeInterviewReport(value);
+
+    expect(
+      decoded.report?.dimensions.last.scoreabilityStatus,
+      InterviewReportScoreabilityStatus.insufficient,
+    );
+    expect(
+      decoded.report?.scoreabilityStatus,
+      InterviewReportScoreabilityStatus.provisional,
+    );
+  });
+
+  test('strictly validates question type and PRIMARY parent lineage', () {
+    final contract = interviewReportContractFixture();
+    final unknownType = cloneInterviewReportFixture(contract['ready']);
+    _questions(unknownType).first['question_type'] = 'SECONDARY';
+    final primaryWithParent = cloneInterviewReportFixture(contract['ready']);
+    _questions(primaryWithParent).first['parent_question_id'] =
+        'question_followup_001';
+    final followupToFollowup = cloneInterviewReportFixture(contract['ready']);
+    _questions(followupToFollowup).last['parent_question_id'] =
+        'question_followup_001';
+
+    for (final value in [unknownType, primaryWithParent, followupToFollowup]) {
+      expect(
+        () => decodeInterviewReport(value),
+        throwsA(isA<InterviewReportDecodeException>()),
+      );
+    }
+  });
+
+  test('strictly validates stable failure reasons and retryability', () {
+    final contract = interviewReportContractFixture();
+    final nonRetryable = cloneInterviewReportFixture(contract['failed']);
+    (nonRetryable['stable_failure']! as Map<String, Object?>)
+      ..['reason_code'] = 'INTERNAL_NON_RETRYABLE'
+      ..['retryable'] = false;
+    final decodedNonRetryable = decodeInterviewReport(nonRetryable);
+    expect(
+      decodedNonRetryable.stableFailure?.reasonCode,
+      'INTERNAL_NON_RETRYABLE',
+    );
+    expect(decodedNonRetryable.stableFailure?.retryable, isFalse);
+
+    final unsupported = cloneInterviewReportFixture(contract['failed']);
+    (unsupported['stable_failure']! as Map<String, Object?>)['reason_code'] =
+        'AUDIO_UNUSABLE';
+    final internalNotRetryable = cloneInterviewReportFixture(
+      contract['failed'],
+    );
+    (internalNotRetryable['stable_failure']!
+            as Map<String, Object?>)['retryable'] =
+        false;
+    final policyRetryable = cloneInterviewReportFixture(contract['failed']);
+    (policyRetryable['stable_failure']! as Map<String, Object?>)
+      ..['reason_code'] = 'POLICY_VIOLATION'
+      ..['retryable'] = true;
+    final internalRetryable = cloneInterviewReportFixture(contract['failed']);
+    (internalRetryable['stable_failure']! as Map<String, Object?>)
+      ..['reason_code'] = 'INTERNAL_NON_RETRYABLE'
+      ..['retryable'] = true;
+
+    for (final value in [
+      unsupported,
+      internalNotRetryable,
+      policyRetryable,
+      internalRetryable,
+    ]) {
+      expect(
+        () => decodeInterviewReport(value),
+        throwsA(isA<InterviewReportDecodeException>()),
+      );
+    }
+  });
+
+  test('enforces UTF-8 budgets for feedback and source text separately', () {
+    final contract = interviewReportContractFixture();
+    final oversizedFeedback = cloneInterviewReportFixture(contract['ready']);
+    final firstImprovement =
+        (_firstDimension(oversizedFeedback)['improvements']! as List<Object?>)
+                .first
+            as Map<String, Object?>;
+    firstImprovement['message'] = '好' * 683;
+    final oversizedSource = cloneInterviewReportFixture(contract['ready']);
+    _questions(oversizedSource).first['question_text'] = '好' * 5462;
+
+    expect(
+      () => decodeInterviewReport(oversizedFeedback),
+      throwsA(isA<InterviewReportDecodeException>()),
+    );
+    expect(
+      () => decodeInterviewReport(oversizedSource),
+      throwsA(isA<InterviewReportDecodeException>()),
+    );
+  });
+
+  test('allows one evidence ref to carry different valid anchors', () {
+    final value = cloneInterviewReportFixture(
+      interviewReportContractFixture()['ready'],
+    );
+    final structure = _dimensions(value)[1] as Map<String, Object?>;
+    final finding =
+        (structure['improvements']! as List<Object?>).single
+            as Map<String, Object?>;
+    final anchor =
+        (finding['evidence']! as List<Object?>).single as Map<String, Object?>
+          ..['start_utf8_byte'] = 0
+          ..['end_utf8_byte'] = 1
+          ..['original_excerpt'] = 'I';
+
+    final decoded = decodeInterviewReport(value);
+
+    expect(anchor['evidence_ref_id'], 'evidence_primary_001');
+    expect(
+      decoded
+          .report
+          ?.dimensions[1]
+          .improvements
+          .single
+          .evidence
+          .single
+          .originalExcerpt,
+      'I',
+    );
+  });
+
+  test('allows one finding to anchor evidence across two questions', () {
+    final value = cloneInterviewReportFixture(
+      interviewReportContractFixture()['ready'],
+    );
+    final dimensions = _dimensions(value);
+    final relevance = dimensions.first as Map<String, Object?>;
+    relevance['evidence_ref_ids'] = [
+      'evidence_primary_001',
+      'evidence_followup_001',
+    ];
+    final relevanceFinding =
+        (relevance['improvements']! as List<Object?>).single
+            as Map<String, Object?>;
+    final interaction = dimensions.last as Map<String, Object?>;
+    final interactionFinding =
+        (interaction['improvements']! as List<Object?>).single
+            as Map<String, Object?>;
+    final followupAnchor =
+        ((interactionFinding['evidence']! as List<Object?>).single
+            as Map<String, Object?>);
+    (relevanceFinding['evidence']! as List<Object?>).add(
+      Map<String, Object?>.from(followupAnchor),
+    );
+
+    final decoded = decodeInterviewReport(value);
+
+    expect(
+      decoded.report?.dimensions.first.improvements.single.evidence,
+      hasLength(2),
+    );
+  });
+}
+
+List<Object?> _dimensions(Map<String, Object?> value) =>
+    (value['report']! as Map<String, Object?>)['dimensions']! as List<Object?>;
+
+Map<String, Object?> _firstDimension(Map<String, Object?> value) =>
+    _dimensions(value).first as Map<String, Object?>;
+
+Map<String, Object?> _firstQuestionDimension(Map<String, Object?> value) {
+  final questions = _questions(value);
+  final dimensions = questions.first['dimension_findings']! as List<Object?>;
+  return dimensions.first as Map<String, Object?>;
+}
+
+List<Map<String, Object?>> _questions(Map<String, Object?> value) =>
+    ((value['report']! as Map<String, Object?>)['questions']! as List<Object?>)
+        .cast<Map<String, Object?>>();

--- a/mobile/test/review/interview_report_fixture.dart
+++ b/mobile/test/review/interview_report_fixture.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+import 'dart:io';
+
+Map<String, Object?> interviewReportContractFixture() {
+  final decoded = jsonDecode(
+    File('../api/examples/interview-report-contract.json').readAsStringSync(),
+  );
+  return decoded as Map<String, Object?>;
+}
+
+Map<String, Object?> cloneInterviewReportFixture(Object? value) =>
+    jsonDecode(jsonEncode(value)) as Map<String, Object?>;

--- a/mobile/test/review/interview_report_flow_test.dart
+++ b/mobile/test/review/interview_report_flow_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/features/review/review.dart';
+import 'package:speakup/review/formal_review.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/interview_report_controller.dart';
+import 'package:speakup/review/interview_report_decoder.dart';
+import 'package:speakup/review/review_history_client.dart';
+import 'package:speakup/review/review_history_controller.dart';
+
+import 'interview_report_fixture.dart';
+
+void main() {
+  testWidgets('Interview detail loads its session report and clears on leave', (
+    tester,
+  ) async {
+    final item = _scenarioItem(
+      contextType: FormalReviewContextType.interviewProjectDeepDive,
+      practiceSessionId: 'session_interview_report_001',
+    );
+    final history = ReviewHistoryController(client: _HistoryClient([item]));
+    final reportClient = _ReportClient(
+      value: decodeInterviewReport(interviewReportContractFixture()['ready']),
+    );
+    final report = InterviewReportController(
+      client: reportClient,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(history.dispose);
+    addTearDown(report.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ReviewPage(
+          historyController: history,
+          interviewReportController: report,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(Key('review-history-select-${item.review.id}')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(reportClient.sessionIds, ['session_interview_report_001']);
+    expect(find.byKey(const Key('interview-report-ready')), findsOneWidget);
+    expect(find.byKey(const Key('review-detail-summary')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('review-detail-back')));
+    await tester.pumpAndSettle();
+    expect(report.practiceSessionId, isNull);
+    expect(report.envelope, isNull);
+  });
+
+  testWidgets('a report 404 preserves the existing FormalReview detail', (
+    tester,
+  ) async {
+    final item = _scenarioItem(
+      contextType: FormalReviewContextType.interviewProjectDeepDive,
+      practiceSessionId: 'session_interview_report_404',
+    );
+    final history = ReviewHistoryController(client: _HistoryClient([item]));
+    final reportClient = _ReportClient(
+      error: const InterviewReportException(
+        kind: InterviewReportFailureKind.notFound,
+      ),
+    );
+    final report = InterviewReportController(
+      client: reportClient,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(history.dispose);
+    addTearDown(report.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ReviewPage(
+          historyController: history,
+          interviewReportController: report,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(Key('review-history-select-${item.review.id}')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('review-detail-summary')), findsOneWidget);
+    expect(find.text('FormalReview 仍可查看。'), findsOneWidget);
+    expect(find.byKey(const Key('interview-report-failed')), findsNothing);
+  });
+
+  testWidgets('non-Interview FormalReview never requests an Interview report', (
+    tester,
+  ) async {
+    final item = _scenarioItem(
+      contextType: FormalReviewContextType.dailyHotelCheckinIssue,
+      practiceSessionId: 'session_daily_001',
+    );
+    final history = ReviewHistoryController(client: _HistoryClient([item]));
+    final reportClient = _ReportClient(
+      value: decodeInterviewReport(interviewReportContractFixture()['ready']),
+    );
+    final report = InterviewReportController(
+      client: reportClient,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(history.dispose);
+    addTearDown(report.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ReviewPage(
+          historyController: history,
+          interviewReportController: report,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(Key('review-history-select-${item.review.id}')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(reportClient.sessionIds, isEmpty);
+    expect(find.byKey(const Key('review-detail-summary')), findsOneWidget);
+    expect(find.byKey(const Key('interview-report-ready')), findsNothing);
+  });
+}
+
+ReviewHistoryItem _scenarioItem({
+  required FormalReviewContextType contextType,
+  required String practiceSessionId,
+}) {
+  final review = AgentReview(
+    id: 'review_$practiceSessionId',
+    title: '面试复盘',
+    summary: 'FormalReview 仍可查看。',
+    strength: '回答与问题相关。',
+    nextFocus: '下一次补充具体结果。',
+  );
+  final createdAt = DateTime.utc(2026, 7, 30, 9);
+  final completedAt = DateTime.utc(2026, 7, 30, 9, 10);
+  final formalReview = FormalReview(
+    id: review.id,
+    practiceSessionId: practiceSessionId,
+    status: FormalReviewStatus.completed,
+    schema: FormalReviewSchema.scenarioV2,
+    implementationVersion: 'qianwen-scenario-review-v2',
+    sourceTurnId: 'turn_review_001',
+    sourceTurnVersion: 'conversation-turn:evidence-v1',
+    contextType: contextType,
+    result: const FormalReviewResult(
+      eligibility: FormalReviewSummaryEligibility.provisional,
+      summary: 'FormalReview 仍可查看。',
+      dimensions: <FormalReviewDimension>[
+        FormalReviewDimension(
+          key: 'relevance',
+          category: 'relevance',
+          message: '回答与问题相关。',
+        ),
+      ],
+      feedbackItems: <FormalReviewFeedbackItem>[],
+      repracticeSuggestionRefs: <String>[],
+      insufficientEvidenceReasons: <String>['audio_not_assessed'],
+    ),
+    createdAt: createdAt,
+    updatedAt: completedAt,
+    completedAt: completedAt,
+  );
+  return ReviewHistoryItem(
+    review: review,
+    formalReview: formalReview,
+    practiceSessionId: practiceSessionId,
+    createdAt: createdAt,
+    completedAt: completedAt,
+  );
+}
+
+final class _HistoryClient implements ReviewHistoryClient {
+  const _HistoryClient(this.items);
+
+  final List<ReviewHistoryItem> items;
+
+  @override
+  Future<ReviewHistoryPage> list({String? cursor, int limit = 20}) async =>
+      ReviewHistoryPage(items: items);
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _ReportClient implements InterviewReportClient {
+  _ReportClient({this.value, this.error});
+
+  final InterviewReportEnvelope? value;
+  final InterviewReportException? error;
+  final List<String> sessionIds = <String>[];
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) async {
+    sessionIds.add(practiceSessionId);
+    if (error case final failure?) {
+      throw failure;
+    }
+    return value!;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+}

--- a/mobile/test/review/interview_report_view_test.dart
+++ b/mobile/test/review/interview_report_view_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/review/interview_report_view.dart';
+import 'package:speakup/review/interview_report.dart';
+import 'package:speakup/review/interview_report_client.dart';
+import 'package:speakup/review/interview_report_controller.dart';
+import 'package:speakup/review/interview_report_decoder.dart';
+
+import 'interview_report_fixture.dart';
+
+void main() {
+  testWidgets(
+    'READY renders qualitative evidence without numeric or acoustic scores',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(320, 568));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final ready = decodeInterviewReport(
+        interviewReportContractFixture()['ready'],
+      );
+      final controller = InterviewReportController(
+        client: _FixedClient(ready),
+        maximumPollAttempts: 1,
+      );
+      addTearDown(controller.dispose);
+      await controller.load(ready.practiceSessionId);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) {
+            return MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: const TextScaler.linear(2)),
+              child: child!,
+            );
+          },
+          home: Scaffold(
+            body: ListView(
+              padding: const EdgeInsets.all(12),
+              children: [InterviewReportPanel(controller: controller)],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('暂定文本反馈'), findsOneWidget);
+      expect(
+        find.byKey(const Key('interview-report-readiness-notice')),
+        findsOneWidget,
+      );
+      expect(find.text('五维反馈'), findsOneWidget);
+      expect(find.text('逐题复盘'), findsOneWidget);
+      expect(find.text('优先改进'), findsOneWidget);
+      expect(find.textContaining('I led the migration'), findsOneWidget);
+      expect(find.textContaining('/ 100'), findsNothing);
+      expect(find.textContaining('录用概率：'), findsNothing);
+      expect(tester.takeException(), isNull);
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('interview-report-priority-actions')),
+        300,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('INSUFFICIENT renders evidence shortage without a zero', (
+    tester,
+  ) async {
+    final insufficient = decodeInterviewReport(
+      interviewReportContractFixture()['insufficient'],
+    );
+    final controller = InterviewReportController(
+      client: _FixedClient(insufficient),
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load(insufficient.practiceSessionId);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: InterviewReportPanel(controller: controller)),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('interview-report-insufficient')),
+      findsOneWidget,
+    );
+    expect(find.text('证据不足'), findsOneWidget);
+    expect(find.textContaining('0 分'), findsOneWidget);
+    expect(find.textContaining('/ 100'), findsNothing);
+    expect(find.byKey(const Key('interview-report-dimensions')), findsNothing);
+  });
+
+  testWidgets('FAILED is explicitly technical and only retries when allowed', (
+    tester,
+  ) async {
+    final failed = decodeInterviewReport(
+      interviewReportContractFixture()['failed'],
+    );
+    final controller = InterviewReportController(
+      client: _FixedClient(failed),
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load(failed.practiceSessionId);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: InterviewReportPanel(controller: controller)),
+      ),
+    );
+
+    expect(find.textContaining('技术问题'), findsOneWidget);
+    expect(find.textContaining('表现较差'), findsOneWidget);
+    expect(find.byKey(const Key('interview-report-retry')), findsOneWidget);
+    expect(find.byKey(const Key('interview-report-dimensions')), findsNothing);
+  });
+}
+
+final class _FixedClient implements InterviewReportClient {
+  const _FixedClient(this.value);
+
+  final InterviewReportEnvelope value;
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) async =>
+      value;
+
+  @override
+  Future<void> clearAccountState() async {}
+}

--- a/server/internal/bootstrap/evaluation.go
+++ b/server/internal/bootstrap/evaluation.go
@@ -115,6 +115,7 @@ func NewEvaluationComposition(
 	application := &evaluationHTTPApplication{
 		evaluations:   evaluationService,
 		runtime:       repository,
+		reports:       repository,
 		configuration: runtimeConfiguration,
 	}
 	handler, err := evaluationtransport.NewHTTPHandler(application)
@@ -237,9 +238,18 @@ type evaluationRuntimeReader interface {
 	) (evaluation.InterviewShadowReadState, error)
 }
 
+type interviewReportReader interface {
+	GetCurrentInterviewReportState(
+		context.Context,
+		string,
+		string,
+	) (evaluation.InterviewReportReadState, error)
+}
+
 type evaluationHTTPApplication struct {
 	evaluations   evaluationService
 	runtime       evaluationRuntimeReader
+	reports       interviewReportReader
 	configuration evaluation.InterviewShadowRuntimeConfiguration
 }
 
@@ -343,6 +353,43 @@ func (application *evaluationHTTPApplication) Get(
 		value,
 		state,
 		application.configuration,
+	)
+}
+
+func (application *evaluationHTTPApplication) GetInterviewReport(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	practiceSessionID string,
+) (evaluationtransport.InterviewReportResource, error) {
+	if application == nil || application.reports == nil ||
+		ctx == nil || !actor.Valid() ||
+		!application.configuration.Valid() {
+		return evaluationtransport.InterviewReportResource{},
+			evaluation.ErrInvalidRequest
+	}
+	trustedActor, ok := requestcontext.ActorFromContext(ctx)
+	if !ok || trustedActor != actor {
+		return evaluationtransport.InterviewReportResource{},
+			evaluation.ErrInvalidRequest
+	}
+	state, err := application.reports.GetCurrentInterviewReportState(
+		ctx,
+		actor.UserID,
+		practiceSessionID,
+	)
+	if err != nil {
+		if errors.Is(
+			err,
+			evaluation.ErrInterviewShadowConfigurationConflict,
+		) {
+			return evaluationtransport.InterviewReportResource{},
+				interviewShadowVersionConflictError()
+		}
+		return evaluationtransport.InterviewReportResource{}, err
+	}
+	return interviewReportResource(
+		practiceSessionID,
+		state,
 	)
 }
 
@@ -467,14 +514,90 @@ func interviewShadowResource(
 			return evaluationtransport.EvaluationResource{},
 				evaluation.ErrInvalidRequest
 		}
-		resource.StableFailure = &evaluationtransport.EvaluationFailure{
-			ReasonCode: interviewShadowFailureReason(
-				state.Failure.Code,
-			),
-			Retryable: state.Failure.Retryable,
-		}
+		failure := interviewShadowFailure(state.Failure.Code)
+		resource.StableFailure = &failure
 	default:
 		return evaluationtransport.EvaluationResource{},
+			evaluation.ErrInvalidRequest
+	}
+	return resource, nil
+}
+
+func interviewReportResource(
+	practiceSessionID string,
+	state evaluation.InterviewReportReadState,
+) (evaluationtransport.InterviewReportResource, error) {
+	value := state.Evaluation
+	if practiceSessionID == "" ||
+		value.PracticeSessionID != practiceSessionID ||
+		!interviewShadowEvaluation(value) ||
+		value.Revision.IsFinal {
+		return evaluationtransport.InterviewReportResource{},
+			evaluation.ErrInvalidRequest
+	}
+	resource := evaluationtransport.InterviewReportResource{
+		PracticeSessionID:    value.PracticeSessionID,
+		EvaluationID:         value.ID,
+		EvaluationRevisionID: value.Revision.ID,
+		Revision:             value.Revision.Number,
+		EvaluationStatus:     value.Revision.Status,
+		IsFinal:              false,
+	}
+	switch value.Revision.Status {
+	case evaluation.StatusQueued:
+		if state.Runtime.ModuleStatus !=
+			evaluation.InterviewShadowRuntimePending ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot != nil {
+			return evaluationtransport.InterviewReportResource{},
+				evaluation.ErrInvalidRequest
+		}
+	case evaluation.StatusRunning:
+		if (state.Runtime.ModuleStatus !=
+			evaluation.InterviewShadowRuntimePending &&
+			state.Runtime.ModuleStatus !=
+				evaluation.InterviewShadowRuntimeRunning) ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot != nil {
+			return evaluationtransport.InterviewReportResource{},
+				evaluation.ErrInvalidRequest
+		}
+	case evaluation.StatusReady:
+		if state.Runtime.ModuleStatus !=
+			evaluation.InterviewShadowRuntimeReady ||
+			state.Runtime.Result == nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot == nil ||
+			state.Snapshot.ID != value.InputSnapshotID ||
+			state.Snapshot.OwnerUserID != value.OwnerUserID ||
+			state.Snapshot.PracticeSessionID !=
+				value.PracticeSessionID {
+			return evaluationtransport.InterviewReportResource{},
+				evaluation.ErrInvalidRequest
+		}
+		report, err := evaluation.ProjectInterviewReport(
+			*state.Snapshot,
+			*state.Runtime.Result,
+		)
+		if err != nil {
+			return evaluationtransport.InterviewReportResource{}, err
+		}
+		resource.Report = &report
+	case evaluation.StatusFailed:
+		if state.Runtime.ModuleStatus !=
+			evaluation.InterviewShadowRuntimeFailed ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure == nil ||
+			state.Snapshot != nil {
+			return evaluationtransport.InterviewReportResource{},
+				evaluation.ErrInvalidRequest
+		}
+		failure := interviewShadowFailure(state.Runtime.Failure.Code)
+		resource.StableFailure = &failure
+	default:
+		return evaluationtransport.InterviewReportResource{},
 			evaluation.ErrInvalidRequest
 	}
 	return resource, nil
@@ -650,18 +773,39 @@ func validInterviewShadowDimensionGate(
 	}
 }
 
-func interviewShadowFailureReason(
+func interviewShadowFailure(
 	code string,
-) evaluationtransport.ReasonCode {
+) evaluationtransport.EvaluationFailure {
 	switch code {
 	case "provider_invalid_response":
-		return evaluationtransport.ReasonPolicyViolation
+		return evaluationtransport.EvaluationFailure{
+			ReasonCode: evaluationtransport.ReasonPolicyViolation,
+		}
 	case "evidence_ref_invalid":
-		return evaluationtransport.ReasonEvidenceRefInvalid
-	case "version_conflict":
-		return evaluationtransport.ReasonVersionConflict
+		return evaluationtransport.EvaluationFailure{
+			ReasonCode: evaluationtransport.ReasonEvidenceRefInvalid,
+		}
+	case "version_conflict", "runtime_configuration_changed":
+		return evaluationtransport.EvaluationFailure{
+			ReasonCode: evaluationtransport.ReasonVersionConflict,
+		}
+	case "provider_canceled",
+		"provider_timeout",
+		"rate_limited",
+		"timeout",
+		"provider_unavailable",
+		"invalid_response",
+		"cancelled",
+		"dependency_error",
+		"attempts_exhausted":
+		return evaluationtransport.EvaluationFailure{
+			ReasonCode: evaluationtransport.ReasonInternalRetryable,
+			Retryable:  true,
+		}
 	default:
-		return evaluationtransport.ReasonInternalRetryable
+		return evaluationtransport.EvaluationFailure{
+			ReasonCode: evaluationtransport.ReasonInternalNonRetryable,
+		}
 	}
 }
 

--- a/server/internal/bootstrap/evaluation_test.go
+++ b/server/internal/bootstrap/evaluation_test.go
@@ -275,6 +275,214 @@ func TestEvaluationHTTPApplicationRejectsReevaluationBeforeMutation(
 	}
 }
 
+func TestEvaluationHTTPApplicationGetsOwnerScopedInterviewReport(
+	t *testing.T,
+) {
+	t.Parallel()
+	actor := requestcontext.Actor{
+		UserID:    "00000000-0000-4000-8000-000000000001",
+		SessionID: "session-authenticated",
+	}
+	reader := &interviewReportReaderStub{
+		result: evaluation.InterviewReportReadState{
+			Evaluation: evaluationTestValue(evaluation.StatusQueued),
+			Runtime: evaluation.InterviewShadowReadState{
+				ModuleStatus: evaluation.InterviewShadowRuntimePending,
+			},
+		},
+	}
+	application := &evaluationHTTPApplication{
+		reports:       reader,
+		configuration: evaluationTestRuntimeConfiguration(t),
+	}
+	resource, err := application.GetInterviewReport(
+		requestcontext.WithActor(context.Background(), actor),
+		actor,
+		"session_demo_001",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reader.ownerUserID != actor.UserID ||
+		reader.practiceSessionID != "session_demo_001" ||
+		resource.PracticeSessionID != "session_demo_001" ||
+		resource.EvaluationStatus != evaluation.StatusQueued ||
+		resource.Report != nil ||
+		resource.StableFailure != nil ||
+		resource.IsFinal {
+		t.Fatalf("reader=%#v resource=%#v", reader, resource)
+	}
+}
+
+func TestEvaluationHTTPApplicationMapsAmbiguousInterviewReportToConflict(
+	t *testing.T,
+) {
+	t.Parallel()
+	actor := requestcontext.Actor{
+		UserID:    "00000000-0000-4000-8000-000000000001",
+		SessionID: "session-authenticated",
+	}
+	application := &evaluationHTTPApplication{
+		reports: &interviewReportReaderStub{
+			err: evaluation.ErrInterviewShadowConfigurationConflict,
+		},
+		configuration: evaluationTestRuntimeConfiguration(t),
+	}
+	_, err := application.GetInterviewReport(
+		requestcontext.WithActor(context.Background(), actor),
+		actor,
+		"session_demo_001",
+	)
+	appError, ok := apperror.From(err)
+	if !ok || appError.Code() != "evaluation_version_conflict" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestInterviewShadowFailureDerivesStableRetryability(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		code          string
+		reason        evaluationtransport.ReasonCode
+		wantRetryable bool
+	}{
+		{
+			code:   "provider_invalid_response",
+			reason: evaluationtransport.ReasonPolicyViolation,
+		},
+		{
+			code:   "evidence_ref_invalid",
+			reason: evaluationtransport.ReasonEvidenceRefInvalid,
+		},
+		{
+			code:   "version_conflict",
+			reason: evaluationtransport.ReasonVersionConflict,
+		},
+		{
+			code:   "runtime_configuration_changed",
+			reason: evaluationtransport.ReasonVersionConflict,
+		},
+		{
+			code:          "provider_canceled",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "provider_timeout",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "rate_limited",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "timeout",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "provider_unavailable",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "invalid_response",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "cancelled",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "dependency_error",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:          "attempts_exhausted",
+			reason:        evaluationtransport.ReasonInternalRetryable,
+			wantRetryable: true,
+		},
+		{
+			code:   "authentication",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "authorization",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "configuration",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "invalid_request",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "quota_exhausted",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "provider_error",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+		{
+			code:   "unknown_failure",
+			reason: evaluationtransport.ReasonInternalNonRetryable,
+		},
+	}
+	for _, test := range tests {
+		failure := interviewShadowFailure(test.code)
+		if failure.ReasonCode != test.reason ||
+			failure.Retryable != test.wantRetryable {
+			t.Errorf("%q failure = %#v", test.code, failure)
+		}
+	}
+	failed := evaluationTestValue(evaluation.StatusFailed)
+	resource, err := interviewReportResource(
+		failed.PracticeSessionID,
+		evaluation.InterviewReportReadState{
+			Evaluation: failed,
+			Runtime: evaluation.InterviewShadowReadState{
+				ModuleStatus: evaluation.InterviewShadowRuntimeFailed,
+				Failure: &evaluation.InterviewShadowFailure{
+					Code: "provider_timeout",
+				},
+			},
+		},
+	)
+	if err != nil ||
+		resource.StableFailure == nil ||
+		resource.StableFailure.ReasonCode !=
+			evaluationtransport.ReasonInternalRetryable ||
+		!resource.StableFailure.Retryable {
+		t.Fatalf("failed report resource = %#v, %v", resource, err)
+	}
+	genericResource, err := interviewShadowResource(
+		failed,
+		evaluation.InterviewShadowReadState{
+			ModuleStatus: evaluation.InterviewShadowRuntimeFailed,
+			Failure: &evaluation.InterviewShadowFailure{
+				Code:      "authentication",
+				Retryable: true,
+			},
+		},
+		evaluationTestRuntimeConfiguration(t),
+	)
+	if err != nil ||
+		genericResource.StableFailure == nil ||
+		genericResource.StableFailure.ReasonCode !=
+			evaluationtransport.ReasonInternalNonRetryable ||
+		genericResource.StableFailure.Retryable {
+		t.Fatalf("generic failed resource = %#v, %v", genericResource, err)
+	}
+}
+
 func evaluationTestRuntimeConfiguration(
 	t *testing.T,
 ) evaluation.InterviewShadowRuntimeConfiguration {
@@ -425,6 +633,23 @@ func (*evaluationRuntimeReaderStub) GetInterviewShadowState(
 	string,
 ) (evaluation.InterviewShadowReadState, error) {
 	return evaluation.InterviewShadowReadState{}, evaluation.ErrNotFound
+}
+
+type interviewReportReaderStub struct {
+	result            evaluation.InterviewReportReadState
+	err               error
+	ownerUserID       string
+	practiceSessionID string
+}
+
+func (stub *interviewReportReaderStub) GetCurrentInterviewReportState(
+	_ context.Context,
+	ownerUserID string,
+	practiceSessionID string,
+) (evaluation.InterviewReportReadState, error) {
+	stub.ownerUserID = ownerUserID
+	stub.practiceSessionID = practiceSessionID
+	return stub.result, stub.err
 }
 
 var _ evaluationtransport.Application = (*evaluationHTTPApplication)(nil)

--- a/server/internal/evaluation/interview_report.go
+++ b/server/internal/evaluation/interview_report.go
@@ -1,0 +1,600 @@
+package evaluation
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"slices"
+)
+
+const (
+	InterviewReportSchemaVersion   = "interview-report/v1"
+	InterviewReportReadinessNotice = InterviewShadowReadinessNotice
+)
+
+type InterviewAssessmentStatus string
+
+const (
+	InterviewAssessmentAssessed    InterviewAssessmentStatus = "ASSESSED"
+	InterviewAssessmentNotAssessed InterviewAssessmentStatus = "NOT_ASSESSED"
+)
+
+type InterviewReport struct {
+	SchemaVersion      string                       `json:"schema_version"`
+	ScoreabilityStatus InterviewScoreabilityStatus  `json:"scoreability_status"`
+	GateStatus         InterviewGateStatus          `json:"gate_status"`
+	ReadinessLevel     InterviewReadinessLevel      `json:"readiness_level"`
+	ReadinessNotice    string                       `json:"readiness_notice"`
+	Dimensions         []InterviewReportDimension   `json:"dimensions"`
+	Questions          []InterviewReportQuestion    `json:"questions"`
+	PriorityActions    []InterviewReportPriorityRef `json:"priority_actions"`
+}
+
+type InterviewReportDimension struct {
+	DimensionID            InterviewDimension          `json:"dimension_id"`
+	ScoreabilityStatus     InterviewScoreabilityStatus `json:"scoreability_status"`
+	GateStatus             InterviewGateStatus         `json:"gate_status"`
+	Coverage               float64                     `json:"coverage"`
+	Confidence             float64                     `json:"confidence"`
+	ReasonCodes            []InterviewReasonCode       `json:"reason_codes"`
+	EvidenceRefIDs         []string                    `json:"evidence_ref_ids"`
+	Strengths              []InterviewReportFinding    `json:"strengths"`
+	Improvements           []InterviewReportFinding    `json:"improvements"`
+	RecommendedExpressions []InterviewReportFinding    `json:"recommended_expressions"`
+}
+
+type InterviewReportFinding struct {
+	FindingID  string                    `json:"finding_id"`
+	Message    string                    `json:"message"`
+	Suggestion string                    `json:"suggestion,omitempty"`
+	Evidence   []InterviewReportEvidence `json:"evidence"`
+}
+
+type InterviewReportEvidence struct {
+	EvidenceRefID   string `json:"evidence_ref_id"`
+	TurnID          string `json:"turn_id"`
+	StartUTF8Byte   int    `json:"start_utf8_byte"`
+	EndUTF8Byte     int    `json:"end_utf8_byte"`
+	OriginalExcerpt string `json:"original_excerpt"`
+}
+
+type InterviewReportQuestion struct {
+	QuestionID          string                           `json:"question_id"`
+	QuestionType        string                           `json:"question_type"`
+	ParentQuestionID    string                           `json:"parent_question_id,omitempty"`
+	OpportunityStatus   InterviewOpportunityStatus       `json:"opportunity_status"`
+	AssessmentStatus    InterviewAssessmentStatus        `json:"assessment_status"`
+	QuestionText        string                           `json:"question_text"`
+	ConfirmedTranscript string                           `json:"confirmed_transcript,omitempty"`
+	ResponseTurnID      string                           `json:"response_turn_id,omitempty"`
+	EvidenceRefIDs      []string                         `json:"evidence_ref_ids"`
+	DimensionFindings   []InterviewQuestionDimensionRefs `json:"dimension_findings"`
+}
+
+type InterviewQuestionDimensionRefs struct {
+	DimensionID                     InterviewDimension `json:"dimension_id"`
+	StrengthFindingIDs              []string           `json:"strength_finding_ids"`
+	ImprovementFindingIDs           []string           `json:"improvement_finding_ids"`
+	RecommendedExpressionFindingIDs []string           `json:"recommended_expression_finding_ids"`
+}
+
+type InterviewReportPriorityRef struct {
+	DimensionID InterviewDimension `json:"dimension_id"`
+	FindingID   string             `json:"finding_id"`
+}
+
+func ProjectInterviewReport(
+	snapshot EvidenceSnapshot,
+	result InterviewShadowResult,
+) (InterviewReport, error) {
+	if err := ValidateInterviewShadowResult(snapshot, result); err != nil {
+		return InterviewReport{}, err
+	}
+	var payload evidencePayload
+	decoder := json.NewDecoder(bytes.NewReader(snapshot.Payload))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&payload) != nil || ensureJSONEOF(decoder) != nil {
+		return InterviewReport{}, ErrInvalidInterviewShadow
+	}
+	turns := make(
+		map[string]evidenceConfirmedTurn,
+		len(payload.ConfirmedTurns),
+	)
+	for _, turn := range payload.ConfirmedTurns {
+		turns[turn.TurnID] = turn
+	}
+
+	report := InterviewReport{
+		SchemaVersion:      InterviewReportSchemaVersion,
+		ScoreabilityStatus: result.Scoreability,
+		GateStatus:         result.Gate,
+		ReadinessLevel:     result.Readiness,
+		ReadinessNotice:    result.ReadinessNotice,
+		Dimensions: make(
+			[]InterviewReportDimension,
+			len(result.Dimensions),
+		),
+		Questions: make(
+			[]InterviewReportQuestion,
+			len(result.QuestionResults),
+		),
+		PriorityActions: []InterviewReportPriorityRef{},
+	}
+	for index, dimension := range result.Dimensions {
+		report.Dimensions[index] = projectInterviewReportDimension(
+			dimension,
+		)
+		for _, finding := range dimension.Improvements {
+			if len(report.PriorityActions) == 3 {
+				break
+			}
+			report.PriorityActions = append(
+				report.PriorityActions,
+				InterviewReportPriorityRef{
+					DimensionID: dimension.DimensionID,
+					FindingID:   finding.ID,
+				},
+			)
+		}
+	}
+	for index, question := range result.QuestionResults {
+		opportunity := payload.OpportunityManifest[index]
+		projected := InterviewReportQuestion{
+			QuestionID:        question.QuestionID,
+			QuestionType:      question.QuestionType,
+			ParentQuestionID:  question.ParentQuestionID,
+			OpportunityStatus: question.OpportunityStatus,
+			AssessmentStatus:  InterviewAssessmentNotAssessed,
+			QuestionText:      opportunity.QuestionText,
+			ResponseTurnID:    question.ResponseTurnID,
+			EvidenceRefIDs: slices.Clone(
+				question.EvidenceRefIDs,
+			),
+			DimensionFindings: make(
+				[]InterviewQuestionDimensionRefs,
+				len(question.DimensionResults),
+			),
+		}
+		if question.OpportunityStatus == InterviewOpportunityProvided {
+			turn, exists := turns[question.ResponseTurnID]
+			if !exists || turn.QuestionID != question.QuestionID {
+				return InterviewReport{}, ErrInvalidInterviewShadow
+			}
+			projected.AssessmentStatus = InterviewAssessmentAssessed
+			projected.ConfirmedTranscript = turn.Transcript.Text
+		}
+		for dimensionIndex, dimension := range question.DimensionResults {
+			projected.DimensionFindings[dimensionIndex] =
+				InterviewQuestionDimensionRefs{
+					DimensionID: dimension.DimensionID,
+					StrengthFindingIDs: slices.Clone(
+						dimension.StrengthFindingIDs,
+					),
+					ImprovementFindingIDs: slices.Clone(
+						dimension.ImprovementFindingIDs,
+					),
+					RecommendedExpressionFindingIDs: slices.Clone(
+						dimension.
+							RecommendedExpressionFindingIDs,
+					),
+				}
+		}
+		report.Questions[index] = projected
+	}
+	if !report.Valid() {
+		return InterviewReport{}, ErrInvalidInterviewShadow
+	}
+	return report, nil
+}
+
+func projectInterviewReportDimension(
+	source InterviewShadowDimensionResult,
+) InterviewReportDimension {
+	return InterviewReportDimension{
+		DimensionID:        source.DimensionID,
+		ScoreabilityStatus: source.Scoreability,
+		GateStatus:         source.Gate,
+		Coverage:           source.Coverage,
+		Confidence:         source.Confidence,
+		ReasonCodes:        slices.Clone(source.ReasonCodes),
+		EvidenceRefIDs:     slices.Clone(source.EvidenceRefIDs),
+		Strengths: projectInterviewReportFindings(
+			source.Strengths,
+		),
+		Improvements: projectInterviewReportFindings(
+			source.Improvements,
+		),
+		RecommendedExpressions: projectInterviewReportFindings(
+			source.RecommendedExpressions,
+		),
+	}
+}
+
+func projectInterviewReportFindings(
+	source []InterviewShadowFinding,
+) []InterviewReportFinding {
+	result := make([]InterviewReportFinding, len(source))
+	for index, finding := range source {
+		evidence := make(
+			[]InterviewReportEvidence,
+			len(finding.Evidence),
+		)
+		for evidenceIndex, ref := range finding.Evidence {
+			evidence[evidenceIndex] = InterviewReportEvidence{
+				EvidenceRefID:   ref.EvidenceRefID,
+				TurnID:          ref.TurnID,
+				StartUTF8Byte:   ref.StartUTF8Byte,
+				EndUTF8Byte:     ref.EndUTF8Byte,
+				OriginalExcerpt: ref.OriginalExcerpt,
+			}
+		}
+		result[index] = InterviewReportFinding{
+			FindingID:  finding.ID,
+			Message:    finding.Message,
+			Suggestion: finding.Suggestion,
+			Evidence:   evidence,
+		}
+	}
+	return result
+}
+
+func (report InterviewReport) Valid() bool {
+	if report.SchemaVersion != InterviewReportSchemaVersion ||
+		!validInterviewReportGate(
+			report.ScoreabilityStatus,
+			report.GateStatus,
+		) ||
+		report.ReadinessLevel != InterviewReadinessNotAssessed ||
+		report.ReadinessNotice != InterviewReportReadinessNotice ||
+		len(report.Dimensions) != len(interviewDimensionOrder) ||
+		len(report.Questions) == 0 ||
+		len(report.Questions) > 64 ||
+		report.PriorityActions == nil ||
+		len(report.PriorityActions) > 3 {
+		return false
+	}
+	improvements := make(map[InterviewDimension]map[string]struct{}, 5)
+	strengths := make(map[InterviewDimension]map[string]struct{}, 5)
+	recommended := make(map[InterviewDimension]map[string]struct{}, 5)
+	allFindingIDs := make(map[string]struct{})
+	findingEvidenceRefs := make(map[string]map[string]struct{})
+	for index, dimension := range report.Dimensions {
+		if dimension.DimensionID != interviewDimensionOrder[index] ||
+			!validInterviewReportGate(
+				dimension.ScoreabilityStatus,
+				dimension.GateStatus,
+			) ||
+			!validInterviewReportRatio(dimension.Coverage) ||
+			!validInterviewReportRatio(dimension.Confidence) ||
+			dimension.ReasonCodes == nil ||
+			len(dimension.ReasonCodes) != 1 ||
+			dimension.EvidenceRefIDs == nil ||
+			!validInterviewReportIDList(
+				dimension.EvidenceRefIDs,
+				64,
+			) ||
+			dimension.Strengths == nil ||
+			len(dimension.Strengths) > interviewShadowMaximumFindings ||
+			dimension.Improvements == nil ||
+			len(dimension.Improvements) > interviewShadowMaximumFindings ||
+			dimension.RecommendedExpressions == nil {
+			return false
+		}
+		if len(dimension.RecommendedExpressions) >
+			interviewShadowMaximumFindings {
+			return false
+		}
+		if report.ScoreabilityStatus ==
+			InterviewScoreabilityInsufficient &&
+			dimension.ScoreabilityStatus !=
+				InterviewScoreabilityInsufficient {
+			return false
+		}
+		for _, reason := range dimension.ReasonCodes {
+			if !validInterviewReportReason(reason) {
+				return false
+			}
+		}
+		strengths[dimension.DimensionID] = make(map[string]struct{})
+		improvements[dimension.DimensionID] = make(map[string]struct{})
+		recommended[dimension.DimensionID] = make(map[string]struct{})
+		evidenceRefSet := make(map[string]struct{})
+		for _, collection := range []struct {
+			findings []InterviewReportFinding
+			ids      map[string]struct{}
+		}{
+			{dimension.Strengths, strengths[dimension.DimensionID]},
+			{dimension.Improvements, improvements[dimension.DimensionID]},
+			{
+				dimension.RecommendedExpressions,
+				recommended[dimension.DimensionID],
+			},
+		} {
+			for _, finding := range collection.findings {
+				if !validInterviewReportFinding(finding) {
+					return false
+				}
+				if _, duplicate := allFindingIDs[finding.FindingID]; duplicate {
+					return false
+				}
+				allFindingIDs[finding.FindingID] = struct{}{}
+				collection.ids[finding.FindingID] =
+					struct{}{}
+				findingEvidenceRefs[finding.FindingID] =
+					make(map[string]struct{}, len(finding.Evidence))
+				for _, evidence := range finding.Evidence {
+					evidenceRefSet[evidence.EvidenceRefID] =
+						struct{}{}
+					findingEvidenceRefs[finding.FindingID][evidence.EvidenceRefID] =
+						struct{}{}
+				}
+			}
+		}
+		expectedEvidenceRefs := make(
+			[]string,
+			0,
+			len(evidenceRefSet),
+		)
+		for refID := range evidenceRefSet {
+			expectedEvidenceRefs = append(expectedEvidenceRefs, refID)
+		}
+		slices.Sort(expectedEvidenceRefs)
+		if !slices.Equal(
+			dimension.EvidenceRefIDs,
+			expectedEvidenceRefs,
+		) {
+			return false
+		}
+		switch dimension.ScoreabilityStatus {
+		case InterviewScoreabilityProvisional:
+			if dimension.ReasonCodes[0] !=
+				InterviewReasonASRConfidenceUnavailable ||
+				len(dimension.EvidenceRefIDs) == 0 ||
+				len(dimension.Strengths)+
+					len(dimension.Improvements) == 0 {
+				return false
+			}
+		case InterviewScoreabilityInsufficient:
+			if (dimension.ReasonCodes[0] !=
+				InterviewReasonInsufficientEvidence &&
+				dimension.ReasonCodes[0] !=
+					InterviewReasonOpportunityNotProvided) ||
+				len(dimension.EvidenceRefIDs) != 0 ||
+				len(dimension.Strengths) != 0 ||
+				len(dimension.Improvements) != 0 ||
+				len(dimension.RecommendedExpressions) != 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	questions := make(map[string]struct{}, len(report.Questions))
+	for _, question := range report.Questions {
+		if !validIdentifier(question.QuestionID) ||
+			(question.QuestionType != "PRIMARY" &&
+				question.QuestionType != "FOLLOW_UP") ||
+			!validInterviewText(
+				question.QuestionText,
+				interviewShadowMaximumInputString,
+			) ||
+			question.EvidenceRefIDs == nil ||
+			!validInterviewReportIDList(
+				question.EvidenceRefIDs,
+				64,
+			) ||
+			len(question.DimensionFindings) !=
+				len(interviewDimensionOrder) {
+			return false
+		}
+		if _, duplicate := questions[question.QuestionID]; duplicate {
+			return false
+		}
+		if question.QuestionType == "PRIMARY" {
+			if question.ParentQuestionID != "" {
+				return false
+			}
+		} else if _, exists := questions[question.ParentQuestionID]; !exists {
+			return false
+		}
+		questions[question.QuestionID] = struct{}{}
+		switch question.OpportunityStatus {
+		case InterviewOpportunityProvided:
+			if question.AssessmentStatus !=
+				InterviewAssessmentAssessed ||
+				!validIdentifier(question.ResponseTurnID) ||
+				!validInterviewText(
+					question.ConfirmedTranscript,
+					interviewShadowMaximumInputString,
+				) ||
+				len(question.EvidenceRefIDs) == 0 {
+				return false
+			}
+		case InterviewOpportunityNotProvided:
+			if question.AssessmentStatus !=
+				InterviewAssessmentNotAssessed ||
+				question.ResponseTurnID != "" ||
+				question.ConfirmedTranscript != "" ||
+				len(question.EvidenceRefIDs) != 0 {
+				return false
+			}
+		default:
+			return false
+		}
+		for index, dimension := range question.DimensionFindings {
+			if dimension.DimensionID != interviewDimensionOrder[index] ||
+				dimension.StrengthFindingIDs == nil ||
+				dimension.ImprovementFindingIDs == nil ||
+				dimension.RecommendedExpressionFindingIDs == nil ||
+				!validInterviewQuestionFindingRefs(
+					dimension.StrengthFindingIDs,
+					strengths[dimension.DimensionID],
+				) ||
+				!validInterviewQuestionFindingRefs(
+					dimension.ImprovementFindingIDs,
+					improvements[dimension.DimensionID],
+				) ||
+				!validInterviewQuestionFindingRefs(
+					dimension.RecommendedExpressionFindingIDs,
+					recommended[dimension.DimensionID],
+				) ||
+				!interviewQuestionFindingsOverlapEvidence(
+					dimension.StrengthFindingIDs,
+					question.EvidenceRefIDs,
+					findingEvidenceRefs,
+				) ||
+				!interviewQuestionFindingsOverlapEvidence(
+					dimension.ImprovementFindingIDs,
+					question.EvidenceRefIDs,
+					findingEvidenceRefs,
+				) ||
+				!interviewQuestionFindingsOverlapEvidence(
+					dimension.RecommendedExpressionFindingIDs,
+					question.EvidenceRefIDs,
+					findingEvidenceRefs,
+				) {
+				return false
+			}
+		}
+	}
+
+	expectedActions := make([]InterviewReportPriorityRef, 0, 3)
+	for _, dimension := range report.Dimensions {
+		for _, finding := range dimension.Improvements {
+			if len(expectedActions) == 3 {
+				break
+			}
+			expectedActions = append(
+				expectedActions,
+				InterviewReportPriorityRef{
+					DimensionID: dimension.DimensionID,
+					FindingID:   finding.FindingID,
+				},
+			)
+		}
+	}
+	return slices.Equal(report.PriorityActions, expectedActions)
+}
+
+func validInterviewReportGate(
+	scoreability InterviewScoreabilityStatus,
+	gate InterviewGateStatus,
+) bool {
+	return (scoreability == InterviewScoreabilityProvisional &&
+		gate == InterviewGateFeedbackOnly) ||
+		(scoreability == InterviewScoreabilityInsufficient &&
+			gate == InterviewGateBlocked)
+}
+
+func validInterviewReportReason(reason InterviewReasonCode) bool {
+	switch reason {
+	case InterviewReasonASRConfidenceUnavailable,
+		InterviewReasonInsufficientEvidence,
+		InterviewReasonOpportunityNotProvided:
+		return true
+	default:
+		return false
+	}
+}
+
+func validInterviewReportRatio(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) &&
+		value >= 0 && value <= 1
+}
+
+func validInterviewReportFinding(finding InterviewReportFinding) bool {
+	if !validIdentifier(finding.FindingID) ||
+		!validInterviewText(
+			finding.Message,
+			interviewShadowMaximumTextBytes,
+		) ||
+		finding.Evidence == nil ||
+		len(finding.Evidence) == 0 ||
+		len(finding.Evidence) > interviewShadowMaximumAnchors {
+		return false
+	}
+	if finding.Suggestion != "" &&
+		!validInterviewText(
+			finding.Suggestion,
+			interviewShadowMaximumTextBytes,
+		) {
+		return false
+	}
+	for _, evidence := range finding.Evidence {
+		if !validIdentifier(evidence.EvidenceRefID) ||
+			!validIdentifier(evidence.TurnID) ||
+			evidence.StartUTF8Byte < 0 ||
+			evidence.EndUTF8Byte <= evidence.StartUTF8Byte ||
+			evidence.EndUTF8Byte-evidence.StartUTF8Byte !=
+				len(evidence.OriginalExcerpt) ||
+			!validInterviewText(
+				evidence.OriginalExcerpt,
+				interviewShadowMaximumTextBytes,
+			) {
+			return false
+		}
+	}
+	return true
+}
+
+func validInterviewQuestionFindingRefs(
+	refs []string,
+	allowed map[string]struct{},
+) bool {
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if _, exists := allowed[ref]; !exists {
+			return false
+		}
+		if _, duplicate := seen[ref]; duplicate {
+			return false
+		}
+		seen[ref] = struct{}{}
+	}
+	return true
+}
+
+func interviewQuestionFindingsOverlapEvidence(
+	findingIDs []string,
+	questionEvidenceRefIDs []string,
+	findingEvidenceRefs map[string]map[string]struct{},
+) bool {
+	questionRefs := make(
+		map[string]struct{},
+		len(questionEvidenceRefIDs),
+	)
+	for _, refID := range questionEvidenceRefIDs {
+		questionRefs[refID] = struct{}{}
+	}
+	for _, findingID := range findingIDs {
+		overlaps := false
+		for refID := range findingEvidenceRefs[findingID] {
+			if _, exists := questionRefs[refID]; exists {
+				overlaps = true
+				break
+			}
+		}
+		if !overlaps {
+			return false
+		}
+	}
+	return true
+}
+
+func validInterviewReportIDList(values []string, maximum int) bool {
+	if len(values) > maximum {
+		return false
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if !validIdentifier(value) {
+			return false
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return false
+		}
+		seen[value] = struct{}{}
+	}
+	return true
+}

--- a/server/internal/evaluation/interview_report_postgres.go
+++ b/server/internal/evaluation/interview_report_postgres.go
@@ -1,0 +1,139 @@
+package evaluation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type InterviewReportReadState struct {
+	Evaluation Evaluation
+	Runtime    InterviewShadowReadState
+	Snapshot   *EvidenceSnapshot
+}
+
+func (r *PostgresRepository) GetCurrentInterviewReportState(
+	ctx context.Context,
+	ownerUserID string,
+	practiceSessionID string,
+) (InterviewReportReadState, error) {
+	if r == nil || r.pool == nil || ctx == nil ||
+		!validUUID(ownerUserID) ||
+		!validIdentifier(practiceSessionID) {
+		return InterviewReportReadState{}, ErrInvalidRequest
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return InterviewReportReadState{}, fmt.Errorf(
+			"begin Interview report read: %w",
+			err,
+		)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `
+		SELECT ledger.id::text
+		FROM evaluation_ledgers AS ledger
+		JOIN evaluation_revisions AS revision
+		  ON revision.evaluation_id = ledger.id
+		 AND revision.owner_user_id = ledger.owner_user_id
+		WHERE ledger.owner_user_id = $1
+		  AND ledger.practice_session_id = $2
+		  AND ledger.scope = 'SESSION'
+		  AND ledger.scene_type = 'INTERVIEW'
+		  AND revision.channels = ARRAY['SCENE']::text[]
+		  AND revision.scene_strategy_ref = $3
+		  AND revision.core_4d_strategy_ref IS NULL
+		  AND revision.pipeline_version = $4
+		  AND revision.schema_version = $5
+		  AND NOT EXISTS (
+		      SELECT 1
+		      FROM evaluation_revisions AS later
+		      WHERE later.evaluation_id = revision.evaluation_id
+		        AND later.owner_user_id = revision.owner_user_id
+		        AND later.revision > revision.revision
+		  )
+		ORDER BY ledger.id
+		LIMIT 2
+	`, ownerUserID, practiceSessionID,
+		InterviewShadowStrategyRef,
+		InterviewShadowPipelineVersion,
+		SchemaVersion)
+	if err != nil {
+		return InterviewReportReadState{}, fmt.Errorf(
+			"find Interview report Evaluation: %w",
+			err,
+		)
+	}
+	evaluationIDs := make([]string, 0, 2)
+	for rows.Next() {
+		var evaluationID string
+		if err := rows.Scan(&evaluationID); err != nil {
+			rows.Close()
+			return InterviewReportReadState{}, fmt.Errorf(
+				"scan Interview report Evaluation: %w",
+				err,
+			)
+		}
+		evaluationIDs = append(evaluationIDs, evaluationID)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return InterviewReportReadState{}, fmt.Errorf(
+			"iterate Interview report Evaluations: %w",
+			err,
+		)
+	}
+	switch len(evaluationIDs) {
+	case 0:
+		return InterviewReportReadState{}, ErrNotFound
+	case 1:
+	default:
+		return InterviewReportReadState{},
+			ErrInterviewShadowConfigurationConflict
+	}
+
+	value, err := selectLatest(
+		ctx,
+		tx,
+		ownerUserID,
+		evaluationIDs[0],
+	)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return InterviewReportReadState{},
+				ErrInterviewShadowConfigurationConflict
+		}
+		return InterviewReportReadState{}, err
+	}
+	runtime, snapshot, err := getInterviewShadowState(
+		ctx,
+		tx,
+		ownerUserID,
+		value.ID,
+		value.Revision.ID,
+	)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return InterviewReportReadState{},
+				ErrInterviewShadowConfigurationConflict
+		}
+		return InterviewReportReadState{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return InterviewReportReadState{}, fmt.Errorf(
+			"commit Interview report read: %w",
+			err,
+		)
+	}
+	return InterviewReportReadState{
+		Evaluation: value,
+		Runtime:    runtime,
+		Snapshot:   snapshot,
+	}, nil
+}

--- a/server/internal/evaluation/interview_report_postgres_integration_test.go
+++ b/server/internal/evaluation/interview_report_postgres_integration_test.go
@@ -1,0 +1,306 @@
+package evaluation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresInterviewReportLookupIsOwnerScopedAndFailClosed(
+	t *testing.T,
+) {
+	pool, repository, _, value := prepareInterviewShadowRuntime(t)
+
+	state, err := repository.GetCurrentInterviewReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil {
+		t.Fatalf("GetCurrentInterviewReportState: %v", err)
+	}
+	if state.Evaluation.ID != value.ID ||
+		state.Evaluation.Revision.ID != value.Revision.ID {
+		t.Fatalf("report state = %#v, want Evaluation %#v", state, value)
+	}
+	if _, err := repository.GetCurrentInterviewReportState(
+		context.Background(),
+		testOwnerB,
+		value.PracticeSessionID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("cross-owner report error = %v", err)
+	}
+	if _, err := repository.GetCurrentInterviewReportState(
+		context.Background(),
+		testOwnerA,
+		"session-without-evaluation",
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing report error = %v", err)
+	}
+
+	insertDuplicateInterviewReportEvaluation(
+		t,
+		pool,
+		value,
+	)
+	if _, err := repository.GetCurrentInterviewReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	); !errors.Is(err, ErrInterviewShadowConfigurationConflict) {
+		t.Fatalf("ambiguous report error = %v", err)
+	}
+}
+
+func TestPostgresInterviewReportReadsEveryPublishedState(t *testing.T) {
+	t.Run("queued", func(t *testing.T) {
+		_, repository, _, value := prepareInterviewShadowRuntime(t)
+		state, err := repository.GetCurrentInterviewReportState(
+			context.Background(),
+			testOwnerA,
+			value.PracticeSessionID,
+		)
+		if err != nil {
+			t.Fatalf("queued report: %v", err)
+		}
+		if state.Runtime.ModuleStatus !=
+			InterviewShadowRuntimePending ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot != nil {
+			t.Fatalf("queued state = %#v", state)
+		}
+	})
+	t.Run("running", func(t *testing.T) {
+		_, repository, configuration, value :=
+			prepareInterviewShadowRuntime(t)
+		claimInterviewShadow(t, repository, configuration)
+		state, err := repository.GetCurrentInterviewReportState(
+			context.Background(),
+			testOwnerA,
+			value.PracticeSessionID,
+		)
+		if err != nil {
+			t.Fatalf("running report: %v", err)
+		}
+		if state.Runtime.ModuleStatus !=
+			InterviewShadowRuntimeRunning ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot != nil {
+			t.Fatalf("running state = %#v", state)
+		}
+	})
+	t.Run("ready", func(t *testing.T) {
+		_, repository, configuration, value :=
+			prepareInterviewShadowRuntime(t)
+		claim := claimInterviewShadow(t, repository, configuration)
+		result := evaluateInterviewShadowClaim(t, claim)
+		if err := repository.CompleteInterviewShadow(
+			context.Background(),
+			claim,
+			result,
+		); err != nil {
+			t.Fatalf("CompleteInterviewShadow: %v", err)
+		}
+		state, err := repository.GetCurrentInterviewReportState(
+			context.Background(),
+			testOwnerA,
+			value.PracticeSessionID,
+		)
+		if err != nil {
+			t.Fatalf("ready report: %v", err)
+		}
+		if state.Runtime.ModuleStatus !=
+			InterviewShadowRuntimeReady ||
+			state.Runtime.Result == nil ||
+			state.Runtime.Failure != nil ||
+			state.Snapshot == nil {
+			t.Fatalf("ready state = %#v", state)
+		}
+		report, err := ProjectInterviewReport(
+			*state.Snapshot,
+			*state.Runtime.Result,
+		)
+		if err != nil || !report.Valid() ||
+			len(report.Dimensions) != 5 ||
+			len(report.Questions) == 0 {
+			t.Fatalf("persisted report = %#v, error = %v", report, err)
+		}
+	})
+	t.Run("failed", func(t *testing.T) {
+		_, repository, configuration, value :=
+			prepareInterviewShadowRuntime(t)
+		configuration.MaxAttempts = 1
+		claim := claimInterviewShadow(t, repository, configuration)
+		status, err := repository.FailInterviewShadow(
+			context.Background(),
+			claim,
+			InterviewShadowFailure{
+				Code:      "provider_timeout",
+				Retryable: true,
+			},
+			configuration,
+		)
+		if err != nil || status != InterviewShadowRuntimeFailed {
+			t.Fatalf("FailInterviewShadow = %q, %v", status, err)
+		}
+		state, err := repository.GetCurrentInterviewReportState(
+			context.Background(),
+			testOwnerA,
+			value.PracticeSessionID,
+		)
+		if err != nil {
+			t.Fatalf("failed report: %v", err)
+		}
+		if state.Runtime.ModuleStatus !=
+			InterviewShadowRuntimeFailed ||
+			state.Runtime.Result != nil ||
+			state.Runtime.Failure == nil ||
+			state.Runtime.Failure.Code != "provider_timeout" ||
+			state.Runtime.Failure.Retryable ||
+			state.Snapshot != nil {
+			t.Fatalf("failed state = %#v", state)
+		}
+	})
+}
+
+func TestPostgresInterviewReportDoesNotSelectHistoricalShadowRevision(
+	t *testing.T,
+) {
+	_, repository, _, value := prepareInterviewShadowRuntime(t)
+	service := NewService(repository, repository)
+	_, replayed, err := service.Reevaluate(
+		testActorContext(testOwnerA),
+		testActor(testOwnerA),
+		value.ID,
+		ReevaluateRequest{
+			Channels:         []Channel{ChannelScene},
+			SceneStrategyRef: "another-interview-strategy/v1",
+			PipelineVersion:  InterviewShadowPipelineVersion,
+			ClientRequestID:  "historical-shadow-revision",
+		},
+	)
+	if err != nil || replayed {
+		t.Fatalf("Reevaluate replayed=%t error=%v", replayed, err)
+	}
+	if _, err := repository.GetCurrentInterviewReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("historical Shadow report error = %v", err)
+	}
+}
+
+func insertDuplicateInterviewReportEvaluation(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	source Evaluation,
+) {
+	t.Helper()
+	ctx := context.Background()
+	var evaluationID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO evaluation_ledgers (
+			owner_user_id,
+			root_idempotency_key,
+			root_request_fingerprint,
+			practice_session_id,
+			input_snapshot_id,
+			input_revision,
+			scope,
+			scene_type
+		)
+		VALUES (
+			$1,
+			decode(repeat('11', 32), 'hex'),
+			decode(repeat('22', 32), 'hex'),
+			$2,
+			$3,
+			$4,
+			'SESSION',
+			'INTERVIEW'
+		)
+		RETURNING id::text
+	`, source.OwnerUserID, source.PracticeSessionID,
+		source.InputSnapshotID, source.InputRevision).Scan(
+		&evaluationID,
+	); err != nil {
+		t.Fatalf("insert duplicate report ledger: %v", err)
+	}
+	var revisionID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO evaluation_revisions (
+			evaluation_id,
+			owner_user_id,
+			revision,
+			channels,
+			scene_strategy_ref,
+			pipeline_version,
+			schema_version,
+			request_fingerprint
+		)
+		VALUES (
+			$1,
+			$2,
+			1,
+			ARRAY['SCENE']::text[],
+			$3,
+			$4,
+			$5,
+			decode(repeat('33', 32), 'hex')
+		)
+		RETURNING id::text
+	`, evaluationID, source.OwnerUserID,
+		InterviewShadowStrategyRef,
+		InterviewShadowPipelineVersion,
+		SchemaVersion).Scan(&revisionID); err != nil {
+		t.Fatalf("insert duplicate report revision: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO evaluation_revision_states (
+			revision_id,
+			evaluation_id,
+			owner_user_id
+		)
+		VALUES ($1, $2, $3)
+		RETURNING revision_id::text
+	`, revisionID, evaluationID, source.OwnerUserID).Scan(
+		new(string),
+	); err != nil {
+		t.Fatalf("insert duplicate report state: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO evaluation_outbox (
+			evaluation_id,
+			evaluation_revision_id,
+			owner_user_id,
+			channel,
+			channel_key,
+			event_type,
+			payload
+		)
+		VALUES (
+			$1::uuid,
+			$2::uuid,
+			$3::uuid,
+			'SCENE',
+			decode(repeat('44', 32), 'hex'),
+			'evaluation.revision.queued',
+			jsonb_build_object(
+				'evaluation_id', ($1::uuid)::text,
+				'evaluation_revision_id', ($2::uuid)::text,
+				'revision', 1,
+				'channel', 'SCENE'
+			)
+		)
+		RETURNING id::text
+	`, evaluationID, revisionID, source.OwnerUserID).Scan(
+		new(string),
+	); err != nil {
+		t.Fatalf("insert duplicate report outbox: %v", err)
+	}
+}

--- a/server/internal/evaluation/interview_report_test.go
+++ b/server/internal/evaluation/interview_report_test.go
@@ -1,0 +1,324 @@
+package evaluation
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestProjectInterviewReportUsesFrozenQuestionsAndEvidence(t *testing.T) {
+	t.Parallel()
+	snapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpUnanswered,
+	)
+	prepared, err := prepareInterviewShadow(snapshot)
+	if err != nil {
+		t.Fatalf("prepare Interview Shadow: %v", err)
+	}
+	payload := validInterviewProviderPayloadValue(prepared.input)
+	for index := range payload.Dimensions {
+		if index >= 3 {
+			break
+		}
+		dimension := &payload.Dimensions[index]
+		template, ok := interviewShadowFeedbackTemplate(
+			dimension.DimensionID,
+			interviewFindingImprovement,
+		)
+		if !ok {
+			t.Fatalf("missing improvement template for %q", dimension.DimensionID)
+		}
+		dimension.Improvements = []interviewProviderFinding{{
+			TemplateID: template.ID,
+			Evidence:   dimension.Strengths[0].Evidence,
+		}}
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal Provider payload: %v", err)
+	}
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{payload: encoded},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+
+	report, err := ProjectInterviewReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectInterviewReport: %v", err)
+	}
+	if !report.Valid() ||
+		report.SchemaVersion != InterviewReportSchemaVersion ||
+		report.ScoreabilityStatus != InterviewScoreabilityProvisional ||
+		report.GateStatus != InterviewGateFeedbackOnly ||
+		report.ReadinessLevel != InterviewReadinessNotAssessed ||
+		len(report.Dimensions) != 5 ||
+		len(report.Questions) != 2 ||
+		len(report.PriorityActions) != 3 {
+		t.Fatalf("report = %#v", report)
+	}
+	first := report.Questions[0]
+	if first.QuestionText != "Tell me about a migration you led." ||
+		first.ConfirmedTranscript != "I led a careful migration." ||
+		first.AssessmentStatus != InterviewAssessmentAssessed ||
+		first.ResponseTurnID != "turn-1" ||
+		len(first.EvidenceRefIDs) != 1 ||
+		len(first.DimensionFindings) != 5 {
+		t.Fatalf("first question = %#v", first)
+	}
+	second := report.Questions[1]
+	if second.QuestionText != "What changed after the migration?" ||
+		second.OpportunityStatus != InterviewOpportunityNotProvided ||
+		second.AssessmentStatus != InterviewAssessmentNotAssessed ||
+		second.ConfirmedTranscript != "" ||
+		second.ResponseTurnID != "" ||
+		len(second.EvidenceRefIDs) != 0 {
+		t.Fatalf("unanswered question = %#v", second)
+	}
+	for index, action := range report.PriorityActions {
+		if action.DimensionID != interviewDimensionOrder[index] ||
+			action.FindingID !=
+				report.Dimensions[index].Improvements[0].FindingID {
+			t.Errorf("priority action %d = %#v", index, action)
+		}
+	}
+
+	wire, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	for _, forbidden := range []string{
+		"snapshot_id",
+		"provider_lineage",
+		"raw",
+		"display",
+		"overall",
+		"total",
+		"weights",
+		"probe_weight",
+	} {
+		if jsonContainsExactKey(decoded, forbidden) {
+			t.Errorf("report contains forbidden key %q: %s", forbidden, wire)
+		}
+	}
+}
+
+func TestProjectInterviewReportRejectsCrossSnapshotResult(t *testing.T) {
+	t.Parallel()
+	first := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpNone,
+	)
+	second := interviewShadowTestSnapshot(
+		t,
+		"I led a different migration.",
+		interviewFollowUpNone,
+	)
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), first)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if _, err := ProjectInterviewReport(second, result); err == nil {
+		t.Fatal("cross-snapshot result was projected")
+	}
+}
+
+func TestInterviewReportRejectsNonCanonicalPriorityActions(t *testing.T) {
+	t.Parallel()
+	snapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpNone,
+	)
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	report, err := ProjectInterviewReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectInterviewReport: %v", err)
+	}
+	report.PriorityActions = []InterviewReportPriorityRef{{
+		DimensionID: InterviewDimensionRelevance,
+		FindingID:   report.Dimensions[0].Strengths[0].FindingID,
+	}}
+	if report.Valid() {
+		t.Fatal("strength was accepted as a priority improvement")
+	}
+	if reflect.DeepEqual(report.PriorityActions, []InterviewReportPriorityRef{}) {
+		t.Fatal("test did not mutate priority actions")
+	}
+}
+
+func TestInterviewReportRejectsCrossKindQuestionFindingReference(
+	t *testing.T,
+) {
+	t.Parallel()
+	snapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpNone,
+	)
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	report, err := ProjectInterviewReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectInterviewReport: %v", err)
+	}
+	ref := report.Questions[0].DimensionFindings[0].
+		StrengthFindingIDs[0]
+	report.Questions[0].DimensionFindings[0].
+		StrengthFindingIDs = []string{}
+	report.Questions[0].DimensionFindings[0].
+		RecommendedExpressionFindingIDs = []string{ref}
+	if report.Valid() {
+		t.Fatal("strength finding was accepted as a recommended expression")
+	}
+}
+
+func TestInterviewReportRejectsDimensionEvidenceUnionMismatch(
+	t *testing.T,
+) {
+	t.Parallel()
+	snapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpNone,
+	)
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	report, err := ProjectInterviewReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectInterviewReport: %v", err)
+	}
+	report.Dimensions[0].EvidenceRefIDs = []string{}
+	if report.Valid() {
+		t.Fatal("dimension accepted evidence refs that omit finding evidence")
+	}
+}
+
+func TestInterviewReportRejectsProvisionalDimensionUnderBlockedRoot(
+	t *testing.T,
+) {
+	t.Parallel()
+	blockedSnapshot := interviewShadowTestSnapshot(
+		t,
+		"Yes.",
+		interviewFollowUpNone,
+	)
+	blockedResult, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), blockedSnapshot)
+	if err != nil {
+		t.Fatalf("blocked Evaluate: %v", err)
+	}
+	blockedReport, err := ProjectInterviewReport(
+		blockedSnapshot,
+		blockedResult,
+	)
+	if err != nil {
+		t.Fatalf("blocked report: %v", err)
+	}
+
+	provisionalSnapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpNone,
+	)
+	provisionalResult, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{},
+	).Evaluate(context.Background(), provisionalSnapshot)
+	if err != nil {
+		t.Fatalf("provisional Evaluate: %v", err)
+	}
+	provisionalReport, err := ProjectInterviewReport(
+		provisionalSnapshot,
+		provisionalResult,
+	)
+	if err != nil {
+		t.Fatalf("provisional report: %v", err)
+	}
+	blockedReport.Dimensions[0] = provisionalReport.Dimensions[0]
+	if blockedReport.Valid() {
+		t.Fatal("blocked root accepted a provisional dimension")
+	}
+}
+
+func TestInterviewReportQuestionFindingRequiresEvidenceIntersection(
+	t *testing.T,
+) {
+	t.Parallel()
+	snapshot := interviewShadowTestSnapshot(
+		t,
+		"I led a careful migration.",
+		interviewFollowUpAnswered,
+	)
+	prepared, err := prepareInterviewShadow(snapshot)
+	if err != nil {
+		t.Fatalf("prepare Interview Shadow: %v", err)
+	}
+	payload := validInterviewProviderPayloadValue(prepared.input)
+	followUp := prepared.input.Opportunities[1].Response
+	if followUp == nil {
+		t.Fatal("fixture has no follow-up response")
+	}
+	payload.Dimensions[0].Strengths[0].Evidence = append(
+		payload.Dimensions[0].Strengths[0].Evidence,
+		interviewProviderAnchor{
+			EvidenceRefID: followUp.EvidenceRefID,
+			Quote:         followUp.Transcript,
+			Occurrence:    1,
+		},
+	)
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal Provider payload: %v", err)
+	}
+	result, err := NewInterviewShadowEngine(
+		&stubInterviewShadowProvider{payload: encoded},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	report, err := ProjectInterviewReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectInterviewReport: %v", err)
+	}
+	finding := report.Dimensions[0].Strengths[0]
+	if len(finding.Evidence) != 2 ||
+		len(report.Questions[0].DimensionFindings[0].
+			StrengthFindingIDs) != 1 ||
+		len(report.Questions[1].DimensionFindings[0].
+			StrengthFindingIDs) != 1 ||
+		!report.Valid() {
+		t.Fatalf("multi-question finding report = %#v", report)
+	}
+
+	report.Questions[0].EvidenceRefIDs = []string{
+		"evidence_ref_unrelated",
+	}
+	if report.Valid() {
+		t.Fatal("question accepted a finding without evidence intersection")
+	}
+}

--- a/server/internal/evaluation/interview_shadow_postgres.go
+++ b/server/internal/evaluation/interview_shadow_postgres.go
@@ -884,6 +884,23 @@ func (r *PostgresRepository) GetInterviewShadowState(
 		!validUUID(evaluationRevisionID) {
 		return InterviewShadowReadState{}, ErrInvalidRequest
 	}
+	state, _, err := getInterviewShadowState(
+		ctx,
+		r.pool,
+		ownerUserID,
+		evaluationID,
+		evaluationRevisionID,
+	)
+	return state, err
+}
+
+func getInterviewShadowState(
+	ctx context.Context,
+	db queryable,
+	ownerUserID string,
+	evaluationID string,
+	evaluationRevisionID string,
+) (InterviewShadowReadState, *EvidenceSnapshot, error) {
 	var deliveryStatus string
 	var leaseActive bool
 	var moduleStatus string
@@ -892,7 +909,7 @@ func (r *PostgresRepository) GetInterviewShadowState(
 	var payload []byte
 	var inputSnapshotID string
 	var fullConfigHash []byte
-	err := r.pool.QueryRow(ctx, `
+	err := db.QueryRow(ctx, `
 		SELECT
 			outbox.delivery_status,
 			coalesce(
@@ -954,10 +971,10 @@ func (r *PostgresRepository) GetInterviewShadowState(
 		&inputSnapshotID,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return InterviewShadowReadState{}, ErrNotFound
+		return InterviewShadowReadState{}, nil, ErrNotFound
 	}
 	if err != nil {
-		return InterviewShadowReadState{}, fmt.Errorf(
+		return InterviewShadowReadState{}, nil, fmt.Errorf(
 			"read Interview Shadow state: %w",
 			err,
 		)
@@ -965,7 +982,7 @@ func (r *PostgresRepository) GetInterviewShadowState(
 	var persistedConfigHash [32]byte
 	if len(fullConfigHash) != 0 {
 		if len(fullConfigHash) != len(persistedConfigHash) {
-			return InterviewShadowReadState{},
+			return InterviewShadowReadState{}, nil,
 				ErrInterviewShadowConfigurationConflict
 		}
 		copy(persistedConfigHash[:], fullConfigHash)
@@ -977,22 +994,22 @@ func (r *PostgresRepository) GetInterviewShadowState(
 			return InterviewShadowReadState{
 				ModuleStatus:   InterviewShadowRuntimeRunning,
 				FullConfigHash: persistedConfigHash,
-			}, nil
+			}, nil, nil
 		}
 		if revisionStatus != "QUEUED" &&
 			revisionStatus != "RUNNING" {
-			return InterviewShadowReadState{},
+			return InterviewShadowReadState{}, nil,
 				ErrInterviewShadowConfigurationConflict
 		}
 		return InterviewShadowReadState{
 			ModuleStatus:   InterviewShadowRuntimePending,
 			FullConfigHash: persistedConfigHash,
-		}, nil
+		}, nil, nil
 	case "FAILED":
 		if moduleStatus != "FAILED" ||
 			revisionStatus != "FAILED" ||
 			!interviewShadowFailureCodePattern.MatchString(failureCode) {
-			return InterviewShadowReadState{},
+			return InterviewShadowReadState{}, nil,
 				ErrInterviewShadowConfigurationConflict
 		}
 		return InterviewShadowReadState{
@@ -1001,43 +1018,44 @@ func (r *PostgresRepository) GetInterviewShadowState(
 			Failure: &InterviewShadowFailure{
 				Code: failureCode,
 			},
-		}, nil
+		}, nil, nil
 	case "DELIVERED":
 		if moduleStatus != "READY" ||
 			revisionStatus != "READY" ||
 			len(payload) == 0 {
-			return InterviewShadowReadState{},
+			return InterviewShadowReadState{}, nil,
 				ErrInterviewShadowConfigurationConflict
 		}
 		var result InterviewShadowResult
 		if err := json.Unmarshal(payload, &result); err != nil {
-			return InterviewShadowReadState{}, fmt.Errorf(
+			return InterviewShadowReadState{}, nil, fmt.Errorf(
 				"decode Interview Shadow result: %w",
 				err,
 			)
 		}
-		snapshot, err := r.GetEvidenceSnapshot(
+		snapshot, err := selectEvidenceSnapshotByID(
 			ctx,
+			db,
 			ownerUserID,
 			inputSnapshotID,
 		)
 		if err != nil {
-			return InterviewShadowReadState{}, err
+			return InterviewShadowReadState{}, nil, err
 		}
 		if err := ValidateInterviewShadowResult(
 			snapshot,
 			result,
 		); err != nil {
-			return InterviewShadowReadState{},
+			return InterviewShadowReadState{}, nil,
 				ErrInterviewShadowConfigurationConflict
 		}
 		return InterviewShadowReadState{
 			ModuleStatus:   InterviewShadowRuntimeReady,
 			FullConfigHash: persistedConfigHash,
 			Result:         &result,
-		}, nil
+		}, &snapshot, nil
 	default:
-		return InterviewShadowReadState{},
+		return InterviewShadowReadState{}, nil,
 			ErrInterviewShadowConfigurationConflict
 	}
 }

--- a/server/internal/evaluation/transport/http.go
+++ b/server/internal/evaluation/transport/http.go
@@ -37,6 +37,11 @@ type Application interface {
 		requestcontext.Actor,
 		string,
 	) (EvaluationResource, error)
+	GetInterviewReport(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (InterviewReportResource, error)
 	Reevaluate(
 		context.Context,
 		requestcontext.Actor,
@@ -98,6 +103,7 @@ const (
 	ReasonDuplicateRequest         ReasonCode = "DUPLICATE_REQUEST"
 	ReasonPolicyViolation          ReasonCode = "POLICY_VIOLATION"
 	ReasonInternalRetryable        ReasonCode = "INTERNAL_RETRYABLE"
+	ReasonInternalNonRetryable     ReasonCode = "INTERNAL_NON_RETRYABLE"
 	ReasonOpportunityNotProvided   ReasonCode = "OPPORTUNITY_NOT_PROVIDED"
 )
 
@@ -138,6 +144,17 @@ type EvaluationResource struct {
 	CompletedAt            *time.Time
 }
 
+type InterviewReportResource struct {
+	PracticeSessionID    string
+	EvaluationID         string
+	EvaluationRevisionID string
+	Revision             int
+	EvaluationStatus     evaluation.Status
+	IsFinal              bool
+	Report               *evaluation.InterviewReport
+	StableFailure        *EvaluationFailure
+}
+
 type HTTPHandler struct {
 	application Application
 	errors      *httpresponse.Renderer
@@ -157,6 +174,10 @@ func (h *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
 	routes.POST("/v1/evaluations", h.create)
 	routes.GET("/v1/evaluations/:evaluation_id", h.get)
 	routes.POST("/v1/evaluations/:evaluation_id/re-evaluate", h.reevaluate)
+	routes.GET(
+		"/v1/practice-sessions/:practice_session_id/interview-report",
+		h.getInterviewReport,
+	)
 }
 
 func (h *HTTPHandler) create(c *gin.Context) {
@@ -251,6 +272,35 @@ func (h *HTTPHandler) reevaluate(c *gin.Context) {
 		return
 	}
 	c.JSON(accepted.responseStatus(), accepted.response())
+}
+
+func (h *HTTPHandler) getInterviewReport(c *gin.Context) {
+	setInterviewReportResponseHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	practiceSessionID := c.Param("practice_session_id")
+	if !stableIdentifierPattern.MatchString(practiceSessionID) {
+		h.errors.Write(c, evaluationNotFoundError())
+		return
+	}
+	resource, err := h.application.GetInterviewReport(
+		c.Request.Context(),
+		actor,
+		practiceSessionID,
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	if !resource.valid() ||
+		resource.PracticeSessionID != practiceSessionID {
+		h.errors.Write(c, errInvalidApplicationProjection)
+		return
+	}
+	c.JSON(http.StatusOK, resource.response())
 }
 
 type optionalString struct {
@@ -422,6 +472,75 @@ type evaluationResponse struct {
 	CreatedAt              string                  `json:"created_at"`
 	UpdatedAt              string                  `json:"updated_at"`
 	CompletedAt            string                  `json:"completed_at,omitempty"`
+}
+
+type interviewReportResponse struct {
+	PracticeSessionID    string                      `json:"practice_session_id"`
+	EvaluationID         string                      `json:"evaluation_id"`
+	EvaluationRevisionID string                      `json:"evaluation_revision_id"`
+	Revision             int                         `json:"revision"`
+	EvaluationStatus     evaluation.Status           `json:"evaluation_status"`
+	IsFinal              bool                        `json:"is_final"`
+	StatusURL            string                      `json:"status_url"`
+	Report               *evaluation.InterviewReport `json:"report,omitempty"`
+	StableFailure        *EvaluationFailure          `json:"stable_failure,omitempty"`
+}
+
+func (resource InterviewReportResource) response() interviewReportResponse {
+	return interviewReportResponse{
+		PracticeSessionID:    resource.PracticeSessionID,
+		EvaluationID:         resource.EvaluationID,
+		EvaluationRevisionID: resource.EvaluationRevisionID,
+		Revision:             resource.Revision,
+		EvaluationStatus:     resource.EvaluationStatus,
+		IsFinal:              resource.IsFinal,
+		StatusURL: "/v1/practice-sessions/" +
+			resource.PracticeSessionID +
+			"/interview-report",
+		Report:        resource.Report,
+		StableFailure: resource.StableFailure,
+	}
+}
+
+func (resource InterviewReportResource) valid() bool {
+	if !stableIdentifierPattern.MatchString(resource.PracticeSessionID) ||
+		!validEvaluationID(resource.EvaluationID) ||
+		!validEvaluationID(resource.EvaluationRevisionID) ||
+		resource.Revision < 1 ||
+		resource.IsFinal {
+		return false
+	}
+	switch resource.EvaluationStatus {
+	case evaluation.StatusQueued, evaluation.StatusRunning:
+		return resource.Report == nil &&
+			resource.StableFailure == nil
+	case evaluation.StatusReady:
+		return resource.Report != nil &&
+			resource.Report.Valid() &&
+			resource.StableFailure == nil
+	case evaluation.StatusFailed:
+		return resource.Report == nil &&
+			validInterviewReportFailure(resource.StableFailure)
+	default:
+		return false
+	}
+}
+
+func validInterviewReportFailure(failure *EvaluationFailure) bool {
+	if failure == nil {
+		return false
+	}
+	switch failure.ReasonCode {
+	case ReasonPolicyViolation,
+		ReasonEvidenceRefInvalid,
+		ReasonVersionConflict,
+		ReasonInternalNonRetryable:
+		return !failure.Retryable
+	case ReasonInternalRetryable:
+		return failure.Retryable
+	default:
+		return false
+	}
 }
 
 func (resource EvaluationResource) response() evaluationResponse {
@@ -621,6 +740,7 @@ func validReasonCode(reason ReasonCode) bool {
 		ReasonDuplicateRequest,
 		ReasonPolicyViolation,
 		ReasonInternalRetryable,
+		ReasonInternalNonRetryable,
 		ReasonOpportunityNotProvided:
 		return true
 	default:
@@ -798,6 +918,11 @@ func validJSONContentType(value string) bool {
 
 func setPrivateResponseHeaders(c *gin.Context) {
 	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+}
+
+func setInterviewReportResponseHeaders(c *gin.Context) {
+	c.Header("Cache-Control", "private, no-store")
 	c.Header("Pragma", "no-cache")
 }
 

--- a/server/internal/evaluation/transport/http_test.go
+++ b/server/internal/evaluation/transport/http_test.go
@@ -42,6 +42,11 @@ type applicationStub struct {
 		requestcontext.Actor,
 		string,
 	) (EvaluationResource, error)
+	getInterviewReport func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (InterviewReportResource, error)
 	reevaluate func(
 		context.Context,
 		requestcontext.Actor,
@@ -70,6 +75,18 @@ func (stub applicationStub) Get(
 		return EvaluationResource{}, errors.New("unexpected Get")
 	}
 	return stub.get(ctx, actor, evaluationID)
+}
+
+func (stub applicationStub) GetInterviewReport(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	practiceSessionID string,
+) (InterviewReportResource, error) {
+	if stub.getInterviewReport == nil {
+		return InterviewReportResource{},
+			errors.New("unexpected GetInterviewReport")
+	}
+	return stub.getInterviewReport(ctx, actor, practiceSessionID)
 }
 
 func (stub applicationStub) Reevaluate(
@@ -366,6 +383,223 @@ func TestGetPublishesEveryLifecycleStateHonestly(t *testing.T) {
 	}
 }
 
+func TestGetInterviewReportPublishesStrictLifecycleEnvelope(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   evaluation.Status
+		wantKey  string
+		omitKeys []string
+	}{
+		{
+			name:     "queued",
+			status:   evaluation.StatusQueued,
+			omitKeys: []string{"report", "stable_failure"},
+		},
+		{
+			name:     "running",
+			status:   evaluation.StatusRunning,
+			omitKeys: []string{"report", "stable_failure"},
+		},
+		{
+			name:     "ready",
+			status:   evaluation.StatusReady,
+			wantKey:  "report",
+			omitKeys: []string{"stable_failure"},
+		},
+		{
+			name:     "failed",
+			status:   evaluation.StatusFailed,
+			wantKey:  "stable_failure",
+			omitKeys: []string{"report"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			want := interviewReportResourceForStatus(test.status)
+			router := newTestRouter(t, applicationStub{
+				getInterviewReport: func(
+					ctx context.Context,
+					actor requestcontext.Actor,
+					practiceSessionID string,
+				) (InterviewReportResource, error) {
+					if actor != testActor ||
+						practiceSessionID != "session_demo_001" {
+						t.Fatalf(
+							"report input actor=%#v session=%q",
+							actor,
+							practiceSessionID,
+						)
+					}
+					if trusted, ok := requestcontext.ActorFromContext(ctx); !ok ||
+						trusted != testActor {
+						t.Fatal("trusted actor missing from report context")
+					}
+					return want, nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodGet,
+				"/v1/practice-sessions/session_demo_001/interview-report",
+				"",
+				"",
+			)
+			if response.Code != http.StatusOK {
+				t.Fatalf(
+					"status = %d, body = %s",
+					response.Code,
+					response.Body,
+				)
+			}
+			if response.Header().Get("Cache-Control") !=
+				"private, no-store" ||
+				response.Header().Get("Pragma") != "no-cache" {
+				t.Fatalf("report headers = %#v", response.Header())
+			}
+			body := decodeJSONObjectForTest(t, response.Body.String())
+			for key, expected := range map[string]any{
+				"practice_session_id":    "session_demo_001",
+				"evaluation_id":          testEvaluationID,
+				"evaluation_revision_id": testRevisionID,
+				"revision":               float64(1),
+				"evaluation_status":      string(test.status),
+				"is_final":               false,
+				"status_url": "/v1/practice-sessions/" +
+					"session_demo_001/interview-report",
+			} {
+				if body[key] != expected {
+					t.Errorf("%s = %#v, want %#v", key, body[key], expected)
+				}
+			}
+			if test.wantKey != "" {
+				if _, exists := body[test.wantKey]; !exists {
+					t.Errorf("response missing %q: %s", test.wantKey, response.Body)
+				}
+			}
+			for _, key := range test.omitKeys {
+				if _, exists := body[key]; exists {
+					t.Errorf("response fabricated %q: %s", key, response.Body)
+				}
+			}
+			if report, exists := body["report"].(map[string]any); exists {
+				if report["schema_version"] !=
+					evaluation.InterviewReportSchemaVersion {
+					t.Errorf("report = %#v", report)
+				}
+				if _, exposed := report["snapshot_id"]; exposed {
+					t.Fatal("report exposed snapshot_id")
+				}
+			}
+		})
+	}
+}
+
+func TestGetInterviewReportRejectsInvalidRouteAndProjection(t *testing.T) {
+	calls := 0
+	router := newTestRouter(t, applicationStub{
+		getInterviewReport: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+		) (InterviewReportResource, error) {
+			calls++
+			invalid := interviewReportResourceForStatus(
+				evaluation.StatusReady,
+			)
+			invalid.Report.SchemaVersion = "unknown-report/v1"
+			return invalid, nil
+		},
+	}, &testActor)
+	response := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/practice-sessions/not.valid/interview-report",
+		"",
+		"",
+	)
+	assertAPIError(
+		t,
+		response,
+		http.StatusNotFound,
+		"evaluation_not_found",
+	)
+	if calls != 0 {
+		t.Fatalf("invalid report path called application %d times", calls)
+	}
+
+	response = performRequest(
+		router,
+		http.MethodGet,
+		"/v1/practice-sessions/session_demo_001/interview-report",
+		"",
+		"",
+	)
+	assertAPIError(
+		t,
+		response,
+		http.StatusInternalServerError,
+		"internal_error",
+	)
+	if calls != 1 {
+		t.Fatalf("valid report path called application %d times", calls)
+	}
+}
+
+func TestGetInterviewReportRejectsContradictoryFailureRetryability(
+	t *testing.T,
+) {
+	if !validInterviewReportFailure(&EvaluationFailure{
+		ReasonCode: ReasonInternalNonRetryable,
+	}) {
+		t.Fatal("non-retryable internal failure was rejected")
+	}
+	tests := []EvaluationFailure{
+		{
+			ReasonCode: ReasonInternalRetryable,
+			Retryable:  false,
+		},
+		{
+			ReasonCode: ReasonInternalNonRetryable,
+			Retryable:  true,
+		},
+		{
+			ReasonCode: ReasonPolicyViolation,
+			Retryable:  true,
+		},
+	}
+	for _, failure := range tests {
+		failure := failure
+		t.Run(string(failure.ReasonCode), func(t *testing.T) {
+			resource := interviewReportResourceForStatus(
+				evaluation.StatusFailed,
+			)
+			resource.StableFailure = &failure
+			router := newTestRouter(t, applicationStub{
+				getInterviewReport: func(
+					context.Context,
+					requestcontext.Actor,
+					string,
+				) (InterviewReportResource, error) {
+					return resource, nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodGet,
+				"/v1/practice-sessions/session_demo_001/interview-report",
+				"",
+				"",
+			)
+			assertAPIError(
+				t,
+				response,
+				http.StatusInternalServerError,
+				"internal_error",
+			)
+		})
+	}
+}
+
 func TestReadyProjectionMatchesEveryRequestedChannelExactly(t *testing.T) {
 	sceneOnly := resourceForStatus(evaluation.StatusReady)
 
@@ -463,6 +697,16 @@ func TestEndpointsRequireActorFromRequestContext(t *testing.T) {
 			calls++
 			return resourceForStatus(evaluation.StatusQueued), nil
 		},
+		getInterviewReport: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+		) (InterviewReportResource, error) {
+			calls++
+			return interviewReportResourceForStatus(
+				evaluation.StatusQueued,
+			), nil
+		},
 		reevaluate: func(
 			context.Context,
 			requestcontext.Actor,
@@ -494,6 +738,11 @@ func TestEndpointsRequireActorFromRequestContext(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/v1/evaluations/" + testEvaluationID,
+		},
+		{
+			method: http.MethodGet,
+			path: "/v1/practice-sessions/session_demo_001/" +
+				"interview-report",
 		},
 		{
 			method:      http.MethodPost,
@@ -1450,6 +1699,90 @@ func genericSceneResult() json.RawMessage {
 	return json.RawMessage(`{"summary":"provider-independent result"}`)
 }
 
+func interviewReportResourceForStatus(
+	status evaluation.Status,
+) InterviewReportResource {
+	resource := InterviewReportResource{
+		PracticeSessionID:    "session_demo_001",
+		EvaluationID:         testEvaluationID,
+		EvaluationRevisionID: testRevisionID,
+		Revision:             1,
+		EvaluationStatus:     status,
+		IsFinal:              false,
+	}
+	switch status {
+	case evaluation.StatusReady:
+		report := insufficientInterviewReport()
+		resource.Report = &report
+	case evaluation.StatusFailed:
+		resource.StableFailure = &EvaluationFailure{
+			ReasonCode: ReasonInternalRetryable,
+			Retryable:  true,
+		}
+	}
+	return resource
+}
+
+func insufficientInterviewReport() evaluation.InterviewReport {
+	dimensions := make(
+		[]evaluation.InterviewReportDimension,
+		0,
+		5,
+	)
+	dimensionFindings := make(
+		[]evaluation.InterviewQuestionDimensionRefs,
+		0,
+		5,
+	)
+	for _, dimensionID := range evaluation.InterviewDimensions() {
+		dimensions = append(
+			dimensions,
+			evaluation.InterviewReportDimension{
+				DimensionID: dimensionID,
+				ScoreabilityStatus: evaluation.
+					InterviewScoreabilityInsufficient,
+				GateStatus: evaluation.InterviewGateBlocked,
+				ReasonCodes: []evaluation.InterviewReasonCode{
+					evaluation.InterviewReasonInsufficientEvidence,
+				},
+				EvidenceRefIDs:         []string{},
+				Strengths:              []evaluation.InterviewReportFinding{},
+				Improvements:           []evaluation.InterviewReportFinding{},
+				RecommendedExpressions: []evaluation.InterviewReportFinding{},
+			},
+		)
+		dimensionFindings = append(
+			dimensionFindings,
+			evaluation.InterviewQuestionDimensionRefs{
+				DimensionID:                     dimensionID,
+				StrengthFindingIDs:              []string{},
+				ImprovementFindingIDs:           []string{},
+				RecommendedExpressionFindingIDs: []string{},
+			},
+		)
+	}
+	return evaluation.InterviewReport{
+		SchemaVersion: evaluation.InterviewReportSchemaVersion,
+		ScoreabilityStatus: evaluation.
+			InterviewScoreabilityInsufficient,
+		GateStatus:     evaluation.InterviewGateBlocked,
+		ReadinessLevel: evaluation.InterviewReadinessNotAssessed,
+		ReadinessNotice: evaluation.
+			InterviewReportReadinessNotice,
+		Dimensions: dimensions,
+		Questions: []evaluation.InterviewReportQuestion{{
+			QuestionID:        "question-1",
+			QuestionType:      "PRIMARY",
+			OpportunityStatus: evaluation.InterviewOpportunityNotProvided,
+			AssessmentStatus:  evaluation.InterviewAssessmentNotAssessed,
+			QuestionText:      "Tell me about a migration you led.",
+			EvidenceRefIDs:    []string{},
+			DimensionFindings: dimensionFindings,
+		}},
+		PriorityActions: []evaluation.InterviewReportPriorityRef{},
+	}
+}
+
 func validCreateBody() string {
 	return `{
 		"practice_session_id":"session_demo_001",
@@ -1522,7 +1855,9 @@ func assertPrivateResponse(
 	response *httptest.ResponseRecorder,
 ) {
 	t.Helper()
-	if response.Header().Get("Cache-Control") != "no-store" ||
+	cacheControl := response.Header().Get("Cache-Control")
+	if (cacheControl != "no-store" &&
+		cacheControl != "private, no-store") ||
 		response.Header().Get("Pragma") != "no-cache" {
 		t.Fatalf("private response headers = %#v", response.Header())
 	}


### PR DESCRIPTION
## 功能说明

- 新增 Actor-owned Interview 报告查询端点，严格区分 QUEUED、RUNNING、READY 与 FAILED。
- 将同一 Evaluation revision 的持久化 Shadow 结果和冻结 EvidenceSnapshot 确定性投影为五维定性反馈、逐题原回答、证据引用与最多三项优先改进。
- Flutter 面试复盘详情支持有界轮询、证据不足、技术失败、legacy FormalReview 回退，以及离页、登出和账号切换清理。
- 不生成数值分、录用概率或发音、语速、纯声学流利度结论。

## 实现思路

- OpenAPI 固定 `interview-report/v1` 严格 schema，并校验题目、finding、evidence、priority 的交叉引用。
- Go 使用 owner + practice session + 固定 Shadow strategy 查询唯一当前 logical Evaluation；零匹配返回 404，多匹配返回 409，GET 不触发 Provider 或 re-evaluate。
- READY 报告仅公开已持久化事实；FAILED 返回稳定 failure，不以低分兜底。
- Flutter 使用独立严格 decoder/controller，不伪装为 FormalReviewResult，并通过 generation fence 丢弃迟到响应。
- 报告链路与 #294 的数字开头 Practice Session UUID 规则保持一致。

## 验证

- `cd api && npm run check`
- `cd server && go vet ./...`
- `cd server && TEST_DATABASE_URL=<现有本地 PostgreSQL> go test ./...`
- `cd mobile && dart format --output=none --set-exit-if-changed lib test`
- `cd mobile && flutter analyze --no-pub`
- `cd mobile && flutter test --no-pub`（666 tests）
- 后端与 Flutter/API 两路独立 P0/P1 复审均无阻断项

## 依赖

- #267
- #279
- #294（已合并）

Closes #280