### PR TITLE
feat(evaluation): 接入讯飞 ISE 并验证声学指标

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,16 @@ QIANWEN_ASR_LIVE_TEST=0
 QIANWEN_ASR_LIVE_TEST_AUDIO=
 QIANWEN_TTS_LIVE_TEST=0
 
+# iFlytek streaming ISE pronunciation evaluation (server only).
+APPID=
+APIKey=
+APISecret=
+XFYUN_ISE_ENDPOINT=wss://ise-api.xfyun.cn/v2/open-ise
+XFYUN_ISE_TIMEOUT=90s
+XFYUN_ISE_LIVE_TEST=0
+XFYUN_ISE_LIVE_TEST_AUDIO=
+XFYUN_ISE_LIVE_TEST_TEXT=
+
 # Spatius Direct Mode. The server exchanges SPATIUS_API_KEY for a short-lived
 # Session Token only after verifying the authenticated user owns an interactive
 # WORKPLACE or DAILY Practice Session. Flutter receives App/Avatar IDs and that

--- a/server/internal/ai/xfyun/ise.go
+++ b/server/internal/ai/xfyun/ise.go
@@ -1,0 +1,533 @@
+package xfyun
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	DefaultISEEndpoint = "wss://ise-api.xfyun.cn/v2/open-ise"
+
+	defaultFrameBytes    = 1280
+	defaultFrameInterval = 40 * time.Millisecond
+	maxAudioBytes        = 9_600_000
+	maxTimeout           = 5 * time.Minute
+)
+
+type ISEConfig struct {
+	Endpoint string
+	Timeout  time.Duration
+}
+
+type EvaluationRequest struct {
+	Audio         []byte
+	ReferenceText string
+}
+
+type EvaluationResult struct {
+	SessionID       string
+	RawXML          string
+	AvailableFields []ResultField
+	Summary         ScoreSummary
+}
+
+type ResultField struct {
+	Path  string
+	Name  string
+	Value string
+}
+
+type ScoreSummary struct {
+	TotalScore     *float64
+	AccuracyScore  *float64
+	FluencyScore   *float64
+	IntegrityScore *float64
+	StandardScore  *float64
+	Rejected       *bool
+	ExceptionInfo  string
+}
+
+type Evaluator struct {
+	endpoint      string
+	timeout       time.Duration
+	appID         secret
+	apiKey        secret
+	apiSecret     secret
+	frameBytes    int
+	frameInterval time.Duration
+	dial          dialFunc
+	now           func() time.Time
+}
+
+type secret struct {
+	revealValue func() string
+}
+
+func newSecret(value string) secret {
+	return secret{revealValue: func() string { return value }}
+}
+
+func (value secret) reveal() string {
+	if value.revealValue == nil {
+		return ""
+	}
+	return value.revealValue()
+}
+
+func (secret) String() string   { return "[REDACTED]" }
+func (secret) GoString() string { return "xfyun.secret([REDACTED])" }
+
+type websocketConnection interface {
+	WriteJSON(any) error
+	ReadJSON(any) error
+	SetWriteDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	Close() error
+}
+
+type dialFunc func(
+	context.Context,
+	string,
+) (websocketConnection, *http.Response, error)
+
+func NewEvaluator(
+	config ISEConfig,
+	appID string,
+	apiKey string,
+	apiSecret string,
+) (*Evaluator, error) {
+	endpoint, err := normalizeEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if config.Timeout <= 0 || config.Timeout > maxTimeout {
+		return nil, fmt.Errorf(
+			"iFlytek ISE timeout must be greater than zero and at most %s",
+			maxTimeout,
+		)
+	}
+	appID, err = normalizeCredential("iFlytek ISE APPID", appID)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, err = normalizeCredential("iFlytek ISE APIKey", apiKey)
+	if err != nil {
+		return nil, err
+	}
+	apiSecret, err = normalizeCredential("iFlytek ISE APISecret", apiSecret)
+	if err != nil {
+		return nil, err
+	}
+	dialer := websocket.Dialer{}
+	return &Evaluator{
+		endpoint:      endpoint,
+		timeout:       config.Timeout,
+		appID:         newSecret(appID),
+		apiKey:        newSecret(apiKey),
+		apiSecret:     newSecret(apiSecret),
+		frameBytes:    defaultFrameBytes,
+		frameInterval: defaultFrameInterval,
+		dial: func(
+			ctx context.Context,
+			target string,
+		) (websocketConnection, *http.Response, error) {
+			return dialer.DialContext(ctx, target, nil)
+		},
+		now: time.Now,
+	}, nil
+}
+
+func (evaluator *Evaluator) Evaluate(
+	ctx context.Context,
+	request EvaluationRequest,
+) (EvaluationResult, error) {
+	if ctx == nil {
+		return EvaluationResult{}, errors.New("iFlytek ISE context is required")
+	}
+	if len(request.Audio) == 0 {
+		return EvaluationResult{}, errors.New("iFlytek ISE audio is required")
+	}
+	if len(request.Audio) > maxAudioBytes {
+		return EvaluationResult{}, errors.New("iFlytek ISE audio exceeds five minutes")
+	}
+	reference := strings.TrimSpace(request.ReferenceText)
+	if reference == "" {
+		return EvaluationResult{}, errors.New("iFlytek ISE reference text is required")
+	}
+	if len([]byte(reference)) > 10_000 {
+		return EvaluationResult{}, errors.New("iFlytek ISE reference text is too large")
+	}
+
+	callContext, cancel := context.WithTimeout(ctx, evaluator.timeout)
+	defer cancel()
+	target, err := evaluator.signedURL(evaluator.now().UTC())
+	if err != nil {
+		return EvaluationResult{}, err
+	}
+	connection, response, err := evaluator.dial(callContext, target)
+	if err != nil {
+		if response != nil {
+			return EvaluationResult{}, fmt.Errorf(
+				"iFlytek ISE handshake failed with HTTP %d: %w",
+				response.StatusCode,
+				err,
+			)
+		}
+		return EvaluationResult{}, fmt.Errorf("iFlytek ISE handshake failed: %w", err)
+	}
+	defer connection.Close()
+	if deadline, ok := callContext.Deadline(); ok {
+		if err := connection.SetWriteDeadline(deadline); err != nil {
+			return EvaluationResult{}, fmt.Errorf(
+				"set iFlytek ISE write deadline: %w",
+				err,
+			)
+		}
+		if err := connection.SetReadDeadline(deadline); err != nil {
+			return EvaluationResult{}, fmt.Errorf(
+				"set iFlytek ISE read deadline: %w",
+				err,
+			)
+		}
+	}
+	if err := connection.WriteJSON(initialRequest{
+		Common: initialCommon{AppID: evaluator.appID.reveal()},
+		Business: initialBusiness{
+			AudioEncoding:  "raw",
+			AudioFormat:    "audio/L16;rate=16000",
+			Category:       "read_sentence",
+			Command:        "ssb",
+			Language:       "en_vip",
+			Service:        "ise",
+			Text:           "\ufeff[content]\n" + reference,
+			TextEncoding:   "utf-8",
+			SkipTextUpload: true,
+			ResultEncoding: "utf8",
+			ResultLevel:    "entirety",
+			UnifiedResult:  "1",
+			DetailLevel:    "0",
+			ExtraAbility:   "multi_dimension;pitch;syll_phone_err_msg",
+		},
+		Data: requestData{Status: 0, Data: ""},
+	}); err != nil {
+		return EvaluationResult{}, fmt.Errorf(
+			"send iFlytek ISE parameters: %w",
+			err,
+		)
+	}
+	if err := evaluator.sendAudio(callContext, connection, request.Audio); err != nil {
+		return EvaluationResult{}, err
+	}
+	for {
+		var message responseMessage
+		if err := connection.ReadJSON(&message); err != nil {
+			return EvaluationResult{}, fmt.Errorf(
+				"read iFlytek ISE response: %w",
+				err,
+			)
+		}
+		if message.Code != 0 {
+			return EvaluationResult{}, fmt.Errorf(
+				"iFlytek ISE rejected request: code=%d message=%s sid=%s",
+				message.Code,
+				strings.TrimSpace(message.Message),
+				strings.TrimSpace(message.SessionID),
+			)
+		}
+		if message.Data == nil || message.Data.Status != 2 {
+			continue
+		}
+		rawXML, err := base64.StdEncoding.DecodeString(message.Data.Data)
+		if err != nil {
+			return EvaluationResult{}, errors.New(
+				"decode final iFlytek ISE result",
+			)
+		}
+		result, err := parseResult(rawXML)
+		if err != nil {
+			return EvaluationResult{}, err
+		}
+		result.SessionID = strings.TrimSpace(message.SessionID)
+		return result, nil
+	}
+}
+
+func (evaluator *Evaluator) sendAudio(
+	ctx context.Context,
+	connection websocketConnection,
+	audio []byte,
+) error {
+	first := true
+	for offset := 0; offset < len(audio); offset += evaluator.frameBytes {
+		end := min(offset+evaluator.frameBytes, len(audio))
+		aus := 2
+		if first {
+			aus = 1
+			first = false
+		}
+		if err := connection.WriteJSON(audioRequest{
+			Business: audioBusiness{
+				Command:       "auw",
+				AudioStatus:   aus,
+				AudioEncoding: "raw",
+			},
+			Data: requestData{
+				Status:   1,
+				Data:     base64.StdEncoding.EncodeToString(audio[offset:end]),
+				DataType: 1,
+				Encoding: "raw",
+			},
+		}); err != nil {
+			return fmt.Errorf("send iFlytek ISE audio: %w", err)
+		}
+		if evaluator.frameInterval > 0 {
+			timer := time.NewTimer(evaluator.frameInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("send iFlytek ISE audio: %w", ctx.Err())
+			case <-timer.C:
+			}
+		}
+	}
+	if err := connection.WriteJSON(audioRequest{
+		Business: audioBusiness{
+			Command:       "auw",
+			AudioStatus:   4,
+			AudioEncoding: "raw",
+		},
+		Data: requestData{
+			Status:   2,
+			Data:     "",
+			DataType: 1,
+			Encoding: "raw",
+		},
+	}); err != nil {
+		return fmt.Errorf("finish iFlytek ISE audio: %w", err)
+	}
+	return nil
+}
+
+func (evaluator *Evaluator) signedURL(at time.Time) (string, error) {
+	endpoint, err := url.Parse(evaluator.endpoint)
+	if err != nil {
+		return "", errors.New("parse iFlytek ISE endpoint")
+	}
+	date := at.UTC().Format(http.TimeFormat)
+	signatureOrigin := "host: " + endpoint.Host + "\n" +
+		"date: " + date + "\n" +
+		"GET " + endpoint.EscapedPath() + " HTTP/1.1"
+	mac := hmac.New(sha256.New, []byte(evaluator.apiSecret.reveal()))
+	_, _ = mac.Write([]byte(signatureOrigin))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	authorizationOrigin := fmt.Sprintf(
+		`api_key="%s", algorithm="hmac-sha256", headers="host date request-line", signature="%s"`,
+		evaluator.apiKey.reveal(),
+		signature,
+	)
+	query := endpoint.Query()
+	query.Set(
+		"authorization",
+		base64.StdEncoding.EncodeToString([]byte(authorizationOrigin)),
+	)
+	query.Set("date", date)
+	query.Set("host", endpoint.Host)
+	endpoint.RawQuery = query.Encode()
+	return endpoint.String(), nil
+}
+
+func normalizeEndpoint(value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme != "wss" || parsed.Host == "" ||
+		parsed.Path == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("invalid iFlytek ISE endpoint")
+	}
+	return parsed.String(), nil
+}
+
+func normalizeCredential(name string, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return r < 0x21 || r == 0x7f
+	}) >= 0 {
+		return "", fmt.Errorf("%s contains whitespace or control characters", name)
+	}
+	return value, nil
+}
+
+func parseResult(payload []byte) (EvaluationResult, error) {
+	decoder := xml.NewDecoder(strings.NewReader(string(payload)))
+	result := EvaluationResult{
+		RawXML:          string(payload),
+		AvailableFields: make([]ResultField, 0),
+	}
+	path := make([]string, 0, 8)
+	bestScoreCount := -1
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return EvaluationResult{}, fmt.Errorf(
+				"parse iFlytek ISE XML: %w",
+				err,
+			)
+		}
+		switch value := token.(type) {
+		case xml.StartElement:
+			path = append(path, value.Name.Local)
+			currentPath := strings.Join(path, "/")
+			summary, scoreCount, err := parseAttributes(
+				currentPath,
+				value.Attr,
+				&result.AvailableFields,
+			)
+			if err != nil {
+				return EvaluationResult{}, err
+			}
+			if scoreCount > bestScoreCount {
+				result.Summary = summary
+				bestScoreCount = scoreCount
+			}
+		case xml.EndElement:
+			if len(path) > 0 {
+				path = path[:len(path)-1]
+			}
+		}
+	}
+	if len(result.AvailableFields) == 0 {
+		return EvaluationResult{}, errors.New(
+			"iFlytek ISE XML contains no result fields",
+		)
+	}
+	return result, nil
+}
+
+func parseAttributes(
+	path string,
+	attributes []xml.Attr,
+	fields *[]ResultField,
+) (ScoreSummary, int, error) {
+	summary := ScoreSummary{}
+	scoreCount := 0
+	for _, attribute := range attributes {
+		name := attribute.Name.Local
+		value := attribute.Value
+		*fields = append(*fields, ResultField{
+			Path:  path,
+			Name:  name,
+			Value: value,
+		})
+		var target **float64
+		switch name {
+		case "total_score":
+			target = &summary.TotalScore
+		case "accuracy_score":
+			target = &summary.AccuracyScore
+		case "fluency_score":
+			target = &summary.FluencyScore
+		case "integrity_score":
+			target = &summary.IntegrityScore
+		case "standard_score":
+			target = &summary.StandardScore
+		case "is_rejected":
+			rejected, err := strconv.ParseBool(value)
+			if err != nil {
+				return ScoreSummary{}, 0, fmt.Errorf(
+					"parse iFlytek ISE is_rejected: %w",
+					err,
+				)
+			}
+			summary.Rejected = &rejected
+		case "except_info":
+			summary.ExceptionInfo = value
+		}
+		if target != nil {
+			score, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return ScoreSummary{}, 0, fmt.Errorf(
+					"parse iFlytek ISE %s: %w",
+					name,
+					err,
+				)
+			}
+			*target = &score
+			scoreCount++
+		}
+	}
+	return summary, scoreCount, nil
+}
+
+type initialRequest struct {
+	Common   initialCommon   `json:"common"`
+	Business initialBusiness `json:"business"`
+	Data     requestData     `json:"data"`
+}
+
+type initialCommon struct {
+	AppID string `json:"app_id"`
+}
+
+type initialBusiness struct {
+	AudioEncoding  string `json:"aue"`
+	AudioFormat    string `json:"auf"`
+	Category       string `json:"category"`
+	Command        string `json:"cmd"`
+	Language       string `json:"ent"`
+	Service        string `json:"sub"`
+	Text           string `json:"text"`
+	TextEncoding   string `json:"tte"`
+	SkipTextUpload bool   `json:"ttp_skip"`
+	ResultEncoding string `json:"rstcd"`
+	ResultLevel    string `json:"rst"`
+	UnifiedResult  string `json:"ise_unite"`
+	DetailLevel    string `json:"plev"`
+	ExtraAbility   string `json:"extra_ability"`
+}
+
+type audioRequest struct {
+	Business audioBusiness `json:"business"`
+	Data     requestData   `json:"data"`
+}
+
+type audioBusiness struct {
+	Command       string `json:"cmd"`
+	AudioStatus   int    `json:"aus"`
+	AudioEncoding string `json:"aue"`
+}
+
+type requestData struct {
+	Status   int    `json:"status"`
+	Data     string `json:"data"`
+	DataType int    `json:"data_type,omitempty"`
+	Encoding string `json:"encoding,omitempty"`
+}
+
+type responseMessage struct {
+	Code      int           `json:"code"`
+	Message   string        `json:"message"`
+	SessionID string        `json:"sid"`
+	Data      *responseData `json:"data"`
+}
+
+type responseData struct {
+	Status int    `json:"status"`
+	Data   string `json:"data"`
+}

