### PR TITLE
[MS3][后端] 完成新 Thread 首轮 Memory Extraction 一致性屏障

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -1872,6 +1872,10 @@ components:
         - selected_stable_profile
         - memory_context_policy_version
         - selected_memories
+        - memory_extraction_barrier_policy_version
+        - memory_extraction_barrier_cutoff
+        - memory_extraction_barrier_status
+        - memory_extraction_barrier_waited_milliseconds
         - selected_messages
         - omitted_message_count
         - trim_reason
@@ -1917,6 +1921,31 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ContextMemorySource'
+        memory_extraction_barrier_policy_version:
+          type: string
+          enum:
+            - memory-extraction-barrier-v1
+          readOnly: true
+        memory_extraction_barrier_cutoff:
+          type: string
+          format: date-time
+          readOnly: true
+        memory_extraction_barrier_status:
+          type: string
+          enum:
+            - not_required
+            - ready
+            - waited
+          readOnly: true
+        memory_extraction_barrier_waited_milliseconds:
+          type: integer
+          minimum: 0
+          maximum: 5000
+          readOnly: true
+        memory_extraction_barrier_covered_through:
+          type: string
+          format: date-time
+          readOnly: true
         selected_messages:
           type: array
           minItems: 1

--- a/server/internal/agent/context/assembler.go
+++ b/server/internal/agent/context/assembler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
@@ -38,6 +39,7 @@ type Assembler struct {
 	learningProfiles LearningProfileReader
 	stableProfiles   StableProfileReader
 	memories         MemorySearcher
+	memoryBarrier    MemoryExtractionBarrier
 	images           agentimage.ContextReader
 }
 
