### PR TITLE
feat(interview): add on-demand answer tips

### DIFF
--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -259,6 +259,41 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/voice-practice-sessions/{practice_session_id}/questions/{question_id}/tips:
+    post:
+      tags:
+        - Practice
+      summary: Create or restore a short reference answer for the current interview Question
+      description: |
+        The request has no body. The server verifies that the authenticated
+        Actor owns an active INTERVIEW Session and that `question_id` is its
+        current PRIMARY or FOLLOW_UP Question. One durable Tip is generated per
+        Question and replayed across repeated or concurrent requests. A Tip is
+        a read aid only: it never creates a candidate or Turn, never advances
+        effective turns or follow-up limits, and is excluded from Review,
+        Evaluation, memory, and message history.
+      operationId: ensureVoiceQuestionTip
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/QuestionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The newly generated or previously persisted Question Tip.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VoiceQuestionTip'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/voice-questions/{question_id}/speech:
     get:
       tags:
@@ -966,6 +1001,29 @@ components:
           type: string
           minLength: 1
           maxLength: 2000
+    VoiceQuestionTip:
+      type: object
+      additionalProperties: false
+      required:
+        - tip_id
+        - practice_session_id
+        - question_id
+        - content
+        - created_at
+      properties:
+        tip_id:
+          $ref: '#/components/schemas/ResourceId'
+        practice_session_id:
+          $ref: '#/components/schemas/ResourceId'
+        question_id:
+          $ref: '#/components/schemas/ResourceId'
+        content:
+          type: string
+          minLength: 1
+          maxLength: 800
+        created_at:
+          type: string
+          format: date-time
     VoiceTurnHistoryEntry:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -153,6 +153,8 @@ paths:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1retry-turns~1{retry_turn_id}~1transcription-candidates~1{candidate_id}~1confirmations
   /v1/voice-practice-sessions/{practice_session_id}/questions/{question_id}/text-answers:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-practice-sessions~1{practice_session_id}~1questions~1{question_id}~1text-answers
+  /v1/voice-practice-sessions/{practice_session_id}/questions/{question_id}/tips:
+    $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-practice-sessions~1{practice_session_id}~1questions~1{question_id}~1tips
   /v1/transcription-candidates/{candidate_id}/confirmations:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1transcription-candidates~1{candidate_id}~1confirmations
   /v1/voice-questions/{question_id}/speech:

--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -81,6 +81,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   String? _autoOpenedInterviewReportSessionId;
   bool _interviewReportRouteActive = false;
   IeltsExaminerSpeaker? _ownedTipSpeaker;
+  String? _visibleTipQuestionId;
 
   @override
   void initState() {
@@ -117,6 +118,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     if (controllerChanged) {
       oldWidget.practiceController.removeListener(_handleControllerState);
       _observedMessageCount = widget.practiceController.practiceMessages.length;
+      _visibleTipQuestionId = null;
       widget.practiceController.addListener(_handleControllerState);
       _syncRecordingTimer();
     }
@@ -148,23 +150,37 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
         controller.currentQuestion?.id != tip.questionId) {
       return;
     }
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (context) => QuestionTipSheet(
-        content: tip.content,
-        onSpeak: () async {
-          final speaker = _ownedTipSpeaker ??= SystemIeltsExaminerSpeaker();
-          await speaker.speak(tip.content);
-        },
-      ),
-    );
+    setState(() => _visibleTipQuestionId = tip.questionId);
+  }
+
+  Future<void> _speakQuestionTip() async {
+    final tip = widget.practiceController.questionTip;
+    if (tip == null || _visibleTipQuestionId != tip.questionId) {
+      return;
+    }
+    final speaker = _ownedTipSpeaker ??= SystemIeltsExaminerSpeaker();
+    await speaker.speak(tip.content);
+  }
+
+  void _hideQuestionTip() {
+    if (_visibleTipQuestionId == null) {
+      return;
+    }
+    setState(() => _visibleTipQuestionId = null);
+    unawaited(_stopQuestionTipSpeech());
+  }
+
+  Future<void> _stopQuestionTipSpeech() async {
     try {
       await _ownedTipSpeaker?.stop();
     } on Object {
-      // Closing the reference sheet must not be blocked by a platform TTS error.
+      // Recording and dismissal must not be blocked by a platform TTS error.
     }
+  }
+
+  Future<void> _beforeStartRecording() async {
+    await _stopQuestionTipSpeech();
+    await _runBoundedUserTurnAction(widget.onBeforeStartRecording);
   }
 
   void _handleControllerState() {
@@ -174,6 +190,10 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     final messageCount = widget.practiceController.practiceMessages.length;
     final shouldFollowConversation = messageCount != _observedMessageCount;
     _observedMessageCount = messageCount;
+    if (_visibleTipQuestionId !=
+        widget.practiceController.currentQuestion?.id) {
+      _visibleTipQuestionId = null;
+    }
     _syncRecordingTimer();
     _syncSpeechFeedbackSources();
     setState(() {});
@@ -489,9 +509,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                       recordingSeconds: _recordingSeconds,
                       previewMode: widget.previewMode,
                       conversationTextVisible: _conversationTextVisible,
-                      onBeforeStartRecording: () => _runBoundedUserTurnAction(
-                        widget.onBeforeStartRecording,
-                      ),
+                      onBeforeStartRecording: _beforeStartRecording,
                       onReplayQuestion: widget.onReplayQuestion,
                       speechFeedbackController: widget.speechFeedbackController,
                       replayLoading: widget.replayLoading,
@@ -507,6 +525,9 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                           ? _translateQuestion
                           : null,
                       onShowTip: _showQuestionTip,
+                      onHideTip: _hideQuestionTip,
+                      onSpeakTip: _speakQuestionTip,
+                      visibleTipQuestionId: _visibleTipQuestionId,
                       onOpenReport: _openInterviewReport,
                     );
                     if (landscape) {
@@ -735,6 +756,9 @@ class _ConversationPanel extends StatelessWidget {
     required this.onToggleConversationText,
     required this.onTranslateQuestion,
     required this.onShowTip,
+    required this.onHideTip,
+    required this.onSpeakTip,
+    required this.visibleTipQuestionId,
     required this.onOpenReport,
   });
 
@@ -756,6 +780,9 @@ class _ConversationPanel extends StatelessWidget {
   final VoidCallback onToggleConversationText;
   final Future<String> Function(PracticeMessage message)? onTranslateQuestion;
   final VoidCallback onShowTip;
+  final VoidCallback onHideTip;
+  final Future<void> Function() onSpeakTip;
+  final String? visibleTipQuestionId;
   final VoidCallback onOpenReport;
 
   @override
@@ -769,6 +796,7 @@ class _ConversationPanel extends StatelessWidget {
             controller: controller,
             conversationTextVisible: conversationTextVisible,
             onToggleConversationText: onToggleConversationText,
+            onShowTip: onShowTip,
             onReplayQuestion: onReplayQuestion,
             replayLoading: replayLoading,
             replayPlaying: replayPlaying,
@@ -851,6 +879,26 @@ class _ConversationPanel extends StatelessWidget {
                     },
                   ),
           ),
+          if (controller.questionTip case final tip?
+              when tip.questionId == visibleTipQuestionId)
+            QuestionTipCard(
+              content: tip.content,
+              onClose: onHideTip,
+              onSpeak: onSpeakTip,
+            ),
+          if (controller.questionTipErrorMessage case final message?)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                message,
+                key: const Key('immersive-question-tip-error'),
+                textAlign: TextAlign.right,
+                style: const TextStyle(
+                  color: SpeakUpDesign.error,
+                  fontSize: 12,
+                ),
+              ),
+            ),
           _ImmersiveComposer(
             controller: controller,
             textController: textController,
@@ -860,7 +908,6 @@ class _ConversationPanel extends StatelessWidget {
             onBeforeStartRecording: onBeforeStartRecording,
             onToggleTextMode: onToggleTextMode,
             onSubmitText: onSubmitText,
-            onShowTip: onShowTip,
             onOpenReport: onOpenReport,
           ),
         ],
@@ -908,6 +955,7 @@ class _ConversationHeader extends StatelessWidget {
     required this.controller,
     required this.conversationTextVisible,
     required this.onToggleConversationText,
+    required this.onShowTip,
     required this.onReplayQuestion,
     required this.replayLoading,
     required this.replayPlaying,
@@ -916,6 +964,7 @@ class _ConversationHeader extends StatelessWidget {
   final PracticeController controller;
   final bool conversationTextVisible;
   final VoidCallback onToggleConversationText;
+  final VoidCallback onShowTip;
   final ImmersiveAsyncAction? onReplayQuestion;
   final bool replayLoading;
   final bool replayPlaying;
@@ -956,6 +1005,28 @@ class _ConversationHeader extends StatelessWidget {
                     : Icons.visibility_off_outlined,
               ),
             ),
+          if (controller.isInterviewPractice) ...[
+            const SizedBox(width: 8),
+            TextButton.icon(
+              key: const Key('immersive-question-tip'),
+              onPressed: controller.canRequestQuestionTip ? onShowTip : null,
+              style: TextButton.styleFrom(
+                foregroundColor: SpeakUpDesign.primary,
+                backgroundColor: SpeakUpDesign.primaryMuted,
+                minimumSize: const Size(0, 34),
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity: VisualDensity.compact,
+              ),
+              icon: controller.isQuestionTipLoading
+                  ? const SizedBox.square(
+                      dimension: 15,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.lightbulb_outline_rounded, size: 18),
+              label: Text(controller.isQuestionTipLoading ? '生成中' : 'Tips'),
+            ),
+          ],
           if (onReplayQuestion != null || controller.canPlayQuestionAudio) ...[
             const SizedBox(width: 6),
             IconButton(
@@ -1040,7 +1111,6 @@ class _ImmersiveComposer extends StatefulWidget {
     required this.onBeforeStartRecording,
     required this.onToggleTextMode,
     required this.onSubmitText,
-    required this.onShowTip,
     required this.onOpenReport,
   });
 
@@ -1052,7 +1122,6 @@ class _ImmersiveComposer extends StatefulWidget {
   final ImmersiveAsyncAction? onBeforeStartRecording;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
-  final VoidCallback onShowTip;
   final VoidCallback onOpenReport;
 
   @override
@@ -1124,13 +1193,11 @@ class _ImmersiveComposerState extends State<_ImmersiveComposer> {
             widget.controller.hasPendingPracticeAudio
                 ? _PendingImmersiveAudio(controller: widget.controller)
                 : _IdleComposer(
-                    controller: widget.controller,
                     textController: widget.textController,
                     textFocusNode: widget.textFocusNode,
                     textMode: widget.textMode,
                     onToggleTextMode: widget.onToggleTextMode,
                     onSubmitText: widget.onSubmitText,
-                    onShowTip: widget.onShowTip,
                     capture: capture,
                   ),
           PracticeRecordingState.starting ||
@@ -1163,70 +1230,31 @@ class _ImmersiveComposerState extends State<_ImmersiveComposer> {
 
 class _IdleComposer extends StatelessWidget {
   const _IdleComposer({
-    required this.controller,
     required this.textController,
     required this.textFocusNode,
     required this.textMode,
     required this.onToggleTextMode,
     required this.onSubmitText,
-    required this.onShowTip,
     required this.capture,
   });
 
-  final PracticeController controller;
   final TextEditingController textController;
   final FocusNode textFocusNode;
   final bool textMode;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
-  final VoidCallback onShowTip;
   final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        if (controller.isInterviewPractice) ...[
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton.icon(
-              key: const Key('immersive-question-tip'),
-              onPressed: controller.canRequestQuestionTip ? onShowTip : null,
-              icon: controller.isQuestionTipLoading
-                  ? const SizedBox.square(
-                      dimension: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.lightbulb_outline_rounded, size: 19),
-              label: Text(controller.isQuestionTipLoading ? '正在生成' : 'Tips'),
-            ),
-          ),
-          if (controller.questionTipErrorMessage case final message?)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 6),
-              child: Text(
-                message,
-                key: const Key('immersive-question-tip-error'),
-                textAlign: TextAlign.right,
-                style: const TextStyle(
-                  color: SpeakUpDesign.error,
-                  fontSize: 12,
-                ),
-              ),
-            ),
-        ],
-        PracticeIdleComposer(
-          capture: capture,
-          textController: textController,
-          textFocusNode: textFocusNode,
-          textMode: textMode,
-          onToggleTextMode: onToggleTextMode,
-          onSubmitText: onSubmitText,
-          keyPrefix: 'immersive',
-        ),
-      ],
+    return PracticeIdleComposer(
+      capture: capture,
+      textController: textController,
+      textFocusNode: textFocusNode,
+      textMode: textMode,
+      onToggleTextMode: onToggleTextMode,
+      onSubmitText: onSubmitText,
+      keyPrefix: 'immersive',
     );
   }
 }

