### PR TITLE
refactor(agent): separate Context and Run boundaries

### DIFF
--- a/server/internal/agent/context/assembler.go
+++ b/server/internal/agent/context/assembler.go
@@ -1,4 +1,6 @@
-package runtime
+// Package context selects and budgets the trusted model input for one Agent
+// run. It does not own the run lifecycle or model loop.
+package context
 
 import (
 	"context"
@@ -29,42 +31,8 @@ const (
 	maxContextImages            = 8
 )
 
-type Thread = core.Thread
-type Message = core.Message
-type MessageRole = core.MessageRole
-type Run = core.Run
-type ContextMessageSource = core.ContextMessageSource
-type ContextMemorySource = core.ContextMemorySource
-type ContextStableProfileSource = core.ContextStableProfileSource
-type ContextSummarySource = core.ContextSummarySource
-type ContextManifest = core.ContextManifest
-type ToolCallRecord = core.ToolCallRecord
-type RunConfiguration = core.RunConfiguration
-type RunRepository = core.RunRepository
-type RunSubmission = core.RunSubmission
-type RunRetry = core.RunRetry
-
-const (
-	MessageRoleUser      = core.MessageRoleUser
-	MessageRoleAssistant = core.MessageRoleAssistant
-	RunStatusPending     = core.RunStatusPending
-)
-
-const (
-	RunFailureConfigurationDrift = core.RunFailureConfigurationDrift
-	RunFailureInvalidContext     = core.RunFailureInvalidContext
-	RunFailureInternal           = core.RunFailureInternal
-)
-
-var (
-	ErrInvalidRequest = core.ErrInvalidRequest
-	ErrNotFound       = core.ErrNotFound
-	ErrInvalidContext = core.ErrInvalidContext
-	ErrRepository     = core.ErrRepository
-)
-
-type ContextRepository interface {
-	FindThread(ctx context.Context, ownerID, threadID string) (Thread, error)
+type Repository interface {
+	FindThread(ctx context.Context, ownerID, threadID string) (core.Thread, error)
 	FindLatestSummaryCheckpoint(
 		ctx context.Context,
 		ownerID string,
@@ -78,29 +46,29 @@ type ContextRepository interface {
 		minSequenceExclusive int64,
 		maxSequence int64,
 		characterBudget int,
-	) ([]Message, int, error)
+	) ([]core.Message, int, error)
 	FindMessage(
 		ctx context.Context,
 		ownerID string,
 		threadID string,
 		messageID string,
-	) (Message, error)
+	) (core.Message, error)
 }
 
-type ContextAssembler struct {
-	repository     ContextRepository
+type Assembler struct {
+	repository     Repository
 	matters        matter.Reader
 	stableProfiles StableProfileReader
 	memories       MemorySearcher
 	images         agentimage.ContextReader
 }
 
-type ContextAssemblerOption func(*ContextAssembler) error
+type Option func(*Assembler) error
 
-func WithImageContextReader(
+func WithImageReader(
 	reader agentimage.ContextReader,
-) ContextAssemblerOption {
-	return func(assembler *ContextAssembler) error {
+) Option {
+	return func(assembler *Assembler) error {
 		if reader == nil {
 			return errors.New("agent: image context reader is required")
 		}
@@ -109,18 +77,18 @@ func WithImageContextReader(
 	}
 }
 
-func NewContextAssembler(
-	repository ContextRepository,
+func NewAssembler(
+	repository Repository,
 	matters matter.Reader,
 	stableProfiles StableProfileReader,
 	memories MemorySearcher,
-	options ...ContextAssemblerOption,
-) (*ContextAssembler, error) {
+	options ...Option,
+) (*Assembler, error) {
 	if repository == nil || matters == nil ||
 		stableProfiles == nil || memories == nil {
 		return nil, errors.New("agent: context dependency is required")
 	}
-	assembler := &ContextAssembler{
+	assembler := &Assembler{
 		repository:     repository,
 		matters:        matters,
 		stableProfiles: stableProfiles,
@@ -137,17 +105,17 @@ func NewContextAssembler(
 	return assembler, nil
 }
 
-func (assembler *ContextAssembler) Assemble(
+func (assembler *Assembler) Assemble(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
-	configuration RunConfiguration,
-) (ContextManifest, ai.TextRequest, error) {
+	run core.Run,
+	configuration core.RunConfiguration,
+) (core.ContextManifest, ai.TextRequest, error) {
 	if !actor.Valid() ||
 		run.OwnerID != actor.UserID ||
 		!core.ValidUUID(run.ID) ||
 		!core.ValidRunConfiguration(configuration) {
-		return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 	}
 	thread, err := assembler.repository.FindThread(
 		ctx,
@@ -155,7 +123,7 @@ func (assembler *ContextAssembler) Assemble(
 		run.ThreadID,
 	)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, err
+		return core.ContextManifest{}, ai.TextRequest{}, err
 	}
 	input, err := assembler.repository.FindMessage(
 		ctx,
@@ -164,13 +132,13 @@ func (assembler *ContextAssembler) Assemble(
 		run.InputMessageID,
 	)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, err
+		return core.ContextManifest{}, ai.TextRequest{}, err
 	}
-	if input.Role != MessageRoleUser {
-		return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+	if input.Role != core.MessageRoleUser {
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 	}
 	if len(input.Content) > ai.MaxEmbeddingInputBytes {
-		return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 	}
 
 	systemContent := "You are SpeakUp, an English communication coach. " +
@@ -188,7 +156,7 @@ func (assembler *ContextAssembler) Assemble(
 		"coaching them; do not ask for a profile, plan, session, evaluation, or " +
 		"review identifier. Use historical Review search only when the user asks " +
 		"about an older practice."
-	manifest := ContextManifest{
+	manifest := core.ContextManifest{
 		RunID:                             run.ID,
 		OwnerID:                           actor.UserID,
 		ThreadID:                          run.ThreadID,
@@ -196,9 +164,9 @@ func (assembler *ContextAssembler) Assemble(
 		TrimReason:                        contextTrimNone,
 		InstructionVersion:                instructionV1,
 		StableProfileContextPolicyVersion: stableProfileContextPolicyV1,
-		SelectedStableProfile:             make([]ContextStableProfileSource, 0),
+		SelectedStableProfile:             make([]core.ContextStableProfileSource, 0),
 		MemoryContextPolicyVersion:        memoryContextPolicyV1,
-		SelectedMemories:                  make([]ContextMemorySource, 0),
+		SelectedMemories:                  make([]core.ContextMemorySource, 0),
 		SummaryContextPolicyVersion:       summaryContextPolicyV1,
 		SummaryContextStatus:              summaryContextNotAvailable,
 		MaxInputCharacters:                configuration.MaxInputCharacters,
@@ -214,12 +182,12 @@ func (assembler *ContextAssembler) Assemble(
 		)
 		if readErr != nil {
 			if errors.Is(readErr, matter.ErrNotFound) {
-				return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+				return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 			}
-			return ContextManifest{}, ai.TextRequest{}, ErrRepository
+			return core.ContextManifest{}, ai.TextRequest{}, core.ErrRepository
 		}
 		if activeMatter.Status != matter.StatusActive {
-			return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+			return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 		}
 		manifest.ActiveMatterID = activeMatter.ID
 		manifest.ActiveMatterVersion = activeMatter.Version
@@ -230,14 +198,14 @@ func (assembler *ContextAssembler) Assemble(
 	inputCharacters := utf8.RuneCountInString(input.Content)
 	if utf8.RuneCountInString(systemContent)+inputCharacters >
 		configuration.MaxInputCharacters {
-		return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 	}
 	stableProfile, err := assembler.stableProfiles.ReadStableProfile(
 		ctx,
 		StableProfileReadRequest{Actor: actor},
 	)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, ErrRepository
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrRepository
 	}
 	var excludedCanonicalKeys []string
 	systemContent, manifest.SelectedStableProfile,
@@ -247,7 +215,7 @@ func (assembler *ContextAssembler) Assemble(
 		configuration.MaxInputCharacters-inputCharacters,
 	)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, err
+		return core.ContextManifest{}, ai.TextRequest{}, err
 	}
 	hits, err := assembler.memories.Search(ctx, MemorySearchRequest{
 		Actor:                 actor,
@@ -257,10 +225,10 @@ func (assembler *ContextAssembler) Assemble(
 		Limit:                 memoryContextLimit,
 	})
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, ErrRepository
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrRepository
 	}
 	if len(hits) > memoryContextLimit {
-		return ContextManifest{}, ai.TextRequest{}, ErrRepository
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrRepository
 	}
 	systemContent, manifest.SelectedMemories, err = selectMemoryContext(
 		systemContent,
@@ -269,7 +237,7 @@ func (assembler *ContextAssembler) Assemble(
 		configuration.MaxInputCharacters-inputCharacters,
 	)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, err
+		return core.ContextManifest{}, ai.TextRequest{}, err
 	}
 	usedCharacters := utf8.RuneCountInString(systemContent)
 
@@ -283,15 +251,15 @@ func (assembler *ContextAssembler) Assemble(
 				input.Sequence-1,
 			)
 		switch {
-		case errors.Is(checkpointErr, ErrNotFound):
+		case errors.Is(checkpointErr, core.ErrNotFound):
 		case checkpointErr != nil:
-			return ContextManifest{}, ai.TextRequest{}, ErrRepository
+			return core.ContextManifest{}, ai.TextRequest{}, core.ErrRepository
 		default:
 			if !checkpoint.Valid() ||
 				checkpoint.OwnerID != actor.UserID ||
 				checkpoint.ThreadID != run.ThreadID ||
 				checkpoint.CoveredThroughSequence >= input.Sequence {
-				return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+				return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 			}
 			systemContent, manifest.SelectedSummary,
 				manifest.SummaryContextStatus, err = selectSummaryContext(
@@ -300,7 +268,7 @@ func (assembler *ContextAssembler) Assemble(
 				configuration.MaxInputCharacters-inputCharacters,
 			)
 			if err != nil {
-				return ContextManifest{}, ai.TextRequest{}, err
+				return core.ContextManifest{}, ai.TextRequest{}, err
 			}
 			if manifest.SelectedSummary != nil {
 				minMessageSequence = checkpoint.CoveredThroughSequence
@@ -319,11 +287,11 @@ func (assembler *ContextAssembler) Assemble(
 			configuration.MaxInputCharacters-usedCharacters,
 		)
 	if err != nil {
-		return ContextManifest{}, ai.TextRequest{}, err
+		return core.ContextManifest{}, ai.TextRequest{}, err
 	}
 	if len(messages) == 0 ||
 		messages[len(messages)-1].ID != input.ID {
-		return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+		return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 	}
 	manifest.OmittedMessageCount = omittedMessageCount
 	switch {
@@ -345,8 +313,8 @@ func (assembler *ContextAssembler) Assemble(
 		if message.Modality != core.MessageModalityMultimodal {
 			continue
 		}
-		if message.Role != MessageRoleUser || assembler.images == nil {
-			return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+		if message.Role != core.MessageRoleUser || assembler.images == nil {
+			return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 		}
 		images, imageErr := assembler.images.MessageImages(
 			ctx,
@@ -354,21 +322,21 @@ func (assembler *ContextAssembler) Assemble(
 			message.ThreadID,
 			message.ID,
 		)
-		if errors.Is(imageErr, ErrNotFound) && message.ID != input.ID {
+		if errors.Is(imageErr, core.ErrNotFound) && message.ID != input.ID {
 			continue
 		}
 		if imageErr != nil {
-			return ContextManifest{}, ai.TextRequest{}, imageErr
+			return core.ContextManifest{}, ai.TextRequest{}, imageErr
 		}
 		if len(images) == 0 {
 			if message.ID == input.ID {
-				return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+				return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 			}
 			continue
 		}
 		if len(images) > remainingImages {
 			if message.ID == input.ID {
-				return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+				return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 			}
 			continue
 		}
@@ -383,14 +351,14 @@ func (assembler *ContextAssembler) Assemble(
 		}},
 	}
 	manifest.SelectedMessages = make(
-		[]ContextMessageSource,
+		[]core.ContextMessageSource,
 		0,
 		len(messages),
 	)
 	for _, message := range messages {
 		role, ok := providerRole(message.Role)
 		if !ok {
-			return ContextManifest{}, ai.TextRequest{}, ErrInvalidContext
+			return core.ContextManifest{}, ai.TextRequest{}, core.ErrInvalidContext
 		}
 		providerMessage := ai.TextMessage{
 			Role:    role,
@@ -426,7 +394,7 @@ func (assembler *ContextAssembler) Assemble(
 		request.Messages = append(request.Messages, providerMessage)
 		manifest.SelectedMessages = append(
 			manifest.SelectedMessages,
-			ContextMessageSource{
+			core.ContextMessageSource{
 				MessageID: message.ID,
 				Sequence:  message.Sequence,
 				Role:      message.Role,
@@ -435,9 +403,9 @@ func (assembler *ContextAssembler) Assemble(
 	}
 	manifest.UsedInputCharacters = usedCharacters
 	if err := ai.ValidateTextRequest(request); err != nil {
-		return ContextManifest{}, ai.TextRequest{}, fmt.Errorf(
+		return core.ContextManifest{}, ai.TextRequest{}, fmt.Errorf(
 			"%w: %v",
-			ErrInvalidContext,
+			core.ErrInvalidContext,
 			err,
 		)
 	}
@@ -456,20 +424,20 @@ func selectSummaryContext(
 	systemContent string,
 	checkpoint core.ThreadSummaryCheckpoint,
 	systemBudget int,
-) (string, *ContextSummarySource, string, error) {
+) (string, *core.ContextSummarySource, string, error) {
 	if systemBudget < utf8.RuneCountInString(systemContent) {
-		return "", nil, "", ErrInvalidContext
+		return "", nil, "", core.ErrInvalidContext
 	}
 	content, err := json.Marshal(checkpoint.Content)
 	if err != nil {
-		return "", nil, "", ErrInvalidContext
+		return "", nil, "", core.ErrInvalidContext
 	}
 	candidate := systemContent + summaryContextPrefix +
 		string(content) + summaryContextSuffix
 	if utf8.RuneCountInString(candidate) > systemBudget {
 		return systemContent, nil, summaryContextOmittedBudget, nil
 	}
-	return candidate, &ContextSummarySource{
+	return candidate, &core.ContextSummarySource{
 		CheckpointID:           checkpoint.ID,
 		SourceFromSequence:     checkpoint.SourceFromSequence,
 		CoveredThroughSequence: checkpoint.CoveredThroughSequence,
@@ -493,10 +461,10 @@ func selectMemoryContext(
 	hits []MemorySearchHit,
 	matterID string,
 	systemBudget int,
-) (string, []ContextMemorySource, error) {
-	selected := make([]ContextMemorySource, 0, len(hits))
+) (string, []core.ContextMemorySource, error) {
+	selected := make([]core.ContextMemorySource, 0, len(hits))
 	if systemBudget < utf8.RuneCountInString(systemContent) {
-		return "", nil, ErrInvalidContext
+		return "", nil, core.ErrInvalidContext
 	}
 	if len(hits) == 0 {
 		return systemContent, selected, nil
@@ -505,7 +473,7 @@ func selectMemoryContext(
 	block.WriteString(memoryContextPrefix)
 	for _, hit := range hits {
 		if !hit.valid(matterID) {
-			return "", nil, ErrRepository
+			return "", nil, core.ErrRepository
 		}
 		entry := formatMemoryContextEntry(hit)
 		proposedCharacters := utf8.RuneCountInString(systemContent) +
@@ -532,8 +500,8 @@ func formatMemoryContextEntry(hit MemorySearchHit) string {
 		`</memory>`
 }
 
-func contextMemorySource(hit MemorySearchHit) ContextMemorySource {
-	return ContextMemorySource{
+func contextMemorySource(hit MemorySearchHit) core.ContextMemorySource {
+	return core.ContextMemorySource{
 		MemoryID:               hit.MemoryID,
 		MemoryVersion:          hit.MemoryVersion,
 		Type:                   hit.Type,
@@ -549,17 +517,13 @@ func contextMemorySource(hit MemorySearchHit) ContextMemorySource {
 	}
 }
 
-func providerRole(role MessageRole) (ai.TextRole, bool) {
+func providerRole(role core.MessageRole) (ai.TextRole, bool) {
 	switch role {
-	case MessageRoleUser:
+	case core.MessageRoleUser:
 		return ai.TextRoleUser, true
-	case MessageRoleAssistant:
+	case core.MessageRoleAssistant:
 		return ai.TextRoleAssistant, true
 	default:
 		return "", false
 	}
-}
-
-func validRunConfiguration(configuration RunConfiguration) bool {
-	return core.ValidRunConfiguration(configuration)
 }

--- a/server/internal/agent/context/multimodal_test.go
+++ b/server/internal/agent/context/multimodal_test.go
@@ -1,4 +1,4 @@
-package runtime
+package context
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
-func TestContextAssemblerAddsSignedImagesToMultimodalUserMessage(
+func TestAssemblerAddsSignedImagesToMultimodalUserMessage(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -22,30 +22,30 @@ func TestContextAssemblerAddsSignedImagesToMultimodalUserMessage(
 		messageID = "30000000-0000-4000-8000-000000000001"
 		runID     = "40000000-0000-4000-8000-000000000001"
 	)
-	message := Message{
+	message := core.Message{
 		ID:       messageID,
 		OwnerID:  ownerID,
 		ThreadID: threadID,
 		Sequence: 1,
-		Role:     MessageRoleUser,
+		Role:     core.MessageRoleUser,
 		Modality: core.MessageModalityMultimodal,
 		Content:  "What should I improve?",
 	}
-	repository := multimodalContextRepository{
-		thread:  Thread{ID: threadID, OwnerID: ownerID},
+	repository := multimodalRepository{
+		thread:  core.Thread{ID: threadID, OwnerID: ownerID},
 		message: message,
 	}
-	assembler, err := NewContextAssembler(
+	assembler, err := NewAssembler(
 		repository,
 		multimodalContextMatters{},
 		multimodalContextStableProfile{},
 		multimodalContextMemories{},
-		WithImageContextReader(multimodalContextImages{}),
+		WithImageReader(multimodalContextImages{}),
 	)
 	if err != nil {
 		t.Fatalf("new assembler: %v", err)
 	}
-	configuration := RunConfiguration{
+	configuration := core.RunConfiguration{
 		Provider:           "fake",
 		Model:              "fake-multimodal",
 		MaxOutputTokens:    256,
@@ -57,12 +57,12 @@ func TestContextAssemblerAddsSignedImagesToMultimodalUserMessage(
 			UserID:    ownerID,
 			SessionID: "multimodal-session",
 		},
-		Run{
+		core.Run{
 			ID:                 runID,
 			OwnerID:            ownerID,
 			ThreadID:           threadID,
 			InputMessageID:     messageID,
-			Status:             RunStatusPending,
+			Status:             core.RunStatusPending,
 			RequestedProvider:  configuration.Provider,
 			RequestedModel:     configuration.Model,
 			MaxOutputTokens:    configuration.MaxOutputTokens,
@@ -87,7 +87,7 @@ func TestContextAssemblerAddsSignedImagesToMultimodalUserMessage(
 	}
 }
 
-func TestContextAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
+func TestAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -95,7 +95,7 @@ func TestContextAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 		threadID = "20000000-0000-4000-8000-000000000001"
 		runID    = "40000000-0000-4000-8000-000000000001"
 	)
-	messages := []Message{
+	messages := []core.Message{
 		multimodalContextMessage(
 			"30000000-0000-4000-8000-000000000001",
 			ownerID,
@@ -116,20 +116,20 @@ func TestContextAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 		),
 	}
 	repository := multimodalBudgetRepository{
-		thread:   Thread{ID: threadID, OwnerID: ownerID},
+		thread:   core.Thread{ID: threadID, OwnerID: ownerID},
 		messages: messages,
 	}
-	assembler, err := NewContextAssembler(
+	assembler, err := NewAssembler(
 		repository,
 		multimodalContextMatters{},
 		multimodalContextStableProfile{},
 		multimodalContextMemories{},
-		WithImageContextReader(multimodalBudgetImages{}),
+		WithImageReader(multimodalBudgetImages{}),
 	)
 	if err != nil {
 		t.Fatalf("new assembler: %v", err)
 	}
-	configuration := RunConfiguration{
+	configuration := core.RunConfiguration{
 		Provider:           "fake",
 		Model:              "fake-multimodal",
 		MaxOutputTokens:    256,
@@ -141,12 +141,12 @@ func TestContextAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 			UserID:    ownerID,
 			SessionID: "multimodal-session",
 		},
-		Run{
+		core.Run{
 			ID:                 runID,
 			OwnerID:            ownerID,
 			ThreadID:           threadID,
 			InputMessageID:     messages[2].ID,
-			Status:             RunStatusPending,
+			Status:             core.RunStatusPending,
 			RequestedProvider:  configuration.Provider,
 			RequestedModel:     configuration.Model,
 			MaxOutputTokens:    configuration.MaxOutputTokens,
@@ -170,57 +170,57 @@ func multimodalContextMessage(
 	ownerID string,
 	threadID string,
 	sequence int64,
-) Message {
-	return Message{
+) core.Message {
+	return core.Message{
 		ID:       id,
 		OwnerID:  ownerID,
 		ThreadID: threadID,
 		Sequence: sequence,
-		Role:     MessageRoleUser,
+		Role:     core.MessageRoleUser,
 		Modality: core.MessageModalityMultimodal,
 		Content:  "Message with images.",
 	}
 }
 
-type multimodalContextRepository struct {
-	thread  Thread
-	message Message
+type multimodalRepository struct {
+	thread  core.Thread
+	message core.Message
 }
 
-func (repository multimodalContextRepository) FindThread(
+func (repository multimodalRepository) FindThread(
 	context.Context,
 	string,
 	string,
-) (Thread, error) {
+) (core.Thread, error) {
 	return repository.thread, nil
 }
 
-func (multimodalContextRepository) FindLatestSummaryCheckpoint(
+func (multimodalRepository) FindLatestSummaryCheckpoint(
 	context.Context,
 	string,
 	string,
 	int64,
 ) (core.ThreadSummaryCheckpoint, error) {
-	return core.ThreadSummaryCheckpoint{}, ErrNotFound
+	return core.ThreadSummaryCheckpoint{}, core.ErrNotFound
 }
 
-func (repository multimodalContextRepository) ListMessagesForContext(
+func (repository multimodalRepository) ListMessagesForContext(
 	context.Context,
 	string,
 	string,
 	int64,
 	int64,
 	int,
-) ([]Message, int, error) {
-	return []Message{repository.message}, 0, nil
+) ([]core.Message, int, error) {
+	return []core.Message{repository.message}, 0, nil
 }
 
-func (repository multimodalContextRepository) FindMessage(
+func (repository multimodalRepository) FindMessage(
 	context.Context,
 	string,
 	string,
 	string,
-) (Message, error) {
+) (core.Message, error) {
 	return repository.message, nil
 }
 
@@ -267,15 +267,15 @@ func (multimodalContextImages) MessageImages(
 }
 
 type multimodalBudgetRepository struct {
-	thread   Thread
-	messages []Message
+	thread   core.Thread
+	messages []core.Message
 }
 
 func (repository multimodalBudgetRepository) FindThread(
 	context.Context,
 	string,
 	string,
-) (Thread, error) {
+) (core.Thread, error) {
 	return repository.thread, nil
 }
 
@@ -285,7 +285,7 @@ func (multimodalBudgetRepository) FindLatestSummaryCheckpoint(
 	string,
 	int64,
 ) (core.ThreadSummaryCheckpoint, error) {
-	return core.ThreadSummaryCheckpoint{}, ErrNotFound
+	return core.ThreadSummaryCheckpoint{}, core.ErrNotFound
 }
 
 func (repository multimodalBudgetRepository) ListMessagesForContext(
@@ -295,8 +295,8 @@ func (repository multimodalBudgetRepository) ListMessagesForContext(
 	int64,
 	int64,
 	int,
-) ([]Message, int, error) {
-	return append([]Message(nil), repository.messages...), 0, nil
+) ([]core.Message, int, error) {
+	return append([]core.Message(nil), repository.messages...), 0, nil
 }
 
 func (repository multimodalBudgetRepository) FindMessage(
@@ -304,7 +304,7 @@ func (repository multimodalBudgetRepository) FindMessage(
 	string,
 	string,
 	string,
-) (Message, error) {
+) (core.Message, error) {
 	return repository.messages[len(repository.messages)-1], nil
 }
 

--- a/server/internal/agent/context/relevant_memory.go
+++ b/server/internal/agent/context/relevant_memory.go
@@ -1,4 +1,4 @@
-package runtime
+package context
 
 import (
 	"context"

--- a/server/internal/agent/context/stable_profile.go
+++ b/server/internal/agent/context/stable_profile.go
@@ -1,4 +1,4 @@
-package runtime
+package context
 
 import (
 	"context"

--- a/server/internal/agent/context/stable_profile_selection.go
+++ b/server/internal/agent/context/stable_profile_selection.go
@@ -1,9 +1,11 @@
-package runtime
+package context
 
 import (
 	"html"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 )
 
 const (
@@ -23,17 +25,17 @@ func selectStableProfileContext(
 	systemBudget int,
 ) (
 	string,
-	[]ContextStableProfileSource,
+	[]core.ContextStableProfileSource,
 	[]string,
 	error,
 ) {
-	selected := make([]ContextStableProfileSource, 0, len(items))
+	selected := make([]core.ContextStableProfileSource, 0, len(items))
 	excluded := make([]string, 0, len(items))
 	if systemBudget < utf8.RuneCountInString(systemContent) {
-		return "", nil, nil, ErrInvalidContext
+		return "", nil, nil, core.ErrInvalidContext
 	}
 	if len(items) > stableProfileContextLimit {
-		return "", nil, nil, ErrRepository
+		return "", nil, nil, core.ErrRepository
 	}
 	if len(items) == 0 {
 		return systemContent, selected, excluded, nil
@@ -44,14 +46,14 @@ func selectStableProfileContext(
 	block.WriteString(stableProfileContextPrefix)
 	for _, item := range items {
 		if !item.Valid() {
-			return "", nil, nil, ErrRepository
+			return "", nil, nil, core.ErrRepository
 		}
 		if _, duplicate := seen[item.CanonicalKey]; duplicate {
-			return "", nil, nil, ErrRepository
+			return "", nil, nil, core.ErrRepository
 		}
 		position := stableProfilePositions[item.CanonicalKey]
 		if position <= previousPosition {
-			return "", nil, nil, ErrRepository
+			return "", nil, nil, core.ErrRepository
 		}
 		previousPosition = position
 		seen[item.CanonicalKey] = struct{}{}
@@ -69,7 +71,7 @@ func selectStableProfileContext(
 			break
 		}
 		block.WriteString(entry)
-		selected = append(selected, ContextStableProfileSource{
+		selected = append(selected, core.ContextStableProfileSource{
 			MemoryID:      item.MemoryID,
 			MemoryVersion: item.MemoryVersion,
 			CanonicalKey:  item.CanonicalKey,

--- a/server/internal/agent/context/stable_profile_selection_test.go
+++ b/server/internal/agent/context/stable_profile_selection_test.go
@@ -1,8 +1,10 @@
-package runtime
+package context
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 )
 
 func TestSelectStableProfileContextInjectsWholeEscapedFields(t *testing.T) {
@@ -92,7 +94,7 @@ func TestSelectStableProfileContextRejectsUnsupportedOrDuplicateFields(
 		"system",
 		[]StableProfileMemory{unsupported},
 		4096,
-	); err != ErrRepository {
+	); err != core.ErrRepository {
 		t.Fatalf("unsupported error = %v", err)
 	}
 	duplicate := valid
@@ -101,7 +103,7 @@ func TestSelectStableProfileContextRejectsUnsupportedOrDuplicateFields(
 		"system",
 		[]StableProfileMemory{valid, duplicate},
 		4096,
-	); err != ErrRepository {
+	); err != core.ErrRepository {
 		t.Fatalf("duplicate error = %v", err)
 	}
 	occupation := valid
@@ -112,7 +114,7 @@ func TestSelectStableProfileContextRejectsUnsupportedOrDuplicateFields(
 		"system",
 		[]StableProfileMemory{occupation, valid},
 		4096,
-	); err != ErrRepository {
+	); err != core.ErrRepository {
 		t.Fatalf("out-of-order error = %v", err)
 	}
 }

--- a/server/internal/agent/context/summary_test.go
+++ b/server/internal/agent/context/summary_test.go
@@ -1,4 +1,4 @@
-package runtime
+package context
 
 import (
 	"strings"

--- a/server/internal/agent/memory/extraction_postgres_integration_test.go
+++ b/server/internal/agent/memory/extraction_postgres_integration_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	agentapp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/app"
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	agentpersistence "github.com/1024XEngineer/XE3-ESL/server/internal/agent/persistence"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
 	aifake "github.com/1024XEngineer/XE3-ESL/server/internal/ai/fake"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
@@ -51,7 +52,7 @@ func TestCompletedAgentRunQueuesAndAppliesMemoryExtraction(
 	if err != nil {
 		t.Fatalf("CreateThread: %v", err)
 	}
-	assembler, err := agentruntime.NewContextAssembler(
+	assembler, err := agentcontext.NewAssembler(
 		agentRepository,
 		matterService,
 		emptyAgentStableProfileReader{},
@@ -78,7 +79,7 @@ func TestCompletedAgentRunQueuesAndAppliesMemoryExtraction(
 			TotalTokens:  18,
 		},
 	})
-	runService, err := agentruntime.NewRunService(
+	runService, err := agentrun.NewService(
 		agentRepository,
 		assembler,
 		generator,
@@ -337,14 +338,14 @@ type emptyAgentStableProfileReader struct{}
 
 func (emptyAgentStableProfileReader) ReadStableProfile(
 	context.Context,
-	agentruntime.StableProfileReadRequest,
-) ([]agentruntime.StableProfileMemory, error) {
-	return []agentruntime.StableProfileMemory{}, nil
+	agentcontext.StableProfileReadRequest,
+) ([]agentcontext.StableProfileMemory, error) {
+	return []agentcontext.StableProfileMemory{}, nil
 }
 
 func (emptyAgentMemorySearcher) Search(
 	context.Context,
-	agentruntime.MemorySearchRequest,
-) ([]agentruntime.MemorySearchHit, error) {
-	return []agentruntime.MemorySearchHit{}, nil
+	agentcontext.MemorySearchRequest,
+) ([]agentcontext.MemorySearchHit, error) {
+	return []agentcontext.MemorySearchHit{}, nil
 }

--- a/server/internal/agent/run/doc.go
+++ b/server/internal/agent/run/doc.go
@@ -1,4 +1,4 @@
-// Package runtime contains the bounded Agent runtime: loop budgets,
+// Package run contains the bounded Agent run: loop budgets,
 // tool-call lifecycle control, response dispatching, and run interruption
 // policy.
-package runtime
+package run

--- a/server/internal/agent/run/logging.go
+++ b/server/internal/agent/run/logging.go
@@ -1,4 +1,4 @@
-package runtime
+package run
 
 import (
 	"strings"

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -1,4 +1,4 @@
-package runtime
+package run
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/command"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/mocktool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
@@ -29,7 +30,7 @@ func TestRunLoopExposesAllToolsAndAllowsDirectResponse(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("帮我把这句话说得委婉一点"),
 	)
 	if err != nil {
@@ -67,7 +68,7 @@ func TestRunLoopExecutesToolCallAndFeedsResultBackToModel(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("请结合我的信息处理一下"),
 	)
 	if err != nil {
@@ -121,7 +122,7 @@ func TestRunLoopForcesLatestReportAfterCompletedPractice(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest(
 			"我刚完成了面试练习。请直接读取这次练习的真实评分与报告。",
 		),
@@ -202,7 +203,7 @@ func TestRunLoopExecutesMultipleToolCallsAndFeedsAllResultsBack(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("比较我两次面试评价"),
 	)
 	if err != nil {
@@ -255,7 +256,7 @@ func TestRunLoopSupportsConsecutiveToolRoundsBeforeFinalResponse(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("结合我的评价和简历准备下一轮面试"),
 	)
 	if err != nil {
@@ -286,7 +287,7 @@ func TestRunLoopAllowsModelToAnswerWithoutToolCall(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("帮我找一下上次 PM interview 的 review"),
 	)
 	if err != nil {
@@ -310,7 +311,7 @@ func TestRunLoopExecutesExplicitCommandBeforeModelResponse(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("/查评价 last interview"),
 	)
 	if err != nil {
@@ -369,7 +370,7 @@ func TestRunLoopContinuesToolCallingAfterExplicitCommand(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("/查评价 last interview"),
 	)
 	if err != nil {
@@ -405,7 +406,7 @@ func TestRunLoopFeedsToolErrorBackToModel(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("结合我的简历准备面试"),
 	)
 	if err != nil {
@@ -441,7 +442,7 @@ func TestRunLoopFeedsInvalidArgumentsBackToModel(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("找评价"),
 	)
 	if err != nil {
@@ -470,7 +471,7 @@ func TestRunLoopReturnsFallbackWhenToolBudgetExhausted(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("看看我面试评价"),
 	)
 	if err != nil {
@@ -495,7 +496,7 @@ func TestRunLoopRejectsUnexposedToolCall(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("帮我润色这句话"),
 	)
 	if err != nil {
@@ -523,7 +524,7 @@ func TestRunLoopStopsAfterToolIterationBudget(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("先找评价，再找材料"),
 	)
 	if err != nil {
@@ -557,7 +558,7 @@ func TestRunLoopRejectsRepeatedToolCallIDBeforeSecondExecution(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("创建两个练习场景"),
 	)
 	if err != nil {
@@ -587,7 +588,7 @@ func TestRunLoopReplaysWriteToolWithStableIdempotencyID(t *testing.T) {
 			context.Background(),
 			loopActor(),
 			loopRun(),
-			ContextManifest{},
+			core.ContextManifest{},
 			loopRequest("创建面试场景"),
 		); err != nil {
 			t.Fatalf("generate() error = %v", err)
@@ -632,7 +633,7 @@ func TestRunLoopStopsAfterWriteBudget(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("帮我创建一个英文 PM 面试练习场景"),
 	)
 	if err != nil {
@@ -707,7 +708,7 @@ func TestRunLoopLogsEndToEndToolSequence(t *testing.T) {
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest("看看我上次面试评价"),
 	)
 	if err != nil {
@@ -764,7 +765,7 @@ func TestRunLoopLogOptionsAndPayloadSummariesDoNotLeakSensitiveContent(t *testin
 		context.Background(),
 		loopActor(),
 		loopRun(),
-		ContextManifest{},
+		core.ContextManifest{},
 		loopRequest(secretInput),
 	)
 	if err != nil {
@@ -887,7 +888,7 @@ func (generator *scriptedGenerator) CallCount() int {
 func newLoopTestService(
 	t *testing.T,
 	generator ai.TextGenerator,
-) *RunService {
+) *Service {
 	t.Helper()
 	return newLoopTestServiceWithStore(t, generator, mocktool.NewStore())
 }
@@ -896,15 +897,15 @@ func newLoopTestServiceWithStore(
 	t *testing.T,
 	generator ai.TextGenerator,
 	store *mocktool.Store,
-) *RunService {
+) *Service {
 	t.Helper()
 	registry, err := mocktool.NewRegistry(store)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	return &RunService{
+	return &Service{
 		generator: generator,
-		configuration: RunConfiguration{
+		configuration: core.RunConfiguration{
 			Provider:           "fake",
 			Model:              "configured-model",
 			MaxOutputTokens:    512,
@@ -920,8 +921,8 @@ func loopActor() requestcontext.Actor {
 	return requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
 }
 
-func loopRun() Run {
-	return Run{ID: "run-1", OwnerID: "user-1", ThreadID: "thread-1"}
+func loopRun() core.Run {
+	return core.Run{ID: "run-1", OwnerID: "user-1", ThreadID: "thread-1"}
 }
 
 func loopRequest(input string) ai.TextRequest {

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -1,4 +1,4 @@
-package runtime
+package run
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/command"
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
@@ -33,12 +34,12 @@ const (
 	toolSchemaVersionV1      = "tool-schema-v1"
 )
 
-type RunService struct {
-	repository    RunRepository
+type Service struct {
+	repository    core.RunRepository
 	multimodal    core.MultimodalRunRepository
-	assembler     *ContextAssembler
+	assembler     *agentcontext.Assembler
 	generator     ai.TextGenerator
-	configuration RunConfiguration
+	configuration core.RunConfiguration
 	registry      *tool.Registry
 	executor      *tool.Executor
 	loopLimits    LoopLimits
@@ -62,22 +63,20 @@ type LogOptions struct {
 	InputPreviewMax int
 }
 
-type RunStreamObserver = core.RunStreamObserver
+type Option func(*Service) error
 
-type RunServiceOption func(*RunService) error
-
-func NewRunService(
-	repository RunRepository,
-	assembler *ContextAssembler,
+func NewService(
+	repository core.RunRepository,
+	assembler *agentcontext.Assembler,
 	generator ai.TextGenerator,
-	configuration RunConfiguration,
-	options ...RunServiceOption,
-) (*RunService, error) {
+	configuration core.RunConfiguration,
+	options ...Option,
+) (*Service, error) {
 	if repository == nil || assembler == nil || generator == nil ||
 		!core.ValidRunConfiguration(configuration) {
 		return nil, errors.New("agent: run dependency or configuration is invalid")
 	}
-	service := &RunService{
+	service := &Service{
 		repository:    repository,
 		assembler:     assembler,
 		generator:     generator,
@@ -99,8 +98,8 @@ func NewRunService(
 	return service, nil
 }
 
-func WithToolRegistry(registry *tool.Registry) RunServiceOption {
-	return func(service *RunService) error {
+func WithToolRegistry(registry *tool.Registry) Option {
+	return func(service *Service) error {
 		if registry == nil {
 			return errors.New("agent: tool registry is required")
 		}
@@ -114,8 +113,8 @@ func WithToolRegistry(registry *tool.Registry) RunServiceOption {
 	}
 }
 
-func WithRunLogger(logger *slog.Logger) RunServiceOption {
-	return func(service *RunService) error {
+func WithRunLogger(logger *slog.Logger) Option {
+	return func(service *Service) error {
 		if logger == nil {
 			return errors.New("agent: run logger is required")
 		}
@@ -131,8 +130,8 @@ func WithRunLogger(logger *slog.Logger) RunServiceOption {
 	}
 }
 
-func WithLogOptions(options LogOptions) RunServiceOption {
-	return func(service *RunService) error {
+func WithLogOptions(options LogOptions) Option {
+	return func(service *Service) error {
 		service.logOptions = normalizeLogOptions(options)
 		if service.registry != nil {
 			service.executor = tool.NewExecutorWithLogger(
@@ -145,8 +144,8 @@ func WithLogOptions(options LogOptions) RunServiceOption {
 	}
 }
 
-func WithLoopLimits(limits LoopLimits) RunServiceOption {
-	return func(service *RunService) error {
+func WithLoopLimits(limits LoopLimits) Option {
+	return func(service *Service) error {
 		normalized := normalizeLoopLimits(limits)
 		if normalized.MaxIterations <= 0 ||
 			normalized.MaxToolCalls <= 0 ||
@@ -161,8 +160,8 @@ func WithLoopLimits(limits LoopLimits) RunServiceOption {
 	}
 }
 
-func WithCommandRouter(router *command.Router) RunServiceOption {
-	return func(service *RunService) error {
+func WithCommandRouter(router *command.Router) Option {
+	return func(service *Service) error {
 		if router == nil {
 			return errors.New("agent: command router is required")
 		}
@@ -171,19 +170,19 @@ func WithCommandRouter(router *command.Router) RunServiceOption {
 	}
 }
 
-func (service *RunService) SubmitText(
+func (service *Service) SubmitText(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	threadID string,
 	clientMessageID string,
 	content string,
-) (RunSubmission, error) {
+) (core.RunSubmission, error) {
 	if !actor.Valid() || !core.ValidUUID(threadID) {
-		return RunSubmission{}, ErrNotFound
+		return core.RunSubmission{}, core.ErrNotFound
 	}
 	if !core.ValidClientMessageID(clientMessageID) ||
 		!core.ValidMessageContent(content) {
-		return RunSubmission{}, ErrInvalidRequest
+		return core.RunSubmission{}, core.ErrInvalidRequest
 	}
 	submission, err := service.repository.CreateInitialRun(
 		ctx,
@@ -194,46 +193,46 @@ func (service *RunService) SubmitText(
 		service.configuration,
 	)
 	if err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
 	submission.Run, err = service.process(ctx, actor, submission.Run, nil)
 	if err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
 	return submission, nil
 }
 
-func (service *RunService) SubmitTextStream(
+func (service *Service) SubmitTextStream(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	threadID string,
 	clientMessageID string,
 	content string,
-	observer RunStreamObserver,
-) (RunSubmission, error) {
+	observer core.RunStreamObserver,
+) (core.RunSubmission, error) {
 	if observer == nil {
-		return RunSubmission{}, ErrInvalidRequest
+		return core.RunSubmission{}, core.ErrInvalidRequest
 	}
 	if !actor.Valid() || !core.ValidUUID(threadID) {
-		return RunSubmission{}, ErrNotFound
+		return core.RunSubmission{}, core.ErrNotFound
 	}
 	if !core.ValidClientMessageID(clientMessageID) ||
 		!core.ValidMessageContent(content) {
-		return RunSubmission{}, ErrInvalidRequest
+		return core.RunSubmission{}, core.ErrInvalidRequest
 	}
 	submission, err := service.repository.CreateInitialRun(
 		ctx, actor.UserID, threadID, clientMessageID, content,
 		service.configuration,
 	)
 	if err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
 	if err := observer.OnInputCommitted(ctx, submission); err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
-	if submission.Run.Status == RunStatusPending {
+	if submission.Run.Status == core.RunStatusPending {
 		if err := observer.OnAssistantStarted(ctx, submission.Run); err != nil {
-			return RunSubmission{}, err
+			return core.RunSubmission{}, err
 		}
 	}
 	deltas := &countingDeltaObserver{delegate: observer}
@@ -248,22 +247,22 @@ func (service *RunService) SubmitTextStream(
 	return submission, err
 }
 
-func (service *RunService) SubmitMultimodal(
+func (service *Service) SubmitMultimodal(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	threadID string,
 	clientMessageID string,
 	content string,
 	imageAssetIDs []string,
-) (RunSubmission, error) {
+) (core.RunSubmission, error) {
 	if !actor.Valid() || !core.ValidUUID(threadID) {
-		return RunSubmission{}, ErrNotFound
+		return core.RunSubmission{}, core.ErrNotFound
 	}
 	if service.multimodal == nil ||
 		!core.ValidClientMessageID(clientMessageID) ||
 		!core.ValidMessageContent(content) ||
 		!validMultimodalImageIDs(imageAssetIDs) {
-		return RunSubmission{}, ErrInvalidRequest
+		return core.RunSubmission{}, core.ErrInvalidRequest
 	}
 	submission, err := service.multimodal.CreateInitialMultimodalRun(
 		ctx,
@@ -275,11 +274,11 @@ func (service *RunService) SubmitMultimodal(
 		service.configuration,
 	)
 	if err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
 	submission.Run, err = service.process(ctx, actor, submission.Run, nil)
 	if err != nil {
-		return RunSubmission{}, err
+		return core.RunSubmission{}, err
 	}
 	return submission, nil
 }
@@ -302,17 +301,17 @@ func validMultimodalImageIDs(imageAssetIDs []string) bool {
 	return true
 }
 
-func (service *RunService) RetryText(
+func (service *Service) RetryText(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	runID string,
 	retryClientID string,
-) (RunRetry, error) {
+) (core.RunRetry, error) {
 	if !actor.Valid() || !core.ValidUUID(runID) {
-		return RunRetry{}, ErrNotFound
+		return core.RunRetry{}, core.ErrNotFound
 	}
 	if !core.ValidClientMessageID(retryClientID) {
-		return RunRetry{}, ErrInvalidRequest
+		return core.RunRetry{}, core.ErrInvalidRequest
 	}
 	retry, err := service.repository.CreateRetryRun(
 		ctx,
@@ -322,36 +321,36 @@ func (service *RunService) RetryText(
 		service.configuration,
 	)
 	if err != nil {
-		return RunRetry{}, err
+		return core.RunRetry{}, err
 	}
 	retry.Run, err = service.process(ctx, actor, retry.Run, nil)
 	if err != nil {
-		return RunRetry{}, err
+		return core.RunRetry{}, err
 	}
 	return retry, nil
 }
 
-func (service *RunService) RetryTextStream(
+func (service *Service) RetryTextStream(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	runID string,
 	retryClientID string,
-	observer RunStreamObserver,
-) (RunRetry, error) {
+	observer core.RunStreamObserver,
+) (core.RunRetry, error) {
 	if observer == nil {
-		return RunRetry{}, ErrInvalidRequest
+		return core.RunRetry{}, core.ErrInvalidRequest
 	}
 	if !actor.Valid() || !core.ValidUUID(runID) {
-		return RunRetry{}, ErrNotFound
+		return core.RunRetry{}, core.ErrNotFound
 	}
 	if !core.ValidClientMessageID(retryClientID) {
-		return RunRetry{}, ErrInvalidRequest
+		return core.RunRetry{}, core.ErrInvalidRequest
 	}
 	retry, err := service.repository.CreateRetryRun(
 		ctx, actor.UserID, runID, retryClientID, service.configuration,
 	)
 	if err != nil {
-		return RunRetry{}, err
+		return core.RunRetry{}, err
 	}
 	userMessage, err := service.repository.FindMessage(
 		ctx,
@@ -360,16 +359,16 @@ func (service *RunService) RetryTextStream(
 		retry.Run.InputMessageID,
 	)
 	if err != nil {
-		return RunRetry{}, err
+		return core.RunRetry{}, err
 	}
-	if err := observer.OnInputCommitted(ctx, RunSubmission{
+	if err := observer.OnInputCommitted(ctx, core.RunSubmission{
 		Run: retry.Run, UserMessage: userMessage, Created: retry.Created,
 	}); err != nil {
-		return RunRetry{}, err
+		return core.RunRetry{}, err
 	}
-	if retry.Run.Status == RunStatusPending {
+	if retry.Run.Status == core.RunStatusPending {
 		if err := observer.OnAssistantStarted(ctx, retry.Run); err != nil {
-			return RunRetry{}, err
+			return core.RunRetry{}, err
 		}
 	}
 	deltas := &countingDeltaObserver{delegate: observer}
@@ -384,11 +383,11 @@ func (service *RunService) RetryTextStream(
 	return retry, err
 }
 
-func (service *RunService) waitForTerminalRun(
+func (service *Service) waitForTerminalRun(
 	ctx context.Context,
 	ownerID string,
-	run Run,
-) (Run, error) {
+	run core.Run,
+) (core.Run, error) {
 	if run.Status == core.RunStatusCompleted || run.Status == core.RunStatusFailed {
 		return run, nil
 	}
@@ -397,11 +396,11 @@ func (service *RunService) waitForTerminalRun(
 	for {
 		select {
 		case <-ctx.Done():
-			return Run{}, ctx.Err()
+			return core.Run{}, ctx.Err()
 		case <-ticker.C:
 			current, err := service.repository.FindRun(ctx, ownerID, run.ID)
 			if err != nil {
-				return Run{}, err
+				return core.Run{}, err
 			}
 			switch current.Status {
 			case core.RunStatusCompleted, core.RunStatusFailed:
@@ -409,48 +408,48 @@ func (service *RunService) waitForTerminalRun(
 			case core.RunStatusPending, core.RunStatusRunning:
 				continue
 			default:
-				return Run{}, ErrInvalidContext
+				return core.Run{}, core.ErrInvalidContext
 			}
 		}
 	}
 }
 
-func (service *RunService) GetRun(
+func (service *Service) GetRun(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	runID string,
-) (Run, error) {
+) (core.Run, error) {
 	if !actor.Valid() || !core.ValidUUID(runID) {
-		return Run{}, ErrNotFound
+		return core.Run{}, core.ErrNotFound
 	}
 	return service.repository.FindRun(ctx, actor.UserID, runID)
 }
 
-func (service *RunService) GetContextManifest(
+func (service *Service) GetContextManifest(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	runID string,
-) (ContextManifest, error) {
+) (core.ContextManifest, error) {
 	if !actor.Valid() || !core.ValidUUID(runID) {
-		return ContextManifest{}, ErrNotFound
+		return core.ContextManifest{}, core.ErrNotFound
 	}
 	if _, err := service.repository.FindRun(
 		ctx,
 		actor.UserID,
 		runID,
 	); err != nil {
-		return ContextManifest{}, err
+		return core.ContextManifest{}, err
 	}
 	return service.repository.FindContextManifest(ctx, actor.UserID, runID)
 }
 
-func (service *RunService) GetToolCalls(
+func (service *Service) GetToolCalls(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	runID string,
-) ([]ToolCallRecord, error) {
+) ([]core.ToolCallRecord, error) {
 	if !actor.Valid() || !core.ValidUUID(runID) {
-		return nil, ErrNotFound
+		return nil, core.ErrNotFound
 	}
 	if _, err := service.repository.FindRun(
 		ctx,
@@ -462,7 +461,7 @@ func (service *RunService) GetToolCalls(
 	return service.repository.ListToolCalls(ctx, actor.UserID, runID)
 }
 
-func (service *RunService) RecoverInterruptedRuns(
+func (service *Service) RecoverInterruptedRuns(
 	ctx context.Context,
 ) (int64, error) {
 	return service.repository.RecoverInterruptedRuns(ctx)
@@ -471,28 +470,28 @@ func (service *RunService) RecoverInterruptedRuns(
 // ProcessPending resumes a Run that was atomically created by another
 // Agent-owned input workflow, such as voice-candidate confirmation. It does
 // not create or mutate the input Message itself.
-func (service *RunService) ProcessPending(
+func (service *Service) ProcessPending(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
-) (Run, error) {
+	run core.Run,
+) (core.Run, error) {
 	if ctx == nil || !actor.Valid() ||
 		run.OwnerID != actor.UserID ||
 		!core.ValidUUID(run.ID) ||
 		!core.ValidUUID(run.ThreadID) ||
 		!core.ValidUUID(run.InputMessageID) {
-		return Run{}, ErrInvalidRequest
+		return core.Run{}, core.ErrInvalidRequest
 	}
 	return service.process(ctx, actor, run, nil)
 }
 
-func (service *RunService) process(
+func (service *Service) process(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
+	run core.Run,
 	observer *countingDeltaObserver,
-) (Run, error) {
-	if run.Status != RunStatusPending {
+) (core.Run, error) {
+	if run.Status != core.RunStatusPending {
 		return run, nil
 	}
 	claimed, acquired, err := service.repository.ClaimRun(
@@ -501,7 +500,7 @@ func (service *RunService) process(
 		run.ID,
 	)
 	if err != nil {
-		return Run{}, err
+		return core.Run{}, err
 	}
 	if !acquired {
 		return claimed, nil
@@ -512,12 +511,12 @@ func (service *RunService) process(
 			actor.UserID,
 			claimed.ID,
 			claimed.WorkerLeaseToken,
-			RunFailureConfigurationDrift,
+			core.RunFailureConfigurationDrift,
 			true,
 		)
 		service.logRunFailed(
 			claimed,
-			RunFailureConfigurationDrift,
+			core.RunFailureConfigurationDrift,
 			true,
 			claimed.StartedAt,
 		)
@@ -531,10 +530,10 @@ func (service *RunService) process(
 		service.configuration,
 	)
 	if err != nil {
-		kind := RunFailureInternal
+		kind := core.RunFailureInternal
 		retryable := true
-		if errors.Is(err, ErrInvalidContext) {
-			kind = RunFailureInvalidContext
+		if errors.Is(err, core.ErrInvalidContext) {
+			kind = core.RunFailureInvalidContext
 			retryable = false
 		}
 		failed, failErr := service.persistFailure(
@@ -557,11 +556,11 @@ func (service *RunService) process(
 			actor.UserID,
 			claimed.ID,
 			claimed.WorkerLeaseToken,
-			RunFailureInternal,
+			core.RunFailureInternal,
 			true,
 		)
 		if failErr != nil {
-			return Run{}, err
+			return core.Run{}, err
 		}
 		return failed, nil
 	}
@@ -644,21 +643,21 @@ func (service *RunService) process(
 	return completed, err
 }
 
-func (service *RunService) generate(
+func (service *Service) generate(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
-	manifest ContextManifest,
+	run core.Run,
+	manifest core.ContextManifest,
 	request ai.TextRequest,
 ) (ai.TextResult, error) {
 	return service.generateObserved(ctx, actor, run, manifest, request, nil)
 }
 
-func (service *RunService) generateObserved(
+func (service *Service) generateObserved(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
-	manifest ContextManifest,
+	run core.Run,
+	manifest core.ContextManifest,
 	request ai.TextRequest,
 	observer *countingDeltaObserver,
 ) (ai.TextResult, error) {
@@ -918,7 +917,7 @@ func (service *RunService) generateObserved(
 	}
 }
 
-func (service *RunService) generateModel(
+func (service *Service) generateModel(
 	ctx context.Context,
 	request ai.TextRequest,
 	observer ai.TextDeltaObserver,
@@ -940,7 +939,7 @@ func (service *RunService) generateModel(
 }
 
 type countingDeltaObserver struct {
-	delegate RunStreamObserver
+	delegate core.RunStreamObserver
 	count    int
 }
 
@@ -958,10 +957,10 @@ func (observer *countingDeltaObserver) OnTextDelta(
 	return nil
 }
 
-func (service *RunService) executeToolCall(
+func (service *Service) executeToolCall(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	run Run,
+	run core.Run,
 	call ai.ToolCall,
 ) (ai.TextMessage, error) {
 	toolCtx, cancel := context.WithTimeout(ctx, service.loopLimits.ToolTimeout)
@@ -1046,9 +1045,9 @@ func (service *RunService) executeToolCall(
 	}, nil
 }
 
-func (service *RunService) saveToolCallProposed(
+func (service *Service) saveToolCallProposed(
 	ctx context.Context,
-	run Run,
+	run core.Run,
 	call ai.ToolCall,
 ) error {
 	if service.repository == nil {
@@ -1070,9 +1069,9 @@ func (service *RunService) saveToolCallProposed(
 	return err
 }
 
-func (service *RunService) markToolCallRejected(
+func (service *Service) markToolCallRejected(
 	ctx context.Context,
-	run Run,
+	run core.Run,
 	toolCallID string,
 	errorCategory string,
 ) error {
@@ -1090,9 +1089,9 @@ func (service *RunService) markToolCallRejected(
 	return err
 }
 
-func (service *RunService) saveContextToolSnapshot(
+func (service *Service) saveContextToolSnapshot(
 	ctx context.Context,
-	manifest ContextManifest,
+	manifest core.ContextManifest,
 ) error {
 	if service.repository == nil {
 		return nil
@@ -1143,8 +1142,8 @@ func toolSchemaHashes(definitions []ai.ToolDefinition) map[string]string {
 	return hashes
 }
 
-func (service *RunService) logRunReceived(
-	run Run,
+func (service *Service) logRunReceived(
+	run core.Run,
 	input string,
 	request ai.TextRequest,
 ) {
@@ -1182,8 +1181,8 @@ func textRequestImageCount(request ai.TextRequest) int {
 	return count
 }
 
-func (service *RunService) logLoopIteration(
-	run Run,
+func (service *Service) logLoopIteration(
+	run core.Run,
 	iteration int,
 	toolCallCount int,
 ) {
@@ -1200,8 +1199,8 @@ func (service *RunService) logLoopIteration(
 	)
 }
 
-func (service *RunService) logRoutingDecision(
-	run Run,
+func (service *Service) logRoutingDecision(
+	run core.Run,
 	decision string,
 	selectedTools []string,
 	reasonCode string,
@@ -1223,8 +1222,8 @@ func (service *RunService) logRoutingDecision(
 	)
 }
 
-func (service *RunService) logRunCompleted(
-	run Run,
+func (service *Service) logRunCompleted(
+	run core.Run,
 	decision string,
 	iterations int,
 	toolCallCount int,
@@ -1246,8 +1245,8 @@ func (service *RunService) logRunCompleted(
 	)
 }
 
-func (service *RunService) logRunFailed(
-	run Run,
+func (service *Service) logRunFailed(
+	run core.Run,
 	kind string,
 	retryable bool,
 	startedAt time.Time,
@@ -1265,8 +1264,8 @@ func (service *RunService) logRunFailed(
 	)
 }
 
-func (service *RunService) logInvalidModelResult(
-	run Run,
+func (service *Service) logInvalidModelResult(
+	run core.Run,
 	result ai.TextResult,
 ) {
 	if service.logger == nil {
@@ -1299,14 +1298,14 @@ func (service *RunService) logInvalidModelResult(
 	)
 }
 
-func (service *RunService) persistFailure(
+func (service *Service) persistFailure(
 	ctx context.Context,
 	ownerID string,
 	runID string,
 	workerLeaseToken string,
 	kind string,
 	retryable bool,
-) (Run, error) {
+) (core.Run, error) {
 	persistContext, cancel := runPersistenceContext(ctx)
 	defer cancel()
 	return service.repository.FailRun(
@@ -1381,8 +1380,8 @@ func validTokenUsage(usage ai.TokenUsage) bool {
 }
 
 func runConfigurationMatches(
-	run Run,
-	configuration RunConfiguration,
+	run core.Run,
+	configuration core.RunConfiguration,
 ) bool {
 	return run.RequestedProvider == configuration.Provider &&
 		run.RequestedModel == configuration.Model &&
@@ -1424,7 +1423,7 @@ func normalizeLoopLimits(limits LoopLimits) LoopLimits {
 	return limits
 }
 
-func (service *RunService) parseCommand(input string) (command.Parsed, bool, error) {
+func (service *Service) parseCommand(input string) (command.Parsed, bool, error) {
 	if service.commands == nil {
 		return command.Parsed{}, false, nil
 	}
@@ -1438,7 +1437,7 @@ func requestsLatestPracticeReport(input string) bool {
 	)
 }
 
-func (service *RunService) toolDefinition(name string) (tool.Definition, bool) {
+func (service *Service) toolDefinition(name string) (tool.Definition, bool) {
 	if service.registry == nil {
 		return tool.Definition{}, false
 	}
@@ -1454,7 +1453,7 @@ func toolCallRequestID(runID string, toolCallID string) string {
 	return runID + "-" + toolCallID
 }
 
-func (service *RunService) writeToolCallCount(
+func (service *Service) writeToolCallCount(
 	calls []ai.ToolCall,
 ) int {
 	count := 0
@@ -1480,8 +1479,8 @@ func toolCallMayWrite(call ai.ToolCall) bool {
 		input.PreparationSnapshotID != "") && input.MaxEffectiveTurns > 0
 }
 
-func (service *RunService) loopBudgetFallback(
-	run Run,
+func (service *Service) loopBudgetFallback(
+	run core.Run,
 	content string,
 	modelIterations int,
 	toolCalls int,
@@ -1585,7 +1584,7 @@ func toolExposed(exposed map[string]struct{}, name string) bool {
 }
 
 func fallbackResult(
-	configuration RunConfiguration,
+	configuration core.RunConfiguration,
 	content string,
 ) ai.TextResult {
 	return ai.TextResult{

--- a/server/internal/agent/run/service_test.go
+++ b/server/internal/agent/run/service_test.go
@@ -1,22 +1,26 @@
-package runtime
+package run
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
+)
 
 func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
-	configuration := RunConfiguration{
+	configuration := core.RunConfiguration{
 		Provider:           "qianwen",
 		Model:              "qwen-test",
 		MaxOutputTokens:    512,
 		MaxInputCharacters: 12000,
 	}
-	run := Run{
+	run := core.Run{
 		RequestedProvider:  configuration.Provider,
 		RequestedModel:     configuration.Model,
 		MaxOutputTokens:    configuration.MaxOutputTokens,
 		MaxInputCharacters: configuration.MaxInputCharacters,
 	}
 	tests := map[string]struct {
-		configuration RunConfiguration
+		configuration core.RunConfiguration
 		want          bool
 	}{
 		"matches": {
@@ -24,7 +28,7 @@ func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
 			want:          true,
 		},
 		"provider drift": {
-			configuration: func() RunConfiguration {
+			configuration: func() core.RunConfiguration {
 				changed := configuration
 				changed.Provider = "qianwen_next"
 				return changed
@@ -32,7 +36,7 @@ func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
 			want: false,
 		},
 		"model drift": {
-			configuration: func() RunConfiguration {
+			configuration: func() core.RunConfiguration {
 				changed := configuration
 				changed.Model = "qwen-next"
 				return changed
@@ -40,7 +44,7 @@ func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
 			want: false,
 		},
 		"output budget drift": {
-			configuration: func() RunConfiguration {
+			configuration: func() core.RunConfiguration {
 				changed := configuration
 				changed.MaxOutputTokens++
 				return changed
@@ -48,7 +52,7 @@ func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
 			want: false,
 		},
 		"context budget drift": {
-			configuration: func() RunConfiguration {
+			configuration: func() core.RunConfiguration {
 				changed := configuration
 				changed.MaxInputCharacters++
 				return changed

--- a/server/internal/agent/run/tool_routing.go
+++ b/server/internal/agent/run/tool_routing.go
@@ -1,8 +1,9 @@
-package runtime
+package run
 
 import (
 	"log/slog"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
 )
@@ -54,7 +55,7 @@ func buildModelToolRouting(
 }
 
 func applyModelToolSnapshot(
-	manifest *ContextManifest,
+	manifest *core.ContextManifest,
 	routing modelToolRouting,
 ) {
 	manifest.ExposedTools = exposedToolNameList(routing.Definitions)

--- a/server/internal/agent/run/tool_routing_test.go
+++ b/server/internal/agent/run/tool_routing_test.go
@@ -1,4 +1,4 @@
-package runtime
+package run
 
 import (
 	"bytes"

--- a/server/internal/agent/test_facade_test.go
+++ b/server/internal/agent/test_facade_test.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	agentapp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/app"
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	agentpersistence "github.com/1024XEngineer/XE3-ESL/server/internal/agent/persistence"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
 	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
 	agenttransport "github.com/1024XEngineer/XE3-ESL/server/internal/agent/transport"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/voice"
@@ -58,15 +59,15 @@ type RunRepository = core.RunRepository
 type RunApplication = core.RunApplication
 type IDGenerator = core.IDGenerator
 type Service = agentapp.Service
-type ContextRepository = agentruntime.ContextRepository
-type ContextAssembler = agentruntime.ContextAssembler
-type MemorySearchRequest = agentruntime.MemorySearchRequest
-type MemorySearchHit = agentruntime.MemorySearchHit
-type MemorySearcher = agentruntime.MemorySearcher
-type StableProfileReadRequest = agentruntime.StableProfileReadRequest
-type StableProfileMemory = agentruntime.StableProfileMemory
-type StableProfileReader = agentruntime.StableProfileReader
-type RunService = agentruntime.RunService
+type ContextRepository = agentcontext.Repository
+type ContextAssembler = agentcontext.Assembler
+type MemorySearchRequest = agentcontext.MemorySearchRequest
+type MemorySearchHit = agentcontext.MemorySearchHit
+type MemorySearcher = agentcontext.MemorySearcher
+type StableProfileReadRequest = agentcontext.StableProfileReadRequest
+type StableProfileMemory = agentcontext.StableProfileMemory
+type StableProfileReader = agentcontext.StableProfileReader
+type RunService = agentrun.Service
 type PostgreSQL = agentpersistence.PostgreSQL
 type PostgresRepository = agentpersistence.PostgresRepository
 
@@ -148,9 +149,9 @@ var (
 	ErrVoiceCandidateStale      = core.ErrVoiceCandidateStale
 	ErrVoiceCleanupPending      = core.ErrVoiceCleanupPending
 	NewService                  = agentapp.NewService
-	NewContextAssembler         = agentruntime.NewContextAssembler
-	NewRunService               = agentruntime.NewRunService
-	WithToolRegistry            = agentruntime.WithToolRegistry
+	NewContextAssembler         = agentcontext.NewAssembler
+	NewRunService               = agentrun.NewService
+	WithToolRegistry            = agentrun.WithToolRegistry
 	NewPostgresRepository       = agentpersistence.NewPostgresRepository
 	NewSummaryService           = agentsummary.NewService
 	NewVoiceMessageService      = agentvoice.NewVoiceMessageService

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	agentapp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/app"
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/core"
 	agentimage "github.com/1024XEngineer/XE3-ESL/server/internal/agent/image"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
 	agentpersistence "github.com/1024XEngineer/XE3-ESL/server/internal/agent/persistence"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
 	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/summary"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	agenttransport "github.com/1024XEngineer/XE3-ESL/server/internal/agent/transport"
@@ -79,7 +80,7 @@ type identityAgentComposition struct {
 	agentImageReclaimer AgentImageObjectReclaimer
 	matterService       *matter.Service
 	productionTools     *tool.Registry
-	runService          *agentruntime.RunService
+	runService          *agentrun.Service
 	memoryExtraction    memory.ExtractionProcessor
 	summaryProcessor    agentsummary.Processor
 	ids                 *identity.UUIDv4Generator
@@ -192,14 +193,14 @@ func buildIdentityAgentComposition(
 	if err != nil {
 		return nil, err
 	}
-	var contextOptions []agentruntime.ContextAssemblerOption
+	var contextOptions []agentcontext.Option
 	if agentImages != nil {
 		contextOptions = append(
 			contextOptions,
-			agentruntime.WithImageContextReader(agentImages),
+			agentcontext.WithImageReader(agentImages),
 		)
 	}
-	contextAssembler, err := agentruntime.NewContextAssembler(
+	contextAssembler, err := agentcontext.NewAssembler(
 		agentRepository,
 		matterService,
 		stableProfileReader,
@@ -238,7 +239,7 @@ func buildIdentityAgentComposition(
 			return nil, err
 		}
 	}
-	runService, err := agentruntime.NewRunService(
+	runService, err := agentrun.NewService(
 		runRepository,
 		contextAssembler,
 		generator,

--- a/server/internal/bootstrap/agent_tools.go
+++ b/server/internal/bootstrap/agent_tools.go
@@ -5,52 +5,52 @@ import (
 	"log/slog"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/mocktool"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 )
 
-type agentToolRuntimeOptions struct {
-	runOptions         []agentruntime.RunServiceOption
+type agentRunOptions struct {
+	runOptions         []agentrun.Option
 	productionRegistry *tool.Registry
 }
 
 func agentRunServiceOptions(
 	productionRegistry *tool.Registry,
-) (agentToolRuntimeOptions, error) {
+) (agentRunOptions, error) {
 	if productionRegistry == nil {
-		return agentToolRuntimeOptions{},
+		return agentRunOptions{},
 			errors.New("bootstrap: production Agent tool registry is required")
 	}
 	toolConfig, err := config.LoadAgentTool()
 	if err != nil {
-		return agentToolRuntimeOptions{}, err
+		return agentRunOptions{}, err
 	}
-	options := []agentruntime.RunServiceOption{
-		agentruntime.WithRunLogger(slog.Default()),
+	options := []agentrun.Option{
+		agentrun.WithRunLogger(slog.Default()),
 	}
 	if !toolConfig.FixturesEnabled {
 		options = append(
 			options,
-			agentruntime.WithToolRegistry(productionRegistry),
+			agentrun.WithToolRegistry(productionRegistry),
 		)
-		return agentToolRuntimeOptions{
+		return agentRunOptions{
 			runOptions:         options,
 			productionRegistry: productionRegistry,
 		}, nil
 	}
 	if toolConfig.Environment == "production" {
-		return agentToolRuntimeOptions{},
+		return agentRunOptions{},
 			errors.New("bootstrap: Agent tool fixtures are disabled in production")
 	}
 	registry, err := mocktool.NewRegistry(mocktool.NewStore())
 	if err != nil {
-		return agentToolRuntimeOptions{}, err
+		return agentRunOptions{}, err
 	}
 	slog.Info(
 		"agent tool fixtures enabled",
 		slog.Int("tool_count", len(registry.Definitions())),
 	)
-	options = append(options, agentruntime.WithToolRegistry(registry))
-	return agentToolRuntimeOptions{runOptions: options}, nil
+	options = append(options, agentrun.WithToolRegistry(registry))
+	return agentRunOptions{runOptions: options}, nil
 }

--- a/server/internal/bootstrap/memory_context.go
+++ b/server/internal/bootstrap/memory_context.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
 )
 
 type agentMemoryContextSearcher struct {
@@ -25,8 +25,8 @@ func newAgentMemoryContextSearcher(
 
 func (searcher *agentMemoryContextSearcher) Search(
 	ctx context.Context,
-	request agentruntime.MemorySearchRequest,
-) ([]agentruntime.MemorySearchHit, error) {
+	request agentcontext.MemorySearchRequest,
+) ([]agentcontext.MemorySearchHit, error) {
 	if searcher == nil || searcher.searcher == nil {
 		return nil, errors.New(
 			"bootstrap: Memory Context search dependency is required",
@@ -42,9 +42,9 @@ func (searcher *agentMemoryContextSearcher) Search(
 	if err != nil {
 		return nil, err
 	}
-	result := make([]agentruntime.MemorySearchHit, 0, len(hits))
+	result := make([]agentcontext.MemorySearchHit, 0, len(hits))
 	for _, hit := range hits {
-		result = append(result, agentruntime.MemorySearchHit{
+		result = append(result, agentcontext.MemorySearchHit{
 			MemoryID:               hit.MemoryID,
 			MemoryVersion:          hit.MemoryVersion,
 			CanonicalKey:           hit.CanonicalKey,
@@ -64,4 +64,4 @@ func (searcher *agentMemoryContextSearcher) Search(
 	return result, nil
 }
 
-var _ agentruntime.MemorySearcher = (*agentMemoryContextSearcher)(nil)
+var _ agentcontext.MemorySearcher = (*agentMemoryContextSearcher)(nil)

--- a/server/internal/bootstrap/memory_context_test.go
+++ b/server/internal/bootstrap/memory_context_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
@@ -34,7 +34,7 @@ func TestAgentMemoryContextSearcherPreservesSearchAuditFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAgentMemoryContextSearcher: %v", err)
 	}
-	request := agentruntime.MemorySearchRequest{
+	request := agentcontext.MemorySearchRequest{
 		Actor: requestcontext.Actor{
 			UserID:    "30000000-0000-4000-8000-000000000001",
 			SessionID: "40000000-0000-4000-8000-000000000001",
@@ -90,7 +90,7 @@ func TestAgentMemoryContextSearcherRequiresDependencyAndPropagatesFailure(
 	}
 	if _, err := adapter.Search(
 		context.Background(),
-		agentruntime.MemorySearchRequest{},
+		agentcontext.MemorySearchRequest{},
 	); !errors.Is(err, dependencyError) {
 		t.Fatalf("Search error = %v", err)
 	}

--- a/server/internal/bootstrap/stable_profile.go
+++ b/server/internal/bootstrap/stable_profile.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
 )
 
 type agentStableProfileReader struct {
@@ -25,8 +25,8 @@ func newAgentStableProfileReader(
 
 func (reader *agentStableProfileReader) ReadStableProfile(
 	ctx context.Context,
-	request agentruntime.StableProfileReadRequest,
-) ([]agentruntime.StableProfileMemory, error) {
+	request agentcontext.StableProfileReadRequest,
+) ([]agentcontext.StableProfileMemory, error) {
 	if reader == nil || reader.reader == nil {
 		return nil, errors.New(
 			"bootstrap: Stable Profile read dependency is required",
@@ -42,9 +42,9 @@ func (reader *agentStableProfileReader) ReadStableProfile(
 	if !memory.ValidStableProfileMemories(items, request.Actor.UserID) {
 		return nil, memory.ErrRepository
 	}
-	result := make([]agentruntime.StableProfileMemory, 0, len(items))
+	result := make([]agentcontext.StableProfileMemory, 0, len(items))
 	for _, item := range items {
-		mapped := agentruntime.StableProfileMemory{
+		mapped := agentcontext.StableProfileMemory{
 			MemoryID:      item.ID,
 			MemoryVersion: item.Version,
 			CanonicalKey:  item.CanonicalKey,
@@ -60,4 +60,4 @@ func (reader *agentStableProfileReader) ReadStableProfile(
 	return result, nil
 }
 
-var _ agentruntime.StableProfileReader = (*agentStableProfileReader)(nil)
+var _ agentcontext.StableProfileReader = (*agentStableProfileReader)(nil)

--- a/server/internal/bootstrap/stable_profile_test.go
+++ b/server/internal/bootstrap/stable_profile_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	agentcontext "github.com/1024XEngineer/XE3-ESL/server/internal/agent/context"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
-	agentruntime "github.com/1024XEngineer/XE3-ESL/server/internal/agent/runtime"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
@@ -34,7 +34,7 @@ func TestAgentStableProfileReaderPreservesFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAgentStableProfileReader: %v", err)
 	}
-	request := agentruntime.StableProfileReadRequest{Actor: actor}
+	request := agentcontext.StableProfileReadRequest{Actor: actor}
 	items, err := adapter.ReadStableProfile(context.Background(), request)
 	if err != nil {
 		t.Fatalf("ReadStableProfile: %v", err)
@@ -64,7 +64,7 @@ func TestAgentStableProfileReaderAcceptsEmptyProfile(t *testing.T) {
 	}
 	items, err := adapter.ReadStableProfile(
 		context.Background(),
-		agentruntime.StableProfileReadRequest{Actor: stableProfileActor()},
+		agentcontext.StableProfileReadRequest{Actor: stableProfileActor()},
 	)
 	if err != nil {
 		t.Fatalf("ReadStableProfile: %v", err)
@@ -98,7 +98,7 @@ func TestAgentStableProfileReaderRejectsInvalidDomainResult(t *testing.T) {
 	}
 	if _, err := adapter.ReadStableProfile(
 		context.Background(),
-		agentruntime.StableProfileReadRequest{Actor: actor},
+		agentcontext.StableProfileReadRequest{Actor: actor},
 	); !errors.Is(err, memory.ErrRepository) {
 		t.Fatalf("invalid domain result error = %v", err)
 	}
@@ -121,13 +121,13 @@ func TestAgentStableProfileReaderRequiresDependencyAndPropagatesFailure(
 	}
 	if _, err := adapter.ReadStableProfile(
 		context.Background(),
-		agentruntime.StableProfileReadRequest{Actor: stableProfileActor()},
+		agentcontext.StableProfileReadRequest{Actor: stableProfileActor()},
 	); !errors.Is(err, dependencyError) {
 		t.Fatalf("ReadStableProfile error = %v", err)
 	}
 	if _, err := adapter.ReadStableProfile(
 		context.Background(),
-		agentruntime.StableProfileReadRequest{},
+		agentcontext.StableProfileReadRequest{},
 	); !errors.Is(err, memory.ErrInvalidArgument) {
 		t.Fatalf("invalid request error = %v", err)
 	}


### PR DESCRIPTION
## 功能描述

基于现有 Agent 执行链建立 Context 与 Run 的代码权威位置：

- `server/internal/agent/context` 负责 History、Summary、Stable Profile、Relevant Memory 和图片上下文的选择与预算；
- `server/internal/agent/run` 负责一轮 Run 生命周期、模型循环、工具调用、流式输出和运行审计；
- 原 `server/internal/agent/runtime` 已移除。

## 代码地图

```text
请求入口
server/internal/agent/transport/http.go
  → Thread / Message 应用编排
  server/internal/agent/app
  → 一轮运行与模型循环
  server/internal/agent/run/service.go
  → 本轮上下文组装
  server/internal/agent/context/assembler.go
  → persistence / agent/memory / matter / image / ai
```

依赖方向：

```text
bootstrap → agent/run + agent/context
agent/run → agent/context + agent/core + agent/tool + agent/command
          + practice/agenttool（现有写调用分类） + ai
agent/context → agent/core + agent/image + matter + ai + requestcontext
agent/persistence → agent/core
```

## 实现方式

- 将 4 个 Context 生产文件和 3 个测试文件迁移至 `agent/context`；
- 将 4 个 Run 生产文件和 3 个测试文件迁移至 `agent/run`；
- 删除 `agent/runtime`，一次性更新 Bootstrap、Memory 集成测试和 Agent 测试门面；
- 新包直接使用 `context.Assembler`、`run.Service` 和 `agent/core` 权威类型，不保留生产转发包、re-export 或旧 import；
- 保留 Run 对 `practice/agenttool` 的既有写调用分类行为，后续 Capability 边界切片再处理；
- 不修改 Prompt、上下文预算、工具策略、API、数据库、迁移或运行行为。

## 验证方式

- `cd server && go test -count=1 ./internal/agent/context ./internal/agent/run ./internal/agent ./internal/agent/memory ./internal/bootstrap ./cmd/server`
- 仓库根目录执行 `make check-go`
- `server/internal/agent/runtime` 不存在；全仓不存在旧 Runtime import 或 `package runtime`；
- `agent/context` 不依赖 `agent/run`，`agent/run` 单向依赖 `agent/context`；
- `gofmt -l` 和 `git diff --check` 无输出。

## 关联

- Closes #321
- Agent 架构 Proposal：#316
- 渐进拆分决策：#319