@@ -61,10 +63,11 @@ func NewAssembler(
 	learningProfiles LearningProfileReader,
 	stableProfiles StableProfileReader,
 	memories MemorySearcher,
+	memoryBarrier MemoryExtractionBarrier,
 	options ...Option,
 ) (*Assembler, error) {
 	if repository == nil || goals == nil || learningProfiles == nil ||
-		stableProfiles == nil || memories == nil {
+		stableProfiles == nil || memories == nil || memoryBarrier == nil {
 		return nil, errors.New("agent: context dependency is required")
 	}
 	assembler := &Assembler{
@@ -73,6 +76,7 @@ func NewAssembler(
 		learningProfiles: learningProfiles,
 		stableProfiles:   stableProfiles,
 		memories:         memories,
+		memoryBarrier:    memoryBarrier,
 	}
 	for _, option := range options {
 		if option == nil {
@@ -118,6 +122,33 @@ func (assembler *Assembler) Assemble(
 	if len(input.Content) > ai.MaxEmbeddingInputBytes {
 		return Manifest{}, ai.TextRequest{}, ErrInvalidContext
 	}
+	memoryBarrierStatus := memoryExtractionBarrierNotRequired
+	memoryBarrierWaitedMilliseconds := int64(0)
+	var memoryBarrierCoveredThrough time.Time
+	if input.Sequence == 1 {
+		barrier, barrierErr := assembler.memoryBarrier.Await(
+			ctx,
+			MemoryExtractionBarrierRequest{
+				Actor:  actor,
+				Cutoff: command.RunCreatedAt,
+			},
+		)
+		if barrierErr != nil {
+			if errors.Is(barrierErr, ErrMemoryConsistencyRejected) {
+				return Manifest{}, ai.TextRequest{},
+					ErrMemoryConsistencyRejected
+			}
+			return Manifest{}, ai.TextRequest{},
+				ErrMemoryConsistencyUnavailable
+		}
+		if !barrier.Valid() || !barrier.Cutoff.Equal(command.RunCreatedAt) {
+			return Manifest{}, ai.TextRequest{},
+				ErrMemoryConsistencyUnavailable
+		}
+		memoryBarrierStatus = string(barrier.Status)
+		memoryBarrierWaitedMilliseconds = barrier.Waited.Milliseconds()
+		memoryBarrierCoveredThrough = barrier.CoveredThrough
+	}
 
 	systemContent := "You are SpeakUp, an English communication coach. " +
 		"Give one concise, actionable reply and one helpful follow-up question. " +
@@ -135,24 +166,29 @@ func (assembler *Assembler) Assemble(
 		"review identifier. Use historical Review search only when the user asks " +
 		"about an older practice."
 	manifest := Manifest{
-		RunID:                               command.RunID,
-		OwnerID:                             actor.UserID,
-		ThreadID:                            command.ThreadID,
-		InputMessageID:                      input.ID,
-		TrimReason:                          contextTrimNone,
-		InstructionVersion:                  instructionV1,
-		LearningProfileContextPolicyVersion: learningProfileContextPolicyV1,
-		SelectedLearningProfile:             make([]LearningProfileSource, 0),
-		StableProfileContextPolicyVersion:   stableProfileContextPolicyV1,
-		SelectedStableProfile:               make([]StableProfileSource, 0),
-		MemoryContextPolicyVersion:          memoryContextPolicyV1,
-		SelectedMemories:                    make([]MemorySource, 0),
-		SummaryContextPolicyVersion:         summaryContextPolicyV1,
-		SummaryContextStatus:                summaryContextNotAvailable,
-		MaxInputCharacters:                  command.MaxInputCharacters,
-		RequestedProvider:                   command.Provider,
-		RequestedModel:                      command.Model,
-		MaxOutputTokens:                     command.MaxOutputTokens,
+		RunID:                                     command.RunID,
+		OwnerID:                                   actor.UserID,
+		ThreadID:                                  command.ThreadID,
+		InputMessageID:                            input.ID,
+		TrimReason:                                contextTrimNone,
+		InstructionVersion:                        instructionV1,
+		LearningProfileContextPolicyVersion:       learningProfileContextPolicyV1,
+		SelectedLearningProfile:                   make([]LearningProfileSource, 0),
+		StableProfileContextPolicyVersion:         stableProfileContextPolicyV1,
+		SelectedStableProfile:                     make([]StableProfileSource, 0),
+		MemoryContextPolicyVersion:                memoryContextPolicyV1,
+		SelectedMemories:                          make([]MemorySource, 0),
+		MemoryExtractionBarrierPolicyVersion:      MemoryExtractionBarrierPolicyV1,
+		MemoryExtractionBarrierCutoff:             command.RunCreatedAt,
+		MemoryExtractionBarrierStatus:             memoryBarrierStatus,
+		MemoryExtractionBarrierWaitedMilliseconds: memoryBarrierWaitedMilliseconds,
+		MemoryExtractionBarrierCoveredThrough:     memoryBarrierCoveredThrough,
+		SummaryContextPolicyVersion:               summaryContextPolicyV1,
+		SummaryContextStatus:                      summaryContextNotAvailable,
+		MaxInputCharacters:                        command.MaxInputCharacters,
+		RequestedProvider:                         command.Provider,
+		RequestedModel:                            command.Model,
+		MaxOutputTokens:                           command.MaxOutputTokens,
 	}
 	if thread.ActiveGoalID != "" {
 		activeGoal, readErr := assembler.goals.ReadOwned(

--- a/server/internal/agent/context/command.go
+++ b/server/internal/agent/context/command.go
@@ -1,6 +1,9 @@
 package context
 
-import "regexp"
+import (
+	"regexp"
+	"time"
+)
 
 const maxBudget = 1_000_000
 
@@ -19,6 +22,7 @@ type AssembleCommand struct {
 	OwnerID            string
 	ThreadID           string
 	InputMessageID     string
+	RunCreatedAt       time.Time
 	Provider           string
 	Model              string
 	MaxOutputTokens    int
@@ -30,6 +34,8 @@ func (command AssembleCommand) Valid() bool {
 		uuidPattern.MatchString(command.OwnerID) &&
 		uuidPattern.MatchString(command.ThreadID) &&
 		uuidPattern.MatchString(command.InputMessageID) &&
+		!command.RunCreatedAt.IsZero() &&
+		command.RunCreatedAt.Location() == time.UTC &&
 		providerPattern.MatchString(command.Provider) &&
 		modelPattern.MatchString(command.Model) &&
 		command.MaxOutputTokens > 0 &&

--- a/server/internal/agent/context/errors.go
+++ b/server/internal/agent/context/errors.go
@@ -3,8 +3,14 @@ package context
 import "errors"
 
 var (
-	ErrInvalidContext = errors.New("agent context: invalid context")
-	ErrNotFound       = errors.New("agent context: not found")
-	ErrConflict       = errors.New("agent context: conflict")
-	ErrRepository     = errors.New("agent context repository: operation failed")
+	ErrInvalidContext               = errors.New("agent context: invalid context")
+	ErrNotFound                     = errors.New("agent context: not found")
+	ErrConflict                     = errors.New("agent context: conflict")
+	ErrRepository                   = errors.New("agent context repository: operation failed")
+	ErrMemoryConsistencyUnavailable = errors.New(
+		"agent context: memory consistency unavailable",
+	)
+	ErrMemoryConsistencyRejected = errors.New(
+		"agent context: memory consistency rejected",
+	)
 )

--- a/server/internal/agent/context/manifest.go
+++ b/server/internal/agent/context/manifest.go
@@ -53,33 +53,38 @@ type SummarySource struct {
 }
 
 type Manifest struct {
-	RunID                               string
-	OwnerID                             string
-	ThreadID                            string
-	InputMessageID                      string
-	ActiveGoalID                        string
-	ActiveGoalVersion                   int64
-	InstructionVersion                  string
-	LearningProfileContextPolicyVersion string
-	SelectedLearningProfile             []LearningProfileSource
-	StableProfileContextPolicyVersion   string
-	SelectedStableProfile               []StableProfileSource
-	MemoryContextPolicyVersion          string
-	SelectedMemories                    []MemorySource
-	SummaryContextPolicyVersion         string
-	SummaryContextStatus                string
-	SelectedSummary                     *SummarySource
-	SelectedMessages                    []MessageSource
-	OmittedMessageCount                 int
-	TrimReason                          string
-	MaxInputCharacters                  int
-	UsedInputCharacters                 int
-	RequestedProvider                   string
-	RequestedModel                      string
-	MaxOutputTokens                     int
-	ExposedTools                        []string
-	ToolSchemaHashes                    map[string]string
-	CreatedAt                           time.Time
+	RunID                                     string
+	OwnerID                                   string
+	ThreadID                                  string
+	InputMessageID                            string
+	ActiveGoalID                              string
+	ActiveGoalVersion                         int64
+	InstructionVersion                        string
+	LearningProfileContextPolicyVersion       string
+	SelectedLearningProfile                   []LearningProfileSource
+	StableProfileContextPolicyVersion         string
+	SelectedStableProfile                     []StableProfileSource
+	MemoryContextPolicyVersion                string
+	SelectedMemories                          []MemorySource
+	MemoryExtractionBarrierPolicyVersion      string
+	MemoryExtractionBarrierCutoff             time.Time
+	MemoryExtractionBarrierStatus             string
+	MemoryExtractionBarrierWaitedMilliseconds int64
+	MemoryExtractionBarrierCoveredThrough     time.Time
+	SummaryContextPolicyVersion               string
+	SummaryContextStatus                      string
+	SelectedSummary                           *SummarySource
+	SelectedMessages                          []MessageSource
+	OmittedMessageCount                       int
+	TrimReason                                string
+	MaxInputCharacters                        int
+	UsedInputCharacters                       int
+	RequestedProvider                         string
+	RequestedModel                            string
+	MaxOutputTokens                           int
+	ExposedTools                              []string
+	ToolSchemaHashes                          map[string]string
+	CreatedAt                                 time.Time
 }
 
 func (manifest Manifest) Valid() bool {
@@ -94,5 +99,34 @@ func (manifest Manifest) Valid() bool {
 		manifest.MaxInputCharacters >= 5000 &&
 		manifest.MaxInputCharacters <= maxBudget &&
 		manifest.UsedInputCharacters >= 0 &&
-		manifest.UsedInputCharacters <= manifest.MaxInputCharacters
+		manifest.UsedInputCharacters <= manifest.MaxInputCharacters &&
+		manifest.validMemoryExtractionBarrier()
+}
+
+func (manifest Manifest) validMemoryExtractionBarrier() bool {
+	if manifest.MemoryExtractionBarrierPolicyVersion !=
+		MemoryExtractionBarrierPolicyV1 ||
+		manifest.MemoryExtractionBarrierCutoff.IsZero() ||
+		manifest.MemoryExtractionBarrierCutoff.Location() != time.UTC ||
+		manifest.MemoryExtractionBarrierWaitedMilliseconds < 0 ||
+		manifest.MemoryExtractionBarrierWaitedMilliseconds > 5000 ||
+		(!manifest.MemoryExtractionBarrierCoveredThrough.IsZero() &&
+			(manifest.MemoryExtractionBarrierCoveredThrough.Location() != time.UTC ||
+				manifest.MemoryExtractionBarrierCoveredThrough.After(
+					manifest.MemoryExtractionBarrierCutoff,
+				))) {
+		return false
+	}
+	switch manifest.MemoryExtractionBarrierStatus {
+	case memoryExtractionBarrierNotRequired:
+		return manifest.MemoryExtractionBarrierWaitedMilliseconds == 0 &&
+			manifest.MemoryExtractionBarrierCoveredThrough.IsZero()
+	case string(MemoryExtractionBarrierReady):
+		return manifest.MemoryExtractionBarrierWaitedMilliseconds == 0
+	case string(MemoryExtractionBarrierWaited):
+		return manifest.MemoryExtractionBarrierWaitedMilliseconds > 0 &&
+			!manifest.MemoryExtractionBarrierCoveredThrough.IsZero()
+	default:
+		return false
+	}
 }

--- a/server/internal/agent/context/memory_extraction_barrier.go
+++ b/server/internal/agent/context/memory_extraction_barrier.go
@@ -1,0 +1,59 @@
+package context
+
+import (
+	stdcontext "context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const MemoryExtractionBarrierPolicyV1 = "memory-extraction-barrier-v1"
+
+const memoryExtractionBarrierNotRequired = "not_required"
+
+type MemoryExtractionBarrierStatus string
+
+const (
+	MemoryExtractionBarrierReady  MemoryExtractionBarrierStatus = "ready"
+	MemoryExtractionBarrierWaited MemoryExtractionBarrierStatus = "waited"
+)
+
+type MemoryExtractionBarrierRequest struct {
+	Actor  requestcontext.Actor
+	Cutoff time.Time
+}
+
+type MemoryExtractionBarrierResult struct {
+	PolicyVersion  string
+	Cutoff         time.Time
+	Status         MemoryExtractionBarrierStatus
+	Waited         time.Duration
+	CoveredThrough time.Time
+}
+
+func (result MemoryExtractionBarrierResult) Valid() bool {
+	if result.PolicyVersion != MemoryExtractionBarrierPolicyV1 ||
+		result.Cutoff.IsZero() ||
+		result.Cutoff.Location() != time.UTC ||
+		result.Waited < 0 || result.Waited > 5*time.Second ||
+		(!result.CoveredThrough.IsZero() &&
+			(result.CoveredThrough.Location() != time.UTC ||
+				result.CoveredThrough.After(result.Cutoff))) {
+		return false
+	}
+	switch result.Status {
+	case MemoryExtractionBarrierReady:
+		return result.Waited == 0
+	case MemoryExtractionBarrierWaited:
+		return result.Waited > 0 && !result.CoveredThrough.IsZero()
+	default:
+		return false
+	}
+}
+
+type MemoryExtractionBarrier interface {
+	Await(
+		stdcontext.Context,
+		MemoryExtractionBarrierRequest,
+	) (MemoryExtractionBarrierResult, error)
+}

--- a/server/internal/agent/context/memory_extraction_barrier_test.go
+++ b/server/internal/agent/context/memory_extraction_barrier_test.go
@@ -1,0 +1,164 @@
+package context
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestAssemblerAuditsFirstMessageMemoryExtractionBarrier(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	coveredThrough := cutoff.Add(-time.Second)
+	barrier := &recordingContextMemoryBarrier{result: MemoryExtractionBarrierResult{
+		PolicyVersion:  MemoryExtractionBarrierPolicyV1,
+		Cutoff:         cutoff,
+		Status:         MemoryExtractionBarrierWaited,
+		Waited:         150 * time.Millisecond,
+		CoveredThrough: coveredThrough,
+	}}
+	assembler := newMemoryBarrierTestAssembler(t, 1, barrier)
+
+	manifest, _, err := assembler.Assemble(
+		context.Background(),
+		memoryBarrierTestActor(),
+		memoryBarrierTestCommand(cutoff),
+	)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if barrier.calls != 1 ||
+		barrier.request.Actor != memoryBarrierTestActor() ||
+		!barrier.request.Cutoff.Equal(cutoff) {
+		t.Fatalf("barrier request = %#v calls=%d", barrier.request, barrier.calls)
+	}
+	if manifest.MemoryExtractionBarrierPolicyVersion !=
+		MemoryExtractionBarrierPolicyV1 ||
+		manifest.MemoryExtractionBarrierStatus != "waited" ||
+		manifest.MemoryExtractionBarrierWaitedMilliseconds != 150 ||
+		!manifest.MemoryExtractionBarrierCutoff.Equal(cutoff) ||
+		!manifest.MemoryExtractionBarrierCoveredThrough.Equal(coveredThrough) ||
+		!manifest.Valid() {
+		t.Fatalf("barrier audit = %#v", manifest)
+	}
+}
+
+func TestAssemblerSkipsMemoryExtractionBarrierAfterFirstMessage(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	barrier := &recordingContextMemoryBarrier{
+		err: ErrMemoryConsistencyUnavailable,
+	}
+	assembler := newMemoryBarrierTestAssembler(t, 2, barrier)
+
+	manifest, _, err := assembler.Assemble(
+		context.Background(),
+		memoryBarrierTestActor(),
+		memoryBarrierTestCommand(cutoff),
+	)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if barrier.calls != 0 ||
+		manifest.MemoryExtractionBarrierStatus != "not_required" ||
+		manifest.MemoryExtractionBarrierWaitedMilliseconds != 0 ||
+		!manifest.MemoryExtractionBarrierCoveredThrough.IsZero() {
+		t.Fatalf("continuous-turn audit = %#v calls=%d", manifest, barrier.calls)
+	}
+}
+
+func TestAssemblerStopsBeforeContextReadsWhenBarrierFails(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	for _, expected := range []error{
+		ErrMemoryConsistencyUnavailable,
+		ErrMemoryConsistencyRejected,
+	} {
+		barrier := &recordingContextMemoryBarrier{err: expected}
+		assembler := newMemoryBarrierTestAssembler(t, 1, barrier)
+		_, _, err := assembler.Assemble(
+			context.Background(),
+			memoryBarrierTestActor(),
+			memoryBarrierTestCommand(cutoff),
+		)
+		if !errors.Is(err, expected) {
+			t.Fatalf("Assemble error = %v, want %v", err, expected)
+		}
+	}
+}
+
+func newMemoryBarrierTestAssembler(
+	t *testing.T,
+	sequence int64,
+	barrier MemoryExtractionBarrier,
+) *Assembler {
+	t.Helper()
+	message := conversation.Message{
+		ID:       "30000000-0000-4000-8000-000000000001",
+		OwnerID:  "10000000-0000-4000-8000-000000000001",
+		ThreadID: "20000000-0000-4000-8000-000000000001",
+		Sequence: sequence,
+		Role:     conversation.MessageRoleUser,
+		Modality: conversation.MessageModalityText,
+		Content:  "Help me practice an interview answer.",
+	}
+	assembler, err := NewAssembler(
+		multimodalRepository{
+			thread: conversation.Thread{
+				ID:      message.ThreadID,
+				OwnerID: message.OwnerID,
+			},
+			message: message,
+		},
+		multimodalContextGoals{},
+		multimodalContextLearningProfile{},
+		multimodalContextStableProfile{},
+		multimodalContextMemories{},
+		barrier,
+	)
+	if err != nil {
+		t.Fatalf("NewAssembler: %v", err)
+	}
+	return assembler
+}
+
+func memoryBarrierTestActor() requestcontext.Actor {
+	return requestcontext.Actor{
+		UserID:    "10000000-0000-4000-8000-000000000001",
+		SessionID: "memory-barrier-session",
+	}
+}
+
+func memoryBarrierTestCommand(cutoff time.Time) AssembleCommand {
+	return AssembleCommand{
+		RunID:              "40000000-0000-4000-8000-000000000001",
+		OwnerID:            "10000000-0000-4000-8000-000000000001",
+		ThreadID:           "20000000-0000-4000-8000-000000000001",
+		InputMessageID:     "30000000-0000-4000-8000-000000000001",
+		RunCreatedAt:       cutoff,
+		Provider:           "fake",
+		Model:              "fake-model",
+		MaxOutputTokens:    256,
+		MaxInputCharacters: 12000,
+	}
+}
+
+type recordingContextMemoryBarrier struct {
+	result  MemoryExtractionBarrierResult
+	err     error
+	request MemoryExtractionBarrierRequest
+	calls   int
+}
+
+func (barrier *recordingContextMemoryBarrier) Await(
+	_ context.Context,
+	request MemoryExtractionBarrierRequest,
+) (MemoryExtractionBarrierResult, error) {
+	barrier.calls++
+	barrier.request = request
+	return barrier.result, barrier.err
+}

--- a/server/internal/agent/context/multimodal_test.go
+++ b/server/internal/agent/context/multimodal_test.go
@@ -3,6 +3,7 @@ package context
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation/summary"
@@ -42,6 +43,7 @@ func TestAssemblerAddsSignedImagesToMultimodalUserMessage(
 		multimodalContextLearningProfile{},
 		multimodalContextStableProfile{},
 		multimodalContextMemories{},
+		multimodalContextMemoryBarrier{},
 		WithImageReader(multimodalContextImages{}),
 	)
 	if err != nil {
@@ -52,6 +54,7 @@ func TestAssemblerAddsSignedImagesToMultimodalUserMessage(
 		OwnerID:            ownerID,
 		ThreadID:           threadID,
 		InputMessageID:     messageID,
+		RunCreatedAt:       time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC),
 		Provider:           "fake",
 		Model:              "fake-multimodal",
 		MaxOutputTokens:    256,
@@ -120,6 +123,7 @@ func TestAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 		multimodalContextLearningProfile{},
 		multimodalContextStableProfile{},
 		multimodalContextMemories{},
+		multimodalContextMemoryBarrier{},
 		WithImageReader(multimodalBudgetImages{}),
 	)
 	if err != nil {
@@ -130,6 +134,7 @@ func TestAssemblerImageBudgetKeepsNewestImages(t *testing.T) {
 		OwnerID:            ownerID,
 		ThreadID:           threadID,
 		InputMessageID:     messages[2].ID,
+		RunCreatedAt:       time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC),
 		Provider:           "fake",
 		Model:              "fake-multimodal",
 		MaxOutputTokens:    256,
@@ -248,6 +253,19 @@ func (multimodalContextMemories) Search(
 	MemorySearchRequest,
 ) ([]MemorySearchHit, error) {
 	return nil, nil
+}
+
+type multimodalContextMemoryBarrier struct{}
+
+func (multimodalContextMemoryBarrier) Await(
+	_ context.Context,
+	request MemoryExtractionBarrierRequest,
+) (MemoryExtractionBarrierResult, error) {
+	return MemoryExtractionBarrierResult{
+		PolicyVersion: MemoryExtractionBarrierPolicyV1,
+		Cutoff:        request.Cutoff,
+		Status:        MemoryExtractionBarrierReady,
+	}, nil
 }
 
 type multimodalContextImages struct{}

--- a/server/internal/agent/context/postgres/manifest.go
+++ b/server/internal/agent/context/postgres/manifest.go
@@ -57,6 +57,11 @@ func (r *Repository) SaveManifest(
 		summaryProvider = manifest.SelectedSummary.Provider
 		summaryModel = manifest.SelectedSummary.Model
 	}
+	var memoryExtractionBarrierCoveredThrough any
+	if !manifest.MemoryExtractionBarrierCoveredThrough.IsZero() {
+		memoryExtractionBarrierCoveredThrough =
+			manifest.MemoryExtractionBarrierCoveredThrough
+	}
 	var result agentcontext.Manifest
 	var selectedJSON []byte
 	var selectedMemoriesJSON []byte
@@ -73,6 +78,7 @@ func (r *Repository) SaveManifest(
 	var persistedSummaryPromptVersion pgtype.Text
 	var persistedSummaryProvider pgtype.Text
 	var persistedSummaryModel pgtype.Text
+	var persistedMemoryExtractionBarrierCoveredThrough pgtype.Timestamptz
 	err = r.database.QueryRow(ctx, `
 INSERT INTO agent_context_manifests (
     run_id,
@@ -105,13 +111,18 @@ INSERT INTO agent_context_manifests (
     max_output_tokens,
     learning_profile_context_policy_version,
     selected_learning_profile,
+    memory_extraction_barrier_policy_version,
+    memory_extraction_barrier_cutoff,
+    memory_extraction_barrier_status,
+    memory_extraction_barrier_waited_milliseconds,
+    memory_extraction_barrier_covered_through,
     created_at
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb,
     $10, $11::jsonb, $12, $13, $14, $15, $16, $17, $18,
 	$19, $20,
 	$21::jsonb, $22, $23, $24, $25, $26, $27, $28,
-	$29, $30::jsonb,
+	$29, $30::jsonb, $31, $32, $33, $34, $35,
     CURRENT_TIMESTAMP
 )
 RETURNING
@@ -145,6 +156,11 @@ RETURNING
     max_output_tokens,
     learning_profile_context_policy_version,
     selected_learning_profile,
+    memory_extraction_barrier_policy_version,
+    memory_extraction_barrier_cutoff,
+    memory_extraction_barrier_status,
+    memory_extraction_barrier_waited_milliseconds,
+    memory_extraction_barrier_covered_through,
     exposed_tools,
     tool_schema_hashes,
     created_at`,
@@ -178,6 +194,11 @@ RETURNING
 		manifest.MaxOutputTokens,
 		manifest.LearningProfileContextPolicyVersion,
 		selectedLearningProfile,
+		manifest.MemoryExtractionBarrierPolicyVersion,
+		manifest.MemoryExtractionBarrierCutoff,
+		manifest.MemoryExtractionBarrierStatus,
+		manifest.MemoryExtractionBarrierWaitedMilliseconds,
+		memoryExtractionBarrierCoveredThrough,
 	).Scan(
 		&result.RunID,
 		&result.OwnerID,
@@ -209,6 +230,11 @@ RETURNING
 		&result.MaxOutputTokens,
 		&result.LearningProfileContextPolicyVersion,
 		&selectedLearningProfileJSON,
+		&result.MemoryExtractionBarrierPolicyVersion,
+		&result.MemoryExtractionBarrierCutoff,
+		&result.MemoryExtractionBarrierStatus,
+		&result.MemoryExtractionBarrierWaitedMilliseconds,
+		&persistedMemoryExtractionBarrierCoveredThrough,
 		&exposedToolsJSON,
 		&toolSchemaHashesJSON,
 		&result.CreatedAt,
@@ -236,6 +262,12 @@ RETURNING
 	); err != nil {
 		return agentcontext.Manifest{}, err
 	}
+	if persistedMemoryExtractionBarrierCoveredThrough.Valid {
+		result.MemoryExtractionBarrierCoveredThrough =
+			persistedMemoryExtractionBarrierCoveredThrough.Time.UTC()
+	}
+	result.MemoryExtractionBarrierCutoff =
+		result.MemoryExtractionBarrierCutoff.UTC()
 	return result, nil
 }
 
@@ -260,6 +292,7 @@ func (r *Repository) FindManifest(
 	var selectedSummaryPromptVersion pgtype.Text
 	var selectedSummaryProvider pgtype.Text
 	var selectedSummaryModel pgtype.Text
+	var memoryExtractionBarrierCoveredThrough pgtype.Timestamptz
 	err := r.database.QueryRow(ctx, `
 SELECT
     run_id::text,
@@ -292,6 +325,11 @@ SELECT
     max_output_tokens,
     learning_profile_context_policy_version,
     selected_learning_profile,
+    memory_extraction_barrier_policy_version,
+    memory_extraction_barrier_cutoff,
+    memory_extraction_barrier_status,
+    memory_extraction_barrier_waited_milliseconds,
+    memory_extraction_barrier_covered_through,
     exposed_tools,
     tool_schema_hashes,
     created_at
@@ -330,6 +368,11 @@ WHERE run_id = $1 AND owner_user_id = $2`,
 		&result.MaxOutputTokens,
 		&result.LearningProfileContextPolicyVersion,
 		&selectedLearningProfileJSON,
+		&result.MemoryExtractionBarrierPolicyVersion,
+		&result.MemoryExtractionBarrierCutoff,
+		&result.MemoryExtractionBarrierStatus,
+		&result.MemoryExtractionBarrierWaitedMilliseconds,
+		&memoryExtractionBarrierCoveredThrough,
 		&exposedToolsJSON,
 		&toolSchemaHashesJSON,
 		&result.CreatedAt,
@@ -357,6 +400,12 @@ WHERE run_id = $1 AND owner_user_id = $2`,
 	); err != nil {
 		return agentcontext.Manifest{}, err
 	}
+	if memoryExtractionBarrierCoveredThrough.Valid {
+		result.MemoryExtractionBarrierCoveredThrough =
+			memoryExtractionBarrierCoveredThrough.Time.UTC()
+	}
+	result.MemoryExtractionBarrierCutoff =
+		result.MemoryExtractionBarrierCutoff.UTC()
 	return result, nil
 }
 

--- a/server/internal/agent/memory/extraction_barrier_postgres_integration_test.go
+++ b/server/internal/agent/memory/extraction_barrier_postgres_integration_test.go
@@ -172,6 +172,84 @@ func TestPostgresExtractionBarrierRejectsInvalidRequest(t *testing.T) {
 	}
 }
 
+func TestPostgresExtractionBarrierObservesConcurrentCompletionAndRestart(
+	t *testing.T,
+) {
+	database := newMemoryTestDatabase(t)
+	repository, err := NewPostgresRepository(
+		database,
+		identity.NewUUIDv4Generator(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewPostgresRepository: %v", err)
+	}
+	base := time.Date(2026, time.July, 29, 10, 0, 0, 0, time.UTC)
+	actor := requestcontext.Actor{
+		UserID:    integrationUserA,
+		SessionID: integrationSessionA,
+	}
+	job := barrierIntegrationJob{
+		runID:           "aa000000-0000-4000-8000-000000000010",
+		ownerID:         actor.UserID,
+		status:          "pending",
+		sourceCompleted: base,
+	}
+	insertBarrierIntegrationJob(t, database, job)
+	cutoff := base.Add(2 * time.Second)
+	scheduler := &fakeExtractionBarrierScheduler{now: cutoff.Add(time.Second)}
+	scheduler.onWait = func() {
+		_, updateErr := database.Exec(context.Background(), `
+UPDATE agent_memory_extraction_jobs
+SET
+    status = 'completed',
+    attempt_count = 1,
+    candidate_count = 0,
+    applied_count = 0,
+    rejected_count = 0,
+    updated_at = transaction_timestamp(),
+    completed_at = transaction_timestamp()
+WHERE source_run_id = $1`, job.runID)
+		if updateErr != nil {
+			t.Fatalf("complete Extraction job: %v", updateErr)
+		}
+		scheduler.onWait = nil
+	}
+	coordinator := newTestExtractionBarrierCoordinator(
+		t,
+		repository,
+		scheduler,
+	)
+
+	result, err := coordinator.Await(
+		context.Background(),
+		ExtractionBarrierRequest{Actor: actor, Cutoff: cutoff},
+	)
+	if err != nil {
+		t.Fatalf("Await concurrent completion: %v", err)
+	}
+	if result.Status != ExtractionBarrierWaited ||
+		!result.CoveredThrough.Equal(job.sourceCompleted) {
+		t.Fatalf("waited result = %#v", result)
+	}
+
+	restarted := newTestExtractionBarrierCoordinator(
+		t,
+		repository,
+		&fakeExtractionBarrierScheduler{now: scheduler.now},
+	)
+	restartedResult, err := restarted.Await(
+		context.Background(),
+		ExtractionBarrierRequest{Actor: actor, Cutoff: cutoff},
+	)
+	if err != nil {
+		t.Fatalf("Await after restart: %v", err)
+	}
+	if restartedResult.Status != ExtractionBarrierReady ||
+		restartedResult.Waited != 0 {
+		t.Fatalf("restart result = %#v", restartedResult)
+	}
+}
+
 type barrierIntegrationJob struct {
 	runID           string
 	ownerID         string

--- a/server/internal/agent/memory/extraction_barrier_wait.go
+++ b/server/internal/agent/memory/extraction_barrier_wait.go
@@ -1,0 +1,156 @@
+package memory
+
+import (
+	"context"
+	"time"
+)
+
+const ExtractionBarrierPolicyV1 = "memory-extraction-barrier-v1"
+
+type ExtractionBarrierResultStatus string
+
+const (
+	ExtractionBarrierReady  ExtractionBarrierResultStatus = "ready"
+	ExtractionBarrierWaited ExtractionBarrierResultStatus = "waited"
+)
+
+type ExtractionBarrierResult struct {
+	PolicyVersion  string
+	Cutoff         time.Time
+	Status         ExtractionBarrierResultStatus
+	Waited         time.Duration
+	CoveredThrough time.Time
+}
+
+func (result ExtractionBarrierResult) Valid() bool {
+	if result.PolicyVersion != ExtractionBarrierPolicyV1 ||
+		result.Cutoff.IsZero() ||
+		result.Cutoff.Location() != time.UTC ||
+		result.Waited < 0 ||
+		(!result.CoveredThrough.IsZero() &&
+			(result.CoveredThrough.Location() != time.UTC ||
+				result.CoveredThrough.After(result.Cutoff))) {
+		return false
+	}
+	switch result.Status {
+	case ExtractionBarrierReady:
+		return result.Waited == 0
+	case ExtractionBarrierWaited:
+		return result.Waited > 0 && !result.CoveredThrough.IsZero()
+	default:
+		return false
+	}
+}
+
+type ExtractionBarrierWaitPolicy struct {
+	MaximumWait  time.Duration
+	PollInterval time.Duration
+}
+
+func (policy ExtractionBarrierWaitPolicy) Valid() bool {
+	return policy.MaximumWait > 0 &&
+		policy.MaximumWait <= 30*time.Second &&
+		policy.PollInterval > 0 &&
+		policy.PollInterval <= policy.MaximumWait
+}
+
+type ExtractionBarrierScheduler interface {
+	Now() time.Time
+	Wait(context.Context, time.Duration) error
+}
+
+type SystemExtractionBarrierScheduler struct{}
+
+func (SystemExtractionBarrierScheduler) Now() time.Time {
+	return time.Now().UTC()
+}
+
+func (SystemExtractionBarrierScheduler) Wait(
+	ctx context.Context,
+	duration time.Duration,
+) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type ExtractionBarrierCoordinator struct {
+	reader    ExtractionBarrierReader
+	scheduler ExtractionBarrierScheduler
+	policy    ExtractionBarrierWaitPolicy
+}
+
+func NewExtractionBarrierCoordinator(
+	reader ExtractionBarrierReader,
+	scheduler ExtractionBarrierScheduler,
+	policy ExtractionBarrierWaitPolicy,
+) (*ExtractionBarrierCoordinator, error) {
+	if reader == nil || scheduler == nil || !policy.Valid() {
+		return nil, ErrInvalidArgument
+	}
+	return &ExtractionBarrierCoordinator{
+		reader:    reader,
+		scheduler: scheduler,
+		policy:    policy,
+	}, nil
+}
+
+func (coordinator *ExtractionBarrierCoordinator) Await(
+	ctx context.Context,
+	request ExtractionBarrierRequest,
+) (ExtractionBarrierResult, error) {
+	if ctx == nil || !request.Valid() {
+		return ExtractionBarrierResult{}, ErrInvalidArgument
+	}
+	startedAt := coordinator.scheduler.Now().UTC()
+	if startedAt.IsZero() {
+		return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+	}
+	deadline := startedAt.Add(coordinator.policy.MaximumWait)
+	waited := false
+	for {
+		snapshot, err := coordinator.reader.ReadExtractionBarrier(ctx, request)
+		if err != nil || !snapshot.Valid() {
+			return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+		}
+		switch {
+		case snapshot.DiscardedCount > 0:
+			return ExtractionBarrierResult{}, ErrExtractionBarrierRejected
+		case snapshot.FailedCount > 0:
+			return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+		case snapshot.PendingCount == 0 && snapshot.RunningCount == 0:
+			if waited && coordinator.scheduler.Now().UTC().After(deadline) {
+				return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+			}
+			result := ExtractionBarrierResult{
+				PolicyVersion:  ExtractionBarrierPolicyV1,
+				Cutoff:         request.Cutoff,
+				Status:         ExtractionBarrierReady,
+				CoveredThrough: snapshot.LatestSourceCompletedAt,
+			}
+			if waited {
+				result.Status = ExtractionBarrierWaited
+				result.Waited = coordinator.scheduler.Now().UTC().Sub(startedAt)
+			}
+			if !result.Valid() {
+				return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+			}
+			return result, nil
+		}
+
+		remaining := deadline.Sub(coordinator.scheduler.Now().UTC())
+		if remaining <= 0 {
+			return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+		}
+		pause := min(coordinator.policy.PollInterval, remaining)
+		if err := coordinator.scheduler.Wait(ctx, pause); err != nil {
+			return ExtractionBarrierResult{}, ErrExtractionBarrierUnavailable
+		}
+		waited = true
+	}
+}

--- a/server/internal/agent/memory/extraction_barrier_wait_test.go
+++ b/server/internal/agent/memory/extraction_barrier_wait_test.go
@@ -1,0 +1,215 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestExtractionBarrierCoordinatorReadyWithoutWaiting(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	reader := &scriptedExtractionBarrierReader{snapshots: []ExtractionBarrierSnapshot{{
+		Cutoff: cutoff,
+	}}}
+	scheduler := &fakeExtractionBarrierScheduler{now: cutoff.Add(time.Second)}
+	coordinator := newTestExtractionBarrierCoordinator(t, reader, scheduler)
+
+	result, err := coordinator.Await(
+		context.Background(),
+		testExtractionBarrierRequest(cutoff),
+	)
+	if err != nil {
+		t.Fatalf("Await: %v", err)
+	}
+	if result.Status != ExtractionBarrierReady || result.Waited != 0 ||
+		reader.calls != 1 || scheduler.waits != 0 {
+		t.Fatalf("unexpected immediate result: %#v", result)
+	}
+}
+
+func TestExtractionBarrierCoordinatorRechecksDatabaseUntilCompleted(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	sourceCompletedAt := cutoff.Add(-time.Second)
+	reader := &scriptedExtractionBarrierReader{snapshots: []ExtractionBarrierSnapshot{
+		{
+			Cutoff: cutoff, JobCount: 1, PendingCount: 1,
+			LatestSourceCompletedAt:              sourceCompletedAt,
+			EarliestNonTerminalSourceCompletedAt: sourceCompletedAt,
+		},
+		{
+			Cutoff: cutoff, JobCount: 1, CompletedCount: 1,
+			LatestSourceCompletedAt: sourceCompletedAt,
+		},
+	}}
+	scheduler := &fakeExtractionBarrierScheduler{now: cutoff.Add(time.Second)}
+	coordinator := newTestExtractionBarrierCoordinator(t, reader, scheduler)
+
+	result, err := coordinator.Await(
+		context.Background(),
+		testExtractionBarrierRequest(cutoff),
+	)
+	if err != nil {
+		t.Fatalf("Await: %v", err)
+	}
+	if result.Status != ExtractionBarrierWaited ||
+		result.Waited != 100*time.Millisecond ||
+		!result.CoveredThrough.Equal(sourceCompletedAt) ||
+		reader.calls != 2 || scheduler.waits != 1 {
+		t.Fatalf("unexpected waited result: %#v", result)
+	}
+}
+
+func TestExtractionBarrierCoordinatorFailsExplicitly(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	sourceCompletedAt := cutoff.Add(-time.Second)
+	tests := map[string]struct {
+		snapshot ExtractionBarrierSnapshot
+		readErr  error
+		wantErr  error
+	}{
+		"failed": {
+			snapshot: ExtractionBarrierSnapshot{
+				Cutoff: cutoff, JobCount: 1, FailedCount: 1,
+				LatestSourceCompletedAt: sourceCompletedAt,
+			},
+			wantErr: ErrExtractionBarrierUnavailable,
+		},
+		"discarded": {
+			snapshot: ExtractionBarrierSnapshot{
+				Cutoff: cutoff, JobCount: 1, DiscardedCount: 1,
+				LatestSourceCompletedAt: sourceCompletedAt,
+			},
+			wantErr: ErrExtractionBarrierRejected,
+		},
+		"repository": {
+			readErr: ErrRepository,
+			wantErr: ErrExtractionBarrierUnavailable,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			reader := &scriptedExtractionBarrierReader{
+				snapshots: []ExtractionBarrierSnapshot{test.snapshot},
+				err:       test.readErr,
+			}
+			coordinator := newTestExtractionBarrierCoordinator(
+				t,
+				reader,
+				&fakeExtractionBarrierScheduler{now: cutoff.Add(time.Second)},
+			)
+			_, err := coordinator.Await(
+				context.Background(),
+				testExtractionBarrierRequest(cutoff),
+			)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Await error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractionBarrierCoordinatorTimesOutAtBudget(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	sourceCompletedAt := cutoff.Add(-time.Second)
+	reader := &scriptedExtractionBarrierReader{repeat: ExtractionBarrierSnapshot{
+		Cutoff: cutoff, JobCount: 1, RunningCount: 1,
+		LatestSourceCompletedAt:              sourceCompletedAt,
+		EarliestNonTerminalSourceCompletedAt: sourceCompletedAt,
+	}}
+	scheduler := &fakeExtractionBarrierScheduler{now: cutoff.Add(time.Second)}
+	coordinator := newTestExtractionBarrierCoordinator(t, reader, scheduler)
+
+	_, err := coordinator.Await(
+		context.Background(),
+		testExtractionBarrierRequest(cutoff),
+	)
+	if !errors.Is(err, ErrExtractionBarrierUnavailable) {
+		t.Fatalf("Await error = %v", err)
+	}
+	if elapsed := scheduler.now.Sub(cutoff.Add(time.Second)); elapsed != time.Second {
+		t.Fatalf("elapsed = %s, want 1s", elapsed)
+	}
+}
+
+func newTestExtractionBarrierCoordinator(
+	t *testing.T,
+	reader ExtractionBarrierReader,
+	scheduler ExtractionBarrierScheduler,
+) *ExtractionBarrierCoordinator {
+	t.Helper()
+	coordinator, err := NewExtractionBarrierCoordinator(
+		reader,
+		scheduler,
+		ExtractionBarrierWaitPolicy{
+			MaximumWait:  time.Second,
+			PollInterval: 100 * time.Millisecond,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewExtractionBarrierCoordinator: %v", err)
+	}
+	return coordinator
+}
+
+func testExtractionBarrierRequest(cutoff time.Time) ExtractionBarrierRequest {
+	return ExtractionBarrierRequest{
+		Actor: requestcontext.Actor{
+			UserID:    "10000000-0000-4000-8000-000000000001",
+			SessionID: "20000000-0000-4000-8000-000000000001",
+		},
+		Cutoff: cutoff,
+	}
+}
+
+type scriptedExtractionBarrierReader struct {
+	snapshots []ExtractionBarrierSnapshot
+	repeat    ExtractionBarrierSnapshot
+	err       error
+	calls     int
+}
+
+func (reader *scriptedExtractionBarrierReader) ReadExtractionBarrier(
+	context.Context,
+	ExtractionBarrierRequest,
+) (ExtractionBarrierSnapshot, error) {
+	reader.calls++
+	if reader.err != nil {
+		return ExtractionBarrierSnapshot{}, reader.err
+	}
+	if len(reader.snapshots) > 0 {
+		result := reader.snapshots[0]
+		reader.snapshots = reader.snapshots[1:]
+		return result, nil
+	}
+	return reader.repeat, nil
+}
+
+type fakeExtractionBarrierScheduler struct {
+	now    time.Time
+	waits  int
+	onWait func()
+}
+
+func (scheduler *fakeExtractionBarrierScheduler) Now() time.Time {
+	return scheduler.now
+}
+
+func (scheduler *fakeExtractionBarrierScheduler) Wait(
+	_ context.Context,
+	duration time.Duration,
+) error {
+	scheduler.waits++
+	if scheduler.onWait != nil {
+		scheduler.onWait()
+	}
+	scheduler.now = scheduler.now.Add(duration)
+	return nil
+}

--- a/server/internal/agent/memory/extraction_postgres_integration_test.go
+++ b/server/internal/agent/memory/extraction_postgres_integration_test.go
@@ -70,6 +70,7 @@ func TestCompletedAgentRunQueuesAndAppliesMemoryExtraction(
 		emptyAgentLearningProfileReader{},
 		emptyAgentStableProfileReader{},
 		emptyAgentMemorySearcher{},
+		emptyAgentMemoryExtractionBarrier{},
 	)
 	if err != nil {
 		t.Fatalf("NewContextAssembler: %v", err)
@@ -372,4 +373,17 @@ func (emptyAgentMemorySearcher) Search(
 	agentcontext.MemorySearchRequest,
 ) ([]agentcontext.MemorySearchHit, error) {
 	return []agentcontext.MemorySearchHit{}, nil
+}
+
+type emptyAgentMemoryExtractionBarrier struct{}
+
+func (emptyAgentMemoryExtractionBarrier) Await(
+	_ context.Context,
+	request agentcontext.MemoryExtractionBarrierRequest,
+) (agentcontext.MemoryExtractionBarrierResult, error) {
+	return agentcontext.MemoryExtractionBarrierResult{
+		PolicyVersion: agentcontext.MemoryExtractionBarrierPolicyV1,
+		Cutoff:        request.Cutoff,
+		Status:        agentcontext.MemoryExtractionBarrierReady,
+	}, nil
 }

--- a/server/internal/agent/memory/repository.go
+++ b/server/internal/agent/memory/repository.go
@@ -9,13 +9,19 @@ import (
 )
 
 var (
-	ErrInvalidArgument     = errors.New("memory: invalid argument")
-	ErrNotFound            = errors.New("memory: not found")
-	ErrConflict            = errors.New("memory: conflict")
-	ErrAccountDeleted      = errors.New("memory: account is not active")
-	ErrDeletionGeneration  = errors.New("memory: stale deletion generation")
-	ErrRepository          = errors.New("memory repository: operation failed")
-	ErrExtractionResponse  = errors.New("memory: invalid extraction response")
+	ErrInvalidArgument              = errors.New("memory: invalid argument")
+	ErrNotFound                     = errors.New("memory: not found")
+	ErrConflict                     = errors.New("memory: conflict")
+	ErrAccountDeleted               = errors.New("memory: account is not active")
+	ErrDeletionGeneration           = errors.New("memory: stale deletion generation")
+	ErrRepository                   = errors.New("memory repository: operation failed")
+	ErrExtractionResponse           = errors.New("memory: invalid extraction response")
+	ErrExtractionBarrierUnavailable = errors.New(
+		"memory: extraction barrier unavailable",
+	)
+	ErrExtractionBarrierRejected = errors.New(
+		"memory: extraction barrier rejected",
+	)
 	ErrExtractionExhausted = errors.New(
 		"memory: extraction attempts exhausted during recovery",
 	)

--- a/server/internal/agent/run/http/handler.go
+++ b/server/internal/agent/run/http/handler.go
@@ -386,23 +386,35 @@ func ContextManifestResponse(manifest agentcontext.Manifest) gin.H {
 	}
 	result := gin.H{
 		"run_id": manifest.RunID, "thread_id": manifest.ThreadID,
-		"input_message_id":                      manifest.InputMessageID,
-		"instruction_version":                   manifest.InstructionVersion,
-		"stable_profile_context_policy_version": manifest.StableProfileContextPolicyVersion,
-		"selected_stable_profile":               stableProfile,
-		"memory_context_policy_version":         manifest.MemoryContextPolicyVersion,
-		"selected_memories":                     memories,
-		"summary_context_policy_version":        manifest.SummaryContextPolicyVersion,
-		"summary_context_status":                manifest.SummaryContextStatus,
-		"selected_messages":                     messages,
-		"omitted_message_count":                 manifest.OmittedMessageCount,
-		"trim_reason":                           manifest.TrimReason,
-		"max_input_characters":                  manifest.MaxInputCharacters,
-		"used_input_characters":                 manifest.UsedInputCharacters,
-		"requested_provider":                    manifest.RequestedProvider,
-		"requested_model":                       manifest.RequestedModel,
-		"max_output_tokens":                     manifest.MaxOutputTokens,
-		"created_at":                            manifest.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"input_message_id":                         manifest.InputMessageID,
+		"instruction_version":                      manifest.InstructionVersion,
+		"stable_profile_context_policy_version":    manifest.StableProfileContextPolicyVersion,
+		"selected_stable_profile":                  stableProfile,
+		"memory_context_policy_version":            manifest.MemoryContextPolicyVersion,
+		"selected_memories":                        memories,
+		"memory_extraction_barrier_policy_version": manifest.MemoryExtractionBarrierPolicyVersion,
+		"memory_extraction_barrier_cutoff": manifest.MemoryExtractionBarrierCutoff.UTC().Format(
+			time.RFC3339Nano,
+		),
+		"memory_extraction_barrier_status":              manifest.MemoryExtractionBarrierStatus,
+		"memory_extraction_barrier_waited_milliseconds": manifest.MemoryExtractionBarrierWaitedMilliseconds,
+		"summary_context_policy_version":                manifest.SummaryContextPolicyVersion,
+		"summary_context_status":                        manifest.SummaryContextStatus,
+		"selected_messages":                             messages,
+		"omitted_message_count":                         manifest.OmittedMessageCount,
+		"trim_reason":                                   manifest.TrimReason,
+		"max_input_characters":                          manifest.MaxInputCharacters,
+		"used_input_characters":                         manifest.UsedInputCharacters,
+		"requested_provider":                            manifest.RequestedProvider,
+		"requested_model":                               manifest.RequestedModel,
+		"max_output_tokens":                             manifest.MaxOutputTokens,
+		"created_at":                                    manifest.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if !manifest.MemoryExtractionBarrierCoveredThrough.IsZero() {
+		result["memory_extraction_barrier_covered_through"] =
+			manifest.MemoryExtractionBarrierCoveredThrough.UTC().Format(
+				time.RFC3339Nano,
+			)
 	}
 	if manifest.SelectedSummary != nil {
 		result["selected_summary"] = gin.H{

--- a/server/internal/agent/run/model.go
+++ b/server/internal/agent/run/model.go
@@ -26,10 +26,11 @@ func (status Status) Valid() bool {
 }
 
 const (
-	FailureInterrupted        = "interrupted"
-	FailureConfigurationDrift = "configuration_drift"
-	FailureInvalidContext     = "invalid_context"
-	FailureInternal           = "internal_error"
+	FailureInterrupted                  = "interrupted"
+	FailureConfigurationDrift           = "configuration_drift"
+	FailureInvalidContext               = "invalid_context"
+	FailureMemoryConsistencyUnavailable = "memory_consistency_unavailable"
+	FailureInternal                     = "internal_error"
 )
 
 type Run struct {

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -547,6 +547,7 @@ func (service *Service) process(
 			OwnerID:            claimed.OwnerID,
 			ThreadID:           claimed.ThreadID,
 			InputMessageID:     claimed.InputMessageID,
+			RunCreatedAt:       claimed.CreatedAt.UTC(),
 			Provider:           service.configuration.Provider,
 			Model:              service.configuration.Model,
 			MaxOutputTokens:    service.configuration.MaxOutputTokens,
@@ -556,8 +557,14 @@ func (service *Service) process(
 	if err != nil {
 		kind := FailureInternal
 		retryable := true
-		if errors.Is(err, agentcontext.ErrInvalidContext) {
+		switch {
+		case errors.Is(err, agentcontext.ErrInvalidContext):
 			kind = FailureInvalidContext
+			retryable = false
+		case errors.Is(err, agentcontext.ErrMemoryConsistencyUnavailable):
+			kind = FailureMemoryConsistencyUnavailable
+		case errors.Is(err, agentcontext.ErrMemoryConsistencyRejected):
+			kind = FailureMemoryConsistencyUnavailable
 			retryable = false
 		}
 		failed, failErr := service.persistFailure(

--- a/server/internal/agenttest/postgres/run_integration_test.go
+++ b/server/internal/agenttest/postgres/run_integration_test.go
@@ -89,6 +89,95 @@ func newAgentRunHTTPRouter(
 	return router
 }
 
+func TestPostgresAgentRunMemoryConsistencyFailureSkipsProvider(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	generator := &recordingTextGenerator{result: successfulTextResult()}
+	goalService, dataService, _, repository := newAgentRunServices(
+		t,
+		database.pool,
+		generator,
+		testRunConfiguration,
+	)
+	actor := testActorA()
+	tests := []struct {
+		name      string
+		failure   error
+		retryable bool
+	}{
+		{
+			name:      "unavailable",
+			failure:   agentcontext.ErrMemoryConsistencyUnavailable,
+			retryable: true,
+		},
+		{
+			name:      "rejected",
+			failure:   agentcontext.ErrMemoryConsistencyRejected,
+			retryable: false,
+		},
+	}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			thread, err := dataService.CreateThread(
+				context.Background(),
+				actor,
+				"",
+			)
+			if err != nil {
+				t.Fatalf("create Thread: %v", err)
+			}
+			assembler, err := agentcontext.NewAssembler(
+				repository.context,
+				goalService,
+				emptyLearningProfileReader{},
+				emptyStableProfileReader{},
+				&recordingMemorySearcher{},
+				failingMemoryExtractionBarrier{err: test.failure},
+			)
+			if err != nil {
+				t.Fatalf("new Context Assembler: %v", err)
+			}
+			runService, err := agentrun.NewService(
+				repository.run,
+				repository.conversation,
+				repository.context,
+				assembler,
+				generator,
+				testRunConfiguration,
+			)
+			if err != nil {
+				t.Fatalf("new Run service: %v", err)
+			}
+
+			submission, err := runService.SubmitText(
+				context.Background(),
+				actor,
+				thread.ID,
+				fmt.Sprintf("memory-barrier-%d", index),
+				"What do you remember about me?",
+			)
+			if err != nil {
+				t.Fatalf("submit text: %v", err)
+			}
+			if submission.Run.Status != agentrun.StatusFailed ||
+				submission.Run.FailureKind !=
+					agentrun.FailureMemoryConsistencyUnavailable ||
+				submission.Run.FailureRetryable != test.retryable {
+				t.Fatalf("failed Run = %#v", submission.Run)
+			}
+			if _, err := runService.GetContextManifest(
+				context.Background(),
+				actor,
+				submission.Run.ID,
+			); !errors.Is(err, agentcontext.ErrNotFound) {
+				t.Fatalf("Context Manifest error = %v, want not found", err)
+			}
+		})
+	}
+	if generator.CallCount() != 0 {
+		t.Fatalf("provider calls = %d, want 0", generator.CallCount())
+	}
+}
+
 func TestPostgresAgentRunSuccessReplayAuditAndOwnership(t *testing.T) {
 	database := newAgentTestDatabase(t)
 	generator := &recordingTextGenerator{result: successfulTextResult()}
@@ -255,6 +344,14 @@ func TestPostgresAgentRunSuccessReplayAuditAndOwnership(t *testing.T) {
 		manifest.RequestedModel != testRunConfiguration.Model ||
 		manifest.MaxOutputTokens != testRunConfiguration.MaxOutputTokens ||
 		manifest.InstructionVersion != "speakup_text_v1" ||
+		manifest.MemoryExtractionBarrierPolicyVersion !=
+			agentcontext.MemoryExtractionBarrierPolicyV1 ||
+		manifest.MemoryExtractionBarrierStatus != "ready" ||
+		manifest.MemoryExtractionBarrierWaitedMilliseconds != 0 ||
+		!manifest.MemoryExtractionBarrierCutoff.Equal(
+			submission.Run.CreatedAt,
+		) ||
+		!manifest.MemoryExtractionBarrierCoveredThrough.IsZero() ||
 		len(manifest.SelectedMessages) != 1 ||
 		manifest.SelectedMessages[0].MessageID != submission.UserMessage.ID ||
 		manifest.TrimReason != "none" {
@@ -423,6 +520,7 @@ func TestPostgresAgentToolCallAuditReplayAndOwnership(t *testing.T) {
 		emptyLearningProfileReader{},
 		emptyStableProfileReader{},
 		&recordingMemorySearcher{},
+		readyMemoryExtractionBarrier{},
 	)
 	if err != nil {
 		t.Fatalf("new agentcontext.Assembler: %v", err)
@@ -550,6 +648,7 @@ func TestPostgresAgentHandoffPersistsProjectsAndStaysOutOfProviderInput(
 		emptyLearningProfileReader{},
 		emptyStableProfileReader{},
 		&recordingMemorySearcher{},
+		readyMemoryExtractionBarrier{},
 	)
 	if err != nil {
 		t.Fatalf("new agentcontext.Assembler: %v", err)
@@ -741,6 +840,7 @@ WHERE table_schema = current_schema()
 		emptyLearningProfileReader{},
 		emptyStableProfileReader{},
 		&recordingMemorySearcher{},
+		readyMemoryExtractionBarrier{},
 	)
 	if err != nil {
 		t.Fatalf("new agentcontext.Assembler: %v", err)
@@ -3821,6 +3921,7 @@ func newRunServiceWithContexts(
 		emptyLearningProfileReader{},
 		stableProfiles,
 		memories,
+		readyMemoryExtractionBarrier{},
 	)
 	if err != nil {
 		t.Fatalf("new agentcontext.Assembler: %v", err)
@@ -3858,6 +3959,30 @@ type recordingMemorySearcher struct {
 type emptyStableProfileReader struct{}
 
 type emptyLearningProfileReader struct{}
+
+type readyMemoryExtractionBarrier struct{}
+
+type failingMemoryExtractionBarrier struct {
+	err error
+}
+
+func (barrier failingMemoryExtractionBarrier) Await(
+	context.Context,
+	agentcontext.MemoryExtractionBarrierRequest,
+) (agentcontext.MemoryExtractionBarrierResult, error) {
+	return agentcontext.MemoryExtractionBarrierResult{}, barrier.err
+}
+
+func (readyMemoryExtractionBarrier) Await(
+	_ context.Context,
+	request agentcontext.MemoryExtractionBarrierRequest,
+) (agentcontext.MemoryExtractionBarrierResult, error) {
+	return agentcontext.MemoryExtractionBarrierResult{
+		PolicyVersion: agentcontext.MemoryExtractionBarrierPolicyV1,
+		Cutoff:        request.Cutoff,
+		Status:        agentcontext.MemoryExtractionBarrierReady,
+	}, nil
+}
 
 func (emptyLearningProfileReader) ReadLearningProfile(
 	context.Context,

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -215,6 +215,21 @@ func buildIdentityAgentComposition(
 	if err != nil {
 		return nil, err
 	}
+	memoryBarrier, err := memory.NewExtractionBarrierCoordinator(
+		memoryRepository,
+		memory.SystemExtractionBarrierScheduler{},
+		memory.ExtractionBarrierWaitPolicy{
+			MaximumWait:  5 * time.Second,
+			PollInterval: 50 * time.Millisecond,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	contextMemoryBarrier, err := newAgentMemoryExtractionBarrier(memoryBarrier)
+	if err != nil {
+		return nil, err
+	}
 	stableProfileReader, err := newAgentStableProfileReader(memoryRepository)
 	if err != nil {
 		return nil, err
@@ -236,6 +251,7 @@ func buildIdentityAgentComposition(
 		learningProfileReader,
 		stableProfileReader,
 		contextMemorySearcher,
+		contextMemoryBarrier,
 		contextOptions...,
 	)
 	if err != nil {

--- a/server/internal/bootstrap/memory_context.go
+++ b/server/internal/bootstrap/memory_context.go
@@ -12,6 +12,58 @@ type agentMemoryContextSearcher struct {
 	searcher memory.Searcher
 }
 
+type memoryExtractionBarrier interface {
+	Await(
+		context.Context,
+		memory.ExtractionBarrierRequest,
+	) (memory.ExtractionBarrierResult, error)
+}
+
+type agentMemoryExtractionBarrier struct {
+	barrier memoryExtractionBarrier
+}
+
+func newAgentMemoryExtractionBarrier(
+	barrier memoryExtractionBarrier,
+) (*agentMemoryExtractionBarrier, error) {
+	if barrier == nil {
+		return nil, errors.New(
+			"bootstrap: Memory Extraction Barrier is required",
+		)
+	}
+	return &agentMemoryExtractionBarrier{barrier: barrier}, nil
+}
+
+func (barrier *agentMemoryExtractionBarrier) Await(
+	ctx context.Context,
+	request agentcontext.MemoryExtractionBarrierRequest,
+) (agentcontext.MemoryExtractionBarrierResult, error) {
+	result, err := barrier.barrier.Await(
+		ctx,
+		memory.ExtractionBarrierRequest{
+			Actor:  request.Actor,
+			Cutoff: request.Cutoff,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, memory.ErrExtractionBarrierRejected) {
+			return agentcontext.MemoryExtractionBarrierResult{},
+				agentcontext.ErrMemoryConsistencyRejected
+		}
+		return agentcontext.MemoryExtractionBarrierResult{},
+			agentcontext.ErrMemoryConsistencyUnavailable
+	}
+	return agentcontext.MemoryExtractionBarrierResult{
+		PolicyVersion: result.PolicyVersion,
+		Cutoff:        result.Cutoff,
+		Status: agentcontext.MemoryExtractionBarrierStatus(
+			result.Status,
+		),
+		Waited:         result.Waited,
+		CoveredThrough: result.CoveredThrough,
+	}, nil
+}
+
 func newAgentMemoryContextSearcher(
 	searcher memory.Searcher,
 ) (*agentMemoryContextSearcher, error) {
@@ -65,3 +117,4 @@ func (searcher *agentMemoryContextSearcher) Search(
 }
 
 var _ agentcontext.MemorySearcher = (*agentMemoryContextSearcher)(nil)
+var _ agentcontext.MemoryExtractionBarrier = (*agentMemoryExtractionBarrier)(nil)

--- a/server/migrations/000062_agent_memory_extraction_context_barrier.down.sql
+++ b/server/migrations/000062_agent_memory_extraction_context_barrier.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE agent_context_manifests
+    DROP CONSTRAINT agent_context_manifests_memory_extraction_barrier_shape_check,
+    DROP CONSTRAINT agent_context_manifests_memory_extraction_barrier_policy_check,
+    DROP COLUMN memory_extraction_barrier_covered_through,
+    DROP COLUMN memory_extraction_barrier_waited_milliseconds,
+    DROP COLUMN memory_extraction_barrier_status,
+    DROP COLUMN memory_extraction_barrier_cutoff,
+    DROP COLUMN memory_extraction_barrier_policy_version;
+
+COMMIT;

--- a/server/migrations/000062_agent_memory_extraction_context_barrier.up.sql
+++ b/server/migrations/000062_agent_memory_extraction_context_barrier.up.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+ALTER TABLE agent_context_manifests
+    ADD COLUMN memory_extraction_barrier_policy_version text,
+    ADD COLUMN memory_extraction_barrier_cutoff timestamptz,
+    ADD COLUMN memory_extraction_barrier_status text,
+    ADD COLUMN memory_extraction_barrier_waited_milliseconds bigint,
+    ADD COLUMN memory_extraction_barrier_covered_through timestamptz;
+
+UPDATE agent_context_manifests AS manifests
+SET
+    memory_extraction_barrier_policy_version = 'memory-extraction-barrier-v1',
+    memory_extraction_barrier_cutoff = runs.created_at,
+    memory_extraction_barrier_status = 'not_required',
+    memory_extraction_barrier_waited_milliseconds = 0
+FROM agent_runs AS runs
+WHERE runs.id = manifests.run_id;
+
+ALTER TABLE agent_context_manifests
+    ALTER COLUMN memory_extraction_barrier_policy_version SET NOT NULL,
+    ALTER COLUMN memory_extraction_barrier_cutoff SET NOT NULL,
+    ALTER COLUMN memory_extraction_barrier_status SET NOT NULL,
+    ALTER COLUMN memory_extraction_barrier_waited_milliseconds SET NOT NULL,
+    ADD CONSTRAINT agent_context_manifests_memory_extraction_barrier_policy_check
+        CHECK (
+            memory_extraction_barrier_policy_version =
+                'memory-extraction-barrier-v1'
+        ),
+    ADD CONSTRAINT agent_context_manifests_memory_extraction_barrier_shape_check
+        CHECK (
+            memory_extraction_barrier_cutoff <= created_at
+            AND memory_extraction_barrier_waited_milliseconds BETWEEN 0 AND 5000
+            AND (
+                (
+                    memory_extraction_barrier_status = 'not_required'
+                    AND memory_extraction_barrier_waited_milliseconds = 0
+                    AND memory_extraction_barrier_covered_through IS NULL
+                )
+                OR (
+                    memory_extraction_barrier_status = 'ready'
+                    AND memory_extraction_barrier_waited_milliseconds = 0
+                    AND (
+                        memory_extraction_barrier_covered_through IS NULL
+                        OR memory_extraction_barrier_covered_through <=
+                            memory_extraction_barrier_cutoff
+                    )
+                )
+                OR (
+                    memory_extraction_barrier_status = 'waited'
+                    AND memory_extraction_barrier_waited_milliseconds > 0
+                    AND memory_extraction_barrier_covered_through IS NOT NULL
+                    AND memory_extraction_barrier_covered_through <=
+                        memory_extraction_barrier_cutoff
+                )
+            )
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -47,4 +47,5 @@ import "embed"
 //go:embed 000059_evaluation_general_scene_runtime.*.sql
 //go:embed 000060_resumes.*.sql
 //go:embed 000061_agent_practice_handoffs.*.sql
+//go:embed 000062_agent_memory_extraction_context_barrier.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

为新 Thread 第一条用户消息建立 Memory Extraction 一致性屏障。Context 在读取 Stable Profile 和相关 Memory 前，以当前 Run 创建时间为 cutoff 检查同一用户此前的 Extraction Job；未就绪时最多等待 5 秒并持续以 PostgreSQL 为权威重查。

失败、丢弃、超时或数据库不可用时，Run 记录稳定失败并停止在 Text Provider 之前。连续对话不执行屏障。

## 实现思路

- `agent/memory`：新增有界等待协调器、等待策略和调度 Port，区分 ready、waited、failed 与 discarded。
- `agent/context`：新增窄 Memory Extraction Barrier Port，只在 sequence=1 时调用，并校验可信 cutoff。
- `agent/run`：新增 `memory_consistency_unavailable` failure kind；不可用可重试，明确丢弃不可重试。
- `agent/context/postgres`：迁移 000062 持久化 policy、cutoff、status、waited milliseconds 与 covered-through；既有开发记录初始化为 not_required。
- `bootstrap`：完成 Memory 到 Context 的显式适配与 5 秒/50 毫秒等待策略装配。
- OpenAPI：公开最小 ContextManifest 一致性审计字段，不包含消息正文或 Memory 内容。

## 验证

- `TEST_DATABASE_URL=... go test -count=1 ./...`
- `go vet ./...`
- `npm run check`（OpenAPI、安全、WebSocket 与契约校验）
- PostgreSQL 并发完成、owner/cutoff 隔离、进程重建后数据库权威回归
- Provider 调用次数为 0、失败不创建 ContextManifest 回归
- migration 全量升级、回滚与重放测试
- `git diff --check`

Closes #352
