### PR TITLE
fix(interview): 移除数字人区域重复字幕

### DIFF
--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -416,9 +416,13 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                           ? null
                           : widget.avatarSurfaceBuilder,
                       statusLabel: widget.avatarStatusLabel,
-                      latestAssistantMessage: _latestAssistantMessage(
-                        widget.practiceController.practiceMessages,
-                      ),
+                      latestAssistantMessage:
+                          widget.practiceController.practiceSceneFamily ==
+                              SceneFamily.interview
+                          ? null
+                          : _latestAssistantMessage(
+                              widget.practiceController.practiceMessages,
+                            ),
                       conversationTextVisible: _conversationTextVisible,
                       exitInFlight: _exitInFlight,
                       onExit: _requestExit,

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -62,7 +62,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('toggles interview subtitles and conversation text', (
+  testWidgets('toggles interview text without an avatar subtitle', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(390, 844);
@@ -85,11 +85,8 @@ void main() {
 
     final toggle = find.byKey(const Key('immersive-toggle-conversation-text'));
     expect(toggle, findsOneWidget);
-    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
-    expect(find.text(question), findsWidgets);
-    final subtitleSize = tester.getSize(
-      find.byKey(const Key('immersive-live-subtitle')),
-    );
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
+    expect(find.text(question), findsOneWidget);
     final messageBubble = find.byKey(
       Key('practice-message-${questionMessage.id}'),
     );
@@ -98,16 +95,8 @@ void main() {
     await tester.tap(toggle);
     await tester.pump();
 
-    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
     expect(messageBubble, findsOneWidget);
-    expect(
-      tester
-          .widget<Visibility>(
-            find.byKey(const Key('immersive-live-subtitle-text')),
-          )
-          .visible,
-      isFalse,
-    );
     expect(
       tester
           .widget<Visibility>(
@@ -116,22 +105,18 @@ void main() {
           .visible,
       isFalse,
     );
-    expect(
-      tester.getSize(find.byKey(const Key('immersive-live-subtitle'))),
-      subtitleSize,
-    );
     expect(tester.getSize(messageBubble), messageBubbleSize);
     expect(find.byKey(const Key('immersive-record')).hitTestable(), findsOne);
 
     await tester.tap(toggle);
     await tester.pump();
 
-    expect(find.byKey(const Key('immersive-live-subtitle')), findsOneWidget);
-    expect(find.text(question), findsWidgets);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
+    expect(find.text(question), findsOneWidget);
     expect(
       tester
           .widget<Visibility>(
-            find.byKey(const Key('immersive-live-subtitle-text')),
+            find.byKey(Key('practice-message-text-${questionMessage.id}')),
           )
           .visible,
       isTrue,


### PR DESCRIPTION
## 功能描述

- 移除沉浸式面试数字人区域底部的重复深色字幕框。
- 下方对话区、消息操作、录音入口和其他面试流程保持不变。
- 非面试沉浸式练习仍保留数字人区域字幕。

## 实现思路

- 复用 `AgentController.practiceSceneFamily` 区分面试和非面试场景。
- 面试场景不再向 `_AvatarStage` 传入最新 AI 消息；其他场景保持原有传值和渲染。
- 不修改后端、API、会话模型或下方对话区布局。

## 测试方式

```bash
flutter test --no-pub test/practice/immersive_roleplay_test.dart
```

结果：沉浸式页面 14 个 Widget 测试全部通过，包含“面试不显示顶部字幕”和“非面试仍显示字幕”的隔离验证。

Closes #344
