### PR TITLE
[MS3][全栈] 建立可复用实时连接并流式传输语音

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -347,7 +347,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onOpenReview: () => _selectDestination(2),
         onMessageHandoff: (handoff) => unawaited(_confirmAgentHandoff(handoff)),
         onStartVoice: widget.composerController.supportsAgentVoice
-            ? widget.composerController.startAgentVoiceRecording
+            ? () async {
+                await widget.messageAudioController?.stopPlayback();
+                await widget.composerController.startAgentVoiceRecording();
+              }
             : null,
         voiceController: widget.composerController.voiceController,
         messageAudioController: widget.messageAudioController,

--- a/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
@@ -57,6 +57,14 @@ abstract interface class AgentVoiceStreamingClient {
   });
 }
 
+abstract interface class AgentVoiceRealtimeInputClient {
+  Stream<AgentVoiceTranscriptionEvent> createCandidateRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  });
+}
+
 /// Explicit preview/test provider for voice drafts and committed Message audio.
 final class FakeAgentVoiceClient
     implements

--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -86,6 +86,7 @@ final class AgentVoiceController extends ChangeNotifier
   bool _backgrounded = false;
   int _lifecycleGeneration = 0;
   Future<void>? _workflowOperation;
+  Future<_RealtimeCandidateResult>? _realtimeCandidate;
   Future<void>? _cleanupFuture;
 
   bool _draftPlaying = false;
@@ -186,7 +187,22 @@ final class AgentVoiceController extends ChangeNotifier
       if (!_isWorkflowCurrent(fence)) {
         return;
       }
-      await recorder.start();
+      if (recorder case final AgentVoiceStreamingRecorder streamingRecorder
+          when client is AgentVoiceRealtimeInputClient) {
+        final idempotencyKey = _newId('voice-upload');
+        final chunks = await streamingRecorder.startAudioStream();
+        _uploadIdempotencyKey = idempotencyKey;
+        _realtimeCandidate = _collectRealtimeCandidate(
+          fence,
+          (client as AgentVoiceRealtimeInputClient).createCandidateRealtime(
+            threadId: fence.threadId,
+            audioChunks: chunks,
+            idempotencyKey: idempotencyKey,
+          ),
+        );
+      } else {
+        await recorder.start();
+      }
       if (!_isWorkflowCurrent(fence)) {
         await recorder.discardCurrent();
         return;
@@ -234,27 +250,89 @@ final class AgentVoiceController extends ChangeNotifier
   }
 
   Future<void> _stopRecording(_WorkflowFence fence) async {
+    final usedRealtimeInput = _realtimeCandidate != null;
     try {
-      final recording = await recorder.stop();
+      final realtime = _realtimeCandidate;
+      final recording =
+          realtime != null && recorder is AgentVoiceStreamingRecorder
+          ? await (recorder as AgentVoiceStreamingRecorder).stopAudioStream()
+          : await recorder.stop();
       if (!_isWorkflowCurrent(fence)) {
         await recorder.discard(recording);
         return;
       }
       _recording = recording;
       _recordingElapsed = recording.duration;
-      _uploadIdempotencyKey = _newId('voice-upload');
-      _state = AgentVoiceComposerState.recorded;
+      if (realtime == null) {
+        _uploadIdempotencyKey = _newId('voice-upload');
+        _state = AgentVoiceComposerState.recorded;
+      } else {
+        _state = AgentVoiceComposerState.transcribing;
+        notifyListeners();
+        final result = await realtime;
+        _realtimeCandidate = null;
+        if (result.error case final error?) {
+          throw error;
+        }
+        final candidate = result.candidate;
+        if (candidate == null) {
+          throw StateError('Realtime voice stream ended without a candidate.');
+        }
+        _validateCandidate(candidate, expectedThreadId: fence.threadId);
+        _candidate = candidate;
+        _recording = null;
+        await _discardRecordingBestEffort(recording);
+        if (!_isWorkflowCurrent(fence)) {
+          await _deleteCandidateBestEffort(candidate.id);
+          return;
+        }
+        await _resolveCandidate(fence, candidate);
+        return;
+      }
       _errorMessage = null;
       _retry = null;
     } catch (error) {
       if (_isWorkflowCurrent(fence)) {
+        _realtimeCandidate = null;
         _state = AgentVoiceComposerState.failed;
-        _errorMessage = _recordingFailureMessage(error);
-        _retry = _VoiceRetry.start;
+        if (usedRealtimeInput && _recording != null) {
+          _errorMessage = _uploadFailureMessage(error);
+          _retry = _VoiceRetry.upload;
+        } else {
+          _errorMessage = _recordingFailureMessage(error);
+          _retry = _VoiceRetry.start;
+        }
       }
     }
     if (_isWorkflowCurrent(fence)) {
       notifyListeners();
+    }
+  }
+
+  Future<_RealtimeCandidateResult> _collectRealtimeCandidate(
+    _WorkflowFence fence,
+    Stream<AgentVoiceTranscriptionEvent> events,
+  ) async {
+    AgentVoiceCandidate? completed;
+    try {
+      await for (final event in events) {
+        if (!_isWorkflowCurrent(fence)) {
+          if (event case AgentVoiceCandidateCompleted(:final candidate)) {
+            await _deleteCandidateBestEffort(candidate.id);
+          }
+          continue;
+        }
+        switch (event) {
+          case AgentVoiceTranscriptUpdated(:final text):
+            _liveTranscript = text;
+            notifyListeners();
+          case AgentVoiceCandidateCompleted(:final candidate):
+            completed = candidate;
+        }
+      }
+      return _RealtimeCandidateResult(candidate: completed);
+    } catch (error) {
+      return _RealtimeCandidateResult(error: error);
     }
   }
 
@@ -265,6 +343,7 @@ final class AgentVoiceController extends ChangeNotifier
     _draftPlaybackGeneration++;
     _cancelRecordingTimers();
     _resetWorkflowPresentation();
+    _realtimeCandidate = null;
     _resetDraftPlayback();
     if (!_disposed) {
       notifyListeners();
@@ -1300,6 +1379,7 @@ final class AgentVoiceController extends ChangeNotifier
     _confirmationCommand = null;
     _runRetrySourceRunId = null;
     _runRetryId = null;
+    _realtimeCandidate = null;
     _recordingElapsed = Duration.zero;
   }
 
@@ -1583,6 +1663,13 @@ final class AgentVoiceController extends ChangeNotifier
     }
     return '确认尚未完成，文字与录音已保留，可以重试。';
   }
