### PR TITLE
feat(resume): implement GORM persistence

### DIFF
--- a/server/internal/resume/app/errors.go
+++ b/server/internal/resume/app/errors.go
@@ -50,3 +50,13 @@ func NotImplementedError() error {
 	// TODO(issue-320): 各接口完成真实实现后删除该占位错误。
 	return apperror.New(apperror.Unimplemented, "resume_not_implemented", "Resume operation is not implemented yet.")
 }
+
+// RepositoryError 返回不会泄露数据库细节的内部持久化错误。
+func RepositoryError(cause error) error {
+	return apperror.New(
+		apperror.Internal,
+		"internal_error",
+		"An internal error occurred.",
+		apperror.WithCause(cause),
+	)
+}

--- a/server/internal/resume/app/ports.go
+++ b/server/internal/resume/app/ports.go
@@ -38,7 +38,7 @@ type Repository interface {
 	// CompleteParse 原子保存解析修订并完成解析任务。
 	CompleteParse(context.Context, resume.Resume, resume.Revision) error
 	// FailParse 保存解析失败状态和稳定失败码。
-	FailParse(context.Context, string, string) error
+	FailParse(context.Context, resume.Resume, string) error
 }
 
 // FileStorage 定义原始 PDF 文件的保存、读取、授权访问和删除能力。

--- a/server/internal/resume/migration_test.go
+++ b/server/internal/resume/migration_test.go
@@ -1,0 +1,34 @@
+// 本文件验证 Resume 迁移冻结了所有权、三份上限所需锁点和不可变修订边界。
+package resume_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+)
+
+// TestResumeMigrationDefinesOwnedImmutableResources 验证迁移包含关键约束和索引。
+func TestResumeMigrationDefinesOwnedImmutableResources(t *testing.T) {
+	t.Parallel()
+
+	content, err := migrations.Files.ReadFile("000060_resumes.up.sql")
+	if err != nil {
+		t.Fatalf("read Resume migration: %v", err)
+	}
+	sql := strings.ToLower(string(content))
+	for _, required := range []string{
+		"create table resumes",
+		"create table resume_revisions",
+		"resumes_owner_fkey",
+		"resumes_owner_active_updated_idx",
+		"resumes_parse_queue_idx",
+		"resumes_current_revision_fkey",
+		"resume_revisions_immutable",
+		"on delete cascade",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Errorf("Resume migration is missing %q", required)
+		}
+	}
+}

