### PR TITLE
feat(resume): 在“我的”页面交付简历管理

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -24,6 +24,7 @@ import 'package:speakup/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/review/ielts_speaking_report_index_controller.dart';
 import 'package:speakup/review/review_history_controller.dart';
 import 'package:speakup/review/turn_feedback_controller.dart';
+import 'package:speakup/resume/resume_controller.dart';
 
 class SpeakUpApp extends StatelessWidget {
   const SpeakUpApp({
@@ -38,6 +39,7 @@ class SpeakUpApp extends StatelessWidget {
     this.ieltsSpeakingReportController,
     this.ieltsSpeakingReportIndexController,
     this.speechFeedbackController,
+    this.resumeController,
     super.key,
   }) : _authentication = (controller: authController),
        _allowFakePreview = false;
@@ -53,6 +55,7 @@ class SpeakUpApp extends StatelessWidget {
     this.ieltsSpeakingReportController,
     this.ieltsSpeakingReportIndexController,
     this.speechFeedbackController,
+    this.resumeController,
     super.key,
   }) : _authentication = null,
        _allowFakePreview = true;
@@ -68,6 +71,7 @@ class SpeakUpApp extends StatelessWidget {
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
   final IeltsSpeakingReportIndexController? ieltsSpeakingReportIndexController;
   final SpeechFeedbackController? speechFeedbackController;
+  final ResumeController? resumeController;
   final bool _allowFakePreview;
 
   @override
@@ -90,6 +94,7 @@ class SpeakUpApp extends StatelessWidget {
               ieltsSpeakingReportIndexController:
                   ieltsSpeakingReportIndexController,
               speechFeedbackController: speechFeedbackController,
+              resumeController: resumeController,
               allowFakePreview: _allowFakePreview,
             )
           : AuthGate(
@@ -108,6 +113,7 @@ class SpeakUpApp extends StatelessWidget {
                 ieltsSpeakingReportIndexController:
                     ieltsSpeakingReportIndexController,
                 speechFeedbackController: speechFeedbackController,
+                resumeController: resumeController,
                 allowFakePreview: _allowFakePreview,
               ),
             ),
@@ -129,6 +135,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.ieltsSpeakingReportController,
     this.ieltsSpeakingReportIndexController,
     this.speechFeedbackController,
+    this.resumeController,
     required this.allowFakePreview,
   });
 
@@ -144,6 +151,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
   final IeltsSpeakingReportIndexController? ieltsSpeakingReportIndexController;
   final SpeechFeedbackController? speechFeedbackController;
+  final ResumeController? resumeController;
   final bool allowFakePreview;
 
   @override
@@ -231,6 +239,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             ieltsSpeakingReportIndexController:
                 widget.ieltsSpeakingReportIndexController,
             speechFeedbackController: widget.speechFeedbackController,
+            resumeController: widget.resumeController,
           ),
           AppRoutes.preparation => PreparationPage(
             showBackButton: true,
@@ -270,6 +279,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             ieltsSpeakingReportIndexController:
                 widget.ieltsSpeakingReportIndexController,
             speechFeedbackController: widget.speechFeedbackController,
+            resumeController: widget.resumeController,
           ),
           AppRoutes.review => ReviewPage(
             showBackButton: true,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -23,6 +23,7 @@ import 'package:speakup/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/review/ielts_speaking_report_index_controller.dart';
 import 'package:speakup/review/review_history_controller.dart';
 import 'package:speakup/review/turn_feedback_controller.dart';
+import 'package:speakup/resume/resume.dart';
 
 class SpeakUpShell extends StatefulWidget {
   const SpeakUpShell({
@@ -38,6 +39,7 @@ class SpeakUpShell extends StatefulWidget {
     this.ieltsSpeakingReportController,
     this.ieltsSpeakingReportIndexController,
     this.speechFeedbackController,
+    this.resumeController,
     required this.agentController,
     super.key,
   });
@@ -55,6 +57,7 @@ class SpeakUpShell extends StatefulWidget {
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
   final IeltsSpeakingReportIndexController? ieltsSpeakingReportIndexController;
   final SpeechFeedbackController? speechFeedbackController;
+  final ResumeController? resumeController;
 
   @override
   State<SpeakUpShell> createState() => _SpeakUpShellState();
@@ -419,6 +422,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         profileSaving: widget.authController?.profileSaving ?? false,
         onSaveDisplayName: widget.authController?.updateDisplayName,
         onLogout: widget.authController?.logout,
+        resumeController: widget.resumeController,
       ),
     ];
 
@@ -718,6 +722,7 @@ class _ProfilePage extends StatelessWidget {
     required this.profileSaving,
     required this.onSaveDisplayName,
     required this.onLogout,
+    required this.resumeController,
   });
 
   final bool showBackButton;
@@ -727,6 +732,7 @@ class _ProfilePage extends StatelessWidget {
   final bool profileSaving;
   final Future<String?> Function(String)? onSaveDisplayName;
   final VoidCallback? onLogout;
+  final ResumeController? resumeController;
 
   @override
   Widget build(BuildContext context) {
@@ -792,6 +798,10 @@ class _ProfilePage extends StatelessWidget {
               ),
             ],
             const SizedBox(height: SpeakUpDesign.space16),
+            if (resumeController != null) ...[
+              ResumeSummaryCard(controller: resumeController!),
+              const SizedBox(height: SpeakUpDesign.space16),
+            ],
             OutlinedButton.icon(
               key: const Key('profile-logout-button'),
               onPressed: onLogout,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -40,6 +40,7 @@ import 'package:speakup/review/turn_feedback_controller.dart';
 import 'package:speakup/review/wire_interview_report_client.dart';
 import 'package:speakup/review/wire_review_history_client.dart';
 import 'package:speakup/review/wire_turn_feedback_client.dart';
+import 'package:speakup/resume/resume.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -64,6 +65,7 @@ void main() {
       ieltsSpeakingReportIndexController:
           dependencies.ieltsSpeakingReportIndexController,
       speechFeedbackController: dependencies.speechFeedbackController,
+      resumeController: dependencies.resumeController,
     ),
   );
 }
@@ -81,6 +83,7 @@ final class ProductionAppDependencies {
     required this.ieltsSpeakingReportController,
     required this.ieltsSpeakingReportIndexController,
     required this.speechFeedbackController,
+    required this.resumeController,
   });
 
   final AuthController authController;
