### PR TITLE
[MS3][前端] 移除 IELTS 专项练习万年老题筛选

### DIFF
--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -669,7 +669,7 @@ components:
         part_1_questions:
           type: integer
           minimum: 0
-          maximum: 8
+          maximum: 24
         part_2_questions:
           type: integer
           minimum: 0
@@ -677,11 +677,11 @@ components:
         part_3_questions:
           type: integer
           minimum: 0
-          maximum: 5
+          maximum: 6
         turn_blueprints:
           type: array
           minItems: 1
-          maxItems: 14
+          maxItems: 24
           items:
             type: string
             minLength: 1

--- a/api/modules/scene.yaml
+++ b/api/modules/scene.yaml
@@ -322,11 +322,12 @@ components:
         - season
         - source_cutoff
         - part1_sets
+        - part1_topics
         - topic_groups
       properties:
         schema_version:
           type: integer
-          const: 1
+          const: 2
         bank_id:
           $ref: '#/components/schemas/ResourceId'
         season:
@@ -341,6 +342,12 @@ components:
           maxItems: 38
           items:
             $ref: '#/components/schemas/IeltsPart1Set'
+        part1_topics:
+          type: array
+          minItems: 38
+          maxItems: 38
+          items:
+            $ref: '#/components/schemas/IeltsPart1PracticeTopic'
         topic_groups:
           type: array
           minItems: 56
@@ -397,6 +404,43 @@ components:
           items:
             type: string
             minLength: 1
+    IeltsPart1PracticeTopic:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title_zh
+        - title_en
+        - release
+        - category
+        - questions
+        - published
+      properties:
+        id:
+          $ref: '#/components/schemas/ResourceId'
+        title_zh:
+          type: string
+          minLength: 1
+        title_en:
+          type: string
+          minLength: 1
+        release:
+          type: string
+          enum:
+            - new
+            - carry_over
+            - evergreen
+        category:
+          $ref: '#/components/schemas/IeltsTopicCategory'
+        questions:
+          type: array
+          minItems: 2
+          items:
+            type: string
+            minLength: 1
+        published:
+          type: boolean
+          const: true
     IeltsTopicGroup:
       type: object
       additionalProperties: false
@@ -405,6 +449,7 @@ components:
         - title_zh
         - release
         - region
+        - category
         - part2
         - part3_questions
         - published
@@ -423,6 +468,8 @@ components:
         region:
           type: string
           const: mainland
+        category:
+          $ref: '#/components/schemas/IeltsTopicCategory'
         part2:
           $ref: '#/components/schemas/IeltsPart2CueCard'
         part3_questions:
@@ -455,3 +502,10 @@ components:
           items:
             type: string
             minLength: 1
+    IeltsTopicCategory:
+      type: string
+      enum:
+        - person
+        - place
+        - thing
+        - event

--- a/api/modules/scene.yaml
+++ b/api/modules/scene.yaml
@@ -475,7 +475,7 @@ components:
         part3_questions:
           type: array
           minItems: 1
-          maxItems: 5
+          maxItems: 6
           items:
             type: string
             minLength: 1

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -318,7 +318,6 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     final canContinuePractice =
         widget.practiceController.hasActivePractice ||
         (widget.preparationLaunchController?.hasResumablePractice ?? false);
-    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final practiceSelected = _selectedIndex == 1;
     final safeBottom = math.max(
       MediaQuery.viewPaddingOf(context).bottom,
@@ -405,6 +404,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       ),
       ReviewPage(
         showBackButton: widget.showBackButton,
+        onExit: widget.showBackButton ? null : () => _selectDestination(0),
         previewMode: widget.previewMode,
         practiceAvailable: practiceAvailable,
         historyController: widget.reviewHistoryController,
@@ -441,14 +441,12 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       ),
       drawerScrimColor: const Color(0x52000000),
       body: IndexedStack(index: _selectedIndex, children: pages),
-      bottomNavigationBar: keyboardVisible
-          ? null
-          : GlassNavigationBar(
-              destinations: _destinations,
-              selectedIndex: _selectedIndex,
-              onDestinationSelected: _selectDestination,
-              solid: practiceSelected,
-            ),
+      bottomNavigationBar: GlassNavigationBar(
+        destinations: _destinations,
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: _selectDestination,
+        solid: practiceSelected,
+      ),
     );
   }
 

--- a/mobile/lib/features/coaching/practice/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/practice/ielts_mock_practice.dart
@@ -483,7 +483,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     final completed = widget.controller.completedTurns;
     if (_mode == IeltsPracticeMode.part1) {
       return value.copyWith(
-        phase: completed >= 8 ? IeltsMockPhase.complete : IeltsMockPhase.part1,
+        phase: completed >= widget.controller.turnLimit
+            ? IeltsMockPhase.complete
+            : IeltsMockPhase.part1,
         clearPreparationDeadline: true,
         clearSpeakingStartedAt: true,
         clearSpeakingDeadline: true,
@@ -769,7 +771,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
           complete(IeltsPracticeMode.part3);
         }
       case IeltsPracticeMode.part1:
-        if (completed >= 8) {
+        if (completed >= widget.controller.turnLimit) {
           complete(IeltsPracticeMode.part1);
         }
       case IeltsPracticeMode.part2:

--- a/mobile/lib/features/coaching/practice/practice_client.dart
+++ b/mobile/lib/features/coaching/practice/practice_client.dart
@@ -98,7 +98,7 @@ final class FakePracticeClient
   }) : _snapshot = initialSnapshot {
     if (!validPracticeSceneIdentity(sceneFamily, sceneModel) ||
         turnLimit < 1 ||
-        turnLimit > 14) {
+        turnLimit > 24) {
       throw ArgumentError('Invalid Fake Practice Session configuration.');
     }
   }

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -294,7 +294,7 @@ final class PracticeController extends ChangeNotifier
         scene.id.trim().isEmpty ||
         scene.name.trim().isEmpty ||
         turnLimit < 1 ||
-        turnLimit > 14 ||
+        turnLimit > 24 ||
         clientOperationId.trim().isEmpty ||
         isBusy ||
         _disposed) {
@@ -2081,7 +2081,7 @@ final class PracticeController extends ChangeNotifier
         ) ||
         snapshot.completedTurns < 0 ||
         snapshot.turnLimit < 1 ||
-        snapshot.turnLimit > 14 ||
+        snapshot.turnLimit > 24 ||
         snapshot.completedTurns > snapshot.turnLimit ||
         snapshot.sessionVersion < 1 ||
         (!snapshot.sessionCompleted && snapshot.currentQuestion == null) ||
@@ -2234,7 +2234,7 @@ final class PracticeController extends ChangeNotifier
         confirmation.answer.text != expectedAnswer ||
         confirmation.completedTurns < 1 ||
         confirmation.turnLimit < 1 ||
-        confirmation.turnLimit > 14 ||
+        confirmation.turnLimit > 24 ||
         confirmation.completedTurns > confirmation.turnLimit ||
         (confirmation.sessionVersion != null &&
             confirmation.sessionVersion! < 1) ||

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -848,7 +848,7 @@ PracticeSessionSnapshot _decodeSessionState(
       completed != terminal ||
       effectiveTurns < 0 ||
       turnLimit < 1 ||
-      turnLimit > 14 ||
+      turnLimit > 24 ||
       effectiveTurns > turnLimit ||
       (!completed && question == null) ||
       (completed &&

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -249,7 +249,9 @@ final class WirePracticeClient
         path: _endpoints.voiceActivationPath(sessionId),
         extraHeaders: <String, String>{'Idempotency-Key': clientOperationId},
       );
-      _requireStatus(response, const {HttpStatus.ok});
+      // The server returns 200 for both the initial idempotent activation and
+      // its replay. Keep accepting 201 for compatibility with older servers.
+      _requireStatus(response, const {HttpStatus.ok, HttpStatus.created});
       return _decodeSessionState(response.body, expectedSessionId: sessionId);
     });
   }

