### PR TITLE
feat(interview): 精简模拟面试创建并接入临时简历

### DIFF
--- a/api/modules/resume.yaml
+++ b/api/modules/resume.yaml
@@ -1,5 +1,105 @@
 # 本文件定义 Resume 模块的 REST 契约；所有操作只访问认证 Actor 自己的简历。
 paths:
+  /v1/temporary-resumes:
+    post:
+      tags:
+        - Resume
+      summary: Upload a temporary interview resume
+      description: |
+        Creates an interview-only resume that is excluded from the saved resume
+        list and three-resume quota. It expires after 24 hours and is intended
+        to be deleted after its parsed revision has entered a preparation snapshot.
+      operationId: createTemporaryResume
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CreateTemporaryResumeRequest'
+      responses:
+        '202':
+          description: Temporary resume accepted and queued for parsing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemporaryResume'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/temporary-resumes/{resume_id}:
+    get:
+      tags:
+        - Resume
+      summary: Get a temporary interview resume
+      operationId: getTemporaryResume
+      parameters:
+        - $ref: '#/components/parameters/ResumeId'
+      responses:
+        '200':
+          description: Owned, unexpired temporary resume detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemporaryResumeDetail'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    delete:
+      tags:
+        - Resume
+      summary: Delete a temporary interview resume
+      operationId: deleteTemporaryResume
+      parameters:
+        - $ref: '#/components/parameters/ResumeId'
+        - $ref: '#/components/parameters/ExpectedVersion'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '204':
+          description: Temporary resume deleted.
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/temporary-resumes/{resume_id}/parse-retries:
+    post:
+      tags:
+        - Resume
+      summary: Retry temporary resume parsing
+      operationId: retryTemporaryResumeParse
+      parameters:
+        - $ref: '#/components/parameters/ResumeId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '202':
+          description: Temporary resume parsing retry accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemporaryResume'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/resumes:
     post:
       tags:
@@ -317,6 +417,16 @@ components:
           type: string
           format: binary
           contentMediaType: application/pdf
+    CreateTemporaryResumeRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+          contentMediaType: application/pdf
     ReplaceResumeFileRequest:
       type: object
       additionalProperties: false
@@ -427,6 +537,69 @@ components:
           type: string
           minLength: 1
           maxLength: 512
+    TemporaryResume:
+      type: object
+      additionalProperties: false
+      required:
+        - resume_id
+        - title
+        - original_filename
+        - content_type
+        - size_bytes
+        - file_status
+        - parse_status
+        - version
+        - created_at
+        - updated_at
+        - expires_at
+      properties:
+        resume_id:
+          $ref: '#/components/schemas/ResumeId'
+        title:
+          $ref: '#/components/schemas/ResumeTitle'
+        original_filename:
+          type: string
+          minLength: 1
+          maxLength: 255
+        content_type:
+          type: string
+          const: application/pdf
+        size_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 10485760
+        file_status:
+          type: string
+          enum: [UPLOADING, AVAILABLE, DELETING]
+        parse_status:
+          type: string
+          enum: [QUEUED, PARSING, READY, FAILED]
+        current_revision:
+          type: integer
+          format: int64
+          minimum: 1
+        version:
+          $ref: '#/components/schemas/Version'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    TemporaryResumeDetail:
+      type: object
+      additionalProperties: false
+      required:
+        - resume
+      properties:
+        resume:
+          $ref: '#/components/schemas/TemporaryResume'
+        current_revision:
+          $ref: '#/components/schemas/ResumeRevision'
     ResumeDetail:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,6 +83,12 @@ paths:
     $ref: ./modules/identity.yaml#/paths/~1v1~1me~1profile
   /v1/resumes:
     $ref: ./modules/resume.yaml#/paths/~1v1~1resumes
+  /v1/temporary-resumes:
+    $ref: ./modules/resume.yaml#/paths/~1v1~1temporary-resumes
+  /v1/temporary-resumes/{resume_id}:
+    $ref: ./modules/resume.yaml#/paths/~1v1~1temporary-resumes~1{resume_id}
+  /v1/temporary-resumes/{resume_id}/parse-retries:
+    $ref: ./modules/resume.yaml#/paths/~1v1~1temporary-resumes~1{resume_id}~1parse-retries
   /v1/resumes/{resume_id}:
     $ref: ./modules/resume.yaml#/paths/~1v1~1resumes~1{resume_id}
   /v1/resumes/{resume_id}/content:

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -389,6 +389,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             JobPreparationWizard(
               controller: widget.jobPreparationController!,
               catalogController: widget.preparationController,
+              resumeController: widget.resumeController,
               onPracticeStarted: () => _navigatorKey.currentState
                   ?.pushReplacementNamed(AppRoutes.practice),
             ),

--- a/mobile/lib/features/coaching/interview/job_preparation_controller.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_controller.dart
@@ -63,6 +63,7 @@ final class JobPreparationController extends ChangeNotifier {
   );
   JobTarget? _target;
   JobTargetCandidate? _candidate;
+  JobPreparationResumeSelection? _resumeSelection;
   PracticePlan? _plan;
   PreparationPracticeBootstrap? _bootstrap;
   JobPreparationStep _step = JobPreparationStep.input;
