### PR TITLE
fix(preparation): 修复练习启动失败后返回按钮不可用

### DIFF
--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -395,11 +395,15 @@ class _PreparationPageState extends State<PreparationPage> {
   }
 
   void _handleBack(PreparationController? controller) {
-    if (widget.launchController?.isSelectionLocked ?? false) {
+    final launch = widget.launchController;
+    if (launch?.isNavigationLocked ?? false) {
       return;
     }
     if (controller?.selectedScene != null) {
-      widget.launchController?.selectionChanged();
+      if (!(launch?.prepareFailedAttemptForNavigation() ?? true)) {
+        return;
+      }
+      launch?.selectionChanged();
       controller?.showSceneList();
       return;
     }
@@ -413,11 +417,12 @@ class _PreparationPageState extends State<PreparationPage> {
   @override
   Widget build(BuildContext context) {
     final controller = widget.preparationController;
-    final launchLocked = widget.launchController?.isSelectionLocked ?? false;
+    final navigationLocked =
+        widget.launchController?.isNavigationLocked ?? false;
     final hasInternalRoute =
         controller?.selectedScene != null || _selectedHub != null;
     return PopScope<void>(
-      canPop: !launchLocked && !hasInternalRoute,
+      canPop: !navigationLocked && !hasInternalRoute,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) {
           _handleBack(controller);
@@ -435,7 +440,7 @@ class _PreparationPageState extends State<PreparationPage> {
                 leading: IconButton(
                   key: const Key('preparation-route-back-button'),
                   tooltip: '返回',
-                  onPressed: launchLocked
+                  onPressed: navigationLocked
                       ? null
                       : () => _handleBack(controller),
                   icon: const Icon(Icons.arrow_back_rounded),
@@ -763,7 +768,7 @@ class _SceneLaunchStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final launchLocked = launchController?.isSelectionLocked ?? false;
+    final navigationLocked = launchController?.isNavigationLocked ?? false;
     final message =
         controller.errorMessage ??
         launchController?.errorMessage ??
@@ -782,7 +787,7 @@ class _SceneLaunchStatus extends StatelessWidget {
           child: IconButton(
             key: const Key('preparation-back-to-catalog'),
             tooltip: '取消并返回',
-            onPressed: launchLocked ? null : onBack,
+            onPressed: navigationLocked ? null : onBack,
             icon: const Icon(Icons.arrow_back_rounded),
             color: PreparationDesign.ink,
             style: IconButton.styleFrom(

--- a/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
@@ -56,6 +56,7 @@ final class PreparationLaunchController extends ChangeNotifier {
   int _epoch = 0;
   bool _starting = false;
   bool _commitMayHaveSucceeded = false;
+  bool _failedAttemptSafelyParked = false;
   bool _disposed = false;
 
   String get backgroundSummary => _backgroundSummary;
@@ -69,6 +70,8 @@ final class PreparationLaunchController extends ChangeNotifier {
           (_bootstrap != null ||
               _commitMayHaveSucceeded ||
               (workspaceController != null && _retry!.threadId != null)));
+  bool get isNavigationLocked =>
+      isStarting || (isSelectionLocked && !_failedAttemptSafelyParked);
   bool get canRetry => _retry != null && !isStarting;
   bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
   bool get hasResumablePractice => workspaceController?.hasResumable ?? false;
@@ -223,6 +226,22 @@ final class PreparationLaunchController extends ChangeNotifier {
     return _run(attempt);
   }
 
+  bool prepareFailedAttemptForNavigation() {
+    if (_disposed || isNavigationLocked) {
+      return false;
+    }
+    if (_retry == null) {
+      return true;
+    }
+    final retryCanBeReplaced =
+        !_commitMayHaveSucceeded &&
+        (_bootstrap == null || hasResumablePractice);
+    if (retryCanBeReplaced) {
+      _invalidateAttempt();
+    }
+    return true;
+  }
+
   Future<bool> _run(_LaunchAttempt attempt) async {
     final operationEpoch = _epoch;
     final workspace = workspaceController;
@@ -230,6 +249,7 @@ final class PreparationLaunchController extends ChangeNotifier {
     final preserveCommittedState =
         identical(_retry, attempt) && _hasCommittedOrAmbiguousCreate;
     _starting = true;
+    _failedAttemptSafelyParked = false;
     _errorMessage = null;
     if (!preserveCommittedState) {
       _bootstrap = null;
@@ -392,16 +412,21 @@ final class PreparationLaunchController extends ChangeNotifier {
       }
       return false;
     } finally {
+      var safelyParked = workspace == null;
       if (!launchSucceeded &&
           _isCurrent(operationEpoch) &&
           workspace != null &&
           workspace.currentLease?.operationId == attempt.workspaceOperationId) {
         final parked = await workspace.parkCurrentPractice();
+        safelyParked = parked;
         if (!parked && _isCurrent(operationEpoch)) {
           _errorMessage ??= workspace.errorMessage ?? '练习准备已暂停，但暂时无法返回首页。';
         }
+      } else if (!launchSucceeded && workspace != null) {
+        safelyParked = true;
       }
       if (_isCurrent(operationEpoch)) {
+        _failedAttemptSafelyParked = !launchSucceeded && safelyParked;
         _starting = false;
         notifyListeners();
       }
@@ -416,6 +441,7 @@ final class PreparationLaunchController extends ChangeNotifier {
     _bootstrap = null;
     _retry = null;
     _commitMayHaveSucceeded = false;
+    _failedAttemptSafelyParked = false;
     _starting = false;
     await Future.wait<void>([
       client.clearAccountState(),
@@ -434,6 +460,7 @@ final class PreparationLaunchController extends ChangeNotifier {
     _bootstrap = null;
     _retry = null;
     _commitMayHaveSucceeded = false;
+    _failedAttemptSafelyParked = false;
     _starting = false;
     notifyListeners();
   }

--- a/mobile/test/coaching/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/coaching/preparation/preparation_launch_controller_test.dart
@@ -509,6 +509,8 @@ void main() {
       expect(harness.launchController.stage, PreparationLaunchStage.voice);
       expect(harness.launchController.canRetry, isTrue);
       expect(harness.launchController.hasResumablePractice, isTrue);
+      expect(harness.launchController.isSelectionLocked, isTrue);
+      expect(harness.launchController.isNavigationLocked, isFalse);
 
       expect(await harness.launchController.retry(), isTrue);
 
@@ -533,10 +535,59 @@ void main() {
       expect(harness.launchClient.sessionKeys.toSet(), hasLength(1));
     },
   );
+
+  test(
+    'safely parked pre-commit failure can return and discard its retry',
+    () async {
+      final harness = await _createWorkspaceLaunchHarness(
+        failFirstProfile: true,
+      );
+      addTearDown(harness.dispose);
+
+      expect(await harness.launchController.start(_selection), isFalse);
+
+      expect(harness.launchController.canRetry, isTrue);
+      expect(harness.launchController.isSelectionLocked, isTrue);
+      expect(harness.launchController.isNavigationLocked, isFalse);
+      expect(harness.conversationController.threadId, harness.homeThreadId);
+
+      expect(
+        harness.launchController.prepareFailedAttemptForNavigation(),
+        isTrue,
+      );
+
+      expect(harness.launchController.canRetry, isFalse);
+      expect(harness.launchController.isSelectionLocked, isFalse);
+      expect(harness.launchController.isNavigationLocked, isFalse);
+    },
+  );
+
+  test(
+    'leaving a parked voice failure keeps its committed practice resumable',
+    () async {
+      final harness = await _createWorkspaceLaunchHarness(failFirstVoice: true);
+      addTearDown(harness.dispose);
+
+      expect(await harness.launchController.start(_selection), isFalse);
+      expect(harness.launchController.hasResumablePractice, isTrue);
+      expect(harness.launchController.isNavigationLocked, isFalse);
+
+      expect(
+        harness.launchController.prepareFailedAttemptForNavigation(),
+        isTrue,
+      );
+
+      expect(harness.launchController.canRetry, isFalse);
+      expect(harness.launchController.isSelectionLocked, isFalse);
+      expect(harness.launchController.hasResumablePractice, isTrue);
+      expect(harness.conversationController.threadId, harness.homeThreadId);
+    },
+  );
 }
 
 Future<_WorkspaceLaunchHarness> _createWorkspaceLaunchHarness({
   bool failFirstVoice = false,
+  bool failFirstProfile = false,
 }) async {
   final agentClient = GoalAwareAgentClient();
   final practiceClient = _WorkspacePracticeClient();
@@ -557,7 +608,9 @@ Future<_WorkspaceLaunchHarness> _createWorkspaceLaunchHarness({
     recordStore: recordStore,
   );
   await workspaceController.activateAccount(_userId);
-  final launchClient = _WorkspaceLaunchClient();
+  final launchClient = _WorkspaceLaunchClient(
+    failFirstProfile: failFirstProfile,
+  );
   final goalKeys = <String>[];
   final voiceKeys = <String>[];
   var voiceCalls = 0;
@@ -665,6 +718,9 @@ final class _WorkspaceLaunchHarness {
 }
 
 final class _WorkspaceLaunchClient implements PreparationLaunchClient {
+  _WorkspaceLaunchClient({this.failFirstProfile = false});
+
+  final bool failFirstProfile;
   final profileKeys = <String>[];
   final snapshotKeys = <String>[];
   final planKeys = <String>[];
@@ -676,6 +732,13 @@ final class _WorkspaceLaunchClient implements PreparationLaunchClient {
     required String idempotencyKey,
   }) async {
     profileKeys.add(idempotencyKey);
+    if (failFirstProfile && profileKeys.length == 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.server,
+        stage: PreparationLaunchStage.profile,
+        retryable: true,
+      );
+    }
     expect(input.backgroundSummary, _background);
     return _profile;
   }

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -359,104 +359,126 @@ void main() {
     expect(launchClient.calls, isEmpty);
   });
 
-  testWidgets('direct start stays locked until voice retry succeeds', (
-    tester,
-  ) async {
-    final session = Completer<PreparationPracticeBootstrap>();
-    final preparationController = PreparationController(
-      client: _FixtureClient(),
-    );
-    final launchClient = _PageLaunchClient(sessionCompleter: session);
-    var navigations = 0;
-    var voiceCalls = 0;
-    final launchController = PreparationLaunchController(
-      client: launchClient,
-      contextProvider: () => _pageContext,
-      threadIdProvider: () => _pageContext.threadId,
-      goalActivator:
-          ({
-            required threadId,
-            required selection,
-            required clientOperationId,
-          }) async => _pageContext,
-      voiceActivator:
-          ({
-            required context,
-            required scene,
-            required bootstrap,
-            required clientOperationId,
-          }) async {
-            voiceCalls++;
-            if (voiceCalls == 1) {
-              throw const PreparationLaunchException(
-                kind: PreparationLaunchFailureKind.invalidResponse,
-                stage: PreparationLaunchStage.voice,
-              );
-            }
-          },
-      idFactory: (scope) => '$scope-pending-widget-key',
-    );
-    addTearDown(preparationController.dispose);
-    addTearDown(launchController.dispose);
+  testWidgets(
+    'direct start unlocks return after failure and retries on reentry',
+    (tester) async {
+      final session = Completer<PreparationPracticeBootstrap>();
+      final preparationController = PreparationController(
+        client: _FixtureClient(),
+      );
+      final launchClient = _PageLaunchClient(sessionCompleter: session);
+      var navigations = 0;
+      var voiceCalls = 0;
+      final launchController = PreparationLaunchController(
+        client: launchClient,
+        contextProvider: () => _pageContext,
+        threadIdProvider: () => _pageContext.threadId,
+        goalActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _pageContext,
+        voiceActivator:
+            ({
+              required context,
+              required scene,
+              required bootstrap,
+              required clientOperationId,
+            }) async {
+              voiceCalls++;
+              if (voiceCalls == 1) {
+                throw const PreparationLaunchException(
+                  kind: PreparationLaunchFailureKind.invalidResponse,
+                  stage: PreparationLaunchStage.voice,
+                );
+              }
+            },
+        idFactory: (scope) => '$scope-pending-widget-key',
+      );
+      addTearDown(preparationController.dispose);
+      addTearDown(launchController.dispose);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: PreparationPage(
-          showBackButton: true,
-          preparationController: preparationController,
-          launchController: launchController,
-          onPracticeStarted: () => navigations++,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            showBackButton: true,
+            preparationController: preparationController,
+            launchController: launchController,
+            onPracticeStarted: () => navigations++,
+          ),
         ),
-      ),
-    );
-    await tester.pumpAndSettle();
-    await _openFamily(tester, 'INTERVIEW');
-    await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
-    await tester.pump();
-    await tester.pump();
+      );
+      await tester.pumpAndSettle();
+      await _openFamily(tester, 'INTERVIEW');
+      await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
+      await tester.pump();
+      await tester.pump();
 
-    expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
-    expect(launchController.isStarting, isTrue);
-    expect(
-      tester
-          .widget<IconButton>(
-            find.byKey(const Key('preparation-back-to-catalog')),
-          )
-          .onPressed,
-      isNull,
-    );
-    expect(find.text('选择对话角色'), findsNothing);
+      expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
+      expect(launchController.isStarting, isTrue);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.byKey(const Key('preparation-back-to-catalog')),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(find.text('选择对话角色'), findsNothing);
 
-    session.complete(
-      PreparationPracticeBootstrap(
-        session: PreparationPracticeSession(
-          id: 'session-1',
-          planId: 'plan-1',
-          sceneFamily: SceneFamily.interview,
-          sceneModel: SceneModel.projectExperienceDeepDive,
-          snapshotId: 'session-snapshot-1',
-          status: 'starting',
-          version: 1,
-          createdAt: DateTime.utc(2026, 7, 26),
+      session.complete(
+        PreparationPracticeBootstrap(
+          session: PreparationPracticeSession(
+            id: 'session-1',
+            planId: 'plan-1',
+            sceneFamily: SceneFamily.interview,
+            sceneModel: SceneModel.projectExperienceDeepDive,
+            snapshotId: 'session-snapshot-1',
+            status: 'starting',
+            version: 1,
+            createdAt: DateTime.utc(2026, 7, 26),
+          ),
+          preparationSnapshotId: 'preparation-snapshot-1',
+          maxEffectiveTurns: 6,
         ),
-        preparationSnapshotId: 'preparation-snapshot-1',
-        maxEffectiveTurns: 6,
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    expect(launchController.canRetry, isTrue);
-    expect(navigations, 0);
-    await tester.tap(find.byKey(const Key('preparation-catalog-retry')));
-    await tester.pumpAndSettle();
+      expect(launchController.canRetry, isTrue);
+      expect(navigations, 0);
+      expect(launchController.isSelectionLocked, isTrue);
+      expect(launchController.isNavigationLocked, isFalse);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.byKey(const Key('preparation-back-to-catalog')),
+            )
+            .onPressed,
+        isNotNull,
+      );
 
-    expect(voiceCalls, 2);
-    expect(navigations, 1);
-    expect(
-      find.byKey(const Key('preparation-scene-launch-status')),
-      findsNothing,
-    );
-  });
+      await tester.tap(find.byKey(const Key('preparation-back-to-catalog')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('preparation-scene-launch-status')),
+        findsNothing,
+      );
+      expect(find.byKey(const Key('catalog-scene-$_sceneId')), findsOneWidget);
+      expect(launchController.canRetry, isTrue);
+
+      await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
+      await tester.pumpAndSettle();
+
+      expect(voiceCalls, 2);
+      expect(navigations, 1);
+      expect(
+        find.byKey(const Key('preparation-scene-launch-status')),
+        findsNothing,
+      );
+    },
+  );
 }
 
 class _FixtureClient implements SceneClient {


### PR DESCRIPTION
## 功能描述

修复练习启动失败后左上角返回按钮持续禁用、用户无法回到场景列表的问题。

## 实现思路

- 区分场景选择锁与页面导航锁：请求进行中仍禁止返回，失败状态安全停放后恢复返回。
- 离开失败页时按提交状态清理可替换的重试上下文，并保留已经提交且可恢复的练习。
- 覆盖失败后返回、重新进入并重试，以及已提交练习保持可恢复的回归测试。

## 测试方式

```bash
PUB_HOSTED_URL=https://pub.dev make check-flutter
```

结果：Flutter analyze 通过，726 个测试全部通过。

Closes #406