### PR TITLE
refactor(mobile): 统一 IELTS 完成报告边界

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -32,6 +32,7 @@ import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/resume/resume_controller.dart';
@@ -455,7 +456,12 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       onOpenInterviewReport: widget.interviewReportController == null
           ? null
           : _openInterviewReport,
-      ieltsSpeakingReportController: widget.ieltsSpeakingReportController,
+      ieltsCompletedReportBuilder: widget.ieltsSpeakingReportController == null
+          ? null
+          : (_, practiceSessionId) => IeltsSpeakingSessionReportPanel(
+              practiceSessionId: practiceSessionId,
+              controller: widget.ieltsSpeakingReportController!,
+            ),
       speechFeedbackController: widget.speechFeedbackController,
       onExitRequested: launchController?.parkCurrentPractice,
       onContinueWithAgent: launchController?.completeAndContinueWithAgent,

--- a/mobile/lib/features/coaching/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/practice/ielts_mock_practice.dart
@@ -11,12 +11,10 @@ import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/features/coaching/scene/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/practice/ielts_examiner_speaker.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
-import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 import 'package:speakup/features/coaching/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
-import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_disclosure.dart';
@@ -56,6 +54,9 @@ IeltsPracticeMode? _ieltsPracticeModeForScene(SceneDefinition? scene) {
 
 enum IeltsPracticeCompletionAction { next, retry, list }
 
+typedef IeltsCompletedReportBuilder =
+    Widget Function(BuildContext context, String practiceSessionId);
+
 final class IeltsPracticeRouteResult {
   const IeltsPracticeRouteResult({
     required this.mode,
@@ -74,7 +75,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.onExitRequested,
     this.progressStore,
     this.preparationController,
-    this.reportController,
+    this.completedReportBuilder,
     this.speechFeedbackController,
     this.examinerSpeaker,
     this.now = DateTime.now,
@@ -85,7 +86,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final Future<bool> Function()? onExitRequested;
   final IeltsMockProgressStore? progressStore;
   final PreparationController? preparationController;
-  final IeltsSpeakingReportController? reportController;
+  final IeltsCompletedReportBuilder? completedReportBuilder;
   final SpeechFeedbackController? speechFeedbackController;
   final IeltsExaminerSpeaker? examinerSpeaker;
   final DateTime Function() now;
@@ -140,7 +141,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   String? _questionNarrationErrorId;
   int _questionNarrationGeneration = 0;
   final Set<IeltsPracticeMode> _recordedCompletions = <IeltsPracticeMode>{};
-  String? _reportSessionId;
 
   IeltsPracticeSelection? get _selection {
     final sessionId = widget.controller.practiceSessionId;
@@ -379,11 +379,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   void didUpdateWidget(covariant IeltsSpeakingMockPage oldWidget) {
     super.didUpdateWidget(oldWidget);
     final controllerChanged = oldWidget.controller != widget.controller;
-    final reportControllerChanged =
-        oldWidget.reportController != widget.reportController;
-    if (controllerChanged || reportControllerChanged) {
-      _cancelReport(oldWidget.reportController);
-    }
     if (controllerChanged) {
       oldWidget.controller.removeListener(_handleControllerState);
       widget.controller.addListener(_handleControllerState);
@@ -395,9 +390,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _revealedQuestionIds.clear();
       unawaited(_stopExaminerSpeakerSafely());
       unawaited(_restoreProgress());
-    }
-    if (reportControllerChanged && !controllerChanged) {
-      _syncReport();
     }
   }
 
@@ -418,7 +410,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (_ownsExaminerSpeaker) {
       unawaited(_examinerSpeaker.dispose());
     }
-    _cancelReport(widget.reportController);
     super.dispose();
   }
 
@@ -477,7 +468,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       setState(() => _part2RetryNeeded = true);
     }
     _recordCompletedParts();
-    _syncReport();
     unawaited(_resumePart2Narration(restored.phase));
     _scheduleQuestionNarration();
   }
@@ -656,7 +646,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (_part2TurnConfirmed && _part2ConfirmedTurns == null) {
       _part2ConfirmedTurns = widget.controller.completedTurns;
     }
-    _syncReport();
     _scheduleQuestionNarration();
     _flushBufferedPart3Audio();
   }
@@ -755,26 +744,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
   }
 
