### PR TITLE
feat(interview): add conversation text toggle

### DIFF
--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -72,6 +72,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   bool _exitInFlight = false;
   bool _exitApproved = false;
   bool _feedbackRebuildScheduled = false;
+  bool _conversationTextVisible = true;
   String? _scheduledInterviewReportSessionId;
   String? _autoOpenedInterviewReportSessionId;
   bool _interviewReportRouteActive = false;
@@ -156,6 +157,10 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
         );
       });
     }
+  }
+
+  void _toggleConversationText() {
+    setState(() => _conversationTextVisible = !_conversationTextVisible);
   }
 
   void _syncSpeechFeedbackSources() {
@@ -414,6 +419,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                       latestAssistantMessage: _latestAssistantMessage(
                         widget.practiceController.practiceMessages,
                       ),
+                      conversationTextVisible: _conversationTextVisible,
                       exitInFlight: _exitInFlight,
                       onExit: _requestExit,
                     );
@@ -425,6 +431,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                       textMode: _textMode,
                       recordingSeconds: _recordingSeconds,
                       previewMode: widget.previewMode,
+                      conversationTextVisible: _conversationTextVisible,
                       onBeforeStartRecording: () => _runBoundedUserTurnAction(
                         widget.onBeforeStartRecording,
                       ),
@@ -434,6 +441,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                       replayPlaying: widget.replayPlaying,
                       onToggleTextMode: _toggleTextMode,
                       onSubmitText: _submitText,
+                      onToggleConversationText: _toggleConversationText,
                       onOpenReport: _openInterviewReport,
                     );
                     if (landscape) {
@@ -472,6 +480,7 @@ class _AvatarStage extends StatelessWidget {
     required this.surfaceBuilder,
     required this.statusLabel,
     required this.latestAssistantMessage,
+    required this.conversationTextVisible,
     required this.exitInFlight,
     required this.onExit,
   });
