### PR TITLE
[MS3][联调] 验证 iOS 模拟器场景与 IELTS 启动链路

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ SHELL := /bin/bash
 	check-api-contracts \
 	check-smoke \
 	dev-android \
-	dev-ios-simulator
+	dev-ios-simulator \
+	test-ios-simulator-scenes
 
 help:
 	@printf '%s\n' \
@@ -35,6 +36,8 @@ help:
 		'  make check-smoke    Run the deterministic Mock main flow' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
 		'  make dev-ios-simulator  Start the backend and run without AvatarKit on an iOS Simulator'
+	@printf '%s\n' \
+		'  make test-ios-simulator-scenes  Verify real scene and IELTS launch flows on an iOS Simulator'
 
 check: check-flutter check-go check-api check-smoke
 
@@ -153,3 +156,8 @@ dev-android:
 
 dev-ios-simulator:
 	./tools/ios-simulator-dev/run.sh
+
+test-ios-simulator-scenes:
+	./tools/ios-simulator-dev/run.sh test \
+		integration_test/real_agent_e2e_test.dart \
+		--plain-name 'real iOS IELTS Part 1 creates a Practice Session'

--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -872,6 +872,7 @@ components:
         - scene_version
         - scene_family
         - scene_model
+        - practice_session_status
         - session_version
         - effective_turns
         - turn_limit
@@ -890,6 +891,13 @@ components:
           $ref: ./scene.yaml#/components/schemas/SceneFamily
         scene_model:
           $ref: ./scene.yaml#/components/schemas/SceneModel
+        practice_session_status:
+          type: string
+          enum:
+            - in_progress
+            - paused
+            - completed
+            - ended_early
         session_version:
           type: integer
           minimum: 1
@@ -901,6 +909,10 @@ components:
           minimum: 1
         session_completed:
           type: boolean
+          description: |
+            True when the Practice Session is terminal, whether it completed
+            normally or ended early. `practice_session_status` remains the
+            authoritative reason for the terminal state.
         current_question:
           $ref: '#/components/schemas/VoiceQuestion'
         current_turn:

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -399,6 +399,53 @@ void main() {
       binding,
       'ielts-part1-practice-started',
     );
+
+    final firstSessionId = dependencies.practiceController.practiceSessionId!;
+    final ended = await dependencies.practiceController
+        .endActivePracticeEarly();
+    expect(
+      ended,
+      isTrue,
+      reason:
+          'error=${dependencies.practiceController.errorMessage}; '
+          'session=${dependencies.practiceController.practiceSessionId}; '
+          'version=${dependencies.practiceController.practiceSessionVersion}; '
+          'active=${dependencies.practiceController.hasActivePractice}',
+    );
+    expect(
+      await dependencies.preparationLaunchController.resumeCurrentPractice(),
+      isFalse,
+    );
+    expect(
+      dependencies.preparationLaunchController.hasResumablePractice,
+      isFalse,
+    );
+
+    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save & exit'));
+    await _waitForPreparationTarget(
+      tester,
+      target: questionSet,
+      operation: 'return to IELTS Part 1 after ending the first session',
+      timeout: const Duration(seconds: 20),
+    );
+    await tester.tap(questionSet);
+    await _waitUntil(tester, () {
+      final currentSessionId =
+          dependencies.practiceController.practiceSessionId;
+      return currentSessionId != null && currentSessionId != firstSessionId;
+    }, const Duration(seconds: 90));
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('ielts-mock-page')),
+      operation: 'create a new IELTS Part 1 session after terminal recovery',
+      timeout: const Duration(seconds: 90),
+    );
+    expect(
+      dependencies.practiceController.practiceSessionId,
+      isNot(firstSessionId),
+    );
   });
 }
 

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -11,6 +11,7 @@ import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/main.dart' as app;
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
+import 'package:speakup/identity/session_store.dart';
 
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -280,6 +281,125 @@ void main() {
     await tester.pumpAndSettle();
     await _signOut(tester);
   });