@@ -94,6 +97,7 @@ final class ProductionAppDependencies {
   final IeltsSpeakingReportController ieltsSpeakingReportController;
   final IeltsSpeakingReportIndexController ieltsSpeakingReportIndexController;
   final SpeechFeedbackController speechFeedbackController;
+  final ResumeController resumeController;
 }
 
 ProductionAppDependencies createProductionAppDependencies({
@@ -421,6 +425,21 @@ ProductionAppDependencies createProductionAppDependencies({
     baseUri: baseUri,
     transport: identityTransport,
   );
+  final resumeController = ResumeController(
+    client: WireResumeClient(
+      baseUri: baseUri,
+      credentialProvider: () => authController.currentCredential,
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) {
+            return authController.invalidateSession(
+              expectedSessionToken: expectedSessionToken,
+              expectedGeneration: expectedGeneration,
+            );
+          },
+    ),
+    filePicker: const SystemResumeFilePicker(),
+    urlOpener: const SystemResumeUrlOpener(),
+  );
   Future<void> clearAvatarPrivateState() async {
     final controllers = accountAvatarControllers.toList(growable: false);
     activeAvatarControllers.clear();
@@ -445,6 +464,7 @@ ProductionAppDependencies createProductionAppDependencies({
           .clearPrivateState();
       final speechFeedbackCleanup = speechFeedbackController
           .clearPrivateState();
+      final resumeCleanup = resumeController.clearPrivateState();
       try {
         await preparationLaunchController.clearPrivateState();
         await clearAvatarPrivateState();
@@ -460,6 +480,7 @@ ProductionAppDependencies createProductionAppDependencies({
           ieltsSpeakingReportCleanup,
           ieltsSpeakingReportIndexCleanup,
           speechFeedbackCleanup,
+          resumeCleanup,
         ]);
       }
     },
@@ -476,5 +497,6 @@ ProductionAppDependencies createProductionAppDependencies({
     ieltsSpeakingReportController: ieltsSpeakingReportController,
     ieltsSpeakingReportIndexController: ieltsSpeakingReportIndexController,
     speechFeedbackController: speechFeedbackController,
+    resumeController: resumeController,
   );
 }

--- a/mobile/lib/resume/resume.dart
+++ b/mobile/lib/resume/resume.dart
@@ -1,0 +1,8 @@
+// 本文件统一导出移动端 Resume 模块的公开入口。
+
+export 'resume_client.dart';
+export 'resume_controller.dart';
+export 'resume_file_access.dart';
+export 'resume_models.dart';
+export 'resume_page.dart';
+export 'wire_resume_client.dart';

--- a/mobile/lib/resume/resume_client.dart
+++ b/mobile/lib/resume/resume_client.dart
@@ -1,0 +1,46 @@
+// 本文件定义 Resume 应用层依赖的远端接口和统一失败类型。
+
+import 'resume_models.dart';
+
+/// ResumeClient 描述简历页面需要的全部后端能力。
+abstract interface class ResumeClient {
+  Future<List<ResumeItem>> list();
+  Future<ResumeItem> create({
+    required String title,
+    required ResumePdfFile file,
+  });
+  Future<ResumeDetail> get(String resumeId);
+  Future<ResumeItem> rename(ResumeItem resume, String title);
+  Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file);
+  Future<void> delete(ResumeItem resume);
+  Future<ResumeItem> retryParse(ResumeItem resume);
+  Future<ResumeDetail> updateContent(
+    ResumeDetail detail,
+    ResumeContent content,
+  );
+  Future<Uri> getContentUrl(String resumeId);
+  Future<void> clearAccountState();
+}
+
+enum ResumeFailureKind {
+  authenticationRequired,
+  invalidRequest,
+  notFound,
+  conflict,
+  limitReached,
+  network,
+  invalidResponse,
+  server,
+  superseded,
+}
+
+/// ResumeException 保存可安全呈现给状态层的失败分类。
+final class ResumeException implements Exception {
+  const ResumeException(this.kind, {this.retryable = false});
+
+  final ResumeFailureKind kind;
+  final bool retryable;
+
+  @override
+  String toString() => 'ResumeException(${kind.name})';
+}

--- a/mobile/lib/resume/resume_controller.dart
+++ b/mobile/lib/resume/resume_controller.dart
@@ -1,0 +1,243 @@
+// 本文件编排简历列表、文件操作、详情编辑和用户可见状态。
+
+import 'package:flutter/foundation.dart';
+
+import 'resume_client.dart';
+import 'resume_file_access.dart';
+import 'resume_models.dart';
+
+/// ResumeController 为“我的”页和简历管理页提供同一份可观察状态。
+final class ResumeController extends ChangeNotifier {
+  ResumeController({
+    required this.client,
+    required this.filePicker,
+    required this.urlOpener,
+  });
+
+  static const maxResumes = 3;
+  static const maxPdfBytes = 10 * 1024 * 1024;
+
+  final ResumeClient client;
+  final ResumeFilePicker filePicker;
+  final ResumeUrlOpener urlOpener;
+
+  List<ResumeItem> _items = const <ResumeItem>[];
+  final Map<String, ResumeDetail> _details = <String, ResumeDetail>{};
+  bool _loading = false;
+  String? _busyResumeId;
+  String? _errorMessage;
+  String? _noticeMessage;
+  int _epoch = 0;
+
+  List<ResumeItem> get items => List<ResumeItem>.unmodifiable(_items);
+  bool get isLoading => _loading;
+  bool get canUpload => _items.length < maxResumes && !_loading;
+  String? get busyResumeId => _busyResumeId;
+  String? get errorMessage => _errorMessage;
+  String? get noticeMessage => _noticeMessage;
+
+  /// 返回已缓存的详情，未加载时返回空。
+  ResumeDetail? detailFor(String resumeId) => _details[resumeId];
+
+  /// 加载当前账号的最多三份简历。
+  Future<void> load() async {
+    if (_loading) return;
+    final epoch = _epoch;
+    _loading = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      final loaded = await client.list();
+      if (epoch != _epoch) return;
+      _items = loaded;
+    } on Object catch (error) {
+      if (epoch == _epoch) _errorMessage = _messageFor(error);
+    } finally {
+      if (epoch == _epoch) {
+        _loading = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  /// 打开系统文件面板并上传新简历；用户取消选择时不产生错误。
+  Future<void> pickAndUpload() async {
+    if (!canUpload) {
+      _setNotice('每个账号最多保存 3 份简历。');
+      return;
+    }
+    final file = await filePicker.pickPdf();
+    if (file == null) return;
+    final validation = _validatePdf(file);
+    if (validation != null) {
+      _setNotice(validation);
+      return;
+    }
+    await _runAction(null, () async {
+      final title = file.name.replaceFirst(
+        RegExp(r'\.pdf$', caseSensitive: false),
+        '',
+      );
+      final created = await client.create(title: title, file: file);
+      _items = <ResumeItem>[created, ..._items];
+      _setNotice('简历已上传，正在解析。', notify: false);
+    });
+  }
+
+  /// 修改一份简历的展示名称。
+  Future<void> rename(ResumeItem resume, String title) async {
+    final value = title.trim();
+    if (value.isEmpty || value.length > 120) {
+      _setNotice('简历名称需为 1—120 个字符。');
+      return;
+    }
+    await _runAction(resume.id, () async {
+      final updated = await client.rename(resume, value);
+      _replaceItem(updated);
+      _setNotice('简历名称已更新。', notify: false);
+    });
+  }
+
+  /// 选择新的 PDF 并替换指定简历文件。
+  Future<void> pickAndReplace(ResumeItem resume) async {
+    final file = await filePicker.pickPdf();
+    if (file == null) return;
+    final validation = _validatePdf(file);
+    if (validation != null) {
+      _setNotice(validation);
+      return;
+    }
+    await _runAction(resume.id, () async {
+      final updated = await client.replace(resume, file);
+      _replaceItem(updated);
+      _details.remove(resume.id);
+      _setNotice('PDF 已替换，正在重新解析。', notify: false);
+    });
+  }
+
+  /// 删除指定简历并同步移除本地详情缓存。
+  Future<void> delete(ResumeItem resume) async {
+    await _runAction(resume.id, () async {
+      await client.delete(resume);
+      _items = _items
+          .where((item) => item.id != resume.id)
+          .toList(growable: false);
+      _details.remove(resume.id);
+      _setNotice('简历已删除。', notify: false);
+    });
+  }
+
+  /// 对解析失败的简历重新发起解析。
+  Future<void> retryParse(ResumeItem resume) async {
+    await _runAction(resume.id, () async {
+      final updated = await client.retryParse(resume);
+      _replaceItem(updated);
+      _setNotice('已重新提交解析。', notify: false);
+    });
+  }
+
+  /// 加载并缓存指定简历的结构化详情。
+  Future<void> loadDetail(String resumeId) async {
+    await _runAction(resumeId, () async {
+      final detail = await client.get(resumeId);
+      _details[resumeId] = detail;
+      _replaceItem(detail.resume);
+    });
+  }
+
+  /// 保存人工修改后的结构化内容修订。
+  Future<void> saveContent(ResumeDetail detail, ResumeContent content) async {
+    await _runAction(detail.resume.id, () async {
+      final updated = await client.updateContent(detail, content);
+      _details[detail.resume.id] = updated;
+      _replaceItem(updated.resume);
+      _setNotice('简历内容已保存。', notify: false);
+    });
+  }
+
+  /// 获取短时地址并交给系统应用查看原始 PDF。
+  Future<void> openPdf(String resumeId) async {
+    await _runAction(resumeId, () async {
+      final url = await client.getContentUrl(resumeId);
+      if (!await urlOpener.open(url)) {
+        throw const ResumeException(ResumeFailureKind.invalidResponse);
+      }
+    });
+  }
+
+  /// 清空上一个账号的简历数据，阻止迟到请求污染新账号。
+  Future<void> clearPrivateState() async {
+    _epoch++;
+    _items = const <ResumeItem>[];
+    _details.clear();
+    _loading = false;
+    _busyResumeId = null;
+    _errorMessage = null;
+    _noticeMessage = null;
+    await client.clearAccountState();
+    notifyListeners();
+  }
+
+  /// 消费一次性提示，避免 Widget 重建后重复展示。
+  void consumeNotice() {
+    if (_noticeMessage == null) return;
+    _noticeMessage = null;
+  }
+
+  Future<void> _runAction(
+    String? resumeId,
+    Future<void> Function() action,
+  ) async {
+    if (_busyResumeId != null) return;
+    final epoch = _epoch;
+    _busyResumeId = resumeId ?? '__upload__';
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await action();
+    } on Object catch (error) {
+      if (epoch == _epoch) _setNotice(_messageFor(error), notify: false);
+    } finally {
+      if (epoch == _epoch) {
+        _busyResumeId = null;
+        notifyListeners();
+      }
+    }
+  }
+
+  void _replaceItem(ResumeItem updated) {
+    _items = _items
+        .map((item) => item.id == updated.id ? updated : item)
+        .toList(growable: false);
+  }
+
+  String? _validatePdf(ResumePdfFile file) {
+    if (!file.name.toLowerCase().endsWith('.pdf') ||
+        file.bytes.length < 5 ||
+        String.fromCharCodes(file.bytes.take(5)) != '%PDF-') {
+      return '请选择有效的 PDF 文件。';
+    }
+    if (file.bytes.length > maxPdfBytes) return 'PDF 大小不能超过 10 MiB。';
+    return null;
+  }
+
+  void _setNotice(String message, {bool notify = true}) {
+    _noticeMessage = message;
+    if (notify) notifyListeners();
+  }
+}
+
+String _messageFor(Object error) {
+  if (error is! ResumeException) return '简历操作暂时失败，请稍后重试。';
+  return switch (error.kind) {
+    ResumeFailureKind.authenticationRequired => '登录状态已失效，请重新登录。',
+    ResumeFailureKind.invalidRequest => '提交的简历内容不符合要求。',
+    ResumeFailureKind.notFound => '这份简历已不存在，请刷新列表。',
+    ResumeFailureKind.conflict => '简历已在其他设备更新，请刷新后重试。',
+    ResumeFailureKind.limitReached => '每个账号最多保存 3 份简历。',
+    ResumeFailureKind.network => '网络连接异常，请稍后重试。',
+    ResumeFailureKind.server => '简历服务暂时不可用，请稍后重试。',
+    ResumeFailureKind.invalidResponse => '暂时无法读取简历，请稍后重试。',
+    ResumeFailureKind.superseded => '账号已切换，本次操作已取消。',
+  };
+}

--- a/mobile/lib/resume/resume_file_access.dart
+++ b/mobile/lib/resume/resume_file_access.dart
@@ -1,0 +1,46 @@
+// 本文件封装 PDF 文件选择与受保护阅读链接打开等平台能力。
+
+import 'package:file_picker/file_picker.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'resume_models.dart';
+
+/// ResumeFilePicker 抽象平台文件选择器，便于状态层测试。
+abstract interface class ResumeFilePicker {
+  Future<ResumePdfFile?> pickPdf();
+}
+
+/// SystemResumeFilePicker 使用系统文件面板读取单个 PDF。
+final class SystemResumeFilePicker implements ResumeFilePicker {
+  const SystemResumeFilePicker();
+
+  @override
+  Future<ResumePdfFile?> pickPdf() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const <String>['pdf'],
+      allowMultiple: false,
+      withData: true,
+    );
+    final file = result?.files.single;
+    final bytes = file?.bytes;
+    if (file == null || bytes == null) {
+      return null;
+    }
+    return ResumePdfFile(name: file.name, bytes: bytes);
+  }
+}
+
+/// ResumeUrlOpener 抽象外部 PDF 查看能力。
+abstract interface class ResumeUrlOpener {
+  Future<bool> open(Uri url);
+}
+
+/// SystemResumeUrlOpener 使用系统安全浏览器打开短时 PDF 地址。
+final class SystemResumeUrlOpener implements ResumeUrlOpener {
+  const SystemResumeUrlOpener();
+
+  @override
+  Future<bool> open(Uri url) =>
+      launchUrl(url, mode: LaunchMode.externalApplication);
+}

--- a/mobile/lib/resume/resume_models.dart
+++ b/mobile/lib/resume/resume_models.dart
@@ -63,8 +63,16 @@ final class ResumeContent {
   /// 从服务端结构化内容创建不可变模型。
   factory ResumeContent.fromJson(Map<String, Object?> json) {
     return ResumeContent(
-      targetPosition: _requiredString(json, 'target_position'),
-      professionalSummary: _requiredString(json, 'professional_summary'),
+      targetPosition: _requiredString(
+        json,
+        'target_position',
+        allowEmpty: true,
+      ),
+      professionalSummary: _requiredString(
+        json,
+        'professional_summary',
+        allowEmpty: true,
+      ),
       workExperiences: _objectList(json, 'work_experiences'),
       projectExperiences: _objectList(json, 'project_experiences'),
       educationExperiences: _objectList(json, 'education_experiences'),
@@ -127,9 +135,13 @@ final class ResumePdfFile {
   final List<int> bytes;
 }
 
-String _requiredString(Map<String, Object?> json, String key) {
+String _requiredString(
+  Map<String, Object?> json,
+  String key, {
+  bool allowEmpty = false,
+}) {
   final value = json[key];
-  if (value is! String || value.isEmpty) {
+  if (value is! String || (!allowEmpty && value.isEmpty)) {
     throw FormatException('Invalid $key.');
   }
   return value;

--- a/mobile/lib/resume/resume_models.dart
+++ b/mobile/lib/resume/resume_models.dart
@@ -1,0 +1,175 @@
+// 本文件定义移动端 Resume 模块使用的领域模型与 JSON 映射。
+
+enum ResumeParseStatus { queued, parsing, ready, failed }
+
+/// 描述一份简历的列表元数据和当前并发版本。
+final class ResumeItem {
+  const ResumeItem({
+    required this.id,
+    required this.title,
+    required this.originalFilename,
+    required this.sizeBytes,
+    required this.parseStatus,
+    required this.version,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String title;
+  final String originalFilename;
+  final int sizeBytes;
+  final ResumeParseStatus parseStatus;
+  final int version;
+  final DateTime updatedAt;
+
+  /// 从服务端契约对象创建简历元数据。
+  factory ResumeItem.fromJson(Map<String, Object?> json) {
+    return ResumeItem(
+      id: _requiredString(json, 'resume_id'),
+      title: _requiredString(json, 'title'),
+      originalFilename: _requiredString(json, 'original_filename'),
+      sizeBytes: _requiredInt(json, 'size_bytes'),
+      parseStatus: switch (_requiredString(json, 'parse_status')) {
+        'QUEUED' => ResumeParseStatus.queued,
+        'PARSING' => ResumeParseStatus.parsing,
+        'READY' => ResumeParseStatus.ready,
+        'FAILED' => ResumeParseStatus.failed,
+        _ => throw const FormatException('Invalid resume parse status.'),
+      },
+      version: _requiredInt(json, 'version'),
+      updatedAt: DateTime.parse(_requiredString(json, 'updated_at')),
+    );
+  }
+}
+
+/// 保存解析后或人工修订的结构化简历内容。
+final class ResumeContent {
+  const ResumeContent({
+    this.targetPosition = '',
+    this.professionalSummary = '',
+    this.workExperiences = const <Map<String, Object?>>[],
+    this.projectExperiences = const <Map<String, Object?>>[],
+    this.educationExperiences = const <Map<String, Object?>>[],
+    this.skills = const <String>[],
+  });
+
+  final String targetPosition;
+  final String professionalSummary;
+  final List<Map<String, Object?>> workExperiences;
+  final List<Map<String, Object?>> projectExperiences;
+  final List<Map<String, Object?>> educationExperiences;
+  final List<String> skills;
+
+  /// 从服务端结构化内容创建不可变模型。
+  factory ResumeContent.fromJson(Map<String, Object?> json) {
+    return ResumeContent(
+      targetPosition: _requiredString(json, 'target_position'),
+      professionalSummary: _requiredString(json, 'professional_summary'),
+      workExperiences: _objectList(json, 'work_experiences'),
+      projectExperiences: _objectList(json, 'project_experiences'),
+      educationExperiences: _objectList(json, 'education_experiences'),
+      skills: _stringList(json, 'skills'),
+    );
+  }
+
+  /// 生成更新结构化内容接口需要的 JSON 对象。
+  Map<String, Object?> toJson() => <String, Object?>{
+    'target_position': targetPosition,
+    'professional_summary': professionalSummary,
+    'work_experiences': workExperiences,
+    'project_experiences': projectExperiences,
+    'education_experiences': educationExperiences,
+    'skills': skills,
+  };
+
+  /// 复制内容并替换当前界面允许人工编辑的字段。
+  ResumeContent copyWith({
+    String? targetPosition,
+    String? professionalSummary,
+    List<String>? skills,
+  }) {
+    return ResumeContent(
+      targetPosition: targetPosition ?? this.targetPosition,
+      professionalSummary: professionalSummary ?? this.professionalSummary,
+      workExperiences: workExperiences,
+      projectExperiences: projectExperiences,
+      educationExperiences: educationExperiences,
+      skills: skills ?? this.skills,
+    );
+  }
+}
+
+/// 表示简历详情及其当前结构化修订。
+final class ResumeDetail {
+  const ResumeDetail({required this.resume, this.content});
+
+  final ResumeItem resume;
+  final ResumeContent? content;
+
+  /// 从详情接口响应创建模型。
+  factory ResumeDetail.fromJson(Map<String, Object?> json) {
+    final resume = _requiredObject(json, 'resume');
+    final revision = json['current_revision'];
+    return ResumeDetail(
+      resume: ResumeItem.fromJson(resume),
+      content: revision is Map<String, Object?>
+          ? ResumeContent.fromJson(_requiredObject(revision, 'content'))
+          : null,
+    );
+  }
+}
+
+/// 表示由系统文件选择器返回的 PDF 文件。
+final class ResumePdfFile {
+  const ResumePdfFile({required this.name, required this.bytes});
+
+  final String name;
+  final List<int> bytes;
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.isEmpty) {
+    throw FormatException('Invalid $key.');
+  }
+  return value;
+}
+
+int _requiredInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! int) {
+    throw FormatException('Invalid $key.');
+  }
+  return value;
+}
+
+Map<String, Object?> _requiredObject(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! Map<String, Object?>) {
+    throw FormatException('Invalid $key.');
+  }
+  return value;
+}
+
+List<Map<String, Object?>> _objectList(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! List<Object?>) {
+    throw FormatException('Invalid $key.');
+  }
+  return List<Map<String, Object?>>.unmodifiable(
+    value.map((item) {
+      if (item is! Map<String, Object?>) {
+        throw FormatException('Invalid $key item.');
+      }
+      return Map<String, Object?>.unmodifiable(item);
+    }),
+  );
+}
+
+List<String> _stringList(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! List<Object?> || value.any((item) => item is! String)) {
+    throw FormatException('Invalid $key.');
+  }
+  return List<String>.unmodifiable(value.cast<String>());
+}

--- a/mobile/lib/resume/resume_page.dart
+++ b/mobile/lib/resume/resume_page.dart
@@ -380,75 +380,106 @@ class _ResumeDetailPageState extends State<ResumeDetailPage> {
   }
 
   Future<void> _editContent(ResumeDetail detail) async {
-    final content = detail.content!;
-    final position = TextEditingController(text: content.targetPosition);
-    final summary = TextEditingController(text: content.professionalSummary);
-    final skills = TextEditingController(text: content.skills.join('、'));
     final updated = await showModalBottomSheet<ResumeContent>(
       context: context,
       isScrollControlled: true,
-      builder: (context) => Padding(
-        padding: EdgeInsets.fromLTRB(
-          SpeakUpDesign.space20,
-          SpeakUpDesign.space8,
-          SpeakUpDesign.space20,
-          MediaQuery.viewInsetsOf(context).bottom + SpeakUpDesign.space24,
-        ),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text('完善简历内容', style: Theme.of(context).textTheme.titleLarge),
-              const SizedBox(height: SpeakUpDesign.space16),
-              TextField(
-                controller: position,
-                maxLength: 200,
-                decoration: const InputDecoration(labelText: '目标岗位'),
+      builder: (context) => _ResumeContentEditorSheet(content: detail.content!),
+    );
+    if (updated != null) await widget.controller.saveContent(detail, updated);
+  }
+}
+
+final class _ResumeContentEditorSheet extends StatefulWidget {
+  const _ResumeContentEditorSheet({required this.content});
+
+  final ResumeContent content;
+
+  @override
+  State<_ResumeContentEditorSheet> createState() =>
+      _ResumeContentEditorSheetState();
+}
+
+final class _ResumeContentEditorSheetState
+    extends State<_ResumeContentEditorSheet> {
+  late final TextEditingController _position;
+  late final TextEditingController _summary;
+  late final TextEditingController _skills;
+
+  @override
+  void initState() {
+    super.initState();
+    _position = TextEditingController(text: widget.content.targetPosition);
+    _summary = TextEditingController(text: widget.content.professionalSummary);
+    _skills = TextEditingController(text: widget.content.skills.join('、'));
+  }
+
+  @override
+  void dispose() {
+    _position.dispose();
+    _summary.dispose();
+    _skills.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        SpeakUpDesign.space20,
+        SpeakUpDesign.space8,
+        SpeakUpDesign.space20,
+        MediaQuery.viewInsetsOf(context).bottom + SpeakUpDesign.space24,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('完善简历内容', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: SpeakUpDesign.space16),
+            TextField(
+              controller: _position,
+              maxLength: 200,
+              decoration: const InputDecoration(labelText: '目标岗位'),
+            ),
+            const SizedBox(height: SpeakUpDesign.space12),
+            TextField(
+              controller: _summary,
+              maxLength: 4000,
+              minLines: 4,
+              maxLines: 8,
+              decoration: const InputDecoration(labelText: '个人简介'),
+            ),
+            const SizedBox(height: SpeakUpDesign.space12),
+            TextField(
+              controller: _skills,
+              decoration: const InputDecoration(
+                labelText: '技能',
+                hintText: '使用逗号、顿号或换行分隔',
               ),
-              const SizedBox(height: SpeakUpDesign.space12),
-              TextField(
-                controller: summary,
-                maxLength: 4000,
-                minLines: 4,
-                maxLines: 8,
-                decoration: const InputDecoration(labelText: '个人简介'),
-              ),
-              const SizedBox(height: SpeakUpDesign.space12),
-              TextField(
-                controller: skills,
-                decoration: const InputDecoration(
-                  labelText: '技能',
-                  hintText: '使用逗号、顿号或换行分隔',
+            ),
+            const SizedBox(height: SpeakUpDesign.space16),
+            FilledButton(
+              key: const Key('resume-content-save'),
+              onPressed: () => Navigator.pop(
+                context,
+                widget.content.copyWith(
+                  targetPosition: _position.text.trim(),
+                  professionalSummary: _summary.text.trim(),
+                  skills: _skills.text
+                      .split(RegExp(r'[,，、\n]'))
+                      .map((value) => value.trim())
+                      .where((value) => value.isNotEmpty)
+                      .toSet()
+                      .take(100)
+                      .toList(growable: false),
                 ),
               ),
-              const SizedBox(height: SpeakUpDesign.space16),
-              FilledButton(
-                key: const Key('resume-content-save'),
-                onPressed: () => Navigator.pop(
-                  context,
-                  content.copyWith(
-                    targetPosition: position.text.trim(),
-                    professionalSummary: summary.text.trim(),
-                    skills: skills.text
-                        .split(RegExp(r'[,，、\n]'))
-                        .map((value) => value.trim())
-                        .where((value) => value.isNotEmpty)
-                        .toSet()
-                        .take(100)
-                        .toList(growable: false),
-                  ),
-                ),
-                child: const Text('保存修改'),
-              ),
-            ],
-          ),
+              child: const Text('保存修改'),
+            ),
+          ],
         ),
       ),
     );
-    position.dispose();
-    summary.dispose();
-    skills.dispose();
-    if (updated != null) await widget.controller.saveContent(detail, updated);
   }
 }
 

--- a/mobile/lib/resume/resume_page.dart
+++ b/mobile/lib/resume/resume_page.dart
@@ -1,0 +1,816 @@
+// 本文件提供“我的”页简历概览、简历管理页和结构化详情交互。
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+import 'resume_controller.dart';
+import 'resume_models.dart';
+
+/// ResumeSummaryCard 在“我的”页面展示简历数量和解析概况。
+final class ResumeSummaryCard extends StatefulWidget {
+  const ResumeSummaryCard({required this.controller, super.key});
+
+  final ResumeController controller;
+
+  @override
+  State<ResumeSummaryCard> createState() => _ResumeSummaryCardState();
+}
+
+class _ResumeSummaryCardState extends State<ResumeSummaryCard> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller.items.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(widget.controller.load());
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, _) {
+        final items = widget.controller.items;
+        final ready = items
+            .where((item) => item.parseStatus == ResumeParseStatus.ready)
+            .length;
+        return Card(
+          key: const Key('profile-resume-card'),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => ResumePage(controller: widget.controller),
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(SpeakUpDesign.space16),
+              child: Row(
+                children: [
+                  const _ResumeIcon(),
+                  const SizedBox(width: SpeakUpDesign.space16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '我的简历',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: SpeakUpDesign.space4),
+                        Text(
+                          widget.controller.isLoading && items.isEmpty
+                              ? '正在读取简历…'
+                              : items.isEmpty
+                              ? '上传 PDF，让面试准备更贴合你的经历'
+                              : '${items.length}/3 份 · $ready 份已解析',
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: SpeakUpDesign.space8),
+                  const Icon(
+                    Icons.chevron_right_rounded,
+                    color: SpeakUpDesign.secondary,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// ResumePage 管理当前账号的最多三份 PDF 简历。
+final class ResumePage extends StatefulWidget {
+  const ResumePage({required this.controller, super.key});
+
+  final ResumeController controller;
+
+  @override
+  State<ResumePage> createState() => _ResumePageState();
+}
+
+class _ResumePageState extends State<ResumePage> {
+  Timer? _parsePollTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_showNotice);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(widget.controller.load());
+    });
+    _parsePollTimer = Timer.periodic(const Duration(seconds: 4), (_) {
+      final hasPending = widget.controller.items.any(
+        (item) =>
+            item.parseStatus == ResumeParseStatus.queued ||
+            item.parseStatus == ResumeParseStatus.parsing,
+      );
+      if (mounted &&
+          hasPending &&
+          !widget.controller.isLoading &&
+          widget.controller.busyResumeId == null) {
+        unawaited(widget.controller.load());
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _parsePollTimer?.cancel();
+    widget.controller.removeListener(_showNotice);
+    super.dispose();
+  }
+
+  void _showNotice() {
+    final message = widget.controller.noticeMessage;
+    if (message == null || !mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+      widget.controller.consumeNotice();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('resume-page'),
+      appBar: AppBar(leading: const SpeakUpBackButton()),
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: widget.controller,
+          builder: (context, _) => RefreshIndicator(
+            onRefresh: widget.controller.load,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: SpeakUpDesign.pagePadding(context),
+              children: [
+                SpeakUpPageHeader(
+                  title: '我的简历',
+                  subtitle: '最多保存 3 份 PDF，解析后可检查并完善关键信息。',
+                  trailing: _CountBadge(count: widget.controller.items.length),
+                ),
+                const SizedBox(height: SpeakUpDesign.space24),
+                if (widget.controller.errorMessage != null) ...[
+                  _ErrorCard(
+                    message: widget.controller.errorMessage!,
+                    onRetry: widget.controller.load,
+                  ),
+                  const SizedBox(height: SpeakUpDesign.space16),
+                ],
+                if (widget.controller.isLoading &&
+                    widget.controller.items.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 56),
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                else if (widget.controller.items.isEmpty)
+                  _EmptyResumeCard(onUpload: widget.controller.pickAndUpload)
+                else
+                  for (final resume in widget.controller.items) ...[
+                    _ResumeCard(
+                      resume: resume,
+                      busy: widget.controller.busyResumeId == resume.id,
+                      onOpen: () => _openDetail(resume),
+                      onRename: () => _rename(resume),
+                      onReplace: () => widget.controller.pickAndReplace(resume),
+                      onRetry: resume.parseStatus == ResumeParseStatus.failed
+                          ? () => widget.controller.retryParse(resume)
+                          : null,
+                      onDelete: () => _delete(resume),
+                    ),
+                    const SizedBox(height: SpeakUpDesign.space12),
+                  ],
+                if (widget.controller.items.isNotEmpty) ...[
+                  const SizedBox(height: SpeakUpDesign.space8),
+                  FilledButton.icon(
+                    key: const Key('resume-upload-button'),
+                    onPressed:
+                        widget.controller.canUpload &&
+                            widget.controller.busyResumeId == null
+                        ? widget.controller.pickAndUpload
+                        : null,
+                    icon: const Icon(Icons.upload_file_rounded),
+                    label: Text(
+                      widget.controller.items.length >=
+                              ResumeController.maxResumes
+                          ? '已达到 3 份上限'
+                          : '上传 PDF 简历',
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openDetail(ResumeItem resume) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => ResumeDetailPage(
+          controller: widget.controller,
+          resumeId: resume.id,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _rename(ResumeItem resume) async {
+    final controller = TextEditingController(text: resume.title);
+    final title = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('重命名简历'),
+        content: TextField(
+          key: const Key('resume-title-input'),
+          controller: controller,
+          autofocus: true,
+          maxLength: 120,
+          decoration: const InputDecoration(labelText: '简历名称'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            key: const Key('resume-title-save'),
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (title != null) await widget.controller.rename(resume, title);
+  }
+
+  Future<void> _delete(ResumeItem resume) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('删除这份简历？'),
+        content: Text('“${resume.title}”及其解析内容将被删除，此操作无法撤销。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            key: const Key('resume-delete-confirm'),
+            style: FilledButton.styleFrom(backgroundColor: SpeakUpDesign.error),
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) await widget.controller.delete(resume);
+  }
+}
+
+/// ResumeDetailPage 展示原始 PDF 入口及当前结构化简历内容。
+final class ResumeDetailPage extends StatefulWidget {
+  const ResumeDetailPage({
+    required this.controller,
+    required this.resumeId,
+    super.key,
+  });
+
+  final ResumeController controller;
+  final String resumeId;
+
+  @override
+  State<ResumeDetailPage> createState() => _ResumeDetailPageState();
+}
+
+class _ResumeDetailPageState extends State<ResumeDetailPage> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_refresh);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(widget.controller.loadDetail(widget.resumeId));
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_refresh);
+    super.dispose();
+  }
+
+  void _refresh() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final detail = widget.controller.detailFor(widget.resumeId);
+    final busy = widget.controller.busyResumeId == widget.resumeId;
+    return Scaffold(
+      key: const Key('resume-detail-page'),
+      appBar: AppBar(leading: const SpeakUpBackButton()),
+      body: SafeArea(
+        child: detail == null
+            ? Center(
+                child: busy
+                    ? const CircularProgressIndicator()
+                    : FilledButton(
+                        onPressed: () =>
+                            widget.controller.loadDetail(widget.resumeId),
+                        child: const Text('重新加载'),
+                      ),
+              )
+            : ListView(
+                padding: SpeakUpDesign.pagePadding(context),
+                children: [
+                  SpeakUpPageHeader(
+                    title: detail.resume.title,
+                    subtitle:
+                        '${detail.resume.originalFilename} · ${_formatBytes(detail.resume.sizeBytes)}',
+                  ),
+                  const SizedBox(height: SpeakUpDesign.space20),
+                  OutlinedButton.icon(
+                    key: const Key('resume-open-pdf'),
+                    onPressed: busy
+                        ? null
+                        : () => widget.controller.openPdf(widget.resumeId),
+                    icon: const Icon(Icons.picture_as_pdf_rounded),
+                    label: const Text('查看原始 PDF'),
+                  ),
+                  const SizedBox(height: SpeakUpDesign.space24),
+                  SpeakUpSectionHeader(
+                    title: '结构化内容',
+                    subtitle: detail.content == null
+                        ? '解析完成后会显示在这里'
+                        : '可人工修正岗位、简介和技能',
+                    action: detail.content == null
+                        ? null
+                        : TextButton.icon(
+                            key: const Key('resume-edit-content'),
+                            onPressed: busy ? null : () => _editContent(detail),
+                            icon: const Icon(Icons.edit_rounded, size: 18),
+                            label: const Text('编辑'),
+                          ),
+                  ),
+                  const SizedBox(height: SpeakUpDesign.space12),
+                  if (detail.content == null)
+                    _ParsingCard(status: detail.resume.parseStatus)
+                  else
+                    _ResumeContentView(content: detail.content!),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Future<void> _editContent(ResumeDetail detail) async {
+    final content = detail.content!;
+    final position = TextEditingController(text: content.targetPosition);
+    final summary = TextEditingController(text: content.professionalSummary);
+    final skills = TextEditingController(text: content.skills.join('、'));
+    final updated = await showModalBottomSheet<ResumeContent>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => Padding(
+        padding: EdgeInsets.fromLTRB(
+          SpeakUpDesign.space20,
+          SpeakUpDesign.space8,
+          SpeakUpDesign.space20,
+          MediaQuery.viewInsetsOf(context).bottom + SpeakUpDesign.space24,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text('完善简历内容', style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: SpeakUpDesign.space16),
+              TextField(
+                controller: position,
+                maxLength: 200,
+                decoration: const InputDecoration(labelText: '目标岗位'),
+              ),
+              const SizedBox(height: SpeakUpDesign.space12),
+              TextField(
+                controller: summary,
+                maxLength: 4000,
+                minLines: 4,
+                maxLines: 8,
+                decoration: const InputDecoration(labelText: '个人简介'),
+              ),
+              const SizedBox(height: SpeakUpDesign.space12),
+              TextField(
+                controller: skills,
+                decoration: const InputDecoration(
+                  labelText: '技能',
+                  hintText: '使用逗号、顿号或换行分隔',
+                ),
+              ),
+              const SizedBox(height: SpeakUpDesign.space16),
+              FilledButton(
+                key: const Key('resume-content-save'),
+                onPressed: () => Navigator.pop(
+                  context,
+                  content.copyWith(
+                    targetPosition: position.text.trim(),
+                    professionalSummary: summary.text.trim(),
+                    skills: skills.text
+                        .split(RegExp(r'[,，、\n]'))
+                        .map((value) => value.trim())
+                        .where((value) => value.isNotEmpty)
+                        .toSet()
+                        .take(100)
+                        .toList(growable: false),
+                  ),
+                ),
+                child: const Text('保存修改'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    position.dispose();
+    summary.dispose();
+    skills.dispose();
+    if (updated != null) await widget.controller.saveContent(detail, updated);
+  }
+}
+
+class _ResumeIcon extends StatelessWidget {
+  const _ResumeIcon();
+  @override
+  Widget build(BuildContext context) => Container(
+    width: 48,
+    height: 48,
+    decoration: BoxDecoration(
+      color: SpeakUpDesign.primaryMuted,
+      borderRadius: BorderRadius.circular(14),
+    ),
+    child: const Icon(Icons.description_rounded, color: SpeakUpDesign.primary),
+  );
+}
+
+class _CountBadge extends StatelessWidget {
+  const _CountBadge({required this.count});
+  final int count;
+  @override
+  Widget build(BuildContext context) => Container(
+    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    decoration: const BoxDecoration(
+      color: SpeakUpDesign.primaryMuted,
+      borderRadius: BorderRadius.all(Radius.circular(99)),
+    ),
+    child: Text(
+      '$count / 3',
+      style: SpeakUpDesign.label.copyWith(color: SpeakUpDesign.primary),
+    ),
+  );
+}
+
+class _EmptyResumeCard extends StatelessWidget {
+  const _EmptyResumeCard({required this.onUpload});
+  final VoidCallback onUpload;
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.all(SpeakUpDesign.space24),
+      child: Column(
+        children: [
+          const _ResumeIcon(),
+          const SizedBox(height: SpeakUpDesign.space16),
+          Text('从第一份简历开始', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: SpeakUpDesign.space8),
+          const Text(
+            '上传 10 MiB 以内的文本型 PDF，我们会提取岗位、经历与技能。',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: SpeakUpDesign.space20),
+          FilledButton.icon(
+            key: const Key('resume-empty-upload-button'),
+            onPressed: onUpload,
+            icon: const Icon(Icons.upload_file_rounded),
+            label: const Text('选择 PDF'),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ResumeCard extends StatelessWidget {
+  const _ResumeCard({
+    required this.resume,
+    required this.busy,
+    required this.onOpen,
+    required this.onRename,
+    required this.onReplace,
+    required this.onRetry,
+    required this.onDelete,
+  });
+  final ResumeItem resume;
+  final bool busy;
+  final VoidCallback onOpen;
+  final VoidCallback onRename;
+  final VoidCallback onReplace;
+  final VoidCallback? onRetry;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    key: Key('resume-card-${resume.id}'),
+    child: InkWell(
+      borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+      onTap: busy ? null : onOpen,
+      child: Padding(
+        padding: const EdgeInsets.all(SpeakUpDesign.space16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const _ResumeIcon(),
+            const SizedBox(width: SpeakUpDesign.space12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    resume.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: SpeakUpDesign.space8),
+                  _StatusPill(status: resume.parseStatus),
+                  const SizedBox(height: SpeakUpDesign.space8),
+                  Text(
+                    '${_formatBytes(resume.sizeBytes)} · ${_formatDate(resume.updatedAt)}',
+                    style: SpeakUpDesign.meta,
+                  ),
+                ],
+              ),
+            ),
+            if (busy)
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: SizedBox.square(
+                  dimension: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              )
+            else
+              PopupMenuButton<String>(
+                tooltip: '更多操作',
+                onSelected: (value) => switch (value) {
+                  'rename' => onRename(),
+                  'replace' => onReplace(),
+                  'retry' => onRetry?.call(),
+                  'delete' => onDelete(),
+                  _ => null,
+                },
+                itemBuilder: (_) => [
+                  const PopupMenuItem(value: 'rename', child: Text('重命名')),
+                  const PopupMenuItem(value: 'replace', child: Text('替换 PDF')),
+                  if (onRetry != null)
+                    const PopupMenuItem(value: 'retry', child: Text('重新解析')),
+                  const PopupMenuDivider(),
+                  const PopupMenuItem(value: 'delete', child: Text('删除')),
+                ],
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.status});
+  final ResumeParseStatus status;
+  @override
+  Widget build(BuildContext context) {
+    final (label, color, background, icon) = switch (status) {
+      ResumeParseStatus.ready => (
+        '已解析',
+        SpeakUpDesign.success,
+        SpeakUpDesign.successMuted,
+        Icons.check_circle_rounded,
+      ),
+      ResumeParseStatus.failed => (
+        '解析失败',
+        SpeakUpDesign.error,
+        SpeakUpDesign.errorMuted,
+        Icons.error_rounded,
+      ),
+      ResumeParseStatus.parsing => (
+        '解析中',
+        SpeakUpDesign.primary,
+        SpeakUpDesign.primaryMuted,
+        Icons.autorenew_rounded,
+      ),
+      ResumeParseStatus.queued => (
+        '等待解析',
+        SpeakUpDesign.secondary,
+        SpeakUpDesign.surfaceMuted,
+        Icons.schedule_rounded,
+      ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(99),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(label, style: SpeakUpDesign.meta.copyWith(color: color)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ParsingCard extends StatelessWidget {
+  const _ParsingCard({required this.status});
+  final ResumeParseStatus status;
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.all(SpeakUpDesign.space20),
+      child: Row(
+        children: [
+          if (status == ResumeParseStatus.failed)
+            const Icon(Icons.error_outline_rounded, color: SpeakUpDesign.error)
+          else
+            const SizedBox.square(
+              dimension: 22,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          const SizedBox(width: SpeakUpDesign.space12),
+          Expanded(
+            child: Text(
+              status == ResumeParseStatus.failed
+                  ? '解析未完成，可返回列表重新解析或替换 PDF。'
+                  : '正在提取岗位、经历与技能，请稍后刷新。',
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ResumeContentView extends StatelessWidget {
+  const _ResumeContentView({required this.content});
+  final ResumeContent content;
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      _ContentSection(
+        icon: Icons.work_outline_rounded,
+        title: '目标岗位',
+        body: content.targetPosition.isEmpty ? '暂未填写' : content.targetPosition,
+      ),
+      const SizedBox(height: SpeakUpDesign.space12),
+      _ContentSection(
+        icon: Icons.person_outline_rounded,
+        title: '个人简介',
+        body: content.professionalSummary.isEmpty
+            ? '暂未填写'
+            : content.professionalSummary,
+      ),
+      const SizedBox(height: SpeakUpDesign.space12),
+      _ContentSection(
+        icon: Icons.auto_awesome_rounded,
+        title: '技能',
+        body: content.skills.isEmpty ? '暂未填写' : content.skills.join(' · '),
+      ),
+      if (content.workExperiences.isNotEmpty) ...[
+        const SizedBox(height: SpeakUpDesign.space12),
+        _ContentSection(
+          icon: Icons.business_center_outlined,
+          title: '工作经历',
+          body: _summarize(content.workExperiences, const [
+            'company',
+            'position',
+          ]),
+        ),
+      ],
+      if (content.projectExperiences.isNotEmpty) ...[
+        const SizedBox(height: SpeakUpDesign.space12),
+        _ContentSection(
+          icon: Icons.rocket_launch_outlined,
+          title: '项目经历',
+          body: _summarize(content.projectExperiences, const [
+            'project_name',
+            'role',
+          ]),
+        ),
+      ],
+      if (content.educationExperiences.isNotEmpty) ...[
+        const SizedBox(height: SpeakUpDesign.space12),
+        _ContentSection(
+          icon: Icons.school_outlined,
+          title: '教育经历',
+          body: _summarize(content.educationExperiences, const [
+            'school',
+            'major',
+            'degree',
+          ]),
+        ),
+      ],
+    ],
+  );
+}
+
+class _ContentSection extends StatelessWidget {
+  const _ContentSection({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+  final IconData icon;
+  final String title;
+  final String body;
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.all(SpeakUpDesign.space16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20, color: SpeakUpDesign.primary),
+          const SizedBox(width: SpeakUpDesign.space12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: SpeakUpDesign.space8),
+                Text(body),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ErrorCard extends StatelessWidget {
+  const _ErrorCard({required this.message, required this.onRetry});
+  final String message;
+  final VoidCallback onRetry;
+  @override
+  Widget build(BuildContext context) => Card(
+    color: SpeakUpDesign.errorMuted,
+    child: Padding(
+      padding: const EdgeInsets.all(SpeakUpDesign.space16),
+      child: Row(
+        children: [
+          const Icon(Icons.wifi_off_rounded, color: SpeakUpDesign.error),
+          const SizedBox(width: 12),
+          Expanded(child: Text(message)),
+          TextButton(onPressed: onRetry, child: const Text('重试')),
+        ],
+      ),
+    ),
+  );
+}
+
+String _formatBytes(int bytes) => bytes < 1024 * 1024
+    ? '${(bytes / 1024).toStringAsFixed(0)} KB'
+    : '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
+
+String _formatDate(DateTime value) {
+  final local = value.toLocal();
+  return '${local.year}.${local.month.toString().padLeft(2, '0')}.${local.day.toString().padLeft(2, '0')}';
+}
+
+String _summarize(List<Map<String, Object?>> items, List<String> keys) => items
+    .map(
+      (item) => keys
+          .map((key) => item[key])
+          .whereType<String>()
+          .where((value) => value.isNotEmpty)
+          .join(' · '),
+    )
+    .where((value) => value.isNotEmpty)
+    .join('\n');

--- a/mobile/lib/resume/resume_page.dart
+++ b/mobile/lib/resume/resume_page.dart
@@ -667,7 +667,7 @@ class _ParsingCard extends StatelessWidget {
           Expanded(
             child: Text(
               status == ResumeParseStatus.failed
-                  ? '解析未完成，可返回列表重新解析或替换 PDF。'
+                  ? '解析未完成。如果这是扫描件或图片型 PDF，请先导出带可选中文本的 PDF，再返回列表替换文件。'
                   : '正在提取岗位、经历与技能，请稍后刷新。',
             ),
           ),

--- a/mobile/lib/resume/resume_page.dart
+++ b/mobile/lib/resume/resume_page.dart
@@ -715,49 +715,85 @@ class _ResumeContentView extends StatelessWidget {
   Widget build(BuildContext context) => Column(
     children: [
       _ContentSection(
+        key: const Key('resume-content-target'),
         icon: Icons.work_outline_rounded,
         title: '目标岗位',
         body: content.targetPosition.isEmpty ? '暂未填写' : content.targetPosition,
+        onTap: () => _showResumeContentSheet(
+          context,
+          icon: Icons.work_outline_rounded,
+          title: '目标岗位',
+          child: _TextDetail(value: content.targetPosition),
+        ),
       ),
       const SizedBox(height: SpeakUpDesign.space12),
       _ContentSection(
+        key: const Key('resume-content-summary'),
         icon: Icons.person_outline_rounded,
         title: '个人简介',
         body: content.professionalSummary.isEmpty
             ? '暂未填写'
             : content.professionalSummary,
+        onTap: () => _showResumeContentSheet(
+          context,
+          icon: Icons.person_outline_rounded,
+          title: '个人简介',
+          child: _TextDetail(value: content.professionalSummary),
+        ),
       ),
       const SizedBox(height: SpeakUpDesign.space12),
       _ContentSection(
+        key: const Key('resume-content-skills'),
         icon: Icons.auto_awesome_rounded,
         title: '技能',
         body: content.skills.isEmpty ? '暂未填写' : content.skills.join(' · '),
+        onTap: () => _showResumeContentSheet(
+          context,
+          icon: Icons.auto_awesome_rounded,
+          title: '技能',
+          child: _SkillDetails(skills: content.skills),
+        ),
       ),
       if (content.workExperiences.isNotEmpty) ...[
         const SizedBox(height: SpeakUpDesign.space12),
         _ContentSection(
+          key: const Key('resume-content-work'),
           icon: Icons.business_center_outlined,
           title: '工作经历',
           body: _summarize(content.workExperiences, const [
             'company',
             'position',
           ]),
+          onTap: () => _showResumeContentSheet(
+            context,
+            icon: Icons.business_center_outlined,
+            title: '工作经历',
+            child: _WorkDetails(items: content.workExperiences),
+          ),
         ),
       ],
       if (content.projectExperiences.isNotEmpty) ...[
         const SizedBox(height: SpeakUpDesign.space12),
         _ContentSection(
+          key: const Key('resume-content-projects'),
           icon: Icons.rocket_launch_outlined,
           title: '项目经历',
           body: _summarize(content.projectExperiences, const [
             'project_name',
             'role',
           ]),
+          onTap: () => _showResumeContentSheet(
+            context,
+            icon: Icons.rocket_launch_outlined,
+            title: '项目经历',
+            child: _ProjectDetails(items: content.projectExperiences),
+          ),
         ),
       ],
       if (content.educationExperiences.isNotEmpty) ...[
         const SizedBox(height: SpeakUpDesign.space12),
         _ContentSection(
+          key: const Key('resume-content-education'),
           icon: Icons.school_outlined,
           title: '教育经历',
           body: _summarize(content.educationExperiences, const [
@@ -765,6 +801,12 @@ class _ResumeContentView extends StatelessWidget {
             'major',
             'degree',
           ]),
+          onTap: () => _showResumeContentSheet(
+            context,
+            icon: Icons.school_outlined,
+            title: '教育经历',
+            child: _EducationDetails(items: content.educationExperiences),
+          ),
         ),
       ],
     ],
@@ -773,30 +815,115 @@ class _ResumeContentView extends StatelessWidget {
 
 class _ContentSection extends StatelessWidget {
   const _ContentSection({
+    super.key,
     required this.icon,
     required this.title,
     required this.body,
+    required this.onTap,
   });
   final IconData icon;
   final String title;
   final String body;
+  final VoidCallback onTap;
   @override
   Widget build(BuildContext context) => Card(
-    child: Padding(
-      padding: const EdgeInsets.all(SpeakUpDesign.space16),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    clipBehavior: Clip.antiAlias,
+    child: InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(SpeakUpDesign.space16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, size: 20, color: SpeakUpDesign.primary),
+            const SizedBox(width: SpeakUpDesign.space12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: SpeakUpDesign.space8),
+                  Text(body),
+                ],
+              ),
+            ),
+            const SizedBox(width: SpeakUpDesign.space8),
+            const Padding(
+              padding: EdgeInsets.only(top: 2),
+              child: Icon(
+                Icons.chevron_right_rounded,
+                size: 22,
+                color: SpeakUpDesign.secondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _showResumeContentSheet(
+  BuildContext context, {
+  required IconData icon,
+  required String title,
+  required Widget child,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (context) => FractionallySizedBox(
+      heightFactor: 0.84,
+      child: Column(
         children: [
-          Icon(icon, size: 20, color: SpeakUpDesign.primary),
-          const SizedBox(width: SpeakUpDesign.space12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          const SizedBox(height: SpeakUpDesign.space8),
+          Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: SpeakUpDesign.border,
+              borderRadius: BorderRadius.circular(99),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              SpeakUpDesign.space20,
+              SpeakUpDesign.space20,
+              SpeakUpDesign.space20,
+              SpeakUpDesign.space16,
+            ),
+            child: Row(
               children: [
-                Text(title, style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: SpeakUpDesign.space8),
-                Text(body),
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: SpeakUpDesign.primaryMuted,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Icon(icon, color: SpeakUpDesign.primary),
+                ),
+                const SizedBox(width: SpeakUpDesign.space12),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                ),
+                IconButton(
+                  tooltip: '关闭',
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close_rounded),
+                ),
               ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(SpeakUpDesign.space20),
+              child: Align(alignment: Alignment.topLeft, child: child),
             ),
           ),
         ],
@@ -804,6 +931,283 @@ class _ContentSection extends StatelessWidget {
     ),
   );
 }
+
+class _TextDetail extends StatelessWidget {
+  const _TextDetail({required this.value});
+  final String value;
+  @override
+  Widget build(BuildContext context) => Text(
+    value.isEmpty ? '暂未填写' : value,
+    style: Theme.of(context).textTheme.bodyLarge?.copyWith(height: 1.65),
+  );
+}
+
+class _SkillDetails extends StatelessWidget {
+  const _SkillDetails({required this.skills});
+  final List<String> skills;
+  @override
+  Widget build(BuildContext context) => skills.isEmpty
+      ? const Text('暂未填写')
+      : Wrap(
+          spacing: SpeakUpDesign.space8,
+          runSpacing: SpeakUpDesign.space8,
+          children: skills
+              .map(
+                (skill) => Chip(
+                  avatar: const Icon(Icons.check_rounded, size: 16),
+                  label: Text(skill),
+                  backgroundColor: SpeakUpDesign.primaryMuted,
+                  side: BorderSide.none,
+                ),
+              )
+              .toList(growable: false),
+        );
+}
+
+class _ProjectDetails extends StatelessWidget {
+  const _ProjectDetails({required this.items});
+  final List<Map<String, Object?>> items;
+  @override
+  Widget build(BuildContext context) => _DetailCardList(
+    children: items
+        .map((item) {
+          final technologies = _stringValues(item, 'technologies');
+          return _ExperienceCard(
+            title: _stringValue(item, 'project_name', fallback: '未命名项目'),
+            subtitle: _stringValue(item, 'role'),
+            children: [
+              if (_stringValue(item, 'description').isNotEmpty)
+                _DetailBlock(
+                  title: '项目介绍',
+                  text: _stringValue(item, 'description'),
+                ),
+              if (technologies.isNotEmpty)
+                _TagBlock(title: '技术栈', values: technologies),
+              _BulletBlock(
+                title: '主要职责',
+                values: _stringValues(item, 'duties'),
+              ),
+              _BulletBlock(
+                title: '项目成果',
+                values: _stringValues(item, 'achievements'),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false),
+  );
+}
+
+class _WorkDetails extends StatelessWidget {
+  const _WorkDetails({required this.items});
+  final List<Map<String, Object?>> items;
+  @override
+  Widget build(BuildContext context) => _DetailCardList(
+    children: items
+        .map((item) {
+          return _ExperienceCard(
+            title: _stringValue(item, 'company', fallback: '未填写公司'),
+            subtitle: _joinNonEmpty([
+              _stringValue(item, 'position'),
+              _dateRange(item),
+            ]),
+            children: [
+              _BulletBlock(
+                title: '主要职责',
+                values: _stringValues(item, 'duties'),
+              ),
+              _BulletBlock(
+                title: '工作成果',
+                values: _stringValues(item, 'achievements'),
+              ),
+            ],
+          );
+        })
+        .toList(growable: false),
+  );
+}
+
+class _EducationDetails extends StatelessWidget {
+  const _EducationDetails({required this.items});
+  final List<Map<String, Object?>> items;
+  @override
+  Widget build(BuildContext context) => _DetailCardList(
+    children: items
+        .map((item) {
+          return _ExperienceCard(
+            title: _stringValue(item, 'school', fallback: '未填写学校'),
+            subtitle: _joinNonEmpty([
+              _stringValue(item, 'major'),
+              _stringValue(item, 'degree'),
+            ]),
+            children: [
+              if (_dateRange(item).isNotEmpty)
+                _DetailBlock(title: '就读时间', text: _dateRange(item)),
+            ],
+          );
+        })
+        .toList(growable: false),
+  );
+}
+
+class _DetailCardList extends StatelessWidget {
+  const _DetailCardList({required this.children});
+  final List<Widget> children;
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      for (var index = 0; index < children.length; index++) ...[
+        if (index > 0) const SizedBox(height: SpeakUpDesign.space16),
+        children[index],
+      ],
+    ],
+  );
+}
+
+class _ExperienceCard extends StatelessWidget {
+  const _ExperienceCard({
+    required this.title,
+    required this.subtitle,
+    required this.children,
+  });
+  final String title;
+  final String subtitle;
+  final List<Widget> children;
+  @override
+  Widget build(BuildContext context) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(SpeakUpDesign.space20),
+    decoration: BoxDecoration(
+      color: SpeakUpDesign.surface,
+      border: Border.all(color: SpeakUpDesign.border),
+      borderRadius: BorderRadius.circular(20),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleLarge),
+        if (subtitle.isNotEmpty) ...[
+          const SizedBox(height: SpeakUpDesign.space8),
+          Text(subtitle, style: SpeakUpDesign.meta),
+        ],
+        for (final child in children) child,
+      ],
+    ),
+  );
+}
+
+class _DetailBlock extends StatelessWidget {
+  const _DetailBlock({required this.title, required this.text});
+  final String title;
+  final String text;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(top: SpeakUpDesign.space20),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleSmall),
+        const SizedBox(height: SpeakUpDesign.space8),
+        Text(text, style: const TextStyle(height: 1.6)),
+      ],
+    ),
+  );
+}
+
+class _TagBlock extends StatelessWidget {
+  const _TagBlock({required this.title, required this.values});
+  final String title;
+  final List<String> values;
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(top: SpeakUpDesign.space20),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleSmall),
+        const SizedBox(height: SpeakUpDesign.space8),
+        Wrap(
+          spacing: SpeakUpDesign.space8,
+          runSpacing: SpeakUpDesign.space8,
+          children: values
+              .map(
+                (value) => Chip(
+                  label: Text(value),
+                  backgroundColor: SpeakUpDesign.primaryMuted,
+                  side: BorderSide.none,
+                ),
+              )
+              .toList(growable: false),
+        ),
+      ],
+    ),
+  );
+}
+
+class _BulletBlock extends StatelessWidget {
+  const _BulletBlock({required this.title, required this.values});
+  final String title;
+  final List<String> values;
+  @override
+  Widget build(BuildContext context) {
+    if (values.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: SpeakUpDesign.space20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: SpeakUpDesign.space8),
+          for (final value in values)
+            Padding(
+              padding: const EdgeInsets.only(bottom: SpeakUpDesign.space8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 7),
+                    child: Icon(
+                      Icons.circle,
+                      size: 6,
+                      color: SpeakUpDesign.primary,
+                    ),
+                  ),
+                  const SizedBox(width: SpeakUpDesign.space8),
+                  Expanded(
+                    child: Text(value, style: const TextStyle(height: 1.55)),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+String _stringValue(
+  Map<String, Object?> item,
+  String key, {
+  String fallback = '',
+}) {
+  final value = item[key];
+  return value is String && value.isNotEmpty ? value : fallback;
+}
+
+List<String> _stringValues(Map<String, Object?> item, String key) {
+  final value = item[key];
+  return value is List<Object?>
+      ? value.whereType<String>().where((item) => item.isNotEmpty).toList()
+      : const <String>[];
+}
+
+String _dateRange(Map<String, Object?> item) => _joinNonEmpty([
+  _stringValue(item, 'start_date'),
+  _stringValue(item, 'end_date'),
+], separator: ' – ');
+
+String _joinNonEmpty(List<String> values, {String separator = ' · '}) =>
+    values.where((value) => value.isNotEmpty).join(separator);
 
 class _ErrorCard extends StatelessWidget {
   const _ErrorCard({required this.message, required this.onRetry});

--- a/mobile/lib/resume/wire_resume_client.dart
+++ b/mobile/lib/resume/wire_resume_client.dart
@@ -1,0 +1,352 @@
+// 本文件实现 Resume REST 契约、认证隔离、Multipart 上传与严格响应解码。
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/bearer_authentication.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+import 'resume_client.dart';
+import 'resume_models.dart';
+
+/// WireResumeClient 通过冻结的 `/v1/resumes` 契约访问简历服务。
+final class WireResumeClient implements ResumeClient {
+  static const _maxResponseBytes = 1024 * 1024;
+  factory WireResumeClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    HttpClient? httpClient,
+    Duration requestTimeout = const Duration(seconds: 30),
+  }) => WireResumeClient._(
+    baseUri,
+    credentialProvider,
+    invalidateSession,
+    httpClient ?? HttpClient(),
+    requestTimeout,
+  );
+
+  WireResumeClient._(
+    this._baseUri,
+    this._credentialProvider,
+    this._invalidateSession,
+    this._httpClient,
+    this.requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  final Uri _baseUri;
+  final AuthSessionCredentialProvider _credentialProvider;
+  final AuthSessionInvalidator _invalidateSession;
+  final HttpClient _httpClient;
+  final Duration requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  int _accountGeneration = 0;
+
+  @override
+  Future<List<ResumeItem>> list() async {
+    final response = await _send('GET', '/v1/resumes?limit=3');
+    _expect(response, HttpStatus.ok);
+    final root = _decodeObject(response.body);
+    final items = root['items'];
+    if (items is! List<Object?> || items.length > 3) {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+    try {
+      return List<ResumeItem>.unmodifiable(
+        items.map((item) {
+          if (item is! Map<String, Object?>) {
+            throw const FormatException();
+          }
+          return ResumeItem.fromJson(item);
+        }),
+      );
+    } on FormatException {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+  }
+
+  @override
+  Future<ResumeItem> create({
+    required String title,
+    required ResumePdfFile file,
+  }) async {
+    final multipart = _multipart(<String, String>{'title': title}, file);
+    final response = await _send(
+      'POST',
+      '/v1/resumes',
+      headers: <String, String>{
+        'Idempotency-Key': _idempotencyKey(),
+        HttpHeaders.contentTypeHeader: multipart.contentType,
+      },
+      body: multipart.body,
+    );
+    _expect(response, HttpStatus.accepted);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<ResumeDetail> get(String resumeId) async {
+    final response = await _send('GET', '/v1/resumes/${_segment(resumeId)}');
+    _expect(response, HttpStatus.ok);
+    try {
+      return ResumeDetail.fromJson(_decodeObject(response.body));
+    } on FormatException {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+  }
+
+  @override
+  Future<ResumeItem> rename(ResumeItem resume, String title) async {
+    final response = await _sendJson(
+      'PATCH',
+      '/v1/resumes/${_segment(resume.id)}',
+      <String, Object?>{'title': title, 'expected_version': resume.version},
+    );
+    _expect(response, HttpStatus.ok);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file) async {
+    final multipart = _multipart(<String, String>{
+      'expected_version': '${resume.version}',
+    }, file);
+    final response = await _send(
+      'PUT',
+      '/v1/resumes/${_segment(resume.id)}/file',
+      headers: <String, String>{
+        'Idempotency-Key': _idempotencyKey(),
+        HttpHeaders.contentTypeHeader: multipart.contentType,
+      },
+      body: multipart.body,
+    );
+    _expect(response, HttpStatus.accepted);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<void> delete(ResumeItem resume) async {
+    final response = await _send(
+      'DELETE',
+      '/v1/resumes/${_segment(resume.id)}?expected_version=${resume.version}',
+      headers: <String, String>{'Idempotency-Key': _idempotencyKey()},
+    );
+    _expect(response, HttpStatus.noContent);
+  }
+
+  @override
+  Future<ResumeItem> retryParse(ResumeItem resume) async {
+    final response = await _send(
+      'POST',
+      '/v1/resumes/${_segment(resume.id)}/parse-retries',
+      headers: <String, String>{'Idempotency-Key': _idempotencyKey()},
+    );
+    _expect(response, HttpStatus.accepted);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<ResumeDetail> updateContent(
+    ResumeDetail detail,
+    ResumeContent content,
+  ) async {
+    final response = await _sendJson(
+      'PATCH',
+      '/v1/resumes/${_segment(detail.resume.id)}/content',
+      <String, Object?>{
+        'content': content.toJson(),
+        'expected_version': detail.resume.version,
+      },
+    );
+    _expect(response, HttpStatus.ok);
+    return get(detail.resume.id);
+  }
+
+  @override
+  Future<Uri> getContentUrl(String resumeId) async {
+    final response = await _send(
+      'GET',
+      '/v1/resumes/${_segment(resumeId)}/content-url',
+    );
+    _expect(response, HttpStatus.ok);
+    final value = _decodeObject(response.body)['url'];
+    final uri = value is String ? Uri.tryParse(value) : null;
+    if (uri == null ||
+        !uri.hasScheme ||
+        (uri.scheme != 'https' && uri.scheme != 'http')) {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+    return uri;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+
+  Future<_Response> _sendJson(
+    String method,
+    String path,
+    Map<String, Object?> body,
+  ) {
+    return _send(
+      method,
+      path,
+      headers: <String, String>{
+        'Idempotency-Key': _idempotencyKey(),
+        HttpHeaders.contentTypeHeader: 'application/json',
+      },
+      body: utf8.encode(jsonEncode(body)),
+    );
+  }
+
+  Future<_Response> _send(
+    String method,
+    String path, {
+    Map<String, String> headers = const <String, String>{},
+    List<int>? body,
+  }) async {
+    final credential = _credentialProvider();
+    if (credential == null) {
+      throw const ResumeException(ResumeFailureKind.authenticationRequired);
+    }
+    final generation = _accountGeneration;
+    final uri = _baseUri.resolve(path);
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(
+      uri,
+      sessionToken: credential.sessionToken,
+    );
+    try {
+      final request = await _httpClient
+          .openUrl(method, uri)
+          .timeout(requestTimeout);
+      request.followRedirects = false;
+      request.headers.set(HttpHeaders.acceptHeader, 'application/json');
+      request.headers.set(
+        HttpHeaders.authorizationHeader,
+        bearerAuthorizationValue(credential.sessionToken),
+      );
+      headers.forEach(request.headers.set);
+      if (body != null) {
+        request.add(body);
+      }
+      final raw = await request.close().timeout(requestTimeout);
+      final responseBytes = await raw
+          .fold<List<int>>(<int>[], (all, chunk) {
+            if (all.length + chunk.length > _maxResponseBytes) {
+              throw const ResumeException(ResumeFailureKind.invalidResponse);
+            }
+            all.addAll(chunk);
+            return all;
+          })
+          .timeout(requestTimeout);
+      final responseBody = utf8.decode(responseBytes);
+      if (generation != _accountGeneration ||
+          !isSameAuthSessionCredential(_credentialProvider(), credential)) {
+        throw const ResumeException(ResumeFailureKind.superseded);
+      }
+      if (raw.statusCode == HttpStatus.unauthorized) {
+        await _invalidateSession(
+          expectedSessionToken: credential.sessionToken,
+          expectedGeneration: credential.generation,
+        );
+      }
+      return _Response(raw.statusCode, responseBody);
+    } on ResumeException {
+      rethrow;
+    } on FormatException {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    } on TimeoutException {
+      throw const ResumeException(ResumeFailureKind.network, retryable: true);
+    } on IOException {
+      throw const ResumeException(ResumeFailureKind.network, retryable: true);
+    }
+  }
+
+  void _expect(_Response response, int expected) {
+    if (response.statusCode == expected) {
+      return;
+    }
+    final kind = switch (response.statusCode) {
+      HttpStatus.badRequest => ResumeFailureKind.invalidRequest,
+      HttpStatus.unauthorized => ResumeFailureKind.authenticationRequired,
+      HttpStatus.notFound => ResumeFailureKind.notFound,
+      HttpStatus.conflict =>
+        _isLimitError(response.body)
+            ? ResumeFailureKind.limitReached
+            : ResumeFailureKind.conflict,
+      >= 500 => ResumeFailureKind.server,
+      _ => ResumeFailureKind.invalidResponse,
+    };
+    throw ResumeException(
+      kind,
+      retryable:
+          kind == ResumeFailureKind.server || kind == ResumeFailureKind.network,
+    );
+  }
+
+  ResumeItem _decodeResume(String body) {
+    try {
+      return ResumeItem.fromJson(_decodeObject(body));
+    } on FormatException {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+  }
+}
+
+Map<String, Object?> _decodeObject(String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, Object?>) {
+      throw const FormatException();
+    }
+    return decoded;
+  } on FormatException {
+    throw const ResumeException(ResumeFailureKind.invalidResponse);
+  }
+}
+
+String _segment(String value) => Uri.encodeComponent(value);
+
+String _idempotencyKey() {
+  final random = Random.secure();
+  return 'resume-${DateTime.now().microsecondsSinceEpoch}-${random.nextInt(1 << 32)}';
+}
+
+bool _isLimitError(String body) {
+  return body.contains('resume_limit') || body.contains('limit_reached');
+}
+
+_Multipart _multipart(Map<String, String> fields, ResumePdfFile file) {
+  final boundary = 'speakup-${DateTime.now().microsecondsSinceEpoch}';
+  final bytes = <int>[];
+  void text(String value) => bytes.addAll(utf8.encode(value));
+  for (final entry in fields.entries) {
+    text('--$boundary\r\n');
+    text('Content-Disposition: form-data; name="${entry.key}"\r\n\r\n');
+    text('${entry.value}\r\n');
+  }
+  final safeName = file.name.replaceAll(RegExp(r'[\r\n"]'), '_');
+  text('--$boundary\r\n');
+  text('Content-Disposition: form-data; name="file"; filename="$safeName"\r\n');
+  text('Content-Type: application/pdf\r\n\r\n');
+  bytes.addAll(file.bytes);
+  text('\r\n--$boundary--\r\n');
+  return _Multipart('multipart/form-data; boundary=$boundary', bytes);
+}
+
+final class _Multipart {
+  const _Multipart(this.contentType, this.body);
+  final String contentType;
+  final List<int> body;
+}
+
+final class _Response {
+  const _Response(this.statusCode, this.body);
+  final int statusCode;
+  final String body;
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.14"
   fake_async:
     dependency: transitive
     description:
@@ -153,14 +161,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  ffi_leak_tracker:
-    dependency: transitive
-    description:
-      name: ffi_leak_tracker
-      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -169,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.10"
   file_selector_linux:
     dependency: transitive
     description:
@@ -287,10 +295,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -411,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: "5bc9a9daac5ccfbd6a758377600b9f7fdce13d93f26e8012a8941014a5d978d1"
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
@@ -583,6 +591,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -764,6 +780,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
@@ -808,10 +888,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -820,6 +900,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,10 +13,12 @@ dependencies:
     sdk: flutter
   flutter_markdown_plus: ^1.0.12
   flutter_secure_storage: ^10.3.1
+  file_picker: ^10.3.10
   image_picker: ^1.2.3
   path_provider: ^2.1.5
   record: ^6.1.2
   flutter_tts: ^4.2.5
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   integration_test:

--- a/mobile/test/resume/resume_controller_test.dart
+++ b/mobile/test/resume/resume_controller_test.dart
@@ -1,0 +1,137 @@
+// 本文件验证简历状态编排、三份上限和 PDF 本地校验。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/resume/resume.dart';
+
+void main() {
+  test('loads resumes and blocks a fourth upload', () async {
+    final client = _FakeResumeClient(
+      items: <ResumeItem>[_resume('1'), _resume('2'), _resume('3')],
+    );
+    final picker = _FakePicker(
+      ResumePdfFile(name: 'fourth.pdf', bytes: '%PDF-content'.codeUnits),
+    );
+    final controller = ResumeController(
+      client: client,
+      filePicker: picker,
+      urlOpener: _FakeOpener(),
+    );
+
+    await controller.load();
+    await controller.pickAndUpload();
+
+    expect(controller.items, hasLength(3));
+    expect(controller.canUpload, isFalse);
+    expect(controller.noticeMessage, '每个账号最多保存 3 份简历。');
+    expect(picker.pickCount, 0);
+    expect(client.createCount, 0);
+  });
+
+  test('valid PDF upload uses filename as title and joins the list', () async {
+    final client = _FakeResumeClient();
+    final picker = _FakePicker(
+      ResumePdfFile(
+        name: 'Backend Engineer.pdf',
+        bytes: '%PDF-content'.codeUnits,
+      ),
+    );
+    final controller = ResumeController(
+      client: client,
+      filePicker: picker,
+      urlOpener: _FakeOpener(),
+    );
+
+    await controller.load();
+    await controller.pickAndUpload();
+
+    expect(client.createdTitle, 'Backend Engineer');
+    expect(controller.items.single.title, 'Backend Engineer');
+    expect(controller.noticeMessage, '简历已上传，正在解析。');
+  });
+
+  test('rejects a renamed non-PDF before network upload', () async {
+    final client = _FakeResumeClient();
+    final controller = ResumeController(
+      client: client,
+      filePicker: _FakePicker(
+        ResumePdfFile(name: 'fake.pdf', bytes: 'not-a-pdf'.codeUnits),
+      ),
+      urlOpener: _FakeOpener(),
+    );
+
+    await controller.pickAndUpload();
+
+    expect(client.createCount, 0);
+    expect(controller.noticeMessage, '请选择有效的 PDF 文件。');
+  });
+}
+
+ResumeItem _resume(String id, {String? title}) => ResumeItem(
+  id: id,
+  title: title ?? '简历 $id',
+  originalFilename: '$id.pdf',
+  sizeBytes: 2048,
+  parseStatus: ResumeParseStatus.ready,
+  version: 1,
+  updatedAt: DateTime.utc(2026, 8, 3),
+);
+
+final class _FakePicker implements ResumeFilePicker {
+  _FakePicker(this.file);
+  final ResumePdfFile? file;
+  int pickCount = 0;
+  @override
+  Future<ResumePdfFile?> pickPdf() async {
+    pickCount++;
+    return file;
+  }
+}
+
+final class _FakeOpener implements ResumeUrlOpener {
+  @override
+  Future<bool> open(Uri url) async => true;
+}
+
+final class _FakeResumeClient implements ResumeClient {
+  _FakeResumeClient({this.items = const <ResumeItem>[]});
+  List<ResumeItem> items;
+  int createCount = 0;
+  String? createdTitle;
+
+  @override
+  Future<List<ResumeItem>> list() async => items;
+
+  @override
+  Future<ResumeItem> create({
+    required String title,
+    required ResumePdfFile file,
+  }) async {
+    createCount++;
+    createdTitle = title;
+    return _resume('created', title: title);
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+  @override
+  Future<void> delete(ResumeItem resume) async {}
+  @override
+  Future<ResumeDetail> get(String resumeId) async =>
+      ResumeDetail(resume: _resume(resumeId));
+  @override
+  Future<Uri> getContentUrl(String resumeId) async =>
+      Uri.parse('https://example.test/resume.pdf');
+  @override
+  Future<ResumeItem> rename(ResumeItem resume, String title) async =>
+      _resume(resume.id, title: title);
+  @override
+  Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file) async =>
+      resume;
+  @override
+  Future<ResumeItem> retryParse(ResumeItem resume) async => resume;
+  @override
+  Future<ResumeDetail> updateContent(
+    ResumeDetail detail,
+    ResumeContent content,
+  ) async => ResumeDetail(resume: detail.resume, content: content);
+}

--- a/mobile/test/resume/resume_page_test.dart
+++ b/mobile/test/resume/resume_page_test.dart
@@ -71,12 +71,53 @@ void main() {
     expect(find.textContaining('图片型 PDF'), findsOneWidget);
     expect(find.textContaining('带可选中文本'), findsOneWidget);
   });
+
+  testWidgets('project summary opens the complete parsed project details', (
+    tester,
+  ) async {
+    final ready = _resume('ready', ResumeParseStatus.ready);
+    final controller = _controller(
+      <ResumeItem>[ready],
+      content: const ResumeContent(
+        projectExperiences: <Map<String, Object?>>[
+          <String, Object?>{
+            'project_name': '杭电 Ragent 工程平台',
+            'role': '后端开发',
+            'description': '面向校园知识库的企业级 RAG 系统。',
+            'technologies': <Object?>['SpringBoot', 'Milvus'],
+            'duties': <Object?>['设计混合检索与重排序链路。'],
+            'achievements': <Object?>['Top-5 命中率提升至 91%。'],
+          },
+        ],
+      ),
+    );
+    await tester.pumpWidget(
+      _app(ResumeDetailPage(controller: controller, resumeId: ready.id)),
+    );
+    await tester.pumpAndSettle();
+
+    final projectCard = find.byKey(const Key('resume-content-projects'));
+    await tester.ensureVisible(projectCard);
+    await tester.drag(find.byType(ListView), const Offset(0, -120));
+    await tester.pumpAndSettle();
+    await tester.tap(projectCard);
+    await tester.pumpAndSettle();
+
+    expect(find.text('项目介绍'), findsOneWidget);
+    expect(find.text('面向校园知识库的企业级 RAG 系统。'), findsOneWidget);
+    expect(find.text('SpringBoot'), findsOneWidget);
+    expect(find.text('设计混合检索与重排序链路。'), findsOneWidget);
+    expect(find.text('Top-5 命中率提升至 91%。'), findsOneWidget);
+  });
 }
 
 Widget _app(Widget home) => MaterialApp(theme: SpeakUpTheme.light, home: home);
 
-ResumeController _controller(List<ResumeItem> items) => ResumeController(
-  client: _PageClient(items),
+ResumeController _controller(
+  List<ResumeItem> items, {
+  ResumeContent? content,
+}) => ResumeController(
+  client: _PageClient(items, content),
   filePicker: _NoopPicker(),
   urlOpener: _NoopOpener(),
 );
@@ -102,8 +143,9 @@ final class _NoopOpener implements ResumeUrlOpener {
 }
 
 final class _PageClient implements ResumeClient {
-  _PageClient(this.items);
+  _PageClient(this.items, this.content);
   final List<ResumeItem> items;
+  final ResumeContent? content;
   @override
   Future<List<ResumeItem>> list() async => items;
   @override
@@ -116,8 +158,10 @@ final class _PageClient implements ResumeClient {
   @override
   Future<void> delete(ResumeItem resume) => throw UnimplementedError();
   @override
-  Future<ResumeDetail> get(String resumeId) async =>
-      ResumeDetail(resume: items.singleWhere((item) => item.id == resumeId));
+  Future<ResumeDetail> get(String resumeId) async => ResumeDetail(
+    resume: items.singleWhere((item) => item.id == resumeId),
+    content: content,
+  );
   @override
   Future<Uri> getContentUrl(String resumeId) => throw UnimplementedError();
   @override

--- a/mobile/test/resume/resume_page_test.dart
+++ b/mobile/test/resume/resume_page_test.dart
@@ -57,6 +57,20 @@ void main() {
     expect(button.onPressed, isNull);
     expect(find.text('已达到 3 份上限'), findsOneWidget);
   });
+
+  testWidgets('failed detail explains how to replace an image-only PDF', (
+    tester,
+  ) async {
+    final failed = _resume('failed', ResumeParseStatus.failed);
+    final controller = _controller(<ResumeItem>[failed]);
+    await tester.pumpWidget(
+      _app(ResumeDetailPage(controller: controller, resumeId: failed.id)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('图片型 PDF'), findsOneWidget);
+    expect(find.textContaining('带可选中文本'), findsOneWidget);
+  });
 }
 
 Widget _app(Widget home) => MaterialApp(theme: SpeakUpTheme.light, home: home);
@@ -102,7 +116,8 @@ final class _PageClient implements ResumeClient {
   @override
   Future<void> delete(ResumeItem resume) => throw UnimplementedError();
   @override
-  Future<ResumeDetail> get(String resumeId) => throw UnimplementedError();
+  Future<ResumeDetail> get(String resumeId) async =>
+      ResumeDetail(resume: items.singleWhere((item) => item.id == resumeId));
   @override
   Future<Uri> getContentUrl(String resumeId) => throw UnimplementedError();
   @override

--- a/mobile/test/resume/resume_page_test.dart
+++ b/mobile/test/resume/resume_page_test.dart
@@ -1,0 +1,122 @@
+// 本文件验证简历概览入口、空状态和三份上限的关键 Widget 行为。
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/design/speak_up_theme.dart';
+import 'package:speakup/resume/resume.dart';
+
+void main() {
+  testWidgets('the My tab contains the resume module entry', (tester) async {
+    final controller = _controller(const <ResumeItem>[]);
+    await tester.pumpWidget(SpeakUpApp.preview(resumeController: controller));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('profile-page')), findsOneWidget);
+    expect(find.byKey(const Key('profile-resume-card')), findsOneWidget);
+    expect(find.text('我的简历'), findsOneWidget);
+  });
+
+  testWidgets('summary card opens the empty resume management page', (
+    tester,
+  ) async {
+    final controller = _controller(const <ResumeItem>[]);
+    await tester.pumpWidget(_app(ResumeSummaryCard(controller: controller)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('我的简历'), findsOneWidget);
+    expect(find.textContaining('上传 PDF'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('profile-resume-card')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('resume-page')), findsOneWidget);
+    expect(find.text('从第一份简历开始'), findsOneWidget);
+    expect(find.byKey(const Key('resume-empty-upload-button')), findsOneWidget);
+  });
+
+  testWidgets('three resumes show status and disable upload', (tester) async {
+    final controller = _controller(<ResumeItem>[
+      _resume('1', ResumeParseStatus.ready),
+      _resume('2', ResumeParseStatus.parsing),
+      _resume('3', ResumeParseStatus.failed),
+    ]);
+    await tester.pumpWidget(_app(ResumePage(controller: controller)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('3 / 3'), findsOneWidget);
+    expect(find.text('已解析'), findsOneWidget);
+    expect(find.text('解析中'), findsOneWidget);
+    expect(find.text('解析失败'), findsOneWidget);
+    final button = tester.widget<FilledButton>(
+      find.byKey(const Key('resume-upload-button')),
+    );
+    expect(button.onPressed, isNull);
+    expect(find.text('已达到 3 份上限'), findsOneWidget);
+  });
+}
+
+Widget _app(Widget home) => MaterialApp(theme: SpeakUpTheme.light, home: home);
+
+ResumeController _controller(List<ResumeItem> items) => ResumeController(
+  client: _PageClient(items),
+  filePicker: _NoopPicker(),
+  urlOpener: _NoopOpener(),
+);
+
+ResumeItem _resume(String id, ResumeParseStatus status) => ResumeItem(
+  id: id,
+  title: '简历 $id',
+  originalFilename: '$id.pdf',
+  sizeBytes: 1024,
+  parseStatus: status,
+  version: 1,
+  updatedAt: DateTime.utc(2026, 8, 3),
+);
+
+final class _NoopPicker implements ResumeFilePicker {
+  @override
+  Future<ResumePdfFile?> pickPdf() async => null;
+}
+
+final class _NoopOpener implements ResumeUrlOpener {
+  @override
+  Future<bool> open(Uri url) async => true;
+}
+
+final class _PageClient implements ResumeClient {
+  _PageClient(this.items);
+  final List<ResumeItem> items;
+  @override
+  Future<List<ResumeItem>> list() async => items;
+  @override
+  Future<void> clearAccountState() async {}
+  @override
+  Future<ResumeItem> create({
+    required String title,
+    required ResumePdfFile file,
+  }) => throw UnimplementedError();
+  @override
+  Future<void> delete(ResumeItem resume) => throw UnimplementedError();
+  @override
+  Future<ResumeDetail> get(String resumeId) => throw UnimplementedError();
+  @override
+  Future<Uri> getContentUrl(String resumeId) => throw UnimplementedError();
+  @override
+  Future<ResumeItem> rename(ResumeItem resume, String title) =>
+      throw UnimplementedError();
+  @override
+  Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file) =>
+      throw UnimplementedError();
+  @override
+  Future<ResumeItem> retryParse(ResumeItem resume) =>
+      throw UnimplementedError();
+  @override
+  Future<ResumeDetail> updateContent(
+    ResumeDetail detail,
+    ResumeContent content,
+  ) => throw UnimplementedError();
+}

--- a/mobile/test/resume/wire_resume_client_test.dart
+++ b/mobile/test/resume/wire_resume_client_test.dart
@@ -62,6 +62,44 @@ void main() {
     expect(created.id, 'created');
     await server.close(force: true);
   });
+
+  test('get accepts contract-valid empty target and summary', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final requestSeen = _serveOnce(server, (request, body) {
+      expect(request.method, 'GET');
+      expect(request.uri.path, '/v1/resumes/resume-empty-fields');
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode(<String, Object?>{
+          'resume': _resumeJson('resume-empty-fields'),
+          'current_revision': <String, Object?>{
+            'revision_id': 'revision-1',
+            'revision_number': 1,
+            'source': 'PARSER',
+            'parser_version': 'llm-v1',
+            'content': <String, Object?>{
+              'target_position': '',
+              'professional_summary': '',
+              'work_experiences': <Object?>[],
+              'project_experiences': <Object?>[],
+              'education_experiences': <Object?>[],
+              'skills': <Object?>['Go', 'Flutter'],
+            },
+            'created_at': '2026-08-04T00:00:00Z',
+          },
+        }),
+      );
+    });
+    final client = _client(server);
+
+    final detail = await client.get('resume-empty-fields');
+    await requestSeen;
+
+    expect(detail.content?.targetPosition, isEmpty);
+    expect(detail.content?.professionalSummary, isEmpty);
+    expect(detail.content?.skills, <String>['Go', 'Flutter']);
+    await server.close(force: true);
+  });
 }
 
 WireResumeClient _client(HttpServer server) => WireResumeClient(

--- a/mobile/test/resume/wire_resume_client_test.dart
+++ b/mobile/test/resume/wire_resume_client_test.dart
@@ -1,0 +1,101 @@
+// 本文件验证 Resume 线上客户端的认证、列表解码与 Multipart 上传契约。
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/resume/resume.dart';
+
+void main() {
+  test('list sends Bearer and strictly decodes three-item contract', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final requestSeen = _serveOnce(server, (request, body) {
+      expect(request.method, 'GET');
+      expect(request.uri.path, '/v1/resumes');
+      expect(request.uri.queryParameters['limit'], '3');
+      expect(
+        request.headers.value(HttpHeaders.authorizationHeader),
+        'Bearer sess_resume-test',
+      );
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode(<String, Object?>{
+          'items': <Object?>[_resumeJson('resume-1')],
+        }),
+      );
+    });
+    final client = _client(server);
+
+    final items = await client.list();
+    await requestSeen;
+
+    expect(items.single.id, 'resume-1');
+    expect(items.single.parseStatus, ResumeParseStatus.ready);
+    await server.close(force: true);
+  });
+
+  test('create sends PDF multipart and an idempotency key', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final requestSeen = _serveOnce(server, (request, body) {
+      expect(request.method, 'POST');
+      expect(request.uri.path, '/v1/resumes');
+      expect(request.headers.value('Idempotency-Key'), startsWith('resume-'));
+      expect(request.headers.contentType?.mimeType, 'multipart/form-data');
+      final encoded = latin1.decode(body);
+      expect(encoded, contains('name="title"'));
+      expect(encoded, contains('Backend Engineer'));
+      expect(encoded, contains('filename="resume.pdf"'));
+      expect(encoded, contains('%PDF-test'));
+      request.response.statusCode = HttpStatus.accepted;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(jsonEncode(_resumeJson('created')));
+    });
+    final client = _client(server);
+
+    final created = await client.create(
+      title: 'Backend Engineer',
+      file: ResumePdfFile(name: 'resume.pdf', bytes: '%PDF-test'.codeUnits),
+    );
+    await requestSeen;
+
+    expect(created.id, 'created');
+    await server.close(force: true);
+  });
+}
+
+WireResumeClient _client(HttpServer server) => WireResumeClient(
+  baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+  credentialProvider: () => const AuthSessionCredential(
+    sessionToken: 'sess_resume-test',
+    generation: 1,
+  ),
+  invalidateSession:
+      ({required expectedSessionToken, required expectedGeneration}) async {},
+);
+
+Future<void> _serveOnce(
+  HttpServer server,
+  void Function(HttpRequest request, List<int> body) handler,
+) async {
+  final request = await server.first;
+  final body = await request.fold<List<int>>(<int>[], (all, chunk) {
+    all.addAll(chunk);
+    return all;
+  });
+  handler(request, body);
+  await request.response.close();
+}
+
+Map<String, Object?> _resumeJson(String id) => <String, Object?>{
+  'resume_id': id,
+  'title': 'Backend Engineer',
+  'original_filename': 'resume.pdf',
+  'content_type': 'application/pdf',
+  'size_bytes': 1024,
+  'file_status': 'AVAILABLE',
+  'parse_status': 'READY',
+  'version': 1,
+  'created_at': '2026-08-03T00:00:00Z',
+  'updated_at': '2026-08-03T00:00:00Z',
+};


### PR DESCRIPTION
## 功能描述

- 在“我的”页增加简历概览卡片，展示数量与解析完成情况。
- 新增简历管理页和详情页，支持最多 3 份 PDF 的上传、查看、重命名、替换、删除、解析重试。
- 展示等待、解析中、成功、失败状态，并在处理中自动刷新。
- 展示解析后的岗位、简介、技能、工作/项目/教育经历，支持人工修订岗位、简介和技能。

## 实现思路

- 新增独立 `mobile/lib/resume` 模块，拆分模型、Client、Controller、平台文件能力和页面。
- Wire Client 严格实现 #320 的 REST 契约，Bearer 只进入请求头，写操作携带幂等键与乐观锁版本。
- PDF 选择和外部阅读通过可注入端口隔离，生产环境使用 `file_picker` 与 `url_launcher`。
- Resume Controller 接入全局认证私有状态清理，避免账号切换后残留数据。
- UI 复用 SpeakUp Design System 的色板、间距、圆角、Card、Header 与按钮规范。

## 测试方式

```bash
PUB_HOSTED_URL=https://pub.dev make check-flutter
```

已验证：依赖锁定、格式检查、 Flutter Analyze 零告警、全量 783 项测试通过。新增测试覆盖三份上限、PDF 校验、上传状态、我的页入口、管理页状态、Bearer 与 Multipart 契约。

## 依赖关系

- 前端依据已冻结契约 #320 实现。
- 真实端到端联调依赖后端运行时 #330 合入。

Closes #334