### PR TITLE
fix(evaluation): accept Practice resource UUIDs

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -246,7 +246,7 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: '^[A-Za-z][A-Za-z0-9_-]*$'
+      pattern: '^[A-Za-z0-9][A-Za-z0-9_-]*$'
     VersionReference:
       type: string
       minLength: 3

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -182,6 +182,16 @@ assertValid(
   'CreateEvaluationRequest',
   fixture.create_dual_channel,
 );
+const digitLeadingPracticeCreate = structuredClone(
+  fixture.create_dual_channel,
+);
+digitLeadingPracticeCreate.practice_session_id =
+  '20000000-0000-4000-8000-000000000001';
+assertValid(
+  'digit-leading Practice session create',
+  'CreateEvaluationRequest',
+  digitLeadingPracticeCreate,
+);
 assertValid('queued create response', 'EvaluationAccepted', fixture.queued);
 assert.match(
   fixture.queued.evaluation_id,

--- a/server/internal/evaluation/model.go
+++ b/server/internal/evaluation/model.go
@@ -315,7 +315,7 @@ var (
 		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`,
 	)
 	identifierPattern = regexp.MustCompile(
-		`^[A-Za-z][A-Za-z0-9._:-]{0,127}$`,
+		`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
 	)
 	versionPattern = regexp.MustCompile(
 		`^[A-Za-z][A-Za-z0-9._:/-]{0,127}$`,

--- a/server/internal/evaluation/model_test.go
+++ b/server/internal/evaluation/model_test.go
@@ -1,6 +1,28 @@
 package evaluation
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpaqueIdentifierAcceptsDigitLeadingPracticeUUID(t *testing.T) {
+	t.Parallel()
+	if !validIdentifier("20000000-0000-4000-8000-000000000001") {
+		t.Fatal("digit-leading Practice UUID was rejected")
+	}
+	for _, invalid := range []string{
+		"",
+		"-unsafe",
+		"contains/slash",
+		"contains space",
+		"control\x00inside",
+		strings.Repeat("a", 129),
+	} {
+		if validIdentifier(invalid) {
+			t.Errorf("invalid opaque identifier %q was accepted", invalid)
+		}
+	}
+}
 
 func TestEvaluationValidityRequiresImmutableRevisionLinkage(t *testing.T) {
 	evaluation := validEvaluation()

--- a/server/internal/evaluation/postgres_integration_test.go
+++ b/server/internal/evaluation/postgres_integration_test.go
@@ -20,6 +20,114 @@ import (
 
 const integrationOwnerB = "20000000-0000-4000-8000-000000000002"
 
+func TestPostgresAcceptsDigitLeadingPracticeSessionID(t *testing.T) {
+	const practiceSessionID = "20000000-0000-4000-8000-000000000001"
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA)
+	repository := NewPostgresRepository(pool)
+	command := validEvidenceCommand(
+		testOwnerA,
+		practiceSessionID,
+		ScopeSession,
+		SceneInterview,
+	)
+	installEvidenceAuthorities(t, pool, command)
+	snapshot, replayed, err := repository.EnsureEvidenceSnapshot(
+		testActorContext(testOwnerA),
+		command,
+	)
+	if err != nil {
+		t.Fatalf("EnsureEvidenceSnapshot: %v", err)
+	}
+	if replayed || snapshot.PracticeSessionID != practiceSessionID {
+		t.Fatalf("snapshot = %#v, replayed = %v", snapshot, replayed)
+	}
+	request := validCreateRequest()
+	request.PracticeSessionID = practiceSessionID
+	request.InputSnapshotID = snapshot.ID
+	request.InputRevision = snapshot.InputRevision
+	request.SceneStrategyRef = InterviewShadowStrategyRef
+	request.PipelineVersion = InterviewShadowPipelineVersion
+	created, replayed, err := NewService(
+		repository,
+		repository,
+	).Create(
+		testActorContext(testOwnerA),
+		testActor(testOwnerA),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if replayed || created.PracticeSessionID != practiceSessionID ||
+		!created.Valid() {
+		t.Fatalf("created = %#v, replayed = %v", created, replayed)
+	}
+	configuration := InterviewShadowRuntimeConfiguration{
+		MaxAttempts:     3,
+		LeaseDuration:   5 * time.Second,
+		StrategyRef:     InterviewShadowStrategyRef,
+		PipelineVersion: InterviewShadowPipelineVersion,
+		FullConfigHash: sha256.Sum256(
+			[]byte("practice-resource-id-integration/v1"),
+		),
+		PromptVersion: InterviewShadowPromptVersion,
+		Provider:      "qianwen",
+		Model:         "qwen-plus",
+	}
+	claim := claimInterviewShadow(t, repository, configuration)
+	if claim.EvaluationID != created.ID ||
+		claim.Snapshot.PracticeSessionID != practiceSessionID {
+		t.Fatalf("claim = %#v", claim)
+	}
+
+	down, err := migrations.Files.ReadFile(
+		"000038_evaluation_practice_resource_ids.down.sql",
+	)
+	if err != nil {
+		t.Fatalf("read resource ID down migration: %v", err)
+	}
+	connection, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire migration connection: %v", err)
+	}
+	defer connection.Release()
+	if _, err = connection.Exec(context.Background(), string(down)); err == nil {
+		t.Fatal("down migration accepted digit-leading Practice data")
+	}
+	var databaseError *pgconn.PgError
+	if !errors.As(err, &databaseError) ||
+		databaseError.Code != "23514" ||
+		databaseError.ConstraintName !=
+			"evaluation_module_runs_practice_session_check" {
+		t.Fatalf("down migration error = %v", err)
+	}
+	if _, rollbackErr := connection.Exec(
+		context.Background(),
+		"ROLLBACK",
+	); rollbackErr != nil {
+		t.Fatalf("rollback rejected down migration: %v", rollbackErr)
+	}
+	var preservedRows int64
+	if err := pool.QueryRow(context.Background(), `
+		SELECT
+		    (SELECT count(*)
+		       FROM evaluation_ledgers
+		      WHERE practice_session_id = $1)
+		  + (SELECT count(*)
+		       FROM evaluation_evidence_snapshots
+		      WHERE practice_session_id = $1)
+		  + (SELECT count(*)
+		       FROM evaluation_module_runs
+		      WHERE practice_session_id = $1)
+	`, practiceSessionID).Scan(&preservedRows); err != nil {
+		t.Fatalf("inspect preserved Practice rows: %v", err)
+	}
+	if preservedRows != 3 {
+		t.Fatalf("preserved Practice rows = %d, want 3", preservedRows)
+	}
+}
+
 func TestPostgresLedgerRevisionIdempotencyAndIsolation(t *testing.T) {
 	pool := evaluationDatabase(t)
 	insertEvaluationUsers(t, pool, testOwnerA, integrationOwnerB)

--- a/server/internal/evaluation/practice_resource_id_migration_test.go
+++ b/server/internal/evaluation/practice_resource_id_migration_test.go
@@ -1,0 +1,57 @@
+package evaluation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+)
+
+func TestPracticeResourceIDMigrationOnlyReplacesIdentifierChecks(
+	t *testing.T,
+) {
+	t.Parallel()
+	up, err := migrations.Files.ReadFile(
+		"000038_evaluation_practice_resource_ids.up.sql",
+	)
+	if err != nil {
+		t.Fatalf("read resource ID up migration: %v", err)
+	}
+	down, err := migrations.Files.ReadFile(
+		"000038_evaluation_practice_resource_ids.down.sql",
+	)
+	if err != nil {
+		t.Fatalf("read resource ID down migration: %v", err)
+	}
+	for name, content := range map[string]string{
+		"up":   strings.ToLower(string(up)),
+		"down": strings.ToLower(string(down)),
+	} {
+		for _, constraint := range []string{
+			"evaluation_ledgers_practice_session_check",
+			"evaluation_evidence_snapshots_practice_session_check",
+			"evaluation_module_runs_practice_session_check",
+		} {
+			if !strings.Contains(content, constraint) {
+				t.Errorf("%s migration is missing %q", name, constraint)
+			}
+		}
+		for _, mutation := range []string{"update ", "delete ", "truncate "} {
+			if strings.Contains(content, mutation) {
+				t.Errorf("%s migration contains %q", name, mutation)
+			}
+		}
+	}
+	if !strings.Contains(
+		string(up),
+		"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+	) {
+		t.Fatal("up migration does not allow digit-leading resources")
+	}
+	if !strings.Contains(
+		string(down),
+		"^[A-Za-z][A-Za-z0-9._:-]{0,127}$",
+	) {
+		t.Fatal("down migration does not restore the prior constraint")
+	}
+}

--- a/server/internal/evaluation/transport/http.go
+++ b/server/internal/evaluation/transport/http.go
@@ -908,7 +908,7 @@ func evaluationRetryableFailureError() error {
 
 var (
 	stableIdentifierPattern = regexp.MustCompile(
-		`^[A-Za-z][A-Za-z0-9_-]{0,127}$`,
+		`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`,
 	)
 	evaluationIDPattern = regexp.MustCompile(
 		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`,

--- a/server/internal/evaluation/transport/http_test.go
+++ b/server/internal/evaluation/transport/http_test.go
@@ -144,6 +144,39 @@ func TestCreateUsesTrustedActorAndReturnsQueuedIdentity(t *testing.T) {
 	})
 }
 
+func TestCreateAcceptsDigitLeadingPracticeSessionIdentifier(t *testing.T) {
+	const practiceSessionID = "20000000-0000-4000-8000-000000000001"
+	router := newTestRouter(t, applicationStub{
+		create: func(
+			_ context.Context,
+			_ requestcontext.Actor,
+			request evaluation.CreateRequest,
+		) (EvaluationAccepted, error) {
+			if request.PracticeSessionID != practiceSessionID ||
+				request.InputSnapshotID != "snapshot_demo_001" {
+				t.Fatalf("request = %#v", request)
+			}
+			return queuedAccepted(), nil
+		},
+	}, &testActor)
+	body := strings.Replace(
+		validCreateBody(),
+		"session_demo_001",
+		practiceSessionID,
+		1,
+	)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/evaluations",
+		body,
+		"application/json",
+	)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+}
+
 func TestReevaluateUsesTrustedActorAndReturnsReplacementIdentity(t *testing.T) {
 	expectedRequest := evaluation.ReevaluateRequest{
 		Channels:         []evaluation.Channel{evaluation.ChannelScene},

--- a/server/migrations/000038_evaluation_practice_resource_ids.down.sql
+++ b/server/migrations/000038_evaluation_practice_resource_ids.down.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+ALTER TABLE evaluation_module_runs
+    DROP CONSTRAINT evaluation_module_runs_practice_session_check,
+    ADD CONSTRAINT evaluation_module_runs_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z][A-Za-z0-9._:-]{0,127}$'
+        );
+
+ALTER TABLE evaluation_evidence_snapshots
+    DROP CONSTRAINT evaluation_evidence_snapshots_practice_session_check,
+    ADD CONSTRAINT evaluation_evidence_snapshots_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z][A-Za-z0-9._:-]{0,127}$'
+        );
+
+ALTER TABLE evaluation_ledgers
+    DROP CONSTRAINT evaluation_ledgers_practice_session_check,
+    ADD CONSTRAINT evaluation_ledgers_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z][A-Za-z0-9._:-]{0,127}$'
+        );
+
+COMMIT;

--- a/server/migrations/000038_evaluation_practice_resource_ids.up.sql
+++ b/server/migrations/000038_evaluation_practice_resource_ids.up.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+ALTER TABLE evaluation_ledgers
+    DROP CONSTRAINT evaluation_ledgers_practice_session_check,
+    ADD CONSTRAINT evaluation_ledgers_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        );
+
+ALTER TABLE evaluation_evidence_snapshots
+    DROP CONSTRAINT evaluation_evidence_snapshots_practice_session_check,
+    ADD CONSTRAINT evaluation_evidence_snapshots_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        );
+
+ALTER TABLE evaluation_module_runs
+    DROP CONSTRAINT evaluation_module_runs_practice_session_check,
+    ADD CONSTRAINT evaluation_module_runs_practice_session_check
+        CHECK (
+            practice_session_id ~
+                '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -23,4 +23,5 @@ import "embed"
 //go:embed 000035_ielts_speaking_section_models.*.sql
 //go:embed 000036_evaluation_evidence_snapshots.*.sql
 //go:embed 000037_evaluation_interview_shadow_runtime.*.sql
+//go:embed 000038_evaluation_practice_resource_ids.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

修正 Evaluation 对 Practice/Conversation opaque resource ID 的首字符限制，使正式 UUIDv4 Session 能进入 EvidenceSnapshot 与 Interview Shadow 链路。

- OpenAPI、Go domain 与 HTTP transport 统一允许字母或数字开头。
- 新增 000038 增量迁移，只替换相关 CHECK；不修改历史迁移、不改写业务数据。
- 保留原有 ASCII 字符集、128 字符长度、Evaluation UUID 与版本引用规则。
- 增加数字开头 Session UUID 的 HTTP、领域与 PostgreSQL 回归测试。

## 问题原因

正式 Practice 使用无前缀 UUIDv4 生成 Session、Session Snapshot、Participant 等资源 ID；Evaluation 原规则要求首字符为字母，导致绝大多数真实面试在冻结证据前被拒绝。

## 验证

- `cd api && npm run check`
- `cd server && go vet ./...`
- `cd server && go test -race ./internal/evaluation ./internal/evaluation/transport`
- `cd server && TEST_DATABASE_URL=... go test -count=1 ./...`
- 本地 Docker PostgreSQL：000038 up → down-one → up，最终 `version=38 dirty=false`

Closes #293