-  void _syncReport() {
-    final reportController = widget.reportController;
-    final sessionId = widget.controller.practiceSessionId;
-    if (_mode != IeltsPracticeMode.fullMock ||
-        _progress?.phase != IeltsMockPhase.complete ||
-        reportController == null ||
-        sessionId == null) {
-      _cancelReport(reportController);
-      return;
-    }
-    if (_reportSessionId != null && _reportSessionId != sessionId) {
-      _cancelReport(reportController);
-    }
-    _reportSessionId = sessionId;
-    if (reportController.practiceSessionId == sessionId) {
-      return;
-    }
-    unawaited(reportController.load(sessionId));
-  }
-
   void _recordCompletedParts() {
     final sessionId = widget.controller.practiceSessionId;
     final history = widget.preparationController;
@@ -814,14 +783,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         if (completed >= widget.controller.turnLimit) {
           complete(IeltsPracticeMode.part3);
         }
-    }
-  }
-
-  void _cancelReport(IeltsSpeakingReportController? reportController) {
-    final sessionId = _reportSessionId;
-    _reportSessionId = null;
-    if (sessionId != null) {
-      reportController?.cancel(sessionId);
     }
   }
 
@@ -1632,7 +1593,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             ? _MockComplete(
                 progress: progress,
                 part3AnswerCount: _part3Total,
-                reportController: widget.reportController,
+                report: _completedReport(),
                 onPressed: () => _requestExit(fromCompletion: true),
               )
             : _SectionPracticeComplete(
@@ -1645,6 +1606,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                     _finishSection(IeltsPracticeCompletionAction.list),
               ),
     };
+  }
+
+  Widget? _completedReport() {
+    final builder = widget.completedReportBuilder;
+    final sessionId = widget.controller.practiceSessionId;
+    if (builder == null || sessionId == null) {
+      return null;
+    }
+    return builder(context, sessionId);
   }
 
   int get _part3Start => switch (_mode) {
@@ -2962,13 +2932,13 @@ class _MockComplete extends StatelessWidget {
     required this.progress,
     required this.part3AnswerCount,
     required this.onPressed,
-    this.reportController,
+    this.report,
   });
 
   final IeltsMockProgress progress;
   final int part3AnswerCount;
   final VoidCallback onPressed;
