### PR TITLE
docs(repo): 更新首次预发布 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,83 @@
 # SpeakUp
 
-SpeakUp 是一个面向英语表达训练的 AI 陪练项目。首个验证场景聚焦程序员英文面试，并为后续角色和训练场景扩展保留清晰边界。
+SpeakUp 是一个面向英语口语训练的 AI 陪练项目，通过自由对话、场景练习和练习复盘，帮助学习者持续开口并改进表达。
 
-项目当前处于 **MS1：战略决策** 阶段，代码骨架将通过独立 Issue 和 Pull Request 渐进加入。
+项目当前处于 **MS3：核心功能闭合** 阶段，正在准备首次预发布版本 `v0.1.0-alpha.1`。该版本用于建立可追溯的协作与验证基线，不代表正式生产版本。
 
-## 项目入口
+## 当前能力
+
+- **AI 口语陪练**：支持文字和语音输入、流式回复、语音朗读与对话记录。
+- **四类场景练习**：英文面试、IELTS 口语、职场英语、生活与旅行。
+- **专项训练**：英文面试支持模拟面试与轮次练习；IELTS 支持 Part 1、2、3 与完整模考。
+- **逐句反馈**：在用户表达中提供轻量纠错与更自然的英文表达建议。
+- **练习复盘**：保存练习结果，并按场景展示评分、反馈和历史记录。
+
+## 项目结构
+
+```text
+mobile/   Flutter Android/iOS 客户端
+server/   Go API、Agent、场景练习、评估与数据访问
+api/      OpenAPI、WebSocket 与数据契约
+tools/    本地开发、模拟器验证和专项检查脚本
+```
+
+工程设计和架构决策以已接受的 GitHub Issue 为权威来源，不在仓库中重复维护：
 
 - [产品范围与功能边界](https://github.com/1024XEngineer/XE3-ESL/issues/9)
-- [已接受的 MS1 系统架构](https://github.com/1024XEngineer/XE3-ESL/issues/15)
+- [系统架构](https://github.com/1024XEngineer/XE3-ESL/issues/15)
 - [场景与角色扩展模型](https://github.com/1024XEngineer/XE3-ESL/issues/24)
-- [MS1 Issues](https://github.com/1024XEngineer/XE3-ESL/milestone/1)
+- [MS3：核心功能闭合](https://github.com/1024XEngineer/XE3-ESL/milestone/3)
+- [v0.1.0-alpha.1 首次预发布准备](https://github.com/1024XEngineer/XE3-ESL/issues/452)
 
-工程设计与架构决策以对应 GitHub Issue 为权威来源，不在仓库中重复维护。
+## 本地运行
 
-## 参与协作
+本地开发需要 Flutter 3.44.6、Go 1.26.5、Node.js 22.12 或更高版本，以及可用的 Docker 环境。
 
-所有变更遵循 Issue → Fork → Pull Request → Review 流程。开始开发前请先选择或创建范围单一的 Issue，并关联当前 Milestone；不要在主仓直接创建开发分支。
+先创建本地配置并按照模板注释填写所需的服务端配置；不要提交 `.env`：
 
-Commit 信息遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/)。
+```shell
+cp .env.example .env
+```
 
-## 本地质量检查
+启动一个 iPhone Simulator 后，可从仓库根目录运行：
 
-根目录统一入口会执行 Flutter、Go、API 契约和确定性 Mock 主链检查：
+```shell
+make dev-ios-simulator
+```
+
+连接并授权一台 arm64 Android 真机后，可运行：
+
+```shell
+make dev-android
+```
+
+这两个入口会启动 PostgreSQL、执行数据库迁移、启动本地后端并运行 App。移动端的设备要求和模拟器限制见 [mobile/README.md](mobile/README.md)。
+
+## 质量检查
+
+在仓库根目录执行完整的 Flutter、Go、API 契约和确定性主流程检查：
 
 ```shell
 make check
 ```
 
-也可以分别运行 `make check-flutter`、`make check-go`、`make check-api` 和 `make check-smoke`。PostgreSQL 迁移、Readiness 和数据库集成测试继续由独立的 Database Workflow 验证。
+也可以分别运行：
+
+```shell
+make check-flutter
+make check-go
+make check-api
+make check-smoke
+```
+
+PostgreSQL 迁移、数据库集成、Readiness 和可达 Go 漏洞检查由 Database Workflow 验证。所有合入 `dev` 或 `main` 的变更都必须通过对应的 Pull Request 检查。
+
+## 协作与发布
+
+- 日常开发从最新 `upstream/dev` 创建短期分支，通过个人 Fork 向官方仓 `dev` 提交 Pull Request。
+- 正式发布通过 `dev → main` 的 Release Pull Request 完成，不直接向 `main` 推送功能提交。
+- Tag 只在 Release Pull Request 合入后的 `main` 提交上创建；GitHub Release 以官方仓 Tag 为权威来源。
+- Commit 信息遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/)。
 
 ## License
 


### PR DESCRIPTION
## 功能描述

- 将项目阶段从 MS1 更新为当前 MS3。
- 按实际代码说明 AI 对话、四类场景练习、逐句反馈和练习复盘能力。
- 补充仓库结构、本地配置及 Android/iOS 启动入口。
- 补充质量检查和首次预发布的分支、Tag、Release 规则。

## 实现思路

仅更新根目录 `README.md`，链接现有权威 Issue、Milestone、脚本和移动端说明，不在仓库内重复架构决策正文。

## 验证方式

- `git diff --check`
- `make help`
- 核对 `.env.example`、`mobile/README.md`、Makefile 启动与检查目标均存在。

关联 #452
Closes #453