@@ -480,6 +489,7 @@ class _AvatarStage extends StatelessWidget {
   final ImmersiveAvatarSurfaceBuilder? surfaceBuilder;
   final String? statusLabel;
   final PracticeMessage? latestAssistantMessage;
+  final bool conversationTextVisible;
   final bool exitInFlight;
   final VoidCallback onExit;
 
@@ -594,16 +604,23 @@ class _AvatarStage extends StatelessWidget {
                   color: Colors.black.withValues(alpha: 0.58),
                   borderRadius: BorderRadius.circular(16),
                 ),
-                child: Text(
-                  message.text,
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 15,
-                    height: 1.35,
-                    fontWeight: FontWeight.w500,
+                child: Visibility(
+                  key: const Key('immersive-live-subtitle-text'),
+                  visible: conversationTextVisible,
+                  maintainAnimation: true,
+                  maintainSize: true,
+                  maintainState: true,
+                  child: Text(
+                    message.text,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      height: 1.35,
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
               ),
@@ -642,6 +659,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.textMode,
     required this.recordingSeconds,
     required this.previewMode,
+    required this.conversationTextVisible,
     required this.onBeforeStartRecording,
     required this.onReplayQuestion,
     required this.speechFeedbackController,
@@ -649,6 +667,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.replayPlaying,
     required this.onToggleTextMode,
     required this.onSubmitText,
+    required this.onToggleConversationText,
     required this.onOpenReport,
   });
 
@@ -659,6 +678,7 @@ class _ConversationPanel extends StatelessWidget {
   final bool textMode;
   final int recordingSeconds;
   final bool previewMode;
+  final bool conversationTextVisible;
   final ImmersiveAsyncAction? onBeforeStartRecording;
   final ImmersiveAsyncAction? onReplayQuestion;
   final SpeechFeedbackController? speechFeedbackController;
@@ -666,6 +686,7 @@ class _ConversationPanel extends StatelessWidget {
   final bool replayPlaying;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
+  final VoidCallback onToggleConversationText;
   final VoidCallback onOpenReport;
 
   @override
@@ -677,6 +698,8 @@ class _ConversationPanel extends StatelessWidget {
         children: [
           _ConversationHeader(
             controller: controller,
+            conversationTextVisible: conversationTextVisible,
+            onToggleConversationText: onToggleConversationText,
             onReplayQuestion: onReplayQuestion,
             replayLoading: replayLoading,
             replayPlaying: replayPlaying,
@@ -705,6 +728,7 @@ class _ConversationPanel extends StatelessWidget {
                               message: message,
                               polishedText: _polishedText(projection),
                               polishLoading: projection?.isPolling ?? false,
+                              messageTextVisible: conversationTextVisible,
                             ),
                             if (projection != null) ...[
                               const SizedBox(height: SpeakUpDesign.space8),
@@ -808,12 +832,16 @@ class _ConversationPanel extends StatelessWidget {
 class _ConversationHeader extends StatelessWidget {
   const _ConversationHeader({
     required this.controller,
+    required this.conversationTextVisible,
+    required this.onToggleConversationText,
     required this.onReplayQuestion,
     required this.replayLoading,
     required this.replayPlaying,
   });
 
   final PracticeController controller;
+  final bool conversationTextVisible;
+  final VoidCallback onToggleConversationText;
   final ImmersiveAsyncAction? onReplayQuestion;
   final bool replayLoading;
   final bool replayPlaying;
@@ -842,6 +870,18 @@ class _ConversationHeader extends StatelessWidget {
               style: SpeakUpDesign.meta,
             ),
           ),
+          if (controller.practiceSceneFamily == SceneFamily.interview)
+            IconButton(
+              key: const Key('immersive-toggle-conversation-text'),
+              tooltip: conversationTextVisible ? '隐藏文字' : '显示文字',
+              onPressed: onToggleConversationText,
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                conversationTextVisible
+                    ? Icons.visibility_outlined
+                    : Icons.visibility_off_outlined,
+              ),
+            ),
           if (onReplayQuestion != null || controller.canPlayQuestionAudio) ...[
             const SizedBox(width: 6),
             IconButton(

--- a/mobile/lib/features/coaching/practice/practice_message_bubble.dart
+++ b/mobile/lib/features/coaching/practice/practice_message_bubble.dart
@@ -72,6 +72,7 @@ final class PracticeMessageBubble extends StatelessWidget {
   Widget build(BuildContext context) {
     final user = message.role == PracticeMessageRole.user;
     return Align(
+      key: Key('practice-message-${message.id}'),
       alignment: user ? Alignment.centerRight : Alignment.centerLeft,
       child: FractionallySizedBox(
         widthFactor: 0.82,

--- a/mobile/lib/features/coaching/practice/practice_message_bubble.dart
+++ b/mobile/lib/features/coaching/practice/practice_message_bubble.dart
@@ -59,12 +59,14 @@ final class PracticeMessageBubble extends StatelessWidget {
     required this.message,
     this.polishedText,
     this.polishLoading = false,
+    this.messageTextVisible = true,
     super.key,
   });
 
   final PracticeMessage message;
   final String? polishedText;
   final bool polishLoading;
+  final bool messageTextVisible;
 
   @override
   Widget build(BuildContext context) {
@@ -84,11 +86,18 @@ final class PracticeMessageBubble extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  message.text,
-                  style: TextStyle(
-                    color: user ? Colors.white : SpeakUpDesign.ink,
-                    height: 1.45,
+                Visibility(
+                  key: Key('practice-message-text-${message.id}'),
+                  visible: messageTextVisible,
+                  maintainAnimation: true,
+                  maintainSize: true,
+                  maintainState: true,
+                  child: Text(
+                    message.text,
+                    style: TextStyle(
+                      color: user ? Colors.white : SpeakUpDesign.ink,
+                      height: 1.45,
+                    ),
                   ),
                 ),
                 if (polishLoading) ...[

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -50,11 +50,55 @@ void main() {
     expect(find.text('画面已连接'), findsOneWidget);
     expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
     expect(
+      find.byKey(const Key('immersive-toggle-conversation-text')),
+      findsNothing,
+    );
+    expect(
       tester.getSize(find.byKey(const Key('immersive-avatar-region'))).height,
       closeTo(844 * 0.44, 0.1),
     );
     expect(find.byKey(const Key('immersive-conversation-history')), findsOne);
     expect(find.textContaining('评分'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('toggles interview subtitles and conversation text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final controller = await _roleplayController(
+      practiceClient: _AsyncReviewPracticeClient(
+        sceneFamily: SceneFamily.interview,
+        sceneModel: SceneModel.interviewBasicDialogue,
+      ),
+    );
+    addTearDown(controller.dispose);
+    final question = controller.currentQuestion!.text;
+
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(agentController: controller)),
+    );
+    await tester.pump();
+
+    final toggle = find.byKey(const Key('immersive-toggle-conversation-text'));
+    expect(toggle, findsOneWidget);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
+    expect(find.text(question), findsWidgets);
+
+    await tester.tap(toggle);
+    await tester.pump();
+
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
+    expect(find.text(question), findsNothing);
+    expect(find.byKey(const Key('immersive-record')).hitTestable(), findsOne);
+
+    await tester.tap(toggle);
+    await tester.pump();
+
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
+    expect(find.text(question), findsWidgets);
     expect(tester.takeException(), isNull);
   });
 

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -76,9 +76,10 @@ void main() {
     );
     addTearDown(controller.dispose);
     final question = controller.currentQuestion!.text;
+    final questionMessage = controller.practiceMessages.last;
 
     await tester.pumpWidget(
-      MaterialApp(home: ImmersiveRoleplayPage(agentController: controller)),
+      MaterialApp(home: ImmersiveRoleplayPage(practiceController: controller)),
     );
     await tester.pump();
 
@@ -86,12 +87,40 @@ void main() {
     expect(toggle, findsOneWidget);
     expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
     expect(find.text(question), findsWidgets);
+    final subtitleSize = tester.getSize(
+      find.byKey(const Key('immersive-live-subtitle')),
+    );
+    final messageBubble = find.byKey(
+      Key('practice-message-${questionMessage.id}'),
+    );
+    final messageBubbleSize = tester.getSize(messageBubble);
 
     await tester.tap(toggle);
     await tester.pump();
 
-    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
-    expect(find.text(question), findsNothing);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
+    expect(messageBubble, findsOneWidget);
+    expect(
+      tester
+          .widget<Visibility>(
+            find.byKey(const Key('immersive-live-subtitle-text')),
+          )
+          .visible,
+      isFalse,
+    );
+    expect(
+      tester
+          .widget<Visibility>(
+            find.byKey(Key('practice-message-text-${questionMessage.id}')),
+          )
+          .visible,
+      isFalse,
+    );
+    expect(
+      tester.getSize(find.byKey(const Key('immersive-live-subtitle'))),
+      subtitleSize,
+    );
+    expect(tester.getSize(messageBubble), messageBubbleSize);
     expect(find.byKey(const Key('immersive-record')).hitTestable(), findsOne);
 
     await tester.tap(toggle);
@@ -99,6 +128,14 @@ void main() {
 
     expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
     expect(find.text(question), findsWidgets);
+    expect(
+      tester
+          .widget<Visibility>(
+            find.byKey(const Key('immersive-live-subtitle-text')),
+          )
+          .visible,
+      isTrue,
+    );
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## 功能描述

- 在沉浸式面试对话栏增加一个小眼睛按钮。
- 点击后只隐藏数字人区域和对话历史的会话文字，再次点击恢复。
- 字幕框、消息气泡、原有布局高度、朗读、录音和 Tips 等控件保留。
- 不展示隐藏状态提示文案，非面试沉浸式场景不展示该按钮。

## 实现思路

- 在 `ImmersiveRoleplayPage` 内维护一个页面级布尔状态。
- 消息项和字幕容器始终参与布局，仅切换其会话文字层的可见性。
- `AgentMessageBubble` 新增默认为可见的可选参数，只由沉浸式面试传入隐藏状态，其他调用方行为不变。
- 不修改后端、API、持久化或会话模型。

## 测试方式

```bash
flutter test --no-pub test/practice/immersive_roleplay_test.dart
flutter test --no-pub test/agent/agent_message_bubble_test.dart test/agent/agent_voice_fence_test.dart
```

结果：沉浸式页面 14 个 Widget 测试全部通过；消息气泡与语音边界 21 个测试全部通过。

Closes #342
