### PR TITLE
feat(interview): 支持面试问题按需中文翻译

### DIFF
--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -284,6 +284,33 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/voice-questions/{question_id}/translation:
+    get:
+      tags:
+        - Practice
+      summary: Translate an interview Question into Simplified Chinese on demand
+      description: |
+        Returns an ephemeral read aid for an Actor-owned INTERVIEW Question.
+        Translation never creates a Message, Candidate, or Turn and is excluded
+        from progression, Review, Evaluation, memory, and history.
+      operationId: getVoiceQuestionTranslation
+      parameters:
+        - $ref: '#/components/parameters/QuestionId'
+      responses:
+        '200':
+          description: Simplified Chinese translation of the Question.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VoiceQuestionTranslation'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/practice-sessions/{practice_session_id}/bootstrap:
     get:
       tags:
@@ -922,6 +949,23 @@ components:
           then:
             not:
               required: [parent_question_id]
+    VoiceQuestionTranslation:
+      type: object
+      additionalProperties: false
+      required:
+        - question_id
+        - target_language
+        - translation
+      properties:
+        question_id:
+          $ref: '#/components/schemas/ResourceId'
+        target_language:
+          type: string
+          const: zh-CN
+        translation:
+          type: string
+          minLength: 1
+          maxLength: 2000
     VoiceTurnHistoryEntry:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -157,6 +157,8 @@ paths:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1transcription-candidates~1{candidate_id}~1confirmations
   /v1/voice-questions/{question_id}/speech:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-questions~1{question_id}~1speech
+  /v1/voice-questions/{question_id}/translation:
+    $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-questions~1{question_id}~1translation
   /v1/evaluation-reports:
     $ref: ./modules/review.yaml#/paths/~1v1~1evaluation-reports
   /v1/evaluation-reports/{report_id}:

--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/voice_capture_control.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
@@ -71,6 +72,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   bool _textMode = false;
   bool _exitInFlight = false;
   bool _exitApproved = false;
+  final Map<String, String> _questionTranslations = <String, String>{};
   bool _feedbackRebuildScheduled = false;
   bool _conversationTextVisible = true;
   String? _scheduledInterviewReportSessionId;
@@ -351,6 +353,24 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     });
   }
 
+  Future<String> _translateQuestion(PracticeMessage message) async {
+    final cached = _questionTranslations[message.id];
+    if (cached != null) {
+      return cached;
+    }
+    final client = widget.practiceController.client;
+    if (client is! PracticeQuestionTranslationClient) {
+      throw StateError('Question translation is unavailable.');
+    }
+    final translation = await (client as PracticeQuestionTranslationClient)
+        .translateQuestion(questionId: message.id);
+    if (translation.questionId != message.id) {
+      throw StateError('Question translation does not match the message.');
+    }
+    _questionTranslations[message.id] = translation.content;
+    return translation.content;
+  }
+
   Future<void> _requestExit() async {
     if (!mounted || _exitInFlight || _exitApproved) {
       return;
@@ -442,6 +462,13 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                       onToggleTextMode: _toggleTextMode,
                       onSubmitText: _submitText,
                       onToggleConversationText: _toggleConversationText,
+                      onTranslateQuestion:
+                          widget.practiceController.practiceSceneFamily ==
+                                  SceneFamily.interview &&
+                              widget.practiceController.client
+                                  is PracticeQuestionTranslationClient
+                          ? _translateQuestion
+                          : null,
                       onOpenReport: _openInterviewReport,
                     );
                     if (landscape) {
@@ -668,6 +695,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.onToggleTextMode,
     required this.onSubmitText,
     required this.onToggleConversationText,
+    required this.onTranslateQuestion,
     required this.onOpenReport,
   });
 
@@ -687,6 +715,7 @@ class _ConversationPanel extends StatelessWidget {
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
   final VoidCallback onToggleConversationText;
+  final Future<String> Function(PracticeMessage message)? onTranslateQuestion;
   final VoidCallback onOpenReport;
 
   @override
@@ -729,6 +758,10 @@ class _ConversationPanel extends StatelessWidget {
                               polishedText: _polishedText(projection),
                               polishLoading: projection?.isPolling ?? false,
                               messageTextVisible: conversationTextVisible,
+                              onTranslate:
+                                  message.role == PracticeMessageRole.assistant
+                                  ? onTranslateQuestion
+                                  : null,
                             ),
                             if (projection != null) ...[
                               const SizedBox(height: SpeakUpDesign.space8),

--- a/mobile/lib/features/coaching/practice/practice_client.dart
+++ b/mobile/lib/features/coaching/practice/practice_client.dart
@@ -43,6 +43,12 @@ abstract interface class PracticeLifecycleClient {
   });
 }
 