+}
+
+final class _RealtimeCandidateResult {
+  const _RealtimeCandidateResult({this.candidate, this.error});
+
+  final AgentVoiceCandidate? candidate;
+  final Object? error;
 }
 
 final class _AsrRetryCommand {

--- a/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
@@ -19,6 +20,12 @@ abstract interface class AgentVoiceRecorder {
   Future<void> clearAccountState();
 }
 
+abstract interface class AgentVoiceStreamingRecorder {
+  Future<Stream<Uint8List>> startAudioStream();
+
+  Future<AgentVoiceLocalRecording> stopAudioStream();
+}
+
 final class AgentVoiceRecordingException implements Exception {
   const AgentVoiceRecordingException(this.kind);
 
@@ -38,6 +45,8 @@ abstract interface class NativeAgentVoiceRecorder {
   Future<bool> hasPermission();
 
   Future<void> startWav(String path);
+
+  Future<Stream<Uint8List>> startPcm16Stream();
 
   Future<String?> stop();
 }
@@ -68,12 +77,27 @@ final class RecordNativeAgentVoiceRecorder implements NativeAgentVoiceRecorder {
   }
 
   @override
+  Future<Stream<Uint8List>> startPcm16Stream() {
+    return _recorder.startStream(
+      const RecordConfig(
+        encoder: AudioEncoder.pcm16bits,
+        sampleRate: 16000,
+        numChannels: 1,
+        autoGain: false,
+        echoCancel: false,
+        noiseSuppress: false,
+      ),
+    );
+  }
+
+  @override
   Future<String?> stop() => _recorder.stop();
 }
 
 typedef AgentVoiceClock = DateTime Function();
 
-final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
+final class IosAgentVoiceRecorder
+    implements AgentVoiceRecorder, AgentVoiceStreamingRecorder {
   IosAgentVoiceRecorder({
     NativeAgentVoiceRecorder? recorder,
     Future<Directory> Function()? temporaryDirectory,
@@ -85,6 +109,7 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
   static const _managedDirectoryName = 'speakup-agent-voice-recordings';
   static const _minimumWavBytes = 45;
   static const _maximumWavBytes = 7400000;
+  static const _maximumPCMBytes = 16000 * 2 * 60;
 
   final NativeAgentVoiceRecorder _recorder;
   final Future<Directory> Function() _temporaryDirectory;
@@ -92,6 +117,10 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
   final Random _random = Random.secure();
   String? _activePath;
   DateTime? _startedAt;
+  BytesBuilder? _activePCM;
+  StreamSubscription<Uint8List>? _pcmSubscription;
+  Completer<void>? _pcmDone;
+  StreamController<Uint8List>? _pcmOutput;
 
   @override
   Future<void> start() async {
@@ -115,6 +144,68 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
       _activePath = null;
       _startedAt = null;
       await _deletePath(path);
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.unavailable,
+      );
+    }
+  }
+
+  @override
+  Future<Stream<Uint8List>> startAudioStream() async {
+    if (_activePath != null) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.alreadyRecording,
+      );
+    }
+    if (!await _recorder.hasPermission()) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.permissionDenied,
+      );
+    }
+    final directory = await _managedDirectory();
+    final path = '${directory.path}/${_newFileName()}';
+    _activePath = path;
+    _startedAt = _clock();
+    final pcm = BytesBuilder(copy: false);
+    final done = Completer<void>();
+    final output = StreamController<Uint8List>();
+    _activePCM = pcm;
+    _pcmDone = done;
+    _pcmOutput = output;
+    try {
+      final input = await _recorder.startPcm16Stream();
+      _pcmSubscription = input.listen(
+        (chunk) {
+          if (pcm.length + chunk.lengthInBytes > _maximumPCMBytes) {
+            output.addError(
+              const AgentVoiceRecordingException(
+                AgentVoiceRecordingFailureKind.invalidAudio,
+              ),
+            );
+            return;
+          }
+          pcm.add(chunk);
+          output.add(chunk);
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          output.addError(error, stackTrace);
+          if (!done.isCompleted) {
+            done.completeError(error, stackTrace);
+          }
+        },
+        onDone: () {
+          output.close();
+          if (!done.isCompleted) {
+            done.complete();
+          }
+        },
+        cancelOnError: true,
+      );
+      return output.stream;
+    } catch (_) {
+      _clearStreamingState();
+      _activePath = null;
+      _startedAt = null;
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.unavailable,
       );
@@ -187,6 +278,50 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
   }
 
   @override
+  Future<AgentVoiceLocalRecording> stopAudioStream() async {
+    final path = _activePath;
+    final startedAt = _startedAt;
+    final pcm = _activePCM;
+    final done = _pcmDone;
+    if (path == null || startedAt == null || pcm == null || done == null) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.notRecording,
+      );
+    }
+    _activePath = null;
+    _startedAt = null;
+    try {
+      await _recorder.stop();
+      await done.future.timeout(const Duration(seconds: 2));
+      final pcmBytes = pcm.takeBytes();
+      if (pcmBytes.isEmpty || pcmBytes.lengthInBytes.isOdd) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.emptyAudio,
+        );
+      }
+      final wav = _pcm16MonoWav(pcmBytes, sampleRate: 16000);
+      await File(path).writeAsBytes(wav, flush: true);
+      final elapsed = _boundedRecordingDuration(startedAt);
+      return AgentVoiceLocalRecording(
+        path: path,
+        contentType: 'audio/wav',
+        sizeBytes: wav.lengthInBytes,
+        duration: elapsed,
+      );
+    } on AgentVoiceRecordingException {
+      await _deletePath(path);
+      rethrow;
+    } catch (_) {
+      await _deletePath(path);
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.unavailable,
+      );
+    } finally {
+      _clearStreamingState();
+    }
+  }
+
+  @override
   Future<void> discardCurrent() async {
     final path = _activePath;
     _activePath = null;
@@ -199,7 +334,26 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
     } catch (_) {
       // The owned path is still removed below.
     }
+    await _pcmSubscription?.cancel();
+    await _pcmOutput?.close();
+    _clearStreamingState();
     await _deletePath(path);
+  }
+
+  Duration _boundedRecordingDuration(DateTime startedAt) {
+    final elapsed = _clock().difference(startedAt);
+    return elapsed <= Duration.zero
+        ? const Duration(milliseconds: 1)
+        : elapsed > const Duration(seconds: 60)
+        ? const Duration(seconds: 60)
+        : elapsed;
+  }
+
+  void _clearStreamingState() {
+    _activePCM = null;
+    _pcmSubscription = null;
+    _pcmDone = null;
+    _pcmOutput = null;
   }
 
   @override
@@ -271,6 +425,26 @@ final class IosAgentVoiceRecorder implements AgentVoiceRecorder {
       );
     }
   }
+}
+
+Uint8List _pcm16MonoWav(Uint8List pcm, {required int sampleRate}) {
+  final result = Uint8List(44 + pcm.lengthInBytes);
+  final data = ByteData.sublistView(result);
+  result.setRange(0, 4, 'RIFF'.codeUnits);
+  data.setUint32(4, result.lengthInBytes - 8, Endian.little);
+  result.setRange(8, 12, 'WAVE'.codeUnits);
+  result.setRange(12, 16, 'fmt '.codeUnits);
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, 1, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, sampleRate * 2, Endian.little);
+  data.setUint16(32, 2, Endian.little);
+  data.setUint16(34, 16, Endian.little);
+  result.setRange(36, 40, 'data'.codeUnits);
+  data.setUint32(40, pcm.lengthInBytes, Endian.little);
+  result.setRange(44, result.lengthInBytes, pcm);
+  return result;
 }
 
 final class FakeAgentVoiceRecorder implements AgentVoiceRecorder {

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -75,6 +75,16 @@ final class AgentMessageAudioController extends ChangeNotifier
     return _toggleMessagePlayback(message);
   }
 