@@ -99,6 +100,7 @@ final class JobPreparationController extends ChangeNotifier {
   JobTargetInput get input => _input;
   JobTarget? get target => _target;
   JobTargetCandidate? get candidate => _candidate;
+  JobPreparationResumeSelection? get resumeSelection => _resumeSelection;
   PracticePlan? get plan => _plan;
   PreparationPracticeBootstrap? get bootstrap => _bootstrap;
   JobPreparationStep get step => _step;
@@ -378,6 +380,23 @@ final class JobPreparationController extends ChangeNotifier {
     _confirmationKey = null;
     _errorMessage = null;
     _operationStage = null;
+    notifyListeners();
+    _queueDraftWrite();
+  }
+
+  void selectResume(JobPreparationResumeSelection? value) {
+    if (_disposed || _busy || identical(value, _resumeSelection)) {
+      return;
+    }
+    _epoch++;
+    _resumeSelection = value;
+    _plan = null;
+    _bootstrap = null;
+    if (_step == JobPreparationStep.preview) {
+      _step = JobPreparationStep.setup;
+    }
+    _clearPreviewAttempt();
+    _errorMessage = null;
     notifyListeners();
     _queueDraftWrite();
   }
@@ -716,6 +735,8 @@ final class JobPreparationController extends ChangeNotifier {
       final profile = await client.createProfile(
         input: CreatePreparationProfileInput(
           backgroundSummary: background,
+          resumeId: _resumeSelection?.resumeId,
+          resumeRevision: _resumeSelection?.revision,
           jobTargetId: target.id,
           jobTargetConfirmationVersion: confirmation.confirmationVersion,
         ),
@@ -1036,6 +1057,7 @@ final class JobPreparationController extends ChangeNotifier {
     _input = draft.input;
     _target = null;
     _candidate = draft.candidate;
+    _resumeSelection = draft.resumeSelection;
     _plan = null;
     _bootstrap = null;
     _step = JobPreparationStep.input;
@@ -1088,6 +1110,7 @@ final class JobPreparationController extends ChangeNotifier {
     _agentIntentPrefill = null;
     _target = null;
     _candidate = null;
+    _resumeSelection = null;
     _plan = null;
     _bootstrap = null;
     _step = JobPreparationStep.input;
@@ -1115,6 +1138,7 @@ final class JobPreparationController extends ChangeNotifier {
       input: _input,
       targetId: _target?.id,
       candidate: _candidate,
+      resumeSelection: _resumeSelection,
       planId: _plan?.id,
       createTargetKey: _createTargetKey,
       updateTargetKey: _updateTargetKey,
@@ -1219,6 +1243,7 @@ final class _StoredJobPreparationDraft {
     required this.input,
     this.targetId,
     this.candidate,
+    this.resumeSelection,
     this.planId,
     this.createTargetKey,
     this.updateTargetKey,
@@ -1236,6 +1261,7 @@ final class _StoredJobPreparationDraft {
   final JobTargetInput input;
   final String? targetId;
   final JobTargetCandidate? candidate;
+  final JobPreparationResumeSelection? resumeSelection;
   final String? planId;
   final String? createTargetKey;
   final String? updateTargetKey;
@@ -1251,12 +1277,21 @@ final class _StoredJobPreparationDraft {
 
   String encode() {
     return jsonEncode(<String, Object?>{
-      'schema_version': 2,
+      'schema_version': 3,
       'input': _storedInputJson(input),
       'target_id': ?targetId,
       'candidate': ?(candidate == null
           ? null
           : _storedCandidateJson(candidate!)),
+      'resume_selection': ?(resumeSelection == null
+          ? null
+          : <String, Object?>{
+              'resume_id': resumeSelection!.resumeId,
+              'revision': resumeSelection!.revision,
+              'resource_version': resumeSelection!.resourceVersion,
+              'temporary': resumeSelection!.temporary,
+              'title': resumeSelection!.title,
+            }),
       'plan_id': ?planId,
       'create_target_key': ?createTargetKey,
       'update_target_key': ?updateTargetKey,
@@ -1278,8 +1313,11 @@ final class _StoredJobPreparationDraft {
         return null;
       }
       final value = jsonDecode(encoded);
+      final schemaVersion = value is Map<String, Object?>
+          ? value['schema_version']
+          : null;
       if (value is! Map<String, Object?> ||
-          value['schema_version'] != 2 ||
+          (schemaVersion != 2 && schemaVersion != 3) ||
           !value.containsKey('input') ||
           value.keys.any(
             (key) => !const <String>{
@@ -1287,6 +1325,7 @@ final class _StoredJobPreparationDraft {
               'input',
               'target_id',
               'candidate',
+              'resume_selection',
               'plan_id',
               'create_target_key',
               'update_target_key',
@@ -1300,12 +1339,16 @@ final class _StoredJobPreparationDraft {
               'session_key',
               'voice_key',
             }.contains(key),
-          )) {
+          ) ||
+          (schemaVersion == 2 && value.containsKey('resume_selection'))) {
         return null;
       }
       final input = _storedInput(value['input']);
       final candidate = value.containsKey('candidate')
           ? _storedCandidate(value['candidate'])
+          : null;
+      final resumeSelection = value.containsKey('resume_selection')
+          ? _storedResumeSelection(value['resume_selection'])
           : null;
       final targetId = _storedOptionalId(value, 'target_id');
       final planId = _storedOptionalId(value, 'plan_id');
@@ -1317,6 +1360,7 @@ final class _StoredJobPreparationDraft {
         input: input,
         targetId: targetId,
         candidate: candidate,
+        resumeSelection: resumeSelection,
         planId: planId,
         createTargetKey: _storedOptionalKey(value, 'create_target_key'),
         updateTargetKey: _storedOptionalKey(value, 'update_target_key'),
@@ -1334,6 +1378,42 @@ final class _StoredJobPreparationDraft {
       return null;
     }
   }
+}
+
+JobPreparationResumeSelection _storedResumeSelection(Object? value) {
+  if (value is! Map<String, Object?> ||
+      value.keys.toSet().difference(const <String>{
+        'resume_id',
+        'revision',
+        'resource_version',
+        'temporary',
+        'title',
+      }).isNotEmpty ||
+      value.length != 5 ||
+      value['resume_id'] is! String ||
+      value['revision'] is! int ||
+      value['resource_version'] is! int ||
+      value['temporary'] is! bool ||
+      value['title'] is! String) {
+    throw const FormatException('Invalid stored resume selection.');
+  }
+  final id = value['resume_id']! as String;
+  final revision = value['revision']! as int;
+  final resourceVersion = value['resource_version']! as int;
+  final title = (value['title']! as String).trim();
+  if (!_validResourceId(id) ||
+      revision < 1 ||
+      resourceVersion < 1 ||
+      title.isEmpty) {
+    throw const FormatException('Invalid stored resume selection.');
+  }
+  return JobPreparationResumeSelection(
+    resumeId: id,
+    revision: revision,
+    resourceVersion: resourceVersion,
+    temporary: value['temporary']! as bool,
+    title: title,
+  );
 }
 
 Map<String, Object?> _storedInputJson(JobTargetInput input) {

--- a/mobile/lib/features/coaching/interview/job_preparation_models.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_models.dart
@@ -77,6 +77,22 @@ final class JobTargetInput {
   );
 }
 
+final class JobPreparationResumeSelection {
+  const JobPreparationResumeSelection({
+    required this.resumeId,
+    required this.revision,
+    required this.resourceVersion,
+    required this.temporary,
+    required this.title,
+  });
+
+  final String resumeId;
+  final int revision;
+  final int resourceVersion;
+  final bool temporary;
+  final String title;
+}
+
 final class JobTargetCatalogRecommendation {
   const JobTargetCatalogRecommendation({
     required this.sceneId,

--- a/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
@@ -7,6 +7,8 @@ import 'package:speakup/features/coaching/interview/job_preparation_models.dart'
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/resume/resume_controller.dart';
+import 'package:speakup/resume/resume_models.dart';
 
 enum _JobExistingPracticeAction { cancel, continuePractice, replace }
 
@@ -14,12 +16,14 @@ class JobPreparationWizard extends StatefulWidget {
   const JobPreparationWizard({
     required this.controller,
     this.catalogController,
+    this.resumeController,
     this.onPracticeStarted,
     super.key,
   });
 
   final JobPreparationController controller;
   final PreparationController? catalogController;
+  final ResumeController? resumeController;
   final VoidCallback? onPracticeStarted;
 
   @override
@@ -29,10 +33,6 @@ class JobPreparationWizard extends StatefulWidget {
 class _JobPreparationWizardState extends State<JobPreparationWizard> {
   late final TextEditingController _jd;
   late final TextEditingController _title;
-  late final TextEditingController _company;
-  late final TextEditingController _seniority;
-  late final TextEditingController _background;
-  late final TextEditingController _focus;
   late final TextEditingController _candidateTitle;
   late final TextEditingController _candidateSeniority;
   late final TextEditingController _responsibilities;
@@ -52,10 +52,6 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     final input = widget.controller.input;
     _jd = TextEditingController(text: input.jobDescription);
     _title = TextEditingController(text: input.jobTitle);
-    _company = TextEditingController(text: input.company);
-    _seniority = TextEditingController(text: input.seniority);
-    _background = TextEditingController(text: input.candidateBackground);
-    _focus = TextEditingController(text: input.practiceFocus);
     _candidateTitle = TextEditingController();
     _candidateSeniority = TextEditingController();
     _responsibilities = TextEditingController();
@@ -64,8 +60,12 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     _goals = TextEditingController();
     widget.controller.addListener(_rebuild);
     widget.catalogController?.addListener(_rebuild);
+    widget.resumeController?.addListener(_rebuild);
     _syncCandidate();
     unawaited(_prepareCatalog());
+    if (widget.resumeController case final resumes?) {
+      unawaited(resumes.load());
+    }
   }
 
   @override
@@ -77,6 +77,13 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
         widget.catalogController?.addListener(_rebuild);
         unawaited(_prepareCatalog());
       }
+      if (oldWidget.resumeController != widget.resumeController) {
+        oldWidget.resumeController?.removeListener(_rebuild);
+        widget.resumeController?.addListener(_rebuild);
+        if (widget.resumeController case final resumes?) {
+          unawaited(resumes.load());
+        }
+      }
       return;
     }
     oldWidget.controller.removeListener(_rebuild);
@@ -84,6 +91,13 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     if (oldWidget.catalogController != widget.catalogController) {
       oldWidget.catalogController?.removeListener(_rebuild);
       widget.catalogController?.addListener(_rebuild);
+    }
+    if (oldWidget.resumeController != widget.resumeController) {
+      oldWidget.resumeController?.removeListener(_rebuild);
+      widget.resumeController?.addListener(_rebuild);
+      if (widget.resumeController case final resumes?) {
+        unawaited(resumes.load());
+      }
     }
     _syncInput();
     _syncCandidate();
@@ -94,13 +108,10 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
   void dispose() {
     widget.controller.removeListener(_rebuild);
     widget.catalogController?.removeListener(_rebuild);
+    widget.resumeController?.removeListener(_rebuild);
     for (final controller in <TextEditingController>[
       _jd,
       _title,
-      _company,
-      _seniority,
-      _background,
-      _focus,
       _candidateTitle,
       _candidateSeniority,
       _responsibilities,
@@ -126,10 +137,6 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     final input = widget.controller.input;
     _replaceText(_jd, input.jobDescription);
     _replaceText(_title, input.jobTitle);
-    _replaceText(_company, input.company);
-    _replaceText(_seniority, input.seniority);
-    _replaceText(_background, input.candidateBackground);
-    _replaceText(_focus, input.practiceFocus);
   }
 
   void _syncCandidate() {
@@ -224,15 +231,178 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       jobDescription: resolvedSource == JobTargetSource.jobDescription
           ? normalized(_jd.text)
           : null,
-      company: normalized(_company.text),
-      seniority: normalized(_seniority.text),
-      candidateBackground: normalized(_background.text),
-      practiceFocus: normalized(_focus.text),
     );
   }
 
   void _commitInput() {
     widget.controller.updateInput(_currentInput());
+  }
+
+  void _selectSavedResume(ResumeItem? resume) {
+    final revision = resume?.currentRevision;
+    if (resume == null || revision == null) {
+      widget.controller.selectResume(null);
+      return;
+    }
+    widget.controller.selectResume(
+      JobPreparationResumeSelection(
+        resumeId: resume.id,
+        revision: revision,
+        resourceVersion: resume.version,
+        temporary: false,
+        title: resume.title,
+      ),
+    );
+  }
+
+  Future<void> _pickTemporaryResume() async {
+    await widget.resumeController?.pickTemporary();
+    if (widget.resumeController?.temporaryItem != null) {
+      widget.controller.selectResume(null);
+    }
+    for (
+      var attempt = 0;
+      mounted &&
+          widget.controller.step == JobPreparationStep.confirmation &&
+          attempt < 75;
+      attempt++
+    ) {
+      await _refreshTemporaryResume();
+      final status = widget.resumeController?.temporaryItem?.parseStatus;
+      if (status == null ||
+          status == ResumeParseStatus.ready ||
+          status == ResumeParseStatus.failed) {
+        return;
+      }
+      await Future<void>.delayed(const Duration(seconds: 1));
+    }
+  }
+
+  Future<void> _refreshTemporaryResume() async {
+    final resumes = widget.resumeController;
+    if (resumes == null) return;
+    await resumes.refreshTemporary();
+    final resume = resumes.temporaryItem;
+    final revision = resume?.currentRevision;
+    if (resume?.parseStatus == ResumeParseStatus.ready && revision != null) {
+      widget.controller.selectResume(
+        JobPreparationResumeSelection(
+          resumeId: resume!.id,
+          revision: revision,
+          resourceVersion: resume.version,
+          temporary: true,
+          title: resume.title,
+        ),
+      );
+    }
+  }
+
+  Widget _buildResumeSource() {
+    final resumes = widget.resumeController;
+    if (resumes == null) return const SizedBox.shrink();
+    final ready = resumes.items
+        .where(
+          (item) =>
+              item.parseStatus == ResumeParseStatus.ready &&
+              item.currentRevision != null,
+        )
+        .toList(growable: false);
+    final selection = widget.controller.resumeSelection;
+    final temporary = resumes.temporaryItem;
+    final selectedSavedId =
+        selection?.temporary == false &&
+            ready.any((item) => item.id == selection?.resumeId)
+        ? selection?.resumeId
+        : null;
+    return Card(
+      key: const Key('job-resume-source-card'),
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              '简历（可选）',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 6),
+            const Text('用于生成更贴合个人经历的追问，不使用也可以继续。'),
+            const SizedBox(height: 14),
+            DropdownButtonFormField<String?>(
+              key: ValueKey<String>(
+                'saved-resume-selector-${selectedSavedId ?? 'none'}-'
+                '${ready.map((item) => item.id).join(',')}',
+              ),
+              initialValue: selectedSavedId,
+              decoration: const InputDecoration(labelText: '选择已上传的简历'),
+              items: <DropdownMenuItem<String?>>[
+                const DropdownMenuItem<String?>(
+                  value: null,
+                  child: Text('不使用简历'),
+                ),
+                for (final item in ready)
+                  DropdownMenuItem<String?>(
+                    value: item.id,
+                    child: Text(item.title, overflow: TextOverflow.ellipsis),
+                  ),
+              ],
+              onChanged: widget.controller.isBusy
+                  ? null
+                  : (id) => _selectSavedResume(
+                      ready.where((item) => item.id == id).firstOrNull,
+                    ),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              key: const Key('temporary-resume-upload-button'),
+              onPressed: widget.controller.isBusy
+                  ? null
+                  : () => unawaited(_pickTemporaryResume()),
+              icon: const Icon(Icons.upload_file_outlined),
+              label: Text(temporary == null ? '临时上传简历' : '更换临时简历'),
+            ),
+            if (temporary != null) ...[
+              const SizedBox(height: 10),
+              _Notice(
+                key: const Key('temporary-resume-status'),
+                icon: switch (temporary.parseStatus) {
+                  ResumeParseStatus.ready => Icons.check_circle_outline,
+                  ResumeParseStatus.failed => Icons.error_outline,
+                  _ => Icons.hourglass_top_rounded,
+                },
+                text: switch (temporary.parseStatus) {
+                  ResumeParseStatus.ready => '临时简历已解析，可用于本次面试。',
+                  ResumeParseStatus.failed => '临时简历解析失败，可以重试或重新上传。',
+                  _ => '临时简历正在解析，完成后即可继续。',
+                },
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: [
+                  TextButton(
+                    onPressed: () => unawaited(_refreshTemporaryResume()),
+                    child: const Text('刷新状态'),
+                  ),
+                  if (temporary.parseStatus == ResumeParseStatus.failed)
+                    TextButton(
+                      onPressed: () => unawaited(
+                        resumes.retryTemporaryParse().then(
+                          (_) => _refreshTemporaryResume(),
+                        ),
+                      ),
+                      child: const Text('重试解析'),
+                    ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
   }
 
   JobTargetCandidate _editedCandidate(JobTargetCandidate original) {
@@ -312,9 +482,13 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       }
       replaceCurrentPractice = true;
     }
-    await widget.controller.createPreview(
+    final created = await widget.controller.createPreview(
       replaceCurrentPractice: replaceCurrentPractice,
     );
+    if (created && widget.controller.resumeSelection?.temporary == true) {
+      await widget.resumeController?.refreshTemporary();
+      await widget.resumeController?.deleteTemporary();
+    }
   }
 
   Future<void> _requestExit() async {
@@ -422,19 +596,19 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
           ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
         ),
         const SizedBox(height: 8),
-        const Text('优先粘贴真实 JD。没有 JD 也可以只填岗位快速开始。', style: SpeakUpDesign.body),
+        const Text('只需输入职位名称，或粘贴一份职位 JD。', style: SpeakUpDesign.body),
         const SizedBox(height: 20),
         SegmentedButton<JobTargetSource>(
           key: const Key('job-source-selector'),
           segments: const [
             ButtonSegment(
               value: JobTargetSource.jobDescription,
-              label: Text('粘贴 JD'),
+              label: Text('职位 JD'),
               icon: Icon(Icons.description_outlined),
             ),
             ButtonSegment(
               value: JobTargetSource.quickStart,
-              label: Text('岗位快速开始'),
+              label: Text('职位名称'),
               icon: Icon(Icons.bolt_outlined),
             ),
           ],
@@ -459,15 +633,6 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
             onChanged: (_) => _commitInput(),
           )
         else ...[
-          Semantics(
-            key: const Key('quick-start-notice'),
-            liveRegion: true,
-            child: const _Notice(
-              icon: Icons.info_outline_rounded,
-              text: '快速开始不会基于真实 JD，只会提供通用岗位建议。',
-            ),
-          ),
-          const SizedBox(height: 14),
           _Field(
             key: const Key('job-title-field'),
             controller: _title,
@@ -476,40 +641,6 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
             onChanged: (_) => _commitInput(),
           ),
         ],
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('job-company-field'),
-          controller: _company,
-          label: '公司（可选）',
-          hint: '例如：跨国科技公司',
-          onChanged: (_) => _commitInput(),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('job-seniority-field'),
-          controller: _seniority,
-          label: '职级（可选）',
-          hint: '例如：Senior / 资深',
-          onChanged: (_) => _commitInput(),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('job-background-field'),
-          controller: _background,
-          label: '你的相关背景（可选）',
-          hint: '简要描述经历、项目和想重点表达的成果',
-          maxLines: 4,
-          onChanged: (_) => _commitInput(),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('job-goal-field'),
-          controller: _focus,
-          label: '本次目标（可选）',
-          hint: '例如：练习系统设计取舍的英文表达',
-          maxLines: 3,
-          onChanged: (_) => _commitInput(),
-        ),
         if (controller.agentIntentPrefill case final prefill?) ...[
           const SizedBox(height: 14),
           _AgentIntentCard(
@@ -547,9 +678,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
                   unawaited(controller.analyze());
                 },
           icon: const Icon(Icons.auto_awesome_outlined),
-          label: Text(
-            source == JobTargetSource.jobDescription ? '分析岗位信息' : '生成通用岗位建议',
-          ),
+          label: Text('生成面试信息'),
           style: _primaryButtonStyle,
         ),
       ],
@@ -567,68 +696,85 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
         Text(
-          '确认 AI 提取结果',
+          '面试信息已准备好',
           style: Theme.of(
             context,
           ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800),
         ),
         const SizedBox(height: 8),
-        Text(
-          candidate.scopeNotice,
-          key: const Key('job-analysis-scope-notice'),
-          style: SpeakUpDesign.body,
-        ),
+        const Text('确认岗位重点并选择是否使用简历，然后生成面试方案。'),
         const SizedBox(height: 18),
-        _Field(
-          key: const Key('candidate-title-field'),
-          controller: _candidateTitle,
-          label: '岗位',
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
+        _SummaryCard(
+          title: candidate.jobTitle,
+          subtitle: candidate.seniority,
+          rows: [
+            ('核心职责', candidate.responsibilities.join('、')),
+            ('核心能力', candidate.coreSkills.join('、')),
+            ('建议重点', candidate.practiceGoals.join('、')),
+          ],
         ),
         const SizedBox(height: 14),
-        _Field(
-          key: const Key('candidate-seniority-field'),
-          controller: _candidateSeniority,
-          label: '职级',
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
-        ),
+        _buildResumeSource(),
         const SizedBox(height: 14),
-        _Field(
-          key: const Key('candidate-responsibilities-field'),
-          controller: _responsibilities,
-          label: '核心职责（每行一项）',
-          maxLines: 4,
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('candidate-skills-field'),
-          controller: _skills,
-          label: '核心能力（每行一项）',
-          maxLines: 4,
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('candidate-communication-field'),
-          controller: _communication,
-          label: '英语沟通重点（每行一项）',
-          maxLines: 4,
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
-        ),
-        const SizedBox(height: 14),
-        _Field(
-          key: const Key('candidate-goals-field'),
-          controller: _goals,
-          label: '建议训练重点（每行一项）',
-          maxLines: 4,
-          onChanged: (_) =>
-              controller.updateCandidate(_editedCandidate(candidate)),
+        ExpansionTile(
+          key: const Key('job-analysis-editor'),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 4),
+          title: const Text('查看并编辑岗位分析'),
+          subtitle: Text(candidate.scopeNotice),
+          children: [
+            _Field(
+              key: const Key('candidate-title-field'),
+              controller: _candidateTitle,
+              label: '岗位',
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+            _Field(
+              key: const Key('candidate-seniority-field'),
+              controller: _candidateSeniority,
+              label: '职级',
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+            _Field(
+              key: const Key('candidate-responsibilities-field'),
+              controller: _responsibilities,
+              label: '核心职责（每行一项）',
+              maxLines: 4,
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+            _Field(
+              key: const Key('candidate-skills-field'),
+              controller: _skills,
+              label: '核心能力（每行一项）',
+              maxLines: 4,
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+            _Field(
+              key: const Key('candidate-communication-field'),
+              controller: _communication,
+              label: '英语沟通重点（每行一项）',
+              maxLines: 4,
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+            _Field(
+              key: const Key('candidate-goals-field'),
+              controller: _goals,
+              label: '建议训练重点（每行一项）',
+              maxLines: 4,
+              onChanged: (_) =>
+                  controller.updateCandidate(_editedCandidate(candidate)),
+            ),
+            const SizedBox(height: 12),
+          ],
         ),
         if (controller.errorMessage case final message?)
           _ErrorCard(
@@ -686,7 +832,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
           subtitle: candidate?.seniority ?? '',
           rows: [
             ('训练重点', candidate?.practiceGoals.join('、') ?? '由服务端推荐'),
-            ('个人背景', controller.input.candidateBackground ?? '尚未填写'),
+            ('简历', controller.resumeSelection?.title ?? '不使用简历'),
           ],
         ),
         if (controller.errorMessage case final message?)
@@ -1004,7 +1150,7 @@ class _Field extends StatelessWidget {
 }
 
 class _Notice extends StatelessWidget {
-  const _Notice({required this.icon, required this.text});
+  const _Notice({required this.icon, required this.text, super.key});
 
   final IconData icon;
   final String text;

--- a/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
@@ -482,10 +482,16 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       }
       replaceCurrentPractice = true;
     }
+    final temporarySelected =
+        widget.controller.resumeSelection?.temporary == true;
     final created = await widget.controller.createPreview(
       replaceCurrentPractice: replaceCurrentPractice,
     );
-    if (created && widget.controller.resumeSelection?.temporary == true) {
+    final snapshotCaptured =
+        created ||
+        widget.controller.plan != null ||
+        widget.controller.operationStage == JobPreparationOperationStage.plan;
+    if (temporarySelected && snapshotCaptured) {
       await widget.resumeController?.refreshTemporary();
       await widget.resumeController?.deleteTemporary();
     }

--- a/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
+++ b/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
@@ -236,7 +236,8 @@ final class WireJobPreparationClient implements JobPreparationClient {
       idempotencyKey: idempotencyKey,
       body: <String, Object?>{
         'background_summary': input.backgroundSummary,
-        'resume_ref': ?input.resumeRef,
+        'resume_id': ?input.resumeId,
+        'resume_revision': ?input.resumeRevision,
         'job_description_ref': ?input.jobDescriptionRef,
         'job_target_id': ?input.jobTargetId,
         'job_target_confirmation_version': ?input.jobTargetConfirmationVersion,
@@ -250,7 +251,8 @@ final class WireJobPreparationClient implements JobPreparationClient {
       decode: (body) {
         final profile = decodePreparationProfileBody(body);
         if (profile.backgroundSummary != input.backgroundSummary ||
-            profile.resumeRef != input.resumeRef ||
+            profile.resumeId != input.resumeId ||
+            profile.resumeRevision != input.resumeRevision ||
             profile.jobDescriptionRef != input.jobDescriptionRef ||
             profile.jobTargetId != input.jobTargetId ||
             profile.jobTargetConfirmationVersion !=
@@ -1429,8 +1431,18 @@ Never _invalidResponse([JobPreparationOperationStage? stage]) {
 
 void _requireProfileInput(CreatePreparationProfileInput input) {
   _requireText(input.backgroundSummary, maxBytes: 64 * 1024);
-  if (input.resumeRef case final value?) {
-    _requireText(value, maxBytes: 16 * 1024);
+  final hasResume = input.resumeId != null;
+  if (hasResume != (input.resumeRevision != null)) {
+    throw const JobPreparationException(
+      kind: JobPreparationFailureKind.invalidRequest,
+      stage: JobPreparationOperationStage.profile,
+    );
+  }
+  if (input.resumeId case final value?) {
+    _requireResourceId(value);
+  }
+  if (input.resumeRevision case final value?) {
+    _requireVersion(value);
   }
   if (input.jobDescriptionRef case final value?) {
     _requireText(value, maxBytes: 16 * 1024);

--- a/mobile/lib/features/coaching/preparation/preparation_models.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_models.dart
@@ -26,7 +26,8 @@ final class PreparationProfile {
     required this.backgroundSummary,
     required this.version,
     required this.updatedAt,
-    this.resumeRef,
+    this.resumeId,
+    this.resumeRevision,
     this.jobDescriptionRef,
     this.jobTargetId,
     this.jobTargetConfirmationVersion,
@@ -34,7 +35,8 @@ final class PreparationProfile {
 
   final String id;
   final String userId;
-  final String? resumeRef;
+  final String? resumeId;
+  final int? resumeRevision;
   final String? jobDescriptionRef;
   final String backgroundSummary;
   final String? jobTargetId;
@@ -176,14 +178,16 @@ final class PracticePlan {
 final class CreatePreparationProfileInput {
   const CreatePreparationProfileInput({
     required this.backgroundSummary,
-    this.resumeRef,
+    this.resumeId,
+    this.resumeRevision,
     this.jobDescriptionRef,
     this.jobTargetId,
     this.jobTargetConfirmationVersion,
   });
 
   final String backgroundSummary;
-  final String? resumeRef;
+  final String? resumeId;
+  final int? resumeRevision;
   final String? jobDescriptionRef;
   final String? jobTargetId;
   final int? jobTargetConfirmationVersion;

--- a/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
@@ -28,22 +28,26 @@ PreparationProfile decodePreparationProfile(Object? value) {
       'updated_at',
     },
     optional: const <String>{
-      'resume_ref',
+      'resume_id',
+      'resume_revision',
       'job_description_ref',
       'job_target_id',
       'job_target_confirmation_version',
     },
   );
   final hasJobTarget = object.containsKey('job_target_id');
+  final hasResume = object.containsKey('resume_id');
+  if (hasResume != object.containsKey('resume_revision')) {
+    throw const PreparationWireFormatException();
+  }
   if (hasJobTarget != object.containsKey('job_target_confirmation_version')) {
     throw const PreparationWireFormatException();
   }
   return PreparationProfile(
     id: _resourceId(object['preparation_profile_id']),
     userId: _resourceId(object['user_id']),
-    resumeRef: object.containsKey('resume_ref')
-        ? _text(object['resume_ref'], maximumBytes: 16 * 1024)
-        : null,
+    resumeId: hasResume ? _resourceId(object['resume_id']) : null,
+    resumeRevision: hasResume ? _version(object['resume_revision']) : null,
     jobDescriptionRef: object.containsKey('job_description_ref')
         ? _text(object['job_description_ref'], maximumBytes: 16 * 1024)
         : null,

--- a/mobile/lib/features/coaching/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/coaching/preparation/wire_preparation_launch_client.dart
@@ -88,7 +88,8 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       idempotencyKey: idempotencyKey,
       body: <String, Object?>{
         'background_summary': input.backgroundSummary,
-        'resume_ref': ?input.resumeRef,
+        'resume_id': ?input.resumeId,
+        'resume_revision': ?input.resumeRevision,
         'job_description_ref': ?input.jobDescriptionRef,
         'job_target_id': ?input.jobTargetId,
         'job_target_confirmation_version': ?input.jobTargetConfirmationVersion,
@@ -100,7 +101,8 @@ final class WirePreparationLaunchClient implements PreparationLaunchClient {
       decode: () {
         final profile = decodePreparationProfileBody(response.body);
         if (profile.backgroundSummary != input.backgroundSummary ||
-            profile.resumeRef != input.resumeRef ||
+            profile.resumeId != input.resumeId ||
+            profile.resumeRevision != input.resumeRevision ||
             profile.jobDescriptionRef != input.jobDescriptionRef ||
             profile.jobTargetId != input.jobTargetId ||
             profile.jobTargetConfirmationVersion !=
@@ -876,8 +878,21 @@ void _requireBackground(String value) {
 
 void _requireProfileInput(CreatePreparationProfileInput input) {
   _requireBackground(input.backgroundSummary);
-  if (input.resumeRef case final value?) {
-    _requireText(value, 16 * 1024);
+  final hasResume = input.resumeId != null;
+  if (hasResume != (input.resumeRevision != null)) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+      stage: PreparationLaunchStage.profile,
+    );
+  }
+  if (input.resumeId case final value?) {
+    _requireResourceId(value);
+  }
+  if (input.resumeRevision case final value? when value < 1) {
+    throw const PreparationLaunchException(
+      kind: PreparationLaunchFailureKind.invalidRequest,
+      stage: PreparationLaunchStage.profile,
+    );
   }
   if (input.jobDescriptionRef case final value?) {
     _requireText(value, 16 * 1024);

--- a/mobile/lib/resume/resume_client.dart
+++ b/mobile/lib/resume/resume_client.dart
@@ -9,6 +9,10 @@ abstract interface class ResumeClient {
     required String title,
     required ResumePdfFile file,
   });
+  Future<ResumeItem> createTemporary(ResumePdfFile file);
+  Future<ResumeDetail> getTemporary(String resumeId);
+  Future<ResumeItem> retryTemporaryParse(ResumeItem resume);
+  Future<void> deleteTemporary(ResumeItem resume);
   Future<ResumeDetail> get(String resumeId);
   Future<ResumeItem> rename(ResumeItem resume, String title);
   Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file);

--- a/mobile/lib/resume/resume_controller.dart
+++ b/mobile/lib/resume/resume_controller.dart
@@ -27,6 +27,7 @@ final class ResumeController extends ChangeNotifier {
   String? _busyResumeId;
   String? _errorMessage;
   String? _noticeMessage;
+  ResumeItem? _temporaryItem;
   int _epoch = 0;
 
   List<ResumeItem> get items => List<ResumeItem>.unmodifiable(_items);
@@ -35,6 +36,7 @@ final class ResumeController extends ChangeNotifier {
   String? get busyResumeId => _busyResumeId;
   String? get errorMessage => _errorMessage;
   String? get noticeMessage => _noticeMessage;
+  ResumeItem? get temporaryItem => _temporaryItem;
 
   /// 返回已缓存的详情，未加载时返回空。
   ResumeDetail? detailFor(String resumeId) => _details[resumeId];
@@ -81,6 +83,53 @@ final class ResumeController extends ChangeNotifier {
       final created = await client.create(title: title, file: file);
       _items = <ResumeItem>[created, ..._items];
       _setNotice('简历已上传，正在解析。', notify: false);
+    });
+  }
+
+  /// 上传仅供当前面试使用的简历，不进入已保存简历列表与额度。
+  Future<void> pickTemporary() async {
+    final file = await filePicker.pickPdf();
+    if (file == null) return;
+    final validation = _validatePdf(file);
+    if (validation != null) {
+      _setNotice(validation);
+      return;
+    }
+    await _runAction(null, () async {
+      final previous = _temporaryItem;
+      final created = await client.createTemporary(file);
+      _temporaryItem = created;
+      if (previous != null) {
+        await client.deleteTemporary(previous);
+      }
+      _setNotice('临时简历已上传，正在解析。', notify: false);
+    });
+  }
+
+  Future<void> refreshTemporary() async {
+    final current = _temporaryItem;
+    if (current == null) return;
+    await _runAction(current.id, () async {
+      final detail = await client.getTemporary(current.id);
+      _temporaryItem = detail.resume;
+    });
+  }
+
+  Future<void> retryTemporaryParse() async {
+    final current = _temporaryItem;
+    if (current == null) return;
+    await _runAction(current.id, () async {
+      _temporaryItem = await client.retryTemporaryParse(current);
+      _setNotice('已重新提交临时简历解析。', notify: false);
+    });
+  }
+
+  Future<void> deleteTemporary() async {
+    final current = _temporaryItem;
+    if (current == null) return;
+    await _runAction(current.id, () async {
+      await client.deleteTemporary(current);
+      _temporaryItem = null;
     });
   }
 
@@ -174,6 +223,7 @@ final class ResumeController extends ChangeNotifier {
     _busyResumeId = null;
     _errorMessage = null;
     _noticeMessage = null;
+    _temporaryItem = null;
     await client.clearAccountState();
     notifyListeners();
   }

--- a/mobile/lib/resume/resume_models.dart
+++ b/mobile/lib/resume/resume_models.dart
@@ -10,6 +10,7 @@ final class ResumeItem {
     required this.originalFilename,
     required this.sizeBytes,
     required this.parseStatus,
+    required this.currentRevision,
     required this.version,
     required this.updatedAt,
   });
@@ -19,6 +20,7 @@ final class ResumeItem {
   final String originalFilename;
   final int sizeBytes;
   final ResumeParseStatus parseStatus;
+  final int? currentRevision;
   final int version;
   final DateTime updatedAt;
 
@@ -36,6 +38,9 @@ final class ResumeItem {
         'FAILED' => ResumeParseStatus.failed,
         _ => throw const FormatException('Invalid resume parse status.'),
       },
+      currentRevision: json.containsKey('current_revision')
+          ? _requiredInt(json, 'current_revision')
+          : null,
       version: _requiredInt(json, 'version'),
       updatedAt: DateTime.parse(_requiredString(json, 'updated_at')),
     );

--- a/mobile/lib/resume/wire_resume_client.dart
+++ b/mobile/lib/resume/wire_resume_client.dart
@@ -88,6 +88,58 @@ final class WireResumeClient implements ResumeClient {
   }
 
   @override
+  Future<ResumeItem> createTemporary(ResumePdfFile file) async {
+    final multipart = _multipart(const <String, String>{}, file);
+    final response = await _send(
+      'POST',
+      '/v1/temporary-resumes',
+      headers: <String, String>{
+        'Idempotency-Key': _idempotencyKey(),
+        HttpHeaders.contentTypeHeader: multipart.contentType,
+      },
+      body: multipart.body,
+    );
+    _expect(response, HttpStatus.accepted);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<ResumeDetail> getTemporary(String resumeId) async {
+    final response = await _send(
+      'GET',
+      '/v1/temporary-resumes/${_segment(resumeId)}',
+    );
+    _expect(response, HttpStatus.ok);
+    try {
+      return ResumeDetail.fromJson(_decodeObject(response.body));
+    } on FormatException {
+      throw const ResumeException(ResumeFailureKind.invalidResponse);
+    }
+  }
+
+  @override
+  Future<ResumeItem> retryTemporaryParse(ResumeItem resume) async {
+    final response = await _send(
+      'POST',
+      '/v1/temporary-resumes/${_segment(resume.id)}/parse-retries',
+      headers: <String, String>{'Idempotency-Key': _idempotencyKey()},
+    );
+    _expect(response, HttpStatus.accepted);
+    return _decodeResume(response.body);
+  }
+
+  @override
+  Future<void> deleteTemporary(ResumeItem resume) async {
+    final response = await _send(
+      'DELETE',
+      '/v1/temporary-resumes/${_segment(resume.id)}'
+          '?expected_version=${resume.version}',
+      headers: <String, String>{'Idempotency-Key': _idempotencyKey()},
+    );
+    _expect(response, HttpStatus.noContent);
+  }
+
+  @override
   Future<ResumeDetail> get(String resumeId) async {
     final response = await _send('GET', '/v1/resumes/${_segment(resumeId)}');
     _expect(response, HttpStatus.ok);

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -87,6 +87,34 @@ void main() {
     expect(client.sessionKeys, hasLength(1));
   });
 
+  test(
+    'selected resume revision is bound to the preparation profile',
+    () async {
+      final client = _FakeJobPreparationClient();
+      final controller = _controller(client);
+      addTearDown(controller.dispose);
+      controller.updateInput(_input);
+      await controller.analyze();
+      await controller.confirm();
+      controller.selectResume(
+        const JobPreparationResumeSelection(
+          resumeId: '70000000-0000-4000-8000-000000000007',
+          revision: 3,
+          resourceVersion: 5,
+          temporary: false,
+          title: 'Backend resume',
+        ),
+      );
+
+      expect(await controller.createPreview(), isTrue);
+      expect(
+        client.lastProfileInput?.resumeId,
+        '70000000-0000-4000-8000-000000000007',
+      );
+      expect(client.lastProfileInput?.resumeRevision, 3);
+    },
+  );
+
   test('voice retry never creates a second committed Session', () async {
     final client = _FakeJobPreparationClient();
     var voiceCalls = 0;
@@ -850,6 +878,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   final List<String> analysisKeys = <String>[];
   final List<String> profileKeys = <String>[];
   final List<String> sessionKeys = <String>[];
+  CreatePreparationProfileInput? lastProfileInput;
   int clearCount = 0;
   int _createAttempts = 0;
   int _analysisAttempts = 0;
@@ -943,6 +972,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   }) async {
     calls.add('profile');
     profileKeys.add(idempotencyKey);
+    lastProfileInput = input;
     _profileAttempts++;
     if (failFirstProfile && _profileAttempts == 1) {
       throw const JobPreparationException(

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -12,6 +12,7 @@ import 'package:speakup/features/coaching/interview/job_preparation_wizard.dart'
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/resume/resume.dart';
 
 void main() {
   testWidgets('restorable draft actions fit the shared button theme', (
@@ -91,6 +92,22 @@ void main() {
     expect(find.byKey(const Key('job-title-field')), findsOneWidget);
     expect(find.byKey(const Key('job-description-field')), findsNothing);
     expect(find.byKey(const Key('job-company-field')), findsNothing);
+
+    await tester.enterText(
+      find.byKey(const Key('job-title-field')),
+      'Backend engineer',
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('analyze-job-button'),
+      scrollable: const Key('job-wizard-input-step'),
+    );
+    await tester.tap(find.byKey(const Key('analyze-job-button')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('job-wizard-confirmation-step')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('runs confirmation and preview before one explicit start', (
@@ -172,6 +189,207 @@ void main() {
 
     expect(voiceCalls, 1);
     expect(opened, 1);
+  });
+
+  testWidgets('confirmation selects an existing READY resume or no resume', (
+    tester,
+  ) async {
+    final controller = _controller(_WizardClient());
+    final resumeController = ResumeController(
+      client: _WizardResumeClient(
+        items: <ResumeItem>[_wizardResume('Backend resume')],
+      ),
+      filePicker: const _WizardResumePicker(null),
+      urlOpener: const _WizardResumeOpener(),
+    );
+    addTearDown(controller.dispose);
+    addTearDown(resumeController.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+    await resumeController.load();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: JobPreparationWizard(
+          controller: controller,
+          resumeController: resumeController,
+        ),
+      ),
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('job-resume-source-card'),
+      scrollable: const Key('job-wizard-confirmation-step'),
+    );
+
+    expect(find.text('简历（可选）'), findsOneWidget);
+    expect(find.text('不使用简历'), findsOneWidget);
+    await tester.tap(find.text('不使用简历'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Backend resume').last);
+    await tester.pumpAndSettle();
+
+    expect(controller.resumeSelection?.title, 'Backend resume');
+    expect(controller.resumeSelection?.temporary, isFalse);
+
+    await tester.tap(find.text('Backend resume'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('不使用简历').last);
+    await tester.pumpAndSettle();
+    expect(controller.resumeSelection, isNull);
+  });
+
+  testWidgets('temporary parse failure keeps job context and can be skipped', (
+    tester,
+  ) async {
+    final controller = _controller(_WizardClient());
+    final resumeController = ResumeController(
+      client: _WizardResumeClient(
+        temporary: _wizardResume(
+          'Temporary resume',
+          status: ResumeParseStatus.failed,
+          revision: null,
+        ),
+      ),
+      filePicker: _WizardResumePicker(
+        ResumePdfFile(name: 'temporary.pdf', bytes: '%PDF-temp'.codeUnits),
+      ),
+      urlOpener: const _WizardResumeOpener(),
+    );
+    addTearDown(controller.dispose);
+    addTearDown(resumeController.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: JobPreparationWizard(
+          controller: controller,
+          resumeController: resumeController,
+        ),
+      ),
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('temporary-resume-upload-button'),
+      scrollable: const Key('job-wizard-confirmation-step'),
+    );
+    await tester.tap(find.byKey(const Key('temporary-resume-upload-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('临时简历解析失败，可以重试或重新上传。'), findsOneWidget);
+    expect(find.text('重试解析'), findsOneWidget);
+    expect(find.text('Backend engineer'), findsWidgets);
+    await _scrollTo(
+      tester,
+      target: const Key('confirm-job-analysis-button'),
+      scrollable: const Key('job-wizard-confirmation-step'),
+    );
+    await tester.tap(find.byKey(const Key('confirm-job-analysis-button')));
+    await tester.pumpAndSettle();
+
+    expect(controller.resumeSelection, isNull);
+    expect(find.byKey(const Key('job-wizard-setup-step')), findsOneWidget);
+  });
+
+  testWidgets('temporary upload becomes the selected parsed resume', (
+    tester,
+  ) async {
+    final controller = _controller(_WizardClient());
+    final resumeController = ResumeController(
+      client: _WizardResumeClient(
+        temporaryCreated: _wizardResume(
+          'Temporary resume',
+          status: ResumeParseStatus.queued,
+          revision: null,
+        ),
+        temporaryDetail: _wizardResume('Temporary resume'),
+      ),
+      filePicker: _WizardResumePicker(
+        ResumePdfFile(name: 'temporary.pdf', bytes: '%PDF-temp'.codeUnits),
+      ),
+      urlOpener: const _WizardResumeOpener(),
+    );
+    addTearDown(controller.dispose);
+    addTearDown(resumeController.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: JobPreparationWizard(
+          controller: controller,
+          resumeController: resumeController,
+        ),
+      ),
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('temporary-resume-upload-button'),
+      scrollable: const Key('job-wizard-confirmation-step'),
+    );
+    await tester.tap(find.byKey(const Key('temporary-resume-upload-button')));
+    await tester.pumpAndSettle();
+
+    expect(controller.resumeSelection?.title, 'Temporary resume');
+    expect(controller.resumeSelection?.temporary, isTrue);
+    expect(find.text('临时简历已解析，可用于本次面试。'), findsOneWidget);
+  });
+
+  testWidgets('temporary file is deleted once its snapshot exists', (
+    tester,
+  ) async {
+    final client = _WizardClient(failPlan: true);
+    final controller = _controller(client);
+    final resumeClient = _WizardResumeClient(
+      temporary: _wizardResume('Temporary resume'),
+    );
+    final resumeController = ResumeController(
+      client: resumeClient,
+      filePicker: _WizardResumePicker(
+        ResumePdfFile(name: 'temporary.pdf', bytes: '%PDF-temp'.codeUnits),
+      ),
+      urlOpener: const _WizardResumeOpener(),
+    );
+    addTearDown(controller.dispose);
+    addTearDown(resumeController.dispose);
+    controller.updateInput(_input);
+    await controller.analyze();
+    await controller.confirm();
+    await resumeController.pickTemporary();
+    controller.selectResume(
+      JobPreparationResumeSelection(
+        resumeId: resumeController.temporaryItem!.id,
+        revision: resumeController.temporaryItem!.currentRevision!,
+        resourceVersion: resumeController.temporaryItem!.version,
+        temporary: true,
+        title: resumeController.temporaryItem!.title,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: JobPreparationWizard(
+          controller: controller,
+          resumeController: resumeController,
+        ),
+      ),
+    );
+    await _scrollTo(
+      tester,
+      target: const Key('create-plan-preview-button'),
+      scrollable: const Key('job-wizard-setup-step'),
+    );
+    await tester.tap(find.byKey(const Key('create-plan-preview-button')));
+    await tester.pumpAndSettle();
+
+    expect(client.snapshotCalls, 1);
+    expect(resumeClient.deleteTemporaryCalls, 1);
+    expect(resumeController.temporaryItem, isNull);
   });
 
   testWidgets('voice retry reuses committed Session', (tester) async {
@@ -303,13 +521,15 @@ JobPreparationController _controller(
 }
 
 final class _WizardClient implements JobPreparationClient {
-  _WizardClient({this.sessionCompleter});
+  _WizardClient({this.sessionCompleter, this.failPlan = false});
 
   final Completer<PreparationPracticeBootstrap>? sessionCompleter;
+  final bool failPlan;
   JobTarget? _target;
   PreparationSnapshot? _snapshotValue;
   PracticePlan? _planValue;
   int sessionCalls = 0;
+  int snapshotCalls = 0;
 
   @override
   Future<JobTarget> analyzeJobTarget({
@@ -354,6 +574,13 @@ final class _WizardClient implements JobPreparationClient {
     required CreatePreparationPlanInput input,
     required String idempotencyKey,
   }) async {
+    if (failPlan) {
+      throw const JobPreparationException(
+        kind: JobPreparationFailureKind.network,
+        stage: JobPreparationOperationStage.plan,
+        retryable: true,
+      );
+    }
     final snapshot = _snapshotValue ?? _snapshot;
     _planValue = _planFrom(
       snapshot: snapshot,
@@ -382,6 +609,7 @@ final class _WizardClient implements JobPreparationClient {
     required int sourceVersion,
     required String idempotencyKey,
   }) async {
+    snapshotCalls++;
     final target = _target ?? _targetFor(JobTargetStage.confirmed);
     final candidate =
         target.confirmation?.candidate ?? _candidateFor(target.input.source);
@@ -448,6 +676,108 @@ final class _WizardClient implements JobPreparationClient {
     _target = _targetFor(JobTargetStage.draft, input: input);
     return _target!;
   }
+}
+
+ResumeItem _wizardResume(
+  String title, {
+  ResumeParseStatus status = ResumeParseStatus.ready,
+  int? revision = 1,
+}) => ResumeItem(
+  id: '70000000-0000-4000-8000-000000000007',
+  title: title,
+  originalFilename: 'resume.pdf',
+  sizeBytes: 1024,
+  parseStatus: status,
+  currentRevision: revision,
+  version: 2,
+  updatedAt: DateTime.utc(2026, 8, 6),
+);
+
+final class _WizardResumePicker implements ResumeFilePicker {
+  const _WizardResumePicker(this.file);
+
+  final ResumePdfFile? file;
+
+  @override
+  Future<ResumePdfFile?> pickPdf() async => file;
+}
+
+final class _WizardResumeOpener implements ResumeUrlOpener {
+  const _WizardResumeOpener();
+
+  @override
+  Future<bool> open(Uri url) async => true;
+}
+
+final class _WizardResumeClient implements ResumeClient {
+  _WizardResumeClient({
+    this.items = const <ResumeItem>[],
+    this.temporary,
+    this.temporaryCreated,
+    this.temporaryDetail,
+  });
+
+  final List<ResumeItem> items;
+  final ResumeItem? temporary;
+  final ResumeItem? temporaryCreated;
+  final ResumeItem? temporaryDetail;
+  int deleteTemporaryCalls = 0;
+
+  @override
+  Future<List<ResumeItem>> list() async => items;
+
+  @override
+  Future<ResumeItem> create({
+    required String title,
+    required ResumePdfFile file,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<ResumeItem> createTemporary(ResumePdfFile file) async =>
+      temporaryCreated ?? temporary!;
+
+  @override
+  Future<ResumeDetail> getTemporary(String resumeId) async =>
+      ResumeDetail(resume: temporaryDetail ?? temporary!);
+
+  @override
+  Future<ResumeItem> retryTemporaryParse(ResumeItem resume) async => resume;
+
+  @override
+  Future<void> deleteTemporary(ResumeItem resume) async {
+    deleteTemporaryCalls += 1;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> delete(ResumeItem resume) async => throw UnimplementedError();
+
+  @override
+  Future<ResumeDetail> get(String resumeId) async => throw UnimplementedError();
+
+  @override
+  Future<Uri> getContentUrl(String resumeId) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<ResumeItem> rename(ResumeItem resume, String title) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<ResumeItem> replace(ResumeItem resume, ResumePdfFile file) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<ResumeItem> retryParse(ResumeItem resume) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<ResumeDetail> updateContent(
+    ResumeDetail detail,
+    ResumeContent content,
+  ) async => throw UnimplementedError();
 }
 
 JobTarget _targetFor(

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -51,9 +51,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('starts with JD-first input and labels quick start honestly', (
-    tester,
-  ) async {
+  testWidgets('keeps one job input for either title or JD', (tester) async {
     final controller = JobPreparationController(
       client: _WizardClient(),
       threadIdProvider: () => 'thread-1',
@@ -83,12 +81,16 @@ void main() {
     expect(find.byKey(const Key('job-description-field')), findsOneWidget);
     expect(find.byKey(const Key('job-title-field')), findsNothing);
 
-    await tester.tap(find.text('岗位快速开始'));
+    expect(find.byKey(const Key('job-company-field')), findsNothing);
+    expect(find.byKey(const Key('job-background-field')), findsNothing);
+    expect(find.byKey(const Key('job-goal-field')), findsNothing);
+
+    await tester.tap(find.text('职位名称'));
     await tester.pump();
 
     expect(find.byKey(const Key('job-title-field')), findsOneWidget);
-    expect(find.text('快速开始不会基于真实 JD，只会提供通用岗位建议。'), findsOneWidget);
-    expect(find.text('你的相关背景（可选）'), findsOneWidget);
+    expect(find.byKey(const Key('job-description-field')), findsNothing);
+    expect(find.byKey(const Key('job-company-field')), findsNothing);
   });
 
   testWidgets('runs confirmation and preview before one explicit start', (
@@ -123,10 +125,6 @@ void main() {
     await tester.enterText(
       find.byKey(const Key('job-description-field')),
       'Build reliable Go APIs and explain system design trade-offs.',
-    );
-    await tester.enterText(
-      find.byKey(const Key('job-background-field')),
-      _background,
     );
     await _scrollTo(
       tester,
@@ -240,16 +238,13 @@ void main() {
         child: MaterialApp(home: JobPreparationWizard(controller: controller)),
       ),
     );
-    await tester.tap(find.text('岗位快速开始'));
+    await tester.tap(find.text('职位名称'));
     await tester.pump();
     await tester.tap(find.byKey(const Key('job-title-field')));
     await tester.pump();
 
     expect(tester.takeException(), isNull);
-    final semantics = tester.getSemantics(
-      find.byKey(const Key('quick-start-notice')),
-    );
-    expect(semantics.label, contains('快速开始不会基于真实 JD'));
+    expect(find.byKey(const Key('job-company-field')), findsNothing);
     await _scrollTo(
       tester,
       target: const Key('analyze-job-button'),

--- a/mobile/test/resume/resume_controller_test.dart
+++ b/mobile/test/resume/resume_controller_test.dart
@@ -64,6 +64,24 @@ void main() {
     expect(client.createCount, 0);
     expect(controller.noticeMessage, '请选择有效的 PDF 文件。');
   });
+
+  test('temporary upload stays outside the saved resume list', () async {
+    final client = _FakeResumeClient(items: <ResumeItem>[_resume('saved')]);
+    final controller = ResumeController(
+      client: client,
+      filePicker: _FakePicker(
+        ResumePdfFile(name: 'temporary.pdf', bytes: '%PDF-temp'.codeUnits),
+      ),
+      urlOpener: _FakeOpener(),
+    );
+
+    await controller.load();
+    await controller.pickTemporary();
+
+    expect(controller.items.single.id, 'saved');
+    expect(controller.temporaryItem?.id, 'temporary');
+    expect(controller.canUpload, isTrue);
+  });
 }
 
 ResumeItem _resume(String id, {String? title}) => ResumeItem(
@@ -72,6 +90,7 @@ ResumeItem _resume(String id, {String? title}) => ResumeItem(
   originalFilename: '$id.pdf',
   sizeBytes: 2048,
   parseStatus: ResumeParseStatus.ready,
+  currentRevision: 1,
   version: 1,
   updatedAt: DateTime.utc(2026, 8, 3),
 );
@@ -110,6 +129,17 @@ final class _FakeResumeClient implements ResumeClient {
     createdTitle = title;
     return _resume('created', title: title);
   }
+
+  @override
+  Future<ResumeItem> createTemporary(ResumePdfFile file) async =>
+      _resume('temporary');
+  @override
+  Future<void> deleteTemporary(ResumeItem resume) async {}
+  @override
+  Future<ResumeDetail> getTemporary(String resumeId) async =>
+      ResumeDetail(resume: _resume(resumeId));
+  @override
+  Future<ResumeItem> retryTemporaryParse(ResumeItem resume) async => resume;
 
   @override
   Future<void> clearAccountState() async {}

--- a/mobile/test/resume/resume_page_test.dart
+++ b/mobile/test/resume/resume_page_test.dart
@@ -273,6 +273,7 @@ ResumeItem _resume(String id, ResumeParseStatus status) => ResumeItem(
   originalFilename: '$id.pdf',
   sizeBytes: 1024,
   parseStatus: status,
+  currentRevision: status == ResumeParseStatus.ready ? 1 : null,
   version: 1,
   updatedAt: DateTime.utc(2026, 8, 3),
 );
@@ -301,6 +302,17 @@ final class _PageClient implements ResumeClient {
     required String title,
     required ResumePdfFile file,
   }) => throw UnimplementedError();
+  @override
+  Future<ResumeItem> createTemporary(ResumePdfFile file) =>
+      throw UnimplementedError();
+  @override
+  Future<void> deleteTemporary(ResumeItem resume) => throw UnimplementedError();
+  @override
+  Future<ResumeDetail> getTemporary(String resumeId) =>
+      throw UnimplementedError();
+  @override
+  Future<ResumeItem> retryTemporaryParse(ResumeItem resume) =>
+      throw UnimplementedError();
   @override
   Future<void> delete(ResumeItem resume) => throw UnimplementedError();
   @override

--- a/mobile/test/resume/wire_resume_client_test.dart
+++ b/mobile/test/resume/wire_resume_client_test.dart
@@ -63,6 +63,29 @@ void main() {
     await server.close(force: true);
   });
 
+  test('temporary upload uses the interview-only resume endpoint', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final requestSeen = _serveOnce(server, (request, body) {
+      expect(request.method, 'POST');
+      expect(request.uri.path, '/v1/temporary-resumes');
+      expect(request.headers.value('Idempotency-Key'), startsWith('resume-'));
+      expect(latin1.decode(body), contains('filename="temporary.pdf"'));
+      request.response.statusCode = HttpStatus.accepted;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(jsonEncode(_resumeJson('temporary')));
+    });
+    final client = _client(server);
+
+    final created = await client.createTemporary(
+      ResumePdfFile(name: 'temporary.pdf', bytes: '%PDF-temp'.codeUnits),
+    );
+    await requestSeen;
+
+    expect(created.id, 'temporary');
+    expect(created.currentRevision, 1);
+    await server.close(force: true);
+  });
+
   test('get accepts contract-valid empty target and summary', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     final requestSeen = _serveOnce(server, (request, body) {
@@ -155,6 +178,7 @@ Map<String, Object?> _resumeJson(String id) => <String, Object?>{
   'size_bytes': 1024,
   'file_status': 'AVAILABLE',
   'parse_status': 'READY',
+  'current_revision': 1,
   'version': 1,
   'created_at': '2026-08-03T00:00:00Z',
   'updated_at': '2026-08-03T00:00:00Z',

--- a/server/internal/resume/app/parse_worker.go
+++ b/server/internal/resume/app/parse_worker.go
@@ -71,6 +71,19 @@ func (w *ParseWorker) ProcessNext(ctx context.Context) (bool, error) {
 		ctx == nil || ctx.Err() != nil {
 		return false, InvalidResumeError()
 	}
+	expired, found, err := w.repository.ClaimExpiredTemporary(ctx, time.Now().UTC())
+	if err != nil {
+		return false, err
+	}
+	if found {
+		if err := w.storage.Delete(ctx, expired.ObjectKey); err != nil {
+			return true, RepositoryError(err)
+		}
+		if err := w.repository.MarkDeleted(ctx, expired.OwnerUserID, expired.ID); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
 	claimed, found, err := w.repository.ClaimNextQueuedParse(ctx)
 	if err != nil || !found {
 		return false, err

--- a/server/internal/resume/app/ports.go
+++ b/server/internal/resume/app/ports.go
@@ -37,6 +37,8 @@ type Repository interface {
 	QueueParse(context.Context, string, string) error
 	// ClaimNextQueuedParse 领取下一份可处理的解析任务。
 	ClaimNextQueuedParse(context.Context) (resume.Resume, bool, error)
+	// ClaimExpiredTemporary claims one expired temporary resume for raw-file cleanup.
+	ClaimExpiredTemporary(context.Context, time.Time) (resume.Resume, bool, error)
 	// CompleteParse 原子保存解析修订并完成解析任务。
 	CompleteParse(context.Context, resume.Resume, resume.Revision) error
 	// FailParse 保存解析失败状态和稳定失败码。

--- a/server/internal/resume/app/revision_query.go
+++ b/server/internal/resume/app/revision_query.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume"
@@ -45,6 +46,10 @@ func (query *RevisionQuery) ReadOwnedRevision(
 	}
 	if detail.Resume.ID != resumeID ||
 		detail.Resume.OwnerUserID != actor.UserID {
+		return resume.Revision{}, ResumeNotFoundError()
+	}
+	if detail.Resume.Temporary &&
+		(detail.Resume.ExpiresAt == nil || !detail.Resume.ExpiresAt.After(time.Now().UTC())) {
 		return resume.Revision{}, ResumeNotFoundError()
 	}
 	if detail.Resume.CurrentRevision != revision {

--- a/server/internal/resume/app/service.go
+++ b/server/internal/resume/app/service.go
@@ -21,6 +21,8 @@ const (
 	MaxResumesPerUser = 3
 	// DefaultMaximumFileBytes 是 Resume API 接受的 PDF 最大字节数。
 	DefaultMaximumFileBytes int64 = 10 * 1024 * 1024
+	// TemporaryResumeLifetime bounds abandoned interview-only uploads.
+	TemporaryResumeLifetime = 24 * time.Hour
 )
 
 // ServiceConfiguration 保存应用服务的文件和授权地址边界。
@@ -69,6 +71,24 @@ func (s *Service) Create(
 	actor requestcontext.Actor,
 	command CreateCommand,
 ) (resume.Resume, error) {
+	return s.create(ctx, actor, command, false)
+}
+
+// CreateTemporary creates an interview-only resume excluded from the saved quota.
+func (s *Service) CreateTemporary(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command CreateCommand,
+) (resume.Resume, error) {
+	return s.create(ctx, actor, command, true)
+}
+
+func (s *Service) create(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command CreateCommand,
+	temporary bool,
+) (resume.Resume, error) {
 	if !validServiceCall(s, ctx, actor) || !validTitle(command.Title) ||
 		!validIdempotencyKey(command.IdempotencyKey) {
 		return resume.Resume{}, InvalidResumeError()
@@ -102,6 +122,11 @@ func (s *Service) Create(
 		Version:          1,
 		CreatedAt:        now,
 		UpdatedAt:        now,
+		Temporary:        temporary,
+	}
+	if temporary {
+		expiresAt := now.Add(TemporaryResumeLifetime)
+		item.ExpiresAt = &expiresAt
 	}
 	if err := s.repository.CreateWithinLimit(ctx, item, MaxResumesPerUser); err != nil {
 		if existing, ok := s.replayedCreate(ctx, actor.UserID, item, err); ok {
@@ -124,6 +149,54 @@ func (s *Service) Create(
 		return resume.Resume{}, err
 	}
 	return s.repository.FindByOwnerAndID(ctx, actor.UserID, resumeID)
+}
+
+// GetTemporary returns only an unexpired interview-only resume.
+func (s *Service) GetTemporary(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	resumeID string,
+) (Detail, error) {
+	detail, err := s.Get(ctx, actor, resumeID)
+	if err != nil {
+		return Detail{}, err
+	}
+	if !validTemporary(detail.Resume, s.now()) {
+		return Detail{}, ResumeNotFoundError()
+	}
+	return detail, nil
+}
+
+// RetryTemporaryParse retries parsing only for an unexpired temporary resume.
+func (s *Service) RetryTemporaryParse(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	resumeID string,
+) (resume.Resume, error) {
+	if _, err := s.GetTemporary(ctx, actor, resumeID); err != nil {
+		return resume.Resume{}, err
+	}
+	return s.RetryParse(ctx, actor, resumeID)
+}
+
+// DeleteTemporary deletes only an interview-only resume.
+func (s *Service) DeleteTemporary(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command DeleteCommand,
+) error {
+	if !validServiceCall(s, ctx, actor) || !validUUID(command.ResumeID) ||
+		command.ExpectedVersion < 1 {
+		return ResumeNotFoundError()
+	}
+	item, err := s.repository.FindByOwnerAndID(ctx, actor.UserID, command.ResumeID)
+	if err != nil {
+		return err
+	}
+	if !item.Temporary {
+		return ResumeNotFoundError()
+	}
+	return s.Delete(ctx, actor, command)
 }
 
 // List 列出当前认证用户拥有的活动简历。
@@ -356,6 +429,10 @@ func (s *Service) replayedCreate(
 func (s *Service) abortCreate(ctx context.Context, ownerUserID string, resumeID string, objectKey string) {
 	_ = s.storage.Delete(ctx, objectKey)
 	_ = s.repository.AbortCreate(ctx, ownerUserID, resumeID)
+}
+
+func validTemporary(item resume.Resume, now time.Time) bool {
+	return item.Temporary && item.ExpiresAt != nil && item.ExpiresAt.After(now.UTC())
 }
 
 // readValidatedPDF 双重校验上传大小、声明摘要和 PDF 文件魔数。

--- a/server/internal/resume/app/service_test.go
+++ b/server/internal/resume/app/service_test.go
@@ -39,6 +39,23 @@ func TestServiceCreateIsDurableAndReplayable(t *testing.T) {
 	}
 }
 
+func TestServiceCreateTemporarySetsExpiryAndSkipsSavedCollection(t *testing.T) {
+	repository := &repositoryFake{}
+	service := newTestService(t, repository, newFileStorageFake())
+	fixedNow := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return fixedNow }
+
+	created, err := service.CreateTemporary(
+		context.Background(),
+		serviceTestActor,
+		createTestCommand([]byte("%PDF-1.4 temporary resume")),
+	)
+	if err != nil || !created.Temporary || created.ExpiresAt == nil ||
+		!created.ExpiresAt.Equal(fixedNow.Add(TemporaryResumeLifetime)) {
+		t.Fatalf("created = %#v, err = %v", created, err)
+	}
+}
+
 // TestServiceCreateCompensatesFailedUpload 验证对象保存失败会硬删除 UPLOADING 记录。
 func TestServiceCreateCompensatesFailedUpload(t *testing.T) {
 	repository := &repositoryFake{}
@@ -156,6 +173,28 @@ func TestParseWorkerCompletesAndPersistsFailures(t *testing.T) {
 	processed, err = worker.ProcessNext(context.Background())
 	if err != nil || !processed || repository.failedCode != "pdf_text_unavailable" {
 		t.Fatalf("processed = %v, failedCode = %q, err = %v", processed, repository.failedCode, err)
+	}
+}
+
+func TestParseWorkerDeletesExpiredTemporaryBeforeParsing(t *testing.T) {
+	expired := resume.Resume{
+		ID: "40000000-0000-4000-8000-000000000009", OwnerUserID: serviceTestActor.UserID,
+		ObjectKey: "resume/v1/temporary.pdf", Temporary: true,
+	}
+	repository := &repositoryFake{expired: expired, expiredFound: true}
+	files := newFileStorageFake()
+	files.objects[expired.ObjectKey] = []byte("pdf")
+	worker, err := NewParseWorker(repository, files, &parserFake{}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewParseWorker: %v", err)
+	}
+
+	processed, err := worker.ProcessNext(context.Background())
+	if err != nil || !processed || repository.item.ID != "" {
+		t.Fatalf("processed = %v, item = %#v, err = %v", processed, repository.item, err)
+	}
+	if _, exists := files.objects[expired.ObjectKey]; exists {
+		t.Fatal("expired temporary object was not deleted")
 	}
 }
 
@@ -378,6 +417,8 @@ type repositoryFake struct {
 	completedRevision resume.Revision
 	failedCode        string
 	detailRevision    *resume.Revision
+	expired           resume.Resume
+	expiredFound      bool
 }
 
 // CreateWithinLimit 创建测试记录或返回幂等冲突。
@@ -475,6 +516,15 @@ func (repository *repositoryFake) ClaimNextQueuedParse(context.Context) (resume.
 	found := repository.claimFound
 	repository.claimFound = false
 	return repository.claim, found, nil
+}
+
+func (repository *repositoryFake) ClaimExpiredTemporary(context.Context, time.Time) (resume.Resume, bool, error) {
+	found := repository.expiredFound
+	repository.expiredFound = false
+	if found {
+		repository.item = repository.expired
+	}
+	return repository.expired, found, nil
 }
 
 // CompleteParse 记录测试解析修订。

--- a/server/internal/resume/model.go
+++ b/server/internal/resume/model.go
@@ -17,6 +17,8 @@ type Resume struct {
 	ParseStatus      ParseStatus
 	ParseFailureCode string
 	CurrentRevision  int64
+	Temporary        bool
+	ExpiresAt        *time.Time
 	Version          int64
 	CreatedAt        time.Time
 	UpdatedAt        time.Time

--- a/server/internal/resume/persistence/gorm.go
+++ b/server/internal/resume/persistence/gorm.go
@@ -83,14 +83,16 @@ func (r *GormRepository) CreateWithinLimit(
 			Take(&owner).Error; err != nil {
 			return mapGormError(err)
 		}
-		var count int64
-		if err := tx.Model(&resumeRecord{}).
-			Where("owner_user_id = ?", item.OwnerUserID).
-			Count(&count).Error; err != nil {
-			return mapGormError(err)
-		}
-		if count >= int64(maximum) {
-			return app.ResumeLimitExceededError()
+		if !item.Temporary {
+			var count int64
+			if err := tx.Model(&resumeRecord{}).
+				Where("owner_user_id = ? AND is_temporary = FALSE", item.OwnerUserID).
+				Count(&count).Error; err != nil {
+				return mapGormError(err)
+			}
+			if count >= int64(maximum) {
+				return app.ResumeLimitExceededError()
+			}
 		}
 		if err := tx.Create(&record).Error; err != nil {
 			return mapGormError(err)
@@ -136,7 +138,7 @@ func (r *GormRepository) ListByOwner(
 		return nil, app.InvalidResumeError()
 	}
 	database := r.database.WithContext(ctx).
-		Where("owner_user_id = ?", ownerUserID)
+		Where("owner_user_id = ? AND is_temporary = FALSE", ownerUserID)
 	if query.Cursor != "" {
 		database = database.Where("resume_id < ?", query.Cursor)
 	}
@@ -516,6 +518,52 @@ func (r *GormRepository) ClaimNextQueuedParse(
 	return claimed, found, nil
 }
 
+// ClaimExpiredTemporary locks one expired temporary resume and marks its file for deletion.
+func (r *GormRepository) ClaimExpiredTemporary(
+	ctx context.Context,
+	now time.Time,
+) (resume.Resume, bool, error) {
+	if r == nil || r.database == nil || ctx == nil || now.IsZero() {
+		return resume.Resume{}, false, app.InvalidResumeError()
+	}
+	var claimed resume.Resume
+	found := false
+	err := r.database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var record resumeRecord
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Where("is_temporary = TRUE AND expires_at <= ?", now.UTC()).
+			Where("file_status IN ?", []string{string(resume.FileAvailable), string(resume.FileDeleting)}).
+			Order("expires_at, resume_id").
+			Take(&record).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		if err != nil {
+			return mapGormError(err)
+		}
+		if record.FileStatus != string(resume.FileDeleting) {
+			if err := tx.Model(&record).Clauses(clause.Returning{}).Updates(map[string]any{
+				"file_status": string(resume.FileDeleting),
+				"version":     gorm.Expr("version + 1"),
+				"updated_at":  nextResumeTimestamp(),
+			}).Error; err != nil {
+				return mapGormError(err)
+			}
+		}
+		mapped, err := resumeFromRecord(record)
+		if err != nil {
+			return app.RepositoryError(err)
+		}
+		claimed = mapped
+		found = true
+		return nil
+	})
+	if err != nil {
+		return resume.Resume{}, false, mapTransactionError(err)
+	}
+	return claimed, found, nil
+}
+
 // CompleteParse 保存解析修订并把简历标记为解析完成。
 func (r *GormRepository) CompleteParse(
 	ctx context.Context,
@@ -713,6 +761,8 @@ func validWriteInput(
 
 // validNewResume 校验新建持久化记录的必要不变量。
 func validNewResume(item resume.Resume) bool {
+	temporaryValid := (!item.Temporary && item.ExpiresAt == nil) ||
+		(item.Temporary && item.ExpiresAt != nil && item.ExpiresAt.After(item.CreatedAt))
 	return validUUID(item.ID) && validUUID(item.OwnerUserID) && validTitle(item.Title) &&
 		validFileMetadata(
 			item.OriginalFilename,
@@ -722,7 +772,8 @@ func validNewResume(item resume.Resume) bool {
 			item.ObjectKey,
 		) && item.FileStatus == resume.FileUploading &&
 		item.ParseStatus == resume.ParseQueued && item.ParseFailureCode == "" &&
-		item.CurrentRevision == 0 && (item.Version == 0 || item.Version == 1)
+		item.CurrentRevision == 0 && temporaryValid &&
+		(item.Version == 0 || item.Version == 1)
 }
 
 // validFileMetadata 校验 PDF 元数据是否满足迁移约束。

--- a/server/internal/resume/persistence/gorm_integration_test.go
+++ b/server/internal/resume/persistence/gorm_integration_test.go
@@ -151,6 +151,67 @@ func TestGormRepositoryConcurrentLimitAndCapacityRecovery(t *testing.T) {
 	}
 }
 
+// TestTemporaryResumeDoesNotConsumeSavedQuota verifies the interview-only
+// resource stays out of both the saved list and its three-item quota.
+func TestTemporaryResumeDoesNotConsumeSavedQuota(t *testing.T) {
+	repository := newResumeRepository(t)
+	ctx := context.Background()
+	for index, id := range []string{
+		"41000000-0000-4000-8000-000000000001",
+		"41000000-0000-4000-8000-000000000002",
+		"41000000-0000-4000-8000-000000000003",
+	} {
+		if err := repository.CreateWithinLimit(
+			ctx,
+			resumeCandidate(id, resumeOwnerA),
+			app.MaxResumesPerUser,
+		); err != nil {
+			t.Fatalf("create saved Resume %d: %v", index+1, err)
+		}
+	}
+
+	temporary := resumeCandidate(
+		"41000000-0000-4000-8000-000000000004",
+		resumeOwnerA,
+	)
+	temporary.Temporary = true
+	expiresAt := temporary.CreatedAt.Add(app.TemporaryResumeLifetime)
+	temporary.ExpiresAt = &expiresAt
+	if err := repository.CreateWithinLimit(
+		ctx,
+		temporary,
+		app.MaxResumesPerUser,
+	); err != nil {
+		t.Fatalf("create temporary Resume at saved quota: %v", err)
+	}
+
+	items, err := repository.ListByOwner(
+		ctx,
+		resumeOwnerA,
+		app.ListQuery{Limit: app.MaxResumesPerUser},
+	)
+	if err != nil || len(items) != app.MaxResumesPerUser {
+		t.Fatalf("saved list = %#v, err = %v", items, err)
+	}
+	for _, item := range items {
+		if item.Temporary || item.ID == temporary.ID {
+			t.Fatalf("temporary Resume leaked into saved list: %#v", item)
+		}
+	}
+
+	fourthSaved := resumeCandidate(
+		"41000000-0000-4000-8000-000000000005",
+		resumeOwnerA,
+	)
+	if err := repository.CreateWithinLimit(
+		ctx,
+		fourthSaved,
+		app.MaxResumesPerUser,
+	); errorCode(err) != "resume_limit_exceeded" {
+		t.Fatalf("fourth saved Resume error = %v", err)
+	}
+}
+
 // TestGormRepositoryParseCompletionAndFailure 验证解析领取、完成、失败和重试状态迁移。
 func TestGormRepositoryParseCompletionAndFailure(t *testing.T) {
 	repository := newResumeRepository(t)

--- a/server/internal/resume/persistence/mapping.go
+++ b/server/internal/resume/persistence/mapping.go
@@ -22,6 +22,8 @@ func resumeToRecord(item resume.Resume) resumeRecord {
 		ObjectKey:        item.ObjectKey,
 		FileStatus:       string(item.FileStatus),
 		ParseStatus:      string(item.ParseStatus),
+		Temporary:        item.Temporary,
+		ExpiresAt:        item.ExpiresAt,
 		Version:          item.Version,
 		CreatedAt:        item.CreatedAt,
 		UpdatedAt:        item.UpdatedAt,
@@ -64,6 +66,8 @@ func resumeFromRecord(record resumeRecord) (resume.Resume, error) {
 		ObjectKey:        record.ObjectKey,
 		FileStatus:       fileStatus,
 		ParseStatus:      parseStatus,
+		Temporary:        record.Temporary,
+		ExpiresAt:        record.ExpiresAt,
 		Version:          record.Version,
 		CreatedAt:        record.CreatedAt.UTC(),
 		UpdatedAt:        record.UpdatedAt.UTC(),
@@ -73,6 +77,10 @@ func resumeFromRecord(record resumeRecord) (resume.Resume, error) {
 	}
 	if record.CurrentRevision != nil {
 		item.CurrentRevision = *record.CurrentRevision
+	}
+	if item.ExpiresAt != nil {
+		expiresAt := item.ExpiresAt.UTC()
+		item.ExpiresAt = &expiresAt
 	}
 	if record.DeletedAt.Valid {
 		deletedAt := record.DeletedAt.Time.UTC()

--- a/server/internal/resume/persistence/record.go
+++ b/server/internal/resume/persistence/record.go
@@ -21,6 +21,8 @@ type resumeRecord struct {
 	ParseStatus      string         `gorm:"column:parse_status"`
 	ParseFailureCode *string        `gorm:"column:parse_failure_code"`
 	CurrentRevision  *int64         `gorm:"column:current_revision"`
+	Temporary        bool           `gorm:"column:is_temporary"`
+	ExpiresAt        *time.Time     `gorm:"column:expires_at"`
 	Version          int64          `gorm:"column:version"`
 	CreatedAt        time.Time      `gorm:"column:created_at"`
 	UpdatedAt        time.Time      `gorm:"column:updated_at"`

--- a/server/internal/resume/transport/http.go
+++ b/server/internal/resume/transport/http.go
@@ -39,10 +39,12 @@ var (
 type Application interface {
 	// Create 创建当前用户的一份新简历。
 	Create(context.Context, requestcontext.Actor, app.CreateCommand) (resume.Resume, error)
+	CreateTemporary(context.Context, requestcontext.Actor, app.CreateCommand) (resume.Resume, error)
 	// List 列出当前用户拥有的活动简历。
 	List(context.Context, requestcontext.Actor, app.ListQuery) (app.ListResult, error)
 	// Get 获取当前用户指定简历的详情。
 	Get(context.Context, requestcontext.Actor, string) (app.Detail, error)
+	GetTemporary(context.Context, requestcontext.Actor, string) (app.Detail, error)
 	// UpdateMetadata 修改当前用户指定简历的元数据。
 	UpdateMetadata(context.Context, requestcontext.Actor, app.UpdateMetadataCommand) (resume.Resume, error)
 	// UpdateContent 保存当前用户指定简历的手动内容修订。
@@ -53,8 +55,10 @@ type Application interface {
 	GetContentURL(context.Context, requestcontext.Actor, string) (app.ContentURL, error)
 	// RetryParse 重新提交当前用户指定简历的解析任务。
 	RetryParse(context.Context, requestcontext.Actor, string) (resume.Resume, error)
+	RetryTemporaryParse(context.Context, requestcontext.Actor, string) (resume.Resume, error)
 	// Delete 删除当前用户指定的简历。
 	Delete(context.Context, requestcontext.Actor, app.DeleteCommand) error
+	DeleteTemporary(context.Context, requestcontext.Actor, app.DeleteCommand) error
 }
 
 // HTTPHandler 接收已通过 Identity 认证中间件的 Resume HTTP 请求。
@@ -80,6 +84,10 @@ func NewHTTPHandler(application Application, maximumFileBytes int64) (*HTTPHandl
 // RegisterRoutes 注册 Resume REST 路由；调用方必须挂载到 Identity 认证路由组。
 func (h *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
 	routes.POST("/v1/resumes", h.create)
+	routes.POST("/v1/temporary-resumes", h.createTemporary)
+	routes.GET("/v1/temporary-resumes/:resume_id", h.getTemporary)
+	routes.POST("/v1/temporary-resumes/:resume_id/parse-retries", h.retryTemporaryParse)
+	routes.DELETE("/v1/temporary-resumes/:resume_id", h.deleteTemporary)
 	routes.GET("/v1/resumes", h.list)
 	routes.GET("/v1/resumes/:resume_id", h.get)
 	routes.PATCH("/v1/resumes/:resume_id", h.updateMetadata)
@@ -88,6 +96,103 @@ func (h *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
 	routes.GET("/v1/resumes/:resume_id/content-url", h.getContentURL)
 	routes.POST("/v1/resumes/:resume_id/parse-retries", h.retryParse)
 	routes.DELETE("/v1/resumes/:resume_id", h.delete)
+}
+
+func (h *HTTPHandler) createTemporary(c *gin.Context) {
+	actor, ok := h.actor(c)
+	if !ok {
+		return
+	}
+	idempotencyKey, ok := h.idempotencyKey(c)
+	if !ok {
+		return
+	}
+	upload, ok := h.multipartPDF(c, false, false)
+	if !ok {
+		return
+	}
+	title := strings.TrimSuffix(upload.filename, ".pdf")
+	if title == upload.filename {
+		title = strings.TrimSuffix(upload.filename, ".PDF")
+	}
+	if strings.TrimSpace(title) == "" {
+		title = "Temporary resume"
+	}
+	if len([]rune(title)) > 120 {
+		title = string([]rune(title)[:120])
+	}
+	item, err := h.application.CreateTemporary(c.Request.Context(), actor, app.CreateCommand{
+		Title: title, Filename: upload.filename, ContentType: "application/pdf",
+		SizeBytes: int64(len(upload.body)), ChecksumSHA256: upload.checksum,
+		File: bytes.NewReader(upload.body), IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		h.errors.Write(c, err)
+		return
+	}
+	if !validTemporaryProjection(item, actor.UserID, "") {
+		h.writeProjectionError(c)
+		return
+	}
+	setPrivateHeaders(c)
+	c.JSON(http.StatusAccepted, newTemporaryResumeResponse(item))
+}
+
+func (h *HTTPHandler) getTemporary(c *gin.Context) {
+	actor, resumeID, ok := h.actorAndResumeID(c)
+	if !ok {
+		return
+	}
+	detail, err := h.application.GetTemporary(c.Request.Context(), actor, resumeID)
+	if err != nil {
+		h.errors.Write(c, err)
+		return
+	}
+	if !validTemporaryProjection(detail.Resume, actor.UserID, resumeID) ||
+		(detail.Revision != nil && detail.Revision.ResumeID != resumeID) {
+		h.writeProjectionError(c)
+		return
+	}
+	setPrivateHeaders(c)
+	c.JSON(http.StatusOK, newTemporaryDetailResponse(detail))
+}
+
+func (h *HTTPHandler) retryTemporaryParse(c *gin.Context) {
+	actor, resumeID, ok := h.actorAndResumeID(c)
+	if !ok || !h.requireIdempotencyKey(c) {
+		return
+	}
+	item, err := h.application.RetryTemporaryParse(c.Request.Context(), actor, resumeID)
+	if err != nil {
+		h.errors.Write(c, err)
+		return
+	}
+	if !validTemporaryProjection(item, actor.UserID, resumeID) {
+		h.writeProjectionError(c)
+		return
+	}
+	setPrivateHeaders(c)
+	c.JSON(http.StatusAccepted, newTemporaryResumeResponse(item))
+}
+
+func (h *HTTPHandler) deleteTemporary(c *gin.Context) {
+	actor, resumeID, ok := h.actorAndResumeID(c)
+	if !ok || !h.requireIdempotencyKey(c) {
+		return
+	}
+	expectedVersion, err := strconv.ParseInt(c.Query("expected_version"), 10, 64)
+	if err != nil || expectedVersion < 1 {
+		h.errors.Write(c, app.InvalidResumeError())
+		return
+	}
+	if err := h.application.DeleteTemporary(c.Request.Context(), actor, app.DeleteCommand{
+		ResumeID: resumeID, ExpectedVersion: expectedVersion,
+	}); err != nil {
+		h.errors.Write(c, err)
+		return
+	}
+	setPrivateHeaders(c)
+	c.Status(http.StatusNoContent)
 }
 
 // create 接收新简历 PDF 上传请求。
@@ -504,6 +609,11 @@ func validResumeProjection(item resume.Resume, ownerUserID string, expectedResum
 		item.Title != "" && item.OriginalFilename != "" && item.ContentType == "application/pdf" &&
 		item.SizeBytes > 0 && item.FileStatus != resume.FileDeleted &&
 		!item.CreatedAt.IsZero() && !item.UpdatedAt.IsZero()
+}
+
+func validTemporaryProjection(item resume.Resume, ownerUserID string, expectedResumeID string) bool {
+	return validResumeProjection(item, ownerUserID, expectedResumeID) && item.Temporary &&
+		item.ExpiresAt != nil && item.ExpiresAt.After(item.CreatedAt)
 }
 
 // writeProjectionError 返回不会暴露错误投影内容的内部错误。

--- a/server/internal/resume/transport/http_test.go
+++ b/server/internal/resume/transport/http_test.go
@@ -48,6 +48,38 @@ func TestCreateUsesTrustedActorAndValidatesPDF(t *testing.T) {
 	}
 }
 
+func TestTemporaryResumeRoutesStayOutsideSavedResumeContract(t *testing.T) {
+	application := newTransportApplicationFake()
+	router := newResumeRouter(t, application, &transportTestActor, 1024)
+	body, contentType := multipartRequest(t, nil, "%PDF-1.4 temporary")
+	request := httptest.NewRequest(http.MethodPost, "/v1/temporary-resumes", body)
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("Idempotency-Key", "temporary-key-1")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted || application.calls["create_temporary"] != 1 ||
+		!strings.Contains(response.Body.String(), `"expires_at"`) ||
+		!strings.Contains(response.Body.String(), `"resume_id"`) {
+		t.Fatalf("create temporary response = %d %s", response.Code, response.Body.String())
+	}
+
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "/v1/temporary-resumes/"+transportTestResumeID, nil),
+		httptest.NewRequest(http.MethodPost, "/v1/temporary-resumes/"+transportTestResumeID+"/parse-retries", nil),
+		httptest.NewRequest(http.MethodDelete, "/v1/temporary-resumes/"+transportTestResumeID+"?expected_version=2", nil),
+	} {
+		if request.Method != http.MethodGet {
+			request.Header.Set("Idempotency-Key", "temporary-key-2")
+		}
+		response = httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code < 200 || response.Code >= 300 {
+			t.Fatalf("%s %s response = %d %s", request.Method, request.URL, response.Code, response.Body.String())
+		}
+	}
+}
+
 // TestResumeRoutesCoverCRUDContract 验证其余公开路由调用正确应用用例和状态码。
 func TestResumeRoutesCoverCRUDContract(t *testing.T) {
 	tests := []struct {
@@ -205,6 +237,17 @@ func (application *transportApplicationFake) Create(_ context.Context, actor req
 	return application.item, nil
 }
 
+func (application *transportApplicationFake) CreateTemporary(_ context.Context, actor requestcontext.Actor, command app.CreateCommand) (resume.Resume, error) {
+	application.calls["create_temporary"]++
+	application.actor = actor
+	application.createCommand = command
+	item := application.item
+	item.Temporary = true
+	expiresAt := item.CreatedAt.Add(app.TemporaryResumeLifetime)
+	item.ExpiresAt = &expiresAt
+	return item, nil
+}
+
 // List 返回单份测试简历。
 func (application *transportApplicationFake) List(_ context.Context, actor requestcontext.Actor, _ app.ListQuery) (app.ListResult, error) {
 	application.calls["list"]++
@@ -221,6 +264,17 @@ func (application *transportApplicationFake) Get(_ context.Context, actor reques
 		ParserVersion: "test/v1", Content: emptyTransportContent(), CreatedAt: time.Now().UTC(),
 	}
 	return app.Detail{Resume: application.item, Revision: &revision}, nil
+}
+
+func (application *transportApplicationFake) GetTemporary(ctx context.Context, actor requestcontext.Actor, id string) (app.Detail, error) {
+	detail, err := application.Get(ctx, actor, id)
+	if err != nil {
+		return app.Detail{}, err
+	}
+	detail.Resume.Temporary = true
+	expiresAt := detail.Resume.CreatedAt.Add(app.TemporaryResumeLifetime)
+	detail.Resume.ExpiresAt = &expiresAt
+	return detail, nil
 }
 
 // UpdateMetadata 返回更新后的测试元数据。
@@ -260,11 +314,23 @@ func (application *transportApplicationFake) RetryParse(_ context.Context, actor
 	return application.item, nil
 }
 
+func (application *transportApplicationFake) RetryTemporaryParse(ctx context.Context, actor requestcontext.Actor, id string) (resume.Resume, error) {
+	item, err := application.RetryParse(ctx, actor, id)
+	item.Temporary = true
+	expiresAt := item.CreatedAt.Add(app.TemporaryResumeLifetime)
+	item.ExpiresAt = &expiresAt
+	return item, err
+}
+
 // Delete 记录测试删除请求。
 func (application *transportApplicationFake) Delete(_ context.Context, actor requestcontext.Actor, _ app.DeleteCommand) error {
 	application.calls["delete"]++
 	application.actor = actor
 	return nil
+}
+
+func (application *transportApplicationFake) DeleteTemporary(ctx context.Context, actor requestcontext.Actor, command app.DeleteCommand) error {
+	return application.Delete(ctx, actor, command)
 }
 
 // emptyTransportContent 返回满足公开必填数组约束的空内容。

--- a/server/internal/resume/transport/response.go
+++ b/server/internal/resume/transport/response.go
@@ -30,6 +30,16 @@ type resumeListResponse struct {
 	NextCursor string           `json:"next_cursor,omitempty"`
 }
 
+type temporaryResumeResponse struct {
+	resumeResponse
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type temporaryResumeDetailResponse struct {
+	Resume          temporaryResumeResponse `json:"resume"`
+	CurrentRevision *resumeRevisionResponse `json:"current_revision,omitempty"`
+}
+
 // contentURLResponse 表示原始 PDF 的短时读取地址和过期时间。
 type contentURLResponse struct {
 	URL       string    `json:"url"`
@@ -61,6 +71,23 @@ func newResumeResponse(item resume.Resume) resumeResponse {
 		CurrentRevision: item.CurrentRevision, Version: item.Version,
 		CreatedAt: item.CreatedAt, UpdatedAt: item.UpdatedAt, DeletedAt: item.DeletedAt,
 	}
+}
+
+func newTemporaryResumeResponse(item resume.Resume) temporaryResumeResponse {
+	response := temporaryResumeResponse{resumeResponse: newResumeResponse(item)}
+	if item.ExpiresAt != nil {
+		response.ExpiresAt = item.ExpiresAt.UTC()
+	}
+	return response
+}
+
+func newTemporaryDetailResponse(detail app.Detail) temporaryResumeDetailResponse {
+	response := temporaryResumeDetailResponse{Resume: newTemporaryResumeResponse(detail.Resume)}
+	if detail.Revision != nil {
+		revision := newRevisionResponse(*detail.Revision)
+		response.CurrentRevision = &revision
+	}
+	return response
 }
 
 // newRevisionResponse 把修订领域对象投影为公开响应。

--- a/server/migrations/000074_temporary_resumes.down.sql
+++ b/server/migrations/000074_temporary_resumes.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS resumes_expired_temporary_idx;
+
+ALTER TABLE resumes
+    DROP CONSTRAINT IF EXISTS resumes_temporary_expiry_check,
+    DROP COLUMN IF EXISTS expires_at,
+    DROP COLUMN IF EXISTS is_temporary;

--- a/server/migrations/000074_temporary_resumes.up.sql
+++ b/server/migrations/000074_temporary_resumes.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE resumes
+    ADD COLUMN is_temporary BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN expires_at TIMESTAMPTZ;
+
+ALTER TABLE resumes
+    ADD CONSTRAINT resumes_temporary_expiry_check CHECK (
+        (is_temporary AND expires_at IS NOT NULL)
+        OR (NOT is_temporary AND expires_at IS NULL)
+    );
+
+CREATE INDEX resumes_expired_temporary_idx
+    ON resumes (expires_at, resume_id)
+    WHERE is_temporary = TRUE AND deleted_at IS NULL;

--- a/server/migrations/000076_temporary_resumes.down.sql
+++ b/server/migrations/000076_temporary_resumes.down.sql
@@ -1,6 +1,10 @@
+BEGIN;
+
 DROP INDEX IF EXISTS resumes_expired_temporary_idx;
 
 ALTER TABLE resumes
     DROP CONSTRAINT IF EXISTS resumes_temporary_expiry_check,
     DROP COLUMN IF EXISTS expires_at,
     DROP COLUMN IF EXISTS is_temporary;
+
+COMMIT;

--- a/server/migrations/000076_temporary_resumes.up.sql
+++ b/server/migrations/000076_temporary_resumes.up.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 ALTER TABLE resumes
     ADD COLUMN is_temporary BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN expires_at TIMESTAMPTZ;
@@ -11,3 +13,5 @@ ALTER TABLE resumes
 CREATE INDEX resumes_expired_temporary_idx
     ON resumes (expires_at, resume_id)
     WHERE is_temporary = TRUE AND deleted_at IS NULL;
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -61,4 +61,5 @@ import "embed"
 //go:embed 000073_agent_message_memes.*.sql
 //go:embed 000074_scene_experience_policy_boundary.*.sql
 //go:embed 000075_remove_agent_message_memes.*.sql
+//go:embed 000076_temporary_resumes.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

- 将模拟面试创建入口精简为单一输入区，支持职位名称或完整 JD 两种输入模式。
- 预生成确认页沿用 SpeakUp 现有设计语言，集中确认职位摘要、练习范围和简历来源。
- 支持选择已解析的历史简历、临时上传并解析简历，以及不使用简历。
- 临时简历不占保存配额、不进入简历列表；绑定精确 revision 后删除原始临时文件，遗留资源由 24 小时 TTL 回收。

## 实现思路

- 扩展 Resume API 与后端领域模型，提供临时简历创建、查询、重试和删除能力。
- 复用现有解析队列与准备快照机制，创建面试时以 resume_id + resume_revision 固定输入版本。
- Flutter 创建向导保持单一职位输入，并在确认阶段接入已有简历和临时简历状态流转。
- 增加迁移、契约测试、后端单元/集成测试和移动端交互测试。

## 可复现测试

- `cd api && npm run check`
- `cd server && GOCACHE=/tmp/xe3-issue-426-go-cache go test ./internal/resume/... ./internal/coaching/preparation/... ./migrations`
- `cd server && TEST_DATABASE_URL=postgres://xe3_esl:local-development-only@127.0.0.1:25432/xe3_esl?sslmode=disable GOCACHE=/tmp/xe3-issue-426-go-cache go test -v ./internal/resume/persistence -run TestTemporaryResumeDoesNotConsumeSavedQuota`
- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/coaching/preparation/job_preparation_controller_test.dart test/coaching/preparation/job_preparation_wizard_test.dart test/coaching/preparation/wire_job_preparation_client_test.dart test/coaching/preparation/wire_preparation_client_test.dart test/coaching/preparation/wire_preparation_launch_client_test.dart test/resume/resume_controller_test.dart test/resume/resume_page_test.dart test/resume/wire_resume_client_test.dart`

Closes #426
