### PR TITLE
fix(agent): 修复流式 Unicode 请求编码

### DIFF
--- a/mobile/lib/agent/wire_agent_client.dart
+++ b/mobile/lib/agent/wire_agent_client.dart
@@ -620,6 +620,16 @@ final class WireAgentClient
       uri,
       sessionToken: credential.sessionToken,
     );
+    final requestBody = utf8.encode(
+      jsonEncode(
+        failedRun == null
+            ? <String, Object?>{
+                'client_message_id': clientMessageId,
+                'content': text,
+              }
+            : <String, Object?>{'client_retry_id': 'retry:${failedRun.runId}'},
+      ),
+    );
     final httpClient = HttpClient()..connectionTimeout = _requestTimeout;
     try {
       final request = await httpClient.postUrl(uri).timeout(_requestTimeout);
@@ -631,18 +641,8 @@ final class WireAgentClient
           HttpHeaders.authorizationHeader,
           bearerAuthorizationValue(credential.sessionToken),
         )
-        ..write(
-          jsonEncode(
-            failedRun == null
-                ? <String, Object?>{
-                    'client_message_id': clientMessageId,
-                    'content': text,
-                  }
-                : <String, Object?>{
-                    'client_retry_id': 'retry:${failedRun.runId}',
-                  },
-          ),
-        );
+        ..contentLength = requestBody.length
+        ..add(requestBody);
       final response = await request.close().timeout(_requestTimeout);
       _requireCurrentGeneration(generation);
       if (!isSameAuthSessionCredential(_credentialProvider(), credential)) {

--- a/mobile/test/agent/agent_streaming_test.dart
+++ b/mobile/test/agent/agent_streaming_test.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
+import 'package:speakup/agent/wire_agent_client.dart';
+import 'package:speakup/identity/auth_state.dart';
 
 void main() {
   test(
@@ -58,6 +62,118 @@ void main() {
       expect(controller.messages.last.isStreaming, isFalse);
     },
   );
+
+  test('sends Unicode stream input as UTF-8 and preserves retry', () async {
+    const threadId = '11111111-1111-4111-8111-111111111111';
+    const runId = '22222222-2222-4222-8222-222222222222';
+    const retryRunId = '33333333-3333-4333-8333-333333333333';
+    const userMessageId = '44444444-4444-4444-8444-444444444444';
+    const assistantMessageId = '55555555-5555-4555-8555-555555555555';
+    const clientMessageId = 'unicode-message';
+    const content = '你好，小花';
+    const createdAt = '2026-07-30T03:00:00Z';
+    final requests = <({String path, Map<String, dynamic> body})>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final subscription = server.listen((request) async {
+      final bodyBytes = await request.fold<List<int>>(
+        <int>[],
+        (buffer, chunk) => buffer..addAll(chunk),
+      );
+      requests.add((
+        path: request.uri.path,
+        body: jsonDecode(utf8.decode(bodyBytes)) as Map<String, dynamic>,
+      ));
+      final isRetry = requests.length == 2;
+      final effectiveRunId = isRetry ? retryRunId : runId;
+      final events = <String>[
+        _sse('input.committed', {
+          'run_id': effectiveRunId,
+          'message': <String, Object?>{
+            'message_id': userMessageId,
+            'thread_id': threadId,
+            'sequence': 1,
+            'role': 'user',
+            'client_message_id': clientMessageId,
+            'content': content,
+            'created_at': createdAt,
+          },
+        }),
+        if (!isRetry)
+          _sse('run.failed', {
+            'run_id': runId,
+            'kind': 'provider_unavailable',
+            'retryable': true,
+          })
+        else ...[
+          _sse('assistant.started', {'run_id': retryRunId}),
+          _sse('assistant.delta', {'run_id': retryRunId, 'delta': '你好，小花。'}),
+          _sse('run.completed', {
+            'run': <String, Object?>{
+              'run_id': retryRunId,
+              'assistant_message_id': assistantMessageId,
+            },
+          }),
+        ],
+      ];
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.set(
+          HttpHeaders.contentTypeHeader,
+          'text/event-stream; charset=utf-8',
+        )
+        ..add(utf8.encode(events.join()));
+      await request.response.close();
+    });
+    addTearDown(() async {
+      await subscription.cancel();
+      await server.close(force: true);
+    });
+    const credential = AuthSessionCredential(
+      sessionToken: 'sess_unicode',
+      generation: 1,
+    );
+    final client = WireAgentClient(
+      baseUri: Uri.parse('http://127.0.0.1:${server.port}'),
+      credentialProvider: () => credential,
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+    );
+    addTearDown(client.clearAccountState);
+
+    final firstEvents = await client
+        .sendTextStream(
+          threadId: threadId,
+          text: content,
+          clientMessageId: clientMessageId,
+        )
+        .toList();
+    final retryEvents = await client
+        .sendTextStream(
+          threadId: threadId,
+          text: content,
+          clientMessageId: clientMessageId,
+        )
+        .toList();
+
+    expect(firstEvents.last, isA<AgentRunFailed>());
+    expect(retryEvents.last, isA<AgentRunCompleted>());
+    expect(requests.map((request) => request.path), [
+      '/v1/agent-threads/$threadId/runs/stream',
+      '/v1/agent-runs/$runId/retries/stream',
+    ]);
+    expect(requests[0].body, {
+      'client_message_id': clientMessageId,
+      'content': content,
+    });
+    expect(requests[1].body, {'client_retry_id': 'retry:$runId'});
+  });
+}
+
+String _sse(String event, Map<String, Object?> data) {
+  return 'event: $event\ndata: ${jsonEncode(data)}\n\n';
 }
 
 final class _StreamingAgentClient


### PR DESCRIPTION
## 功能描述

修复 Flutter Agent 流式文本请求无法发送中文等 Unicode 内容的问题。此前 `HttpClientRequest.write(String)` 使用默认 Latin-1 编码，中文 JSON 会在请求到达后端前抛出 `Contains invalid characters`，界面只显示“回复中断了，可以重试”。

Closes #287
Relates to #244

## 实现思路

- 使用 `utf8.encode(jsonEncode(...))` 生成流式提交/重试请求体。
- 设置准确的 `contentLength`，通过 `HttpClientRequest.add(List<int>)` 写入 UTF-8 字节。
- 不改变 SSE 响应协议、认证、幂等键或后端 API 契约。
- 增加真实 loopback `HttpServer` 测试，覆盖中文首次提交、`run.failed` 后流式重试和 `run.completed`。

## 可复现测试

```bash
cd mobile
dart format --output=none --set-exit-if-changed lib test
flutter analyze
flutter test test/agent/agent_streaming_test.dart test/agent/agent_flow_test.dart test/speak_up_app_test.dart test/agent/wire_agent_client_test.dart
```

结果：格式检查通过；`flutter analyze` 无问题；相关测试 69 项通过。

## 真实联调验证

1. 启动当前 `dev` 后端和 iPhone 17 Pro 模拟器。
2. 在 Agent 对话发送中文“你好”。
3. 后端记录 `POST /v1/agent-threads/{thread_id}/runs/stream` 返回 200。
4. App 增量显示并完成 Agent 回复，不再出现“回复中断”。

## 范围说明

仅修改 Flutter 流式请求编码及对应测试；不修改非流式请求、后端逻辑、API 契约或产品交互。