--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -8,6 +8,8 @@ import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/ielts_examiner_speaker.dart';
+import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
@@ -78,6 +80,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   String? _scheduledInterviewReportSessionId;
   String? _autoOpenedInterviewReportSessionId;
   bool _interviewReportRouteActive = false;
+  IeltsExaminerSpeaker? _ownedTipSpeaker;
 
   @override
   void initState() {
@@ -131,7 +134,37 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     _textController.dispose();
     _textFocusNode.dispose();
     unawaited(widget.practiceController.stopPracticeAudio(notify: false));
+    if (_ownedTipSpeaker case final speaker?) {
+      unawaited(speaker.dispose());
+    }
     super.dispose();
+  }
+
+  Future<void> _showQuestionTip() async {
+    final controller = widget.practiceController;
+    final tip = await controller.requestQuestionTip();
+    if (!mounted ||
+        tip == null ||
+        controller.currentQuestion?.id != tip.questionId) {
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => QuestionTipSheet(
+        content: tip.content,
+        onSpeak: () async {
+          final speaker = _ownedTipSpeaker ??= SystemIeltsExaminerSpeaker();
+          await speaker.speak(tip.content);
+        },
+      ),
+    );
+    try {
+      await _ownedTipSpeaker?.stop();
+    } on Object {
+      // Closing the reference sheet must not be blocked by a platform TTS error.
+    }
   }
 
   void _handleControllerState() {
@@ -473,6 +506,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                                   is PracticeQuestionTranslationClient
                           ? _translateQuestion
                           : null,
+                      onShowTip: _showQuestionTip,
                       onOpenReport: _openInterviewReport,
                     );
                     if (landscape) {
@@ -700,6 +734,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.onSubmitText,
     required this.onToggleConversationText,
     required this.onTranslateQuestion,
+    required this.onShowTip,
     required this.onOpenReport,
   });
 
@@ -720,6 +755,7 @@ class _ConversationPanel extends StatelessWidget {
   final VoidCallback onSubmitText;
   final VoidCallback onToggleConversationText;
   final Future<String> Function(PracticeMessage message)? onTranslateQuestion;
+  final VoidCallback onShowTip;
   final VoidCallback onOpenReport;
 
   @override
@@ -824,6 +860,7 @@ class _ConversationPanel extends StatelessWidget {
             onBeforeStartRecording: onBeforeStartRecording,
             onToggleTextMode: onToggleTextMode,
             onSubmitText: onSubmitText,
+            onShowTip: onShowTip,
             onOpenReport: onOpenReport,
           ),
         ],
@@ -1003,6 +1040,7 @@ class _ImmersiveComposer extends StatefulWidget {
     required this.onBeforeStartRecording,
     required this.onToggleTextMode,
     required this.onSubmitText,
+    required this.onShowTip,
     required this.onOpenReport,
   });
 
