### PR TITLE
refactor(preparation): 冻结用户简历版本材料

### DIFF
--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -113,7 +113,8 @@ paths:
         actor may be supplied only by an explicit Mock or Test adapter. When
         supplied, `job_target_id` and `job_target_confirmation_version` bind
         the profile to one exact server-confirmed JobTarget version; the pair
-        must be supplied together.
+        must be supplied together. `resume_id` and `resume_revision` likewise
+        bind one exact, parsed Resume Revision owned by the actor.
       operationId: createPreparationProfile
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
@@ -124,7 +125,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePreparationProfileRequest'
             example:
-              resume_ref: resume_demo_backend_v1
+              resume_id: 50000000-0000-4000-8000-000000000001
+              resume_revision: 1
               job_description_ref: jd_demo_backend_v1
               background_summary: |-
                 Backend engineer with three years of Go experience, responsible
@@ -139,7 +141,8 @@ paths:
               example:
                 preparation_profile_id: prep_demo_backend
                 user_id: user_demo
-                resume_ref: resume_demo_backend_v1
+                resume_id: 50000000-0000-4000-8000-000000000001
+                resume_revision: 1
                 job_description_ref: jd_demo_backend_v1
                 background_summary: |
                   Backend engineer with three years of Go experience, responsible
@@ -182,7 +185,17 @@ paths:
                 preparation_snapshot_id: psnap_demo_backend_v1
                 source_profile_id: prep_demo_backend
                 source_version: 1
-                resume_snapshot: Go backend engineer; API reliability project.
+                resume_snapshot:
+                  resume_id: 50000000-0000-4000-8000-000000000001
+                  revision: 1
+                  material:
+                    target_position: Backend Engineer
+                    professional_summary: Go backend engineer.
+                    work_experiences: []
+                    project_experiences: []
+                    education_experiences: []
+                    skills: [Go, PostgreSQL]
+                    awards: []
                 job_description_snapshot: Build reliable APIs and explain engineering trade-offs.
                 background_snapshot: |
                   Backend engineer with three years of Go experience, responsible
@@ -722,11 +735,13 @@ components:
       required:
         - background_summary
       properties:
-        resume_ref:
+        resume_id:
           type: string
-          minLength: 1
-          maxLength: 16384
-          pattern: '^[^\s\u0000](?:[^\u0000]*[^\s\u0000])?$'
+          format: uuid
+        resume_revision:
+          type: integer
+          format: int64
+          minimum: 1
         job_description_ref:
           type: string
           minLength: 1
@@ -742,6 +757,10 @@ components:
         job_target_confirmation_version:
           $ref: '#/components/schemas/Version'
       dependentRequired:
+        resume_id:
+          - resume_revision
+        resume_revision:
+          - resume_id
         job_target_id:
           - job_target_confirmation_version
         job_target_confirmation_version:
@@ -760,9 +779,13 @@ components:
           $ref: '#/components/schemas/ResourceId'
         user_id:
           $ref: '#/components/schemas/ResourceId'
-        resume_ref:
+        resume_id:
           type: string
-          minLength: 1
+          format: uuid
+        resume_revision:
+          type: integer
+          format: int64
+          minimum: 1
         job_description_ref:
           type: string
           minLength: 1
@@ -779,6 +802,10 @@ components:
           type: string
           format: date-time
       dependentRequired:
+        resume_id:
+          - resume_revision
+        resume_revision:
+          - resume_id
         job_target_id:
           - job_target_confirmation_version
         job_target_confirmation_version:
@@ -816,8 +843,7 @@ components:
         job_target_candidate_snapshot:
           $ref: '#/components/schemas/JobTargetCandidate'
         resume_snapshot:
-          type: string
-          minLength: 1
+          $ref: '#/components/schemas/PreparationResumeRevisionSnapshot'
         job_description_snapshot:
           type: string
           minLength: 1
@@ -844,6 +870,162 @@ components:
           - source_job_target_id
           - source_job_target_confirmation_version
           - job_target_input_snapshot
+    PreparationResumeRevisionSnapshot:
+      type: object
+      additionalProperties: false
+      required:
+        - resume_id
+        - revision
+        - material
+      properties:
+        resume_id:
+          type: string
+          format: uuid
+        revision:
+          type: integer
+          format: int64
+          minimum: 1
+        material:
+          $ref: '#/components/schemas/PreparationResumeMaterial'
+    PreparationResumeMaterial:
+      type: object
+      additionalProperties: false
+      required:
+        - target_position
+        - professional_summary
+        - work_experiences
+        - project_experiences
+        - education_experiences
+        - skills
+        - awards
+      properties:
+        target_position:
+          type: string
+          maxLength: 200
+        professional_summary:
+          type: string
+          maxLength: 4000
+        work_experiences:
+          type: array
+          maxItems: 30
+          items:
+            $ref: '#/components/schemas/PreparationResumeWorkExperience'
+        project_experiences:
+          type: array
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/PreparationResumeProjectExperience'
+        education_experiences:
+          type: array
+          maxItems: 20
+          items:
+            $ref: '#/components/schemas/PreparationResumeEducationExperience'
+        skills:
+          type: array
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+            maxLength: 100
+        awards:
+          type: array
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+            maxLength: 300
+    PreparationResumeWorkExperience:
+      type: object
+      additionalProperties: false
+      required:
+        - company
+        - position
+        - duties
+        - achievements
+      properties:
+        company:
+          type: string
+          maxLength: 200
+        position:
+          type: string
+          maxLength: 200
+        start_date:
+          type: string
+          maxLength: 32
+        end_date:
+          type: string
+          maxLength: 32
+        duties:
+          $ref: '#/components/schemas/PreparationResumeBulletItems'
+        achievements:
+          $ref: '#/components/schemas/PreparationResumeBulletItems'
+    PreparationResumeProjectExperience:
+      type: object
+      additionalProperties: false
+      required:
+        - project_name
+        - role
+        - description
+        - technologies
+        - duties
+        - achievements
+      properties:
+        project_name:
+          type: string
+          maxLength: 200
+        role:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+          maxLength: 4000
+        technologies:
+          type: array
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+            maxLength: 100
+        duties:
+          $ref: '#/components/schemas/PreparationResumeBulletItems'
+        achievements:
+          $ref: '#/components/schemas/PreparationResumeBulletItems'
+    PreparationResumeEducationExperience:
+      type: object
+      additionalProperties: false
+      required:
+        - school
+        - major
+        - degree
+      properties:
+        school:
+          type: string
+          maxLength: 200
+        major:
+          type: string
+          maxLength: 200
+        degree:
+          type: string
+          maxLength: 100
+        gpa:
+          type: string
+          maxLength: 64
+        start_date:
+          type: string
+          maxLength: 32
+        end_date:
+          type: string
+          maxLength: 32
+    PreparationResumeBulletItems:
+      type: array
+      maxItems: 100
+      items:
+        type: string
+        minLength: 1
+        maxLength: 1000
     JobTargetSource:
       type: string
       enum:
@@ -874,10 +1056,6 @@ components:
           minLength: 1
           maxLength: 256
         candidate_background:
-          type: string
-          minLength: 1
-          maxLength: 16384
-        resume_ref:
           type: string
           minLength: 1
           maxLength: 16384
@@ -929,10 +1107,6 @@ components:
           minLength: 1
           maxLength: 256
         candidate_background:
-          type: string
-          minLength: 1
-          maxLength: 16384
-        resume_ref:
           type: string
           minLength: 1
           maxLength: 16384

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -103,7 +103,9 @@ const preparationProfileRequest =
   schemas.CreatePreparationProfileRequest?.properties ?? {};
 const preparationTextPattern =
   preparationProfileRequest.background_summary?.pattern;
