### PR TITLE
feat(coaching): 将场景练习入口区分为四类

### DIFF
--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -17,7 +17,7 @@ import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dar
 import 'package:speakup/features/coaching/preparation/preparation_launch_controller.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 
-enum _PracticeHub { interview, ielts, roleplay }
+enum _PracticeHub { interview, ielts, workplace, life }
 
 enum _ExistingPracticeAction { continuePractice, replace }
 
@@ -579,15 +579,26 @@ class _PreparationPageState extends State<PreparationPage> {
           ),
           const SizedBox(height: 12),
           _PracticeHubEntry(
-            key: const Key('practice-hub-roleplay'),
-            title: '情景对话',
-            description: '工作、旅行与日常英语实战',
-            icon: Icons.record_voice_over_outlined,
+            key: const Key('practice-hub-workplace'),
+            title: '职场英语',
+            description: '会议、协作与客户沟通',
+            icon: Icons.business_center_outlined,
             accentColor: PreparationDesign.roleplay,
             tintColor: PreparationDesign.roleplayTint,
-            assetPath: 'assets/images/scenes/daily-tutor.jpg',
+            assetPath: 'assets/images/scenes/workplace-scene.jpg',
             onPressed: () =>
-                setState(() => _selectedHub = _PracticeHub.roleplay),
+                setState(() => _selectedHub = _PracticeHub.workplace),
+          ),
+          const SizedBox(height: 12),
+          _PracticeHubEntry(
+            key: const Key('practice-hub-life'),
+            title: '生活与旅行',
+            description: '日常交流与出行场景实战',
+            icon: Icons.travel_explore_outlined,
+            accentColor: PreparationDesign.roleplay,
+            tintColor: PreparationDesign.roleplayTint,
+            assetPath: 'assets/images/scenes/travel-scene.jpg',
+            onPressed: () => setState(() => _selectedHub = _PracticeHub.life),
           ),
         ],
       ],
@@ -671,6 +682,9 @@ class _PreparationPageState extends State<PreparationPage> {
             )
         else
           RoleplayCatalog(
+            title: _practiceHubLabel(hub),
+            description: _roleplayHubDescription(hub),
+            titleKey: Key('practice-hub-title-${hub.name}'),
             scenes: scenes,
             onScenePressed: (scene) =>
                 unawaited(_startSceneDirectly(controller, scene)),
@@ -762,14 +776,26 @@ class _PreparationPageState extends State<PreparationPage> {
         ),
         const SizedBox(height: 12),
         _PracticeHubEntry(
-          key: const Key('practice-hub-roleplay'),
-          title: '情景对话',
-          description: '工作、旅行与日常英语实战',
-          icon: Icons.record_voice_over_outlined,
+          key: const Key('practice-hub-workplace'),
+          title: '职场英语',
+          description: '会议、协作与客户沟通',
+          icon: Icons.business_center_outlined,
           accentColor: PreparationDesign.roleplay,
           tintColor: PreparationDesign.roleplayTint,
-          assetPath: 'assets/images/scenes/daily-tutor.jpg',
-          onPressed: () => setState(() => _selectedHub = _PracticeHub.roleplay),
+          assetPath: 'assets/images/scenes/workplace-scene.jpg',
+          onPressed: () =>
+              setState(() => _selectedHub = _PracticeHub.workplace),
+        ),
+        const SizedBox(height: 12),
+        _PracticeHubEntry(
+          key: const Key('practice-hub-life'),
+          title: '生活与旅行',
+          description: '日常交流与出行场景实战',
+          icon: Icons.travel_explore_outlined,
+          accentColor: PreparationDesign.roleplay,
+          tintColor: PreparationDesign.roleplayTint,
+          assetPath: 'assets/images/scenes/travel-scene.jpg',
+          onPressed: () => setState(() => _selectedHub = _PracticeHub.life),
         ),
       ],
     );
@@ -1076,7 +1102,16 @@ String _practiceHubLabel(_PracticeHub hub) {
   return switch (hub) {
     _PracticeHub.interview => '英文面试',
     _PracticeHub.ielts => 'IELTS 口语',
-    _PracticeHub.roleplay => '情景对话',
+    _PracticeHub.workplace => '职场英语',
+    _PracticeHub.life => '生活与旅行',
+  };
+}
+
+String _roleplayHubDescription(_PracticeHub hub) {
+  return switch (hub) {
+    _PracticeHub.workplace => '练习会议、协作、汇报与客户沟通。',
+    _PracticeHub.life => '练习日常交流、旅行与生活问题处理。',
+    _ => throw StateError('Roleplay description requires a Roleplay hub.'),
   };
 }
 
