### PR TITLE
fix(mobile): support Intel iOS simulator fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-smoke \
-	dev-android
+	dev-android \
+	dev-ios-simulator
 
 help:
 	@printf '%s\n' \
@@ -30,7 +31,8 @@ help:
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-smoke    Run the deterministic Mock main flow' \
-		'  make dev-android    Start the backend and run the App on an Android device'
+		'  make dev-android    Start the backend and run the App on an Android device' \
+		'  make dev-ios-simulator  Start the backend and run without AvatarKit on an iOS Simulator'
 
 check: check-flutter check-go check-api check-smoke
 
@@ -114,3 +116,6 @@ check-smoke:
 
 dev-android:
 	./tools/android-dev/run.sh
+
+dev-ios-simulator:
+	./tools/ios-simulator-dev/run.sh

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -24,3 +24,18 @@ Android 真机上运行 App。连接多台设备时，可通过
 `ANDROID_DEVICE_ID=<设备 ID> make dev-android` 指定设备。
 本地调试后端默认使用 `18080` 端口，可通过
 `SPEAKUP_DEV_PORT=<端口> make dev-android` 覆盖。
+
+## iOS 模拟器调试
+
+AvatarKit 当前不提供 Intel Mac 所需的 x86_64 模拟器二进制。先启动一个
+iPhone Simulator，再在仓库根目录执行：
+
+```shell
+make dev-ios-simulator
+```
+
+该命令会把当前移动端源码复制到临时构建目录、启动 PostgreSQL 与本地后端，
+并仅在临时副本中把数字人明确标记为不支持，使情景对话沿用纯语音/文字
+降级链路。正式工作区与真实 AvatarKit 依赖始终不变；Android 与 iOS 真机构建
+不受影响。连接多个模拟器时，可通过
+`IOS_SIMULATOR_ID=<设备 ID> make dev-ios-simulator` 指定设备。

--- a/tools/ios-simulator-dev/avatar_kit_stub/lib/avatar_kit.dart
+++ b/tools/ios-simulator-dev/avatar_kit_stub/lib/avatar_kit.dart
@@ -1,0 +1,118 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+
+class Configuration {
+  const Configuration({
+    required this.environment,
+    this.audioFormat = const AudioFormat(),
+    this.drivingServiceMode = DrivingServiceMode.sdk,
+    this.logLevel = LogLevel.off,
+  });
+
+  final Environment environment;
+  final AudioFormat audioFormat;
+  final DrivingServiceMode drivingServiceMode;
+  final LogLevel logLevel;
+}
+
+enum Environment { intl, cn }
+
+class AudioFormat {
+  const AudioFormat({this.sampleRate = 16000});
+
+  final int sampleRate;
+}
+
+enum DrivingServiceMode { sdk, host }
+
+enum LogLevel { off, error, warning, all }
+
+enum ConnectionState { disconnected, connecting, connected, failed }
+
+enum ConversationState { idle, paused, playing }
+
+enum AvatarError {
+  appIDUnrecognized,
+  avatarIDUnrecognized,
+  avatarAssetMissing,
+  sessionTokenInvalid,
+  sessionTokenExpired,
+  failedToFetchAvatarMetadata,
+  failedToDownloadAvatarAssets,
+  insufficientBalance,
+  sessionTimeout,
+  concurrentLimitExceeded,
+  serverError,
+}
+
+class FrameRateInfo {
+  const FrameRateInfo();
+}
+
+abstract final class AvatarSDK {
+  static Future<bool> isDeviceSupported() async => false;
+
+  static Future<void> initialize({
+    required String appID,
+    required Configuration configuration,
+  }) => Future<void>.error(_unsupported());
+
+  static Future<void> setSessionToken(String sessionToken) =>
+      Future<void>.error(_unsupported());
+}
+
+class AvatarManager {
+  AvatarManager._();
+
+  static final AvatarManager shared = AvatarManager._();
+
+  Future<Avatar> load({required String id}) =>
+      Future<Avatar>.error(_unsupported());
+
+  Future<void> cancelLoading({required String id}) async {}
+}
+
+class Avatar {
+  const Avatar();
+}
+
+class AvatarWidget extends StatelessWidget {
+  const AvatarWidget({
+    super.key,
+    required this.avatar,
+    required this.onPlatformViewCreated,
+  });
+
+  final Avatar avatar;
+  final ValueChanged<AvatarController> onPlatformViewCreated;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+}
+
+class AvatarController {
+  AvatarController._();
+
+  VoidCallback? onFirstRendering;
+  void Function(ConnectionState state, String? errorMessage)? onConnectionState;
+  ValueChanged<ConversationState>? onConversationState;
+  ValueChanged<AvatarError>? onError;
+  ValueChanged<FrameRateInfo>? onFrameRateInfo;
+
+  Future<void> start() => Future<void>.error(_unsupported());
+
+  Future<String> send(Uint8List audioData, {bool end = false}) =>
+      Future<String>.error(_unsupported());
+
+  Future<void> interrupt() async {}
+
+  Future<void> close() async {}
+
+  Future<void> pauseRendering() async {}
+
+  Future<void> resumeRendering() async {}
+}
+
+UnsupportedError _unsupported() =>
+    UnsupportedError('AvatarKit is disabled on the iOS Simulator.');

