### PR TITLE
[MS3][Agent] 统一语音回复流式输出与恢复

### DIFF
--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -182,10 +182,6 @@ class _AgentComposerState extends State<AgentComposer> {
     if (!mounted || !voice.canConfirm) {
       return;
     }
-    await WidgetsBinding.instance.endOfFrame;
-    if (!mounted || !voice.canConfirm) {
-      return;
-    }
     await voice.confirm();
     if (!mounted || voice.editedTranscript.isNotEmpty) {
       return;

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -40,6 +40,8 @@ final class ComposerController extends ChangeNotifier {
         recorder: voiceRecorder ?? FakeAgentVoiceRecorder(),
         audioPlayer: draftAudioPlayer ?? FakeAgentAudioPlayer(),
         onMessagesCommitted: conversationController.commitComposerMessages,
+        onStreamMessageChanged:
+            conversationController.changeComposerStreamMessage,
         onAssistantCommitted: onAssistantCommitted,
         idFactory: _newId,
       )..addListener(_relayVoiceState);

--- a/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
@@ -48,9 +48,21 @@ abstract interface class AgentVoiceClient {
   Future<void> dispose();
 }
 
+abstract interface class AgentVoiceStreamingClient {
+  Stream<AgentVoiceConfirmationStreamEvent> confirmCandidateStream({
+    required String candidateId,
+    required int candidateVersion,
+    required String clientMessageId,
+    required String confirmedText,
+  });
+}
+
 /// Explicit preview/test provider for voice drafts and committed Message audio.
 final class FakeAgentVoiceClient
-    implements AgentVoiceClient, AgentMessageAudioClient {
+    implements
+        AgentVoiceClient,
+        AgentVoiceStreamingClient,
+        AgentMessageAudioClient {
   FakeAgentVoiceClient({this.delay = Duration.zero});
 
   final Duration delay;
@@ -267,6 +279,30 @@ final class FakeAgentVoiceClient
     _messages[assistantMessage.id] = assistantMessage;
     _audioIds.add(audioId);
     return confirmation;
+  }
+
+  @override
+  Stream<AgentVoiceConfirmationStreamEvent> confirmCandidateStream({
+    required String candidateId,
+    required int candidateVersion,
+    required String clientMessageId,
+    required String confirmedText,
+  }) async* {
+    final confirmation = await confirmCandidate(
+      candidateId: candidateId,
+      candidateVersion: candidateVersion,
+      clientMessageId: clientMessageId,
+      confirmedText: confirmedText,
+    );
+    yield AgentVoiceInputCommitted(confirmation);
+    if (confirmation.assistantMessage case final assistant?) {
+      yield AgentVoiceAssistantStarted(runId: confirmation.run.id);
+      yield AgentVoiceAssistantDelta(
+        runId: confirmation.run.id,
+        delta: assistant.text,
+      );
+    }
+    yield AgentVoiceRunCompleted(confirmation.run);
   }
 
   @override

--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -16,6 +16,8 @@ typedef AgentVoiceMessagesCommitted =
     void Function(Iterable<AgentMessage> messages);
 typedef AgentVoiceAssistantCommitted =
     FutureOr<void> Function(AgentMessage message);
+typedef AgentVoiceStreamMessageChanged =
+    void Function(String? previousMessageId, AgentMessage message);
 
 final class AgentVoiceController extends ChangeNotifier
     with WidgetsBindingObserver {
@@ -25,6 +27,7 @@ final class AgentVoiceController extends ChangeNotifier
     required this.audioPlayer,
     required this.onMessagesCommitted,
     this.onAssistantCommitted,
+    this.onStreamMessageChanged,
     required this.idFactory,
     this.clock = DateTime.now,
     this.pollInterval = const Duration(seconds: 1),
@@ -50,6 +53,7 @@ final class AgentVoiceController extends ChangeNotifier
   final AgentAudioPlayer audioPlayer;
   final AgentVoiceMessagesCommitted onMessagesCommitted;
   final AgentVoiceAssistantCommitted? onAssistantCommitted;
+  final AgentVoiceStreamMessageChanged? onStreamMessageChanged;
   final AgentVoiceIdFactory idFactory;
   final AgentVoiceControllerClock clock;
   final Duration pollInterval;
@@ -645,11 +649,180 @@ final class AgentVoiceController extends ChangeNotifier
       confirmedText: text,
     );
     _confirmationCommand = command;
+    if (client is AgentVoiceStreamingClient) {
+      return _startConfirmationStream(
+        client: client as AgentVoiceStreamingClient,
+        candidate: candidate,
+        command: command,
+      );
+    }
     return _startConfirmation(
       candidate: candidate,
       command: command,
       reconcileFirst: false,
     );
+  }
+
+  Future<void> _startConfirmationStream({
+    required AgentVoiceStreamingClient client,
+    required AgentVoiceCandidate candidate,
+    required _ConfirmationCommand command,
+  }) {
+    final fence = _captureWorkflowFence(
+      candidateId: candidate.id,
+      candidateVersion: candidate.version,
+    );
+    _state = AgentVoiceComposerState.confirming;
+    _errorMessage = null;
+    _retry = null;
+    notifyListeners();
+    late final Future<void> operation;
+    operation =
+        _confirmStream(
+          client: client,
+          fence: fence,
+          candidate: candidate,
+          command: command,
+        ).whenComplete(() {
+          if (identical(_workflowOperation, operation)) {
+            _workflowOperation = null;
+          }
+        });
+    _workflowOperation = operation;
+    return operation;
+  }
+
+  Future<void> _confirmStream({
+    required AgentVoiceStreamingClient client,
+    required _WorkflowFence fence,
+    required AgentVoiceCandidate candidate,
+    required _ConfirmationCommand command,
+  }) async {
+    var messageCommitted = false;
+    var assistantText = '';
+    String? transientAssistantId;
+    try {
+      await for (final event in client.confirmCandidateStream(
+        candidateId: command.candidateId,
+        candidateVersion: command.candidateVersion,
+        clientMessageId: command.clientMessageId,
+        confirmedText: command.confirmedText,
+      )) {
+        if (!_isWorkflowCurrent(fence)) {
+          return;
+        }
+        switch (event) {
+          case AgentVoiceInputCommitted(:final confirmation):
+            _validateConfirmation(
+              confirmation,
+              expectedCandidate: candidate,
+              confirmedText: command.confirmedText,
+            );
+            _candidate = confirmation.candidate;
+            _pendingRun = confirmation.run;
+            onMessagesCommitted(<AgentMessage>[confirmation.message]);
+            messageCommitted = true;
+            _editedTranscript = '';
+            _recording = null;
+            _uploadIdempotencyKey = null;
+            _confirmationCommand = null;
+            _state = AgentVoiceComposerState.awaitingAssistant;
+            notifyListeners();
+          case AgentVoiceAssistantStarted(:final runId):
+            transientAssistantId = 'stream-$runId';
+            _changeStreamMessage(
+              null,
+              AgentMessage(
+                id: transientAssistantId,
+                role: AgentMessageRole.assistant,
+                text: '',
+                isStreaming: true,
+              ),
+            );
+          case AgentVoiceAssistantDelta(:final delta):
+            final messageId = transientAssistantId;
+            if (messageId == null) {
+              throw StateError('Voice assistant delta started out of order.');
+            }
+            assistantText += delta;
+            _changeStreamMessage(
+              messageId,
+              AgentMessage(
+                id: messageId,
+                role: AgentMessageRole.assistant,
+                text: assistantText,
+                isStreaming: true,
+              ),
+            );
+          case AgentVoiceRunCompleted(:final run):
+            _pendingRun = run;
+            final messageId = run.assistantMessageId;
+            if (messageId == null) {
+              throw StateError('Completed voice Run has no assistant Message.');
+            }
+            final assistant = await this.client.getMessage(
+              threadId: fence.threadId,
+              messageId: messageId,
+            );
+            if (!_isWorkflowCurrent(fence)) {
+              return;
+            }
+            if (assistant == null ||
+                assistant.role != AgentMessageRole.assistant) {
+              throw StateError('Voice assistant Message is unavailable.');
+            }
+            final transientId = transientAssistantId;
+            if (transientId == null) {
+              onMessagesCommitted(<AgentMessage>[assistant]);
+            } else {
+              _changeStreamMessage(transientId, assistant);
+            }
+            _resetWorkflowPresentation();
+            notifyListeners();
+            _notifyAssistantCommitted(assistant);
+          case AgentVoiceRunFailed(:final kind, :final retryable):
+            throw AgentClientException(
+              kind: AgentClientFailureKind.runFailed,
+              errorCode: kind,
+              retryable: retryable,
+            );
+        }
+      }
+    } catch (error) {
+      if (_isWorkflowCurrent(fence)) {
+        if (transientAssistantId case final messageId?) {
+          _changeStreamMessage(
+            messageId,
+            AgentMessage(
+              id: messageId,
+              role: AgentMessageRole.assistant,
+              text: assistantText,
+              hasFailed: true,
+            ),
+          );
+        }
+        if (messageCommitted) {
+          _state = AgentVoiceComposerState.failed;
+          _retry = _VoiceRetry.run;
+          _errorMessage = '回复中断了，可以重试；你的语音消息已保留。';
+        } else {
+          _state = AgentVoiceComposerState.awaitingConfirmation;
+          _retry = null;
+          _errorMessage = _confirmationFailureMessage(error);
+        }
+        notifyListeners();
+        await _clearOnAuthenticationFailure(error);
+      }
+    }
+  }
+
+  void _changeStreamMessage(String? previousMessageId, AgentMessage message) {
+    final callback = onStreamMessageChanged;
+    if (callback == null) {
+      onMessagesCommitted(<AgentMessage>[message]);
+      return;
+    }
+    callback(previousMessageId, message);
   }
 
   Future<void> _retryConfirmation() {

--- a/mobile/lib/features/agent/composer/voice/agent_voice_models.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_models.dart
@@ -176,6 +176,48 @@ final class AgentVoiceConfirmation {
   final AgentMessage? assistantMessage;
 }
 
+sealed class AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceConfirmationStreamEvent();
+}
+
+final class AgentVoiceInputCommitted extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceInputCommitted(this.confirmation);
+
+  final AgentVoiceConfirmation confirmation;
+}
+
+final class AgentVoiceAssistantStarted
+    extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceAssistantStarted({required this.runId});
+
+  final String runId;
+}
+
+final class AgentVoiceAssistantDelta extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceAssistantDelta({required this.runId, required this.delta});
+
+  final String runId;
+  final String delta;
+}
+
+final class AgentVoiceRunCompleted extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceRunCompleted(this.run);
+
+  final AgentVoiceRun run;
+}
+
+final class AgentVoiceRunFailed extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceRunFailed({
+    required this.runId,
+    required this.kind,
+    required this.retryable,
+  });
+
+  final String runId;
+  final String kind;
+  final bool retryable;
+}
+
 enum AgentVoiceComposerState {
   idle,
   starting,

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -1243,6 +1243,28 @@ final class ConversationController extends ChangeNotifier {
     unawaited(_hydrateMessageMemeContents(fence));
   }
 
+  void changeComposerStreamMessage(
+    String? previousMessageId,
+    AgentMessage message,
+  ) {
+    if (_disposed || _threadId == null) {
+      return;
+    }
+    final messages = List<AgentMessage>.from(_messages);
+    final index = previousMessageId == null
+        ? -1
+        : messages.indexWhere((item) => item.id == previousMessageId);
+    if (index < 0) {
+      if (!messages.any((item) => item.id == message.id)) {
+        messages.add(message);
+      }
+    } else {
+      messages[index] = message;
+    }
+    _messages = messages;
+    notifyListeners();
+  }
+
   void markMessageAudioDeleted(
     String messageId,
     AgentMessageAudio deletedAudio,

--- a/mobile/lib/providers/agent/wire_agent_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_client.dart
@@ -273,6 +273,9 @@ final class WireAgentClient implements AgentClient, AgentStreamingTextClient {
       return const _RestoredTextRun();
     }
     final userMessage = messages.last;
+    if (userMessage.modality == AgentMessageModality.voice) {
+      return const _RestoredTextRun();
+    }
     final imageAssetIds = <String>[
       for (final image in userMessage.images) image.id,
     ];

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -69,7 +69,10 @@ typedef AgentVoiceWireTransportFactory = AgentVoiceWireTransport Function();
 typedef AgentVoiceNow = DateTime Function();
 
 final class WireAgentVoiceClient
-    implements AgentVoiceClient, AgentMessageAudioClient {
+    implements
+        AgentVoiceClient,
+        AgentVoiceStreamingClient,
+        AgentMessageAudioClient {
   factory WireAgentVoiceClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -390,6 +393,53 @@ final class WireAgentVoiceClient
         _zero(response.body);
       }
     });
+  }
+
+  @override
+  Stream<AgentVoiceConfirmationStreamEvent> confirmCandidateStream({
+    required String candidateId,
+    required int candidateVersion,
+    required String clientMessageId,
+    required String confirmedText,
+  }) async* {
+    _requireUuid(candidateId);
+    _requireClientIdentity(clientMessageId);
+    _requireContent(confirmedText);
+    if (candidateVersion < 1) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.invalidRequest,
+      );
+    }
+    final cleanup = _cleanupFuture;
+    if (cleanup != null) {
+      await cleanup;
+    }
+    final generation = _accountGeneration;
+    final response = await _openApiStream(
+      generation: generation,
+      method: 'POST',
+      path:
+          '/v1/agent-voice-message-candidates/${Uri.encodeComponent(candidateId)}/confirmations/stream',
+      accept: 'text/event-stream',
+      maximumResponseBytes: _maximumJsonBytes,
+      contentType: ContentType.json.mimeType,
+      headers: const <String, String>{},
+      body: Uint8List.fromList(
+        utf8.encode(
+          jsonEncode(<String, Object?>{
+            'candidate_version': candidateVersion,
+            'client_message_id': clientMessageId,
+            'confirmed_text': confirmedText,
+          }),
+        ),
+      ),
+    );
+    yield* _decodeConfirmationEvents(
+      response,
+      expectedCandidateId: candidateId,
+      expectedCandidateVersion: candidateVersion,
+      expectedText: confirmedText,
+    );
   }
 
   @override