+
+  testWidgets('real iOS IELTS Part 1 creates a Practice Session', (
+    tester,
+  ) async {
+    const apiBaseUrl = String.fromEnvironment(
+      'SPEAKUP_API_BASE_URL',
+      defaultValue: 'http://127.0.0.1:8080',
+    );
+    final email =
+        'ielts-launch-${DateTime.now().microsecondsSinceEpoch}@example.com';
+    const password = 'IELTS launch e2e password 414';
+    final dependencies = app.createProductionAppDependencies(
+      baseUri: Uri.parse(apiBaseUrl),
+      sessionStore: _MemorySessionStore(),
+    );
+    runApp(
+      SpeakUpApp(
+        authController: dependencies.authController,
+        conversationController: dependencies.conversationController,
+        composerController: dependencies.composerController,
+        messageAudioController: dependencies.messageAudioController,
+        practiceController: dependencies.practiceController,
+        preparationController: dependencies.preparationController,
+        jobPreparationController: dependencies.jobPreparationController,
+        preparationLaunchController: dependencies.preparationLaunchController,
+        reviewHistoryController: dependencies.reviewHistoryController,
+      ),
+    );
+
+    await _registerOrSignIn(
+      tester,
+      email: email,
+      password: password,
+      requireFocusedConversation: false,
+    );
+    await _waitUntil(
+      tester,
+      () => !dependencies.conversationController.isBusy,
+      const Duration(seconds: 20),
+    );
+    await tester.tap(find.byKey(const Key('primary-tab-scenes')));
+    await tester.pump();
+
+    final interviewHub = find.byKey(const Key('practice-hub-interview'));
+    final examHub = find.byKey(const Key('practice-hub-exam'));
+    final roleplayHub = find.byKey(const Key('practice-hub-roleplay'));
+    await _waitForPreparationTarget(
+      tester,
+      target: interviewHub,
+      operation: 'load the three practice hubs',
+      timeout: const Duration(seconds: 30),
+    );
+    expect(examHub, findsOneWidget);
+    expect(roleplayHub, findsOneWidget);
+
+    await _scrollPreparationIntoView(tester, interviewHub);
+    await tester.tap(interviewHub);
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('practice-hub-title-interview')),
+      operation: 'open the English interview hub',
+      timeout: const Duration(seconds: 10),
+    );
+    await tester.tap(find.byKey(const Key('preparation-back-to-families')));
+    await tester.pumpAndSettle();
+
+    await _scrollPreparationIntoView(tester, roleplayHub);
+    await tester.tap(roleplayHub);
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('practice-hub-title-roleplay')),
+      operation: 'open the roleplay hub',
+      timeout: const Duration(seconds: 10),
+    );
+    await tester.tap(find.byKey(const Key('preparation-back-to-families')));
+    await tester.pumpAndSettle();
+
+    await _scrollPreparationIntoView(tester, examHub);
+    await tester.tap(examHub);
+    await tester.pump();
+
+    final part1 = find.byKey(
+      const Key('catalog-scene-scn_ielts_speaking_part_1'),
+    );
+    await _waitForPreparationTarget(
+      tester,
+      target: part1,
+      operation: 'load the IELTS Part 1 entry',
+      timeout: const Duration(seconds: 30),
+    );
+    await _scrollPreparationIntoView(tester, part1);
+    await tester.tap(part1);
+    await tester.pump();
+
+    final questionSet = find.byKey(const Key('ielts-part1-set-p1-001'));
+    await _waitForPreparationTarget(
+      tester,
+      target: questionSet,
+      operation: 'load the first IELTS Part 1 question set',
+      timeout: const Duration(seconds: 30),
+    );
+    await _scrollPreparationIntoView(tester, questionSet);
+    await tester.tap(questionSet);
+    await tester.pump();
+
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('ielts-mock-page')),
+      operation: 'create and open the IELTS Part 1 Practice Session',
+      timeout: const Duration(seconds: 90),
+    );
+    expect(dependencies.practiceController.practiceSessionId, isNotNull);
+    expect(find.byKey(const Key('ielts-mock-part-1')), findsOneWidget);
+    await _expectRealUiScreenshot(
+      tester,
+      binding,
+      'ielts-part1-practice-started',
+    );
+  });
 }
 
 Future<void> _expectRealUiScreenshot(
@@ -297,6 +417,7 @@ Future<void> _registerOrSignIn(
   WidgetTester tester, {
   required String email,
   required String password,
+  bool requireFocusedConversation = true,
 }) async {
   await _waitUntil(
     tester,
@@ -346,7 +467,17 @@ Future<void> _registerOrSignIn(
   await tester.enterText(find.byType(TextFormField).at(0), email);
   await tester.enterText(find.byType(TextFormField).at(1), password);
   await _tapAuthSubmit(tester, '登录');
-  await _ensureFocusedConversation(tester);
+  if (requireFocusedConversation) {
+    await _ensureFocusedConversation(tester);
+  } else {
+    await _waitUntil(
+      tester,
+      () =>
+          find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
+          find.byKey(const Key('primary-tab-scenes')).evaluate().isNotEmpty,
+      const Duration(seconds: 20),
+    );
+  }
 }
 
 Future<void> _signIn(
@@ -844,6 +975,19 @@ List<int> _decodeVoiceFixture(String encoded) {
     fail('SPEAKUP_E2E_WAV_BASE64 must decode to a non-empty WAV file.');
   }
   return bytes;
+}
+
+final class _MemorySessionStore implements SessionStore {
+  String? _token;
+
+  @override
+  Future<void> deleteToken() async => _token = null;
+
+  @override
+  Future<String?> readToken() async => _token;
+
+  @override
+  Future<void> writeToken(String token) async => _token = token;
 }
 
 final class _FixturePracticeRecorder implements PracticeRecorder {

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -784,6 +784,7 @@ PracticeSessionSnapshot _decodeSessionState(
       'scene_version',
       'scene_family',
       'scene_model',
+      'practice_session_status',
       'session_version',
       'effective_turns',
       'turn_limit',
@@ -801,10 +802,24 @@ PracticeSessionSnapshot _decodeSessionState(
   final sceneModel = SceneModel.fromWireValue(
     _string(root, 'scene_model', maxLength: 64),
   );
+  final sessionStatus = switch (_string(
+    root,
+    'practice_session_status',
+    maxLength: 32,
+  )) {
+    'in_progress' => PracticeSessionLifecycleStatus.inProgress,
+    'paused' => PracticeSessionLifecycleStatus.paused,
+    'completed' => PracticeSessionLifecycleStatus.completed,
+    'ended_early' => PracticeSessionLifecycleStatus.endedEarly,
+    _ => throw _invalidResponse(),
+  };
   final sessionVersion = _integer(root, 'session_version');
   final effectiveTurns = _integer(root, 'effective_turns');
   final turnLimit = _integer(root, 'turn_limit');
   final completed = _boolean(root, 'session_completed');
+  final terminal =
+      sessionStatus == PracticeSessionLifecycleStatus.completed ||
+      sessionStatus == PracticeSessionLifecycleStatus.endedEarly;
   if (const {
     'current_question',
     'current_turn',
@@ -830,12 +845,14 @@ PracticeSessionSnapshot _decodeSessionState(
       sceneVersion < 1 ||
       !validPracticeSceneIdentity(sceneFamily, sceneModel) ||
       sessionVersion < 1 ||
+      completed != terminal ||
       effectiveTurns < 0 ||
       turnLimit < 1 ||
       turnLimit > 14 ||
       effectiveTurns > turnLimit ||
       (!completed && question == null) ||
-      (completed && (question != null || turn == null)) ||
+      (completed &&
+          (question != null || (effectiveTurns > 0 && turn == null))) ||
       (question != null && question.sessionId != sessionId) ||
       (turn != null &&
           (turn.sessionId != sessionId ||
@@ -915,6 +932,7 @@ PracticeSessionLifecycle _decodeSessionLifecycle(
     required: const {
       'practice_session_id',
       'practice_plan_id',
+      'plan_revision',
       'scene_family',
       'scene_model',
       'evaluation_policy_ref',
@@ -927,6 +945,7 @@ PracticeSessionLifecycle _decodeSessionLifecycle(
   );
   final sessionId = _string(root, 'practice_session_id');
   _string(root, 'practice_plan_id');
+  final planRevision = _integer(root, 'plan_revision');
   _string(root, 'scene_family', maxLength: 32);
   _string(root, 'scene_model', maxLength: 64);
   _string(root, 'evaluation_policy_ref');
@@ -955,6 +974,7 @@ PracticeSessionLifecycle _decodeSessionLifecycle(
       status == PracticeSessionLifecycleStatus.completed ||
       status == PracticeSessionLifecycleStatus.endedEarly;
   if (sessionId != expectedSessionId ||
+      planRevision < 1 ||
       version < 1 ||
       (startedAt != null && startedAt.isBefore(createdAt)) ||
       (terminal &&

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -26,6 +26,7 @@ void main() {
             'scene_version': 1,
             'scene_family': 'INTERVIEW',
             'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+            'practice_session_status': 'completed',
             'session_version': 5,
             'effective_turns': 4,
             'turn_limit': 6,
@@ -57,6 +58,38 @@ void main() {
       transport.expectDone();
     },
   );
+
+  test('accepts a practice ended before the learner answered', () async {
+    final transport = _Transport([
+      _Step(
+        method: 'GET',
+        path: '/v1/practice-sessions/$_sessionId/voice-state',
+        response: _json(HttpStatus.ok, {
+          'practice_session_id': _sessionId,
+          'practice_plan_id': 'plan-1',
+          'scene_id': 'scene-project-deep-dive',
+          'scene_version': 1,
+          'scene_family': 'INTERVIEW',
+          'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+          'practice_session_status': 'ended_early',
+          'session_version': 2,
+          'effective_turns': 0,
+          'turn_limit': 6,
+          'session_completed': true,
+        }),
+      ),
+    ]);
+
+    final snapshot = await _client(
+      transport,
+    ).restorePractice(sessionId: _sessionId);
+
+    expect(snapshot.completedTurns, 0);
+    expect(snapshot.sessionCompleted, isTrue);
+    expect(snapshot.currentQuestion, isNull);
+    expect(snapshot.currentTurn, isNull);
+    transport.expectDone();
+  });
 
   test('encodes every opaque resource ID as one path segment', () {
     const endpoints = PracticeWireEndpoints();
@@ -212,6 +245,7 @@ void main() {
           'scene_version': 1,
           'scene_family': 'INTERVIEW',
           'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+          'practice_session_status': 'in_progress',
           'session_version': 2,
           'effective_turns': 1,
           'turn_limit': 3,
@@ -336,6 +370,7 @@ void main() {
           'scene_version': 1,
           'scene_family': 'INTERVIEW',
           'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+          'practice_session_status': 'in_progress',
           'session_version': 2,
           'effective_turns': 1,
           'turn_limit': 3,
@@ -391,6 +426,7 @@ void main() {
         response: _json(HttpStatus.ok, {
           'practice_session_id': _sessionId,
           'practice_plan_id': 'plan-1',
+          'plan_revision': 1,
           'scene_family': 'INTERVIEW',
           'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
           'evaluation_policy_ref': 'interview.shadow.evaluation.v1',
@@ -830,6 +866,7 @@ Map<String, Object?> _sessionJson() {
     'scene_version': 1,
     'scene_family': 'INTERVIEW',
     'scene_model': 'PROJECT_EXPERIENCE_DEEP_DIVE',
+    'practice_session_status': 'in_progress',
     'session_version': 1,
     'effective_turns': 0,
     'turn_limit': 3,

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -371,16 +371,18 @@ func (handler *Handler) ensureQuestionTip(c *gin.Context) {
 
 func SessionStateResponse(state practicevoice.SessionState) gin.H {
 	result := gin.H{
-		"practice_session_id": state.Session.ID,
-		"practice_plan_id":    state.Session.PlanID,
-		"scene_id":            state.Session.SceneID,
-		"scene_version":       state.Session.SceneVersion,
-		"scene_family":        state.Session.SceneFamily,
-		"scene_model":         state.Session.SceneModel,
-		"session_version":     state.Session.SessionVersion,
-		"effective_turns":     state.Session.EffectiveTurns,
-		"turn_limit":          state.Session.TurnLimit,
-		"session_completed":   state.Session.Completed,
+		"practice_session_id":     state.Session.ID,
+		"practice_plan_id":        state.Session.PlanID,
+		"scene_id":                state.Session.SceneID,
+		"scene_version":           state.Session.SceneVersion,
+		"scene_family":            state.Session.SceneFamily,
+		"scene_model":             state.Session.SceneModel,
+		"practice_session_status": state.Session.Status,
+		"session_version":         state.Session.SessionVersion,
+		"effective_turns":         state.Session.EffectiveTurns,
+		"turn_limit":              state.Session.TurnLimit,
+		"session_completed": state.Session.Completed ||
+			state.Session.Status == string(practice.SessionEndedEarly),
 	}
 	if state.Question != nil {
 		result["current_question"] = QuestionResponse(*state.Question)

--- a/server/internal/coaching/practice/voice/http/handler_test.go
+++ b/server/internal/coaching/practice/voice/http/handler_test.go
@@ -33,11 +33,13 @@ func TestSessionStateResponseContainsOnlyPracticeRuntimeState(t *testing.T) {
 			SessionVersion: 2,
 			EffectiveTurns: 1,
 			TurnLimit:      3,
+			Status:         "in_progress",
 		},
 		Question: &question,
 		Turn:     &turn,
 	})
 	if response["practice_session_id"] != "session-1" ||
+		response["practice_session_status"] != "in_progress" ||
 		response["current_question"] == nil ||
 		response["current_turn"] == nil {
 		t.Fatalf("response = %#v", response)
@@ -57,5 +59,23 @@ func TestConfirmedTurnResponseHasNoReviewCheckpoint(t *testing.T) {
 	})
 	if _, leaked := response["review_id"]; leaked {
 		t.Fatalf("Turn response contains Review checkpoint: %#v", response)
+	}
+}
+
+func TestSessionStateResponseMarksEndedEarlySessionTerminal(t *testing.T) {
+	response := SessionStateResponse(practicevoice.SessionState{
+		Session: practicevoice.Session{
+			ID:             "session-1",
+			PlanID:         "plan-1",
+			SceneID:        "scene-1",
+			SceneVersion:   1,
+			SessionVersion: 2,
+			TurnLimit:      3,
+			Status:         string(practice.SessionEndedEarly),
+		},
+	})
+
+	if response["session_completed"] != true {
+		t.Fatalf("session_completed = %#v, want true", response["session_completed"])
 	}
 }

--- a/tools/ios-simulator-dev/run.sh
+++ b/tools/ios-simulator-dev/run.sh
@@ -8,19 +8,24 @@ server_dir="$repo_dir/server"
 mobile_source_dir="$repo_dir/mobile"
 server_port="${SPEAKUP_DEV_PORT:-18080}"
 base_url="http://127.0.0.1:$server_port"
-run_dir="$(mktemp -d "${TMPDIR:-/tmp}/xe3-ios-simulator-dev.XXXXXX")"
+run_dir="${SPEAKUP_SIMULATOR_WORK_DIR:-${TMPDIR:-/tmp}/xe3-ios-simulator-dev-cache}"
 mobile_dir="$run_dir/mobile"
 override_file="$mobile_dir/pubspec_overrides.yaml"
 server_binary="$run_dir/server"
 server_log="$run_dir/server.log"
 server_pid=""
+flutter_mode="run"
+
+if [[ "${1:-}" == "test" ]]; then
+  flutter_mode="test"
+  shift
+fi
 
 cleanup() {
   if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
     kill "$server_pid" 2>/dev/null || true
     wait "$server_pid" 2>/dev/null || true
   fi
-  rm -rf "$run_dir"
 }
 trap cleanup EXIT
 trap 'exit 130' INT
@@ -61,7 +66,8 @@ if [[ -z "$device_id" ]]; then
 fi
 xcrun simctl bootstatus "$device_id" -b
 
-rsync -a \
+mkdir -p "$mobile_dir"
+rsync -a --delete \
   --exclude '/.dart_tool/' \
   --exclude '/build/' \
   --exclude '/ios/Pods/' \
@@ -109,9 +115,13 @@ if [[ "$ready" != "1" ]]; then
   exit 1
 fi
 
-print "启动 SpeakUp iOS Simulator；数字人已明确禁用，按 q 退出。"
+if [[ "$flutter_mode" == "test" ]]; then
+  print "在 iOS Simulator 运行 SpeakUp 集成测试；数字人已明确禁用。"
+else
+  print "启动 SpeakUp iOS Simulator；数字人已明确禁用，按 q 退出。"
+fi
 cd "$mobile_dir"
-flutter run \
+flutter "$flutter_mode" \
+  "$@" \
   -d "$device_id" \
-  --dart-define="SPEAKUP_API_BASE_URL=$base_url" \
-  "$@"
+  --dart-define="SPEAKUP_API_BASE_URL=$base_url"


### PR DESCRIPTION
## 功能描述

统一 iOS Simulator 的普通启动与真实集成测试环境，并验证从场景入口进入 IELTS Part 1、提前结束、退出后再次创建新练习的完整链路。

本次同时统一 Practice 终态契约，避免已提前结束的会话在再次进入时被误判为“无法核验当前练习”。

Closes #414

## 实现思路

- iOS Simulator 的运行与真实集成测试共用真实后端、数据库迁移和明确的 AvatarKit Stub。
- Practice Voice State 明确返回 `practice_session_status`，状态以 `in_progress`、`paused`、`completed`、`ended_early` 为权威来源。
- `session_completed` 统一表示终态；正常完成和提前结束都返回 `true`。
- Flutter 严格校验会话状态、终态布尔值和生命周期响应中的 `plan_revision`，允许没有有效轮次的提前结束会话被正常恢复和清理。
- 真实集成测试覆盖首次创建、提前结束、终态清理、退出重进，并通过 Session ID 变化确认创建了新练习。

## 代码地图

- 请求入口 → `mobile/lib/features/coaching/preparation`：选择 IELTS 题目并发起练习。
- 应用编排 → `mobile/lib/features/coaching/practice/wire_practice_client.dart`：解析并校验 Practice HTTP 契约。
- 领域能力 → `server/internal/coaching/practice/voice/http/handler.go`：返回权威会话状态与当前轮次。
- API 契约 → `api/modules/practice-runtime.yaml`：定义 Voice State 的必填状态和终态语义。
- 数据库链路 → 复用现有 Practice Repository；真实集成测试通过本地 PostgreSQL 验证新旧 Session 的持久化边界。
- 端到端验收 → `mobile/integration_test/real_agent_e2e_test.dart`：验证退出重进后生成不同的 Session。

## 验证

- `make test-ios-simulator-scenes`：iOS 26.5 模拟器通过，覆盖创建 → 提前结束 → 清理终态 → 再次创建。
- `flutter test test/coaching/practice/wire_practice_client_test.dart test/coaching/preparation/practice_workspace_controller_test.dart`：41 项通过。
- `go test ./internal/coaching/practice/voice/http ./internal/coaching/practice/voice/...`：通过。
- `go test ./internal/coaching/practice/voice/http ./internal/bootstrap`：通过。
- `make check-api`：通过。
- `git diff --check`：通过。