--- a/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
@@ -1215,7 +1215,7 @@ final class _StoredPracticeWorkspace {
           (completedTurns != null &&
               (completedTurns is! int ||
                   completedTurns < 0 ||
-                  completedTurns > 14)) ||
+                  completedTurns > 24)) ||
           !_validOpaqueId(accountId) ||
           !_validOperationId(operationId) ||
           !_validOpaqueId(practiceThreadId) ||

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -577,8 +577,14 @@ class _PreparationPageState extends State<PreparationPage> {
 
   Widget _buildHub(PreparationController controller, _PracticeHub hub) {
     final scenes = _scenesForHub(controller.scenes, hub);
+    final routeKey = hub == _PracticeHub.ielts
+        ? (_ieltsBrowserOpen ? 'ielts-browser' : 'ielts-modes')
+        : hub.name;
     return ListView(
-      key: Key('preparation-hub-list-${hub.name}'),
+      // IELTS mode selection and the question browser are distinct screens.
+      // Give them distinct scroll state so the browser always opens with its
+      // exit control visible, even after scrolling to the specialty card.
+      key: Key('preparation-hub-list-$routeKey'),
       primary: false,
       padding: PreparationDesign.pagePadding(
         context,

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -766,55 +766,74 @@ class _SceneLaunchStatus extends StatelessWidget {
         controller.errorMessage ??
         launchController?.errorMessage ??
         launchController?.workspaceErrorMessage;
-    return ListView(
+    final pagePadding = PreparationDesign.pagePadding(
+      context,
+      hasPrimaryNavigation: hasPrimaryNavigation,
+      top: 8,
+    );
+    return Column(
       key: const Key('preparation-scene-launch-status'),
-      primary: false,
-      padding: PreparationDesign.pagePadding(
-        context,
-        hasPrimaryNavigation: hasPrimaryNavigation,
-        top: 8,
-      ),
       children: [
-        Align(
-          alignment: Alignment.centerLeft,
-          child: IconButton(
-            key: const Key('preparation-back-to-catalog'),
-            tooltip: '取消并返回',
-            onPressed: navigationLocked ? null : onBack,
-            icon: const Icon(Icons.arrow_back_rounded),
-            color: PreparationDesign.ink,
-            style: IconButton.styleFrom(
-              backgroundColor: PreparationDesign.surface,
-              side: const BorderSide(color: PreparationDesign.border),
+        Padding(
+          padding: EdgeInsets.fromLTRB(
+            pagePadding.left,
+            pagePadding.top,
+            pagePadding.right,
+            0,
+          ),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: IconButton(
+              key: const Key('preparation-back-to-catalog'),
+              tooltip: '取消并返回',
+              onPressed: navigationLocked ? null : onBack,
+              icon: const Icon(Icons.arrow_back_rounded),
+              color: PreparationDesign.ink,
+              style: IconButton.styleFrom(
+                backgroundColor: PreparationDesign.surface,
+                side: const BorderSide(color: PreparationDesign.border),
+              ),
             ),
           ),
         ),
-        const SizedBox(height: 18),
-        Text(
-          scene.name,
-          key: const Key('preparation-scene-title'),
-          style: PreparationDesign.pageTitle,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          message == null ? '正在准备练习…' : '暂时无法开始这项练习。',
-          style: PreparationDesign.body,
-        ),
-        const SizedBox(height: 28),
-        if (message != null)
-          _CatalogFailure(
-            key: const Key('preparation-launch-error'),
-            message: message,
-            onRetry: controller.errorMessage != null
-                ? controller.retryLastFailure
-                : launchController?.canRetry == true
-                ? onRetry
-                : () async => onBack(),
-          )
-        else
-          const LinearProgressIndicator(
-            key: Key('preparation-launch-progress'),
+        Expanded(
+          child: ListView(
+            primary: false,
+            padding: EdgeInsets.fromLTRB(
+              pagePadding.left,
+              18,
+              pagePadding.right,
+              pagePadding.bottom,
+            ),
+            children: [
+              Text(
+                scene.name,
+                key: const Key('preparation-scene-title'),
+                style: PreparationDesign.pageTitle,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                message == null ? '正在准备练习…' : '暂时无法开始这项练习。',
+                style: PreparationDesign.body,
+              ),
+              const SizedBox(height: 28),
+              if (message != null)
+                _CatalogFailure(
+                  key: const Key('preparation-launch-error'),
+                  message: message,
+                  onRetry: controller.errorMessage != null
+                      ? controller.retryLastFailure
+                      : launchController?.canRetry == true
+                      ? onRetry
+                      : () async => onBack(),
+                )
+              else
+                const LinearProgressIndicator(
+                  key: Key('preparation-launch-progress'),
+                ),
+            ],
           ),
+        ),
       ],
     );
   }

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -61,6 +61,7 @@ class PreparationPage extends StatefulWidget {
 class _PreparationPageState extends State<PreparationPage> {
   TextEditingController? _backgroundController;
   _PracticeHub? _selectedHub;
+  bool _ieltsBrowserOpen = false;
   _IeltsBrowserState _ieltsBrowserState = const _IeltsBrowserState();
   IeltsPracticeSelection? _launchingIeltsSelection;
   bool _handlingIeltsNavigation = false;
@@ -138,6 +139,7 @@ class _PreparationPageState extends State<PreparationPage> {
     }
     setState(() {
       _selectedHub = _PracticeHub.ielts;
+      _ieltsBrowserOpen = true;
       _ieltsBrowserState = _ieltsBrowserState.copyWith(part: request.mode);
     });
     final selection = request.selection;
@@ -549,7 +551,10 @@ class _PreparationPageState extends State<PreparationPage> {
             tintColor: PreparationDesign.ieltsTint,
             assetPath: 'assets/images/scenes/ielts-hero.jpg',
             onPressed: () {
-              setState(() => _selectedHub = _PracticeHub.ielts);
+              setState(() {
+                _selectedHub = _PracticeHub.ielts;
+                _ieltsBrowserOpen = false;
+              });
               unawaited(controller.loadIeltsQuestionBankIfNeeded());
             },
           ),
@@ -586,7 +591,13 @@ class _PreparationPageState extends State<PreparationPage> {
           child: IconButton(
             key: const Key('preparation-back-to-families'),
             tooltip: '返回场景练习',
-            onPressed: () => setState(() => _selectedHub = null),
+            onPressed: () => setState(() {
+              if (hub == _PracticeHub.ielts && _ieltsBrowserOpen) {
+                _ieltsBrowserOpen = false;
+              } else {
+                _selectedHub = null;
+              }
+            }),
             icon: const Icon(Icons.arrow_back_rounded),
             color: PreparationDesign.ink,
             style: IconButton.styleFrom(
@@ -607,6 +618,8 @@ class _PreparationPageState extends State<PreparationPage> {
           _IeltsHub(
             controller: controller,
             scenes: scenes,
+            browserOpen: _ieltsBrowserOpen,
+            onOpenBrowser: () => setState(() => _ieltsBrowserOpen = true),
             initialBrowserState: _ieltsBrowserState,
             onBrowserStateChanged: (value) => _ieltsBrowserState = value,
             onRetry: controller.loadIeltsQuestionBankIfNeeded,
@@ -1238,6 +1251,8 @@ class _IeltsHub extends StatefulWidget {
   const _IeltsHub({
     required this.controller,
     required this.scenes,
+    required this.browserOpen,
+    required this.onOpenBrowser,
     required this.onFullMockPressed,
     required this.onSelectionPressed,
     required this.onRetry,
@@ -1247,6 +1262,8 @@ class _IeltsHub extends StatefulWidget {
 
   final PreparationController controller;
   final List<SceneDefinition> scenes;
+  final bool browserOpen;
+  final VoidCallback onOpenBrowser;
   final ValueChanged<SceneDefinition> onFullMockPressed;
   final void Function(SceneDefinition scene, IeltsPracticeSelection selection)
   onSelectionPressed;
@@ -1333,6 +1350,32 @@ class _IeltsHubState extends State<_IeltsHub> {
         partScenes.values.every((scene) => scene == null)) {
       return const _HubEmpty(message: '当前没有可用的 IELTS 口语练习。');
     }
+    if (widget.browserOpen) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _HubHeader(
+            title: '专项练习',
+            description: '按题季、Part 和主题分类选择题目。',
+            titleKey: Key('ielts-special-browser-title'),
+          ),
+          const SizedBox(height: 20),
+          _IeltsQuestionBrowser(
+            controller: widget.controller,
+            searchController: _searchController,
+            source: _source,
+            part: _part,
+            category: _category,
+            partScenes: partScenes,
+            onRetry: widget.onRetry,
+            onSourceChanged: _setSource,
+            onPartChanged: _setPart,
+            onCategoryChanged: _setCategory,
+            onSelectionPressed: widget.onSelectionPressed,
+          ),
+        ],
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1355,22 +1398,19 @@ class _IeltsHubState extends State<_IeltsHub> {
             assetPath: 'assets/images/scenes/ielts-hero.jpg',
             onPressed: () => widget.onFullMockPressed(fullScene),
           ),
-          const SizedBox(height: 26),
+          const SizedBox(height: 16),
         ],
-        const Text('专项练习', style: PreparationDesign.sectionTitle),
-        const SizedBox(height: 12),
-        _IeltsQuestionBrowser(
-          controller: widget.controller,
-          searchController: _searchController,
-          source: _source,
-          part: _part,
-          category: _category,
-          partScenes: partScenes,
-          onRetry: widget.onRetry,
-          onSourceChanged: _setSource,
-          onPartChanged: _setPart,
-          onCategoryChanged: _setCategory,
-          onSelectionPressed: widget.onSelectionPressed,
+        _FeaturedScene(
+          key: const Key('ielts-mode-special'),
+          eyebrow: '分类题库',
+          title: '按 Part 专项突破',
+          description: '按新题、保留题、万年老题和主题标签精准选题。',
+          actionLabel: '选择专项题目',
+          icon: Icons.grid_view_rounded,
+          color: const Color(0xFF0EA5E9),
+          foregroundColor: Colors.white,
+          assetPath: 'assets/images/scenes/ielts-hero.jpg',
+          onPressed: widget.onOpenBrowser,
         ),
       ],
     );

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -61,7 +61,7 @@ class PreparationPage extends StatefulWidget {
 class _PreparationPageState extends State<PreparationPage> {
   TextEditingController? _backgroundController;
   _PracticeHub? _selectedHub;
-  IeltsPracticeMode? _selectedIeltsSection;
+  _IeltsBrowserState _ieltsBrowserState = const _IeltsBrowserState();
   IeltsPracticeSelection? _launchingIeltsSelection;
   bool _handlingIeltsNavigation = false;
 
@@ -138,7 +138,7 @@ class _PreparationPageState extends State<PreparationPage> {
     }
     setState(() {
       _selectedHub = _PracticeHub.ielts;
-      _selectedIeltsSection = request.mode;
+      _ieltsBrowserState = _ieltsBrowserState.copyWith(part: request.mode);
     });
     final selection = request.selection;
     if (selection != null) {
@@ -204,7 +204,6 @@ class _PreparationPageState extends State<PreparationPage> {
       catalog.showSceneList();
       setState(() {
         _selectedHub = null;
-        _selectedIeltsSection = null;
         _launchingIeltsSelection = null;
       });
       widget.onPracticeStarted?.call();
@@ -223,7 +222,6 @@ class _PreparationPageState extends State<PreparationPage> {
       catalog?.showSceneList();
       setState(() {
         _selectedHub = null;
-        _selectedIeltsSection = null;
         _launchingIeltsSelection = null;
       });
       widget.onPracticeStarted?.call();
@@ -574,9 +572,6 @@ class _PreparationPageState extends State<PreparationPage> {
 
   Widget _buildHub(PreparationController controller, _PracticeHub hub) {
     final scenes = _scenesForHub(controller.scenes, hub);
-    final ieltsSection = hub == _PracticeHub.ielts
-        ? _selectedIeltsSection
-        : null;
     return ListView(
       key: Key('preparation-hub-list-${hub.name}'),
       primary: false,
@@ -591,13 +586,7 @@ class _PreparationPageState extends State<PreparationPage> {
           child: IconButton(
             key: const Key('preparation-back-to-families'),
             tooltip: '返回场景练习',
-            onPressed: () => setState(() {
-              if (ieltsSection != null) {
-                _selectedIeltsSection = null;
-              } else {
-                _selectedHub = null;
-              }
-            }),
+            onPressed: () => setState(() => _selectedHub = null),
             icon: const Icon(Icons.arrow_back_rounded),
             color: PreparationDesign.ink,
             style: IconButton.styleFrom(
@@ -615,33 +604,18 @@ class _PreparationPageState extends State<PreparationPage> {
             onOpenJobPreparation: widget.onOpenJobPreparation,
           )
         else if (hub == _PracticeHub.ielts)
-          if (ieltsSection == null)
-            _IeltsHub(
-              scenes: scenes,
-              onFullMockPressed: (scene) =>
-                  unawaited(_startIeltsFullMock(controller, scene)),
-              onPartPressed: (scene) {
-                final mode = _ieltsModeForScene(scene.id);
-                if (mode != null) {
-                  setState(() => _selectedIeltsSection = mode);
-                  unawaited(controller.loadIeltsQuestionBankIfNeeded());
-                }
-              },
-            )
-          else
-            _IeltsSetList(
-              controller: controller,
-              mode: ieltsSection,
-              scene: _ieltsSceneForMode(scenes, ieltsSection),
-              onRetry: controller.loadIeltsQuestionBankIfNeeded,
-              onSelectionPressed: (scene, selection) => unawaited(
-                _startSceneDirectly(
-                  controller,
-                  scene,
-                  ieltsSelection: selection,
-                ),
-              ),
-            )
+          _IeltsHub(
+            controller: controller,
+            scenes: scenes,
+            initialBrowserState: _ieltsBrowserState,
+            onBrowserStateChanged: (value) => _ieltsBrowserState = value,
+            onRetry: controller.loadIeltsQuestionBankIfNeeded,
+            onFullMockPressed: (scene) =>
+                unawaited(_startIeltsFullMock(controller, scene)),
+            onSelectionPressed: (scene, selection) => unawaited(
+              _startSceneDirectly(controller, scene, ieltsSelection: selection),
+            ),
+          )
         else
           _RoleplayHub(
             scenes: scenes,
@@ -1232,26 +1206,131 @@ class _InterviewHub extends StatelessWidget {
   }
 }
 
-class _IeltsHub extends StatelessWidget {
-  const _IeltsHub({
-    required this.scenes,
-    required this.onFullMockPressed,
-    required this.onPartPressed,
+enum _IeltsSourceFilter { all, newSeason, carryOver, evergreen }
+
+final class _IeltsBrowserState {
+  const _IeltsBrowserState({
+    this.query = '',
+    this.source = _IeltsSourceFilter.all,
+    this.part,
+    this.category,
   });
 
+  final String query;
+  final _IeltsSourceFilter source;
+  final IeltsPracticeMode? part;
+  final IeltsTopicCategory? category;
+
+  _IeltsBrowserState copyWith({
+    String? query,
+    _IeltsSourceFilter? source,
+    IeltsPracticeMode? part,
+    IeltsTopicCategory? category,
+  }) => _IeltsBrowserState(
+    query: query ?? this.query,
+    source: source ?? this.source,
+    part: part ?? this.part,
+    category: category ?? this.category,
+  );
+}
+
+class _IeltsHub extends StatefulWidget {
+  const _IeltsHub({
+    required this.controller,
+    required this.scenes,
+    required this.onFullMockPressed,
+    required this.onSelectionPressed,
+    required this.onRetry,
+    required this.initialBrowserState,
+    required this.onBrowserStateChanged,
+  });
+
+  final PreparationController controller;
   final List<SceneDefinition> scenes;
   final ValueChanged<SceneDefinition> onFullMockPressed;
-  final ValueChanged<SceneDefinition> onPartPressed;
+  final void Function(SceneDefinition scene, IeltsPracticeSelection selection)
+  onSelectionPressed;
+  final Future<void> Function() onRetry;
+  final _IeltsBrowserState initialBrowserState;
+  final ValueChanged<_IeltsBrowserState> onBrowserStateChanged;
+
+  @override
+  State<_IeltsHub> createState() => _IeltsHubState();
+}
+
+class _IeltsHubState extends State<_IeltsHub> {
+  late final TextEditingController _searchController;
+  _IeltsSourceFilter _source = _IeltsSourceFilter.all;
+  IeltsPracticeMode? _part;
+  IeltsTopicCategory? _category;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initialBrowserState;
+    _source = initial.source;
+    _part = initial.part;
+    _category = initial.category;
+    _searchController = TextEditingController(text: initial.query)
+      ..addListener(_onSearchChanged);
+  }
+
+  @override
+  void dispose() {
+    _searchController
+      ..removeListener(_onSearchChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged() {
+    setState(() {});
+    _publishBrowserState();
+  }
+
+  void _publishBrowserState() => widget.onBrowserStateChanged(
+    _IeltsBrowserState(
+      query: _searchController.text,
+      source: _source,
+      part: _part,
+      category: _category,
+    ),
+  );
+
+  void _setSource(_IeltsSourceFilter value) {
+    setState(() => _source = value);
+    _publishBrowserState();
+  }
+
+  void _setPart(IeltsPracticeMode? value) {
+    setState(() => _part = value);
+    _publishBrowserState();
+  }
+
+  void _setCategory(IeltsTopicCategory? value) {
+    setState(() => _category = value);
+    _publishBrowserState();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final fullScene = _sceneById(scenes, _ieltsFullSceneId);
-    final partScenes = _scenesByIds(scenes, const [
-      'scn_ielts_speaking_part_1',
-      'scn_ielts_speaking_part_2',
-      'scn_ielts_speaking_part_3',
-    ]);
-    if (fullScene == null && partScenes.isEmpty) {
+    final fullScene = _sceneById(widget.scenes, _ieltsFullSceneId);
+    final partScenes = <IeltsPracticeMode, SceneDefinition?>{
+      IeltsPracticeMode.part1: _ieltsSceneForMode(
+        widget.scenes,
+        IeltsPracticeMode.part1,
+      ),
+      IeltsPracticeMode.part2: _ieltsSceneForMode(
+        widget.scenes,
+        IeltsPracticeMode.part2,
+      ),
+      IeltsPracticeMode.part3: _ieltsSceneForMode(
+        widget.scenes,
+        IeltsPracticeMode.part3,
+      ),
+    };
+    if (fullScene == null &&
+        partScenes.values.every((scene) => scene == null)) {
       return const _HubEmpty(message: '当前没有可用的 IELTS 口语练习。');
     }
     return Column(
@@ -1274,253 +1353,600 @@ class _IeltsHub extends StatelessWidget {
             color: PreparationDesign.ielts,
             foregroundColor: Colors.white,
             assetPath: 'assets/images/scenes/ielts-hero.jpg',
-            onPressed: () => onFullMockPressed(fullScene),
+            onPressed: () => widget.onFullMockPressed(fullScene),
           ),
-          const SizedBox(height: 28),
+          const SizedBox(height: 26),
         ],
-        if (partScenes.isNotEmpty) ...[
-          const Text('分段练习', style: PreparationDesign.sectionTitle),
-          const SizedBox(height: 12),
-          for (var index = 0; index < partScenes.length; index++)
-            _IeltsPartStep(
-              scene: partScenes[index],
-              partNumber: _ieltsPartNumber(partScenes[index].id),
-              label: _ieltsPartLabel(partScenes[index].id),
-              isLast: index == partScenes.length - 1,
-              onPressed: () => onPartPressed(partScenes[index]),
-            ),
-        ],
+        const Text('专项练习', style: PreparationDesign.sectionTitle),
+        const SizedBox(height: 12),
+        _IeltsQuestionBrowser(
+          controller: widget.controller,
+          searchController: _searchController,
+          source: _source,
+          part: _part,
+          category: _category,
+          partScenes: partScenes,
+          onRetry: widget.onRetry,
+          onSourceChanged: _setSource,
+          onPartChanged: _setPart,
+          onCategoryChanged: _setCategory,
+          onSelectionPressed: widget.onSelectionPressed,
+        ),
       ],
     );
   }
 }
 
-class _IeltsSetList extends StatelessWidget {
-  const _IeltsSetList({
+class _IeltsQuestionBrowser extends StatelessWidget {
+  const _IeltsQuestionBrowser({
     required this.controller,
-    required this.mode,
-    required this.scene,
+    required this.searchController,
+    required this.source,
+    required this.part,
+    required this.category,
+    required this.partScenes,
     required this.onRetry,
+    required this.onSourceChanged,
+    required this.onPartChanged,
+    required this.onCategoryChanged,
     required this.onSelectionPressed,
   });
 
   final PreparationController controller;
-  final IeltsPracticeMode mode;
-  final SceneDefinition? scene;
+  final TextEditingController searchController;
+  final _IeltsSourceFilter source;
+  final IeltsPracticeMode? part;
+  final IeltsTopicCategory? category;
+  final Map<IeltsPracticeMode, SceneDefinition?> partScenes;
   final Future<void> Function() onRetry;
+  final ValueChanged<_IeltsSourceFilter> onSourceChanged;
+  final ValueChanged<IeltsPracticeMode?> onPartChanged;
+  final ValueChanged<IeltsTopicCategory?> onCategoryChanged;
   final void Function(SceneDefinition scene, IeltsPracticeSelection selection)
   onSelectionPressed;
 
   @override
   Widget build(BuildContext context) {
     final bank = controller.ieltsQuestionBank;
-    final title = switch (mode) {
-      IeltsPracticeMode.part1 => 'Part 1 套题',
-      IeltsPracticeMode.part2 => 'Part 2 题卡',
-      IeltsPracticeMode.part3 => 'Part 3 主题讨论',
-      IeltsPracticeMode.fullMock => '完整模考',
-    };
     if (controller.isLoadingIeltsQuestionBank && bank == null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _HubHeader(
-            title: title,
-            description: '正在读取本季题库…',
-            titleKey: Key('ielts-set-list-title-${mode.name}'),
-          ),
-          const SizedBox(height: 36),
-          const Center(child: CircularProgressIndicator()),
-        ],
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 36),
+        child: Center(
+          child: CircularProgressIndicator(color: PreparationDesign.ielts),
+        ),
       );
     }
     if (bank == null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _HubHeader(
-            title: title,
-            description: '暂时无法显示套题。',
-            titleKey: Key('ielts-set-list-title-${mode.name}'),
-          ),
-          const SizedBox(height: 24),
-          _InlineFailure(
-            message: controller.ieltsErrorMessage ?? '雅思口语题库暂时不可用。',
-            retryKey: const Key('ielts-question-bank-retry'),
-            onRetry: onRetry,
-          ),
-        ],
+      return _InlineFailure(
+        message: controller.ieltsErrorMessage ?? '雅思口语题库暂时不可用。',
+        retryKey: const Key('ielts-question-bank-retry'),
+        onRetry: onRetry,
       );
     }
-    final total = mode == IeltsPracticeMode.part1
-        ? bank.part1Sets.length
-        : bank.topicGroups.length;
-    final completed = mode == IeltsPracticeMode.part1
-        ? bank.part1Sets
-              .where(
-                (set) => controller
-                    .ieltsProgress(IeltsPracticeMode.part1, set.id)
-                    .completed,
-              )
-              .length
-        : bank.topicGroups
-              .where(
-                (group) => controller.ieltsProgress(mode, group.id).completed,
-              )
-              .length;
+    final items = _visibleItems(bank);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _HubHeader(
-          title: title,
-          description: switch (mode) {
-            IeltsPracticeMode.part1 => '每套包含 3 个熟悉话题，共 8 道题。',
-            IeltsPracticeMode.part2 => '完成题卡后，可以继续同主题 Part 3。',
-            IeltsPracticeMode.part3 => '先看对应 Part 2 背景，再练绑定讨论题。',
-            IeltsPracticeMode.fullMock => '按正式顺序完成三个 Part。',
-          },
-          titleKey: Key('ielts-set-list-title-${mode.name}'),
-        ),
-        const SizedBox(height: 14),
-        Text(
-          '已完成 $completed / $total 套',
-          key: Key('ielts-set-list-progress-${mode.name}'),
-          style: PreparationDesign.meta.copyWith(
-            color: PreparationDesign.ielts,
-            fontWeight: FontWeight.w800,
+        TextField(
+          key: const Key('ielts-browser-search'),
+          controller: searchController,
+          textInputAction: TextInputAction.search,
+          decoration: InputDecoration(
+            hintText: '搜索中英文题目…',
+            prefixIcon: const Icon(Icons.search_rounded),
+            suffixIcon: searchController.text.isEmpty
+                ? null
+                : IconButton(
+                    tooltip: '清除搜索',
+                    onPressed: searchController.clear,
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+            filled: true,
+            fillColor: Colors.white,
+            contentPadding: const EdgeInsets.symmetric(vertical: 16),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(18),
+              borderSide: const BorderSide(
+                color: PreparationDesign.ieltsBorder,
+              ),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(18),
+              borderSide: const BorderSide(
+                color: PreparationDesign.ieltsBorder,
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(18),
+              borderSide: const BorderSide(
+                color: PreparationDesign.ielts,
+                width: 1.5,
+              ),
+            ),
           ),
         ),
         const SizedBox(height: 18),
-        if (scene == null)
-          const _HubEmpty(message: '当前分段练习尚未开放。')
-        else if (mode == IeltsPracticeMode.part1)
-          for (final set in bank.part1Sets) ...[
-            _IeltsSetCard(
-              key: Key('ielts-part1-set-${set.id}'),
-              title: set.title,
-              description: set.topicSummary,
-              meta: '${set.questionCount} 道题',
-              progress: controller.ieltsProgress(mode, set.id),
-              onPressed: () => onSelectionPressed(
-                scene!,
-                IeltsPracticeSelection(mode: mode, part1SetId: set.id),
-              ),
-            ),
-            const SizedBox(height: 10),
-          ]
-        else
-          for (final group in bank.topicGroups) ...[
-            _IeltsSetCard(
-              key: Key('ielts-${mode.name}-set-${group.id}'),
-              title: mode == IeltsPracticeMode.part2
-                  ? group.cueCard.prompt
-                  : group.title,
-              description: mode == IeltsPracticeMode.part2
-                  ? '${_ieltsReleaseLabel(group.release)} · 可继续对应 Part 3'
-                  : '对应 Part 2：${group.cueCard.prompt}',
-              meta: mode == IeltsPracticeMode.part2
-                  ? _pairedProgressLabel(controller, group.id)
-                  : '${group.part3Questions.length} 道讨论题',
-              progress: controller.ieltsProgress(mode, group.id),
-              showProgressStatus: mode != IeltsPracticeMode.part2,
-              onPressed: () => onSelectionPressed(
-                scene!,
-                IeltsPracticeSelection(mode: mode, topicGroupId: group.id),
-              ),
-            ),
-            const SizedBox(height: 10),
+        _IeltsFilterRow<_IeltsSourceFilter>(
+          values: _IeltsSourceFilter.values,
+          selected: source,
+          label: _ieltsSourceFilterLabel,
+          keyFor: (value) => Key('ielts-source-${value.name}'),
+          onChanged: onSourceChanged,
+        ),
+        const SizedBox(height: 10),
+        _IeltsNullableFilterRow<IeltsPracticeMode>(
+          values: const [
+            IeltsPracticeMode.part1,
+            IeltsPracticeMode.part2,
+            IeltsPracticeMode.part3,
           ],
+          selected: part,
+          allLabel: 'All',
+          label: _ieltsBrowserPartLabel,
+          keyFor: (value) => Key('ielts-part-${value?.name ?? 'all'}'),
+          onChanged: onPartChanged,
+        ),
+        const SizedBox(height: 10),
+        _IeltsNullableFilterRow<IeltsTopicCategory>(
+          values: IeltsTopicCategory.values,
+          selected: category,
+          allLabel: '全标签',
+          label: _ieltsCategoryLabel,
+          keyFor: (value) => Key('ielts-category-${value?.name ?? 'all'}'),
+          onChanged: onCategoryChanged,
+        ),
+        const SizedBox(height: 18),
+        Text(
+          '共 ${items.length} 道专项题',
+          key: const Key('ielts-browser-result-count'),
+          style: PreparationDesign.meta.copyWith(
+            color: PreparationDesign.ieltsDeep,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (items.isEmpty)
+          _IeltsEmptyResult(
+            onClear: () {
+              searchController.clear();
+              onSourceChanged(_IeltsSourceFilter.all);
+              onPartChanged(null);
+              onCategoryChanged(null);
+            },
+          )
+        else
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final textScale = MediaQuery.textScalerOf(context).scale(1);
+              final columns = constraints.maxWidth < 350 || textScale >= 1.6
+                  ? 1
+                  : constraints.maxWidth >= 760
+                  ? 3
+                  : 2;
+              return GridView.builder(
+                key: const Key('ielts-browser-grid'),
+                shrinkWrap: true,
+                primary: false,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: items.length,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: columns,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                  mainAxisExtent: textScale >= 1.3 ? 184 : 154,
+                ),
+                itemBuilder: (context, index) {
+                  final item = items[index];
+                  final scene = partScenes[item.mode];
+                  return _IeltsTopicCard(
+                    key: Key('ielts-browser-card-${item.mode.name}-${item.id}'),
+                    item: item,
+                    progress: controller.ieltsProgress(item.mode, item.id),
+                    onPressed: scene == null
+                        ? null
+                        : () => onSelectionPressed(scene, item.selection),
+                  );
+                },
+              );
+            },
+          ),
       ],
     );
   }
+
+  List<_IeltsBrowseItem> _visibleItems(IeltsQuestionBank bank) {
+    final items = <_IeltsBrowseItem>[
+      for (final topic in bank.part1Topics) _IeltsBrowseItem.part1(topic),
+      for (final group in bank.topicGroups) ...[
+        _IeltsBrowseItem.part2(group),
+        _IeltsBrowseItem.part3(group),
+      ],
+    ];
+    final query = searchController.text.trim().toLowerCase();
+    return items
+        .where((item) {
+          if (part != null && item.mode != part) return false;
+          if (category != null && item.category != category) return false;
+          if (!_matchesSource(item.release, source)) return false;
+          return query.isEmpty || item.searchText.toLowerCase().contains(query);
+        })
+        .toList(growable: false);
+  }
 }
 
-class _IeltsSetCard extends StatelessWidget {
-  const _IeltsSetCard({
+final class _IeltsBrowseItem {
+  const _IeltsBrowseItem({
+    required this.id,
+    required this.mode,
     required this.title,
-    required this.description,
-    required this.meta,
+    required this.subtitle,
+    required this.release,
+    required this.category,
+    required this.searchText,
+    required this.selection,
+  });
+
+  factory _IeltsBrowseItem.part1(IeltsPart1PracticeTopic topic) =>
+      _IeltsBrowseItem(
+        id: topic.id,
+        mode: IeltsPracticeMode.part1,
+        title: topic.titleZh,
+        subtitle: topic.titleEn,
+        release: topic.release,
+        category: topic.category,
+        searchText: [
+          topic.titleZh,
+          topic.titleEn,
+          ...topic.questions,
+        ].join(' '),
+        selection: IeltsPracticeSelection(
+          mode: IeltsPracticeMode.part1,
+          part1SetId: topic.id,
+        ),
+      );
+
+  factory _IeltsBrowseItem.part2(IeltsTopicGroup group) => _IeltsBrowseItem(
+    id: group.id,
+    mode: IeltsPracticeMode.part2,
+    title: group.title,
+    subtitle: group.cueCard.prompt,
+    release: group.release,
+    category: group.category,
+    searchText: [
+      group.title,
+      group.cueCard.prompt,
+      ...group.cueCard.points,
+    ].join(' '),
+    selection: IeltsPracticeSelection(
+      mode: IeltsPracticeMode.part2,
+      topicGroupId: group.id,
+    ),
+  );
+
+  factory _IeltsBrowseItem.part3(IeltsTopicGroup group) => _IeltsBrowseItem(
+    id: group.id,
+    mode: IeltsPracticeMode.part3,
+    title: group.title,
+    subtitle: group.cueCard.prompt,
+    release: group.release,
+    category: group.category,
+    searchText: [
+      group.title,
+      group.cueCard.prompt,
+      ...group.part3Questions,
+    ].join(' '),
+    selection: IeltsPracticeSelection(
+      mode: IeltsPracticeMode.part3,
+      topicGroupId: group.id,
+    ),
+  );
+
+  final String id;
+  final IeltsPracticeMode mode;
+  final String title;
+  final String subtitle;
+  final String release;
+  final IeltsTopicCategory category;
+  final String searchText;
+  final IeltsPracticeSelection selection;
+}
+
+class _IeltsTopicCard extends StatelessWidget {
+  const _IeltsTopicCard({
+    required this.item,
     required this.progress,
     required this.onPressed,
-    this.showProgressStatus = true,
     super.key,
   });
 
-  final String title;
-  final String description;
-  final String meta;
+  final _IeltsBrowseItem item;
   final IeltsSetProgress progress;
-  final VoidCallback onPressed;
-  final bool showProgressStatus;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    final status = _ieltsProgressLabel(progress);
-    return Material(
-      color: PreparationDesign.surface,
-      clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(PreparationDesign.radiusCard),
-        side: const BorderSide(color: PreparationDesign.border),
+    final badge = switch (item.mode) {
+      IeltsPracticeMode.part1 => (
+        'PART 1',
+        const Color(0xFFE0F2FE),
+        const Color(0xFF0369A1),
       ),
-      child: InkWell(
-        onTap: onPressed,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 15, 14, 15),
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+      IeltsPracticeMode.part2 => (
+        'PART 2',
+        const Color(0xFFDBEAFE),
+        const Color(0xFF1D4ED8),
+      ),
+      IeltsPracticeMode.part3 => (
+        'PART 3',
+        const Color(0xFFEDE9FE),
+        const Color(0xFF6D28D9),
+      ),
+      IeltsPracticeMode.fullMock => (
+        'MOCK',
+        const Color(0xFFE0F2FE),
+        const Color(0xFF075985),
+      ),
+    };
+    return Semantics(
+      button: true,
+      label: '${badge.$1}。${item.title}。${item.subtitle}',
+      child: Material(
+        color: Colors.white,
+        elevation: 0,
+        shadowColor: const Color(0x1A075985),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+          side: BorderSide(
+            color: progress.completed
+                ? PreparationDesign.ielts
+                : PreparationDesign.ieltsBorder,
+          ),
+        ),
+        child: InkWell(
+          onTap: onPressed,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(14, 14, 14, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
-                    Text(
-                      title,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: PreparationDesign.cardTitle,
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      description,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: PreparationDesign.meta,
-                    ),
-                    const SizedBox(height: 9),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 5,
-                      children: [
-                        Text(
-                          meta,
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: badge.$2,
+                        borderRadius: BorderRadius.circular(7),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 5,
+                        ),
+                        child: Text(
+                          badge.$1,
                           style: PreparationDesign.meta.copyWith(
-                            color: PreparationDesign.inkSecondary,
+                            color: badge.$3,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: .4,
                           ),
                         ),
-                        if (showProgressStatus)
-                          Text(
-                            status,
-                            style: PreparationDesign.meta.copyWith(
-                              color: progress.completed || progress.inProgress
-                                  ? PreparationDesign.ielts
-                                  : PreparationDesign.inkSecondary,
-                              fontWeight: FontWeight.w800,
-                            ),
-                          ),
-                      ],
+                      ),
                     ),
+                    const Spacer(),
+                    if (progress.completed)
+                      const Icon(
+                        Icons.check_circle_rounded,
+                        size: 18,
+                        color: PreparationDesign.ielts,
+                      ),
                   ],
                 ),
-              ),
-              const SizedBox(width: 12),
-              const Icon(Icons.arrow_forward_rounded, size: 22),
-            ],
+                const SizedBox(height: 12),
+                Text(
+                  item.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: PreparationDesign.cardTitle.copyWith(
+                    color: const Color(0xFF102A43),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 7),
+                Expanded(
+                  child: Text(
+                    item.subtitle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: PreparationDesign.meta.copyWith(
+                      color: const Color(0xFF60758A),
+                      height: 1.3,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 }
+
+class _IeltsFilterRow<T> extends StatelessWidget {
+  const _IeltsFilterRow({
+    required this.values,
+    required this.selected,
+    required this.label,
+    required this.keyFor,
+    required this.onChanged,
+  });
+
+  final List<T> values;
+  final T selected;
+  final String Function(T value) label;
+  final Key Function(T value) keyFor;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) => SingleChildScrollView(
+    scrollDirection: Axis.horizontal,
+    child: Row(
+      children: [
+        for (final value in values) ...[
+          _IeltsFilterChip(
+            key: keyFor(value),
+            label: label(value),
+            selected: value == selected,
+            onPressed: () => onChanged(value),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ],
+    ),
+  );
+}
+
+class _IeltsNullableFilterRow<T> extends StatelessWidget {
+  const _IeltsNullableFilterRow({
+    required this.values,
+    required this.selected,
+    required this.allLabel,
+    required this.label,
+    required this.keyFor,
+    required this.onChanged,
+  });
+
+  final List<T> values;
+  final T? selected;
+  final String allLabel;
+  final String Function(T value) label;
+  final Key Function(T? value) keyFor;
+  final ValueChanged<T?> onChanged;
+
+  @override
+  Widget build(BuildContext context) => SingleChildScrollView(
+    scrollDirection: Axis.horizontal,
+    child: Row(
+      children: [
+        _IeltsFilterChip(
+          key: keyFor(null),
+          label: allLabel,
+          selected: selected == null,
+          onPressed: () => onChanged(null),
+        ),
+        const SizedBox(width: 8),
+        for (final value in values) ...[
+          _IeltsFilterChip(
+            key: keyFor(value),
+            label: label(value),
+            selected: value == selected,
+            onPressed: () => onChanged(value),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ],
+    ),
+  );
+}
+
+class _IeltsFilterChip extends StatelessWidget {
+  const _IeltsFilterChip({
+    required this.label,
+    required this.selected,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) => Material(
+    color: selected ? PreparationDesign.ieltsTint : Colors.transparent,
+    shape: StadiumBorder(
+      side: BorderSide(
+        color: selected
+            ? PreparationDesign.ielts
+            : PreparationDesign.ieltsBorder,
+      ),
+    ),
+    child: InkWell(
+      borderRadius: BorderRadius.circular(999),
+      onTap: onPressed,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 9),
+        child: Text(
+          label,
+          style: PreparationDesign.body.copyWith(
+            color: selected
+                ? PreparationDesign.ieltsDeep
+                : PreparationDesign.inkSecondary,
+            fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _IeltsEmptyResult extends StatelessWidget {
+  const _IeltsEmptyResult({required this.onClear});
+
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(24),
+    decoration: BoxDecoration(
+      color: PreparationDesign.ieltsTint,
+      borderRadius: BorderRadius.circular(20),
+      border: Border.all(color: PreparationDesign.ieltsBorder),
+    ),
+    child: Column(
+      children: [
+        const Icon(
+          Icons.search_off_rounded,
+          color: PreparationDesign.ieltsDeep,
+        ),
+        const SizedBox(height: 10),
+        const Text('没有找到符合条件的题目'),
+        const SizedBox(height: 8),
+        TextButton(onPressed: onClear, child: const Text('清除筛选')),
+      ],
+    ),
+  );
+}
+
+bool _matchesSource(String release, _IeltsSourceFilter source) =>
+    switch (source) {
+      _IeltsSourceFilter.all => true,
+      _IeltsSourceFilter.newSeason => release == 'new',
+      _IeltsSourceFilter.carryOver => release == 'carry_over',
+      _IeltsSourceFilter.evergreen => release == 'evergreen',
+    };
+
+String _ieltsSourceFilterLabel(_IeltsSourceFilter value) => switch (value) {
+  _IeltsSourceFilter.all => '全部',
+  _IeltsSourceFilter.newSeason => '5–8月新题',
+  _IeltsSourceFilter.carryOver => '5–8月保留题',
+  _IeltsSourceFilter.evergreen => '万年老题',
+};
+
+String _ieltsBrowserPartLabel(IeltsPracticeMode value) => switch (value) {
+  IeltsPracticeMode.part1 => 'Part 1',
+  IeltsPracticeMode.part2 => 'Part 2',
+  IeltsPracticeMode.part3 => 'Part 3',
+  IeltsPracticeMode.fullMock => '完整模拟',
+};
+
+String _ieltsCategoryLabel(IeltsTopicCategory value) => switch (value) {
+  IeltsTopicCategory.person => '人物类',
+  IeltsTopicCategory.place => '地点类',
+  IeltsTopicCategory.thing => '事物类',
+  IeltsTopicCategory.event => '事件类',
+};
 
 enum _RoleplayFilter { recommended, workplace, travel, daily }
 
@@ -1943,92 +2369,6 @@ class _InterviewModeCard extends StatelessWidget {
                 ),
               ),
             ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _IeltsPartStep extends StatelessWidget {
-  const _IeltsPartStep({
-    required this.scene,
-    required this.partNumber,
-    required this.label,
-    required this.isLast,
-    required this.onPressed,
-  });
-
-  final SceneDefinition scene;
-  final String partNumber;
-  final String label;
-  final bool isLast;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: isLast ? 0 : 10),
-      child: Material(
-        color: PreparationDesign.surface,
-        clipBehavior: Clip.antiAlias,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(PreparationDesign.radiusCard),
-          side: const BorderSide(color: PreparationDesign.border),
-        ),
-        child: Semantics(
-          button: true,
-          label: 'Part $partNumber，$label。${scene.prompt.publicSceneBrief}',
-          onTap: onPressed,
-          excludeSemantics: true,
-          child: InkWell(
-            key: Key('catalog-scene-${scene.id}'),
-            onTap: onPressed,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(14, 13, 14, 13),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Container(
-                    width: 42,
-                    height: 42,
-                    alignment: Alignment.center,
-                    decoration: const BoxDecoration(
-                      color: PreparationDesign.ieltsTint,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Text(
-                      partNumber,
-                      style: const TextStyle(
-                        color: PreparationDesign.ielts,
-                        fontSize: 17,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 14),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Part $partNumber',
-                          style: PreparationDesign.cardTitle,
-                        ),
-                        const SizedBox(height: 3),
-                        Text(label, style: PreparationDesign.meta),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 10),
-                  const Icon(
-                    Icons.arrow_forward_rounded,
-                    size: 20,
-                    color: PreparationDesign.ink,
-                  ),
-                ],
-              ),
-            ),
           ),
         ),
       ),
@@ -2478,34 +2818,6 @@ List<SceneDefinition> _scenesByIds(
   return [for (final id in ids) ?byId[id]];
 }
 
-String _ieltsPartNumber(String sceneId) {
-  return switch (sceneId) {
-    'scn_ielts_speaking_part_1' => '1',
-    'scn_ielts_speaking_part_2' => '2',
-    'scn_ielts_speaking_part_3' => '3',
-    _ => '•',
-  };
-}
-
-String _ieltsPartLabel(String sceneId) {
-  return switch (sceneId) {
-    'scn_ielts_speaking_part_1' => '熟悉话题问答',
-    'scn_ielts_speaking_part_2' => '题卡陈述 · 可继续 Part 3',
-    'scn_ielts_speaking_part_3' => '承接 Part 2 主题讨论',
-    _ => '专项练习',
-  };
-}
-
-IeltsPracticeMode? _ieltsModeForScene(String sceneId) {
-  return switch (sceneId) {
-    'scn_ielts_speaking_part_1' => IeltsPracticeMode.part1,
-    'scn_ielts_speaking_part_2' => IeltsPracticeMode.part2,
-    'scn_ielts_speaking_part_3' => IeltsPracticeMode.part3,
-    _ieltsFullSceneId => IeltsPracticeMode.fullMock,
-    _ => null,
-  };
-}
-
 SceneDefinition? _ieltsSceneForMode(
   List<SceneDefinition> scenes,
   IeltsPracticeMode mode,
@@ -2517,48 +2829,6 @@ SceneDefinition? _ieltsSceneForMode(
     IeltsPracticeMode.part3 => 'scn_ielts_speaking_part_3',
   };
   return _sceneById(scenes, id);
-}
-
-String _ieltsReleaseLabel(String release) {
-  return switch (release) {
-    'new' => '当季新题',
-    'carry_over' => '老题沿用',
-    _ => '本季题目',
-  };
-}
-
-String _pairedProgressLabel(PreparationController controller, String groupId) {
-  final part2 = controller.ieltsProgress(IeltsPracticeMode.part2, groupId);
-  final part3 = controller.ieltsProgress(IeltsPracticeMode.part3, groupId);
-  return '${_ieltsPartProgressLabel('Part 2', part2)}'
-      ' · ${_ieltsPartProgressLabel('Part 3', part3)}';
-}
-
-String _ieltsPartProgressLabel(String part, IeltsSetProgress progress) {
-  if (progress.inProgress) {
-    return '$part 进行中';
-  }
-  if (progress.completed) {
-    final date = progress.lastPracticedAt?.toLocal();
-    final recent = date == null ? '' : ' · ${date.month}月${date.day}日';
-    return '$part 已完成 ✓ · ${progress.attemptCount} 次$recent';
-  }
-  return '$part 未练习';
-}
-
-String _ieltsProgressLabel(IeltsSetProgress progress) {
-  if (progress.inProgress) {
-    final completed = progress.attemptCount == 0
-        ? ''
-        : ' · 已练 ${progress.attemptCount} 次';
-    return '进行中$completed';
-  }
-  if (progress.completed) {
-    final date = progress.lastPracticedAt?.toLocal();
-    final recent = date == null ? '' : ' · 最近 ${date.month}月${date.day}日';
-    return '已完成 ✓ · 练习 ${progress.attemptCount} 次$recent';
-  }
-  return '未练习';
 }
 
 String _roleplayFilterLabel(_RoleplayFilter filter) {

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -1244,7 +1244,7 @@ class _InterviewHub extends StatelessWidget {
   }
 }
 
-enum _IeltsSourceFilter { all, newSeason, carryOver, evergreen }
+enum _IeltsSourceFilter { all, newSeason, carryOver }
 
 final class _IeltsBrowserState {
   const _IeltsBrowserState({
@@ -1429,7 +1429,7 @@ class _IeltsHubState extends State<_IeltsHub> {
           key: const Key('ielts-mode-special'),
           eyebrow: '分类题库',
           title: '按 Part 专项突破',
-          description: '按新题、保留题、万年老题和主题标签精准选题。',
+          description: '按新题、保留题和主题标签精准选题。',
           actionLabel: '选择专项题目',
           icon: Icons.grid_view_rounded,
           color: const Color(0xFF0EA5E9),
@@ -1989,14 +1989,12 @@ bool _matchesSource(String release, _IeltsSourceFilter source) =>
       _IeltsSourceFilter.all => true,
       _IeltsSourceFilter.newSeason => release == 'new',
       _IeltsSourceFilter.carryOver => release == 'carry_over',
-      _IeltsSourceFilter.evergreen => release == 'evergreen',
     };
 
 String _ieltsSourceFilterLabel(_IeltsSourceFilter value) => switch (value) {
   _IeltsSourceFilter.all => '全部',
   _IeltsSourceFilter.newSeason => '5–8月新题',
   _IeltsSourceFilter.carryOver => '5–8月保留题',
-  _IeltsSourceFilter.evergreen => '万年老题',
 };
 
 String _ieltsBrowserPartLabel(IeltsPracticeMode value) => switch (value) {

--- a/mobile/lib/features/coaching/preparation/preparation_controller.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_controller.dart
@@ -208,7 +208,7 @@ final class PreparationController extends ChangeNotifier {
       return null;
     }
     final ids = mode == IeltsPracticeMode.part1
-        ? bank.part1Sets.map((set) => set.id).toList(growable: false)
+        ? bank.part1Topics.map((topic) => topic.id).toList(growable: false)
         : bank.topicGroups.map((group) => group.id).toList(growable: false);
     if (ids.isEmpty) {
       return null;

--- a/mobile/lib/features/coaching/preparation/preparation_design.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_design.dart
@@ -22,8 +22,10 @@ abstract final class PreparationDesign {
 
   static const interview = Color(0xFF20252A);
   static const interviewTint = Color(0xFFE9EAEC);
-  static const ielts = Color(0xFF274B3E);
-  static const ieltsTint = Color(0xFFF4EFE4);
+  static const ielts = Color(0xFF0284C7);
+  static const ieltsDeep = Color(0xFF075985);
+  static const ieltsTint = Color(0xFFE0F2FE);
+  static const ieltsBorder = Color(0xFFBAE6FD);
   static const roleplay = Color(0xFF173B47);
   static const roleplayTint = Color(0xFFDDECF0);
 

--- a/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
@@ -73,6 +73,8 @@ final class PreparationLaunchController extends ChangeNotifier {
   bool get isNavigationLocked =>
       isStarting || (isSelectionLocked && !_failedAttemptSafelyParked);
   bool get canRetry => _retry != null && !isStarting;
+  bool get canDismissFailedLaunch =>
+      !isStarting && _retry != null && _errorMessage != null;
   bool get hasValidBackground => _validBackground(_backgroundSummary.trim());
   bool get hasResumablePractice => workspaceController?.hasResumable ?? false;
   bool get resumableHasProgress =>
@@ -239,6 +241,23 @@ final class PreparationLaunchController extends ChangeNotifier {
     if (retryCanBeReplaced) {
       _invalidateAttempt();
     }
+    return true;
+  }
+
+  Future<bool> dismissFailedLaunch() async {
+    if (_disposed || !canDismissFailedLaunch) {
+      return false;
+    }
+    final workspace = workspaceController;
+    if (workspace != null && workspace.currentLease != null) {
+      final parked = await workspace.parkCurrentPractice();
+      if (!parked) {
+        _errorMessage = workspace.errorMessage ?? '暂时无法安全退出当前练习，请重试。';
+        notifyListeners();
+        return false;
+      }
+    }
+    _invalidateAttempt();
     return true;
   }
 

--- a/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
@@ -270,7 +270,7 @@ IeltsPracticeAssignment decodeIeltsPracticeAssignment(Object? value) {
   final part2CueCard = object.containsKey('part_2_cue_card')
       ? _text(object['part_2_cue_card'])
       : null;
-  final part1QuestionCount = _count(object['part_1_questions'], maximum: 8);
+  final part1QuestionCount = _count(object['part_1_questions'], maximum: 24);
   final part2QuestionCount = _count(object['part_2_questions'], maximum: 1);
   final part3QuestionCount = _count(object['part_3_questions'], maximum: 5);
   final turnBlueprints = _textList(
@@ -293,10 +293,10 @@ IeltsPracticeAssignment decodeIeltsPracticeAssignment(Object? value) {
           topicGroupId == null &&
           topicTitle == null &&
           part2CueCard == null &&
-          part1QuestionCount == 8 &&
+          part1QuestionCount >= 2 &&
           part2QuestionCount == 0 &&
           part3QuestionCount == 0 &&
-          turnBlueprints.length == 8,
+          turnBlueprints.length == part1QuestionCount,
     IeltsPracticeMode.part2 =>
       part1SetId == null &&
           topicGroupId != null &&

--- a/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
@@ -272,11 +272,11 @@ IeltsPracticeAssignment decodeIeltsPracticeAssignment(Object? value) {
       : null;
   final part1QuestionCount = _count(object['part_1_questions'], maximum: 24);
   final part2QuestionCount = _count(object['part_2_questions'], maximum: 1);
-  final part3QuestionCount = _count(object['part_3_questions'], maximum: 5);
+  final part3QuestionCount = _count(object['part_3_questions'], maximum: 6);
   final turnBlueprints = _textList(
     object['turn_blueprints'],
     minimumLength: 1,
-    maximumLength: 14,
+    maximumLength: 24,
   );
   final validShape = switch (mode) {
     IeltsPracticeMode.fullMock =>

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -17,6 +17,7 @@ import 'package:speakup/features/coaching/review/review_history_controller.dart'
 class ReviewPage extends StatefulWidget {
   const ReviewPage({
     this.showBackButton = false,
+    this.onExit,
     this.previewMode = false,
     this.practiceAvailable = true,
     this.historyController,
@@ -27,6 +28,7 @@ class ReviewPage extends StatefulWidget {
   });
 
   final bool showBackButton;
+  final VoidCallback? onExit;
   final bool previewMode;
   final bool practiceAvailable;
   final ReviewHistoryController? historyController;
@@ -135,12 +137,15 @@ class _ReviewPageState extends State<ReviewPage> {
         : null;
     return Scaffold(
       key: const Key('review-page'),
-      appBar: widget.showBackButton
+      appBar: widget.showBackButton || widget.onExit != null
           ? AppBar(
               leading: IconButton(
-                key: const Key('review-route-back-button'),
+                key: widget.showBackButton
+                    ? const Key('review-route-back-button')
+                    : const Key('review-exit-button'),
                 tooltip: '返回',
-                onPressed: () => Navigator.of(context).maybePop(),
+                onPressed:
+                    widget.onExit ?? () => Navigator.of(context).maybePop(),
                 icon: const Icon(Icons.arrow_back_rounded),
               ),
             )

--- a/mobile/lib/features/coaching/scene/ielts_question_bank.dart
+++ b/mobile/lib/features/coaching/scene/ielts_question_bank.dart
@@ -16,12 +16,29 @@ enum IeltsPracticeMode {
       .firstOrNull;
 }
 
+enum IeltsTopicCategory {
+  person('person'),
+  place('place'),
+  thing('thing'),
+  event('event');
+
+  const IeltsTopicCategory(this.wireName);
+
+  final String wireName;
+
+  static IeltsTopicCategory? fromWireName(String value) => IeltsTopicCategory
+      .values
+      .where((category) => category.wireName == value)
+      .firstOrNull;
+}
+
 final class IeltsQuestionBank {
   const IeltsQuestionBank({
     required this.bankId,
     required this.season,
     required this.sourceCutoff,
     required this.part1Sets,
+    this.part1Topics = const <IeltsPart1PracticeTopic>[],
     required this.topicGroups,
   });
 
@@ -29,7 +46,26 @@ final class IeltsQuestionBank {
   final String season;
   final DateTime sourceCutoff;
   final List<IeltsPart1Set> part1Sets;
+  final List<IeltsPart1PracticeTopic> part1Topics;
   final List<IeltsTopicGroup> topicGroups;
+}
+
+final class IeltsPart1PracticeTopic {
+  const IeltsPart1PracticeTopic({
+    required this.id,
+    required this.titleZh,
+    required this.titleEn,
+    required this.release,
+    required this.category,
+    required this.questions,
+  });
+
+  final String id;
+  final String titleZh;
+  final String titleEn;
+  final String release;
+  final IeltsTopicCategory category;
+  final List<String> questions;
 }
 
 final class IeltsPart1Set {
@@ -65,6 +101,7 @@ final class IeltsTopicGroup {
     required this.id,
     required this.title,
     required this.release,
+    this.category = IeltsTopicCategory.thing,
     required this.cueCard,
     required this.part3Questions,
     required this.supplementedQuestionCount,
@@ -73,6 +110,7 @@ final class IeltsTopicGroup {
   final String id;
   final String title;
   final String release;
+  final IeltsTopicCategory category;
   final IeltsCueCard cueCard;
   final List<String> part3Questions;
   final int supplementedQuestionCount;

--- a/mobile/lib/features/coaching/scene/wire_scene_client.dart
+++ b/mobile/lib/features/coaching/scene/wire_scene_client.dart
@@ -108,18 +108,22 @@ final class WireSceneClient implements SceneClient, SceneQuestionBankClient {
         'season',
         'source_cutoff',
         'part1_sets',
+        'part1_topics',
         'topic_groups',
       },
     );
-    if (root['schema_version'] != 1) {
+    if (root['schema_version'] != 2) {
       throw _invalidResponse();
     }
     final sourceCutoff = DateTime.tryParse(_string(root['source_cutoff']));
     final rawPart1Sets = root['part1_sets'];
+    final rawPart1Topics = root['part1_topics'];
     final rawTopicGroups = root['topic_groups'];
     if (sourceCutoff == null ||
         rawPart1Sets is! List<Object?> ||
         rawPart1Sets.length != 38 ||
+        rawPart1Topics is! List<Object?> ||
+        rawPart1Topics.length != 38 ||
         rawTopicGroups is! List<Object?> ||
         rawTopicGroups.length != 56) {
       throw _invalidResponse();
@@ -135,6 +139,16 @@ final class WireSceneClient implements SceneClient, SceneQuestionBankClient {
         })
         .toList(growable: false);
     final groupIds = <String>{};
+    final part1TopicIds = <String>{};
+    final part1Topics = rawPart1Topics
+        .map((raw) {
+          final topic = _ieltsPart1PracticeTopic(raw);
+          if (!part1TopicIds.add(topic.id)) {
+            throw _invalidResponse();
+          }
+          return topic;
+        })
+        .toList(growable: false);
     final topicGroups = rawTopicGroups
         .map((raw) {
           final group = _ieltsTopicGroup(raw);
@@ -149,6 +163,7 @@ final class WireSceneClient implements SceneClient, SceneQuestionBankClient {
       season: _string(root['season']),
       sourceCutoff: sourceCutoff.toUtc(),
       part1Sets: List<IeltsPart1Set>.unmodifiable(part1Sets),
+      part1Topics: List<IeltsPart1PracticeTopic>.unmodifiable(part1Topics),
       topicGroups: List<IeltsTopicGroup>.unmodifiable(topicGroups),
     );
   }
@@ -414,6 +429,40 @@ IeltsPart1Topic _ieltsPart1Topic(Object? value) {
   );
 }
 
+IeltsPart1PracticeTopic _ieltsPart1PracticeTopic(Object? value) {
+  final object = _object(
+    value,
+    required: const <String>{
+      'id',
+      'title_zh',
+      'title_en',
+      'release',
+      'category',
+      'questions',
+      'published',
+    },
+  );
+  final release = _string(object['release'], maximumBytes: 32);
+  final category = IeltsTopicCategory.fromWireName(
+    _string(object['category'], maximumBytes: 16),
+  );
+  final questions = _stringList(object['questions'], maximumItemBytes: 1024);
+  if (!const <String>{'new', 'carry_over', 'evergreen'}.contains(release) ||
+      category == null ||
+      questions.length < 2 ||
+      object['published'] != true) {
+    throw _invalidResponse();
+  }
+  return IeltsPart1PracticeTopic(
+    id: _resourceId(object['id']),
+    titleZh: _string(object['title_zh']),
+    titleEn: _string(object['title_en']),
+    release: release,
+    category: category,
+    questions: questions,
+  );
+}
+
 IeltsTopicGroup _ieltsTopicGroup(Object? value) {
   final object = _object(
     value,
@@ -422,6 +471,7 @@ IeltsTopicGroup _ieltsTopicGroup(Object? value) {
       'title_zh',
       'release',
       'region',
+      'category',
       'part2',
       'part3_questions',
       'published',
@@ -429,8 +479,12 @@ IeltsTopicGroup _ieltsTopicGroup(Object? value) {
     },
   );
   final release = _string(object['release'], maximumBytes: 32);
+  final category = IeltsTopicCategory.fromWireName(
+    _string(object['category'], maximumBytes: 16),
+  );
   final supplemented = object['supplemented_question_count'];
   if (!const <String>{'new', 'carry_over'}.contains(release) ||
+      category == null ||
       object['region'] != 'mainland' ||
       object['published'] != true ||
       supplemented is! int ||
@@ -454,6 +508,7 @@ IeltsTopicGroup _ieltsTopicGroup(Object? value) {
     id: _resourceId(object['id']),
     title: _string(object['title_zh']),
     release: release,
+    category: category,
     cueCard: IeltsCueCard(prompt: _string(cueObject['prompt']), points: points),
     part3Questions: questions,
     supplementedQuestionCount: supplemented,

--- a/mobile/lib/features/coaching/scene/wire_scene_client.dart
+++ b/mobile/lib/features/coaching/scene/wire_scene_client.dart
@@ -501,7 +501,7 @@ IeltsTopicGroup _ieltsTopicGroup(Object? value) {
     object['part3_questions'],
     maximumItemBytes: 1024,
   );
-  if (points.length < 3 || questions.isEmpty || questions.length > 5) {
+  if (points.length < 3 || questions.isEmpty || questions.length > 6) {
     throw _invalidResponse();
   }
   return IeltsTopicGroup(

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -962,7 +962,7 @@ void main() {
   testWidgets('section completion never requests the full-mock report', (
     tester,
   ) async {
-    final practice = _IeltsPracticeClient(initialCompleted: 7, turnLimit: 8);
+    final practice = _IeltsPracticeClient(initialCompleted: 3, turnLimit: 4);
     final controller = PracticeController(
       client: practice,
       recorder: _Recorder(),
@@ -1009,7 +1009,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 220));
 
-    expect(controller.completedTurns, 8);
+    expect(controller.completedTurns, 4);
     expect(
       find.byKey(const Key('ielts-section-practice-complete-part1')),
       findsOneWidget,

--- a/mobile/test/coaching/practice/practice_restore_conflict_test.dart
+++ b/mobile/test/coaching/practice/practice_restore_conflict_test.dart
@@ -208,6 +208,7 @@ Map<String, Object?> _activeSessionJson(String sessionId) {
     'scene_version': 1,
     'scene_family': 'INTERVIEW',
     'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+    'practice_session_status': 'in_progress',
     'session_version': 2,
     'effective_turns': 0,
     'turn_limit': 3,

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -671,12 +671,63 @@ void main() {
     transport.expectDone();
   });
 
-  test('does not accept a noncanonical success status', () async {
+  test('accepts the server activation success status', () async {
+    final response = <String, Object?>{
+      ..._sessionJson(),
+      'scene_id': 'scn_ielts_speaking_part_1',
+      'scene_version': 1,
+    };
     final transport = _Transport([
       _Step(
         method: 'POST',
         path: '/v1/practice-sessions/$_sessionId/voice-activation',
-        response: _json(HttpStatus.created, _sessionJson()),
+        response: _json(HttpStatus.ok, response),
+      ),
+    ]);
+
+    final snapshot = await _client(transport).activatePractice(
+      sessionId: _sessionId,
+      clientOperationId: 'scene-operation',
+    );
+
+    expect(snapshot.sessionId, _sessionId);
+    transport.expectDone();
+  });
+
+  test('accepts the legacy server activation created status', () async {
+    final response = <String, Object?>{
+      ..._sessionJson(),
+      'scene_id': 'scn_ielts_speaking_part_1',
+      'scene_version': 1,
+    };
+    final transport = _Transport([
+      _Step(
+        method: 'POST',
+        path: '/v1/practice-sessions/$_sessionId/voice-activation',
+        response: _json(HttpStatus.created, response),
+      ),
+    ]);
+
+    final snapshot = await _client(transport).activatePractice(
+      sessionId: _sessionId,
+      clientOperationId: 'scene-operation',
+    );
+
+    expect(snapshot.sessionId, _sessionId);
+    transport.expectDone();
+  });
+
+  test('rejects malformed server scene identity metadata', () async {
+    final response = <String, Object?>{
+      ..._sessionJson(),
+      'scene_id': 'scn_ielts_speaking_part_1',
+      'scene_version': 0,
+    };
+    final transport = _Transport([
+      _Step(
+        method: 'POST',
+        path: '/v1/practice-sessions/$_sessionId/voice-activation',
+        response: _json(HttpStatus.ok, response),
       ),
     ]);
 

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -2,6 +2,10 @@ import '../../support/scene_fixtures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/preparation/preparation.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/scene/scene_client.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -72,14 +76,10 @@ void main() {
 
       expect(find.text('IELTS 口语'), findsOneWidget);
       expect(find.text('一次完成三个 Part'), findsOneWidget);
-      expect(find.text('专项练习'), findsOneWidget);
-      expect(find.text('共 3 道专项题'), findsOneWidget);
-      expect(find.byKey(const Key('ielts-part-all')), findsOneWidget);
-      expect(find.byKey(const Key('ielts-category-all')), findsOneWidget);
-      expect(
-        find.byKey(const Key('ielts-browser-card-part1-p1-topic-001')),
-        findsOneWidget,
-      );
+      expect(find.text('按 Part 专项突破'), findsOneWidget);
+      expect(find.byKey(const Key('ielts-mode-full')), findsOneWidget);
+      expect(find.byKey(const Key('ielts-mode-special')), findsOneWidget);
+      expect(find.byKey(const Key('ielts-browser-search')), findsNothing);
       expect(find.text('自定义口语考试'), findsNothing);
       expect(find.text('英文自我介绍'), findsNothing);
     },
@@ -92,6 +92,7 @@ void main() {
     addTearDown(controller.dispose);
     await _pumpHub(tester, controller);
     await _openModule(tester, const Key('practice-hub-exam'));
+    await _openIeltsBrowser(tester);
 
     await tester.tap(find.byKey(const Key('ielts-part-part2')));
     await tester.pumpAndSettle();
@@ -107,6 +108,68 @@ void main() {
     );
   });
 
+  testWidgets('starts full mock and the exact selected specialty card', (
+    tester,
+  ) async {
+    final catalog = PreparationController(client: _HubFixtureClient());
+    final launchClient = _HubLaunchClient();
+    final launch = _hubLaunchController(launchClient);
+    var starts = 0;
+    addTearDown(catalog.dispose);
+    addTearDown(launch.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: catalog,
+          launchController: launch,
+          onPracticeStarted: () => starts++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openModule(tester, const Key('practice-hub-exam'));
+    await _openIeltsBrowser(tester);
+    final part1Card = find.byKey(
+      const Key('ielts-browser-card-part1-p1-topic-001'),
+    );
+    await tester.scrollUntilVisible(
+      part1Card,
+      180,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(
+      find.descendant(of: part1Card, matching: find.byType(InkWell)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(catalog.errorMessage, isNull);
+    expect(launch.errorMessage, isNull);
+    expect(launchClient.lastPlanInput, isNotNull);
+    expect(starts, 1);
+    expect(
+      launchClient.lastPlanInput?.ieltsSelection,
+      const IeltsPracticeSelection(
+        mode: IeltsPracticeMode.part1,
+        part1SetId: 'p1-topic-001',
+      ),
+    );
+
+    await _openModule(tester, const Key('practice-hub-exam'));
+    await tester.tap(find.byKey(const Key('ielts-mode-full')));
+    await tester.pumpAndSettle();
+
+    expect(starts, 2);
+    expect(
+      launchClient.lastPlanInput?.ieltsSelection,
+      const IeltsPracticeSelection(
+        mode: IeltsPracticeMode.fullMock,
+        part1SetId: 'p1-001',
+        topicGroupId: 'p23-001',
+      ),
+    );
+  });
+
   testWidgets('filters and searches IELTS topic cards by intersection', (
     tester,
   ) async {
@@ -114,6 +177,7 @@ void main() {
     addTearDown(controller.dispose);
     await _pumpHub(tester, controller);
     await _openModule(tester, const Key('practice-hub-exam'));
+    await _openIeltsBrowser(tester);
 
     expect(find.text('共 3 道专项题'), findsOneWidget);
     await tester.enterText(
@@ -150,6 +214,7 @@ void main() {
     addTearDown(controller.dispose);
     await _pumpHub(tester, controller);
     await _openModule(tester, const Key('practice-hub-exam'));
+    await _openIeltsBrowser(tester);
 
     await tester.tap(find.byKey(const Key('ielts-part-part3')));
     await tester.tap(find.byKey(const Key('ielts-category-event')));
@@ -162,7 +227,8 @@ void main() {
 
     await tester.tap(find.byKey(const Key('preparation-back-to-families')));
     await tester.pumpAndSettle();
-    await _openModule(tester, const Key('practice-hub-exam'));
+    expect(find.byKey(const Key('ielts-mode-special')), findsOneWidget);
+    await _openIeltsBrowser(tester);
 
     expect(find.text('共 1 道专项题'), findsOneWidget);
     expect(
@@ -322,7 +388,7 @@ void main() {
       (
         entry: Key('practice-hub-exam'),
         title: Key('practice-hub-title-ielts'),
-        scene: Key('ielts-browser-card-part1-p1-topic-001'),
+        scene: Key('ielts-mode-special'),
       ),
       (
         entry: Key('practice-hub-roleplay'),
@@ -426,22 +492,225 @@ Future<void> _openModule(WidgetTester tester, Key key) async {
   await tester.pumpAndSettle();
 }
 
+Future<void> _openIeltsBrowser(WidgetTester tester) async {
+  final entry = find.byKey(const Key('ielts-mode-special'));
+  await tester.ensureVisible(entry);
+  await tester.tap(entry);
+  await tester.pumpAndSettle();
+  expect(find.byKey(const Key('ielts-browser-search')), findsOneWidget);
+}
+
 final class _HubFixtureClient implements SceneClient, SceneQuestionBankClient {
   @override
-  Future<SceneDefinition> getScene(String sceneId) {
-    throw UnimplementedError('The hub test does not open scene details.');
+  Future<SceneDefinition> getScene(String sceneId) async {
+    final scene = _hubScenes.firstWhere((item) => item.id == sceneId);
+    return testScene(
+      id: scene.id,
+      family: scene.family,
+      model: scene.model,
+      name: scene.name,
+      version: scene.version,
+      status: scene.status,
+      turnPolicyRef: scene.turnPolicyRef,
+      sessionPolicyRef: scene.sessionPolicyRef,
+      prompt: scene.prompt,
+      roles: scene.roles,
+      practiceOptions: [
+        PracticeOption(
+          id: 'option-${scene.id}-full',
+          sceneId: scene.id,
+          type: PracticeOptionType.fullSimulation,
+          displayName: '完整练习',
+        ),
+        for (final role in scene.roles)
+          PracticeOption(
+            id: 'option-${scene.id}-${role.id}',
+            sceneId: scene.id,
+            type: PracticeOptionType.focus,
+            displayName: role.displayName,
+            roleId: role.id,
+          ),
+      ],
+    );
   }
 
   @override
   Future<List<SceneDefinition>> listScenes() async => _hubScenes;
 
   @override
-  Future<List<RoleDefinition>> listRoles(String sceneId) {
-    throw UnimplementedError('The hub test does not open scene details.');
-  }
+  Future<List<RoleDefinition>> listRoles(String sceneId) async =>
+      _hubScenes.firstWhere((scene) => scene.id == sceneId).roles;
 
   @override
   Future<IeltsQuestionBank> getIeltsQuestionBank() async => _ieltsBank;
+}
+
+PreparationLaunchController _hubLaunchController(_HubLaunchClient client) =>
+    PreparationLaunchController(
+      client: client,
+      contextProvider: () => const AgentPracticeContext(
+        threadId: 'thread-ielts-hub',
+        goalId: 'goal-ielts-hub',
+      ),
+      threadIdProvider: () => 'thread-ielts-hub',
+      goalActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => const AgentPracticeContext(
+            threadId: 'thread-ielts-hub',
+            goalId: 'goal-ielts-hub',
+          ),
+      voiceActivator:
+          ({
+            required context,
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+      idFactory: (scope) => '$scope-ielts-hub',
+    );
+
+final class _HubLaunchClient implements PreparationLaunchClient {
+  CreatePreparationPlanInput? lastPlanInput;
+  PreparationSnapshot? _snapshot;
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PreparationProfile> createProfile({
+    required CreatePreparationProfileInput input,
+    required String idempotencyKey,
+  }) async => PreparationProfile(
+    id: 'profile-ielts-hub',
+    userId: 'user-ielts-hub',
+    backgroundSummary: input.backgroundSummary,
+    version: 1,
+    updatedAt: DateTime.utc(2026, 8, 5),
+  );
+
+  @override
+  Future<PreparationSnapshot> createSnapshot({
+    required String profileId,
+    required int sourceVersion,
+    required String idempotencyKey,
+  }) async {
+    final snapshot = PreparationSnapshot(
+      id: 'snapshot-ielts-hub',
+      sourceProfileId: profileId,
+      sourceVersion: sourceVersion,
+      backgroundSnapshot: 'IELTS speaking practice',
+      createdAt: DateTime.utc(2026, 8, 5),
+    );
+    _snapshot = snapshot;
+    return snapshot;
+  }
+
+  @override
+  Future<PracticePlan> createPlan({
+    required CreatePreparationPlanInput input,
+    required String idempotencyKey,
+  }) async {
+    lastPlanInput = input;
+    final snapshot = _snapshot!;
+    final scene = _hubScenes.firstWhere((item) => item.id == input.sceneId);
+    final selection = input.ieltsSelection!;
+    final assignment = switch (selection.mode) {
+      IeltsPracticeMode.fullMock => const IeltsPracticeAssignment(
+        bankId: 'ielts-bank-1',
+        season: '2026-05-08',
+        mode: IeltsPracticeMode.fullMock,
+        part1SetId: 'p1-001',
+        topicGroupId: 'p23-001',
+        topicTitle: '学习技能',
+        part2CueCard: 'Describe a skill you would like to learn',
+        part1QuestionCount: 8,
+        part2QuestionCount: 1,
+        part3QuestionCount: 5,
+        turnBlueprints: <String>[
+          'P1-1',
+          'P1-2',
+          'P1-3',
+          'P1-4',
+          'P1-5',
+          'P1-6',
+          'P1-7',
+          'P1-8',
+          'P2',
+          'P3-1',
+          'P3-2',
+          'P3-3',
+          'P3-4',
+          'P3-5',
+        ],
+      ),
+      IeltsPracticeMode.part1 => const IeltsPracticeAssignment(
+        bankId: 'ielts-bank-1',
+        season: '2026-05-08',
+        mode: IeltsPracticeMode.part1,
+        part1SetId: 'p1-topic-001',
+        part1QuestionCount: 4,
+        part2QuestionCount: 0,
+        part3QuestionCount: 0,
+        turnBlueprints: <String>['P1-1', 'P1-2', 'P1-3', 'P1-4'],
+      ),
+      _ => throw StateError('Unexpected IELTS mode in hub launch test.'),
+    };
+    return PracticePlan(
+      id: 'plan-ielts-hub',
+      userId: 'user-ielts-hub',
+      sourceThreadId: input.sourceThreadId,
+      goalSnapshot: PreparationGoalSnapshot(
+        id: input.goalId!,
+        title: scene.name,
+        version: 1,
+      ),
+      preparationSnapshot: snapshot,
+      sceneSelection: SceneSelectionSnapshot(
+        scene: scene,
+        selectedRoleIds: input.selectedRoleIds,
+        practiceOptionId: input.practiceOptionId,
+      ),
+      sessionPolicy: PreparationSessionPolicy(
+        suggestedDurationSeconds: 600,
+        minEffectiveTurns: assignment.turnBlueprints.length,
+        maxEffectiveTurns: assignment.turnBlueprints.length,
+        coverageCheckpointTurn: assignment.turnBlueprints.length,
+        maxFollowUpsPerQuestion: 0,
+        earlyCompletionRule: 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+      ),
+      practiceObjectives: const <PracticeObjective>[
+        PracticeObjective(id: 'ielts', description: 'Complete IELTS practice.'),
+      ],
+      ieltsAssignment: assignment,
+      revision: 1,
+      status: PracticePlanStatus.ready,
+      createdAt: DateTime.utc(2026, 8, 5),
+      updatedAt: DateTime.utc(2026, 8, 5),
+    );
+  }
+
+  @override
+  Future<PreparationPracticeBootstrap> createSession({
+    required PracticePlan plan,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  }) async => PreparationPracticeBootstrap(
+    session: PreparationPracticeSession(
+      id: 'session-ielts-${plan.ieltsAssignment!.mode.name}',
+      planId: plan.id,
+      sceneFamily: plan.sceneSelection.scene.family,
+      sceneModel: plan.sceneSelection.scene.model,
+      snapshotId: 'session-snapshot-ielts-hub',
+      status: 'starting',
+      version: 1,
+      createdAt: DateTime.utc(2026, 8, 5),
+    ),
+    preparationSnapshotId: plan.preparationSnapshot.id,
+    maxEffectiveTurns: plan.sessionPolicy.maxEffectiveTurns,
+  );
 }
 
 final _ieltsBank = IeltsQuestionBank(

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -244,6 +244,41 @@ void main() {
     );
   });
 
+  testWidgets('opens the specialty browser with its exit control visible', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final controller = PreparationController(client: _HubFixtureClient());
+    addTearDown(controller.dispose);
+    await _pumpHub(tester, controller);
+    await _openModule(tester, const Key('practice-hub-exam'));
+
+    final specialty = find.byKey(const Key('ielts-mode-special'));
+    await tester.scrollUntilVisible(
+      specialty,
+      180,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(specialty);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('preparation-back-to-families')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('ielts-special-browser-title')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('ielts-browser-search')).hitTestable(),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('combines workplace and daily templates in AI roleplay', (
     tester,
   ) async {

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -72,11 +72,12 @@ void main() {
 
       expect(find.text('IELTS 口语'), findsOneWidget);
       expect(find.text('一次完成三个 Part'), findsOneWidget);
-      expect(find.text('Part 1'), findsOneWidget);
-      expect(find.text('题卡陈述 · 可继续 Part 3'), findsOneWidget);
-      expect(find.text('承接 Part 2 主题讨论'), findsOneWidget);
+      expect(find.text('专项练习'), findsOneWidget);
+      expect(find.text('共 3 道专项题'), findsOneWidget);
+      expect(find.byKey(const Key('ielts-part-all')), findsOneWidget);
+      expect(find.byKey(const Key('ielts-category-all')), findsOneWidget);
       expect(
-        find.byKey(const Key('catalog-scene-scn_ielts_speaking_part_1')),
+        find.byKey(const Key('ielts-browser-card-part1-p1-topic-001')),
         findsOneWidget,
       );
       expect(find.text('自定义口语考试'), findsNothing);
@@ -92,20 +93,89 @@ void main() {
     await _pumpHub(tester, controller);
     await _openModule(tester, const Key('practice-hub-exam'));
 
-    await tester.tap(
-      find.byKey(const Key('catalog-scene-scn_ielts_speaking_part_2')),
-    );
+    await tester.tap(find.byKey(const Key('ielts-part-part2')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Part 2 题卡'), findsOneWidget);
-    expect(find.text('已完成 0 / 1 套'), findsOneWidget);
+    expect(find.text('共 1 道专项题'), findsOneWidget);
     expect(
       find.text('Describe a skill you would like to learn'),
       findsOneWidget,
     );
-    expect(find.textContaining('可继续对应 Part 3'), findsOneWidget);
-    expect(find.textContaining('Part 2 未练习'), findsOneWidget);
-    expect(find.byKey(const Key('ielts-part2-set-p23-001')), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-browser-card-part2-p23-001')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('filters and searches IELTS topic cards by intersection', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _HubFixtureClient());
+    addTearDown(controller.dispose);
+    await _pumpHub(tester, controller);
+    await _openModule(tester, const Key('practice-hub-exam'));
+
+    expect(find.text('共 3 道专项题'), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const Key('ielts-browser-search')),
+      'Music',
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('共 1 道专项题'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-browser-card-part1-p1-topic-001')),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byKey(const Key('ielts-browser-search')), '');
+    await tester.tap(find.byKey(const Key('ielts-part-part3')));
+    await tester.tap(find.byKey(const Key('ielts-category-event')));
+    await tester.pumpAndSettle();
+    expect(find.text('共 1 道专项题'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-browser-card-part3-p23-001')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('ielts-source-evergreen')));
+    await tester.pumpAndSettle();
+    expect(find.text('共 0 道专项题'), findsOneWidget);
+    expect(find.text('没有找到符合条件的题目'), findsOneWidget);
+  });
+
+  testWidgets('keeps IELTS browser filters when returning to the catalog', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _HubFixtureClient());
+    addTearDown(controller.dispose);
+    await _pumpHub(tester, controller);
+    await _openModule(tester, const Key('practice-hub-exam'));
+
+    await tester.tap(find.byKey(const Key('ielts-part-part3')));
+    await tester.tap(find.byKey(const Key('ielts-category-event')));
+    await tester.enterText(
+      find.byKey(const Key('ielts-browser-search')),
+      'skill',
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('共 1 道专项题'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('preparation-back-to-families')));
+    await tester.pumpAndSettle();
+    await _openModule(tester, const Key('practice-hub-exam'));
+
+    expect(find.text('共 1 道专项题'), findsOneWidget);
+    expect(
+      tester
+          .widget<TextField>(find.byKey(const Key('ielts-browser-search')))
+          .controller!
+          .text,
+      'skill',
+    );
+    expect(
+      find.byKey(const Key('ielts-browser-card-part3-p23-001')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('combines workplace and daily templates in AI roleplay', (
@@ -252,7 +322,7 @@ void main() {
       (
         entry: Key('practice-hub-exam'),
         title: Key('practice-hub-title-ielts'),
-        scene: Key('catalog-scene-scn_ielts_speaking_part_1'),
+        scene: Key('ielts-browser-card-part1-p1-topic-001'),
       ),
       (
         entry: Key('practice-hub-roleplay'),
@@ -402,11 +472,22 @@ final _ieltsBank = IeltsQuestionBank(
       questionCount: 8,
     ),
   ],
+  part1Topics: const [
+    IeltsPart1PracticeTopic(
+      id: 'p1-topic-001',
+      titleZh: '音乐',
+      titleEn: 'Music',
+      release: 'new',
+      category: IeltsTopicCategory.thing,
+      questions: ['Q1', 'Q2', 'Q3', 'Q4'],
+    ),
+  ],
   topicGroups: const [
     IeltsTopicGroup(
       id: 'p23-001',
       title: '学习技能',
       release: 'new',
+      category: IeltsTopicCategory.event,
       cueCard: IeltsCueCard(
         prompt: 'Describe a skill you would like to learn',
         points: ['What', 'Why', 'How', 'Benefit'],

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -715,6 +715,8 @@ final class _HubLaunchClient implements PreparationLaunchClient {
         coverageCheckpointTurn: assignment.turnBlueprints.length,
         maxFollowUpsPerQuestion: 0,
         earlyCompletionRule: 'COVERAGE_SATISFIED_AFTER_CHECKPOINT',
+        retryAllowed: false,
+        questionTranslationAllowed: false,
       ),
       practiceObjectives: const <PracticeObjective>[
         PracticeObjective(id: 'ielts', description: 'Complete IELTS practice.'),

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -201,10 +201,7 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.tap(find.byKey(const Key('ielts-source-evergreen')));
-    await tester.pumpAndSettle();
-    expect(find.text('共 0 道专项题'), findsOneWidget);
-    expect(find.text('没有找到符合条件的题目'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-source-evergreen')), findsNothing);
   });
 
   testWidgets('keeps IELTS browser filters when returning to the catalog', (

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -542,6 +542,62 @@ void main() {
       );
     },
   );
+
+  testWidgets('failed direct start can exit and preserve its retry', (
+    tester,
+  ) async {
+    final preparationController = PreparationController(
+      client: _FixtureClient(),
+    );
+    final launchController = PreparationLaunchController(
+      client: _PageLaunchClient(),
+      contextProvider: () => _pageContext,
+      threadIdProvider: () => _pageContext.threadId,
+      goalActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => _pageContext,
+      voiceActivator:
+          ({
+            required context,
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async => throw const PreparationLaunchException(
+            kind: PreparationLaunchFailureKind.invalidResponse,
+            stage: PreparationLaunchStage.voice,
+          ),
+      idFactory: (scope) => '$scope-exit-widget-key',
+    );
+    addTearDown(preparationController.dispose);
+    addTearDown(launchController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: preparationController,
+          launchController: launchController,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _openFamily(tester, 'INTERVIEW');
+    await tester.tap(find.byKey(const Key('catalog-scene-$_sceneId')));
+    await tester.pumpAndSettle();
+
+    expect(launchController.canDismissFailedLaunch, isTrue);
+    await tester.tap(find.byKey(const Key('preparation-back-to-catalog')));
+    await tester.pumpAndSettle();
+
+    expect(launchController.canRetry, isTrue);
+    expect(preparationController.selectedScene, isNull);
+    expect(
+      find.byKey(const Key('preparation-scene-launch-status')),
+      findsNothing,
+    );
+  });
 }
 
 class _FixtureClient implements SceneClient {

--- a/mobile/test/coaching/preparation/wire_preparation_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_preparation_client_test.dart
@@ -257,6 +257,8 @@ void main() {
     final bank = await client.getIeltsQuestionBank();
 
     expect(bank.part1Sets, hasLength(38));
+    expect(bank.part1Topics, hasLength(38));
+    expect(bank.part1Topics.first.titleZh, '主题 1');
     expect(bank.part1Sets.first.questionCount, 8);
     expect(bank.part1Sets.first.topics, hasLength(3));
     expect(bank.topicGroups, hasLength(56));
@@ -333,7 +335,7 @@ IdentityHttpResponse _response(Object body) =>
     IdentityHttpResponse(statusCode: HttpStatus.ok, body: jsonEncode(body));
 
 Map<String, Object?> _ieltsQuestionBankJson() => <String, Object?>{
-  'schema_version': 1,
+  'schema_version': 2,
   'bank_id': 'ielts-speaking-2026-season',
   'season': '2026-05-08',
   'source_cutoff': '2026-06-18T10:00:00Z',
@@ -371,6 +373,22 @@ Map<String, Object?> _ieltsQuestionBankJson() => <String, Object?>{
       'published': true,
     },
   ),
+  'part1_topics': List<Object?>.generate(
+    38,
+    (index) => <String, Object?>{
+      'id': 'p1-topic-${index + 1}',
+      'title_zh': '主题 ${index + 1}',
+      'title_en': 'Topic ${index + 1}',
+      'release': index < 16
+          ? 'new'
+          : index < 33
+          ? 'carry_over'
+          : 'evergreen',
+      'category': index.isEven ? 'thing' : 'event',
+      'questions': ['Topic ${index + 1}-1', 'Topic ${index + 1}-2'],
+      'published': true,
+    },
+  ),
   'topic_groups': List<Object?>.generate(
     56,
     (index) => <String, Object?>{
@@ -378,6 +396,7 @@ Map<String, Object?> _ieltsQuestionBankJson() => <String, Object?>{
       'title_zh': '主题 ${index + 1}',
       'release': index.isEven ? 'new' : 'carry_over',
       'region': 'mainland',
+      'category': index.isEven ? 'person' : 'place',
       'part2': <String, Object?>{
         'prompt': 'Describe topic ${index + 1}',
         'points': ['What', 'Where', 'Who', 'Why'],

--- a/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
@@ -281,7 +281,7 @@ void main() {
     );
   });
 
-  test('decodes the canonical IELTS Part 3 assignment shape', () {
+  test('decodes a six-question IELTS Part 3 assignment', () {
     final assignment = decodeIeltsPracticeAssignment(<String, Object?>{
       'bank_id': 'ielts-2026-05-08',
       'season': '2026-05-08',
@@ -290,13 +290,36 @@ void main() {
       'topic_title': '语言学习',
       'part_1_questions': 0,
       'part_2_questions': 0,
-      'part_3_questions': 2,
-      'turn_blueprints': <String>['Question 1', 'Question 2'],
+      'part_3_questions': 6,
+      'turn_blueprints': List<String>.generate(
+        6,
+        (index) => 'Question ${index + 1}',
+      ),
     });
 
     expect(assignment.mode, IeltsPracticeMode.part3);
     expect(assignment.part2CueCard, isNull);
-    expect(assignment.turnBlueprints, hasLength(2));
+    expect(assignment.turnBlueprints, hasLength(6));
+  });
+
+  test('decodes a complete twenty-two-question IELTS Part 1 topic', () {
+    final assignment = decodeIeltsPracticeAssignment(<String, Object?>{
+      'bank_id': 'ielts-2026-05-08',
+      'season': '2026-05-08',
+      'mode': 'PART_1',
+      'part_1_set_id': 'p1-topic-020',
+      'part_1_questions': 22,
+      'part_2_questions': 0,
+      'part_3_questions': 0,
+      'turn_blueprints': List<String>.generate(
+        22,
+        (index) => 'Question ${index + 1}',
+      ),
+    });
+
+    expect(assignment.mode, IeltsPracticeMode.part1);
+    expect(assignment.part1SetId, 'p1-topic-020');
+    expect(assignment.turnBlueprints, hasLength(22));
   });
 
   group('rejects cross-resource Session bootstrap data', () {

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -103,6 +103,16 @@ void main() {
       key: 'primary-tab-review',
       expectedPageKey: 'review-page',
     );
+    expect(find.byKey(const Key('review-exit-button')), findsOneWidget);
+    expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('review-exit-button')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
+    await _tapPrimaryDestination(
+      tester,
+      key: 'primary-tab-review',
+      expectedPageKey: 'review-page',
+    );
     await _tapPrimaryDestination(
       tester,
       key: 'primary-tab-profile',
@@ -884,7 +894,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('agent-composer-field')), findsOneWidget);
-    expect(find.byKey(const Key('primary-navigation')), findsNothing);
+    expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
     final keyboardTop =
         tester.view.physicalSize.height / tester.view.devicePixelRatio - 240;
     final composerRect = tester.getRect(

--- a/mobile/test/support/practice_fixtures.dart
+++ b/mobile/test/support/practice_fixtures.dart
@@ -14,7 +14,7 @@ PracticeSessionSnapshot testPracticeSnapshot({
   if (completedTurns < 0 ||
       completedTurns > turnLimit ||
       turnLimit < 1 ||
-      turnLimit > 14) {
+      turnLimit > 24) {
     throw ArgumentError('Invalid test Practice progress.');
   }
   final completed = completedTurns == turnLimit;

--- a/server/internal/coaching/practice/postgres/context.go
+++ b/server/internal/coaching/practice/postgres/context.go
@@ -1076,7 +1076,8 @@ func validCreatedIELTSAssignment(
 			assignment.Part3Questions >= 1 && assignment.Part3Questions <= 5
 	case practice.IELTSPracticeModePart1:
 		return validContextResourceID(assignment.Part1SetID) &&
-			assignment.TopicGroupID == "" && assignment.Part1Questions == 8 &&
+			assignment.TopicGroupID == "" && assignment.Part1Questions >= 2 &&
+			assignment.Part1Questions <= 24 &&
 			assignment.Part2Questions == 0 && assignment.Part3Questions == 0
 	case practice.IELTSPracticeModePart2:
 		return assignment.Part1SetID == "" &&

--- a/server/internal/coaching/practice/postgres/context.go
+++ b/server/internal/coaching/practice/postgres/context.go
@@ -1083,12 +1083,12 @@ func validCreatedIELTSAssignment(
 		return assignment.Part1SetID == "" &&
 			validContextResourceID(assignment.TopicGroupID) &&
 			assignment.Part1Questions == 0 && assignment.Part2Questions == 1 &&
-			assignment.Part3Questions >= 1 && assignment.Part3Questions <= 5
+			assignment.Part3Questions >= 1 && assignment.Part3Questions <= 6
 	case practice.IELTSPracticeModePart3:
 		return assignment.Part1SetID == "" &&
 			validContextResourceID(assignment.TopicGroupID) &&
 			assignment.Part1Questions == 0 && assignment.Part2Questions == 0 &&
-			assignment.Part3Questions >= 1 && assignment.Part3Questions <= 5
+			assignment.Part3Questions >= 1 && assignment.Part3Questions <= 6
 	default:
 		return false
 	}

--- a/server/internal/coaching/practice/postgres/context_voice.go
+++ b/server/internal/coaching/practice/postgres/context_voice.go
@@ -130,7 +130,7 @@ func (r *Repository) advanceTurnInTransaction(
 		snapshot.ID != snapshotID ||
 		snapshot.SessionID != command.SessionID ||
 		snapshot.SessionPolicy.MaxEffectiveTurns != turnLimit ||
-		turnLimit < 1 || turnLimit > 14 ||
+		turnLimit < 1 || turnLimit > 24 ||
 		effectiveTurns < 0 || effectiveTurns > turnLimit {
 		return practice.TurnResult{}, practice.ErrConflict
 	}

--- a/server/internal/coaching/practice/voice/round_orchestrator.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator.go
@@ -288,7 +288,7 @@ func validVoiceTurnCheckpoint(turn practice.Turn) bool {
 		turn.EvidenceVersion < 1 ||
 		strings.TrimSpace(turn.AnswerText) == "" ||
 		turn.EffectiveTurns < 0 ||
-		turn.EffectiveTurns > 14 {
+		turn.EffectiveTurns > 24 {
 		return false
 	}
 	return turn.EffectiveTurns > 0

--- a/server/internal/coaching/practice/voice/session_adapter.go
+++ b/server/internal/coaching/practice/voice/session_adapter.go
@@ -269,7 +269,7 @@ func mapPracticeSession(
 		result.LearnerParticipantID == "" ||
 		len(facilitatorRoles) != len(selectedRoles) ||
 		result.TurnLimit < 1 ||
-		result.TurnLimit > 14 ||
+		result.TurnLimit > 24 ||
 		result.EffectiveTurns < 0 ||
 		result.EffectiveTurns > result.TurnLimit ||
 		(result.Status == string(
@@ -292,7 +292,7 @@ func validPersistedSessionLifecycle(
 	session practice.Session,
 	turnLimit int,
 ) bool {
-	if turnLimit < 1 || turnLimit > 14 ||
+	if turnLimit < 1 || turnLimit > 24 ||
 		session.EffectiveTurns < 0 ||
 		session.EffectiveTurns > turnLimit {
 		return false

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -343,7 +343,7 @@ func (application *SessionApplication) state(
 		!validVoiceScenePrompt(session) ||
 		session.SessionVersion < 1 ||
 		session.TurnLimit < 1 ||
-		session.TurnLimit > 14 ||
+		session.TurnLimit > 24 ||
 		session.EffectiveTurns < 0 ||
 		session.EffectiveTurns > session.TurnLimit ||
 		!validVoiceSessionLifecycle(session) ||

--- a/server/internal/coaching/preparation/plan_service.go
+++ b/server/internal/coaching/preparation/plan_service.go
@@ -569,10 +569,11 @@ func validResolvedIELTSQuestionSet(
 	case scene.IELTSPracticeModePart1:
 		return resolved.TopicTitle == "" &&
 			resolved.Part2CueCard == "" &&
-			resolved.Part1Questions == 8 &&
+			resolved.Part1Questions >= 2 &&
+			resolved.Part1Questions <= 24 &&
 			resolved.Part2Questions == 0 &&
 			resolved.Part3Questions == 0 &&
-			len(resolved.TurnBlueprints) == 8
+			len(resolved.TurnBlueprints) == resolved.Part1Questions
 	case scene.IELTSPracticeModePart2:
 		return validPlanText(resolved.TopicTitle) &&
 			validPlanText(resolved.Part2CueCard) &&
@@ -627,10 +628,11 @@ func validPlanIELTSAssignment(
 			assignment.TopicGroupID == "" &&
 			assignment.TopicTitle == "" &&
 			assignment.Part2CueCard == "" &&
-			assignment.Part1Questions == 8 &&
+			assignment.Part1Questions >= 2 &&
+			assignment.Part1Questions <= 24 &&
 			assignment.Part2Questions == 0 &&
 			assignment.Part3Questions == 0 &&
-			len(assignment.TurnBlueprints) == 8
+			len(assignment.TurnBlueprints) == assignment.Part1Questions
 	case scene.IELTSPracticeModePart2:
 		return assignment.Part1SetID == "" &&
 			validPlanResourceID(assignment.TopicGroupID) &&

--- a/server/internal/coaching/preparation/plan_service.go
+++ b/server/internal/coaching/preparation/plan_service.go
@@ -580,14 +580,14 @@ func validResolvedIELTSQuestionSet(
 			resolved.Part1Questions == 0 &&
 			resolved.Part2Questions == 1 &&
 			resolved.Part3Questions >= 1 &&
-			resolved.Part3Questions <= 5 &&
+			resolved.Part3Questions <= 6 &&
 			len(resolved.TurnBlueprints) == 1+resolved.Part3Questions
 	case scene.IELTSPracticeModePart3:
 		return validPlanText(resolved.TopicTitle) &&
 			resolved.Part1Questions == 0 &&
 			resolved.Part2Questions == 0 &&
 			resolved.Part3Questions >= 1 &&
-			resolved.Part3Questions <= 5 &&
+			resolved.Part3Questions <= 6 &&
 			len(resolved.TurnBlueprints) == resolved.Part3Questions
 	default:
 		return false
@@ -641,7 +641,7 @@ func validPlanIELTSAssignment(
 			assignment.Part1Questions == 0 &&
 			assignment.Part2Questions == 1 &&
 			assignment.Part3Questions >= 1 &&
-			assignment.Part3Questions <= 5 &&
+			assignment.Part3Questions <= 6 &&
 			len(assignment.TurnBlueprints) == 1+assignment.Part3Questions
 	case scene.IELTSPracticeModePart3:
 		return assignment.Part1SetID == "" &&
@@ -651,7 +651,7 @@ func validPlanIELTSAssignment(
 			assignment.Part1Questions == 0 &&
 			assignment.Part2Questions == 0 &&
 			assignment.Part3Questions >= 1 &&
-			assignment.Part3Questions <= 5 &&
+			assignment.Part3Questions <= 6 &&
 			len(assignment.TurnBlueprints) == assignment.Part3Questions
 	default:
 		return false

--- a/server/internal/coaching/scene/ielts_question_bank.go
+++ b/server/internal/coaching/scene/ielts_question_bank.go
@@ -27,12 +27,13 @@ const (
 )
 
 type IELTSQuestionBank struct {
-	SchemaVersion int               `json:"schema_version"`
-	BankID        string            `json:"bank_id"`
-	Season        string            `json:"season"`
-	SourceCutoff  string            `json:"source_cutoff"`
-	Part1Sets     []IELTSPart1Set   `json:"part1_sets"`
-	TopicGroups   []IELTSTopicGroup `json:"topic_groups"`
+	SchemaVersion int                       `json:"schema_version"`
+	BankID        string                    `json:"bank_id"`
+	Season        string                    `json:"season"`
+	SourceCutoff  string                    `json:"source_cutoff"`
+	Part1Sets     []IELTSPart1Set           `json:"part1_sets"`
+	Part1Topics   []IELTSPart1PracticeTopic `json:"part1_topics"`
+	TopicGroups   []IELTSTopicGroup         `json:"topic_groups"`
 }
 
 type IELTSPart1Set struct {
@@ -49,11 +50,22 @@ type IELTSPart1Topic struct {
 	Questions []string `json:"questions"`
 }
 
+type IELTSPart1PracticeTopic struct {
+	ID        string   `json:"id"`
+	TitleZH   string   `json:"title_zh"`
+	TitleEN   string   `json:"title_en"`
+	Release   string   `json:"release"`
+	Category  string   `json:"category"`
+	Questions []string `json:"questions"`
+	Published bool     `json:"published"`
+}
+
 type IELTSTopicGroup struct {
 	ID                        string            `json:"id"`
 	TitleZH                   string            `json:"title_zh"`
 	Release                   string            `json:"release"`
 	Region                    string            `json:"region"`
+	Category                  string            `json:"category"`
 	Part2                     IELTSPart2CueCard `json:"part2"`
 	Part3Questions            []string          `json:"part3_questions"`
 	Published                 bool              `json:"published"`
@@ -108,11 +120,12 @@ func loadEmbeddedIELTSQuestionBank() (IELTSQuestionBank, error) {
 }
 
 func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
-	if bank.SchemaVersion != 1 ||
+	if bank.SchemaVersion != 2 ||
 		!nonBlank(bank.BankID) ||
 		!nonBlank(bank.Season) ||
 		!nonBlank(bank.SourceCutoff) ||
-		len(bank.Part1Sets) != 38 {
+		len(bank.Part1Sets) != 38 ||
+		len(bank.Part1Topics) != 38 {
 		return ErrIELTSQuestionBankUnavailable
 	}
 	part1IDs := make(map[string]struct{}, len(bank.Part1Sets))
@@ -165,6 +178,40 @@ func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
 	if len(part1QuestionsByTopic) != 38 || part1QuestionCount != 234 {
 		return ErrIELTSQuestionBankUnavailable
 	}
+	practiceTopicIDs := make(map[string]struct{}, len(bank.Part1Topics))
+	practiceTopicTitles := make(map[string]struct{}, len(bank.Part1Topics))
+	practiceQuestionCount := 0
+	for _, topic := range bank.Part1Topics {
+		if !validResourceID(topic.ID) ||
+			!nonBlank(topic.TitleZH) ||
+			!nonBlank(topic.TitleEN) ||
+			!validIELTSRelease(topic.Release, true) ||
+			!validIELTSCategory(topic.Category) ||
+			!topic.Published ||
+			len(topic.Questions) < 2 {
+			return ErrIELTSQuestionBankUnavailable
+		}
+		if _, duplicate := practiceTopicIDs[topic.ID]; duplicate {
+			return ErrIELTSQuestionBankUnavailable
+		}
+		if _, duplicate := practiceTopicTitles[topic.TitleEN]; duplicate {
+			return ErrIELTSQuestionBankUnavailable
+		}
+		practiceTopicIDs[topic.ID] = struct{}{}
+		practiceTopicTitles[topic.TitleEN] = struct{}{}
+		if _, exists := part1QuestionsByTopic[topic.TitleEN]; !exists {
+			return ErrIELTSQuestionBankUnavailable
+		}
+		for _, question := range topic.Questions {
+			if !nonBlank(question) {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			practiceQuestionCount++
+		}
+	}
+	if practiceQuestionCount != 234 {
+		return ErrIELTSQuestionBankUnavailable
+	}
 	published := 0
 	hidden := 0
 	groupIDs := make(map[string]struct{}, len(bank.TopicGroups))
@@ -173,6 +220,7 @@ func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
 			!nonBlank(group.TitleZH) ||
 			!nonBlank(group.Release) ||
 			!nonBlank(group.Region) ||
+			!validIELTSCategory(group.Category) ||
 			!nonBlank(group.Part2.Prompt) ||
 			len(group.Part2.Points) < 3 {
 			return ErrIELTSQuestionBankUnavailable
@@ -225,6 +273,17 @@ func cloneIELTSQuestionBank(source IELTSQuestionBank) IELTSQuestionBank {
 			)
 		}
 	}
+	result.Part1Topics = make(
+		[]IELTSPart1PracticeTopic,
+		len(source.Part1Topics),
+	)
+	for index, topic := range source.Part1Topics {
+		result.Part1Topics[index] = topic
+		result.Part1Topics[index].Questions = append(
+			[]string(nil),
+			topic.Questions...,
+		)
+	}
 	result.TopicGroups = make([]IELTSTopicGroup, len(source.TopicGroups))
 	for index, group := range source.TopicGroups {
 		result.TopicGroups[index] = group
@@ -249,6 +308,13 @@ func publishedIELTSQuestionBank(source IELTSQuestionBank) IELTSQuestionBank {
 		}
 	}
 	result.Part1Sets = part1Sets
+	part1Topics := result.Part1Topics[:0]
+	for _, topic := range result.Part1Topics {
+		if topic.Published {
+			part1Topics = append(part1Topics, topic)
+		}
+	}
+	result.Part1Topics = part1Topics
 	topicGroups := result.TopicGroups[:0]
 	for _, group := range result.TopicGroups {
 		if group.Published {
@@ -264,7 +330,7 @@ func resolveIELTSQuestionSet(
 	selection IELTSQuestionSetSelection,
 ) (IELTSResolvedQuestionSet, error) {
 	var part1Set *IELTSPart1Set
-	if selection.Part1SetID != "" {
+	if selection.Part1SetID != "" && selection.Mode == IELTSPracticeModeFullMock {
 		for index := range bank.Part1Sets {
 			if bank.Part1Sets[index].ID == selection.Part1SetID &&
 				bank.Part1Sets[index].Published {
@@ -273,6 +339,19 @@ func resolveIELTSQuestionSet(
 			}
 		}
 		if part1Set == nil {
+			return IELTSResolvedQuestionSet{}, ErrIELTSQuestionSetNotFound
+		}
+	}
+	var part1Topic *IELTSPart1PracticeTopic
+	if selection.Part1SetID != "" && selection.Mode == IELTSPracticeModePart1 {
+		for index := range bank.Part1Topics {
+			if bank.Part1Topics[index].ID == selection.Part1SetID &&
+				bank.Part1Topics[index].Published {
+				part1Topic = &bank.Part1Topics[index]
+				break
+			}
+		}
+		if part1Topic == nil {
 			return IELTSResolvedQuestionSet{}, ErrIELTSQuestionSetNotFound
 		}
 	}
@@ -289,7 +368,7 @@ func resolveIELTSQuestionSet(
 			return IELTSResolvedQuestionSet{}, ErrIELTSQuestionSetNotFound
 		}
 	}
-	if !validIELTSSelectionShape(selection, part1Set, topicGroup) {
+	if !validIELTSSelectionShape(selection, part1Set, part1Topic, topicGroup) {
 		return IELTSResolvedQuestionSet{}, ErrIELTSPracticeModeInvalid
 	}
 	result := IELTSResolvedQuestionSet{
@@ -311,6 +390,15 @@ func resolveIELTSQuestionSet(
 				)
 				result.Part1Questions++
 			}
+		}
+	}
+	if part1Topic != nil {
+		for _, question := range part1Topic.Questions {
+			result.TurnBlueprints = append(
+				result.TurnBlueprints,
+				"Part 1 question: "+question,
+			)
+			result.Part1Questions++
 		}
 	}
 	if topicGroup != nil {
@@ -338,15 +426,32 @@ func resolveIELTSQuestionSet(
 func validIELTSSelectionShape(
 	selection IELTSQuestionSetSelection,
 	part1Set *IELTSPart1Set,
+	part1Topic *IELTSPart1PracticeTopic,
 	topicGroup *IELTSTopicGroup,
 ) bool {
 	switch selection.Mode {
 	case IELTSPracticeModeFullMock:
-		return part1Set != nil && topicGroup != nil
+		return part1Set != nil && part1Topic == nil && topicGroup != nil
 	case IELTSPracticeModePart1:
-		return part1Set != nil && topicGroup == nil
+		return part1Set == nil && part1Topic != nil && topicGroup == nil
 	case IELTSPracticeModePart2, IELTSPracticeModePart3:
-		return part1Set == nil && topicGroup != nil
+		return part1Set == nil && part1Topic == nil && topicGroup != nil
+	default:
+		return false
+	}
+}
+
+func validIELTSRelease(value string, allowEvergreen bool) bool {
+	if value == "new" || value == "carry_over" {
+		return true
+	}
+	return allowEvergreen && value == "evergreen"
+}
+
+func validIELTSCategory(value string) bool {
+	switch value {
+	case "person", "place", "thing", "event":
+		return true
 	default:
 		return false
 	}

--- a/server/internal/coaching/scene/ielts_question_bank.go
+++ b/server/internal/coaching/scene/ielts_question_bank.go
@@ -199,13 +199,22 @@ func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
 		}
 		practiceTopicIDs[topic.ID] = struct{}{}
 		practiceTopicTitles[topic.TitleEN] = struct{}{}
-		if _, exists := part1QuestionsByTopic[topic.TitleEN]; !exists {
+		canonicalQuestions, exists := part1QuestionsByTopic[topic.TitleEN]
+		if !exists || len(canonicalQuestions) != len(topic.Questions) {
 			return ErrIELTSQuestionBankUnavailable
 		}
+		questions := make(map[string]struct{}, len(topic.Questions))
 		for _, question := range topic.Questions {
 			if !nonBlank(question) {
 				return ErrIELTSQuestionBankUnavailable
 			}
+			if _, duplicate := questions[question]; duplicate {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			if _, canonical := canonicalQuestions[question]; !canonical {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			questions[question] = struct{}{}
 			practiceQuestionCount++
 		}
 	}
@@ -214,7 +223,10 @@ func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
 	}
 	published := 0
 	hidden := 0
+	publishedPart3Questions := 0
 	groupIDs := make(map[string]struct{}, len(bank.TopicGroups))
+	publishedTitles := make(map[string]struct{}, 56)
+	publishedPrompts := make(map[string]struct{}, 56)
 	for _, group := range bank.TopicGroups {
 		if !validResourceID(group.ID) ||
 			!nonBlank(group.TitleZH) ||
@@ -234,23 +246,37 @@ func validateIELTSQuestionBank(bank IELTSQuestionBank) error {
 				return ErrIELTSQuestionBankUnavailable
 			}
 		}
+		part3Questions := make(map[string]struct{}, len(group.Part3Questions))
 		for _, question := range group.Part3Questions {
 			if !nonBlank(question) {
 				return ErrIELTSQuestionBankUnavailable
 			}
+			if _, duplicate := part3Questions[question]; duplicate {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			part3Questions[question] = struct{}{}
 		}
 		if group.Published {
 			published++
 			if group.Region != "mainland" ||
 				len(group.Part3Questions) < 1 ||
-				len(group.Part3Questions) > 5 {
+				len(group.Part3Questions) > 6 {
 				return ErrIELTSQuestionBankUnavailable
 			}
+			if _, duplicate := publishedTitles[group.TitleZH]; duplicate {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			if _, duplicate := publishedPrompts[group.Part2.Prompt]; duplicate {
+				return ErrIELTSQuestionBankUnavailable
+			}
+			publishedTitles[group.TitleZH] = struct{}{}
+			publishedPrompts[group.Part2.Prompt] = struct{}{}
+			publishedPart3Questions += len(group.Part3Questions)
 		} else {
 			hidden++
 		}
 	}
-	if published != 56 || hidden != 8 {
+	if published != 56 || hidden != 8 || publishedPart3Questions != 317 {
 		return ErrIELTSQuestionBankUnavailable
 	}
 	return nil
@@ -412,7 +438,11 @@ func resolveIELTSQuestionSet(
 			)
 			result.Part2Questions = 1
 		}
-		for _, question := range topicGroup.Part3Questions {
+		part3Questions := topicGroup.Part3Questions
+		if selection.Mode == IELTSPracticeModeFullMock && len(part3Questions) > 5 {
+			part3Questions = part3Questions[:5]
+		}
+		for _, question := range part3Questions {
 			result.TurnBlueprints = append(
 				result.TurnBlueprints,
 				"Part 3 question: "+question,

--- a/server/internal/coaching/scene/ielts_question_bank.json
+++ b/server/internal/coaching/scene/ielts_question_bank.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "bank_id": "ielts-speaking-2026-05-08-mainland",
   "season": "2026-05-08",
   "source_cutoff": "2026-06-18T18:00:00+08:00",
@@ -1320,7 +1320,8 @@
         "Why do some people like to remodel and decorate their homes themselves?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-new-002",
@@ -1344,7 +1345,8 @@
         "Are there any differences between the videos that young men and young women like to watch?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-003",
@@ -1368,7 +1370,8 @@
         "Why do some young people feel bored when talking with old people?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-new-004",
@@ -1392,7 +1395,8 @@
         "Is it good to arrive early in any situation?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-005",
@@ -1416,7 +1420,8 @@
         "Why do some people prefer to grow their own fruits and vegetables instead of buying them from the market?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-006",
@@ -1441,7 +1446,8 @@
         "What are the benefits for people to obey rules?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-007",
@@ -1465,7 +1471,8 @@
         "What's the difference between having younger friends and older friends?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-008",
@@ -1489,7 +1496,8 @@
         "Why is some doctors' pay high and others' low?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-009",
@@ -1514,7 +1522,8 @@
         "What makes a business fail?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-010",
@@ -1538,7 +1547,8 @@
         "What kind of plans do people often make?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-011",
@@ -1562,7 +1572,8 @@
         "What advantages are there for students experiencing teamwork at school?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-012",
@@ -1586,7 +1597,8 @@
         "Do you think the influence of advertising is good?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-013",
@@ -1610,7 +1622,8 @@
         "Why do some people spend a lot going to other countries to watch sports events?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-014",
@@ -1633,7 +1646,8 @@
         "Do people today prefer eating at home or in a restaurant?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-015",
@@ -1657,7 +1671,8 @@
         "How do people learn new things?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-016",
@@ -1681,7 +1696,8 @@
         "Do you think students are overly reliant on AI?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-017",
@@ -1705,7 +1721,8 @@
         "Is advertising important for a company? Why?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-018",
@@ -1729,7 +1746,8 @@
         "Why do many countries try to attract people to visit?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-new-019",
@@ -1753,7 +1771,8 @@
         "What kind of gifts do people usually bring when they visit others?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-new-020",
@@ -1777,7 +1796,8 @@
         "What are the advantages of keeping a pet?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-021",
@@ -1797,7 +1817,8 @@
         "How important is it for schools to help children become smarter?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-022",
@@ -1821,7 +1842,8 @@
         "What are the rules people should obey at work?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-023",
@@ -1845,7 +1867,8 @@
         "How do you show your respect in your messages?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-024",
@@ -1869,7 +1892,8 @@
         "Do you think it is necessary to be ambitious when working in a team in a company?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-025",
@@ -1889,7 +1913,8 @@
         "In your country, what industry is it easier to be successful in?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-new-026",
@@ -1912,7 +1937,8 @@
         "Who do young people like to share opinions with?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-new-027",
@@ -1935,7 +1961,8 @@
         "What environmental laws does your country already have?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-028",
@@ -1958,7 +1985,8 @@
         "How can people develop their national identity?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-new-029",
@@ -1982,7 +2010,8 @@
         "Who tend to change their daily routine more, young people or old people?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-001",
@@ -2006,7 +2035,8 @@
         "Is salary the main reason why people choose a certain job?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-002",
@@ -2030,7 +2060,8 @@
         "Is it easy to become famous in your country?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-003",
@@ -2054,7 +2085,8 @@
         "What are examples of good and poor phone manners?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-004",
@@ -2078,7 +2110,8 @@
         "Why do some people think it is better to ask for advice from friends than from parents?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-005",
@@ -2102,7 +2135,8 @@
         "What negative effects does technology have on people's relationships?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-006",
@@ -2126,7 +2160,8 @@
         "Is making study plans popular among young people?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-007",
@@ -2150,7 +2185,8 @@
         "How do artworks inspire people?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-008",
@@ -2175,7 +2211,8 @@
         "Do you think young people are more and more reliant on these programs?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-009",
@@ -2199,7 +2236,8 @@
         "Is smiling important in your culture?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-010",
@@ -2223,7 +2261,8 @@
         "Do rewards help a child become better?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-011",
@@ -2247,7 +2286,8 @@
         "What are the benefits of technology for learning history?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-012",
@@ -2271,7 +2311,8 @@
         "Why do more people own and drive private vehicles now?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-013",
@@ -2295,7 +2336,8 @@
         "Do you think smart children are happier than other children?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-014",
@@ -2319,7 +2361,8 @@
         "Do you think enterprises should provide training for their employees?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-015",
@@ -2343,7 +2386,8 @@
         "Why do many people like listening to music while doing sports?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-016",
@@ -2367,7 +2411,8 @@
         "Do you think successful movies should have well-known actors or actresses in leading roles?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-017",
@@ -2391,7 +2436,8 @@
         "Do you think it's reasonable to charge an entry fee for visiting interesting buildings?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-old-018",
@@ -2415,7 +2461,8 @@
         "What games help develop children's imagination?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-019",
@@ -2439,7 +2486,8 @@
         "Do you think schools should teach children to do household chores?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-020",
@@ -2463,7 +2511,8 @@
         "Do you think it is the rich people's responsibility to donate money to people in need?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-021",
@@ -2487,7 +2536,8 @@
         "Should children do everything their parents ask them to do?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-old-022",
@@ -2511,7 +2561,8 @@
         "What kind of work can young people do in foreign countries?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-old-023",
@@ -2536,7 +2587,8 @@
         "What can people do to protect the natural world?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-old-024",
@@ -2560,7 +2612,8 @@
         "What are the differences in the shopping habits of different age groups?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-old-025",
@@ -2585,7 +2638,8 @@
         "Do you prefer to visit well-developed cities or cities with a long history?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-old-026",
@@ -2610,7 +2664,8 @@
         "Why do old people prefer to live in quiet places?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-old-027",
@@ -2634,7 +2689,8 @@
         "Do you think watching talk shows is a waste of time?"
       ],
       "published": true,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-intl-001",
@@ -2655,7 +2711,8 @@
         "Do you think a gap period in life is important?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-intl-002",
@@ -2680,7 +2737,8 @@
         "What do you think of people using their mobile phones during a meal?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "thing"
     },
     {
       "id": "p23-intl-003",
@@ -2702,7 +2760,8 @@
         "Do you think customer satisfaction is important for a company?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "person"
     },
     {
       "id": "p23-intl-004",
@@ -2727,7 +2786,8 @@
         "Some people think that technology has made it unnecessary to learn languages. What do you think?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-intl-005",
@@ -2752,7 +2812,8 @@
         "How can rivers and lakes benefit local people?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "place"
     },
     {
       "id": "p23-intl-006",
@@ -2777,7 +2838,8 @@
         "Going out to have holidays is tiring. Why do people still want to do it?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-intl-007",
@@ -2802,7 +2864,8 @@
         "Do you prefer to prepare and organize an activity or just take part in an activity?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
     },
     {
       "id": "p23-intl-008",
@@ -2827,7 +2890,624 @@
         "Would you rather be in a car or a bus in a traffic jam?"
       ],
       "published": false,
-      "supplemented_question_count": 0
+      "supplemented_question_count": 0,
+      "category": "event"
+    }
+  ],
+  "part1_topics": [
+    {
+      "id": "p1-topic-001",
+      "title_zh": "音乐",
+      "title_en": "Music",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you prefer sad or happy music?",
+        "Does happy music make you feel more excited?",
+        "Have you taken any music classes?",
+        "Do you listen to music while doing other things?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-002",
+      "title_zh": "老师",
+      "title_en": "Teachers",
+      "release": "new",
+      "category": "person",
+      "questions": [
+        "Do you have a favorite teacher?",
+        "Do you want to be a teacher in the future?",
+        "Do you have a teacher from your past that you still remember?",
+        "Do you like your primary school teachers more than your high school teachers?",
+        "Are you still in touch with your primary school teachers?",
+        "In what way has your favourite teacher helped you?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-003",
+      "title_zh": "社交媒体",
+      "title_en": "Social media",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Have you ever posted anything on social media?",
+        "When did you start using social media?",
+        "Do you think you spend too much time on social media?",
+        "Do your friends use social media?",
+        "What do people often do on social media?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-004",
+      "title_zh": "整洁",
+      "title_en": "Tidiness",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you like to keep things tidy?",
+        "Did you keep your room tidy as a child?",
+        "How do you keep your work or study space tidy?",
+        "Do you think that it is necessary to be tidy?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-005",
+      "title_zh": "网站",
+      "title_en": "Websites",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "What kinds of websites do you often visit?",
+        "What is your favourite website?",
+        "Are there any changes to the websites you often visit?",
+        "What kinds of websites are popular in your country?",
+        "Do you prefer getting information from websites or books?",
+        "Would you like to have your own website?",
+        "What have you learned from websites that help with your life or studies?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-006",
+      "title_zh": "手表",
+      "title_en": "Watch",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you wear a watch?",
+        "Have you ever got a watch as a gift?",
+        "Why do some people wear expensive watches?",
+        "Do you think it is important to wear a watch? Why?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-007",
+      "title_zh": "购物",
+      "title_en": "Shopping",
+      "release": "new",
+      "category": "event",
+      "questions": [
+        "Do you like shopping?",
+        "How often do you go shopping?",
+        "Do you prefer online shopping or in-store shopping?",
+        "Have you ever returned anything you bought online?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-008",
+      "title_zh": "汽车",
+      "title_en": "Cars",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Did you enjoy traveling by car when you were a kid?",
+        "What types of cars do you like?",
+        "Do you prefer to be a driver or a passenger?",
+        "What do you usually do when there is a traffic jam?",
+        "Do you think car colours are important?",
+        "Will you buy an expensive car in the future?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-009",
+      "title_zh": "公园与花园",
+      "title_en": "Public gardens and parks",
+      "release": "new",
+      "category": "place",
+      "questions": [
+        "Did you like going to parks as a child?",
+        "Do you still like going to parks now?",
+        "Would you like to see more parks in your city?",
+        "Would you like to play in a public garden or park?",
+        "Are there any parks you want to go to in the future?",
+        "Would you prefer to play in a personal garden or public garden?",
+        "How are the parks today different from those you visited as a kid?",
+        "What do you like to do when visiting a park?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-010",
+      "title_zh": "科学",
+      "title_en": "Science",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you like science?",
+        "When did you start to learn about science?",
+        "Which science subject is interesting to you?",
+        "What kinds of interesting things have you done with science?",
+        "Do you like watching science TV programs?",
+        "Do Chinese people often visit science museums?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-011",
+      "title_zh": "镜子",
+      "title_en": "Mirrors",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you like looking at yourself in the mirror? How often?",
+        "Have you ever bought mirrors?",
+        "Do you usually take a mirror with you?",
+        "Would you use mirrors to decorate your room?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-012",
+      "title_zh": "外太空与星星",
+      "title_en": "Outer space and stars",
+      "release": "new",
+      "category": "place",
+      "questions": [
+        "Have you ever learnt about outer space and stars?",
+        "Do you like science fiction movies? Why?",
+        "Do you want to know more about outer space?",
+        "Do you want to go into outer space in the future?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-013",
+      "title_zh": "唱歌",
+      "title_en": "Singing",
+      "release": "new",
+      "category": "event",
+      "questions": [
+        "Do you like singing? Why?",
+        "Have you ever learnt how to sing?",
+        "Who do you want to sing for?",
+        "Do you think singing can bring happiness to people?",
+        "Do you like listening to others singing?",
+        "Have you ever taken a singing class?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-014",
+      "title_zh": "服装",
+      "title_en": "Clothing",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "What kind of clothes do you like to wear?",
+        "Do you prefer to wear comfortable and casual clothes or smart clothes?",
+        "Do you like wearing T-shirts?",
+        "Do you spend a lot of time choosing clothes?",
+        "Do you wear different styles of clothes on weekdays and weekends?",
+        "What colour clothes do you like?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-015",
+      "title_zh": "笑话与喜剧",
+      "title_en": "Jokes & Comedies",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Are you good at telling jokes?",
+        "Do your friends like to tell jokes?",
+        "Do you like to watch comedies?",
+        "Have you ever watched a live show?",
+        "Are comedy shows popular in your country?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-016",
+      "title_zh": "耳机",
+      "title_en": "Headphones",
+      "release": "new",
+      "category": "thing",
+      "questions": [
+        "Do you use headphones?",
+        "What type of headphones do you use?",
+        "When would you use headphones?",
+        "In what conditions would you not use headphones?",
+        "Is wearing headphones comfortable?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-017",
+      "title_zh": "食物",
+      "title_en": "Food",
+      "release": "carry_over",
+      "category": "thing",
+      "questions": [
+        "What is your favourite food?",
+        "What kind of food did you like when you were young?",
+        "Do you eat different foods at different times of the year?",
+        "Has your favourite food changed since you were a child?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-018",
+      "title_zh": "宠物与动物",
+      "title_en": "Pets and Animals",
+      "release": "carry_over",
+      "category": "thing",
+      "questions": [
+        "What's your favourite animal? Why?",
+        "Where do you prefer to keep your pet, indoors or outdoors?",
+        "Have you ever had a pet before?",
+        "What is the most popular animal in China?",
+        "Have you ever visited a zoo?",
+        "How often do you visit a zoo?",
+        "Are there many people keeping pets in your country?",
+        "Should schools teach students knowledge about pets or animals?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-019",
+      "title_zh": "运动队",
+      "title_en": "Sports team",
+      "release": "carry_over",
+      "category": "person",
+      "questions": [
+        "Have you ever been part of a sports team?",
+        "Is team sports popular in your culture?",
+        "Do you like watching team games? Why?",
+        "What are the differences between team sports and individual sports?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-020",
+      "title_zh": "兴趣爱好",
+      "title_en": "Hobby",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you have any hobbies?",
+        "Did you have any hobbies when you were a child?",
+        "Do you have a hobby that you've had since childhood?",
+        "Do you have the same hobbies as your family members?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-021",
+      "title_zh": "早晨时光",
+      "title_en": "Morning time",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you like getting up early in the morning?",
+        "What do you usually do in the morning?",
+        "What did you do in the morning when you were little? Why?",
+        "Are there any differences between what you do in the morning now and what you did in the past?",
+        "Do you spend your mornings doing the same things on both weekends and weekdays? Why?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-022",
+      "title_zh": "礼物",
+      "title_en": "Gifts",
+      "release": "carry_over",
+      "category": "thing",
+      "questions": [
+        "Have you ever sent handmade gifts to others?",
+        "Have you ever received a great gift?",
+        "What do you consider when choosing a gift?",
+        "Do you think you are good at choosing gifts?",
+        "What gift have you received recently?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-023",
+      "title_zh": "阅读",
+      "title_en": "Reading",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you like reading?",
+        "Do you prefer to read on paper or on a screen?",
+        "When do you need to read carefully, and when not?",
+        "Do you prefer scanning or detailed reading?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-024",
+      "title_zh": "散步",
+      "title_en": "Walking",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you walk a lot?",
+        "Did you often go outside to have a walk when you were a child?",
+        "Why do people like to walk in parks?",
+        "Where would you like to take a long walk if you had the chance?",
+        "Where did you go for a walk lately?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-025",
+      "title_zh": "打字",
+      "title_en": "Typing",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you prefer typing or handwriting?",
+        "Do you type on a desktop or laptop keyboard every day?",
+        "When did you learn how to type on a keyboard?",
+        "How do you improve your typing?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-026",
+      "title_zh": "风景",
+      "title_en": "Scenery",
+      "release": "carry_over",
+      "category": "place",
+      "questions": [
+        "Do you look out the window at the scenery when travelling by bus or car?",
+        "Do you prefer the mountains or the sea?",
+        "Do you like to take scenery pictures?",
+        "What are the most beautiful sights you have seen while traveling?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-027",
+      "title_zh": "建筑",
+      "title_en": "Building",
+      "release": "carry_over",
+      "category": "place",
+      "questions": [
+        "Are there tall buildings near your home?",
+        "Do you take photos of buildings?",
+        "Is there a building that you would like to visit?",
+        "Do you want to live in a tall building?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-028",
+      "title_zh": "童年活动",
+      "title_en": "Childhood activities",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "What are your favourite activities?",
+        "What were your favourite activities when you were a child?",
+        "Did you prefer to do activities alone or with a group of people when you were a child?",
+        "Are there any differences between the activities you liked when you were a child and those you like now?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-029",
+      "title_zh": "景色",
+      "title_en": "Views",
+      "release": "carry_over",
+      "category": "place",
+      "questions": [
+        "Do you like taking pictures of different views?",
+        "Do you prefer views in urban areas or rural areas?",
+        "Do you prefer views in your own country or in other countries?",
+        "Have you seen an unforgettable and beautiful view or scenery?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-030",
+      "title_zh": "人生阶段",
+      "title_en": "Life stages",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "What did you often do with your friends in your childhood?",
+        "What do you think is the most important at the moment?",
+        "Do you have any plans for the next five years?",
+        "At what age do you think people are the happiest?",
+        "How do people remember each stage of their lives?",
+        "Do you enjoy being the age you are now?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-031",
+      "title_zh": "空闲时间",
+      "title_en": "Spare time",
+      "release": "carry_over",
+      "category": "event",
+      "questions": [
+        "Do you often have free time?",
+        "What do you usually do in your spare time?",
+        "Which day do you have more free time on, Saturday or Sunday?",
+        "Would you like to have more free time in the future?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-032",
+      "title_zh": "记忆",
+      "title_en": "Memory",
+      "release": "carry_over",
+      "category": "thing",
+      "questions": [
+        "Are you good at memorising things?",
+        "Have you ever forgotten something important?",
+        "What do you need to remember in your daily life?",
+        "How do you remember important things?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-033",
+      "title_zh": "拥挤的地方",
+      "title_en": "Crowded place",
+      "release": "carry_over",
+      "category": "place",
+      "questions": [
+        "Is the city where you live crowded?",
+        "Is there a crowded place near where you live?",
+        "Do you like crowded places?",
+        "Do most people like crowded places?",
+        "When was the last time you were in a crowded place?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-034",
+      "title_zh": "工作或学习",
+      "title_en": "Work or studies",
+      "release": "evergreen",
+      "category": "event",
+      "questions": [
+        "What subjects are you studying?",
+        "Do you like your subject?",
+        "Why did you choose to study that subject?",
+        "Do you think that your subject is popular in your country?",
+        "Do you have any plans for your studies in the next five years?",
+        "What are the benefits of being your age?",
+        "Do you want to change your major?",
+        "Do you prefer to study in the mornings or in the afternoons?",
+        "How much time do you spend on your studies each week?",
+        "Are you looking forward to working?",
+        "What technology do you use when you study?",
+        "What changes would you like to see in your school?",
+        "What work do you do?",
+        "Why did you choose to do that type of work (or that job)?",
+        "Do you like your job?",
+        "What requirements did you need to meet to get your current job?",
+        "Do you have any plans for your work in the next five years?",
+        "What do you think is the most important at the moment?",
+        "Do you want to change to another job?",
+        "Do you miss being a student?",
+        "What technology do you use at work?",
+        "Who helps you the most? And how?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-035",
+      "title_zh": "住房",
+      "title_en": "Home/accommodation",
+      "release": "evergreen",
+      "category": "place",
+      "questions": [
+        "What kind of house or apartment do you want to live in in the future?",
+        "Are the transport facilities to your home very good?",
+        "Do you prefer living in a house or an apartment?",
+        "Please describe the room you live in.",
+        "What part of your home do you like the most?",
+        "How long have you lived there?",
+        "Do you plan to live there for a long time?",
+        "What's the difference between where you are living now and where you have lived in the past?",
+        "Can you describe the place where you live?",
+        "What room does your family spend most of the time in?",
+        "What's your favorite room in your apartment or house?",
+        "What makes you feel pleasant in your home?",
+        "Do you think it is important to live in a comfortable environment?",
+        "Do you live in an apartment or a house?",
+        "Who do you live with?",
+        "What do you usually do in your apartment?",
+        "What kinds of accommodation do you live in?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-036",
+      "title_zh": "家乡",
+      "title_en": "Hometown",
+      "release": "evergreen",
+      "category": "place",
+      "questions": [
+        "Where is your hometown?",
+        "Is that a big city or a small place?",
+        "Please describe your hometown a little.",
+        "How long have you been living there?",
+        "Do you think you will continue living there for a long time?",
+        "Do you like your hometown?",
+        "Do you like living there?",
+        "What do you like (most) about your hometown?",
+        "Is there anything you dislike about it?",
+        "What's your hometown famous for?",
+        "Did you learn about the history of your hometown at school?",
+        "Are there many young people in your hometown?",
+        "Is your hometown a good place for young people to pursue their careers?",
+        "Have you learned anything about the history of your hometown?",
+        "Did you learn about the culture of your hometown in your childhood?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-037",
+      "title_zh": "居住区域",
+      "title_en": "The area you live in",
+      "release": "evergreen",
+      "category": "place",
+      "questions": [
+        "Do you like the area that you live in?",
+        "Where do you like to go in that area?",
+        "Do you know any famous people in your area?",
+        "What are some changes in the area recently?",
+        "Do you know any of your neighbors?",
+        "Are the people in your neighborhood nice and friendly?",
+        "Do you live in a noisy or a quiet area?"
+      ],
+      "published": true
+    },
+    {
+      "id": "p1-topic-038",
+      "title_zh": "居住城市",
+      "title_en": "The city you live in",
+      "release": "evergreen",
+      "category": "place",
+      "questions": [
+        "What city do you live in?",
+        "Do you like this city? Why?",
+        "How long have you lived in this city?",
+        "Are there big changes in this city?",
+        "Is this city your permanent residence?",
+        "Are there people of different ages living in this city?",
+        "Are the people friendly in the city?",
+        "Is the city friendly to children and old people?",
+        "Do you often see your neighbors?",
+        "What's the weather like where you live?",
+        "Would you recommend your city to others?"
+      ],
+      "published": true
     }
   ]
 }

--- a/server/internal/coaching/scene/ielts_question_bank.json
+++ b/server/internal/coaching/scene/ielts_question_bank.json
@@ -1317,7 +1317,8 @@
         "What are the differences between those tall buildings in your country?",
         "Why are different places laid out and designed differently?",
         "What are the advantages of living in tall buildings?",
-        "Why do some people like to remodel and decorate their homes themselves?"
+        "Why do some people like to remodel and decorate their homes themselves?",
+        "What kind of interior design style do most people like?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1342,7 +1343,8 @@
         "Which is more helpful, watching videos or reading books?",
         "What skills can people learn from watching videos?",
         "Are there any differences between the videos that young people and old people like to watch?",
-        "Are there any differences between the videos that young men and young women like to watch?"
+        "Are there any differences between the videos that young men and young women like to watch?",
+        "What makes a video go viral online?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1367,7 +1369,8 @@
         "Why aren't young people willing to listen to the experiences of older people?",
         "What can people do when they feel bored?",
         "Why are some teachers' classes boring? Are there any solutions?",
-        "Why do some young people feel bored when talking with old people?"
+        "Why do some young people feel bored when talking with old people?",
+        "Do most people think news about celebrities is boring?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1392,7 +1395,8 @@
         "Why do people get up early?",
         "What kinds of occasions need people to arrive early?",
         "Why do some people like to stay up late?",
-        "Is it good to arrive early in any situation?"
+        "Is it good to arrive early in any situation?",
+        "What kind of people like getting up early?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1417,7 +1421,8 @@
         "Do many people grow vegetables or flowers at home in your country?",
         "Is it easy to grow plants at home?",
         "Why do some people like to grow plants?",
-        "Why do some people prefer to grow their own fruits and vegetables instead of buying them from the market?"
+        "Why do some people prefer to grow their own fruits and vegetables instead of buying them from the market?",
+        "Do you think students should learn to grow plant?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1443,7 +1448,8 @@
         "Do people in your country usually obey the law?",
         "What kinds of behavior are considered as good behavior?",
         "Do you think children can learn about the law outside of school?",
-        "What are the benefits for people to obey rules?"
+        "What are the benefits for people to obey rules?",
+        "How can parents teach children to obey rules?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1468,7 +1474,8 @@
         "How important is childhood friendship to children?",
         "What do you think of communicating via social media?",
         "Do you think online communication through social media will replace face-to-face communication?",
-        "What's the difference between having younger friends and older friends?"
+        "What's the difference between having younger friends and older friends?",
+        "Has technology changed people's friendships? How?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1493,7 +1500,8 @@
         "Do you think learning biology is interesting for children?",
         "Why do some children want to become doctors?",
         "Do you think governments should put a large amount of money into medical research?",
-        "Why is some doctors' pay high and others' low?"
+        "Why is some doctors' pay high and others' low?",
+        "Do you think doctors should be paid more?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1519,7 +1527,8 @@
         "Should governments provide financial support to start-ups?",
         "Do most people prefer shopping at big stores or small stores?",
         "What makes a business successful?",
-        "What makes a business fail?"
+        "What makes a business fail?",
+        "Is it easy to set up a new business in your country?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1544,7 +1553,8 @@
         "Would you tell others if you change your plan?",
         "Why do you think parents still make plans for their children nowadays?",
         "How does technology help people make plans?",
-        "What kind of plans do people often make?"
+        "What kind of plans do people often make?",
+        "Do you think people like the process of making plans more, or the moment of carrying them out?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1569,7 +1579,8 @@
         "What should a leader do to make team members want to follow him or her?",
         "Should students learn to do group work?",
         "What group tasks are there in schools?",
-        "What advantages are there for students experiencing teamwork at school?"
+        "What advantages are there for students experiencing teamwork at school?",
+        "How can you tell if a person is a good leader?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1594,7 +1605,8 @@
         "What important decisions do teenagers need to make after graduation?",
         "Who can children turn to for help when making a decision?",
         "Do you think advertisements can influence our decisions when shopping?",
-        "Do you think the influence of advertising is good?"
+        "Do you think the influence of advertising is good?",
+        "How do people usually make important decisions?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1619,7 +1631,8 @@
         "Where do people normally watch sports events?",
         "What are the advantages of watching sports events online?",
         "What sports matches are suitable for children to attend?",
-        "Why do some people spend a lot going to other countries to watch sports events?"
+        "Why do some people spend a lot going to other countries to watch sports events?",
+        "What sports games are popular in your country?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1668,7 +1681,8 @@
         "Does speaking other languages help at work?",
         "Do people learn any languages other than English?",
         "Why is it easier for children to learn new things than for adults?",
-        "How do people learn new things?"
+        "How do people learn new things?",
+        "What is the most important thing for learning a language well?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1693,7 +1707,8 @@
         "Do you think people today should learn about AI technology?",
         "Should children learn to use AI?",
         "How can AI help in our lives?",
-        "Do you think students are overly reliant on AI?"
+        "Do you think students are overly reliant on AI?",
+        "What can teachers do to stop students from relying too much on AI?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1718,7 +1733,8 @@
         "Why are many advertisements endorsed by celebrities? How useful are they?",
         "What is the most important factor in an advertisement?",
         "Why are some advertisements boring?",
-        "Is advertising important for a company? Why?"
+        "Is advertising important for a company? Why?",
+        "Which is more effective, online advertising or offline advertising?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1743,7 +1759,8 @@
         "What is the ideal length for a holiday?",
         "How do people usually plan holidays?",
         "Is it important to plan a holiday ahead?",
-        "Why do many countries try to attract people to visit?"
+        "Why do many countries try to attract people to visit?",
+        "How do people decide when to travel?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1768,7 +1785,8 @@
         "What do Chinese people do when they visit others?",
         "What kind of place do people in your country like to live in?",
         "What's the difference between homes in cities and those in the countryside?",
-        "What kind of gifts do people usually bring when they visit others?"
+        "What kind of gifts do people usually bring when they visit others?",
+        "How often do you visit your relatives or friends?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1793,7 +1811,8 @@
         "Some people think pets should not be kept in cities. What do you think?",
         "Many people regard pets as members of their family. What do you think?",
         "Do many people keep pets in your country?",
-        "What are the advantages of keeping a pet?"
+        "What are the advantages of keeping a pet?",
+        "Why do people always tell children stories with animals?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1839,7 +1858,8 @@
         "Do you think school rules are important?",
         "Are children unhappy with the school rules?",
         "How can parents and teachers help children understand and follow rules?",
-        "What are the rules people should obey at work?"
+        "What are the rules people should obey at work?",
+        "What is the purpose of punishment?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1864,7 +1884,8 @@
         "In what situations do people not respond to messages at all?",
         "What would you do if you did not receive a reply after sending out a message?",
         "Why do some people prefer sending a message instead of making a call?",
-        "How do you show your respect in your messages?"
+        "How do you show your respect in your messages?",
+        "Why do some people feel angry when others don't reply to their message?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -1889,7 +1910,8 @@
         "What do you think of people going after high positions?",
         "Why are some young people keen on being fans of superstars?",
         "Is it good for a person to be ambitious?",
-        "Do you think it is necessary to be ambitious when working in a team in a company?"
+        "Do you think it is necessary to be ambitious when working in a team in a company?",
+        "Should parents support their children in pursuing their ambitions?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2032,7 +2054,8 @@
         "What jobs do children want to do when they grow up?",
         "Do people's ideal jobs change as they grow up?",
         "What should people consider when choosing jobs?",
-        "Is salary the main reason why people choose a certain job?"
+        "Is salary the main reason why people choose a certain job?",
+        "What kind of jobs are the most popular in your country?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2057,7 +2080,8 @@
         "What can today's children do to become famous?",
         "What can children do with their fame?",
         "Do people become famous because of their talent?",
-        "Is it easy to become famous in your country?"
+        "Is it easy to become famous in your country?",
+        "Do you want to be a famous person?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2082,7 +2106,8 @@
         "What positive and negative impact do mobile phones have on friendship?",
         "Is it a waste of time to take pictures with mobile phones?",
         "Do you think it is necessary to have laws on the use of mobile phones?",
-        "What are examples of good and poor phone manners?"
+        "What are examples of good and poor phone manners?",
+        "How does the internet benefit people?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2107,7 +2132,8 @@
         "Is it good to ask advice from strangers online?",
         "What are the personalities of people whose job is to give advice to others?",
         "What are the problems if you ask too many people for advice?",
-        "Why do some people think it is better to ask for advice from friends than from parents?"
+        "Why do some people think it is better to ask for advice from friends than from parents?",
+        "When would old people ask young people for advice?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2132,7 +2158,8 @@
         "What technology do young people like to use?",
         "What are the differences between online and face-to-face communication?",
         "Do you think technology has changed the way people communicate?",
-        "What negative effects does technology have on people's relationships?"
+        "What negative effects does technology have on people's relationships?",
+        "What are the differences between making friends in real life and online?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2157,7 +2184,8 @@
         "What activities do we need to plan ahead?",
         "Do you think children should plan their future careers?",
         "Should children ask their teachers or parents for advice when making plans?",
-        "Is making study plans popular among young people?"
+        "Is making study plans popular among young people?",
+        "Do you think choosing a college major is closely related to a person's future career?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2182,7 +2210,8 @@
         "Why do most children draw more often than adults do?",
         "Why do some people visit galleries or museums instead of viewing artworks online?",
         "Do you think galleries and museums should be free of charge?",
-        "How do artworks inspire people?"
+        "How do artworks inspire people?",
+        "What are the differences between reading a book and visiting a museum?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2208,7 +2237,8 @@
         "Why do some people not like using apps?",
         "What apps are popular in your country? Why?",
         "Should parents limit their children's use of computer programs and computer games? Why and how?",
-        "Do you think young people are more and more reliant on these programs?"
+        "Do you think young people are more and more reliant on these programs?",
+        "What do you think about some countries banning children from using social media?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2233,7 +2263,8 @@
         "Why do most people smile in photographs?",
         "Do women smile more than men? Why?",
         "Do people smile more when they are younger or older?",
-        "Is smiling important in your culture?"
+        "Is smiling important in your culture?",
+        "Are there any occasions when people need to pretend to smile?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2258,7 +2289,8 @@
         "Should parents reward children? Why and how?",
         "Is it good to reward children too often? Why?",
         "On what occasions would adults be proud of themselves?",
-        "Do rewards help a child become better?"
+        "Do rewards help a child become better?",
+        "What do you think about children working hard just for grades?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2283,7 +2315,8 @@
         "What's the difference between things valued by people in the past and today?",
         "What kinds of things are kept in museums?",
         "What's the influence of technology on museums?",
-        "What are the benefits of technology for learning history?"
+        "What are the benefits of technology for learning history?",
+        "Why do people visit museums?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2308,7 +2341,8 @@
         "Do you think air pollution comes mostly from mobile vehicles?",
         "Do you think people need to change the way of transportation drastically to protect the environment?",
         "How are the transportation systems in urban areas and rural areas different?",
-        "Why do more people own and drive private vehicles now?"
+        "Why do more people own and drive private vehicles now?",
+        "What do you think of the future of electric cars?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2333,7 +2367,8 @@
         "How do children become smart at school?",
         "Why are some people well-rounded and others only good at one thing?",
         "Why does modern society need talents of all kinds?",
-        "Do you think smart children are happier than other children?"
+        "Do you think smart children are happier than other children?",
+        "Is it important for schools to identify and develop each student's talents?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2358,7 +2393,8 @@
         "Should teachers make learning in their classes fun?",
         "Do you think there are too many subjects for students to learn?",
         "Is it better to focus on a few subjects or to learn many subjects?",
-        "Do you think enterprises should provide training for their employees?"
+        "Do you think enterprises should provide training for their employees?",
+        "Do you think it is good for older adults to continue learning?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2383,7 +2419,8 @@
         "Do you think children should receive some musical education?",
         "What are the differences between old and young people's music preferences?",
         "What kind of music events are there in your country?",
-        "Why do many people like listening to music while doing sports?"
+        "Why do many people like listening to music while doing sports?",
+        "What are the differences between listening to music at home and at a live concert?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2408,7 +2445,8 @@
         "What are the factors that make a successful movie?",
         "Do Chinese people prefer to watch domestic movies or foreign movies?",
         "Do you think only well-known directors can create the best movies?",
-        "Do you think successful movies should have well-known actors or actresses in leading roles?"
+        "Do you think successful movies should have well-known actors or actresses in leading roles?",
+        "Why do people prefer to watch movies in the cinema?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2433,7 +2471,8 @@
         "Is it worth spending a lot of money on the exterior appearance of a building?",
         "Is it more important for a building to look good on the outside or on the inside?",
         "Why do people like to visit historical sites?",
-        "Do you think it's reasonable to charge an entry fee for visiting interesting buildings?"
+        "Do you think it's reasonable to charge an entry fee for visiting interesting buildings?",
+        "Is it better to live in a new building or an old one?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2458,7 +2497,8 @@
         "Do you think imagination is essential for scientists?",
         "What kinds of jobs need imagination?",
         "What subjects are helpful for children's imagination?",
-        "What games help develop children's imagination?"
+        "What games help develop children's imagination?",
+        "How important is imagination to children?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2483,7 +2523,8 @@
         "Should children help their parents with household chores?",
         "What kind of help do people need when looking for a new job?",
         "Who should people ask for help, colleagues or family members?",
-        "Do you think schools should teach children to do household chores?"
+        "Do you think schools should teach children to do household chores?",
+        "Why are employees reluctant to ask their managers for help?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2508,7 +2549,8 @@
         "What do you think young people spend most of their money on?",
         "Do you think it is important to save money? Why?",
         "Do people buy things they don't need?",
-        "Do you think it is the rich people's responsibility to donate money to people in need?"
+        "Do you think it is the rich people's responsibility to donate money to people in need?",
+        "What kind of things are people happy to pay a high price for?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2533,7 +2575,8 @@
         "When should parents encourage their children?",
         "What kind of encouragement should parents give?",
         "Do you think some people are better than others at persuading?",
-        "Should children do everything their parents ask them to do?"
+        "Should children do everything their parents ask them to do?",
+        "How can employers encourage their staff?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2558,7 +2601,8 @@
         "What challenges do young people face when working abroad?",
         "What are the benefits of working for an international company?",
         "What personal skills are required to work in an international company?",
-        "What kind of work can young people do in foreign countries?"
+        "What kind of work can young people do in foreign countries?",
+        "Why are some people unwilling to work in other countries?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2584,7 +2628,8 @@
         "What laws about the environment are effective in your country?",
         "Which do you think people prefer, rewards or punishment, when it comes to government intervention in environmental protection?",
         "Is it easy for children in cities to get close to the natural world?",
-        "What can people do to protect the natural world?"
+        "What can people do to protect the natural world?",
+        "Is it important to teach students environmental protection at school?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2609,7 +2654,8 @@
         "How have people's shopping habits changed in recent decades?",
         "Do you think shops and shopping malls will disappear in the future?",
         "What are the differences between shopping in street markets and big shopping malls?",
-        "What are the differences in the shopping habits of different age groups?"
+        "What are the differences in the shopping habits of different age groups?",
+        "What are the differences between shopping online and in-store?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2635,7 +2681,8 @@
         "Do you think modern cities are suitable for young people or old people?",
         "Before you travel to a city, what factors would you consider?",
         "What are the disadvantages of living in a very famous city?",
-        "Do you prefer to visit well-developed cities or cities with a long history?"
+        "Do you prefer to visit well-developed cities or cities with a long history?",
+        "For those who live in cities, is it because they want to or have to?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2661,7 +2708,8 @@
         "How do people spend their leisure time in your country?",
         "How does technology affect the way people spend their leisure time?",
         "Do you think only old people have time for leisure?",
-        "Why do old people prefer to live in quiet places?"
+        "Why do old people prefer to live in quiet places?",
+        "Why are there more noises made at home now than in the past?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2686,7 +2734,8 @@
         "Do people in your country like to watch foreign TV programs?",
         "What's the benefit of letting kids watch animal videos than visiting zoos?",
         "Do teachers play videos in class in your country?",
-        "Do you think watching talk shows is a waste of time?"
+        "Do you think watching talk shows is a waste of time?",
+        "Do you think we can acquire knowledge from watching TV programs?"
       ],
       "published": true,
       "supplemented_question_count": 0,
@@ -2919,9 +2968,9 @@
         "Do you have a favorite teacher?",
         "Do you want to be a teacher in the future?",
         "Do you have a teacher from your past that you still remember?",
-        "Do you like your primary school teachers more than your high school teachers?",
         "Are you still in touch with your primary school teachers?",
-        "In what way has your favourite teacher helped you?"
+        "In what way has your favourite teacher helped you?",
+        "Do you like your primary school teachers more than your high school teachers?"
       ],
       "published": true
     },
@@ -3025,11 +3074,11 @@
         "Did you like going to parks as a child?",
         "Do you still like going to parks now?",
         "Would you like to see more parks in your city?",
-        "Would you like to play in a public garden or park?",
         "Are there any parks you want to go to in the future?",
         "Would you prefer to play in a personal garden or public garden?",
         "How are the parks today different from those you visited as a kid?",
-        "What do you like to do when visiting a park?"
+        "What do you like to do when visiting a park?",
+        "Would you like to play in a public garden or park?"
       ],
       "published": true
     },
@@ -3338,9 +3387,9 @@
         "What did you often do with your friends in your childhood?",
         "What do you think is the most important at the moment?",
         "Do you have any plans for the next five years?",
-        "At what age do you think people are the happiest?",
         "How do people remember each stage of their lives?",
-        "Do you enjoy being the age you are now?"
+        "Do you enjoy being the age you are now?",
+        "At what age do you think people are the happiest?"
       ],
       "published": true
     },

--- a/server/internal/coaching/scene/ielts_question_bank_test.go
+++ b/server/internal/coaching/scene/ielts_question_bank_test.go
@@ -75,15 +75,35 @@ func TestEmbeddedIELTSQuestionBankPublishesOnlyCompleteMainlandGroups(
 		)
 	}
 	groupCategories := map[string]int{}
+	groupIDs := map[string]struct{}{}
+	groupTitles := map[string]struct{}{}
+	groupPrompts := map[string]struct{}{}
+	part3QuestionCount := 0
 	for _, group := range published.TopicGroups {
 		if !group.Published ||
 			group.Region != "mainland" ||
 			len(group.Part3Questions) < 1 ||
-			len(group.Part3Questions) > 5 ||
+			len(group.Part3Questions) > 6 ||
 			group.SupplementedQuestionCount != 0 {
 			t.Fatalf("published incomplete group: %#v", group)
 		}
+		if _, duplicate := groupIDs[group.ID]; duplicate {
+			t.Fatalf("duplicate group ID: %s", group.ID)
+		}
+		if _, duplicate := groupTitles[group.TitleZH]; duplicate {
+			t.Fatalf("duplicate group title: %s", group.TitleZH)
+		}
+		if _, duplicate := groupPrompts[group.Part2.Prompt]; duplicate {
+			t.Fatalf("duplicate Part 2 prompt: %s", group.Part2.Prompt)
+		}
+		groupIDs[group.ID] = struct{}{}
+		groupTitles[group.TitleZH] = struct{}{}
+		groupPrompts[group.Part2.Prompt] = struct{}{}
+		part3QuestionCount += len(group.Part3Questions)
 		groupCategories[group.Category]++
+	}
+	if part3QuestionCount != 317 {
+		t.Fatalf("published Part 3 question count = %d, want 317", part3QuestionCount)
 	}
 	if !reflect.DeepEqual(
 		groupCategories,
@@ -95,6 +115,45 @@ func TestEmbeddedIELTSQuestionBankPublishesOnlyCompleteMainlandGroups(
 		if group.Region == "international" && group.Published {
 			t.Fatalf("international group was published: %#v", group)
 		}
+	}
+}
+
+func TestEmbeddedIELTSPart1TopicsPreserveSourceOrder(t *testing.T) {
+	t.Parallel()
+
+	bank, err := loadEmbeddedIELTSQuestionBank()
+	if err != nil {
+		t.Fatalf("loadEmbeddedIELTSQuestionBank: %v", err)
+	}
+	wants := map[string][]string{
+		"Teachers": {
+			"Do you have a favorite teacher?",
+			"Do you want to be a teacher in the future?",
+			"Do you have a teacher from your past that you still remember?",
+			"Are you still in touch with your primary school teachers?",
+			"In what way has your favourite teacher helped you?",
+			"Do you like your primary school teachers more than your high school teachers?",
+		},
+		"Public gardens and parks": {
+			"Did you like going to parks as a child?",
+			"Do you still like going to parks now?",
+			"Would you like to see more parks in your city?",
+			"Are there any parks you want to go to in the future?",
+			"Would you prefer to play in a personal garden or public garden?",
+			"How are the parks today different from those you visited as a kid?",
+			"What do you like to do when visiting a park?",
+			"Would you like to play in a public garden or park?",
+		},
+	}
+	for _, topic := range bank.Part1Topics {
+		want, found := wants[topic.TitleEN]
+		if found && !reflect.DeepEqual(topic.Questions, want) {
+			t.Fatalf("%s questions = %#v, want %#v", topic.TitleEN, topic.Questions, want)
+		}
+		delete(wants, topic.TitleEN)
+	}
+	if len(wants) != 0 {
+		t.Fatalf("missing canonical topics: %#v", wants)
 	}
 }
 
@@ -182,6 +241,10 @@ func TestResolveIELTSQuestionSetKeepsPart2AndPart3Bound(t *testing.T) {
 	if part2.TopicGroupID != part3.TopicGroupID ||
 		part2.TopicTitle != part3.TopicTitle ||
 		part2.Part2CueCard != part3.Part2CueCard ||
+		part2.Part3Questions != 6 ||
+		part3.Part3Questions != 6 ||
+		len(part2.TurnBlueprints) != 7 ||
+		len(part3.TurnBlueprints) != 6 ||
 		!reflect.DeepEqual(
 			part2.TurnBlueprints[1:],
 			part3.TurnBlueprints,

--- a/server/internal/coaching/scene/ielts_question_bank_test.go
+++ b/server/internal/coaching/scene/ielts_question_bank_test.go
@@ -257,6 +257,99 @@ func TestResolveIELTSQuestionSetKeepsPart2AndPart3Bound(t *testing.T) {
 	}
 }
 
+func TestEveryPublishedIELTSCardAndFullMockCombinationResolves(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustTestCatalog(t)
+	bank, err := catalog.IELTSQuestionBank()
+	if err != nil {
+		t.Fatalf("IELTSQuestionBank: %v", err)
+	}
+
+	for _, topic := range bank.Part1Topics {
+		topic := topic
+		t.Run("part1/"+topic.ID, func(t *testing.T) {
+			t.Parallel()
+			resolved, err := catalog.ResolveIELTSQuestionSet(
+				IELTSQuestionSetSelection{
+					Mode:       IELTSPracticeModePart1,
+					Part1SetID: topic.ID,
+				},
+			)
+			if err != nil {
+				t.Fatalf("resolve Part 1 card: %v", err)
+			}
+			if resolved.Part1Questions != len(topic.Questions) ||
+				len(resolved.TurnBlueprints) != len(topic.Questions) {
+				t.Fatalf("resolved Part 1 card = %#v", resolved)
+			}
+		})
+	}
+
+	for _, group := range bank.TopicGroups {
+		group := group
+		for _, mode := range []IELTSPracticeMode{
+			IELTSPracticeModePart2,
+			IELTSPracticeModePart3,
+		} {
+			mode := mode
+			t.Run(string(mode)+"/"+group.ID, func(t *testing.T) {
+				t.Parallel()
+				resolved, err := catalog.ResolveIELTSQuestionSet(
+					IELTSQuestionSetSelection{
+						Mode:         mode,
+						TopicGroupID: group.ID,
+					},
+				)
+				if err != nil {
+					t.Fatalf("resolve %s card: %v", mode, err)
+				}
+				wantTurns := len(group.Part3Questions)
+				if mode == IELTSPracticeModePart2 {
+					wantTurns++
+				}
+				if resolved.TopicGroupID != group.ID ||
+					len(resolved.TurnBlueprints) != wantTurns {
+					t.Fatalf("resolved %s card = %#v", mode, resolved)
+				}
+			})
+		}
+	}
+
+	for _, part1Set := range bank.Part1Sets {
+		for _, group := range bank.TopicGroups {
+			resolved, err := catalog.ResolveIELTSQuestionSet(
+				IELTSQuestionSetSelection{
+					Mode:         IELTSPracticeModeFullMock,
+					Part1SetID:   part1Set.ID,
+					TopicGroupID: group.ID,
+				},
+			)
+			if err != nil {
+				t.Fatalf(
+					"resolve full mock %s/%s: %v",
+					part1Set.ID,
+					group.ID,
+					err,
+				)
+			}
+			if resolved.Part1Questions != 8 ||
+				resolved.Part2Questions != 1 ||
+				resolved.Part3Questions < 1 ||
+				resolved.Part3Questions > 5 ||
+				len(resolved.TurnBlueprints) !=
+					9+resolved.Part3Questions {
+				t.Fatalf(
+					"invalid full mock %s/%s: %#v",
+					part1Set.ID,
+					group.ID,
+					resolved,
+				)
+			}
+		}
+	}
+}
+
 func TestResolveIELTSQuestionSetPreservesShortOriginalPart3(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/coaching/scene/ielts_question_bank_test.go
+++ b/server/internal/coaching/scene/ielts_question_bank_test.go
@@ -17,10 +17,12 @@ func TestEmbeddedIELTSQuestionBankPublishesOnlyCompleteMainlandGroups(
 	}
 	published := publishedIELTSQuestionBank(bank)
 	if len(published.Part1Sets) != 38 ||
+		len(published.Part1Topics) != 38 ||
 		len(published.TopicGroups) != 56 {
 		t.Fatalf(
-			"published counts = (%d, %d)",
+			"published counts = (%d, %d, %d)",
 			len(published.Part1Sets),
+			len(published.Part1Topics),
 			len(published.TopicGroups),
 		)
 	}
@@ -48,6 +50,31 @@ func TestEmbeddedIELTSQuestionBankPublishesOnlyCompleteMainlandGroups(
 			part1QuestionCount,
 		)
 	}
+	practiceQuestionCount := 0
+	part1Releases := map[string]int{}
+	part1Categories := map[string]int{}
+	for _, topic := range published.Part1Topics {
+		practiceQuestionCount += len(topic.Questions)
+		part1Releases[topic.Release]++
+		part1Categories[topic.Category]++
+	}
+	if practiceQuestionCount != 234 ||
+		!reflect.DeepEqual(
+			part1Releases,
+			map[string]int{"new": 16, "carry_over": 17, "evergreen": 5},
+		) ||
+		!reflect.DeepEqual(
+			part1Categories,
+			map[string]int{"person": 2, "place": 10, "thing": 15, "event": 11},
+		) {
+		t.Fatalf(
+			"Part 1 practice taxonomy = questions %d, releases %#v, categories %#v",
+			practiceQuestionCount,
+			part1Releases,
+			part1Categories,
+		)
+	}
+	groupCategories := map[string]int{}
 	for _, group := range published.TopicGroups {
 		if !group.Published ||
 			group.Region != "mainland" ||
@@ -56,10 +83,52 @@ func TestEmbeddedIELTSQuestionBankPublishesOnlyCompleteMainlandGroups(
 			group.SupplementedQuestionCount != 0 {
 			t.Fatalf("published incomplete group: %#v", group)
 		}
+		groupCategories[group.Category]++
+	}
+	if !reflect.DeepEqual(
+		groupCategories,
+		map[string]int{"person": 12, "place": 8, "thing": 17, "event": 19},
+	) {
+		t.Fatalf("Part 2/3 categories = %#v", groupCategories)
 	}
 	for _, group := range bank.TopicGroups {
 		if group.Region == "international" && group.Published {
 			t.Fatalf("international group was published: %#v", group)
+		}
+	}
+}
+
+func TestResolveIELTSPart1PracticeUsesOnlySelectedTopic(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustTestCatalog(t)
+	bank, err := catalog.IELTSQuestionBank()
+	if err != nil {
+		t.Fatalf("IELTSQuestionBank: %v", err)
+	}
+	selected := bank.Part1Topics[0]
+	resolved, err := catalog.ResolveIELTSQuestionSet(
+		IELTSQuestionSetSelection{
+			Mode:       IELTSPracticeModePart1,
+			Part1SetID: selected.ID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ResolveIELTSQuestionSet Part 1 topic: %v", err)
+	}
+	if resolved.Part1Questions != len(selected.Questions) ||
+		len(resolved.TurnBlueprints) != len(selected.Questions) {
+		t.Fatalf("Part 1 topic resolution = %#v", resolved)
+	}
+	for index, question := range selected.Questions {
+		want := "Part 1 question: " + question
+		if resolved.TurnBlueprints[index] != want {
+			t.Fatalf(
+				"turn %d = %q, want %q",
+				index,
+				resolved.TurnBlueprints[index],
+				want,
+			)
 		}
 	}
 }

--- a/server/migrations/000072_ielts_dedicated_assignment_limits.down.sql
+++ b/server/migrations/000072_ielts_dedicated_assignment_limits.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DROP CONSTRAINT preparation_practice_plan_revisions_ielts_check,
+    ADD CONSTRAINT preparation_practice_plan_revisions_ielts_check
+        CHECK (
+            preparation_plan_ielts_assignment_is_valid_v1(
+                scene_selection,
+                ielts_assignment
+            )
+        );
+
+DROP FUNCTION preparation_plan_ielts_assignment_is_valid_v2(jsonb, jsonb);
+
+COMMIT;

--- a/server/migrations/000072_ielts_dedicated_assignment_limits.up.sql
+++ b/server/migrations/000072_ielts_dedicated_assignment_limits.up.sql
@@ -1,0 +1,171 @@
+BEGIN;
+
+CREATE FUNCTION preparation_plan_ielts_assignment_is_valid_v2(
+    scene_selection jsonb,
+    payload jsonb
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    expected_mode text;
+    required_keys text[];
+    part_1_questions integer;
+    part_2_questions integer;
+    part_3_questions integer;
+BEGIN
+    expected_mode := CASE scene_selection #>> '{scene,scene_model}'
+        WHEN 'IELTS_SPEAKING_FULL_MOCK' THEN 'FULL_MOCK'
+        WHEN 'IELTS_SPEAKING_PART_1' THEN 'PART_1'
+        WHEN 'IELTS_SPEAKING_PART_2' THEN 'PART_2'
+        WHEN 'IELTS_SPEAKING_PART_3' THEN 'PART_3'
+        ELSE NULL
+    END;
+
+    IF expected_mode IS NULL OR expected_mode = 'FULL_MOCK' THEN
+        RETURN preparation_plan_ielts_assignment_is_valid_v1(
+            scene_selection,
+            payload
+        );
+    END IF;
+
+    IF scene_selection #>> '{scene,scene_family}' <> 'EXAM'
+       OR payload IS NULL
+       OR jsonb_typeof(payload) <> 'object' THEN
+        RETURN false;
+    END IF;
+
+    required_keys := CASE expected_mode
+        WHEN 'PART_1' THEN ARRAY[
+            'bank_id',
+            'season',
+            'mode',
+            'part_1_set_id',
+            'part_1_questions',
+            'part_2_questions',
+            'part_3_questions',
+            'turn_blueprints'
+        ]
+        WHEN 'PART_2' THEN ARRAY[
+            'bank_id',
+            'season',
+            'mode',
+            'topic_group_id',
+            'topic_title',
+            'part_2_cue_card',
+            'part_1_questions',
+            'part_2_questions',
+            'part_3_questions',
+            'turn_blueprints'
+        ]
+        WHEN 'PART_3' THEN ARRAY[
+            'bank_id',
+            'season',
+            'mode',
+            'topic_group_id',
+            'topic_title',
+            'part_1_questions',
+            'part_2_questions',
+            'part_3_questions',
+            'turn_blueprints'
+        ]
+    END;
+
+    IF NOT payload ?& required_keys
+       OR payload - required_keys <> '{}'::jsonb
+       OR jsonb_typeof(payload -> 'bank_id') <> 'string'
+       OR payload ->> 'bank_id' !~
+           '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+       OR jsonb_typeof(payload -> 'season') <> 'string'
+       OR payload ->> 'season' = ''
+       OR payload ->> 'season' <> btrim(payload ->> 'season')
+       OR jsonb_typeof(payload -> 'mode') <> 'string'
+       OR payload ->> 'mode' <> expected_mode
+       OR jsonb_typeof(payload -> 'part_1_questions') <> 'number'
+       OR jsonb_typeof(payload -> 'part_2_questions') <> 'number'
+       OR jsonb_typeof(payload -> 'part_3_questions') <> 'number'
+       OR (payload ->> 'part_1_questions') !~ '^[0-9]{1,3}$'
+       OR (payload ->> 'part_2_questions') !~ '^[0-9]{1,3}$'
+       OR (payload ->> 'part_3_questions') !~ '^[0-9]{1,3}$'
+       OR NOT coaching_scene_nonempty_string_array_is_valid_v1(
+           payload -> 'turn_blueprints'
+       )
+       OR payload -> 'turn_blueprints' IS DISTINCT FROM
+           scene_selection #> '{scene,prompt,turn_blueprints}'
+       OR jsonb_typeof(
+           scene_selection #> '{scene,prompt,public_scene_brief}'
+       ) IS DISTINCT FROM 'string'
+       OR scene_selection #>> '{scene,prompt,public_scene_brief}' = ''
+       OR scene_selection #>> '{scene,prompt,public_scene_brief}' <>
+           btrim(scene_selection #>> '{scene,prompt,public_scene_brief}') THEN
+        RETURN false;
+    END IF;
+
+    part_1_questions := (payload ->> 'part_1_questions')::integer;
+    part_2_questions := (payload ->> 'part_2_questions')::integer;
+    part_3_questions := (payload ->> 'part_3_questions')::integer;
+
+    CASE expected_mode
+        WHEN 'PART_1' THEN
+            IF jsonb_typeof(payload -> 'part_1_set_id') <> 'string'
+               OR payload ->> 'part_1_set_id' !~
+                   '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+               OR part_1_questions NOT BETWEEN 1 AND 24
+               OR part_2_questions <> 0
+               OR part_3_questions <> 0
+               OR jsonb_array_length(payload -> 'turn_blueprints') <>
+                   part_1_questions THEN
+                RETURN false;
+            END IF;
+        WHEN 'PART_2' THEN
+            IF jsonb_typeof(payload -> 'topic_group_id') <> 'string'
+               OR jsonb_typeof(payload -> 'topic_title') <> 'string'
+               OR jsonb_typeof(payload -> 'part_2_cue_card') <> 'string'
+               OR payload ->> 'topic_group_id' !~
+                   '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+               OR payload ->> 'topic_title' = ''
+               OR payload ->> 'topic_title' <>
+                   btrim(payload ->> 'topic_title')
+               OR payload ->> 'part_2_cue_card' = ''
+               OR payload ->> 'part_2_cue_card' <>
+                   btrim(payload ->> 'part_2_cue_card')
+               OR part_1_questions <> 0
+               OR part_2_questions <> 1
+               OR part_3_questions NOT BETWEEN 1 AND 6
+               OR jsonb_array_length(payload -> 'turn_blueprints') <>
+                   1 + part_3_questions THEN
+                RETURN false;
+            END IF;
+        WHEN 'PART_3' THEN
+            IF jsonb_typeof(payload -> 'topic_group_id') <> 'string'
+               OR jsonb_typeof(payload -> 'topic_title') <> 'string'
+               OR payload ->> 'topic_group_id' !~
+                   '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+               OR payload ->> 'topic_title' = ''
+               OR payload ->> 'topic_title' <>
+                   btrim(payload ->> 'topic_title')
+               OR part_1_questions <> 0
+               OR part_2_questions <> 0
+               OR part_3_questions NOT BETWEEN 1 AND 6
+               OR jsonb_array_length(payload -> 'turn_blueprints') <>
+                   part_3_questions THEN
+                RETURN false;
+            END IF;
+    END CASE;
+
+    RETURN true;
+END;
+$$;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DROP CONSTRAINT preparation_practice_plan_revisions_ielts_check,
+    ADD CONSTRAINT preparation_practice_plan_revisions_ielts_check
+        CHECK (
+            preparation_plan_ielts_assignment_is_valid_v2(
+                scene_selection,
+                ielts_assignment
+            )
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -57,4 +57,5 @@ import "embed"
 //go:embed 000069_scene_evaluation_policy_ref.*.sql
 //go:embed 000070_practice_question_tips.*.sql
 //go:embed 000071_practice_execution_policy_refs.*.sql
+//go:embed 000072_ielts_dedicated_assignment_limits.*.sql
 var Files embed.FS

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -151,6 +151,30 @@ func TestIELTSSpeakingSectionModelMigrationIsEmbedded(t *testing.T) {
 	}
 }
 
+func TestIELTSDedicatedAssignmentLimitsMigrationIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	up := readMigration(t, "000072_ielts_dedicated_assignment_limits.up.sql")
+	for _, required := range []string{
+		"PART_1_QUESTIONS NOT BETWEEN 1 AND 24",
+		"PART_3_QUESTIONS NOT BETWEEN 1 AND 6",
+		"EXPECTED_MODE = 'FULL_MOCK'",
+		"PREPARATION_PLAN_IELTS_ASSIGNMENT_IS_VALID_V1",
+	} {
+		if !strings.Contains(up, required) {
+			t.Errorf("IELTS dedicated limits migration is missing %q", required)
+		}
+	}
+
+	down := readMigration(t, "000072_ielts_dedicated_assignment_limits.down.sql")
+	if !strings.Contains(
+		down,
+		"PREPARATION_PLAN_IELTS_ASSIGNMENT_IS_VALID_V1",
+	) {
+		t.Error("IELTS dedicated limits rollback must restore v1 validation")
+	}
+}
+
 func TestDatabaseBaselineContainsNoBusinessDDL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 功能描述

移除 IELTS 专项练习中的“万年老题”独立筛选入口，同时保留所有原 evergreen 题目数据；这些题仍会出现在“全部”、对应 Part、主题分类和搜索结果中。

## 实现思路

- 将题季筛选限制为“全部 / 5–8月新题 / 5–8月保留题”。
- 更新专项练习入口卡片说明。
- 保留题库模型、题目 release 字段和“全部”筛选逻辑，不删除或重分类任何题目。
- 更新 Widget 测试，明确断言页面不再渲染 evergreen 筛选。

## 验证

- `flutter test --no-pub test/coaching/preparation/preparation_hub_test.dart`
- IELTS 相关 109 项回归测试通过。
- `flutter analyze --no-pub`：No issues found。
- 题库解码仍为 38 个 P1 主题 + 56 个 P2/P3 组合，共 150 张题卡。

## 依赖

本 PR 基于尚未合入的 #395，先保持 Draft；#395 合入后即可复核并转 Ready。

Closes #410