--- a/server/internal/resume/model.go
+++ b/server/internal/resume/model.go
@@ -15,6 +15,7 @@ type Resume struct {
 	ObjectKey        string
 	FileStatus       FileStatus
 	ParseStatus      ParseStatus
+	ParseFailureCode string
 	CurrentRevision  int64
 	Version          int64
 	CreatedAt        time.Time

--- a/server/internal/resume/persistence/gorm.go
+++ b/server/internal/resume/persistence/gorm.go
@@ -1,18 +1,30 @@
-// Package persistence 定义 Resume 模块的 GORM 持久化适配骨架。
+// Package persistence 使用 GORM 实现 Resume 模块的 PostgreSQL 持久化边界。
 package persistence
 
 import (
 	"context"
 	"errors"
+	"regexp"
+	"strings"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	postgresdriver "gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/app"
+)
+
+var (
+	resumeUUIDPattern     = regexp.MustCompile(`\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z`)
+	resumeChecksumPattern = regexp.MustCompile(`\A[0-9a-f]{64}\z`)
+	parseFailurePattern   = regexp.MustCompile(`\A[a-z][a-z0-9_]{0,127}\z`)
 )
 
 // GormRepository 使用进程已有数据库连接池实现 Resume Repository。
@@ -22,7 +34,6 @@ type GormRepository struct {
 
 // NewGormRepository 使用已有 GORM 数据库句柄创建 Repository。
 func NewGormRepository(database *gorm.DB) (*GormRepository, error) {
-	// TODO(issue-320): 在 CRUD 实现完成后补充数据库能力检查。
 	if database == nil {
 		return nil, errors.New("resume: GORM database is required")
 	}
@@ -31,7 +42,6 @@ func NewGormRepository(database *gorm.DB) (*GormRepository, error) {
 
 // NewGormRepositoryFromPool 复用进程已有 pgx 连接池创建 GORM Repository。
 func NewGormRepositoryFromPool(pool *pgxpool.Pool) (*GormRepository, error) {
-	// TODO(issue-320): 在持久化 Issue 中补充连接与事务集成测试。
 	if pool == nil {
 		return nil, errors.New("resume: pgx pool is required")
 	}
@@ -49,87 +59,673 @@ func NewGormRepositoryFromPool(pool *pgxpool.Pool) (*GormRepository, error) {
 }
 
 // CreateWithinLimit 在原子事务中校验三份上限并创建简历记录。
-func (r *GormRepository) CreateWithinLimit(context.Context, resume.Resume, int) error {
-	// TODO(issue-320): 实现按用户加锁、计数、幂等和创建事务。
-	return app.NotImplementedError()
+func (r *GormRepository) CreateWithinLimit(
+	ctx context.Context,
+	item resume.Resume,
+	maximum int,
+) error {
+	if r == nil || r.database == nil || ctx == nil ||
+		!validNewResume(item) || maximum < 1 || maximum > app.MaxResumesPerUser {
+		return app.InvalidResumeError()
+	}
+	record := resumeToRecord(item)
+	if record.Version == 0 {
+		record.Version = 1
+	}
+	err := r.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var owner struct {
+			ID string `gorm:"column:id"`
+		}
+		if err := tx.Table("identity_users").
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Select("id").
+			Where("id = ? AND account_status = ?", item.OwnerUserID, "active").
+			Take(&owner).Error; err != nil {
+			return mapGormError(err)
+		}
+		var count int64
+		if err := tx.Model(&resumeRecord{}).
+			Where("owner_user_id = ?", item.OwnerUserID).
+			Count(&count).Error; err != nil {
+			return mapGormError(err)
+		}
+		if count >= int64(maximum) {
+			return app.ResumeLimitExceededError()
+		}
+		if err := tx.Create(&record).Error; err != nil {
+			return mapGormError(err)
+		}
+		return nil
+	})
+	return mapTransactionError(err)
 }
 
 // ListByOwner 按稳定顺序分页查询当前用户的活动简历。
-func (r *GormRepository) ListByOwner(context.Context, string, app.ListQuery) ([]resume.Resume, error) {
-	// TODO(issue-320): 实现所有权过滤和游标分页。
-	return nil, app.NotImplementedError()
+func (r *GormRepository) ListByOwner(
+	ctx context.Context,
+	ownerUserID string,
+	query app.ListQuery,
+) ([]resume.Resume, error) {
+	if r == nil || r.database == nil || ctx == nil || !validUUID(ownerUserID) ||
+		query.Limit < 1 || query.Limit > app.MaxResumesPerUser ||
+		(query.Cursor != "" && !validUUID(query.Cursor)) {
+		return nil, app.InvalidResumeError()
+	}
+	database := r.database.WithContext(ctx).
+		Where("owner_user_id = ?", ownerUserID)
+	if query.Cursor != "" {
+		database = database.Where("resume_id < ?", query.Cursor)
+	}
+	var records []resumeRecord
+	if err := database.Order("resume_id DESC").Limit(query.Limit).Find(&records).Error; err != nil {
+		return nil, mapGormError(err)
+	}
+	items := make([]resume.Resume, 0, len(records))
+	for _, record := range records {
+		item, err := resumeFromRecord(record)
+		if err != nil {
+			return nil, app.RepositoryError(err)
+		}
+		items = append(items, item)
+	}
+	return items, nil
 }
 
 // FindByOwnerAndID 查询当前用户拥有的指定简历元数据。
-func (r *GormRepository) FindByOwnerAndID(context.Context, string, string) (resume.Resume, error) {
-	// TODO(issue-320): 实现 owner_user_id 与 resume_id 联合过滤。
-	return resume.Resume{}, app.NotImplementedError()
+func (r *GormRepository) FindByOwnerAndID(
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+) (resume.Resume, error) {
+	if r == nil || r.database == nil || ctx == nil ||
+		!validUUID(ownerUserID) || !validUUID(resumeID) {
+		return resume.Resume{}, app.ResumeNotFoundError()
+	}
+	var record resumeRecord
+	if err := r.database.WithContext(ctx).
+		Where("owner_user_id = ? AND resume_id = ?", ownerUserID, resumeID).
+		Take(&record).Error; err != nil {
+		return resume.Resume{}, mapGormError(err)
+	}
+	item, err := resumeFromRecord(record)
+	if err != nil {
+		return resume.Resume{}, app.RepositoryError(err)
+	}
+	return item, nil
 }
 
 // FindDetailByOwnerAndID 查询指定简历和当前内容修订。
-func (r *GormRepository) FindDetailByOwnerAndID(context.Context, string, string) (app.Detail, error) {
-	// TODO(issue-320): 实现元数据与当前修订的一致性读取。
-	return app.Detail{}, app.NotImplementedError()
+func (r *GormRepository) FindDetailByOwnerAndID(
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+) (app.Detail, error) {
+	item, err := r.FindByOwnerAndID(ctx, ownerUserID, resumeID)
+	if err != nil {
+		return app.Detail{}, err
+	}
+	detail := app.Detail{Resume: item}
+	if item.CurrentRevision == 0 {
+		return detail, nil
+	}
+	var record revisionRecord
+	if err := r.database.WithContext(ctx).
+		Where(
+			"owner_user_id = ? AND resume_id = ? AND revision = ?",
+			ownerUserID,
+			resumeID,
+			item.CurrentRevision,
+		).
+		Take(&record).Error; err != nil {
+		return app.Detail{}, mapGormError(err)
+	}
+	revision, err := revisionFromRecord(record)
+	if err != nil {
+		return app.Detail{}, app.RepositoryError(err)
+	}
+	detail.Revision = &revision
+	return detail, nil
 }
 
 // UpdateMetadata 使用期望版本更新简历展示名称。
-func (r *GormRepository) UpdateMetadata(context.Context, string, app.UpdateMetadataCommand) (resume.Resume, error) {
-	// TODO(issue-320): 实现所有权过滤和乐观锁条件更新。
-	return resume.Resume{}, app.NotImplementedError()
+func (r *GormRepository) UpdateMetadata(
+	ctx context.Context,
+	ownerUserID string,
+	command app.UpdateMetadataCommand,
+) (resume.Resume, error) {
+	if !validWriteInput(r, ctx, ownerUserID, command.ResumeID, command.ExpectedVersion) ||
+		!validTitle(command.Title) {
+		return resume.Resume{}, app.InvalidResumeError()
+	}
+	var record resumeRecord
+	result := r.database.WithContext(ctx).
+		Model(&record).
+		Clauses(clause.Returning{}).
+		Where(
+			"owner_user_id = ? AND resume_id = ? AND version = ?",
+			ownerUserID,
+			command.ResumeID,
+			command.ExpectedVersion,
+		).
+		Where("file_status NOT IN ?", []string{string(resume.FileDeleting), string(resume.FileDeleted)}).
+		Updates(map[string]any{
+			"title":      command.Title,
+			"version":    gorm.Expr("version + 1"),
+			"updated_at": nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return resume.Resume{}, mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return resume.Resume{}, r.writeMiss(ctx, ownerUserID, command.ResumeID)
+	}
+	return mappedResume(record)
 }
 
 // ReplaceFileRecord 原子替换文件元数据并重新排队解析任务。
-func (r *GormRepository) ReplaceFileRecord(context.Context, string, app.ReplaceFileRecordCommand) (resume.Resume, error) {
-	// TODO(issue-320): 实现文件版本切换和解析状态重置。
-	return resume.Resume{}, app.NotImplementedError()
+func (r *GormRepository) ReplaceFileRecord(
+	ctx context.Context,
+	ownerUserID string,
+	command app.ReplaceFileRecordCommand,
+) (resume.Resume, error) {
+	if !validWriteInput(r, ctx, ownerUserID, command.ResumeID, command.ExpectedVersion) ||
+		!validFileMetadata(
+			command.Filename,
+			command.ContentType,
+			command.SizeBytes,
+			command.ChecksumSHA256,
+			command.ObjectKey,
+		) {
+		return resume.Resume{}, app.InvalidResumeError()
+	}
+	var record resumeRecord
+	result := r.database.WithContext(ctx).
+		Model(&record).
+		Clauses(clause.Returning{}).
+		Where(
+			"owner_user_id = ? AND resume_id = ? AND version = ?",
+			ownerUserID,
+			command.ResumeID,
+			command.ExpectedVersion,
+		).
+		Where("file_status NOT IN ?", []string{string(resume.FileDeleting), string(resume.FileDeleted)}).
+		Updates(map[string]any{
+			"original_filename":  command.Filename,
+			"content_type":       command.ContentType,
+			"size_bytes":         command.SizeBytes,
+			"checksum_sha256":    command.ChecksumSHA256,
+			"object_key":         command.ObjectKey,
+			"file_status":        string(resume.FileAvailable),
+			"parse_status":       string(resume.ParseQueued),
+			"parse_failure_code": nil,
+			"current_revision":   nil,
+			"version":            gorm.Expr("version + 1"),
+			"updated_at":         nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return resume.Resume{}, mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return resume.Resume{}, r.writeMiss(ctx, ownerUserID, command.ResumeID)
+	}
+	return mappedResume(record)
 }
 
 // MarkFileAvailableAndQueueParse 把已保存文件标记为可用并进入解析队列。
-func (r *GormRepository) MarkFileAvailableAndQueueParse(context.Context, string, string) error {
-	// TODO(issue-320): 实现文件状态与解析状态的原子迁移。
-	return app.NotImplementedError()
+func (r *GormRepository) MarkFileAvailableAndQueueParse(
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+) error {
+	if r == nil || r.database == nil || ctx == nil ||
+		!validUUID(ownerUserID) || !validUUID(resumeID) {
+		return app.InvalidResumeError()
+	}
+	result := r.database.WithContext(ctx).
+		Model(&resumeRecord{}).
+		Where("owner_user_id = ? AND resume_id = ?", ownerUserID, resumeID).
+		Where("file_status = ?", string(resume.FileUploading)).
+		Updates(map[string]any{
+			"file_status":  string(resume.FileAvailable),
+			"parse_status": string(resume.ParseQueued),
+			"version":      gorm.Expr("version + 1"),
+			"updated_at":   nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return r.writeMiss(ctx, ownerUserID, resumeID)
+	}
+	return nil
 }
 
 // SaveManualRevision 创建用户手动内容修订并更新当前修订指针。
-func (r *GormRepository) SaveManualRevision(context.Context, string, app.UpdateContentCommand) (resume.Revision, error) {
-	// TODO(issue-320): 实现不可变修订插入和聚合版本更新。
-	return resume.Revision{}, app.NotImplementedError()
+func (r *GormRepository) SaveManualRevision(
+	ctx context.Context,
+	ownerUserID string,
+	command app.UpdateContentCommand,
+) (resume.Revision, error) {
+	if !validWriteInput(r, ctx, ownerUserID, command.ResumeID, command.ExpectedVersion) {
+		return resume.Revision{}, app.InvalidResumeError()
+	}
+	var saved resume.Revision
+	err := r.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		record, err := lockOwnedResume(tx, ownerUserID, command.ResumeID)
+		if err != nil {
+			return err
+		}
+		if record.Version != command.ExpectedVersion ||
+			record.FileStatus == string(resume.FileDeleting) ||
+			record.FileStatus == string(resume.FileDeleted) {
+			return app.ResumeVersionConflictError()
+		}
+		nextRevision, err := nextRevision(tx, command.ResumeID)
+		if err != nil {
+			return err
+		}
+		saved = resume.Revision{
+			ResumeID:  command.ResumeID,
+			Revision:  nextRevision,
+			Source:    resume.RevisionManual,
+			Content:   command.Content,
+			CreatedAt: time.Now().UTC(),
+		}
+		revisionRecord, err := revisionToRecord(saved)
+		if err != nil {
+			return app.InvalidResumeError()
+		}
+		revisionRecord.OwnerUserID = ownerUserID
+		if err := tx.Create(&revisionRecord).Error; err != nil {
+			return mapGormError(err)
+		}
+		result := tx.Model(&resumeRecord{}).
+			Where("owner_user_id = ? AND resume_id = ?", ownerUserID, command.ResumeID).
+			Updates(map[string]any{
+				"current_revision": nextRevision,
+				"version":          gorm.Expr("version + 1"),
+				"updated_at":       nextResumeTimestamp(),
+			})
+		if result.Error != nil {
+			return mapGormError(result.Error)
+		}
+		return nil
+	})
+	if err != nil {
+		return resume.Revision{}, mapTransactionError(err)
+	}
+	return saved, nil
 }
 
 // MarkDeleting 使用期望版本把简历标记为删除中。
-func (r *GormRepository) MarkDeleting(context.Context, string, app.DeleteCommand) (resume.Resume, error) {
-	// TODO(issue-320): 实现删除状态迁移和乐观锁。
-	return resume.Resume{}, app.NotImplementedError()
+func (r *GormRepository) MarkDeleting(
+	ctx context.Context,
+	ownerUserID string,
+	command app.DeleteCommand,
+) (resume.Resume, error) {
+	if !validWriteInput(r, ctx, ownerUserID, command.ResumeID, command.ExpectedVersion) {
+		return resume.Resume{}, app.InvalidResumeError()
+	}
+	var record resumeRecord
+	result := r.database.WithContext(ctx).
+		Model(&record).
+		Clauses(clause.Returning{}).
+		Where(
+			"owner_user_id = ? AND resume_id = ? AND version = ?",
+			ownerUserID,
+			command.ResumeID,
+			command.ExpectedVersion,
+		).
+		Where("file_status NOT IN ?", []string{string(resume.FileDeleting), string(resume.FileDeleted)}).
+		Updates(map[string]any{
+			"file_status": string(resume.FileDeleting),
+			"version":     gorm.Expr("version + 1"),
+			"updated_at":  nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return resume.Resume{}, mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return resume.Resume{}, r.writeMiss(ctx, ownerUserID, command.ResumeID)
+	}
+	return mappedResume(record)
 }
 
 // MarkDeleted 完成简历软删除状态写入。
-func (r *GormRepository) MarkDeleted(context.Context, string, string) error {
-	// TODO(issue-320): 实现删除完成和解析任务失效。
-	return app.NotImplementedError()
+func (r *GormRepository) MarkDeleted(
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+) error {
+	if r == nil || r.database == nil || ctx == nil ||
+		!validUUID(ownerUserID) || !validUUID(resumeID) {
+		return app.ResumeNotFoundError()
+	}
+	now := time.Now().UTC()
+	result := r.database.WithContext(ctx).
+		Model(&resumeRecord{}).
+		Where("owner_user_id = ? AND resume_id = ?", ownerUserID, resumeID).
+		Where("file_status = ?", string(resume.FileDeleting)).
+		Updates(map[string]any{
+			"file_status": string(resume.FileDeleted),
+			"deleted_at":  now,
+			"version":     gorm.Expr("version + 1"),
+			"updated_at":  nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return r.writeMiss(ctx, ownerUserID, resumeID)
+	}
+	return nil
 }
 
 // QueueParse 把当前用户指定的失败简历重新放入解析队列。
-func (r *GormRepository) QueueParse(context.Context, string, string) error {
-	// TODO(issue-320): 实现可重试状态校验和幂等入队。
-	return app.NotImplementedError()
+func (r *GormRepository) QueueParse(
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+) error {
+	if r == nil || r.database == nil || ctx == nil ||
+		!validUUID(ownerUserID) || !validUUID(resumeID) {
+		return app.InvalidResumeError()
+	}
+	result := r.database.WithContext(ctx).
+		Model(&resumeRecord{}).
+		Where("owner_user_id = ? AND resume_id = ?", ownerUserID, resumeID).
+		Where("file_status = ? AND parse_status = ?", string(resume.FileAvailable), string(resume.ParseFailed)).
+		Updates(map[string]any{
+			"parse_status":       string(resume.ParseQueued),
+			"parse_failure_code": nil,
+			"version":            gorm.Expr("version + 1"),
+			"updated_at":         nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return r.writeMiss(ctx, ownerUserID, resumeID)
+	}
+	return nil
 }
 
 // ClaimNextQueuedParse 领取下一份等待解析的简历任务。
-func (r *GormRepository) ClaimNextQueuedParse(context.Context) (resume.Resume, bool, error) {
-	// TODO(issue-320): 实现跳过锁定、租约和并发 Worker 防重。
-	return resume.Resume{}, false, app.NotImplementedError()
+func (r *GormRepository) ClaimNextQueuedParse(
+	ctx context.Context,
+) (resume.Resume, bool, error) {
+	if r == nil || r.database == nil || ctx == nil {
+		return resume.Resume{}, false, app.InvalidResumeError()
+	}
+	var claimed resume.Resume
+	found := false
+	err := r.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var record resumeRecord
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Where("file_status = ? AND parse_status = ?", string(resume.FileAvailable), string(resume.ParseQueued)).
+			Order("updated_at, resume_id").
+			Take(&record).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		if err != nil {
+			return mapGormError(err)
+		}
+		if err := tx.Model(&record).Clauses(clause.Returning{}).Updates(map[string]any{
+			"parse_status": string(resume.ParseRunning),
+			"version":      gorm.Expr("version + 1"),
+			"updated_at":   nextResumeTimestamp(),
+		}).Error; err != nil {
+			return mapGormError(err)
+		}
+		mapped, err := resumeFromRecord(record)
+		if err != nil {
+			return app.RepositoryError(err)
+		}
+		claimed = mapped
+		found = true
+		return nil
+	})
+	if err != nil {
+		return resume.Resume{}, false, mapTransactionError(err)
+	}
+	return claimed, found, nil
 }
 
 // CompleteParse 保存解析修订并把简历标记为解析完成。
-func (r *GormRepository) CompleteParse(context.Context, resume.Resume, resume.Revision) error {
-	// TODO(issue-320): 实现修订写入和当前修订指针原子更新。
-	return app.NotImplementedError()
+func (r *GormRepository) CompleteParse(
+	ctx context.Context,
+	claimed resume.Resume,
+	revision resume.Revision,
+) error {
+	if r == nil || r.database == nil || ctx == nil || !validUUID(claimed.OwnerUserID) ||
+		!validUUID(claimed.ID) || claimed.Version < 1 || revision.Source != resume.RevisionParser ||
+		strings.TrimSpace(revision.ParserVersion) == "" {
+		return app.InvalidResumeError()
+	}
+	return mapTransactionError(r.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		record, err := lockOwnedResume(tx, claimed.OwnerUserID, claimed.ID)
+		if err != nil {
+			return err
+		}
+		if record.FileStatus != string(resume.FileAvailable) ||
+			record.ParseStatus != string(resume.ParseRunning) ||
+			record.ObjectKey != claimed.ObjectKey ||
+			record.ChecksumSHA256 != claimed.ChecksumSHA256 {
+			return app.ResumeVersionConflictError()
+		}
+		number, err := nextRevision(tx, claimed.ID)
+		if err != nil {
+			return err
+		}
+		revision.ResumeID = claimed.ID
+		revision.Revision = number
+		if revision.CreatedAt.IsZero() {
+			revision.CreatedAt = time.Now().UTC()
+		}
+		revisionRecord, err := revisionToRecord(revision)
+		if err != nil {
+			return app.InvalidResumeError()
+		}
+		revisionRecord.OwnerUserID = claimed.OwnerUserID
+		if err := tx.Create(&revisionRecord).Error; err != nil {
+			return mapGormError(err)
+		}
+		updates := map[string]any{
+			"parse_status":       string(resume.ParseReady),
+			"parse_failure_code": nil,
+			"version":            gorm.Expr("version + 1"),
+			"updated_at":         nextResumeTimestamp(),
+		}
+		if currentRevision(record.CurrentRevision) == claimed.CurrentRevision {
+			updates["current_revision"] = number
+		}
+		result := tx.Model(&resumeRecord{}).
+			Where("owner_user_id = ? AND resume_id = ?", claimed.OwnerUserID, claimed.ID).
+			Updates(updates)
+		return mapGormError(result.Error)
+	}))
 }
 
-// FailParse 保存稳定失败码并把简历标记为解析失败。
-func (r *GormRepository) FailParse(context.Context, string, string) error {
-	// TODO(issue-320): 实现失败状态、尝试次数和重试边界。
-	return app.NotImplementedError()
+// FailParse 保存稳定失败码并把已领取简历标记为解析失败。
+func (r *GormRepository) FailParse(
+	ctx context.Context,
+	claimed resume.Resume,
+	failureCode string,
+) error {
+	if r == nil || r.database == nil || ctx == nil || !validUUID(claimed.OwnerUserID) ||
+		!validUUID(claimed.ID) || claimed.Version < 1 || !parseFailurePattern.MatchString(failureCode) {
+		return app.InvalidResumeError()
+	}
+	result := r.database.WithContext(ctx).
+		Model(&resumeRecord{}).
+		Where(
+			"owner_user_id = ? AND resume_id = ? AND object_key = ? AND checksum_sha256 = ?",
+			claimed.OwnerUserID,
+			claimed.ID,
+			claimed.ObjectKey,
+			claimed.ChecksumSHA256,
+		).
+		Where("parse_status = ?", string(resume.ParseRunning)).
+		Updates(map[string]any{
+			"parse_status":       string(resume.ParseFailed),
+			"parse_failure_code": failureCode,
+			"version":            gorm.Expr("version + 1"),
+			"updated_at":         nextResumeTimestamp(),
+		})
+	if result.Error != nil {
+		return mapGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return r.writeMiss(ctx, claimed.OwnerUserID, claimed.ID)
+	}
+	return nil
+}
+
+// currentRevision 把数据库可空修订号转换为领域层的零值语义。
+func currentRevision(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+// lockOwnedResume 锁定指定用户的一份活动简历记录。
+func lockOwnedResume(tx *gorm.DB, ownerUserID string, resumeID string) (resumeRecord, error) {
+	var record resumeRecord
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("owner_user_id = ? AND resume_id = ?", ownerUserID, resumeID).
+		Take(&record).Error; err != nil {
+		return resumeRecord{}, mapGormError(err)
+	}
+	return record, nil
+}
+
+// nextRevision 返回指定简历在当前事务中的下一个修订号。
+func nextRevision(tx *gorm.DB, resumeID string) (int64, error) {
+	var number int64
+	if err := tx.Model(&revisionRecord{}).
+		Select("COALESCE(MAX(revision), 0) + 1").
+		Where("resume_id = ?", resumeID).
+		Scan(&number).Error; err != nil {
+		return 0, mapGormError(err)
+	}
+	if number < 1 {
+		return 0, app.RepositoryError(errors.New("resume: invalid next revision"))
+	}
+	return number, nil
+}
+
+// writeMiss 把零行更新区分为不可见资源和版本冲突。
+func (r *GormRepository) writeMiss(ctx context.Context, ownerUserID string, resumeID string) error {
+	_, err := r.FindByOwnerAndID(ctx, ownerUserID, resumeID)
+	if err != nil {
+		return err
+	}
+	return app.ResumeVersionConflictError()
+}
+
+// mappedResume 把更新后的 Record 安全转换为领域对象。
+func mappedResume(record resumeRecord) (resume.Resume, error) {
+	item, err := resumeFromRecord(record)
+	if err != nil {
+		return resume.Resume{}, app.RepositoryError(err)
+	}
+	return item, nil
+}
+
+// mapTransactionError 保留应用错误并净化数据库事务错误。
+func mapTransactionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := apperror.From(err); ok {
+		return err
+	}
+	return mapGormError(err)
+}
+
+// mapGormError 把 GORM/PostgreSQL 错误转换为公共应用错误。
+func mapGormError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if appError, ok := apperror.From(err); ok {
+		return appError
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return app.ResumeNotFoundError()
+	}
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		switch postgresError.Code {
+		case "23505", "40001", "40P01":
+			return app.ResumeVersionConflictError()
+		case "23503", "23514", "22P02":
+			return app.InvalidResumeError()
+		}
+	}
+	return app.RepositoryError(err)
+}
+
+// nextResumeTimestamp 生成严格单调递增的数据库更新时间表达式。
+func nextResumeTimestamp() clause.Expr {
+	return gorm.Expr(
+		"GREATEST(transaction_timestamp(), updated_at + interval '1 microsecond')",
+	)
+}
+
+// validWriteInput 校验带所有权和乐观锁的写入公共输入。
+func validWriteInput(
+	repository *GormRepository,
+	ctx context.Context,
+	ownerUserID string,
+	resumeID string,
+	expectedVersion int64,
+) bool {
+	return repository != nil && repository.database != nil && ctx != nil &&
+		validUUID(ownerUserID) && validUUID(resumeID) && expectedVersion >= 1
+}
+
+// validNewResume 校验新建持久化记录的必要不变量。
+func validNewResume(item resume.Resume) bool {
+	return validUUID(item.ID) && validUUID(item.OwnerUserID) && validTitle(item.Title) &&
+		validFileMetadata(
+			item.OriginalFilename,
+			item.ContentType,
+			item.SizeBytes,
+			item.ChecksumSHA256,
+			item.ObjectKey,
+		) && item.FileStatus == resume.FileUploading &&
+		item.ParseStatus == resume.ParseQueued && item.ParseFailureCode == "" &&
+		item.CurrentRevision == 0 && (item.Version == 0 || item.Version == 1)
+}
+
+// validFileMetadata 校验 PDF 元数据是否满足迁移约束。
+func validFileMetadata(
+	filename string,
+	contentType string,
+	sizeBytes int64,
+	checksum string,
+	objectKey string,
+) bool {
+	return strings.TrimSpace(filename) == filename && filename != "" &&
+		len(filename) <= 1024 && !strings.ContainsAny(filename, "\x00\r\n/\\") &&
+		contentType == "application/pdf" && sizeBytes >= 1 && sizeBytes <= 10*1024*1024 &&
+		resumeChecksumPattern.MatchString(checksum) && len(objectKey) >= 16 &&
+		len(objectKey) <= 1024 && !strings.Contains(objectKey, "..") &&
+		!strings.ContainsAny(objectKey, "\x00\r\n\\")
+}
+
+// validTitle 校验简历展示名称是否满足迁移约束。
+func validTitle(title string) bool {
+	return strings.TrimSpace(title) == title && title != "" && len(title) <= 360 &&
+		!strings.ContainsAny(title, "\x00\r\n")
+}
+
+// validUUID 校验资源标识是否为规范小写 UUID。
+func validUUID(value string) bool {
+	return resumeUUIDPattern.MatchString(value)
 }
 
 var _ app.Repository = (*GormRepository)(nil)

--- a/server/internal/resume/persistence/gorm_integration_test.go
+++ b/server/internal/resume/persistence/gorm_integration_test.go
@@ -1,0 +1,344 @@
+// 本文件在隔离 PostgreSQL Schema 中验证 Resume GORM Repository 的真实事务语义。
+package persistence_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/app"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/persistence"
+)
+
+const (
+	resumeOwnerA = "10000000-0000-4000-8000-000000000001"
+	resumeOwnerB = "20000000-0000-4000-8000-000000000002"
+)
+
+// TestGormRepositoryCRUDAndIsolation 验证 CRUD、所有权隔离、乐观锁和手动修订。
+func TestGormRepositoryCRUDAndIsolation(t *testing.T) {
+	repository := newResumeRepository(t)
+	ctx := context.Background()
+	item := resumeCandidate("30000000-0000-4000-8000-000000000001", resumeOwnerA)
+	if err := repository.CreateWithinLimit(ctx, item, app.MaxResumesPerUser); err != nil {
+		t.Fatalf("create Resume: %v", err)
+	}
+
+	if _, err := repository.FindByOwnerAndID(ctx, resumeOwnerB, item.ID); errorCode(err) != "resume_not_found" {
+		t.Fatalf("cross-owner read error = %v", err)
+	}
+	listed, err := repository.ListByOwner(ctx, resumeOwnerA, app.ListQuery{Limit: 3})
+	if err != nil || len(listed) != 1 || listed[0].ID != item.ID {
+		t.Fatalf("list = %#v, err = %v", listed, err)
+	}
+
+	updated, err := repository.UpdateMetadata(ctx, resumeOwnerA, app.UpdateMetadataCommand{
+		ResumeID: item.ID, Title: "Primary Resume", ExpectedVersion: 1,
+	})
+	if err != nil || updated.Title != "Primary Resume" || updated.Version != 2 {
+		t.Fatalf("update = %#v, err = %v", updated, err)
+	}
+	if _, err := repository.UpdateMetadata(ctx, resumeOwnerA, app.UpdateMetadataCommand{
+		ResumeID: item.ID, Title: "Stale", ExpectedVersion: 1,
+	}); errorCode(err) != "resume_version_conflict" {
+		t.Fatalf("stale update error = %v", err)
+	}
+
+	if err := repository.MarkFileAvailableAndQueueParse(ctx, resumeOwnerA, item.ID); err != nil {
+		t.Fatalf("mark available: %v", err)
+	}
+	current, err := repository.FindByOwnerAndID(ctx, resumeOwnerA, item.ID)
+	if err != nil {
+		t.Fatalf("find current: %v", err)
+	}
+	revision, err := repository.SaveManualRevision(ctx, resumeOwnerA, app.UpdateContentCommand{
+		ResumeID: item.ID,
+		Content: resume.Content{
+			TargetPosition: "Backend Engineer",
+			Skills:         []string{"Go", "PostgreSQL"},
+		},
+		ExpectedVersion: current.Version,
+	})
+	if err != nil || revision.Revision != 1 || revision.Source != resume.RevisionManual {
+		t.Fatalf("manual revision = %#v, err = %v", revision, err)
+	}
+	detail, err := repository.FindDetailByOwnerAndID(ctx, resumeOwnerA, item.ID)
+	if err != nil || detail.Revision == nil || detail.Revision.Content.TargetPosition != "Backend Engineer" {
+		t.Fatalf("detail = %#v, err = %v", detail, err)
+	}
+}
+
+// TestGormRepositoryConcurrentLimitAndCapacityRecovery 验证并发创建不突破三份上限且删除后释放容量。
+func TestGormRepositoryConcurrentLimitAndCapacityRecovery(t *testing.T) {
+	repository := newResumeRepository(t)
+	ctx := context.Background()
+	ids := []string{
+		"40000000-0000-4000-8000-000000000001",
+		"40000000-0000-4000-8000-000000000002",
+		"40000000-0000-4000-8000-000000000003",
+		"40000000-0000-4000-8000-000000000004",
+	}
+	var wait sync.WaitGroup
+	errorsByID := make(map[string]error, len(ids))
+	var mutex sync.Mutex
+	for _, id := range ids {
+		id := id
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			err := repository.CreateWithinLimit(ctx, resumeCandidate(id, resumeOwnerA), app.MaxResumesPerUser)
+			mutex.Lock()
+			errorsByID[id] = err
+			mutex.Unlock()
+		}()
+	}
+	wait.Wait()
+	succeeded := 0
+	limited := 0
+	for _, err := range errorsByID {
+		switch errorCode(err) {
+		case "":
+			succeeded++
+		case "resume_limit_exceeded":
+			limited++
+		default:
+			t.Fatalf("unexpected create error: %v", err)
+		}
+	}
+	if succeeded != 3 || limited != 1 {
+		t.Fatalf("succeeded = %d, limited = %d", succeeded, limited)
+	}
+
+	items, err := repository.ListByOwner(ctx, resumeOwnerA, app.ListQuery{Limit: 3})
+	if err != nil || len(items) != 3 {
+		t.Fatalf("list after concurrent creates = %#v, %v", items, err)
+	}
+	deleting, err := repository.MarkDeleting(ctx, resumeOwnerA, app.DeleteCommand{
+		ResumeID: items[0].ID, ExpectedVersion: items[0].Version,
+	})
+	if err != nil {
+		t.Fatalf("mark deleting: %v", err)
+	}
+	if err := repository.MarkDeleted(ctx, resumeOwnerA, deleting.ID); err != nil {
+		t.Fatalf("mark deleted: %v", err)
+	}
+	newID := "40000000-0000-4000-8000-000000000005"
+	if err := repository.CreateWithinLimit(ctx, resumeCandidate(newID, resumeOwnerA), app.MaxResumesPerUser); err != nil {
+		t.Fatalf("create after deletion: %v", err)
+	}
+}
+
+// TestGormRepositoryParseCompletionAndFailure 验证解析领取、完成、失败和重试状态迁移。
+func TestGormRepositoryParseCompletionAndFailure(t *testing.T) {
+	repository := newResumeRepository(t)
+	ctx := context.Background()
+	first := resumeCandidate("50000000-0000-4000-8000-000000000001", resumeOwnerA)
+	if err := repository.CreateWithinLimit(ctx, first, 3); err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	if err := repository.MarkFileAvailableAndQueueParse(ctx, resumeOwnerA, first.ID); err != nil {
+		t.Fatalf("queue first: %v", err)
+	}
+	claimed, found, err := repository.ClaimNextQueuedParse(ctx)
+	if err != nil || !found || claimed.ID != first.ID || claimed.ParseStatus != resume.ParseRunning {
+		t.Fatalf("claim = %#v, found = %v, err = %v", claimed, found, err)
+	}
+	if err := repository.CompleteParse(ctx, claimed, resume.Revision{
+		Source:        resume.RevisionParser,
+		ParserVersion: "resume-parser/v1",
+		Content:       resume.Content{TargetPosition: "Platform Engineer"},
+	}); err != nil {
+		t.Fatalf("complete parse: %v", err)
+	}
+	detail, err := repository.FindDetailByOwnerAndID(ctx, resumeOwnerA, first.ID)
+	if err != nil || detail.Resume.ParseStatus != resume.ParseReady ||
+		detail.Revision == nil || detail.Revision.Source != resume.RevisionParser {
+		t.Fatalf("parsed detail = %#v, err = %v", detail, err)
+	}
+
+	second := resumeCandidate("50000000-0000-4000-8000-000000000002", resumeOwnerA)
+	if err := repository.CreateWithinLimit(ctx, second, 3); err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+	if err := repository.MarkFileAvailableAndQueueParse(ctx, resumeOwnerA, second.ID); err != nil {
+		t.Fatalf("queue second: %v", err)
+	}
+	failedClaim, found, err := repository.ClaimNextQueuedParse(ctx)
+	if err != nil || !found || failedClaim.ID != second.ID {
+		t.Fatalf("failed claim = %#v, found = %v, err = %v", failedClaim, found, err)
+	}
+	if err := repository.FailParse(ctx, failedClaim, "pdf_text_unavailable"); err != nil {
+		t.Fatalf("fail parse: %v", err)
+	}
+	failed, err := repository.FindByOwnerAndID(ctx, resumeOwnerA, second.ID)
+	if err != nil || failed.ParseStatus != resume.ParseFailed || failed.ParseFailureCode != "pdf_text_unavailable" {
+		t.Fatalf("failed Resume = %#v, err = %v", failed, err)
+	}
+	if err := repository.QueueParse(ctx, resumeOwnerA, second.ID); err != nil {
+		t.Fatalf("retry parse: %v", err)
+	}
+}
+
+// TestGormRepositoryManualEditWinsConcurrentParse 验证解析期间的手动内容不会被稍后完成的解析结果覆盖。
+func TestGormRepositoryManualEditWinsConcurrentParse(t *testing.T) {
+	repository := newResumeRepository(t)
+	ctx := context.Background()
+	item := resumeCandidate("60000000-0000-4000-8000-000000000001", resumeOwnerA)
+	if err := repository.CreateWithinLimit(ctx, item, app.MaxResumesPerUser); err != nil {
+		t.Fatalf("create Resume: %v", err)
+	}
+	if err := repository.MarkFileAvailableAndQueueParse(ctx, resumeOwnerA, item.ID); err != nil {
+		t.Fatalf("queue Resume: %v", err)
+	}
+	claimed, found, err := repository.ClaimNextQueuedParse(ctx)
+	if err != nil || !found {
+		t.Fatalf("claim = %#v, found = %v, err = %v", claimed, found, err)
+	}
+	manual, err := repository.SaveManualRevision(ctx, resumeOwnerA, app.UpdateContentCommand{
+		ResumeID: item.ID,
+		Content: resume.Content{
+			TargetPosition: "User Edited Position",
+		},
+		ExpectedVersion: claimed.Version,
+	})
+	if err != nil {
+		t.Fatalf("save manual revision: %v", err)
+	}
+	if err := repository.CompleteParse(ctx, claimed, resume.Revision{
+		Source:        resume.RevisionParser,
+		ParserVersion: "resume-parser/v1",
+		Content:       resume.Content{TargetPosition: "Parsed Position"},
+	}); err != nil {
+		t.Fatalf("complete concurrent parse: %v", err)
+	}
+	detail, err := repository.FindDetailByOwnerAndID(ctx, resumeOwnerA, item.ID)
+	if err != nil || detail.Resume.ParseStatus != resume.ParseReady || detail.Revision == nil ||
+		detail.Revision.Revision != manual.Revision ||
+		detail.Revision.Content.TargetPosition != "User Edited Position" {
+		t.Fatalf("detail after concurrent parse = %#v, err = %v", detail, err)
+	}
+}
+
+// resumeCandidate 创建满足数据库约束的测试简历。
+func resumeCandidate(id string, ownerID string) resume.Resume {
+	return resume.Resume{
+		ID:               id,
+		OwnerUserID:      ownerID,
+		Title:            "Backend Resume",
+		OriginalFilename: "backend.pdf",
+		ContentType:      "application/pdf",
+		SizeBytes:        1024,
+		ChecksumSHA256:   strings.Repeat("a", 64),
+		ObjectKey:        "resume/v1/" + id + ".pdf",
+		FileStatus:       resume.FileUploading,
+		ParseStatus:      resume.ParseQueued,
+		Version:          1,
+		CreatedAt:        time.Now().UTC(),
+		UpdatedAt:        time.Now().UTC(),
+	}
+}
+
+// errorCode 返回公共应用错误的稳定机器码。
+func errorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	applicationError, ok := apperror.From(err)
+	if !ok {
+		return "unknown"
+	}
+	return applicationError.Code()
+}
+
+// newResumeRepository 创建带完整迁移和测试身份的隔离 GORM Repository。
+func newResumeRepository(t *testing.T) *persistence.GormRepository {
+	t.Helper()
+	pool := newResumeTestPool(t)
+	repository, err := persistence.NewGormRepositoryFromPool(pool)
+	if err != nil {
+		t.Fatalf("new Resume Repository: %v", err)
+	}
+	return repository
+}
+
+// newResumeTestPool 创建一个仅供当前测试使用的 PostgreSQL Schema 和连接池。
+func newResumeTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	config, err := pgx.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatal("parse TEST_DATABASE_URL")
+	}
+	admin, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatal("connect to TEST_DATABASE_URL")
+	}
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("generate schema name: %v", err)
+	}
+	schema := "resume_" + hex.EncodeToString(random)
+	identifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(context.Background(), "CREATE SCHEMA "+identifier); err != nil {
+		t.Fatalf("create Resume schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE"); err != nil {
+			t.Errorf("drop Resume schema: %v", err)
+		}
+	})
+	scopedURL, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatal("parse database URL")
+	}
+	query := scopedURL.Query()
+	query.Set("search_path", schema)
+	scopedURL.RawQuery = query.Encode()
+	runner, err := migration.Open(scopedURL.String())
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Close() })
+	if _, err := runner.Up(); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+	poolConfig, err := pgxpool.ParseConfig(scopedURL.String())
+	if err != nil {
+		t.Fatal("parse scoped pool config")
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	if err != nil {
+		t.Fatal("open scoped pool")
+	}
+	t.Cleanup(pool.Close)
+	for _, user := range []struct {
+		id    string
+		email string
+	}{
+		{id: resumeOwnerA, email: "resume-a@example.com"},
+		{id: resumeOwnerB, email: "resume-b@example.com"},
+	} {
+		if _, err := pool.Exec(context.Background(), `
+INSERT INTO identity_users (id, canonical_email)
+VALUES ($1, $2)`, user.id, user.email); err != nil {
+			t.Fatalf("insert Resume owner: %v", err)
+		}
+	}
+	return pool
+}

--- a/server/internal/resume/persistence/mapping.go
+++ b/server/internal/resume/persistence/mapping.go
@@ -1,28 +1,159 @@
-// 本文件声明 GORM Record 与 Resume 领域模型之间的转换边界。
+// 本文件实现 GORM Record 与 Resume 领域模型之间的转换边界。
 package persistence
 
-import "github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+)
 
 // resumeToRecord 把 Resume 领域模型转换为持久化 Record。
-func resumeToRecord(resume.Resume) resumeRecord {
-	// TODO(issue-320): 实现领域模型到数据库字段的完整转换。
-	return resumeRecord{}
+func resumeToRecord(item resume.Resume) resumeRecord {
+	record := resumeRecord{
+		ResumeID:         item.ID,
+		OwnerUserID:      item.OwnerUserID,
+		Title:            item.Title,
+		OriginalFilename: item.OriginalFilename,
+		ContentType:      item.ContentType,
+		SizeBytes:        item.SizeBytes,
+		ChecksumSHA256:   item.ChecksumSHA256,
+		ObjectKey:        item.ObjectKey,
+		FileStatus:       string(item.FileStatus),
+		ParseStatus:      string(item.ParseStatus),
+		Version:          item.Version,
+		CreatedAt:        item.CreatedAt,
+		UpdatedAt:        item.UpdatedAt,
+	}
+	if item.ParseFailureCode != "" {
+		record.ParseFailureCode = stringPointer(item.ParseFailureCode)
+	}
+	if item.CurrentRevision > 0 {
+		record.CurrentRevision = int64Pointer(item.CurrentRevision)
+	}
+	if item.DeletedAt != nil {
+		record.DeletedAt.Time = item.DeletedAt.UTC()
+		record.DeletedAt.Valid = true
+	}
+	return record
 }
 
 // resumeFromRecord 把持久化 Record 转换为 Resume 领域模型。
-func resumeFromRecord(resumeRecord) (resume.Resume, error) {
-	// TODO(issue-320): 实现数据库字段校验和领域模型恢复。
-	return resume.Resume{}, nil
+func resumeFromRecord(record resumeRecord) (resume.Resume, error) {
+	if record.ResumeID == "" || record.OwnerUserID == "" ||
+		record.Title == "" || record.OriginalFilename == "" ||
+		record.ContentType != "application/pdf" || record.SizeBytes < 1 ||
+		record.ChecksumSHA256 == "" || record.ObjectKey == "" ||
+		record.Version < 1 || record.CreatedAt.IsZero() || record.UpdatedAt.IsZero() {
+		return resume.Resume{}, errors.New("resume: invalid persisted resume")
+	}
+	fileStatus := resume.FileStatus(record.FileStatus)
+	parseStatus := resume.ParseStatus(record.ParseStatus)
+	if !validFileStatus(fileStatus) || !validParseStatus(parseStatus) {
+		return resume.Resume{}, errors.New("resume: invalid persisted status")
+	}
+	item := resume.Resume{
+		ID:               record.ResumeID,
+		OwnerUserID:      record.OwnerUserID,
+		Title:            record.Title,
+		OriginalFilename: record.OriginalFilename,
+		ContentType:      record.ContentType,
+		SizeBytes:        record.SizeBytes,
+		ChecksumSHA256:   record.ChecksumSHA256,
+		ObjectKey:        record.ObjectKey,
+		FileStatus:       fileStatus,
+		ParseStatus:      parseStatus,
+		Version:          record.Version,
+		CreatedAt:        record.CreatedAt.UTC(),
+		UpdatedAt:        record.UpdatedAt.UTC(),
+	}
+	if record.ParseFailureCode != nil {
+		item.ParseFailureCode = *record.ParseFailureCode
+	}
+	if record.CurrentRevision != nil {
+		item.CurrentRevision = *record.CurrentRevision
+	}
+	if record.DeletedAt.Valid {
+		deletedAt := record.DeletedAt.Time.UTC()
+		item.DeletedAt = &deletedAt
+	}
+	return item, nil
 }
 
 // revisionToRecord 把结构化内容修订转换为持久化 Record。
-func revisionToRecord(resume.Revision) (revisionRecord, error) {
-	// TODO(issue-320): 实现 JSON 编码和修订元数据转换。
-	return revisionRecord{}, nil
+func revisionToRecord(item resume.Revision) (revisionRecord, error) {
+	if item.ResumeID == "" || item.Revision < 1 || !validRevisionSource(item.Source) {
+		return revisionRecord{}, errors.New("resume: invalid revision")
+	}
+	if (item.Source == resume.RevisionParser && strings.TrimSpace(item.ParserVersion) == "") ||
+		(item.Source == resume.RevisionManual && item.ParserVersion != "") {
+		return revisionRecord{}, errors.New("resume: invalid revision parser version")
+	}
+	content, err := json.Marshal(item.Content)
+	if err != nil {
+		return revisionRecord{}, errors.New("resume: encode revision content")
+	}
+	record := revisionRecord{
+		ResumeID:  item.ResumeID,
+		Revision:  item.Revision,
+		Source:    string(item.Source),
+		Content:   content,
+		CreatedAt: item.CreatedAt,
+	}
+	if item.ParserVersion != "" {
+		record.ParserVersion = stringPointer(item.ParserVersion)
+	}
+	return record, nil
 }
 
 // revisionFromRecord 把持久化 Record 转换为结构化内容修订。
-func revisionFromRecord(revisionRecord) (resume.Revision, error) {
-	// TODO(issue-320): 实现 JSON 解码和修订内容校验。
-	return resume.Revision{}, nil
+func revisionFromRecord(record revisionRecord) (resume.Revision, error) {
+	source := resume.RevisionSource(record.Source)
+	if record.ResumeID == "" || record.Revision < 1 ||
+		!validRevisionSource(source) || len(record.Content) == 0 {
+		return resume.Revision{}, errors.New("resume: invalid persisted revision")
+	}
+	var content resume.Content
+	if err := json.Unmarshal(record.Content, &content); err != nil {
+		return resume.Revision{}, errors.New("resume: decode revision content")
+	}
+	item := resume.Revision{
+		ResumeID:  record.ResumeID,
+		Revision:  record.Revision,
+		Source:    source,
+		Content:   content,
+		CreatedAt: record.CreatedAt.UTC(),
+	}
+	if record.ParserVersion != nil {
+		item.ParserVersion = *record.ParserVersion
+	}
+	return item, nil
+}
+
+// validFileStatus 判断持久化文件状态是否属于领域允许集合。
+func validFileStatus(status resume.FileStatus) bool {
+	return status == resume.FileUploading || status == resume.FileAvailable ||
+		status == resume.FileDeleting || status == resume.FileDeleted
+}
+
+// validParseStatus 判断持久化解析状态是否属于领域允许集合。
+func validParseStatus(status resume.ParseStatus) bool {
+	return status == resume.ParseQueued || status == resume.ParseRunning ||
+		status == resume.ParseReady || status == resume.ParseFailed
+}
+
+// validRevisionSource 判断持久化修订来源是否属于领域允许集合。
+func validRevisionSource(source resume.RevisionSource) bool {
+	return source == resume.RevisionParser || source == resume.RevisionManual
+}
+
+// int64Pointer 返回 int64 值的独立指针。
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+// stringPointer 返回字符串值的独立指针。
+func stringPointer(value string) *string {
+	return &value
 }

--- a/server/internal/resume/persistence/mapping_test.go
+++ b/server/internal/resume/persistence/mapping_test.go
@@ -1,0 +1,79 @@
+// 本文件验证 Resume 领域模型与 GORM Record 的无损转换。
+package persistence
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+)
+
+// TestResumeRecordRoundTrip 验证简历元数据、状态和可空字段能够往返转换。
+func TestResumeRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	deletedAt := now.Add(time.Minute)
+	want := resume.Resume{
+		ID:               "10000000-0000-4000-8000-000000000001",
+		OwnerUserID:      "20000000-0000-4000-8000-000000000001",
+		Title:            "Backend Resume",
+		OriginalFilename: "backend.pdf",
+		ContentType:      "application/pdf",
+		SizeBytes:        1024,
+		ChecksumSHA256:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ObjectKey:        "resume/v1/backend.pdf",
+		FileStatus:       resume.FileDeleted,
+		ParseStatus:      resume.ParseFailed,
+		ParseFailureCode: "parser_unavailable",
+		CurrentRevision:  2,
+		Version:          4,
+		CreatedAt:        now,
+		UpdatedAt:        deletedAt,
+		DeletedAt:        &deletedAt,
+	}
+
+	got, err := resumeFromRecord(resumeToRecord(want))
+	if err != nil {
+		t.Fatalf("round trip Resume: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Resume round trip = %#v, want %#v", got, want)
+	}
+}
+
+// TestRevisionRecordRoundTrip 验证结构化内容能够通过 JSONB Record 往返转换。
+func TestRevisionRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := resume.Revision{
+		ResumeID:      "10000000-0000-4000-8000-000000000001",
+		Revision:      3,
+		Source:        resume.RevisionParser,
+		ParserVersion: "resume-parser/v1",
+		Content: resume.Content{
+			TargetPosition:      "Backend Engineer",
+			ProfessionalSummary: "Go developer",
+			ProjectExperiences: []resume.ProjectExperience{{
+				ProjectName:  "API Platform",
+				Role:         "Backend Engineer",
+				Technologies: []string{"Go", "PostgreSQL"},
+			}},
+			Skills: []string{"Go", "SQL"},
+		},
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+
+	record, err := revisionToRecord(want)
+	if err != nil {
+		t.Fatalf("revision to record: %v", err)
+	}
+	got, err := revisionFromRecord(record)
+	if err != nil {
+		t.Fatalf("revision from record: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Revision round trip = %#v, want %#v", got, want)
+	}
+}

--- a/server/internal/resume/persistence/record.go
+++ b/server/internal/resume/persistence/record.go
@@ -19,7 +19,8 @@ type resumeRecord struct {
 	ObjectKey        string         `gorm:"column:object_key"`
 	FileStatus       string         `gorm:"column:file_status"`
 	ParseStatus      string         `gorm:"column:parse_status"`
-	CurrentRevision  int64          `gorm:"column:current_revision"`
+	ParseFailureCode *string        `gorm:"column:parse_failure_code"`
+	CurrentRevision  *int64         `gorm:"column:current_revision"`
 	Version          int64          `gorm:"column:version"`
 	CreatedAt        time.Time      `gorm:"column:created_at"`
 	UpdatedAt        time.Time      `gorm:"column:updated_at"`
@@ -28,22 +29,21 @@ type resumeRecord struct {
 
 // TableName 返回 Resume 元数据表的稳定名称。
 func (resumeRecord) TableName() string {
-	// TODO(issue-320): 在数据库迁移 Issue 中验证表名和约束。
 	return "resumes"
 }
 
 // revisionRecord 映射 resume_revisions 表的一行。
 type revisionRecord struct {
+	OwnerUserID   string    `gorm:"column:owner_user_id;type:uuid"`
 	ResumeID      string    `gorm:"column:resume_id;type:uuid;primaryKey"`
 	Revision      int64     `gorm:"column:revision;primaryKey"`
 	Source        string    `gorm:"column:source"`
-	ParserVersion string    `gorm:"column:parser_version"`
+	ParserVersion *string   `gorm:"column:parser_version"`
 	Content       []byte    `gorm:"column:content;type:jsonb"`
 	CreatedAt     time.Time `gorm:"column:created_at"`
 }
 
 // TableName 返回结构化简历修订表的稳定名称。
 func (revisionRecord) TableName() string {
-	// TODO(issue-320): 在数据库迁移 Issue 中验证复合主键和外键。
 	return "resume_revisions"
 }

--- a/server/migrations/000060_resumes.down.sql
+++ b/server/migrations/000060_resumes.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS resume_revisions_immutable ON resume_revisions;
+DROP FUNCTION IF EXISTS resume_revisions_reject_mutation();
+ALTER TABLE IF EXISTS resumes
+    DROP CONSTRAINT IF EXISTS resumes_current_revision_fkey;
+DROP TABLE IF EXISTS resume_revisions;
+DROP TABLE IF EXISTS resumes;
+
+COMMIT;

--- a/server/migrations/000060_resumes.up.sql
+++ b/server/migrations/000060_resumes.up.sql
@@ -1,0 +1,137 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '15s';
+SET LOCAL statement_timeout = '2min';
+
+CREATE TABLE resumes (
+    resume_id uuid PRIMARY KEY,
+    owner_user_id uuid NOT NULL,
+    title text NOT NULL,
+    original_filename text NOT NULL,
+    content_type text NOT NULL,
+    size_bytes bigint NOT NULL,
+    checksum_sha256 text NOT NULL,
+    object_key text NOT NULL,
+    file_status text NOT NULL DEFAULT 'UPLOADING',
+    parse_status text NOT NULL DEFAULT 'QUEUED',
+    parse_failure_code text,
+    current_revision bigint,
+    version bigint NOT NULL DEFAULT 1,
+    created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at timestamptz,
+    CONSTRAINT resumes_owner_identity_key
+        UNIQUE (owner_user_id, resume_id),
+    CONSTRAINT resumes_object_key_key UNIQUE (object_key),
+    CONSTRAINT resumes_owner_fkey
+        FOREIGN KEY (owner_user_id)
+        REFERENCES identity_users (id)
+        ON DELETE CASCADE,
+    CONSTRAINT resumes_title_check
+        CHECK (
+            octet_length(title) BETWEEN 1 AND 360
+            AND title = btrim(title)
+            AND title !~ '[[:cntrl:]]'
+        ),
+    CONSTRAINT resumes_filename_check
+        CHECK (
+            octet_length(original_filename) BETWEEN 1 AND 1024
+            AND original_filename = btrim(original_filename)
+            AND original_filename !~ '[[:cntrl:]/\\]'
+        ),
+    CONSTRAINT resumes_file_metadata_check
+        CHECK (
+            content_type = 'application/pdf'
+            AND size_bytes BETWEEN 1 AND 10485760
+            AND checksum_sha256 ~ '^[0-9a-f]{64}$'
+            AND octet_length(object_key) BETWEEN 16 AND 1024
+            AND object_key NOT LIKE '%..%'
+            AND object_key !~ '[[:cntrl:]\\]'
+        ),
+    CONSTRAINT resumes_file_status_check
+        CHECK (file_status IN ('UPLOADING', 'AVAILABLE', 'DELETING', 'DELETED')),
+    CONSTRAINT resumes_parse_status_check
+        CHECK (parse_status IN ('QUEUED', 'PARSING', 'READY', 'FAILED')),
+    CONSTRAINT resumes_parse_failure_check
+        CHECK (
+            (parse_status = 'FAILED'
+                AND parse_failure_code ~ '^[a-z][a-z0-9_]{0,127}$')
+            OR (parse_status <> 'FAILED' AND parse_failure_code IS NULL)
+        ),
+    CONSTRAINT resumes_revision_version_check
+        CHECK (
+            (current_revision IS NULL OR current_revision >= 1)
+            AND version >= 1
+        ),
+    CONSTRAINT resumes_state_shape_check
+        CHECK (
+            (file_status = 'DELETED' AND deleted_at IS NOT NULL)
+            OR (file_status <> 'DELETED' AND deleted_at IS NULL)
+        ),
+    CONSTRAINT resumes_timestamps_check
+        CHECK (updated_at >= created_at AND (deleted_at IS NULL OR deleted_at >= created_at))
+);
+
+CREATE TABLE resume_revisions (
+    owner_user_id uuid NOT NULL,
+    resume_id uuid NOT NULL,
+    revision bigint NOT NULL,
+    source text NOT NULL,
+    parser_version text,
+    content jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (resume_id, revision),
+    CONSTRAINT resume_revisions_owner_identity_key
+        UNIQUE (owner_user_id, resume_id, revision),
+    CONSTRAINT resume_revisions_resume_owner_fkey
+        FOREIGN KEY (owner_user_id, resume_id)
+        REFERENCES resumes (owner_user_id, resume_id)
+        ON DELETE CASCADE,
+    CONSTRAINT resume_revisions_revision_check CHECK (revision >= 1),
+    CONSTRAINT resume_revisions_source_check CHECK (source IN ('PARSER', 'MANUAL')),
+    CONSTRAINT resume_revisions_parser_version_check
+        CHECK (
+            (source = 'PARSER'
+                AND octet_length(parser_version) BETWEEN 1 AND 128
+                AND parser_version = btrim(parser_version))
+            OR (source = 'MANUAL' AND parser_version IS NULL)
+        ),
+    CONSTRAINT resume_revisions_content_check
+        CHECK (jsonb_typeof(content) = 'object')
+);
+
+ALTER TABLE resumes
+    ADD CONSTRAINT resumes_current_revision_fkey
+    FOREIGN KEY (owner_user_id, resume_id, current_revision)
+    REFERENCES resume_revisions (owner_user_id, resume_id, revision)
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE INDEX resumes_owner_active_updated_idx
+    ON resumes (owner_user_id, updated_at DESC, resume_id DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX resumes_parse_queue_idx
+    ON resumes (updated_at, resume_id)
+    WHERE deleted_at IS NULL
+      AND file_status = 'AVAILABLE'
+      AND parse_status = 'QUEUED';
+
+CREATE FUNCTION resume_revisions_reject_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF pg_trigger_depth() > 1 THEN
+        RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'resume revisions are immutable'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER resume_revisions_immutable
+BEFORE UPDATE OR DELETE ON resume_revisions
+FOR EACH ROW
+EXECUTE FUNCTION resume_revisions_reject_mutation();
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -45,4 +45,5 @@ import "embed"
 //go:embed 000057_agent_learning_profile_context_manifest.*.sql
 //go:embed 000058_evaluation_report_authority.*.sql
 //go:embed 000059_evaluation_general_scene_runtime.*.sql
+//go:embed 000060_resumes.*.sql
 var Files embed.FS

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -275,6 +275,19 @@ func TestPreparationPlanAuthorityMigrationIsEmbeddedAndHasNoLegacyPlanTable(
 	}
 }
 
+func TestResumeMigrationIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"000060_resumes.up.sql",
+		"000060_resumes.down.sql",
+	} {
+		if _, err := Files.ReadFile(name); err != nil {
+			t.Fatalf("read Resume migration %q: %v", name, err)
+		}
+	}
+}
+
 func readMigration(t *testing.T, name string) string {
 	t.Helper()
 


### PR DESCRIPTION
## 功能描述

实现 Resume 模块的 PostgreSQL/GORM 持久化边界，为每用户最多三份简历提供具备所有权隔离、乐观锁和不可变内容修订的 CRUD。

Closes #324

## 实现思路

- 增加 `resumes`、`resume_revisions` 的 000049 up/down migration，包含状态约束、外键、索引和不可变修订触发器。
- 通过锁定 `identity_users` 用户行串行化同一用户的创建事务，确保并发上传不突破三份活动简历上限。
- 所有用户侧读写使用 `owner_user_id + resume_id` 隔离，更新与删除使用 `expected_version` 乐观锁。
- 实现元数据更新、文件记录替换、手动修订、软删除以及解析队列领取/完成/失败/重试。
- 解析期间如用户手动编辑，解析修订保留为历史记录，但不覆盖用户当前修订。
- 复用公共 `apperror`，不新增重复错误框架。

## 可复现测试

```bash
cd server
go test ./...
```

使用 PostgreSQL 验证真实事务、迁移 up/down 和并发行为：

```bash
cd server
TEST_DATABASE_URL="postgres://xe3_esl:local-development-only@127.0.0.1:5432/xe3_esl?sslmode=disable" \
  go test ./internal/resume/persistence -run "TestGormRepository" -count=1 -v
TEST_DATABASE_URL="postgres://xe3_esl:local-development-only@127.0.0.1:5432/xe3_esl?sslmode=disable" \
  go test ./internal/platform/migration -count=1
```

本地以上命令均已通过。

## 范围边界

本 PR 不实现 PDF 对象存储、multipart Handler、真实解析器/Worker 轮询、用户模块衔接或 `main.go` 接线。