-  final IeltsSpeakingReportController? reportController;
+  final Widget? report;
 
   @override
   Widget build(BuildContext context) {
@@ -2996,9 +2966,9 @@ class _MockComplete extends StatelessWidget {
             textAlign: TextAlign.center,
             style: SpeakUpDesign.body,
           ),
-          if (reportController case final controller?) ...[
+          if (report case final reportPanel?) ...[
             const SizedBox(height: 24),
-            IeltsSpeakingReportPanel(controller: controller),
+            reportPanel,
           ],
           const SizedBox(height: 28),
           Align(

--- a/mobile/lib/features/coaching/practice/practice.dart
+++ b/mobile/lib/features/coaching/practice/practice.dart
@@ -16,7 +16,6 @@ import 'package:speakup/features/coaching/preparation/preparation_controller.dar
 import 'package:speakup/features/coaching/practice/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recordings.dart';
-import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_disclosure.dart';
@@ -30,7 +29,7 @@ class PracticePage extends StatefulWidget {
     this.ieltsMockProgressStore,
     this.preparationController,
     this.onOpenInterviewReport,
-    this.ieltsSpeakingReportController,
+    this.ieltsCompletedReportBuilder,
     this.speechFeedbackController,
     this.ieltsExaminerSpeaker,
     super.key,
@@ -43,7 +42,7 @@ class PracticePage extends StatefulWidget {
   final IeltsMockProgressStore? ieltsMockProgressStore;
   final PreparationController? preparationController;
   final OpenInterviewPracticeReport? onOpenInterviewReport;
-  final IeltsSpeakingReportController? ieltsSpeakingReportController;
+  final IeltsCompletedReportBuilder? ieltsCompletedReportBuilder;
   final SpeechFeedbackController? speechFeedbackController;
   final IeltsExaminerSpeaker? ieltsExaminerSpeaker;
 
@@ -480,7 +479,7 @@ class _PracticePageState extends State<PracticePage>
         onExitRequested: widget.onExitRequested,
         progressStore: widget.ieltsMockProgressStore,
         preparationController: widget.preparationController,
-        reportController: widget.ieltsSpeakingReportController,
+        completedReportBuilder: widget.ieltsCompletedReportBuilder,
         speechFeedbackController: widget.speechFeedbackController,
         examinerSpeaker: widget.ieltsExaminerSpeaker,
       );

--- a/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
@@ -1,9 +1,61 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+
+class IeltsSpeakingSessionReportPanel extends StatefulWidget {
+  const IeltsSpeakingSessionReportPanel({
+    required this.practiceSessionId,
+    required this.controller,
+    super.key,
+  });
+
+  final String practiceSessionId;
+  final IeltsSpeakingReportController controller;
+
+  @override
+  State<IeltsSpeakingSessionReportPanel> createState() =>
+      _IeltsSpeakingSessionReportPanelState();
+}
+
+class _IeltsSpeakingSessionReportPanelState
+    extends State<IeltsSpeakingSessionReportPanel> {
+  @override
+  void initState() {
+    super.initState();
+    _loadCurrentSession();
+  }
+
+  @override
+  void didUpdateWidget(covariant IeltsSpeakingSessionReportPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller &&
+        oldWidget.practiceSessionId == widget.practiceSessionId) {
+      return;
+    }
+    oldWidget.controller.cancel(oldWidget.practiceSessionId);
+    _loadCurrentSession();
+  }
+
+  void _loadCurrentSession() {
+    if (widget.controller.practiceSessionId != widget.practiceSessionId) {
+      unawaited(widget.controller.load(widget.practiceSessionId));
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.cancel(widget.practiceSessionId);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      IeltsSpeakingReportPanel(controller: widget.controller);
+}
 
 class IeltsSpeakingReportPanel extends StatefulWidget {
   const IeltsSpeakingReportPanel({

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -23,6 +23,7 @@ import 'package:speakup/features/coaching/practice/practice_recording.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_client.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 
 void main() {
   testWidgets('Part 1 prefers the shared practice question voice', (
@@ -938,7 +939,11 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
-          reportController: reportController,
+          completedReportBuilder: (_, practiceSessionId) =>
+              IeltsSpeakingSessionReportPanel(
+                practiceSessionId: practiceSessionId,
+                controller: reportController,
+              ),
         ),
       ),
     );
@@ -987,7 +992,11 @@ void main() {
           controller: controller,
           progressStore: _MemoryProgressStore(),
           preparationController: preparation,
-          reportController: reportController,
+          completedReportBuilder: (_, practiceSessionId) =>
+              IeltsSpeakingSessionReportPanel(
+                practiceSessionId: practiceSessionId,
+                controller: reportController,
+              ),
         ),
       ),
     );

--- a/mobile/test/review/ielts_speaking_report_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_view_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
@@ -119,6 +121,35 @@ void main() {
 
     controller.cancel('session_ielts_report_001');
   });
+
+  testWidgets('session panel owns report loading and cancellation', (
+    tester,
+  ) async {
+    final client = _PendingClient();
+    final controller = IeltsSpeakingReportController(client: client);
+    addTearDown(controller.dispose);
+
+    Widget app(String sessionId) => MaterialApp(
+      home: IeltsSpeakingSessionReportPanel(
+        practiceSessionId: sessionId,
+        controller: controller,
+      ),
+    );
+
+    await tester.pumpWidget(app('session-one'));
+    await tester.pump();
+    expect(client.sessionIds, <String>['session-one']);
+    expect(controller.practiceSessionId, 'session-one');
+
+    await tester.pumpWidget(app('session-two'));
+    await tester.pump();
+    expect(client.sessionIds, <String>['session-one', 'session-two']);
+    expect(controller.practiceSessionId, 'session-two');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(controller.practiceSessionId, isNull);
+  });
 }
 
 Future<IeltsSpeakingReportController> _controllerFor(String fixtureKey) async {
@@ -158,6 +189,19 @@ final class _Client implements IeltsSpeakingReportClient {
   Future<IeltsSpeakingReportEnvelope> getReport(
     String practiceSessionId,
   ) async => envelope;
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _PendingClient implements IeltsSpeakingReportClient {
+  final sessionIds = <String>[];
+
+  @override
+  Future<IeltsSpeakingReportEnvelope> getReport(String practiceSessionId) {
+    sessionIds.add(practiceSessionId);
+    return Completer<IeltsSpeakingReportEnvelope>().future;
+  }
 
   @override
   Future<void> clearAccountState() async {}


### PR DESCRIPTION
## 功能描述

统一 IELTS 完成报告的加载与展示边界，使 Practice 只提供已完成的 Practice Session，Review 独立管理报告状态。

Closes #402

## 实现思路

- App 在组合根中把已完成的 Practice Session 映射为 Review 报告组件。
- Practice 仅在完整模拟完成页提供 Session ID，不再持有报告 Controller、轮询或取消逻辑。
- Review 新增 Session 报告入口，统一负责加载、切换 Session 与离开页面时取消请求。
- 保留现有 IELTS 报告展示和接口契约，不增加兼容路径。

## 代码地图

- 请求入口：mobile/lib/app/speak_up_app.dart，负责 App 级依赖装配。
- 应用编排：mobile/lib/features/coaching/practice/practice.dart，仅传递完成报告构建入口。
- 领域能力：mobile/lib/features/coaching/practice/ielts_mock_practice.dart，负责 IELTS 练习状态与完成事实。
- 报告能力：mobile/lib/features/coaching/review/ielts_speaking_report_view.dart，负责报告加载生命周期和展示。
- 数据来源：现有 IeltsSpeakingReportController 与 Client 保持为 Review 的报告读取实现。

## 验证

- flutter analyze
- flutter test --reporter compact（725 tests）
- Practice 目录不再依赖 IELTS 报告 Controller 或 View
- git diff --check