@@ -1014,6 +1052,7 @@ class _ImmersiveComposer extends StatefulWidget {
   final ImmersiveAsyncAction? onBeforeStartRecording;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
+  final VoidCallback onShowTip;
   final VoidCallback onOpenReport;
 
   @override
@@ -1085,11 +1124,13 @@ class _ImmersiveComposerState extends State<_ImmersiveComposer> {
             widget.controller.hasPendingPracticeAudio
                 ? _PendingImmersiveAudio(controller: widget.controller)
                 : _IdleComposer(
+                    controller: widget.controller,
                     textController: widget.textController,
                     textFocusNode: widget.textFocusNode,
                     textMode: widget.textMode,
                     onToggleTextMode: widget.onToggleTextMode,
                     onSubmitText: widget.onSubmitText,
+                    onShowTip: widget.onShowTip,
                     capture: capture,
                   ),
           PracticeRecordingState.starting ||
@@ -1122,31 +1163,70 @@ class _ImmersiveComposerState extends State<_ImmersiveComposer> {
 
 class _IdleComposer extends StatelessWidget {
   const _IdleComposer({
+    required this.controller,
     required this.textController,
     required this.textFocusNode,
     required this.textMode,
     required this.onToggleTextMode,
     required this.onSubmitText,
+    required this.onShowTip,
     required this.capture,
   });
 
+  final PracticeController controller;
   final TextEditingController textController;
   final FocusNode textFocusNode;
   final bool textMode;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
+  final VoidCallback onShowTip;
   final VoiceCaptureView capture;
 
   @override
   Widget build(BuildContext context) {
-    return PracticeIdleComposer(
-      capture: capture,
-      textController: textController,
-      textFocusNode: textFocusNode,
-      textMode: textMode,
-      onToggleTextMode: onToggleTextMode,
-      onSubmitText: onSubmitText,
-      keyPrefix: 'immersive',
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (controller.isInterviewPractice) ...[
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              key: const Key('immersive-question-tip'),
+              onPressed: controller.canRequestQuestionTip ? onShowTip : null,
+              icon: controller.isQuestionTipLoading
+                  ? const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.lightbulb_outline_rounded, size: 19),
+              label: Text(controller.isQuestionTipLoading ? '正在生成' : 'Tips'),
+            ),
+          ),
+          if (controller.questionTipErrorMessage case final message?)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text(
+                message,
+                key: const Key('immersive-question-tip-error'),
+                textAlign: TextAlign.right,
+                style: const TextStyle(
+                  color: SpeakUpDesign.error,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+        ],
+        PracticeIdleComposer(
+          capture: capture,
+          textController: textController,
+          textFocusNode: textFocusNode,
+          textMode: textMode,
+          onToggleTextMode: onToggleTextMode,
+          onSubmitText: onSubmitText,
+          keyPrefix: 'immersive',
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/coaching/practice/practice.dart
+++ b/mobile/lib/features/coaching/practice/practice.dart
@@ -11,6 +11,7 @@ import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/practice/ielts_mock_practice.dart';
 import 'package:speakup/features/coaching/practice/ielts_examiner_speaker.dart';
+import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/practice/ielts_mock_progress_store.dart';
@@ -144,7 +145,7 @@ class _PracticePageState extends State<PracticePage>
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      builder: (context) => _QuestionTipSheet(
+      builder: (context) => QuestionTipSheet(
         content: tip.content,
         onSpeak: () async {
           final speaker =
@@ -1108,10 +1109,7 @@ class _IdleAnswerPanel extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (isInterviewPracticeScenario(
-          controller.practiceScenarioType,
-          controller.practiceScenarioModel,
-        )) ...[
+        if (controller.isInterviewPractice) ...[
           Align(
             alignment: Alignment.centerRight,
             child: TextButton.icon(
@@ -1150,101 +1148,6 @@ class _IdleAnswerPanel extends StatelessWidget {
           keyPrefix: 'practice',
         ),
       ],
-    );
-  }
-}
-
-class _QuestionTipSheet extends StatefulWidget {
-  const _QuestionTipSheet({required this.content, required this.onSpeak});
-
-  final String content;
-  final Future<void> Function() onSpeak;
-
-  @override
-  State<_QuestionTipSheet> createState() => _QuestionTipSheetState();
-}
-
-class _QuestionTipSheetState extends State<_QuestionTipSheet> {
-  bool _speaking = false;
-  String? _speechError;
-
-  Future<void> _speak() async {
-    if (_speaking) {
-      return;
-    }
-    setState(() {
-      _speaking = true;
-      _speechError = null;
-    });
-    try {
-      await widget.onSpeak();
-    } catch (_) {
-      if (mounted) {
-        setState(() => _speechError = '暂时无法朗读，请稍后重试。');
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _speaking = false);
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-        24,
-        12,
-        24,
-        24 + MediaQuery.viewInsetsOf(context).bottom,
-      ),
-      child: Column(
-        key: const Key('practice-question-tip-sheet'),
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              const Expanded(
-                child: Text('参考回答', style: SpeakUpDesign.sectionTitle),
-              ),
-              IconButton(
-                tooltip: '关闭',
-                onPressed: () => Navigator.of(context).pop(),
-                icon: const Icon(Icons.close_rounded),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          Text(widget.content, style: SpeakUpDesign.body),
-          const SizedBox(height: 18),
-          OutlinedButton.icon(
-            key: const Key('practice-question-tip-speak'),
-            onPressed: _speaking ? null : _speak,
-            icon: _speaking
-                ? const SizedBox.square(
-                    dimension: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.volume_up_outlined),
-            label: Text(_speaking ? '正在朗读' : '朗读参考回答'),
-          ),
-          if (_speechError case final message?) ...[
-            const SizedBox(height: 8),
-            Text(
-              message,
-              textAlign: TextAlign.center,
-              style: const TextStyle(color: SpeakUpDesign.error, fontSize: 12),
-            ),
-          ],
-          const SizedBox(height: 8),
-          const Text(
-            '你可以照着念，也可以用自己的表达；此内容不会自动提交。',
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.meta,
-          ),
-        ],
-      ),
     );
   }
 }

--- a/mobile/lib/features/coaching/practice/practice.dart
+++ b/mobile/lib/features/coaching/practice/practice.dart
@@ -72,6 +72,7 @@ class _PracticePageState extends State<PracticePage>
   int _recordingSeconds = 0;
   bool _speechFeedbackRebuildScheduled = false;
   bool _interviewReportRouteActive = false;
+  IeltsExaminerSpeaker? _ownedTipSpeaker;
 
   @override
   void initState() {
@@ -122,7 +123,42 @@ class _PracticePageState extends State<PracticePage>
     _textAnswerController.dispose();
     _textAnswerFocusNode.dispose();
     unawaited(widget.practiceController?.stopPracticeAudio(notify: false));
+    if (_ownedTipSpeaker case final speaker?) {
+      unawaited(speaker.dispose());
+    }
     super.dispose();
+  }
+
+  Future<void> _showQuestionTip() async {
+    final controller = widget.practiceController;
+    if (controller == null) {
+      return;
+    }
+    final tip = await controller.requestQuestionTip();
+    if (!mounted ||
+        tip == null ||
+        controller.currentQuestion?.id != tip.questionId) {
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => _QuestionTipSheet(
+        content: tip.content,
+        onSpeak: () async {
+          final speaker =
+              widget.ieltsExaminerSpeaker ??
+              (_ownedTipSpeaker ??= SystemIeltsExaminerSpeaker());
+          await speaker.speak(tip.content);
+        },
+      ),
+    );
+    try {
+      await (widget.ieltsExaminerSpeaker ?? _ownedTipSpeaker)?.stop();
+    } on Object {
+      // Closing the reference sheet must not be blocked by a platform TTS error.
+    }
   }
 
   void _handleState() {
@@ -509,6 +545,7 @@ class _PracticePageState extends State<PracticePage>
                       onToggleTextMode: _toggleTextAnswerMode,
                       recordingSeconds: _recordingSeconds,
                       onOpenReport: _openInterviewReport,
+                      onShowTip: _showQuestionTip,
                     ),
                   ],
                 ),
@@ -899,6 +936,7 @@ class _RecordingPanel extends StatefulWidget {
     required this.onToggleTextMode,
     required this.recordingSeconds,
     required this.onOpenReport,
+    required this.onShowTip,
   });
 
   final PracticeController controller;
@@ -909,6 +947,7 @@ class _RecordingPanel extends StatefulWidget {
   final VoidCallback onToggleTextMode;
   final int recordingSeconds;
   final VoidCallback onOpenReport;
+  final VoidCallback onShowTip;
 
   @override
   State<_RecordingPanel> createState() => _RecordingPanelState();
@@ -979,12 +1018,14 @@ class _RecordingPanelState extends State<_RecordingPanel> {
             widget.controller.hasPendingPracticeAudio
                 ? _PendingPracticeAudioPanel(controller: widget.controller)
                 : _IdleAnswerPanel(
+                    controller: widget.controller,
                     textController: widget.textController,
                     textFocusNode: widget.textFocusNode,
                     onSubmitText: widget.onSubmitText,
                     textMode: widget.textMode,
                     onToggleTextMode: widget.onToggleTextMode,
                     capture: capture,
+                    onShowTip: widget.onShowTip,
                   ),
           PracticeRecordingState.starting ||
           PracticeRecordingState.recording => PracticeRecordingComposer(
@@ -1042,31 +1083,168 @@ class _CompletedPracticePanel extends StatelessWidget {
 
 class _IdleAnswerPanel extends StatelessWidget {
   const _IdleAnswerPanel({
+    required this.controller,
     required this.textController,
     required this.textFocusNode,
     required this.onSubmitText,
     required this.textMode,
     required this.onToggleTextMode,
     required this.capture,
+    required this.onShowTip,
   });
 
+  final PracticeController controller;
   final TextEditingController textController;
   final FocusNode textFocusNode;
   final VoidCallback onSubmitText;
   final bool textMode;
   final VoidCallback onToggleTextMode;
   final VoiceCaptureView capture;
+  final VoidCallback onShowTip;
 
   @override
   Widget build(BuildContext context) {
-    return PracticeIdleComposer(
-      capture: capture,
-      textController: textController,
-      textFocusNode: textFocusNode,
-      textMode: textMode,
-      onToggleTextMode: onToggleTextMode,
-      onSubmitText: onSubmitText,
-      keyPrefix: 'practice',
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (isInterviewPracticeScenario(
+          controller.practiceScenarioType,
+          controller.practiceScenarioModel,
+        )) ...[
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              key: const Key('practice-question-tip'),
+              onPressed: controller.canRequestQuestionTip ? onShowTip : null,
+              icon: controller.isQuestionTipLoading
+                  ? const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.lightbulb_outline_rounded, size: 19),
+              label: Text(controller.isQuestionTipLoading ? '正在生成' : 'Tips'),
+            ),
+          ),
+          if (controller.questionTipErrorMessage case final message?)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text(
+                message,
+                key: const Key('practice-question-tip-error'),
+                textAlign: TextAlign.right,
+                style: const TextStyle(
+                  color: SpeakUpDesign.error,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+        ],
+        PracticeIdleComposer(
+          capture: capture,
+          textController: textController,
+          textFocusNode: textFocusNode,
+          textMode: textMode,
+          onToggleTextMode: onToggleTextMode,
+          onSubmitText: onSubmitText,
+          keyPrefix: 'practice',
+        ),
+      ],
+    );
+  }
+}
+
+class _QuestionTipSheet extends StatefulWidget {
+  const _QuestionTipSheet({required this.content, required this.onSpeak});
+
+  final String content;
+  final Future<void> Function() onSpeak;
+
+  @override
+  State<_QuestionTipSheet> createState() => _QuestionTipSheetState();
+}
+
+class _QuestionTipSheetState extends State<_QuestionTipSheet> {
+  bool _speaking = false;
+  String? _speechError;
+
+  Future<void> _speak() async {
+    if (_speaking) {
+      return;
+    }
+    setState(() {
+      _speaking = true;
+      _speechError = null;
+    });
+    try {
+      await widget.onSpeak();
+    } catch (_) {
+      if (mounted) {
+        setState(() => _speechError = '暂时无法朗读，请稍后重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _speaking = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24,
+        12,
+        24,
+        24 + MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: Column(
+        key: const Key('practice-question-tip-sheet'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text('参考回答', style: SpeakUpDesign.sectionTitle),
+              ),
+              IconButton(
+                tooltip: '关闭',
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close_rounded),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(widget.content, style: SpeakUpDesign.body),
+          const SizedBox(height: 18),
+          OutlinedButton.icon(
+            key: const Key('practice-question-tip-speak'),
+            onPressed: _speaking ? null : _speak,
+            icon: _speaking
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.volume_up_outlined),
+            label: Text(_speaking ? '正在朗读' : '朗读参考回答'),
+          ),
+          if (_speechError case final message?) ...[
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: SpeakUpDesign.error, fontSize: 12),
+            ),
+          ],
+          const SizedBox(height: 8),
+          const Text(
+            '你可以照着念，也可以用自己的表达；此内容不会自动提交。',
+            textAlign: TextAlign.center,
+            style: SpeakUpDesign.meta,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/features/coaching/practice/practice_client.dart
+++ b/mobile/lib/features/coaching/practice/practice_client.dart
@@ -49,6 +49,17 @@ abstract interface class PracticeQuestionTranslationClient {
   });
 }
 
+/// Optional interview-only reference answer capability.
+///
+/// A Tip is a separate read aid. It is never submitted as a candidate or Turn.
+abstract interface class PracticeQuestionTipClient {
+  Future<PracticeQuestionTip> ensureQuestionTip({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+  });
+}
+
 /// Optional Daily/Workplace same-question retry capability.
 ///
 /// Keeping this separate from [PracticeClient] lets existing test doubles and

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -202,6 +202,8 @@ final class PracticeController extends ChangeNotifier
   String? get errorMessage => _errorMessage;
   int get completedTurns => _completedTurns;
   int get turnLimit => _turnLimit;
+  bool get isInterviewPractice =>
+      isInterviewPracticeScene(_practiceSceneFamily, _practiceSceneModel);
   bool get isFinalInterviewSubmission =>
       _recordingState == PracticeRecordingState.submitting &&
       _speechFeedbackRetry == null &&
@@ -1558,10 +1560,9 @@ final class PracticeController extends ChangeNotifier
   }
 
   Future<PracticeQuestionTip?> requestQuestionTip() async {
-    final tipClient = client;
     final sessionId = _practiceSessionId;
     final question = _currentQuestion;
-    if (tipClient is! PracticeQuestionTipClient ||
+    if (client is! PracticeQuestionTipClient ||
         sessionId == null ||
         question == null ||
         !isInterviewPracticeScene(_practiceSceneFamily, _practiceSceneModel) ||
@@ -1569,6 +1570,7 @@ final class PracticeController extends ChangeNotifier
         _recordingState != PracticeRecordingState.idle) {
       return null;
     }
+    final tipClient = client as PracticeQuestionTipClient;
     final cached = _questionTip;
     if (cached != null &&
         cached.sessionId == sessionId &&

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -63,6 +63,11 @@ final class PracticeController extends ChangeNotifier
   int? _practiceSessionVersion;
   String? _endPracticeClientId;
   PracticeQuestion? _currentQuestion;
+  PracticeQuestionTip? _questionTip;
+  String? _questionTipRequestId;
+  String? _questionTipErrorMessage;
+  bool _questionTipLoading = false;
+  int _questionTipGeneration = 0;
   TranscriptionCandidate? _candidate;
   _PendingPracticeAudio? _pendingPracticeAudio;
   String? _activeConfirmationId;
@@ -100,6 +105,19 @@ final class PracticeController extends ChangeNotifier
   SceneModel? get practiceSceneModel => _practiceSceneModel;
   int? get practiceSessionVersion => _practiceSessionVersion;
   PracticeQuestion? get currentQuestion => _currentQuestion;
+  PracticeQuestionTip? get questionTip => _questionTip;
+  bool get isQuestionTipLoading => _questionTipLoading;
+  String? get questionTipErrorMessage => _questionTipErrorMessage;
+  bool get canRequestQuestionTip =>
+      client is PracticeQuestionTipClient &&
+      isInterviewPracticeScene(_practiceSceneFamily, _practiceSceneModel) &&
+      _practiceSessionId != null &&
+      _currentQuestion != null &&
+      !_sessionCompleted &&
+      !_disposed &&
+      !isBusy &&
+      !_questionTipLoading &&
+      _recordingState == PracticeRecordingState.idle;
   String? get questionId => _currentQuestion?.id;
   String? get candidateId => _candidate?.id;
   bool get hasPendingPracticeAudio => _pendingPracticeAudio != null;
@@ -192,7 +210,10 @@ final class PracticeController extends ChangeNotifier
       _completedTurns + 1 == _turnLimit &&
       isInterviewPracticeScene(_practiceSceneFamily, _practiceSceneModel);
   bool get isBusy =>
-      _busy || _practiceRequestInFlight || _speechFeedbackRetry != null;
+      _busy ||
+      _practiceRequestInFlight ||
+      _questionTipLoading ||
+      _speechFeedbackRetry != null;
   bool get isSpeechFeedbackRetryActive => _speechFeedbackRetry != null;
   int get speechFeedbackRetryCompletionCount =>
       _speechFeedbackRetryCompletionCount;
@@ -1507,6 +1528,7 @@ final class PracticeController extends ChangeNotifier
         confirmation.sessionVersion ?? _practiceSessionVersion;
     _endPracticeClientId = null;
     _currentQuestion = confirmation.nextQuestion;
+    _clearQuestionTip();
     final audioAssetId = confirmation.audioAssetId;
     if (audioAssetId != null &&
         !_recordings.any(
@@ -1533,6 +1555,76 @@ final class PracticeController extends ChangeNotifier
     } else {
       _recordingState = PracticeRecordingState.idle;
     }
+  }
+
+  Future<PracticeQuestionTip?> requestQuestionTip() async {
+    final tipClient = client;
+    final sessionId = _practiceSessionId;
+    final question = _currentQuestion;
+    if (tipClient is! PracticeQuestionTipClient ||
+        sessionId == null ||
+        question == null ||
+        !isInterviewPracticeScene(_practiceSceneFamily, _practiceSceneModel) ||
+        _sessionCompleted ||
+        _recordingState != PracticeRecordingState.idle) {
+      return null;
+    }
+    final cached = _questionTip;
+    if (cached != null &&
+        cached.sessionId == sessionId &&
+        cached.questionId == question.id) {
+      return cached;
+    }
+    if (_questionTipLoading) {
+      return null;
+    }
+    final generation = ++_questionTipGeneration;
+    _questionTipLoading = true;
+    _questionTipErrorMessage = null;
+    _questionTipRequestId ??= _newClientId('question-tip');
+    notifyListeners();
+    try {
+      final tip = await tipClient.ensureQuestionTip(
+        sessionId: sessionId,
+        questionId: question.id,
+        idempotencyKey: _questionTipRequestId!,
+      );
+      if (_disposed ||
+          generation != _questionTipGeneration ||
+          _practiceSessionId != sessionId ||
+          _currentQuestion?.id != question.id) {
+        return null;
+      }
+      if (tip.sessionId != sessionId ||
+          tip.questionId != question.id ||
+          tip.content.trim().isEmpty) {
+        throw StateError('Invalid question Tip response.');
+      }
+      _questionTip = tip;
+      _questionTipRequestId = null;
+      return tip;
+    } catch (_) {
+      if (!_disposed &&
+          generation == _questionTipGeneration &&
+          _practiceSessionId == sessionId &&
+          _currentQuestion?.id == question.id) {
+        _questionTipErrorMessage = '暂时无法生成参考答案，请稍后重试。';
+      }
+      return null;
+    } finally {
+      if (!_disposed && generation == _questionTipGeneration) {
+        _questionTipLoading = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  void _clearQuestionTip() {
+    _questionTipGeneration++;
+    _questionTip = null;
+    _questionTipRequestId = null;
+    _questionTipErrorMessage = null;
+    _questionTipLoading = false;
   }
 
   Future<bool> _reconcileFinalInterviewSubmission({
@@ -1591,6 +1683,7 @@ final class PracticeController extends ChangeNotifier
     _practiceSessionVersion = null;
     _endPracticeClientId = null;
     _currentQuestion = null;
+    _clearQuestionTip();
     _candidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
@@ -1718,6 +1811,7 @@ final class PracticeController extends ChangeNotifier
       _practiceSessionVersion = null;
       _endPracticeClientId = null;
       _currentQuestion = null;
+      _clearQuestionTip();
       _activeScene = null;
       _completedTurns = 0;
       _turnLimit = 0;
@@ -1739,6 +1833,7 @@ final class PracticeController extends ChangeNotifier
     _practiceSessionVersion = snapshot.sessionVersion;
     _endPracticeClientId = null;
     _currentQuestion = snapshot.currentQuestion;
+    _clearQuestionTip();
     _completedTurns = snapshot.completedTurns;
     _turnLimit = snapshot.turnLimit;
     _sessionCompleted = snapshot.sessionCompleted;

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -116,6 +116,22 @@ final class PracticeQuestionTranslation {
   final String content;
 }
 
+final class PracticeQuestionTip {
+  const PracticeQuestionTip({
+    required this.id,
+    required this.sessionId,
+    required this.questionId,
+    required this.content,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String sessionId;
+  final String questionId;
+  final String content;
+  final DateTime createdAt;
+}
+
 /// The server-authoritative practice projection consumed by Flutter.
 ///
 /// The projection is always loaded by the explicit opaque [sessionId].

--- a/mobile/lib/features/coaching/practice/question_tip_sheet.dart
+++ b/mobile/lib/features/coaching/practice/question_tip_sheet.dart
@@ -1,6 +1,129 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 
+class QuestionTipCard extends StatefulWidget {
+  const QuestionTipCard({
+    required this.content,
+    required this.onClose,
+    required this.onSpeak,
+    super.key,
+  });
+
+  final String content;
+  final VoidCallback onClose;
+  final Future<void> Function() onSpeak;
+
+  @override
+  State<QuestionTipCard> createState() => _QuestionTipCardState();
+}
+
+class _QuestionTipCardState extends State<QuestionTipCard> {
+  bool _speaking = false;
+  String? _speechError;
+
+  Future<void> _speak() async {
+    if (_speaking) {
+      return;
+    }
+    setState(() {
+      _speaking = true;
+      _speechError = null;
+    });
+    try {
+      await widget.onSpeak();
+    } catch (_) {
+      if (mounted) {
+        setState(() => _speechError = '暂时无法朗读，请稍后重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _speaking = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('practice-question-tip-card'),
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      padding: const EdgeInsets.fromLTRB(14, 10, 10, 10),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.primaryMuted,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFC9DEE3)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.lightbulb_outline_rounded,
+                size: 18,
+                color: SpeakUpDesign.primary,
+              ),
+              const SizedBox(width: 6),
+              const Expanded(
+                child: Text('参考回答', style: SpeakUpDesign.cardTitle),
+              ),
+              IconButton(
+                tooltip: '收起参考回答',
+                onPressed: widget.onClose,
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints.tightFor(
+                  width: 34,
+                  height: 34,
+                ),
+                icon: const Icon(Icons.close_rounded, size: 20),
+              ),
+            ],
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 112),
+            child: SingleChildScrollView(
+              child: Text(widget.content, style: SpeakUpDesign.body),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              TextButton.icon(
+                key: const Key('practice-question-tip-speak-inline'),
+                onPressed: _speaking ? null : _speak,
+                style: TextButton.styleFrom(
+                  foregroundColor: SpeakUpDesign.primary,
+                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  minimumSize: const Size(0, 34),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                ),
+                icon: _speaking
+                    ? const SizedBox.square(
+                        dimension: 15,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.volume_up_outlined, size: 18),
+                label: Text(_speaking ? '正在朗读' : '朗读'),
+              ),
+              const Spacer(),
+              const Text('可边看边说', style: SpeakUpDesign.meta),
+            ],
+          ),
+          if (_speechError case final message?) ...[
+            const SizedBox(height: 4),
+            Text(
+              message,
+              style: const TextStyle(color: SpeakUpDesign.error, fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 class QuestionTipSheet extends StatefulWidget {
   const QuestionTipSheet({
     required this.content,

--- a/mobile/lib/features/coaching/practice/question_tip_sheet.dart
+++ b/mobile/lib/features/coaching/practice/question_tip_sheet.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+class QuestionTipSheet extends StatefulWidget {
+  const QuestionTipSheet({
+    required this.content,
+    required this.onSpeak,
+    super.key,
+  });
+
+  final String content;
+  final Future<void> Function() onSpeak;
+
+  @override
+  State<QuestionTipSheet> createState() => _QuestionTipSheetState();
+}
+
+class _QuestionTipSheetState extends State<QuestionTipSheet> {
+  bool _speaking = false;
+  String? _speechError;
+
+  Future<void> _speak() async {
+    if (_speaking) {
+      return;
+    }
+    setState(() {
+      _speaking = true;
+      _speechError = null;
+    });
+    try {
+      await widget.onSpeak();
+    } catch (_) {
+      if (mounted) {
+        setState(() => _speechError = '暂时无法朗读，请稍后重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _speaking = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24,
+        12,
+        24,
+        24 + MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: Column(
+        key: const Key('practice-question-tip-sheet'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text('参考回答', style: SpeakUpDesign.sectionTitle),
+              ),
+              IconButton(
+                tooltip: '关闭',
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close_rounded),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(widget.content, style: SpeakUpDesign.body),
+          const SizedBox(height: 18),
+          OutlinedButton.icon(
+            key: const Key('practice-question-tip-speak'),
+            onPressed: _speaking ? null : _speak,
+            icon: _speaking
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.volume_up_outlined),
+            label: Text(_speaking ? '正在朗读' : '朗读参考回答'),
+          ),
+          if (_speechError case final message?) ...[
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: SpeakUpDesign.error, fontSize: 12),
+            ),
+          ],
+          const SizedBox(height: 8),
+          const Text(
+            '你可以照着念，也可以用自己的表达；此内容不会自动提交。',
+            textAlign: TextAlign.center,
+            style: SpeakUpDesign.meta,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -28,6 +28,9 @@ final class PracticeWireEndpoints {
     this.submitText =
         '/v1/voice-practice-sessions/{practice_session_id}/questions/'
         '{question_id}/text-answers',
+    this.questionTip =
+        '/v1/voice-practice-sessions/{practice_session_id}/questions/'
+        '{question_id}/tips',
     this.confirm = '/v1/transcription-candidates/{candidate_id}/confirmations',
     this.endEarly = '/v1/practice-sessions/{practice_session_id}/end-early',
     this.retryRequest = '/v1/feedback-items/{feedback_item_id}/retry-requests',
@@ -42,6 +45,7 @@ final class PracticeWireEndpoints {
   final String voiceState;
   final String transcribe;
   final String submitText;
+  final String questionTip;
   final String confirm;
   final String endEarly;
   final String retryRequest;
@@ -70,6 +74,10 @@ final class PracticeWireEndpoints {
 
   String questionTranslationPath(String questionId) =>
       questionTranslation.replaceAll('{question_id}', _pathSegment(questionId));
+
+  String questionTipPath(String sessionId, String questionId) => questionTip
+      .replaceAll('{practice_session_id}', _pathSegment(sessionId))
+      .replaceAll('{question_id}', _pathSegment(questionId));
 
   String endEarlyPath(String sessionId) =>
       endEarly.replaceAll('{practice_session_id}', _pathSegment(sessionId));
@@ -136,6 +144,7 @@ final class WirePracticeClient
         PracticeClient,
         PracticeLifecycleClient,
         PracticeSpeechFeedbackRetryClient,
+        PracticeQuestionTipClient,
         PracticeQuestionTranslationClient {
   factory WirePracticeClient({
     required Uri baseUri,
@@ -460,6 +469,32 @@ final class WirePracticeClient
       _requireStatus(response, const {HttpStatus.ok});
       return _decodeQuestionTranslation(
         response.body,
+        expectedQuestionId: questionId,
+      );
+    });
+  }
+
+  @override
+  Future<PracticeQuestionTip> ensureQuestionTip({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+  }) {
+    return _run((generation) async {
+      _requireOpaqueId(sessionId);
+      _requireOpaqueId(questionId);
+      _requireClientId(idempotencyKey);
+      final response = await _send(
+        generation: generation,
+        timeout: _jsonTimeout,
+        method: 'POST',
+        path: _endpoints.questionTipPath(sessionId, questionId),
+        extraHeaders: <String, String>{'Idempotency-Key': idempotencyKey},
+      );
+      _requireStatus(response, const {HttpStatus.ok});
+      return _decodeQuestionTip(
+        response.body,
+        expectedSessionId: sessionId,
         expectedQuestionId: questionId,
       );
     });
@@ -962,6 +997,35 @@ TranscriptionCandidate _decodeCandidate(
     throw _invalidResponse();
   }
   return candidate;
+}
+
+PracticeQuestionTip _decodeQuestionTip(
+  String body, {
+  required String expectedSessionId,
+  required String expectedQuestionId,
+}) {
+  final root = _exactObject(
+    jsonDecode(body),
+    required: const {
+      'tip_id',
+      'practice_session_id',
+      'question_id',
+      'content',
+      'created_at',
+    },
+  );
+  final tip = PracticeQuestionTip(
+    id: _string(root, 'tip_id'),
+    sessionId: _string(root, 'practice_session_id'),
+    questionId: _string(root, 'question_id'),
+    content: _utf8String(root, 'content', maxLength: 800, maxBytes: 2400),
+    createdAt: _dateTime(root, 'created_at'),
+  );
+  if (tip.sessionId != expectedSessionId ||
+      tip.questionId != expectedQuestionId) {
+    throw _invalidResponse();
+  }
+  return tip;
 }
 
 PracticeRetryRequest _decodeRetryRequest(

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -167,6 +167,37 @@ void main() {
     },
   );
 
+  testWidgets('shows interview Tips in the immersive answer composer', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final controller = await _roleplayController(
+      practiceClient: _QuestionTipPracticeClient(),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(practiceController: controller)),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('immersive-question-tip')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('immersive-question-tip')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('practice-question-tip-sheet')),
+      findsOneWidget,
+    );
+    expect(
+      find.text('I would describe the situation and my specific role.'),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('removes the avatar surface before leaving practice', (
     tester,
   ) async {
@@ -610,11 +641,13 @@ Future<PracticeController> _roleplayController({
   final sceneFamily = switch (practiceClient) {
     final _AsyncReviewPracticeClient client => client.resolvedSceneFamily,
     final _TranslationPracticeClient client => client.resolvedSceneFamily,
+    _QuestionTipPracticeClient() => SceneFamily.interview,
     _ => SceneFamily.daily,
   };
   final sceneModel = switch (practiceClient) {
     final _AsyncReviewPracticeClient client => client.resolvedSceneModel,
     final _TranslationPracticeClient client => client.resolvedSceneModel,
+    _QuestionTipPracticeClient() => SceneModel.interviewBasicDialogue,
     _ => SceneModel.hotelCheckinAndIssueHandling,
   };
   final scene = testScene(
@@ -870,6 +903,75 @@ final class _FailOncePracticeClient implements PracticeClient {
     ),
     SceneFamily.daily,
     SceneModel.hotelCheckinAndIssueHandling,
+  );
+}
+
+final class _QuestionTipPracticeClient
+    implements PracticeClient, PracticeQuestionTipClient {
+  final _delegate = FakePracticeClient(
+    sceneFamily: SceneFamily.interview,
+    sceneModel: SceneModel.interviewBasicDialogue,
+  );
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<PracticeSessionSnapshot> restorePractice({
+    required String sessionId,
+  }) => _delegate.restorePractice(sessionId: sessionId);
+
+  @override
+  Future<PracticeSessionSnapshot> activatePractice({
+    required String sessionId,
+    required String clientOperationId,
+  }) => _delegate.activatePractice(
+    sessionId: sessionId,
+    clientOperationId: clientOperationId,
+  );
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) => _delegate.transcribe(request);
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) => _delegate.confirm(
+    sessionId: sessionId,
+    questionId: questionId,
+    candidateId: candidateId,
+    idempotencyKey: idempotencyKey,
+  );
+
+  @override
+  Future<PracticeTurnConfirmation> submitText({
+    required String sessionId,
+    required String questionId,
+    required String answerText,
+    required String idempotencyKey,
+  }) => _delegate.submitText(
+    sessionId: sessionId,
+    questionId: questionId,
+    answerText: answerText,
+    idempotencyKey: idempotencyKey,
+  );
+
+  @override
+  Future<PracticeQuestionTip> ensureQuestionTip({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+  }) async => PracticeQuestionTip(
+    id: 'tip-1',
+    sessionId: sessionId,
+    questionId: questionId,
+    content: 'I would describe the situation and my specific role.',
+    createdAt: DateTime.utc(2026, 8, 3),
   );
 }
 

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -167,7 +167,7 @@ void main() {
     },
   );
 
-  testWidgets('shows interview Tips in the immersive answer composer', (
+  testWidgets('shows inline interview Tips without blocking the composer', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(390, 844);
@@ -187,12 +187,13 @@ void main() {
     await tester.tap(find.byKey(const Key('immersive-question-tip')));
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
     expect(
-      find.byKey(const Key('practice-question-tip-sheet')),
+      find.text('I would describe the situation and my specific role.'),
       findsOneWidget,
     );
     expect(
-      find.text('I would describe the situation and my specific role.'),
+      find.byKey(const Key('immersive-record')).hitTestable(),
       findsOneWidget,
     );
     expect(tester.takeException(), isNull);

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -80,6 +80,10 @@ void main() {
       '$encoded/text-answers',
     );
     expect(
+      endpoints.questionTipPath(opaque, opaque),
+      '/v1/voice-practice-sessions/$encoded/questions/$encoded/tips',
+    );
+    expect(
       endpoints.confirmPath(opaque),
       '/v1/transcription-candidates/$encoded/confirmations',
     );
@@ -113,6 +117,41 @@ void main() {
     expect(translation.questionId, _questionId);
     expect(translation.targetLanguage, 'zh-CN');
     expect(translation.content, '请介绍一次你解决团队分歧的经历。');
+    transport.expectDone();
+  });
+
+  test('requests and decodes a Question Tip without an answer body', () async {
+    final transport = _Transport([
+      _Step(
+        method: 'POST',
+        path:
+            '/v1/voice-practice-sessions/$_sessionId/questions/'
+            '$_questionId/tips',
+        verify: (request) {
+          expect(request.jsonBody, isNull);
+          expect(request.rawFilePath, isNull);
+          expect(request.headers['Idempotency-Key'], 'question-tip-operation');
+        },
+        response: _json(HttpStatus.ok, {
+          'tip_id': 'question-tip-1',
+          'practice_session_id': _sessionId,
+          'question_id': _questionId,
+          'content':
+              'I would clarify the goal first. Then I would explain my approach clearly.',
+          'created_at': _timestamp,
+        }),
+      ),
+    ]);
+
+    final tip = await _client(transport).ensureQuestionTip(
+      sessionId: _sessionId,
+      questionId: _questionId,
+      idempotencyKey: 'question-tip-operation',
+    );
+
+    expect(tip.id, 'question-tip-1');
+    expect(tip.questionId, _questionId);
+    expect(tip.content, contains('clarify the goal'));
     transport.expectDone();
   });
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -121,6 +121,11 @@ func run() int {
 		logger.Error("Practice question translation startup failed")
 		return 1
 	}
+	practiceAnswerTips, err := bootstrap.NewPracticeAnswerTipGenerator(textConfig)
+	if err != nil {
+		logger.Error("Practice answer Tip generation startup failed")
+		return 1
+	}
 	temporaryAudioConfig, err := config.LoadTemporaryAudio()
 	if err != nil {
 		logger.Error("temporary audio configuration failed")
@@ -360,6 +365,7 @@ func run() int {
 				PracticeSynthesizer:    practiceSynthesizer,
 				QuestionGenerator:      practiceQuestions,
 				QuestionTranslator:     practiceQuestionTranslator,
+				AnswerTipGenerator:     practiceAnswerTips,
 				TemporaryAudio:         audioVault,
 				ObjectStore:            recordingStore,
 				AgentVoiceInputEnabled: storageConfig.Enabled,

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -25,6 +25,7 @@ type VoiceConfiguration struct {
 	PracticeSynthesizer       practicevoice.SpeechSynthesizer
 	QuestionGenerator         practicevoice.QuestionGenerator
 	QuestionTranslator        practicevoice.QuestionTranslator
+	AnswerTipGenerator        practicevoice.AnswerTipGenerator
 	TemporaryAudio            practicevoice.TemporaryAudioVault
 	ObjectStore               objectstore.Store
 	AgentVoiceInputEnabled    bool
@@ -166,6 +167,26 @@ func NewPracticeQuestionTranslator(
 	)
 }
 
+// NewPracticeAnswerTipGenerator selects the Practice Voice Tip adapter.
+func NewPracticeAnswerTipGenerator(
+	configuration config.TextGenerationConfig,
+) (practicevoice.AnswerTipGenerator, error) {
+	if configuration.Provider != config.TextProviderQianwen {
+		return nil, errors.New(
+			"bootstrap: Practice answer Tip provider is not registered",
+		)
+	}
+	return qianwen.NewPracticeVoiceAnswerTipGenerator(
+		qianwen.TextConfig{
+			BaseURL:         configuration.BaseURL,
+			Model:           configuration.Model,
+			Timeout:         configuration.Timeout,
+			MaxOutputTokens: configuration.MaxOutputTokens,
+		},
+		configuration.APIKey.Reveal(),
+	)
+}
+
 // buildProductionVoiceApplication constructs infrastructure and delegates all
 // Practice Voice business wiring to the owning package.
 func buildProductionVoiceApplication(
@@ -236,6 +257,7 @@ func buildProductionVoiceApplication(
 				Synthesizer:        configuration.PracticeSynthesizer,
 				QuestionGenerator:  configuration.QuestionGenerator,
 				QuestionTranslator: configuration.QuestionTranslator,
+				AnswerTipGenerator: configuration.AnswerTipGenerator,
 				Recordings:         recordings,
 				AudioAssets:        audioAssets,
 				ASRLease:           configuration.ASRLease,

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -74,6 +74,10 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 		handler.submitText,
 	)
 	routes.POST(
+		"/v1/voice-practice-sessions/:practice_session_id/questions/:question_id/tips",
+		handler.ensureQuestionTip,
+	)
+	routes.POST(
 		"/v1/transcription-candidates/:candidate_id/confirmations",
 		handler.confirmCandidate,
 	)
@@ -335,6 +339,36 @@ func (handler *Handler) questionTranslation(c *gin.Context) {
 	})
 }
 
+func (handler *Handler) ensureQuestionTip(c *gin.Context) {
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	key, ok := httpinput.IdempotencyKey(c.Request)
+	if !ok {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	tip, err := handler.application.EnsureQuestionTip(
+		c.Request.Context(),
+		actor,
+		c.Param("practice_session_id"),
+		c.Param("question_id"),
+		key,
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	c.Header("Cache-Control", "private, no-store")
+	c.JSON(http.StatusOK, QuestionTipResponse(tip))
+}
+
 func SessionStateResponse(state practicevoice.SessionState) gin.H {
 	result := gin.H{
 		"practice_session_id": state.Session.ID,
@@ -380,6 +414,16 @@ func QuestionResponse(question practice.Question) gin.H {
 		result["parent_question_id"] = question.ParentQuestionID
 	}
 	return result
+}
+
+func QuestionTipResponse(tip practicevoice.QuestionTipResult) gin.H {
+	return gin.H{
+		"tip_id":              tip.ID,
+		"practice_session_id": tip.SessionID,
+		"question_id":         tip.QuestionID,
+		"content":             tip.Content,
+		"created_at":          tip.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}
 }
 
 func TranscriptionCandidateResponse(

--- a/server/internal/coaching/practice/voice/persistence.go
+++ b/server/internal/coaching/practice/voice/persistence.go
@@ -185,3 +185,74 @@ type PersistenceStore interface {
 	GetTurn(context.Context, Actor, string) (practice.Turn, error)
 	ListSessionTurns(context.Context, Actor, string) ([]practice.Turn, error)
 }
+
+type QuestionTipStatus string
+
+const (
+	QuestionTipProcessing QuestionTipStatus = "processing"
+	QuestionTipCompleted  QuestionTipStatus = "completed"
+	QuestionTipFailed     QuestionTipStatus = "failed"
+)
+
+type QuestionTip struct {
+	ID                 string
+	SessionID          string
+	QuestionID         string
+	IdempotencyKey     string
+	Status             QuestionTipStatus
+	FencingToken       int64
+	DeletionGeneration int64
+	LeaseAcquired      bool
+	LeaseExpiresAt     time.Time
+	Content            string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	CompletedAt        *time.Time
+}
+
+type ClaimQuestionTipCommand struct {
+	SessionID      string
+	QuestionID     string
+	IdempotencyKey string
+	LeaseDuration  time.Duration
+}
+
+type CompleteQuestionTipCommand struct {
+	TipID              string
+	FencingToken       int64
+	DeletionGeneration int64
+	Content            string
+	Provider           string
+	Model              string
+	ProviderRequestID  string
+}
+
+type FailQuestionTipCommand struct {
+	TipID              string
+	FencingToken       int64
+	DeletionGeneration int64
+}
+
+type QuestionTipStore interface {
+	ClaimQuestionTip(
+		context.Context,
+		Actor,
+		ClaimQuestionTipCommand,
+	) (QuestionTip, error)
+	GetQuestionTip(
+		context.Context,
+		Actor,
+		string,
+		string,
+	) (QuestionTip, error)
+	CompleteQuestionTip(
+		context.Context,
+		Actor,
+		CompleteQuestionTipCommand,
+	) (QuestionTip, error)
+	FailQuestionTip(
+		context.Context,
+		Actor,
+		FailQuestionTipCommand,
+	) error
+}

--- a/server/internal/coaching/practice/voice/postgres/question_tip.go
+++ b/server/internal/coaching/practice/voice/postgres/question_tip.go
@@ -1,0 +1,240 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
+)
+
+const questionTipColumns = `SELECT tip_id, practice_session_id, question_id,
+       idempotency_key, status, fencing_token, deletion_generation,
+       lease_expires_at, COALESCE(content, ''), created_at, updated_at,
+       completed_at
+  FROM practice_question_tips`
+
+func (r *Repository) ClaimQuestionTip(
+	ctx context.Context,
+	actor practicevoice.Actor,
+	command practicevoice.ClaimQuestionTipCommand,
+) (practicevoice.QuestionTip, error) {
+	if !validInputActor(actor) || strings.TrimSpace(command.SessionID) == "" ||
+		strings.TrimSpace(command.QuestionID) == "" ||
+		strings.TrimSpace(command.IdempotencyKey) == "" ||
+		command.LeaseDuration <= 0 {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceInvalid
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	generation, err := ensureActorWritable(ctx, tx, actor.UserID)
+	if err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+	if err := lockKey(ctx, tx, actor.UserID, "question-tip", command.SessionID, command.QuestionID); err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+
+	byKey, keyErr := getQuestionTipByKey(ctx, tx, actor.UserID, command.IdempotencyKey)
+	if keyErr == nil && (byKey.SessionID != command.SessionID || byKey.QuestionID != command.QuestionID) {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceConflict
+	}
+	if keyErr != nil && !errors.Is(keyErr, practicevoice.ErrPersistenceNotFound) {
+		return practicevoice.QuestionTip{}, keyErr
+	}
+
+	now := databaseTime(r.now)
+	tip, getErr := getQuestionTip(ctx, tx, actor.UserID, command.SessionID, command.QuestionID)
+	if errors.Is(getErr, practicevoice.ErrPersistenceNotFound) {
+		tip = practicevoice.QuestionTip{
+			ID:                 newID("question_tip"),
+			SessionID:          command.SessionID,
+			QuestionID:         command.QuestionID,
+			IdempotencyKey:     command.IdempotencyKey,
+			Status:             practicevoice.QuestionTipProcessing,
+			FencingToken:       1,
+			DeletionGeneration: generation,
+			LeaseAcquired:      true,
+			LeaseExpiresAt:     now.Add(command.LeaseDuration),
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}
+		_, err = tx.Exec(ctx, `INSERT INTO practice_question_tips (
+			owner_user_id, tip_id, practice_session_id, question_id,
+			idempotency_key, status, fencing_token, deletion_generation,
+			lease_expires_at, created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			actor.UserID, tip.ID, tip.SessionID, tip.QuestionID,
+			tip.IdempotencyKey, tip.Status, tip.FencingToken,
+			tip.DeletionGeneration, tip.LeaseExpiresAt, tip.CreatedAt, tip.UpdatedAt)
+		if err != nil {
+			return practicevoice.QuestionTip{}, safeDatabaseError(err)
+		}
+	} else if getErr != nil {
+		return practicevoice.QuestionTip{}, getErr
+	} else if tip.Status != practicevoice.QuestionTipCompleted &&
+		(tip.Status == practicevoice.QuestionTipFailed || !tip.LeaseExpiresAt.After(now)) {
+		tip.Status = practicevoice.QuestionTipProcessing
+		tip.FencingToken++
+		tip.DeletionGeneration = generation
+		tip.LeaseAcquired = true
+		tip.LeaseExpiresAt = now.Add(command.LeaseDuration)
+		tip.UpdatedAt = now
+		_, err = tx.Exec(ctx, `UPDATE practice_question_tips
+			SET status = 'processing', fencing_token = $4,
+			    deletion_generation = $5, lease_expires_at = $6,
+			    updated_at = $7, content = NULL, completed_at = NULL
+			WHERE owner_user_id = $1 AND practice_session_id = $2 AND question_id = $3`,
+			actor.UserID, command.SessionID, command.QuestionID,
+			tip.FencingToken, generation, tip.LeaseExpiresAt, now)
+		if err != nil {
+			return practicevoice.QuestionTip{}, safeDatabaseError(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	return tip, nil
+}
+
+func (r *Repository) GetQuestionTip(
+	ctx context.Context,
+	actor practicevoice.Actor,
+	sessionID string,
+	questionID string,
+) (practicevoice.QuestionTip, error) {
+	if !validInputActor(actor) || strings.TrimSpace(sessionID) == "" || strings.TrimSpace(questionID) == "" {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceInvalid
+	}
+	tx, err := r.beginActorRead(ctx, actor)
+	if err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	tip, err := getQuestionTip(ctx, tx, actor.UserID, sessionID, questionID)
+	if err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	return tip, nil
+}
+
+func (r *Repository) CompleteQuestionTip(
+	ctx context.Context,
+	actor practicevoice.Actor,
+	command practicevoice.CompleteQuestionTipCommand,
+) (practicevoice.QuestionTip, error) {
+	if !validInputActor(actor) || strings.TrimSpace(command.TipID) == "" ||
+		command.FencingToken <= 0 || command.DeletionGeneration < 0 ||
+		strings.TrimSpace(command.Content) == "" {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceInvalid
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	generation, err := ensureActorWritable(ctx, tx, actor.UserID)
+	if err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+	if generation != command.DeletionGeneration {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceConflict
+	}
+	now := databaseTime(r.now)
+	row := tx.QueryRow(ctx, questionTipColumns+` WHERE owner_user_id = $1 AND tip_id = $2
+		FOR UPDATE`, actor.UserID, command.TipID)
+	tip, err := scanQuestionTip(row)
+	if err != nil {
+		return practicevoice.QuestionTip{}, err
+	}
+	if tip.Status == practicevoice.QuestionTipCompleted {
+		if tip.Content != strings.TrimSpace(command.Content) {
+			return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceConflict
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return practicevoice.QuestionTip{}, safeDatabaseError(err)
+		}
+		return tip, nil
+	}
+	if tip.Status != practicevoice.QuestionTipProcessing ||
+		tip.FencingToken != command.FencingToken ||
+		tip.DeletionGeneration != command.DeletionGeneration {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceConflict
+	}
+	content := strings.TrimSpace(command.Content)
+	_, err = tx.Exec(ctx, `UPDATE practice_question_tips
+		SET status = 'completed', content = $3, provider = $4, model = $5,
+		    provider_request_id = $6, completed_at = $7, updated_at = $7
+		WHERE owner_user_id = $1 AND tip_id = $2`, actor.UserID, command.TipID,
+		content, command.Provider, command.Model, command.ProviderRequestID, now)
+	if err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	tip.Status = practicevoice.QuestionTipCompleted
+	tip.Content = content
+	tip.UpdatedAt = now
+	tip.CompletedAt = &now
+	if err := tx.Commit(ctx); err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	return tip, nil
+}
+
+func (r *Repository) FailQuestionTip(
+	ctx context.Context,
+	actor practicevoice.Actor,
+	command practicevoice.FailQuestionTipCommand,
+) error {
+	if !validInputActor(actor) || strings.TrimSpace(command.TipID) == "" ||
+		command.FencingToken <= 0 || command.DeletionGeneration < 0 {
+		return practicevoice.ErrPersistenceInvalid
+	}
+	tag, err := r.pool.Exec(ctx, `UPDATE practice_question_tips SET status = 'failed',
+		updated_at = $5 WHERE owner_user_id = $1 AND tip_id = $2
+		AND status = 'processing' AND fencing_token = $3 AND deletion_generation = $4`,
+		actor.UserID, command.TipID, command.FencingToken,
+		command.DeletionGeneration, databaseTime(r.now))
+	if err != nil {
+		return safeDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return practicevoice.ErrPersistenceConflict
+	}
+	return nil
+}
+
+func getQuestionTip(ctx context.Context, row queryRow, owner, sessionID, questionID string) (practicevoice.QuestionTip, error) {
+	return scanQuestionTip(row.QueryRow(ctx, questionTipColumns+`
+		WHERE owner_user_id = $1 AND practice_session_id = $2 AND question_id = $3`,
+		owner, sessionID, questionID))
+}
+
+func getQuestionTipByKey(ctx context.Context, row queryRow, owner, key string) (practicevoice.QuestionTip, error) {
+	return scanQuestionTip(row.QueryRow(ctx, questionTipColumns+`
+		WHERE owner_user_id = $1 AND idempotency_key = $2`, owner, key))
+}
+
+func scanQuestionTip(row pgx.Row) (practicevoice.QuestionTip, error) {
+	var tip practicevoice.QuestionTip
+	err := row.Scan(&tip.ID, &tip.SessionID, &tip.QuestionID, &tip.IdempotencyKey,
+		&tip.Status, &tip.FencingToken, &tip.DeletionGeneration,
+		&tip.LeaseExpiresAt, &tip.Content, &tip.CreatedAt, &tip.UpdatedAt,
+		&tip.CompletedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return practicevoice.QuestionTip{}, practicevoice.ErrPersistenceNotFound
+	}
+	if err != nil {
+		return practicevoice.QuestionTip{}, safeDatabaseError(err)
+	}
+	return tip, nil
+}
+
+var _ practicevoice.QuestionTipStore = (*Repository)(nil)

--- a/server/internal/coaching/practice/voice/postgres/round_repository_integration_test.go
+++ b/server/internal/coaching/practice/voice/postgres/round_repository_integration_test.go
@@ -24,6 +24,52 @@ const (
 	testUserB = "10000000-0000-4000-8000-000000000002"
 )
 
+func TestRepositoryQuestionTipHasOneGenerationLeasePerQuestion(t *testing.T) {
+	repository, _ := newIntegrationRepository(t)
+	actor := testActor(testUserA)
+	question := saveTestQuestion(t, repository, actor, "question-tip", "session-tip")
+	command := practicevoice.ClaimQuestionTipCommand{
+		SessionID: question.SessionID, QuestionID: question.ID,
+		IdempotencyKey: "question-tip-request-1", LeaseDuration: time.Minute,
+	}
+	claimed, err := repository.ClaimQuestionTip(context.Background(), actor, command)
+	if err != nil || !claimed.LeaseAcquired || claimed.Status != practicevoice.QuestionTipProcessing {
+		t.Fatalf("first claim = %+v, %v", claimed, err)
+	}
+	concurrentCommand := command
+	concurrentCommand.IdempotencyKey = "question-tip-request-2"
+	concurrent, err := repository.ClaimQuestionTip(context.Background(), actor, concurrentCommand)
+	if err != nil || concurrent.ID != claimed.ID || concurrent.LeaseAcquired {
+		t.Fatalf("concurrent claim = %+v, %v", concurrent, err)
+	}
+	completed, err := repository.CompleteQuestionTip(
+		context.Background(), actor, practicevoice.CompleteQuestionTipCommand{
+			TipID: claimed.ID, FencingToken: claimed.FencingToken,
+			DeletionGeneration: claimed.DeletionGeneration,
+			Content:            "I would clarify the goal first. Then I would explain my approach clearly.",
+			Provider:           "fake", Model: "fake-model", ProviderRequestID: "provider-request-1",
+		},
+	)
+	if err != nil || completed.Status != practicevoice.QuestionTipCompleted || completed.Content == "" {
+		t.Fatalf("completed Tip = %+v, %v", completed, err)
+	}
+	replayed, err := repository.ClaimQuestionTip(context.Background(), actor, concurrentCommand)
+	if err != nil || replayed.ID != claimed.ID || replayed.Content != completed.Content || replayed.LeaseAcquired {
+		t.Fatalf("completed replay = %+v, %v", replayed, err)
+	}
+
+	otherQuestion := saveTestQuestion(t, repository, actor, "question-tip-other", "session-tip-other")
+	_, err = repository.ClaimQuestionTip(
+		context.Background(), actor, practicevoice.ClaimQuestionTipCommand{
+			SessionID: otherQuestion.SessionID, QuestionID: otherQuestion.ID,
+			IdempotencyKey: command.IdempotencyKey, LeaseDuration: time.Minute,
+		},
+	)
+	if !errors.Is(err, practicevoice.ErrPersistenceConflict) {
+		t.Fatalf("cross-question idempotency error = %v", err)
+	}
+}
+
 func TestRepositoryRecoversQuestionCandidateAttemptAndTurn(t *testing.T) {
 	repository, pool := newIntegrationRepository(t)
 	actor := testActor(testUserA)
@@ -1454,6 +1500,15 @@ func newIntegrationRepository(t *testing.T) (*Repository, *pgxpool.Pool) {
 		conversationRetryIntegrationSchema,
 	); err != nil {
 		t.Fatalf("apply Conversation retry integration schema: %v", err)
+	}
+	tipMigration, err := migrations.Files.ReadFile(
+		"000070_practice_question_tips.up.sql",
+	)
+	if err != nil {
+		t.Fatalf("read Practice Tip migration: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), string(tipMigration)); err != nil {
+		t.Fatalf("apply Practice Tip migration: %v", err)
 	}
 	for _, userID := range []string{testUserA, testUserB} {
 		if _, err := pool.Exec(

--- a/server/internal/coaching/practice/voice/provider.go
+++ b/server/internal/coaching/practice/voice/provider.go
@@ -39,6 +39,7 @@ type ProviderOperation string
 const (
 	ProviderOperationQuestionGeneration  ProviderOperation = "question_generation"
 	ProviderOperationQuestionTranslation ProviderOperation = "question_translation"
+	ProviderOperationAnswerTipGeneration ProviderOperation = "answer_tip_generation"
 	ProviderOperationTranscription       ProviderOperation = "transcription"
 	ProviderOperationSynthesis           ProviderOperation = "synthesis"
 )
@@ -150,4 +151,23 @@ type QuestionTranslator interface {
 		context.Context,
 		QuestionTranslationRequest,
 	) (string, error)
+}
+
+type AnswerTipGenerationRequest struct {
+	SystemPrompt string
+	UserPrompt   string
+}
+
+type AnswerTipGenerationResult struct {
+	RequestID string
+	Provider  string
+	Model     string
+	Content   string
+}
+
+type AnswerTipGenerator interface {
+	GenerateAnswerTip(
+		context.Context,
+		AnswerTipGenerationRequest,
+	) (AnswerTipGenerationResult, error)
 }

--- a/server/internal/coaching/practice/voice/question_tip.go
+++ b/server/internal/coaching/practice/voice/question_tip.go
@@ -1,0 +1,220 @@
+package voice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const (
+	questionTipLease      = 45 * time.Second
+	questionTipPoll       = 75 * time.Millisecond
+	questionTipMaxRunes   = 800
+	questionTipMaxHistory = 6
+)
+
+type QuestionTipResult struct {
+	ID         string
+	SessionID  string
+	QuestionID string
+	Content    string
+	CreatedAt  time.Time
+}
+
+type QuestionTipPort interface {
+	EnsureQuestionTip(
+		context.Context,
+		requestcontext.Actor,
+		Session,
+		practice.Question,
+		[]TurnExchange,
+		string,
+	) (QuestionTipResult, error)
+}
+
+type QuestionTipService struct {
+	store     QuestionTipStore
+	generator AnswerTipGenerator
+}
+
+func NewQuestionTipService(
+	store QuestionTipStore,
+	generator AnswerTipGenerator,
+) (*QuestionTipService, error) {
+	if store == nil || generator == nil {
+		return nil, ErrInvalidRequest
+	}
+	return &QuestionTipService{store: store, generator: generator}, nil
+}
+
+func (service *QuestionTipService) EnsureQuestionTip(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	session Session,
+	question practice.Question,
+	history []TurnExchange,
+	idempotencyKey string,
+) (QuestionTipResult, error) {
+	if service == nil || service.store == nil || service.generator == nil ||
+		!actor.Valid() || session.ID == "" || session.SceneFamily != "INTERVIEW" ||
+		question.ID == "" || question.SessionID != session.ID ||
+		strings.TrimSpace(question.Content) == "" ||
+		strings.TrimSpace(idempotencyKey) == "" {
+		return QuestionTipResult{}, ErrInvalidRequest
+	}
+	storedActor := persistenceActor(actor)
+	for {
+		tip, err := service.store.ClaimQuestionTip(
+			ctx,
+			storedActor,
+			ClaimQuestionTipCommand{
+				SessionID:      session.ID,
+				QuestionID:     question.ID,
+				IdempotencyKey: idempotencyKey,
+				LeaseDuration:  questionTipLease,
+			},
+		)
+		if err != nil {
+			return QuestionTipResult{}, mapPersistenceError(err)
+		}
+		if tip.Status == QuestionTipCompleted {
+			return mapQuestionTip(tip)
+		}
+		if tip.LeaseAcquired {
+			return service.generateQuestionTip(
+				ctx,
+				storedActor,
+				tip,
+				session,
+				question,
+				history,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			return QuestionTipResult{}, ctx.Err()
+		case <-time.After(questionTipPoll):
+		}
+		persisted, err := service.store.GetQuestionTip(
+			ctx,
+			storedActor,
+			session.ID,
+			question.ID,
+		)
+		if err != nil {
+			return QuestionTipResult{}, mapPersistenceError(err)
+		}
+		if persisted.Status == QuestionTipCompleted {
+			return mapQuestionTip(persisted)
+		}
+	}
+}
+
+func (service *QuestionTipService) generateQuestionTip(
+	ctx context.Context,
+	actor Actor,
+	tip QuestionTip,
+	session Session,
+	question practice.Question,
+	history []TurnExchange,
+) (QuestionTipResult, error) {
+	result, err := service.generator.GenerateAnswerTip(
+		ctx,
+		questionTipRequest(session, question, history),
+	)
+	content := strings.TrimSpace(result.Content)
+	if err != nil || content == "" || utf8.RuneCountInString(content) > questionTipMaxRunes {
+		failureCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			2*time.Second,
+		)
+		defer cancel()
+		_ = service.store.FailQuestionTip(
+			failureCtx,
+			actor,
+			FailQuestionTipCommand{
+				TipID:              tip.ID,
+				FencingToken:       tip.FencingToken,
+				DeletionGeneration: tip.DeletionGeneration,
+			},
+		)
+		if err != nil {
+			return QuestionTipResult{}, err
+		}
+		return QuestionTipResult{}, ErrInvalidContext
+	}
+	completed, err := service.store.CompleteQuestionTip(
+		ctx,
+		actor,
+		CompleteQuestionTipCommand{
+			TipID:              tip.ID,
+			FencingToken:       tip.FencingToken,
+			DeletionGeneration: tip.DeletionGeneration,
+			Content:            content,
+			Provider:           result.Provider,
+			Model:              result.Model,
+			ProviderRequestID:  result.RequestID,
+		},
+	)
+	if err != nil {
+		return QuestionTipResult{}, mapPersistenceError(err)
+	}
+	return mapQuestionTip(completed)
+}
+
+func questionTipRequest(
+	session Session,
+	question practice.Question,
+	history []TurnExchange,
+) AnswerTipGenerationRequest {
+	var prior strings.Builder
+	start := len(history) - questionTipMaxHistory
+	if start < 0 {
+		start = 0
+	}
+	for _, exchange := range history[start:] {
+		fmt.Fprintf(
+			&prior,
+			"Interviewer: %s\nCandidate: %s\n",
+			exchange.Question.Content,
+			exchange.Turn.AnswerText,
+		)
+	}
+	return AnswerTipGenerationRequest{
+		SystemPrompt: `You help an English learner answer an interview question aloud. ` +
+			`Return only one short natural English sample answer of 2 to 4 sentences, ` +
+			`roughly 15 to 30 seconds when spoken. Use simple, speakable language. ` +
+			`Use conversation facts only when explicitly provided. Never invent names, employers, ` +
+			`metrics, credentials, or personal experiences; use safe generic phrasing instead. ` +
+			`Do not add headings, coaching notes, placeholders, quotation marks, or markdown.`,
+		UserPrompt: fmt.Sprintf(
+			"Interview context: %s\nPractice goal: %s\nPrior conversation:\n%sCurrent question: %s",
+			session.Prompt.PublicSceneBrief,
+			session.Prompt.PracticeGoal,
+			prior.String(),
+			question.Content,
+		),
+	}
+}
+
+func mapQuestionTip(tip QuestionTip) (QuestionTipResult, error) {
+	if tip.Status != QuestionTipCompleted || tip.ID == "" ||
+		tip.SessionID == "" || tip.QuestionID == "" ||
+		strings.TrimSpace(tip.Content) == "" || tip.CreatedAt.IsZero() {
+		return QuestionTipResult{}, ErrInvalidContext
+	}
+	return QuestionTipResult{
+		ID:         tip.ID,
+		SessionID:  tip.SessionID,
+		QuestionID: tip.QuestionID,
+		Content:    tip.Content,
+		CreatedAt:  tip.CreatedAt,
+	}, nil
+}
+
+var _ QuestionTipPort = (*QuestionTipService)(nil)

--- a/server/internal/coaching/practice/voice/runtime.go
+++ b/server/internal/coaching/practice/voice/runtime.go
@@ -16,6 +16,7 @@ type RuntimeRepository interface {
 	RecordingConfirmationStore
 	RetryTurnStore
 	practice.RetryTurnRepository
+	QuestionTipStore
 }
 
 // TurnFeedbackStatusReader is the read-only Evaluation boundary used when a
@@ -37,6 +38,7 @@ type RuntimeConfiguration struct {
 	Synthesizer        SpeechSynthesizer
 	QuestionGenerator  QuestionGenerator
 	QuestionTranslator QuestionTranslator
+	AnswerTipGenerator AnswerTipGenerator
 	Recordings         VoiceRecordingLifecycle
 	AudioAssets        *AudioAssetService
 	ASRLease           time.Duration
@@ -120,6 +122,17 @@ func NewRuntimeApplications(
 			configuration.QuestionTranslator,
 		)
 	}
+	var tipPort QuestionTipPort
+	if configuration.AnswerTipGenerator != nil {
+		tipService, tipErr := NewQuestionTipService(
+			configuration.Repository,
+			configuration.AnswerTipGenerator,
+		)
+		if tipErr != nil {
+			return nil, nil, tipErr
+		}
+		tipPort = tipService
+	}
 	application, err := NewSessionApplication(
 		&sessionAdapter{repository: configuration.Repository},
 		&questionAdapter{
@@ -137,5 +150,6 @@ func NewRuntimeApplications(
 	if err != nil {
 		return nil, nil, err
 	}
+	application.tips = tipPort
 	return application, retryApplication, nil
 }

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -100,6 +100,7 @@ type SessionApplication struct {
 	checkpoints  CheckpointPort
 	orchestrator *RoundOrchestrator
 	translator   QuestionTranslator
+	tips         QuestionTipPort
 }
 
 func NewSessionApplication(
@@ -170,6 +171,45 @@ func (application *SessionApplication) QuestionTranslation(
 		TargetLanguage: "zh-CN",
 		Content:        content,
 	}, nil
+}
+
+func (application *SessionApplication) EnsureQuestionTip(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+	questionID string,
+	idempotencyKey string,
+) (QuestionTipResult, error) {
+	if application.tips == nil || validateVoiceActor(ctx, actor) != nil ||
+		strings.TrimSpace(sessionID) == "" ||
+		strings.TrimSpace(questionID) == "" ||
+		strings.TrimSpace(idempotencyKey) == "" {
+		return QuestionTipResult{}, ErrInvalidRequest
+	}
+	session, err := application.sessions.GetByID(ctx, actor, sessionID)
+	if err != nil {
+		return QuestionTipResult{}, err
+	}
+	if session.ID != sessionID || session.SceneFamily != "INTERVIEW" ||
+		session.Completed || session.Status == "paused" ||
+		session.Status == "ended_early" {
+		return QuestionTipResult{}, ErrInvalidContext
+	}
+	state, err := application.state(ctx, actor, session)
+	if err != nil {
+		return QuestionTipResult{}, err
+	}
+	if state.Question == nil || state.Question.ID != questionID {
+		return QuestionTipResult{}, ErrInvalidContext
+	}
+	return application.tips.EnsureQuestionTip(
+		ctx,
+		actor,
+		state.Session,
+		*state.Question,
+		state.TurnHistory,
+		idempotencyKey,
+	)
 }
 
 func (application *SessionApplication) Start(

--- a/server/internal/providers/qianwen/practice_voice.go
+++ b/server/internal/providers/qianwen/practice_voice.go
@@ -192,6 +192,55 @@ func (translator *PracticeVoiceQuestionTranslator) TranslateQuestion(
 	return result.Content, nil
 }
 
+type PracticeVoiceAnswerTipGenerator struct {
+	generator *textClient
+}
+
+func NewPracticeVoiceAnswerTipGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*PracticeVoiceAnswerTipGenerator, error) {
+	generator, err := newTextClient(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &PracticeVoiceAnswerTipGenerator{generator: generator}, nil
+}
+
+func (generator *PracticeVoiceAnswerTipGenerator) GenerateAnswerTip(
+	ctx context.Context,
+	request practicevoice.AnswerTipGenerationRequest,
+) (practicevoice.AnswerTipGenerationResult, error) {
+	if generator == nil || generator.generator == nil {
+		return practicevoice.AnswerTipGenerationResult{},
+			practicevoice.NewProviderError(
+				practicevoice.ProviderOperationAnswerTipGeneration,
+				practicevoice.ProviderErrorConfiguration,
+				"",
+				errors.New("Qianwen Practice Voice answer Tip generator is required"),
+			)
+	}
+	result, err := generator.generator.Generate(ctx, protocol.TextRequest{
+		Messages: []protocol.TextMessage{
+			{Role: protocol.TextRoleSystem, Content: request.SystemPrompt},
+			{Role: protocol.TextRoleUser, Content: request.UserPrompt},
+		},
+	})
+	if err != nil {
+		return practicevoice.AnswerTipGenerationResult{},
+			mapPracticeVoiceError(
+				err,
+				practicevoice.ProviderOperationAnswerTipGeneration,
+			)
+	}
+	return practicevoice.AnswerTipGenerationResult{
+		RequestID: result.ID,
+		Provider:  result.Provider,
+		Model:     result.Model,
+		Content:   result.Content,
+	}, nil
+}
+
 func mapPracticeVoiceUsage(usage protocol.SpeechUsage) practicevoice.SpeechUsage {
 	return practicevoice.SpeechUsage{
 		InputTokens:  usage.InputTokens,
@@ -264,4 +313,5 @@ var (
 	_ practicevoice.SpeechSynthesizer  = (*PracticeVoiceSynthesizer)(nil)
 	_ practicevoice.QuestionGenerator  = (*PracticeVoiceQuestionGenerator)(nil)
 	_ practicevoice.QuestionTranslator = (*PracticeVoiceQuestionTranslator)(nil)
+	_ practicevoice.AnswerTipGenerator = (*PracticeVoiceAnswerTipGenerator)(nil)
 )

--- a/server/internal/providers/qianwen/practice_voice_test.go
+++ b/server/internal/providers/qianwen/practice_voice_test.go
@@ -106,6 +106,14 @@ func TestPracticeVoiceAdaptersRejectMissingProvider(t *testing.T) {
 	); !isPracticeVoiceConfigurationError(err) {
 		t.Fatalf("translator error = %v", err)
 	}
+
+	var tipGenerator *PracticeVoiceAnswerTipGenerator
+	if _, err := tipGenerator.GenerateAnswerTip(
+		context.Background(),
+		practicevoice.AnswerTipGenerationRequest{},
+	); !isPracticeVoiceConfigurationError(err) {
+		t.Fatalf("Tip generator error = %v", err)
+	}
 }
 
 func isPracticeVoiceConfigurationError(err error) bool {

--- a/server/migrations/000070_practice_question_tips.down.sql
+++ b/server/migrations/000070_practice_question_tips.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS practice_question_tips;
+
+COMMIT;

--- a/server/migrations/000070_practice_question_tips.up.sql
+++ b/server/migrations/000070_practice_question_tips.up.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+CREATE TABLE practice_question_tips (
+    owner_user_id uuid NOT NULL,
+    tip_id text NOT NULL,
+    practice_session_id text NOT NULL,
+    question_id text NOT NULL,
+    idempotency_key text NOT NULL,
+    status text NOT NULL CHECK (status IN ('processing', 'completed', 'failed')),
+    fencing_token bigint NOT NULL CHECK (fencing_token > 0),
+    deletion_generation bigint NOT NULL CHECK (deletion_generation >= 0),
+    lease_expires_at timestamptz NOT NULL,
+    content text,
+    provider text NOT NULL DEFAULT '',
+    model text NOT NULL DEFAULT '',
+    provider_request_id text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    PRIMARY KEY (owner_user_id, tip_id),
+    UNIQUE (owner_user_id, practice_session_id, question_id),
+    UNIQUE (owner_user_id, idempotency_key),
+    FOREIGN KEY (owner_user_id, practice_session_id, question_id)
+        REFERENCES practice_questions (
+            owner_user_id,
+            practice_session_id,
+            question_id
+        )
+        ON DELETE CASCADE,
+    CHECK (
+        (status = 'completed' AND content IS NOT NULL AND btrim(content) <> ''
+            AND completed_at IS NOT NULL)
+        OR
+        (status <> 'completed' AND content IS NULL AND completed_at IS NULL)
+    )
+);
+
+CREATE INDEX practice_question_tips_recovery_idx
+    ON practice_question_tips
+        (owner_user_id, status, lease_expires_at, tip_id);
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -55,4 +55,5 @@ import "embed"
 //go:embed 000067_evaluation_ielts_speaking_acoustic_payload.*.sql
 //go:embed 000068_preparation_resume_revision.*.sql
 //go:embed 000069_scene_evaluation_policy_ref.*.sql
+//go:embed 000070_practice_question_tips.*.sql
 var Files embed.FS

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -409,6 +409,19 @@ func TestSceneEvaluationPolicyReferenceMigrationIsEmbedded(t *testing.T) {
 	}
 }
 
+func TestPracticeQuestionTipsMigrationIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"000070_practice_question_tips.up.sql",
+		"000070_practice_question_tips.down.sql",
+	} {
+		if _, err := Files.ReadFile(name); err != nil {
+			t.Fatalf("read Practice Question Tip migration %q: %v", name, err)
+		}
+	}
+}
+
 func readMigration(t *testing.T, name string) string {
 	t.Helper()
 


### PR DESCRIPTION
## 功能描述

- 在面试当前题目增加用户主动触发的 Tips 参考回答
- 为每个 PRIMARY/FOLLOW_UP Question 持久化唯一 Tip，并以租约和 fencing token 防止并发重复生成
- Tip 独立于 Candidate/Turn，不影响有效轮数、追问上限、Review、Evaluation、Memory 或消息历史
- Flutter 增加 Tips 加载/失败态、参考回答底部弹层和英文朗读，内容不会自动填入或提交
- 补充 OpenAPI、000049 数据库迁移及后端/客户端测试

## 实现思路

- Agent 只允许为当前活跃 INTERVIEW Question 请求 Tip
- Conversation PostgreSQL 以 owner/session/question 唯一约束和短租约管理生成权，完成后稳定回放同一资源
- 生成提示限定 2–4 句、约 15–30 秒，不允许编造个人事实
- Flutter 使用可选 PracticeQuestionTipClient 能力，按当前题目缓存并在切题时清空

## 可复现测试

- `cd api && npm run check`
- `cd server && go vet ./...`
- `cd server && go test -count=1 ./...`
- `TEST_DATABASE_URL=... go test -count=1 -run TestRepositoryQuestionTipHasOneGenerationLeasePerQuestion ./internal/conversation/postgres`
- `cd mobile && flutter analyze --no-pub`
- `cd mobile && flutter test --no-pub`
- `flutter build ios --simulator --no-codesign --no-pub`（按仓库 iOS Simulator 流程使用 AvatarKit stub）

Closes #326