### PR TITLE
refactor(agent): unify capability invocation effects

### DIFF
--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -393,6 +393,42 @@ func TestRunLoopContinuesToolCallingAfterExplicitCommand(t *testing.T) {
 	}
 }
 
+func TestRunLoopCountsExplicitWriteCommand(t *testing.T) {
+	store := mocktool.NewStore()
+	firstTitle := "explicit-write-first-unique"
+	secondTitle := "explicit-write-second-unique"
+	generator := newScriptedGenerator(toolLoopResult(
+		"call-create-after-command",
+		mattertool.ScenarioCreateToolName,
+		`{"title":"`+secondTitle+`"}`,
+	))
+	service := newLoopTestServiceWithStore(t, generator, store)
+	commandRegistry, err := command.NewRegistry(command.Builtins()...)
+	if err != nil {
+		t.Fatalf("command.NewRegistry() error = %v", err)
+	}
+	service.commands = command.NewRouter(commandRegistry)
+
+	result, err := service.generate(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		core.ContextManifest{},
+		loopRequest("/创建面试 "+firstTitle),
+	)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if !strings.Contains(result.Content, "写操作上限") {
+		t.Fatalf("fallback content = %q", result.Content)
+	}
+	if got, want := generator.CallCount(), 1; got != want {
+		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+	assertScenarioCreated(t, store, firstTitle)
+	assertScenarioNotCreated(t, store, secondTitle)
+}
+
 func TestRunLoopFeedsToolErrorBackToModel(t *testing.T) {
 	generator := newScriptedGenerator(
 		toolLoopResult("call-material-1", mocktool.MaterialSearchToolName, `{"query":"backend"}`),
@@ -608,6 +644,9 @@ func TestRunLoopReplaysWriteToolWithStableIdempotencyID(t *testing.T) {
 }
 
 func TestRunLoopStopsAfterWriteBudget(t *testing.T) {
+	store := mocktool.NewStore()
+	firstTitle := "write-budget-first-unique"
+	secondTitle := "write-budget-second-unique"
 	generator := newScriptedGenerator(ai.TextResult{
 		ID:           "fake-completion-tools",
 		Provider:     "fake",
@@ -617,17 +656,17 @@ func TestRunLoopStopsAfterWriteBudget(t *testing.T) {
 			{
 				ID:        "call-create-1",
 				Name:      mattertool.ScenarioCreateToolName,
-				Arguments: json.RawMessage(`{"title":"PM interview"}`),
+				Arguments: json.RawMessage(`{"title":"` + firstTitle + `"}`),
 			},
 			{
 				ID:        "call-create-2",
 				Name:      mattertool.ScenarioCreateToolName,
-				Arguments: json.RawMessage(`{"title":"Client meeting"}`),
+				Arguments: json.RawMessage(`{"title":"` + secondTitle + `"}`),
 			},
 		},
 		Usage: ai.TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 	})
-	service := newLoopTestService(t, generator)
+	service := newLoopTestServiceWithStore(t, generator, store)
 
 	result, err := service.generate(
 		context.Background(),
@@ -642,42 +681,168 @@ func TestRunLoopStopsAfterWriteBudget(t *testing.T) {
 	if !strings.Contains(result.Content, "写操作上限") {
 		t.Fatalf("fallback content = %q", result.Content)
 	}
+	assertScenarioNotCreated(t, store, firstTitle)
+	assertScenarioNotCreated(t, store, secondTitle)
 }
 
-func TestPracticePreviewOnlyConsumesWriteBudgetWhenItCanCreatePlan(
-	t *testing.T,
-) {
+func TestRunLoopCountsConditionalWritesAcrossExplicitCommand(t *testing.T) {
+	store := mocktool.NewStore()
+	conditional := &loopConditionalTool{}
+	generator := newScriptedGenerator(
+		toolLoopResult(
+			"call-conditional-write",
+			loopConditionalToolName,
+			`{"write_value":"persisted-value"}`,
+		),
+		toolLoopResult(
+			"call-create-after-conditional",
+			mattertool.ScenarioCreateToolName,
+			`{"title":"write-after-conditional-unique"}`,
+		),
+	)
+	service := newLoopTestServiceWithStore(t, generator, store)
+	setLoopTools(t, service, store, conditional)
+	commandRegistry, err := command.NewRegistry(command.Definition{
+		Name:        "条件查询",
+		Description: "Run the query-only form of a conditional tool.",
+		ToolName:    loopConditionalToolName,
+		BuildInput: func(_ string) (json.RawMessage, error) {
+			return command.JSONObjectInput(nil)
+		},
+	})
+	if err != nil {
+		t.Fatalf("command.NewRegistry() error = %v", err)
+	}
+	service.commands = command.NewRouter(commandRegistry)
+
+	result, err := service.generate(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		core.ContextManifest{},
+		loopRequest("/条件查询"),
+	)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if !strings.Contains(result.Content, "写操作上限") {
+		t.Fatalf("fallback content = %q", result.Content)
+	}
+	if got, want := len(conditional.inputs), 2; got != want {
+		t.Fatalf("conditional calls = %d, want %d", got, want)
+	}
+	if conditional.inputs[0].WriteValue != "" ||
+		conditional.inputs[1].WriteValue == "" {
+		t.Fatalf("conditional inputs = %#v", conditional.inputs)
+	}
+	if got, want := generator.CallCount(), 2; got != want {
+		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+	assertScenarioNotCreated(t, store, "write-after-conditional-unique")
+}
+
+func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
+	store := mocktool.NewStore()
+	conditional := &loopConditionalTool{}
+	generator := newScriptedGenerator(
+		toolLoopResult(
+			"call-conditional-query",
+			loopConditionalToolName,
+			`{}`,
+		),
+		toolLoopResult(
+			"call-conditional-write",
+			loopConditionalToolName,
+			`{"write_value":"persisted-value"}`,
+		),
+		finalLoopResult("The conditional write completed."),
+	)
+	service := newLoopTestServiceWithStore(t, generator, store)
+	setLoopTools(t, service, store, conditional)
+
+	result, err := service.generate(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		core.ContextManifest{},
+		loopRequest("先查询，再执行一次条件写入"),
+	)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if got, want := result.Content, "The conditional write completed."; got != want {
+		t.Fatalf("Content = %q, want %q", got, want)
+	}
+	if got, want := len(conditional.inputs), 2; got != want {
+		t.Fatalf("conditional calls = %d, want %d", got, want)
+	}
+	if conditional.inputs[0].WriteValue != "" ||
+		conditional.inputs[1].WriteValue == "" {
+		t.Fatalf("conditional inputs = %#v", conditional.inputs)
+	}
+	if got, want := generator.CallCount(), 3; got != want {
+		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+}
+
+func TestRunLoopReservesWriteBudgetForRejectedInvocations(t *testing.T) {
 	tests := []struct {
-		name      string
-		arguments string
-		want      bool
+		name string
+		call ai.TextResult
 	}{
 		{
-			name:      "candidate lookup",
-			arguments: `{"scenario_query":"AI product manager interview"}`,
-			want:      false,
+			name: "unknown tool",
+			call: toolLoopResult(
+				"call-unknown-write",
+				"missing.write.v1",
+				`{}`,
+			),
 		},
 		{
-			name: "ready plan input",
-			arguments: `{"background_summary":"AI PM interview",` +
-				`"max_effective_turns":3}`,
-			want: true,
-		},
-		{
-			name:      "invalid input fails closed",
-			arguments: `{`,
-			want:      true,
+			name: "schema invalid conditional tool",
+			call: toolLoopResult(
+				"call-invalid-conditional",
+				loopConditionalToolName,
+				`{"write_value":0}`,
+			),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			call := ai.ToolCall{
-				Name:      "practice.preview.v1",
-				Arguments: json.RawMessage(test.arguments),
+			store := mocktool.NewStore()
+			conditional := &loopConditionalTool{}
+			title := "write-after-rejected-" + strings.ReplaceAll(test.name, " ", "-")
+			generator := newScriptedGenerator(
+				test.call,
+				toolLoopResult(
+					"call-create-after-rejected",
+					mattertool.ScenarioCreateToolName,
+					`{"title":"`+title+`"}`,
+				),
+			)
+			service := newLoopTestServiceWithStore(t, generator, store)
+			setLoopTools(t, service, store, conditional)
+
+			result, err := service.generate(
+				context.Background(),
+				loopActor(),
+				loopRun(),
+				core.ContextManifest{},
+				loopRequest("attempt a guarded write"),
+			)
+			if err != nil {
+				t.Fatalf("generate() error = %v", err)
 			}
-			if got := toolCallMayWrite(call); got != test.want {
-				t.Fatalf("toolCallMayWrite() = %t, want %t", got, test.want)
+			if !strings.Contains(result.Content, "写操作上限") {
+				t.Fatalf("fallback content = %q", result.Content)
 			}
+			if got, want := generator.CallCount(), 2; got != want {
+				t.Fatalf("Generate calls = %d, want %d", got, want)
+			}
+			if len(conditional.inputs) != 0 {
+				t.Fatalf("rejected invocation reached tool: %#v", conditional.inputs)
+			}
+			assertScenarioNotCreated(t, store, title)
 		})
 	}
 }
@@ -829,6 +994,118 @@ func TestValidLoopTextResultRejectsInvalidToolCalls(t *testing.T) {
 				t.Fatal("invalid tool call accepted")
 			}
 		})
+	}
+}
+
+const loopConditionalToolName = "conditional.write.v1"
+
+type loopConditionalInput struct {
+	WriteValue string `json:"write_value,omitempty"`
+}
+
+type loopConditionalTool struct {
+	inputs []loopConditionalInput
+}
+
+func (conditional *loopConditionalTool) Definition() tool.Definition {
+	return tool.Definition{
+		Name:        loopConditionalToolName,
+		Description: "Query without input or perform one conditional write.",
+		InputSchema: tool.ObjectSchema(map[string]any{
+			"write_value": tool.TextSchema("Value to persist.", 100),
+		}, nil),
+		ReadOnly: false,
+		Risk:     tool.RiskLowRiskWrite,
+	}
+}
+
+func (conditional *loopConditionalTool) ClassifyInvocationEffect(
+	input json.RawMessage,
+) (tool.InvocationEffect, error) {
+	parsed, err := parseLoopConditionalInput(input)
+	if err != nil {
+		return 0, err
+	}
+	if parsed.WriteValue != "" {
+		return tool.InvocationEffectMayWrite, nil
+	}
+	return tool.InvocationEffectReadOnly, nil
+}
+
+func (conditional *loopConditionalTool) Execute(
+	_ context.Context,
+	_ tool.CallContext,
+	input json.RawMessage,
+) (tool.Result, error) {
+	parsed, err := parseLoopConditionalInput(input)
+	if err != nil {
+		return tool.Result{}, err
+	}
+	conditional.inputs = append(conditional.inputs, parsed)
+	return tool.Result{Content: map[string]any{"ok": true}}, nil
+}
+
+func parseLoopConditionalInput(
+	input json.RawMessage,
+) (loopConditionalInput, error) {
+	var parsed loopConditionalInput
+	if err := json.Unmarshal(input, &parsed); err != nil {
+		return loopConditionalInput{}, tool.ErrInvalidInput
+	}
+	return parsed, nil
+}
+
+func setLoopTools(
+	t *testing.T,
+	service *Service,
+	store *mocktool.Store,
+	extra ...tool.Tool,
+) {
+	t.Helper()
+	items := append(mocktool.Tools(store), extra...)
+	registry, err := tool.NewRegistry(items...)
+	if err != nil {
+		t.Fatalf("tool.NewRegistry() error = %v", err)
+	}
+	service.registry = registry
+	service.executor = tool.NewExecutor(registry)
+}
+
+func assertScenarioNotCreated(
+	t *testing.T,
+	store *mocktool.Store,
+	title string,
+) {
+	t.Helper()
+	items, err := store.SearchScenarios(
+		context.Background(),
+		tool.CallContext{},
+		mattertool.ScenarioSearchInput{Query: title},
+	)
+	if err != nil {
+		t.Fatalf("SearchScenarios() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("scenario %q was created before batch rejection: %#v", title, items)
+	}
+}
+
+func assertScenarioCreated(
+	t *testing.T,
+	store *mocktool.Store,
+	title string,
+) {
+	t.Helper()
+	items, err := store.SearchScenarios(
+		context.Background(),
+		tool.CallContext{},
+		mattertool.ScenarioSearchInput{Query: title},
+	)
+	if err != nil {
+		t.Fatalf("SearchScenarios() error = %v", err)
+	}
+	if len(items) != 1 || items[0].Title != title {
+		t.Fatalf("scenario %q was not created: %#v", title, items)
 	}
 }
 

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/tool"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/ai"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
-	practiceagenttool "github.com/1024XEngineer/XE3-ESL/server/internal/practice/agenttool"
 )
 
 const (
@@ -715,6 +714,10 @@ func (service *Service) generateObserved(
 			Name:      parsed.Invocation.Name,
 			Arguments: parsed.Invocation.Input,
 		}
+		commandEffect := service.registry.InvocationEffect(parsed.Invocation)
+		if commandEffect.MayWrite() {
+			writeCalls++
+		}
 		if err := service.saveToolCallProposed(loopCtx, run, commandCall); err != nil {
 			return ai.TextResult{}, err
 		}
@@ -734,10 +737,6 @@ func (service *Service) generateObserved(
 		seenToolCallIDs[commandCall.ID] = struct{}{}
 		toolCalls = 1
 		toolIterations = 1
-		if definition, ok := service.toolDefinition(commandCall.Name); ok &&
-			!definition.ReadOnly {
-			writeCalls = 1
-		}
 		finalDecision = "tool_call_then_response"
 	}
 	for {
@@ -834,8 +833,10 @@ func (service *Service) generateObserved(
 			)
 			return result, nil
 		}
-		// 先检查整批调用，防止同一批写操作只执行一部分后才发现预算不足。
-		if writeCalls+service.writeToolCallCount(result.ToolCalls) >
+		// 先分类并预留整批调用的写预算，防止部分执行以及未知、
+		// 非法调用在后续循环中重新获得写额度。
+		pendingWriteCalls := service.writeToolCallCount(result.ToolCalls)
+		if writeCalls+pendingWriteCalls >
 			service.loopLimits.MaxWriteToolCalls {
 			result := fallbackResult(
 				service.configuration,
@@ -851,6 +852,7 @@ func (service *Service) generateObserved(
 			)
 			return result, nil
 		}
+		writeCalls += pendingWriteCalls
 		request.Messages = append(request.Messages, ai.TextMessage{
 			Content:   result.Content,
 			Role:      ai.TextRoleAssistant,
@@ -882,7 +884,7 @@ func (service *Service) generateObserved(
 				)
 				continue
 			}
-			definition, ok := service.toolDefinition(call.Name)
+			_, ok := service.toolDefinition(call.Name)
 			if !ok {
 				if err := service.markToolCallRejected(
 					loopCtx,
@@ -897,9 +899,6 @@ func (service *Service) generateObserved(
 					toolFailureMessage(call.ID, tool.ErrUnknownTool),
 				)
 				continue
-			}
-			if !definition.ReadOnly {
-				writeCalls++
 			}
 			toolMessage, err := service.executeToolCall(
 				loopCtx,
@@ -1458,25 +1457,15 @@ func (service *Service) writeToolCallCount(
 ) int {
 	count := 0
 	for _, call := range calls {
-		definition, ok := service.toolDefinition(call.Name)
-		if ok && !definition.ReadOnly && toolCallMayWrite(call) {
+		effect := service.registry.InvocationEffect(tool.Invocation{
+			Name:  call.Name,
+			Input: call.Arguments,
+		})
+		if effect.MayWrite() {
 			count++
 		}
 	}
 	return count
-}
-
-func toolCallMayWrite(call ai.ToolCall) bool {
-	if call.Name != practiceagenttool.PracticePreviewToolName {
-		return true
-	}
-	var input practiceagenttool.PreviewInput
-	if err := json.Unmarshal(call.Arguments, &input); err != nil {
-		return true
-	}
-	return (input.BackgroundSummary != "" ||
-		input.PreparationProfileID != "" ||
-		input.PreparationSnapshotID != "") && input.MaxEffectiveTurns > 0
 }
 
 func (service *Service) loopBudgetFallback(

--- a/server/internal/agent/tool/registry.go
+++ b/server/internal/agent/tool/registry.go
@@ -31,6 +31,11 @@ func (registry *Registry) Register(tool Tool) error {
 	if err := ValidateDefinition(definition); err != nil {
 		return err
 	}
+	if definition.ReadOnly {
+		if _, conditional := tool.(InvocationEffectClassifier); conditional {
+			return ErrInvalidDefinition
+		}
+	}
 	if registry.tools == nil {
 		registry.tools = make(map[string]Tool)
 	}
@@ -48,6 +53,38 @@ func (registry *Registry) Get(name string) (Tool, bool) {
 	}
 	tool, ok := registry.tools[name]
 	return tool, ok
+}
+
+// InvocationEffect is the authoritative write-effect classification for one
+// registered invocation. Anything unknown or invalid fails closed as a
+// possible write; Executor remains responsible for returning execution errors.
+func (registry *Registry) InvocationEffect(
+	invocation Invocation,
+) InvocationEffect {
+	registered, ok := registry.Get(invocation.Name)
+	if !ok {
+		return InvocationEffectMayWrite
+	}
+	definition := registered.Definition()
+	normalizedInput, err := NormalizeInput(
+		definition.InputSchema,
+		invocation.Input,
+	)
+	if err != nil {
+		return InvocationEffectMayWrite
+	}
+	if definition.ReadOnly {
+		return InvocationEffectReadOnly
+	}
+	classifier, conditional := registered.(InvocationEffectClassifier)
+	if !conditional {
+		return InvocationEffectMayWrite
+	}
+	effect, err := classifier.ClassifyInvocationEffect(normalizedInput)
+	if err != nil || !validInvocationEffect(effect) {
+		return InvocationEffectMayWrite
+	}
+	return effect
 }
 
 // Definitions 按稳定顺序返回所有工具定义，供模型侧暴露使用。
@@ -68,6 +105,11 @@ func (registry *Registry) Definitions() []Definition {
 func cloneDefinition(definition Definition) Definition {
 	definition.InputSchema = cloneSchemaMap(definition.InputSchema)
 	return definition
+}
+
+func validInvocationEffect(effect InvocationEffect) bool {
+	return effect == InvocationEffectReadOnly ||
+		effect == InvocationEffectMayWrite
 }
 
 func cloneSchemaMap(schema map[string]any) map[string]any {

--- a/server/internal/agent/tool/registry_test.go
+++ b/server/internal/agent/tool/registry_test.go
@@ -17,6 +17,20 @@ type stubTool struct {
 	calls      int
 }
 
+type conditionalStubTool struct {
+	*stubTool
+	effect      InvocationEffect
+	effectErr   error
+	effectInput json.RawMessage
+}
+
+func (tool *conditionalStubTool) ClassifyInvocationEffect(
+	input json.RawMessage,
+) (InvocationEffect, error) {
+	tool.effectInput = append(json.RawMessage{}, input...)
+	return tool.effect, tool.effectErr
+}
+
 func (tool *stubTool) Definition() Definition {
 	return tool.definition
 }
@@ -39,6 +53,18 @@ func TestRegistryRejectsDuplicateTools(t *testing.T) {
 	}
 	if err := registry.Register(tool); !errors.Is(err, ErrDuplicateTool) {
 		t.Fatalf("Register duplicate error = %v, want %v", err, ErrDuplicateTool)
+	}
+}
+
+func TestRegistryRejectsReadOnlyConditionalClassifier(t *testing.T) {
+	conditional := &conditionalStubTool{
+		stubTool: &stubTool{
+			definition: readToolDefinition("conditional.readonly.v1"),
+		},
+		effect: InvocationEffectMayWrite,
+	}
+	if _, err := NewRegistry(conditional); !errors.Is(err, ErrInvalidDefinition) {
+		t.Fatalf("NewRegistry() error = %v, want %v", err, ErrInvalidDefinition)
 	}
 }
 
@@ -78,6 +104,176 @@ func TestRegistryDefinitionsAreCompleteSortedAndIsolated(t *testing.T) {
 	}
 	if got, want := fresh[0].InputSchema["required"].([]string)[0], "query"; got != want {
 		t.Fatalf("fresh required field = %v, want %v", got, want)
+	}
+}
+
+func TestRegistryClassifiesInvocationEffects(t *testing.T) {
+	readOnly := &stubTool{
+		definition: readToolDefinition("readonly.search.v1"),
+	}
+	ordinaryWrite := &stubTool{
+		definition: writeToolDefinition("ordinary.write.v1"),
+	}
+	conditionalRead := &conditionalStubTool{
+		stubTool: &stubTool{
+			definition: writeToolDefinition("conditional.read.v1"),
+		},
+		effect: InvocationEffectReadOnly,
+	}
+	conditionalWrite := &conditionalStubTool{
+		stubTool: &stubTool{
+			definition: writeToolDefinition("conditional.write.v1"),
+		},
+		effect: InvocationEffectMayWrite,
+	}
+	registry, err := NewRegistry(
+		readOnly,
+		ordinaryWrite,
+		conditionalRead,
+		conditionalWrite,
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		invocation Invocation
+		want       InvocationEffect
+	}{
+		{
+			name: "static readonly",
+			invocation: Invocation{
+				Name:  "readonly.search.v1",
+				Input: json.RawMessage(`{"query":"history"}`),
+			},
+			want: InvocationEffectReadOnly,
+		},
+		{
+			name: "ordinary write",
+			invocation: Invocation{
+				Name:  "ordinary.write.v1",
+				Input: json.RawMessage(`{"query":"create"}`),
+			},
+			want: InvocationEffectMayWrite,
+		},
+		{
+			name: "conditional readonly",
+			invocation: Invocation{
+				Name: "conditional.read.v1",
+				Input: json.RawMessage(
+					`{"query":"lookup","unexpected":true}`,
+				),
+			},
+			want: InvocationEffectReadOnly,
+		},
+		{
+			name: "conditional write",
+			invocation: Invocation{
+				Name:  "conditional.write.v1",
+				Input: json.RawMessage(`{"query":"create"}`),
+			},
+			want: InvocationEffectMayWrite,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := registry.InvocationEffect(test.invocation); got != test.want {
+				t.Fatalf("InvocationEffect() = %v, want %v", got, test.want)
+			}
+		})
+	}
+	if got, want := string(conditionalRead.effectInput),
+		`{"query":"lookup"}`; got != want {
+		t.Fatalf("classifier input = %s, want %s", got, want)
+	}
+}
+
+func TestRegistryInvocationEffectFailsClosed(t *testing.T) {
+	classifierFailure := &conditionalStubTool{
+		stubTool: &stubTool{
+			definition: writeToolDefinition("conditional.error.v1"),
+		},
+		effect:    InvocationEffectReadOnly,
+		effectErr: errors.New("classification failed"),
+	}
+	invalidEffect := &conditionalStubTool{
+		stubTool: &stubTool{
+			definition: writeToolDefinition("conditional.invalid.v1"),
+		},
+	}
+	readOnly := &stubTool{
+		definition: readToolDefinition("readonly.search.v1"),
+	}
+	registry, err := NewRegistry(classifierFailure, invalidEffect, readOnly)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		registry   *Registry
+		invocation Invocation
+	}{
+		{
+			name:     "nil registry",
+			registry: nil,
+			invocation: Invocation{
+				Name:  "readonly.search.v1",
+				Input: json.RawMessage(`{"query":"history"}`),
+			},
+		},
+		{
+			name:     "unknown tool",
+			registry: registry,
+			invocation: Invocation{
+				Name:  "missing.v1",
+				Input: json.RawMessage(`{}`),
+			},
+		},
+		{
+			name:     "malformed input",
+			registry: registry,
+			invocation: Invocation{
+				Name:  "readonly.search.v1",
+				Input: json.RawMessage(`{`),
+			},
+		},
+		{
+			name:     "schema invalid input",
+			registry: registry,
+			invocation: Invocation{
+				Name:  "readonly.search.v1",
+				Input: json.RawMessage(`{"query":" "}`),
+			},
+		},
+		{
+			name:     "classifier error",
+			registry: registry,
+			invocation: Invocation{
+				Name:  "conditional.error.v1",
+				Input: json.RawMessage(`{"query":"lookup"}`),
+			},
+		},
+		{
+			name:     "classifier invalid effect",
+			registry: registry,
+			invocation: Invocation{
+				Name:  "conditional.invalid.v1",
+				Input: json.RawMessage(`{"query":"lookup"}`),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			effect := test.registry.InvocationEffect(test.invocation)
+			if effect != InvocationEffectMayWrite || !effect.MayWrite() {
+				t.Fatalf("InvocationEffect() = %v, want fail-closed write", effect)
+			}
+		})
+	}
+	if !InvocationEffect(0).MayWrite() {
+		t.Fatal("zero InvocationEffect must fail closed")
 	}
 }
 
@@ -223,6 +419,13 @@ func readToolDefinition(name string) Definition {
 		ReadOnly: true,
 		Risk:     RiskReadOnly,
 	}
+}
+
+func writeToolDefinition(name string) Definition {
+	definition := readToolDefinition(name)
+	definition.ReadOnly = false
+	definition.Risk = RiskLowRiskWrite
+	return definition
 }
 
 func TestExecutorNormalizesEmptyResultAndErrorCategories(t *testing.T) {

--- a/server/internal/agent/tool/schema.go
+++ b/server/internal/agent/tool/schema.go
@@ -68,6 +68,27 @@ type Invocation struct {
 	Input json.RawMessage
 }
 
+type InvocationEffect uint8
+
+const (
+	InvocationEffectReadOnly InvocationEffect = iota + 1
+	InvocationEffectMayWrite
+)
+
+// MayWrite reports whether an invocation must consume the write budget.
+// Unknown values fail closed and therefore also report a possible write.
+func (effect InvocationEffect) MayWrite() bool {
+	return effect != InvocationEffectReadOnly
+}
+
+// InvocationEffectClassifier lets a conditionally writing tool classify one
+// invocation after Registry has normalized its input against the tool schema.
+type InvocationEffectClassifier interface {
+	ClassifyInvocationEffect(
+		input json.RawMessage,
+	) (InvocationEffect, error)
+}
+
 type Result struct {
 	Content    map[string]any `json:"content"`
 	SourceRefs []SourceRef    `json:"source_refs,omitempty"`

--- a/server/internal/practice/agenttool/preview.go
+++ b/server/internal/practice/agenttool/preview.go
@@ -130,6 +130,19 @@ func (tool PreviewTool) Definition() Definition {
 	}
 }
 
+func (tool PreviewTool) ClassifyInvocationEffect(
+	input json.RawMessage,
+) (InvocationEffect, error) {
+	parsed, err := parsePreviewInput(input)
+	if err != nil {
+		return 0, err
+	}
+	if parsed.BackgroundSummary != "" && parsed.MaxEffectiveTurns > 0 {
+		return InvocationEffectMayWrite, nil
+	}
+	return InvocationEffectReadOnly, nil
+}
+
 func (tool PreviewTool) Execute(
 	ctx context.Context,
 	call CallContext,
@@ -138,15 +151,23 @@ func (tool PreviewTool) Execute(
 	if tool.port == nil {
 		return Result{}, ErrExecutionRejected
 	}
-	var parsed PreviewInput
-	if err := json.Unmarshal(input, &parsed); err != nil {
-		return Result{}, ErrInvalidInput
+	parsed, err := parsePreviewInput(input)
+	if err != nil {
+		return Result{}, err
 	}
 	result, err := tool.port.PreviewPractice(ctx, call, parsed)
 	if err != nil {
 		return Result{}, err
 	}
 	return previewToolResult(result), nil
+}
+
+func parsePreviewInput(input json.RawMessage) (PreviewInput, error) {
+	var parsed PreviewInput
+	if err := json.Unmarshal(input, &parsed); err != nil {
+		return PreviewInput{}, ErrInvalidInput
+	}
+	return parsed, nil
 }
 
 func previewToolResult(preview PreviewResult) Result {

--- a/server/internal/practice/agenttool/preview_test.go
+++ b/server/internal/practice/agenttool/preview_test.go
@@ -63,3 +63,49 @@ func TestPreviewToolSchemaAllowsNeedsInputRequest(t *testing.T) {
 		t.Fatalf("properties expose internal Preparation identifiers: %#v", properties)
 	}
 }
+
+func TestPreviewToolClassifiesInvocationEffect(t *testing.T) {
+	registry, err := tool.NewRegistry(NewPreviewTool(&previewPortStub{}))
+	if err != nil {
+		t.Fatalf("tool.NewRegistry() error = %v", err)
+	}
+	tests := []struct {
+		name  string
+		input string
+		want  tool.InvocationEffect
+	}{
+		{
+			name:  "candidate lookup",
+			input: `{"scenario_query":"AI product manager interview"}`,
+			want:  tool.InvocationEffectReadOnly,
+		},
+		{
+			name:  "missing effective turns",
+			input: `{"background_summary":"AI product manager"}`,
+			want:  tool.InvocationEffectReadOnly,
+		},
+		{
+			name: "schema invalid effective turns fails closed",
+			input: `{"background_summary":"AI product manager",` +
+				`"max_effective_turns":0}`,
+			want: tool.InvocationEffectMayWrite,
+		},
+		{
+			name: "ready plan input",
+			input: `{"background_summary":"AI product manager",` +
+				`"max_effective_turns":3}`,
+			want: tool.InvocationEffectMayWrite,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := registry.InvocationEffect(tool.Invocation{
+				Name:  PracticePreviewToolName,
+				Input: json.RawMessage(test.input),
+			})
+			if got != test.want {
+				t.Fatalf("InvocationEffect() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 功能描述

统一一次 Agent Capability Invocation 是否可能写入的判定入口：

- `agent/tool.Registry` 负责按 Schema 规范化参数并返回通用 Invocation Effect；
- 静态只读、普通写入和条件写入使用同一协议；
- 未知工具、非法参数和无法确定的分类按可能写入处理；
- Practice Preview 在所属 Adapter 内区分候选查询和可能创建 Plan 的调用；
- Agent Run 不再导入或解析 Practice 具体输入类型。

## 代码地图

```text
server/internal/agent/run/service.go
  → server/internal/agent/tool.Registry.InvocationEffect
  → 条件写 Capability 的 InvocationEffectClassifier
  → server/internal/agent/tool.Executor
  → 业务 Application Port
```

依赖方向保持为：

```text
agent/run → agent/tool
practice/agenttool → agent/tool + Practice Application Port
agent/tool 不依赖业务模块
```

## 实现思路

- 新增 `InvocationEffectReadOnly` 与 `InvocationEffectMayWrite`；
- Registry 使用 Executor 同一套 `NormalizeInput` 规则后再调用条件分类器；
- 拒绝同时声明静态只读和条件分类的冲突 Tool 定义；
- Run 对每批调用只分类一次，并在执行前整体预留写预算；
- 显式 Command、模型批量预检和后续循环计数全部消费 Registry 结果；
- 删除 Run 中的 Practice Preview 业务特判。

不修改 Tool 名称、InputSchema、输出、执行顺序、Prompt、API、数据库或 Flutter。

## 验证方式

- `cd server && go test -count=1 ./internal/agent/tool ./internal/agent/run ./internal/practice/agenttool ./internal/bootstrap ./internal/smoke ./cmd/server`
- `cd server && go test -race -count=1 ./internal/agent/tool ./internal/agent/run ./internal/practice/agenttool`
- `make check-go`
- `make check-smoke`
- `git diff --check`

覆盖静态只读、普通写入、条件查询、条件写入、显式写 Command、候选查询后一次写入、未知/非法调用安全闭合，以及同批超限无部分写入。

## 关联

Closes #328