### PR TITLE
fix(mobile): 修复训练入口、对话删除与 IELTS 交互一致性

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -234,6 +234,27 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+    delete:
+      tags:
+        - Agent
+      summary: Delete one owned Agent Thread
+      description: |
+        Deletes only a Thread owned by the trusted Actor. Threads referenced by
+        a Practice Plan are protected and return conflict so conversation
+        cleanup cannot erase practice history. Deleting the focused Thread also
+        clears the focused selection.
+      operationId: deleteAgentThread
+      responses:
+        '204':
+          description: The owned Thread was deleted.
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/agent-threads/{thread_id}/active-matter:
     parameters:
       - $ref: '#/components/parameters/AgentThreadId'

--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -239,10 +239,10 @@ paths:
         - Agent
       summary: Delete one owned Agent Thread
       description: |
-        Deletes only a Thread owned by the trusted Actor. Threads referenced by
-        a Practice Plan are protected and return conflict so conversation
-        cleanup cannot erase practice history. Deleting the focused Thread also
-        clears the focused selection.
+        Removes only a Thread owned by the trusted Actor from conversation
+        history. Practice-linked records remain available to the training and
+        review flows. Deleting the focused Thread also clears the focused
+        selection.
       operationId: deleteAgentThread
       responses:
         '204':
@@ -251,8 +251,6 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
           $ref: ../common/errors.yaml#/components/responses/NotFound
-        '409':
-          $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/agent-threads/{thread_id}/active-matter:

--- a/mobile/lib/agent/agent_client.dart
+++ b/mobile/lib/agent/agent_client.dart
@@ -122,6 +122,10 @@ abstract interface class AgentThreadHistoryClient {
   });
 }
 
+abstract interface class AgentThreadDeletionClient {
+  Future<void> deleteThread({required String threadId});
+}
+
 abstract interface class AgentMatterSelectionClient {
   Future<AgentMatter> selectExistingMatter({
     required String threadId,
@@ -196,6 +200,7 @@ final class FakeAgentClient
     implements
         AgentClient,
         AgentThreadHistoryClient,
+        AgentThreadDeletionClient,
         AgentMatterSelectionClient,
         AgentVoiceClient,
         AgentImageClient,
@@ -347,6 +352,26 @@ final class FakeAgentClient
       await _wait(generation);
       _requireCurrentGeneration(generation);
       _focusedThreadId = null;
+    });
+  }
+
+  @override
+  Future<void> deleteThread({required String threadId}) {
+    return _runAccountOperation((generation) async {
+      await _wait(generation);
+      _requireCurrentGeneration(generation);
+      if (!_threads.containsKey(threadId)) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.notFound,
+          errorCode: 'resource_not_found',
+        );
+      }
+      _threads.remove(threadId);
+      _threadMessages.remove(threadId);
+      _threadMatters.remove(threadId);
+      if (_focusedThreadId == threadId) {
+        _focusedThreadId = null;
+      }
     });
   }
 

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -757,10 +757,8 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       }
       notifyListeners();
       return true;
-    } on AgentClientException catch (error) {
-      _threadHistoryErrorMessage = error.kind == AgentClientFailureKind.conflict
-          ? '练习使用中的对话不能删除。'
-          : '暂时无法删除对话，请稍后再试。';
+    } on AgentClientException catch (_) {
+      _threadHistoryErrorMessage = '暂时无法删除对话，请稍后再试。';
       return false;
     } catch (_) {
       _threadHistoryErrorMessage = '暂时无法删除对话，请稍后再试。';

--- a/mobile/lib/agent/agent_controller.dart
+++ b/mobile/lib/agent/agent_controller.dart
@@ -168,6 +168,7 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       List<AgentThreadSummary>.unmodifiable(_threads);
   bool get isInitialized => _initialized;
   bool get supportsThreadHistory => client is AgentThreadHistoryClient;
+  bool get supportsThreadDeletion => client is AgentThreadDeletionClient;
   bool get isThreadTransitionInFlight => _threadTransitionInFlight;
   bool get hasMoreThreads => _nextThreadCursor != null;
   bool get isLoadingMoreThreads => _loadingMoreThreads;
@@ -712,6 +713,60 @@ final class AgentController extends ChangeNotifier with WidgetsBindingObserver {
       }
       await _clearFocusedThread(historyClient);
     } finally {
+      _finishThreadTransition(transitionGeneration);
+    }
+  }
+
+  Future<bool> deleteThread(String threadId) async {
+    if (client is! AgentThreadDeletionClient ||
+        _disposed ||
+        threadId.trim().isEmpty) {
+      return false;
+    }
+    final accountEpoch = _epoch;
+    final transitionGeneration = _beginThreadTransition();
+    if (transitionGeneration == null) {
+      return false;
+    }
+    final deletionClient = client as AgentThreadDeletionClient;
+    _threadHistoryErrorMessage = null;
+    _setBusy(true);
+    try {
+      await _ensureInitialized();
+      if (!_isCurrent(accountEpoch)) {
+        return false;
+      }
+      await deletionClient.deleteThread(threadId: threadId);
+      if (!_isCurrent(accountEpoch)) {
+        return false;
+      }
+      _threads = <AgentThreadSummary>[
+        for (final thread in _threads)
+          if (thread.id != threadId) thread,
+      ];
+      if (_threadId == threadId) {
+        _epoch++;
+        _practiceGeneration++;
+        _cancelRecordingLimit();
+        await stopPracticeAudio();
+        await _voiceController?.bindThread(null);
+        _pendingFocusThreadId = null;
+        _threadHistoryRecovery = null;
+        _resetSelectedThreadPresentation();
+        _initialized = true;
+      }
+      notifyListeners();
+      return true;
+    } on AgentClientException catch (error) {
+      _threadHistoryErrorMessage = error.kind == AgentClientFailureKind.conflict
+          ? '练习使用中的对话不能删除。'
+          : '暂时无法删除对话，请稍后再试。';
+      return false;
+    } catch (_) {
+      _threadHistoryErrorMessage = '暂时无法删除对话，请稍后再试。';
+      return false;
+    } finally {
+      _setBusy(false);
       _finishThreadTransition(transitionGeneration);
     }
   }

--- a/mobile/lib/agent/wire_agent_client.dart
+++ b/mobile/lib/agent/wire_agent_client.dart
@@ -17,6 +17,7 @@ final class WireAgentClient
         AgentClient,
         AgentStreamingTextClient,
         AgentThreadHistoryClient,
+        AgentThreadDeletionClient,
         AgentMatterSelectionClient,
         AgentPracticeAvailability,
         AgentMultimodalClient {
@@ -205,6 +206,20 @@ final class WireAgentClient
         generation: generation,
         method: 'DELETE',
         path: '/v1/agent-threads/focused',
+      );
+      _requireStatus(response, const <int>{HttpStatus.noContent});
+      _requireEmptyBody(response);
+    });
+  }
+
+  @override
+  Future<void> deleteThread({required String threadId}) {
+    return _runAccountOperation((generation) async {
+      _requireUuid(threadId);
+      final response = await _send(
+        generation: generation,
+        method: 'DELETE',
+        path: '/v1/agent-threads/$threadId',
       );
       _requireStatus(response, const <int>{HttpStatus.noContent});
       _requireEmptyBody(response);

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -545,6 +545,13 @@ class _ConversationDrawer extends StatelessWidget {
                 selected: true,
                 enabled: !controller.isBusy,
                 onTap: () => Navigator.of(context).pop(),
+                onDelete: controller.supportsThreadDeletion
+                    ? () => _confirmDelete(
+                        context,
+                        currentThreadId,
+                        current?.title,
+                      )
+                    : null,
               ),
             const SizedBox(height: 24),
             const Text('近期对话', style: SpeakUpDesign.label),
@@ -573,6 +580,9 @@ class _ConversationDrawer extends StatelessWidget {
                     }
                     Navigator.of(context).pop();
                   },
+                  onDelete: controller.supportsThreadDeletion
+                      ? () => _confirmDelete(context, thread.id, thread.title)
+                      : null,
                 ),
             if (controller.threadHistoryErrorMessage case final message?) ...[
               const SizedBox(height: 10),
@@ -597,6 +607,36 @@ class _ConversationDrawer extends StatelessWidget {
       ),
     );
   }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    String threadId,
+    String? title,
+  ) async {
+    final displayTitle = title ?? '新对话';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('删除对话？'),
+        content: Text('“$displayTitle”及其中的消息将被永久删除。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            key: const Key('confirm-delete-conversation'),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) {
+      return;
+    }
+    await controller.deleteThread(threadId);
+  }
 }
 
 class _ConversationThreadTile extends StatelessWidget {
@@ -607,6 +647,7 @@ class _ConversationThreadTile extends StatelessWidget {
     required this.selected,
     required this.enabled,
     required this.onTap,
+    required this.onDelete,
   });
 
   final String threadId;