--- a/server/internal/ai/xfyun/ise_live_test.go
+++ b/server/internal/ai/xfyun/ise_live_test.go
@@ -1,0 +1,89 @@
+package xfyun_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai/xfyun"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+)
+
+func TestISELive(t *testing.T) {
+	if os.Getenv("XFYUN_ISE_LIVE_TEST") != "1" {
+		t.Skip("set XFYUN_ISE_LIVE_TEST=1 to call iFlytek ISE")
+	}
+	audioPath := os.Getenv("XFYUN_ISE_LIVE_TEST_AUDIO")
+	referenceText := os.Getenv("XFYUN_ISE_LIVE_TEST_TEXT")
+	if audioPath == "" || referenceText == "" {
+		t.Fatal(
+			"XFYUN_ISE_LIVE_TEST_AUDIO and XFYUN_ISE_LIVE_TEST_TEXT are required",
+		)
+	}
+	audio, err := os.ReadFile(audioPath)
+	if err != nil {
+		t.Fatalf("read live audio: %v", err)
+	}
+	configuration, err := config.LoadISE()
+	if err != nil {
+		t.Fatalf("load ISE config: %v", err)
+	}
+	evaluator, err := xfyun.NewEvaluator(
+		xfyun.ISEConfig{
+			Endpoint: configuration.Endpoint,
+			Timeout:  configuration.Timeout,
+		},
+		configuration.AppID.Reveal(),
+		configuration.APIKey.Reveal(),
+		configuration.APISecret.Reveal(),
+	)
+	if err != nil {
+		t.Fatalf("new ISE evaluator: %v", err)
+	}
+	result, err := evaluator.Evaluate(context.Background(), xfyun.EvaluationRequest{
+		Audio:         audio,
+		ReferenceText: referenceText,
+	})
+	if err != nil {
+		t.Fatalf("evaluate live audio: %v", err)
+	}
+
+	fieldNames := make(map[string]struct{}, len(result.AvailableFields))
+	for _, field := range result.AvailableFields {
+		fieldNames[field.Name] = struct{}{}
+	}
+	available := make([]string, 0, len(fieldNames))
+	for name := range fieldNames {
+		available = append(available, name)
+	}
+	sort.Strings(available)
+	t.Logf("sid=%s", result.SessionID)
+	t.Logf(
+		"scores total=%s accuracy=%s fluency=%s integrity=%s standard=%s rejected=%s exception=%s",
+		floatValue(result.Summary.TotalScore),
+		floatValue(result.Summary.AccuracyScore),
+		floatValue(result.Summary.FluencyScore),
+		floatValue(result.Summary.IntegrityScore),
+		floatValue(result.Summary.StandardScore),
+		boolValue(result.Summary.Rejected),
+		result.Summary.ExceptionInfo,
+	)
+	t.Logf("available_fields=%v", available)
+}
+
+func floatValue(value *float64) string {
+	if value == nil {
+		return "unavailable"
+	}
+	return fmt.Sprintf("%.6f", *value)
+}
+
+func boolValue(value *bool) string {
+	if value == nil {
+		return "unavailable"
+	}
+	return strconv.FormatBool(*value)
+}