@@ -1091,8 +1126,13 @@ List<SceneDefinition> _scenesForHub(
             scene.experience == PracticeExperience.interview,
           _PracticeHub.ielts =>
             scene.experience == PracticeExperience.ieltsSpeaking,
-          _PracticeHub.roleplay =>
-            scene.experience == PracticeExperience.roleplay,
+          _PracticeHub.workplace =>
+            scene.experience == PracticeExperience.roleplay &&
+                scene.category == SceneCategory.roleplayWorkplace,
+          _PracticeHub.life =>
+            scene.experience == PracticeExperience.roleplay &&
+                (scene.category == SceneCategory.roleplayDaily ||
+                    scene.category == SceneCategory.roleplayTravel),
         };
       })
       .toList(growable: false);

--- a/mobile/lib/features/coaching/roleplay/roleplay_catalog.dart
+++ b/mobile/lib/features/coaching/roleplay/roleplay_catalog.dart
@@ -7,11 +7,17 @@ enum _RoleplayFilter { recommended, workplace, travel, daily }
 
 class RoleplayCatalog extends StatefulWidget {
   const RoleplayCatalog({
+    required this.title,
+    required this.description,
+    required this.titleKey,
     required this.scenes,
     required this.onScenePressed,
     super.key,
   });
 
+  final String title;
+  final String description;
+  final Key titleKey;
   final List<SceneDefinition> scenes;
   final ValueChanged<SceneDefinition> onScenePressed;
 
@@ -21,6 +27,24 @@ class RoleplayCatalog extends StatefulWidget {
 
 class _RoleplayCatalogState extends State<RoleplayCatalog> {
   _RoleplayFilter _filter = _RoleplayFilter.recommended;
+
+  List<_RoleplayFilter> get _availableFilters {
+    return [
+      _RoleplayFilter.recommended,
+      if (widget.scenes.any(
+        (scene) => scene.category == SceneCategory.roleplayWorkplace,
+      ))
+        _RoleplayFilter.workplace,
+      if (widget.scenes.any(
+        (scene) => scene.category == SceneCategory.roleplayTravel,
+      ))
+        _RoleplayFilter.travel,
+      if (widget.scenes.any(
+        (scene) => scene.category == SceneCategory.roleplayDaily,
+      ))
+        _RoleplayFilter.daily,
+    ];
+  }
 
   List<SceneDefinition> get _visibleScenes {
     final available = widget.scenes;
@@ -51,40 +75,46 @@ class _RoleplayCatalogState extends State<RoleplayCatalog> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _RoleplayModuleHeader(),
-        const SizedBox(height: 20),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final filter in _RoleplayFilter.values)
-              ChoiceChip(
-                key: Key('roleplay-filter-${filter.name}'),
-                label: Text(_roleplayFilterLabel(filter)),
-                selected: _filter == filter,
-                onSelected: (_) => setState(() => _filter = filter),
-                showCheckmark: false,
-                visualDensity: VisualDensity.compact,
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-                side: BorderSide(
-                  color: _filter == filter
-                      ? PreparationDesign.roleplay
-                      : PreparationDesign.border,
-                ),
-                selectedColor: PreparationDesign.roleplay,
-                backgroundColor: PreparationDesign.surface,
-                labelStyle: TextStyle(
-                  color: _filter == filter
-                      ? Colors.white
-                      : PreparationDesign.secondary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                ),
-                shape: const StadiumBorder(),
-              ),
-          ],
+        _RoleplayModuleHeader(
+          title: widget.title,
+          description: widget.description,
+          titleKey: widget.titleKey,
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 20),
+        if (_availableFilters.length > 2) ...[
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final filter in _availableFilters)
+                ChoiceChip(
+                  key: Key('roleplay-filter-${filter.name}'),
+                  label: Text(_roleplayFilterLabel(filter)),
+                  selected: _filter == filter,
+                  onSelected: (_) => setState(() => _filter = filter),
+                  showCheckmark: false,
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  side: BorderSide(
+                    color: _filter == filter
+                        ? PreparationDesign.roleplay
+                        : PreparationDesign.border,
+                  ),
+                  selectedColor: PreparationDesign.roleplay,
+                  backgroundColor: PreparationDesign.surface,
+                  labelStyle: TextStyle(
+                    color: _filter == filter
+                        ? Colors.white
+                        : PreparationDesign.secondary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  shape: const StadiumBorder(),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+        ],
         if (visibleScenes.isEmpty)
           const Padding(
             padding: EdgeInsets.symmetric(vertical: 36),
@@ -107,7 +137,15 @@ class _RoleplayCatalogState extends State<RoleplayCatalog> {
 }
 
 class _RoleplayModuleHeader extends StatelessWidget {
-  const _RoleplayModuleHeader();
+  const _RoleplayModuleHeader({
+    required this.title,
+    required this.description,
+    required this.titleKey,
+  });
+
+  final String title;
+  final String description;
+  final Key titleKey;
 
   @override
   Widget build(BuildContext context) {
@@ -121,14 +159,14 @@ class _RoleplayModuleHeader extends StatelessWidget {
               Semantics(
                 header: true,
                 container: true,
-                child: const Text(
-                  '情景对话',
-                  key: Key('practice-hub-title-roleplay'),
+                child: Text(
+                  title,
+                  key: titleKey,
                   style: PreparationDesign.pageTitle,
                 ),
               ),
               const SizedBox(height: 8),
-              const Text('选一个真实场景，马上开口。', style: PreparationDesign.body),
+              Text(description, style: PreparationDesign.body),
             ],
           ),
         ),

--- a/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
@@ -125,7 +125,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
-      await _openScene(tester, _progressScene.id);
+      await _openScene(tester, _progressScene);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       final firstPracticeThreadId = conversationController.threadId!;
@@ -230,7 +230,7 @@ void main() {
       await tester.pump();
       expect(practiceController.hasActivePractice, isTrue);
       await _tapVisible(tester, find.byKey(const Key('primary-tab-scenes')));
-      await _openScene(tester, _progressScene.id);
+      await _openScene(tester, _progressScene);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(conversationController.threadId, firstPracticeThreadId);
@@ -243,7 +243,7 @@ void main() {
       expect(conversationController.threadId, homeThreadId);
 
       expect(find.byKey(const Key('practice-continuation')), findsNothing);
-      await _openScene(tester, _progressScene.id);
+      await _openScene(tester, _progressScene);
 
       expect(find.byKey(const Key('immersive-roleplay-page')), findsOneWidget);
       expect(find.text('开始新的练习？'), findsNothing);
@@ -253,7 +253,7 @@ void main() {
       await _leavePractice(tester);
       expect(conversationController.threadId, homeThreadId);
 
-      await _openScene(tester, _hotelScene.id);
+      await _openScene(tester, _hotelScene);
 
       expect(find.text('开始新的练习？'), findsOneWidget);
       expect(find.text('开始“${_hotelScene.name}”'), findsOneWidget);
@@ -283,9 +283,15 @@ void main() {
   );
 }
 
-Future<void> _openScene(WidgetTester tester, String sceneId) async {
-  await _tapVisible(tester, find.byKey(const Key('practice-hub-roleplay')));
-  final scene = find.byKey(Key('catalog-scene-$sceneId'));
+Future<void> _openScene(WidgetTester tester, SceneDefinition definition) async {
+  final hubKey = switch (definition.category) {
+    SceneCategory.roleplayWorkplace => const Key('practice-hub-workplace'),
+    SceneCategory.roleplayDaily ||
+    SceneCategory.roleplayTravel => const Key('practice-hub-life'),
+    _ => throw ArgumentError.value(definition.category, 'category'),
+  };
+  await _tapVisible(tester, find.byKey(hubKey));
+  final scene = find.byKey(Key('catalog-scene-${definition.id}'));
   expect(scene, findsOneWidget);
   await tester.ensureVisible(scene);
   await tester.pumpAndSettle();

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -10,7 +10,7 @@ import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart'
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 
 void main() {
-  testWidgets('shows exactly the three product-level practice entries', (
+  testWidgets('shows exactly the four product-level practice entries', (
     tester,
   ) async {
     final controller = PreparationController(client: _HubFixtureClient());
@@ -32,7 +32,8 @@ void main() {
 
     expect(find.byKey(const Key('practice-hub-interview')), findsOneWidget);
     expect(find.byKey(const Key('practice-hub-exam')), findsOneWidget);
-    expect(find.byKey(const Key('practice-hub-roleplay')), findsOneWidget);
+    expect(find.byKey(const Key('practice-hub-workplace')), findsOneWidget);
+    expect(find.byKey(const Key('practice-hub-life')), findsOneWidget);
     expect(find.byKey(const Key('practice-continuation')), findsNothing);
     expect(find.text('最近练习'), findsNothing);
     expect(find.byKey(const Key('preparation-family-INTERVIEW')), findsNothing);
@@ -119,28 +120,38 @@ void main() {
     expect(find.byKey(const Key('ielts-part2-set-p23-001')), findsOneWidget);
   });
 
-  testWidgets('combines workplace and daily templates in AI roleplay', (
+  testWidgets('separates workplace from life and travel scenes', (
     tester,
   ) async {
     final controller = PreparationController(client: _HubFixtureClient());
     addTearDown(controller.dispose);
     await _pumpHub(tester, controller);
 
-    await _openModule(tester, const Key('practice-hub-roleplay'));
+    await _openModule(tester, const Key('practice-hub-workplace'));
 
-    expect(find.text('情景对话'), findsOneWidget);
+    expect(find.text('职场英语'), findsOneWidget);
     expect(find.text('进度与风险汇报'), findsOneWidget);
-    expect(find.text('酒店入住与问题处理'), findsOneWidget);
-    expect(find.byKey(const Key('roleplay-filter-workplace')), findsOneWidget);
-    expect(find.byKey(const Key('roleplay-filter-travel')), findsOneWidget);
+    expect(find.text('酒店入住与问题处理'), findsNothing);
+    expect(find.byKey(const Key('roleplay-filter-workplace')), findsNothing);
     expect(find.text('英文自我介绍'), findsNothing);
     expect(find.text('IELTS 口语完整模拟'), findsNothing);
     expect(find.text('自定义职场沟通'), findsNothing);
     expect(find.text('自定义日常交流'), findsNothing);
     expect(find.byKey(const Key('roleplay-custom-reserved')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('preparation-back-to-families')));
+    await tester.pumpAndSettle();
+    await _openModule(tester, const Key('practice-hub-life'));
+
+    expect(find.text('生活与旅行'), findsOneWidget);
+    expect(find.text('酒店入住与问题处理'), findsOneWidget);
+    expect(find.text('餐厅点餐'), findsOneWidget);
+    expect(find.text('进度与风险汇报'), findsNothing);
+    expect(find.byKey(const Key('roleplay-filter-travel')), findsOneWidget);
+    expect(find.byKey(const Key('roleplay-filter-workplace')), findsNothing);
   });
 
-  testWidgets('keeps the three entries usable at 320px and 3x text', (
+  testWidgets('keeps the four entries usable at 320px and 3x text', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(320, 568);
@@ -156,7 +167,8 @@ void main() {
     for (final entryData in const [
       (key: Key('practice-hub-interview'), title: '英文面试'),
       (key: Key('practice-hub-exam'), title: 'IELTS 口语'),
-      (key: Key('practice-hub-roleplay'), title: '情景对话'),
+      (key: Key('practice-hub-workplace'), title: '职场英语'),
+      (key: Key('practice-hub-life'), title: '生活与旅行'),
     ]) {
       final entry = find.byKey(entryData.key);
       await tester.scrollUntilVisible(
@@ -204,7 +216,7 @@ void main() {
     await tester.tap(back);
     await tester.pumpAndSettle();
 
-    await _openModule(tester, const Key('practice-hub-roleplay'));
+    await _openModule(tester, const Key('practice-hub-life'));
     final roleplayScene = find.byKey(
       const Key('catalog-scene-scn_daily_hotel_checkin_issue'),
     );
@@ -227,7 +239,7 @@ void main() {
     addTearDown(controller.dispose);
     await _pumpHub(tester, controller);
 
-    final entry = find.byKey(const Key('practice-hub-roleplay'));
+    final entry = find.byKey(const Key('practice-hub-workplace'));
     await tester.scrollUntilVisible(
       entry,
       180,
@@ -243,12 +255,12 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.byKey(const Key('practice-hub-title-roleplay')).hitTestable(),
+      find.byKey(const Key('practice-hub-title-workplace')).hitTestable(),
       findsOneWidget,
     );
   });
 
-  testWidgets('keeps exam and roleplay modules usable in landscape', (
+  testWidgets('keeps exam and workplace modules usable in landscape', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(844, 390);
@@ -266,8 +278,8 @@ void main() {
         scene: Key('catalog-scene-scene_ielts_speaking-part1'),
       ),
       (
-        entry: Key('practice-hub-roleplay'),
-        title: Key('practice-hub-title-roleplay'),
+        entry: Key('practice-hub-workplace'),
+        title: Key('practice-hub-title-workplace'),
         scene: Key('catalog-scene-scn_workplace_progress_risk_update'),
       ),
     ]) {
@@ -320,7 +332,8 @@ void main() {
       for (final entryData in const [
         (key: Key('practice-hub-interview'), label: '英文面试。模拟面试与轮次专项练习'),
         (key: Key('practice-hub-exam'), label: 'IELTS 口语。Part 1、2、3 与完整模考'),
-        (key: Key('practice-hub-roleplay'), label: '情景对话。工作、旅行与日常英语实战'),
+        (key: Key('practice-hub-workplace'), label: '职场英语。会议、协作与客户沟通'),
+        (key: Key('practice-hub-life'), label: '生活与旅行。日常交流与出行场景实战'),
       ]) {
         final entry = find.byKey(entryData.key);
         await tester.scrollUntilVisible(
@@ -515,6 +528,14 @@ final _hubScenes = <SceneDefinition>[
     category: SceneCategory.roleplayTravel,
     name: '酒店入住与问题处理',
     prompt: _hubPrompt('办理入住并解决一个房间问题。'),
+    version: 1,
+  ),
+  testScene(
+    id: 'scn_daily_restaurant_ordering',
+    experience: PracticeExperience.roleplay,
+    category: SceneCategory.roleplayDaily,
+    name: '餐厅点餐',
+    prompt: _hubPrompt('练习点餐、确认需求与礼貌沟通。'),
     version: 1,
   ),
 ];

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -19,7 +19,8 @@ Future<void> _openFamily(WidgetTester tester, String family) async {
   final hubKey = switch (family) {
     'INTERVIEW' => 'practice-hub-interview',
     'EXAM' => 'practice-hub-exam',
-    'WORKPLACE' || 'DAILY' => 'practice-hub-roleplay',
+    'WORKPLACE' => 'practice-hub-workplace',
+    'DAILY' => 'practice-hub-life',
     _ => throw ArgumentError.value(family, 'family'),
   };
   final hub = find.byKey(Key(hubKey));
@@ -174,7 +175,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('groups the catalog into three product directions', (
+  testWidgets('groups the catalog into four product directions', (
     tester,
   ) async {
     final controller = PreparationController(client: _FourFamilyClient());
@@ -188,7 +189,8 @@ void main() {
     for (final hub in const [
       'practice-hub-interview',
       'practice-hub-exam',
-      'practice-hub-roleplay',
+      'practice-hub-workplace',
+      'practice-hub-life',
     ]) {
       final entry = find.byKey(Key(hub));
       await tester.scrollUntilVisible(


### PR DESCRIPTION
## 功能描述

- 将训练首页从三个入口调整为英文面试、IELTS 口语、职场英语、生活与旅行四个入口。
- 使用 `practice_experience + scene_category` 对 Roleplay Scene 分组，不依赖固定 Scene ID。
- 复用现有 Roleplay Catalog，并根据入口显示对应标题、说明和筛选项。

## 实现思路

页面入口负责选择用户意图，Scene Catalog 继续作为唯一数据来源；职场入口只消费 `ROLEPLAY_WORKPLACE`，生活与旅行入口消费 `ROLEPLAY_DAILY / ROLEPLAY_TRAVEL`。未修改后端、数据库、Scene API 或练习运行策略。

## 测试

```bash
cd mobile
flutter test test/coaching/preparation/preparation_hub_test.dart test/coaching/preparation/preparation_page_test.dart test/coaching/preparation/practice_lifecycle_flow_test.dart
```

结果：21 项通过。

Closes #428