@@ -615,6 +656,7 @@ class _ConversationThreadTile extends StatelessWidget {
   final bool selected;
   final bool enabled;
   final VoidCallback onTap;
+  final VoidCallback? onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -637,13 +679,23 @@ class _ConversationThreadTile extends StatelessWidget {
         subtitle: lastUpdatedAt == null
             ? null
             : Text('更新于 ${_formatThreadUpdatedAt(lastUpdatedAt)}'),
-        trailing: selected
-            ? const Icon(
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (selected)
+              const Icon(
                 Icons.check_rounded,
                 key: Key('focused-conversation-indicator'),
                 size: 20,
-              )
-            : null,
+              ),
+            IconButton(
+              key: Key('delete-conversation-$threadId'),
+              tooltip: '删除对话',
+              onPressed: enabled ? onDelete : null,
+              icon: const Icon(Icons.delete_outline_rounded, size: 20),
+            ),
+          ],
+        ),
         onTap: enabled ? onTap : null,
       ),
     );

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -618,7 +618,7 @@ class _ConversationDrawer extends StatelessWidget {
       context: context,
       builder: (dialogContext) => AlertDialog(
         title: const Text('删除对话？'),
-        content: Text('“$displayTitle”及其中的消息将被永久删除。'),
+        content: Text('“$displayTitle”将从对话列表中删除，相关练习与复盘记录会保留。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),

--- a/mobile/lib/features/practice/ielts_examiner_speaker.dart
+++ b/mobile/lib/features/practice/ielts_examiner_speaker.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_tts/flutter_tts.dart';
+
+abstract interface class IeltsExaminerSpeaker {
+  Future<void> speak(String text);
+
+  Future<void> stop();
+
+  Future<void> dispose();
+}
+
+final class SystemIeltsExaminerSpeaker implements IeltsExaminerSpeaker {
+  SystemIeltsExaminerSpeaker({FlutterTts? flutterTts})
+    : _flutterTts = flutterTts ?? FlutterTts();
+
+  final FlutterTts _flutterTts;
+  bool _configured = false;
+
+  Future<void> _configure() async {
+    if (_configured) {
+      return;
+    }
+    await _flutterTts.setLanguage('en-US');
+    await _flutterTts.setSpeechRate(0.45);
+    await _flutterTts.setPitch(1.0);
+    await _flutterTts.setVolume(1.0);
+    await _flutterTts.awaitSpeakCompletion(true);
+    _configured = true;
+  }
+
+  @override
+  Future<void> speak(String text) async {
+    final value = text.trim();
+    if (value.isEmpty) {
+      throw StateError('IELTS examiner narration cannot be empty.');
+    }
+    await _configure();
+    await _flutterTts.stop();
+    final result = await _flutterTts.speak(value);
+    if (result != 1) {
+      throw StateError('IELTS examiner narration did not start.');
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    await _flutterTts.stop();
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _flutterTts.stop();
+  }
+}

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -8,6 +8,7 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/preparation/ielts_question_bank.dart';
+import 'package:speakup/features/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/review/ielts_speaking_report_view.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
@@ -23,6 +24,9 @@ const _ieltsSpeakingPart2ScenarioId = 'scn_ielts_speaking_part_2';
 const _ieltsSpeakingPart2Title = 'IELTS Speaking Part 2';
 const _ieltsSpeakingPart3ScenarioId = 'scn_ielts_speaking_part_3';
 const _ieltsSpeakingPart3Title = 'IELTS Speaking Part 3';
+const _part2IntroNarration =
+    'You will have one minute to prepare and up to two minutes to speak. '
+    'You may take notes during preparation.';
 
 bool isIeltsSpeakingFullMockSession(AgentController controller) =>
     isIeltsSpeakingFullMockScenario(
@@ -68,6 +72,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.preparationController,
     this.reportController,
     this.speechFeedbackController,
+    this.examinerSpeaker,
     this.now = DateTime.now,
     super.key,
   });
@@ -78,6 +83,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final PreparationController? preparationController;
   final IeltsSpeakingReportController? reportController;
   final SpeechFeedbackController? speechFeedbackController;
+  final IeltsExaminerSpeaker? examinerSpeaker;
   final DateTime Function() now;
 
   @override
@@ -86,6 +92,8 @@ class IeltsSpeakingMockPage extends StatefulWidget {
 
 class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   late final IeltsMockProgressStore _progressStore;
+  late final IeltsExaminerSpeaker _examinerSpeaker;
+  late final bool _ownsExaminerSpeaker;
   final TextEditingController _notesController = TextEditingController();
   final TextEditingController _convertedAnswerController =
       TextEditingController();
@@ -103,6 +111,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   bool _finishingPart2Recording = false;
   bool _exitApproved = false;
   bool _exitInFlight = false;
+  bool _narrationBusy = false;
+  bool _introNarrated = false;
+  String? _narrationError;
   final Set<IeltsPracticeMode> _recordedCompletions = <IeltsPracticeMode>{};
   String? _reportSessionId;
 
@@ -132,6 +143,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   void initState() {
     super.initState();
     _progressStore = widget.progressStore ?? FileIeltsMockProgressStore();
+    _ownsExaminerSpeaker = widget.examinerSpeaker == null;
+    _examinerSpeaker = widget.examinerSpeaker ?? SystemIeltsExaminerSpeaker();
     _now = widget.now().toUtc();
     widget.controller.addListener(_handleControllerState);
     _notesController.addListener(_saveNotes);
@@ -166,6 +179,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _convertedAnswerController.dispose();
     _convertedAnswerFocusNode.dispose();
     _ticker?.cancel();
+    unawaited(_examinerSpeaker.stop());
+    if (_ownsExaminerSpeaker) {
+      unawaited(_examinerSpeaker.dispose());
+    }
     _cancelReport(widget.reportController);
     super.dispose();
   }
@@ -204,6 +221,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _handleExpiredTimer();
     _recordCompletedParts();
     _syncReport();
+    unawaited(_resumePart2Narration(restored.phase));
   }
 
   IeltsMockPhase _initialPhase() => switch (_mode) {
@@ -262,6 +280,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       }
       final phase = switch (value.phase) {
         IeltsMockPhase.part2Intro ||
+        IeltsMockPhase.part2CueCard ||
         IeltsMockPhase.part2Preparation => value.phase,
         IeltsMockPhase.part2Speaking => IeltsMockPhase.part2Speaking,
         _ => IeltsMockPhase.part2Intro,
@@ -296,6 +315,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       final phase = switch (value.phase) {
         IeltsMockPhase.part1Complete ||
         IeltsMockPhase.part2Intro ||
+        IeltsMockPhase.part2CueCard ||
         IeltsMockPhase.part2Preparation => value.phase,
         IeltsMockPhase.part2Speaking
             when widget.controller.errorMessage != null ||
@@ -503,6 +523,22 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     await _setProgress(progress.copyWith(phase: IeltsMockPhase.part2Intro));
+    await _narratePart2Intro();
+  }
+
+  Future<void> _beginPart2CueCard() async {
+    final progress = _progress;
+    if (progress == null || !_introNarrated || _narrationBusy) {
+      return;
+    }
+    await _examinerSpeaker.stop();
+    await _setProgress(
+      progress.copyWith(
+        phase: IeltsMockPhase.part2CueCard,
+        clearPreparationDeadline: true,
+      ),
+    );
+    await _narratePart2CueCard();
   }
 
   Future<void> _beginPart2Preparation() async {
@@ -519,6 +555,67 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         clearSpeakingDeadline: true,
       ),
     );
+  }
+
+  Future<void> _resumePart2Narration(IeltsMockPhase phase) async {
+    if (phase == IeltsMockPhase.part2Intro) {
+      await _narratePart2Intro();
+    } else if (phase == IeltsMockPhase.part2CueCard) {
+      await _narratePart2CueCard();
+    }
+  }
+
+  Future<void> _narratePart2Intro() async {
+    if (_narrationBusy ||
+        _progress?.phase != IeltsMockPhase.part2Intro ||
+        _introNarrated) {
+      return;
+    }
+    setState(() {
+      _narrationBusy = true;
+      _narrationError = null;
+    });
+    try {
+      await _examinerSpeaker.speak(_part2IntroNarration);
+      if (!mounted || _progress?.phase != IeltsMockPhase.part2Intro) {
+        return;
+      }
+      setState(() => _introNarrated = true);
+    } catch (_) {
+      if (mounted && _progress?.phase == IeltsMockPhase.part2Intro) {
+        setState(() => _narrationError = '考官说明播放失败，请重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _narrationBusy = false);
+      }
+    }
+  }
+
+  Future<void> _narratePart2CueCard() async {
+    if (_narrationBusy || _progress?.phase != IeltsMockPhase.part2CueCard) {
+      return;
+    }
+    setState(() {
+      _narrationBusy = true;
+      _narrationError = null;
+    });
+    var completed = false;
+    try {
+      await _examinerSpeaker.speak(_currentQuestionText());
+      completed = mounted && _progress?.phase == IeltsMockPhase.part2CueCard;
+    } catch (_) {
+      if (mounted && _progress?.phase == IeltsMockPhase.part2CueCard) {
+        setState(() => _narrationError = 'Cue Card 播放失败，请重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _narrationBusy = false);
+      }
+    }
+    if (completed) {
+      await _beginPart2Preparation();
+    }
   }
 
   Future<void> _startPart2Speaking({bool restart = false}) async {
@@ -864,6 +961,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     final title = switch (phase) {
       IeltsMockPhase.part1 => 'IELTS · Part 1',
       IeltsMockPhase.part2Intro ||
+      IeltsMockPhase.part2CueCard ||
       IeltsMockPhase.part2Preparation ||
       IeltsMockPhase.part2Speaking => 'IELTS · Part 2',
       IeltsMockPhase.part3Intro || IeltsMockPhase.part3 => 'IELTS · Part 3',
@@ -907,7 +1005,17 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         onPressed: _beginPart2Intro,
       ),
       IeltsMockPhase.part2Intro => _Part2Intro(
-        onPressed: _beginPart2Preparation,
+        narrationBusy: _narrationBusy,
+        narrationReady: _introNarrated,
+        errorMessage: _narrationError,
+        onRetry: _narratePart2Intro,
+        onPressed: _beginPart2CueCard,
+      ),
+      IeltsMockPhase.part2CueCard => _Part2CueCardReading(
+        question: _currentQuestionText(),
+        narrationBusy: _narrationBusy,
+        errorMessage: _narrationError,
+        onRetry: _narratePart2CueCard,
       ),
       IeltsMockPhase.part2Preparation => _Part2Preparation(
         secondsRemaining: _secondsUntil(progress.preparationDeadline),
@@ -1691,8 +1799,18 @@ class _Part3Intro extends StatelessWidget {
 }
 
 class _Part2Intro extends StatelessWidget {
-  const _Part2Intro({required this.onPressed});
+  const _Part2Intro({
+    required this.narrationBusy,
+    required this.narrationReady,
+    required this.errorMessage,
+    required this.onRetry,
+    required this.onPressed,
+  });
 
+  final bool narrationBusy;
+  final bool narrationReady;
+  final String? errorMessage;
+  final VoidCallback onRetry;
   final VoidCallback onPressed;
 
   @override
@@ -1723,18 +1841,99 @@ class _Part2Intro extends StatelessWidget {
                 const SizedBox(height: 28),
                 FilledButton(
                   key: const Key('ielts-mock-part-2-start'),
-                  onPressed: onPressed,
+                  onPressed: narrationReady ? onPressed : null,
                   style: FilledButton.styleFrom(
                     minimumSize: const Size.fromHeight(58),
                     backgroundColor: SpeakUpDesign.ink,
                     foregroundColor: Colors.white,
                   ),
-                  child: const Text('I understand — Start →'),
+                  child: Text(
+                    narrationBusy
+                        ? 'Examiner is speaking…'
+                        : 'I understand — Start →',
+                  ),
                 ),
+                if (errorMessage != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    errorMessage!,
+                    key: const Key('ielts-part2-narration-error'),
+                    textAlign: TextAlign.center,
+                    style: SpeakUpDesign.meta.copyWith(
+                      color: SpeakUpDesign.error,
+                    ),
+                  ),
+                  TextButton(
+                    key: const Key('ielts-part2-retry-narration'),
+                    onPressed: narrationBusy ? null : onRetry,
+                    child: const Text('Replay examiner'),
+                  ),
+                ],
                 const Spacer(flex: 3),
               ],
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Part2CueCardReading extends StatelessWidget {
+  const _Part2CueCardReading({
+    required this.question,
+    required this.narrationBusy,
+    required this.errorMessage,
+    required this.onRetry,
+  });
+
+  final String question;
+  final bool narrationBusy;
+  final String? errorMessage;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      key: const Key('ielts-mock-part-2-cue-card-reading'),
+      padding: const EdgeInsets.fromLTRB(20, 24, 20, 28),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Listen to the examiner',
+            textAlign: TextAlign.center,
+            style: SpeakUpDesign.sectionTitle,
+          ),
+          const SizedBox(height: 18),
+          _CueCard(question: question),
+          const SizedBox(height: 18),
+          if (narrationBusy)
+            const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                SizedBox(width: 10),
+                Text('Examiner is reading the Cue Card…'),
+              ],
+            ),
+          if (errorMessage != null) ...[
+            Text(
+              errorMessage!,
+              key: const Key('ielts-part2-narration-error'),
+              textAlign: TextAlign.center,
+              style: SpeakUpDesign.meta.copyWith(color: SpeakUpDesign.error),
+            ),
+            const SizedBox(height: 10),
+            FilledButton(
+              key: const Key('ielts-part2-retry-narration'),
+              onPressed: narrationBusy ? null : onRetry,
+              child: const Text('Replay Cue Card'),
+            ),
+          ],
         ],
       ),
     );

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -14,6 +14,7 @@ import 'package:speakup/features/review/ielts_speaking_report_view.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/practice/practice_models.dart';
 import 'package:speakup/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/review/turn_feedback.dart';
 import 'package:speakup/review/turn_feedback_controller.dart';
 import 'package:speakup/review/turn_feedback_disclosure.dart';
 
@@ -1350,7 +1351,7 @@ class _ExamConversation extends StatelessWidget {
       itemBuilder: (context, index) {
         final message = messages[index];
         final assistant = message.role == AgentMessageRole.assistant;
-        final projection =
+        final candidateProjection =
             !assistant &&
                 message.speechFeedbackStatusUrl != null &&
                 speechFeedbackController != null
@@ -1358,6 +1359,11 @@ class _ExamConversation extends StatelessWidget {
                 _ieltsFeedbackSourceKey(controller, message),
               )
             : null;
+        final projection =
+            candidateProjection?.feedback?.scoreabilityStatus ==
+                SpeechFeedbackScoreabilityStatus.insufficient
+            ? null
+            : candidateProjection;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -1150,10 +1150,18 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                 key: const Key('ielts-mock-part-2-complete'),
                 title: 'Part 2 Complete',
                 message: "Well done! You've finished Part 2. Next up: Part 3.",
+                detail: _Part2AnswerFeedback(
+                  controller: widget.controller,
+                  speechFeedbackController: widget.speechFeedbackController,
+                ),
                 buttonLabel: 'Continue to Part 3',
                 onPressed: _beginPart3,
               )
             : _Part2PracticeComplete(
+                detail: _Part2AnswerFeedback(
+                  controller: widget.controller,
+                  speechFeedbackController: widget.speechFeedbackController,
+                ),
                 onContinuePart3: _beginPart3,
                 onNext: () =>
                     _finishSection(IeltsPracticeCompletionAction.next),
@@ -1732,6 +1740,7 @@ class _CompletionStep extends StatelessWidget {
     required this.message,
     required this.buttonLabel,
     required this.onPressed,
+    this.detail,
     this.buttonKey = const Key('ielts-mock-continue'),
     super.key,
   });
@@ -1741,6 +1750,7 @@ class _CompletionStep extends StatelessWidget {
   final String buttonLabel;
   final VoidCallback onPressed;
   final Key buttonKey;
+  final Widget? detail;
 
   @override
   Widget build(BuildContext context) {
@@ -1773,6 +1783,10 @@ class _CompletionStep extends StatelessWidget {
                 textAlign: TextAlign.center,
                 style: SpeakUpDesign.body,
               ),
+              if (detail case final content?) ...[
+                const SizedBox(height: 20),
+                content,
+              ],
               const SizedBox(height: 36),
               FilledButton(
                 key: buttonKey,
@@ -1799,14 +1813,67 @@ class _CompletionStep extends StatelessWidget {
   }
 }
 
+class _Part2AnswerFeedback extends StatelessWidget {
+  const _Part2AnswerFeedback({
+    required this.controller,
+    required this.speechFeedbackController,
+  });
+
+  final AgentController controller;
+  final SpeechFeedbackController? speechFeedbackController;
+
+  @override
+  Widget build(BuildContext context) {
+    final answer = controller.practiceMessages
+        .where((message) => message.role == AgentMessageRole.user)
+        .lastOrNull;
+    if (answer == null) {
+      return const SizedBox.shrink();
+    }
+    final candidateProjection =
+        answer.speechFeedbackStatusUrl != null &&
+            speechFeedbackController != null
+        ? speechFeedbackController!.projectionFor(
+            _ieltsFeedbackSourceKey(controller, answer),
+          )
+        : null;
+    final projection =
+        candidateProjection?.feedback?.scoreabilityStatus ==
+            SpeechFeedbackScoreabilityStatus.insufficient
+        ? null
+        : candidateProjection;
+    return Column(
+      key: const Key('ielts-part2-answer-feedback'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        PracticeChatBubble(message: answer, maxWidth: 420),
+        if (projection != null) ...[
+          const SizedBox(height: 10),
+          SpeechFeedbackDisclosure(
+            key: ValueKey('ielts-speech-feedback-${projection.sourceKey}'),
+            projection: projection,
+            onRetry: projection.canRetry
+                ? () => unawaited(
+                    speechFeedbackController!.retry(projection.sourceKey),
+                  )
+                : null,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
 class _Part2PracticeComplete extends StatelessWidget {
   const _Part2PracticeComplete({
+    required this.detail,
     required this.onContinuePart3,
     required this.onNext,
     required this.onRetry,
     required this.onList,
   });
 
+  final Widget detail;
   final VoidCallback onContinuePart3;
   final VoidCallback onNext;
   final VoidCallback onRetry;
@@ -1818,6 +1885,7 @@ class _Part2PracticeComplete extends StatelessWidget {
       key: const Key('ielts-part2-practice-complete'),
       title: 'Part 2 Complete',
       message: '题卡陈述已完成。你可以继续练同主题 Part 3，或切换下一张题卡。',
+      detail: detail,
       primaryLabel: '继续对应 Part 3',
       onPrimary: onContinuePart3,
       onNext: onNext,
@@ -1870,6 +1938,7 @@ class _SectionActionLayout extends StatelessWidget {
     required this.onNext,
     required this.onRetry,
     required this.onList,
+    this.detail,
     super.key,
   });
 
@@ -1880,6 +1949,7 @@ class _SectionActionLayout extends StatelessWidget {
   final VoidCallback? onNext;
   final VoidCallback onRetry;
   final VoidCallback onList;
+  final Widget? detail;
 
   @override
   Widget build(BuildContext context) {
@@ -1912,6 +1982,10 @@ class _SectionActionLayout extends StatelessWidget {
                 textAlign: TextAlign.center,
                 style: SpeakUpDesign.body,
               ),
+              if (detail case final content?) ...[
+                const SizedBox(height: 20),
+                content,
+              ],
               const SizedBox(height: 30),
               FilledButton(
                 key: const Key('ielts-section-primary-action'),

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -391,6 +391,16 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   Future<void> _playQuestionNarration(String questionId, String text) async {
+    final currentQuestion = widget.controller.currentQuestion;
+    if (currentQuestion?.id == questionId &&
+        widget.controller.canUsePracticeAudio) {
+      await _stopExaminerSpeakerSafely();
+      _questionNarrationGeneration++;
+      _playingQuestionId = null;
+      _questionNarrationErrorId = null;
+      await widget.controller.toggleQuestionAudio();
+      return;
+    }
     if (_playingQuestionId == questionId) {
       await _stopQuestionNarration();
       return;
@@ -419,6 +429,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   Future<void> _stopQuestionNarration() async {
     _questionNarrationGeneration++;
+    await widget.controller.stopPracticeAudio();
     await _stopExaminerSpeakerSafely();
     if (mounted && _playingQuestionId != null) {
       setState(() => _playingQuestionId = null);
@@ -787,6 +798,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   Future<void> _sendShortVoice() async {
     _conversionRequested = false;
     await widget.controller.finishRecordingGesture();
+    if (widget.controller.hasPendingPracticeAudio) {
+      await widget.controller.discardPendingPracticeAudio();
+      return;
+    }
     _confirmPendingTranscript();
   }
 
@@ -1206,6 +1221,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             revealedQuestionIds: _revealedQuestionIds,
             playingQuestionId: _playingQuestionId,
             narrationErrorQuestionId: _questionNarrationErrorId,
+            mediaPlayingQuestionId: widget.controller.isQuestionAudioPlaying
+                ? widget.controller.questionId
+                : null,
             onPlayQuestion: _playQuestionNarration,
             onToggleTranscript: _toggleQuestionTranscript,
           ),
@@ -1307,6 +1325,7 @@ class _ExamConversation extends StatelessWidget {
     required this.revealedQuestionIds,
     required this.playingQuestionId,
     required this.narrationErrorQuestionId,
+    required this.mediaPlayingQuestionId,
     required this.onPlayQuestion,
     required this.onToggleTranscript,
     this.speechFeedbackController,
@@ -1317,6 +1336,7 @@ class _ExamConversation extends StatelessWidget {
   final Set<String> revealedQuestionIds;
   final String? playingQuestionId;
   final String? narrationErrorQuestionId;
+  final String? mediaPlayingQuestionId;
   final Future<void> Function(String questionId, String text) onPlayQuestion;
   final ValueChanged<String> onToggleTranscript;
   final SpeechFeedbackController? speechFeedbackController;
@@ -1346,7 +1366,9 @@ class _ExamConversation extends StatelessWidget {
               child: assistant
                   ? _ExaminerQuestionBubble(
                       message: message,
-                      playing: playingQuestionId == message.id,
+                      playing:
+                          playingQuestionId == message.id ||
+                          mediaPlayingQuestionId == message.id,
                       transcriptVisible: revealedQuestionIds.contains(
                         message.id,
                       ),
@@ -1556,8 +1578,6 @@ class _RecorderDock extends StatelessWidget {
                 onSubmit: onSubmitConvertedAnswer,
                 onCancel: onCancelConvertedAnswer,
               )
-            : controller.hasPendingPracticeAudio
-            ? _IeltsPendingAudioDock(controller: controller)
             : working
             ? _IeltsRecorderWorkingState(state: state)
             : _IeltsVoiceCaptureDock(

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -110,6 +110,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   bool _convertedAnswerSubmitting = false;
   bool _startingPart2Recording = false;
   bool _finishingPart2Recording = false;
+  bool _part2RetryNeeded = false;
   bool _exitApproved = false;
   bool _exitInFlight = false;
   bool _narrationBusy = false;
@@ -331,7 +332,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         IeltsMockPhase.part2CueCard ||
         IeltsMockPhase.part2Preparation => value.phase,
         IeltsMockPhase.part2Speaking
-            when widget.controller.errorMessage != null ||
+            when _part2RetryNeeded ||
+                widget.controller.errorMessage != null ||
                 widget.controller.hasPendingPracticeAudio ||
                 widget.controller.recordingState !=
                     PracticeRecordingState.idle =>
@@ -721,6 +723,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     _startingPart2Recording = true;
+    _part2RetryNeeded = false;
     final now = widget.now().toUtc();
     final speaking = progress.copyWith(
       phase: IeltsMockPhase.part2Speaking,
@@ -782,6 +785,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (state == PracticeRecordingState.starting ||
         state == PracticeRecordingState.recording) {
       await widget.controller.finishRecordingGesture();
+      if (widget.controller.hasPendingPracticeAudio) {
+        _part2RetryNeeded = true;
+        await widget.controller.discardPendingPracticeAudio();
+      }
     } else if (state == PracticeRecordingState.awaitingConfirmation) {
       _confirmPendingTranscript();
     }
@@ -1719,47 +1726,6 @@ class _IeltsConvertedAnswerDock extends StatelessWidget {
   }
 }
 
-class _IeltsPendingAudioDock extends StatelessWidget {
-  const _IeltsPendingAudioDock({required this.controller});
-
-  final AgentController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: const Key('ielts-mock-pending-audio'),
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const Text(
-          'Recording kept after transcription failed.',
-          style: SpeakUpDesign.cardTitle,
-        ),
-        const SizedBox(height: 10),
-        Row(
-          children: [
-            Expanded(
-              child: OutlinedButton(
-                key: const Key('ielts-mock-delete-pending-audio'),
-                onPressed: controller.discardPendingPracticeAudio,
-                child: const Text('Delete'),
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: FilledButton(
-                key: const Key('ielts-mock-retry-transcription'),
-                onPressed: controller.retryPracticeTranscription,
-                child: const Text('Retry transcript'),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-}
-
 class _CompletionStep extends StatelessWidget {
   const _CompletionStep({
     required this.title,
@@ -2296,51 +2262,32 @@ class _Part2Speaking extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 26),
-          if (controller.hasPendingPracticeAudio)
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _IeltsPendingAudioDock(controller: controller),
-                const SizedBox(height: 12),
-                FilledButton(
-                  key: const Key('ielts-mock-finish-speaking'),
-                  onPressed: busy ? null : onPressed,
-                  style: FilledButton.styleFrom(
-                    minimumSize: const Size.fromHeight(58),
-                    backgroundColor: SpeakUpDesign.ink,
-                    foregroundColor: Colors.white,
-                  ),
-                  child: const Text('Record Again →'),
-                ),
-              ],
-            )
-          else
-            FilledButton(
-              key: const Key('ielts-mock-finish-speaking'),
-              onPressed: busy ? null : onPressed,
-              style: FilledButton.styleFrom(
-                minimumSize: const Size.fromHeight(58),
-                backgroundColor: SpeakUpDesign.ink,
-                foregroundColor: Colors.white,
-              ),
-              child: busy
-                  ? const SizedBox.square(
-                      dimension: 22,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2.4,
-                        color: Colors.white,
-                      ),
-                    )
-                  : Text(switch (recordingState) {
-                      PracticeRecordingState.idle =>
-                        errorMessage == null
-                            ? 'Start Speaking →'
-                            : 'Record Again →',
-                      PracticeRecordingState.awaitingConfirmation =>
-                        'Submit Answer →',
-                      _ => 'Finish Speaking →',
-                    }),
+          FilledButton(
+            key: const Key('ielts-mock-finish-speaking'),
+            onPressed: busy ? null : onPressed,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(58),
+              backgroundColor: SpeakUpDesign.ink,
+              foregroundColor: Colors.white,
             ),
+            child: busy
+                ? const SizedBox.square(
+                    dimension: 22,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.4,
+                      color: Colors.white,
+                    ),
+                  )
+                : Text(switch (recordingState) {
+                    PracticeRecordingState.idle =>
+                      errorMessage == null
+                          ? 'Start Speaking →'
+                          : 'Record Again →',
+                    PracticeRecordingState.awaitingConfirmation =>
+                      'Submit Answer →',
+                    _ => 'Finish Speaking →',
+                  }),
+          ),
         ],
       ),
     );

--- a/mobile/lib/features/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/practice/ielts_mock_practice.dart
@@ -114,6 +114,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   bool _narrationBusy = false;
   bool _introNarrated = false;
   String? _narrationError;
+  final Set<String> _revealedQuestionIds = <String>{};
+  String? _autoNarratedQuestionId;
+  String? _playingQuestionId;
+  String? _questionNarrationErrorId;
+  int _questionNarrationGeneration = 0;
   final Set<IeltsPracticeMode> _recordedCompletions = <IeltsPracticeMode>{};
   String? _reportSessionId;
 
@@ -163,6 +168,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (controllerChanged) {
       oldWidget.controller.removeListener(_handleControllerState);
       widget.controller.addListener(_handleControllerState);
+      _questionNarrationGeneration++;
+      _autoNarratedQuestionId = null;
+      _playingQuestionId = null;
+      _questionNarrationErrorId = null;
+      _revealedQuestionIds.clear();
+      unawaited(_stopExaminerSpeakerSafely());
       unawaited(_restoreProgress());
     }
     if (reportControllerChanged && !controllerChanged) {
@@ -179,7 +190,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _convertedAnswerController.dispose();
     _convertedAnswerFocusNode.dispose();
     _ticker?.cancel();
-    unawaited(_examinerSpeaker.stop());
+    unawaited(_stopExaminerSpeakerSafely());
     if (_ownsExaminerSpeaker) {
       unawaited(_examinerSpeaker.dispose());
     }
@@ -222,6 +233,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _recordCompletedParts();
     _syncReport();
     unawaited(_resumePart2Narration(restored.phase));
+    _scheduleQuestionNarration();
   }
 
   IeltsMockPhase _initialPhase() => switch (_mode) {
@@ -358,6 +370,75 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _recordCompletedParts();
     setState(() {});
     _syncReport();
+    _scheduleQuestionNarration();
+  }
+
+  void _scheduleQuestionNarration() {
+    final phase = _progress?.phase;
+    final question = widget.controller.currentQuestion;
+    if ((phase != IeltsMockPhase.part1 && phase != IeltsMockPhase.part3) ||
+        question == null ||
+        _autoNarratedQuestionId == question.id) {
+      return;
+    }
+    _autoNarratedQuestionId = question.id;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || widget.controller.currentQuestion?.id != question.id) {
+        return;
+      }
+      unawaited(_playQuestionNarration(question.id, question.text));
+    });
+  }
+
+  Future<void> _playQuestionNarration(String questionId, String text) async {
+    if (_playingQuestionId == questionId) {
+      await _stopQuestionNarration();
+      return;
+    }
+    final generation = ++_questionNarrationGeneration;
+    await _stopExaminerSpeakerSafely();
+    if (!mounted || generation != _questionNarrationGeneration) {
+      return;
+    }
+    setState(() {
+      _playingQuestionId = questionId;
+      _questionNarrationErrorId = null;
+    });
+    try {
+      await _examinerSpeaker.speak(text);
+    } catch (_) {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _questionNarrationErrorId = questionId);
+      }
+    } finally {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _playingQuestionId = null);
+      }
+    }
+  }
+
+  Future<void> _stopQuestionNarration() async {
+    _questionNarrationGeneration++;
+    await _stopExaminerSpeakerSafely();
+    if (mounted && _playingQuestionId != null) {
+      setState(() => _playingQuestionId = null);
+    }
+  }
+
+  Future<void> _stopExaminerSpeakerSafely() async {
+    try {
+      await _examinerSpeaker.stop();
+    } catch (_) {
+      // Playback is best-effort; recording and navigation must stay usable.
+    }
+  }
+
+  void _toggleQuestionTranscript(String questionId) {
+    setState(() {
+      if (!_revealedQuestionIds.add(questionId)) {
+        _revealedQuestionIds.remove(questionId);
+      }
+    });
   }
 
   void _syncReport() {
@@ -469,6 +550,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
     _syncTicker();
     await _progressStore.write(value);
+    _scheduleQuestionNarration();
   }
 
   void _syncTicker() {
@@ -522,6 +604,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (progress == null) {
       return;
     }
+    await _stopQuestionNarration();
     await _setProgress(progress.copyWith(phase: IeltsMockPhase.part2Intro));
     await _narratePart2Intro();
   }
@@ -697,6 +780,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   Future<void> _startShortRecording() {
     _conversionRequested = false;
+    unawaited(_stopQuestionNarration());
     return widget.controller.startRecording();
   }
 
@@ -1119,6 +1203,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             messages: _sectionMessages(sectionStart, completed),
             controller: widget.controller,
             speechFeedbackController: widget.speechFeedbackController,
+            revealedQuestionIds: _revealedQuestionIds,
+            playingQuestionId: _playingQuestionId,
+            narrationErrorQuestionId: _questionNarrationErrorId,
+            onPlayQuestion: _playQuestionNarration,
+            onToggleTranscript: _toggleQuestionTranscript,
           ),
         ),
         if (widget.controller.errorMessage case final error?)
@@ -1215,11 +1304,21 @@ class _ExamConversation extends StatelessWidget {
   const _ExamConversation({
     required this.messages,
     required this.controller,
+    required this.revealedQuestionIds,
+    required this.playingQuestionId,
+    required this.narrationErrorQuestionId,
+    required this.onPlayQuestion,
+    required this.onToggleTranscript,
     this.speechFeedbackController,
   });
 
   final List<AgentMessage> messages;
   final AgentController controller;
+  final Set<String> revealedQuestionIds;
+  final String? playingQuestionId;
+  final String? narrationErrorQuestionId;
+  final Future<void> Function(String questionId, String text) onPlayQuestion;
+  final ValueChanged<String> onToggleTranscript;
   final SpeechFeedbackController? speechFeedbackController;
 
   @override
@@ -1244,31 +1343,18 @@ class _ExamConversation extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.only(bottom: 12),
-              child: PracticeChatBubble(
-                message: message,
-                maxWidth: 340,
-                actions: assistant && message.id == controller.questionId
-                    ? TextButton.icon(
-                        key: const Key('ielts-mock-question-audio'),
-                        onPressed: controller.canUsePracticeAudio
-                            ? controller.toggleQuestionAudio
-                            : null,
-                        icon: Icon(
-                          controller.isQuestionAudioPlaying
-                              ? Icons.stop_rounded
-                              : Icons.volume_up_outlined,
-                          size: 18,
-                        ),
-                        label: Text(
-                          controller.isQuestionAudioLoading
-                              ? 'Loading…'
-                              : controller.isQuestionAudioPlaying
-                              ? 'Stop'
-                              : 'Play question',
-                        ),
-                      )
-                    : null,
-              ),
+              child: assistant
+                  ? _ExaminerQuestionBubble(
+                      message: message,
+                      playing: playingQuestionId == message.id,
+                      transcriptVisible: revealedQuestionIds.contains(
+                        message.id,
+                      ),
+                      playbackFailed: narrationErrorQuestionId == message.id,
+                      onPlay: () => onPlayQuestion(message.id, message.text),
+                      onToggleTranscript: () => onToggleTranscript(message.id),
+                    )
+                  : PracticeChatBubble(message: message, maxWidth: 340),
             ),
             if (projection != null)
               Align(
@@ -1296,6 +1382,109 @@ class _ExamConversation extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+}
+
+class _ExaminerQuestionBubble extends StatelessWidget {
+  const _ExaminerQuestionBubble({
+    required this.message,
+    required this.playing,
+    required this.transcriptVisible,
+    required this.playbackFailed,
+    required this.onPlay,
+    required this.onToggleTranscript,
+  });
+
+  final AgentMessage message;
+  final bool playing;
+  final bool transcriptVisible;
+  final bool playbackFailed;
+  final VoidCallback onPlay;
+  final VoidCallback onToggleTranscript;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 340),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Material(
+              key: ValueKey('ielts-question-voice-${message.id}'),
+              color: SpeakUpDesign.surfaceMuted,
+              borderRadius: BorderRadius.circular(22),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(22),
+                onTap: onPlay,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        playing
+                            ? Icons.stop_circle_outlined
+                            : Icons.play_circle_outline_rounded,
+                        color: SpeakUpDesign.primary,
+                      ),
+                      const SizedBox(width: 10),
+                      Icon(
+                        Icons.graphic_eq_rounded,
+                        color: SpeakUpDesign.primary,
+                        size: 34,
+                      ),
+                      const SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          playing ? 'Examiner is speaking…' : 'Examiner voice',
+                          style: SpeakUpDesign.body.copyWith(
+                            color: SpeakUpDesign.primary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            TextButton.icon(
+              key: ValueKey('ielts-question-transcript-toggle-${message.id}'),
+              onPressed: onToggleTranscript,
+              icon: Icon(
+                transcriptVisible
+                    ? Icons.visibility_off_outlined
+                    : Icons.visibility_outlined,
+                size: 18,
+              ),
+              label: Text(transcriptVisible ? 'Hide English' : 'Show English'),
+            ),
+            if (playbackFailed)
+              const Padding(
+                padding: EdgeInsets.only(left: 12, bottom: 8),
+                child: Text(
+                  'Playback failed. Tap the voice bubble to retry.',
+                  style: TextStyle(color: SpeakUpDesign.error, fontSize: 12),
+                ),
+              ),
+            if (transcriptVisible)
+              Container(
+                key: ValueKey('ielts-question-transcript-${message.id}'),
+                margin: const EdgeInsets.only(bottom: 4),
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: SpeakUpDesign.surface,
+                  border: Border.all(color: SpeakUpDesign.border),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(message.text, style: SpeakUpDesign.body),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/practice/practice.dart
+++ b/mobile/lib/features/practice/practice.dart
@@ -10,6 +10,7 @@ import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/practice/ielts_mock_practice.dart';
+import 'package:speakup/features/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/review/interview_report_view.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
@@ -32,6 +33,7 @@ class PracticePage extends StatefulWidget {
     this.interviewReportController,
     this.ieltsSpeakingReportController,
     this.speechFeedbackController,
+    this.ieltsExaminerSpeaker,
     super.key,
   });
 
@@ -44,6 +46,7 @@ class PracticePage extends StatefulWidget {
   final InterviewReportController? interviewReportController;
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
   final SpeechFeedbackController? speechFeedbackController;
+  final IeltsExaminerSpeaker? ieltsExaminerSpeaker;
 
   @override
   State<PracticePage> createState() => _PracticePageState();
@@ -576,6 +579,7 @@ class _PracticePageState extends State<PracticePage>
         preparationController: widget.preparationController,
         reportController: widget.ieltsSpeakingReportController,
         speechFeedbackController: widget.speechFeedbackController,
+        examinerSpeaker: widget.ieltsExaminerSpeaker,
       );
     }
     final scene = controller?.scene;

--- a/mobile/lib/features/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/preparation/practice_workspace_controller.dart
@@ -40,7 +40,9 @@ final class PracticeWorkspaceController extends ChangeNotifier {
   PracticeWorkspaceController({
     required this.agentController,
     required this.recordStore,
-  });
+  }) {
+    agentController.addListener(_capturePracticeProgress);
+  }
 
   final AgentController agentController;
   final PracticeLaunchRecordStore recordStore;
@@ -67,6 +69,7 @@ final class PracticeWorkspaceController extends ChangeNotifier {
       _accountId != null &&
       _loadedAccountId != _accountId;
   bool get hasResumable => _current?.isCommitted ?? false;
+  bool get resumableHasProgress => _current?.hasMeaningfulProgress ?? false;
   PracticeWorkspaceLease? get currentLease => _current?.lease;
   String? get currentPracticeThreadId => _current?.practiceThreadId;
   String? get currentMatterId => _current?.matterId;
@@ -303,6 +306,7 @@ final class PracticeWorkspaceController extends ChangeNotifier {
         scenarioTitle: scenarioTitle,
         scenarioType: scenarioType,
         presentationMode: presentationMode,
+        completedTurns: agentController.completedTurns,
       );
       _current = committed;
       notifyListeners();
@@ -414,6 +418,7 @@ final class PracticeWorkspaceController extends ChangeNotifier {
     final operationGeneration = ++_operationGeneration;
     _beginOperation();
     try {
+      _capturePracticeProgress();
       final terminalPracticeWasFocused =
           current.isCommitted &&
           agentController.threadId == current.practiceThreadId &&
@@ -742,6 +747,39 @@ final class PracticeWorkspaceController extends ChangeNotifier {
       scenarioTitle: matter.scene.title,
       scenarioType: matter.scene.scenarioType,
       presentationMode: matter.scene.presentationMode,
+      completedTurns: agentController.completedTurns,
+    );
+  }
+
+  void _capturePracticeProgress() {
+    final current = _current;
+    if (_disposed ||
+        current == null ||
+        !current.isCommitted ||
+        agentController.threadId != current.practiceThreadId ||
+        agentController.practiceSessionId != current.sessionId) {
+      return;
+    }
+    final completedTurns = agentController.completedTurns;
+    if (current.completedTurns == completedTurns) {
+      return;
+    }
+    final updated = current.withCompletedTurns(completedTurns);
+    _current = updated;
+    notifyListeners();
+    final accountId = _accountId;
+    final accountGeneration = _accountGeneration;
+    if (accountId == null || current.accountId != accountId) {
+      return;
+    }
+    unawaited(
+      _enqueueStoreWrite(
+        () => recordStore.write(accountId, updated.encode()),
+      ).catchError((_) {
+        if (_isCurrentAccount(accountGeneration, accountId)) {
+          _setErrorIfAbsent('练习进度暂时无法保存，请稍后重试。');
+        }
+      }),
     );
   }
 
@@ -1004,6 +1042,7 @@ final class PracticeWorkspaceController extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
+    agentController.removeListener(_capturePracticeProgress);
     ++_accountGeneration;
     ++_operationGeneration;
     super.dispose();
@@ -1024,6 +1063,7 @@ final class _StoredPracticeWorkspace {
     required this.scenarioTitle,
     required this.scenarioType,
     required this.presentationMode,
+    required this.completedTurns,
   });
 
   factory _StoredPracticeWorkspace.pending({
@@ -1043,10 +1083,11 @@ final class _StoredPracticeWorkspace {
       scenarioTitle: null,
       scenarioType: null,
       presentationMode: AgentScenePresentationMode.standard,
+      completedTurns: null,
     );
   }
 
-  static const schemaVersion = 2;
+  static const schemaVersion = 3;
 
   final String accountId;
   final String operationId;
@@ -1058,12 +1099,16 @@ final class _StoredPracticeWorkspace {
   final String? scenarioTitle;
   final String? scenarioType;
   final AgentScenePresentationMode presentationMode;
+  final int? completedTurns;
 
   bool get isCommitted =>
       matterId != null &&
       sessionId != null &&
       scenarioId != null &&
       scenarioTitle != null;
+
+  bool get hasMeaningfulProgress =>
+      isCommitted && (completedTurns == null || completedTurns! > 0);
 
   PracticeWorkspaceLease get lease => PracticeWorkspaceLease(
     operationId: operationId,
@@ -1079,6 +1124,7 @@ final class _StoredPracticeWorkspace {
     String? scenarioType,
     AgentScenePresentationMode presentationMode =
         AgentScenePresentationMode.standard,
+    int completedTurns = 0,
   }) {
     return _StoredPracticeWorkspace(
       accountId: accountId,
@@ -1091,6 +1137,7 @@ final class _StoredPracticeWorkspace {
       scenarioTitle: scenarioTitle,
       scenarioType: scenarioType,
       presentationMode: presentationMode,
+      completedTurns: completedTurns,
     );
   }
 
@@ -1106,6 +1153,23 @@ final class _StoredPracticeWorkspace {
       scenarioTitle: scenarioTitle,
       scenarioType: scenarioType,
       presentationMode: presentationMode,
+      completedTurns: completedTurns,
+    );
+  }
+
+  _StoredPracticeWorkspace withCompletedTurns(int value) {
+    return _StoredPracticeWorkspace(
+      accountId: accountId,
+      operationId: operationId,
+      practiceThreadId: practiceThreadId,
+      returnThreadId: returnThreadId,
+      matterId: matterId,
+      sessionId: sessionId,
+      scenarioId: scenarioId,
+      scenarioTitle: scenarioTitle,
+      scenarioType: scenarioType,
+      presentationMode: presentationMode,
+      completedTurns: value,
     );
   }
 
@@ -1122,6 +1186,7 @@ final class _StoredPracticeWorkspace {
       'scenario_title': scenarioTitle,
       'scenario_type': scenarioType,
       'presentation_mode': presentationMode.name,
+      'completed_turns': completedTurns,
     });
   }
 
@@ -1147,6 +1212,20 @@ final class _StoredPracticeWorkspace {
               'scenario_definition_id',
               'scenario_title',
             }
+          : version == 2
+          ? const <String>{
+              'schema_version',
+              'account_id',
+              'operation_id',
+              'practice_thread_id',
+              'return_thread_id',
+              'matter_id',
+              'practice_session_id',
+              'scenario_definition_id',
+              'scenario_title',
+              'scenario_type',
+              'presentation_mode',
+            }
           : const <String>{
               'schema_version',
               'account_id',
@@ -1159,9 +1238,10 @@ final class _StoredPracticeWorkspace {
               'scenario_title',
               'scenario_type',
               'presentation_mode',
+              'completed_turns',
             };
       if (!setEquals(decoded.keys.toSet(), expectedKeys) ||
-          (version != 1 && version != schemaVersion) ||
+          (version != 1 && version != 2 && version != schemaVersion) ||
           decoded['account_id'] != expectedAccountId) {
         return null;
       }
@@ -1180,6 +1260,9 @@ final class _StoredPracticeWorkspace {
       final storedPresentationMode = AgentScenePresentationMode.values
           .where((value) => value.name == presentationModeName)
           .firstOrNull;
+      final completedTurns = version == schemaVersion
+          ? decoded['completed_turns']
+          : null;
       if (accountId is! String ||
           operationId is! String ||
           practiceThreadId is! String ||
@@ -1189,6 +1272,8 @@ final class _StoredPracticeWorkspace {
           (scenarioId != null && scenarioId is! String) ||
           (scenarioTitle != null && scenarioTitle is! String) ||
           (scenarioType != null && scenarioType is! String) ||
+          (completedTurns != null &&
+              (completedTurns is! int || completedTurns < 0)) ||
           storedPresentationMode == null ||
           !_validOpaqueId(accountId) ||
           !_validOperationId(operationId) ||
@@ -1235,6 +1320,7 @@ final class _StoredPracticeWorkspace {
         scenarioTitle: scenarioTitle as String?,
         scenarioType: scenarioType as String?,
         presentationMode: presentationMode,
+        completedTurns: completedTurns as int?,
       );
     } on Object {
       return null;

--- a/mobile/lib/features/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/preparation/practice_workspace_controller.dart
@@ -1108,7 +1108,7 @@ final class _StoredPracticeWorkspace {
       scenarioTitle != null;
 
   bool get hasMeaningfulProgress =>
-      isCommitted && (completedTurns == null || completedTurns! > 0);
+      isCommitted && completedTurns != null && completedTurns! > 0;
 
   PracticeWorkspaceLease get lease => PracticeWorkspaceLease(
     operationId: operationId,

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -500,20 +500,6 @@ class _PreparationPageState extends State<PreparationPage> {
     }
   }
 
-  bool get _canContinueCurrentPractice {
-    if (widget.launchController?.hasResumablePractice ?? false) {
-      return widget.onPracticeStarted != null;
-    }
-    final agent = widget.agentController;
-    if (agent?.activeMatter == null) {
-      return false;
-    }
-    if (agent?.hasActivePractice ?? false) {
-      return widget.onPracticeStarted != null;
-    }
-    return widget.onSceneSelected != null || widget.showBackButton;
-  }
-
   void _handleBack(PreparationController? controller) {
     if (widget.launchController?.isSelectionLocked ?? false) {
       return;
@@ -610,21 +596,6 @@ class _PreparationPageState extends State<PreparationPage> {
           key: Key('practice-hub-page-title'),
           style: PreparationDesign.body,
         ),
-        if ((widget.launchController?.hasResumablePractice ?? false) ||
-            widget.agentController?.activeMatter != null) ...[
-          const SizedBox(height: 20),
-          _PracticeContinuation(
-            sceneTitle:
-                widget.launchController?.resumablePracticeTitle ??
-                widget.agentController?.activeMatter?.scene.title,
-            hasActivePractice:
-                (widget.launchController?.hasResumablePractice ?? false) ||
-                (widget.agentController?.hasActivePractice ?? false),
-            onPressed: _canContinueCurrentPractice
-                ? () => unawaited(_continueCurrentPractice())
-                : null,
-          ),
-        ],
         if (widget.launchController?.workspaceErrorMessage case final message?)
           Padding(
             padding: const EdgeInsets.only(top: 10),
@@ -1060,94 +1031,6 @@ class _CatalogEmpty extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _PracticeContinuation extends StatelessWidget {
-  const _PracticeContinuation({
-    required this.sceneTitle,
-    required this.hasActivePractice,
-    required this.onPressed,
-  });
-
-  final String? sceneTitle;
-  final bool hasActivePractice;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final title = sceneTitle;
-    final hasCurrentPractice = title != null;
-    final label = hasCurrentPractice
-        ? hasActivePractice
-              ? '继续练习'
-              : '继续当前话题'
-        : '最近练习';
-    final description = title ?? '完成一次练习后，这里会保留你的进度。';
-    final content = Padding(
-      padding: const EdgeInsets.symmetric(vertical: 14),
-      child: Row(
-        children: [
-          Container(
-            width: 38,
-            height: 38,
-            decoration: BoxDecoration(
-              color: PreparationDesign.surfaceMuted,
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: const Icon(
-              Icons.history_rounded,
-              size: 20,
-              color: PreparationDesign.inkSecondary,
-            ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  label,
-                  style: const TextStyle(
-                    color: PreparationDesign.inkSecondary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
-                const SizedBox(height: 3),
-                Text(
-                  description,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 14, height: 1.35),
-                ),
-              ],
-            ),
-          ),
-          if (onPressed != null) ...[
-            const SizedBox(width: 10),
-            const Icon(Icons.arrow_forward_rounded, size: 20),
-          ],
-        ],
-      ),
-    );
-    return DecoratedBox(
-      key: const Key('practice-continuation'),
-      decoration: const BoxDecoration(
-        border: Border.symmetric(
-          horizontal: BorderSide(color: PreparationDesign.border),
-        ),
-      ),
-      child: onPressed == null
-          ? content
-          : Semantics(
-              button: true,
-              label: '$label，$description',
-              onTap: onPressed,
-              excludeSemantics: true,
-              child: InkWell(onTap: onPressed, child: content),
-            ),
     );
   }
 }

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -308,28 +308,32 @@ class _PreparationPageState extends State<PreparationPage> {
     final launch = widget.launchController;
     if ((launch?.hasResumablePractice ?? false) &&
         !forceReplaceCurrentPractice) {
-      if (launch?.resumableScenarioId == scenario.id) {
-        final resumableSessionId = launch?.resumableSessionId;
-        final resumableSelection = resumableSessionId == null
-            ? null
-            : controller.ieltsSelectionForSession(resumableSessionId);
-        if (ieltsSelection == null || resumableSelection == ieltsSelection) {
+      if (!(launch?.resumableHasProgress ?? true)) {
+        replaceCurrentPractice = true;
+      } else {
+        if (launch?.resumableScenarioId == scenario.id) {
+          final resumableSessionId = launch?.resumableSessionId;
+          final resumableSelection = resumableSessionId == null
+              ? null
+              : controller.ieltsSelectionForSession(resumableSessionId);
+          if (ieltsSelection == null || resumableSelection == ieltsSelection) {
+            await _continueCurrentPractice();
+            return;
+          }
+        }
+        final action = await _chooseExistingPracticeAction(
+          currentTitle: launch?.resumablePracticeTitle,
+          nextTitle: scenario.name,
+        );
+        if (!mounted || action == null) {
+          return;
+        }
+        if (action == _ExistingPracticeAction.continuePractice) {
           await _continueCurrentPractice();
           return;
         }
+        replaceCurrentPractice = true;
       }
-      final action = await _chooseExistingPracticeAction(
-        currentTitle: launch?.resumablePracticeTitle,
-        nextTitle: scenario.name,
-      );
-      if (!mounted || action == null) {
-        return;
-      }
-      if (action == _ExistingPracticeAction.continuePractice) {
-        await _continueCurrentPractice();
-        return;
-      }
-      replaceCurrentPractice = true;
     }
     await controller.selectScenario(scenario);
     if (!mounted || controller.selectedScenario?.id != scenario.id) {

--- a/mobile/lib/features/preparation/preparation.dart
+++ b/mobile/lib/features/preparation/preparation.dart
@@ -308,7 +308,9 @@ class _PreparationPageState extends State<PreparationPage> {
     final launch = widget.launchController;
     if ((launch?.hasResumablePractice ?? false) &&
         !forceReplaceCurrentPractice) {
-      if (!(launch?.resumableHasProgress ?? true)) {
+      if (ieltsSelection != null) {
+        replaceCurrentPractice = true;
+      } else if (!(launch?.resumableHasProgress ?? true)) {
         replaceCurrentPractice = true;
       } else {
         if (launch?.resumableScenarioId == scenario.id) {

--- a/mobile/lib/features/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/preparation/preparation_launch_controller.dart
@@ -69,6 +69,8 @@ final class PreparationLaunchController extends ChangeNotifier {
   bool get canRetry => _retry != null && !isStarting;
   bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
   bool get hasResumablePractice => workspaceController?.hasResumable ?? false;
+  bool get resumableHasProgress =>
+      workspaceController?.resumableHasProgress ?? false;
   String? get resumablePracticeTitle => workspaceController?.currentTitle;
   String? get resumableMatterId => workspaceController?.currentMatterId;
   String? get resumableScenarioId => workspaceController?.currentScenarioId;

--- a/mobile/lib/practice/ielts_mock_progress_store.dart
+++ b/mobile/lib/practice/ielts_mock_progress_store.dart
@@ -7,6 +7,7 @@ enum IeltsMockPhase {
   part1,
   part1Complete,
   part2Intro,
+  part2CueCard,
   part2Preparation,
   part2Speaking,
   part2Complete,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -296,6 +296,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_tts:
+    dependency: "direct main"
+    description:
+      name: flutter_tts
+      sha256: ce5eb209b40e95f2f4a1397116c87ab2fcdff32257d04ed7a764e75894c03775
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   image_picker: ^1.2.3
   path_provider: ^2.1.5
   record: ^6.1.2
+  flutter_tts: ^4.2.5
 
 dev_dependencies:
   integration_test:

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -464,6 +464,24 @@ void main() {
       transport.expectDone();
     });
 
+    test('deletes one owned Thread with an empty 204 response', () async {
+      final transport = _ScriptedTransport([
+        const _Step(
+          method: 'DELETE',
+          path: '/v1/agent-threads/$_threadId',
+          response: IdentityHttpResponse(
+            statusCode: HttpStatus.noContent,
+            body: '',
+          ),
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      await harness.client.deleteThread(threadId: _threadId);
+
+      transport.expectDone();
+    });
+
     test(
       'recovers an ambiguous create with GET only and never repeats POST',
       () async {

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -317,7 +317,7 @@ void main() {
   );
 
   testWidgets(
-    'failed Part 2 transcription stays on speaking and retry reaches Part 3',
+    'failed Part 2 transcription returns to recording without recovery actions',
     (tester) async {
       final practice = _IeltsPracticeClient(
         initialCompleted: 8,
@@ -359,8 +359,10 @@ void main() {
         find.byKey(const Key('ielts-mock-part-2-speaking')),
         findsOneWidget,
       );
-      expect(find.text('Record Again →'), findsOneWidget);
-      expect(find.textContaining('请重新录音'), findsOneWidget);
+      expect(find.text('Start Speaking →'), findsOneWidget);
+      expect(controller.hasPendingPracticeAudio, isFalse);
+      expect(find.text('Delete'), findsNothing);
+      expect(find.text('Retry transcript'), findsNothing);
 
       await tester.tap(find.byKey(const Key('ielts-mock-finish-speaking')));
       await tester.pump();
@@ -425,7 +427,7 @@ void main() {
     expect(find.text('restored note'), findsOneWidget);
   });
 
-  testWidgets('Part 2 keeps failed audio reachable and retries in place', (
+  testWidgets('Part 2 clears failed audio without Delete or Retry actions', (
     tester,
   ) async {
     final practice = _IeltsPracticeClient(initialCompleted: 8)
@@ -460,18 +462,11 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const Key('ielts-mock-part-2-speaking')), findsOneWidget);
-    expect(find.byKey(const Key('ielts-mock-pending-audio')), findsOneWidget);
-    expect(controller.hasPendingPracticeAudio, isTrue);
-
-    practice.transcribeFailure = null;
-    await tester.tap(find.byKey(const Key('ielts-mock-retry-transcription')));
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 220));
-
     expect(controller.hasPendingPracticeAudio, isFalse);
-    expect(controller.completedTurns, 9);
-    expect(find.byKey(const Key('ielts-mock-part-2-complete')), findsOneWidget);
+    expect(controller.completedTurns, 8);
+    expect(find.text('Delete'), findsNothing);
+    expect(find.text('Retry transcript'), findsNothing);
+    expect(find.text('Start Speaking →'), findsOneWidget);
   });
 
   testWidgets('Part 1 clears failed transcription without a recovery dock', (

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -307,6 +307,11 @@ void main() {
         find.byKey(const Key('ielts-mock-part-2-complete')),
         findsOneWidget,
       );
+      expect(
+        find.byKey(const Key('ielts-part2-answer-feedback')),
+        findsOneWidget,
+      );
+      expect(find.text('Answer 9'), findsOneWidget);
       expect(store.value?.notes, contains('weekly practice'));
 
       await tester.tap(find.text('Continue to Part 3'));

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -6,6 +6,7 @@ import 'package:speakup/agent/agent_client.dart';
 import 'package:speakup/agent/agent_controller.dart';
 import 'package:speakup/agent/agent_models.dart';
 import 'package:speakup/features/practice/ielts_mock_practice.dart';
+import 'package:speakup/features/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/practice/practice.dart';
 import 'package:speakup/features/preparation/ielts_question_bank.dart';
 import 'package:speakup/features/preparation/preparation_client.dart';
@@ -20,6 +21,73 @@ import 'package:speakup/review/ielts_speaking_report_client.dart';
 import 'package:speakup/review/ielts_speaking_report_controller.dart';
 
 void main() {
+  testWidgets(
+    'Part 2 reads instructions and Cue Card before starting 60 seconds',
+    (tester) async {
+      final now = DateTime.utc(2026, 8, 3, 4, 30);
+      final speaker = _ControlledExaminerSpeaker();
+      final practice = _IeltsPracticeClient(initialCompleted: 8);
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: _Recorder(),
+      );
+      final store = _MemoryProgressStore();
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(_ieltsScene);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: store,
+            examinerSpeaker: speaker,
+            now: () => now,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Continue to Part 2'));
+      await tester.pump();
+      expect(speaker.spoken.single, contains('one minute to prepare'));
+      expect(find.text('Examiner is speaking…'), findsOneWidget);
+      expect(store.value?.preparationDeadline, isNull);
+
+      speaker.completeCurrent();
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-mock-part-2-cue-card-reading')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ielts-mock-preparation-countdown')),
+        findsNothing,
+      );
+      expect(speaker.spoken.last, _question(9).text);
+      expect(store.value?.phase, IeltsMockPhase.part2CueCard);
+      expect(store.value?.preparationDeadline, isNull);
+
+      speaker.completeCurrent();
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-mock-part-2-preparation')),
+        findsOneWidget,
+      );
+      expect(find.text('60s'), findsOneWidget);
+      expect(
+        store.value?.preparationDeadline,
+        now.add(const Duration(seconds: 60)),
+      );
+    },
+  );
+
   testWidgets(
     'Part 1 boundary enters prep, keeps notes, and submits the Part 2 long turn',
     (tester) async {
@@ -39,6 +107,7 @@ void main() {
           home: PracticePage(
             agentController: controller,
             ieltsMockProgressStore: store,
+            ieltsExaminerSpeaker: _ImmediateExaminerSpeaker(),
           ),
         ),
       );
@@ -133,6 +202,7 @@ void main() {
           home: PracticePage(
             agentController: controller,
             ieltsMockProgressStore: store,
+            ieltsExaminerSpeaker: _ImmediateExaminerSpeaker(),
           ),
         ),
       );
@@ -238,6 +308,7 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
         ),
       ),
     );
@@ -286,6 +357,7 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
         ),
       ),
     );
@@ -1085,6 +1157,45 @@ final class _Recorder implements PracticeRecorder {
   Future<void> clearAccountState() async {
     recording = false;
   }
+}
+
+final class _ImmediateExaminerSpeaker implements IeltsExaminerSpeaker {
+  final List<String> spoken = <String>[];
+
+  @override
+  Future<void> speak(String text) async {
+    spoken.add(text);
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+final class _ControlledExaminerSpeaker implements IeltsExaminerSpeaker {
+  final List<String> spoken = <String>[];
+  Completer<void>? _current;
+
+  @override
+  Future<void> speak(String text) {
+    spoken.add(text);
+    final completion = Completer<void>();
+    _current = completion;
+    return completion.future;
+  }
+
+  void completeCurrent() {
+    _current?.complete();
+    _current = null;
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 final class _PendingReportClient implements IeltsSpeakingReportClient {

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,7 +14,9 @@ import 'package:speakup/features/preparation/preparation_client.dart';
 import 'package:speakup/features/preparation/preparation_controller.dart';
 import 'package:speakup/features/preparation/preparation_models.dart';
 import 'package:speakup/practice/ielts_mock_progress_store.dart';
+import 'package:speakup/practice/practice_audio_player.dart';
 import 'package:speakup/practice/practice_client.dart';
+import 'package:speakup/practice/practice_media.dart';
 import 'package:speakup/practice/practice_models.dart';
 import 'package:speakup/practice/practice_recording.dart';
 import 'package:speakup/review/ielts_speaking_report.dart';
@@ -21,6 +24,40 @@ import 'package:speakup/review/ielts_speaking_report_client.dart';
 import 'package:speakup/review/ielts_speaking_report_controller.dart';
 
 void main() {
+  testWidgets('Part 1 prefers the shared practice question voice', (
+    tester,
+  ) async {
+    final speaker = _ImmediateExaminerSpeaker();
+    final media = _QuestionMediaClient();
+    final player = _QuestionAudioPlayer();
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _IeltsPracticeClient(initialCompleted: 0),
+      mediaClient: media,
+      audioPlayer: player,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: speaker,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(media.loadedPaths, ['speech/question-1.wav']);
+    expect(player.playCount, 1);
+    expect(speaker.spoken, isEmpty);
+  });
+
   testWidgets(
     'Part 1 auto-plays voice bubbles and reveals English only on request',
     (tester) async {
@@ -435,6 +472,43 @@ void main() {
     expect(controller.hasPendingPracticeAudio, isFalse);
     expect(controller.completedTurns, 9);
     expect(find.byKey(const Key('ielts-mock-part-2-complete')), findsOneWidget);
+  });
+
+  testWidgets('Part 1 clears failed transcription without a recovery dock', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 0)
+      ..transcribeFailure = StateError('transcription failed');
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('ielts-mock-pending-audio')), findsNothing);
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    expect(find.byKey(const Key('ielts-mock-record')), findsOneWidget);
   });
 
   testWidgets('disposing Part 2 cancels recording without an exit callback', (
@@ -1321,7 +1395,51 @@ PracticeQuestion _question(int turn) {
               '• What the skill is\n'
               '• Why you want to learn it'
         : 'Question $turn',
+    speechPath: 'speech/question-$turn.wav',
   );
+}
+
+final class _QuestionMediaClient implements PracticeMediaClient {
+  final List<String> loadedPaths = <String>[];
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) async {
+    loadedPaths.add(speechPath);
+    return Uint8List.fromList(<int>[1, 2, 3]);
+  }
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) async => Uint8List(0);
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+final class _QuestionAudioPlayer implements PracticeAudioPlayer {
+  final StreamController<void> _completions =
+      StreamController<void>.broadcast();
+  int playCount = 0;
+
+  @override
+  Stream<void> get onComplete => _completions.stream;
+
+  @override
+  Future<void> playWav(Uint8List bytes) async => playCount++;
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() => _completions.close();
 }
 
 const _sessionId = 'session-ielts-full';

--- a/mobile/test/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/practice/ielts_mock_practice_test.dart
@@ -22,6 +22,105 @@ import 'package:speakup/review/ielts_speaking_report_controller.dart';
 
 void main() {
   testWidgets(
+    'Part 1 auto-plays voice bubbles and reveals English only on request',
+    (tester) async {
+      final speaker = _ImmediateExaminerSpeaker();
+      final practice = _IeltsPracticeClient(initialCompleted: 0);
+      final controller = AgentController(
+        client: FakeAgentClient(),
+        practiceClient: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.selectScene(_ieltsScene);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+            examinerSpeaker: speaker,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(speaker.spoken, [_question(1).text]);
+      expect(
+        find.byKey(const Key('ielts-question-voice-question-1')),
+        findsOneWidget,
+      );
+      expect(find.text(_question(1).text), findsNothing);
+
+      await tester.tap(
+        find.byKey(const Key('ielts-question-transcript-toggle-question-1')),
+      );
+      await tester.pump();
+
+      expect(find.text(_question(1).text), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-question-transcript-question-1')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('ielts-mock-record')));
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('ielts-mock-record')));
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 220));
+      await tester.pump();
+
+      expect(speaker.spoken.last, _question(2).text);
+      expect(find.text(_question(2).text), findsNothing);
+    },
+  );
+
+  testWidgets('Part 3 starts with an auto-playing hidden-text voice bubble', (
+    tester,
+  ) async {
+    final speaker = _ImmediateExaminerSpeaker();
+    final practice = _IeltsPracticeClient(
+      initialCompleted: 0,
+      turnLimit: 1,
+      scenarioModel: 'IELTS_SPEAKING_PART_3',
+    );
+    final controller = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.selectScene(_ieltsPart3Scene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: speaker,
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(speaker.spoken, isEmpty);
+
+    await tester.tap(find.byKey(const Key('ielts-part3-start')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(speaker.spoken, [_question(1).text]);
+    expect(
+      find.byKey(const Key('ielts-question-voice-question-1')),
+      findsOneWidget,
+    );
+    expect(find.text(_question(1).text), findsNothing);
+  });
+
+  testWidgets(
     'Part 2 reads instructions and Cue Card before starting 60 seconds',
     (tester) async {
       final now = DateTime.utc(2026, 8, 3, 4, 30);

--- a/mobile/test/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/preparation/practice_lifecycle_flow_test.dart
@@ -150,7 +150,7 @@ void main() {
       await _leavePractice(tester);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsNothing);
-      expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
+      expect(find.byKey(const Key('practice-continuation')), findsNothing);
       expect(agentController.threadId, homeThreadId);
       expect(agentController.hasActivePractice, isFalse);
       expect(workspaceController.hasResumable, isTrue);
@@ -222,7 +222,7 @@ void main() {
       await tester.pump();
       expect(agentController.hasActivePractice, isTrue);
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
-      await _tapVisible(tester, find.byKey(const Key('practice-continuation')));
+      await _openScenario(tester, _progressScenario.id);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(agentController.threadId, firstPracticeThreadId);
@@ -234,7 +234,7 @@ void main() {
       await _leavePractice(tester);
       expect(agentController.threadId, homeThreadId);
 
-      expect(find.byKey(const Key('practice-continuation')), findsOneWidget);
+      expect(find.byKey(const Key('practice-continuation')), findsNothing);
       await _openScenario(tester, _progressScenario.id);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);

--- a/mobile/test/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/preparation/practice_workspace_controller_test.dart
@@ -48,7 +48,7 @@ void main() {
         containsPair('practice_thread_id', retried?.practiceThreadId),
       );
       expect(record, containsPair('return_thread_id', homeThreadId));
-      expect(record, containsPair('schema_version', 2));
+      expect(record, containsPair('schema_version', 3));
 
       final replacement = await workspace.acquireThread(
         'different-operation-2',
@@ -83,6 +83,7 @@ void main() {
       );
 
       expect(firstWorkspace.hasResumable, isTrue);
+      expect(firstWorkspace.resumableHasProgress, isFalse);
       expect(await firstWorkspace.parkCurrentPractice(), isTrue);
       expect(harness.agent.threadId, homeThreadId);
       expect(await harness.agent.createThread(), isTrue);

--- a/mobile/test/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/preparation/practice_workspace_controller_test.dart
@@ -116,6 +116,43 @@ void main() {
   );
 
   test(
+    'only a confirmed answer marks a practice as resumable progress',
+    () async {
+      final store = _InspectableRecordStore();
+      final harness = await _createHarness();
+      final workspace = PracticeWorkspaceController(
+        agentController: harness.agent,
+        recordStore: store,
+      );
+      addTearDown(() {
+        workspace.dispose();
+        harness.agent.dispose();
+      });
+      await workspace.activateAccount('account-1');
+      await _launchPractice(
+        harness: harness,
+        workspace: workspace,
+        operationId: 'launch-progress-operation',
+        scenarioId: 'interview-screening',
+        scenarioTitle: '招聘初筛',
+        sessionId: 'practice-progress-session',
+      );
+
+      expect(workspace.resumableHasProgress, isFalse);
+      expect(
+        await harness.agent.submitPracticeText('A confirmed answer.'),
+        isTrue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(workspace.resumableHasProgress, isTrue);
+      expect(await workspace.parkCurrentPractice(), isTrue);
+      final record = jsonDecode((await store.read('account-1'))!);
+      expect(record, containsPair('completed_turns', 1));
+    },
+  );
+
+  test(
     'park returns to the conversation being viewed, not a stale launch Home',
     () async {
       final store = _InspectableRecordStore();
@@ -1309,7 +1346,48 @@ final class _WorkspacePracticeClient
     if (pending != null) {
       return pending.future;
     }
-    throw UnimplementedError();
+    final current = _sessions.values.single;
+    final completedTurns = current.completedTurns + 1;
+    final completed = completedTurns >= current.turnLimit;
+    final nextQuestion = completed
+        ? null
+        : PracticeQuestion(
+            id: 'question-${current.sessionId}-$completedTurns',
+            sessionId: current.sessionId,
+            text: 'What happened next?',
+          );
+    _sessions[current.threadId!] = PracticeSessionSnapshot(
+      sessionId: current.sessionId,
+      threadId: current.threadId,
+      sessionVersion: (current.sessionVersion ?? 1) + 1,
+      scenarioType: current.scenarioType,
+      scenarioModel: current.scenarioModel,
+      matter: current.matter,
+      completedTurns: completedTurns,
+      turnLimit: current.turnLimit,
+      sessionCompleted: completed,
+      currentQuestion: nextQuestion,
+    );
+    return Future<PracticeTurnConfirmation>.value(
+      PracticeTurnConfirmation(
+        turnId: 'turn-$completedTurns',
+        sessionId: sessionId,
+        questionId: questionId,
+        candidateId: 'text-candidate-$completedTurns',
+        answer: AgentMessage(
+          id: 'answer-$completedTurns',
+          role: AgentMessageRole.user,
+          text: answerText,
+        ),
+        completedTurns: completedTurns,
+        turnLimit: current.turnLimit,
+        sessionCompleted: completed,
+        scenarioType: current.scenarioType,
+        scenarioModel: current.scenarioModel,
+        sessionVersion: (current.sessionVersion ?? 1) + 1,
+        nextQuestion: nextQuestion,
+      ),
+    );
   }
 
   PracticeSessionSnapshot _activeSnapshot({

--- a/mobile/test/preparation/preparation_hub_test.dart
+++ b/mobile/test/preparation/preparation_hub_test.dart
@@ -32,48 +32,28 @@ void main() {
     expect(find.byKey(const Key('preparation-family-DAILY')), findsNothing);
   });
 
-  testWidgets('continues the current topic through one accessible action', (
-    tester,
-  ) async {
-    final semantics = tester.ensureSemantics();
+  testWidgets('does not show the legacy continuation row', (tester) async {
     final agentController = AgentController(client: FakeAgentClient());
     final preparationController = PreparationController(
       client: _HubFixtureClient(),
     );
     addTearDown(agentController.dispose);
     addTearDown(preparationController.dispose);
-    try {
-      await agentController.initialize();
-      await agentController.selectScene(agentScenes.first);
-      expect(agentController.activeMatter, isNotNull);
-      var opens = 0;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PreparationPage(
-            agentController: agentController,
-            preparationController: preparationController,
-            onPracticeStarted: () => opens++,
-          ),
+    await agentController.initialize();
+    await agentController.selectScene(agentScenes.first);
+    expect(agentController.activeMatter, isNotNull);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          agentController: agentController,
+          preparationController: preparationController,
         ),
-      );
-      await tester.pumpAndSettle();
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      final continuation = find.byKey(const Key('practice-continuation'));
-      expect(find.text('继续练习'), findsOneWidget);
-      expect(
-        tester.getSemantics(continuation),
-        isSemantics(
-          label: '继续练习，${agentScenes.first.title}',
-          isButton: true,
-          hasTapAction: true,
-        ),
-      );
-      await tester.tap(continuation);
-      await tester.pump();
-      expect(opens, 1);
-    } finally {
-      semantics.dispose();
-    }
+    expect(find.byKey(const Key('practice-continuation')), findsNothing);
+    expect(find.text('继续练习'), findsNothing);
   });
 
   testWidgets('opens the English interview module from the hub', (

--- a/mobile/test/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/preparation/preparation_launch_controller_test.dart
@@ -407,6 +407,7 @@ void main() {
       expect(harness.agentController.hasActivePractice, isTrue);
       expect(harness.agentController.practiceSessionId, _sessionId);
       expect(harness.launchController.hasResumablePractice, isTrue);
+      expect(harness.launchController.resumableHasProgress, isFalse);
       expect(harness.launchController.resumableMatterId, matterId);
 
       final persisted =
@@ -421,6 +422,7 @@ void main() {
         containsPair('scenario_definition_id', _selection.scenarioDefinitionId),
       );
       expect(persisted, containsPair('presentation_mode', 'immersiveRoleplay'));
+      expect(persisted, containsPair('completed_turns', 0));
 
       expect(await harness.launchController.parkCurrentPractice(), isTrue);
       expect(harness.agentController.threadId, harness.homeThreadId);

--- a/mobile/test/review/turn_feedback_page_integration_test.dart
+++ b/mobile/test/review/turn_feedback_page_integration_test.dart
@@ -155,7 +155,7 @@ void main() {
     },
   );
 
-  testWidgets('IELTS user voice bubble shows the shared feedback entry', (
+  testWidgets('IELTS Part 2 English answer shows the shared feedback entry', (
     tester,
   ) async {
     final feedback = _practiceFeedback();
@@ -171,8 +171,8 @@ void main() {
         _practiceSnapshot(
           feedback.statusUrl,
           scenarioType: 'EXAM',
-          scenarioModel: 'IELTS_SPEAKING_FULL_MOCK',
-          turnLimit: 14,
+          scenarioModel: 'IELTS_SPEAKING_PART_2',
+          turnLimit: 6,
         ),
       ),
     );
@@ -194,6 +194,15 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(client.calls, 1);
+    expect(
+      find.byKey(const Key('ielts-part2-practice-complete')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('ielts-part2-answer-feedback')),
+      findsOneWidget,
+    );
+    expect(find.text('I manage the release.'), findsOneWidget);
     expect(
       feedbackController.projectionFor(
         'practice:practice_session_001:practice_turn_001',
@@ -224,8 +233,8 @@ void main() {
     final snapshot = _practiceSnapshot(
       feedback.statusUrl,
       scenarioType: 'EXAM',
-      scenarioModel: 'IELTS_SPEAKING_FULL_MOCK',
-      turnLimit: 14,
+      scenarioModel: 'IELTS_SPEAKING_PART_2',
+      turnLimit: 6,
     );
     final practiceController = AgentController(
       client: FakeAgentClient(),
@@ -279,6 +288,10 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(find.text('然后，黄天宇主要来把这个。'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-part2-practice-complete')),
+      findsOneWidget,
+    );
     expect(find.textContaining('证据不足'), findsNothing);
     expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
   });
@@ -481,6 +494,13 @@ PracticeSessionSnapshot _practiceSnapshot(
   int turnLimit = 3,
 }) {
   const sessionId = 'practice_session_001';
+  final scene = scenarioModel == 'IELTS_SPEAKING_PART_2'
+      ? const AgentScene(
+          id: 'scn_ielts_speaking_part_2',
+          title: 'IELTS Speaking Part 2',
+          description: 'Part 2 cue card with bound Part 3',
+        )
+      : agentScenes.first;
   const question = PracticeQuestion(
     id: 'practice_question_001',
     sessionId: sessionId,
@@ -491,7 +511,7 @@ PracticeSessionSnapshot _practiceSnapshot(
     threadId: 'thread_001',
     scenarioType: scenarioType,
     scenarioModel: scenarioModel,
-    matter: AgentMatter(id: 'matter_001', scene: agentScenes.first),
+    matter: AgentMatter(id: 'matter_001', scene: scene),
     completedTurns: 1,
     turnLimit: turnLimit,
     sessionCompleted: false,

--- a/mobile/test/review/turn_feedback_page_integration_test.dart
+++ b/mobile/test/review/turn_feedback_page_integration_test.dart
@@ -12,6 +12,7 @@ import 'package:speakup/practice/practice_recording.dart';
 import 'package:speakup/review/turn_feedback.dart';
 import 'package:speakup/review/turn_feedback_client.dart';
 import 'package:speakup/review/turn_feedback_controller.dart';
+import 'package:speakup/review/turn_feedback_disclosure.dart';
 
 void main() {
   testWidgets(
@@ -210,6 +211,78 @@ void main() {
     );
   });
 
+  testWidgets('IELTS keeps a Chinese answer but hides insufficient feedback', (
+    tester,
+  ) async {
+    final feedback = _practiceFeedback(insufficient: true);
+    final client = _Client(feedback);
+    final feedbackController = SpeechFeedbackController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    final snapshot = _practiceSnapshot(
+      feedback.statusUrl,
+      scenarioType: 'EXAM',
+      scenarioModel: 'IELTS_SPEAKING_FULL_MOCK',
+      turnLimit: 14,
+    );
+    final practiceController = AgentController(
+      client: FakeAgentClient(),
+      practiceClient: _PracticeClient(
+        PracticeSessionSnapshot(
+          sessionId: snapshot.sessionId,
+          threadId: snapshot.threadId,
+          scenarioType: snapshot.scenarioType,
+          scenarioModel: snapshot.scenarioModel,
+          matter: snapshot.matter,
+          completedTurns: snapshot.completedTurns,
+          turnLimit: snapshot.turnLimit,
+          sessionCompleted: snapshot.sessionCompleted,
+          currentQuestion: snapshot.currentQuestion,
+          turnHistory: [
+            PracticeTurnExchange(
+              question: snapshot.turnHistory.single.question,
+              turn: PracticeTurnSnapshot(
+                id: snapshot.turnHistory.single.turn.id,
+                sessionId: snapshot.sessionId,
+                questionId: snapshot.turnHistory.single.question.id,
+                respondentParticipantId: 'participant_user',
+                candidateId: 'candidate_001',
+                answerText: '然后，黄天宇主要来把这个。',
+                evidenceVersion: 1,
+                effectiveTurns: 1,
+                sessionCompleted: false,
+                audioAssetId: 'audio_asset_001',
+                speechFeedbackStatusUrl: feedback.statusUrl,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    addTearDown(feedbackController.dispose);
+    addTearDown(practiceController.dispose);
+    await practiceController.initialize();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticePage(
+          agentController: practiceController,
+          speechFeedbackController: feedbackController,
+          ieltsMockProgressStore: _MemoryIeltsProgressStore(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('然后，黄天宇主要来把这个。'), findsOneWidget);
+    expect(find.textContaining('证据不足'), findsNothing);
+    expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
+  });
+
   testWidgets(
     'shared feedback controller does not rebuild another route mid-frame',
     (tester) async {
@@ -347,7 +420,7 @@ SpeechFeedback _agentFeedback() {
   );
 }
 
-SpeechFeedback _practiceFeedback() {
+SpeechFeedback _practiceFeedback({bool insufficient = false}) {
   const statusUrl = '/v1/speech-feedback/speech_feedback_practice_001';
   return SpeechFeedback(
     speechFeedbackId: 'speech_feedback_practice_001',
@@ -358,31 +431,37 @@ SpeechFeedback _practiceFeedback() {
       evidenceSnapshotId: 'evidence_snapshot_001',
     ),
     feedbackStatus: SpeechFeedbackStatus.ready,
-    scoreabilityStatus: SpeechFeedbackScoreabilityStatus.provisional,
+    scoreabilityStatus: insufficient
+        ? SpeechFeedbackScoreabilityStatus.insufficient
+        : SpeechFeedbackScoreabilityStatus.provisional,
     gateStatus: SpeechFeedbackGateStatus.feedbackOnly,
-    reasonCodes: const [],
+    reasonCodes: insufficient
+        ? const ['TRANSCRIPT_CONFIDENCE_INSUFFICIENT']
+        : const [],
     schemaVersion: 'speech-feedback/v1',
     strategyRef: 'qianwen-speech-feedback/v1',
     pipelineVersion: 'speech-feedback-pipeline/v1',
     isFinal: false,
-    items: [
-      SpeechFeedbackItem(
-        feedbackItemId: 'item_practice_001',
-        speechFeedbackId: 'speech_feedback_practice_001',
-        kind: SpeechFeedbackItemKind.correction,
-        anchor: const ConversationTranscriptFeedbackAnchor(
-          evidenceRefId: 'evidence_ref_001',
-          turnId: 'practice_turn_001',
-          startUtf8Byte: 0,
-          endUtf8Byte: 8,
-          originalExcerpt: 'I manage',
-        ),
-        explanation: 'Use the past tense for the completed release.',
-        suggestedText: 'I managed',
-        repracticeMode: SpeechFeedbackRepracticeMode.sameQuestion,
-        createdAt: DateTime.utc(2026, 7, 30, 10, 1, 1),
-      ),
-    ],
+    items: insufficient
+        ? const []
+        : [
+            SpeechFeedbackItem(
+              feedbackItemId: 'item_practice_001',
+              speechFeedbackId: 'speech_feedback_practice_001',
+              kind: SpeechFeedbackItemKind.correction,
+              anchor: const ConversationTranscriptFeedbackAnchor(
+                evidenceRefId: 'evidence_ref_001',
+                turnId: 'practice_turn_001',
+                startUtf8Byte: 0,
+                endUtf8Byte: 8,
+                originalExcerpt: 'I manage',
+              ),
+              explanation: 'Use the past tense for the completed release.',
+              suggestedText: 'I managed',
+              repracticeMode: SpeechFeedbackRepracticeMode.sameQuestion,
+              createdAt: DateTime.utc(2026, 7, 30, 10, 1, 1),
+            ),
+          ],
     acousticAssessment: const SpeechFeedbackAcousticAssessment(
       pronunciation: SpeechFeedbackAssessmentStatus.notAssessed,
       acousticFluency: SpeechFeedbackAssessmentStatus.notAssessed,

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -662,6 +662,46 @@ void main() {
     },
   );
 
+  testWidgets('conversation drawer confirms and deletes each Thread', (
+    tester,
+  ) async {
+    final controller = AgentController(client: FakeAgentClient());
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(SpeakUpApp.preview(agentController: controller));
+    await tester.pumpAndSettle();
+    final originalThreadId = controller.threadId!;
+
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('new-conversation-button')));
+    await tester.pumpAndSettle();
+    final currentThreadId = controller.threadId!;
+
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(Key('delete-conversation-$originalThreadId')));
+    await tester.pumpAndSettle();
+    expect(find.text('删除对话？'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('confirm-delete-conversation')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(Key('conversation-thread-$originalThreadId')),
+      findsNothing,
+    );
+
+    await tester.tap(find.byKey(Key('delete-conversation-$currentThreadId')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('confirm-delete-conversation')));
+    await tester.pumpAndSettle();
+
+    expect(controller.threadId, isNull);
+    expect(
+      find.byKey(Key('conversation-thread-$currentThreadId')),
+      findsNothing,
+    );
+    expect(find.byKey(const Key('no-focused-conversation')), findsOneWidget);
+  });
+
   testWidgets('Agent actions start planning or open the matching destination', (
     tester,
   ) async {

--- a/server/internal/agent/app/service.go
+++ b/server/internal/agent/app/service.go
@@ -127,6 +127,21 @@ func (s *Service) GetThread(
 	return s.repository.FindThread(ctx, actor.UserID, threadID)
 }
 
+func (s *Service) DeleteThread(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) error {
+	if !actor.Valid() || !core.ValidUUID(threadID) {
+		return ErrNotFound
+	}
+	repository, ok := s.repository.(core.ThreadDeletionRepository)
+	if !ok {
+		return ErrRepository
+	}
+	return repository.DeleteThread(ctx, actor.UserID, threadID)
+}
+
 func (s *Service) GetFocusedThread(
 	ctx context.Context,
 	actor requestcontext.Actor,

--- a/server/internal/agent/core/model.go
+++ b/server/internal/agent/core/model.go
@@ -328,6 +328,10 @@ type Repository interface {
 	) ([]Message, error)
 }
 
+type ThreadDeletionRepository interface {
+	DeleteThread(ctx context.Context, ownerID string, threadID string) error
+}
+
 type Application interface {
 	CreateThread(
 		ctx context.Context,
@@ -387,6 +391,14 @@ type Application interface {
 		pageSize int,
 		cursor string,
 	) (MessagePage, error)
+}
+
+type ThreadDeletionApplication interface {
+	DeleteThread(
+		ctx context.Context,
+		actor requestcontext.Actor,
+		threadID string,
+	) error
 }
 
 type RunRepository interface {

--- a/server/internal/agent/persistence/postgres.go
+++ b/server/internal/agent/persistence/postgres.go
@@ -461,6 +461,66 @@ SELECT COUNT(*) FROM deleted`,
 	return nil
 }
 
+func (r *PostgresRepository) DeleteThread(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+) error {
+	tx, err := r.database.Begin(ctx)
+	if err != nil {
+		return ErrRepository
+	}
+	defer rollback(tx)
+
+	var lockedThreadID string
+	if err := tx.QueryRow(ctx, `
+SELECT id::text
+FROM agent_threads
+WHERE id = $1 AND owner_user_id = $2
+FOR UPDATE`,
+		threadID,
+		ownerID,
+	).Scan(&lockedThreadID); errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	} else if err != nil {
+		return mapPostgresError(err)
+	}
+
+	var protected bool
+	if err := tx.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM practice_plans
+    WHERE owner_user_id = $1
+      AND agent_thread_id = $2
+)`,
+		ownerID,
+		threadID,
+	).Scan(&protected); err != nil {
+		return mapPostgresError(err)
+	}
+	if protected {
+		return ErrConflict
+	}
+
+	tag, err := tx.Exec(ctx, `
+DELETE FROM agent_threads
+WHERE id = $1 AND owner_user_id = $2`,
+		threadID,
+		ownerID,
+	)
+	if err != nil {
+		return mapPostgresError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrRepository
+	}
+	return nil
+}
+
 func (r *PostgresRepository) SetActiveMatter(
 	ctx context.Context,
 	ownerID string,

--- a/server/internal/agent/persistence/postgres.go
+++ b/server/internal/agent/persistence/postgres.go
@@ -138,6 +138,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) AS first_user ON true
 WHERE threads.owner_user_id = $1
+  AND threads.sidebar_deleted_at IS NULL
 ORDER BY threads.updated_at DESC, threads.id DESC`,
 		ownerID,
 	)
@@ -199,6 +200,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) AS first_user ON true
 WHERE threads.owner_user_id = $1
+  AND threads.sidebar_deleted_at IS NULL
 ORDER BY threads.updated_at DESC, threads.id DESC
 LIMIT $2`
 	arguments := []any{ownerID, limit}
@@ -227,6 +229,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) AS first_user ON true
 WHERE threads.owner_user_id = $1
+  AND threads.sidebar_deleted_at IS NULL
   AND (threads.updated_at, threads.id) < ($2, $3)
 ORDER BY threads.updated_at DESC, threads.id DESC
 LIMIT $4`
@@ -476,7 +479,9 @@ func (r *PostgresRepository) DeleteThread(
 	if err := tx.QueryRow(ctx, `
 SELECT id::text
 FROM agent_threads
-WHERE id = $1 AND owner_user_id = $2
+WHERE id = $1
+  AND owner_user_id = $2
+  AND sidebar_deleted_at IS NULL
 FOR UPDATE`,
 		threadID,
 		ownerID,
@@ -486,26 +491,12 @@ FOR UPDATE`,
 		return mapPostgresError(err)
 	}
 
-	var protected bool
-	if err := tx.QueryRow(ctx, `
-SELECT EXISTS (
-    SELECT 1
-    FROM practice_plans
-    WHERE owner_user_id = $1
-      AND agent_thread_id = $2
-)`,
-		ownerID,
-		threadID,
-	).Scan(&protected); err != nil {
-		return mapPostgresError(err)
-	}
-	if protected {
-		return ErrConflict
-	}
-
 	tag, err := tx.Exec(ctx, `
-DELETE FROM agent_threads
-WHERE id = $1 AND owner_user_id = $2`,
+UPDATE agent_threads
+SET sidebar_deleted_at = CURRENT_TIMESTAMP
+WHERE id = $1
+  AND owner_user_id = $2
+  AND sidebar_deleted_at IS NULL`,
 		threadID,
 		ownerID,
 	)
@@ -514,6 +505,14 @@ WHERE id = $1 AND owner_user_id = $2`,
 	}
 	if tag.RowsAffected() != 1 {
 		return ErrNotFound
+	}
+	if _, err := tx.Exec(ctx, `
+DELETE FROM agent_thread_focuses
+WHERE owner_user_id = $1 AND thread_id = $2`,
+		ownerID,
+		threadID,
+	); err != nil {
+		return mapPostgresError(err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return ErrRepository

--- a/server/internal/agent/transport/http.go
+++ b/server/internal/agent/transport/http.go
@@ -259,6 +259,7 @@ func (h *HTTPHandler) RegisterRoutes(router *gin.Engine) {
 	protected.PUT("/v1/agent-threads/focused", h.setFocusedThread)
 	protected.DELETE("/v1/agent-threads/focused", h.clearFocusedThread)
 	protected.GET("/v1/agent-threads/:thread_id", h.getThread)
+	protected.DELETE("/v1/agent-threads/:thread_id", h.deleteThread)
 	protected.PUT(
 		"/v1/agent-threads/:thread_id/active-matter",
 		h.setActiveMatter,
@@ -656,6 +657,28 @@ func (h *HTTPHandler) getThread(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, threadResponse(thread))
+}
+
+func (h *HTTPHandler) deleteThread(c *gin.Context) {
+	actor, ok := trustedActor(c)
+	if !ok {
+		h.writeAuthenticationRequired(c)
+		return
+	}
+	application, ok := h.application.(ThreadDeletionApplication)
+	if !ok {
+		h.writeAgentError(c, ErrRepository)
+		return
+	}
+	if err := application.DeleteThread(
+		c.Request.Context(),
+		actor,
+		c.Param("thread_id"),
+	); err != nil {
+		h.writeAgentError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func (h *HTTPHandler) setActiveMatter(c *gin.Context) {

--- a/server/internal/agent/transport/model.go
+++ b/server/internal/agent/transport/model.go
@@ -21,6 +21,7 @@ type RunSubmission = core.RunSubmission
 type RunRetry = core.RunRetry
 type RunStreamObserver = core.RunStreamObserver
 type Application = core.Application
+type ThreadDeletionApplication = core.ThreadDeletionApplication
 type RunApplication = core.RunApplication
 type MultimodalRunApplication = core.MultimodalRunApplication
 type Service = agentapp.Service

--- a/server/internal/agent/transport/pagination_integration_test.go
+++ b/server/internal/agent/transport/pagination_integration_test.go
@@ -690,6 +690,50 @@ WHERE id = $2 AND owner_user_id = $1`,
 		)
 	}
 
+	crossOwnerDelete := performAgentRequest(
+		router,
+		http.MethodDelete,
+		"/v1/agent-threads/"+threads[2].ID,
+		"",
+		"token-b",
+	)
+	if crossOwnerDelete.Code != http.StatusNotFound {
+		t.Fatalf(
+			"cross-owner Thread delete response: %d %s",
+			crossOwnerDelete.Code,
+			crossOwnerDelete.Body,
+		)
+	}
+	deletedThread := performAgentRequest(
+		router,
+		http.MethodDelete,
+		"/v1/agent-threads/"+threads[2].ID,
+		"",
+		"token-a",
+	)
+	if deletedThread.Code != http.StatusNoContent ||
+		deletedThread.Body.Len() != 0 {
+		t.Fatalf(
+			"Thread delete response: %d %q",
+			deletedThread.Code,
+			deletedThread.Body.String(),
+		)
+	}
+	repeatedDelete := performAgentRequest(
+		router,
+		http.MethodDelete,
+		"/v1/agent-threads/"+threads[2].ID,
+		"",
+		"token-a",
+	)
+	if repeatedDelete.Code != http.StatusNotFound {
+		t.Fatalf(
+			"repeated Thread delete response: %d %s",
+			repeatedDelete.Code,
+			repeatedDelete.Body,
+		)
+	}
+
 	clearFocus := performAgentRequest(
 		router,
 		http.MethodDelete,

--- a/server/internal/agent/transport/pagination_integration_test.go
+++ b/server/internal/agent/transport/pagination_integration_test.go
@@ -719,6 +719,20 @@ WHERE id = $2 AND owner_user_id = $1`,
 			deletedThread.Body.String(),
 		)
 	}
+	var sidebarDeleted bool
+	if err := database.pool.QueryRow(context.Background(), `
+SELECT sidebar_deleted_at IS NOT NULL
+FROM agent_threads
+WHERE id = $1 AND owner_user_id = $2`,
+		threads[2].ID,
+		actorA.UserID,
+	).Scan(&sidebarDeleted); err != nil || !sidebarDeleted {
+		t.Fatalf(
+			"sidebar deletion marker = %t, error %v; want marked",
+			sidebarDeleted,
+			err,
+		)
+	}
 	repeatedDelete := performAgentRequest(
 		router,
 		http.MethodDelete,

--- a/server/internal/review/speech_feedback_acoustics_test.go
+++ b/server/internal/review/speech_feedback_acoustics_test.go
@@ -201,7 +201,7 @@ func TestXFYUNSpeechFeedbackAcousticProviderRejectsChineseBeforeReadingAudio(
 	}
 }
 
-func TestSpeechFeedbackWorkerPersistsAcousticsBeforeShortTextResult(
+func TestSpeechFeedbackWorkerPersistsAcousticsForShortEnglishText(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -227,7 +227,12 @@ func TestSpeechFeedbackWorkerPersistsAcousticsBeforeShortTextResult(
 	worker, err := NewSpeechFeedbackWorkerWithAcoustics(
 		repository,
 		&speechFeedbackProviderStub{
-			err: errors.New("text provider must not be called"),
+			result: SpeechFeedbackProviderResult{
+				Payload:   []byte(`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"Use a complete answer.","suggested_text":"Hello, it is nice to meet you."}]}`),
+				Provider:  "qianwen",
+				Model:     "qwen-plus",
+				RequestID: "request-short-english-acoustics",
+			},
 		},
 		repository,
 		acoustics,
@@ -243,7 +248,7 @@ func TestSpeechFeedbackWorkerPersistsAcousticsBeforeShortTextResult(
 	if acoustics.calls != 1 ||
 		repository.acousticEvidence == nil ||
 		sweep.Completed != 1 ||
-		sweep.Insufficient != 1 {
+		sweep.Insufficient != 0 {
 		t.Fatalf(
 			"unexpected acoustic result: calls=%d evidence=%#v sweep=%#v",
 			acoustics.calls,

--- a/server/internal/review/speech_feedback_worker.go
+++ b/server/internal/review/speech_feedback_worker.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
 )
@@ -388,18 +387,6 @@ func classifySpeechFeedbackFailure(
 }
 
 func speechFeedbackTextHasEnoughEvidence(text string) bool {
-	words := 0
-	inWord := false
-	for _, character := range strings.TrimSpace(text) {
-		isWord := unicode.IsLetter(character) ||
-			unicode.IsNumber(character)
-		if isWord && !inWord {
-			words++
-			if words >= 2 {
-				return true
-			}
-		}
-		inWord = isWord
-	}
-	return false
+	return classifySpeechFeedbackLanguage(text) ==
+		speechFeedbackLanguageEnglish
 }

--- a/server/internal/review/speech_feedback_worker_test.go
+++ b/server/internal/review/speech_feedback_worker_test.go
@@ -9,15 +9,62 @@ import (
 	"time"
 )
 
-func TestSpeechFeedbackWorkerCompletesShortTextAsInsufficient(
+func TestSpeechFeedbackWorkerGeneratesFeedbackForShortEnglishText(
 	t *testing.T,
 ) {
 	t.Parallel()
 	claim := validSpeechFeedbackClaim()
-	claim.CanonicalText = "Hi"
+	claim.CanonicalText = "Hello."
 	repository := &speechFeedbackRepositoryStub{
 		claim: claim,
 	}
+	payload, err := json.Marshal(map[string]any{
+		"items": []any{map[string]any{
+			"kind":           "RECOMMENDED_EXPRESSION",
+			"explanation":    "Use a complete answer for speaking practice.",
+			"suggested_text": "Hello, it is nice to meet you.",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &speechFeedbackProviderStub{
+		result: SpeechFeedbackProviderResult{
+			Payload:   payload,
+			Provider:  "qianwen",
+			Model:     "qwen-plus",
+			RequestID: "request-short-english",
+		},
+	}
+	worker, err := NewSpeechFeedbackWorker(
+		repository,
+		provider,
+		validSpeechFeedbackWorkerConfiguration(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sweep, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("process short English text: %v", err)
+	}
+	if provider.calls != 1 ||
+		sweep.Claimed != 1 ||
+		sweep.Completed != 1 ||
+		sweep.Insufficient != 0 ||
+		len(repository.completedItems) != 1 {
+		t.Fatalf("unexpected sweep/provider: %#v calls=%d", sweep, provider.calls)
+	}
+	if len(repository.insufficientReasons) != 0 {
+		t.Fatalf("insufficient reasons = %#v", repository.insufficientReasons)
+	}
+}
+
+func TestSpeechFeedbackWorkerKeepsChineseTextInsufficient(t *testing.T) {
+	t.Parallel()
+	claim := validSpeechFeedbackClaim()
+	claim.CanonicalText = "你好。"
+	repository := &speechFeedbackRepositoryStub{claim: claim}
 	provider := &speechFeedbackProviderStub{
 		err: errors.New("provider must not be called"),
 	}
@@ -31,19 +78,14 @@ func TestSpeechFeedbackWorkerCompletesShortTextAsInsufficient(
 	}
 	sweep, err := worker.ProcessPending(context.Background(), 1)
 	if err != nil {
-		t.Fatalf("process short text: %v", err)
+		t.Fatalf("process Chinese text: %v", err)
 	}
-	if provider.calls != 0 ||
-		sweep.Claimed != 1 ||
-		sweep.Completed != 1 ||
-		sweep.Insufficient != 1 {
-		t.Fatalf("unexpected sweep/provider: %#v calls=%d", sweep, provider.calls)
-	}
-	if len(repository.insufficientReasons) != 1 ||
-		repository.insufficientReasons[0] !=
-			SpeechFeedbackReasonTextTooShort {
+	if provider.calls != 0 || sweep.Insufficient != 1 ||
+		len(repository.insufficientReasons) != 1 {
 		t.Fatalf(
-			"insufficient reasons = %#v",
+			"unexpected Chinese result: %#v calls=%d reasons=%#v",
+			sweep,
+			provider.calls,
 			repository.insufficientReasons,
 		)
 	}

--- a/server/migrations/000046_agent_thread_sidebar_deletion.down.sql
+++ b/server/migrations/000046_agent_thread_sidebar_deletion.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX IF EXISTS agent_threads_owner_visible_updated_idx;
+
+ALTER TABLE agent_threads
+    DROP COLUMN IF EXISTS sidebar_deleted_at;
+
+COMMIT;

--- a/server/migrations/000046_agent_thread_sidebar_deletion.up.sql
+++ b/server/migrations/000046_agent_thread_sidebar_deletion.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE agent_threads
+    ADD COLUMN sidebar_deleted_at timestamptz;
+
+CREATE INDEX agent_threads_owner_visible_updated_idx
+    ON agent_threads (owner_user_id, updated_at DESC, id DESC)
+    WHERE sidebar_deleted_at IS NULL;
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -31,4 +31,5 @@ import "embed"
 //go:embed 000043_speech_feedback_ise_evidence.*.sql
 //go:embed 000044_speech_feedback_practice_session_ids.*.sql
 //go:embed 000045_speech_feedback_ise_topic.*.sql
+//go:embed 000046_agent_thread_sidebar_deletion.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

修复移动端训练入口、侧边栏会话管理与 IELTS 口语练习中的一组联调问题：

- 移除首页“继续练习”入口，并支持侧边栏逐条隐藏会话
- IELTS 分项练习和完整模拟按所选 Part 直接开始，不再弹出错误的恢复提示
- Part 1 / Part 3 以考官语音气泡自动播报，英文原文按需展开
- Part 2 先完整播报说明与题卡，再开始 1 分钟准备计时
- 统一 IELTS 考官音色、录音完成和转写失败后的交互
- 中文回答只保留转写，不显示“证据不足”或评分入口
- 英文回答（包括 “Hello.” 等短回答）显示可展开的“评分与纠错”
- 补齐 Part 2 与完整模拟中的回答展示和评分入口
- 修复训练关联会话无法从侧边栏删除的问题

## 实现思路

- 复用统一的 IELTS 考官播报、对话与反馈组件，减少分项练习和完整模拟之间的行为差异
- 以真实练习进度判断是否存在可恢复任务，并让用户主动选择 Part 时直接创建新练习
- 新增会话侧边栏隐藏能力及对应 API、持久化字段和数据库迁移
- 在语音反馈任务中按语言判定可评分性：英文进入评分生成，中文保持不评分；移除英文最少词数限制
- 对不可评分结果统一在展示层过滤，不向用户暴露内部“证据不足”状态

## 可复现测试

1. 在 `mobile/` 运行 `flutter test`
   - 结果：770 项测试全部通过
2. 在 `server/` 运行 `go test ./...`
   - 结果：全部通过
3. iOS 模拟器手动验证：
   - IELTS P1/P2/P3 专项及完整模拟的播报、计时和反馈流程
   - 中文回答不显示评分或“证据不足”
   - 英文短回答和完整回答均显示“评分与纠错”
   - 侧边栏会话可逐条删除

Closes #309
