### PR TITLE
fix(interview): 移除沉浸式页面重复顶部字幕

### DIFF
--- a/mobile/lib/features/coaching/roleplay/immersive_roleplay.dart
+++ b/mobile/lib/features/coaching/roleplay/immersive_roleplay.dart
@@ -434,9 +434,13 @@ class _ImmersiveRoleplayPageState extends State<ImmersiveRoleplayPage> {
                           ? null
                           : widget.avatarSurfaceBuilder,
                       statusLabel: widget.avatarStatusLabel,
-                      latestAssistantMessage: _latestAssistantMessage(
-                        widget.practiceController.practiceMessages,
-                      ),
+                      latestAssistantMessage:
+                          widget.practiceController.practiceExperience ==
+                              PracticeExperience.interview
+                          ? null
+                          : _latestAssistantMessage(
+                              widget.practiceController.practiceMessages,
+                            ),
                       exitInFlight: _exitInFlight,
                       onExit: _requestExit,
                     );

--- a/mobile/test/coaching/practice/immersive_roleplay_test.dart
+++ b/mobile/test/coaching/practice/immersive_roleplay_test.dart
@@ -97,6 +97,31 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('hides the duplicate avatar subtitle for interviews', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final controller = await _roleplayController(
+      selectedScene: testScenes.first,
+    );
+    addTearDown(controller.dispose);
+    final question = controller.currentQuestion!.text;
+
+    await tester.pumpWidget(
+      MaterialApp(home: ImmersiveRoleplayPage(practiceController: controller)),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('immersive-avatar-region')), findsOneWidget);
+    expect(find.byKey(const Key('immersive-live-subtitle')), findsNothing);
+    expect(find.text(question), findsOneWidget);
+    expect(find.byKey(const Key('immersive-conversation-history')), findsOne);
+    expect(find.byKey(const Key('immersive-record')).hitTestable(), findsOne);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('translates a roleplay question once and toggles the read aid', (
     tester,
   ) async {
@@ -611,29 +636,30 @@ void main() {
 
 Future<PracticeController> _roleplayController({
   PracticeClient? practiceClient,
+  SceneDefinition? selectedScene,
 }) async {
-  const practiceExperience = PracticeExperience.roleplay;
-  const sceneCategory = SceneCategory.roleplayTravel;
-  final scene = testScene(
-    id: 'daily-hotel',
-    experience: practiceExperience,
-    category: sceneCategory,
-    name: '酒店入住',
-    prompt: const ScenePrompt(
-      publicSceneBrief: '练习办理入住与需求沟通。',
-      practiceGoal: 'Complete the hotel check-in conversation.',
-      userRole: 'Guest',
-      aiRole: 'Receptionist',
-      personaSummary: 'Professional and helpful.',
-      focusAreas: <String>['check_in'],
-      turnBlueprints: <String>['Confirm the booking.'],
-    ),
-  );
+  final scene =
+      selectedScene ??
+      testScene(
+        id: 'daily-hotel',
+        experience: PracticeExperience.roleplay,
+        category: SceneCategory.roleplayTravel,
+        name: '酒店入住',
+        prompt: const ScenePrompt(
+          publicSceneBrief: '练习办理入住与需求沟通。',
+          practiceGoal: 'Complete the hotel check-in conversation.',
+          userRole: 'Guest',
+          aiRole: 'Receptionist',
+          personaSummary: 'Professional and helpful.',
+          focusAreas: <String>['check_in'],
+          turnBlueprints: <String>['Confirm the booking.'],
+        ),
+      );
   final resolvedPracticeClient =
       practiceClient ??
       _ScenePracticeClient(
-        practiceExperience: practiceExperience,
-        sceneCategory: sceneCategory,
+        practiceExperience: scene.experience,
+        sceneCategory: scene.category,
       );
   final controller = PracticeController(client: resolvedPracticeClient);
   await controller.activateCreatedPractice(


### PR DESCRIPTION
## 功能描述

- 恢复 #344 的既定行为：沉浸式面试不再显示数字人区域底部的重复字幕。
- 保留画面区域、下方对话列表、Tips、翻译、朗读和语音输入。
- Workplace、Daily 等非面试沉浸式场景继续显示顶部字幕。

## 实现思路

根据 `PracticeExperience` 决定是否向数字人区域传入最新 AI 消息；仅 `INTERVIEW` 传入空值，其余沉浸式场景保持现状。

## 可复现测试

- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/coaching/practice/immersive_roleplay_test.dart test/coaching/practice/immersive_roleplay_session_test.dart test/coaching/scene/scene_presentation_test.dart`

Closes #443
