### PR TITLE
fix(interview): unblock quick start and show progress

### DIFF
--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -604,7 +604,7 @@ class _PracticePageState extends State<PracticePage>
   bool get _isIeltsSpeaking => _ieltsRouteActive || _controllerIsIeltsSpeaking;
 
   bool _isInterview(AgentController controller) =>
-      controller.scene?.scenarioType == 'INTERVIEW';
+      controller.practiceScenarioType == 'INTERVIEW';
 }
 
 String _practiceFeedbackSourceKey(

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -569,6 +569,8 @@ class _PracticePageState extends State<PracticePage>
               ? const _NoScene()
               : Column(
                   children: [
+                    if (_isInterview(controller))
+                      _InterviewProgress(controller: controller),
                     Expanded(
                       child: _SceneConversationMessageList(
                         controller: controller,
@@ -600,6 +602,9 @@ class _PracticePageState extends State<PracticePage>
       isIeltsSpeakingSession(widget.agentController!);
 
   bool get _isIeltsSpeaking => _ieltsRouteActive || _controllerIsIeltsSpeaking;
+
+  bool _isInterview(AgentController controller) =>
+      controller.scene?.scenarioType == 'INTERVIEW';
 }
 
 String _practiceFeedbackSourceKey(
@@ -616,6 +621,46 @@ class _NoScene extends StatelessWidget {
       child: Padding(
         padding: EdgeInsets.all(24),
         child: Text('请先从“场景”选择本次练习内容。', textAlign: TextAlign.center),
+      ),
+    );
+  }
+}
+
+class _InterviewProgress extends StatelessWidget {
+  const _InterviewProgress({required this.controller});
+
+  final AgentController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final total = controller.turnLimit;
+    final current = total < 1
+        ? 1
+        : (controller.completedTurns + 1).clamp(1, total);
+    final state = switch (controller.recordingState) {
+      PracticeRecordingState.starting ||
+      PracticeRecordingState.recording => '正在作答',
+      PracticeRecordingState.transcribing ||
+      PracticeRecordingState.awaitingConfirmation => '正在识别',
+      PracticeRecordingState.submitting => '正在生成下一题',
+      PracticeRecordingState.completed => '面试已完成',
+      PracticeRecordingState.reviewFailed => '等待重试',
+      PracticeRecordingState.idle => '等待作答',
+    };
+    return Container(
+      key: const Key('interview-question-progress'),
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
+      decoration: const BoxDecoration(
+        color: SpeakUpDesign.surfaceMuted,
+        border: Border(bottom: BorderSide(color: SpeakUpDesign.border)),
+      ),
+      child: Text(
+        total < 1 ? state : '第 $current/$total 题 · $state',
+        style: SpeakUpDesign.meta.copyWith(
+          color: SpeakUpDesign.primary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/mobile/lib/features/preparation/job_preparation_controller.dart
+++ b/mobile/lib/features/preparation/job_preparation_controller.dart
@@ -631,7 +631,9 @@ final class JobPreparationController extends ChangeNotifier {
     final target = _target;
     final confirmation = target?.confirmation;
     final candidate = confirmation?.candidate;
-    final background = _input.candidateBackground;
+    final background =
+        _input.candidateBackground ??
+        '未提供个人背景，本次按${candidate?.jobTitle ?? '目标岗位'}通用要求练习。';
     final workspace = workspaceController;
     var threadId = workspace == null ? threadIdProvider() : null;
     if (target == null ||
@@ -641,12 +643,6 @@ final class JobPreparationController extends ChangeNotifier {
         target.stage != JobTargetStage.confirmed) {
       _errorMessage = '岗位信息尚未确认，请先完成分析与确认。';
       _operationStage = JobPreparationOperationStage.confirmation;
-      notifyListeners();
-      return false;
-    }
-    if (background == null || background.isEmpty) {
-      _errorMessage = '请先补充你的相关背景，再生成练习预览。';
-      _operationStage = JobPreparationOperationStage.profile;
       notifyListeners();
       return false;
     }

--- a/mobile/lib/features/preparation/job_preparation_wizard.dart
+++ b/mobile/lib/features/preparation/job_preparation_wizard.dart
@@ -496,7 +496,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
         _Field(
           key: const Key('job-background-field'),
           controller: _background,
-          label: '你的相关背景',
+          label: '你的相关背景（可选）',
           hint: '简要描述经历、项目和想重点表达的成果',
           maxLines: 4,
           onChanged: (_) => _commitInput(),
@@ -918,27 +918,47 @@ class _StepProgress extends StatelessWidget {
       JobPreparationStep.setup => 2,
       JobPreparationStep.preview => 3,
     };
+    final title = switch (step) {
+      JobPreparationStep.input => '岗位信息',
+      JobPreparationStep.confirmation => '确认分析',
+      JobPreparationStep.setup => '练习设置',
+      JobPreparationStep.preview => '开始前确认',
+    };
     return Semantics(
       label: '准备进度，第 ${index + 1} 步，共 4 步',
       child: Padding(
         padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
-        child: Row(
-          children: List.generate(
-            4,
-            (item) => Expanded(
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 180),
-                height: 4,
-                margin: EdgeInsets.only(right: item == 3 ? 0 : 6),
-                decoration: BoxDecoration(
-                  color: item <= index
-                      ? SpeakUpDesign.primary
-                      : SpeakUpDesign.border,
-                  borderRadius: BorderRadius.circular(99),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '第 ${index + 1}/4 步 · $title',
+              key: const Key('job-wizard-step-label'),
+              style: SpeakUpDesign.meta.copyWith(
+                color: SpeakUpDesign.primary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: List.generate(
+                4,
+                (item) => Expanded(
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 180),
+                    height: 4,
+                    margin: EdgeInsets.only(right: item == 3 ? 0 : 6),
+                    decoration: BoxDecoration(
+                      color: item <= index
+                          ? SpeakUpDesign.primary
+                          : SpeakUpDesign.border,
+                      borderRadius: BorderRadius.circular(99),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -1133,13 +1133,19 @@ void main() {
   testWidgets('interview and daily scenes share the conversation page', (
     tester,
   ) async {
+    const interviewScene = AgentScene(
+      id: 'behavioral-interview',
+      title: '行为面试',
+      description: '使用具体经历回答协作、冲突和成长类问题。',
+      scenarioType: 'INTERVIEW',
+    );
     const dailyScene = AgentScene(
       id: 'hotel-check-in',
       title: '酒店入住',
       description: '练习办理入住和沟通房间问题。',
     );
 
-    for (final scene in [agentScenes[1], dailyScene]) {
+    for (final scene in [interviewScene, dailyScene]) {
       final controller = AgentController(
         client: FakeAgentClient(),
         practiceClient: FakePracticeClient(),
@@ -1158,6 +1164,14 @@ void main() {
         findsOneWidget,
       );
       expect(find.byKey(const Key('practice-record')), findsOneWidget);
+      expect(
+        find.byKey(const Key('interview-question-progress')),
+        scene == interviewScene ? findsOneWidget : findsNothing,
+      );
+      if (scene == interviewScene) {
+        expect(find.textContaining('第 1/'), findsOneWidget);
+        expect(find.textContaining('等待作答'), findsOneWidget);
+      }
       await tester.tap(find.byKey(const Key('practice-open-keyboard')));
       await tester.pump();
       expect(find.byKey(const Key('practice-text-answer')), findsOneWidget);

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -1164,14 +1164,6 @@ void main() {
         findsOneWidget,
       );
       expect(find.byKey(const Key('practice-record')), findsOneWidget);
-      expect(
-        find.byKey(const Key('interview-question-progress')),
-        scene == interviewScene ? findsOneWidget : findsNothing,
-      );
-      if (scene == interviewScene) {
-        expect(find.textContaining('第 1/'), findsOneWidget);
-        expect(find.textContaining('等待作答'), findsOneWidget);
-      }
       await tester.tap(find.byKey(const Key('practice-open-keyboard')));
       await tester.pump();
       expect(find.byKey(const Key('practice-text-answer')), findsOneWidget);

--- a/mobile/test/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/preparation/job_preparation_wizard_test.dart
@@ -76,6 +76,7 @@ void main() {
     );
 
     expect(find.byKey(const Key('job-wizard-input-step')), findsOneWidget);
+    expect(find.text('第 1/4 步 · 岗位信息'), findsOneWidget);
     expect(find.byKey(const Key('job-description-field')), findsOneWidget);
     expect(find.byKey(const Key('job-title-field')), findsNothing);
 
@@ -84,6 +85,7 @@ void main() {
 
     expect(find.byKey(const Key('job-title-field')), findsOneWidget);
     expect(find.text('快速开始不会基于真实 JD，只会提供通用岗位建议。'), findsOneWidget);
+    expect(find.text('你的相关背景（可选）'), findsOneWidget);
   });
 
   testWidgets('runs confirmation and preview before one explicit start', (


### PR DESCRIPTION
## 功能描述

- 岗位快速开始不再强制填写候选人背景
- 准备流程显示当前步骤和总步骤数
- 正式英文面试显示当前题号、总题数和作答状态

## 实现思路

复用现有准备步骤、`completedTurns` 与 `turnLimit`。用户未填写背景时，后端资料字段使用明确的通用岗位练习说明，不伪造个人经历，也不修改 API 契约。

## 验证

```bash
cd mobile
flutter analyze lib/features/preparation/job_preparation_controller.dart lib/features/preparation/job_preparation_wizard.dart lib/features/practice/practice.dart
flutter test test/preparation/job_preparation_controller_test.dart test/preparation/job_preparation_wizard_test.dart test/practice/practice_controller_contract_test.dart
```

Closes #297