### PR TITLE
fix(preparation): 统一练习失败页返回状态处理

### DIFF
--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -467,7 +467,7 @@ class _PreparationPageState extends State<PreparationPage> {
         scene: selectedScene,
         launchController: widget.launchController,
         hasPrimaryNavigation: !widget.showBackButton,
-        onBack: () => controller.showSceneList(),
+        onBack: () => _handleBack(controller),
         onRetry: _retryLaunch,
       );
     }

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -360,7 +360,7 @@ void main() {
   });
 
   testWidgets(
-    'direct start unlocks return after failure and retries on reentry',
+    'direct start return preserves a committed retry for reconnection',
     (tester) async {
       final session = Completer<PreparationPracticeBootstrap>();
       final preparationController = PreparationController(
@@ -479,6 +479,69 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'inline return discards a replaceable failure before a new launch',
+    (tester) async {
+      final preparationController = PreparationController(
+        client: _MultiSceneClient(),
+      );
+      final launchClient = _PageLaunchClient(failFirstProfile: true);
+      var navigations = 0;
+      final launchController = PreparationLaunchController(
+        client: launchClient,
+        contextProvider: () => _pageContext,
+        threadIdProvider: () => _pageContext.threadId,
+        goalActivator:
+            ({
+              required threadId,
+              required selection,
+              required clientOperationId,
+            }) async => _pageContext,
+        voiceActivator:
+            ({
+              required context,
+              required scene,
+              required bootstrap,
+              required clientOperationId,
+            }) async {},
+        idFactory: (scope) => '$scope-replaceable-widget-key',
+      );
+      addTearDown(preparationController.dispose);
+      addTearDown(launchController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            preparationController: preparationController,
+            launchController: launchController,
+            onPracticeStarted: () => navigations++,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _openFamily(tester, 'INTERVIEW');
+      await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
+      await tester.pumpAndSettle();
+
+      expect(launchController.canRetry, isTrue);
+      await tester.tap(find.byKey(const Key('preparation-back-to-catalog')));
+      await tester.pumpAndSettle();
+
+      expect(launchController.canRetry, isFalse);
+      expect(launchController.isSelectionLocked, isFalse);
+      expect(preparationController.selectedScene, isNull);
+
+      await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
+      await tester.pumpAndSettle();
+
+      expect(navigations, 1);
+      expect(
+        launchClient.calls.where((call) => call == 'profile'),
+        hasLength(2),
+      );
+    },
+  );
 }
 
 class _FixtureClient implements SceneClient {
@@ -568,9 +631,10 @@ final class _ControlledListClient implements SceneClient {
 }
 
 final class _PageLaunchClient implements PreparationLaunchClient {
-  _PageLaunchClient({this.sessionCompleter});
+  _PageLaunchClient({this.sessionCompleter, this.failFirstProfile = false});
 
   final Completer<PreparationPracticeBootstrap>? sessionCompleter;
+  final bool failFirstProfile;
   final calls = <String>[];
   PreparationLaunchSelection? selection;
   PreparationSnapshot? _snapshot;
@@ -584,6 +648,14 @@ final class _PageLaunchClient implements PreparationLaunchClient {
     required String idempotencyKey,
   }) async {
     calls.add('profile');
+    if (failFirstProfile &&
+        calls.where((call) => call == 'profile').length == 1) {
+      throw const PreparationLaunchException(
+        kind: PreparationLaunchFailureKind.network,
+        stage: PreparationLaunchStage.profile,
+        retryable: true,
+      );
+    }
     return PreparationProfile(
       id: 'profile-1',
       userId: 'user-1',


### PR DESCRIPTION
## 功能描述

统一练习启动失败页的页面内返回与系统返回状态处理，确保离开前按练习创建结果清理或保留当前尝试。

Closes #409

## 实现思路

- 页面内返回复用 `_handleBack`，不再直接清空场景选择。
- `_handleBack` 调用现有 `prepareFailedAttemptForNavigation()`：可替换失败解除锁定，已提交或结果不确定的练习继续保留重连状态。
- 新增 Widget 回归测试，验证失败返回后可以重新启动，并保留已提交练习的重连行为。

## 代码地图

- 请求入口：`mobile/lib/features/coaching/preparation/preparation.dart` 的失败状态返回按钮。
- 应用编排：`_PreparationPageState._handleBack`。
- 状态边界：`PreparationLaunchController.prepareFailedAttemptForNavigation()`。
- 回归验证：`mobile/test/coaching/preparation/preparation_page_test.dart`。

## 验证

- `flutter analyze` 通过。
- Preparation 页面与 Controller 相关 21 个测试通过。
- Flutter 全量 730 个测试通过。
- `git diff --check` 通过。