@@ -873,6 +923,152 @@ final class WireAgentVoiceClient
         eventName.isNotEmpty ||
         eventData.isNotEmpty) {
       throw _invalidResponse();
+    }
+  }
+
+  Stream<AgentVoiceConfirmationStreamEvent> _decodeConfirmationEvents(
+    AgentVoiceWireStreamResponse response, {
+    required String expectedCandidateId,
+    required int expectedCandidateVersion,
+    required String expectedText,
+  }) async* {
+    var responseBytes = 0;
+    var eventName = '';
+    var eventData = '';
+    var phase = 0;
+    String? runId;
+    try {
+      final lines = response.body
+          .map((chunk) {
+            responseBytes += chunk.length;
+            if (responseBytes > _maximumJsonBytes) {
+              throw _invalidResponse();
+            }
+            return chunk;
+          })
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter());
+      await for (final line in lines.timeout(_requestTimeout)) {
+        if (line.isEmpty) {
+          if (eventName.isEmpty && eventData.isEmpty) {
+            continue;
+          }
+          final event = _decodeConfirmationEvent(
+            eventName,
+            eventData,
+            expectedCandidateId: expectedCandidateId,
+            expectedCandidateVersion: expectedCandidateVersion,
+            expectedText: expectedText,
+            expectedRunId: runId,
+          );
+          switch (event) {
+            case AgentVoiceInputCommitted(:final confirmation) when phase == 0:
+              phase = 1;
+              runId = confirmation.run.id;
+            case AgentVoiceAssistantStarted() when phase == 1:
+              phase = 2;
+            case AgentVoiceAssistantDelta() when phase == 2:
+              phase = 2;
+            case AgentVoiceRunCompleted() when phase == 1 || phase == 2:
+              phase = 3;
+            case AgentVoiceRunFailed() when phase == 1 || phase == 2:
+              phase = 3;
+            default:
+              throw const _InvalidVoiceResponse();
+          }
+          yield event;
+          eventName = '';
+          eventData = '';
+          continue;
+        }
+        if (line.startsWith(':')) {
+          continue;
+        }
+        if (line.startsWith('event: ') && eventName.isEmpty) {
+          eventName = line.substring(7);
+          continue;
+        }
+        if (line.startsWith('data: ') && eventData.isEmpty) {
+          eventData = line.substring(6);
+          continue;
+        }
+        throw const _InvalidVoiceResponse();
+      }
+    } on _InvalidVoiceResponse {
+      throw _invalidResponse();
+    }
+    if (phase != 3 || eventName.isNotEmpty || eventData.isNotEmpty) {
+      throw _invalidResponse();
+    }
+  }
+
+  AgentVoiceConfirmationStreamEvent _decodeConfirmationEvent(
+    String event,
+    String data, {
+    required String expectedCandidateId,
+    required int expectedCandidateVersion,
+    required String expectedText,
+    required String? expectedRunId,
+  }) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(data);
+    } catch (_) {
+      throw const _InvalidVoiceResponse();
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const _InvalidVoiceResponse();
+    }
+    final object = Map<String, Object?>.from(decoded);
+    switch (event) {
+      case 'input.committed':
+        final confirmation = _decodeConfirmationObject(object);
+        if (confirmation.candidate.id != expectedCandidateId ||
+            confirmation.candidate.version != expectedCandidateVersion ||
+            confirmation.message.text != expectedText ||
+            confirmation.run.inputMessageId != confirmation.message.id) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceInputCommitted(confirmation);
+      case 'assistant.started':
+        final runId = _strictString(object['run_id'], min: 1, max: 128);
+        if (object.length != 1 || runId != expectedRunId) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceAssistantStarted(runId: runId);
+      case 'assistant.delta':
+        final runId = _strictString(object['run_id'], min: 1, max: 128);
+        final delta = _strictContent(object['delta']);
+        if (object.length != 2 || runId != expectedRunId) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceAssistantDelta(runId: runId, delta: delta);
+      case 'run.completed':
+        final run = _decodeRunObject(object['run']);
+        if (object.length != 1 ||
+            run.id != expectedRunId ||
+            run.status != AgentVoiceRunStatus.completed) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceRunCompleted(run);
+      case 'run.failed':
+        final run = object['run'];
+        final runId = run == null
+            ? _strictString(object['run_id'], min: 1, max: 128)
+            : _decodeRunObject(run).id;
+        final kind = _strictString(object['kind'], min: 1, max: 64);
+        final retryable = _strictBool(object['retryable']);
+        if (runId != expectedRunId) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceRunFailed(
+          runId: runId,
+          kind: kind,
+          retryable: retryable,
+        );
+      default:
+        throw const _InvalidVoiceResponse();
     }
   }
 
