### PR TITLE
test(agent): expand interview mainline eval

### DIFF
--- a/server/internal/agent/eval/cases.go
+++ b/server/internal/agent/eval/cases.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/mocktool"
+	evaluationtool "github.com/1024XEngineer/XE3-ESL/server/internal/evaluation/agenttool"
 	mattertool "github.com/1024XEngineer/XE3-ESL/server/internal/matter/agenttool"
+	practicetool "github.com/1024XEngineer/XE3-ESL/server/internal/practice/agenttool"
 	reviewtool "github.com/1024XEngineer/XE3-ESL/server/internal/review/agenttool"
 )
 
@@ -92,6 +94,42 @@ func BaselineCases() []RoutingCase {
 			ExpectedToolNames: []string{reviewtool.ReviewSearchToolName},
 		},
 		{
+			Name:              "practice_preview",
+			Messages:          userOnly("先预览一下英文产品经理面试的练习方案"),
+			ExpectedDecision:  DecisionToolCall,
+			ExpectedToolNames: []string{practicetool.PracticePreviewToolName},
+			ExpectedArgs: map[string]map[string]any{
+				practicetool.PracticePreviewToolName: {
+					"scenario_query": "英文产品经理面试",
+				},
+			},
+		},
+		{
+			Name:             "practice_start_requires_confirmation",
+			Messages:         userOnly("开始练习"),
+			ExpectedDecision: DecisionClarify,
+			ForbiddenTools:   []string{practicetool.PracticeStartToolName},
+		},
+		{
+			Name:              "confirmed_practice_start",
+			Messages:          userOnly("确认开始练习"),
+			ExpectedDecision:  DecisionToolCall,
+			ExpectedToolNames: []string{practicetool.PracticeStartToolName},
+			ExpectedArgs: map[string]map[string]any{
+				practicetool.PracticeStartToolName: {
+					"practice_plan_id":       "eval-practice-plan-001",
+					"expected_plan_revision": 1,
+					"user_confirmed":         true,
+				},
+			},
+		},
+		{
+			Name:              "latest_practice_report",
+			Messages:          userOnly("看看我刚完成练习的最新报告"),
+			ExpectedDecision:  DecisionToolCall,
+			ExpectedToolNames: []string{evaluationtool.LatestPracticeReportToolName},
+		},
+		{
 			Name: "expand_first_review_candidate",
 			Messages: []EvalMessage{
 				{Role: "user", Content: "看看我上次面试评价"},
@@ -160,6 +198,9 @@ func allToolNames() []string {
 	return []string{
 		mattertool.ScenarioCreateToolName,
 		mattertool.ScenarioSearchToolName,
+		practicetool.PracticePreviewToolName,
+		practicetool.PracticeStartToolName,
+		evaluationtool.LatestPracticeReportToolName,
 		reviewtool.ReviewSearchToolName,
 		reviewtool.ReviewGetToolName,
 		mocktool.MaterialSearchToolName,

--- a/server/internal/agent/eval/evaluator.go
+++ b/server/internal/agent/eval/evaluator.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/mocktool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
+	evaluationtool "github.com/1024XEngineer/XE3-ESL/server/internal/evaluation/agenttool"
 	mattertool "github.com/1024XEngineer/XE3-ESL/server/internal/matter/agenttool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	practicetool "github.com/1024XEngineer/XE3-ESL/server/internal/practice/agenttool"
 	reviewtool "github.com/1024XEngineer/XE3-ESL/server/internal/review/agenttool"
 )
 
-const DatasetVersion = "agent-routing-eval-v2"
+const DatasetVersion = "agent-routing-eval-v3"
 
 type EvaluationResult struct {
 	DatasetVersion      string
@@ -45,7 +47,7 @@ type Evaluator struct {
 }
 
 func NewEvaluator() (*Evaluator, error) {
-	registry, err := mocktool.NewRegistry(mocktool.NewStore())
+	registry, err := newEvaluationRegistry()
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +70,7 @@ func (e *Evaluator) Evaluate(
 		Total:          len(cases),
 		CaseResults:    make([]CaseResult, 0, len(cases)),
 	}
+	writeTools := registeredWriteToolNames(e.registry)
 	var directCases, directMisroutes, writeCases, writeMisroutes int
 	for index, item := range cases {
 		caseResult, err := e.evaluateCase(ctx, index, item)
@@ -83,9 +86,9 @@ func (e *Evaluator) Evaluate(
 				directMisroutes++
 			}
 		}
-		if containsString(item.ForbiddenTools, mattertool.ScenarioCreateToolName) {
+		if intersects(item.ForbiddenTools, writeTools) {
 			writeCases++
-			if containsString(caseResult.ToolNames, mattertool.ScenarioCreateToolName) {
+			if intersects(caseResult.ToolNames, writeTools) {
 				writeMisroutes++
 			}
 		}
@@ -213,6 +216,44 @@ func (DeterministicRouter) Route(
 				}},
 			}
 		}
+	case hasAny(input, "刚完成", "刚练完", "最新报告", "latest report"):
+		if containsString(allowed, evaluationtool.LatestPracticeReportToolName) {
+			return Route{
+				Decision: DecisionToolCall,
+				ToolCalls: []ToolCall{{
+					Name:  evaluationtool.LatestPracticeReportToolName,
+					Input: mustRaw(map[string]any{}),
+				}},
+			}
+		}
+	case hasAny(input, "确认开始练习", "确认开始面试", "confirm practice"):
+		if containsString(allowed, practicetool.PracticeStartToolName) {
+			return Route{
+				Decision: DecisionToolCall,
+				ToolCalls: []ToolCall{{
+					Name: practicetool.PracticeStartToolName,
+					Input: mustRaw(map[string]any{
+						"practice_plan_id":       "eval-practice-plan-001",
+						"expected_plan_revision": 1,
+						"user_confirmed":         true,
+					}),
+				}},
+			}
+		}
+	case hasAny(input, "开始练习", "开始面试", "start practice"):
+		return Route{Decision: DecisionClarify}
+	case hasAny(input, "预览", "练习方案", "preview"):
+		if containsString(allowed, practicetool.PracticePreviewToolName) {
+			return Route{
+				Decision: DecisionToolCall,
+				ToolCalls: []ToolCall{{
+					Name: practicetool.PracticePreviewToolName,
+					Input: mustRaw(map[string]any{
+						"scenario_query": "英文产品经理面试",
+					}),
+				}},
+			}
+		}
 	case hasAny(input, "评价", "评家", "复盘", "review", "feedback"):
 		if containsString(allowed, reviewtool.ReviewSearchToolName) {
 			return Route{
@@ -309,6 +350,19 @@ func registeredToolNames(registry *tool.Registry) []string {
 	return names
 }
 
+func registeredWriteToolNames(registry *tool.Registry) []string {
+	if registry == nil {
+		return nil
+	}
+	names := make([]string, 0)
+	for _, definition := range registry.Definitions() {
+		if !definition.ReadOnly {
+			names = append(names, definition.Name)
+		}
+	}
+	return names
+}
+
 func validateCase(item RoutingCase, result CaseResult) []string {
 	failures := make([]string, 0)
 	if result.Decision != item.ExpectedDecision {
@@ -364,6 +418,15 @@ func lastUserContent(messages []EvalMessage) string {
 func containsString(values []string, expected string) bool {
 	for _, value := range values {
 		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func intersects(left, right []string) bool {
+	for _, item := range left {
+		if containsString(right, item) {
 			return true
 		}
 	}

--- a/server/internal/agent/eval/evaluator_test.go
+++ b/server/internal/agent/eval/evaluator_test.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	evaluationtool "github.com/1024XEngineer/XE3-ESL/server/internal/evaluation/agenttool"
+	mattertool "github.com/1024XEngineer/XE3-ESL/server/internal/matter/agenttool"
+	practicetool "github.com/1024XEngineer/XE3-ESL/server/internal/practice/agenttool"
+	reviewtool "github.com/1024XEngineer/XE3-ESL/server/internal/review/agenttool"
 )
 
 func TestBaselineRoutingEval(t *testing.T) {
@@ -31,5 +36,53 @@ func TestBaselineRoutingEval(t *testing.T) {
 	}
 	if result.CoreRoutingAccuracy < 0.90 {
 		t.Fatalf("CoreRoutingAccuracy = %v, want >= 0.90", result.CoreRoutingAccuracy)
+	}
+}
+
+func TestEvaluationRegistryContainsInterviewMainlineTools(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+	want := map[string]bool{
+		mattertool.ScenarioCreateToolName:           true,
+		mattertool.ScenarioSearchToolName:           true,
+		practicetool.PracticePreviewToolName:        true,
+		practicetool.PracticeStartToolName:          true,
+		evaluationtool.LatestPracticeReportToolName: true,
+		reviewtool.ReviewSearchToolName:             true,
+		reviewtool.ReviewGetToolName:                true,
+	}
+	for _, definition := range evaluator.registry.Definitions() {
+		delete(want, definition.Name)
+	}
+	if len(want) != 0 {
+		t.Fatalf("evaluation registry missing tools: %#v", want)
+	}
+}
+
+func TestRegisteredWriteToolNamesUsesToolDefinitions(t *testing.T) {
+	evaluator, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+	writes := registeredWriteToolNames(evaluator.registry)
+	for _, name := range []string{
+		mattertool.ScenarioCreateToolName,
+		practicetool.PracticePreviewToolName,
+		practicetool.PracticeStartToolName,
+	} {
+		if !containsString(writes, name) {
+			t.Errorf("write tools missing %q", name)
+		}
+	}
+	for _, name := range []string{
+		mattertool.ScenarioSearchToolName,
+		evaluationtool.LatestPracticeReportToolName,
+		reviewtool.ReviewSearchToolName,
+	} {
+		if containsString(writes, name) {
+			t.Errorf("read-only tool %q classified as write", name)
+		}
 	}
 }

--- a/server/internal/agent/eval/tool_registry.go
+++ b/server/internal/agent/eval/tool_registry.go
@@ -1,0 +1,68 @@
+package eval
+
+import (
+	"context"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/mocktool"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
+	evaluationtool "github.com/1024XEngineer/XE3-ESL/server/internal/evaluation/agenttool"
+	practicetool "github.com/1024XEngineer/XE3-ESL/server/internal/practice/agenttool"
+)
+
+func newEvaluationRegistry() (*tool.Registry, error) {
+	tools := mocktool.Tools(mocktool.NewStore())
+	ports := evaluationPorts{}
+	tools = append(
+		tools,
+		practicetool.NewPreviewTool(ports),
+		practicetool.NewStartTool(ports),
+		evaluationtool.NewLatestPracticeReportTool(ports),
+	)
+	return tool.NewRegistry(tools...)
+}
+
+type evaluationPorts struct{}
+
+func (evaluationPorts) PreviewPractice(
+	context.Context,
+	tool.CallContext,
+	practicetool.PreviewInput,
+) (practicetool.PreviewResult, error) {
+	return practicetool.PreviewResult{
+		Status:             "preview_ready",
+		PracticePlanID:     "eval-practice-plan-001",
+		PlanRevision:       1,
+		PracticePlanStatus: "ready",
+		ScenarioName:       "英文产品经理面试",
+		ScenarioFamily:     "interview",
+		ScenarioModel:      "structured_interview",
+		SelectedRoleIDs:    []string{"eval-role-001"},
+		PracticeOptionID:   "eval-option-001",
+		MaxEffectiveTurns:  3,
+	}, nil
+}
+
+func (evaluationPorts) StartPractice(
+	context.Context,
+	tool.CallContext,
+	practicetool.StartInput,
+) (practicetool.StartResult, error) {
+	return practicetool.StartResult{
+		Status:            "started",
+		PracticeSessionID: "eval-practice-session-001",
+		PracticePlanID:    "eval-practice-plan-001",
+		PlanRevision:      1,
+		SessionStatus:     "active",
+		StartTarget:       "immersive_roleplay",
+	}, nil
+}
+
+func (evaluationPorts) LatestPracticeReport(
+	context.Context,
+	tool.CallContext,
+) (evaluationtool.LatestPracticeReport, error) {
+	return evaluationtool.LatestPracticeReport{
+		Scene:          "英文产品经理面试",
+		AssessmentMode: "interview",
+	}, nil
+}


### PR DESCRIPTION
## 功能描述

扩展 Agent 离线行为回归基线，使现有场景创建/查询、练习预览/启动、最新报告和历史评价七个生产工具都进入面试主链评测，并把写操作误调用指标从单一场景创建扩展到 Registry 中全部写工具。

Closes #312

## 实现思路

- 复用生产 `practice`、`evaluation` 工具定义，为离线 Executor 提供最小内存端口，不复制 Schema。
- 新增练习预览、未确认禁止启动、确认启动、最新报告四类确定性用例。
- 从工具 Definition 的 `ReadOnly` 属性计算写工具集合，统一统计写操作误调用。
- 将 Dataset Version 更新为 `agent-routing-eval-v3`。
- 离线 `DeterministicRouter` 仍只存在于 `internal/agent/eval`，生产 Runtime 继续使用 Provider `tool_choice=auto`。

## 可复现测试

在 `server` 目录执行：

```bash
go test ./internal/agent/eval ./internal/agent/runtime ./internal/agent/tool
go test ./...
go vet ./...
go list -deps ./internal/agent/runtime | rg '/internal/agent/eval$'
```

结果：前三项通过；最后一项无输出，证明生产 Runtime 不依赖离线评测包。
