### PR TITLE
fix(ielts): 修复模考与分段练习启动冲突

### DIFF
--- a/mobile/lib/features/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/preparation/wire_preparation_launch_client.dart
@@ -138,11 +138,7 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
         'selected_role_ids': <String>[input.selection.roleDefinitionId],
         'practice_option_id': input.selection.practiceOptionId,
         'practice_option_version': input.selection.practiceOptionVersion,
-        'max_effective_turns':
-            input.selection.practiceOptionType ==
-                PreparationOptionType.fullSimulation
-            ? 6
-            : 3,
+        'max_effective_turns': _planMaxEffectiveTurns(input.selection),
       },
       stage: PreparationLaunchStage.plan,
     );
@@ -432,6 +428,12 @@ PreparationPracticePlan _plan(
       'practice_plan_status',
       'created_at',
       'updated_at',
+    },
+    optional: const <String>{
+      'preparation_snapshot',
+      'catalog_snapshot',
+      'session_policy',
+      'practice_focuses',
     },
   );
   final context = AgentPracticeContext(
@@ -846,6 +848,22 @@ void _validatePracticeOption(
     throw _invalidResponse();
   }
   _text(object['display_name']);
+}
+
+int _planMaxEffectiveTurns(PreparationLaunchSelection selection) {
+  if (selection.practiceOptionType == PreparationOptionType.focus) {
+    return 3;
+  }
+  return switch (selection.scenarioModel) {
+    'IELTS_SPEAKING_FULL_MOCK' => 14,
+    'IELTS_SPEAKING_PART_1' => 8,
+    // The Part 2 catalog preview has four frozen blueprints. The selected
+    // question group replaces this preview with its exact turn count when the
+    // Session is created.
+    'IELTS_SPEAKING_PART_2' => 4,
+    'IELTS_SPEAKING_PART_3' => 5,
+    _ => 6,
+  };
 }
 
 int _validateSessionPolicy(

--- a/mobile/test/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/preparation/wire_preparation_launch_client_test.dart
@@ -98,6 +98,81 @@ void main() {
     },
   );
 