+abstract interface class PracticeQuestionTranslationClient {
+  Future<PracticeQuestionTranslation> translateQuestion({
+    required String questionId,
+  });
+}
+
 /// Optional Daily/Workplace same-question retry capability.
 ///
 /// Keeping this separate from [PracticeClient] lets existing test doubles and

--- a/mobile/lib/features/coaching/practice/practice_message_bubble.dart
+++ b/mobile/lib/features/coaching/practice/practice_message_bubble.dart
@@ -54,12 +54,13 @@ final class PracticeChatBubble extends StatelessWidget {
   }
 }
 
-final class PracticeMessageBubble extends StatelessWidget {
+final class PracticeMessageBubble extends StatefulWidget {
   const PracticeMessageBubble({
     required this.message,
     this.polishedText,
     this.polishLoading = false,
     this.messageTextVisible = true,
+    this.onTranslate,
     super.key,
   });
 
@@ -67,9 +68,70 @@ final class PracticeMessageBubble extends StatelessWidget {
   final String? polishedText;
   final bool polishLoading;
   final bool messageTextVisible;
+  final Future<String> Function(PracticeMessage message)? onTranslate;
+
+  @override
+  State<PracticeMessageBubble> createState() => _PracticeMessageBubbleState();
+}
+
+final class _PracticeMessageBubbleState extends State<PracticeMessageBubble> {
+  String? _translation;
+  bool _translationExpanded = false;
+  bool _translationLoading = false;
+  bool _translationFailed = false;
+
+  @override
+  void didUpdateWidget(covariant PracticeMessageBubble oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.message.id != widget.message.id) {
+      _translation = null;
+      _translationExpanded = false;
+      _translationLoading = false;
+      _translationFailed = false;
+    }
+  }
+
+  Future<void> _toggleTranslation() async {
+    if (_translationExpanded) {
+      setState(() => _translationExpanded = false);
+      return;
+    }
+    if (_translation != null) {
+      setState(() => _translationExpanded = true);
+      return;
+    }
+    final translate = widget.onTranslate;
+    if (translate == null || _translationLoading) {
+      return;
+    }
+    setState(() {
+      _translationLoading = true;
+      _translationFailed = false;
+    });
+    try {
+      final translation = (await translate(widget.message)).trim();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _translation = translation;
+        _translationExpanded = true;
+        _translationLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _translationLoading = false;
+        _translationFailed = true;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final message = widget.message;
     final user = message.role == PracticeMessageRole.user;
     return Align(
       key: Key('practice-message-${message.id}'),
@@ -89,7 +151,7 @@ final class PracticeMessageBubble extends StatelessWidget {
               children: [
                 Visibility(
                   key: Key('practice-message-text-${message.id}'),
-                  visible: messageTextVisible,
+                  visible: widget.messageTextVisible,
                   maintainAnimation: true,
                   maintainSize: true,
                   maintainState: true,
@@ -101,10 +163,71 @@ final class PracticeMessageBubble extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (polishLoading) ...[
+                if (_translationExpanded && _translation != null) ...[
+                  const SizedBox(height: 8),
+                  Container(
+                    key: Key('practice-assistant-translation-${message.id}'),
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: SpeakUpDesign.surfaceMuted,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Text(
+                      _translation!,
+                      style: const TextStyle(
+                        color: SpeakUpDesign.ink,
+                        fontSize: 14,
+                        height: 1.45,
+                      ),
+                    ),
+                  ),
+                ],
+                if (_translationFailed) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    '翻译失败，请重试。',
+                    key: Key(
+                      'practice-assistant-translation-error-${message.id}',
+                    ),
+                    style: const TextStyle(
+                      color: SpeakUpDesign.error,
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                ],
+                if (widget.onTranslate != null) ...[
+                  const SizedBox(height: 6),
+                  TextButton.icon(
+                    key: Key('practice-assistant-translate-${message.id}'),
+                    onPressed: _translationLoading ? null : _toggleTranslation,
+                    style: TextButton.styleFrom(
+                      foregroundColor: SpeakUpDesign.primary,
+                      minimumSize: const Size(0, 32),
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                    icon: _translationLoading
+                        ? const SizedBox.square(
+                            dimension: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.translate_rounded, size: 17),
+                    label: Text(
+                      _translationLoading
+                          ? '翻译中'
+                          : _translationExpanded
+                          ? '收起'
+                          : _translationFailed
+                          ? '重试'
+                          : '翻译',
+                    ),
+                  ),
+                ],
+                if (widget.polishLoading) ...[
                   const SizedBox(height: 8),
                   const LinearProgressIndicator(minHeight: 2),
-                ] else if (polishedText case final text?) ...[
+                ] else if (widget.polishedText case final text?) ...[
                   const SizedBox(height: 8),
                   Text(
                     text,

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -104,6 +104,18 @@ final class PracticeQuestion {
       PracticeMessage(id: id, role: PracticeMessageRole.assistant, text: text);
 }
 
+final class PracticeQuestionTranslation {
+  const PracticeQuestionTranslation({
+    required this.questionId,
+    required this.targetLanguage,
+    required this.content,
+  });
+
+  final String questionId;
+  final String targetLanguage;
+  final String content;
+}
+
 /// The server-authoritative practice projection consumed by Flutter.
 ///
 /// The projection is always loaded by the explicit opaque [sessionId].

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -35,6 +35,7 @@ final class PracticeWireEndpoints {
     this.retryConfirmation =
         '/v1/retry-turns/{retry_turn_id}/transcription-candidates/'
         '{candidate_id}/confirmations',
+    this.questionTranslation = '/v1/voice-questions/{question_id}/translation',
   });
 
   final String voiceActivation;
@@ -46,6 +47,7 @@ final class PracticeWireEndpoints {
   final String retryRequest;
   final String retryRequestStatus;
   final String retryConfirmation;
+  final String questionTranslation;
 
   String voiceActivationPath(String sessionId) => voiceActivation.replaceAll(
     '{practice_session_id}',
@@ -65,6 +67,9 @@ final class PracticeWireEndpoints {
   String submitTextPath(String sessionId, String questionId) => submitText
       .replaceAll('{practice_session_id}', _pathSegment(sessionId))
       .replaceAll('{question_id}', _pathSegment(questionId));
+
+  String questionTranslationPath(String questionId) =>
+      questionTranslation.replaceAll('{question_id}', _pathSegment(questionId));
 
   String endEarlyPath(String sessionId) =>
       endEarly.replaceAll('{practice_session_id}', _pathSegment(sessionId));
@@ -130,7 +135,8 @@ final class WirePracticeClient
     implements
         PracticeClient,
         PracticeLifecycleClient,
-        PracticeSpeechFeedbackRetryClient {
+        PracticeSpeechFeedbackRetryClient,
+        PracticeQuestionTranslationClient {
   factory WirePracticeClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -436,6 +442,26 @@ final class WirePracticeClient
         throw _invalidResponse();
       }
       return confirmation;
+    });
+  }
+
+  @override
+  Future<PracticeQuestionTranslation> translateQuestion({
+    required String questionId,
+  }) {
+    return _run((generation) async {
+      _requireOpaqueId(questionId);
+      final response = await _send(
+        generation: generation,
+        timeout: _jsonTimeout,
+        method: 'GET',
+        path: _endpoints.questionTranslationPath(questionId),
+      );
+      _requireStatus(response, const {HttpStatus.ok});
+      return _decodeQuestionTranslation(
+        response.body,
+        expectedQuestionId: questionId,
+      );
     });
   }
 
@@ -1044,6 +1070,27 @@ PracticeRetryRequest _decodeRetryRequest(
     stableFailure: stableFailure,
     completedAt: completedAt,
   );
+}
+
+PracticeQuestionTranslation _decodeQuestionTranslation(
+  String body, {
+  required String expectedQuestionId,
+}) {
+  final root = _exactObject(
+    jsonDecode(body),
+    required: const {'question_id', 'target_language', 'translation'},
+  );
+  final translation = PracticeQuestionTranslation(
+    questionId: _string(root, 'question_id', maxLength: 128),
+    targetLanguage: _string(root, 'target_language', maxLength: 16),
+    content: _string(root, 'translation', maxLength: 2000),
+  );
+  if (translation.questionId != expectedQuestionId ||
+      translation.targetLanguage != 'zh-CN' ||
+      translation.content.trim().isEmpty) {
+    throw _invalidResponse();
+  }
+  return translation;
 }
 
 PracticeRetryFailure _decodePracticeRetryFailure(Object? value) {

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -59,6 +59,7 @@ void main() {
     );
     expect(find.byKey(const Key('immersive-conversation-history')), findsOne);
     expect(find.textContaining('评分'), findsNothing);
+    expect(find.text('翻译'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
@@ -138,6 +139,48 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'translates an interview question once and toggles the read aid',
+    (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final practice = _TranslationPracticeClient();
+      final controller = await _roleplayController(practiceClient: practice);
+      addTearDown(controller.dispose);
+      final question = controller.currentQuestion!;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ImmersiveRoleplayPage(practiceController: controller),
+        ),
+      );
+      await tester.pump();
+
+      final button = find.byKey(
+        Key('practice-assistant-translate-${question.id}'),
+      );
+      expect(button, findsOneWidget);
+
+      await tester.tap(button);
+      await tester.pumpAndSettle();
+
+      expect(find.text(practice.translation), findsOneWidget);
+      expect(practice.translationCalls, 1);
+      expect(controller.completedTurns, 0);
+
+      await tester.tap(button);
+      await tester.pump();
+      expect(find.text(practice.translation), findsNothing);
+
+      await tester.tap(button);
+      await tester.pump();
+      expect(find.text(practice.translation), findsOneWidget);
+      expect(practice.translationCalls, 1);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('removes the avatar surface before leaving practice', (
     tester,
@@ -581,10 +624,12 @@ Future<PracticeController> _roleplayController({
 }) async {
   final sceneFamily = switch (practiceClient) {
     final _AsyncReviewPracticeClient client => client.resolvedSceneFamily,
+    final _TranslationPracticeClient client => client.resolvedSceneFamily,
     _ => SceneFamily.daily,
   };
   final sceneModel = switch (practiceClient) {
     final _AsyncReviewPracticeClient client => client.resolvedSceneModel,
+    final _TranslationPracticeClient client => client.resolvedSceneModel,
     _ => SceneModel.hotelCheckinAndIssueHandling,
   };
   final scene = testScene(
@@ -689,6 +734,80 @@ final class _ScenePracticeClient implements PracticeClient {
     sceneFamily,
     sceneModel,
   );
+}
+
+final class _TranslationPracticeClient
+    implements PracticeClient, PracticeQuestionTranslationClient {
+  final _delegate = _AsyncReviewPracticeClient(
+    sceneFamily: SceneFamily.interview,
+    sceneModel: SceneModel.interviewBasicDialogue,
+  );
+
+  final String translation = '请介绍一次你解决团队分歧的经历。';
+  int translationCalls = 0;
+
+  SceneFamily get resolvedSceneFamily => _delegate.resolvedSceneFamily;
+  SceneModel get resolvedSceneModel => _delegate.resolvedSceneModel;
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<PracticeSessionSnapshot> restorePractice({
+    required String sessionId,
+  }) => _delegate.restorePractice(sessionId: sessionId);
+
+  @override
+  Future<PracticeSessionSnapshot> activatePractice({
+    required String sessionId,
+    required String clientOperationId,
+  }) => _delegate.activatePractice(
+    sessionId: sessionId,
+    clientOperationId: clientOperationId,
+  );
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) => _delegate.transcribe(request);
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) => _delegate.confirm(
+    sessionId: sessionId,
+    questionId: questionId,
+    candidateId: candidateId,
+    idempotencyKey: idempotencyKey,
+  );
+
+  @override
+  Future<PracticeTurnConfirmation> submitText({
+    required String sessionId,
+    required String questionId,
+    required String answerText,
+    required String idempotencyKey,
+  }) => _delegate.submitText(
+    sessionId: sessionId,
+    questionId: questionId,
+    answerText: answerText,
+    idempotencyKey: idempotencyKey,
+  );
+
+  @override
+  Future<PracticeQuestionTranslation> translateQuestion({
+    required String questionId,
+  }) async {
+    translationCalls++;
+    return PracticeQuestionTranslation(
+      questionId: questionId,
+      targetLanguage: 'zh-CN',
+      content: translation,
+    );
+  }
 }
 
 final class _FailOncePracticeClient implements PracticeClient {

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -84,9 +84,36 @@ void main() {
       '/v1/transcription-candidates/$encoded/confirmations',
     );
     expect(
+      endpoints.questionTranslationPath(opaque),
+      '/v1/voice-questions/$encoded/translation',
+    );
+    expect(
       endpoints.endEarlyPath(opaque),
       '/v1/practice-sessions/$encoded/end-early',
     );
+  });
+
+  test('decodes one bounded Simplified Chinese question translation', () async {
+    final transport = _Transport([
+      _Step(
+        method: 'GET',
+        path: '/v1/voice-questions/$_questionId/translation',
+        response: _json(HttpStatus.ok, {
+          'question_id': _questionId,
+          'target_language': 'zh-CN',
+          'translation': '请介绍一次你解决团队分歧的经历。',
+        }),
+      ),
+    ]);
+
+    final translation = await _client(
+      transport,
+    ).translateQuestion(questionId: _questionId);
+
+    expect(translation.questionId, _questionId);
+    expect(translation.targetLanguage, 'zh-CN');
+    expect(translation.content, '请介绍一次你解决团队分歧的经历。');
+    transport.expectDone();
   });
 
   test('uses the frozen #87 empty-body and raw WAV routes', () async {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -114,6 +114,13 @@ func run() int {
 		logger.Error("Practice question generation startup failed")
 		return 1
 	}
+	practiceQuestionTranslator, err := bootstrap.NewPracticeQuestionTranslator(
+		textConfig,
+	)
+	if err != nil {
+		logger.Error("Practice question translation startup failed")
+		return 1
+	}
 	temporaryAudioConfig, err := config.LoadTemporaryAudio()
 	if err != nil {
 		logger.Error("temporary audio configuration failed")
@@ -347,6 +354,7 @@ func run() int {
 				PracticeRecognizer:     practiceRecognizer,
 				PracticeSynthesizer:    practiceSynthesizer,
 				QuestionGenerator:      practiceQuestions,
+				QuestionTranslator:     practiceQuestionTranslator,
 				TemporaryAudio:         audioVault,
 				ObjectStore:            recordingStore,
 				AgentVoiceInputEnabled: storageConfig.Enabled,

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -24,6 +24,7 @@ type VoiceConfiguration struct {
 	PracticeRecognizer        practicevoice.SpeechRecognizer
 	PracticeSynthesizer       practicevoice.SpeechSynthesizer
 	QuestionGenerator         practicevoice.QuestionGenerator
+	QuestionTranslator        practicevoice.QuestionTranslator
 	TemporaryAudio            practicevoice.TemporaryAudioVault
 	ObjectStore               objectstore.Store
 	AgentVoiceInputEnabled    bool
@@ -145,6 +146,26 @@ func NewPracticeQuestionGenerator(
 	)
 }
 
+// NewPracticeQuestionTranslator selects the Practice Voice translation adapter.
+func NewPracticeQuestionTranslator(
+	configuration config.TextGenerationConfig,
+) (practicevoice.QuestionTranslator, error) {
+	if configuration.Provider != config.TextProviderQianwen {
+		return nil, errors.New(
+			"bootstrap: Practice question translation provider is not registered",
+		)
+	}
+	return qianwen.NewPracticeVoiceQuestionTranslator(
+		qianwen.TextConfig{
+			BaseURL:         configuration.BaseURL,
+			Model:           configuration.Model,
+			Timeout:         configuration.Timeout,
+			MaxOutputTokens: configuration.MaxOutputTokens,
+		},
+		configuration.APIKey.Reveal(),
+	)
+}
+
 // buildProductionVoiceApplication constructs infrastructure and delegates all
 // Practice Voice business wiring to the owning package.
 func buildProductionVoiceApplication(
@@ -209,16 +230,17 @@ func buildProductionVoiceApplication(
 	application, retryApplication, err :=
 		practicevoice.NewRuntimeApplications(
 			practicevoice.RuntimeConfiguration{
-				Repository:        repository,
-				TemporaryAudio:    configuration.TemporaryAudio,
-				Recognizer:        configuration.PracticeRecognizer,
-				Synthesizer:       configuration.PracticeSynthesizer,
-				QuestionGenerator: configuration.QuestionGenerator,
-				Recordings:        recordings,
-				AudioAssets:       audioAssets,
-				ASRLease:          configuration.ASRLease,
-				Feedback:          feedback,
-				FeedbackReader:    feedbackReader,
+				Repository:         repository,
+				TemporaryAudio:     configuration.TemporaryAudio,
+				Recognizer:         configuration.PracticeRecognizer,
+				Synthesizer:        configuration.PracticeSynthesizer,
+				QuestionGenerator:  configuration.QuestionGenerator,
+				QuestionTranslator: configuration.QuestionTranslator,
+				Recordings:         recordings,
+				AudioAssets:        audioAssets,
+				ASRLease:           configuration.ASRLease,
+				Feedback:           feedback,
+				FeedbackReader:     feedbackReader,
 			},
 		)
 	if err != nil {

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -78,6 +78,10 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 		handler.confirmCandidate,
 	)
 	routes.GET("/v1/voice-questions/:question_id/speech", handler.questionSpeech)
+	routes.GET(
+		"/v1/voice-questions/:question_id/translation",
+		handler.questionTranslation,
+	)
 	if handler.retry != nil {
 		routes.POST(
 			"/v1/retry-turns/:retry_turn_id/transcription-candidates",
@@ -309,6 +313,26 @@ func (handler *Handler) questionSpeech(c *gin.Context) {
 	c.DataFromReader(
 		http.StatusOK, speech.Audio.Size(), speech.Audio.MediaType(), reader, nil,
 	)
+}
+
+func (handler *Handler) questionTranslation(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	translation, err := handler.application.QuestionTranslation(
+		c.Request.Context(), actor, c.Param("question_id"),
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"question_id":     translation.QuestionID,
+		"target_language": translation.TargetLanguage,
+		"translation":     translation.Content,
+	})
 }
 
 func SessionStateResponse(state practicevoice.SessionState) gin.H {

--- a/server/internal/coaching/practice/voice/provider.go
+++ b/server/internal/coaching/practice/voice/provider.go
@@ -37,9 +37,10 @@ func (kind ProviderErrorKind) Retryable() bool {
 type ProviderOperation string
 
 const (
-	ProviderOperationQuestionGeneration ProviderOperation = "question_generation"
-	ProviderOperationTranscription      ProviderOperation = "transcription"
-	ProviderOperationSynthesis          ProviderOperation = "synthesis"
+	ProviderOperationQuestionGeneration  ProviderOperation = "question_generation"
+	ProviderOperationQuestionTranslation ProviderOperation = "question_translation"
+	ProviderOperationTranscription       ProviderOperation = "transcription"
+	ProviderOperationSynthesis           ProviderOperation = "synthesis"
 )
 
 type ProviderError struct {
@@ -137,5 +138,16 @@ type QuestionGenerator interface {
 	GenerateQuestion(
 		context.Context,
 		QuestionGenerationRequest,
+	) (string, error)
+}
+
+type QuestionTranslationRequest struct {
+	Question string
+}
+
+type QuestionTranslator interface {
+	TranslateQuestion(
+		context.Context,
+		QuestionTranslationRequest,
 	) (string, error)
 }

--- a/server/internal/coaching/practice/voice/runtime.go
+++ b/server/internal/coaching/practice/voice/runtime.go
@@ -31,16 +31,17 @@ type TurnFeedbackStatusReader interface {
 // RuntimeConfiguration supplies the infrastructure and cross-module ports
 // needed by the complete Practice Voice flow.
 type RuntimeConfiguration struct {
-	Repository        RuntimeRepository
-	TemporaryAudio    TemporaryAudioVault
-	Recognizer        SpeechRecognizer
-	Synthesizer       SpeechSynthesizer
-	QuestionGenerator QuestionGenerator
-	Recordings        VoiceRecordingLifecycle
-	AudioAssets       *AudioAssetService
-	ASRLease          time.Duration
-	Feedback          TurnFeedbackPort
-	FeedbackReader    TurnFeedbackStatusReader
+	Repository         RuntimeRepository
+	TemporaryAudio     TemporaryAudioVault
+	Recognizer         SpeechRecognizer
+	Synthesizer        SpeechSynthesizer
+	QuestionGenerator  QuestionGenerator
+	QuestionTranslator QuestionTranslator
+	Recordings         VoiceRecordingLifecycle
+	AudioAssets        *AudioAssetService
+	ASRLease           time.Duration
+	Feedback           TurnFeedbackPort
+	FeedbackReader     TurnFeedbackStatusReader
 }
 
 // NewRuntimeApplications assembles the authoritative Practice Voice runtime.
@@ -112,6 +113,13 @@ func NewRuntimeApplications(
 	if err != nil {
 		return nil, nil, err
 	}
+	translationPorts := make([]QuestionTranslator, 0, 1)
+	if configuration.QuestionTranslator != nil {
+		translationPorts = append(
+			translationPorts,
+			configuration.QuestionTranslator,
+		)
+	}
 	application, err := NewSessionApplication(
 		&sessionAdapter{repository: configuration.Repository},
 		&questionAdapter{
@@ -124,6 +132,7 @@ func NewRuntimeApplications(
 			feedback:    configuration.FeedbackReader,
 		},
 		orchestrator,
+		translationPorts...,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
@@ -87,11 +88,18 @@ type SessionState struct {
 	TurnHistory []TurnExchange
 }
 
+type QuestionTranslation struct {
+	QuestionID     string
+	TargetLanguage string
+	Content        string
+}
+
 type SessionApplication struct {
 	sessions     SessionPort
 	questions    QuestionPort
 	checkpoints  CheckpointPort
 	orchestrator *RoundOrchestrator
+	translator   QuestionTranslator
 }
 
 func NewSessionApplication(
@@ -99,16 +107,68 @@ func NewSessionApplication(
 	questions QuestionPort,
 	checkpoints CheckpointPort,
 	orchestrator *RoundOrchestrator,
+	translators ...QuestionTranslator,
 ) (*SessionApplication, error) {
 	if sessions == nil || questions == nil || checkpoints == nil ||
-		orchestrator == nil {
+		orchestrator == nil || len(translators) > 1 ||
+		(len(translators) == 1 && translators[0] == nil) {
 		return nil, errors.New("practice voice: session dependency is required")
+	}
+	var translator QuestionTranslator
+	if len(translators) == 1 {
+		translator = translators[0]
 	}
 	return &SessionApplication{
 		sessions:     sessions,
 		questions:    questions,
 		checkpoints:  checkpoints,
 		orchestrator: orchestrator,
+		translator:   translator,
+	}, nil
+}
+
+func (application *SessionApplication) QuestionTranslation(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	questionID string,
+) (QuestionTranslation, error) {
+	if err := validateVoiceActor(ctx, actor); err != nil ||
+		strings.TrimSpace(questionID) == "" {
+		return QuestionTranslation{}, ErrInvalidRequest
+	}
+	if application.translator == nil {
+		return QuestionTranslation{}, ErrInvalidContext
+	}
+	question, err := application.questions.GetQuestion(ctx, actor, questionID)
+	if err != nil {
+		return QuestionTranslation{}, err
+	}
+	if question.ID != questionID || strings.TrimSpace(question.SessionID) == "" ||
+		strings.TrimSpace(question.Content) == "" {
+		return QuestionTranslation{}, ErrInvalidContext
+	}
+	session, err := application.sessions.GetByID(ctx, actor, question.SessionID)
+	if err != nil {
+		return QuestionTranslation{}, err
+	}
+	if session.ID != question.SessionID || session.SceneFamily != "INTERVIEW" {
+		return QuestionTranslation{}, ErrInvalidContext
+	}
+	content, err := application.translator.TranslateQuestion(
+		ctx,
+		QuestionTranslationRequest{Question: question.Content},
+	)
+	if err != nil {
+		return QuestionTranslation{}, err
+	}
+	content = strings.TrimSpace(content)
+	if content == "" || utf8.RuneCountInString(content) > 2000 {
+		return QuestionTranslation{}, ErrInvalidContext
+	}
+	return QuestionTranslation{
+		QuestionID:     question.ID,
+		TargetLanguage: "zh-CN",
+		Content:        content,
 	}, nil
 }
 

--- a/server/internal/coaching/practice/voice/session_application_test.go
+++ b/server/internal/coaching/practice/voice/session_application_test.go
@@ -2,12 +2,107 @@ package voice
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
+
+func TestSessionTranslatesOnlyInterviewQuestions(t *testing.T) {
+	translator := &questionTranslatorStub{content: "接下来发生了什么？"}
+	application := translationApplication(
+		t,
+		sessionPortStub{session: sessionFixture()},
+		translator,
+	)
+
+	translation, err := application.QuestionTranslation(
+		context.Background(), roundActor(), "question-1",
+	)
+	if err != nil {
+		t.Fatalf("QuestionTranslation: %v", err)
+	}
+	if translation.QuestionID != "question-1" ||
+		translation.TargetLanguage != "zh-CN" ||
+		translation.Content != translator.content ||
+		translator.calls != 1 ||
+		translator.question != "What happened next?" {
+		t.Fatalf("translation = %#v, translator = %#v", translation, translator)
+	}
+
+	daily := sessionFixture()
+	daily.SceneFamily = "DAILY"
+	dailyTranslator := &questionTranslatorStub{content: "不应调用"}
+	dailyApplication := translationApplication(
+		t,
+		sessionPortStub{session: daily},
+		dailyTranslator,
+	)
+	_, err = dailyApplication.QuestionTranslation(
+		context.Background(), roundActor(), "question-1",
+	)
+	if !errors.Is(err, ErrInvalidContext) || dailyTranslator.calls != 0 {
+		t.Fatalf("daily translation error = %v, calls = %d", err, dailyTranslator.calls)
+	}
+}
+
+func translationApplication(
+	t *testing.T,
+	sessions SessionPort,
+	translator QuestionTranslator,
+) *SessionApplication {
+	t.Helper()
+	candidate := roundCandidate()
+	orchestrator, err := NewRoundOrchestrator(
+		&roundVoice{candidate: candidate, turn: roundTurn(candidate)},
+		roundPractice{},
+	)
+	if err != nil {
+		t.Fatalf("NewRoundOrchestrator: %v", err)
+	}
+	application, err := NewSessionApplication(
+		sessions,
+		translationQuestionPortStub{},
+		checkpointPortStub{},
+		orchestrator,
+		translator,
+	)
+	if err != nil {
+		t.Fatalf("NewSessionApplication: %v", err)
+	}
+	return application
+}
+
+type translationQuestionPortStub struct{ questionPortStub }
+
+func (translationQuestionPortStub) GetQuestion(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (practice.Question, error) {
+	return practice.Question{
+		ID:        "question-1",
+		SessionID: "session-1",
+		Content:   "What happened next?",
+	}, nil
+}
+
+type questionTranslatorStub struct {
+	content  string
+	question string
+	calls    int
+}
+
+func (stub *questionTranslatorStub) TranslateQuestion(
+	_ context.Context,
+	request QuestionTranslationRequest,
+) (string, error) {
+	stub.calls++
+	stub.question = request.Question
+	return stub.content, nil
+}
 
 func TestSessionStartReturnsQuestionFromFrozenSession(t *testing.T) {
 	session := sessionFixture()

--- a/server/internal/providers/qianwen/practice_voice.go
+++ b/server/internal/providers/qianwen/practice_voice.go
@@ -147,6 +147,51 @@ func (generator *PracticeVoiceQuestionGenerator) GenerateQuestion(
 	return result.Content, nil
 }
 
+type PracticeVoiceQuestionTranslator struct {
+	generator *textClient
+}
+
+func NewPracticeVoiceQuestionTranslator(
+	configuration TextConfig,
+	apiKey string,
+) (*PracticeVoiceQuestionTranslator, error) {
+	generator, err := newTextClient(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &PracticeVoiceQuestionTranslator{generator: generator}, nil
+}
+
+func (translator *PracticeVoiceQuestionTranslator) TranslateQuestion(
+	ctx context.Context,
+	request practicevoice.QuestionTranslationRequest,
+) (string, error) {
+	if translator == nil || translator.generator == nil {
+		return "", practicevoice.NewProviderError(
+			practicevoice.ProviderOperationQuestionTranslation,
+			practicevoice.ProviderErrorConfiguration,
+			"",
+			errors.New("Qianwen Practice Voice question translator is required"),
+		)
+	}
+	result, err := translator.generator.Generate(ctx, protocol.TextRequest{
+		Messages: []protocol.TextMessage{
+			{
+				Role:    protocol.TextRoleSystem,
+				Content: "Translate the interview question into natural Simplified Chinese. Preserve its meaning and tone. Return only the translation, with no quotation marks, markdown, answer, coaching, or explanation.",
+			},
+			{Role: protocol.TextRoleUser, Content: request.Question},
+		},
+	})
+	if err != nil {
+		return "", mapPracticeVoiceError(
+			err,
+			practicevoice.ProviderOperationQuestionTranslation,
+		)
+	}
+	return result.Content, nil
+}
+
 func mapPracticeVoiceUsage(usage protocol.SpeechUsage) practicevoice.SpeechUsage {
 	return practicevoice.SpeechUsage{
 		InputTokens:  usage.InputTokens,
@@ -215,7 +260,8 @@ func mapPracticeVoiceErrorKind(kind protocol.ErrorKind) practicevoice.ProviderEr
 }
 
 var (
-	_ practicevoice.SpeechRecognizer  = (*PracticeVoiceRecognizer)(nil)
-	_ practicevoice.SpeechSynthesizer = (*PracticeVoiceSynthesizer)(nil)
-	_ practicevoice.QuestionGenerator = (*PracticeVoiceQuestionGenerator)(nil)
+	_ practicevoice.SpeechRecognizer   = (*PracticeVoiceRecognizer)(nil)
+	_ practicevoice.SpeechSynthesizer  = (*PracticeVoiceSynthesizer)(nil)
+	_ practicevoice.QuestionGenerator  = (*PracticeVoiceQuestionGenerator)(nil)
+	_ practicevoice.QuestionTranslator = (*PracticeVoiceQuestionTranslator)(nil)
 )

--- a/server/internal/providers/qianwen/practice_voice_test.go
+++ b/server/internal/providers/qianwen/practice_voice_test.go
@@ -98,6 +98,14 @@ func TestPracticeVoiceAdaptersRejectMissingProvider(t *testing.T) {
 	); !isPracticeVoiceConfigurationError(err) {
 		t.Fatalf("generator error = %v", err)
 	}
+
+	var translator *PracticeVoiceQuestionTranslator
+	if _, err := translator.TranslateQuestion(
+		context.Background(),
+		practicevoice.QuestionTranslationRequest{},
+	); !isPracticeVoiceConfigurationError(err) {
+		t.Fatalf("translator error = %v", err)
+	}
 }
 
 func isPracticeVoiceConfigurationError(err error) bool {


### PR DESCRIPTION
## 功能描述

- 在沉浸式面试的面试官问题中，为“朗读”旁增加“翻译”按钮
- 点击后按需生成简体中文翻译，并在英文问题下方展示
- 再次点击可收起；同一页面再次展开复用按问题 ID 缓存的结果
- 翻译失败时允许重试，不产生对话消息、回答、轮数或评分记录

## 实现思路

- 新增只读接口 `GET /v1/voice-questions/{question_id}/translation`
- 服务端校验问题归属和会话类型，仅允许 `INTERVIEW` 场景
- 通过现有文本生成能力输出纯简体中文翻译，不写数据库
- Flutter 端仅在面试场景的助手问题上提供入口，并在页面内缓存结果

## 验证方式

- `make check-api`
- `make check-go`
- `cd mobile && flutter test --no-pub`（774 项通过）
- `cd mobile && flutter test --no-pub test/practice/immersive_roleplay_test.dart`
- `cd mobile && flutter test --no-pub test/practice/wire_practice_client_test.dart test/agent/agent_message_bubble_test.dart`

Closes #346
