### PR TITLE
refactor(mobile): 统一面试完成后的报告导航边界

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -17,6 +17,7 @@ import 'package:speakup/features/coaching/preparation/practice_plan_handoff_cont
 import 'package:speakup/features/coaching/practice/immersive_roleplay.dart';
 import 'package:speakup/features/coaching/practice/immersive_roleplay_session.dart';
 import 'package:speakup/features/coaching/practice/practice.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/preparation/job_preparation_controller.dart';
 import 'package:speakup/features/coaching/preparation/job_preparation_wizard.dart';
 import 'package:speakup/features/coaching/preparation/preparation.dart';
@@ -29,6 +30,7 @@ import 'package:speakup/identity/model/identity_models.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_controller.dart';
+import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -306,6 +308,29 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     super.dispose();
   }
 
+  Future<CompletedPracticeRouteResult?> _openInterviewReport(
+    InterviewPracticeCompletion completion,
+  ) {
+    final navigator = _navigatorKey.currentState;
+    final reportController = widget.interviewReportController;
+    if (navigator == null || reportController == null) {
+      throw StateError('Interview report route is not configured.');
+    }
+    return navigator.push<CompletedPracticeRouteResult>(
+      MaterialPageRoute<CompletedPracticeRouteResult>(
+        builder: (_) => InterviewReportPage(
+          practiceSessionId: completion.practiceSessionId,
+          controller: reportController,
+          title: completion.title,
+          speechFeedbackController: widget.speechFeedbackController,
+          speechFeedbackSourceKeys: completion.speechFeedbackSourceKeys,
+          onContinueWithAgent:
+              widget.preparationLaunchController?.completeAndContinueWithAgent,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Navigator(
@@ -404,7 +429,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
         return ImmersiveRoleplaySession(
           practiceController: _practiceController,
           avatarControllerFactory: factory,
-          interviewReportController: widget.interviewReportController,
+          onOpenInterviewReport: widget.interviewReportController == null
+              ? null
+              : _openInterviewReport,
           speechFeedbackController: widget.speechFeedbackController,
           onExitRequested: launchController?.parkCurrentPractice,
           onContinueWithAgent: launchController?.completeAndContinueWithAgent,
@@ -413,7 +440,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       return ImmersiveRoleplayPage(
         previewMode: widget.allowFakePreview,
         practiceController: _practiceController,
-        interviewReportController: widget.interviewReportController,
+        onOpenInterviewReport: widget.interviewReportController == null
+            ? null
+            : _openInterviewReport,
         speechFeedbackController: widget.speechFeedbackController,
         onExitRequested: launchController?.parkCurrentPractice,
         onContinueWithAgent: launchController?.completeAndContinueWithAgent,
@@ -423,7 +452,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       previewMode: widget.allowFakePreview,
       practiceController: _practiceController,
       preparationController: widget.preparationController,
-      interviewReportController: widget.interviewReportController,
+      onOpenInterviewReport: widget.interviewReportController == null
+          ? null
+          : _openInterviewReport,
       ieltsSpeakingReportController: widget.ieltsSpeakingReportController,
       speechFeedbackController: widget.speechFeedbackController,
       onExitRequested: launchController?.parkCurrentPractice,

--- a/mobile/lib/features/coaching/practice/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay.dart
@@ -10,10 +10,8 @@ import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
-import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
-import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_disclosure.dart';
@@ -34,7 +32,7 @@ class ImmersiveRoleplayPage extends StatefulWidget {
     this.onBeforeStartRecording,
     this.onBeforeSubmitText,
     this.onReplayQuestion,
-    this.interviewReportController,
+    this.onOpenInterviewReport,
     this.speechFeedbackController,
     this.replayLoading = false,
     this.replayPlaying = false,
@@ -50,7 +48,7 @@ class ImmersiveRoleplayPage extends StatefulWidget {
   final ImmersiveAsyncAction? onBeforeStartRecording;
   final ImmersiveAsyncAction? onBeforeSubmitText;
   final ImmersiveAsyncAction? onReplayQuestion;
-  final InterviewReportController? interviewReportController;
+  final OpenInterviewPracticeReport? onOpenInterviewReport;
   final SpeechFeedbackController? speechFeedbackController;
   final bool replayLoading;
   final bool replayPlaying;
@@ -310,7 +308,7 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   void _scheduleInterviewReportIfNeeded() {
     final controller = widget.practiceController;
     final sessionId = controller.practiceSessionId;
-    if (widget.interviewReportController == null ||
+    if (widget.onOpenInterviewReport == null ||
         sessionId == null ||
         controller.recordingState != PracticeRecordingState.completed ||
         !isInterviewPracticeScene(
@@ -340,10 +338,10 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
   }
 
   Future<void> _openInterviewReport() async {
-    final reportController = widget.interviewReportController;
+    final openReport = widget.onOpenInterviewReport;
     final practiceController = widget.practiceController;
     final sessionId = practiceController.practiceSessionId;
-    if (reportController == null ||
+    if (openReport == null ||
         sessionId == null ||
         practiceController.recordingState != PracticeRecordingState.completed ||
         _interviewReportRouteActive ||
@@ -355,17 +353,12 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
     }
     _interviewReportRouteActive = true;
     try {
-      final result = await Navigator.of(context).push<Object?>(
-        MaterialPageRoute<Object?>(
-          builder: (_) => InterviewReportPage(
-            practiceSessionId: sessionId,
-            controller: reportController,
-            title: '${widget.practiceController.scene?.name ?? '面试'} · 复盘',
-            speechFeedbackController: widget.speechFeedbackController,
-            speechFeedbackSourceKeys: List<String>.unmodifiable(
-              _feedbackSources.keys,
-            ),
-            onContinueWithAgent: widget.onContinueWithAgent,
+      final result = await openReport(
+        InterviewPracticeCompletion(
+          practiceSessionId: sessionId,
+          title: '${widget.practiceController.scene?.name ?? '面试'} · 复盘',
+          speechFeedbackSourceKeys: List<String>.unmodifiable(
+            _feedbackSources.keys,
           ),
         ),
       );

--- a/mobile/lib/features/coaching/practice/immersive_roleplay_session.dart
+++ b/mobile/lib/features/coaching/practice/immersive_roleplay_session.dart
@@ -6,7 +6,6 @@ import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/practice/immersive_roleplay.dart';
 import 'package:speakup/features/coaching/practice/avatar/avatar.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
-import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 
 typedef AvatarControllerFactory = AvatarController Function();
@@ -20,7 +19,7 @@ class ImmersiveRoleplaySession extends StatefulWidget {
   const ImmersiveRoleplaySession({
     required this.practiceController,
     required this.avatarControllerFactory,
-    this.interviewReportController,
+    this.onOpenInterviewReport,
     this.speechFeedbackController,
     this.onExitRequested,
     this.onContinueWithAgent,
@@ -29,7 +28,7 @@ class ImmersiveRoleplaySession extends StatefulWidget {
 
   final PracticeController practiceController;
   final AvatarControllerFactory avatarControllerFactory;
-  final InterviewReportController? interviewReportController;
+  final OpenInterviewPracticeReport? onOpenInterviewReport;
   final SpeechFeedbackController? speechFeedbackController;
   final Future<bool> Function()? onExitRequested;
   final Future<bool> Function()? onContinueWithAgent;
@@ -570,7 +569,7 @@ class _ImmersiveRoleplaySessionState extends State<ImmersiveRoleplaySession>
           widget.practiceController.currentQuestion?.speechPath == null
           ? null
           : _replayQuestion,
-      interviewReportController: widget.interviewReportController,
+      onOpenInterviewReport: widget.onOpenInterviewReport,
       speechFeedbackController: widget.speechFeedbackController,
       replayLoading: _replayLoading,
       replayPlaying: _isAvatarSpeaking,

--- a/mobile/lib/features/coaching/practice/practice.dart
+++ b/mobile/lib/features/coaching/practice/practice.dart
@@ -13,11 +13,9 @@ import 'package:speakup/features/coaching/practice/ielts_mock_practice.dart';
 import 'package:speakup/features/coaching/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
-import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recordings.dart';
-import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -31,7 +29,7 @@ class PracticePage extends StatefulWidget {
     this.onContinueWithAgent,
     this.ieltsMockProgressStore,
     this.preparationController,
-    this.interviewReportController,
+    this.onOpenInterviewReport,
     this.ieltsSpeakingReportController,
     this.speechFeedbackController,
     this.ieltsExaminerSpeaker,
@@ -44,7 +42,7 @@ class PracticePage extends StatefulWidget {
   final Future<bool> Function()? onContinueWithAgent;
   final IeltsMockProgressStore? ieltsMockProgressStore;
   final PreparationController? preparationController;
-  final InterviewReportController? interviewReportController;
+  final OpenInterviewPracticeReport? onOpenInterviewReport;
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
   final SpeechFeedbackController? speechFeedbackController;
   final IeltsExaminerSpeaker? ieltsExaminerSpeaker;
@@ -204,10 +202,10 @@ class _PracticePageState extends State<PracticePage>
   }
 
   Future<void> _openInterviewReport() async {
-    final reportController = widget.interviewReportController;
+    final openReport = widget.onOpenInterviewReport;
     final practiceController = widget.practiceController;
     final sessionId = practiceController?.practiceSessionId;
-    if (reportController == null ||
+    if (openReport == null ||
         practiceController == null ||
         sessionId == null ||
         practiceController.recordingState != PracticeRecordingState.completed ||
@@ -220,17 +218,12 @@ class _PracticePageState extends State<PracticePage>
     }
     _interviewReportRouteActive = true;
     try {
-      final result = await Navigator.of(context).push<Object?>(
-        MaterialPageRoute<Object?>(
-          builder: (_) => InterviewReportPage(
-            practiceSessionId: sessionId,
-            controller: reportController,
-            title: '${practiceController.scene?.name ?? '面试'} · 复盘',
-            speechFeedbackController: widget.speechFeedbackController,
-            speechFeedbackSourceKeys: List<String>.unmodifiable(
-              _feedbackSources.keys,
-            ),
-            onContinueWithAgent: widget.onContinueWithAgent,
+      final result = await openReport(
+        InterviewPracticeCompletion(
+          practiceSessionId: sessionId,
+          title: '${practiceController.scene?.name ?? '面试'} · 复盘',
+          speechFeedbackSourceKeys: List<String>.unmodifiable(
+            _feedbackSources.keys,
           ),
         ),
       );

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -389,6 +389,23 @@ enum PracticeSessionLifecycleStatus {
 
 enum CompletedPracticeRouteResult { continueWithAgent }
 
+final class InterviewPracticeCompletion {
+  const InterviewPracticeCompletion({
+    required this.practiceSessionId,
+    required this.title,
+    required this.speechFeedbackSourceKeys,
+  });
+
+  final String practiceSessionId;
+  final String title;
+  final List<String> speechFeedbackSourceKeys;
+}
+
+typedef OpenInterviewPracticeReport =
+    Future<CompletedPracticeRouteResult?> Function(
+      InterviewPracticeCompletion completion,
+    );
+
 final class PracticeSessionLifecycle {
   const PracticeSessionLifecycle({
     required this.sessionId,

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -11,9 +11,6 @@ import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/coaching/practice/immersive_roleplay.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
-import 'package:speakup/features/coaching/review/interview_report.dart';
-import 'package:speakup/features/coaching/review/interview_report_client.dart';
-import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_client.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -510,7 +507,7 @@ void main() {
     expect(find.text('查看报告'), findsOneWidget);
   });
 
-  testWidgets('opens report generation after the final interview turn', (
+  testWidgets('hands the completed interview to the report route', (
     tester,
   ) async {
     final controller = await _roleplayController(
@@ -527,29 +524,23 @@ void main() {
     }
     expect(controller.recordingState, PracticeRecordingState.completed);
 
-    final reportController = InterviewReportController(
-      client: _PendingInterviewReportClient(),
-      pollInterval: Duration.zero,
-      maximumPollAttempts: 1,
-    );
-    addTearDown(reportController.dispose);
+    InterviewPracticeCompletion? completion;
     await tester.pumpWidget(
       MaterialApp(
         home: ImmersiveRoleplayPage(
           practiceController: controller,
-          interviewReportController: reportController,
+          onOpenInterviewReport: (value) async {
+            completion = value;
+            return null;
+          },
         ),
       ),
     );
     await tester.pump();
     await tester.pump();
 
-    expect(find.byKey(const Key('interview-report-page')), findsOneWidget);
-    expect(
-      find.byKey(const Key('interview-report-generating')),
-      findsOneWidget,
-    );
-    expect(reportController.practiceSessionId, controller.practiceSessionId);
+    expect(completion?.practiceSessionId, controller.practiceSessionId);
+    expect(completion?.title, '${controller.scene?.name} · 复盘');
   });
 
   testWidgets('prefers the injected avatar replay action over audio playback', (
@@ -1158,17 +1149,6 @@ final class _PendingSpeechFeedbackClient implements SpeechFeedbackClient {
 
   @override
   Future<SpeechFeedback> getFeedback(String statusUrl) => _pending.future;
-
-  @override
-  Future<void> clearAccountState() async {}
-}
-
-final class _PendingInterviewReportClient implements InterviewReportClient {
-  final _pending = Completer<InterviewReportEnvelope>();
-
-  @override
-  Future<InterviewReportEnvelope> getReport(String practiceSessionId) =>
-      _pending.future;
 
   @override
   Future<void> clearAccountState() async {}

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -12,7 +12,11 @@ import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/app/speak_up_shell.dart';
 import 'package:speakup/features/agent/conversation/conversation.dart';
 import 'package:speakup/features/coaching/practice/practice.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation.dart';
+import 'package:speakup/features/coaching/review/interview_report.dart';
+import 'package:speakup/features/coaching/review/interview_report_client.dart';
+import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/review/review.dart';
 
 void main() {
@@ -766,6 +770,40 @@ void main() {
     );
   });
 
+  testWidgets('opens an interview report from the App route boundary', (
+    tester,
+  ) async {
+    final reportController = InterviewReportController(
+      client: _PendingInterviewReportClient(),
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(reportController.dispose);
+    await tester.pumpWidget(
+      SpeakUpApp.preview(interviewReportController: reportController),
+    );
+    final shellContext = tester.element(find.byType(SpeakUpShell));
+    Navigator.of(shellContext).pushNamed(AppRoutes.practice);
+    await tester.pumpAndSettle();
+
+    final practicePage = tester.widget<PracticePage>(find.byType(PracticePage));
+    unawaited(
+      practicePage.onOpenInterviewReport!(
+        const InterviewPracticeCompletion(
+          practiceSessionId: 'practice-session-report-route',
+          title: '模拟面试 · 复盘',
+          speechFeedbackSourceKeys: <String>[],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('interview-report-page')), findsOneWidget);
+    expect(find.text('模拟面试 · 复盘'), findsOneWidget);
+    expect(reportController.practiceSessionId, 'practice-session-report-route');
+  });
+
   testWidgets('keeps the named conversation route escapable on every tab', (
     tester,
   ) async {
@@ -958,6 +996,17 @@ const _primaryTabKeys = [
 Future<void> _openAgentTextInput(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('agent-show-text-composer')));
   await tester.pump();
+}
+
+final class _PendingInterviewReportClient implements InterviewReportClient {
+  final _pending = Completer<InterviewReportEnvelope>();
+
+  @override
+  Future<InterviewReportEnvelope> getReport(String practiceSessionId) =>
+      _pending.future;
+
+  @override
+  Future<void> clearAccountState() async {}
 }
 
 Future<void> _tapPrimaryDestination(


### PR DESCRIPTION
## 功能描述

Practice 页面只产生已完成面试的结构化结果，由 App 装配层打开 Review 报告并处理返回结果。

Closes #400

## 实现思路

- Practice 定义最小 `InterviewPracticeCompletion`，包含 Session、标题和已确认的反馈来源标识。
- 标准面试与沉浸式面试通过注入动作交接完成结果，不再构造报告页面或持有报告 Controller。
- `speak_up_app.dart` 统一创建 Interview Report 路由并注入 Review、Evaluation 与继续对话依赖。
- 缺少正式报告依赖时不注入打开动作，Practice 保持已完成状态。

## 代码地图

请求入口 → 应用编排 → 领域状态 → 结果展示

- `mobile/lib/features/coaching/practice/practice.dart`：标准训练完成检测与结果交接。
- `mobile/lib/features/coaching/practice/immersive_roleplay.dart`：沉浸式训练完成检测与结果交接。
- `mobile/lib/features/coaching/practice/practice_models.dart`：Practice-owned 完成结果。
- `mobile/lib/app/speak_up_app.dart`：报告路由与跨功能装配。
- `mobile/lib/features/coaching/review/interview_report_view.dart`：报告加载与展示入口。

依赖方向：Practice → 完成结果；App → Practice + Review。Practice 不再依赖 Interview Review 页面或 Controller。

## 验证

- `flutter analyze`
- `flutter test`（724 项全部通过）
- `git diff --check`

不调整 IELTS 报告流程、评分逻辑、视觉样式或 API。