+  test('sends the catalog-compatible IELTS plan turn budgets', () async {
+    const cases = <(String, int)>[
+      ('IELTS_SPEAKING_FULL_MOCK', 14),
+      ('IELTS_SPEAKING_PART_1', 8),
+      ('IELTS_SPEAKING_PART_2', 4),
+      ('IELTS_SPEAKING_PART_3', 5),
+    ];
+
+    for (final testCase in cases) {
+      final model = testCase.$1;
+      final expectedTurns = testCase.$2;
+      final scenarioId = 'scenario-${model.toLowerCase()}';
+      final configId = 'config-${model.toLowerCase()}';
+      final selection = PreparationLaunchSelection(
+        scenarioDefinitionId: scenarioId,
+        scenarioDefinitionVersion: 1,
+        scenarioType: 'EXAM',
+        scenarioModel: model,
+        scenarioDisplayName: model,
+        scenarioDescription: 'IELTS practice',
+        scenarioConfigId: configId,
+        scenarioConfigVersion: 1,
+        roleDefinitionId: _roleId,
+        roleDefinitionVersion: 1,
+        practiceOptionId: _fullOptionId,
+        practiceOptionType: PreparationOptionType.fullSimulation,
+        practiceOptionVersion: 1,
+      );
+      final response = _planJson()
+        ..['scenario_definition_id'] = scenarioId
+        ..['scenario_type'] = 'EXAM'
+        ..['scenario_model'] = model
+        ..['scenario_config_id'] = configId;
+      final transport = _QueueTransport([_response(response)]);
+      final client = _client(transport);
+
+      await client.createPlan(
+        input: CreatePreparationPlanInput(
+          context: _context,
+          selection: selection,
+          preparationProfileId: _profileId,
+          preparationSnapshotId: _preparationSnapshotId,
+          preparationUserId: _userId,
+        ),
+        idempotencyKey: 'plan-$expectedTurns-key',
+      );
+
+      final body =
+          jsonDecode(transport.calls.single.body!) as Map<String, Object?>;
+      expect(body['max_effective_turns'], expectedTurns, reason: model);
+    }
+  });
+
+  test('accepts the configured preview fields in a created Plan', () async {
+    final response = _planJson()
+      ..['preparation_snapshot'] = <String, Object?>{}
+      ..['catalog_snapshot'] = <String, Object?>{}
+      ..['session_policy'] = <String, Object?>{}
+      ..['practice_focuses'] = <Object?>[];
+    final client = _client(_QueueTransport([_response(response)]));
+
+    final plan = await client.createPlan(
+      input: const CreatePreparationPlanInput(
+        context: _context,
+        selection: _selection,
+        preparationProfileId: _profileId,
+        preparationSnapshotId: _preparationSnapshotId,
+        preparationUserId: _userId,
+      ),
+      idempotencyKey: 'configured-plan-key',
+    );
+
+    expect(plan.id, _planId);
+  });
+
   test(
     'marks malformed 201 creates ambiguous and retries Session with one key',
     () async {

--- a/server/internal/practice/postgres/context.go
+++ b/server/internal/practice/postgres/context.go
@@ -2084,24 +2084,35 @@ func contextSnapshotMatchesPlan(
 		return false
 	}
 	if plan.PreparationSnapshot != nil {
-		if plan.CatalogSnapshot == nil || plan.SessionPolicy == nil ||
-			!equalPreparationSnapshot(
-				*plan.PreparationSnapshot,
-				snapshot.Preparation,
-			) ||
+		if plan.CatalogSnapshot == nil || plan.SessionPolicy == nil {
+			return false
+		}
+		configMatches := reflect.DeepEqual(
+			plan.CatalogSnapshot.ScenarioConfig,
+			snapshot.ScenarioConfig,
+		)
+		policyMatches := reflect.DeepEqual(
+			*plan.SessionPolicy,
+			snapshot.SessionPolicy,
+		)
+		if snapshot.IELTSAssignment != nil {
+			configMatches, policyMatches =
+				dynamicIELTSPreviewMatchesPlan(snapshot, plan)
+		}
+		if !equalPreparationSnapshot(
+			*plan.PreparationSnapshot,
+			snapshot.Preparation,
+		) ||
 			!reflect.DeepEqual(
 				plan.CatalogSnapshot.ScenarioDefinition,
 				snapshot.ScenarioDefinition,
 			) ||
-			!reflect.DeepEqual(
-				plan.CatalogSnapshot.ScenarioConfig,
-				snapshot.ScenarioConfig,
-			) ||
+			!configMatches ||
 			!reflect.DeepEqual(
 				plan.CatalogSnapshot.PracticeOption,
 				snapshot.PracticeOption,
 			) ||
-			!reflect.DeepEqual(*plan.SessionPolicy, snapshot.SessionPolicy) ||
+			!policyMatches ||
 			!reflect.DeepEqual(
 				plan.PracticeFocuses,
 				snapshot.PracticeFocuses,
@@ -2187,6 +2198,49 @@ func contextSnapshotMatchesPlan(
 			selectedFacilitatorRole
 	}
 	return snapshot.PracticeOption.RoleDefinitionID == ""
+}
+
+func dynamicIELTSPreviewMatchesPlan(
+	snapshot persistence.ContextSessionSnapshot,
+	plan persistence.Plan,
+) (bool, bool) {
+	if snapshot.IELTSAssignment == nil ||
+		plan.CatalogSnapshot == nil ||
+		plan.SessionPolicy == nil {
+		return false, false
+	}
+
+	planConfig := plan.CatalogSnapshot.ScenarioConfig
+	normalizedConfig := snapshot.ScenarioConfig
+	normalizedConfig.PromptModel.PublicSceneBrief =
+		planConfig.PromptModel.PublicSceneBrief
+	normalizedConfig.PromptModel.TurnBlueprints =
+		planConfig.PromptModel.TurnBlueprints
+	normalizedConfig.PromptModel.SuggestedDurationSeconds =
+		planConfig.PromptModel.SuggestedDurationSeconds
+	configMatches := reflect.DeepEqual(planConfig, normalizedConfig)
+
+	turns := len(snapshot.IELTSAssignment.TurnBlueprints)
+	policy := snapshot.SessionPolicy
+	dynamicPolicyValid :=
+		policy.SuggestedDurationSeconds ==
+			snapshot.ScenarioConfig.PromptModel.SuggestedDurationSeconds &&
+			policy.MinEffectiveTurns == turns &&
+			policy.MaxEffectiveTurns == turns &&
+			policy.CoverageCheckpointTurn == turns
+	normalizedPolicy := policy
+	normalizedPolicy.SuggestedDurationSeconds =
+		plan.SessionPolicy.SuggestedDurationSeconds
+	normalizedPolicy.MinEffectiveTurns =
+		plan.SessionPolicy.MinEffectiveTurns
+	normalizedPolicy.MaxEffectiveTurns =
+		plan.SessionPolicy.MaxEffectiveTurns
+	normalizedPolicy.CoverageCheckpointTurn =
+		plan.SessionPolicy.CoverageCheckpointTurn
+	policyMatches := dynamicPolicyValid &&
+		reflect.DeepEqual(*plan.SessionPolicy, normalizedPolicy)
+
+	return configMatches, policyMatches
 }
 
 func completeStoredPlanPreview(plan persistence.Plan) bool {

--- a/server/internal/practice/postgres/context_validation_test.go
+++ b/server/internal/practice/postgres/context_validation_test.go
@@ -69,3 +69,95 @@ func TestValidContextPolicyScopesFourteenTurnsToIELTSFullMock(t *testing.T) {
 		t.Fatal("IELTS focus option accepted the full-mock policy")
 	}
 }
+
+func TestDynamicIELTSPreviewMatchesPlanAllowsFrozenQuestionSelection(t *testing.T) {
+	objectives := []persistence.PracticeObjective{
+		{ID: "objective-1", Description: "Discuss the selected topic."},
+	}
+	planConfig := persistence.ScenarioConfigSnapshot{
+		ID:                   "config-1",
+		ScenarioDefinitionID: "scenario-1",
+		Type:                 persistence.ScenarioFamilyExam,
+		Model:                persistence.ScenarioModelIELTSSpeakingFullMock,
+		Version:              1,
+		PromptModel: persistence.ScenarioPromptModel{
+			PublicSceneBrief:         "Generic IELTS Part 3.",
+			PracticeGoal:             "Answer every discussion question.",
+			UserRole:                 "Candidate",
+			AIRole:                   "Examiner",
+			PersonaSummary:           "IELTS examiner",
+			FocusAreas:               []string{"fluency"},
+			TurnBlueprints:           []string{"q1", "q2", "q3", "q4", "q5"},
+			SuggestedDurationSeconds: 300,
+		},
+		FocusAreas: []string{"fluency"},
+	}
+	planPolicy := persistence.ContextSessionPolicy{
+		SuggestedDurationSeconds: 300,
+		MinEffectiveTurns:        5,
+		MaxEffectiveTurns:        5,
+		CoverageCheckpointTurn:   5,
+		MaxFollowUpsPerQuestion:  0,
+		TargetObjectives:         objectives,
+		EarlyCompletionRule:      "Complete all frozen questions.",
+	}
+	plan := persistence.Plan{
+		CatalogSnapshot: &persistence.PlanCatalogSnapshot{
+			ScenarioConfig: planConfig,
+		},
+		SessionPolicy: &planPolicy,
+	}
+
+	selectedQuestions := []string{"selected q1", "selected q2", "selected q3"}
+	snapshotConfig := planConfig
+	snapshotConfig.PromptModel.PublicSceneBrief = "Selected IELTS topic."
+	snapshotConfig.PromptModel.TurnBlueprints = selectedQuestions
+	snapshot := persistence.ContextSessionSnapshot{
+		ScenarioConfig: snapshotConfig,
+		SessionPolicy: persistence.ContextSessionPolicy{
+			SuggestedDurationSeconds: 300,
+			MinEffectiveTurns:        3,
+			MaxEffectiveTurns:        3,
+			CoverageCheckpointTurn:   3,
+			MaxFollowUpsPerQuestion:  0,
+			TargetObjectives:         objectives,
+			EarlyCompletionRule:      "Complete all frozen questions.",
+		},
+		IELTSAssignment: &persistence.IELTSPracticeAssignment{
+			TurnBlueprints: selectedQuestions,
+		},
+	}
+
+	configMatches, policyMatches := dynamicIELTSPreviewMatchesPlan(
+		snapshot,
+		plan,
+	)
+	if !configMatches || !policyMatches {
+		t.Fatalf(
+			"selected IELTS questions were rejected: config=%t policy=%t",
+			configMatches,
+			policyMatches,
+		)
+	}
+
+	changedConfig := snapshot
+	changedConfig.ScenarioConfig.PromptModel.PracticeGoal = "Changed goal."
+	configMatches, _ = dynamicIELTSPreviewMatchesPlan(changedConfig, plan)
+	if configMatches {
+		t.Fatal("static IELTS prompt changes were accepted")
+	}
+
+	changedPolicy := snapshot
+	changedPolicy.SessionPolicy.EarlyCompletionRule = "Changed rule."
+	_, policyMatches = dynamicIELTSPreviewMatchesPlan(changedPolicy, plan)
+	if policyMatches {
+		t.Fatal("static IELTS policy changes were accepted")
+	}
+
+	wrongTurnCount := snapshot
+	wrongTurnCount.SessionPolicy.MaxEffectiveTurns = 4
+	_, policyMatches = dynamicIELTSPreviewMatchesPlan(wrongTurnCount, plan)
+	if policyMatches {
+		t.Fatal("IELTS policy count mismatching its assignment was accepted")
+	}
+}


### PR DESCRIPTION
## 功能描述

- 修复 IELTS 完整模考及 Part 1/2/3 分段练习创建计划时轮次数不匹配的问题
- 接受服务端返回的已冻结计划预览字段
- 允许 IELTS 随机抽题后题目、时长和实际轮次数按冻结题组变化，同时继续校验其他静态配置

## 实现思路

- 移动端按场景模型发送目录约定的计划轮次数：完整模考 14、Part 1 为 8、Part 2 为 4、Part 3 为 5
- 服务端仅对 IELTS 抽题会动态变化的题目、时长及轮次字段做归一化比较
- 对练习目标、角色、早停规则等静态字段继续执行严格一致性校验

## 测试方式

- `cd mobile && flutter test test/practice/ielts_mock_practice_test.dart test/preparation/wire_preparation_launch_client_test.dart`
- `cd mobile && flutter analyze lib/features/preparation/wire_preparation_launch_client.dart test/preparation/wire_preparation_launch_client_test.dart`
- `cd server && go test ./internal/practice/... ./internal/preparation -count=1`
- iOS 模拟器实测：Part 3 完成 5/5；完整模考成功随机进入 Part 1；录音、转写、确认、下一题与完成页正常

Closes #247