+  Future<void> stopPlayback() {
+    if (_disposed) {
+      return Future<void>.value();
+    }
+    _generation++;
+    _resetPlaybackPresentation();
+    notifyListeners();
+    return audioPlayer.stop();
+  }
+
   Future<void> _toggleMessagePlayback(
     AgentMessage message, {
     String? previewText,

--- a/mobile/lib/identity/network/authenticated_web_socket.dart
+++ b/mobile/lib/identity/network/authenticated_web_socket.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/platform/network/web_socket_transport.dart';
 
 import 'bearer_authentication.dart';
 import 'transport_security.dart';
@@ -159,10 +160,21 @@ final class SessionAuthenticatedWebSocketConnector {
 
 final class IoAuthenticatedWebSocketConnector
     implements AuthenticatedWebSocketConnector {
-  IoAuthenticatedWebSocketConnector({WebSocketDialer? dialer})
-    : _dialer = dialer ?? WebSocket.connect;
+  IoAuthenticatedWebSocketConnector({
+    WebSocketDialer? dialer,
+    PlatformWebSocketTransport? transport,
+    Iterable<String> protocols = const <String>[identityWebSocketProtocol],
+  }) : _transport =
+           transport ??
+           IoPlatformWebSocketTransport(dialer: dialer ?? WebSocket.connect),
+       _protocols = List<String>.unmodifiable(protocols) {
+    if (_protocols.isEmpty || _protocols.any((value) => value.trim().isEmpty)) {
+      throw ArgumentError('At least one WebSocket protocol is required.');
+    }
+  }
 
-  final WebSocketDialer _dialer;
+  final PlatformWebSocketTransport _transport;
+  final List<String> _protocols;
 
   @override
   Future<WebSocket> connect({
@@ -172,14 +184,14 @@ final class IoAuthenticatedWebSocketConnector
     _validateUri(uri, sessionToken);
     final authorization = bearerAuthorizationValue(sessionToken);
     try {
-      return await _dialer(
-        uri.toString(),
-        protocols: const <String>[identityWebSocketProtocol],
+      return await _transport.connect(
+        uri: uri,
+        protocols: _protocols,
         headers: <String, dynamic>{
           HttpHeaders.authorizationHeader: authorization,
         },
       );
-    } on WebSocketException catch (error) {
+    } on PlatformWebSocketException catch (error) {
       throw AuthenticatedWebSocketException(
         error.httpStatusCode == HttpStatus.unauthorized
             ? WebSocketFailureKind.authenticationInvalid

--- a/mobile/lib/platform/network/web_socket_transport.dart
+++ b/mobile/lib/platform/network/web_socket_transport.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+typedef PlatformWebSocketDialer =
+    Future<WebSocket> Function(
+      String url, {
+      Iterable<String>? protocols,
+      Map<String, dynamic>? headers,
+    });
+
+final class PlatformWebSocketException implements Exception {
+  const PlatformWebSocketException({this.httpStatusCode});
+
+  final int? httpStatusCode;
+}
+
+abstract interface class PlatformWebSocketTransport {
+  Future<WebSocket> connect({
+    required Uri uri,
+    required Iterable<String> protocols,
+    required Map<String, dynamic> headers,
+  });
+}
+
+/// Protocol-neutral WebSocket transport shared by authenticated product flows.
+final class IoPlatformWebSocketTransport implements PlatformWebSocketTransport {
+  IoPlatformWebSocketTransport({PlatformWebSocketDialer? dialer})
+    : _dialer = dialer ?? WebSocket.connect;
+
+  final PlatformWebSocketDialer _dialer;
+
+  @override
+  Future<WebSocket> connect({
+    required Uri uri,
+    required Iterable<String> protocols,
+    required Map<String, dynamic> headers,
+  }) async {
+    if (uri.scheme != 'ws' && uri.scheme != 'wss') {
+      throw ArgumentError('WebSocket URI must use ws or wss.');
+    }
+    if (!uri.hasAuthority || uri.host.isEmpty) {
+      throw ArgumentError('WebSocket URI must include a host.');
+    }
+    if (uri.hasFragment) {
+      throw ArgumentError('WebSocket URI must not include a fragment.');
+    }
+    if (uri.userInfo.isNotEmpty) {
+      throw ArgumentError('WebSocket URI must not contain credentials.');
+    }
+    try {
+      return await _dialer(
+        uri.toString(),
+        protocols: protocols,
+        headers: headers,
+      );
+    } on WebSocketException catch (error) {
+      throw PlatformWebSocketException(httpStatusCode: error.httpStatusCode);
+    } on SocketException {
+      throw const PlatformWebSocketException();
+    } on HttpException {
+      throw const PlatformWebSocketException();
+    } catch (_) {
+      throw const PlatformWebSocketException();
+    }
+  }
+}

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/bearer_authentication.dart';
+import 'package:speakup/identity/network/authenticated_web_socket.dart';
 import 'package:speakup/identity/network/transport_security.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff_codec.dart';
@@ -72,6 +73,7 @@ final class WireAgentVoiceClient
     implements
         AgentVoiceClient,
         AgentVoiceStreamingClient,
+        AgentVoiceRealtimeInputClient,
         AgentMessageAudioClient {
   factory WireAgentVoiceClient({
     required Uri baseUri,
@@ -80,6 +82,7 @@ final class WireAgentVoiceClient
     AgentVoiceWireTransport? apiTransport,
     AgentVoiceWireTransport? signedAudioTransport,
     AgentVoiceWireTransportFactory? transportFactory,
+    AuthenticatedWebSocketConnector? realtimeConnector,
     AgentVoiceNow? now,
     Duration requestTimeout = const Duration(seconds: 75),
   }) {
@@ -103,6 +106,16 @@ final class WireAgentVoiceClient
       apiTransport == null,
       signedAudioTransport == null,
       createTransport,
+      SessionAuthenticatedWebSocketConnector(
+        connector:
+            realtimeConnector ??
+            IoAuthenticatedWebSocketConnector(
+              protocols: const <String>[_voiceInputWebSocketProtocol],
+            ),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: _webSocketBaseUri(baseUri),
+      ),
       requestTimeout,
       now ?? _utcNow,
     );
@@ -118,6 +131,7 @@ final class WireAgentVoiceClient
     this._ownsApiTransport,
     this._ownsSignedAudioTransport,
     this._transportFactory,
+    this._realtimeConnector,
     this._requestTimeout,
     this._now,
   );
@@ -126,6 +140,7 @@ final class WireAgentVoiceClient
   static const _maximumAudioBytes = 7400000;
   static const _maximumPlaybackLifetime = Duration(minutes: 2);
   static const _maximumLocalClockSkew = Duration(seconds: 30);
+  static const _voiceInputWebSocketProtocol = 'speakup.voice-input.v1';
 
   final Uri _baseUri;
   final TrustedIdentityHttpOrigin _trustedOrigin;
@@ -136,6 +151,7 @@ final class WireAgentVoiceClient
   final bool _ownsApiTransport;
   final bool _ownsSignedAudioTransport;
   final AgentVoiceWireTransportFactory _transportFactory;
+  final SessionAuthenticatedWebSocketConnector _realtimeConnector;
   final Duration _requestTimeout;
   final AgentVoiceNow _now;
 
@@ -215,20 +231,12 @@ final class WireAgentVoiceClient
             kind: AgentClientFailureKind.invalidRequest,
           );
         }
-        final response = await _openApiStream(
-          generation: generation,
-          method: 'POST',
-          path:
-              '/v1/agent-threads/${Uri.encodeComponent(threadId)}/voice-message-candidates/stream',
-          accept: 'text/event-stream',
-          contentType: 'audio/wav',
-          headers: <String, String>{'Idempotency-Key': idempotencyKey},
-          body: bytes,
-          maximumResponseBytes: _maximumJsonBytes,
-        );
-        await for (final event in _decodeTranscriptionEvents(
-          response,
-          expectedThreadId: threadId,
+        await for (final event in createCandidateRealtime(
+          threadId: threadId,
+          audioChunks: Stream<Uint8List>.value(
+            Uint8List.sublistView(bytes, 44),
+          ),
+          idempotencyKey: idempotencyKey,
         )) {
           _requireGeneration(generation);
           yield event;
@@ -260,6 +268,86 @@ final class WireAgentVoiceClient
     } finally {
       _inFlight.remove(marker);
       completion.complete();
+    }
+  }
+
+  @override
+  Stream<AgentVoiceTranscriptionEvent> createCandidateRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) async* {
+    _requireUuid(threadId);
+    _requireClientIdentity(idempotencyKey, minimumLength: 8);
+    final generation = _accountGeneration;
+    final uri = _webSocketBaseUri(_baseUri).resolve(
+      '/v1/agent-threads/${Uri.encodeComponent(threadId)}/voice-message-candidates/realtime',
+    );
+    SessionAuthenticatedWebSocketConnection? connection;
+    try {
+      connection = await _realtimeConnector.connect(uri: uri);
+      _requireGeneration(generation);
+      connection.socket.add(
+        jsonEncode(<String, Object>{
+          'type': 'start',
+          'idempotency_key': idempotencyKey,
+          'sample_rate': 16000,
+        }),
+      );
+      await for (final chunk in audioChunks) {
+        _requireGeneration(generation);
+        if (chunk.isEmpty || chunk.lengthInBytes > _maximumAudioBytes) {
+          throw const AgentClientException(
+            kind: AgentClientFailureKind.invalidRequest,
+          );
+        }
+        connection.socket.add(chunk);
+      }
+      connection.socket.add(
+        jsonEncode(const <String, String>{'type': 'finish'}),
+      );
+      await for (final message in connection.socket) {
+        _requireGeneration(generation);
+        if (message is! String) {
+          throw _invalidResponse();
+        }
+        final envelope = _strictObject(
+          jsonDecode(message),
+          allowed: const <String>{'type', 'data'},
+          required: const <String>{'type', 'data'},
+        );
+        final event = _strictString(envelope['type'], min: 1, max: 64);
+        final decoded = _decodeTranscriptionEvent(
+          event,
+          jsonEncode(envelope['data']),
+          expectedThreadId: threadId,
+        );
+        if (decoded != null) {
+          yield decoded;
+        }
+        if (event == 'candidate.ready' || event == 'candidate.failed') {
+          return;
+        }
+      }
+      await connection.handleDisconnect(
+        closeCode: connection.socket.closeCode,
+        closeReason: connection.socket.closeReason,
+      );
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
+    } on AuthenticatedWebSocketException catch (error) {
+      throw AgentClientException(
+        kind: error.invalidatesAuthentication
+            ? AgentClientFailureKind.authenticationRequired
+            : AgentClientFailureKind.network,
+        retryable: !error.invalidatesAuthentication,
+      );
+    } on FormatException {
+      throw _invalidResponse();
+    } finally {
+      await connection?.socket.close();
     }
   }
 
@@ -841,88 +929,6 @@ final class WireAgentVoiceClient
         kind: AgentClientFailureKind.network,
         retryable: true,
       );
-    }
-  }
-
-  Stream<AgentVoiceTranscriptionEvent> _decodeTranscriptionEvents(
-    AgentVoiceWireStreamResponse response, {
-    required String expectedThreadId,
-  }) async* {
-    var responseBytes = 0;
-    var eventName = '';
-    var eventData = '';
-    var started = false;
-    var completed = false;
-    try {
-      final lines = response.body
-          .map((chunk) {
-            responseBytes += chunk.length;
-            if (responseBytes > _maximumJsonBytes) {
-              throw _invalidResponse();
-            }
-            return chunk;
-          })
-          .cast<List<int>>()
-          .transform(utf8.decoder)
-          .transform(const LineSplitter());
-      await for (final line in lines.timeout(_requestTimeout)) {
-        if (line.isEmpty) {
-          if (eventName.isEmpty && eventData.isEmpty) {
-            continue;
-          }
-          if (completed) {
-            throw _invalidResponse();
-          }
-          final decoded = _decodeTranscriptionEvent(
-            eventName,
-            eventData,
-            expectedThreadId: expectedThreadId,
-          );
-          if (eventName == 'transcription.started') {
-            if (started || decoded != null) {
-              throw _invalidResponse();
-            }
-            started = true;
-          } else {
-            if (!started || decoded == null) {
-              throw _invalidResponse();
-            }
-            if (decoded is AgentVoiceCandidateCompleted) {
-              completed = true;
-            }
-            yield decoded;
-          }
-          eventName = '';
-          eventData = '';
-          continue;
-        }
-        if (line.startsWith(':')) {
-          continue;
-        }
-        if (line.startsWith('event: ')) {
-          if (eventName.isNotEmpty) {
-            throw _invalidResponse();
-          }
-          eventName = line.substring(7);
-          continue;
-        }
-        if (line.startsWith('data: ')) {
-          if (eventData.isNotEmpty) {
-            throw _invalidResponse();
-          }
-          eventData = line.substring(6);
-          continue;
-        }
-        throw _invalidResponse();
-      }
-    } on _InvalidVoiceResponse {
-      throw _invalidResponse();
-    }
-    if (!started ||
-        !completed ||
-        eventName.isNotEmpty ||
-        eventData.isNotEmpty) {
-      throw _invalidResponse();
     }
   }
 
@@ -2291,6 +2297,15 @@ void _zero(Uint8List bytes) {
 }
 
 DateTime _utcNow() => DateTime.now().toUtc();
+
+Uri _webSocketBaseUri(Uri httpBaseUri) {
+  final scheme = switch (httpBaseUri.scheme) {
+    'https' => 'wss',
+    'http' => 'ws',
+    _ => throw ArgumentError('Agent voice base URI must use HTTP or HTTPS.'),
+  };
+  return httpBaseUri.replace(scheme: scheme);
+}
 
 final RegExp _uuidPattern = RegExp(
   r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',

--- a/mobile/test/agent/agent_voice_fence_test.dart
+++ b/mobile/test/agent/agent_voice_fence_test.dart
@@ -17,6 +17,26 @@ import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
 import 'package:speakup/features/agent/conversation/conversation.dart';
 
 void main() {
+  test('production-capable recorder uses realtime input before stop', () async {
+    final client = _ControlledVoiceClient();
+    final recorder = _StreamingVoiceRecorder();
+    final controller = _controller(
+      client,
+      <AgentMessage>[],
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+
+    await controller.startRecording();
+    expect(controller.state, AgentVoiceComposerState.recording);
+    await controller.stopRecording();
+
+    expect(client.realtimeCalls, 1);
+    expect(client.fileUploadCalls, 0);
+    expect(controller.state, AgentVoiceComposerState.awaitingConfirmation);
+    expect(controller.editedTranscript, 'Candidate text');
+  });
   test('late upload result cannot cross the Thread fence', () async {
     final client = _ControlledVoiceClient();
     final committed = <AgentMessage>[];
@@ -724,11 +744,54 @@ Future<void> _pumpVoiceOperation(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 50));
 }
 
+final class _StreamingVoiceRecorder
+    implements AgentVoiceRecorder, AgentVoiceStreamingRecorder {
+  StreamController<Uint8List>? _stream;
+
+  @override
+  Future<Stream<Uint8List>> startAudioStream() async {
+    final stream = StreamController<Uint8List>();
+    _stream = stream;
+    stream.add(Uint8List.fromList(<int>[1, 2, 3, 4]));
+    return stream.stream;
+  }
+
+  @override
+  Future<AgentVoiceLocalRecording> stopAudioStream() async {
+    await _stream?.close();
+    _stream = null;
+    return const AgentVoiceLocalRecording(
+      path: '/tmp/realtime.wav',
+      contentType: 'audio/wav',
+      sizeBytes: 48,
+      duration: Duration(seconds: 1),
+    );
+  }
+
+  @override
+  Future<void> start() => throw UnimplementedError();
+
+  @override
+  Future<AgentVoiceLocalRecording> stop() => throw UnimplementedError();
+
+  @override
+  Future<void> discardCurrent() async {
+    await _stream?.close();
+    _stream = null;
+  }
+
+  @override
+  Future<void> discard(AgentVoiceLocalRecording recording) async {}
+
+  @override
+  Future<void> clearAccountState() => discardCurrent();
+}
+
 AgentVoiceController _controller(
   _ControlledVoiceClient client,
   List<AgentMessage> committed, {
   FakeAgentAudioPlayer? player,
-  FakeAgentVoiceRecorder? recorder,
+  AgentVoiceRecorder? recorder,
   AgentVoiceControllerClock? clock,
   Duration recordingLimit = const Duration(seconds: 58),
 }) {
@@ -877,7 +940,10 @@ typedef _ConfirmationCall = ({
 typedef _RetryRunCall = ({String runId, String clientRetryId});
 
 final class _ControlledVoiceClient
-    implements AgentVoiceClient, AgentMessageAudioClient {
+    implements
+        AgentVoiceClient,
+        AgentVoiceRealtimeInputClient,
+        AgentMessageAudioClient {
   Completer<AgentVoiceCandidate>? createCompleter;
   Completer<AgentVoiceConfirmation>? confirmCompleter;
   Completer<Uint8List>? speechCompleter;
@@ -898,6 +964,8 @@ final class _ControlledVoiceClient
   final List<String> getRunCalls = <String>[];
   final List<String> getMessageCalls = <String>[];
   final List<String> deletedCandidateIds = <String>[];
+  int realtimeCalls = 0;
+  int fileUploadCalls = 0;
 
   @override
   Stream<AgentVoiceTranscriptionEvent> createCandidateStream({
@@ -905,12 +973,28 @@ final class _ControlledVoiceClient
     required AgentVoiceLocalRecording recording,
     required String idempotencyKey,
   }) async* {
+    fileUploadCalls++;
     final candidate = await createCandidate(
       threadId: threadId,
       recording: recording,
       idempotencyKey: idempotencyKey,
     );
     yield AgentVoiceCandidateCompleted(candidate);
+  }
+
+  @override
+  Stream<AgentVoiceTranscriptionEvent> createCandidateRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) async* {
+    realtimeCalls++;
+    await for (final _ in audioChunks) {}
+    yield const AgentVoiceTranscriptUpdated(
+      text: 'Realtime candidate text.',
+      finalResult: true,
+    );
+    yield AgentVoiceCandidateCompleted(_readyCandidate(threadId: threadId));
   }
 
   @override

--- a/mobile/test/agent/agent_voice_recording_stream_test.dart
+++ b/mobile/test/agent/agent_voice_recording_stream_test.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
+
+void main() {
+  test(
+    'streaming recorder forwards PCM and retains one valid local WAV',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'agent-voice-stream-recorder-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final native = _StreamingNativeRecorder();
+      final recorder = IosAgentVoiceRecorder(
+        recorder: native,
+        temporaryDirectory: () async => directory,
+        clock: () => DateTime.utc(2026, 8, 6, 1, 0, 1),
+      );
+
+      final stream = await recorder.startAudioStream();
+      final forwarded = stream.expand((chunk) => chunk).toList();
+      native.add(Uint8List.fromList(<int>[0, 0, 1, 0]));
+      final recording = await recorder.stopAudioStream();
+
+      expect(await forwarded, <int>[0, 0, 1, 0]);
+      expect(recording.contentType, 'audio/wav');
+      expect(recording.sizeBytes, 48);
+      final bytes = await File(recording.path).readAsBytes();
+      expect(String.fromCharCodes(bytes.sublist(0, 4)), 'RIFF');
+      expect(String.fromCharCodes(bytes.sublist(8, 12)), 'WAVE');
+      expect(bytes.sublist(44), <int>[0, 0, 1, 0]);
+
+      await recorder.discard(recording);
+      expect(await File(recording.path).exists(), isFalse);
+    },
+  );
+}
+
+final class _StreamingNativeRecorder implements NativeAgentVoiceRecorder {
+  final StreamController<Uint8List> _chunks = StreamController<Uint8List>();
+
+  void add(Uint8List chunk) => _chunks.add(chunk);
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> startWav(String path) => throw UnimplementedError();
+
+  @override
+  Future<Stream<Uint8List>> startPcm16Stream() async => _chunks.stream;
+
+  @override
+  Future<String?> stop() async {
+    await _chunks.close();
+    return null;
+  }
+}

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
@@ -12,62 +13,80 @@ import 'package:speakup/features/agent/handoff/agent_handoff.dart';
 import 'package:speakup/identity/auth_state.dart';
 
 void main() {
-  test('uploads raw WAV to the exact candidate route', () async {
-    final root = await Directory.systemTemp.createTemp(
-      'agent-voice-wire-test-',
-    );
-    addTearDown(() => root.delete(recursive: true));
-    final file = File('${root.path}/message.wav');
-    await file.writeAsBytes(_waveBytes);
-    final transport = _ScriptedVoiceTransport([
-      _Step(
-        method: 'POST',
-        path: '/v1/agent-threads/$_threadId/voice-message-candidates/stream',
-        verify: (request) {
-          expect(
-            request.headers[HttpHeaders.authorizationHeader],
-            'Bearer sess_voice',
+  test('streams PCM chunks over the authenticated voice WebSocket', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    final received = <Object>[];
+    final handled = Completer<void>();
+    server.listen((request) async {
+      expect(
+        request.uri.path,
+        '/v1/agent-threads/$_threadId/voice-message-candidates/realtime',
+      );
+      expect(
+        request.headers.value(HttpHeaders.authorizationHeader),
+        'Bearer sess_voice',
+      );
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (protocols) => 'speakup.voice-input.v1',
+      );
+      await for (final message in socket) {
+        received.add(message);
+        if (message is String &&
+            (jsonDecode(message) as Map<String, dynamic>)['type'] == 'finish') {
+          socket.add(
+            jsonEncode(<String, Object>{
+              'type': 'candidate.failed',
+              'data': <String, Object>{
+                'kind': 'test_complete',
+                'retryable': true,
+              },
+            }),
           );
-          expect(request.headers[HttpHeaders.contentTypeHeader], 'audio/wav');
-          expect(request.headers['Idempotency-Key'], 'voice_upload_001');
-          expect(request.body, _waveBytes);
-        },
-        response: _sseResponse(<(String, Object?)>[
-          ('transcription.started', <String, Object?>{}),
-          (
-            'transcription.updated',
-            <String, Object?>{
-              'transcript': 'Candidate transcript',
-              'final': false,
-            },
-          ),
-          (
-            'candidate.ready',
-            <String, Object?>{
-              'candidate': _candidateJson(status: 'candidate_ready'),
-            },
-          ),
-        ]),
-      ),
-    ]);
-    final client = _client(transport);
+          await socket.close();
+          if (!handled.isCompleted) {
+            handled.complete();
+          }
+          break;
+        }
+      }
+    });
+    final baseUri = Uri.parse(
+      'http://${server.address.address}:${server.port}',
+    );
+    final client = WireAgentVoiceClient(
+      baseUri: baseUri,
+      credentialProvider: () => _credential,
+      invalidateSession: _ignoreInvalidation,
+      apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+    );
     addTearDown(client.dispose);
 
-    final candidate = await client.createCandidate(
-      threadId: _threadId,
-      recording: AgentVoiceLocalRecording(
-        path: file.path,
-        contentType: 'audio/wav',
-        sizeBytes: _waveBytes.length,
-        duration: const Duration(seconds: 3),
+    await expectLater(
+      client.createCandidateRealtime(
+        threadId: _threadId,
+        audioChunks: Stream<Uint8List>.fromIterable(<Uint8List>[
+          Uint8List.fromList(<int>[1, 2]),
+          Uint8List.fromList(<int>[3, 4]),
+        ]),
+        idempotencyKey: 'voice_realtime_001',
       ),
-      idempotencyKey: 'voice_upload_001',
+      emitsError(isA<AgentClientException>()),
     );
+    await handled.future;
 
-    expect(candidate.id, _candidateId);
-    expect(candidate.transcript?.text, 'Candidate transcript');
-    expect(candidate.status, AgentVoiceCandidateStatus.candidateReady);
-    transport.expectDone();
+    expect(jsonDecode(received.first as String), <String, Object?>{
+      'type': 'start',
+      'idempotency_key': 'voice_realtime_001',
+      'sample_rate': 16000,
+    });
+    expect(received[1], <int>[1, 2]);
+    expect(received[2], <int>[3, 4]);
+    expect(jsonDecode(received.last as String), <String, Object?>{
+      'type': 'finish',
+    });
   });
 
   test('confirms one voice Message with exact strict JSON', () async {

--- a/server/internal/agent/input/voice/http/handler.go
+++ b/server/internal/agent/input/voice/http/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
@@ -16,7 +15,6 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpinput"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
-	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 	"github.com/gin-gonic/gin"
@@ -25,11 +23,6 @@ import (
 const defaultReadTimeout = 15 * time.Second
 
 type Application interface {
-	Upload(
-		context.Context,
-		requestcontext.Actor,
-		agentvoice.UploadRequest,
-	) (agentvoice.Candidate, error)
 	UploadStream(
 		context.Context,
 		requestcontext.Actor,
@@ -102,13 +95,9 @@ func NewHandler(
 }
 
 func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
-	routes.POST(
-		"/v1/agent-threads/:thread_id/voice-message-candidates",
-		handler.upload,
-	)
-	routes.POST(
-		"/v1/agent-threads/:thread_id/voice-message-candidates/stream",
-		handler.uploadStream,
+	routes.GET(
+		"/v1/agent-threads/:thread_id/voice-message-candidates/realtime",
+		handler.uploadRealtime,
 	)
 	routes.GET(
 		"/v1/agent-voice-message-candidates/:candidate_id",
@@ -130,93 +119,6 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 		"/v1/agent-voice-message-candidates/:candidate_id/confirmations/stream",
 		handler.confirmStream,
 	)
-}
-
-func (handler *Handler) upload(c *gin.Context) {
-	actor, request, cleanup, ok := handler.prepareUpload(c)
-	if !ok {
-		return
-	}
-	defer cleanup()
-	candidate, err := handler.application.Upload(
-		c.Request.Context(), actor, request,
-	)
-	if err != nil {
-		handler.write(c, mapError(err))
-		return
-	}
-	c.JSON(http.StatusCreated, CandidateResponse(candidate))
-}
-
-func (handler *Handler) uploadStream(c *gin.Context) {
-	actor, request, cleanup, ok := handler.prepareUpload(c)
-	if !ok {
-		return
-	}
-	defer cleanup()
-	controller := http.NewResponseController(c.Writer)
-	if err := controller.EnableFullDuplex(); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		handler.write(c, internalError(err))
-		return
-	}
-	stream := &transcriptionSSEWriter{context: c}
-	if err := stream.write("transcription.started", gin.H{}); err != nil {
-		return
-	}
-	candidate, err := handler.application.UploadStream(
-		c.Request.Context(), actor, request, stream,
-	)
-	if err != nil {
-		_ = stream.write("candidate.failed", gin.H{
-			"kind": "stream_interrupted", "retryable": true,
-		})
-		return
-	}
-	event := "candidate.ready"
-	if candidate.Status == agentvoice.StatusFailed {
-		event = "candidate.failed"
-	}
-	_ = stream.write(event, gin.H{"candidate": CandidateResponse(candidate)})
-}
-
-func (handler *Handler) prepareUpload(c *gin.Context) (
-	requestcontext.Actor,
-	agentvoice.UploadRequest,
-	func(),
-	bool,
-) {
-	key, ok := httpinput.IdempotencyKey(c.Request)
-	if !ok || c.Request.Body == nil ||
-		c.Request.ContentLength > platformmedia.MaxAudioBytes ||
-		!strings.EqualFold(
-			strings.TrimSpace(c.GetHeader("Content-Type")),
-			platformmedia.ContentTypeWAV,
-		) {
-		handler.write(c, invalidRequest(nil))
-		return requestcontext.Actor{}, agentvoice.UploadRequest{}, nil, false
-	}
-	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
-	if !ok {
-		handler.write(c, authenticationRequired())
-		return requestcontext.Actor{}, agentvoice.UploadRequest{}, nil, false
-	}
-	thread, err := handler.threads.GetThread(
-		c.Request.Context(), actor, c.Param("thread_id"),
-	)
-	if err != nil {
-		handler.write(c, mapThreadError(err))
-		return requestcontext.Actor{}, agentvoice.UploadRequest{}, nil, false
-	}
-	controller := http.NewResponseController(c.Writer)
-	if err := controller.SetReadDeadline(time.Now().Add(handler.readTimeout)); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		handler.write(c, internalError(err))
-		return requestcontext.Actor{}, agentvoice.UploadRequest{}, nil, false
-	}
-	body := http.MaxBytesReader(c.Writer, c.Request.Body, platformmedia.MaxAudioBytes)
-	return actor, agentvoice.UploadRequest{
-		ThreadID: thread.ID, IdempotencyKey: key,
-		ContentType: platformmedia.ContentTypeWAV, Audio: body,
-	}, func() { _ = controller.SetReadDeadline(time.Time{}) }, true
 }
 
 func (handler *Handler) get(c *gin.Context) {
@@ -420,42 +322,6 @@ func (writer *confirmationSSEWriter) OnAssistantDelta(
 }
 
 func (writer *confirmationSSEWriter) write(event string, data any) error {
-	encoded, err := json.Marshal(data)
-	if err != nil {
-		return err
-	}
-	if !writer.started {
-		writer.context.Header("Content-Type", "text/event-stream; charset=utf-8")
-		writer.context.Header("Cache-Control", "no-cache, no-store")
-		writer.context.Header("X-Accel-Buffering", "no")
-		writer.context.Header("Connection", "keep-alive")
-		writer.context.Status(http.StatusOK)
-		writer.started = true
-	}
-	if _, err := writer.context.Writer.WriteString(
-		"event: " + event + "\ndata: " + string(encoded) + "\n\n",
-	); err != nil {
-		return err
-	}
-	writer.context.Writer.Flush()
-	return writer.context.Request.Context().Err()
-}
-
-type transcriptionSSEWriter struct {
-	context *gin.Context
-	started bool
-}
-
-func (writer *transcriptionSSEWriter) OnTranscriptionUpdate(
-	_ context.Context,
-	update agentvoice.TranscriptionUpdate,
-) error {
-	return writer.write("transcription.updated", gin.H{
-		"transcript": update.Transcript, "final": update.Final,
-	})
-}
-
-func (writer *transcriptionSSEWriter) write(event string, data any) error {
 	encoded, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/server/internal/agent/input/voice/http/handler_test.go
+++ b/server/internal/agent/input/voice/http/handler_test.go
@@ -3,7 +3,6 @@ package voicehttp
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -50,72 +49,6 @@ func TestAgentVoiceInputHTTPVerticalContract(t *testing.T) {
 		now: now,
 	}
 	router := newAgentVoiceInputHTTPRouter(t, application)
-
-	upload := voiceHTTPRequest(
-		t,
-		router,
-		http.MethodPost,
-		"/v1/agent-threads/thread-1/voice-message-candidates",
-		voiceTestWAV(0x55),
-		map[string]string{
-			"Content-Type":    platformmedia.ContentTypeWAV,
-			"Idempotency-Key": "voice-http-upload-1",
-		},
-	)
-	if upload.Code != http.StatusCreated {
-		t.Fatalf("upload status = %d body = %s", upload.Code, upload.Body)
-	}
-	candidate := decodeVoiceJSONObject(t, upload)
-	if candidate["candidate_id"] != application.candidate.ID ||
-		candidate["status"] != string(agentvoice.StatusReady) ||
-		candidate["candidate_version"] != float64(1) ||
-		!strings.Contains(upload.Body.String(), "Provider candidate text.") ||
-		strings.Contains(upload.Body.String(), "private-server-key") ||
-		strings.Contains(upload.Body.String(), "checksum") ||
-		strings.Contains(upload.Body.String(), "owner") {
-		t.Fatalf("unsafe candidate response = %#v", candidate)
-	}
-	if application.uploadThreadID != "thread-1" ||
-		application.uploadKey != "voice-http-upload-1" ||
-		application.uploadBytes == 0 {
-		t.Fatalf("upload command = %#v", application)
-	}
-
-	streamed := voiceHTTPRequest(
-		t,
-		router,
-		http.MethodPost,
-		"/v1/agent-threads/thread-1/voice-message-candidates/stream",
-		voiceTestWAV(0x56),
-		map[string]string{
-			"Content-Type":    platformmedia.ContentTypeWAV,
-			"Idempotency-Key": "voice-http-stream-1",
-		},
-	)
-	if streamed.Code != http.StatusOK ||
-		!strings.HasPrefix(
-			streamed.Header().Get("Content-Type"),
-			"text/event-stream",
-		) {
-		t.Fatalf("stream status = %d headers = %#v body = %s",
-			streamed.Code,
-			streamed.Header(),
-			streamed.Body,
-		)
-	}
-	streamBody := streamed.Body.String()
-	started := strings.Index(streamBody, "event: transcription.started")
-	updated := strings.Index(streamBody, "event: transcription.updated")
-	ready := strings.Index(streamBody, "event: candidate.ready")
-	if started < 0 || updated <= started || ready <= updated ||
-		strings.Count(streamBody, "event: transcription.updated") != 2 ||
-		!strings.Contains(streamBody, `"transcript":"Provider candidate"`) ||
-		!strings.Contains(streamBody, `"final":false`) ||
-		!strings.Contains(streamBody, `"final":true`) ||
-		application.streamCalls != 1 ||
-		strings.Contains(streamBody, "private-server-key") {
-		t.Fatalf("unsafe or unordered stream = %s", streamBody)
-	}
 
 	for _, test := range []struct {
 		method string
@@ -509,32 +442,6 @@ func decodeVoiceJSONObject(
 	var result map[string]any
 	if err := json.Unmarshal(response.Body.Bytes(), &result); err != nil {
 		t.Fatalf("decode response %q: %v", response.Body.String(), err)
-	}
-	return result
-}
-
-func voiceTestWAV(sample byte) []byte {
-	const (
-		sampleRate = 16_000
-		samples    = 1_600
-		dataSize   = samples * 2
-	)
-	result := make([]byte, 44+dataSize)
-	copy(result[0:4], "RIFF")
-	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
-	copy(result[8:12], "WAVE")
-	copy(result[12:16], "fmt ")
-	binary.LittleEndian.PutUint32(result[16:20], 16)
-	binary.LittleEndian.PutUint16(result[20:22], 1)
-	binary.LittleEndian.PutUint16(result[22:24], 1)
-	binary.LittleEndian.PutUint32(result[24:28], sampleRate)
-	binary.LittleEndian.PutUint32(result[28:32], sampleRate*2)
-	binary.LittleEndian.PutUint16(result[32:34], 2)
-	binary.LittleEndian.PutUint16(result[34:36], 16)
-	copy(result[36:40], "data")
-	binary.LittleEndian.PutUint32(result[40:44], dataSize)
-	for index := 44; index < len(result); index++ {
-		result[index] = sample
 	}
 	return result
 }

--- a/server/internal/agent/input/voice/http/realtime.go
+++ b/server/internal/agent/input/voice/http/realtime.go
@@ -1,0 +1,233 @@
+package voicehttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const voiceInputWebSocketProtocol = "speakup.voice-input.v1"
+const maxRealtimePCMBytes = 16_000 * 2 * 60
+
+type realtimeStartFrame struct {
+	Type           string `json:"type"`
+	IdempotencyKey string `json:"idempotency_key"`
+	SampleRate     int    `json:"sample_rate"`
+}
+
+type realtimeControlFrame struct {
+	Type string `json:"type"`
+}
+
+func (handler *Handler) uploadRealtime(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	thread, err := handler.threads.GetThread(
+		c.Request.Context(), actor, c.Param("thread_id"),
+	)
+	if err != nil {
+		handler.write(c, mapThreadError(err))
+		return
+	}
+	if !containsWebSocketProtocol(
+		websocket.Subprotocols(c.Request),
+		voiceInputWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := (&websocket.Upgrader{
+		Subprotocols: []string{voiceInputWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	connection.SetReadLimit(platformmedia.MaxAudioBytes)
+	if err := connection.SetReadDeadline(
+		time.Now().Add(handler.readTimeout),
+	); err != nil {
+		return
+	}
+	start, err := readRealtimeStart(connection)
+	if err != nil {
+		writeRealtimeFailure(connection, "invalid_request", false)
+		return
+	}
+	pcm, err := readRealtimePCM(connection, handler.readTimeout)
+	if err != nil {
+		writeRealtimeFailure(connection, "stream_interrupted", true)
+		return
+	}
+	wav, err := pcm16MonoWAV(pcm, start.SampleRate)
+	if err != nil {
+		writeRealtimeFailure(connection, "invalid_audio", false)
+		return
+	}
+	observer := &realtimeTranscriptionWriter{connection: connection}
+	if err := observer.write("transcription.started", gin.H{}); err != nil {
+		return
+	}
+	candidate, err := handler.application.UploadStream(
+		c.Request.Context(),
+		actor,
+		agentvoice.UploadRequest{
+			ThreadID:       thread.ID,
+			IdempotencyKey: start.IdempotencyKey,
+			ContentType:    platformmedia.ContentTypeWAV,
+			Audio:          bytes.NewReader(wav),
+		},
+		observer,
+	)
+	if err != nil {
+		writeRealtimeFailure(connection, "stream_interrupted", true)
+		return
+	}
+	event := "candidate.ready"
+	if candidate.Status == agentvoice.StatusFailed {
+		event = "candidate.failed"
+	}
+	_ = observer.write(event, gin.H{"candidate": CandidateResponse(candidate)})
+}
+
+func readRealtimeStart(connection *websocket.Conn) (realtimeStartFrame, error) {
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage {
+		return realtimeStartFrame{}, errors.New("voice realtime start frame is required")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var frame realtimeStartFrame
+	if err := decoder.Decode(&frame); err != nil ||
+		frame.Type != "start" ||
+		!validRealtimeIdempotencyKey(frame.IdempotencyKey) ||
+		frame.SampleRate != 16_000 {
+		return realtimeStartFrame{}, errors.New("voice realtime start frame is invalid")
+	}
+	return frame, nil
+}
+
+func readRealtimePCM(
+	connection *websocket.Conn,
+	readTimeout time.Duration,
+) ([]byte, error) {
+	var pcm bytes.Buffer
+	for {
+		if err := connection.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+			return nil, err
+		}
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			return nil, err
+		}
+		switch messageType {
+		case websocket.BinaryMessage:
+			if len(payload) == 0 ||
+				pcm.Len()+len(payload) > maxRealtimePCMBytes {
+				return nil, errors.New("voice realtime audio exceeds the accepted size")
+			}
+			_, _ = pcm.Write(payload)
+		case websocket.TextMessage:
+			var frame realtimeControlFrame
+			decoder := json.NewDecoder(bytes.NewReader(payload))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&frame); err != nil {
+				return nil, err
+			}
+			switch frame.Type {
+			case "finish":
+				if pcm.Len() == 0 || pcm.Len()%2 != 0 {
+					return nil, errors.New("voice realtime audio is incomplete")
+				}
+				return pcm.Bytes(), nil
+			case "cancel":
+				return nil, context.Canceled
+			default:
+				return nil, errors.New("voice realtime control frame is invalid")
+			}
+		default:
+			return nil, errors.New("voice realtime frame type is invalid")
+		}
+	}
+}
+
+func pcm16MonoWAV(pcm []byte, sampleRate int) ([]byte, error) {
+	if len(pcm) == 0 || len(pcm)%2 != 0 || sampleRate != 16_000 {
+		return nil, errors.New("voice realtime PCM is invalid")
+	}
+	result := make([]byte, 44+len(pcm))
+	copy(result[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
+	copy(result[8:12], "WAVE")
+	copy(result[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(result[16:20], 16)
+	binary.LittleEndian.PutUint16(result[20:22], 1)
+	binary.LittleEndian.PutUint16(result[22:24], 1)
+	binary.LittleEndian.PutUint32(result[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(result[28:32], uint32(sampleRate*2))
+	binary.LittleEndian.PutUint16(result[32:34], 2)
+	binary.LittleEndian.PutUint16(result[34:36], 16)
+	copy(result[36:40], "data")
+	binary.LittleEndian.PutUint32(result[40:44], uint32(len(pcm)))
+	copy(result[44:], pcm)
+	return result, nil
+}
+
+type realtimeTranscriptionWriter struct {
+	connection *websocket.Conn
+}
+
+func (writer *realtimeTranscriptionWriter) OnTranscriptionUpdate(
+	_ context.Context,
+	update agentvoice.TranscriptionUpdate,
+) error {
+	return writer.write("transcription.updated", gin.H{
+		"transcript": update.Transcript,
+		"final":      update.Final,
+	})
+}
+
+func (writer *realtimeTranscriptionWriter) write(
+	event string,
+	data any,
+) error {
+	return writer.connection.WriteJSON(gin.H{"type": event, "data": data})
+}
+
+func writeRealtimeFailure(
+	connection *websocket.Conn,
+	kind string,
+	retryable bool,
+) {
+	_ = connection.WriteJSON(gin.H{
+		"type": "candidate.failed",
+		"data": gin.H{"kind": kind, "retryable": retryable},
+	})
+}
+
+func containsWebSocketProtocol(protocols []string, required string) bool {
+	for _, protocol := range protocols {
+		if protocol == required {
+			return true
+		}
+	}
+	return false
+}
+
+func validRealtimeIdempotencyKey(value string) bool {
+	value = strings.TrimSpace(value)
+	return len(value) >= 8 && len(value) <= 128
+}

--- a/server/internal/agent/input/voice/http/realtime_test.go
+++ b/server/internal/agent/input/voice/http/realtime_test.go
@@ -1,0 +1,105 @@
+package voicehttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/gorilla/websocket"
+)
+
+func TestRealtimeVoiceInputUsesAuthenticatedWebSocketFrames(t *testing.T) {
+	now := time.Date(2026, 8, 6, 1, 0, 0, 0, time.UTC)
+	application := &voiceInputHTTPApplication{
+		candidate: agentvoice.Candidate{
+			ID:               "30000000-0000-4000-8000-000000000001",
+			OwnerID:          "user-a",
+			ThreadID:         "thread-1",
+			ObjectKey:        "audio/v1/agent/private.wav",
+			ContentType:      platformmedia.ContentTypeWAV,
+			Size:             3244,
+			ChecksumSHA256:   strings.Repeat("a", 64),
+			Duration:         100 * time.Millisecond,
+			SampleRate:       16_000,
+			Status:           agentvoice.StatusReady,
+			ASRAttempt:       1,
+			CandidateVersion: 1,
+			ASRRequestID:     "request-1",
+			ASRProvider:      "fake",
+			ASRModel:         "fake-asr",
+			ASRCandidateText: "Provider candidate",
+			ExpiresAt:        now.Add(24 * time.Hour),
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+		now: now,
+	}
+	server := httptest.NewServer(newAgentVoiceInputHTTPRouter(t, application))
+	defer server.Close()
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/agent-threads/thread-1/voice-message-candidates/realtime"
+	header := http.Header{"Authorization": []string{"Bearer voice-token-a"}}
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{voiceInputWebSocketProtocol},
+	}).Dial(endpoint, header)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial realtime voice status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial realtime voice: %v", err)
+	}
+	defer connection.Close()
+	if connection.Subprotocol() != voiceInputWebSocketProtocol {
+		t.Fatalf("subprotocol = %q", connection.Subprotocol())
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"type": "start", "idempotency_key": "voice-realtime-1",
+		"sample_rate": 16_000,
+	}); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+	if err := connection.WriteMessage(
+		websocket.BinaryMessage,
+		make([]byte, 3_200),
+	); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
+		t.Fatalf("write finish: %v", err)
+	}
+	var eventTypes []string
+	for len(eventTypes) < 4 {
+		_, payload, readErr := connection.ReadMessage()
+		if readErr != nil {
+			t.Fatalf("read event %d: %v", len(eventTypes), readErr)
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		eventTypes = append(eventTypes, envelope.Type)
+	}
+	want := []string{
+		"transcription.started",
+		"transcription.updated",
+		"transcription.updated",
+		"candidate.ready",
+	}
+	for index := range want {
+		if eventTypes[index] != want[index] {
+			t.Fatalf("events = %#v", eventTypes)
+		}
+	}
+	if application.uploadThreadID != "thread-1" ||
+		application.uploadKey != "voice-realtime-1" ||
+		application.uploadBytes != 3_244 {
+		t.Fatalf("upload = %#v", application)
+	}
+}

--- a/server/internal/bootstrap/agent_voice_bootstrap_test.go
+++ b/server/internal/bootstrap/agent_voice_bootstrap_test.go
@@ -213,9 +213,9 @@ func TestProductionAgentVoiceCompositionRegistersAllRoutes(t *testing.T) {
 		path   string
 	}{
 		{
-			http.MethodPost,
+			http.MethodGet,
 			"/v1/agent-threads/" + resourceID +
-				"/voice-message-candidates",
+				"/voice-message-candidates/realtime",
 		},
 		{
 			http.MethodGet,


### PR DESCRIPTION
## 功能说明

录音期间持续通过受认证 WebSocket 上传 PCM16 分片，停止录音后直接进入现有转写、候选与确认流程，避免停止后才整体上传 WAV。

## 实现思路

- `mobile/lib/platform/network` 提供不绑定业务协议的 WebSocket 建连能力
- `mobile/lib/identity/network` 保留 Session 捕获、可信源与 4401 失效语义
- Agent Voice 使用独立 `speakup.voice-input.v1` 子协议传输 start、音频分片与 finish
- 移动端流式录音同时保留一份本地 WAV，用于原声播放和明确失败后的重试
- 服务端 Voice HTTP 入口将 PCM16 组装为受验证 WAV，继续复用现有候选、对象存储与千问转写流程
- 移除旧整段 WAV HTTP/SSE 上传路由；确认后的 Agent 文本回复仍使用 #436 的 SSE 流
- 开始录音前停止正在播放的 Agent 原声或 TTS

## 代码地图

- 请求入口：`server/internal/agent/input/voice/http`，负责升级连接、校验帧和输出转写事件
- 应用编排：`server/internal/agent/input/voice`，继续负责候选、存储、转写与确认
- 通用传输：`mobile/lib/platform/network`，只负责协议无关的 WebSocket 建连
- 会话认证：`mobile/lib/identity/network`，负责登录凭证与失效处理
- 业务调用：`mobile/lib/features/agent/composer/voice` 与 `mobile/lib/providers/agent`

依赖方向：Agent Voice → Identity 会话认证 → Platform WebSocket；服务端 Voice → 语音端口 → Qianwen。

## 测试

- `cd server && go test ./internal/agent/input/voice/... ./internal/bootstrap/...`
- `cd mobile && flutter analyze lib/app/speak_up_shell.dart lib/platform/network/web_socket_transport.dart lib/identity/network/authenticated_web_socket.dart lib/features/agent/composer/voice lib/features/agent/conversation/agent_message_audio_controller.dart lib/providers/agent/wire_agent_voice_client.dart`
- `cd mobile && flutter test test/identity/authenticated_web_socket_test.dart test/identity/auth_invalidation_cas_test.dart test/agent/agent_voice_recording_stream_test.dart test/agent/agent_voice_fence_test.dart test/agent/agent_voice_flow_test.dart test/agent/wire_agent_voice_client_test.dart`
- `git diff --check`

## 依赖

依赖 #436；#436 合入后将同步 `dev` 并移除 PR 中已经合入的前置差异。

Closes #438