### PR TITLE
[MS3][后端] 建立 Practice Turn Prompt Policy 权威路由

### DIFF
--- a/server/internal/coaching/practice/postgres/context_integration_test.go
+++ b/server/internal/coaching/practice/postgres/context_integration_test.go
@@ -77,6 +77,97 @@ func TestContextRepositoryRequiresCurrentReadyPlanRevision(t *testing.T) {
 	}
 }
 
+func TestContextRepositoryFreezesTurnPolicyReferenceAcrossRestart(t *testing.T) {
+	repository, pool := newContextRepository(t)
+	owner := contextOwnerA()
+	seedContextOwner(t, pool, &owner)
+	plan := createContextPlan(
+		t,
+		pool,
+		preparation.NewPostgresPlanRepository(pool),
+		owner,
+		"plan-turn-policy",
+	)
+	originalReference := plan.SceneSelection.Scene.TurnPolicyRef
+	command := contextSessionCommand(
+		owner,
+		plan,
+		"session-turn-policy",
+		"snapshot-turn-policy",
+		"session-turn-policy-key",
+	)
+	created, replayed, err := repository.CreateSession(
+		context.Background(),
+		owner.Actor,
+		command,
+	)
+	if err != nil || replayed {
+		t.Fatalf("CreateSession = (%#v,%t,%v)", created, replayed, err)
+	}
+	if created.Snapshot.SceneSelection.Scene.TurnPolicyRef != originalReference {
+		t.Fatalf(
+			"created TurnPolicyRef = %q, want %q",
+			created.Snapshot.SceneSelection.Scene.TurnPolicyRef,
+			originalReference,
+		)
+	}
+
+	replacementReference := "generic.practice.turn.v1"
+	if originalReference == replacementReference {
+		replacementReference = "interview.project_deep_dive.turn.v1"
+	}
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO coaching_scene_versions (
+			scene_id, scene_version, scene_family, scene_model, name,
+			status, turn_policy_ref, session_policy_ref, prompt, roles,
+			practice_options, display_order
+		)
+		SELECT
+			scene_id, scene_version + 1, scene_family, scene_model, name,
+			status, $3, session_policy_ref, prompt, roles,
+			practice_options, display_order
+		FROM coaching_scene_versions
+		WHERE scene_id = $1 AND scene_version = $2
+	`,
+		plan.SceneSelection.Scene.ID,
+		plan.SceneSelection.Scene.Version,
+		replacementReference,
+	); err != nil {
+		t.Fatalf("publish later Scene version: %v", err)
+	}
+	catalog, err := scene.NewPostgresCatalog(pool)
+	if err != nil {
+		t.Fatalf("NewPostgresCatalog: %v", err)
+	}
+	latest, err := catalog.GetScene(
+		context.Background(),
+		plan.SceneSelection.Scene.ID,
+	)
+	if err != nil || latest.TurnPolicyRef != replacementReference {
+		t.Fatalf("latest Scene = (%#v,%v)", latest, err)
+	}
+
+	restarted, err := practicepostgres.New(pool)
+	if err != nil {
+		t.Fatalf("restart Practice repository: %v", err)
+	}
+	recovered, err := restarted.ResolveSessionByPlan(
+		context.Background(),
+		owner.Actor,
+		plan.ID,
+	)
+	if err != nil {
+		t.Fatalf("ResolveSessionByPlan: %v", err)
+	}
+	if recovered.Snapshot.SceneSelection.Scene.TurnPolicyRef != originalReference {
+		t.Fatalf(
+			"recovered TurnPolicyRef = %q, want frozen %q",
+			recovered.Snapshot.SceneSelection.Scene.TurnPolicyRef,
+			originalReference,
+		)
+	}
+}
+
 func TestContextRepositoryRejectsArchivedPlanAndConflictsByPlan(t *testing.T) {
 	repository, pool := newContextRepository(t)
 	owner := contextOwnerA()

--- a/server/internal/coaching/practice/voice/question.go
+++ b/server/internal/coaching/practice/voice/question.go
@@ -16,11 +16,21 @@ import (
 const voiceQuestionObjective = "targeted-english-practice"
 
 type questionAdapter struct {
-	repository PersistenceStore
+	repository questionRepository
 	generator  QuestionGenerator
 }
 
-type sessionQuestionLister interface {
+type questionRepository interface {
+	SaveQuestion(
+		context.Context,
+		Actor,
+		practice.Question,
+	) (practice.Question, error)
+	GetQuestion(
+		context.Context,
+		Actor,
+		string,
+	) (practice.Question, error)
 	ListSessionQuestions(
 		context.Context,
 		Actor,
@@ -39,33 +49,35 @@ func (adapter *questionAdapter) EnsureQuestion(
 	session Session,
 	sequence int,
 ) (practice.Question, error) {
+	policy, err := resolveTurnPolicy(session.TurnPolicyRef)
+	if err != nil {
+		return practice.Question{}, err
+	}
 	questionID := fmt.Sprintf(
 		"%s_%d",
 		stableID("voice_question", session.ID),
 		sequence,
 	)
 	persistenceActor := persistenceActor(actor)
-	existing, err := adapter.repository.GetQuestion(
+	existing, getErr := adapter.repository.GetQuestion(
 		ctx,
 		persistenceActor,
 		questionID,
 	)
-	if err == nil {
+	if getErr == nil {
 		return mapVoiceQuestion(existing), nil
 	}
-	if !errors.Is(err, ErrPersistenceNotFound) {
-		return practice.Question{}, mapPersistenceError(err)
+	if !errors.Is(getErr, ErrPersistenceNotFound) {
+		return practice.Question{}, mapPersistenceError(getErr)
 	}
 	var request QuestionGenerationRequest
+	var generationErr error
 	parentQuestionID := ""
 	followUpAllowed := false
-	if session.SceneFamily == "INTERVIEW" &&
-		session.MaxFollowUpsPerQuestion > 0 && sequence > 1 {
-		lister, ok := adapter.repository.(sessionQuestionLister)
-		if !ok {
-			return practice.Question{}, ErrInvalidContext
-		}
-		questions, listErr := lister.ListSessionQuestions(
+	interviewDecision := policy == turnPolicyInterview &&
+		session.MaxFollowUpsPerQuestion > 0 && sequence > 1
+	if interviewDecision {
+		questions, listErr := adapter.repository.ListSessionQuestions(
 			ctx,
 			persistenceActor,
 			session.ID,
@@ -77,26 +89,25 @@ func (adapter *questionAdapter) EnsureQuestion(
 			questions,
 			session.MaxFollowUpsPerQuestion,
 		)
-		request, err = interviewQuestionGenerationRequest(
+		request, generationErr = interviewQuestionGenerationRequest(
 			session,
 			sequence,
 			followUpAllowed,
 		)
-	} else {
-		request, err = questionGenerationRequest(session, sequence)
+	} else if policy != turnPolicyFrozenIELTS {
+		request, generationErr = questionGenerationRequest(session, sequence)
 	}
-	if err != nil {
-		return practice.Question{}, err
+	if generationErr != nil {
+		return practice.Question{}, generationErr
 	}
 	content := ""
 	questionType := "PRIMARY"
-	if isFrozenIELTSSpeakingModel(session.SceneModel) {
-		content, err = frozenIELTSFullMockQuestion(session, sequence)
+	if policy == turnPolicyFrozenIELTS {
+		content, generationErr = frozenIELTSQuestion(session, sequence)
 	} else {
-		content, err = adapter.generator.GenerateQuestion(ctx, request)
+		content, generationErr = adapter.generator.GenerateQuestion(ctx, request)
 		content = strings.TrimSpace(content)
-		if err == nil && session.SceneFamily == "INTERVIEW" &&
-			session.MaxFollowUpsPerQuestion > 0 && sequence > 1 {
+		if generationErr == nil && interviewDecision {
 			var decision generatedInterviewQuestion
 			if decodeErr := json.Unmarshal([]byte(content), &decision); decodeErr != nil {
 				return practice.Question{}, ErrInvalidContext
@@ -108,8 +119,8 @@ func (adapter *questionAdapter) EnsureQuestion(
 			}
 		}
 	}
-	if err != nil {
-		return practice.Question{}, err
+	if generationErr != nil {
+		return practice.Question{}, generationErr
 	}
 	if strings.TrimSpace(content) == "" {
 		return practice.Question{}, ErrInvalidContext
@@ -175,19 +186,7 @@ func followUpParent(
 	return "", false
 }
 
-func isFrozenIELTSSpeakingModel(model string) bool {
-	switch model {
-	case "IELTS_SPEAKING_PART_1",
-		"IELTS_SPEAKING_PART_2",
-		"IELTS_SPEAKING_PART_3",
-		"IELTS_SPEAKING_FULL_MOCK":
-		return true
-	default:
-		return false
-	}
-}
-
-func frozenIELTSFullMockQuestion(
+func frozenIELTSQuestion(
 	session Session,
 	sequence int,
 ) (string, error) {

--- a/server/internal/coaching/practice/voice/runtime.go
+++ b/server/internal/coaching/practice/voice/runtime.go
@@ -12,6 +12,7 @@ import (
 type RuntimeRepository interface {
 	sessionRepository
 	PersistenceStore
+	questionRepository
 	RecordingConfirmationStore
 	RetryTurnStore
 	practice.RetryTurnRepository

--- a/server/internal/coaching/practice/voice/session_adapter.go
+++ b/server/internal/coaching/practice/voice/session_adapter.go
@@ -164,6 +164,7 @@ func mapPracticeSession(
 		selection.Scene.Version < 1 ||
 		selection.Scene.Family != session.SceneFamily ||
 		selection.Scene.Model != session.SceneModel ||
+		!validVoiceTurnPolicy(selection.Scene.TurnPolicyRef) ||
 		len(selection.SelectedRoleIDs) == 0 {
 		return Session{}, ErrInvalidContext
 	}
@@ -174,6 +175,7 @@ func mapPracticeSession(
 		SceneVersion:            selection.Scene.Version,
 		SceneFamily:             string(snapshot.SceneFamily),
 		SceneModel:              string(snapshot.SceneModel),
+		TurnPolicyRef:           selection.Scene.TurnPolicyRef,
 		Prompt:                  cloneScenePrompt(selection.Scene.Prompt),
 		SessionVersion:          session.Version,
 		EffectiveTurns:          session.EffectiveTurns,

--- a/server/internal/coaching/practice/voice/session_adapter.go
+++ b/server/internal/coaching/practice/voice/session_adapter.go
@@ -86,6 +86,23 @@ func (adapter *sessionAdapter) Start(
 	if session.ID != sessionID || strings.TrimSpace(session.PlanID) == "" {
 		return Session{}, ErrInvalidContext
 	}
+	snapshot, err := adapter.repository.GetSessionSnapshot(
+		ctx,
+		practiceActor,
+		sessionID,
+	)
+	if err != nil {
+		return Session{}, mapPracticeError(err)
+	}
+	if _, err := mapPracticeSession(
+		practice.SessionBootstrap{
+			Session:  session,
+			Snapshot: snapshot,
+		},
+		actor.UserID,
+	); err != nil {
+		return Session{}, err
+	}
 	activated, err := adapter.repository.ActivateSession(
 		ctx,
 		practiceActor,

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -20,6 +20,7 @@ type Session struct {
 	SceneVersion             int
 	SceneFamily              string
 	SceneModel               string
+	TurnPolicyRef            string
 	Prompt                   scene.ScenePrompt
 	PreviousUserResponse     string
 	PreviousQuestion         string
@@ -238,6 +239,7 @@ func (application *SessionApplication) state(
 		session.PlanID == "" ||
 		session.SceneID == "" ||
 		session.SceneVersion < 1 ||
+		!validVoiceTurnPolicy(session.TurnPolicyRef) ||
 		!validVoiceScenePrompt(session) ||
 		session.SessionVersion < 1 ||
 		session.TurnLimit < 1 ||
@@ -403,6 +405,11 @@ func (application *SessionApplication) restoreTurnHistory(
 		return nil, ErrInvalidContext
 	}
 	return history, nil
+}
+
+func validVoiceTurnPolicy(reference string) bool {
+	_, err := resolveTurnPolicy(reference)
+	return err == nil
 }
 
 func validVoiceScenePrompt(session Session) bool {

--- a/server/internal/coaching/practice/voice/session_application_test.go
+++ b/server/internal/coaching/practice/voice/session_application_test.go
@@ -111,12 +111,13 @@ func (checkpointPortStub) ListTurnHistory(
 
 func sessionFixture() Session {
 	return Session{
-		ID:           "session-1",
-		PlanID:       "plan-1",
-		SceneID:      "scene-1",
-		SceneVersion: 1,
-		SceneFamily:  "INTERVIEW",
-		SceneModel:   "INTERVIEW_STANDARD",
+		ID:            "session-1",
+		PlanID:        "plan-1",
+		SceneID:       "scene-1",
+		SceneVersion:  1,
+		SceneFamily:   "INTERVIEW",
+		SceneModel:    "INTERVIEW_STANDARD",
+		TurnPolicyRef: interviewProjectDeepDiveTurnPolicy,
 		Prompt: scene.ScenePrompt{
 			PublicSceneBrief: "Interview practice",
 			PracticeGoal:     "Answer clearly",

--- a/server/internal/coaching/practice/voice/turn_policy.go
+++ b/server/internal/coaching/practice/voice/turn_policy.go
@@ -1,0 +1,40 @@
+package voice
+
+// turnPolicy identifies one Practice-owned question behavior. Scene versions
+// select a policy by reference; they do not define or execute that behavior.
+type turnPolicy uint8
+
+const (
+	turnPolicyGenerated turnPolicy = iota + 1
+	turnPolicyInterview
+	turnPolicyFrozenIELTS
+)
+
+const (
+	genericPracticeTurnPolicy             = "generic.practice.turn.v1"
+	dailyHotelCheckinIssueTurnPolicy      = "daily.hotel_checkin_issue.turn.v1"
+	workplaceProgressRiskUpdateTurnPolicy = "workplace.progress_risk_update.turn.v1"
+	interviewProjectDeepDiveTurnPolicy    = "interview.project_deep_dive.turn.v1"
+	ieltsSpeakingPart1TurnPolicy          = "ielts.speaking_part1.turn.v1"
+	ieltsSpeakingPart2TurnPolicy          = "ielts.speaking_part2.turn.v1"
+	ieltsSpeakingPart3TurnPolicy          = "ielts.speaking_part3.turn.v1"
+	ieltsSpeakingFullMockTurnPolicy       = "ielts.speaking_full_mock.turn.v1"
+)
+
+func resolveTurnPolicy(reference string) (turnPolicy, error) {
+	switch reference {
+	case genericPracticeTurnPolicy,
+		dailyHotelCheckinIssueTurnPolicy,
+		workplaceProgressRiskUpdateTurnPolicy:
+		return turnPolicyGenerated, nil
+	case interviewProjectDeepDiveTurnPolicy:
+		return turnPolicyInterview, nil
+	case ieltsSpeakingPart1TurnPolicy,
+		ieltsSpeakingPart2TurnPolicy,
+		ieltsSpeakingPart3TurnPolicy,
+		ieltsSpeakingFullMockTurnPolicy:
+		return turnPolicyFrozenIELTS, nil
+	default:
+		return 0, ErrInvalidContext
+	}
+}

--- a/server/internal/coaching/practice/voice/turn_policy_integration_test.go
+++ b/server/internal/coaching/practice/voice/turn_policy_integration_test.go
@@ -1,0 +1,119 @@
+package voice
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
+)
+
+func TestPostgresSceneCatalogReferencesRegisteredTurnPolicies(t *testing.T) {
+	pool := newTurnPolicyCatalogPool(t)
+	catalog, err := scene.NewPostgresCatalog(pool)
+	if err != nil {
+		t.Fatalf("NewPostgresCatalog: %v", err)
+	}
+	definitions, err := catalog.ListActiveScenes(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveScenes: %v", err)
+	}
+	if len(definitions) == 0 {
+		t.Fatal("active Scene catalog is empty")
+	}
+
+	checked := make(map[string]struct{})
+	for _, definition := range definitions {
+		reference := definition.TurnPolicyRef
+		if _, found := checked[reference]; found {
+			continue
+		}
+		checked[reference] = struct{}{}
+		if _, err := resolveTurnPolicy(reference); err != nil {
+			t.Errorf(
+				"Scene %q references unsupported turn policy %q: %v",
+				definition.ID,
+				reference,
+				err,
+			)
+		}
+	}
+}
+
+func newTurnPolicyCatalogPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	rawURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if rawURL == "" {
+		t.Skip("TEST_DATABASE_URL is required for PostgreSQL integration tests")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse TEST_DATABASE_URL: %v", err)
+	}
+	schema := fmt.Sprintf(
+		"voice_turn_policy_%d_%d",
+		os.Getpid(),
+		time.Now().UnixNano(),
+	)
+	admin, err := pgx.Connect(context.Background(), rawURL)
+	if err != nil {
+		t.Fatalf("connect PostgreSQL: %v", err)
+	}
+	if _, err := admin.Exec(
+		context.Background(),
+		"CREATE SCHEMA "+pgx.Identifier{schema}.Sanitize(),
+	); err != nil {
+		_ = admin.Close(context.Background())
+		t.Fatalf("create isolated schema: %v", err)
+	}
+	if err := admin.Close(context.Background()); err != nil {
+		t.Fatalf("close PostgreSQL admin connection: %v", err)
+	}
+	t.Cleanup(func() {
+		admin, err := pgx.Connect(context.Background(), rawURL)
+		if err != nil {
+			return
+		}
+		defer admin.Close(context.Background())
+		_, _ = admin.Exec(
+			context.Background(),
+			"DROP SCHEMA "+pgx.Identifier{schema}.Sanitize()+" CASCADE",
+		)
+	})
+
+	query := parsed.Query()
+	query.Set("search_path", schema)
+	parsed.RawQuery = query.Encode()
+	databaseURL := parsed.String()
+	runner, err := migration.Open(databaseURL)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	changed, err := runner.Up()
+	if err != nil {
+		_ = runner.Close()
+		t.Fatalf("apply migrations: %v", err)
+	}
+	if !changed {
+		_ = runner.Close()
+		t.Fatal("empty database reported no migration")
+	}
+	if err := runner.Close(); err != nil {
+		t.Fatalf("close migration runner: %v", err)
+	}
+
+	pool, err := pgxpool.New(context.Background(), databaseURL)
+	if err != nil {
+		t.Fatalf("open PostgreSQL pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/server/internal/coaching/practice/voice/turn_policy_test.go
+++ b/server/internal/coaching/practice/voice/turn_policy_test.go
@@ -152,18 +152,63 @@ func TestQuestionAdapterRejectsUnknownPolicyBeforeDependencies(t *testing.T) {
 	}
 }
 
+func TestSessionAdapterRejectsUnknownPolicyBeforeActivation(t *testing.T) {
+	bootstrap := turnPolicySessionBootstrap(
+		"unknown.practice.turn.v1",
+	)
+	repository := &turnPolicySessionRepository{bootstrap: bootstrap}
+
+	_, err := (&sessionAdapter{repository: repository}).Start(
+		context.Background(),
+		persistenceRequestActor(),
+		bootstrap.Session.ID,
+		"voice-start-key",
+	)
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("Start error = %v", err)
+	}
+	if repository.activateCalls != 0 {
+		t.Fatalf("ActivateSession calls = %d", repository.activateCalls)
+	}
+}
+
 func TestMapPracticeSessionFreezesTurnPolicyReference(t *testing.T) {
+	bootstrap := turnPolicySessionBootstrap(
+		interviewProjectDeepDiveTurnPolicy,
+	)
+
+	mapped, err := mapPracticeSession(bootstrap, "user-1")
+	if err != nil {
+		t.Fatalf("mapPracticeSession: %v", err)
+	}
+	if mapped.TurnPolicyRef != interviewProjectDeepDiveTurnPolicy {
+		t.Fatalf("TurnPolicyRef = %q", mapped.TurnPolicyRef)
+	}
+
+	bootstrap.Snapshot.SceneSelection.Scene.TurnPolicyRef =
+		"unknown.practice.turn.v1"
+	if _, err := mapPracticeSession(
+		bootstrap,
+		"user-1",
+	); !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("unknown TurnPolicyRef error = %v", err)
+	}
+}
+
+func turnPolicySessionBootstrap(
+	turnPolicyRef string,
+) practice.SessionBootstrap {
 	role := scene.RoleDefinition{ID: "role-1", SceneID: "scene-1"}
 	definition := scene.SceneDefinition{
 		ID:            "scene-1",
 		Family:        scene.SceneFamilyInterview,
 		Model:         scene.SceneModelProjectExperienceDeepDive,
 		Version:       1,
-		TurnPolicyRef: interviewProjectDeepDiveTurnPolicy,
+		TurnPolicyRef: turnPolicyRef,
 		Prompt:        sessionFixture().Prompt,
 		Roles:         []scene.RoleDefinition{role},
 	}
-	bootstrap := practice.SessionBootstrap{
+	return practice.SessionBootstrap{
 		Session: practice.Session{
 			ID:             "session-1",
 			PlanID:         "plan-1",
@@ -212,19 +257,46 @@ func TestMapPracticeSessionFreezesTurnPolicyReference(t *testing.T) {
 			},
 		},
 	}
+}
 
-	mapped, err := mapPracticeSession(bootstrap, "user-1")
-	if err != nil {
-		t.Fatalf("mapPracticeSession: %v", err)
-	}
-	if mapped.TurnPolicyRef != definition.TurnPolicyRef {
-		t.Fatalf("TurnPolicyRef = %q", mapped.TurnPolicyRef)
-	}
+type turnPolicySessionRepository struct {
+	bootstrap     practice.SessionBootstrap
+	activateCalls int
+}
 
-	bootstrap.Snapshot.SceneSelection.Scene.TurnPolicyRef = "unknown.practice.turn.v1"
-	if _, err := mapPracticeSession(bootstrap, "user-1"); !errors.Is(err, ErrInvalidContext) {
-		t.Fatalf("unknown TurnPolicyRef error = %v", err)
-	}
+func (repository *turnPolicySessionRepository) GetSession(
+	context.Context,
+	practice.Actor,
+	string,
+) (practice.Session, error) {
+	return repository.bootstrap.Session, nil
+}
+
+func (repository *turnPolicySessionRepository) GetSessionSnapshot(
+	context.Context,
+	practice.Actor,
+	string,
+) (practice.SessionSnapshot, error) {
+	return repository.bootstrap.Snapshot, nil
+}
+
+func (*turnPolicySessionRepository) ReplayVoiceStart(
+	context.Context,
+	practice.Actor,
+	practice.IdempotencyIntent,
+) (practice.SessionBootstrap, bool, error) {
+	return practice.SessionBootstrap{}, false, nil
+}
+
+func (repository *turnPolicySessionRepository) ActivateSession(
+	context.Context,
+	practice.Actor,
+	string,
+	string,
+	practice.IdempotencyIntent,
+) (practice.SessionBootstrap, error) {
+	repository.activateCalls++
+	return repository.bootstrap, nil
 }
 
 type turnPolicyQuestionRepository struct {

--- a/server/internal/coaching/practice/voice/turn_policy_test.go
+++ b/server/internal/coaching/practice/voice/turn_policy_test.go
@@ -1,0 +1,291 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestResolveTurnPolicyUsesExactRegisteredReference(t *testing.T) {
+	tests := map[string]turnPolicy{
+		genericPracticeTurnPolicy:             turnPolicyGenerated,
+		dailyHotelCheckinIssueTurnPolicy:      turnPolicyGenerated,
+		workplaceProgressRiskUpdateTurnPolicy: turnPolicyGenerated,
+		interviewProjectDeepDiveTurnPolicy:    turnPolicyInterview,
+		ieltsSpeakingPart1TurnPolicy:          turnPolicyFrozenIELTS,
+		ieltsSpeakingPart2TurnPolicy:          turnPolicyFrozenIELTS,
+		ieltsSpeakingPart3TurnPolicy:          turnPolicyFrozenIELTS,
+		ieltsSpeakingFullMockTurnPolicy:       turnPolicyFrozenIELTS,
+	}
+	for reference, want := range tests {
+		t.Run(reference, func(t *testing.T) {
+			got, err := resolveTurnPolicy(reference)
+			if err != nil || got != want {
+				t.Fatalf("resolveTurnPolicy(%q) = %d, %v", reference, got, err)
+			}
+		})
+	}
+	for _, reference := range []string{
+		"",
+		" interview.project_deep_dive.turn.v1",
+		"interview.test.turn.v1",
+		"generic.practice.turn.v2",
+	} {
+		t.Run("reject "+reference, func(t *testing.T) {
+			if _, err := resolveTurnPolicy(reference); !errors.Is(err, ErrInvalidContext) {
+				t.Fatalf("resolveTurnPolicy(%q) error = %v", reference, err)
+			}
+		})
+	}
+}
+
+func TestQuestionAdapterRoutesByTurnPolicyReference(t *testing.T) {
+	t.Run("generic policy ignores interview family", func(t *testing.T) {
+		repository := newTurnPolicyQuestionRepository()
+		generator := &turnPolicyQuestionGenerator{
+			response: "What outcome do you need?",
+		}
+		session := sessionFixture()
+		session.TurnPolicyRef = genericPracticeTurnPolicy
+		session.SceneFamily = "INTERVIEW"
+		session.SceneModel = "IELTS_SPEAKING_FULL_MOCK"
+		session.Prompt.TurnBlueprints = []string{"Open", "Clarify"}
+
+		question, err := (&questionAdapter{
+			repository: repository,
+			generator:  generator,
+		}).EnsureQuestion(context.Background(), persistenceRequestActor(), session, 2)
+		if err != nil {
+			t.Fatalf("EnsureQuestion: %v", err)
+		}
+		if question.Type != "PRIMARY" ||
+			question.Content != generator.response ||
+			generator.calls != 1 || repository.listCalls != 0 {
+			t.Fatalf("generic question = %#v, calls = %d/%d", question, generator.calls, repository.listCalls)
+		}
+	})
+
+	t.Run("interview policy ignores daily family", func(t *testing.T) {
+		repository := newTurnPolicyQuestionRepository()
+		repository.history = []practice.Question{{
+			ID:   "primary-1",
+			Type: "PRIMARY",
+		}}
+		generator := &turnPolicyQuestionGenerator{
+			response: `{"question_type":"FOLLOW_UP","content":"What changed after launch?"}`,
+		}
+		session := sessionFixture()
+		session.TurnPolicyRef = interviewProjectDeepDiveTurnPolicy
+		session.SceneFamily = "DAILY"
+		session.SceneModel = "DAILY_BASIC_DIALOGUE"
+		session.EffectiveTurns = 1
+		session.PreviousQuestion = "What did you deliver?"
+		session.PreviousUserResponse = "I led the launch."
+		session.Prompt.TurnBlueprints = []string{"Open", "Explore impact"}
+
+		question, err := (&questionAdapter{
+			repository: repository,
+			generator:  generator,
+		}).EnsureQuestion(context.Background(), persistenceRequestActor(), session, 2)
+		if err != nil {
+			t.Fatalf("EnsureQuestion: %v", err)
+		}
+		if question.Type != "FOLLOW_UP" ||
+			question.ParentQuestionID != "primary-1" ||
+			question.Content != "What changed after launch?" ||
+			generator.calls != 1 || repository.listCalls != 1 {
+			t.Fatalf("interview question = %#v, calls = %d/%d", question, generator.calls, repository.listCalls)
+		}
+	})
+
+	t.Run("IELTS policy does not call generator", func(t *testing.T) {
+		repository := newTurnPolicyQuestionRepository()
+		generator := &turnPolicyQuestionGenerator{response: "must not be used"}
+		session := sessionFixture()
+		session.TurnPolicyRef = ieltsSpeakingPart1TurnPolicy
+		session.SceneFamily = "DAILY"
+		session.SceneModel = "DAILY_BASIC_DIALOGUE"
+		session.Prompt.TurnBlueprints = []string{"Part 1: What do you do?"}
+
+		question, err := (&questionAdapter{
+			repository: repository,
+			generator:  generator,
+		}).EnsureQuestion(context.Background(), persistenceRequestActor(), session, 1)
+		if err != nil {
+			t.Fatalf("EnsureQuestion: %v", err)
+		}
+		if question.Content != "What do you do?" || generator.calls != 0 {
+			t.Fatalf("IELTS question = %#v, generator calls = %d", question, generator.calls)
+		}
+	})
+}
+
+func TestQuestionAdapterRejectsUnknownPolicyBeforeDependencies(t *testing.T) {
+	repository := newTurnPolicyQuestionRepository()
+	generator := &turnPolicyQuestionGenerator{response: "must not be used"}
+	session := sessionFixture()
+	session.TurnPolicyRef = "unknown.practice.turn.v1"
+
+	_, err := (&questionAdapter{
+		repository: repository,
+		generator:  generator,
+	}).EnsureQuestion(context.Background(), persistenceRequestActor(), session, 1)
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("EnsureQuestion error = %v", err)
+	}
+	if repository.getCalls != 0 ||
+		repository.saveCalls != 0 ||
+		repository.listCalls != 0 ||
+		generator.calls != 0 {
+		t.Fatalf(
+			"unknown policy reached dependencies: get=%d save=%d list=%d generator=%d",
+			repository.getCalls,
+			repository.saveCalls,
+			repository.listCalls,
+			generator.calls,
+		)
+	}
+}
+
+func TestMapPracticeSessionFreezesTurnPolicyReference(t *testing.T) {
+	role := scene.RoleDefinition{ID: "role-1", SceneID: "scene-1"}
+	definition := scene.SceneDefinition{
+		ID:            "scene-1",
+		Family:        scene.SceneFamilyInterview,
+		Model:         scene.SceneModelProjectExperienceDeepDive,
+		Version:       1,
+		TurnPolicyRef: interviewProjectDeepDiveTurnPolicy,
+		Prompt:        sessionFixture().Prompt,
+		Roles:         []scene.RoleDefinition{role},
+	}
+	bootstrap := practice.SessionBootstrap{
+		Session: practice.Session{
+			ID:             "session-1",
+			PlanID:         "plan-1",
+			PlanRevision:   1,
+			SceneFamily:    definition.Family,
+			SceneModel:     definition.Model,
+			SnapshotID:     "snapshot-1",
+			Status:         practice.SessionStarting,
+			Version:        1,
+			EffectiveTurns: 0,
+		},
+		Snapshot: practice.SessionSnapshot{
+			ID:           "snapshot-1",
+			SessionID:    "session-1",
+			PlanRevision: 1,
+			SceneFamily:  definition.Family,
+			SceneModel:   definition.Model,
+			SceneSelection: scene.SelectionSnapshot{
+				Scene:           definition,
+				SelectedRoleIDs: []string{role.ID},
+			},
+			Participants: []practice.Participant{
+				{
+					ID:               "facilitator-1",
+					SessionID:        "session-1",
+					Role:             "FACILITATOR",
+					SubjectRef:       practice.SubjectRef{Namespace: "speakup.role", SubjectID: role.ID},
+					RoleDefinitionID: role.ID,
+					RoleSnapshot:     &role,
+					Order:            1,
+				},
+				{
+					ID:        "learner-1",
+					SessionID: "session-1",
+					Role:      "LEARNER",
+					SubjectRef: practice.SubjectRef{
+						Namespace: "speakup.user",
+						SubjectID: "user-1",
+					},
+					Order: 2,
+				},
+			},
+			SessionPolicy: preparation.SessionPolicy{
+				MaxEffectiveTurns:       3,
+				MaxFollowUpsPerQuestion: 1,
+			},
+		},
+	}
+
+	mapped, err := mapPracticeSession(bootstrap, "user-1")
+	if err != nil {
+		t.Fatalf("mapPracticeSession: %v", err)
+	}
+	if mapped.TurnPolicyRef != definition.TurnPolicyRef {
+		t.Fatalf("TurnPolicyRef = %q", mapped.TurnPolicyRef)
+	}
+
+	bootstrap.Snapshot.SceneSelection.Scene.TurnPolicyRef = "unknown.practice.turn.v1"
+	if _, err := mapPracticeSession(bootstrap, "user-1"); !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("unknown TurnPolicyRef error = %v", err)
+	}
+}
+
+type turnPolicyQuestionRepository struct {
+	questions map[string]practice.Question
+	history   []practice.Question
+	getCalls  int
+	saveCalls int
+	listCalls int
+}
+
+func newTurnPolicyQuestionRepository() *turnPolicyQuestionRepository {
+	return &turnPolicyQuestionRepository{
+		questions: make(map[string]practice.Question),
+	}
+}
+
+func (repository *turnPolicyQuestionRepository) GetQuestion(
+	_ context.Context,
+	_ Actor,
+	questionID string,
+) (practice.Question, error) {
+	repository.getCalls++
+	question, found := repository.questions[questionID]
+	if !found {
+		return practice.Question{}, ErrPersistenceNotFound
+	}
+	return question, nil
+}
+
+func (repository *turnPolicyQuestionRepository) SaveQuestion(
+	_ context.Context,
+	_ Actor,
+	question practice.Question,
+) (practice.Question, error) {
+	repository.saveCalls++
+	repository.questions[question.ID] = question
+	return question, nil
+}
+
+func (repository *turnPolicyQuestionRepository) ListSessionQuestions(
+	_ context.Context,
+	_ Actor,
+	_ string,
+) ([]practice.Question, error) {
+	repository.listCalls++
+	return append([]practice.Question(nil), repository.history...), nil
+}
+
+type turnPolicyQuestionGenerator struct {
+	response string
+	calls    int
+}
+
+func (generator *turnPolicyQuestionGenerator) GenerateQuestion(
+	context.Context,
+	QuestionGenerationRequest,
+) (string, error) {
+	generator.calls++
+	return generator.response, nil
+}
+
+func persistenceRequestActor() requestcontext.Actor {
+	return requestcontext.Actor{UserID: "user-1", SessionID: "auth-1"}
+}


### PR DESCRIPTION
## 功能描述

Practice 现在根据冻结在 Scene Version 中的 turn_policy_ref 选择明确的轮次行为。未知引用会在 Session 状态变更、问题持久化或模型供应商调用前显式失败。

Closes #372

## 实现思路

- Practice Voice Session 从权威 Session Snapshot 读取并冻结 turn_policy_ref，在激活 Session 前完成策略与上下文校验。
- Practice 内显式注册当前 Policy 引用，并映射到通用生成、面试追问和 IELTS 固定题序三类行为。
- 问题生成只按 Policy 引用路由；Scene Family 与 Scene Model 继续作为结构化上下文，不再决定运行行为。
- 移除按 IELTS Scene Model 和 Interview Scene Family 隐式选择行为的路径。
- 将问题持久化依赖收窄为 Question 所需 Port。

## 代码地图

请求入口 → server/internal/coaching/practice/voice/http

应用编排 → server/internal/coaching/practice/voice/session_application.go

Policy 路由 → server/internal/coaching/practice/voice/turn_policy.go

问题构造 → server/internal/coaching/practice/voice/question.go

Session Snapshot 映射 → server/internal/coaching/practice/voice/session_adapter.go

数据库实现 → server/internal/coaching/practice/postgres

供应商实现 → server/internal/providers/qianwen

## 验证

- make check-go
- PostgreSQL：真实 Scene Catalog 的全部活跃 turn_policy_ref 均可解析
- PostgreSQL：CreateSession 后发布不同策略的新 Scene Version，重启 Repository 仍读取原冻结策略
- 单元测试：未知策略不会调用 ActivateSession、Question Repository 或模型生成器
- git diff --check

测试同时覆盖 Policy 优先于 Family/Model，以及 IELTS 固定题序不会调用生成模型。