### PR TITLE
fix(interview): complete final report transition

### DIFF
--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -2850,6 +2850,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         final reconciled = isFinalInterviewTurn && _canRetry(error)
             ? await _reconcileFinalInterviewSubmission(
                 practice: practice,
+                fence: fence,
                 expectedSessionId: sessionId,
                 expectedQuestionId: question.id,
                 expectedCandidateId: candidate.id,
@@ -2995,6 +2996,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         final reconciled = isFinalInterviewTurn && _canRetry(error)
             ? await _reconcileFinalInterviewSubmission(
                 practice: practice,
+                fence: fence,
                 expectedSessionId: sessionId,
                 expectedQuestionId: question.id,
                 expectedAnswer: text,
@@ -3072,6 +3074,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
 
   Future<bool> _reconcileFinalInterviewSubmission({
     required PracticeClient practice,
+    required _AgentOperationFence fence,
     required String expectedSessionId,
     required String expectedQuestionId,
     required String expectedAnswer,
@@ -3088,6 +3091,9 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         threadId: threadId,
         activeMatter: _activeMatter,
       );
+      if (!_isOperationCurrent(fence)) {
+        return false;
+      }
       final currentTurn = snapshot?.currentTurn;
       if (snapshot == null ||
           snapshot.sessionId != expectedSessionId ||

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -215,6 +215,16 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
   String? get errorMessage => _errorMessage;
   int get completedTurns => _completedTurns;
   int get turnLimit => _turnLimit;
+  bool get isFinalInterviewSubmission =>
+      _recordingState == PracticeRecordingState.submitting &&
+      _speechFeedbackRetry == null &&
+      !_sessionCompleted &&
+      _turnLimit > 0 &&
+      _completedTurns + 1 == _turnLimit &&
+      isInterviewPracticeScenario(
+        _practiceScenarioType,
+        _practiceScenarioModel,
+      );
   bool get isBusy =>
       _busy ||
       _practiceRequestInFlight ||
@@ -2800,6 +2810,15 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
         _recordingState != PracticeRecordingState.awaitingConfirmation) {
       return;
     }
+    final isFinalInterviewTurn =
+        _turnLimit > 0 &&
+        _completedTurns + 1 == _turnLimit &&
+        isInterviewPracticeScenario(
+          _practiceScenarioType,
+          _practiceScenarioModel,
+        );
+    final completedTurns = _completedTurns;
+    final turnLimit = _turnLimit;
     final fence = _captureOperationFence(
       threadId: _threadId,
       practiceGeneration: _practiceGeneration,
@@ -2828,8 +2847,21 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _applyPracticeConfirmation(confirmation);
     } catch (error) {
       if (_isOperationCurrent(fence)) {
-        _recordingState = PracticeRecordingState.awaitingConfirmation;
-        _errorMessage = _confirmationFailureMessage(error);
+        final reconciled = isFinalInterviewTurn && _canRetry(error)
+            ? await _reconcileFinalInterviewSubmission(
+                practice: practice,
+                expectedSessionId: sessionId,
+                expectedQuestionId: question.id,
+                expectedCandidateId: candidate.id,
+                expectedAnswer: candidate.text,
+                previousCompletedTurns: completedTurns,
+                expectedTurnLimit: turnLimit,
+              )
+            : false;
+        if (!reconciled && _isOperationCurrent(fence)) {
+          _recordingState = PracticeRecordingState.awaitingConfirmation;
+          _errorMessage = _confirmationFailureMessage(error);
+        }
       }
     }
     if (_isCurrent(fence.epoch)) {
@@ -2917,6 +2949,15 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       _activeConfirmationId = _newClientId('text-turn');
       _activeTextAnswer = text;
     }
+    final isFinalInterviewTurn =
+        _turnLimit > 0 &&
+        _completedTurns + 1 == _turnLimit &&
+        isInterviewPracticeScenario(
+          _practiceScenarioType,
+          _practiceScenarioModel,
+        );
+    final completedTurns = _completedTurns;
+    final turnLimit = _turnLimit;
     final fence = _captureOperationFence(
       threadId: _threadId,
       practiceGeneration: generation,
@@ -2951,8 +2992,23 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       return true;
     } catch (error) {
       if (_isOperationCurrent(fence)) {
-        _recordingState = PracticeRecordingState.idle;
-        _errorMessage = _confirmationFailureMessage(error);
+        final reconciled = isFinalInterviewTurn && _canRetry(error)
+            ? await _reconcileFinalInterviewSubmission(
+                practice: practice,
+                expectedSessionId: sessionId,
+                expectedQuestionId: question.id,
+                expectedAnswer: text,
+                previousCompletedTurns: completedTurns,
+                expectedTurnLimit: turnLimit,
+              )
+            : false;
+        if (reconciled) {
+          return true;
+        }
+        if (_isOperationCurrent(fence)) {
+          _recordingState = PracticeRecordingState.idle;
+          _errorMessage = _confirmationFailureMessage(error);
+        }
       }
       return false;
     } finally {
@@ -3011,6 +3067,51 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
           : null;
     } else {
       _recordingState = PracticeRecordingState.idle;
+    }
+  }
+
+  Future<bool> _reconcileFinalInterviewSubmission({
+    required PracticeClient practice,
+    required String expectedSessionId,
+    required String expectedQuestionId,
+    required String expectedAnswer,
+    required int previousCompletedTurns,
+    required int expectedTurnLimit,
+    String? expectedCandidateId,
+  }) async {
+    final threadId = _threadId;
+    if (threadId == null) {
+      return false;
+    }
+    try {
+      final snapshot = await practice.restorePractice(
+        threadId: threadId,
+        activeMatter: _activeMatter,
+      );
+      final currentTurn = snapshot?.currentTurn;
+      if (snapshot == null ||
+          snapshot.sessionId != expectedSessionId ||
+          snapshot.scenarioType != _practiceScenarioType ||
+          snapshot.scenarioModel != _practiceScenarioModel ||
+          !snapshot.sessionCompleted ||
+          snapshot.completedTurns != previousCompletedTurns + 1 ||
+          snapshot.completedTurns != expectedTurnLimit ||
+          snapshot.turnLimit != expectedTurnLimit ||
+          currentTurn == null ||
+          currentTurn.sessionId != expectedSessionId ||
+          currentTurn.questionId != expectedQuestionId ||
+          currentTurn.answerText != expectedAnswer ||
+          currentTurn.effectiveTurns != expectedTurnLimit ||
+          !currentTurn.sessionCompleted ||
+          (expectedCandidateId != null &&
+              currentTurn.candidateId != expectedCandidateId)) {
+        return false;
+      }
+      _applyPracticeSnapshot(snapshot, preserveKnownRecordings: true);
+      _errorMessage = null;
+      return true;
+    } on Object {
+      return false;
     }
   }
 

--- a/mobile/lib/features/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/practice/immersive_roleplay.dart
@@ -71,6 +71,9 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   bool _exitInFlight = false;
   bool _exitApproved = false;
   bool _feedbackRebuildScheduled = false;
+  String? _scheduledInterviewReportSessionId;
+  String? _autoOpenedInterviewReportSessionId;
+  bool _interviewReportRouteActive = false;
 
   @override
   void initState() {
@@ -80,6 +83,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     widget.speechFeedbackController?.addListener(_handleFeedbackState);
     _syncSpeechFeedbackSources();
     _syncRecordingTimer();
+    _scheduleInterviewReportIfNeeded();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted && _conversationScrollController.hasClients) {
         _conversationScrollController.jumpTo(
@@ -110,6 +114,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
       _syncRecordingTimer();
     }
     _syncSpeechFeedbackSources();
+    _scheduleInterviewReportIfNeeded();
   }
 
   @override
@@ -135,6 +140,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     _syncRecordingTimer();
     _syncSpeechFeedbackSources();
     setState(() {});
+    _scheduleInterviewReportIfNeeded();
     if (shouldFollowConversation) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted || !_conversationScrollController.hasClients) {
@@ -236,6 +242,38 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     }
   }
 