--- a/tools/ios-simulator-dev/avatar_kit_stub/pubspec.yaml
+++ b/tools/ios-simulator-dev/avatar_kit_stub/pubspec.yaml
@@ -1,0 +1,11 @@
+name: avatar_kit
+description: Explicit unsupported-device adapter for local iOS Simulator builds.
+version: 1.0.0-beta.44
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+
+dependencies:
+  flutter:
+    sdk: flutter

--- a/tools/ios-simulator-dev/run.sh
+++ b/tools/ios-simulator-dev/run.sh
@@ -1,0 +1,112 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+tool_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "$tool_dir/../.." && pwd)"
+server_dir="$repo_dir/server"
+mobile_source_dir="$repo_dir/mobile"
+server_port="${SPEAKUP_DEV_PORT:-18080}"
+base_url="http://127.0.0.1:$server_port"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/xe3-ios-simulator-dev.XXXXXX")"
+mobile_dir="$run_dir/mobile"
+override_file="$mobile_dir/pubspec_overrides.yaml"
+server_binary="$run_dir/server"
+server_log="$run_dir/server.log"
+server_pid=""
+
+cleanup() {
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$run_dir"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command_name in curl docker flutter go rsync xcrun; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    print -u2 "缺少命令：$command_name"
+    exit 1
+  fi
+done
+
+if [[ ! -f "$repo_dir/.env" ]]; then
+  print -u2 "缺少 $repo_dir/.env，无法启动真实后端。"
+  exit 1
+fi
+set -a
+source "$repo_dir/.env"
+set +a
+
+device_id="${IOS_SIMULATOR_ID:-}"
+if [[ -n "$device_id" ]]; then
+  xcrun simctl boot "$device_id" >/dev/null 2>&1 || true
+else
+  device_id="$(
+    xcrun simctl list devices booted |
+      awk -F '[()]' '/iPhone/ {print $2; exit}'
+  )"
+fi
+if [[ -z "$device_id" ]]; then
+  print -u2 "没有已启动的 iPhone 模拟器。请先打开 Simulator，或设置 IOS_SIMULATOR_ID。"
+  exit 1
+fi
+xcrun simctl bootstatus "$device_id" -b
+
+rsync -a \
+  --exclude '/.dart_tool/' \
+  --exclude '/build/' \
+  --exclude '/ios/Pods/' \
+  --exclude '/pubspec_overrides.yaml' \
+  "$mobile_source_dir/" \
+  "$mobile_dir/"
+cat >"$override_file" <<EOF
+dependency_overrides:
+  avatar_kit:
+    path: $tool_dir/avatar_kit_stub
+EOF
+
+print "启动 PostgreSQL..."
+docker compose -p xe3-esl -f "$repo_dir/compose.yaml" up -d --wait postgres
+
+print "执行数据库迁移..."
+(cd "$server_dir" && go run ./cmd/migrate up)
+
+print "构建并启动本地后端..."
+(cd "$server_dir" && go build -o "$server_binary" ./cmd/server)
+(
+  cd "$server_dir"
+  SERVER_HOST=127.0.0.1 \
+  SERVER_PORT="$server_port" \
+  "$server_binary"
+) >"$server_log" 2>&1 &
+server_pid=$!
+
+ready=0
+for _ in {1..120}; do
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    print -u2 "后端启动失败："
+    tail -80 "$server_log" >&2
+    exit 1
+  fi
+  if curl --silent --fail --max-time 2 "$base_url/readyz" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$ready" != "1" ]]; then
+  print -u2 "等待后端就绪超时："
+  tail -80 "$server_log" >&2
+  exit 1
+fi
+
+print "启动 SpeakUp iOS Simulator；数字人已明确禁用，按 q 退出。"
+cd "$mobile_dir"
+flutter run \
+  -d "$device_id" \
+  --dart-define="SPEAKUP_API_BASE_URL=$base_url" \
+  "$@"


### PR DESCRIPTION
## 功能描述

让 Intel Mac 可以启动 iOS Simulator 调试 SpeakUp。模拟器明确禁用不含 x86_64 slice 的 AvatarKit，并沿用现有纯语音/文字降级；Android 与 iOS 真机继续使用真实 AvatarKit。

## 实现思路

- 新增 `make dev-ios-simulator` 团队统一入口。
- 将当前移动端源码复制到临时构建目录，避免 Flutter/CocoaPods 改写开发者工作区。
- 仅在临时副本中通过 `pubspec_overrides.yaml` 使用 Dart-only AvatarKit unsupported-device adapter。
- adapter 的 `isDeviceSupported()` 明确返回 false，其余原生入口拒绝执行，不伪装数字人成功。
- 启动脚本同时拉起 PostgreSQL、迁移和本地后端，退出后清理临时目录。

## 可复现验证

- `make check-flutter`：761 tests passed。
- `flutter build apk --debug --target-platform android-arm64`：通过，依赖仍为真实 `avatar_kit 1.0.0-beta.44`。
- `IOS_SIMULATOR_ID=05F528B2-656E-4451-ACBA-415353BCEBD1 SPEAKUP_DEV_PORT=18081 make dev-ios-simulator`：Intel Core i7、iOS 26.5 模拟器构建、安装、启动和 Flutter attach 通过。
- 启动期间 `git status --short` 仅显示本 PR 文件，未产生 Podfile.lock、pbxproj 或 pubspec.lock 污染。

Closes #307