-assert.equal(preparationProfileRequest.resume_ref?.maxLength, 16 * 1024);
+assert.equal(preparationProfileRequest.resume_ref, undefined);
+assert.equal(preparationProfileRequest.resume_id?.format, 'uuid');
+assert.equal(preparationProfileRequest.resume_revision?.minimum, 1);
 assert.equal(
   preparationProfileRequest.job_description_ref?.maxLength,
   16 * 1024,
@@ -111,10 +113,6 @@ assert.equal(
 assert.equal(
   preparationProfileRequest.background_summary?.maxLength,
   64 * 1024,
-);
-assert.equal(
-  preparationProfileRequest.resume_ref?.pattern,
-  preparationTextPattern,
 );
 assert.equal(
   preparationProfileRequest.job_description_ref?.pattern,

--- a/server/internal/bootstrap/practice_context.go
+++ b/server/internal/bootstrap/practice_context.go
@@ -17,6 +17,9 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	resumeapp "github.com/1024XEngineer/XE3-ESL/server/internal/resume/app"
+	resumepersistence "github.com/1024XEngineer/XE3-ESL/server/internal/resume/persistence"
+	resumepreparationsource "github.com/1024XEngineer/XE3-ESL/server/internal/resume/preparationsource"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -216,9 +219,24 @@ func newIdentityAgentAndPracticeComposition(
 	}
 
 	preparationRepository := preparation.NewPostgresProfileRepository(database)
+	resumeRepository, err := resumepersistence.NewGormRepositoryFromPool(database)
+	if err != nil {
+		return nil, err
+	}
+	resumeRevisionQuery, err := resumeapp.NewRevisionQuery(resumeRepository)
+	if err != nil {
+		return nil, err
+	}
+	resumeRevisionReader, err := resumepreparationsource.New(
+		resumeRevisionQuery,
+	)
+	if err != nil {
+		return nil, err
+	}
 	preparationApplication, err := preparation.NewPersistenceService(
 		preparationRepository,
 		base.ids,
+		resumeRevisionReader,
 	)
 	if err != nil {
 		return nil, err

--- a/server/internal/bootstrap/practice_context_integration_test.go
+++ b/server/internal/bootstrap/practice_context_integration_test.go
@@ -147,7 +147,6 @@ func TestIdentityAgentPracticeCompositionPersistsAndResolvesContext(
 		http.MethodPost,
 		"/v1/preparation-profiles",
 		`{
-			"resume_ref":"resume-v1",
 			"job_description_ref":"job-v1",
 			"background_summary":"Go engineer preparing for a backend interview."
 		}`,

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -1190,10 +1190,9 @@ func createVoiceInterviewFormalContext(
 		http.MethodPost,
 		"/v1/preparation-profiles",
 		fmt.Sprintf(`{
-			"resume_ref":"resume-%s",
 			"job_description_ref":"job-%s",
 			"background_summary":"Interview follow-up context %s."
-		}`, key, key, key),
+		}`, key, key),
 		"voice-"+key+"-profile",
 		http.StatusCreated,
 	)
@@ -1273,10 +1272,9 @@ func createVoiceFormalContext(
 		http.MethodPost,
 		"/v1/preparation-profiles",
 		fmt.Sprintf(`{
-			"resume_ref":"resume-%s",
 			"job_description_ref":"job-%s",
 			"background_summary":"Voice integration context %s."
-		}`, key, key, key),
+		}`, key, key),
 		"voice-"+key+"-profile",
 		http.StatusCreated,
 	)

--- a/server/internal/coaching/evaluation/evidence/source.go
+++ b/server/internal/coaching/evaluation/evidence/source.go
@@ -1201,7 +1201,7 @@ func evidencePreparationContextFromSnapshot(
 		SourceVersion:                      source.SourceVersion,
 		SourceJobTargetID:                  source.SourceJobTargetID,
 		SourceJobTargetConfirmationVersion: source.SourceJobTargetConfirmationVersion,
-		ResumeSnapshotHash: evidenceTextHash(
+		ResumeSnapshotHash: evidenceResumeSnapshotHash(
 			source.ResumeSnapshot,
 		),
 		JobDescriptionSnapshotHash: evidenceTextHash(
@@ -1254,6 +1254,20 @@ func evidenceTextHash(value string) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func evidenceResumeSnapshotHash(
+	value *preparation.ResumeRevisionSnapshot,
+) string {
+	if value == nil {
+		return ""
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(encoded)
 	return hex.EncodeToString(sum[:])
 }
 

--- a/server/internal/coaching/evaluation/evidence/source_test.go
+++ b/server/internal/coaching/evaluation/evidence/source_test.go
@@ -606,7 +606,17 @@ func newEvidenceSourceFixture(t *testing.T) *evidenceSourceFixture {
 					CandidateBackground: "Needs a quiet room.",
 					PracticeFocus:       "Make a clear request.",
 				},
-				ResumeSnapshot:         "sensitive resume snapshot",
+				ResumeSnapshot: &preparation.ResumeRevisionSnapshot{
+					ResumeID: "50000000-0000-4000-8000-000000000001",
+					Revision: 1,
+					Material: preparation.ResumeMaterial{
+						WorkExperiences:      []preparation.ResumeWorkExperience{},
+						ProjectExperiences:   []preparation.ResumeProjectExperience{},
+						EducationExperiences: []preparation.ResumeEducationExperience{},
+						Skills:               []string{"Go"},
+						Awards:               []string{},
+					},
+				},
 				BackgroundSnapshot:     "sensitive background snapshot",
 				JobDescriptionSnapshot: "confirmed job description snapshot",
 			},

--- a/server/internal/coaching/preparation/job_target.go
+++ b/server/internal/coaching/preparation/job_target.go
@@ -56,7 +56,6 @@ const (
 	maxJobTargetCompanyBytes     = 512
 	maxJobTargetSeniorityBytes   = 256
 	maxJobTargetBackgroundBytes  = 16 * 1024
-	maxJobTargetResumeRefBytes   = 16 * 1024
 	maxJobTargetFocusBytes       = 8 * 1024
 
 	maxJobTargetCandidateItemCharacters = 2048
@@ -77,7 +76,6 @@ type JobTargetInput struct {
 	Company             string          `json:"company,omitempty"`
 	Seniority           string          `json:"seniority,omitempty"`
 	CandidateBackground string          `json:"candidate_background,omitempty"`
-	ResumeRef           string          `json:"resume_ref,omitempty"`
 	PracticeFocus       string          `json:"practice_focus,omitempty"`
 }
 
@@ -143,7 +141,6 @@ type CreateJobTargetRequest struct {
 	Company             string          `json:"company,omitempty"`
 	Seniority           string          `json:"seniority,omitempty"`
 	CandidateBackground string          `json:"candidate_background,omitempty"`
-	ResumeRef           string          `json:"resume_ref,omitempty"`
 	PracticeFocus       string          `json:"practice_focus,omitempty"`
 }
 
@@ -155,7 +152,6 @@ type UpdateJobTargetRequest struct {
 	Company              string          `json:"company,omitempty"`
 	Seniority            string          `json:"seniority,omitempty"`
 	CandidateBackground  string          `json:"candidate_background,omitempty"`
-	ResumeRef            string          `json:"resume_ref,omitempty"`
 	PracticeFocus        string          `json:"practice_focus,omitempty"`
 }
 
@@ -536,7 +532,6 @@ func (r CreateJobTargetRequest) input() JobTargetInput {
 		Company:             r.Company,
 		Seniority:           r.Seniority,
 		CandidateBackground: r.CandidateBackground,
-		ResumeRef:           r.ResumeRef,
 		PracticeFocus:       r.PracticeFocus,
 	}
 }
@@ -549,7 +544,6 @@ func (r UpdateJobTargetRequest) input() JobTargetInput {
 		Company:             r.Company,
 		Seniority:           r.Seniority,
 		CandidateBackground: r.CandidateBackground,
-		ResumeRef:           r.ResumeRef,
 		PracticeFocus:       r.PracticeFocus,
 	}
 }
@@ -617,11 +611,6 @@ func validJobTargetInput(input JobTargetInput) bool {
 		validJobTargetText(
 			input.CandidateBackground,
 			maxJobTargetBackgroundBytes,
-			false,
-		) &&
-		validJobTargetText(
-			input.ResumeRef,
-			maxJobTargetResumeRefBytes,
 			false,
 		) &&
 		validJobTargetText(

--- a/server/internal/coaching/preparation/job_target_parser.go
+++ b/server/internal/coaching/preparation/job_target_parser.go
@@ -83,9 +83,6 @@ func (p *AIJobTargetParser) ParseJobTarget(
 		)
 	}
 
-	// resume_ref is deliberately excluded. The parser has no resource reader,
-	// URL client, or file tool and receives only inline material needed for the
-	// current parse.
 	material, err := json.Marshal(struct {
 		Source              JobTargetSource `json:"source"`
 		JobTitle            string          `json:"job_title,omitempty"`

--- a/server/internal/coaching/preparation/job_target_parser_test.go
+++ b/server/internal/coaching/preparation/job_target_parser_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestAIJobTargetParserSeparatesUntrustedMaterialAndOmitsResumeRef(
+func TestAIJobTargetParserSeparatesUntrustedMaterial(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -41,7 +41,6 @@ func TestAIJobTargetParserSeparatesUntrustedMaterialAndOmitsResumeRef(
 			Company:        "Example",
 			CandidateBackground: "Engineer. " +
 				injection,
-			ResumeRef: "https://private.invalid/resume-secret",
 		},
 	)
 	if err != nil {
@@ -65,12 +64,6 @@ func TestAIJobTargetParserSeparatesUntrustedMaterialAndOmitsResumeRef(
 		injection,
 	) {
 		t.Fatal("untrusted material was not serialized as user data")
-	}
-	if strings.Contains(
-		generator.request.SystemInstruction+generator.request.UserMaterial,
-		"resume-secret",
-	) {
-		t.Fatal("resume reference was sent to the parser provider")
 	}
 	system := generator.request.SystemInstruction
 	for _, required := range []string{

--- a/server/internal/coaching/preparation/job_target_postgres.go
+++ b/server/internal/coaching/preparation/job_target_postgres.go
@@ -94,10 +94,9 @@ func (r *PostgresJobTargetRepository) Create(
 			company,
 			seniority,
 			candidate_background,
-			resume_ref,
 			practice_focus
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`,
 		actor.UserID,
 		command.TargetID,
@@ -107,7 +106,6 @@ func (r *PostgresJobTargetRepository) Create(
 		nullablePreparationText(input.Company),
 		nullablePreparationText(input.Seniority),
 		nullablePreparationText(input.CandidateBackground),
-		nullablePreparationText(input.ResumeRef),
 		nullablePreparationText(input.PracticeFocus),
 	)
 	if err != nil {
@@ -267,14 +265,13 @@ func (r *PostgresJobTargetRepository) Update(
 			    company = $6,
 			    seniority = $7,
 			    candidate_background = $8,
-			    resume_ref = $9,
-			    practice_focus = $10,
+			    practice_focus = $9,
 			    input_version = input_version + 1,
 			    stage = 'draft',
 			    updated_at = transaction_timestamp()
 			WHERE owner_user_id = $1
 			  AND target_id = $2
-			  AND input_version = $11
+			  AND input_version = $10
 		`,
 			actor.UserID,
 			command.TargetID,
@@ -284,7 +281,6 @@ func (r *PostgresJobTargetRepository) Update(
 			nullablePreparationText(nextInput.Company),
 			nullablePreparationText(nextInput.Seniority),
 			nullablePreparationText(nextInput.CandidateBackground),
-			nullablePreparationText(nextInput.ResumeRef),
 			nullablePreparationText(nextInput.PracticeFocus),
 			command.Request.ExpectedInputVersion,
 		)
@@ -1119,7 +1115,6 @@ const jobTargetSelect = `
 		coalesce(target.company, ''),
 		coalesce(target.seniority, ''),
 		coalesce(target.candidate_background, ''),
-		coalesce(target.resume_ref, ''),
 		coalesce(target.practice_focus, ''),
 		target.input_version,
 		target.stage,
@@ -1195,7 +1190,6 @@ func scanJobTarget(row jobTargetRowScanner) (JobTarget, error) {
 		&target.Input.Company,
 		&target.Input.Seniority,
 		&target.Input.CandidateBackground,
-		&target.Input.ResumeRef,
 		&target.Input.PracticeFocus,
 		&target.InputVersion,
 		&stage,
@@ -1375,7 +1369,6 @@ func lockJobTarget(
 			coalesce(target.company, ''),
 			coalesce(target.seniority, ''),
 			coalesce(target.candidate_background, ''),
-			coalesce(target.resume_ref, ''),
 			coalesce(target.practice_focus, ''),
 			target.input_version,
 			target.stage,
@@ -1394,7 +1387,6 @@ func lockJobTarget(
 		&target.Input.Company,
 		&target.Input.Seniority,
 		&target.Input.CandidateBackground,
-		&target.Input.ResumeRef,
 		&target.Input.PracticeFocus,
 		&target.InputVersion,
 		&stage,

--- a/server/internal/coaching/preparation/module.go
+++ b/server/internal/coaching/preparation/module.go
@@ -9,7 +9,8 @@ func (Module) Name() string { return "preparation" }
 
 // CreateProfileRequest is the application input for one preparation profile.
 type CreateProfileRequest struct {
-	ResumeRef                    string `json:"resume_ref,omitempty"`
+	ResumeID                     string `json:"resume_id,omitempty"`
+	ResumeRevision               int64  `json:"resume_revision,omitempty"`
 	JobDescriptionRef            string `json:"job_description_ref,omitempty"`
 	BackgroundSummary            string `json:"background_summary"`
 	JobTargetID                  string `json:"job_target_id,omitempty"`

--- a/server/internal/coaching/preparation/plan_service_test.go
+++ b/server/internal/coaching/preparation/plan_service_test.go
@@ -817,10 +817,20 @@ func planActor() requestcontext.Actor {
 
 func planSnapshotFixture() Snapshot {
 	return Snapshot{
-		ID:                 "snapshot-1",
-		SourceProfileID:    "profile-1",
-		SourceVersion:      2,
-		ResumeSnapshot:     "resume",
+		ID:              "snapshot-1",
+		SourceProfileID: "profile-1",
+		SourceVersion:   2,
+		ResumeSnapshot: &ResumeRevisionSnapshot{
+			ResumeID: "50000000-0000-4000-8000-000000000001",
+			Revision: 1,
+			Material: ResumeMaterial{
+				WorkExperiences:      []ResumeWorkExperience{},
+				ProjectExperiences:   []ResumeProjectExperience{},
+				EducationExperiences: []ResumeEducationExperience{},
+				Skills:               []string{"Go"},
+				Awards:               []string{},
+			},
+		},
 		BackgroundSnapshot: "backend engineer",
 		CreatedAt:          time.Date(2026, 8, 4, 8, 0, 0, 0, time.UTC),
 	}

--- a/server/internal/coaching/preparation/profile.go
+++ b/server/internal/coaching/preparation/profile.go
@@ -30,7 +30,8 @@ const (
 type Profile struct {
 	ID                           string    `json:"preparation_profile_id"`
 	UserID                       string    `json:"user_id"`
-	ResumeRef                    string    `json:"resume_ref,omitempty"`
+	ResumeID                     string    `json:"resume_id,omitempty"`
+	ResumeRevision               int64     `json:"resume_revision,omitempty"`
 	JobDescriptionRef            string    `json:"job_description_ref,omitempty"`
 	BackgroundSummary            string    `json:"background_summary"`
 	JobTargetID                  string    `json:"job_target_id,omitempty"`
@@ -43,17 +44,17 @@ type Profile struct {
 // create request. Optional source references are copied as frozen values; no
 // later Profile or external reference change can reinterpret this record.
 type Snapshot struct {
-	ID                                 string              `json:"preparation_snapshot_id"`
-	SourceProfileID                    string              `json:"source_profile_id"`
-	SourceVersion                      int                 `json:"source_version"`
-	SourceJobTargetID                  string              `json:"source_job_target_id,omitempty"`
-	SourceJobTargetConfirmationVersion int                 `json:"source_job_target_confirmation_version,omitempty"`
-	JobTargetInputSnapshot             *JobTargetInput     `json:"job_target_input_snapshot,omitempty"`
-	JobTargetCandidateSnapshot         *JobTargetCandidate `json:"job_target_candidate_snapshot,omitempty"`
-	ResumeSnapshot                     string              `json:"resume_snapshot,omitempty"`
-	JobDescriptionSnapshot             string              `json:"job_description_snapshot,omitempty"`
-	BackgroundSnapshot                 string              `json:"background_snapshot"`
-	CreatedAt                          time.Time           `json:"created_at"`
+	ID                                 string                  `json:"preparation_snapshot_id"`
+	SourceProfileID                    string                  `json:"source_profile_id"`
+	SourceVersion                      int                     `json:"source_version"`
+	SourceJobTargetID                  string                  `json:"source_job_target_id,omitempty"`
+	SourceJobTargetConfirmationVersion int                     `json:"source_job_target_confirmation_version,omitempty"`
+	JobTargetInputSnapshot             *JobTargetInput         `json:"job_target_input_snapshot,omitempty"`
+	JobTargetCandidateSnapshot         *JobTargetCandidate     `json:"job_target_candidate_snapshot,omitempty"`
+	ResumeSnapshot                     *ResumeRevisionSnapshot `json:"resume_snapshot,omitempty"`
+	JobDescriptionSnapshot             string                  `json:"job_description_snapshot,omitempty"`
+	BackgroundSnapshot                 string                  `json:"background_snapshot"`
+	CreatedAt                          time.Time               `json:"created_at"`
 }
 
 // IdempotencyIntent is derived from trusted transport routing plus a canonical
@@ -67,9 +68,10 @@ type IdempotencyIntent struct {
 }
 
 type CreateProfileCommand struct {
-	ProfileID string
-	Request   CreateProfileRequest
-	Intent    IdempotencyIntent
+	ProfileID      string
+	Request        CreateProfileRequest
+	ResumeRevision *ResumeRevisionSnapshot
+	Intent         IdempotencyIntent
 }
 
 type CreateSnapshotCommand struct {
@@ -145,16 +147,22 @@ type ResourceIDGenerator interface {
 type PersistenceService struct {
 	repository ProfileRepository
 	ids        ResourceIDGenerator
+	resumes    ResumeRevisionReader
 }
 
 func NewPersistenceService(
 	repository ProfileRepository,
 	ids ResourceIDGenerator,
+	resumes ResumeRevisionReader,
 ) (*PersistenceService, error) {
-	if repository == nil || ids == nil {
+	if repository == nil || ids == nil || resumes == nil {
 		return nil, errors.New("preparation: persistence dependency is required")
 	}
-	return &PersistenceService{repository: repository, ids: ids}, nil
+	return &PersistenceService{
+		repository: repository,
+		ids:        ids,
+		resumes:    resumes,
+	}, nil
 }
 
 func (s *PersistenceService) CreateProfile(
@@ -186,14 +194,34 @@ func (s *PersistenceService) CreateProfile(
 	if found {
 		return replayedProfile, true, nil
 	}
+	var resumeRevision *ResumeRevisionSnapshot
+	if request.ResumeID != "" {
+		resolved, err := s.resumes.ReadOwnedRevision(
+			ctx,
+			actor,
+			request.ResumeID,
+			request.ResumeRevision,
+		)
+		if err != nil {
+			return Profile{}, false, err
+		}
+		if !validResumeRevisionSnapshot(resolved) ||
+			resolved.ResumeID != request.ResumeID ||
+			resolved.Revision != request.ResumeRevision {
+			return Profile{}, false, ErrProfileConflict
+		}
+		resolved = cloneResumeRevisionSnapshot(resolved)
+		resumeRevision = &resolved
+	}
 	profileID, err := s.ids.NewID()
 	if err != nil {
 		return Profile{}, false, ErrProfileRepository
 	}
 	return s.repository.CreateProfile(ctx, actor, CreateProfileCommand{
-		ProfileID: profileID,
-		Request:   request,
-		Intent:    intent,
+		ProfileID:      profileID,
+		Request:        request,
+		ResumeRevision: resumeRevision,
+		Intent:         intent,
 	})
 }
 
@@ -296,14 +324,13 @@ func newPreparationIntent(
 }
 
 func validCreateProfileRequest(request CreateProfileRequest) bool {
+	resumePairValid := (request.ResumeID == "" && request.ResumeRevision == 0) ||
+		(validResourceIdentifier(request.ResumeID) && request.ResumeRevision > 0)
 	targetPairValid := (request.JobTargetID == "" &&
 		request.JobTargetConfirmationVersion == 0) ||
 		(validResourceIdentifier(request.JobTargetID) &&
 			request.JobTargetConfirmationVersion > 0)
-	return targetPairValid && validOptionalPreparationText(
-		request.ResumeRef,
-		maxPreparationReferenceLength,
-	) &&
+	return resumePairValid && targetPairValid &&
 		validOptionalPreparationText(
 			request.JobDescriptionRef,
 			maxPreparationReferenceLength,

--- a/server/internal/coaching/preparation/profile_http_test.go
+++ b/server/internal/coaching/preparation/profile_http_test.go
@@ -62,7 +62,8 @@ func TestProfileHTTPCreateProfileUsesTrustedActor(t *testing.T) {
 	want := Profile{
 		ID:                "profile-1",
 		UserID:            actor.UserID,
-		ResumeRef:         "resume-1",
+		ResumeID:          "50000000-0000-4000-8000-000000000001",
+		ResumeRevision:    3,
 		JobDescriptionRef: "job-1",
 		BackgroundSummary: "Confirmed background.",
 		Version:           1,
@@ -84,7 +85,8 @@ func TestProfileHTTPCreateProfileUsesTrustedActor(t *testing.T) {
 				t.Fatalf("idempotency key = %q", key)
 			}
 			if request != (CreateProfileRequest{
-				ResumeRef:         "resume-1",
+				ResumeID:          "50000000-0000-4000-8000-000000000001",
+				ResumeRevision:    3,
 				JobDescriptionRef: "job-1",
 				BackgroundSummary: "Confirmed background.",
 			}) {
@@ -98,7 +100,8 @@ func TestProfileHTTPCreateProfileUsesTrustedActor(t *testing.T) {
 		router,
 		http.MethodPost,
 		"/v1/preparation-profiles",
-		`{"resume_ref":"resume-1","job_description_ref":"job-1",`+
+		`{"resume_id":"50000000-0000-4000-8000-000000000001",`+
+			`"resume_revision":3,"job_description_ref":"job-1",`+
 			`"background_summary":"Confirmed background."}`,
 		"application/json; charset=utf-8",
 		"profile-key-0001",
@@ -185,10 +188,20 @@ func TestProfileHTTPCreateSnapshotReplayKeepsCreatedSemantics(t *testing.T) {
 	actor := profileHTTPActor()
 	createdAt := time.Date(2026, 7, 26, 11, 13, 14, 0, time.UTC)
 	want := Snapshot{
-		ID:                     "snapshot-1",
-		SourceProfileID:        "profile-1",
-		SourceVersion:          3,
-		ResumeSnapshot:         "Frozen resume.",
+		ID:              "snapshot-1",
+		SourceProfileID: "profile-1",
+		SourceVersion:   3,
+		ResumeSnapshot: &ResumeRevisionSnapshot{
+			ResumeID: "50000000-0000-4000-8000-000000000001",
+			Revision: 3,
+			Material: ResumeMaterial{
+				WorkExperiences:      []ResumeWorkExperience{},
+				ProjectExperiences:   []ResumeProjectExperience{},
+				EducationExperiences: []ResumeEducationExperience{},
+				Skills:               []string{"Go"},
+				Awards:               []string{},
+			},
+		},
 		JobDescriptionSnapshot: "Frozen job.",
 		BackgroundSnapshot:     "Frozen background.",
 		CreatedAt:              createdAt,

--- a/server/internal/coaching/preparation/profile_postgres.go
+++ b/server/internal/coaching/preparation/profile_postgres.go
@@ -73,6 +73,7 @@ func (r *PostgresProfileRepository) CreateProfile(
 		!validPreparationActor(actor) ||
 		!validResourceIdentifier(command.ProfileID) ||
 		!validCreateProfileRequest(command.Request) ||
+		!validCreateProfileResume(command) ||
 		!validPreparationIntent(
 			command.Intent,
 			"/v1/preparation-profiles",
@@ -133,29 +134,38 @@ func (r *PostgresProfileRepository) CreateProfile(
 	profile := Profile{
 		ID:                           command.ProfileID,
 		UserID:                       actor.UserID,
-		ResumeRef:                    command.Request.ResumeRef,
+		ResumeID:                     command.Request.ResumeID,
+		ResumeRevision:               command.Request.ResumeRevision,
 		JobDescriptionRef:            command.Request.JobDescriptionRef,
 		BackgroundSummary:            command.Request.BackgroundSummary,
 		JobTargetID:                  command.Request.JobTargetID,
 		JobTargetConfirmationVersion: command.Request.JobTargetConfirmationVersion,
 		Version:                      1,
 	}
+	resumeMaterial, err := encodeResumeMaterial(command.ResumeRevision)
+	if err != nil {
+		return Profile{}, false, err
+	}
 	err = tx.QueryRow(ctx, `
 		INSERT INTO preparation_profiles (
 			owner_user_id,
 			profile_id,
-				resume_ref,
+				resume_id,
+				resume_revision,
+				resume_material,
 				job_description_ref,
 				background_summary,
 				job_target_id,
 				job_target_confirmation_version
 			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		RETURNING version, updated_at
 	`,
 		actor.UserID,
 		profile.ID,
-		nullablePreparationText(profile.ResumeRef),
+		nullablePreparationText(profile.ResumeID),
+		nullablePreparationRevision(profile.ResumeRevision),
+		resumeMaterial,
 		nullablePreparationText(profile.JobDescriptionRef),
 		profile.BackgroundSummary,
 		nullablePreparationText(profile.JobTargetID),
@@ -293,10 +303,14 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 		SourceVersion:   command.Request.SourceVersion,
 	}
 	var sourceVersion int
-	var targetInput, targetCandidate []byte
+	var resumeID string
+	var resumeRevision int64
+	var resumeMaterial, targetInput, targetCandidate []byte
 	err = tx.QueryRow(ctx, `
 		SELECT
-			COALESCE(profile.resume_ref, ''),
+			COALESCE(profile.resume_id::text, ''),
+			COALESCE(profile.resume_revision, 0),
+			profile.resume_material,
 			COALESCE(profile.job_description_ref, ''),
 			profile.background_summary,
 			profile.version,
@@ -314,7 +328,9 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 		  AND profile.profile_id = $2
 		FOR SHARE OF profile
 	`, actor.UserID, command.ProfileID).Scan(
-		&snapshot.ResumeSnapshot,
+		&resumeID,
+		&resumeRevision,
+		&resumeMaterial,
 		&snapshot.JobDescriptionSnapshot,
 		&snapshot.BackgroundSnapshot,
 		&sourceVersion,
@@ -334,6 +350,26 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 	if sourceVersion != command.Request.SourceVersion {
 		return Snapshot{}, false, ErrProfileConflict
 	}
+	if resumeID != "" {
+		var material ResumeMaterial
+		if len(resumeMaterial) == 0 ||
+			json.Unmarshal(resumeMaterial, &material) != nil {
+			return Snapshot{}, false, profileDatabaseFailure(
+				"decode profile Resume material",
+			)
+		}
+		resumeSnapshot := ResumeRevisionSnapshot{
+			ResumeID: resumeID,
+			Revision: resumeRevision,
+			Material: material,
+		}
+		if !validResumeRevisionSnapshot(resumeSnapshot) {
+			return Snapshot{}, false, profileDatabaseFailure(
+				"validate profile Resume material",
+			)
+		}
+		snapshot.ResumeSnapshot = &resumeSnapshot
+	}
 	if snapshot.SourceJobTargetID != "" {
 		if len(targetInput) == 0 || len(targetCandidate) == 0 {
 			return Snapshot{}, false, ErrProfileConflict
@@ -352,6 +388,11 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 		snapshot.JobTargetCandidateSnapshot = &candidate
 	}
 
+	resumeSnapshotID, resumeSnapshotRevision, encodedResumeMaterial, err :=
+		encodeSnapshotResume(snapshot.ResumeSnapshot)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
 	encodedTargetInput, encodedTargetCandidate, err :=
 		encodeSnapshotJobTarget(snapshot)
 	if err != nil {
@@ -363,7 +404,9 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 			snapshot_id,
 			source_profile_id,
 			source_version,
-				resume_snapshot,
+				resume_id,
+				resume_revision,
+				resume_material,
 				job_description_snapshot,
 				background_snapshot,
 				source_job_target_id,
@@ -372,7 +415,8 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 				job_target_candidate_snapshot
 			)
 			VALUES (
-				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+				$12, $13
 			)
 		RETURNING created_at
 	`,
@@ -380,7 +424,9 @@ func (r *PostgresProfileRepository) CreateSnapshot(
 		snapshot.ID,
 		snapshot.SourceProfileID,
 		snapshot.SourceVersion,
-		nullablePreparationText(snapshot.ResumeSnapshot),
+		resumeSnapshotID,
+		resumeSnapshotRevision,
+		encodedResumeMaterial,
 		nullablePreparationText(snapshot.JobDescriptionSnapshot),
 		snapshot.BackgroundSnapshot,
 		nullablePreparationText(snapshot.SourceJobTargetID),
@@ -429,7 +475,8 @@ func (r *PostgresProfileRepository) ReadProfile(
 		SELECT
 			profile.profile_id,
 			profile.owner_user_id::text,
-			COALESCE(profile.resume_ref, ''),
+			COALESCE(profile.resume_id::text, ''),
+			COALESCE(profile.resume_revision, 0),
 				COALESCE(profile.job_description_ref, ''),
 				profile.background_summary,
 				COALESCE(profile.job_target_id, ''),
@@ -471,7 +518,9 @@ func (r *PostgresProfileRepository) ReadSnapshot(
 			snapshot.snapshot_id,
 			snapshot.source_profile_id,
 			snapshot.source_version,
-			COALESCE(snapshot.resume_snapshot, ''),
+			COALESCE(snapshot.resume_id::text, ''),
+			COALESCE(snapshot.resume_revision, 0),
+			snapshot.resume_material,
 				COALESCE(snapshot.job_description_snapshot, ''),
 				snapshot.background_snapshot,
 				COALESCE(snapshot.source_job_target_id, ''),
@@ -635,7 +684,8 @@ func scanPreparationProfile(row preparationRowScanner) (Profile, error) {
 	err := row.Scan(
 		&profile.ID,
 		&profile.UserID,
-		&profile.ResumeRef,
+		&profile.ResumeID,
+		&profile.ResumeRevision,
 		&profile.JobDescriptionRef,
 		&profile.BackgroundSummary,
 		&profile.JobTargetID,
@@ -649,12 +699,16 @@ func scanPreparationProfile(row preparationRowScanner) (Profile, error) {
 
 func scanPreparationSnapshot(row preparationRowScanner) (Snapshot, error) {
 	var snapshot Snapshot
-	var targetInput, targetCandidate []byte
+	var resumeID string
+	var resumeRevision int64
+	var resumeMaterial, targetInput, targetCandidate []byte
 	err := row.Scan(
 		&snapshot.ID,
 		&snapshot.SourceProfileID,
 		&snapshot.SourceVersion,
-		&snapshot.ResumeSnapshot,
+		&resumeID,
+		&resumeRevision,
+		&resumeMaterial,
 		&snapshot.JobDescriptionSnapshot,
 		&snapshot.BackgroundSnapshot,
 		&snapshot.SourceJobTargetID,
@@ -663,6 +717,21 @@ func scanPreparationSnapshot(row preparationRowScanner) (Snapshot, error) {
 		&targetCandidate,
 		&snapshot.CreatedAt,
 	)
+	if err == nil && resumeID != "" {
+		var material ResumeMaterial
+		if len(resumeMaterial) == 0 ||
+			json.Unmarshal(resumeMaterial, &material) != nil {
+			return Snapshot{}, ErrProfileRepository
+		}
+		snapshot.ResumeSnapshot = &ResumeRevisionSnapshot{
+			ResumeID: resumeID,
+			Revision: resumeRevision,
+			Material: material,
+		}
+		if !validResumeRevisionSnapshot(*snapshot.ResumeSnapshot) {
+			return Snapshot{}, ErrProfileRepository
+		}
+	}
 	if err == nil && snapshot.SourceJobTargetID != "" {
 		var input JobTargetInput
 		var candidate JobTargetCandidate
@@ -699,6 +768,7 @@ func replayProfile(
 		profile.ID != resourceID ||
 		profile.UserID != userID ||
 		!validResourceIdentifier(profile.ID) ||
+		((profile.ResumeID == "") != (profile.ResumeRevision == 0)) ||
 		((profile.JobTargetID == "") !=
 			(profile.JobTargetConfirmationVersion == 0)) {
 		return Profile{}, false, profileDatabaseFailure(
@@ -731,6 +801,8 @@ func replaySnapshot(
 		!validResourceIdentifier(snapshot.ID) ||
 		!validResourceIdentifier(snapshot.SourceProfileID) ||
 		snapshot.SourceVersion < 1 ||
+		(snapshot.ResumeSnapshot != nil &&
+			!validResumeRevisionSnapshot(*snapshot.ResumeSnapshot)) ||
 		((snapshot.SourceJobTargetID == "") !=
 			(snapshot.SourceJobTargetConfirmationVersion == 0)) {
 		return Snapshot{}, false, profileDatabaseFailure(
@@ -964,6 +1036,54 @@ func nullablePreparationVersion(value int) any {
 		return nil
 	}
 	return value
+}
+
+func nullablePreparationRevision(value int64) any {
+	if value == 0 {
+		return nil
+	}
+	return value
+}
+
+func validCreateProfileResume(command CreateProfileCommand) bool {
+	if command.Request.ResumeID == "" {
+		return command.Request.ResumeRevision == 0 &&
+			command.ResumeRevision == nil
+	}
+	return command.ResumeRevision != nil &&
+		command.ResumeRevision.ResumeID == command.Request.ResumeID &&
+		command.ResumeRevision.Revision == command.Request.ResumeRevision &&
+		validResumeRevisionSnapshot(*command.ResumeRevision)
+}
+
+func encodeResumeMaterial(snapshot *ResumeRevisionSnapshot) (any, error) {
+	if snapshot == nil {
+		return nil, nil
+	}
+	if !validResumeRevisionSnapshot(*snapshot) {
+		return nil, ErrProfileInvalid
+	}
+	encoded, err := json.Marshal(snapshot.Material)
+	if err != nil {
+		return nil, ErrProfileRepository
+	}
+	return encoded, nil
+}
+
+func encodeSnapshotResume(
+	snapshot *ResumeRevisionSnapshot,
+) (any, any, any, error) {
+	if snapshot == nil {
+		return nil, nil, nil, nil
+	}
+	if !validResumeRevisionSnapshot(*snapshot) {
+		return nil, nil, nil, ErrProfileConflict
+	}
+	encoded, err := json.Marshal(snapshot.Material)
+	if err != nil {
+		return nil, nil, nil, ErrProfileRepository
+	}
+	return snapshot.ResumeID, snapshot.Revision, encoded, nil
 }
 
 func encodeSnapshotJobTarget(snapshot Snapshot) (any, any, error) {

--- a/server/internal/coaching/preparation/profile_postgres_integration_test.go
+++ b/server/internal/coaching/preparation/profile_postgres_integration_test.go
@@ -170,15 +170,22 @@ func TestPostgresProfileRepositoryPersistsReplaysAndScopesResources(
 	ctx := context.Background()
 	actorA := preparationActor(preparationUserA, preparationSessionA)
 	actorB := preparationActor(preparationUserB, preparationSessionB)
+	resumeID := "50000000-0000-4000-8000-000000000111"
+	seedPreparationResumeRevision(t, pool, actorA.UserID, resumeID)
 
 	profileRequest := preparation.CreateProfileRequest{
-		ResumeRef:         "oss://resume/object-v1",
+		ResumeID:          resumeID,
+		ResumeRevision:    1,
 		JobDescriptionRef: "oss://job/object-v1",
 		BackgroundSummary: "Backend engineer with distributed systems work.",
 	}
 	profileCommand := preparation.CreateProfileCommand{
 		ProfileID: "profile-original",
 		Request:   profileRequest,
+		ResumeRevision: preparationResumeSnapshot(
+			profileRequest.ResumeID,
+			profileRequest.ResumeRevision,
+		),
 		Intent: profileIntent(
 			"profile-create-key",
 			profileRequest,
@@ -243,6 +250,12 @@ func TestPostgresProfileRepositoryPersistsReplaysAndScopesResources(
 	); !errors.Is(err, preparation.ErrProfileNotFound) {
 		t.Fatalf("cross-user ReadProfile error = %v, want not found", err)
 	}
+	if _, err := pool.Exec(ctx, `
+		DELETE FROM resumes
+		WHERE owner_user_id = $1 AND resume_id = $2
+	`, actorA.UserID, resumeID); err != nil {
+		t.Fatalf("delete source Resume after Profile creation: %v", err)
+	}
 
 	snapshotRequest := preparation.CreateSnapshotRequest{SourceVersion: 1}
 	snapshotCommand := preparation.CreateSnapshotCommand{
@@ -263,7 +276,10 @@ func TestPostgresProfileRepositoryPersistsReplaysAndScopesResources(
 	if err != nil || replayed {
 		t.Fatalf("CreateSnapshot replayed = %v, error = %v", replayed, err)
 	}
-	if snapshot.ResumeSnapshot != profile.ResumeRef ||
+	if !reflect.DeepEqual(
+		snapshot.ResumeSnapshot,
+		profileCommand.ResumeRevision,
+	) ||
 		snapshot.JobDescriptionSnapshot != profile.JobDescriptionRef ||
 		snapshot.BackgroundSnapshot != profile.BackgroundSummary ||
 		snapshot.SourceVersion != profile.Version ||
@@ -396,6 +412,75 @@ func TestPostgresProfileRepositoryPersistsReplaysAndScopesResources(
 			replayed,
 			err,
 		)
+	}
+}
+
+func preparationResumeSnapshot(
+	resumeID string,
+	revision int64,
+) *preparation.ResumeRevisionSnapshot {
+	return &preparation.ResumeRevisionSnapshot{
+		ResumeID: resumeID,
+		Revision: revision,
+		Material: preparation.ResumeMaterial{
+			TargetPosition:       "Backend Engineer",
+			ProfessionalSummary:  "Builds reliable Go services.",
+			WorkExperiences:      []preparation.ResumeWorkExperience{},
+			ProjectExperiences:   []preparation.ResumeProjectExperience{},
+			EducationExperiences: []preparation.ResumeEducationExperience{},
+			Skills:               []string{"Go", "PostgreSQL"},
+			Awards:               []string{},
+		},
+	}
+}
+
+func seedPreparationResumeRevision(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	ownerID string,
+	resumeID string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	transaction, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin Resume seed: %v", err)
+	}
+	defer func() { _ = transaction.Rollback(ctx) }()
+	if _, err := transaction.Exec(ctx, `
+		INSERT INTO resumes (
+			resume_id, owner_user_id, title, original_filename,
+			content_type, size_bytes, checksum_sha256, object_key,
+			file_status, parse_status, version
+		) VALUES (
+			$1, $2, 'Backend Resume', 'resume.pdf',
+			'application/pdf', 128, $3, $4,
+			'AVAILABLE', 'READY', 1
+		)
+	`, resumeID, ownerID, strings.Repeat("a", 64),
+		"resume/v1/00000000000000000000000000000001.pdf"); err != nil {
+		t.Fatalf("seed Resume: %v", err)
+	}
+	content, err := json.Marshal(
+		preparationResumeSnapshot(resumeID, 1).Material,
+	)
+	if err != nil {
+		t.Fatalf("marshal Resume seed content: %v", err)
+	}
+	if _, err := transaction.Exec(ctx, `
+		INSERT INTO resume_revisions (
+			owner_user_id, resume_id, revision, source, content
+		) VALUES ($1, $2, 1, 'MANUAL', $3)
+	`, ownerID, resumeID, content); err != nil {
+		t.Fatalf("seed Resume Revision: %v", err)
+	}
+	if _, err := transaction.Exec(ctx, `
+		UPDATE resumes SET current_revision = 1 WHERE resume_id = $1
+	`, resumeID); err != nil {
+		t.Fatalf("bind current Resume Revision: %v", err)
+	}
+	if err := transaction.Commit(ctx); err != nil {
+		t.Fatalf("commit Resume seed: %v", err)
 	}
 }
 

--- a/server/internal/coaching/preparation/profile_test.go
+++ b/server/internal/coaching/preparation/profile_test.go
@@ -23,11 +23,17 @@ func TestPersistenceServiceReplaysBeforeAllocatingResourceID(t *testing.T) {
 		SourceVersion:   1,
 	}
 	repository := &profileRepositoryReplayStub{
-		profile:  profile,
-		snapshot: snapshot,
+		profile:       profile,
+		profileFound:  true,
+		snapshot:      snapshot,
+		snapshotFound: true,
 	}
 	ids := &failingProfileIDGenerator{}
-	service, err := NewPersistenceService(repository, ids)
+	service, err := NewPersistenceService(
+		repository,
+		ids,
+		&profileResumeReaderStub{},
+	)
 	if err != nil {
 		t.Fatalf("NewPersistenceService: %v", err)
 	}
@@ -66,11 +72,79 @@ func TestPersistenceServiceReplaysBeforeAllocatingResourceID(t *testing.T) {
 	}
 }
 
+func TestPersistenceServiceResolvesExactResumeRevisionAfterReplayCheck(
+	t *testing.T,
+) {
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	request := CreateProfileRequest{
+		ResumeID:          "50000000-0000-4000-8000-000000000001",
+		ResumeRevision:    2,
+		BackgroundSummary: "Backend engineer.",
+	}
+	resolved := ResumeRevisionSnapshot{
+		ResumeID: request.ResumeID,
+		Revision: request.ResumeRevision,
+		Material: ResumeMaterial{
+			WorkExperiences:      []ResumeWorkExperience{},
+			ProjectExperiences:   []ResumeProjectExperience{},
+			EducationExperiences: []ResumeEducationExperience{},
+			Skills:               []string{"Go"},
+			Awards:               []string{},
+		},
+	}
+	repository := &profileRepositoryReplayStub{}
+	reader := &profileResumeReaderStub{read: func(
+		_ context.Context,
+		gotActor requestcontext.Actor,
+		resumeID string,
+		revision int64,
+	) (ResumeRevisionSnapshot, error) {
+		if gotActor != actor || resumeID != request.ResumeID ||
+			revision != request.ResumeRevision {
+			t.Fatalf(
+				"Resume read = (%+v, %q, %d)",
+				gotActor,
+				resumeID,
+				revision,
+			)
+		}
+		return resolved, nil
+	}}
+	service, err := NewPersistenceService(
+		repository,
+		profileFixedIDGenerator("profile-1"),
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("NewPersistenceService: %v", err)
+	}
+
+	profile, replayed, err := service.CreateProfile(
+		context.Background(),
+		actor,
+		"profile-create-key",
+		request,
+	)
+	if err != nil || replayed || profile.ResumeID != request.ResumeID ||
+		profile.ResumeRevision != request.ResumeRevision {
+		t.Fatalf("CreateProfile = (%+v, %t, %v)", profile, replayed, err)
+	}
+	if repository.createdProfile.ResumeRevision == nil ||
+		!validResumeRevisionSnapshot(*repository.createdProfile.ResumeRevision) {
+		t.Fatalf("created command = %+v", repository.createdProfile)
+	}
+	resolved.Material.Skills[0] = "mutated"
+	if repository.createdProfile.ResumeRevision.Material.Skills[0] != "Go" {
+		t.Fatal("repository command retained mutable Reader material")
+	}
+}
+
 func TestCreateProfileRequestTextBoundaries(t *testing.T) {
 	referenceAtLimit := strings.Repeat("界", maxPreparationReferenceLength)
 	summaryAtLimit := strings.Repeat("语", maxPreparationSummaryLength)
 	if !validCreateProfileRequest(CreateProfileRequest{
-		ResumeRef:         referenceAtLimit,
+		ResumeID:          "50000000-0000-4000-8000-000000000001",
+		ResumeRevision:    1,
 		JobDescriptionRef: referenceAtLimit,
 		BackgroundSummary: summaryAtLimit,
 	}) {
@@ -78,7 +152,11 @@ func TestCreateProfileRequestTextBoundaries(t *testing.T) {
 	}
 	for _, request := range []CreateProfileRequest{
 		{
-			ResumeRef:         referenceAtLimit + "r",
+			ResumeID:          "50000000-0000-4000-8000-000000000001",
+			BackgroundSummary: "valid",
+		},
+		{
+			ResumeRevision:    1,
 			BackgroundSummary: "valid",
 		},
 		{
@@ -96,9 +174,35 @@ func TestCreateProfileRequestTextBoundaries(t *testing.T) {
 	}
 }
 
+type profileResumeReaderStub struct {
+	read func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		int64,
+	) (ResumeRevisionSnapshot, error)
+}
+
+func (stub *profileResumeReaderStub) ReadOwnedRevision(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	resumeID string,
+	revision int64,
+) (ResumeRevisionSnapshot, error) {
+	if stub.read == nil {
+		return ResumeRevisionSnapshot{}, errors.New(
+			"unexpected ReadOwnedRevision",
+		)
+	}
+	return stub.read(ctx, actor, resumeID, revision)
+}
+
 type profileRepositoryReplayStub struct {
-	profile  Profile
-	snapshot Snapshot
+	profile        Profile
+	profileFound   bool
+	snapshot       Snapshot
+	snapshotFound  bool
+	createdProfile CreateProfileCommand
 }
 
 func (stub *profileRepositoryReplayStub) ReplayProfile(
@@ -106,15 +210,22 @@ func (stub *profileRepositoryReplayStub) ReplayProfile(
 	requestcontext.Actor,
 	IdempotencyIntent,
 ) (Profile, bool, error) {
-	return stub.profile, true, nil
+	return stub.profile, stub.profileFound, nil
 }
 
-func (*profileRepositoryReplayStub) CreateProfile(
-	context.Context,
-	requestcontext.Actor,
-	CreateProfileCommand,
+func (stub *profileRepositoryReplayStub) CreateProfile(
+	_ context.Context,
+	actor requestcontext.Actor,
+	command CreateProfileCommand,
 ) (Profile, bool, error) {
-	return Profile{}, false, errors.New("unexpected CreateProfile")
+	stub.createdProfile = command
+	return Profile{
+		ID: command.ProfileID, UserID: actor.UserID,
+		ResumeID:          command.Request.ResumeID,
+		ResumeRevision:    command.Request.ResumeRevision,
+		BackgroundSummary: command.Request.BackgroundSummary,
+		Version:           1,
+	}, false, nil
 }
 
 func (stub *profileRepositoryReplayStub) ReplaySnapshot(
@@ -122,7 +233,7 @@ func (stub *profileRepositoryReplayStub) ReplaySnapshot(
 	requestcontext.Actor,
 	IdempotencyIntent,
 ) (Snapshot, bool, error) {
-	return stub.snapshot, true, nil
+	return stub.snapshot, stub.snapshotFound, nil
 }
 
 func (*profileRepositoryReplayStub) CreateSnapshot(
@@ -158,6 +269,12 @@ func (*profileRepositoryReplayStub) DeleteProfileData(
 
 type failingProfileIDGenerator struct {
 	calls int
+}
+
+type profileFixedIDGenerator string
+
+func (generator profileFixedIDGenerator) NewID() (string, error) {
+	return string(generator), nil
 }
 
 func (generator *failingProfileIDGenerator) NewID() (string, error) {

--- a/server/internal/coaching/preparation/resume_revision.go
+++ b/server/internal/coaching/preparation/resume_revision.go
@@ -1,0 +1,145 @@
+package preparation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const maxResumeMaterialBytes = 512 * 1024
+
+// ResumeMaterial is Preparation's immutable projection of one Resume
+// Revision. It deliberately owns its model instead of exposing Resume's
+// aggregate or file lifecycle to Preparation.
+type ResumeMaterial struct {
+	TargetPosition       string                      `json:"target_position"`
+	ProfessionalSummary  string                      `json:"professional_summary"`
+	WorkExperiences      []ResumeWorkExperience      `json:"work_experiences"`
+	ProjectExperiences   []ResumeProjectExperience   `json:"project_experiences"`
+	EducationExperiences []ResumeEducationExperience `json:"education_experiences"`
+	Skills               []string                    `json:"skills"`
+	Awards               []string                    `json:"awards"`
+}
+
+type ResumeWorkExperience struct {
+	Company      string   `json:"company"`
+	Position     string   `json:"position"`
+	StartDate    string   `json:"start_date,omitempty"`
+	EndDate      string   `json:"end_date,omitempty"`
+	Duties       []string `json:"duties"`
+	Achievements []string `json:"achievements"`
+}
+
+type ResumeProjectExperience struct {
+	ProjectName  string   `json:"project_name"`
+	Role         string   `json:"role"`
+	Description  string   `json:"description"`
+	Technologies []string `json:"technologies"`
+	Duties       []string `json:"duties"`
+	Achievements []string `json:"achievements"`
+}
+
+type ResumeEducationExperience struct {
+	School    string `json:"school"`
+	Major     string `json:"major"`
+	Degree    string `json:"degree"`
+	GPA       string `json:"gpa,omitempty"`
+	StartDate string `json:"start_date,omitempty"`
+	EndDate   string `json:"end_date,omitempty"`
+}
+
+// ResumeRevisionSnapshot pins the actor-owned Resume Revision and the exact
+// material accepted when the Preparation Profile was created.
+type ResumeRevisionSnapshot struct {
+	ResumeID string         `json:"resume_id"`
+	Revision int64          `json:"revision"`
+	Material ResumeMaterial `json:"material"`
+}
+
+// ResumeRevisionReader is the narrow source capability owned by Preparation.
+// Implementations must enforce Actor ownership and exact-current-Revision
+// semantics before returning material.
+type ResumeRevisionReader interface {
+	ReadOwnedRevision(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		int64,
+	) (ResumeRevisionSnapshot, error)
+}
+
+func validResumeRevisionSnapshot(snapshot ResumeRevisionSnapshot) bool {
+	material := snapshot.Material
+	if !validResourceIdentifier(snapshot.ResumeID) || snapshot.Revision < 1 ||
+		material.WorkExperiences == nil ||
+		material.ProjectExperiences == nil ||
+		material.EducationExperiences == nil ||
+		material.Skills == nil || material.Awards == nil {
+		return false
+	}
+	for _, item := range material.WorkExperiences {
+		if item.Duties == nil || item.Achievements == nil {
+			return false
+		}
+	}
+	for _, item := range material.ProjectExperiences {
+		if item.Technologies == nil || item.Duties == nil ||
+			item.Achievements == nil {
+			return false
+		}
+	}
+	encoded, err := json.Marshal(material)
+	return err == nil && len(encoded) <= maxResumeMaterialBytes
+}
+
+func cloneResumeRevisionSnapshot(
+	snapshot ResumeRevisionSnapshot,
+) ResumeRevisionSnapshot {
+	result := snapshot
+	result.Material = cloneResumeMaterial(snapshot.Material)
+	return result
+}
+
+func cloneResumeMaterial(material ResumeMaterial) ResumeMaterial {
+	result := material
+	result.Skills = append([]string{}, material.Skills...)
+	result.Awards = append([]string{}, material.Awards...)
+	result.WorkExperiences = append(
+		[]ResumeWorkExperience{},
+		material.WorkExperiences...,
+	)
+	for index := range result.WorkExperiences {
+		result.WorkExperiences[index].Duties = append(
+			[]string{},
+			material.WorkExperiences[index].Duties...,
+		)
+		result.WorkExperiences[index].Achievements = append(
+			[]string{},
+			material.WorkExperiences[index].Achievements...,
+		)
+	}
+	result.ProjectExperiences = append(
+		[]ResumeProjectExperience{},
+		material.ProjectExperiences...,
+	)
+	for index := range result.ProjectExperiences {
+		result.ProjectExperiences[index].Technologies = append(
+			[]string{},
+			material.ProjectExperiences[index].Technologies...,
+		)
+		result.ProjectExperiences[index].Duties = append(
+			[]string{},
+			material.ProjectExperiences[index].Duties...,
+		)
+		result.ProjectExperiences[index].Achievements = append(
+			[]string{},
+			material.ProjectExperiences[index].Achievements...,
+		)
+	}
+	result.EducationExperiences = append(
+		[]ResumeEducationExperience{},
+		material.EducationExperiences...,
+	)
+	return result
+}

--- a/server/internal/platform/migration/preparation_resume_revision_migration_integration_test.go
+++ b/server/internal/platform/migration/preparation_resume_revision_migration_integration_test.go
@@ -1,0 +1,85 @@
+package migration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestPreparationResumeRevisionMigrationRejectsLegacyReferenceData(
+	t *testing.T,
+) {
+	migrationConfig, admin, schema := isolatedMigrationConfig(t)
+	runner, err := openConfig(migrationConfig)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := runner.Close(); err != nil {
+			t.Errorf("close migration runner: %v", err)
+		}
+	})
+	if err := runner.migrate.Steps(67); err != nil {
+		t.Fatalf("apply migrations through version 67: %v", err)
+	}
+
+	scoped, err := pgx.ConnectConfig(context.Background(), migrationConfig)
+	if err != nil {
+		t.Fatalf("connect to version 67 schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := scoped.Close(context.Background()); err != nil {
+			t.Errorf("close version 67 schema connection: %v", err)
+		}
+	})
+	const ownerID = "10000000-0000-4000-8000-000000000383"
+	if _, err := scoped.Exec(context.Background(), `
+		INSERT INTO identity_users (id, canonical_email)
+		VALUES ($1, 'preparation-resume-migration@example.com')
+	`, ownerID); err != nil {
+		t.Fatalf("seed migration owner: %v", err)
+	}
+	if _, err := scoped.Exec(context.Background(), `
+		INSERT INTO preparation_profiles (
+			owner_user_id, profile_id, resume_ref, background_summary
+		) VALUES ($1, 'legacy-profile', 'legacy-resume-body', 'Background')
+	`, ownerID); err != nil {
+		t.Fatalf("seed legacy Resume reference: %v", err)
+	}
+
+	err = runner.migrate.Steps(1)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"recreate the development or test database",
+	) {
+		t.Fatalf("legacy Resume migration error = %v", err)
+	}
+
+	var oldColumn, newColumn bool
+	if err := admin.QueryRow(context.Background(), `
+		SELECT
+			EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = $1
+				  AND table_name = 'preparation_profiles'
+				  AND column_name = 'resume_ref'
+			),
+			EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = $1
+				  AND table_name = 'preparation_profiles'
+				  AND column_name = 'resume_id'
+			)
+	`, schema).Scan(&oldColumn, &newColumn); err != nil {
+		t.Fatalf("inspect rejected migration schema: %v", err)
+	}
+	if !oldColumn || newColumn {
+		t.Fatalf(
+			"schema after rejection: resume_ref=%t resume_id=%t",
+			oldColumn,
+			newColumn,
+		)
+	}
+}

--- a/server/internal/resume/app/errors.go
+++ b/server/internal/resume/app/errors.go
@@ -23,6 +23,16 @@ func ResumeVersionConflictError() error {
 	return apperror.New(apperror.Conflict, "resume_version_conflict", "Resume changed before this operation.")
 }
 
+// ResumeRevisionUnavailableError reports that a Resume has no parsed Revision
+// that can be bound to a Preparation Profile yet.
+func ResumeRevisionUnavailableError() error {
+	return apperror.New(
+		apperror.FailedPrecondition,
+		"resume_revision_unavailable",
+		"Resume parsing has not produced an available revision.",
+	)
+}
+
 // UnsupportedResumeFormatError 返回上传文件不是受支持文本型 PDF 的错误。
 func UnsupportedResumeFormatError() error {
 	return apperror.New(apperror.InvalidArgument, "unsupported_resume_format", "Only text-based PDF resumes are supported.")

--- a/server/internal/resume/app/revision_query.go
+++ b/server/internal/resume/app/revision_query.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"errors"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+)
+
+// RevisionQuery exposes only the owner-scoped, parsed Revision capability
+// needed by downstream business modules.
+type RevisionQuery struct {
+	repository Repository
+}
+
+func NewRevisionQuery(repository Repository) (*RevisionQuery, error) {
+	if repository == nil {
+		return nil, errors.New("resume: revision repository is required")
+	}
+	return &RevisionQuery{repository: repository}, nil
+}
+
+// ReadOwnedRevision returns the exact current parsed Revision for the Actor.
+// A stale Revision number is rejected instead of silently reading either the
+// latest or an older Revision.
+func (query *RevisionQuery) ReadOwnedRevision(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	resumeID string,
+	revision int64,
+) (resume.Revision, error) {
+	if query == nil || query.repository == nil || ctx == nil || ctx.Err() != nil ||
+		!actor.Valid() || !validUUID(actor.UserID) || !validUUID(resumeID) ||
+		revision < 1 {
+		return resume.Revision{}, InvalidResumeError()
+	}
+	detail, err := query.repository.FindDetailByOwnerAndID(
+		ctx,
+		actor.UserID,
+		resumeID,
+	)
+	if err != nil {
+		return resume.Revision{}, err
+	}
+	if detail.Resume.ID != resumeID ||
+		detail.Resume.OwnerUserID != actor.UserID {
+		return resume.Revision{}, ResumeNotFoundError()
+	}
+	if detail.Resume.CurrentRevision != revision {
+		return resume.Revision{}, ResumeVersionConflictError()
+	}
+	if detail.Resume.FileStatus != resume.FileAvailable ||
+		detail.Resume.ParseStatus != resume.ParseReady ||
+		detail.Revision == nil {
+		return resume.Revision{}, ResumeRevisionUnavailableError()
+	}
+	if detail.Revision.ResumeID != resumeID ||
+		detail.Revision.Revision != revision {
+		return resume.Revision{}, RepositoryError(
+			errors.New("resume: current Revision identity is inconsistent"),
+		)
+	}
+	result := *detail.Revision
+	result.Content = normalizeContent(result.Content)
+	return result, nil
+}

--- a/server/internal/resume/app/revision_query_test.go
+++ b/server/internal/resume/app/revision_query_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+)
+
+func TestRevisionQueryRequiresExactReadyCurrentRevision(t *testing.T) {
+	item := resume.Resume{
+		ID:              "50000000-0000-4000-8000-000000000001",
+		OwnerUserID:     serviceTestActor.UserID,
+		FileStatus:      resume.FileAvailable,
+		ParseStatus:     resume.ParseReady,
+		CurrentRevision: 2,
+	}
+	revision := &resume.Revision{
+		ResumeID: item.ID,
+		Revision: 2,
+		Content:  resume.Content{Skills: []string{"Go"}},
+	}
+	repository := &repositoryFake{item: item, detailRevision: revision}
+	query, err := NewRevisionQuery(repository)
+	if err != nil {
+		t.Fatalf("NewRevisionQuery: %v", err)
+	}
+
+	got, err := query.ReadOwnedRevision(
+		context.Background(),
+		serviceTestActor,
+		item.ID,
+		2,
+	)
+	if err != nil || got.ResumeID != item.ID || got.Revision != 2 ||
+		got.Content.WorkExperiences == nil || got.Content.Awards == nil {
+		t.Fatalf("ReadOwnedRevision = (%+v, %v)", got, err)
+	}
+
+	if _, err := query.ReadOwnedRevision(
+		context.Background(),
+		serviceTestActor,
+		item.ID,
+		1,
+	); !apperror.IsCategory(err, apperror.Conflict) {
+		t.Fatalf("stale Revision error = %v", err)
+	}
+
+	repository.item.ParseStatus = resume.ParseRunning
+	if _, err := query.ReadOwnedRevision(
+		context.Background(),
+		serviceTestActor,
+		item.ID,
+		2,
+	); !apperror.IsCategory(err, apperror.FailedPrecondition) {
+		t.Fatalf("incomplete parse error = %v", err)
+	}
+}
+
+func TestRevisionQueryRejectsRepositoryOwnershipMismatch(t *testing.T) {
+	repository := &repositoryFake{
+		item: resume.Resume{
+			ID:              "50000000-0000-4000-8000-000000000001",
+			OwnerUserID:     "10000000-0000-4000-8000-000000000999",
+			FileStatus:      resume.FileAvailable,
+			ParseStatus:     resume.ParseReady,
+			CurrentRevision: 1,
+		},
+		detailRevision: &resume.Revision{
+			ResumeID: "50000000-0000-4000-8000-000000000001",
+			Revision: 1,
+		},
+	}
+	query, err := NewRevisionQuery(repository)
+	if err != nil {
+		t.Fatalf("NewRevisionQuery: %v", err)
+	}
+	if _, err := query.ReadOwnedRevision(
+		context.Background(),
+		serviceTestActor,
+		repository.item.ID,
+		1,
+	); !apperror.IsCategory(err, apperror.NotFound) {
+		t.Fatalf("ownership mismatch error = %v", err)
+	}
+}

--- a/server/internal/resume/preparationsource/reader.go
+++ b/server/internal/resume/preparationsource/reader.go
@@ -1,0 +1,115 @@
+// Package preparationsource adapts Resume-owned revisions into Preparation's
+// consumer-owned material contract.
+package preparationsource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+)
+
+type source interface {
+	ReadOwnedRevision(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		int64,
+	) (resume.Revision, error)
+}
+
+// Reader maps Resume's aggregate-owned Revision into Preparation's immutable
+// material projection.
+type Reader struct {
+	source source
+}
+
+func New(source source) (*Reader, error) {
+	if source == nil {
+		return nil, fmt.Errorf("Preparation Resume Revision source is required")
+	}
+	return &Reader{source: source}, nil
+}
+
+func (reader *Reader) ReadOwnedRevision(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	resumeID string,
+	revision int64,
+) (preparation.ResumeRevisionSnapshot, error) {
+	if reader == nil || reader.source == nil || ctx == nil || !actor.Valid() {
+		return preparation.ResumeRevisionSnapshot{}, preparation.ErrProfileInvalid
+	}
+	value, err := reader.source.ReadOwnedRevision(
+		ctx,
+		actor,
+		resumeID,
+		revision,
+	)
+	if err != nil {
+		return preparation.ResumeRevisionSnapshot{}, mapError(err)
+	}
+	if value.ResumeID != resumeID || value.Revision != revision {
+		return preparation.ResumeRevisionSnapshot{}, preparation.ErrProfileConflict
+	}
+	return preparation.ResumeRevisionSnapshot{
+		ResumeID: value.ResumeID,
+		Revision: value.Revision,
+		Material: mapMaterial(value.Content),
+	}, nil
+}
+
+func mapMaterial(content resume.Content) preparation.ResumeMaterial {
+	material := preparation.ResumeMaterial{
+		TargetPosition:       content.TargetPosition,
+		ProfessionalSummary:  content.ProfessionalSummary,
+		WorkExperiences:      make([]preparation.ResumeWorkExperience, len(content.WorkExperiences)),
+		ProjectExperiences:   make([]preparation.ResumeProjectExperience, len(content.ProjectExperiences)),
+		EducationExperiences: make([]preparation.ResumeEducationExperience, len(content.EducationExperiences)),
+		Skills:               append([]string{}, content.Skills...),
+		Awards:               append([]string{}, content.Awards...),
+	}
+	for index, item := range content.WorkExperiences {
+		material.WorkExperiences[index] = preparation.ResumeWorkExperience{
+			Company: item.Company, Position: item.Position,
+			StartDate: item.StartDate, EndDate: item.EndDate,
+			Duties:       append([]string{}, item.Duties...),
+			Achievements: append([]string{}, item.Achievements...),
+		}
+	}
+	for index, item := range content.ProjectExperiences {
+		material.ProjectExperiences[index] = preparation.ResumeProjectExperience{
+			ProjectName: item.ProjectName, Role: item.Role,
+			Description:  item.Description,
+			Technologies: append([]string{}, item.Technologies...),
+			Duties:       append([]string{}, item.Duties...),
+			Achievements: append([]string{}, item.Achievements...),
+		}
+	}
+	for index, item := range content.EducationExperiences {
+		material.EducationExperiences[index] = preparation.ResumeEducationExperience{
+			School: item.School, Major: item.Major, Degree: item.Degree,
+			GPA: item.GPA, StartDate: item.StartDate, EndDate: item.EndDate,
+		}
+	}
+	return material
+}
+
+func mapError(err error) error {
+	switch {
+	case apperror.IsCategory(err, apperror.InvalidArgument):
+		return preparation.ErrProfileInvalid
+	case apperror.IsCategory(err, apperror.NotFound):
+		return preparation.ErrProfileNotFound
+	case apperror.IsCategory(err, apperror.Conflict),
+		apperror.IsCategory(err, apperror.FailedPrecondition):
+		return preparation.ErrProfileConflict
+	default:
+		return fmt.Errorf("read Resume Revision for Preparation: %w", err)
+	}
+}
+
+var _ preparation.ResumeRevisionReader = (*Reader)(nil)

--- a/server/internal/resume/preparationsource/reader_test.go
+++ b/server/internal/resume/preparationsource/reader_test.go
@@ -1,0 +1,90 @@
+package preparationsource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
+	resumeapp "github.com/1024XEngineer/XE3-ESL/server/internal/resume/app"
+)
+
+type sourceStub struct {
+	value resume.Revision
+	err   error
+}
+
+func (stub sourceStub) ReadOwnedRevision(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	int64,
+) (resume.Revision, error) {
+	return stub.value, stub.err
+}
+
+func TestReaderProjectsAndCopiesResumeMaterial(t *testing.T) {
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	value := resume.Revision{
+		ResumeID: "50000000-0000-4000-8000-000000000001",
+		Revision: 3,
+		Content: resume.Content{
+			WorkExperiences: []resume.WorkExperience{{
+				Company: "Example", Duties: []string{"Built APIs"},
+			}},
+			ProjectExperiences:   []resume.ProjectExperience{},
+			EducationExperiences: []resume.EducationExperience{},
+			Skills:               []string{"Go"}, Awards: []string{},
+		},
+	}
+	reader, err := New(sourceStub{value: value})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, err := reader.ReadOwnedRevision(
+		context.Background(),
+		actor,
+		value.ResumeID,
+		value.Revision,
+	)
+	if err != nil || got.ResumeID != value.ResumeID ||
+		got.Revision != value.Revision || got.Material.Skills[0] != "Go" {
+		t.Fatalf("ReadOwnedRevision = (%+v, %v)", got, err)
+	}
+	value.Content.Skills[0] = "mutated"
+	value.Content.WorkExperiences[0].Duties[0] = "mutated"
+	if got.Material.Skills[0] != "Go" ||
+		got.Material.WorkExperiences[0].Duties[0] != "Built APIs" {
+		t.Fatal("Preparation projection retained Resume-owned slices")
+	}
+}
+
+func TestReaderMapsResumeRevisionFailures(t *testing.T) {
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	for _, test := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "owner", err: resumeapp.ResumeNotFoundError(), want: preparation.ErrProfileNotFound},
+		{name: "revision", err: resumeapp.ResumeVersionConflictError(), want: preparation.ErrProfileConflict},
+		{name: "parsing", err: resumeapp.ResumeRevisionUnavailableError(), want: preparation.ErrProfileConflict},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader, err := New(sourceStub{err: test.err})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			_, err = reader.ReadOwnedRevision(
+				context.Background(),
+				actor,
+				"50000000-0000-4000-8000-000000000001",
+				1,
+			)
+			if err != test.want {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}

--- a/server/migrations/000068_preparation_resume_revision.down.sql
+++ b/server/migrations/000068_preparation_resume_revision.down.sql
@@ -1,0 +1,109 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '15s';
+SET LOCAL statement_timeout = '2min';
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM preparation_profiles WHERE resume_id IS NOT NULL
+    ) OR EXISTS (
+        SELECT 1 FROM preparation_snapshots WHERE resume_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION
+            'Preparation Resume Revision data exists; recreate the development or test database before reverting migration 000068'
+            USING ERRCODE = '55000';
+    END IF;
+END;
+$$;
+
+DELETE FROM preparation_idempotency_records;
+DELETE FROM preparation_job_target_idempotency_records;
+
+ALTER TABLE preparation_job_targets
+    DROP CONSTRAINT preparation_job_targets_text_check,
+    ADD COLUMN resume_ref text,
+    ADD CONSTRAINT preparation_job_targets_text_check
+        CHECK (
+            (
+                job_title IS NULL
+                OR (
+                    btrim(job_title) = job_title
+                    AND octet_length(job_title) BETWEEN 1 AND 512
+                )
+            )
+            AND octet_length(coalesce(job_description, '')) <= 65536
+            AND (
+                company IS NULL
+                OR (
+                    btrim(company) = company
+                    AND octet_length(company) BETWEEN 1 AND 512
+                )
+            )
+            AND (
+                seniority IS NULL
+                OR (
+                    btrim(seniority) = seniority
+                    AND octet_length(seniority) BETWEEN 1 AND 256
+                )
+            )
+            AND (
+                candidate_background IS NULL
+                OR (
+                    btrim(candidate_background) = candidate_background
+                    AND btrim(candidate_background) <> ''
+                    AND octet_length(candidate_background) <= 16384
+                )
+            )
+            AND (
+                resume_ref IS NULL
+                OR (
+                    btrim(resume_ref) = resume_ref
+                    AND btrim(resume_ref) <> ''
+                    AND octet_length(resume_ref) <= 16384
+                )
+            )
+            AND (
+                practice_focus IS NULL
+                OR (
+                    btrim(practice_focus) = practice_focus
+                    AND btrim(practice_focus) <> ''
+                    AND octet_length(practice_focus) <= 8192
+                )
+            )
+        );
+
+ALTER TABLE preparation_snapshots
+    DROP CONSTRAINT preparation_snapshots_profile_resume_fkey,
+    DROP CONSTRAINT preparation_snapshots_resume_shape_check,
+    DROP CONSTRAINT preparation_snapshots_optional_content_check,
+    DROP COLUMN resume_id,
+    DROP COLUMN resume_revision,
+    DROP COLUMN resume_material,
+    ADD COLUMN resume_snapshot text,
+    ADD CONSTRAINT preparation_snapshots_optional_content_check
+        CHECK (
+            (resume_snapshot IS NULL OR btrim(resume_snapshot) <> '')
+            AND
+            (
+                job_description_snapshot IS NULL
+                OR btrim(job_description_snapshot) <> ''
+            )
+        );
+
+ALTER TABLE preparation_profiles
+    DROP CONSTRAINT preparation_profiles_resume_identity_key,
+    DROP CONSTRAINT preparation_profiles_resume_shape_check,
+    DROP CONSTRAINT preparation_profiles_optional_refs_check,
+    DROP COLUMN resume_id,
+    DROP COLUMN resume_revision,
+    DROP COLUMN resume_material,
+    ADD COLUMN resume_ref text,
+    ADD CONSTRAINT preparation_profiles_optional_refs_check
+        CHECK (
+            (resume_ref IS NULL OR btrim(resume_ref) <> '')
+            AND
+            (job_description_ref IS NULL OR btrim(job_description_ref) <> '')
+        );
+
+COMMIT;

--- a/server/migrations/000068_preparation_resume_revision.up.sql
+++ b/server/migrations/000068_preparation_resume_revision.up.sql
@@ -1,0 +1,151 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '15s';
+SET LOCAL statement_timeout = '2min';
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM preparation_profiles WHERE resume_ref IS NOT NULL
+    ) OR EXISTS (
+        SELECT 1 FROM preparation_snapshots WHERE resume_snapshot IS NOT NULL
+    ) OR EXISTS (
+        SELECT 1 FROM preparation_job_targets WHERE resume_ref IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION
+            'Preparation Resume reference data exists; recreate the development or test database before applying migration 000068'
+            USING ERRCODE = '55000';
+    END IF;
+END;
+$$;
+
+-- Stored idempotency responses contain the retired request/response shape and
+-- cannot be replayed under the Revision contract.
+DELETE FROM preparation_idempotency_records;
+DELETE FROM preparation_job_target_idempotency_records;
+
+UPDATE preparation_job_target_confirmations
+SET input_snapshot = input_snapshot - 'resume_ref'
+WHERE input_snapshot ? 'resume_ref';
+
+ALTER TABLE preparation_profiles
+    DROP CONSTRAINT preparation_profiles_optional_refs_check,
+    DROP COLUMN resume_ref,
+    ADD COLUMN resume_id uuid,
+    ADD COLUMN resume_revision bigint,
+    ADD COLUMN resume_material jsonb,
+    ADD CONSTRAINT preparation_profiles_optional_refs_check
+        CHECK (
+            job_description_ref IS NULL
+            OR btrim(job_description_ref) <> ''
+        ),
+    ADD CONSTRAINT preparation_profiles_resume_shape_check
+        CHECK (
+            (
+                resume_id IS NULL
+                AND resume_revision IS NULL
+                AND resume_material IS NULL
+            )
+            OR
+            (
+                resume_id IS NOT NULL
+                AND resume_revision >= 1
+                AND jsonb_typeof(resume_material) = 'object'
+                AND octet_length(resume_material::text) <= 524288
+            )
+        ),
+    ADD CONSTRAINT preparation_profiles_resume_identity_key
+        UNIQUE (
+            owner_user_id,
+            profile_id,
+            resume_id,
+            resume_revision
+        );
+
+ALTER TABLE preparation_snapshots
+    DROP CONSTRAINT preparation_snapshots_optional_content_check,
+    DROP COLUMN resume_snapshot,
+    ADD COLUMN resume_id uuid,
+    ADD COLUMN resume_revision bigint,
+    ADD COLUMN resume_material jsonb,
+    ADD CONSTRAINT preparation_snapshots_optional_content_check
+        CHECK (
+            job_description_snapshot IS NULL
+            OR btrim(job_description_snapshot) <> ''
+        ),
+    ADD CONSTRAINT preparation_snapshots_resume_shape_check
+        CHECK (
+            (
+                resume_id IS NULL
+                AND resume_revision IS NULL
+                AND resume_material IS NULL
+            )
+            OR
+            (
+                resume_id IS NOT NULL
+                AND resume_revision >= 1
+                AND jsonb_typeof(resume_material) = 'object'
+                AND octet_length(resume_material::text) <= 524288
+            )
+        ),
+    ADD CONSTRAINT preparation_snapshots_profile_resume_fkey
+        FOREIGN KEY (
+            owner_user_id,
+            source_profile_id,
+            resume_id,
+            resume_revision
+        )
+        REFERENCES preparation_profiles (
+            owner_user_id,
+            profile_id,
+            resume_id,
+            resume_revision
+        )
+        ON DELETE CASCADE;
+
+ALTER TABLE preparation_job_targets
+    DROP CONSTRAINT preparation_job_targets_text_check,
+    DROP COLUMN resume_ref,
+    ADD CONSTRAINT preparation_job_targets_text_check
+        CHECK (
+            (
+                job_title IS NULL
+                OR (
+                    btrim(job_title) = job_title
+                    AND octet_length(job_title) BETWEEN 1 AND 512
+                )
+            )
+            AND octet_length(coalesce(job_description, '')) <= 65536
+            AND (
+                company IS NULL
+                OR (
+                    btrim(company) = company
+                    AND octet_length(company) BETWEEN 1 AND 512
+                )
+            )
+            AND (
+                seniority IS NULL
+                OR (
+                    btrim(seniority) = seniority
+                    AND octet_length(seniority) BETWEEN 1 AND 256
+                )
+            )
+            AND (
+                candidate_background IS NULL
+                OR (
+                    btrim(candidate_background) = candidate_background
+                    AND btrim(candidate_background) <> ''
+                    AND octet_length(candidate_background) <= 16384
+                )
+            )
+            AND (
+                practice_focus IS NULL
+                OR (
+                    btrim(practice_focus) = practice_focus
+                    AND btrim(practice_focus) <> ''
+                    AND octet_length(practice_focus) <= 8192
+                )
+            )
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -53,4 +53,5 @@ import "embed"
 //go:embed 000065_evaluation_ielts_speaking_prompt_v3.*.sql
 //go:embed 000066_evaluation_ielts_speaking_prompt_v4.*.sql
 //go:embed 000067_evaluation_ielts_speaking_acoustic_payload.*.sql
+//go:embed 000068_preparation_resume_revision.*.sql
 var Files embed.FS

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -352,6 +352,23 @@ func TestIELTSSpeakingAcousticPayloadMigrationIsEmbedded(t *testing.T) {
 	}
 }
 
+func TestPreparationResumeRevisionMigrationIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"000068_preparation_resume_revision.up.sql",
+		"000068_preparation_resume_revision.down.sql",
+	} {
+		if _, err := Files.ReadFile(name); err != nil {
+			t.Fatalf("read Preparation Resume migration %q: %v", name, err)
+		}
+	}
+	up := readMigration(t, "000068_preparation_resume_revision.up.sql")
+	if !strings.Contains(up, "RECREATE THE DEVELOPMENT OR TEST DATABASE") {
+		t.Fatal("Preparation Resume migration must state its initialization requirement")
+	}
+}
+
 func readMigration(t *testing.T, name string) string {
 	t.Helper()
 

--- a/server/test/smoke/http.go
+++ b/server/test/smoke/http.go
@@ -185,7 +185,8 @@ func (s *Server) createProfile(c *gin.Context) {
 	}
 	s.executeIdempotent(c, raw, func() apiResponse {
 		var request struct {
-			ResumeRef         *string `json:"resume_ref"`
+			ResumeID          *string `json:"resume_id"`
+			ResumeRevision    *int64  `json:"resume_revision"`
 			JobDescriptionRef *string `json:"job_description_ref"`
 			BackgroundSummary *string `json:"background_summary"`
 		}
@@ -193,13 +194,16 @@ func (s *Server) createProfile(c *gin.Context) {
 			return invalidRequest()
 		}
 		if request.BackgroundSummary == nil || strings.TrimSpace(*request.BackgroundSummary) == "" ||
-			(request.ResumeRef != nil && strings.TrimSpace(*request.ResumeRef) == "") ||
+			(request.ResumeID == nil) != (request.ResumeRevision == nil) ||
+			(request.ResumeID != nil && strings.TrimSpace(*request.ResumeID) == "") ||
+			(request.ResumeRevision != nil && *request.ResumeRevision < 1) ||
 			(request.JobDescriptionRef != nil && strings.TrimSpace(*request.JobDescriptionRef) == "") {
 			return invalidRequest()
 		}
 		input := preparation.CreateProfileRequest{BackgroundSummary: *request.BackgroundSummary}
-		if request.ResumeRef != nil {
-			input.ResumeRef = *request.ResumeRef
+		if request.ResumeID != nil {
+			input.ResumeID = *request.ResumeID
+			input.ResumeRevision = *request.ResumeRevision
 		}
 		if request.JobDescriptionRef != nil {
 			input.JobDescriptionRef = *request.JobDescriptionRef

--- a/server/test/smoke/runtime.go
+++ b/server/test/smoke/runtime.go
@@ -22,6 +22,7 @@ const (
 	demoLearnerID           = "participant_learner_001"
 	demoPreparationProfile  = "profile_demo_001"
 	demoPreparationSnapshot = "preparation_snapshot_demo_001"
+	demoResumeID            = "50000000-0000-4000-8000-000000000001"
 	demoPracticePlan        = "plan_demo_001"
 	demoPracticeSession     = "session_demo_001"
 )
@@ -170,7 +171,8 @@ func (r *Runtime) createProfile() map[string]any {
 	return map[string]any{
 		"preparation_profile_id": demoPreparationProfile,
 		"user_id":                DemoUserID,
-		"resume_ref":             "resume_demo_backend_v1",
+		"resume_id":              demoResumeID,
+		"resume_revision":        int64(1),
 		"job_description_ref":    "jd_demo_backend_v1",
 		"background_summary":     "Backend engineer preparing for an English technical interview.",
 		"version":                1,
@@ -189,7 +191,7 @@ func (r *Runtime) createSnapshot() (map[string]any, error) {
 		"preparation_snapshot_id":  demoPreparationSnapshot,
 		"source_profile_id":        demoPreparationProfile,
 		"source_version":           1,
-		"resume_snapshot":          "Go backend engineer; API reliability project.",
+		"resume_snapshot":          demoResumeSnapshot(),
 		"job_description_snapshot": "Build reliable APIs and explain engineering trade-offs.",
 		"background_snapshot":      "Backend engineer preparing for an English technical interview.",
 		"created_at":               r.timestamp(2),
@@ -201,10 +203,42 @@ func (r *Runtime) preparationSnapshotLocked() preparation.Snapshot {
 		ID:                     demoPreparationSnapshot,
 		SourceProfileID:        demoPreparationProfile,
 		SourceVersion:          1,
-		ResumeSnapshot:         "Go backend engineer; API reliability project.",
+		ResumeSnapshot:         demoPreparationResumeSnapshot(),
 		JobDescriptionSnapshot: "Build reliable APIs and explain engineering trade-offs.",
 		BackgroundSnapshot:     "Backend engineer preparing for an English technical interview.",
 		CreatedAt:              r.now.Add(2 * time.Second),
+	}
+}
+
+func demoResumeSnapshot() map[string]any {
+	return map[string]any{
+		"resume_id": demoResumeID,
+		"revision":  int64(1),
+		"material": map[string]any{
+			"target_position":       "Backend Engineer",
+			"professional_summary":  "Go backend engineer.",
+			"work_experiences":      []any{},
+			"project_experiences":   []any{},
+			"education_experiences": []any{},
+			"skills":                []any{"Go", "PostgreSQL"},
+			"awards":                []any{},
+		},
+	}
+}
+
+func demoPreparationResumeSnapshot() *preparation.ResumeRevisionSnapshot {
+	return &preparation.ResumeRevisionSnapshot{
+		ResumeID: demoResumeID,
+		Revision: 1,
+		Material: preparation.ResumeMaterial{
+			TargetPosition:       "Backend Engineer",
+			ProfessionalSummary:  "Go backend engineer.",
+			WorkExperiences:      []preparation.ResumeWorkExperience{},
+			ProjectExperiences:   []preparation.ResumeProjectExperience{},
+			EducationExperiences: []preparation.ResumeEducationExperience{},
+			Skills:               []string{"Go", "PostgreSQL"},
+			Awards:               []string{},
+		},
 	}
 }
 

--- a/server/test/smoke/services.go
+++ b/server/test/smoke/services.go
@@ -20,10 +20,12 @@ func (b preparationBackend) CreateProfile(
 ) (map[string]any, error) {
 	result := b.runtime.createProfile()
 	result["background_summary"] = request.BackgroundSummary
-	if request.ResumeRef == "" {
-		delete(result, "resume_ref")
+	if request.ResumeID == "" {
+		delete(result, "resume_id")
+		delete(result, "resume_revision")
 	} else {
-		result["resume_ref"] = request.ResumeRef
+		result["resume_id"] = request.ResumeID
+		result["resume_revision"] = request.ResumeRevision
 	}
 	if request.JobDescriptionRef == "" {
 		delete(result, "job_description_ref")


### PR DESCRIPTION
## 功能描述

Preparation 通过明确的 Resume Revision 读取边界冻结用户拥有的简历材料，Profile、Snapshot 与后续练习不再接受自由字符串 `resume_ref` 作为材料来源。

Closes #383

## 实现思路

- Preparation 拥有 `ResumeRevisionReader` Port 与不可变材料投影。
- Resume 侧通过 owner-scoped `RevisionQuery` 校验当前解析版本，并由 `resume/preparationsource` 转换为 Preparation 投影。
- Profile 与 Snapshot 持久化精确 `resume_id`、`resume_revision` 和冻结材料；源 Resume 后续删除不影响已冻结快照。
- migration `000068` 明确拒绝含旧 Resume 引用数据的开发/测试库，避免静默解释旧字段。

## 代码地图

- 请求入口：`api/modules/preparation.yaml`
- 应用编排：`server/internal/coaching/preparation/profile.go`
- Resume 读取：`server/internal/resume/app/revision_query.go`
- 边界适配：`server/internal/resume/preparationsource/reader.go`
- 数据实现：`server/internal/coaching/preparation/profile_postgres.go`、`server/migrations/000068_*`

依赖方向：Preparation 定义所需 Port/投影；Resume 侧 Adapter 实现该 Port；Practice 与 Evaluation 只读取 Preparation 已冻结的材料。

## 验证

- `cd server && go test ./...`
- `cd api && npm run check`
- `git diff --check upstream/dev...HEAD`
- PostgreSQL 集成覆盖：非所有者、版本不匹配、未完成解析显式拒绝；删除源 Resume 后已冻结 Snapshot 仍可用。