+  void _scheduleInterviewReportIfNeeded() {
+    final controller = widget.agentController;
+    final sessionId = controller.practiceSessionId;
+    if (widget.interviewReportController == null ||
+        sessionId == null ||
+        controller.recordingState != PracticeRecordingState.completed ||
+        !isInterviewPracticeScenario(
+          controller.practiceScenarioType,
+          controller.practiceScenarioModel,
+        ) ||
+        _interviewReportRouteActive ||
+        _scheduledInterviewReportSessionId == sessionId ||
+        _autoOpenedInterviewReportSessionId == sessionId) {
+      return;
+    }
+    _scheduledInterviewReportSessionId = sessionId;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          widget.agentController.practiceSessionId != sessionId ||
+          widget.agentController.recordingState !=
+              PracticeRecordingState.completed) {
+        if (_scheduledInterviewReportSessionId == sessionId) {
+          _scheduledInterviewReportSessionId = null;
+        }
+        return;
+      }
+      _scheduledInterviewReportSessionId = null;
+      _autoOpenedInterviewReportSessionId = sessionId;
+      unawaited(_openInterviewReport());
+    });
+  }
+
   Future<void> _openInterviewReport() async {
     final reportController = widget.interviewReportController;
     final agentController = widget.agentController;
@@ -243,28 +281,34 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     if (reportController == null ||
         sessionId == null ||
         agentController.recordingState != PracticeRecordingState.completed ||
+        _interviewReportRouteActive ||
         !isInterviewPracticeScenario(
           agentController.practiceScenarioType,
           agentController.practiceScenarioModel,
         )) {
       return;
     }
-    final result = await Navigator.of(context).push<Object?>(
-      MaterialPageRoute<Object?>(
-        builder: (_) => InterviewReportPage(
-          practiceSessionId: sessionId,
-          controller: reportController,
-          title: '${widget.agentController.scene?.title ?? '面试'} · 复盘',
-          speechFeedbackController: widget.speechFeedbackController,
-          speechFeedbackSourceKeys: List<String>.unmodifiable(
-            _feedbackSources.keys,
+    _interviewReportRouteActive = true;
+    try {
+      final result = await Navigator.of(context).push<Object?>(
+        MaterialPageRoute<Object?>(
+          builder: (_) => InterviewReportPage(
+            practiceSessionId: sessionId,
+            controller: reportController,
+            title: '${widget.agentController.scene?.title ?? '面试'} · 复盘',
+            speechFeedbackController: widget.speechFeedbackController,
+            speechFeedbackSourceKeys: List<String>.unmodifiable(
+              _feedbackSources.keys,
+            ),
+            onContinueWithAgent: widget.onContinueWithAgent,
           ),
-          onContinueWithAgent: widget.onContinueWithAgent,
         ),
-      ),
-    );
-    if (mounted && result == CompletedPracticeRouteResult.continueWithAgent) {
-      Navigator.of(context).pop(result);
+      );
+      if (mounted && result == CompletedPracticeRouteResult.continueWithAgent) {
+        Navigator.of(context).pop(result);
+      }
+    } finally {
+      _interviewReportRouteActive = false;
     }
   }
 
@@ -979,8 +1023,10 @@ class _ImmersiveComposerState extends State<_ImmersiveComposer> {
           PracticeRecordingState.awaitingConfirmation => _TranscriptComposer(
             controller: widget.controller,
           ),
-          PracticeRecordingState.submitting => const _ComposerProgress(
-            label: '回答已发送，Agent 正在回复…',
+          PracticeRecordingState.submitting => _ComposerProgress(
+            label: widget.controller.isFinalInterviewSubmission
+                ? '正在提交最后一轮回答，完成后将生成报告…'
+                : '回答已发送，Agent 正在回复…',
           ),
           PracticeRecordingState.reviewFailed => _ComposerAction(
             label: '本轮录音和转写已保留，复盘结果暂未同步。无需重新录音。',

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -74,6 +74,9 @@ class _PracticePageState extends State<PracticePage>
   DateTime? _recordingStartedAt;
   int _recordingSeconds = 0;
   bool _speechFeedbackRebuildScheduled = false;
+  String? _scheduledInterviewReportSessionId;
+  String? _autoOpenedInterviewReportSessionId;
+  bool _interviewReportRouteActive = false;
 
   @override
   void initState() {
@@ -87,6 +90,7 @@ class _PracticePageState extends State<PracticePage>
     _captureConversationState();
     _syncRecordingTimer();
     _scheduleReviewExitIfNeeded();
+    _scheduleInterviewReportIfNeeded();
     _scheduleScrollToLatest(animated: false);
   }
 
@@ -102,6 +106,7 @@ class _PracticePageState extends State<PracticePage>
     }
     if (oldWidget.agentController == widget.agentController) {
       _syncSpeechFeedbackSources();
+      _scheduleInterviewReportIfNeeded();
       return;
     }
     oldWidget.agentController?.removeListener(_handleState);
@@ -111,6 +116,7 @@ class _PracticePageState extends State<PracticePage>
     _captureConversationState();
     _syncSpeechFeedbackSources();
     _scheduleReviewExitIfNeeded();
+    _scheduleInterviewReportIfNeeded();
     _scheduleScrollToLatest(animated: false);
   }
 
@@ -157,6 +163,7 @@ class _PracticePageState extends State<PracticePage>
     _syncRecordingTimer();
     _syncSpeechFeedbackSources();
     setState(() {});
+    _scheduleInterviewReportIfNeeded();
     if (retryCompleted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) {
@@ -181,6 +188,39 @@ class _PracticePageState extends State<PracticePage>
     _scheduleReviewExitIfNeeded();
   }
 
+  void _scheduleInterviewReportIfNeeded() {
+    final controller = widget.agentController;
+    final sessionId = controller?.practiceSessionId;
+    if (controller == null ||
+        widget.interviewReportController == null ||
+        sessionId == null ||
+        controller.recordingState != PracticeRecordingState.completed ||
+        !isInterviewPracticeScenario(
+          controller.practiceScenarioType,
+          controller.practiceScenarioModel,
+        ) ||
+        _interviewReportRouteActive ||
+        _scheduledInterviewReportSessionId == sessionId ||
+        _autoOpenedInterviewReportSessionId == sessionId) {
+      return;
+    }
+    _scheduledInterviewReportSessionId = sessionId;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          widget.agentController?.practiceSessionId != sessionId ||
+          widget.agentController?.recordingState !=
+              PracticeRecordingState.completed) {
+        if (_scheduledInterviewReportSessionId == sessionId) {
+          _scheduledInterviewReportSessionId = null;
+        }
+        return;
+      }
+      _scheduledInterviewReportSessionId = null;
+      _autoOpenedInterviewReportSessionId = sessionId;
+      unawaited(_openInterviewReport());
+    });
+  }
+
   Future<void> _openInterviewReport() async {
     final reportController = widget.interviewReportController;
     final agentController = widget.agentController;
@@ -189,28 +229,34 @@ class _PracticePageState extends State<PracticePage>
         agentController == null ||
         sessionId == null ||
         agentController.recordingState != PracticeRecordingState.completed ||
+        _interviewReportRouteActive ||
         !isInterviewPracticeScenario(
           agentController.practiceScenarioType,
           agentController.practiceScenarioModel,
         )) {
       return;
     }
-    final result = await Navigator.of(context).push<Object?>(
-      MaterialPageRoute<Object?>(
-        builder: (_) => InterviewReportPage(
-          practiceSessionId: sessionId,
-          controller: reportController,
-          title: '${agentController.scene?.title ?? '面试'} · 复盘',
-          speechFeedbackController: widget.speechFeedbackController,
-          speechFeedbackSourceKeys: List<String>.unmodifiable(
-            _feedbackSources.keys,
+    _interviewReportRouteActive = true;
+    try {
+      final result = await Navigator.of(context).push<Object?>(
+        MaterialPageRoute<Object?>(
+          builder: (_) => InterviewReportPage(
+            practiceSessionId: sessionId,
+            controller: reportController,
+            title: '${agentController.scene?.title ?? '面试'} · 复盘',
+            speechFeedbackController: widget.speechFeedbackController,
+            speechFeedbackSourceKeys: List<String>.unmodifiable(
+              _feedbackSources.keys,
+            ),
+            onContinueWithAgent: widget.onContinueWithAgent,
           ),
-          onContinueWithAgent: widget.onContinueWithAgent,
         ),
-      ),
-    );
-    if (mounted && result == CompletedPracticeRouteResult.continueWithAgent) {
-      Navigator.of(context).pop(result);
+      );
+      if (mounted && result == CompletedPracticeRouteResult.continueWithAgent) {
+        Navigator.of(context).pop(result);
+      }
+    } finally {
+      _interviewReportRouteActive = false;
     }
   }
 
@@ -690,7 +736,8 @@ class _InterviewProgress extends StatelessWidget {
       PracticeRecordingState.recording => '正在作答',
       PracticeRecordingState.transcribing ||
       PracticeRecordingState.awaitingConfirmation => '正在识别',
-      PracticeRecordingState.submitting => '正在生成下一题',
+      PracticeRecordingState.submitting =>
+        controller.isFinalInterviewSubmission ? '正在提交最后一题' : '正在生成下一题',
       PracticeRecordingState.completed => '面试已完成',
       PracticeRecordingState.reviewFailed => '等待重试',
       PracticeRecordingState.idle => '等待作答',
@@ -1129,6 +1176,8 @@ class _RecordingPanelState extends State<_RecordingPanel> {
           PracticeRecordingState.submitting => _WorkingState(
             label: widget.controller.isSpeechFeedbackRetryActive
                 ? '正在提交同题复练…'
+                : widget.controller.isFinalInterviewSubmission
+                ? '正在提交最后一轮回答，完成后将生成报告…'
                 : '回答已发送，Agent 正在回复…',
           ),
           PracticeRecordingState.reviewFailed => _ReviewRetry(

--- a/mobile/test/practice/immersive_roleplay_test.dart
+++ b/mobile/test/practice/immersive_roleplay_test.dart
@@ -336,7 +336,7 @@ void main() {
     expect(find.text('刷新复盘'), findsOneWidget);
   });
 
-  testWidgets('keeps the final turn visible until report is requested', (
+  testWidgets('opens report generation after the final interview turn', (
     tester,
   ) async {
     final controller = await _roleplayController(
@@ -367,17 +367,6 @@ void main() {
         ),
       ),
     );
-    await tester.pump();
-    await tester.pump();
-
-    expect(find.byKey(const Key('interview-report-page')), findsNothing);
-    expect(find.text('查看报告'), findsOneWidget);
-    expect(
-      find.byKey(const Key('immersive-conversation-history')),
-      findsOneWidget,
-    );
-
-    await tester.tap(find.text('查看报告'));
     await tester.pump();
     await tester.pump();
 

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -49,6 +49,131 @@ void main() {
     expect(recorder.discarded, 2);
   });
 
+  test('reconciles an ambiguous final interview voice confirmation', () async {
+    final practice = _TwoTurnPracticeClient(
+      scenarioType: 'INTERVIEW',
+      scenarioModel: 'INTERVIEW_BASIC_DIALOGUE',
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    await controller.confirmTranscript();
+
+    const answer = 'Answer 2';
+    practice
+      ..confirmFailure = const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      )
+      ..restoreResult = _completedInterviewSnapshot(
+        matter: controller.activeMatter!,
+        questionId: 'question-2',
+        candidateId: 'candidate-2',
+        answer: answer,
+      );
+    await controller.startRecording();
+    await controller.stopRecording();
+    expect(controller.isFinalInterviewSubmission, isFalse);
+    final restoreCount = practice.restoreCount;
+
+    final confirmation = controller.confirmTranscript();
+    expect(controller.isFinalInterviewSubmission, isTrue);
+    await confirmation;
+
+    expect(controller.recordingState, PracticeRecordingState.completed);
+    expect(controller.completedTurns, 2);
+    expect(controller.errorMessage, isNull);
+    expect(practice.restoreCount, restoreCount + 1);
+  });
+
+  test('reconciles an ambiguous final interview text submission', () async {
+    final practice = _TwoTurnPracticeClient(
+      scenarioType: 'INTERVIEW',
+      scenarioModel: 'INTERVIEW_BASIC_DIALOGUE',
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    await controller.confirmTranscript();
+
+    const answer = 'Typed final answer';
+    practice
+      ..textFailure = const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      )
+      ..restoreResult = _completedInterviewSnapshot(
+        matter: controller.activeMatter!,
+        questionId: 'question-2',
+        candidateId: 'server-text-candidate',
+        answer: answer,
+      );
+    final restoreCount = practice.restoreCount;
+
+    final submission = controller.submitPracticeText(answer);
+    expect(controller.isFinalInterviewSubmission, isTrue);
+    expect(await submission, isTrue);
+    expect(controller.recordingState, PracticeRecordingState.completed);
+    expect(controller.completedTurns, 2);
+    expect(controller.errorMessage, isNull);
+    expect(practice.restoreCount, restoreCount + 1);
+  });
+
+  test('does not accept a mismatched final interview recovery', () async {
+    final practice = _TwoTurnPracticeClient(
+      scenarioType: 'INTERVIEW',
+      scenarioModel: 'INTERVIEW_BASIC_DIALOGUE',
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(agentScenes.first);
+    await controller.startRecording();
+    await controller.stopRecording();
+    await controller.confirmTranscript();
+
+    practice
+      ..confirmFailure = const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      )
+      ..restoreResult = _completedInterviewSnapshot(
+        matter: controller.activeMatter!,
+        questionId: 'question-2',
+        candidateId: 'different-candidate',
+        answer: 'Answer 2',
+      );
+    await controller.startRecording();
+    await controller.stopRecording();
+    await controller.confirmTranscript();
+
+    expect(
+      controller.recordingState,
+      PracticeRecordingState.awaitingConfirmation,
+    );
+    expect(controller.completedTurns, 1);
+    expect(controller.candidateId, 'candidate-2');
+    expect(controller.errorMessage, '网络连接不稳定，这一轮尚未确认，请重试。');
+  });
+
   test(
     'retains failed transcription audio and retries with one Turn identity',
     () async {
@@ -1278,6 +1403,8 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     this.firstAnswer = 'Answer 1',
     this.secondQuestion = 'Second question',
     this.formalReview,
+    this.scenarioType,
+    this.scenarioModel,
   });
 
   final bool includeAudioAssets;
@@ -1285,6 +1412,8 @@ final class _TwoTurnPracticeClient implements PracticeClient {
   final String firstAnswer;
   final String secondQuestion;
   final FormalReview? formalReview;
+  final String? scenarioType;
+  final String? scenarioModel;
   int completed = 0;
   int cleanupCount = 0;
   final List<String> confirmedQuestionIds = [];
@@ -1297,6 +1426,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
   Object? restoreFailure;
   PracticeSessionSnapshot? restoreResult;
   int transcribeCount = 0;
+  int restoreCount = 0;
   final List<String> transcriptionClientTurnIds = <String>[];
 
   @override
@@ -1310,6 +1440,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     required String threadId,
     AgentMatter? activeMatter,
   }) async {
+    restoreCount++;
     if (restoreFailure case final failure?) {
       throw failure;
     }
@@ -1325,6 +1456,8 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     return PracticeStartResult(
       snapshot: PracticeSessionSnapshot(
         sessionId: _sessionId,
+        scenarioType: scenarioType,
+        scenarioModel: scenarioModel,
         matter: activeMatter,
         completedTurns: 0,
         turnLimit: 2,
@@ -1387,6 +1520,8 @@ final class _TwoTurnPracticeClient implements PracticeClient {
       sessionId: sessionId,
       questionId: questionId,
       candidateId: candidateId,
+      scenarioType: scenarioType,
+      scenarioModel: scenarioModel,
       answer: AgentMessage(
         id: 'answer-$completed',
         role: AgentMessageRole.user,
@@ -1422,6 +1557,34 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     }
     throw UnimplementedError();
   }
+}
+
+PracticeSessionSnapshot _completedInterviewSnapshot({
+  required AgentMatter matter,
+  required String questionId,
+  required String candidateId,
+  required String answer,
+}) {
+  return PracticeSessionSnapshot(
+    sessionId: _sessionId,
+    scenarioType: 'INTERVIEW',
+    scenarioModel: 'INTERVIEW_BASIC_DIALOGUE',
+    matter: matter,
+    completedTurns: 2,
+    turnLimit: 2,
+    sessionCompleted: true,
+    currentTurn: PracticeTurnSnapshot(
+      id: 'turn-2',
+      sessionId: _sessionId,
+      questionId: questionId,
+      respondentParticipantId: 'respondent-1',
+      candidateId: candidateId,
+      answerText: answer,
+      evidenceVersion: 1,
+      effectiveTurns: 2,
+      sessionCompleted: true,
+    ),
+  );
 }
 
 final class _NoopMediaClient implements PracticeMediaClient {

--- a/mobile/test/practice/practice_controller_contract_test.dart
+++ b/mobile/test/practice/practice_controller_contract_test.dart
@@ -175,6 +175,55 @@ void main() {
   });
 
   test(
+    'does not apply final recovery after private state is cleared',
+    () async {
+      final practice = _TwoTurnPracticeClient(
+        scenarioType: 'INTERVIEW',
+        scenarioModel: 'INTERVIEW_BASIC_DIALOGUE',
+      );
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(agentScenes.first);
+      await controller.startRecording();
+      await controller.stopRecording();
+      await controller.confirmTranscript();
+      await controller.startRecording();
+      await controller.stopRecording();
+      final matter = controller.activeMatter!;
+
+      final restoreGate = Completer<PracticeSessionSnapshot?>();
+      practice
+        ..confirmFailure = const AgentClientException(
+          kind: AgentClientFailureKind.network,
+          retryable: true,
+        )
+        ..restoreGate = restoreGate;
+      final confirmation = controller.confirmTranscript();
+      await Future<void>.delayed(Duration.zero);
+
+      await controller.clearPrivateState();
+      restoreGate.complete(
+        _completedInterviewSnapshot(
+          matter: matter,
+          questionId: 'question-2',
+          candidateId: 'candidate-2',
+          answer: 'Answer 2',
+        ),
+      );
+      await confirmation;
+
+      expect(controller.practiceSessionId, isNull);
+      expect(controller.recordingState, PracticeRecordingState.idle);
+      expect(controller.completedTurns, 0);
+    },
+  );
+
+  test(
     'retains failed transcription audio and retries with one Turn identity',
     () async {
       final practice = _TwoTurnPracticeClient()
@@ -1425,6 +1474,7 @@ final class _TwoTurnPracticeClient implements PracticeClient {
   Object? textFailure;
   Object? restoreFailure;
   PracticeSessionSnapshot? restoreResult;
+  Completer<PracticeSessionSnapshot?>? restoreGate;
   int transcribeCount = 0;
   int restoreCount = 0;
   final List<String> transcriptionClientTurnIds = <String>[];
@@ -1443,6 +1493,9 @@ final class _TwoTurnPracticeClient implements PracticeClient {
     restoreCount++;
     if (restoreFailure case final failure?) {
       throw failure;
+    }
+    if (restoreGate case final gate?) {
+      return gate.future;
     }
     return restoreResult;
   }


### PR DESCRIPTION
## 功能描述
- 最后一轮面试回答提交时显示明确的报告生成过渡
- 服务端确认完成后自动进入报告页并沿用现有轮询
- 网络模糊失败时仅在服务端快照与本轮答案严格一致后恢复成功状态

## 实现思路
- 使用服务端下发的 `turnLimit` 判断最后一轮，不写死轮数
- 语音与文字提交共用严格的最终轮对账条件
- 标准练习页与沉浸式练习页都只为每个 Session 自动打开一次报告页
- 保留完成页手动入口，用户返回后可再次查看报告

## 可复现测试
```bash
cd mobile
flutter analyze lib/agent/agent_controller.dart lib/features/practice/practice.dart lib/features/practice/immersive_roleplay.dart test/practice/practice_controller_contract_test.dart test/practice/immersive_roleplay_test.dart
flutter test test/practice/practice_controller_contract_test.dart test/practice/immersive_roleplay_test.dart
```

结果：静态分析通过；50 个相关测试通过。

Closes #299