### PR TITLE
[P0][后端] Evaluation HTTP transport 基础层

### DIFF
--- a/server/internal/evaluation/transport/http.go
+++ b/server/internal/evaluation/transport/http.go
@@ -1,0 +1,914 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const maxEvaluationRequestBody = 32 * 1024
+
+// Application is the authenticated application boundary used by the
+// Evaluation HTTP transport. Implementations must join the immutable ledger
+// with any persisted result or failure before returning an EvaluationResource.
+type Application interface {
+	Create(
+		context.Context,
+		requestcontext.Actor,
+		evaluation.CreateRequest,
+	) (EvaluationAccepted, error)
+	Get(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (EvaluationResource, error)
+	Reevaluate(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		evaluation.ReevaluateRequest,
+	) (EvaluationAccepted, error)
+}
+
+// EvaluationAccepted is the immutable revision identity returned by a fresh
+// write. The transport accepts only genuinely queued revisions.
+type EvaluationAccepted struct {
+	EvaluationID         string
+	EvaluationRevisionID string
+	Revision             int
+	SupersedesRevisionID string
+	EvaluationStatus     evaluation.Status
+}
+
+type ScoreabilityStatus string
+
+const (
+	ScoreabilityReliable     ScoreabilityStatus = "RELIABLE"
+	ScoreabilityProvisional  ScoreabilityStatus = "PROVISIONAL"
+	ScoreabilityInsufficient ScoreabilityStatus = "INSUFFICIENT"
+)
+
+type GateStatus string
+
+const (
+	GatePass         GateStatus = "PASS"
+	GateFeedbackOnly GateStatus = "FEEDBACK_ONLY"
+	GateBlocked      GateStatus = "BLOCKED"
+)
+
+type ModuleStatus string
+
+const (
+	ModulePending ModuleStatus = "PENDING"
+	ModuleRunning ModuleStatus = "RUNNING"
+	ModuleReady   ModuleStatus = "READY"
+	ModuleFailed  ModuleStatus = "FAILED"
+	ModuleSkipped ModuleStatus = "SKIPPED"
+)
+
+type ReasonCode string
+
+const (
+	ReasonStrategyNotAvailable     ReasonCode = "STRATEGY_NOT_AVAILABLE"
+	ReasonAudioUnusable            ReasonCode = "AUDIO_UNUSABLE"
+	ReasonSpeakerAttributionFailed ReasonCode = "SPEAKER_ATTRIBUTION_FAILED"
+	ReasonInsufficientEvidence     ReasonCode = "INSUFFICIENT_EVIDENCE"
+	ReasonASRLowConfidence         ReasonCode = "ASR_LOW_CONFIDENCE"
+	ReasonRequiredDimensionMissing ReasonCode = "REQUIRED_DIMENSION_MISSING"
+	ReasonScoreInconsistent        ReasonCode = "SCORE_INCONSISTENT"
+	ReasonEvidenceRefInvalid       ReasonCode = "EVIDENCE_REF_INVALID"
+	ReasonVersionConflict          ReasonCode = "VERSION_CONFLICT"
+	ReasonDuplicateRequest         ReasonCode = "DUPLICATE_REQUEST"
+	ReasonPolicyViolation          ReasonCode = "POLICY_VIOLATION"
+	ReasonInternalRetryable        ReasonCode = "INTERNAL_RETRYABLE"
+	ReasonOpportunityNotProvided   ReasonCode = "OPPORTUNITY_NOT_PROVIDED"
+)
+
+type EvaluationFailure struct {
+	ReasonCode ReasonCode `json:"reason_code"`
+	Retryable  bool       `json:"retryable"`
+}
+
+// EvaluationResource is an already-authorized, publishable projection. Result
+// payloads remain raw only at the polymorphic result boundary; the application
+// owns their schema validation before constructing this projection.
+type EvaluationResource struct {
+	EvaluationID           string
+	EvaluationRevisionID   string
+	Revision               int
+	SupersedesRevisionID   string
+	SupersededByRevisionID string
+	PracticeSessionID      string
+	InputSnapshotID        string
+	InputRevision          int
+	Scope                  evaluation.Scope
+	SceneType              evaluation.SceneType
+	Channels               []evaluation.Channel
+	SceneStrategyRef       string
+	Core4DStrategyRef      string
+	PipelineVersion        string
+	SchemaVersion          string
+	EvaluationStatus       evaluation.Status
+	ScoreabilityStatus     ScoreabilityStatus
+	GateStatus             GateStatus
+	ModuleStatuses         map[string]ModuleStatus
+	SceneResult            json.RawMessage
+	Core4DObservations     json.RawMessage
+	StableFailure          *EvaluationFailure
+	IsFinal                bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	CompletedAt            *time.Time
+}
+
+type HTTPHandler struct {
+	application Application
+	errors      *httpresponse.Renderer
+}
+
+func NewHTTPHandler(application Application) (*HTTPHandler, error) {
+	if application == nil {
+		return nil, errors.New("evaluation: HTTP application is required")
+	}
+	return &HTTPHandler{
+		application: application,
+		errors:      httpresponse.NewRenderer(nil),
+	}, nil
+}
+
+func (h *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
+	routes.POST("/v1/evaluations", h.create)
+	routes.GET("/v1/evaluations/:evaluation_id", h.get)
+	routes.POST("/v1/evaluations/:evaluation_id/re-evaluate", h.reevaluate)
+}
+
+func (h *HTTPHandler) create(c *gin.Context) {
+	setPrivateResponseHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+
+	var request createEvaluationRequest
+	if !decodeJSONObject(c, &request) || !request.valid() {
+		h.writeInvalidRequest(c)
+		return
+	}
+	accepted, err := h.application.Create(
+		c.Request.Context(),
+		actor,
+		request.applicationRequest(),
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	if !accepted.valid() || accepted.Revision != 1 {
+		h.errors.Write(c, errInvalidApplicationProjection)
+		return
+	}
+	c.JSON(http.StatusAccepted, accepted.response())
+}
+
+func (h *HTTPHandler) get(c *gin.Context) {
+	setPrivateResponseHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	evaluationID := c.Param("evaluation_id")
+	if !validEvaluationID(evaluationID) {
+		h.errors.Write(c, evaluationNotFoundError())
+		return
+	}
+	resource, err := h.application.Get(
+		c.Request.Context(),
+		actor,
+		evaluationID,
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	if !resource.valid() || resource.EvaluationID != evaluationID {
+		h.errors.Write(c, errInvalidApplicationProjection)
+		return
+	}
+	c.JSON(http.StatusOK, resource.response())
+}
+
+func (h *HTTPHandler) reevaluate(c *gin.Context) {
+	setPrivateResponseHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	evaluationID := c.Param("evaluation_id")
+	if !validEvaluationID(evaluationID) {
+		h.errors.Write(c, evaluationNotFoundError())
+		return
+	}
+
+	var request reevaluateEvaluationRequest
+	if !decodeJSONObject(c, &request) || !request.valid() {
+		h.writeInvalidRequest(c)
+		return
+	}
+	accepted, err := h.application.Reevaluate(
+		c.Request.Context(),
+		actor,
+		evaluationID,
+		request.applicationRequest(),
+	)
+	if err != nil {
+		h.writeApplicationError(c, err)
+		return
+	}
+	if !accepted.valid() ||
+		accepted.EvaluationID != evaluationID ||
+		accepted.Revision < 2 {
+		h.errors.Write(c, errInvalidApplicationProjection)
+		return
+	}
+	c.JSON(http.StatusAccepted, accepted.response())
+}
+
+type optionalString struct {
+	value   string
+	present bool
+}
+
+func (value *optionalString) UnmarshalJSON(raw []byte) error {
+	value.present = true
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return errors.New("null string")
+	}
+	return json.Unmarshal(raw, &value.value)
+}
+
+type createEvaluationRequest struct {
+	PracticeSessionID string               `json:"practice_session_id"`
+	InputSnapshotID   string               `json:"input_snapshot_id"`
+	InputRevision     int                  `json:"input_revision"`
+	Scope             evaluation.Scope     `json:"scope"`
+	SceneType         evaluation.SceneType `json:"scene_type"`
+	Channels          []evaluation.Channel `json:"channels"`
+	SceneStrategyRef  optionalString       `json:"scene_strategy_ref"`
+	Core4DStrategyRef optionalString       `json:"core_4d_strategy_ref"`
+	PipelineVersion   string               `json:"pipeline_version"`
+	ClientRequestID   optionalString       `json:"client_request_id"`
+}
+
+func (request createEvaluationRequest) valid() bool {
+	channels, ok := requestedChannels(request.Channels)
+	if !ok ||
+		!stableIdentifierPattern.MatchString(request.PracticeSessionID) ||
+		!stableIdentifierPattern.MatchString(request.InputSnapshotID) ||
+		request.InputRevision < 1 ||
+		!validScope(request.Scope) ||
+		!validSceneType(request.SceneType) ||
+		!validVersionReference(request.PipelineVersion) ||
+		!validOptionalVersion(request.SceneStrategyRef) ||
+		!validOptionalVersion(request.Core4DStrategyRef) ||
+		!validOptionalClientRequestID(request.ClientRequestID) {
+		return false
+	}
+	return (!channels[evaluation.ChannelScene] ||
+		request.SceneStrategyRef.present) &&
+		(!channels[evaluation.ChannelCore4D] ||
+			request.Core4DStrategyRef.present)
+}
+
+func (request createEvaluationRequest) applicationRequest() evaluation.CreateRequest {
+	return evaluation.CreateRequest{
+		PracticeSessionID: request.PracticeSessionID,
+		InputSnapshotID:   request.InputSnapshotID,
+		InputRevision:     request.InputRevision,
+		Scope:             request.Scope,
+		SceneType:         request.SceneType,
+		Channels:          append([]evaluation.Channel(nil), request.Channels...),
+		SceneStrategyRef:  request.SceneStrategyRef.value,
+		Core4DStrategyRef: request.Core4DStrategyRef.value,
+		PipelineVersion:   request.PipelineVersion,
+		ClientRequestID:   request.ClientRequestID.value,
+	}
+}
+
+type reevaluateEvaluationRequest struct {
+	Channels          []evaluation.Channel `json:"channels"`
+	SceneStrategyRef  optionalString       `json:"scene_strategy_ref"`
+	Core4DStrategyRef optionalString       `json:"core_4d_strategy_ref"`
+	PipelineVersion   string               `json:"pipeline_version"`
+	ClientRequestID   optionalString       `json:"client_request_id"`
+}
+
+func (request reevaluateEvaluationRequest) valid() bool {
+	channels, ok := requestedChannels(request.Channels)
+	if !ok ||
+		!validVersionReference(request.PipelineVersion) ||
+		!validOptionalVersion(request.SceneStrategyRef) ||
+		!validOptionalVersion(request.Core4DStrategyRef) ||
+		!validOptionalClientRequestID(request.ClientRequestID) {
+		return false
+	}
+	return (!channels[evaluation.ChannelScene] ||
+		request.SceneStrategyRef.present) &&
+		(!channels[evaluation.ChannelCore4D] ||
+			request.Core4DStrategyRef.present)
+}
+
+func (request reevaluateEvaluationRequest) applicationRequest() evaluation.ReevaluateRequest {
+	return evaluation.ReevaluateRequest{
+		Channels:          append([]evaluation.Channel(nil), request.Channels...),
+		SceneStrategyRef:  request.SceneStrategyRef.value,
+		Core4DStrategyRef: request.Core4DStrategyRef.value,
+		PipelineVersion:   request.PipelineVersion,
+		ClientRequestID:   request.ClientRequestID.value,
+	}
+}
+
+type evaluationAcceptedResponse struct {
+	EvaluationID         string            `json:"evaluation_id"`
+	EvaluationRevisionID string            `json:"evaluation_revision_id"`
+	Revision             int               `json:"revision"`
+	SupersedesRevisionID string            `json:"supersedes_revision_id,omitempty"`
+	EvaluationStatus     evaluation.Status `json:"evaluation_status"`
+	StatusURL            string            `json:"status_url"`
+}
+
+func (accepted EvaluationAccepted) valid() bool {
+	if !validEvaluationID(accepted.EvaluationID) ||
+		!validEvaluationID(accepted.EvaluationRevisionID) ||
+		accepted.Revision < 1 ||
+		accepted.EvaluationStatus != evaluation.StatusQueued {
+		return false
+	}
+	if accepted.Revision == 1 {
+		return accepted.SupersedesRevisionID == ""
+	}
+	return validEvaluationID(accepted.SupersedesRevisionID) &&
+		accepted.SupersedesRevisionID != accepted.EvaluationRevisionID
+}
+
+func (accepted EvaluationAccepted) response() evaluationAcceptedResponse {
+	return evaluationAcceptedResponse{
+		EvaluationID:         accepted.EvaluationID,
+		EvaluationRevisionID: accepted.EvaluationRevisionID,
+		Revision:             accepted.Revision,
+		SupersedesRevisionID: accepted.SupersedesRevisionID,
+		EvaluationStatus:     accepted.EvaluationStatus,
+		StatusURL:            "/v1/evaluations/" + accepted.EvaluationID,
+	}
+}
+
+type evaluationResponse struct {
+	EvaluationID           string                  `json:"evaluation_id"`
+	EvaluationRevisionID   string                  `json:"evaluation_revision_id"`
+	Revision               int                     `json:"revision"`
+	SupersedesRevisionID   string                  `json:"supersedes_revision_id,omitempty"`
+	SupersededByRevisionID string                  `json:"superseded_by_revision_id,omitempty"`
+	PracticeSessionID      string                  `json:"practice_session_id"`
+	InputSnapshotID        string                  `json:"input_snapshot_id"`
+	InputRevision          int                     `json:"input_revision"`
+	Scope                  evaluation.Scope        `json:"scope"`
+	SceneType              evaluation.SceneType    `json:"scene_type"`
+	Channels               []evaluation.Channel    `json:"channels"`
+	SceneStrategyRef       string                  `json:"scene_strategy_ref,omitempty"`
+	Core4DStrategyRef      string                  `json:"core_4d_strategy_ref,omitempty"`
+	PipelineVersion        string                  `json:"pipeline_version"`
+	SchemaVersion          string                  `json:"schema_version"`
+	EvaluationStatus       evaluation.Status       `json:"evaluation_status"`
+	ScoreabilityStatus     ScoreabilityStatus      `json:"scoreability_status,omitempty"`
+	GateStatus             GateStatus              `json:"gate_status,omitempty"`
+	ModuleStatuses         map[string]ModuleStatus `json:"module_statuses"`
+	SceneResult            json.RawMessage         `json:"scene_result,omitempty"`
+	Core4DObservations     json.RawMessage         `json:"core_4d_observations,omitempty"`
+	StableFailure          *EvaluationFailure      `json:"stable_failure,omitempty"`
+	IsFinal                bool                    `json:"is_final"`
+	CreatedAt              string                  `json:"created_at"`
+	UpdatedAt              string                  `json:"updated_at"`
+	CompletedAt            string                  `json:"completed_at,omitempty"`
+}
+
+func (resource EvaluationResource) response() evaluationResponse {
+	response := evaluationResponse{
+		EvaluationID:           resource.EvaluationID,
+		EvaluationRevisionID:   resource.EvaluationRevisionID,
+		Revision:               resource.Revision,
+		SupersedesRevisionID:   resource.SupersedesRevisionID,
+		SupersededByRevisionID: resource.SupersededByRevisionID,
+		PracticeSessionID:      resource.PracticeSessionID,
+		InputSnapshotID:        resource.InputSnapshotID,
+		InputRevision:          resource.InputRevision,
+		Scope:                  resource.Scope,
+		SceneType:              resource.SceneType,
+		Channels: append(
+			[]evaluation.Channel(nil),
+			resource.Channels...,
+		),
+		SceneStrategyRef:   resource.SceneStrategyRef,
+		Core4DStrategyRef:  resource.Core4DStrategyRef,
+		PipelineVersion:    resource.PipelineVersion,
+		SchemaVersion:      resource.SchemaVersion,
+		EvaluationStatus:   resource.EvaluationStatus,
+		ScoreabilityStatus: resource.ScoreabilityStatus,
+		GateStatus:         resource.GateStatus,
+		ModuleStatuses:     resource.ModuleStatuses,
+		SceneResult:        resource.SceneResult,
+		Core4DObservations: resource.Core4DObservations,
+		StableFailure:      resource.StableFailure,
+		IsFinal:            resource.IsFinal,
+		CreatedAt:          resource.CreatedAt.UTC().Format(time.RFC3339Nano),
+		UpdatedAt:          resource.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if resource.CompletedAt != nil {
+		response.CompletedAt = resource.CompletedAt.UTC().
+			Format(time.RFC3339Nano)
+	}
+	return response
+}
+
+func (resource EvaluationResource) valid() bool {
+	channels, channelsOK := requestedChannels(resource.Channels)
+	if !channelsOK ||
+		!validEvaluationID(resource.EvaluationID) ||
+		!validEvaluationID(resource.EvaluationRevisionID) ||
+		resource.Revision < 1 ||
+		!validRevisionLineage(
+			resource.Revision,
+			resource.EvaluationRevisionID,
+			resource.SupersedesRevisionID,
+		) ||
+		!stableIdentifierPattern.MatchString(resource.PracticeSessionID) ||
+		!stableIdentifierPattern.MatchString(resource.InputSnapshotID) ||
+		resource.InputRevision < 1 ||
+		!validScope(resource.Scope) ||
+		!validSceneType(resource.SceneType) ||
+		!validSelectedStrategies(resource, channels) ||
+		!validVersionReference(resource.PipelineVersion) ||
+		!validVersionReference(resource.SchemaVersion) ||
+		!validEvaluationStatus(resource.EvaluationStatus) ||
+		!validModuleStatuses(resource.ModuleStatuses) ||
+		resource.CreatedAt.IsZero() ||
+		resource.UpdatedAt.Before(resource.CreatedAt) ||
+		!validCompletedAt(resource) {
+		return false
+	}
+
+	hasSceneResult := len(resource.SceneResult) > 0
+	hasCore4DResult := len(resource.Core4DObservations) > 0
+	if hasSceneResult &&
+		(!channels[evaluation.ChannelScene] ||
+			!validJSONObject(resource.SceneResult)) {
+		return false
+	}
+	if hasCore4DResult &&
+		(!channels[evaluation.ChannelCore4D] ||
+			!validJSONArray(resource.Core4DObservations, 4)) {
+		return false
+	}
+	if resource.ScoreabilityStatus != "" &&
+		!validScoreabilityStatus(resource.ScoreabilityStatus) {
+		return false
+	}
+	if resource.GateStatus != "" && !validGateStatus(resource.GateStatus) {
+		return false
+	}
+	if (resource.ScoreabilityStatus == "") != (resource.GateStatus == "") {
+		return false
+	}
+
+	switch resource.EvaluationStatus {
+	case evaluation.StatusReceived,
+		evaluation.StatusValidating,
+		evaluation.StatusQueued,
+		evaluation.StatusRunning:
+		return resource.ScoreabilityStatus == "" &&
+			resource.GateStatus == "" &&
+			!hasSceneResult &&
+			!hasCore4DResult &&
+			resource.StableFailure == nil &&
+			resource.SupersededByRevisionID == "" &&
+			!resource.IsFinal
+	case evaluation.StatusPartialReady:
+		return (hasSceneResult || hasCore4DResult) &&
+			resource.StableFailure == nil &&
+			resource.SupersededByRevisionID == "" &&
+			!resource.IsFinal
+	case evaluation.StatusReady:
+		return resource.ScoreabilityStatus != "" &&
+			resource.GateStatus != "" &&
+			(resource.ScoreabilityStatus != ScoreabilityProvisional ||
+				!resource.IsFinal) &&
+			hasSceneResult == channels[evaluation.ChannelScene] &&
+			hasCore4DResult == channels[evaluation.ChannelCore4D] &&
+			resource.StableFailure == nil &&
+			resource.SupersededByRevisionID == ""
+	case evaluation.StatusFailed:
+		return resource.ScoreabilityStatus == "" &&
+			resource.GateStatus == "" &&
+			!hasSceneResult &&
+			!hasCore4DResult &&
+			validFailure(resource.StableFailure) &&
+			resource.SupersededByRevisionID == ""
+	case evaluation.StatusSuperseded:
+		return validEvaluationID(resource.SupersededByRevisionID) &&
+			resource.SupersededByRevisionID !=
+				resource.EvaluationRevisionID &&
+			resource.SupersededByRevisionID !=
+				resource.SupersedesRevisionID &&
+			(resource.StableFailure == nil ||
+				validFailure(resource.StableFailure))
+	default:
+		return false
+	}
+}
+
+func validRevisionLineage(
+	revision int,
+	evaluationRevisionID string,
+	supersedesRevisionID string,
+) bool {
+	if revision == 1 {
+		return supersedesRevisionID == ""
+	}
+	return validEvaluationID(supersedesRevisionID) &&
+		supersedesRevisionID != evaluationRevisionID
+}
+
+func validSelectedStrategies(
+	resource EvaluationResource,
+	channels map[evaluation.Channel]bool,
+) bool {
+	if channels[evaluation.ChannelScene] {
+		if !validVersionReference(resource.SceneStrategyRef) {
+			return false
+		}
+	} else if resource.SceneStrategyRef != "" {
+		return false
+	}
+	if channels[evaluation.ChannelCore4D] {
+		if !validVersionReference(resource.Core4DStrategyRef) {
+			return false
+		}
+	} else if resource.Core4DStrategyRef != "" {
+		return false
+	}
+	return true
+}
+
+func validCompletedAt(resource EvaluationResource) bool {
+	terminal := resource.EvaluationStatus == evaluation.StatusReady ||
+		resource.EvaluationStatus == evaluation.StatusFailed ||
+		resource.EvaluationStatus == evaluation.StatusSuperseded
+	if !terminal {
+		return resource.CompletedAt == nil
+	}
+	return resource.CompletedAt != nil &&
+		!resource.CompletedAt.IsZero() &&
+		!resource.CompletedAt.Before(resource.CreatedAt)
+}
+
+func validFailure(failure *EvaluationFailure) bool {
+	return failure != nil && validReasonCode(failure.ReasonCode)
+}
+
+func validReasonCode(reason ReasonCode) bool {
+	switch reason {
+	case ReasonStrategyNotAvailable,
+		ReasonAudioUnusable,
+		ReasonSpeakerAttributionFailed,
+		ReasonInsufficientEvidence,
+		ReasonASRLowConfidence,
+		ReasonRequiredDimensionMissing,
+		ReasonScoreInconsistent,
+		ReasonEvidenceRefInvalid,
+		ReasonVersionConflict,
+		ReasonDuplicateRequest,
+		ReasonPolicyViolation,
+		ReasonInternalRetryable,
+		ReasonOpportunityNotProvided:
+		return true
+	default:
+		return false
+	}
+}
+
+func validScoreabilityStatus(status ScoreabilityStatus) bool {
+	return status == ScoreabilityReliable ||
+		status == ScoreabilityProvisional ||
+		status == ScoreabilityInsufficient
+}
+
+func validGateStatus(status GateStatus) bool {
+	return status == GatePass ||
+		status == GateFeedbackOnly ||
+		status == GateBlocked
+}
+
+func validModuleStatuses(statuses map[string]ModuleStatus) bool {
+	if len(statuses) < 1 || len(statuses) > 32 {
+		return false
+	}
+	for name, status := range statuses {
+		if !moduleNamePattern.MatchString(name) {
+			return false
+		}
+		switch status {
+		case ModulePending,
+			ModuleRunning,
+			ModuleReady,
+			ModuleFailed,
+			ModuleSkipped:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validJSONObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' || !json.Valid(trimmed) {
+		return false
+	}
+	var object map[string]json.RawMessage
+	return json.Unmarshal(trimmed, &object) == nil && object != nil
+}
+
+func validJSONArray(raw json.RawMessage, maximumItems int) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' || !json.Valid(trimmed) {
+		return false
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(trimmed, &items) != nil ||
+		items == nil || len(items) > maximumItems {
+		return false
+	}
+	for _, item := range items {
+		if !validJSONObject(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func requestedChannels(
+	channels []evaluation.Channel,
+) (map[evaluation.Channel]bool, bool) {
+	if len(channels) < 1 || len(channels) > 2 {
+		return nil, false
+	}
+	result := make(map[evaluation.Channel]bool, len(channels))
+	for _, channel := range channels {
+		if channel != evaluation.ChannelScene &&
+			channel != evaluation.ChannelCore4D {
+			return nil, false
+		}
+		if result[channel] {
+			return nil, false
+		}
+		result[channel] = true
+	}
+	return result, true
+}
+
+func validScope(scope evaluation.Scope) bool {
+	return scope == evaluation.ScopeTurn || scope == evaluation.ScopeSession
+}
+
+func validSceneType(sceneType evaluation.SceneType) bool {
+	switch sceneType {
+	case evaluation.SceneIELTSSpeaking,
+		evaluation.SceneInterview,
+		evaluation.SceneOverseasDaily,
+		evaluation.SceneOverseasWorkplace:
+		return true
+	default:
+		return false
+	}
+}
+
+func validEvaluationStatus(status evaluation.Status) bool {
+	switch status {
+	case evaluation.StatusReceived,
+		evaluation.StatusValidating,
+		evaluation.StatusQueued,
+		evaluation.StatusRunning,
+		evaluation.StatusPartialReady,
+		evaluation.StatusReady,
+		evaluation.StatusFailed,
+		evaluation.StatusSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+func validOptionalVersion(value optionalString) bool {
+	return !value.present || validVersionReference(value.value)
+}
+
+func validOptionalClientRequestID(value optionalString) bool {
+	return !value.present || clientRequestIDPattern.MatchString(value.value)
+}
+
+func validVersionReference(value string) bool {
+	return versionReferencePattern.MatchString(value)
+}
+
+func validEvaluationID(value string) bool {
+	return evaluationIDPattern.MatchString(value)
+}
+
+func decodeJSONObject(c *gin.Context, target any) bool {
+	if c.Request.Body == nil ||
+		c.Request.ContentLength > maxEvaluationRequestBody ||
+		!validJSONContentType(c.GetHeader("Content-Type")) {
+		return false
+	}
+	body := http.MaxBytesReader(
+		c.Writer,
+		c.Request.Body,
+		maxEvaluationRequestBody,
+	)
+	raw, err := io.ReadAll(body)
+	trimmed := bytes.TrimSpace(raw)
+	if err != nil || !utf8.Valid(raw) || len(trimmed) == 0 ||
+		trimmed[0] != '{' {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return false
+	}
+	var trailing any
+	return errors.Is(decoder.Decode(&trailing), io.EOF)
+}
+
+func validJSONContentType(value string) bool {
+	mediaType, parameters, err := mime.ParseMediaType(value)
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	for name, parameter := range parameters {
+		if !strings.EqualFold(name, "charset") ||
+			!strings.EqualFold(parameter, "utf-8") {
+			return false
+		}
+	}
+	return true
+}
+
+func setPrivateResponseHeaders(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+}
+
+func (h *HTTPHandler) writeAuthenticationRequired(c *gin.Context) {
+	c.Header("WWW-Authenticate", "Bearer")
+	h.errors.Write(c, apperror.New(
+		apperror.Unauthenticated,
+		"authentication_required",
+		"Authentication is required.",
+	))
+}
+
+func (h *HTTPHandler) writeInvalidRequest(c *gin.Context) {
+	h.errors.Write(c, invalidRequestError())
+}
+
+func (h *HTTPHandler) writeApplicationError(c *gin.Context, err error) {
+	h.errors.Write(c, publicApplicationError(err))
+}
+
+func publicApplicationError(err error) error {
+	if appError, ok := apperror.From(err); ok {
+		switch {
+		case appError.Code() == "invalid_request" &&
+			appError.Category() == apperror.InvalidArgument:
+			return invalidRequestError()
+		case appError.Code() == "evaluation_not_found" &&
+			appError.Category() == apperror.NotFound:
+			return evaluationNotFoundError()
+		case appError.Code() == "evaluation_version_conflict" &&
+			appError.Category() == apperror.Conflict:
+			return evaluationVersionConflictError()
+		case appError.Code() == "evaluation_strategy_not_available" &&
+			appError.Category() == apperror.UnprocessableEntity:
+			return evaluationStrategyNotAvailableError()
+		case appError.Code() == "evaluation_policy_violation" &&
+			appError.Category() == apperror.UnprocessableEntity:
+			return evaluationPolicyViolationError()
+		case appError.Code() == "evaluation_retryable_failure" &&
+			appError.Category() == apperror.Unavailable:
+			return evaluationRetryableFailureError()
+		default:
+			return errInvalidApplicationError
+		}
+	}
+	switch {
+	case errors.Is(err, evaluation.ErrInvalidRequest):
+		return invalidRequestError()
+	case errors.Is(err, evaluation.ErrNotFound):
+		return evaluationNotFoundError()
+	case errors.Is(err, evaluation.ErrIdempotencyConflict),
+		errors.Is(err, evaluation.ErrAccountUnavailable),
+		errors.Is(err, evaluation.ErrDeletionGenerationStale):
+		return evaluationVersionConflictError()
+	default:
+		return err
+	}
+}
+
+func invalidRequestError() error {
+	return apperror.New(
+		apperror.InvalidArgument,
+		"invalid_request",
+		"Request validation failed.",
+	)
+}
+
+func evaluationNotFoundError() error {
+	return apperror.New(
+		apperror.NotFound,
+		"evaluation_not_found",
+		"Evaluation was not found.",
+	)
+}
+
+func evaluationVersionConflictError() error {
+	return apperror.New(
+		apperror.Conflict,
+		"evaluation_version_conflict",
+		"Evaluation state changed before the operation completed.",
+	)
+}
+
+func evaluationStrategyNotAvailableError() error {
+	return apperror.New(
+		apperror.UnprocessableEntity,
+		"evaluation_strategy_not_available",
+		"The requested Evaluation strategy is not available.",
+	)
+}
+
+func evaluationPolicyViolationError() error {
+	return apperror.New(
+		apperror.UnprocessableEntity,
+		"evaluation_policy_violation",
+		"The requested Evaluation policy is not available.",
+	)
+}
+
+func evaluationRetryableFailureError() error {
+	return apperror.New(
+		apperror.Unavailable,
+		"evaluation_retryable_failure",
+		"Evaluation is temporarily unavailable.",
+		apperror.WithRetryable(true),
+	)
+}
+
+var (
+	stableIdentifierPattern = regexp.MustCompile(
+		`^[A-Za-z][A-Za-z0-9_-]{0,127}$`,
+	)
+	evaluationIDPattern = regexp.MustCompile(
+		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`,
+	)
+	versionReferencePattern = regexp.MustCompile(
+		`^[A-Za-z][A-Za-z0-9._:/-]{2,159}$`,
+	)
+	clientRequestIDPattern = regexp.MustCompile(
+		`^[A-Za-z0-9._:-]{1,128}$`,
+	)
+	moduleNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
+
+	errInvalidApplicationProjection = errors.New(
+		"evaluation: invalid application projection",
+	)
+	errInvalidApplicationError = errors.New(
+		"evaluation: application error is outside HTTP contract",
+	)
+)

--- a/server/internal/evaluation/transport/http_test.go
+++ b/server/internal/evaluation/transport/http_test.go
@@ -1,0 +1,1377 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	testEvaluationID = "12345678-1234-4234-8234-123456789abc"
+	testRevisionID   = "22345678-1234-4234-8234-123456789abc"
+	testNextRevision = "32345678-1234-4234-8234-123456789abc"
+	testOtherID      = "52345678-1234-4234-8234-123456789abc"
+)
+
+var testActor = requestcontext.Actor{
+	UserID:    "42345678-1234-4234-8234-123456789abc",
+	SessionID: "authenticated-session",
+}
+
+type applicationStub struct {
+	create func(
+		context.Context,
+		requestcontext.Actor,
+		evaluation.CreateRequest,
+	) (EvaluationAccepted, error)
+	get func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (EvaluationResource, error)
+	reevaluate func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		evaluation.ReevaluateRequest,
+	) (EvaluationAccepted, error)
+}
+
+func (stub applicationStub) Create(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	request evaluation.CreateRequest,
+) (EvaluationAccepted, error) {
+	if stub.create == nil {
+		return EvaluationAccepted{}, errors.New("unexpected Create")
+	}
+	return stub.create(ctx, actor, request)
+}
+
+func (stub applicationStub) Get(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	evaluationID string,
+) (EvaluationResource, error) {
+	if stub.get == nil {
+		return EvaluationResource{}, errors.New("unexpected Get")
+	}
+	return stub.get(ctx, actor, evaluationID)
+}
+
+func (stub applicationStub) Reevaluate(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	evaluationID string,
+	request evaluation.ReevaluateRequest,
+) (EvaluationAccepted, error) {
+	if stub.reevaluate == nil {
+		return EvaluationAccepted{}, errors.New("unexpected Reevaluate")
+	}
+	return stub.reevaluate(ctx, actor, evaluationID, request)
+}
+
+func TestNewHTTPHandlerRequiresApplication(t *testing.T) {
+	handler, err := NewHTTPHandler(nil)
+	if err == nil || handler != nil {
+		t.Fatal("expected a missing application to be rejected")
+	}
+}
+
+func TestCreateUsesTrustedActorAndReturnsQueuedIdentity(t *testing.T) {
+	expectedRequest := evaluation.CreateRequest{
+		PracticeSessionID: "session_demo_001",
+		InputSnapshotID:   "snapshot_demo_001",
+		InputRevision:     3,
+		Scope:             evaluation.ScopeSession,
+		SceneType:         evaluation.SceneOverseasDaily,
+		Channels:          []evaluation.Channel{evaluation.ChannelScene},
+		SceneStrategyRef:  "daily-scene/1.0.0",
+		PipelineVersion:   "evaluation-pipeline/1.0.0",
+		ClientRequestID:   "trace_create_001",
+	}
+	application := applicationStub{
+		create: func(
+			ctx context.Context,
+			actor requestcontext.Actor,
+			request evaluation.CreateRequest,
+		) (EvaluationAccepted, error) {
+			if actor != testActor {
+				t.Fatalf("actor = %#v, want trusted actor %#v", actor, testActor)
+			}
+			fromContext, ok := requestcontext.ActorFromContext(ctx)
+			if !ok || fromContext != testActor {
+				t.Fatal("trusted actor was not preserved in request context")
+			}
+			if !reflect.DeepEqual(request, expectedRequest) {
+				t.Fatalf("request = %#v, want %#v", request, expectedRequest)
+			}
+			return queuedAccepted(), nil
+		},
+	}
+	router := newTestRouter(t, application, &testActor)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/evaluations",
+		validCreateBody(),
+		"application/json; charset=UTF-8",
+	)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	assertPrivateResponse(t, response)
+	assertJSONEquals(t, response.Body.String(), map[string]any{
+		"evaluation_id":          testEvaluationID,
+		"evaluation_revision_id": testRevisionID,
+		"revision":               float64(1),
+		"evaluation_status":      "QUEUED",
+		"status_url":             "/v1/evaluations/" + testEvaluationID,
+	})
+}
+
+func TestReevaluateUsesTrustedActorAndReturnsReplacementIdentity(t *testing.T) {
+	expectedRequest := evaluation.ReevaluateRequest{
+		Channels:         []evaluation.Channel{evaluation.ChannelScene},
+		SceneStrategyRef: "daily-scene/1.0.0",
+		PipelineVersion:  "evaluation-pipeline/1.0.1",
+		ClientRequestID:  "trace_reevaluate_001",
+	}
+	application := applicationStub{
+		reevaluate: func(
+			ctx context.Context,
+			actor requestcontext.Actor,
+			evaluationID string,
+			request evaluation.ReevaluateRequest,
+		) (EvaluationAccepted, error) {
+			if actor != testActor || evaluationID != testEvaluationID {
+				t.Fatal("re-evaluate did not receive trusted route input")
+			}
+			fromContext, ok := requestcontext.ActorFromContext(ctx)
+			if !ok || fromContext != testActor {
+				t.Fatal("trusted actor was not preserved in request context")
+			}
+			if !reflect.DeepEqual(request, expectedRequest) {
+				t.Fatalf("request = %#v, want %#v", request, expectedRequest)
+			}
+			return queuedReevaluation(), nil
+		},
+	}
+	router := newTestRouter(t, application, &testActor)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/evaluations/"+testEvaluationID+"/re-evaluate",
+		validReevaluateBody(),
+		"application/json",
+	)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	assertPrivateResponse(t, response)
+	assertJSONEquals(t, response.Body.String(), map[string]any{
+		"evaluation_id":          testEvaluationID,
+		"evaluation_revision_id": testNextRevision,
+		"revision":               float64(2),
+		"supersedes_revision_id": testRevisionID,
+		"evaluation_status":      "QUEUED",
+		"status_url":             "/v1/evaluations/" + testEvaluationID,
+	})
+}
+
+func TestGetPublishesEveryLifecycleStateHonestly(t *testing.T) {
+	statuses := []evaluation.Status{
+		evaluation.StatusReceived,
+		evaluation.StatusValidating,
+		evaluation.StatusQueued,
+		evaluation.StatusRunning,
+		evaluation.StatusPartialReady,
+		evaluation.StatusReady,
+		evaluation.StatusFailed,
+		evaluation.StatusSuperseded,
+	}
+
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			resource := resourceForStatus(status)
+			router := newTestRouter(t, applicationStub{
+				get: func(
+					ctx context.Context,
+					actor requestcontext.Actor,
+					evaluationID string,
+				) (EvaluationResource, error) {
+					if actor != testActor || evaluationID != testEvaluationID {
+						t.Fatal("Get did not receive trusted route input")
+					}
+					fromContext, ok := requestcontext.ActorFromContext(ctx)
+					if !ok || fromContext != testActor {
+						t.Fatal("trusted actor was not preserved in request context")
+					}
+					return resource, nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodGet,
+				"/v1/evaluations/"+testEvaluationID,
+				"",
+				"",
+			)
+			if response.Code != http.StatusOK {
+				t.Fatalf(
+					"status = %d, body = %s",
+					response.Code,
+					response.Body,
+				)
+			}
+			assertPrivateResponse(t, response)
+			body := decodeJSONObjectForTest(t, response.Body.String())
+			if body["evaluation_status"] != string(status) {
+				t.Fatalf(
+					"evaluation_status = %#v, want %q",
+					body["evaluation_status"],
+					status,
+				)
+			}
+			if _, exists := body["owner_user_id"]; exists {
+				t.Fatal("response exposed owner_user_id")
+			}
+			assertLifecycleFields(t, status, body)
+		})
+	}
+}
+
+func TestReadyProjectionMatchesEveryRequestedChannelExactly(t *testing.T) {
+	sceneOnly := resourceForStatus(evaluation.StatusReady)
+
+	coreOnly := resourceForStatus(evaluation.StatusReady)
+	coreOnly.Channels = []evaluation.Channel{evaluation.ChannelCore4D}
+	coreOnly.SceneStrategyRef = ""
+	coreOnly.Core4DStrategyRef = "speaking-core4d/1.0.0"
+	coreOnly.ModuleStatuses = map[string]ModuleStatus{"core_4d": ModuleReady}
+	coreOnly.SceneResult = nil
+	coreOnly.Core4DObservations = json.RawMessage(`[]`)
+
+	dual := resourceForStatus(evaluation.StatusReady)
+	dual.Channels = []evaluation.Channel{
+		evaluation.ChannelScene,
+		evaluation.ChannelCore4D,
+	}
+	dual.Core4DStrategyRef = "speaking-core4d/1.0.0"
+	dual.ModuleStatuses = map[string]ModuleStatus{
+		"scene":   ModuleReady,
+		"core_4d": ModuleReady,
+	}
+	dual.Core4DObservations = json.RawMessage(`[]`)
+
+	tests := []struct {
+		name       string
+		resource   EvaluationResource
+		wantScene  bool
+		wantCore4D bool
+	}{
+		{name: "scene", resource: sceneOnly, wantScene: true},
+		{name: "core 4d", resource: coreOnly, wantCore4D: true},
+		{
+			name:       "dual",
+			resource:   dual,
+			wantScene:  true,
+			wantCore4D: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := newTestRouter(t, applicationStub{
+				get: func(
+					context.Context,
+					requestcontext.Actor,
+					string,
+				) (EvaluationResource, error) {
+					return test.resource, nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodGet,
+				"/v1/evaluations/"+testEvaluationID,
+				"",
+				"",
+			)
+			if response.Code != http.StatusOK {
+				t.Fatalf(
+					"status = %d, body = %s",
+					response.Code,
+					response.Body,
+				)
+			}
+			body := decodeJSONObjectForTest(t, response.Body.String())
+			_, hasScene := body["scene_result"]
+			_, hasCore4D := body["core_4d_observations"]
+			if hasScene != test.wantScene || hasCore4D != test.wantCore4D {
+				t.Fatalf(
+					"result presence scene=%v core4d=%v, body=%s",
+					hasScene,
+					hasCore4D,
+					response.Body,
+				)
+			}
+		})
+	}
+}
+
+func TestEndpointsRequireActorFromRequestContext(t *testing.T) {
+	calls := 0
+	application := applicationStub{
+		create: func(
+			context.Context,
+			requestcontext.Actor,
+			evaluation.CreateRequest,
+		) (EvaluationAccepted, error) {
+			calls++
+			return queuedAccepted(), nil
+		},
+		get: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+		) (EvaluationResource, error) {
+			calls++
+			return resourceForStatus(evaluation.StatusQueued), nil
+		},
+		reevaluate: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+			evaluation.ReevaluateRequest,
+		) (EvaluationAccepted, error) {
+			calls++
+			return queuedReevaluation(), nil
+		},
+	}
+	router := newTestRouter(t, application, nil)
+	requests := []struct {
+		method      string
+		path        string
+		body        string
+		contentType string
+	}{
+		{
+			method: http.MethodPost,
+			path:   "/v1/evaluations",
+			body: strings.Replace(
+				validCreateBody(),
+				"{",
+				`{"owner_user_id":"`+testActor.UserID+`",`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			method: http.MethodGet,
+			path:   "/v1/evaluations/" + testEvaluationID,
+		},
+		{
+			method:      http.MethodPost,
+			path:        "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body:        validReevaluateBody(),
+			contentType: "application/json",
+		},
+	}
+	for _, request := range requests {
+		response := performRequest(
+			router,
+			request.method,
+			request.path,
+			request.body,
+			request.contentType,
+		)
+		assertAPIError(
+			t,
+			response,
+			http.StatusUnauthorized,
+			"authentication_required",
+		)
+		if response.Header().Get("WWW-Authenticate") != "Bearer" {
+			t.Fatal("missing Bearer challenge")
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("application was called %d times without a trusted actor", calls)
+	}
+}
+
+func TestCreateRejectsMalformedOrOutOfContractBodies(t *testing.T) {
+	oversized := strings.Repeat("x", maxEvaluationRequestBody+1)
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+	}{
+		{name: "missing content type", body: validCreateBody()},
+		{
+			name:        "wrong content type",
+			body:        validCreateBody(),
+			contentType: "text/plain",
+		},
+		{
+			name:        "unsupported charset",
+			body:        validCreateBody(),
+			contentType: "application/json; charset=iso-8859-1",
+		},
+		{
+			name:        "unsupported content type parameter",
+			body:        validCreateBody(),
+			contentType: "application/json; profile=testing",
+		},
+		{name: "empty body", contentType: "application/json"},
+		{name: "array", body: `[]`, contentType: "application/json"},
+		{name: "malformed", body: `{`, contentType: "application/json"},
+		{
+			name:        "invalid utf8",
+			body:        string([]byte{'{', '"', 0xff, '"', ':', '1', '}'}),
+			contentType: "application/json",
+		},
+		{
+			name: "unknown owner property",
+			body: strings.Replace(
+				validCreateBody(),
+				"{",
+				`{"owner_user_id":"ignored",`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name:        "trailing document",
+			body:        validCreateBody() + `{}`,
+			contentType: "application/json",
+		},
+		{
+			name: "null optional string",
+			body: strings.Replace(
+				validCreateBody(),
+				`"trace_create_001"`,
+				`null`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "missing selected strategy",
+			body: strings.Replace(
+				validCreateBody(),
+				`"scene_strategy_ref":"daily-scene/1.0.0",`,
+				"",
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "duplicate channels",
+			body: strings.Replace(
+				validCreateBody(),
+				`["SCENE"]`,
+				`["SCENE","SCENE"]`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "invalid channel",
+			body: strings.Replace(
+				validCreateBody(),
+				`["SCENE"]`,
+				`["UNKNOWN"]`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "invalid stable identifier",
+			body: strings.Replace(
+				validCreateBody(),
+				`session_demo_001`,
+				`session.demo.001`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "invalid scope",
+			body: strings.Replace(
+				validCreateBody(),
+				`"SESSION"`,
+				`"UNKNOWN"`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "short pipeline version",
+			body: strings.Replace(
+				validCreateBody(),
+				`evaluation-pipeline/1.0.0`,
+				`v1`,
+				1,
+			),
+			contentType: "application/json",
+		},
+		{
+			name: "oversized body",
+			body: `{"practice_session_id":"session_demo_001","padding":"` +
+				oversized + `"}`,
+			contentType: "application/json",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			router := newTestRouter(t, applicationStub{
+				create: func(
+					context.Context,
+					requestcontext.Actor,
+					evaluation.CreateRequest,
+				) (EvaluationAccepted, error) {
+					calls++
+					return queuedAccepted(), nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodPost,
+				"/v1/evaluations",
+				test.body,
+				test.contentType,
+			)
+			assertAPIError(
+				t,
+				response,
+				http.StatusBadRequest,
+				"invalid_request",
+			)
+			if calls != 0 {
+				t.Fatalf("application was called %d times", calls)
+			}
+		})
+	}
+}
+
+func TestReevaluateRejectsMalformedOrOutOfContractBodies(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty body"},
+		{
+			name: "unknown field",
+			body: strings.Replace(
+				validReevaluateBody(),
+				"{",
+				`{"scene_type":"OVERSEAS_DAILY_LIFE",`,
+				1,
+			),
+		},
+		{
+			name: "null selected strategy",
+			body: strings.Replace(
+				validReevaluateBody(),
+				`"daily-scene/1.0.0"`,
+				`null`,
+				1,
+			),
+		},
+		{
+			name: "missing selected strategy",
+			body: strings.Replace(
+				validReevaluateBody(),
+				`"scene_strategy_ref":"daily-scene/1.0.0",`,
+				"",
+				1,
+			),
+		},
+		{
+			name: "trailing document",
+			body: validReevaluateBody() + `{}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			router := newTestRouter(t, applicationStub{
+				reevaluate: func(
+					context.Context,
+					requestcontext.Actor,
+					string,
+					evaluation.ReevaluateRequest,
+				) (EvaluationAccepted, error) {
+					calls++
+					return queuedReevaluation(), nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodPost,
+				"/v1/evaluations/"+testEvaluationID+"/re-evaluate",
+				test.body,
+				"application/json",
+			)
+			assertAPIError(
+				t,
+				response,
+				http.StatusBadRequest,
+				"invalid_request",
+			)
+			if calls != 0 {
+				t.Fatalf("application was called %d times", calls)
+			}
+		})
+	}
+}
+
+func TestApplicationErrorsUseEvaluationContract(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "invalid",
+			err:        evaluation.ErrInvalidRequest,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "invalid_request",
+		},
+		{
+			name:       "not found",
+			err:        evaluation.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+			wantCode:   "evaluation_not_found",
+		},
+		{
+			name:       "version conflict",
+			err:        evaluation.ErrIdempotencyConflict,
+			wantStatus: http.StatusConflict,
+			wantCode:   "evaluation_version_conflict",
+		},
+		{
+			name: "strategy unavailable is rewritten safely",
+			err: apperror.New(
+				apperror.UnprocessableEntity,
+				"evaluation_strategy_not_available",
+				"Provider token and secret must not escape.",
+				apperror.WithDetails(apperror.Detail{
+					Field:  "provider_token",
+					Reason: "secret",
+				}),
+			),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   "evaluation_strategy_not_available",
+		},
+		{
+			name: "policy violation",
+			err: apperror.New(
+				apperror.UnprocessableEntity,
+				"evaluation_policy_violation",
+				"The requested Evaluation policy is not available.",
+			),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   "evaluation_policy_violation",
+		},
+		{
+			name: "retryable failure",
+			err: apperror.New(
+				apperror.Unavailable,
+				"evaluation_retryable_failure",
+				"Evaluation is temporarily unavailable.",
+				apperror.WithRetryable(true),
+			),
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "evaluation_retryable_failure",
+		},
+		{
+			name: "foreign module code is sanitized",
+			err: apperror.New(
+				apperror.NotFound,
+				"practice_session_not_found",
+				"Practice Session was not found.",
+			),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   "internal_error",
+		},
+		{
+			name: "application internal error is sanitized",
+			err: apperror.New(
+				apperror.Internal,
+				"internal_error",
+				"Provider token and secret must not escape.",
+				apperror.WithDetails(apperror.Detail{
+					Field:  "provider_token",
+					Reason: "secret",
+				}),
+			),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   "internal_error",
+		},
+		{
+			name:       "unknown error is sanitized",
+			err:        errors.New("database DSN and secret"),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   "internal_error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := newTestRouter(t, applicationStub{
+				create: func(
+					context.Context,
+					requestcontext.Actor,
+					evaluation.CreateRequest,
+				) (EvaluationAccepted, error) {
+					return EvaluationAccepted{}, test.err
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodPost,
+				"/v1/evaluations",
+				validCreateBody(),
+				"application/json",
+			)
+			assertAPIError(
+				t,
+				response,
+				test.wantStatus,
+				test.wantCode,
+			)
+			if strings.Contains(response.Body.String(), "DSN") ||
+				strings.Contains(response.Body.String(), "secret") ||
+				strings.Contains(response.Body.String(), "provider_token") {
+				t.Fatal("internal error was exposed")
+			}
+		})
+	}
+}
+
+func TestPolicyIsDelegatedToApplication(t *testing.T) {
+	calls := 0
+	application := applicationStub{
+		create: func(
+			_ context.Context,
+			_ requestcontext.Actor,
+			request evaluation.CreateRequest,
+		) (EvaluationAccepted, error) {
+			calls++
+			if request.Scope != evaluation.ScopeTurn ||
+				request.SceneType != evaluation.SceneOverseasWorkplace ||
+				!reflect.DeepEqual(
+					request.Channels,
+					[]evaluation.Channel{evaluation.ChannelCore4D},
+				) ||
+				request.Core4DStrategyRef != "speaking-core4d/1.0.0" {
+				t.Fatalf("transport altered policy-owned input: %#v", request)
+			}
+			return EvaluationAccepted{}, apperror.New(
+				apperror.UnprocessableEntity,
+				"evaluation_policy_violation",
+				"The requested Evaluation policy is not available.",
+			)
+		},
+	}
+	router := newTestRouter(t, application, &testActor)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/evaluations",
+		`{
+			"practice_session_id":"session_demo_001",
+			"input_snapshot_id":"snapshot_demo_001",
+			"input_revision":3,
+			"scope":"TURN",
+			"scene_type":"OVERSEAS_WORKPLACE",
+			"channels":["CORE_4D"],
+			"core_4d_strategy_ref":"speaking-core4d/1.0.0",
+			"pipeline_version":"evaluation-pipeline/1.0.0"
+		}`,
+		"application/json",
+	)
+	assertAPIError(
+		t,
+		response,
+		http.StatusUnprocessableEntity,
+		"evaluation_policy_violation",
+	)
+	if calls != 1 {
+		t.Fatalf("application calls = %d, want 1", calls)
+	}
+}
+
+func TestInvalidApplicationResourceProjectionsFailClosed(t *testing.T) {
+	readyWithoutResult := resourceForStatus(evaluation.StatusReady)
+	readyWithoutResult.SceneResult = nil
+
+	readyWithUnrequestedCore := resourceForStatus(evaluation.StatusReady)
+	readyWithUnrequestedCore.Core4DObservations = json.RawMessage(`[]`)
+
+	failedWithoutFailure := resourceForStatus(evaluation.StatusFailed)
+	failedWithoutFailure.StableFailure = nil
+
+	runningWithResult := resourceForStatus(evaluation.StatusRunning)
+	runningWithResult.SceneResult = genericSceneResult()
+
+	partialWithoutResult := resourceForStatus(evaluation.StatusPartialReady)
+	partialWithoutResult.SceneResult = nil
+
+	queuedWithCompletion := resourceForStatus(evaluation.StatusQueued)
+	completedAt := queuedWithCompletion.UpdatedAt
+	queuedWithCompletion.CompletedAt = &completedAt
+
+	supersededWithoutReplacement := resourceForStatus(evaluation.StatusSuperseded)
+	supersededWithoutReplacement.SupersededByRevisionID = ""
+
+	revisionWithoutParent := resourceForStatus(evaluation.StatusQueued)
+	revisionWithoutParent.Revision = 2
+
+	revisionSupersedesItself := resourceForStatus(evaluation.StatusQueued)
+	revisionSupersedesItself.Revision = 2
+	revisionSupersedesItself.SupersedesRevisionID =
+		revisionSupersedesItself.EvaluationRevisionID
+
+	supersededByItself := resourceForStatus(evaluation.StatusSuperseded)
+	supersededByItself.SupersededByRevisionID =
+		supersededByItself.EvaluationRevisionID
+
+	invalidModule := resourceForStatus(evaluation.StatusRunning)
+	invalidModule.ModuleStatuses = map[string]ModuleStatus{
+		"Scene": ModuleRunning,
+	}
+
+	invalidRawResult := resourceForStatus(evaluation.StatusReady)
+	invalidRawResult.SceneResult = json.RawMessage(`[]`)
+
+	provisionalMarkedFinal := resourceForStatus(evaluation.StatusReady)
+	provisionalMarkedFinal.ScoreabilityStatus = ScoreabilityProvisional
+	provisionalMarkedFinal.IsFinal = true
+
+	runningMarkedFinal := resourceForStatus(evaluation.StatusRunning)
+	runningMarkedFinal.IsFinal = true
+
+	partialMarkedFinal := resourceForStatus(evaluation.StatusPartialReady)
+	partialMarkedFinal.IsFinal = true
+
+	gateWithoutScoreability := resourceForStatus(evaluation.StatusPartialReady)
+	gateWithoutScoreability.ScoreabilityStatus = ""
+
+	wrongEvaluationID := resourceForStatus(evaluation.StatusQueued)
+	wrongEvaluationID.EvaluationID = testOtherID
+
+	tests := []struct {
+		name     string
+		resource EvaluationResource
+	}{
+		{name: "READY missing requested result", resource: readyWithoutResult},
+		{
+			name:     "READY has unrequested Core4D result",
+			resource: readyWithUnrequestedCore,
+		},
+		{name: "FAILED missing stable failure", resource: failedWithoutFailure},
+		{name: "RUNNING has result", resource: runningWithResult},
+		{name: "PARTIAL_READY missing result", resource: partialWithoutResult},
+		{name: "QUEUED has completion", resource: queuedWithCompletion},
+		{
+			name:     "SUPERSEDED missing replacement",
+			resource: supersededWithoutReplacement,
+		},
+		{name: "revision lineage missing parent", resource: revisionWithoutParent},
+		{
+			name:     "revision lineage points to itself",
+			resource: revisionSupersedesItself,
+		},
+		{
+			name:     "superseded replacement points to itself",
+			resource: supersededByItself,
+		},
+		{name: "invalid module map", resource: invalidModule},
+		{name: "invalid raw result kind", resource: invalidRawResult},
+		{name: "PROVISIONAL is marked final", resource: provisionalMarkedFinal},
+		{name: "RUNNING is marked final", resource: runningMarkedFinal},
+		{name: "PARTIAL_READY is marked final", resource: partialMarkedFinal},
+		{name: "gate without scoreability", resource: gateWithoutScoreability},
+		{name: "path ID mismatch", resource: wrongEvaluationID},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := newTestRouter(t, applicationStub{
+				get: func(
+					context.Context,
+					requestcontext.Actor,
+					string,
+				) (EvaluationResource, error) {
+					return test.resource, nil
+				},
+			}, &testActor)
+			response := performRequest(
+				router,
+				http.MethodGet,
+				"/v1/evaluations/"+testEvaluationID,
+				"",
+				"",
+			)
+			assertAPIError(
+				t,
+				response,
+				http.StatusInternalServerError,
+				"internal_error",
+			)
+		})
+	}
+}
+
+func TestWriteEndpointsAcceptOnlyFreshQueuedLineage(t *testing.T) {
+	createRunning := queuedAccepted()
+	createRunning.EvaluationStatus = evaluation.StatusRunning
+
+	createRevisionTwo := queuedAccepted()
+	createRevisionTwo.Revision = 2
+	createRevisionTwo.SupersedesRevisionID = testRevisionID
+
+	reevaluateRunning := queuedReevaluation()
+	reevaluateRunning.EvaluationStatus = evaluation.StatusRunning
+
+	reevaluateMissingParent := queuedReevaluation()
+	reevaluateMissingParent.SupersedesRevisionID = ""
+
+	reevaluateWrongID := queuedReevaluation()
+	reevaluateWrongID.EvaluationID = testOtherID
+
+	reevaluateSupersedesItself := queuedReevaluation()
+	reevaluateSupersedesItself.SupersedesRevisionID =
+		reevaluateSupersedesItself.EvaluationRevisionID
+
+	tests := []struct {
+		name        string
+		path        string
+		body        string
+		application applicationStub
+	}{
+		{
+			name: "create returned RUNNING",
+			path: "/v1/evaluations",
+			body: validCreateBody(),
+			application: applicationStub{
+				create: fixedCreate(createRunning),
+			},
+		},
+		{
+			name: "create returned revision two",
+			path: "/v1/evaluations",
+			body: validCreateBody(),
+			application: applicationStub{
+				create: fixedCreate(createRevisionTwo),
+			},
+		},
+		{
+			name: "re-evaluate returned RUNNING",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(reevaluateRunning),
+			},
+		},
+		{
+			name: "re-evaluate omitted immutable lineage",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(reevaluateMissingParent),
+			},
+		},
+		{
+			name: "re-evaluate returned another evaluation",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(reevaluateWrongID),
+			},
+		},
+		{
+			name: "re-evaluate revision supersedes itself",
+			path: "/v1/evaluations/" + testEvaluationID + "/re-evaluate",
+			body: validReevaluateBody(),
+			application: applicationStub{
+				reevaluate: fixedReevaluation(reevaluateSupersedesItself),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := newTestRouter(t, test.application, &testActor)
+			response := performRequest(
+				router,
+				http.MethodPost,
+				test.path,
+				test.body,
+				"application/json",
+			)
+			assertAPIError(
+				t,
+				response,
+				http.StatusInternalServerError,
+				"internal_error",
+			)
+		})
+	}
+}
+
+func TestInvalidEvaluationPathsAreNotPassedToApplication(t *testing.T) {
+	calls := 0
+	application := applicationStub{
+		get: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+		) (EvaluationResource, error) {
+			calls++
+			return EvaluationResource{}, nil
+		},
+		reevaluate: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+			evaluation.ReevaluateRequest,
+		) (EvaluationAccepted, error) {
+			calls++
+			return EvaluationAccepted{}, nil
+		},
+	}
+	router := newTestRouter(t, application, &testActor)
+	requests := []struct {
+		method      string
+		path        string
+		body        string
+		contentType string
+	}{
+		{
+			method: http.MethodGet,
+			path:   "/v1/evaluations/not-a-uuid",
+		},
+		{
+			method:      http.MethodPost,
+			path:        "/v1/evaluations/not-a-uuid/re-evaluate",
+			body:        validReevaluateBody(),
+			contentType: "application/json",
+		},
+	}
+	for _, request := range requests {
+		response := performRequest(
+			router,
+			request.method,
+			request.path,
+			request.body,
+			request.contentType,
+		)
+		assertAPIError(
+			t,
+			response,
+			http.StatusNotFound,
+			"evaluation_not_found",
+		)
+	}
+	if calls != 0 {
+		t.Fatalf("application was called %d times", calls)
+	}
+}
+
+func fixedCreate(
+	accepted EvaluationAccepted,
+) func(
+	context.Context,
+	requestcontext.Actor,
+	evaluation.CreateRequest,
+) (EvaluationAccepted, error) {
+	return func(
+		context.Context,
+		requestcontext.Actor,
+		evaluation.CreateRequest,
+	) (EvaluationAccepted, error) {
+		return accepted, nil
+	}
+}
+
+func fixedReevaluation(
+	accepted EvaluationAccepted,
+) func(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	evaluation.ReevaluateRequest,
+) (EvaluationAccepted, error) {
+	return func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		evaluation.ReevaluateRequest,
+	) (EvaluationAccepted, error) {
+		return accepted, nil
+	}
+}
+
+func newTestRouter(
+	t *testing.T,
+	application Application,
+	actor *requestcontext.Actor,
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler, err := NewHTTPHandler(application)
+	if err != nil {
+		t.Fatalf("NewHTTPHandler: %v", err)
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		ctx := httpresponse.WithCorrelationID(
+			c.Request.Context(),
+			"corr_evaluation_http_test",
+		)
+		if actor != nil {
+			ctx = requestcontext.WithActor(ctx, *actor)
+		}
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	return router
+}
+
+func performRequest(
+	router http.Handler,
+	method string,
+	path string,
+	body string,
+	contentType string,
+) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+	}
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func queuedAccepted() EvaluationAccepted {
+	return EvaluationAccepted{
+		EvaluationID:         testEvaluationID,
+		EvaluationRevisionID: testRevisionID,
+		Revision:             1,
+		EvaluationStatus:     evaluation.StatusQueued,
+	}
+}
+
+func queuedReevaluation() EvaluationAccepted {
+	return EvaluationAccepted{
+		EvaluationID:         testEvaluationID,
+		EvaluationRevisionID: testNextRevision,
+		Revision:             2,
+		SupersedesRevisionID: testRevisionID,
+		EvaluationStatus:     evaluation.StatusQueued,
+	}
+}
+
+func resourceForStatus(status evaluation.Status) EvaluationResource {
+	createdAt := time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Second)
+	resource := EvaluationResource{
+		EvaluationID:         testEvaluationID,
+		EvaluationRevisionID: testRevisionID,
+		Revision:             1,
+		PracticeSessionID:    "session_demo_001",
+		InputSnapshotID:      "snapshot_demo_001",
+		InputRevision:        3,
+		Scope:                evaluation.ScopeSession,
+		SceneType:            evaluation.SceneOverseasDaily,
+		Channels:             []evaluation.Channel{evaluation.ChannelScene},
+		SceneStrategyRef:     "daily-scene/1.0.0",
+		PipelineVersion:      "evaluation-pipeline/1.0.0",
+		SchemaVersion:        evaluation.SchemaVersion,
+		EvaluationStatus:     status,
+		ModuleStatuses: map[string]ModuleStatus{
+			"scene": ModulePending,
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+	switch status {
+	case evaluation.StatusRunning:
+		resource.ModuleStatuses["scene"] = ModuleRunning
+	case evaluation.StatusPartialReady:
+		resource.ModuleStatuses["scene"] = ModuleReady
+		resource.ScoreabilityStatus = ScoreabilityProvisional
+		resource.GateStatus = GateFeedbackOnly
+		resource.SceneResult = genericSceneResult()
+	case evaluation.StatusReady:
+		resource.ModuleStatuses["scene"] = ModuleReady
+		resource.ScoreabilityStatus = ScoreabilityReliable
+		resource.GateStatus = GatePass
+		resource.SceneResult = genericSceneResult()
+		resource.IsFinal = true
+		resource.CompletedAt = &updatedAt
+	case evaluation.StatusFailed:
+		resource.ModuleStatuses["scene"] = ModuleFailed
+		resource.StableFailure = &EvaluationFailure{
+			ReasonCode: ReasonInternalRetryable,
+			Retryable:  true,
+		}
+		resource.IsFinal = true
+		resource.CompletedAt = &updatedAt
+	case evaluation.StatusSuperseded:
+		resource.ModuleStatuses["scene"] = ModuleSkipped
+		resource.SupersededByRevisionID = testNextRevision
+		resource.CompletedAt = &updatedAt
+	}
+	return resource
+}
+
+func genericSceneResult() json.RawMessage {
+	return json.RawMessage(`{"summary":"provider-independent result"}`)
+}
+
+func validCreateBody() string {
+	return `{
+		"practice_session_id":"session_demo_001",
+		"input_snapshot_id":"snapshot_demo_001",
+		"input_revision":3,
+		"scope":"SESSION",
+		"scene_type":"OVERSEAS_DAILY_LIFE",
+		"channels":["SCENE"],
+		"scene_strategy_ref":"daily-scene/1.0.0",
+		"pipeline_version":"evaluation-pipeline/1.0.0",
+		"client_request_id":"trace_create_001"
+	}`
+}
+
+func validReevaluateBody() string {
+	return `{
+		"channels":["SCENE"],
+		"scene_strategy_ref":"daily-scene/1.0.0",
+		"pipeline_version":"evaluation-pipeline/1.0.1",
+		"client_request_id":"trace_reevaluate_001"
+	}`
+}
+
+func assertLifecycleFields(
+	t *testing.T,
+	status evaluation.Status,
+	body map[string]any,
+) {
+	t.Helper()
+	_, hasCompletedAt := body["completed_at"]
+	_, hasScoreability := body["scoreability_status"]
+	_, hasGate := body["gate_status"]
+	_, hasSceneResult := body["scene_result"]
+	_, hasFailure := body["stable_failure"]
+	_, hasSupersededBy := body["superseded_by_revision_id"]
+
+	switch status {
+	case evaluation.StatusReceived,
+		evaluation.StatusValidating,
+		evaluation.StatusQueued,
+		evaluation.StatusRunning:
+		if hasCompletedAt || hasScoreability || hasGate ||
+			hasSceneResult || hasFailure || hasSupersededBy {
+			t.Fatalf("active lifecycle fabricated terminal fields: %#v", body)
+		}
+	case evaluation.StatusPartialReady:
+		if hasCompletedAt || !hasScoreability || !hasGate ||
+			!hasSceneResult || hasFailure || hasSupersededBy {
+			t.Fatalf("partial lifecycle fields are inconsistent: %#v", body)
+		}
+	case evaluation.StatusReady:
+		if !hasCompletedAt || !hasScoreability || !hasGate ||
+			!hasSceneResult || hasFailure || hasSupersededBy {
+			t.Fatalf("ready lifecycle fields are inconsistent: %#v", body)
+		}
+	case evaluation.StatusFailed:
+		if !hasCompletedAt || hasScoreability || hasGate ||
+			hasSceneResult || !hasFailure || hasSupersededBy {
+			t.Fatalf("failed lifecycle fields are inconsistent: %#v", body)
+		}
+	case evaluation.StatusSuperseded:
+		if !hasCompletedAt || !hasSupersededBy {
+			t.Fatalf("superseded lifecycle fields are inconsistent: %#v", body)
+		}
+	}
+}
+
+func assertPrivateResponse(
+	t *testing.T,
+	response *httptest.ResponseRecorder,
+) {
+	t.Helper()
+	if response.Header().Get("Cache-Control") != "no-store" ||
+		response.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("private response headers = %#v", response.Header())
+	}
+}
+
+func assertAPIError(
+	t *testing.T,
+	response *httptest.ResponseRecorder,
+	wantStatus int,
+	wantCode string,
+) {
+	t.Helper()
+	if response.Code != wantStatus {
+		t.Fatalf(
+			"status = %d, want %d; body = %s",
+			response.Code,
+			wantStatus,
+			response.Body,
+		)
+	}
+	body := decodeJSONObjectForTest(t, response.Body.String())
+	payload, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing error payload: %s", response.Body)
+	}
+	if payload["code"] != wantCode {
+		t.Fatalf("error code = %#v, want %q", payload["code"], wantCode)
+	}
+	if payload["correlation_id"] != "corr_evaluation_http_test" {
+		t.Fatalf("correlation_id = %#v", payload["correlation_id"])
+	}
+	assertPrivateResponse(t, response)
+}
+
+func assertJSONEquals(t *testing.T, raw string, want map[string]any) {
+	t.Helper()
+	got := decodeJSONObjectForTest(t, raw)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON = %#v, want %#v", got, want)
+	}
+}
+
+func decodeJSONObjectForTest(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode JSON %q: %v", raw, err)
+	}
+	return result
+}


### PR DESCRIPTION
## 功能描述

为统一 Evaluation Platform 增加独立、场景无关的 Gin HTTP transport 基础层，提供以下三条通用路由：

- `POST /v1/evaluations`
- `GET /v1/evaluations/{evaluation_id}`
- `POST /v1/evaluations/{evaluation_id}/re-evaluate`

本 PR 只交付 HTTP 输入输出、安全校验与通用生命周期投影，不接入生产路由，不启动 Worker/Provider，也不包含 Interview Shadow 或幂等 replay 分支。

## 实现思路

- 通过最小 `Application` interface 注入 create/get/re-evaluate 应用能力，transport 不依赖数据库、Worker、Provider 或具体场景。
- 只从受信 request context 获取 Actor；严格拒绝非法 Content-Type、空或超限 body、未知字段、非法 UTF-8、显式 `null`、尾随 JSON、非法 channel 与 UUID。
- fresh create 仅接受 `revision=1 + QUEUED`；fresh re-evaluate 仅接受 `revision>=2 + QUEUED`，并校验返回 Evaluation ID 与路径一致。
- GET 对八类 Evaluation lifecycle、revision lineage、channel/result envelope、stable failure、完成时间与 final 状态做 fail-closed 校验。
- 所有响应使用 `no-store`；认证失败保留 Bearer challenge；应用错误通过共享 canonical renderer 输出并隐藏未知内部错误。
- `200 replay / 202 fresh` 由后续 #277 PR 单独实现，避免基础层提前混入 replay 语义。

## 测试方式

1. 在 `server` 目录执行：
   `go test -count=1 ./internal/evaluation/transport`
2. 执行：
   `go test -race -count=1 ./internal/evaluation/transport`
3. 执行：
   `go vet ./internal/evaluation/transport`
4. 执行相关模块回归：
   `go test -count=1 ./internal/evaluation/... ./internal/platform/apperror ./internal/platform/httpresponse`
5. 预期全部通过；三条路由可只使用 application stub 验证，无需数据库或外部服务。

## 相关 Issue / 备注

Closes #290

- 后续顺序：#277 replay → #272 Interview Shadow。
- 本 PR 不修改 OpenAPI；现有 #176 契约仍保持 fresh write `202 + QUEUED`。
- 本 PR 不修改数据库迁移或本地数据。

## AI 辅助说明

使用 AI 对旧混合 PR 中的通用 transport 进行职责拆分、测试补全与安全复审。提交前已逐项复核以下边界：

- 无 replay、Interview Shadow、Provider、bootstrap/main 或数据库迁移内容。
- create/re-evaluate revision lineage 与 GET path/resource ID 均 fail closed。
- 相关测试、竞态检查、静态检查和密钥扫描均通过。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