@@ -1689,7 +1885,6 @@ AgentMessage _decodeMessageObject(
       'modality',
       'content',
       'audio',
-      'memes',
       'handoffs',
       'speech_feedback_status_url',
       'created_at',
@@ -1734,14 +1929,10 @@ AgentMessage _decodeMessageObject(
   final handoffs = object['handoffs'] == null
       ? const <AgentHandoff>[]
       : decodeAgentHandoffs(object['handoffs']);
-  final memes = object['memes'] == null
-      ? const <AgentMessageMeme>[]
-      : _decodeVoiceMessageMemes(object['memes']);
   if ((role == AgentMessageRole.user &&
           (clientId == null || producedBy != null || handoffs.isNotEmpty)) ||
       (role == AgentMessageRole.assistant &&
           (clientId != null || producedBy == null)) ||
-      (role != AgentMessageRole.assistant && memes.isNotEmpty) ||
       (modality == AgentMessageModality.voice &&
           (role != AgentMessageRole.user || audio == null)) ||
       (modality == AgentMessageModality.text && audio != null) ||
@@ -1759,74 +1950,8 @@ AgentMessage _decodeMessageObject(
     createdAt: _strictDateTime(object['created_at']),
     modality: modality,
     audio: audio,
-    memes: memes,
     handoffs: handoffs,
     speechFeedbackStatusUrl: speechFeedbackStatusUrl,
-  );
-}
-
-List<AgentMessageMeme> _decodeVoiceMessageMemes(Object? value) {
-  final values = _strictList(value, max: 4);
-  if (values.isEmpty) {
-    throw const _InvalidVoiceResponse();
-  }
-  final ids = <String>{};
-  return List<AgentMessageMeme>.unmodifiable(
-    values.map((item) {
-      final object = _strictObject(
-        item,
-        allowed: const <String>{
-          'meme_attachment_id',
-          'meme_id',
-          'category',
-          'content_type',
-          'size_bytes',
-          'width',
-          'height',
-          'content_path',
-        },
-        required: const <String>{
-          'meme_attachment_id',
-          'meme_id',
-          'category',
-          'content_type',
-          'size_bytes',
-          'width',
-          'height',
-          'content_path',
-        },
-      );
-      final id = _strictUuid(object['meme_attachment_id']);
-      final contentType = _strictString(
-        object['content_type'],
-        min: 1,
-        max: 32,
-      );
-      final contentPath = _strictString(
-        object['content_path'],
-        min: 1,
-        max: 200,
-      );
-      if (!ids.add(id) ||
-          !_memeContentTypes.contains(contentType) ||
-          contentPath != '/v1/agent-message-memes/$id/content') {
-        throw const _InvalidVoiceResponse();
-      }
-      return AgentMessageMeme(
-        id: id,
-        memeId: _strictPattern(object['meme_id'], _stableMemeIdPattern, 128),
-        category: _strictPattern(object['category'], _stableMemeIdPattern, 128),
-        contentType: contentType,
-        sizeBytes: _strictInt(
-          object['size_bytes'],
-          min: 1,
-          max: 20 * 1024 * 1024,
-        ),
-        width: _strictInt(object['width'], min: 1, max: 16384),
-        height: _strictInt(object['height'], min: 1, max: 16384),
-        contentPath: contentPath,
-      );
-    }),
   );
 }
 
@@ -2173,15 +2298,6 @@ final RegExp _uuidPattern = RegExp(
 final RegExp _clientIdentityPattern = RegExp(
   r'^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$',
 );
-final RegExp _stableMemeIdPattern = RegExp(
-  r'^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$',
-);
-const _memeContentTypes = <String>{
-  'image/gif',
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-};
 final RegExp _providerPattern = RegExp(r'^[a-z][a-z0-9_-]{0,63}$');
 final RegExp _failurePattern = RegExp(r'^[a-z][a-z0-9_]{0,63}$');
 final RegExp _playbackPathPattern = RegExp(

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -168,7 +168,10 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.byKey(Key('agent-user-voice-progress-${voiceMessage.id}')),
+        find.descendant(
+          of: voiceBubble,
+          matching: find.byIcon(Icons.graphic_eq_rounded),
+        ),
         findsOneWidget,
       );
       expect(

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -168,10 +168,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.descendant(
-          of: voiceBubble,
-          matching: find.byIcon(Icons.graphic_eq_rounded),
-        ),
+        find.byKey(Key('agent-user-voice-progress-${voiceMessage.id}')),
         findsOneWidget,
       );
       expect(

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -109,6 +109,49 @@ void main() {
       transport.expectDone();
     });
 
+    test('does not replay a voice Message through the text Run API', () async {
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/focused',
+          response: _jsonResponse(HttpStatus.ok, _threadJson()),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/messages',
+          response: _jsonResponse(HttpStatus.ok, {
+            'messages': [
+              _messageJson(
+                id: _userMessageId,
+                sequence: 1,
+                role: 'user',
+                content: 'Let us practice this sentence.',
+                clientMessageId: 'voice_message_restore',
+                modality: 'voice',
+                audio: {
+                  'audio_id': '50000000-0000-4000-8000-000000000001',
+                  'status': 'readable',
+                  'content_type': 'audio/wav',
+                  'size_bytes': 3244,
+                  'duration_ms': 100,
+                  'playback_path':
+                      '/v1/agent-message-audios/50000000-0000-4000-8000-000000000001/playback',
+                },
+              ),
+            ],
+          }),
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      final snapshot = (await harness.client.getFocusedThread())!;
+
+      expect(snapshot.messages, hasLength(1));
+      expect(snapshot.messages.single.modality, AgentMessageModality.voice);
+      expect(snapshot.textRecovery, isNull);
+      transport.expectDone();
+    });
+
     test(
       'lists an empty account before explicitly creating one Thread',
       () async {
@@ -1709,6 +1752,7 @@ Map<String, Object?> _messageJson({
   String? producedByRunId,
   List<Object?>? handoffs,
   String? modality,
+  Map<String, Object?>? audio,
   List<Object?>? images,
   List<Object?>? memes,
 }) {
@@ -1721,6 +1765,7 @@ Map<String, Object?> _messageJson({
     'produced_by_run_id': ?producedByRunId,
     'handoffs': ?handoffs,
     'modality': ?modality,
+    'audio': ?audio,
     'images': ?images,
     'memes': ?memes,
     'content': content,

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -106,6 +106,69 @@ void main() {
     transport.expectDone();
   });
 
+  test('keeps a confirmation SSE stream open across assistant deltas', () async {
+    final completedRun = _runJson(status: 'completed')
+      ..['assistant_message_id'] = _assistantMessageId
+      ..['provider_completion_id'] = 'completion-voice-001'
+      ..['provider_model'] = 'qwen-plus'
+      ..['finish_reason'] = 'stop'
+      ..['usage'] = <String, Object?>{
+        'input_tokens': 10,
+        'output_tokens': 4,
+        'total_tokens': 14,
+      }
+      ..['started_at'] = _timestamp
+      ..['completed_at'] = _timestamp;
+    final transport = _ScriptedVoiceTransport([
+      _Step(
+        method: 'POST',
+        path:
+            '/v1/agent-voice-message-candidates/$_candidateId/confirmations/stream',
+        response: _sseResponse(<(String, Object?)>[
+          (
+            'input.committed',
+            <String, Object?>{
+              'candidate': _candidateJson(status: 'confirmed', confirmed: true),
+              'message': _voiceMessageJson(
+                content: 'Edited confirmed transcript',
+              ),
+              'run': _runJson(status: 'pending'),
+            },
+          ),
+          ('assistant.started', <String, Object?>{'run_id': _runId}),
+          (
+            'assistant.delta',
+            <String, Object?>{'run_id': _runId, 'delta': 'Hello'},
+          ),
+          (
+            'assistant.delta',
+            <String, Object?>{'run_id': _runId, 'delta': ', how can I help?'},
+          ),
+          ('run.completed', <String, Object?>{'run': completedRun}),
+        ]),
+      ),
+    ]);
+    final client = _client(transport);
+    addTearDown(client.dispose);
+
+    final events = await client
+        .confirmCandidateStream(
+          candidateId: _candidateId,
+          candidateVersion: 1,
+          clientMessageId: 'voice_message_001',
+          confirmedText: 'Edited confirmed transcript',
+        )
+        .toList();
+
+    expect(events, hasLength(5));
+    expect(
+      events.whereType<AgentVoiceAssistantDelta>().map((event) => event.delta),
+      <String>['Hello', ', how can I help?'],
+    );
+    expect(events.last, isA<AgentVoiceRunCompleted>());
+    transport.expectDone();
+  });
+
   test(
     'decodes confirmation fields for confirmed deleting and deleted candidates',
     () async {

--- a/server/internal/agent/input/voice/http/handler.go
+++ b/server/internal/agent/input/voice/http/handler.go
@@ -11,6 +11,7 @@ import (
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	agentconversationhttp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation/http"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
 	agentrunhttp "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run/http"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpinput"
@@ -51,6 +52,15 @@ type Application interface {
 		agentvoice.ConfirmCandidateCommand,
 	) (agentvoice.Confirmation, error)
 	DeleteCandidate(context.Context, requestcontext.Actor, string) error
+}
+
+type streamingConfirmationApplication interface {
+	ConfirmStream(
+		context.Context,
+		requestcontext.Actor,
+		agentvoice.ConfirmCandidateCommand,
+		agentvoice.ConfirmationStreamObserver,
+	) (agentvoice.Confirmation, error)
 }
 
 type ThreadReader interface {
@@ -115,6 +125,10 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 	routes.POST(
 		"/v1/agent-voice-message-candidates/:candidate_id/confirmations",
 		handler.confirm,
+	)
+	routes.POST(
+		"/v1/agent-voice-message-candidates/:candidate_id/confirmations/stream",
+		handler.confirmStream,
 	)
 }
 
@@ -261,6 +275,80 @@ func (handler *Handler) delete(c *gin.Context) {
 }
 
 func (handler *Handler) confirm(c *gin.Context) {
+	actor, command, ok := handler.prepareConfirmation(c)
+	if !ok {
+		return
+	}
+	confirmation, err := handler.application.Confirm(
+		c.Request.Context(),
+		actor,
+		command,
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	confirmation.Message.Audio = &confirmation.Audio
+	c.JSON(
+		agentrunhttp.RunWriteStatus(confirmation.Run),
+		confirmationResponse(confirmation),
+	)
+}
+
+func (handler *Handler) confirmStream(c *gin.Context) {
+	application, ok := handler.application.(streamingConfirmationApplication)
+	if !ok {
+		handler.write(c, internalError(nil))
+		return
+	}
+	actor, command, ok := handler.prepareConfirmation(c)
+	if !ok {
+		return
+	}
+	stream := &confirmationSSEWriter{context: c}
+	confirmation, err := application.ConfirmStream(
+		c.Request.Context(),
+		actor,
+		command,
+		stream,
+	)
+	if err != nil {
+		if !stream.started {
+			handler.write(c, mapError(err))
+			return
+		}
+		_ = stream.write("run.failed", gin.H{
+			"run_id":    confirmation.Run.ID,
+			"kind":      "stream_interrupted",
+			"retryable": true,
+		})
+		return
+	}
+	switch confirmation.Run.Status {
+	case agentrun.StatusCompleted:
+		_ = stream.write("run.completed", gin.H{
+			"run": agentrunhttp.RunResponse(confirmation.Run),
+		})
+	case agentrun.StatusFailed:
+		_ = stream.write("run.failed", gin.H{
+			"run":       agentrunhttp.RunResponse(confirmation.Run),
+			"kind":      confirmation.Run.FailureKind,
+			"retryable": confirmation.Run.FailureRetryable,
+		})
+	default:
+		_ = stream.write("run.failed", gin.H{
+			"run":       agentrunhttp.RunResponse(confirmation.Run),
+			"kind":      "run_not_terminal",
+			"retryable": true,
+		})
+	}
+}
+
+func (handler *Handler) prepareConfirmation(c *gin.Context) (
+	requestcontext.Actor,
+	agentvoice.ConfirmCandidateCommand,
+	bool,
+) {
 	values, ok := httpinput.DecodeObject(
 		c,
 		[]string{"candidate_version", "client_message_id", "confirmed_text"},
@@ -270,41 +358,87 @@ func (handler *Handler) confirm(c *gin.Context) {
 	)
 	if !ok {
 		handler.write(c, invalidRequest(nil))
-		return
+		return requestcontext.Actor{}, agentvoice.ConfirmCandidateCommand{}, false
 	}
 	version, versionOK := httpinput.Int64(values["candidate_version"])
 	clientMessageID, clientOK := httpinput.String(values["client_message_id"])
 	confirmedText, textOK := httpinput.String(values["confirmed_text"])
 	if !versionOK || !clientOK || !textOK {
 		handler.write(c, invalidRequest(nil))
-		return
+		return requestcontext.Actor{}, agentvoice.ConfirmCandidateCommand{}, false
 	}
 	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
 	if !ok {
 		handler.write(c, authenticationRequired())
-		return
+		return requestcontext.Actor{}, agentvoice.ConfirmCandidateCommand{}, false
 	}
-	confirmation, err := handler.application.Confirm(
-		c.Request.Context(),
-		actor,
-		agentvoice.ConfirmCandidateCommand{
-			CandidateID: c.Param("candidate_id"), CandidateVersion: version,
-			ClientMessageID: clientMessageID, ConfirmedText: confirmedText,
-		},
-	)
-	if err != nil {
-		handler.write(c, mapError(err))
-		return
+	return actor, agentvoice.ConfirmCandidateCommand{
+		CandidateID: c.Param("candidate_id"), CandidateVersion: version,
+		ClientMessageID: clientMessageID, ConfirmedText: confirmedText,
+	}, true
+}
+
+func confirmationResponse(confirmation agentvoice.Confirmation) gin.H {
+	return gin.H{
+		"candidate": CandidateResponse(confirmation.Candidate),
+		"message":   agentconversationhttp.MessageResponse(confirmation.Message),
+		"run":       agentrunhttp.RunResponse(confirmation.Run),
 	}
+}
+
+type confirmationSSEWriter struct {
+	context *gin.Context
+	started bool
+	runID   string
+}
+
+func (writer *confirmationSSEWriter) OnConfirmationCommitted(
+	_ context.Context,
+	confirmation agentvoice.Confirmation,
+) error {
+	writer.runID = confirmation.Run.ID
 	confirmation.Message.Audio = &confirmation.Audio
-	c.JSON(
-		agentrunhttp.RunWriteStatus(confirmation.Run),
-		gin.H{
-			"candidate": CandidateResponse(confirmation.Candidate),
-			"message":   agentconversationhttp.MessageResponse(confirmation.Message),
-			"run":       agentrunhttp.RunResponse(confirmation.Run),
-		},
-	)
+	return writer.write("input.committed", confirmationResponse(confirmation))
+}
+
+func (writer *confirmationSSEWriter) OnAssistantStarted(
+	_ context.Context,
+	pending agentrun.Run,
+) error {
+	writer.runID = pending.ID
+	return writer.write("assistant.started", gin.H{"run_id": pending.ID})
+}
+
+func (writer *confirmationSSEWriter) OnAssistantDelta(
+	_ context.Context,
+	delta string,
+) error {
+	return writer.write("assistant.delta", gin.H{
+		"run_id": writer.runID,
+		"delta":  delta,
+	})
+}
+
+func (writer *confirmationSSEWriter) write(event string, data any) error {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if !writer.started {
+		writer.context.Header("Content-Type", "text/event-stream; charset=utf-8")
+		writer.context.Header("Cache-Control", "no-cache, no-store")
+		writer.context.Header("X-Accel-Buffering", "no")
+		writer.context.Header("Connection", "keep-alive")
+		writer.context.Status(http.StatusOK)
+		writer.started = true
+	}
+	if _, err := writer.context.Writer.WriteString(
+		"event: " + event + "\ndata: " + string(encoded) + "\n\n",
+	); err != nil {
+		return err
+	}
+	writer.context.Writer.Flush()
+	return writer.context.Request.Context().Err()
 }
 
 type transcriptionSSEWriter struct {

--- a/server/internal/agent/input/voice/run_processor.go
+++ b/server/internal/agent/input/voice/run_processor.go
@@ -74,6 +74,26 @@ func (processor *deferredRunProcessor) ProcessPending(
 	}
 }
 
+func (processor *deferredRunProcessor) ProcessPendingStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	pendingRun run.Run,
+	observer run.StreamObserver,
+) (run.Run, error) {
+	delegate, ok := processor.delegate.(streamingPendingRunProcessor)
+	if !ok {
+		return run.Run{}, errors.New(
+			"agent voice input: streaming Run processor is required",
+		)
+	}
+	return delegate.ProcessPendingStream(
+		ctx,
+		actor,
+		pendingRun,
+		observer,
+	)
+}
+
 func (processor *deferredRunProcessor) run() {
 	for {
 		select {

--- a/server/internal/agent/input/voice/service.go
+++ b/server/internal/agent/input/voice/service.go
@@ -44,6 +44,21 @@ type PendingRunProcessor interface {
 	) (run.Run, error)
 }
 
+type streamingPendingRunProcessor interface {
+	ProcessPendingStream(
+		context.Context,
+		requestcontext.Actor,
+		run.Run,
+		run.StreamObserver,
+	) (run.Run, error)
+}
+
+type ConfirmationStreamObserver interface {
+	OnConfirmationCommitted(context.Context, Confirmation) error
+	OnAssistantStarted(context.Context, run.Run) error
+	OnAssistantDelta(context.Context, string) error
+}
+
 type FeedbackReference struct {
 	StatusURL string
 }
@@ -99,6 +114,12 @@ type Application interface {
 		context.Context,
 		requestcontext.Actor,
 		ConfirmCandidateCommand,
+	) (Confirmation, error)
+	ConfirmStream(
+		context.Context,
+		requestcontext.Actor,
+		ConfirmCandidateCommand,
+		ConfirmationStreamObserver,
 	) (Confirmation, error)
 	Playback(
 		context.Context,
@@ -490,6 +511,30 @@ func (service *Service) Confirm(
 	actor requestcontext.Actor,
 	command ConfirmCandidateCommand,
 ) (Confirmation, error) {
+	return service.confirm(ctx, actor, command, nil)
+}
+
+func (service *Service) ConfirmStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command ConfirmCandidateCommand,
+	observer ConfirmationStreamObserver,
+) (Confirmation, error) {
+	if observer == nil {
+		return Confirmation{}, ErrInvalidRequest
+	}
+	if _, ok := service.runs.(streamingPendingRunProcessor); !ok {
+		return Confirmation{}, ErrInvalidRequest
+	}
+	return service.confirm(ctx, actor, command, observer)
+}
+
+func (service *Service) confirm(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command ConfirmCandidateCommand,
+	observer ConfirmationStreamObserver,
+) (Confirmation, error) {
 	if ctx == nil || !actor.Valid() || !ValidUUID(command.CandidateID) ||
 		command.CandidateVersion < 1 ||
 		!ValidClientMessageID(command.ClientMessageID) ||
@@ -521,17 +566,56 @@ func (service *Service) Confirm(
 				reference.StatusURL
 		}
 	}
-	if confirmation.Run.Status == run.StatusPending {
-		confirmation.Run, err = service.runs.ProcessPending(
-			ctx,
-			actor,
-			confirmation.Run,
-		)
-		if err != nil {
+	if observer != nil {
+		if err := observer.OnConfirmationCommitted(ctx, confirmation); err != nil {
 			return Confirmation{}, err
 		}
 	}
+	if confirmation.Run.Status == run.StatusPending {
+		if observer == nil {
+			confirmation.Run, err = service.runs.ProcessPending(
+				ctx,
+				actor,
+				confirmation.Run,
+			)
+		} else {
+			confirmation.Run, err = service.runs.(streamingPendingRunProcessor).ProcessPendingStream(
+				ctx,
+				actor,
+				confirmation.Run,
+				confirmationRunObserver{delegate: observer},
+			)
+		}
+		if err != nil {
+			return confirmation, err
+		}
+	}
 	return confirmation, nil
+}
+
+type confirmationRunObserver struct {
+	delegate ConfirmationStreamObserver
+}
+
+func (confirmationRunObserver) OnInputCommitted(
+	context.Context,
+	run.Submission,
+) error {
+	return nil
+}
+
+func (observer confirmationRunObserver) OnAssistantStarted(
+	ctx context.Context,
+	pending run.Run,
+) error {
+	return observer.delegate.OnAssistantStarted(ctx, pending)
+}
+
+func (observer confirmationRunObserver) OnAssistantDelta(
+	ctx context.Context,
+	delta string,
+) error {
+	return observer.delegate.OnAssistantDelta(ctx, delta)
 }
 
 func (service *Service) Playback(

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -499,6 +499,38 @@ func (service *Service) ProcessPending(
 	return service.process(ctx, actor, run, nil)
 }
 
+// ProcessPendingStream resumes a Run created by another Agent input workflow
+// while forwarding model output to that workflow's live response.
+func (service *Service) ProcessPendingStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	run Run,
+	observer StreamObserver,
+) (Run, error) {
+	if ctx == nil || observer == nil || !actor.Valid() ||
+		run.OwnerID != actor.UserID ||
+		!ValidUUID(run.ID) ||
+		!ValidUUID(run.ThreadID) ||
+		!ValidUUID(run.InputMessageID) {
+		return Run{}, ErrInvalidRequest
+	}
+	if run.Status == StatusPending {
+		if err := observer.OnAssistantStarted(ctx, run); err != nil {
+			return Run{}, err
+		}
+	}
+	deltas := &countingDeltaObserver{delegate: observer}
+	processed, err := service.process(ctx, actor, run, deltas)
+	if err == nil {
+		processed, err = service.waitForTerminalRun(
+			ctx,
+			actor.UserID,
+			processed,
+		)
+	}
+	return processed, err
+}
+
 func (service *Service) process(
 	ctx context.Context,
 	actor requestcontext.Actor,
@@ -574,6 +606,7 @@ func (service *Service) process(
 			retryable,
 		)
 		service.logRunFailed(claimed, kind, retryable, claimed.StartedAt)
+		service.logGenerationFailureDetail(claimed, err)
 		return failed, failErr
 	}
 	request, err := textRequestFromContext(modelInput)
@@ -1280,6 +1313,22 @@ func (service *Service) logRunFailed(
 		"failure_category", kind,
 		"retryable", retryable,
 		"duration_ms", durationSince(startedAt).Milliseconds(),
+	)
+}
+
+func (service *Service) logGenerationFailureDetail(run Run, err error) {
+	if service.logger == nil || err == nil {
+		return
+	}
+	cause := err
+	for errors.Unwrap(cause) != nil {
+		cause = errors.Unwrap(cause)
+	}
+	service.logger.Error(
+		"agent.run.generation_failed",
+		"run_id", run.ID,
+		"thread_id", run.ThreadID,
+		"detail", cause.Error(),
 	)
 }
 

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -660,10 +660,12 @@ func decodeCompletionStream(
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			return protocol.TextResult{}, errors.New("decode Qianwen stream event")
 		}
+		chunkID := sanitizeIdentifier(chunk.ID)
+		chunkModel, _ := normalizeModel(chunk.Model)
 		if completionID == "" {
-			completionID = sanitizeIdentifier(chunk.ID)
-			model, _ = normalizeModel(chunk.Model)
-		} else if chunk.ID != completionID || chunk.Model != model {
+			completionID = chunkID
+			model = chunkModel
+		} else if chunkID != completionID || chunkModel != model {
 			return protocol.TextResult{}, errors.New("Qianwen stream changed completion identity")
 		}
 		if completionID == "" || model == "" {
@@ -690,6 +692,12 @@ func decodeCompletionStream(
 				return protocol.TextResult{}, errors.New("Qianwen stream has invalid token usage")
 			}
 			sawUsage = true
+			continue
+		}
+		// Official OpenAI-compatible examples consume chunks by state: choice
+		// chunks carry deltas, while the final empty-choice chunk carries usage.
+		// Provider metadata-only chunks do not change the completion.
+		if len(chunk.Choices) == 0 {
 			continue
 		}
 		if sawUsage || len(chunk.Choices) != 1 {
@@ -759,7 +767,7 @@ func decodeCompletionStream(
 			}
 		}
 		if choice.FinishReason != nil {
-			if finishReason != "" {
+			if finishReason != "" && finishReason != *choice.FinishReason {
 				return protocol.TextResult{}, errors.New("Qianwen stream duplicated finish reason")
 			}
 			finishReason = *choice.FinishReason

--- a/server/internal/providers/qianwen/text_generator_test.go
+++ b/server/internal/providers/qianwen/text_generator_test.go
@@ -163,6 +163,38 @@ func TestGenerateStreamEmitsCanonicalVisibleText(t *testing.T) {
 	}
 }
 
+func TestGenerateStreamFollowsOfficialChunkStateFlow(t *testing.T) {
+	t.Parallel()
+
+	doer := doerFunc(func(*http.Request) (*http.Response, error) {
+		return streamResponse(
+			`data: {"id":"chatcmpl-official-flow","model":"qwen3.5-flash","choices":[{"delta":{"role":"assistant","content":""}}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-official-flow","model":"qwen3.5-flash","choices":[{"delta":{"content":"Let"}}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-official-flow","model":"qwen3.5-flash","choices":[]}` + "\n\n" +
+				`data: {"id":"chatcmpl-official-flow","model":"qwen3.5-flash","choices":[{"delta":{"content":"'s practice."},"finish_reason":"stop"}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-official-flow","model":"qwen3.5-flash","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":4,"total_tokens":14}}` + "\n\n" +
+				"data: [DONE]\n\n",
+		), nil
+	})
+	generator := mustGenerator(t, doer, "test-api-key")
+	var deltas []string
+	result, err := generator.GenerateStream(
+		context.Background(),
+		validRequest(),
+		protocol.TextDeltaObserverFunc(func(_ context.Context, delta string) error {
+			deltas = append(deltas, delta)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("generate stream: %v", err)
+	}
+	if got := strings.Join(deltas, ""); got != "Let's practice." ||
+		result.Content != got || result.Usage.TotalTokens != 14 {
+		t.Fatalf("result = %#v, deltas = %#v", result, deltas)
+	}
+}
+
 func TestGenerateStreamKeepsToolFragmentsPrivate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 功能说明

语音确认后立即建立回复流，逐段显示 Agent 内容，并避免重启恢复时把语音消息错误重放到文本接口。

## 实现思路

- 语音确认接口支持 SSE 事件流，按提交、开始、增量、完成或失败返回
- 移动端将临时回复气泡原位更新为最终权威消息
- 语音消息恢复时跳过文本 Run 重放
- 修正千问流式事件解析及完成阶段处理

## 测试

- `cd server && go test ./internal/agent/input/voice/... ./internal/agent/run/... ./internal/providers/qianwen/...`
- `cd mobile && flutter test test/agent/agent_voice_flow_test.dart test/agent/wire_agent_client_test.dart test/agent/wire_agent_voice_client_test.dart`
- `git diff --check`

Closes #433