--- a/server/internal/ai/xfyun/ise_test.go
+++ b/server/internal/ai/xfyun/ise_test.go
@@ -1,0 +1,262 @@
+package xfyun
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testResultXML = `<?xml version="1.0" encoding="UTF-8"?>
+<xml_result>
+  <read_sentence>
+    <rec_paper>
+      <read_sentence total_score="87.5" accuracy_score="86.0" fluency_score="82.5" integrity_score="100" standard_score="0" is_rejected="false" except_info="0">
+        <sentence total_score="87.5" accuracy_score="86.0" fluency_score="82.5">
+          <word content="hello" total_score="91.2" beg_pos="0" end_pos="42">
+            <syll content="həˈləʊ" syll_score="90.1" syll_accent="1"/>
+            <phone content="h" dp_message="0"/>
+          </word>
+        </sentence>
+      </read_sentence>
+    </rec_paper>
+  </read_sentence>
+</xml_result>`
+
+func TestEvaluatorSendsDocumentedFramesAndParsesFinalResult(t *testing.T) {
+	connection := &fakeConnection{
+		responses: []responseMessage{{
+			Code:      0,
+			Message:   "success",
+			SessionID: "ise-session",
+			Data: &responseData{
+				Status: 2,
+				Data: base64.StdEncoding.EncodeToString(
+					[]byte(testResultXML),
+				),
+			},
+		}},
+	}
+	evaluator := newTestEvaluator(t, connection)
+	evaluator.frameBytes = 2
+	evaluator.frameInterval = 0
+
+	result, err := evaluator.Evaluate(context.Background(), EvaluationRequest{
+		Audio:         []byte{1, 2, 3},
+		ReferenceText: "Hello.",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if result.SessionID != "ise-session" ||
+		result.RawXML != testResultXML ||
+		result.Summary.TotalScore == nil ||
+		*result.Summary.TotalScore != 87.5 ||
+		result.Summary.AccuracyScore == nil ||
+		*result.Summary.AccuracyScore != 86 ||
+		result.Summary.FluencyScore == nil ||
+		*result.Summary.FluencyScore != 82.5 ||
+		result.Summary.IntegrityScore == nil ||
+		*result.Summary.IntegrityScore != 100 ||
+		result.Summary.Rejected == nil ||
+		*result.Summary.Rejected {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if !hasField(result.AvailableFields, "syll", "syll_score") ||
+		!hasField(result.AvailableFields, "syll", "syll_accent") ||
+		!hasField(result.AvailableFields, "phone", "dp_message") {
+		t.Fatalf("missing detailed fields: %#v", result.AvailableFields)
+	}
+
+	if len(connection.writes) != 4 {
+		t.Fatalf("writes = %d, want 4", len(connection.writes))
+	}
+	initial := decodeObject(t, connection.writes[0])
+	business := objectValue(t, initial, "business")
+	if business["category"] != "read_sentence" ||
+		business["ent"] != "en_vip" ||
+		business["plev"] != "0" ||
+		business["extra_ability"] !=
+			"multi_dimension;pitch;syll_phone_err_msg" ||
+		business["text"] != "\ufeff[content]\nHello." {
+		t.Fatalf("unexpected initial business: %#v", business)
+	}
+	firstAudio := objectValue(t, decodeObject(t, connection.writes[1]), "business")
+	secondAudio := objectValue(t, decodeObject(t, connection.writes[2]), "business")
+	lastAudio := objectValue(t, decodeObject(t, connection.writes[3]), "business")
+	if firstAudio["aus"] != float64(1) ||
+		secondAudio["aus"] != float64(2) ||
+		lastAudio["aus"] != float64(4) {
+		t.Fatalf(
+			"unexpected audio states: first=%v middle=%v last=%v",
+			firstAudio["aus"],
+			secondAudio["aus"],
+			lastAudio["aus"],
+		)
+	}
+}
+
+func TestEvaluatorReportsProviderFailureWithoutFallback(t *testing.T) {
+	connection := &fakeConnection{
+		responses: []responseMessage{{
+			Code:      10105,
+			Message:   "illegal access",
+			SessionID: "ise-failed",
+		}},
+	}
+	evaluator := newTestEvaluator(t, connection)
+	evaluator.frameInterval = 0
+
+	_, err := evaluator.Evaluate(context.Background(), EvaluationRequest{
+		Audio:         []byte{1},
+		ReferenceText: "Hello.",
+	})
+	if err == nil ||
+		!strings.Contains(err.Error(), "code=10105") ||
+		!strings.Contains(err.Error(), "ise-failed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSignedURLUsesHMACAndNeverFormatsCredentials(t *testing.T) {
+	evaluator := newTestEvaluator(t, &fakeConnection{})
+	target, err := evaluator.signedURL(
+		time.Date(2026, time.July, 31, 4, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("signed URL: %v", err)
+	}
+	parsed, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse signed URL: %v", err)
+	}
+	authorization, err := base64.StdEncoding.DecodeString(
+		parsed.Query().Get("authorization"),
+	)
+	if err != nil {
+		t.Fatalf("decode authorization: %v", err)
+	}
+	if !strings.Contains(string(authorization), `api_key="test-api-key"`) ||
+		!strings.Contains(string(authorization), `algorithm="hmac-sha256"`) ||
+		parsed.Query().Get("host") != "ise-api.xfyun.cn" ||
+		parsed.Query().Get("date") != "Fri, 31 Jul 2026 04:00:00 GMT" {
+		t.Fatalf("unexpected signed URL: %s", target)
+	}
+	if evaluator.appID.String() != "[REDACTED]" ||
+		evaluator.apiKey.GoString() != "xfyun.secret([REDACTED])" ||
+		strings.Contains(evaluator.apiSecret.String(), "test-api-secret") {
+		t.Fatal("credential formatting is not redacted")
+	}
+}
+
+func TestEvaluatorRejectsInvalidInputBeforeDial(t *testing.T) {
+	evaluator := newTestEvaluator(t, &fakeConnection{})
+	tests := []EvaluationRequest{
+		{},
+		{Audio: []byte{1}},
+		{ReferenceText: "Hello."},
+	}
+	for _, request := range tests {
+		if _, err := evaluator.Evaluate(context.Background(), request); err == nil {
+			t.Fatalf("request %#v should fail", request)
+		}
+	}
+}
+
+func newTestEvaluator(
+	t *testing.T,
+	connection websocketConnection,
+) *Evaluator {
+	t.Helper()
+	evaluator, err := NewEvaluator(
+		ISEConfig{
+			Endpoint: DefaultISEEndpoint,
+			Timeout:  time.Second,
+		},
+		"test-app-id",
+		"test-api-key",
+		"test-api-secret",
+	)
+	if err != nil {
+		t.Fatalf("new evaluator: %v", err)
+	}
+	evaluator.dial = func(
+		context.Context,
+		string,
+	) (websocketConnection, *http.Response, error) {
+		return connection, nil, nil
+	}
+	evaluator.now = func() time.Time {
+		return time.Date(2026, time.July, 31, 4, 0, 0, 0, time.UTC)
+	}
+	return evaluator
+}
+
+type fakeConnection struct {
+	writes    [][]byte
+	responses []responseMessage
+}
+
+func (connection *fakeConnection) WriteJSON(value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	connection.writes = append(connection.writes, payload)
+	return nil
+}
+
+func (connection *fakeConnection) ReadJSON(target any) error {
+	if len(connection.responses) == 0 {
+		return errors.New("no response")
+	}
+	response := connection.responses[0]
+	connection.responses = connection.responses[1:]
+	typed, ok := target.(*responseMessage)
+	if !ok {
+		return errors.New("unexpected response target")
+	}
+	*typed = response
+	return nil
+}
+
+func (*fakeConnection) SetWriteDeadline(time.Time) error { return nil }
+func (*fakeConnection) SetReadDeadline(time.Time) error  { return nil }
+func (*fakeConnection) Close() error                     { return nil }
+
+func decodeObject(t *testing.T, payload []byte) map[string]any {
+	t.Helper()
+	var object map[string]any
+	if err := json.Unmarshal(payload, &object); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	return object
+}
+
+func objectValue(
+	t *testing.T,
+	object map[string]any,
+	key string,
+) map[string]any {
+	t.Helper()
+	value, ok := object[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object: %#v", key, object[key])
+	}
+	return value
+}
+
+func hasField(fields []ResultField, pathSuffix string, name string) bool {
+	for _, field := range fields {
+		if strings.HasSuffix(field.Path, "/"+pathSuffix) &&
+			field.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/platform/config/ise.go
+++ b/server/internal/platform/config/ise.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai/xfyun"
+)
+
+const defaultISETimeout = 90 * time.Second
+
+type ISEConfig struct {
+	Endpoint  string
+	Timeout   time.Duration
+	AppID     Secret
+	APIKey    Secret
+	APISecret Secret
+}
+
+func LoadISE() (ISEConfig, error) {
+	endpoint := strings.TrimSpace(os.Getenv("XFYUN_ISE_ENDPOINT"))
+	if endpoint == "" {
+		endpoint = xfyun.DefaultISEEndpoint
+	}
+	timeout, err := durationOrDefault(
+		"XFYUN_ISE_TIMEOUT",
+		defaultISETimeout,
+	)
+	if err != nil {
+		return ISEConfig{}, err
+	}
+	if timeout <= 0 || timeout > 5*time.Minute {
+		return ISEConfig{}, fmt.Errorf(
+			"XFYUN_ISE_TIMEOUT must be greater than zero and at most %s",
+			5*time.Minute,
+		)
+	}
+	appID, err := loadISESecret("APPID")
+	if err != nil {
+		return ISEConfig{}, err
+	}
+	apiKey, err := loadISESecret("APIKey")
+	if err != nil {
+		return ISEConfig{}, err
+	}
+	apiSecret, err := loadISESecret("APISecret")
+	if err != nil {
+		return ISEConfig{}, err
+	}
+	return ISEConfig{
+		Endpoint:  endpoint,
+		Timeout:   timeout,
+		AppID:     appID,
+		APIKey:    apiKey,
+		APISecret: apiSecret,
+	}, nil
+}
+
+func loadISESecret(name string) (Secret, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return Secret{}, fmt.Errorf("%s is required", name)
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return r < 0x21 || r == 0x7f
+	}) >= 0 {
+		return Secret{}, fmt.Errorf(
+			"%s contains whitespace or control characters",
+			name,
+		)
+	}
+	return Secret{value: value}, nil
+}

--- a/server/internal/platform/config/ise_test.go
+++ b/server/internal/platform/config/ise_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/ai/xfyun"
+)
+
+func TestLoadISE(t *testing.T) {
+	setISEEnvironment(t)
+	t.Setenv("XFYUN_ISE_TIMEOUT", "45s")
+
+	configuration, err := LoadISE()
+	if err != nil {
+		t.Fatalf("load ISE: %v", err)
+	}
+	if configuration.Endpoint != xfyun.DefaultISEEndpoint ||
+		configuration.Timeout != 45*time.Second ||
+		configuration.AppID.Reveal() != "test-app-id" ||
+		configuration.APIKey.Reveal() != "test-api-key" ||
+		configuration.APISecret.Reveal() != "test-api-secret" {
+		t.Fatalf("unexpected ISE config: %#v", configuration)
+	}
+}
+
+func TestLoadISERejectsIncompleteOrUnsafeConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "missing app ID", key: "APPID", value: ""},
+		{name: "missing API key", key: "APIKey", value: ""},
+		{name: "missing API secret", key: "APISecret", value: ""},
+		{name: "unsafe API secret", key: "APISecret", value: "secret value"},
+		{name: "invalid timeout", key: "XFYUN_ISE_TIMEOUT", value: "soon"},
+		{name: "excessive timeout", key: "XFYUN_ISE_TIMEOUT", value: "301s"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setISEEnvironment(t)
+			t.Setenv(test.key, test.value)
+			if _, err := LoadISE(); err == nil {
+				t.Fatal("expected configuration error")
+			}
+		})
+	}
+}
+
+func setISEEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("APPID", "test-app-id")
+	t.Setenv("APIKey", "test-api-key")
+	t.Setenv("APISecret", "test-api-secret")
+	t.Setenv("XFYUN_ISE_ENDPOINT", "")
+	t.Setenv("XFYUN_ISE_TIMEOUT", "")
+}


### PR DESCRIPTION
## 功能描述

接入讯飞语音评测流式 API，支持服务端对 16kHz、16bit、单声道英文音频执行真实评测，并保留原始 XML、汇总已知分值、枚举全部返回字段。

## 实现思路

- 按官方 HMAC-SHA256 规则生成 WebSocket 鉴权地址。
- 按 1280 字节/40ms 上传音频帧，处理最终 Base64 XML 结果。
- 请求全维度、基频和音素错误信息，不直接采用讯飞总分。
- 密钥仅从服务端环境读取，格式化时始终脱敏。

## 测试

- `go test -count=1 ./internal/ai/... ./internal/platform/config`
- 使用真实讯飞账号和临时 16kHz WAV 调用通过。
- 实测返回 accuracy、fluency、integrity、pitch、syll_score、syll_accent、dp_message 等字段。

Closes #301