### PR TITLE
feat(agent): stream assistant speech during generation

### DIFF
--- a/mobile/android/app/src/main/kotlin/com/xengineer/speakup/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/xengineer/speakup/MainActivity.kt
@@ -1,5 +1,168 @@
 package com.xengineer.speakup
 
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.media.PlaybackParams
+import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val executor = Executors.newSingleThreadExecutor()
+    private val generation = AtomicInteger()
+
+    @Volatile
+    private var track: AudioTrack? = null
+    private var writtenFrames = 0L
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "speakup/agent_pcm_player",
+        ).setMethodCallHandler(::handlePCMCall)
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        stopNative()
+        super.cleanUpFlutterEngine(flutterEngine)
+    }
+
+    private fun handlePCMCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "start" -> start(call, result)
+            "append" -> append(call, result)
+            "finish" -> finish(result)
+            "stop" -> {
+                stopNative()
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun start(call: MethodCall, result: MethodChannel.Result) {
+        val sampleRate = call.argument<Int>("sampleRate")
+        val channelCount = call.argument<Int>("channelCount")
+        val bitsPerSample = call.argument<Int>("bitsPerSample")
+        val speed = call.argument<Double>("speed")
+        if (sampleRate != 24_000 || channelCount != 1 || bitsPerSample != 16 ||
+            speed == null || speed < 0.5 || speed > 2.0
+        ) {
+            result.error("agent_pcm_playback_failed", "Invalid PCM format.", null)
+            return
+        }
+        stopNative()
+        val current = generation.incrementAndGet()
+        executor.execute {
+            try {
+                val minimum = AudioTrack.getMinBufferSize(
+                    sampleRate,
+                    AudioFormat.CHANNEL_OUT_MONO,
+                    AudioFormat.ENCODING_PCM_16BIT,
+                )
+                val nextTrack = AudioTrack.Builder()
+                    .setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                            .build(),
+                    )
+                    .setAudioFormat(
+                        AudioFormat.Builder()
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setSampleRate(sampleRate)
+                            .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                            .build(),
+                    )
+                    .setBufferSizeInBytes(maxOf(minimum, sampleRate))
+                    .setTransferMode(AudioTrack.MODE_STREAM)
+                    .build()
+                nextTrack.playbackParams = PlaybackParams().setSpeed(speed.toFloat())
+                nextTrack.play()
+                if (generation.get() != current) {
+                    nextTrack.release()
+                    postSuccess(result)
+                    return@execute
+                }
+                track = nextTrack
+                writtenFrames = 0
+                postSuccess(result)
+            } catch (_: Exception) {
+                postFailure(result)
+            }
+        }
+    }
+
+    private fun append(call: MethodCall, result: MethodChannel.Result) {
+        val audio = call.arguments as? ByteArray
+        if (audio == null || audio.isEmpty() || audio.size % 2 != 0) {
+            result.error("agent_pcm_playback_failed", "Invalid PCM audio.", null)
+            return
+        }
+        val current = generation.get()
+        executor.execute {
+            val active = track
+            if (active == null || generation.get() != current) {
+                postFailure(result)
+                return@execute
+            }
+            val written = active.write(audio, 0, audio.size, AudioTrack.WRITE_BLOCKING)
+            if (written != audio.size) {
+                postFailure(result)
+                return@execute
+            }
+            writtenFrames += written / 2
+            audio.fill(0)
+            postSuccess(result)
+        }
+    }
+
+    private fun finish(result: MethodChannel.Result) {
+        val current = generation.get()
+        executor.execute {
+            val active = track
+            if (active == null) {
+                postFailure(result)
+                return@execute
+            }
+            while (generation.get() == current &&
+                active.playbackHeadPosition.toLong() < writtenFrames
+            ) {
+                Thread.sleep(10)
+            }
+            if (generation.get() == current) {
+                stopNative()
+            }
+            postSuccess(result)
+        }
+    }
+
+    private fun stopNative() {
+        generation.incrementAndGet()
+        val active = track
+        track = null
+        writtenFrames = 0
+        try {
+            active?.pause()
+            active?.flush()
+            active?.release()
+        } catch (_: IllegalStateException) {
+            // The AudioTrack is already stopped.
+        }
+    }
+
+    private fun postSuccess(result: MethodChannel.Result) {
+        runOnUiThread { result.success(null) }
+    }
+
+    private fun postFailure(result: MethodChannel.Result) {
+        runOnUiThread {
+            result.error("agent_pcm_playback_failed", "PCM playback failed.", null)
+        }
+    }
+}

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -101,10 +101,8 @@ private final class AgentPCMStreamPlayer {
     )
     try session.setActive(true)
     guard let format = AVAudioFormat(
-      commonFormat: .pcmFormatInt16,
-      sampleRate: 24_000,
-      channels: 1,
-      interleaved: true
+      standardFormatWithSampleRate: 24_000,
+      channels: 1
     ) else {
       throw PlayerError.invalidState
     }
@@ -128,25 +126,26 @@ private final class AgentPCMStreamPlayer {
       data.count > 0,
       data.count.isMultiple(of: 2),
       let format = AVAudioFormat(
-        commonFormat: .pcmFormatInt16,
-        sampleRate: 24_000,
-        channels: 1,
-        interleaved: true
+        standardFormatWithSampleRate: 24_000,
+        channels: 1
       ),
       let buffer = AVAudioPCMBuffer(
         pcmFormat: format,
         frameCapacity: AVAudioFrameCount(data.count / 2)
-      )
+      ),
+      let samples = buffer.floatChannelData?[0]
     else {
       throw PlayerError.invalidState
     }
     buffer.frameLength = buffer.frameCapacity
-    let audioBuffer = buffer.mutableAudioBufferList.pointee.mBuffers
-    guard let destination = audioBuffer.mData else {
-      throw PlayerError.invalidState
+    data.withUnsafeBytes { rawBuffer in
+      let bytes = rawBuffer.bindMemory(to: UInt8.self)
+      for frame in 0..<Int(buffer.frameLength) {
+        let offset = frame * 2
+        let value = UInt16(bytes[offset]) | (UInt16(bytes[offset + 1]) << 8)
+        samples[frame] = Float(Int16(bitPattern: value)) / 32_768
+      }
     }
-    data.copyBytes(to: destination.assumingMemoryBound(to: UInt8.self), count: data.count)
-    buffer.mutableAudioBufferList.pointee.mBuffers.mDataByteSize = UInt32(data.count)
     pendingBuffers += 1
     player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) {
       [weak self] _ in

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -1,8 +1,11 @@
+import AVFoundation
 import Flutter
 import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private var agentPCMPlayer: AgentPCMStreamPlayer?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,5 +15,171 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    agentPCMPlayer = AgentPCMStreamPlayer(
+      messenger: engineBridge.applicationRegistrar.messenger()
+    )
+  }
+}
+
+private final class AgentPCMStreamPlayer {
+  private let channel: FlutterMethodChannel
+  private var engine: AVAudioEngine?
+  private var player: AVAudioPlayerNode?
+  private var pendingBuffers = 0
+  private var finishResult: FlutterResult?
+
+  init(messenger: FlutterBinaryMessenger) {
+    channel = FlutterMethodChannel(
+      name: "speakup/agent_pcm_player",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    do {
+      switch call.method {
+      case "start":
+        guard
+          let arguments = call.arguments as? [String: Any],
+          let sampleRate = arguments["sampleRate"] as? NSNumber,
+          let channelCount = arguments["channelCount"] as? NSNumber,
+          let bitsPerSample = arguments["bitsPerSample"] as? NSNumber,
+          let speed = arguments["speed"] as? NSNumber,
+          sampleRate.intValue == 24_000,
+          channelCount.intValue == 1,
+          bitsPerSample.intValue == 16,
+          speed.doubleValue >= 0.5,
+          speed.doubleValue <= 2
+        else {
+          throw PlayerError.invalidArguments
+        }
+        try start(speed: speed.floatValue)
+        result(nil)
+      case "append":
+        guard let data = call.arguments as? FlutterStandardTypedData else {
+          throw PlayerError.invalidArguments
+        }
+        try append(data.data)
+        result(nil)
+      case "finish":
+        guard player != nil, finishResult == nil else {
+          throw PlayerError.invalidState
+        }
+        if pendingBuffers == 0 {
+          stopNative()
+          result(nil)
+        } else {
+          finishResult = result
+        }
+      case "stop":
+        stopNative()
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    } catch {
+      result(
+        FlutterError(
+          code: "agent_pcm_playback_failed",
+          message: "PCM playback failed.",
+          details: nil
+        )
+      )
+    }
+  }
+
+  private func start(speed: Float) throws {
+    stopNative()
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(
+      .playAndRecord,
+      mode: .spokenAudio,
+      options: [.defaultToSpeaker, .allowBluetoothHFP]
+    )
+    try session.setActive(true)
+    guard let format = AVAudioFormat(
+      commonFormat: .pcmFormatInt16,
+      sampleRate: 24_000,
+      channels: 1,
+      interleaved: true
+    ) else {
+      throw PlayerError.invalidState
+    }
+    let nextEngine = AVAudioEngine()
+    let nextPlayer = AVAudioPlayerNode()
+    let timePitch = AVAudioUnitTimePitch()
+    timePitch.rate = speed
+    nextEngine.attach(nextPlayer)
+    nextEngine.attach(timePitch)
+    nextEngine.connect(nextPlayer, to: timePitch, format: format)
+    nextEngine.connect(timePitch, to: nextEngine.mainMixerNode, format: format)
+    try nextEngine.start()
+    nextPlayer.play()
+    engine = nextEngine
+    player = nextPlayer
+  }
+
+  private func append(_ data: Data) throws {
+    guard
+      let player,
+      data.count > 0,
+      data.count.isMultiple(of: 2),
+      let format = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: 24_000,
+        channels: 1,
+        interleaved: true
+      ),
+      let buffer = AVAudioPCMBuffer(
+        pcmFormat: format,
+        frameCapacity: AVAudioFrameCount(data.count / 2)
+      )
+    else {
+      throw PlayerError.invalidState
+    }
+    buffer.frameLength = buffer.frameCapacity
+    let audioBuffer = buffer.mutableAudioBufferList.pointee.mBuffers
+    guard let destination = audioBuffer.mData else {
+      throw PlayerError.invalidState
+    }
+    data.copyBytes(to: destination.assumingMemoryBound(to: UInt8.self), count: data.count)
+    buffer.mutableAudioBufferList.pointee.mBuffers.mDataByteSize = UInt32(data.count)
+    pendingBuffers += 1
+    player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) {
+      [weak self] _ in
+      DispatchQueue.main.async {
+        self?.didPlayBuffer()
+      }
+    }
+  }
+
+  private func didPlayBuffer() {
+    pendingBuffers = max(0, pendingBuffers - 1)
+    guard pendingBuffers == 0, let result = finishResult else {
+      return
+    }
+    finishResult = nil
+    stopNative()
+    result(nil)
+  }
+
+  private func stopNative() {
+    player?.stop()
+    engine?.stop()
+    player = nil
+    engine = nil
+    pendingBuffers = 0
+    if let result = finishResult {
+      finishResult = nil
+      result(nil)
+    }
+  }
+
+  private enum PlayerError: Error {
+    case invalidArguments
+    case invalidState
   }
 }

--- a/mobile/lib/features/agent/audio/agent_audio_player.dart
+++ b/mobile/lib/features/agent/audio/agent_audio_player.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -24,12 +24,20 @@ abstract interface class AgentAudioPlayer {
   Future<void> dispose();
 }
 
+abstract interface class AgentPCMStreamPlayer {
+  Future<void> startPCMStream({required double speed});
+
+  Future<void> appendPCM(Uint8List bytes);
+
+  Future<void> finishPCMStream();
+}
+
 final class AgentAudioPlaybackException implements Exception {
   const AgentAudioPlaybackException();
 }
 
 final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
-    implements AgentAudioPlayer {
+    implements AgentAudioPlayer, AgentPCMStreamPlayer {
   AudioplayersAgentAudioPlayer({
     AudioPlayer? player,
     Future<Directory> Function()? temporaryDirectory,
@@ -40,6 +48,7 @@ final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
   }
 
   static const _managedDirectoryName = 'speakup-agent-voice-playback';
+  static const _pcmChannel = MethodChannel('speakup/agent_pcm_player');
 
   final AudioPlayer _player;
   final Future<Directory> Function() _temporaryDirectory;
@@ -54,6 +63,7 @@ final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
   String? _ownedPlaybackPath;
   int _generation = 0;
   bool _disposed = false;
+  bool _pcmStreaming = false;
 
   @override
   Stream<Duration> get onPosition => _positions.stream;
@@ -94,6 +104,55 @@ final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
       speed: speed,
       generation: generation,
     );
+  }
+
+  @override
+  Future<void> startPCMStream({required double speed}) async {
+    if (_disposed || speed < 0.5 || speed > 2) {
+      throw const AgentAudioPlaybackException();
+    }
+    _generation++;
+    await _stopActive();
+    try {
+      await _pcmChannel.invokeMethod<void>('start', <String, Object>{
+        'sampleRate': 24000,
+        'channelCount': 1,
+        'bitsPerSample': 16,
+        'speed': speed,
+      });
+      _pcmStreaming = true;
+    } on PlatformException {
+      await _stopActive();
+      throw const AgentAudioPlaybackException();
+    }
+  }
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) async {
+    if (!_pcmStreaming || bytes.isEmpty || bytes.length.isOdd) {
+      throw const AgentAudioPlaybackException();
+    }
+    try {
+      await _pcmChannel.invokeMethod<void>('append', bytes);
+    } on PlatformException {
+      await _stopActive();
+      throw const AgentAudioPlaybackException();
+    }
+  }
+
+  @override
+  Future<void> finishPCMStream() async {
+    if (!_pcmStreaming) {
+      throw const AgentAudioPlaybackException();
+    }
+    try {
+      await _pcmChannel.invokeMethod<void>('finish');
+      _pcmStreaming = false;
+      _completions.add(null);
+    } on PlatformException {
+      await _stopActive();
+      throw const AgentAudioPlaybackException();
+    }
   }
 
   Future<void> _play(
@@ -181,6 +240,14 @@ final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
   }
 
   Future<void> _stopActive() async {
+    if (_pcmStreaming) {
+      _pcmStreaming = false;
+      try {
+        await _pcmChannel.invokeMethod<void>('stop');
+      } on PlatformException {
+        // Native playback is already treated as stopped locally.
+      }
+    }
     try {
       await _player.stop();
     } catch (_) {
@@ -228,7 +295,8 @@ final class AudioplayersAgentAudioPlayer extends WidgetsBindingObserver
   }
 }
 
-final class FakeAgentAudioPlayer implements AgentAudioPlayer {
+final class FakeAgentAudioPlayer
+    implements AgentAudioPlayer, AgentPCMStreamPlayer {
   final StreamController<Duration> _positions =
       StreamController<Duration>.broadcast(sync: true);
   final StreamController<void> _completions = StreamController<void>.broadcast(
@@ -236,6 +304,7 @@ final class FakeAgentAudioPlayer implements AgentAudioPlayer {
   );
   bool playing = false;
   double? speed;
+  final List<Uint8List> pcmChunks = <Uint8List>[];
 
   @override
   Stream<Duration> get onPosition => _positions.stream;
@@ -254,6 +323,20 @@ final class FakeAgentAudioPlayer implements AgentAudioPlayer {
     playing = true;
     this.speed = speed;
   }
+
+  @override
+  Future<void> startPCMStream({required double speed}) async {
+    playing = true;
+    this.speed = speed;
+  }
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) async {
+    pcmChunks.add(Uint8List.fromList(bytes));
+  }
+
+  @override
+  Future<void> finishPCMStream() async {}
 
   void emitPosition(Duration position) => _positions.add(position);
 

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -27,6 +27,10 @@ final class ComposerController extends ChangeNotifier {
     AgentVoiceRecorder? voiceRecorder,
     AgentAudioPlayer? draftAudioPlayer,
     this.onAssistantCommitted,
+    this.onAssistantStreamStarted,
+    this.onAssistantStreamDelta,
+    this.onAssistantStreamCompleted,
+    this.onAssistantStreamFailed,
     ComposerClientIdFactory? clientIdFactory,
   }) : _clientIdFactory = clientIdFactory ?? _createSecureComposerId {
     if (voiceClient != null) {
@@ -43,6 +47,10 @@ final class ComposerController extends ChangeNotifier {
         onStreamMessageChanged:
             conversationController.changeComposerStreamMessage,
         onAssistantCommitted: onAssistantCommitted,
+        onAssistantStreamStarted: onAssistantStreamStarted,
+        onAssistantStreamDelta: onAssistantStreamDelta,
+        onAssistantStreamCompleted: onAssistantStreamCompleted,
+        onAssistantStreamFailed: onAssistantStreamFailed,
         idFactory: _newId,
       )..addListener(_relayVoiceState);
     }
@@ -54,6 +62,10 @@ final class ComposerController extends ChangeNotifier {
   final AgentImageClient? imageClient;
   final AgentImagePicker? imagePicker;
   final AgentVoiceAssistantCommitted? onAssistantCommitted;
+  final AgentVoiceAssistantStreamStarted? onAssistantStreamStarted;
+  final AgentVoiceAssistantStreamDelta? onAssistantStreamDelta;
+  final AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted;
+  final AgentVoiceAssistantStreamFailed? onAssistantStreamFailed;
   final ComposerClientIdFactory _clientIdFactory;
 
   AgentVoiceController? _voiceController;

--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -16,6 +16,14 @@ typedef AgentVoiceMessagesCommitted =
     void Function(Iterable<AgentMessage> messages);
 typedef AgentVoiceAssistantCommitted =
     FutureOr<void> Function(AgentMessage message);
+typedef AgentVoiceAssistantStreamStarted =
+    Future<void> Function(String transientMessageId);
+typedef AgentVoiceAssistantStreamDelta =
+    void Function(String transientMessageId, String delta);
+typedef AgentVoiceAssistantStreamCompleted =
+    void Function(String transientMessageId, AgentMessage message);
+typedef AgentVoiceAssistantStreamFailed =
+    void Function(String transientMessageId);
 typedef AgentVoiceStreamMessageChanged =
     void Function(String? previousMessageId, AgentMessage message);
 
@@ -27,6 +35,10 @@ final class AgentVoiceController extends ChangeNotifier
     required this.audioPlayer,
     required this.onMessagesCommitted,
     this.onAssistantCommitted,
+    this.onAssistantStreamStarted,
+    this.onAssistantStreamDelta,
+    this.onAssistantStreamCompleted,
+    this.onAssistantStreamFailed,
     this.onStreamMessageChanged,
     required this.idFactory,
     this.clock = DateTime.now,
@@ -53,6 +65,10 @@ final class AgentVoiceController extends ChangeNotifier
   final AgentAudioPlayer audioPlayer;
   final AgentVoiceMessagesCommitted onMessagesCommitted;
   final AgentVoiceAssistantCommitted? onAssistantCommitted;
+  final AgentVoiceAssistantStreamStarted? onAssistantStreamStarted;
+  final AgentVoiceAssistantStreamDelta? onAssistantStreamDelta;
+  final AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted;
+  final AgentVoiceAssistantStreamFailed? onAssistantStreamFailed;
   final AgentVoiceStreamMessageChanged? onStreamMessageChanged;
   final AgentVoiceIdFactory idFactory;
   final AgentVoiceControllerClock clock;
@@ -818,6 +834,10 @@ final class AgentVoiceController extends ChangeNotifier
                 isStreaming: true,
               ),
             );
+            final streamStarted = onAssistantStreamStarted;
+            if (streamStarted != null) {
+              await streamStarted(transientAssistantId);
+            }
           case AgentVoiceAssistantDelta(:final delta):
             final messageId = transientAssistantId;
             if (messageId == null) {
@@ -833,6 +853,7 @@ final class AgentVoiceController extends ChangeNotifier
                 isStreaming: true,
               ),
             );
+            onAssistantStreamDelta?.call(messageId, delta);
           case AgentVoiceRunCompleted(:final run):
             _pendingRun = run;
             final messageId = run.assistantMessageId;
@@ -854,6 +875,7 @@ final class AgentVoiceController extends ChangeNotifier
             if (transientId == null) {
               onMessagesCommitted(<AgentMessage>[assistant]);
             } else {
+              onAssistantStreamCompleted?.call(transientId, assistant);
               _changeStreamMessage(transientId, assistant);
             }
             _resetWorkflowPresentation();
@@ -870,6 +892,7 @@ final class AgentVoiceController extends ChangeNotifier
     } catch (error) {
       if (_isWorkflowCurrent(fence)) {
         if (transientAssistantId case final messageId?) {
+          onAssistantStreamFailed?.call(messageId);
           _changeStreamMessage(
             messageId,
             AgentMessage(

--- a/mobile/lib/features/agent/conversation/agent_message_audio_client.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_client.dart
@@ -27,10 +27,12 @@ final class AgentAssistantSpeechTextSegment {
 final class AgentAssistantSpeechAudioSegment {
   const AgentAssistantSpeechAudioSegment({
     required this.sequence,
+    required this.chunkIndex,
     required this.audio,
   });
 
   final int sequence;
+  final int chunkIndex;
   final Uint8List audio;
 }
 

--- a/mobile/lib/features/agent/conversation/agent_message_audio_client.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_client.dart
@@ -13,3 +13,30 @@ abstract interface class AgentMessageAudioClient {
     required String text,
   });
 }
+
+final class AgentAssistantSpeechTextSegment {
+  const AgentAssistantSpeechTextSegment({
+    required this.sequence,
+    required this.text,
+  });
+
+  final int sequence;
+  final String text;
+}
+
+final class AgentAssistantSpeechAudioSegment {
+  const AgentAssistantSpeechAudioSegment({
+    required this.sequence,
+    required this.audio,
+  });
+
+  final int sequence;
+  final Uint8List audio;
+}
+
+abstract interface class AgentAssistantSpeechClient {
+  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
+    required String threadId,
+    required Stream<AgentAssistantSpeechTextSegment> segments,
+  });
+}

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -110,7 +110,7 @@ final class AgentMessageAudioController extends ChangeNotifier
         delta.isEmpty) {
       return;
     }
-    _appendLiveAssistantText(live, live.observedText + delta, finalText: false);
+    _appendLiveAssistantText(live, live.observedText + delta);
   }
 
   void completeLiveAssistantSpeech({
@@ -141,7 +141,7 @@ final class AgentMessageAudioController extends ChangeNotifier
       );
       return;
     }
-    _appendLiveAssistantText(live, message.text, finalText: true);
+    _appendLiveAssistantText(live, message.text);
     live.inputClosed = true;
     unawaited(live.segments.close());
   }
@@ -516,44 +516,34 @@ final class AgentMessageAudioController extends ChangeNotifier
         );
   }
 
-  void _appendLiveAssistantText(
-    _LiveAssistantSpeech live,
-    String text, {
-    required bool finalText,
-  }) {
+  void _appendLiveAssistantText(_LiveAssistantSpeech live, String text) {
     if (!identical(_liveAssistantSpeech, live) ||
         live.inputClosed ||
         !text.startsWith(live.observedText)) {
       return;
     }
+    final delta = text.substring(live.observedText.length);
     live.observedText = text;
-    final boundaries = _assistantSpeechBoundaries(
-      text,
-      live.consumedOffset,
-      finalText: finalText,
-    );
-    for (final boundary in boundaries) {
-      if (live.nextSequence > 64) {
-        _failLiveAssistantSpeech(
-          live,
-          StateError('Assistant speech segment limit exceeded.'),
-        );
-        return;
-      }
-      final spoken = _cleanAssistantSpeechText(
-        text.substring(live.consumedOffset, boundary),
-      );
-      live.consumedOffset = boundary;
-      if (spoken.isEmpty) {
-        continue;
-      }
-      live.segments.add(
-        AgentAssistantSpeechTextSegment(
-          sequence: live.nextSequence++,
-          text: spoken,
-        ),
-      );
+    if (delta.isEmpty) {
+      return;
     }
+    if (live.nextSequence > 1024) {
+      _failLiveAssistantSpeech(
+        live,
+        StateError('Assistant speech text chunk limit exceeded.'),
+      );
+      return;
+    }
+    final spoken = _cleanAssistantSpeechDelta(delta);
+    if (spoken.trim().isEmpty) {
+      return;
+    }
+    live.segments.add(
+      AgentAssistantSpeechTextSegment(
+        sequence: live.nextSequence++,
+        text: spoken,
+      ),
+    );
   }
 
   void _handleLiveAssistantAudio(
@@ -798,7 +788,6 @@ final class _LiveAssistantSpeech {
       StreamController<AgentAssistantSpeechTextSegment>();
   StreamSubscription<AgentAssistantSpeechAudioSegment>? subscription;
   String observedText = '';
-  int consumedOffset = 0;
   int nextSequence = 1;
   int audioSequence = 0;
   int nextChunkIndex = 1;
@@ -809,36 +798,8 @@ final class _LiveAssistantSpeech {
   Future<void> playbackOperation = Future<void>.value();
 }
 
-List<int> _assistantSpeechBoundaries(
-  String text,
-  int start, {
-  required bool finalText,
-}) {
-  final boundaries = <int>[];
-  for (var index = start; index < text.length; index++) {
-    if (_assistantSpeechTerminators.contains(text[index])) {
-      boundaries.add(index + 1);
-    }
-  }
-  if (finalText && (boundaries.isEmpty || boundaries.last < text.length)) {
-    boundaries.add(text.length);
-  }
-  return boundaries;
-}
-
-String _cleanAssistantSpeechText(String value) {
+String _cleanAssistantSpeechDelta(String value) {
   return value
       .replaceAll(RegExp(r'[`*_#>]'), '')
-      .replaceAll(RegExp(r'^\s*[-+]\s+', multiLine: true), '')
-      .trim();
+      .replaceAll(RegExp(r'^\s*[-+]\s+', multiLine: true), '');
 }
-
-const _assistantSpeechTerminators = <String>{
-  '.',
-  '?',
-  '!',
-  '。',
-  '？',
-  '！',
-  '\n',
-};

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
@@ -14,6 +16,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     required this.conversationController,
     required this.client,
     required this.audioPlayer,
+    this.assistantSpeechClient,
   }) {
     _positionSubscription = audioPlayer.onPosition.listen(_handlePosition);
     _completionSubscription = audioPlayer.onComplete.listen((_) {
@@ -27,6 +30,7 @@ final class AgentMessageAudioController extends ChangeNotifier
   final ConversationController conversationController;
   final AgentMessageAudioClient client;
   final AgentAudioPlayer audioPlayer;
+  final AgentAssistantSpeechClient? assistantSpeechClient;
 
   String? _threadId;
   Set<String> _visibleMessageIds = <String>{};
@@ -48,6 +52,9 @@ final class AgentMessageAudioController extends ChangeNotifier
   Future<void>? _cleanupFuture;
   StreamSubscription<Duration>? _positionSubscription;
   StreamSubscription<void>? _completionSubscription;
+  _LiveAssistantSpeech? _liveAssistantSpeech;
+  Object? _liveSpeechStartToken;
+  String? _liveSpeechCommittedMessageId;
 
   String? get threadId => _threadId;
   double get speechSpeed => _speechSpeed;
@@ -72,23 +79,32 @@ final class AgentMessageAudioController extends ChangeNotifier
     if (message.role != AgentMessageRole.assistant) {
       return Future<void>.value();
     }
+    if (_liveSpeechCommittedMessageId == message.id) {
+      return Future<void>.value();
+    }
     return _toggleMessagePlayback(message);
   }
 
-  Future<void> stopPlayback() {
+  Future<void> stopPlayback() async {
     if (_disposed) {
-      return Future<void>.value();
+      return;
     }
     _generation++;
+    await _cancelLiveAssistantSpeech();
     _resetPlaybackPresentation();
     notifyListeners();
-    return audioPlayer.stop();
+    await audioPlayer.stop();
   }
 
   Future<void> _toggleMessagePlayback(
     AgentMessage message, {
     String? previewText,
   }) {
+    if (_liveAssistantSpeech != null) {
+      return _cancelLiveAssistantSpeech().then(
+        (_) => _toggleMessagePlayback(message, previewText: previewText),
+      );
+    }
     if (!_visibleMessageIds.contains(message.id) ||
         _threadId == null ||
         _disposed ||
@@ -184,6 +200,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     _speechSpeed = speeds[(index + 1) % speeds.length];
     if (_playingMessageId != null) {
       _generation++;
+      unawaited(_cancelLiveAssistantSpeech());
       _resetPlaybackPresentation();
       unawaited(audioPlayer.stop());
     }
@@ -269,6 +286,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     }
     _accountEpoch++;
     _generation++;
+    await _cancelLiveAssistantSpeech();
     _threadId = null;
     _visibleMessageIds = <String>{};
     _visibleMessageAudioIds = <String, String?>{};
@@ -295,6 +313,7 @@ final class AgentMessageAudioController extends ChangeNotifier
       return;
     }
     _generation++;
+    unawaited(_cancelLiveAssistantSpeech());
     _resetPlaybackPresentation(clearError: false);
     notifyListeners();
     unawaited(audioPlayer.stop());
@@ -310,6 +329,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     conversationController.removeListener(_syncConversation);
     _accountEpoch++;
     _generation++;
+    unawaited(_cancelLiveAssistantSpeech());
     unawaited(_positionSubscription?.cancel());
     unawaited(_completionSubscription?.cancel());
     unawaited(audioPlayer.dispose());
@@ -331,6 +351,8 @@ final class AgentMessageAudioController extends ChangeNotifier
     };
     if (nextThreadId != _threadId) {
       _generation++;
+      unawaited(_cancelLiveAssistantSpeech());
+      _liveSpeechCommittedMessageId = null;
       _threadId = nextThreadId;
       _visibleMessageIds = messageIds;
       _visibleMessageAudioIds = messageAudioIds;
@@ -341,6 +363,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     }
     _visibleMessageIds = messageIds;
     _visibleMessageAudioIds = messageAudioIds;
+    _syncLiveAssistantSpeech(messages);
     _fenceUnavailableMedia();
   }
 
@@ -356,8 +379,270 @@ final class AgentMessageAudioController extends ChangeNotifier
     if (_disposed) {
       return;
     }
+    final live = _liveAssistantSpeech;
+    if (live != null && live.playing) {
+      live.playing = false;
+      if (live.audio.isNotEmpty) {
+        unawaited(_playNextLiveAssistantSegment(live));
+      } else if (live.remoteCompleted) {
+        _finishLiveAssistantSpeech(live);
+      } else {
+        _playingMessageId = null;
+        _loadingMessageId = live.messageId;
+        notifyListeners();
+      }
+      return;
+    }
     _resetPlaybackPresentation(clearError: false);
     notifyListeners();
+  }
+
+  void _syncLiveAssistantSpeech(List<AgentMessage> messages) {
+    final speechClient = assistantSpeechClient;
+    final threadId = _threadId;
+    if (speechClient == null || threadId == null) {
+      return;
+    }
+    AgentMessage? streaming;
+    for (var index = messages.length - 1; index >= 0; index--) {
+      final candidate = messages[index];
+      if (candidate.role != AgentMessageRole.assistant ||
+          !candidate.isStreaming ||
+          candidate.hasFailed ||
+          !candidate.id.startsWith('stream-')) {
+        continue;
+      }
+      AgentMessage? precedingUser;
+      for (var userIndex = index - 1; userIndex >= 0; userIndex--) {
+        if (messages[userIndex].role == AgentMessageRole.user) {
+          precedingUser = messages[userIndex];
+          break;
+        }
+      }
+      if (precedingUser?.modality == AgentMessageModality.voice) {
+        streaming = candidate;
+      }
+      break;
+    }
+    final live = _liveAssistantSpeech;
+    if (streaming != null) {
+      if (live == null || live.messageId != streaming.id) {
+        unawaited(_startLiveAssistantSpeech(threadId, streaming));
+        return;
+      }
+      _appendLiveAssistantText(live, streaming.text, finalText: false);
+      return;
+    }
+    if (live == null || live.inputClosed) {
+      return;
+    }
+    AgentMessage? committed;
+    for (var index = messages.length - 1; index >= 0; index--) {
+      final candidate = messages[index];
+      if (candidate.role == AgentMessageRole.assistant &&
+          !candidate.isStreaming &&
+          !candidate.hasFailed &&
+          candidate.text == live.observedText) {
+        committed = candidate;
+        break;
+      }
+    }
+    if (committed == null) {
+      unawaited(_cancelLiveAssistantSpeech());
+      return;
+    }
+    final transientId = live.messageId;
+    live.messageId = committed.id;
+    _liveSpeechCommittedMessageId = committed.id;
+    if (_playingMessageId == transientId) {
+      _playingMessageId = committed.id;
+    }
+    if (_loadingMessageId == transientId) {
+      _loadingMessageId = committed.id;
+    }
+    _appendLiveAssistantText(live, committed.text, finalText: true);
+    live.inputClosed = true;
+    unawaited(live.segments.close());
+  }
+
+  Future<void> _startLiveAssistantSpeech(
+    String threadId,
+    AgentMessage message,
+  ) async {
+    final startToken = Object();
+    _liveSpeechStartToken = startToken;
+    await _cancelLiveAssistantSpeech(preserveStartToken: true);
+    if (_disposed ||
+        _threadId != threadId ||
+        !identical(_liveSpeechStartToken, startToken)) {
+      return;
+    }
+    _liveSpeechStartToken = null;
+    final speechClient = assistantSpeechClient;
+    if (speechClient == null) {
+      return;
+    }
+    final live = _LiveAssistantSpeech(
+      threadId: threadId,
+      messageId: message.id,
+    );
+    _liveAssistantSpeech = live;
+    _liveSpeechCommittedMessageId = null;
+    _loadingMessageId = message.id;
+    _playingMessageId = null;
+    _messagePlaybackUsesPreview = false;
+    _errorMessage = null;
+    _errorMessageId = null;
+    notifyListeners();
+    live.subscription = speechClient
+        .streamAssistantSpeech(
+          threadId: threadId,
+          segments: live.segments.stream,
+        )
+        .listen(
+          (segment) => _handleLiveAssistantAudio(live, segment),
+          onError: (Object error, StackTrace _) {
+            _failLiveAssistantSpeech(live, error);
+          },
+          onDone: () {
+            if (!identical(_liveAssistantSpeech, live)) {
+              return;
+            }
+            live.remoteCompleted = true;
+            if (!live.playing && live.audio.isEmpty) {
+              _finishLiveAssistantSpeech(live);
+            }
+          },
+        );
+    _appendLiveAssistantText(live, message.text, finalText: false);
+  }
+
+  void _appendLiveAssistantText(
+    _LiveAssistantSpeech live,
+    String text, {
+    required bool finalText,
+  }) {
+    if (!identical(_liveAssistantSpeech, live) ||
+        live.inputClosed ||
+        !text.startsWith(live.observedText)) {
+      return;
+    }
+    live.observedText = text;
+    final boundaries = _assistantSpeechBoundaries(
+      text,
+      live.consumedOffset,
+      finalText: finalText,
+    );
+    for (final boundary in boundaries) {
+      if (live.nextSequence > 64) {
+        _failLiveAssistantSpeech(
+          live,
+          StateError('Assistant speech segment limit exceeded.'),
+        );
+        return;
+      }
+      final spoken = _cleanAssistantSpeechText(
+        text.substring(live.consumedOffset, boundary),
+      );
+      live.consumedOffset = boundary;
+      if (spoken.isEmpty) {
+        continue;
+      }
+      live.segments.add(
+        AgentAssistantSpeechTextSegment(
+          sequence: live.nextSequence++,
+          text: spoken,
+        ),
+      );
+    }
+  }
+
+  void _handleLiveAssistantAudio(
+    _LiveAssistantSpeech live,
+    AgentAssistantSpeechAudioSegment segment,
+  ) {
+    if (!identical(_liveAssistantSpeech, live) ||
+        segment.sequence != live.nextAudioSequence) {
+      segment.audio.fillRange(0, segment.audio.length, 0);
+      _failLiveAssistantSpeech(
+        live,
+        StateError('Assistant speech audio sequence is invalid.'),
+      );
+      return;
+    }
+    live.nextAudioSequence++;
+    live.audio.add(segment.audio);
+    if (!live.playing) {
+      unawaited(_playNextLiveAssistantSegment(live));
+    }
+  }
+
+  Future<void> _playNextLiveAssistantSegment(_LiveAssistantSpeech live) async {
+    if (!identical(_liveAssistantSpeech, live) ||
+        live.playing ||
+        live.audio.isEmpty) {
+      return;
+    }
+    final audio = live.audio.removeFirst();
+    live.playing = true;
+    _loadingMessageId = null;
+    _playingMessageId = live.messageId;
+    _playbackPosition = Duration.zero;
+    notifyListeners();
+    try {
+      await audioPlayer.playWav(audio, speed: _speechSpeed);
+    } catch (error) {
+      _failLiveAssistantSpeech(live, error);
+    } finally {
+      audio.fillRange(0, audio.length, 0);
+    }
+  }
+
+  void _finishLiveAssistantSpeech(_LiveAssistantSpeech live) {
+    if (!identical(_liveAssistantSpeech, live)) {
+      return;
+    }
+    _liveAssistantSpeech = null;
+    _loadingMessageId = null;
+    _playingMessageId = null;
+    _playbackPosition = Duration.zero;
+    notifyListeners();
+  }
+
+  void _failLiveAssistantSpeech(_LiveAssistantSpeech live, Object error) {
+    if (!identical(_liveAssistantSpeech, live)) {
+      return;
+    }
+    final messageId = live.messageId;
+    unawaited(_cancelLiveAssistantSpeech());
+    _loadingMessageId = null;
+    _playingMessageId = null;
+    _errorMessageId = messageId;
+    _errorMessage = '实时朗读中断，可点击朗读重新播放。';
+    notifyListeners();
+    unawaited(_clearOnAuthenticationFailure(error));
+  }
+
+  Future<void> _cancelLiveAssistantSpeech({
+    bool preserveStartToken = false,
+  }) async {
+    if (!preserveStartToken) {
+      _liveSpeechStartToken = null;
+    }
+    final live = _liveAssistantSpeech;
+    if (live == null) {
+      return;
+    }
+    _liveAssistantSpeech = null;
+    if (!live.inputClosed) {
+      live.inputClosed = true;
+      await live.segments.close();
+    }
+    await live.subscription?.cancel();
+    while (live.audio.isNotEmpty) {
+      final audio = live.audio.removeFirst();
+      audio.fillRange(0, audio.length, 0);
+    }
   }
 
   void _fenceUnavailableMedia() {
@@ -496,3 +781,55 @@ final class _MessageAudioFence {
   final String messageId;
   final String? audioId;
 }
+
+final class _LiveAssistantSpeech {
+  _LiveAssistantSpeech({required this.threadId, required this.messageId});
+
+  final String threadId;
+  String messageId;
+  final StreamController<AgentAssistantSpeechTextSegment> segments =
+      StreamController<AgentAssistantSpeechTextSegment>();
+  StreamSubscription<AgentAssistantSpeechAudioSegment>? subscription;
+  final Queue<Uint8List> audio = Queue<Uint8List>();
+  String observedText = '';
+  int consumedOffset = 0;
+  int nextSequence = 1;
+  int nextAudioSequence = 1;
+  bool inputClosed = false;
+  bool remoteCompleted = false;
+  bool playing = false;
+}
+
+List<int> _assistantSpeechBoundaries(
+  String text,
+  int start, {
+  required bool finalText,
+}) {
+  final boundaries = <int>[];
+  for (var index = start; index < text.length; index++) {
+    if (_assistantSpeechTerminators.contains(text[index])) {
+      boundaries.add(index + 1);
+    }
+  }
+  if (finalText && (boundaries.isEmpty || boundaries.last < text.length)) {
+    boundaries.add(text.length);
+  }
+  return boundaries;
+}
+
+String _cleanAssistantSpeechText(String value) {
+  return value
+      .replaceAll(RegExp(r'[`*_#>]'), '')
+      .replaceAll(RegExp(r'^\s*[-+]\s+', multiLine: true), '')
+      .trim();
+}
+
+const _assistantSpeechTerminators = <String>{
+  '.',
+  '?',
+  '!',
+  '。',
+  '？',
+  '！',
+  '\n',
+};

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -77,10 +77,74 @@ final class AgentMessageAudioController extends ChangeNotifier
     if (message.role != AgentMessageRole.assistant) {
       return Future<void>.value();
     }
-    if (_liveSpeechCommittedMessageId == message.id) {
+    if (_liveAssistantSpeech != null ||
+        _liveSpeechCommittedMessageId == message.id) {
       return Future<void>.value();
     }
     return _toggleMessagePlayback(message);
+  }
+
+  Future<void> startLiveAssistantSpeech({
+    required String transientMessageId,
+  }) async {
+    final threadId = _threadId;
+    if (_disposed ||
+        threadId == null ||
+        transientMessageId.isEmpty ||
+        assistantSpeechClient == null ||
+        audioPlayer is! AgentPCMStreamPlayer) {
+      return;
+    }
+    await _startLiveAssistantSpeech(threadId, transientMessageId);
+  }
+
+  void appendLiveAssistantSpeech({
+    required String transientMessageId,
+    required String delta,
+  }) {
+    final live = _liveAssistantSpeech;
+    if (_disposed ||
+        live == null ||
+        live.inputClosed ||
+        live.messageId != transientMessageId ||
+        delta.isEmpty) {
+      return;
+    }
+    _appendLiveAssistantText(live, live.observedText + delta, finalText: false);
+  }
+
+  void completeLiveAssistantSpeech({
+    required String transientMessageId,
+    required AgentMessage message,
+  }) {
+    final live = _liveAssistantSpeech;
+    if (_disposed ||
+        live == null ||
+        live.inputClosed ||
+        live.messageId != transientMessageId ||
+        message.role != AgentMessageRole.assistant ||
+        message.hasFailed) {
+      return;
+    }
+    live.messageId = message.id;
+    _liveSpeechCommittedMessageId = message.id;
+    if (_playingMessageId == transientMessageId) {
+      _playingMessageId = message.id;
+    }
+    if (_loadingMessageId == transientMessageId) {
+      _loadingMessageId = message.id;
+    }
+    _appendLiveAssistantText(live, live.observedText, finalText: true);
+    live.inputClosed = true;
+    unawaited(live.segments.close());
+  }
+
+  void failLiveAssistantSpeech({required String transientMessageId}) {
+    final live = _liveAssistantSpeech;
+    if (live == null || live.messageId != transientMessageId) {
+      return;
+    }
+    unawaited(_cancelLiveAssistantSpeech());
   }
 
   Future<void> stopPlayback() async {
@@ -361,7 +425,6 @@ final class AgentMessageAudioController extends ChangeNotifier
     }
     _visibleMessageIds = messageIds;
     _visibleMessageAudioIds = messageAudioIds;
-    _syncLiveAssistantSpeech(messages);
     _fenceUnavailableMedia();
   }
 
@@ -389,95 +452,10 @@ final class AgentMessageAudioController extends ChangeNotifier
     notifyListeners();
   }
 
-  void _syncLiveAssistantSpeech(List<AgentMessage> messages) {
-    final speechClient = assistantSpeechClient;
-    final threadId = _threadId;
-    if (speechClient == null ||
-        threadId == null ||
-        audioPlayer is! AgentPCMStreamPlayer) {
-      return;
-    }
-    final live = _liveAssistantSpeech;
-    AgentMessage? streaming;
-    for (var index = messages.length - 1; index >= 0; index--) {
-      final candidate = messages[index];
-      if (candidate.role != AgentMessageRole.assistant ||
-          !candidate.isStreaming ||
-          candidate.hasFailed ||
-          !candidate.id.startsWith('stream-')) {
-        continue;
-      }
-      AgentMessage? precedingUser;
-      for (var userIndex = index - 1; userIndex >= 0; userIndex--) {
-        if (messages[userIndex].role == AgentMessageRole.user) {
-          precedingUser = messages[userIndex];
-          break;
-        }
-      }
-      if (precedingUser?.modality == AgentMessageModality.voice) {
-        streaming = candidate;
-        if (live == null || live.messageId != candidate.id) {
-          unawaited(
-            _startLiveAssistantSpeech(
-              threadId,
-              candidate,
-              precedingUserMessageId: precedingUser!.id,
-            ),
-          );
-          return;
-        }
-      }
-      break;
-    }
-    if (streaming != null && live != null) {
-      _appendLiveAssistantText(live, streaming.text, finalText: false);
-      return;
-    }
-    if (live == null || live.inputClosed) {
-      return;
-    }
-    final userIndex = messages.indexWhere(
-      (message) => message.id == live.precedingUserMessageId,
-    );
-    AgentMessage? committed;
-    if (userIndex >= 0) {
-      for (var index = userIndex + 1; index < messages.length; index++) {
-        final candidate = messages[index];
-        if (candidate.role == AgentMessageRole.user) {
-          break;
-        }
-        if (candidate.role == AgentMessageRole.assistant &&
-            !candidate.isStreaming &&
-            !candidate.hasFailed &&
-            candidate.text.startsWith(live.observedText)) {
-          committed = candidate;
-          break;
-        }
-      }
-    }
-    if (committed == null) {
-      unawaited(_cancelLiveAssistantSpeech());
-      return;
-    }
-    final transientId = live.messageId;
-    live.messageId = committed.id;
-    _liveSpeechCommittedMessageId = committed.id;
-    if (_playingMessageId == transientId) {
-      _playingMessageId = committed.id;
-    }
-    if (_loadingMessageId == transientId) {
-      _loadingMessageId = committed.id;
-    }
-    _appendLiveAssistantText(live, committed.text, finalText: true);
-    live.inputClosed = true;
-    unawaited(live.segments.close());
-  }
-
   Future<void> _startLiveAssistantSpeech(
     String threadId,
-    AgentMessage message, {
-    required String precedingUserMessageId,
-  }) async {
+    String messageId,
+  ) async {
     final startToken = Object();
     _liveSpeechStartToken = startToken;
     await _cancelLiveAssistantSpeech(preserveStartToken: true);
@@ -491,14 +469,10 @@ final class AgentMessageAudioController extends ChangeNotifier
     if (speechClient == null || audioPlayer is! AgentPCMStreamPlayer) {
       return;
     }
-    final live = _LiveAssistantSpeech(
-      threadId: threadId,
-      messageId: message.id,
-      precedingUserMessageId: precedingUserMessageId,
-    );
+    final live = _LiveAssistantSpeech(threadId: threadId, messageId: messageId);
     _liveAssistantSpeech = live;
     _liveSpeechCommittedMessageId = null;
-    _loadingMessageId = message.id;
+    _loadingMessageId = messageId;
     _playingMessageId = null;
     _messagePlaybackUsesPreview = false;
     _errorMessage = null;
@@ -533,7 +507,6 @@ final class AgentMessageAudioController extends ChangeNotifier
                 });
           },
         );
-    _appendLiveAssistantText(live, message.text, finalText: false);
   }
 
   void _appendLiveAssistantText(
@@ -810,14 +783,9 @@ final class _MessageAudioFence {
 }
 
 final class _LiveAssistantSpeech {
-  _LiveAssistantSpeech({
-    required this.threadId,
-    required this.messageId,
-    required this.precedingUserMessageId,
-  });
+  _LiveAssistantSpeech({required this.threadId, required this.messageId});
 
   final String threadId;
-  final String precedingUserMessageId;
   String messageId;
   final StreamController<AgentAssistantSpeechTextSegment> segments =
       StreamController<AgentAssistantSpeechTextSegment>();

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -397,6 +397,7 @@ final class AgentMessageAudioController extends ChangeNotifier
         audioPlayer is! AgentPCMStreamPlayer) {
       return;
     }
+    final live = _liveAssistantSpeech;
     AgentMessage? streaming;
     for (var index = messages.length - 1; index >= 0; index--) {
       final candidate = messages[index];
@@ -415,30 +416,43 @@ final class AgentMessageAudioController extends ChangeNotifier
       }
       if (precedingUser?.modality == AgentMessageModality.voice) {
         streaming = candidate;
+        if (live == null || live.messageId != candidate.id) {
+          unawaited(
+            _startLiveAssistantSpeech(
+              threadId,
+              candidate,
+              precedingUserMessageId: precedingUser!.id,
+            ),
+          );
+          return;
+        }
       }
       break;
     }
-    final live = _liveAssistantSpeech;
-    if (streaming != null) {
-      if (live == null || live.messageId != streaming.id) {
-        unawaited(_startLiveAssistantSpeech(threadId, streaming));
-        return;
-      }
+    if (streaming != null && live != null) {
       _appendLiveAssistantText(live, streaming.text, finalText: false);
       return;
     }
     if (live == null || live.inputClosed) {
       return;
     }
+    final userIndex = messages.indexWhere(
+      (message) => message.id == live.precedingUserMessageId,
+    );
     AgentMessage? committed;
-    for (var index = messages.length - 1; index >= 0; index--) {
-      final candidate = messages[index];
-      if (candidate.role == AgentMessageRole.assistant &&
-          !candidate.isStreaming &&
-          !candidate.hasFailed &&
-          candidate.text == live.observedText) {
-        committed = candidate;
-        break;
+    if (userIndex >= 0) {
+      for (var index = userIndex + 1; index < messages.length; index++) {
+        final candidate = messages[index];
+        if (candidate.role == AgentMessageRole.user) {
+          break;
+        }
+        if (candidate.role == AgentMessageRole.assistant &&
+            !candidate.isStreaming &&
+            !candidate.hasFailed &&
+            candidate.text.startsWith(live.observedText)) {
+          committed = candidate;
+          break;
+        }
       }
     }
     if (committed == null) {
@@ -461,8 +475,9 @@ final class AgentMessageAudioController extends ChangeNotifier
 
   Future<void> _startLiveAssistantSpeech(
     String threadId,
-    AgentMessage message,
-  ) async {
+    AgentMessage message, {
+    required String precedingUserMessageId,
+  }) async {
     final startToken = Object();
     _liveSpeechStartToken = startToken;
     await _cancelLiveAssistantSpeech(preserveStartToken: true);
@@ -479,6 +494,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     final live = _LiveAssistantSpeech(
       threadId: threadId,
       messageId: message.id,
+      precedingUserMessageId: precedingUserMessageId,
     );
     _liveAssistantSpeech = live;
     _liveSpeechCommittedMessageId = null;
@@ -794,9 +810,14 @@ final class _MessageAudioFence {
 }
 
 final class _LiveAssistantSpeech {
-  _LiveAssistantSpeech({required this.threadId, required this.messageId});
+  _LiveAssistantSpeech({
+    required this.threadId,
+    required this.messageId,
+    required this.precedingUserMessageId,
+  });
 
   final String threadId;
+  final String precedingUserMessageId;
   String messageId;
   final StreamController<AgentAssistantSpeechTextSegment> segments =
       StreamController<AgentAssistantSpeechTextSegment>();

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -134,7 +134,14 @@ final class AgentMessageAudioController extends ChangeNotifier
     if (_loadingMessageId == transientMessageId) {
       _loadingMessageId = message.id;
     }
-    _appendLiveAssistantText(live, live.observedText, finalText: true);
+    if (!message.text.startsWith(live.observedText)) {
+      _failLiveAssistantSpeech(
+        live,
+        StateError('Committed assistant text does not match streamed text.'),
+      );
+      return;
+    }
+    _appendLiveAssistantText(live, message.text, finalText: true);
     live.inputClosed = true;
     unawaited(live.segments.close());
   }

--- a/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_audio_controller.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
@@ -382,14 +380,8 @@ final class AgentMessageAudioController extends ChangeNotifier
     final live = _liveAssistantSpeech;
     if (live != null && live.playing) {
       live.playing = false;
-      if (live.audio.isNotEmpty) {
-        unawaited(_playNextLiveAssistantSegment(live));
-      } else if (live.remoteCompleted) {
+      if (live.remoteCompleted) {
         _finishLiveAssistantSpeech(live);
-      } else {
-        _playingMessageId = null;
-        _loadingMessageId = live.messageId;
-        notifyListeners();
       }
       return;
     }
@@ -400,7 +392,9 @@ final class AgentMessageAudioController extends ChangeNotifier
   void _syncLiveAssistantSpeech(List<AgentMessage> messages) {
     final speechClient = assistantSpeechClient;
     final threadId = _threadId;
-    if (speechClient == null || threadId == null) {
+    if (speechClient == null ||
+        threadId == null ||
+        audioPlayer is! AgentPCMStreamPlayer) {
       return;
     }
     AgentMessage? streaming;
@@ -479,7 +473,7 @@ final class AgentMessageAudioController extends ChangeNotifier
     }
     _liveSpeechStartToken = null;
     final speechClient = assistantSpeechClient;
-    if (speechClient == null) {
+    if (speechClient == null || audioPlayer is! AgentPCMStreamPlayer) {
       return;
     }
     final live = _LiveAssistantSpeech(
@@ -509,9 +503,18 @@ final class AgentMessageAudioController extends ChangeNotifier
               return;
             }
             live.remoteCompleted = true;
-            if (!live.playing && live.audio.isEmpty) {
+            if (!live.playing) {
               _finishLiveAssistantSpeech(live);
+              return;
             }
+            live.playbackOperation = live.playbackOperation
+                .then(
+                  (_) =>
+                      (audioPlayer as AgentPCMStreamPlayer).finishPCMStream(),
+                )
+                .catchError((Object error) {
+                  _failLiveAssistantSpeech(live, error);
+                });
           },
         );
     _appendLiveAssistantText(live, message.text, finalText: false);
@@ -561,8 +564,12 @@ final class AgentMessageAudioController extends ChangeNotifier
     _LiveAssistantSpeech live,
     AgentAssistantSpeechAudioSegment segment,
   ) {
-    if (!identical(_liveAssistantSpeech, live) ||
-        segment.sequence != live.nextAudioSequence) {
+    final sameSegment = segment.sequence == live.audioSequence;
+    final nextSegment = segment.sequence == live.audioSequence + 1;
+    final validChunk = sameSegment
+        ? segment.chunkIndex == live.nextChunkIndex
+        : nextSegment && segment.chunkIndex == 1;
+    if (!identical(_liveAssistantSpeech, live) || !validChunk) {
       segment.audio.fillRange(0, segment.audio.length, 0);
       _failLiveAssistantSpeech(
         live,
@@ -570,32 +577,37 @@ final class AgentMessageAudioController extends ChangeNotifier
       );
       return;
     }
-    live.nextAudioSequence++;
-    live.audio.add(segment.audio);
+    if (nextSegment) {
+      live.audioSequence = segment.sequence;
+      live.nextChunkIndex = 1;
+    }
+    live.nextChunkIndex++;
+    final audio = segment.audio;
+    final streamPlayer = audioPlayer as AgentPCMStreamPlayer;
     if (!live.playing) {
-      unawaited(_playNextLiveAssistantSegment(live));
+      live.playing = true;
+      _loadingMessageId = null;
+      _playingMessageId = live.messageId;
+      _playbackPosition = Duration.zero;
+      notifyListeners();
     }
-  }
-
-  Future<void> _playNextLiveAssistantSegment(_LiveAssistantSpeech live) async {
-    if (!identical(_liveAssistantSpeech, live) ||
-        live.playing ||
-        live.audio.isEmpty) {
-      return;
-    }
-    final audio = live.audio.removeFirst();
-    live.playing = true;
-    _loadingMessageId = null;
-    _playingMessageId = live.messageId;
-    _playbackPosition = Duration.zero;
-    notifyListeners();
-    try {
-      await audioPlayer.playWav(audio, speed: _speechSpeed);
-    } catch (error) {
-      _failLiveAssistantSpeech(live, error);
-    } finally {
-      audio.fillRange(0, audio.length, 0);
-    }
+    live.playbackOperation = live.playbackOperation
+        .then((_) async {
+          if (!identical(_liveAssistantSpeech, live)) {
+            return;
+          }
+          if (!live.playerStarted) {
+            live.playerStarted = true;
+            await streamPlayer.startPCMStream(speed: _speechSpeed);
+          }
+          await streamPlayer.appendPCM(audio);
+        })
+        .catchError((Object error) {
+          _failLiveAssistantSpeech(live, error);
+        })
+        .whenComplete(() {
+          audio.fillRange(0, audio.length, 0);
+        });
   }
 
   void _finishLiveAssistantSpeech(_LiveAssistantSpeech live) {
@@ -639,9 +651,8 @@ final class AgentMessageAudioController extends ChangeNotifier
       await live.segments.close();
     }
     await live.subscription?.cancel();
-    while (live.audio.isNotEmpty) {
-      final audio = live.audio.removeFirst();
-      audio.fillRange(0, audio.length, 0);
+    if (live.playerStarted) {
+      await audioPlayer.stop();
     }
   }
 
@@ -790,14 +801,16 @@ final class _LiveAssistantSpeech {
   final StreamController<AgentAssistantSpeechTextSegment> segments =
       StreamController<AgentAssistantSpeechTextSegment>();
   StreamSubscription<AgentAssistantSpeechAudioSegment>? subscription;
-  final Queue<Uint8List> audio = Queue<Uint8List>();
   String observedText = '';
   int consumedOffset = 0;
   int nextSequence = 1;
-  int nextAudioSequence = 1;
+  int audioSequence = 0;
+  int nextChunkIndex = 1;
   bool inputClosed = false;
   bool remoteCompleted = false;
   bool playing = false;
+  bool playerStarted = false;
+  Future<void> playbackOperation = Future<void>.value();
 }
 
 List<int> _assistantSpeechBoundaries(

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -157,7 +157,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         ),
       );
     }
-    if (message.isStreaming || message.hasFailed) {
+    if (message.hasFailed) {
       return markdown;
     }
     if (audioController == null) {
@@ -180,7 +180,9 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           children: [
             TextButton.icon(
               key: Key('agent-assistant-tts-${message.id}'),
-              onPressed: () => audioController.toggleMessagePlayback(message),
+              onPressed: message.isStreaming
+                  ? null
+                  : () => audioController.toggleMessagePlayback(message),
               style: TextButton.styleFrom(
                 foregroundColor: SpeakUpDesign.primary,
                 backgroundColor: SpeakUpDesign.surfaceMuted,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -279,6 +279,7 @@ ProductionAppDependencies createProductionAppDependencies({
     conversationController: conversationController,
     client: agentVoiceClient,
     audioPlayer: agentMessageAudioPlayer ?? AudioplayersAgentAudioPlayer(),
+    assistantSpeechClient: agentVoiceClient,
   );
   final composerController = ComposerController(
     conversationController: conversationController,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -289,7 +289,20 @@ ProductionAppDependencies createProductionAppDependencies({
     voiceRecorder: agentVoiceRecorder ?? IosAgentVoiceRecorder(),
     draftAudioPlayer:
         agentComposerAudioPlayer ?? AudioplayersAgentAudioPlayer(),
-    onAssistantCommitted: messageAudioController.playCommittedAssistant,
+    onAssistantStreamStarted: (transientMessageId) => messageAudioController
+        .startLiveAssistantSpeech(transientMessageId: transientMessageId),
+    onAssistantStreamDelta: (transientMessageId, delta) =>
+        messageAudioController.appendLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          delta: delta,
+        ),
+    onAssistantStreamCompleted: (transientMessageId, message) =>
+        messageAudioController.completeLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          message: message,
+        ),
+    onAssistantStreamFailed: (transientMessageId) => messageAudioController
+        .failLiveAssistantSpeech(transientMessageId: transientMessageId),
   );
   final practiceController = PracticeController(
     client: practiceClient,

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -74,7 +74,8 @@ final class WireAgentVoiceClient
         AgentVoiceClient,
         AgentVoiceStreamingClient,
         AgentVoiceRealtimeInputClient,
-        AgentMessageAudioClient {
+        AgentMessageAudioClient,
+        AgentAssistantSpeechClient {
   factory WireAgentVoiceClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -83,6 +84,7 @@ final class WireAgentVoiceClient
     AgentVoiceWireTransport? signedAudioTransport,
     AgentVoiceWireTransportFactory? transportFactory,
     AuthenticatedWebSocketConnector? realtimeConnector,
+    AuthenticatedWebSocketConnector? assistantSpeechConnector,
     AgentVoiceNow? now,
     Duration requestTimeout = const Duration(seconds: 75),
   }) {
@@ -116,6 +118,16 @@ final class WireAgentVoiceClient
         invalidateSession: invalidateSession,
         trustedBaseUri: _webSocketBaseUri(baseUri),
       ),
+      SessionAuthenticatedWebSocketConnector(
+        connector:
+            assistantSpeechConnector ??
+            IoAuthenticatedWebSocketConnector(
+              protocols: const <String>[_assistantSpeechWebSocketProtocol],
+            ),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: _webSocketBaseUri(baseUri),
+      ),
       requestTimeout,
       now ?? _utcNow,
     );
@@ -132,6 +144,7 @@ final class WireAgentVoiceClient
     this._ownsSignedAudioTransport,
     this._transportFactory,
     this._realtimeConnector,
+    this._assistantSpeechConnector,
     this._requestTimeout,
     this._now,
   );
@@ -141,6 +154,8 @@ final class WireAgentVoiceClient
   static const _maximumPlaybackLifetime = Duration(minutes: 2);
   static const _maximumLocalClockSkew = Duration(seconds: 30);
   static const _voiceInputWebSocketProtocol = 'speakup.voice-input.v1';
+  static const _assistantSpeechWebSocketProtocol =
+      'speakup.assistant-speech.v1';
 
   final Uri _baseUri;
   final TrustedIdentityHttpOrigin _trustedOrigin;
@@ -152,6 +167,7 @@ final class WireAgentVoiceClient
   final bool _ownsSignedAudioTransport;
   final AgentVoiceWireTransportFactory _transportFactory;
   final SessionAuthenticatedWebSocketConnector _realtimeConnector;
+  final SessionAuthenticatedWebSocketConnector _assistantSpeechConnector;
   final Duration _requestTimeout;
   final AgentVoiceNow _now;
 
@@ -347,6 +363,85 @@ final class WireAgentVoiceClient
     } on FormatException {
       throw _invalidResponse();
     } finally {
+      await connection?.socket.close();
+    }
+  }
+
+  @override
+  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
+    required String threadId,
+    required Stream<AgentAssistantSpeechTextSegment> segments,
+  }) async* {
+    _requireUuid(threadId);
+    final generation = _accountGeneration;
+    final uri = _webSocketBaseUri(_baseUri).resolve(
+      '/v1/agent-threads/${Uri.encodeComponent(threadId)}/assistant-speech/realtime',
+    );
+    SessionAuthenticatedWebSocketConnection? connection;
+    StreamIterator<dynamic>? messages;
+    try {
+      connection = await _assistantSpeechConnector.connect(uri: uri);
+      _requireGeneration(generation);
+      messages = StreamIterator<dynamic>(connection.socket);
+      final ready = await _nextAssistantSpeechMessage(messages);
+      _requireAssistantSpeechEvent(ready, 'stream.ready');
+      var expectedSequence = 1;
+      await for (final segment in segments) {
+        _requireGeneration(generation);
+        if (segment.sequence != expectedSequence ||
+            segment.text.trim().isEmpty ||
+            segment.text.runes.length > 800) {
+          throw const AgentClientException(
+            kind: AgentClientFailureKind.invalidRequest,
+          );
+        }
+        connection.socket.add(
+          jsonEncode(<String, Object>{
+            'type': 'segment',
+            'sequence': segment.sequence,
+            'text': segment.text,
+          }),
+        );
+        final started = await _nextAssistantSpeechMessage(messages);
+        _requireAssistantSpeechEvent(
+          started,
+          'segment.started',
+          sequence: expectedSequence,
+        );
+        final audioMessage = await _nextAssistantSpeechMessage(messages);
+        if (audioMessage is! List<int> ||
+            audioMessage.isEmpty ||
+            audioMessage.length > _maximumAudioBytes) {
+          throw _invalidResponse();
+        }
+        final completed = await _nextAssistantSpeechMessage(messages);
+        _requireAssistantSpeechEvent(
+          completed,
+          'segment.completed',
+          sequence: expectedSequence,
+        );
+        yield AgentAssistantSpeechAudioSegment(
+          sequence: expectedSequence,
+          audio: Uint8List.fromList(audioMessage),
+        );
+        expectedSequence++;
+      }
+      connection.socket.add(
+        jsonEncode(const <String, String>{'type': 'finish'}),
+      );
+      final completed = await _nextAssistantSpeechMessage(messages);
+      _requireAssistantSpeechEvent(completed, 'stream.completed');
+    } on AuthenticatedWebSocketException catch (error) {
+      throw AgentClientException(
+        kind: error.invalidatesAuthentication
+            ? AgentClientFailureKind.authenticationRequired
+            : AgentClientFailureKind.network,
+        retryable: !error.invalidatesAuthentication,
+      );
+    } on FormatException {
+      throw _invalidResponse();
+    } finally {
+      await messages?.cancel();
       await connection?.socket.close();
     }
   }
@@ -2208,6 +2303,67 @@ DateTime? _optionalDateTime(Map<String, Object?> object, String key) {
     return null;
   }
   return _strictDateTime(object[key]);
+}
+
+Future<dynamic> _nextAssistantSpeechMessage(
+  StreamIterator<dynamic> messages,
+) async {
+  if (!await messages.moveNext()) {
+    throw const AgentClientException(
+      kind: AgentClientFailureKind.network,
+      retryable: true,
+    );
+  }
+  return messages.current;
+}
+
+void _requireAssistantSpeechEvent(
+  dynamic message,
+  String expected, {
+  int? sequence,
+}) {
+  if (message is! String) {
+    throw _invalidResponse();
+  }
+  final envelope = _strictObject(
+    jsonDecode(message),
+    allowed: const <String>{'type', 'data'},
+    required: const <String>{'type', 'data'},
+  );
+  final type = _strictString(envelope['type'], min: 1, max: 64);
+  final data = _strictObject(
+    envelope['data'],
+    allowed: switch (type) {
+      'segment.started' => const <String>{'sequence'},
+      'segment.completed' => const <String>{'sequence', 'content_type'},
+      'stream.failed' => const <String>{'kind', 'retryable'},
+      _ => const <String>{},
+    },
+    required: switch (type) {
+      'segment.started' => const <String>{'sequence'},
+      'segment.completed' => const <String>{'sequence', 'content_type'},
+      'stream.failed' => const <String>{'kind', 'retryable'},
+      _ => const <String>{},
+    },
+  );
+  if (type == 'stream.failed') {
+    throw AgentClientException(
+      kind: AgentClientFailureKind.network,
+      errorCode: _strictString(data['kind'], min: 1, max: 64),
+      retryable: data['retryable'] == true,
+    );
+  }
+  if (type != expected) {
+    throw _invalidResponse();
+  }
+  if (sequence != null &&
+      _strictInt(data['sequence'], min: 1, max: 64) != sequence) {
+    throw _invalidResponse();
+  }
+  if (type == 'segment.completed' &&
+      _strictString(data['content_type'], min: 1, max: 32) != 'audio/wav') {
+    throw _invalidResponse();
+  }
 }
 
 void _requireUuid(String value) {

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -408,22 +408,36 @@ final class WireAgentVoiceClient
           'segment.started',
           sequence: expectedSequence,
         );
-        final audioMessage = await _nextAssistantSpeechMessage(messages);
-        if (audioMessage is! List<int> ||
-            audioMessage.isEmpty ||
-            audioMessage.length > _maximumAudioBytes) {
-          throw _invalidResponse();
+        var chunkIndex = 0;
+        var receivedBytes = 0;
+        while (true) {
+          final message = await _nextAssistantSpeechMessage(messages);
+          if (message is String) {
+            _requireAssistantSpeechEvent(
+              message,
+              'segment.completed',
+              sequence: expectedSequence,
+            );
+            if (chunkIndex == 0) {
+              throw _invalidResponse();
+            }
+            break;
+          }
+          if (message is! List<int> ||
+              message.isEmpty ||
+              message.length.isOdd) {
+            throw _invalidResponse();
+          }
+          receivedBytes += message.length;
+          if (receivedBytes > _maximumAudioBytes) {
+            throw _invalidResponse();
+          }
+          yield AgentAssistantSpeechAudioSegment(
+            sequence: expectedSequence,
+            chunkIndex: ++chunkIndex,
+            audio: Uint8List.fromList(message),
+          );
         }
-        final completed = await _nextAssistantSpeechMessage(messages);
-        _requireAssistantSpeechEvent(
-          completed,
-          'segment.completed',
-          sequence: expectedSequence,
-        );
-        yield AgentAssistantSpeechAudioSegment(
-          sequence: expectedSequence,
-          audio: Uint8List.fromList(audioMessage),
-        );
         expectedSequence++;
       }
       connection.socket.add(
@@ -2334,14 +2348,26 @@ void _requireAssistantSpeechEvent(
   final data = _strictObject(
     envelope['data'],
     allowed: switch (type) {
-      'segment.started' => const <String>{'sequence'},
-      'segment.completed' => const <String>{'sequence', 'content_type'},
+      'segment.started' => const <String>{
+        'sequence',
+        'content_type',
+        'sample_rate',
+        'channel_count',
+        'bits_per_sample',
+      },
+      'segment.completed' => const <String>{'sequence'},
       'stream.failed' => const <String>{'kind', 'retryable'},
       _ => const <String>{},
     },
     required: switch (type) {
-      'segment.started' => const <String>{'sequence'},
-      'segment.completed' => const <String>{'sequence', 'content_type'},
+      'segment.started' => const <String>{
+        'sequence',
+        'content_type',
+        'sample_rate',
+        'channel_count',
+        'bits_per_sample',
+      },
+      'segment.completed' => const <String>{'sequence'},
       'stream.failed' => const <String>{'kind', 'retryable'},
       _ => const <String>{},
     },
@@ -2360,9 +2386,13 @@ void _requireAssistantSpeechEvent(
       _strictInt(data['sequence'], min: 1, max: 64) != sequence) {
     throw _invalidResponse();
   }
-  if (type == 'segment.completed' &&
-      _strictString(data['content_type'], min: 1, max: 32) != 'audio/wav') {
-    throw _invalidResponse();
+  if (type == 'segment.started') {
+    if (_strictString(data['content_type'], min: 1, max: 32) != 'audio/pcm' ||
+        _strictInt(data['sample_rate'], min: 8000, max: 48000) != 24000 ||
+        _strictInt(data['channel_count'], min: 1, max: 2) != 1 ||
+        _strictInt(data['bits_per_sample'], min: 8, max: 32) != 16) {
+      throw _invalidResponse();
+    }
   }
 }
 

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -385,42 +385,56 @@ final class WireAgentVoiceClient
       messages = StreamIterator<dynamic>(connection.socket);
       final ready = await _nextAssistantSpeechMessage(messages);
       _requireAssistantSpeechEvent(ready, 'stream.ready');
-      var expectedSequence = 1;
-      await for (final segment in segments) {
-        _requireGeneration(generation);
-        if (segment.sequence != expectedSequence ||
-            segment.text.trim().isEmpty ||
-            segment.text.runes.length > 800) {
-          throw const AgentClientException(
-            kind: AgentClientFailureKind.invalidRequest,
-          );
-        }
-        connection.socket.add(
-          jsonEncode(<String, Object>{
-            'type': 'segment',
-            'sequence': segment.sequence,
-            'text': segment.text,
-          }),
-        );
-        final started = await _nextAssistantSpeechMessage(messages);
-        _requireAssistantSpeechEvent(
-          started,
-          'segment.started',
-          sequence: expectedSequence,
-        );
-        var chunkIndex = 0;
-        var receivedBytes = 0;
+      final outgoing = StreamIterator<AgentAssistantSpeechTextSegment>(
+        segments,
+      );
+      Object? sendingError;
+      StackTrace? sendingStackTrace;
+      var stopSending = false;
+      final sending =
+          () async {
+            var expectedSequence = 1;
+            while (!stopSending && await outgoing.moveNext()) {
+              _requireGeneration(generation);
+              final segment = outgoing.current;
+              if (segment.sequence != expectedSequence ||
+                  segment.text.trim().isEmpty ||
+                  segment.text.runes.length > 800 ||
+                  expectedSequence > 1024) {
+                throw const AgentClientException(
+                  kind: AgentClientFailureKind.invalidRequest,
+                );
+              }
+              connection!.socket.add(
+                jsonEncode(<String, Object>{
+                  'type': 'segment',
+                  'sequence': segment.sequence,
+                  'text': segment.text,
+                }),
+              );
+              expectedSequence++;
+            }
+            if (!stopSending) {
+              connection!.socket.add(
+                jsonEncode(const <String, String>{'type': 'finish'}),
+              );
+            }
+          }().onError((Object error, StackTrace stackTrace) async {
+            sendingError = error;
+            sendingStackTrace = stackTrace;
+            await connection?.socket.close();
+          });
+      var chunkIndex = 0;
+      var receivedBytes = 0;
+      try {
         while (true) {
           final message = await _nextAssistantSpeechMessage(messages);
           if (message is String) {
-            _requireAssistantSpeechEvent(
-              message,
-              'segment.completed',
-              sequence: expectedSequence,
-            );
+            _requireAssistantSpeechEvent(message, 'stream.completed');
             if (chunkIndex == 0) {
               throw _invalidResponse();
             }
+            await sending;
             break;
           }
           if (message is! List<int> ||
@@ -433,18 +447,21 @@ final class WireAgentVoiceClient
             throw _invalidResponse();
           }
           yield AgentAssistantSpeechAudioSegment(
-            sequence: expectedSequence,
+            sequence: 1,
             chunkIndex: ++chunkIndex,
             audio: Uint8List.fromList(message),
           );
         }
-        expectedSequence++;
+      } catch (_) {
+        if (sendingError != null) {
+          Error.throwWithStackTrace(sendingError!, sendingStackTrace!);
+        }
+        rethrow;
+      } finally {
+        stopSending = true;
+        await outgoing.cancel();
+        await sending;
       }
-      connection.socket.add(
-        jsonEncode(const <String, String>{'type': 'finish'}),
-      );
-      final completed = await _nextAssistantSpeechMessage(messages);
-      _requireAssistantSpeechEvent(completed, 'stream.completed');
     } on AuthenticatedWebSocketException catch (error) {
       throw AgentClientException(
         kind: error.invalidatesAuthentication
@@ -2331,11 +2348,7 @@ Future<dynamic> _nextAssistantSpeechMessage(
   return messages.current;
 }
 
-void _requireAssistantSpeechEvent(
-  dynamic message,
-  String expected, {
-  int? sequence,
-}) {
+void _requireAssistantSpeechEvent(dynamic message, String expected) {
   if (message is! String) {
     throw _invalidResponse();
   }
@@ -2348,26 +2361,22 @@ void _requireAssistantSpeechEvent(
   final data = _strictObject(
     envelope['data'],
     allowed: switch (type) {
-      'segment.started' => const <String>{
-        'sequence',
+      'stream.ready' => const <String>{
         'content_type',
         'sample_rate',
         'channel_count',
         'bits_per_sample',
       },
-      'segment.completed' => const <String>{'sequence'},
       'stream.failed' => const <String>{'kind', 'retryable'},
       _ => const <String>{},
     },
     required: switch (type) {
-      'segment.started' => const <String>{
-        'sequence',
+      'stream.ready' => const <String>{
         'content_type',
         'sample_rate',
         'channel_count',
         'bits_per_sample',
       },
-      'segment.completed' => const <String>{'sequence'},
       'stream.failed' => const <String>{'kind', 'retryable'},
       _ => const <String>{},
     },
@@ -2382,11 +2391,7 @@ void _requireAssistantSpeechEvent(
   if (type != expected) {
     throw _invalidResponse();
   }
-  if (sequence != null &&
-      _strictInt(data['sequence'], min: 1, max: 64) != sequence) {
-    throw _invalidResponse();
-  }
-  if (type == 'segment.started') {
+  if (type == 'stream.ready') {
     if (_strictString(data['content_type'], min: 1, max: 32) != 'audio/pcm' ||
         _strictInt(data['sample_rate'], min: 8000, max: 48000) != 24000 ||
         _strictInt(data['channel_count'], min: 1, max: 2) != 1 ||

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -93,7 +93,7 @@ void main() {
     expect(controller.playingMessageId, isNull);
   });
 
-  testWidgets('voice reply keeps speaking after transient message commits', (
+  testWidgets('voice reply fills streamed suffix from committed message', (
     tester,
   ) async {
     final conversation = ConversationController(client: FakeAgentClient());
@@ -145,14 +145,10 @@ void main() {
     await tester.pump();
     expect(speech.texts, <String>['Actually.']);
 
-    controller.appendLiveAssistantSpeech(
-      transientMessageId: 'stream-run-b',
-      delta: ' Please say the complete sentence again.',
-    );
     const committed = AgentMessage(
       id: 'assistant-b',
       role: AgentMessageRole.assistant,
-      text: 'The authoritative message does not drive speech segmentation.',
+      text: 'Actually. Please say the complete sentence again.',
     );
     controller.completeLiveAssistantSpeech(
       transientMessageId: 'stream-run-b',

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -10,7 +10,7 @@ import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 
 void main() {
-  testWidgets('voice reply speaks complete sentences before commit', (
+  testWidgets('voice reply forwards assistant deltas before commit', (
     tester,
   ) async {
     final conversation = ConversationController(client: FakeAgentClient());
@@ -72,7 +72,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(speech.texts, <String>['First sentence.']);
+    expect(speech.texts, <String>['First sentence. Second sentence']);
     expect(controller.playingMessageId, 'stream-run-a');
 
     const committed = AgentMessage(
@@ -86,7 +86,7 @@ void main() {
     );
     conversation.changeComposerStreamMessage('stream-run-a', committed);
     await tester.pump();
-    expect(speech.texts, <String>['First sentence.', 'Second sentence']);
+    expect(speech.texts, <String>['First sentence. Second sentence']);
     expect(controller.playingMessageId, 'assistant-a');
     player.complete();
     await tester.pump();
@@ -162,7 +162,7 @@ void main() {
 
     expect(speech.texts, <String>[
       'Actually.',
-      'Please say the complete sentence again.',
+      ' Please say the complete sentence again.',
     ]);
     expect(speech.cancelledBeforeRelease, isFalse);
   });

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -78,9 +78,6 @@ void main() {
     );
     await tester.pump();
     expect(speech.texts, <String>['First sentence.', 'Second sentence']);
-
-    player.complete();
-    await tester.pump();
     expect(controller.playingMessageId, 'assistant-a');
     player.complete();
     await tester.pump();
@@ -98,10 +95,13 @@ final class _FakeAssistantSpeechClient implements AgentAssistantSpeechClient {
   }) async* {
     await for (final segment in segments) {
       texts.add(segment.text);
-      yield AgentAssistantSpeechAudioSegment(
-        sequence: segment.sequence,
-        audio: Uint8List.fromList(<int>[1, 2, 3]),
-      );
+      for (var chunkIndex = 1; chunkIndex <= 2; chunkIndex++) {
+        yield AgentAssistantSpeechAudioSegment(
+          sequence: segment.sequence,
+          chunkIndex: chunkIndex,
+          audio: Uint8List.fromList(<int>[1, 2, 3, 4]),
+        );
+      }
     }
   }
 }

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -83,6 +83,70 @@ void main() {
     await tester.pump();
     expect(controller.playingMessageId, isNull);
   });
+
+  testWidgets('voice reply keeps speaking after transient message commits', (
+    tester,
+  ) async {
+    final conversation = ConversationController(client: FakeAgentClient());
+    await conversation.initialize();
+    final speech = _BlockingAssistantSpeechClient();
+    final controller = AgentMessageAudioController(
+      conversationController: conversation,
+      client: _FakeMessageAudioClient(),
+      audioPlayer: FakeAgentAudioPlayer(),
+      assistantSpeechClient: speech,
+    );
+    addTearDown(() {
+      controller.dispose();
+      conversation.dispose();
+    });
+
+    conversation.commitComposerMessages(const <AgentMessage>[
+      AgentMessage(
+        id: 'voice-user',
+        role: AgentMessageRole.user,
+        text: 'Please correct me.',
+        modality: AgentMessageModality.voice,
+        audio: AgentMessageAudio(
+          id: 'voice-audio',
+          status: AgentMessageAudioStatus.readable,
+          contentType: 'audio/wav',
+          sizeBytes: 64,
+          duration: Duration(seconds: 2),
+          playbackPath: '/audio',
+        ),
+      ),
+    ]);
+    conversation.changeComposerStreamMessage(
+      null,
+      const AgentMessage(
+        id: 'stream-run-b',
+        role: AgentMessageRole.assistant,
+        text: 'Actually.',
+        isStreaming: true,
+      ),
+    );
+    await tester.pump();
+    expect(speech.texts, <String>['Actually.']);
+
+    conversation.changeComposerStreamMessage(
+      'stream-run-b',
+      const AgentMessage(
+        id: 'assistant-b',
+        role: AgentMessageRole.assistant,
+        text: 'Actually. Please say the complete sentence again.',
+      ),
+    );
+    await tester.pump();
+    speech.releaseFirstSegment();
+    await tester.pumpAndSettle();
+
+    expect(speech.texts, <String>[
+      'Actually.',
+      'Please say the complete sentence again.',
+    ]);
+    expect(speech.cancelledBeforeRelease, isFalse);
+  });
 }
 
 final class _FakeAssistantSpeechClient implements AgentAssistantSpeechClient {
@@ -101,6 +165,43 @@ final class _FakeAssistantSpeechClient implements AgentAssistantSpeechClient {
           chunkIndex: chunkIndex,
           audio: Uint8List.fromList(<int>[1, 2, 3, 4]),
         );
+      }
+    }
+  }
+}
+
+final class _BlockingAssistantSpeechClient
+    implements AgentAssistantSpeechClient {
+  final List<String> texts = <String>[];
+  final Completer<void> _firstSegmentRelease = Completer<void>();
+  bool _released = false;
+  bool cancelledBeforeRelease = false;
+
+  void releaseFirstSegment() {
+    _released = true;
+    _firstSegmentRelease.complete();
+  }
+
+  @override
+  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
+    required String threadId,
+    required Stream<AgentAssistantSpeechTextSegment> segments,
+  }) async* {
+    try {
+      await for (final segment in segments) {
+        texts.add(segment.text);
+        yield AgentAssistantSpeechAudioSegment(
+          sequence: segment.sequence,
+          chunkIndex: 1,
+          audio: Uint8List.fromList(<int>[1, 2, 3, 4]),
+        );
+        if (segment.sequence == 1) {
+          await _firstSegmentRelease.future;
+        }
+      }
+    } finally {
+      if (!_released) {
+        cancelledBeforeRelease = true;
       }
     }
   }

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -63,19 +63,28 @@ void main() {
         isStreaming: true,
       ),
     );
+    await controller.startLiveAssistantSpeech(
+      transientMessageId: 'stream-run-a',
+    );
+    controller.appendLiveAssistantSpeech(
+      transientMessageId: 'stream-run-a',
+      delta: 'First sentence. Second sentence',
+    );
     await tester.pump();
 
     expect(speech.texts, <String>['First sentence.']);
     expect(controller.playingMessageId, 'stream-run-a');
 
-    conversation.changeComposerStreamMessage(
-      'stream-run-a',
-      const AgentMessage(
-        id: 'assistant-a',
-        role: AgentMessageRole.assistant,
-        text: 'First sentence. Second sentence',
-      ),
+    const committed = AgentMessage(
+      id: 'assistant-a',
+      role: AgentMessageRole.assistant,
+      text: 'First sentence. Second sentence',
     );
+    controller.completeLiveAssistantSpeech(
+      transientMessageId: 'stream-run-a',
+      message: committed,
+    );
+    conversation.changeComposerStreamMessage('stream-run-a', committed);
     await tester.pump();
     expect(speech.texts, <String>['First sentence.', 'Second sentence']);
     expect(controller.playingMessageId, 'assistant-a');
@@ -126,17 +135,31 @@ void main() {
         isStreaming: true,
       ),
     );
+    await controller.startLiveAssistantSpeech(
+      transientMessageId: 'stream-run-b',
+    );
+    controller.appendLiveAssistantSpeech(
+      transientMessageId: 'stream-run-b',
+      delta: 'Actually.',
+    );
     await tester.pump();
     expect(speech.texts, <String>['Actually.']);
 
-    conversation.changeComposerStreamMessage(
-      'stream-run-b',
-      const AgentMessage(
-        id: 'assistant-b',
-        role: AgentMessageRole.assistant,
-        text: 'Actually. Please say the complete sentence again.',
-      ),
+    controller.appendLiveAssistantSpeech(
+      transientMessageId: 'stream-run-b',
+      delta: ' Please say the complete sentence again.',
     );
+    const committed = AgentMessage(
+      id: 'assistant-b',
+      role: AgentMessageRole.assistant,
+      text: 'The authoritative message does not drive speech segmentation.',
+    );
+    controller.completeLiveAssistantSpeech(
+      transientMessageId: 'stream-run-b',
+      message: committed,
+    );
+    conversation.changeComposerStreamMessage('stream-run-b', committed);
+    unawaited(controller.playCommittedAssistant(committed));
     await tester.pump();
     speech.releaseFirstSegment();
     await tester.pumpAndSettle();

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/agent/audio/agent_audio_player.dart';
+import 'package:speakup/features/agent/conversation/agent_client.dart';
+import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
+import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
+import 'package:speakup/features/agent/conversation/agent_models.dart';
+import 'package:speakup/features/agent/conversation/conversation_controller.dart';
+
+void main() {
+  testWidgets('voice reply speaks complete sentences before commit', (
+    tester,
+  ) async {
+    final conversation = ConversationController(client: FakeAgentClient());
+    await conversation.initialize();
+    final media = _FakeMessageAudioClient();
+    final speech = _FakeAssistantSpeechClient();
+    final player = FakeAgentAudioPlayer();
+    final controller = AgentMessageAudioController(
+      conversationController: conversation,
+      client: media,
+      audioPlayer: player,
+      assistantSpeechClient: speech,
+    );
+    addTearDown(() {
+      controller.dispose();
+      conversation.dispose();
+    });
+
+    conversation.commitComposerMessages(const <AgentMessage>[
+      AgentMessage(
+        id: 'voice-user',
+        role: AgentMessageRole.user,
+        text: 'Please help me practice.',
+        modality: AgentMessageModality.voice,
+        audio: AgentMessageAudio(
+          id: 'voice-audio',
+          status: AgentMessageAudioStatus.readable,
+          contentType: 'audio/wav',
+          sizeBytes: 64,
+          duration: Duration(seconds: 2),
+          playbackPath: '/audio',
+        ),
+      ),
+    ]);
+    conversation.changeComposerStreamMessage(
+      null,
+      const AgentMessage(
+        id: 'stream-run-a',
+        role: AgentMessageRole.assistant,
+        text: '',
+        isStreaming: true,
+      ),
+    );
+    conversation.changeComposerStreamMessage(
+      'stream-run-a',
+      const AgentMessage(
+        id: 'stream-run-a',
+        role: AgentMessageRole.assistant,
+        text: 'First sentence. Second sentence',
+        isStreaming: true,
+      ),
+    );
+    await tester.pump();
+
+    expect(speech.texts, <String>['First sentence.']);
+    expect(controller.playingMessageId, 'stream-run-a');
+
+    conversation.changeComposerStreamMessage(
+      'stream-run-a',
+      const AgentMessage(
+        id: 'assistant-a',
+        role: AgentMessageRole.assistant,
+        text: 'First sentence. Second sentence',
+      ),
+    );
+    await tester.pump();
+    expect(speech.texts, <String>['First sentence.', 'Second sentence']);
+
+    player.complete();
+    await tester.pump();
+    expect(controller.playingMessageId, 'assistant-a');
+    player.complete();
+    await tester.pump();
+    expect(controller.playingMessageId, isNull);
+  });
+}
+
+final class _FakeAssistantSpeechClient implements AgentAssistantSpeechClient {
+  final List<String> texts = <String>[];
+
+  @override
+  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
+    required String threadId,
+    required Stream<AgentAssistantSpeechTextSegment> segments,
+  }) async* {
+    await for (final segment in segments) {
+      texts.add(segment.text);
+      yield AgentAssistantSpeechAudioSegment(
+        sequence: segment.sequence,
+        audio: Uint8List.fromList(<int>[1, 2, 3]),
+      );
+    }
+  }
+}
+
+final class _FakeMessageAudioClient implements AgentMessageAudioClient {
+  @override
+  Future<void> deleteMessageAudio({required String audioId}) async {}
+
+  @override
+  Future<Uint8List> loadAssistantSpeech({required String messageId}) async =>
+      Uint8List(0);
+
+  @override
+  Future<Uint8List> loadMessageAudio({required String audioId}) async =>
+      Uint8List(0);
+
+  @override
+  Future<Uint8List> loadSpeechPreview({
+    required String messageId,
+    required String text,
+  }) async => Uint8List(0);
+}

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -10,6 +10,7 @@ import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dar
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
+import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
@@ -63,16 +64,32 @@ void main() {
     (tester) async {
       final client = FakeAgentClient();
       final voiceClient = FakeAgentVoiceClient();
+      final assistantSpeech = _FlowAssistantSpeechClient();
+      final messagePlayer = FakeAgentAudioPlayer();
       final conversationController = ConversationController(client: client);
       final messageAudioController = AgentMessageAudioController(
         conversationController: conversationController,
         client: voiceClient,
-        audioPlayer: FakeAgentAudioPlayer(),
+        audioPlayer: messagePlayer,
+        assistantSpeechClient: assistantSpeech,
       );
       final composerController = ComposerController(
         conversationController: conversationController,
         voiceClient: voiceClient,
-        onAssistantCommitted: messageAudioController.playCommittedAssistant,
+        onAssistantStreamStarted: (transientMessageId) => messageAudioController
+            .startLiveAssistantSpeech(transientMessageId: transientMessageId),
+        onAssistantStreamDelta: (transientMessageId, delta) =>
+            messageAudioController.appendLiveAssistantSpeech(
+              transientMessageId: transientMessageId,
+              delta: delta,
+            ),
+        onAssistantStreamCompleted: (transientMessageId, message) =>
+            messageAudioController.completeLiveAssistantSpeech(
+              transientMessageId: transientMessageId,
+              message: message,
+            ),
+        onAssistantStreamFailed: (transientMessageId) => messageAudioController
+            .failLiveAssistantSpeech(transientMessageId: transientMessageId),
         clientIdFactory: _sequentialIdFactory(),
       );
       addTearDown(() {
@@ -135,9 +152,14 @@ void main() {
       final assistantTts = find.byKey(
         Key('agent-assistant-tts-${assistant.id}'),
       );
+      await tester.pumpAndSettle();
       expect(assistantTts.hitTestable(), findsOneWidget);
+      expect(assistantSpeech.texts, <String>[
+        'That was clear.',
+        'Add one measurable result to make the answer stronger.',
+      ]);
       expect(messageAudioController.playingMessageId, assistant.id);
-      await tester.tap(assistantTts);
+      messagePlayer.complete();
       await tester.pump();
       expect(messageAudioController.playingMessageId, isNull);
       await tester.tap(assistantTts);
@@ -644,6 +666,25 @@ final class _FailNextStopAgentAudioPlayer implements AgentAudioPlayer {
 
   @override
   Future<void> dispose() async {}
+}
+
+final class _FlowAssistantSpeechClient implements AgentAssistantSpeechClient {
+  final List<String> texts = <String>[];
+
+  @override
+  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
+    required String threadId,
+    required Stream<AgentAssistantSpeechTextSegment> segments,
+  }) async* {
+    await for (final segment in segments) {
+      texts.add(segment.text);
+      yield AgentAssistantSpeechAudioSegment(
+        sequence: segment.sequence,
+        chunkIndex: 1,
+        audio: Uint8List.fromList(<int>[1, 2, 3, 4]),
+      );
+    }
+  }
 }
 
 Future<void> _pumpVoiceOperation(WidgetTester tester) async {

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -155,8 +155,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(assistantTts.hitTestable(), findsOneWidget);
       expect(assistantSpeech.texts, <String>[
-        'That was clear.',
-        'Add one measurable result to make the answer stronger.',
+        'That was clear. Add one measurable result to make the answer stronger.',
       ]);
       expect(messageAudioController.playingMessageId, assistant.id);
       messagePlayer.complete();

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
+import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/providers/agent/wire_agent_voice_client.dart';
@@ -13,6 +14,79 @@ import 'package:speakup/features/agent/handoff/agent_handoff.dart';
 import 'package:speakup/identity/auth_state.dart';
 
 void main() {
+  test('receives assistant PCM before text input stream completes', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    final handled = Completer<void>();
+    server.listen((request) async {
+      expect(
+        request.uri.path,
+        '/v1/agent-threads/$_threadId/assistant-speech/realtime',
+      );
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (protocols) => 'speakup.assistant-speech.v1',
+      );
+      socket.add(
+        jsonEncode(<String, Object>{
+          'type': 'stream.ready',
+          'data': <String, Object>{
+            'content_type': 'audio/pcm',
+            'sample_rate': 24000,
+            'channel_count': 1,
+            'bits_per_sample': 16,
+          },
+        }),
+      );
+      var sentAudio = false;
+      await for (final message in socket) {
+        final frame = jsonDecode(message as String) as Map<String, dynamic>;
+        if (frame['type'] == 'segment' && !sentAudio) {
+          sentAudio = true;
+          socket.add(Uint8List.fromList(<int>[1, 2, 3, 4]));
+        }
+        if (frame['type'] == 'finish') {
+          socket.add(
+            jsonEncode(const <String, Object>{
+              'type': 'stream.completed',
+              'data': <String, Object>{},
+            }),
+          );
+          await socket.close();
+          handled.complete();
+          break;
+        }
+      }
+    });
+    final client = WireAgentVoiceClient(
+      baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+      credentialProvider: () => _credential,
+      invalidateSession: _ignoreInvalidation,
+      apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+    );
+    addTearDown(client.dispose);
+    final text = StreamController<AgentAssistantSpeechTextSegment>();
+    addTearDown(text.close);
+    final audio = StreamIterator<AgentAssistantSpeechAudioSegment>(
+      client.streamAssistantSpeech(threadId: _threadId, segments: text.stream),
+    );
+    addTearDown(audio.cancel);
+
+    final firstAudio = audio.moveNext();
+    text.add(
+      const AgentAssistantSpeechTextSegment(
+        sequence: 1,
+        text: 'This arrives while the model is still streaming',
+      ),
+    );
+    expect(await firstAudio.timeout(const Duration(seconds: 2)), isTrue);
+    expect(audio.current.audio, <int>[1, 2, 3, 4]);
+    await text.close();
+    expect(await audio.moveNext(), isFalse);
+    await handled.future;
+  });
+
   test('streams PCM chunks over the authenticated voice WebSocket', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -377,6 +377,7 @@ func run() int {
 			bootstrap.VoiceConfiguration{
 				Recognizer:             recognizer,
 				Synthesizer:            synthesizer,
+				AssistantSpeech:        synthesizer,
 				PracticeRecognizer:     practiceRecognizer,
 				PracticeSynthesizer:    practiceSynthesizer,
 				QuestionGenerator:      practiceQuestions,

--- a/server/internal/agent/conversation/assistant_speech.go
+++ b/server/internal/agent/conversation/assistant_speech.go
@@ -11,9 +11,10 @@ const (
 )
 
 type AssistantSpeechSynthesizer interface {
-	StreamAssistantSegment(
-		context.Context,
-		string,
-		func([]byte) error,
-	) error
+	OpenAssistantSpeech(context.Context) (AssistantSpeechSession, error)
+}
+
+type AssistantSpeechSession interface {
+	StreamSegment(string, func([]byte) error) error
+	Close() error
 }

--- a/server/internal/agent/conversation/assistant_speech.go
+++ b/server/internal/agent/conversation/assistant_speech.go
@@ -1,0 +1,20 @@
+package conversation
+
+import "context"
+
+const (
+	AssistantSpeechContentTypeWAV  = "audio/wav"
+	MaxAssistantSpeechSegmentRunes = 800
+)
+
+type AssistantSpeechSegment struct {
+	ContentType string
+	Audio       []byte
+}
+
+type AssistantSpeechSynthesizer interface {
+	SynthesizeAssistantSegment(
+		context.Context,
+		string,
+	) (AssistantSpeechSegment, error)
+}

--- a/server/internal/agent/conversation/assistant_speech.go
+++ b/server/internal/agent/conversation/assistant_speech.go
@@ -11,10 +11,14 @@ const (
 )
 
 type AssistantSpeechSynthesizer interface {
-	OpenAssistantSpeech(context.Context) (AssistantSpeechSession, error)
+	OpenAssistantSpeech(
+		context.Context,
+		func([]byte) error,
+	) (AssistantSpeechSession, error)
 }
 
 type AssistantSpeechSession interface {
-	StreamSegment(string, func([]byte) error) error
+	AppendText(string) error
+	Finish() error
 	Close() error
 }

--- a/server/internal/agent/conversation/assistant_speech.go
+++ b/server/internal/agent/conversation/assistant_speech.go
@@ -3,18 +3,17 @@ package conversation
 import "context"
 
 const (
-	AssistantSpeechContentTypeWAV  = "audio/wav"
+	AssistantSpeechContentTypePCM  = "audio/pcm"
+	AssistantSpeechSampleRate      = 24_000
+	AssistantSpeechChannelCount    = 1
+	AssistantSpeechBitsPerSample   = 16
 	MaxAssistantSpeechSegmentRunes = 800
 )
 
-type AssistantSpeechSegment struct {
-	ContentType string
-	Audio       []byte
-}
-
 type AssistantSpeechSynthesizer interface {
-	SynthesizeAssistantSegment(
+	StreamAssistantSegment(
 		context.Context,
 		string,
-	) (AssistantSpeechSegment, error)
+		func([]byte) error,
+	) error
 }

--- a/server/internal/agent/conversation/http/handler.go
+++ b/server/internal/agent/conversation/http/handler.go
@@ -50,11 +50,24 @@ type SpeechFeedbackProjectionReader interface {
 }
 
 type Handler struct {
-	application    agentconversation.Application
-	toolCalls      ToolCallReader
-	images         MessageImageReader
-	speechFeedback SpeechFeedbackProjectionReader
-	errors         *httpresponse.Renderer
+	application     agentconversation.Application
+	toolCalls       ToolCallReader
+	images          MessageImageReader
+	speechFeedback  SpeechFeedbackProjectionReader
+	assistantSpeech agentconversation.AssistantSpeechSynthesizer
+	errors          *httpresponse.Renderer
+}
+
+func WithAssistantSpeech(
+	synthesizer agentconversation.AssistantSpeechSynthesizer,
+) Option {
+	return func(handler *Handler) error {
+		if synthesizer == nil {
+			return errors.New("agent conversation: assistant speech synthesizer is required")
+		}
+		handler.assistantSpeech = synthesizer
+		return nil
+	}
 }
 
 type Option func(*Handler) error
@@ -128,6 +141,12 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 		"/v1/agent-threads/:thread_id/messages",
 		handler.listMessages,
 	)
+	if handler.assistantSpeech != nil {
+		routes.GET(
+			"/v1/agent-threads/:thread_id/assistant-speech/realtime",
+			handler.streamAssistantSpeech,
+		)
+	}
 }
 
 func (handler *Handler) createThread(c *gin.Context) {

--- a/server/internal/agent/conversation/http/realtime_speech.go
+++ b/server/internal/agent/conversation/http/realtime_speech.go
@@ -1,0 +1,169 @@
+package conversationhttp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	assistantSpeechWebSocketProtocol = "speakup.assistant-speech.v1"
+	maxAssistantSpeechSegments       = 64
+)
+
+type assistantSpeechFrame struct {
+	Type     string `json:"type"`
+	Sequence int    `json:"sequence"`
+	Text     string `json:"text"`
+}
+
+func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
+	trusted, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	if _, err := handler.application.GetThread(
+		c.Request.Context(), trusted, c.Param("thread_id"),
+	); err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	if !containsProtocol(
+		websocket.Subprotocols(c.Request),
+		assistantSpeechWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := (&websocket.Upgrader{
+		Subprotocols: []string{assistantSpeechWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	connection.SetReadLimit(4096)
+	if err := connection.WriteJSON(gin.H{
+		"type": "stream.ready", "data": gin.H{},
+	}); err != nil {
+		return
+	}
+	expectedSequence := 1
+	for {
+		messageType, payload, readErr := connection.ReadMessage()
+		if readErr != nil {
+			return
+		}
+		if messageType != websocket.TextMessage {
+			writeAssistantSpeechFailure(connection, "invalid_request", false)
+			return
+		}
+		frame, frameErr := decodeAssistantSpeechFrame(payload)
+		if frameErr != nil {
+			writeAssistantSpeechFailure(connection, "invalid_request", false)
+			return
+		}
+		switch frame.Type {
+		case "segment":
+			if frame.Sequence != expectedSequence ||
+				frame.Sequence > maxAssistantSpeechSegments {
+				writeAssistantSpeechFailure(connection, "invalid_sequence", false)
+				return
+			}
+			if err := connection.WriteJSON(gin.H{
+				"type": "segment.started",
+				"data": gin.H{"sequence": frame.Sequence},
+			}); err != nil {
+				return
+			}
+			segment, synthesisErr := handler.assistantSpeech.
+				SynthesizeAssistantSegment(c.Request.Context(), frame.Text)
+			if synthesisErr != nil ||
+				segment.ContentType != agentconversation.AssistantSpeechContentTypeWAV ||
+				len(segment.Audio) == 0 {
+				writeAssistantSpeechFailure(connection, "synthesis_failed", true)
+				return
+			}
+			if err := connection.WriteMessage(
+				websocket.BinaryMessage,
+				segment.Audio,
+			); err != nil {
+				return
+			}
+			if err := connection.WriteJSON(gin.H{
+				"type": "segment.completed",
+				"data": gin.H{
+					"sequence":     frame.Sequence,
+					"content_type": segment.ContentType,
+				},
+			}); err != nil {
+				return
+			}
+			expectedSequence++
+		case "finish":
+			_ = connection.WriteJSON(gin.H{
+				"type": "stream.completed", "data": gin.H{},
+			})
+			return
+		case "cancel":
+			return
+		default:
+			writeAssistantSpeechFailure(connection, "invalid_request", false)
+			return
+		}
+	}
+}
+
+func decodeAssistantSpeechFrame(payload []byte) (assistantSpeechFrame, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var frame assistantSpeechFrame
+	if err := decoder.Decode(&frame); err != nil {
+		return assistantSpeechFrame{}, err
+	}
+	trimmed := strings.TrimSpace(frame.Text)
+	switch frame.Type {
+	case "segment":
+		if frame.Sequence < 1 || trimmed == "" || !utf8.ValidString(trimmed) ||
+			utf8.RuneCountInString(trimmed) >
+				agentconversation.MaxAssistantSpeechSegmentRunes {
+			return assistantSpeechFrame{}, errors.New("assistant speech segment is invalid")
+		}
+		frame.Text = trimmed
+	case "finish", "cancel":
+		if frame.Sequence != 0 || frame.Text != "" {
+			return assistantSpeechFrame{}, errors.New("assistant speech control frame is invalid")
+		}
+	default:
+		return assistantSpeechFrame{}, errors.New("assistant speech frame type is invalid")
+	}
+	return frame, nil
+}
+
+func writeAssistantSpeechFailure(
+	connection *websocket.Conn,
+	kind string,
+	retryable bool,
+) {
+	_ = connection.WriteJSON(gin.H{
+		"type": "stream.failed",
+		"data": gin.H{"kind": kind, "retryable": retryable},
+	})
+}
+
+func containsProtocol(protocols []string, required string) bool {
+	for _, protocol := range protocols {
+		if protocol == required {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/agent/conversation/http/realtime_speech.go
+++ b/server/internal/agent/conversation/http/realtime_speech.go
@@ -80,29 +80,33 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 			}
 			if err := connection.WriteJSON(gin.H{
 				"type": "segment.started",
-				"data": gin.H{"sequence": frame.Sequence},
+				"data": gin.H{
+					"sequence":        frame.Sequence,
+					"content_type":    agentconversation.AssistantSpeechContentTypePCM,
+					"sample_rate":     agentconversation.AssistantSpeechSampleRate,
+					"channel_count":   agentconversation.AssistantSpeechChannelCount,
+					"bits_per_sample": agentconversation.AssistantSpeechBitsPerSample,
+				},
 			}); err != nil {
 				return
 			}
-			segment, synthesisErr := handler.assistantSpeech.
-				SynthesizeAssistantSegment(c.Request.Context(), frame.Text)
-			if synthesisErr != nil ||
-				segment.ContentType != agentconversation.AssistantSpeechContentTypeWAV ||
-				len(segment.Audio) == 0 {
+			chunkCount := 0
+			synthesisErr := handler.assistantSpeech.StreamAssistantSegment(
+				c.Request.Context(),
+				frame.Text,
+				func(audio []byte) error {
+					chunkCount++
+					return connection.WriteMessage(websocket.BinaryMessage, audio)
+				},
+			)
+			if synthesisErr != nil || chunkCount == 0 {
 				writeAssistantSpeechFailure(connection, "synthesis_failed", true)
-				return
-			}
-			if err := connection.WriteMessage(
-				websocket.BinaryMessage,
-				segment.Audio,
-			); err != nil {
 				return
 			}
 			if err := connection.WriteJSON(gin.H{
 				"type": "segment.completed",
 				"data": gin.H{
-					"sequence":     frame.Sequence,
-					"content_type": segment.ContentType,
+					"sequence": frame.Sequence,
 				},
 			}); err != nil {
 				return

--- a/server/internal/agent/conversation/http/realtime_speech.go
+++ b/server/internal/agent/conversation/http/realtime_speech.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
@@ -15,7 +17,8 @@ import (
 
 const (
 	assistantSpeechWebSocketProtocol = "speakup.assistant-speech.v1"
-	maxAssistantSpeechSegments       = 64
+	maxAssistantSpeechSegments       = 1024
+	maxAssistantSpeechRunes          = 4096
 )
 
 type assistantSpeechFrame struct {
@@ -52,28 +55,59 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 	defer connection.Close()
 	connection.SetReadLimit(4096)
 	if err := connection.WriteJSON(gin.H{
-		"type": "stream.ready", "data": gin.H{},
+		"type": "stream.ready",
+		"data": gin.H{
+			"content_type":    agentconversation.AssistantSpeechContentTypePCM,
+			"sample_rate":     agentconversation.AssistantSpeechSampleRate,
+			"channel_count":   agentconversation.AssistantSpeechChannelCount,
+			"bits_per_sample": agentconversation.AssistantSpeechBitsPerSample,
+		},
 	}); err != nil {
 		return
 	}
-	speech, err := handler.assistantSpeech.OpenAssistantSpeech(c.Request.Context())
+	chunkCount := 0
+	audioBytes := 0
+	var firstAudio sync.Once
+	speech, err := handler.assistantSpeech.OpenAssistantSpeech(
+		c.Request.Context(),
+		func(audio []byte) error {
+			firstAudio.Do(func() {
+				slog.InfoContext(
+					c.Request.Context(),
+					"agent.assistant_speech.first_audio",
+				)
+			})
+			chunkCount++
+			audioBytes += len(audio)
+			return connection.WriteMessage(websocket.BinaryMessage, audio)
+		},
+	)
 	if err != nil {
+		slog.WarnContext(
+			c.Request.Context(),
+			"agent.assistant_speech.failed",
+			slog.String("stage", "open"),
+			slog.Any("error", err),
+		)
 		writeAssistantSpeechFailure(connection, "synthesis_failed", true)
 		return
 	}
 	defer speech.Close()
 	expectedSequence := 1
+	totalRunes := 0
 	for {
 		messageType, payload, readErr := connection.ReadMessage()
 		if readErr != nil {
 			return
 		}
 		if messageType != websocket.TextMessage {
+			_ = speech.Close()
 			writeAssistantSpeechFailure(connection, "invalid_request", false)
 			return
 		}
 		frame, frameErr := decodeAssistantSpeechFrame(payload)
 		if frameErr != nil {
+			_ = speech.Close()
 			writeAssistantSpeechFailure(connection, "invalid_request", false)
 			return
 		}
@@ -81,43 +115,67 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 		case "segment":
 			if frame.Sequence != expectedSequence ||
 				frame.Sequence > maxAssistantSpeechSegments {
+				_ = speech.Close()
 				writeAssistantSpeechFailure(connection, "invalid_sequence", false)
 				return
 			}
-			if err := connection.WriteJSON(gin.H{
-				"type": "segment.started",
-				"data": gin.H{
-					"sequence":        frame.Sequence,
-					"content_type":    agentconversation.AssistantSpeechContentTypePCM,
-					"sample_rate":     agentconversation.AssistantSpeechSampleRate,
-					"channel_count":   agentconversation.AssistantSpeechChannelCount,
-					"bits_per_sample": agentconversation.AssistantSpeechBitsPerSample,
-				},
-			}); err != nil {
+			totalRunes += utf8.RuneCountInString(frame.Text)
+			if totalRunes > maxAssistantSpeechRunes {
+				_ = speech.Close()
+				writeAssistantSpeechFailure(connection, "invalid_request", false)
 				return
 			}
-			chunkCount := 0
-			synthesisErr := speech.StreamSegment(
-				frame.Text,
-				func(audio []byte) error {
-					chunkCount++
-					return connection.WriteMessage(websocket.BinaryMessage, audio)
-				},
-			)
-			if synthesisErr != nil || chunkCount == 0 {
+			if err := speech.AppendText(frame.Text); err != nil {
+				_ = speech.Close()
+				slog.WarnContext(
+					c.Request.Context(),
+					"agent.assistant_speech.failed",
+					slog.String("stage", "append"),
+					slog.Int("text_chunks", expectedSequence-1),
+					slog.Any("error", err),
+				)
 				writeAssistantSpeechFailure(connection, "synthesis_failed", true)
-				return
-			}
-			if err := connection.WriteJSON(gin.H{
-				"type": "segment.completed",
-				"data": gin.H{
-					"sequence": frame.Sequence,
-				},
-			}); err != nil {
 				return
 			}
 			expectedSequence++
 		case "finish":
+			if expectedSequence == 1 {
+				_ = speech.Close()
+				writeAssistantSpeechFailure(connection, "invalid_request", false)
+				return
+			}
+			if err := speech.Finish(); err != nil {
+				slog.WarnContext(
+					c.Request.Context(),
+					"agent.assistant_speech.failed",
+					slog.String("stage", "finish"),
+					slog.Int("text_chunks", expectedSequence-1),
+					slog.Int("audio_chunks", chunkCount),
+					slog.Any("error", err),
+				)
+				writeAssistantSpeechFailure(connection, "synthesis_failed", true)
+				return
+			}
+			if chunkCount == 0 {
+				slog.WarnContext(
+					c.Request.Context(),
+					"agent.assistant_speech.failed",
+					slog.String("stage", "finish"),
+					slog.Int("text_chunks", expectedSequence-1),
+					slog.Int("audio_chunks", chunkCount),
+					slog.String("error", "no audio returned"),
+				)
+				writeAssistantSpeechFailure(connection, "synthesis_failed", true)
+				return
+			}
+			slog.InfoContext(
+				c.Request.Context(),
+				"agent.assistant_speech.completed",
+				slog.Int("text_chunks", expectedSequence-1),
+				slog.Int("text_runes", totalRunes),
+				slog.Int("audio_chunks", chunkCount),
+				slog.Int("audio_bytes", audioBytes),
+			)
 			_ = connection.WriteJSON(gin.H{
 				"type": "stream.completed", "data": gin.H{},
 			})
@@ -125,6 +183,7 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 		case "cancel":
 			return
 		default:
+			_ = speech.Close()
 			writeAssistantSpeechFailure(connection, "invalid_request", false)
 			return
 		}
@@ -146,7 +205,6 @@ func decodeAssistantSpeechFrame(payload []byte) (assistantSpeechFrame, error) {
 				agentconversation.MaxAssistantSpeechSegmentRunes {
 			return assistantSpeechFrame{}, errors.New("assistant speech segment is invalid")
 		}
-		frame.Text = trimmed
 	case "finish", "cancel":
 		if frame.Sequence != 0 || frame.Text != "" {
 			return assistantSpeechFrame{}, errors.New("assistant speech control frame is invalid")

--- a/server/internal/agent/conversation/http/realtime_speech.go
+++ b/server/internal/agent/conversation/http/realtime_speech.go
@@ -56,6 +56,12 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 	}); err != nil {
 		return
 	}
+	speech, err := handler.assistantSpeech.OpenAssistantSpeech(c.Request.Context())
+	if err != nil {
+		writeAssistantSpeechFailure(connection, "synthesis_failed", true)
+		return
+	}
+	defer speech.Close()
 	expectedSequence := 1
 	for {
 		messageType, payload, readErr := connection.ReadMessage()
@@ -91,8 +97,7 @@ func (handler *Handler) streamAssistantSpeech(c *gin.Context) {
 				return
 			}
 			chunkCount := 0
-			synthesisErr := handler.assistantSpeech.StreamAssistantSegment(
-				c.Request.Context(),
+			synthesisErr := speech.StreamSegment(
 				frame.Text,
 				func(audio []byte) error {
 					chunkCount++

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -416,6 +416,15 @@ func buildIdentityAgentComposition(
 			),
 		)
 	}
+	if len(voiceConfigurations) == 1 &&
+		voiceConfigurations[0].AssistantSpeech != nil {
+		conversationHTTPOptions = append(
+			conversationHTTPOptions,
+			agentconversationhttp.WithAssistantSpeech(
+				voiceConfigurations[0].AssistantSpeech,
+			),
+		)
+	}
 	conversationHTTP, err := agentconversationhttp.NewHandler(
 		agentService,
 		errorRenderer,

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
 	speechfeedback "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
@@ -21,6 +22,7 @@ import (
 type VoiceConfiguration struct {
 	Recognizer                agentvoice.StreamingSpeechRecognizer
 	Synthesizer               agentvoice.SpeechSynthesizer
+	AssistantSpeech           agentconversation.AssistantSpeechSynthesizer
 	PracticeRecognizer        practicevoice.SpeechRecognizer
 	PracticeSynthesizer       practicevoice.SpeechSynthesizer
 	QuestionGenerator         practicevoice.QuestionGenerator
@@ -37,6 +39,11 @@ type VoiceConfiguration struct {
 	AudioReadTimeout          time.Duration
 	ReviewHistoryCursorKey    []byte
 	SpeechFeedbackCoordinator *speechfeedback.SpeechFeedbackCoordinator
+}
+
+type AgentSpeechSynthesizer interface {
+	agentvoice.SpeechSynthesizer
+	agentconversation.AssistantSpeechSynthesizer
 }
 
 type AgentImageConfiguration struct {
@@ -67,7 +74,7 @@ func NewAgentSpeechRecognizer(
 // NewAgentSpeechSynthesizer selects the Agent Voice TTS implementation.
 func NewAgentSpeechSynthesizer(
 	configuration config.SpeechSynthesisConfig,
-) (agentvoice.SpeechSynthesizer, error) {
+) (AgentSpeechSynthesizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
 			"bootstrap: speech synthesis provider is not registered",

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -15,13 +15,14 @@ type AgentVoiceRecognizer struct {
 
 func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 	ctx context.Context,
+	consume func([]byte) error,
 ) (agentconversation.AssistantSpeechSession, error) {
 	if synthesizer == nil || synthesizer.synthesizer == nil {
 		return nil, errors.New(
 			"qianwen: Agent assistant speech synthesizer is required",
 		)
 	}
-	return synthesizer.synthesizer.openRealtimeSpeech(ctx)
+	return synthesizer.synthesizer.openRealtimeSpeech(ctx, consume)
 }
 
 func NewAgentVoiceRecognizer(

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -13,23 +13,17 @@ type AgentVoiceRecognizer struct {
 	recognizer *speechRecognizer
 }
 
-func (synthesizer *AgentVoiceSynthesizer) SynthesizeAssistantSegment(
+func (synthesizer *AgentVoiceSynthesizer) StreamAssistantSegment(
 	ctx context.Context,
 	text string,
-) (agentconversation.AssistantSpeechSegment, error) {
+	consume func([]byte) error,
+) error {
 	if synthesizer == nil || synthesizer.synthesizer == nil {
-		return agentconversation.AssistantSpeechSegment{}, errors.New(
+		return errors.New(
 			"qianwen: Agent assistant speech synthesizer is required",
 		)
 	}
-	audio, err := synthesizer.synthesizer.synthesizeRealtimeWAV(ctx, text)
-	if err != nil {
-		return agentconversation.AssistantSpeechSegment{}, err
-	}
-	return agentconversation.AssistantSpeechSegment{
-		ContentType: agentconversation.AssistantSpeechContentTypeWAV,
-		Audio:       audio,
-	}, nil
+	return synthesizer.synthesizer.streamRealtimePCM(ctx, text, consume)
 }
 
 func NewAgentVoiceRecognizer(

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -4,12 +4,32 @@ import (
 	"context"
 	"errors"
 
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
 type AgentVoiceRecognizer struct {
 	recognizer *speechRecognizer
+}
+
+func (synthesizer *AgentVoiceSynthesizer) SynthesizeAssistantSegment(
+	ctx context.Context,
+	text string,
+) (agentconversation.AssistantSpeechSegment, error) {
+	if synthesizer == nil || synthesizer.synthesizer == nil {
+		return agentconversation.AssistantSpeechSegment{}, errors.New(
+			"qianwen: Agent assistant speech synthesizer is required",
+		)
+	}
+	audio, err := synthesizer.synthesizer.synthesizeRealtimeWAV(ctx, text)
+	if err != nil {
+		return agentconversation.AssistantSpeechSegment{}, err
+	}
+	return agentconversation.AssistantSpeechSegment{
+		ContentType: agentconversation.AssistantSpeechContentTypeWAV,
+		Audio:       audio,
+	}, nil
 }
 
 func NewAgentVoiceRecognizer(
@@ -221,6 +241,7 @@ func mapAgentVoiceErrorKind(kind protocol.ErrorKind) agentvoice.ErrorKind {
 }
 
 var (
-	_ agentvoice.StreamingSpeechRecognizer = (*AgentVoiceRecognizer)(nil)
-	_ agentvoice.SpeechSynthesizer         = (*AgentVoiceSynthesizer)(nil)
+	_ agentvoice.StreamingSpeechRecognizer         = (*AgentVoiceRecognizer)(nil)
+	_ agentvoice.SpeechSynthesizer                 = (*AgentVoiceSynthesizer)(nil)
+	_ agentconversation.AssistantSpeechSynthesizer = (*AgentVoiceSynthesizer)(nil)
 )

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -13,17 +13,15 @@ type AgentVoiceRecognizer struct {
 	recognizer *speechRecognizer
 }
 
-func (synthesizer *AgentVoiceSynthesizer) StreamAssistantSegment(
+func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 	ctx context.Context,
-	text string,
-	consume func([]byte) error,
-) error {
+) (agentconversation.AssistantSpeechSession, error) {
 	if synthesizer == nil || synthesizer.synthesizer == nil {
-		return errors.New(
+		return nil, errors.New(
 			"qianwen: Agent assistant speech synthesizer is required",
 		)
 	}
-	return synthesizer.synthesizer.streamRealtimePCM(ctx, text, consume)
+	return synthesizer.synthesizer.openRealtimeSpeech(ctx)
 }
 
 func NewAgentVoiceRecognizer(

--- a/server/internal/providers/qianwen/speech_live_test.go
+++ b/server/internal/providers/qianwen/speech_live_test.go
@@ -150,6 +150,59 @@ func TestLiveSpeechSynthesis(t *testing.T) {
 	)
 }
 
+func TestLiveRealtimeSpeechSynthesis(t *testing.T) {
+	if os.Getenv("QIANWEN_TTS_LIVE_TEST") != "1" {
+		t.Skip(
+			"set QIANWEN_TTS_LIVE_TEST=1 and the TTS environment variables " +
+				"to run; the real request may incur charges",
+		)
+	}
+	cfg, err := platformconfig.LoadSpeechSynthesis()
+	if err != nil {
+		t.Fatalf("load speech synthesis config: %v", err)
+	}
+	synthesizer, err := newSpeechSynthesizer(TTSConfig{
+		BaseURL:       cfg.BaseURL,
+		Model:         cfg.Model,
+		Voice:         cfg.Voice,
+		LanguageHint:  cfg.LanguageHint,
+		Timeout:       cfg.Timeout,
+		TempDirectory: cfg.TempDirectory,
+	}, cfg.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create Qianwen synthesizer: %v", err)
+	}
+	startedAt := time.Now()
+	firstChunkDelay := time.Duration(0)
+	chunkCount := 0
+	audioBytes := 0
+	err = synthesizer.streamRealtimePCM(
+		context.Background(),
+		"Please repeat after me. This audio should start immediately.",
+		func(chunk []byte) error {
+			if chunkCount == 0 {
+				firstChunkDelay = time.Since(startedAt)
+			}
+			chunkCount++
+			audioBytes += len(chunk)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("live realtime Qianwen TTS failed: %s", safeLiveSpeechError(err))
+	}
+	if chunkCount == 0 || audioBytes == 0 || audioBytes%2 != 0 {
+		t.Fatalf("invalid realtime PCM: chunks=%d bytes=%d", chunkCount, audioBytes)
+	}
+	t.Logf(
+		"realtime TTS success: first_chunk_delay=%s total_duration=%s chunks=%d bytes=%d",
+		firstChunkDelay,
+		time.Since(startedAt),
+		chunkCount,
+		audioBytes,
+	)
+}
+
 func safeLiveSpeechError(err error) string {
 	var speechError *protocol.SpeechError
 	if !errors.As(err, &speechError) {

--- a/server/internal/providers/qianwen/speech_synthesizer.go
+++ b/server/internal/providers/qianwen/speech_synthesizer.go
@@ -38,15 +38,16 @@ type TTSConfig struct {
 }
 
 type speechSynthesizer struct {
-	endpoint      string
-	model         string
-	voice         string
-	languageHint  string
-	timeout       time.Duration
-	tempDirectory string
-	apiKey        providerSecret
-	client        httpDoer
-	now           func() time.Time
+	endpoint         string
+	realtimeEndpoint string
+	model            string
+	voice            string
+	languageHint     string
+	timeout          time.Duration
+	tempDirectory    string
+	apiKey           providerSecret
+	client           httpDoer
+	now              func() time.Time
 }
 
 func (synthesizer *speechSynthesizer) String() string {
@@ -90,6 +91,10 @@ func newSynthesizerWithClient(
 			"Qwen-Audio-TTS is available only through a China (Beijing) endpoint",
 		)
 	}
+	realtimeEndpoint, err := realtimeTTSEndpoint(baseURL)
+	if err != nil {
+		return nil, err
+	}
 	model, err := normalizeTTSModel(config.Model)
 	if err != nil {
 		return nil, err
@@ -113,15 +118,16 @@ func newSynthesizerWithClient(
 		return nil, errors.New("Qianwen TTS HTTP client is required")
 	}
 	return &speechSynthesizer{
-		endpoint:      baseURL + ttsSpeechSynthesizerPath,
-		model:         model,
-		voice:         voice,
-		languageHint:  language,
-		timeout:       config.Timeout,
-		tempDirectory: strings.TrimSpace(config.TempDirectory),
-		apiKey:        newProviderSecret(apiKey),
-		client:        client,
-		now:           time.Now,
+		endpoint:         baseURL + ttsSpeechSynthesizerPath,
+		realtimeEndpoint: realtimeEndpoint,
+		model:            model,
+		voice:            voice,
+		languageHint:     language,
+		timeout:          config.Timeout,
+		tempDirectory:    strings.TrimSpace(config.TempDirectory),
+		apiKey:           newProviderSecret(apiKey),
+		client:           client,
+		now:              time.Now,
 	}, nil
 }
 

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime.go
@@ -49,16 +49,29 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	text string,
 	consume func([]byte) error,
 ) error {
-	if synthesizer == nil || ctx == nil || consume == nil {
-		return errors.New("Qianwen realtime TTS is unavailable")
-	}
-	if err := protocol.ValidateSynthesisRequest(
-		protocol.SynthesisRequest{Text: text},
-	); err != nil {
+	session, err := synthesizer.openRealtimeSpeech(ctx)
+	if err != nil {
 		return err
 	}
+	defer session.Close()
+	return session.StreamSegment(text, consume)
+}
+
+type speechRealtimeSession struct {
+	context    context.Context
+	cancel     context.CancelFunc
+	connection *websocket.Conn
+	model      string
+	voice      string
+}
+
+func (synthesizer *speechSynthesizer) openRealtimeSpeech(
+	ctx context.Context,
+) (*speechRealtimeSession, error) {
+	if synthesizer == nil || ctx == nil {
+		return nil, errors.New("Qianwen realtime TTS is unavailable")
+	}
 	callContext, cancel := context.WithTimeout(ctx, synthesizer.timeout)
-	defer cancel()
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+synthesizer.apiKey.reveal())
 	header.Set("X-DashScope-DataInspection", "enable")
@@ -71,30 +84,48 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 		defer response.Body.Close()
 	}
 	if err != nil {
-		return speechTransportError(
+		cancel()
+		return nil, speechTransportError(
 			protocol.SpeechOperationSynthesis,
 			callContext,
 			err,
 		)
 	}
-	defer connection.Close()
 	if deadline, ok := callContext.Deadline(); ok {
 		_ = connection.SetReadDeadline(deadline)
 		_ = connection.SetWriteDeadline(deadline)
+	}
+	return &speechRealtimeSession{
+		context: callContext, cancel: cancel, connection: connection,
+		model: synthesizer.model, voice: synthesizer.voice,
+	}, nil
+}
+
+func (session *speechRealtimeSession) StreamSegment(
+	text string,
+	consume func([]byte) error,
+) error {
+	if session == nil || session.connection == nil || consume == nil {
+		return errors.New("Qianwen realtime TTS session is unavailable")
+	}
+	if err := protocol.ValidateSynthesisRequest(
+		protocol.SynthesisRequest{Text: text},
+	); err != nil {
+		return err
 	}
 	taskID, err := newRealtimeTaskID()
 	if err != nil {
 		return err
 	}
-	if err := connection.WriteJSON(map[string]any{
+	if err := session.connection.WriteJSON(map[string]any{
 		"header": map[string]any{
 			"action": "run-task", "task_id": taskID, "streaming": "duplex",
 		},
 		"payload": map[string]any{
 			"task_group": "audio", "task": "tts",
-			"function": "SpeechSynthesizer", "model": synthesizer.model,
+			"function": "SpeechSynthesizer", "model": session.model,
 			"parameters": map[string]any{
-				"text_type": "PlainText", "voice": synthesizer.voice,
+				"text_type": "PlainText", "voice": session.voice,
 				"format": "pcm", "sample_rate": agentconversation.AssistantSpeechSampleRate,
 				"volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false,
 			},
@@ -103,10 +134,14 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	}); err != nil {
 		return err
 	}
-	if err := waitForSpeechRealtimeEvent(connection, taskID, "task-started"); err != nil {
+	if err := waitForSpeechRealtimeEvent(
+		session.connection,
+		taskID,
+		"task-started",
+	); err != nil {
 		return err
 	}
-	if err := connection.WriteJSON(map[string]any{
+	if err := session.connection.WriteJSON(map[string]any{
 		"header": map[string]any{
 			"action": "continue-task", "task_id": taskID, "streaming": "duplex",
 		},
@@ -114,7 +149,7 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	}); err != nil {
 		return err
 	}
-	if err := connection.WriteJSON(map[string]any{
+	if err := session.connection.WriteJSON(map[string]any{
 		"header": map[string]any{
 			"action": "finish-task", "task_id": taskID, "streaming": "duplex",
 		},
@@ -124,9 +159,13 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	}
 	var audioBytes int64
 	for {
-		messageType, payload, readErr := connection.ReadMessage()
+		messageType, payload, readErr := session.connection.ReadMessage()
 		if readErr != nil {
-			return readErr
+			return speechTransportError(
+				protocol.SpeechOperationSynthesis,
+				session.context,
+				readErr,
+			)
 		}
 		switch messageType {
 		case websocket.BinaryMessage:
@@ -156,6 +195,22 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 			return errors.New("Qianwen realtime TTS returned an invalid frame")
 		}
 	}
+}
+
+func (session *speechRealtimeSession) Close() error {
+	if session == nil {
+		return nil
+	}
+	if session.cancel != nil {
+		session.cancel()
+		session.cancel = nil
+	}
+	if session.connection == nil {
+		return nil
+	}
+	err := session.connection.Close()
+	session.connection = nil
+	return err
 }
 
 func waitForSpeechRealtimeEvent(

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime.go
@@ -1,0 +1,214 @@
+package qianwen
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+	"github.com/gorilla/websocket"
+)
+
+const ttsRealtimePath = "/api-ws/v1/inference/"
+
+type speechRealtimeEnvelope struct {
+	Header speechRealtimeHeader `json:"header"`
+}
+
+type speechRealtimeHeader struct {
+	Event        string `json:"event"`
+	TaskID       string `json:"task_id"`
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+func realtimeTTSEndpoint(baseURL string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return "", errors.New("Qianwen realtime TTS base URL is invalid")
+	}
+	parsed.Scheme = "wss"
+	parsed.Path = ttsRealtimePath
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
+	ctx context.Context,
+	text string,
+) ([]byte, error) {
+	if synthesizer == nil || ctx == nil {
+		return nil, errors.New("Qianwen realtime TTS is unavailable")
+	}
+	if err := protocol.ValidateSynthesisRequest(
+		protocol.SynthesisRequest{Text: text},
+	); err != nil {
+		return nil, err
+	}
+	callContext, cancel := context.WithTimeout(ctx, synthesizer.timeout)
+	defer cancel()
+	header := make(http.Header)
+	header.Set("Authorization", "Bearer "+synthesizer.apiKey.reveal())
+	header.Set("X-DashScope-DataInspection", "enable")
+	connection, response, err := websocket.DefaultDialer.DialContext(
+		callContext,
+		synthesizer.realtimeEndpoint,
+		header,
+	)
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		return nil, speechTransportError(
+			protocol.SpeechOperationSynthesis,
+			callContext,
+			err,
+		)
+	}
+	defer connection.Close()
+	if deadline, ok := callContext.Deadline(); ok {
+		_ = connection.SetReadDeadline(deadline)
+		_ = connection.SetWriteDeadline(deadline)
+	}
+	taskID, err := newRealtimeTaskID()
+	if err != nil {
+		return nil, err
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"header": map[string]any{
+			"action": "run-task", "task_id": taskID, "streaming": "duplex",
+		},
+		"payload": map[string]any{
+			"task_group": "audio", "task": "tts",
+			"function": "SpeechSynthesizer", "model": synthesizer.model,
+			"parameters": map[string]any{
+				"text_type": "PlainText", "voice": synthesizer.voice,
+				"format": "wav", "sample_rate": ttsOutputSampleRate,
+				"volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false,
+			},
+			"input": map[string]any{},
+		},
+	}); err != nil {
+		return nil, err
+	}
+	if err := waitForSpeechRealtimeEvent(connection, taskID, "task-started"); err != nil {
+		return nil, err
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"header": map[string]any{
+			"action": "continue-task", "task_id": taskID, "streaming": "duplex",
+		},
+		"payload": map[string]any{"input": map[string]any{"text": strings.TrimSpace(text)}},
+	}); err != nil {
+		return nil, err
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"header": map[string]any{
+			"action": "finish-task", "task_id": taskID, "streaming": "duplex",
+		},
+		"payload": map[string]any{"input": map[string]any{}},
+	}); err != nil {
+		return nil, err
+	}
+	var audio bytes.Buffer
+	for {
+		messageType, payload, readErr := connection.ReadMessage()
+		if readErr != nil {
+			return nil, readErr
+		}
+		switch messageType {
+		case websocket.BinaryMessage:
+			if len(payload) == 0 ||
+				int64(audio.Len()+len(payload)) > platformmedia.MaxAudioBytes {
+				return nil, errors.New("Qianwen realtime TTS audio exceeds the accepted size")
+			}
+			_, _ = audio.Write(payload)
+		case websocket.TextMessage:
+			event, eventErr := decodeSpeechRealtimeEvent(payload, taskID)
+			if eventErr != nil {
+				return nil, eventErr
+			}
+			switch event {
+			case "result-generated":
+			case "task-finished":
+				return normalizeRealtimeWAV(audio.Bytes())
+			default:
+				return nil, fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
+			}
+		default:
+			return nil, errors.New("Qianwen realtime TTS returned an invalid frame")
+		}
+	}
+}
+
+func waitForSpeechRealtimeEvent(
+	connection *websocket.Conn,
+	taskID string,
+	expected string,
+) error {
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage {
+		return errors.New("Qianwen realtime TTS start event is unavailable")
+	}
+	event, err := decodeSpeechRealtimeEvent(payload, taskID)
+	if err != nil {
+		return err
+	}
+	if event != expected {
+		return fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
+	}
+	return nil
+}
+
+func decodeSpeechRealtimeEvent(payload []byte, taskID string) (string, error) {
+	var envelope speechRealtimeEnvelope
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if err := decoder.Decode(&envelope); err != nil || envelope.Header.TaskID != taskID {
+		return "", errors.New("Qianwen realtime TTS returned an invalid event")
+	}
+	if envelope.Header.Event == "task-failed" {
+		return "", errors.New("Qianwen realtime TTS task failed")
+	}
+	if strings.TrimSpace(envelope.Header.Event) == "" {
+		return "", errors.New("Qianwen realtime TTS event type is missing")
+	}
+	return envelope.Header.Event, nil
+}
+
+func normalizeRealtimeWAV(audio []byte) ([]byte, error) {
+	if len(audio) < 44 || int64(len(audio)) > platformmedia.MaxAudioBytes {
+		return nil, errors.New("Qianwen realtime TTS returned invalid WAV audio")
+	}
+	normalized, err := normalizeProviderWAVSizeMarkers(
+		bytes.NewReader(audio),
+		int64(len(audio)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	result, err := io.ReadAll(io.LimitReader(normalized, platformmedia.MaxAudioBytes+1))
+	if err != nil || len(result) != len(audio) || string(result[:4]) != "RIFF" ||
+		string(result[8:12]) != "WAVE" {
+		return nil, errors.New("Qianwen realtime TTS returned malformed WAV audio")
+	}
+	return result, nil
+}
+
+func newRealtimeTaskID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
@@ -49,27 +50,40 @@ func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	text string,
 	consume func([]byte) error,
 ) error {
-	session, err := synthesizer.openRealtimeSpeech(ctx)
+	session, err := synthesizer.openRealtimeSpeech(ctx, consume)
 	if err != nil {
 		return err
 	}
 	defer session.Close()
-	return session.StreamSegment(text, consume)
+	if err := session.AppendText(text); err != nil {
+		return err
+	}
+	return session.Finish()
 }
 
 type speechRealtimeSession struct {
 	context    context.Context
 	cancel     context.CancelFunc
 	connection *websocket.Conn
-	model      string
-	voice      string
+	taskID     string
+	consume    func([]byte) error
+	result     chan error
+	done       chan struct{}
+	closeOnce  sync.Once
+	reading    bool
+	finished   bool
 }
 
 func (synthesizer *speechSynthesizer) openRealtimeSpeech(
 	ctx context.Context,
+	consume func([]byte) error,
 ) (*speechRealtimeSession, error) {
-	if synthesizer == nil || ctx == nil {
+	if synthesizer == nil || ctx == nil || consume == nil {
 		return nil, errors.New("Qianwen realtime TTS is unavailable")
+	}
+	taskID, err := newRealtimeTaskID()
+	if err != nil {
+		return nil, err
 	}
 	callContext, cancel := context.WithTimeout(ctx, synthesizer.timeout)
 	header := make(http.Header)
@@ -95,17 +109,46 @@ func (synthesizer *speechSynthesizer) openRealtimeSpeech(
 		_ = connection.SetReadDeadline(deadline)
 		_ = connection.SetWriteDeadline(deadline)
 	}
-	return &speechRealtimeSession{
+	session := &speechRealtimeSession{
 		context: callContext, cancel: cancel, connection: connection,
-		model: synthesizer.model, voice: synthesizer.voice,
-	}, nil
+		taskID: taskID, consume: consume,
+		result: make(chan error, 1), done: make(chan struct{}),
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"header": map[string]any{
+			"action": "run-task", "task_id": taskID, "streaming": "duplex",
+		},
+		"payload": map[string]any{
+			"task_group": "audio", "task": "tts",
+			"function": "SpeechSynthesizer", "model": synthesizer.model,
+			"parameters": map[string]any{
+				"text_type": "PlainText", "voice": synthesizer.voice,
+				"format": "pcm", "sample_rate": agentconversation.AssistantSpeechSampleRate,
+				"volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false,
+			},
+			"input": map[string]any{},
+		},
+	}); err != nil {
+		cancel()
+		_ = connection.Close()
+		return nil, err
+	}
+	if err := waitForSpeechRealtimeEvent(
+		connection,
+		taskID,
+		"task-started",
+	); err != nil {
+		cancel()
+		_ = connection.Close()
+		return nil, err
+	}
+	session.reading = true
+	go session.readAudio()
+	return session, nil
 }
 
-func (session *speechRealtimeSession) StreamSegment(
-	text string,
-	consume func([]byte) error,
-) error {
-	if session == nil || session.connection == nil || consume == nil {
+func (session *speechRealtimeSession) AppendText(text string) error {
+	if session == nil || session.connection == nil || session.finished {
 		return errors.New("Qianwen realtime TTS session is unavailable")
 	}
 	if err := protocol.ValidateSynthesisRequest(
@@ -113,86 +156,88 @@ func (session *speechRealtimeSession) StreamSegment(
 	); err != nil {
 		return err
 	}
-	taskID, err := newRealtimeTaskID()
-	if err != nil {
-		return err
-	}
 	if err := session.connection.WriteJSON(map[string]any{
 		"header": map[string]any{
-			"action": "run-task", "task_id": taskID, "streaming": "duplex",
+			"action": "continue-task", "task_id": session.taskID, "streaming": "duplex",
 		},
-		"payload": map[string]any{
-			"task_group": "audio", "task": "tts",
-			"function": "SpeechSynthesizer", "model": session.model,
-			"parameters": map[string]any{
-				"text_type": "PlainText", "voice": session.voice,
-				"format": "pcm", "sample_rate": agentconversation.AssistantSpeechSampleRate,
-				"volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false,
-			},
-			"input": map[string]any{},
-		},
+		"payload": map[string]any{"input": map[string]any{"text": text}},
 	}); err != nil {
 		return err
 	}
-	if err := waitForSpeechRealtimeEvent(
-		session.connection,
-		taskID,
-		"task-started",
-	); err != nil {
-		return err
+	return nil
+}
+
+func (session *speechRealtimeSession) Finish() error {
+	if session == nil || session.connection == nil || session.finished {
+		return errors.New("Qianwen realtime TTS session is unavailable")
 	}
+	session.finished = true
 	if err := session.connection.WriteJSON(map[string]any{
 		"header": map[string]any{
-			"action": "continue-task", "task_id": taskID, "streaming": "duplex",
-		},
-		"payload": map[string]any{"input": map[string]any{"text": strings.TrimSpace(text)}},
-	}); err != nil {
-		return err
-	}
-	if err := session.connection.WriteJSON(map[string]any{
-		"header": map[string]any{
-			"action": "finish-task", "task_id": taskID, "streaming": "duplex",
+			"action": "finish-task", "task_id": session.taskID, "streaming": "duplex",
 		},
 		"payload": map[string]any{"input": map[string]any{}},
 	}); err != nil {
 		return err
 	}
+	select {
+	case err := <-session.result:
+		return err
+	case <-session.context.Done():
+		return speechTransportError(
+			protocol.SpeechOperationSynthesis,
+			session.context,
+			session.context.Err(),
+		)
+	}
+}
+
+func (session *speechRealtimeSession) readAudio() {
+	defer close(session.done)
 	var audioBytes int64
 	for {
 		messageType, payload, readErr := session.connection.ReadMessage()
 		if readErr != nil {
-			return speechTransportError(
+			session.result <- speechTransportError(
 				protocol.SpeechOperationSynthesis,
 				session.context,
 				readErr,
 			)
+			return
 		}
 		switch messageType {
 		case websocket.BinaryMessage:
 			if len(payload) == 0 || audioBytes+int64(len(payload)) > platformmedia.MaxAudioBytes {
-				return errors.New("Qianwen realtime TTS audio exceeds the accepted size")
+				session.result <- errors.New("Qianwen realtime TTS audio exceeds the accepted size")
+				return
 			}
 			audioBytes += int64(len(payload))
-			if err := consume(payload); err != nil {
-				return err
+			if err := session.consume(payload); err != nil {
+				session.result <- err
+				return
 			}
 		case websocket.TextMessage:
-			event, eventErr := decodeSpeechRealtimeEvent(payload, taskID)
+			event, eventErr := decodeSpeechRealtimeEvent(payload, session.taskID)
 			if eventErr != nil {
-				return eventErr
+				session.result <- eventErr
+				return
 			}
 			switch event {
 			case "result-generated":
 			case "task-finished":
 				if audioBytes == 0 {
-					return errors.New("Qianwen realtime TTS returned no audio")
+					session.result <- errors.New("Qianwen realtime TTS returned no audio")
+					return
 				}
-				return nil
+				session.result <- nil
+				return
 			default:
-				return fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
+				session.result <- fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
+				return
 			}
 		default:
-			return errors.New("Qianwen realtime TTS returned an invalid frame")
+			session.result <- errors.New("Qianwen realtime TTS returned an invalid frame")
+			return
 		}
 	}
 }
@@ -201,15 +246,14 @@ func (session *speechRealtimeSession) Close() error {
 	if session == nil {
 		return nil
 	}
-	if session.cancel != nil {
+	var err error
+	session.closeOnce.Do(func() {
 		session.cancel()
-		session.cancel = nil
-	}
-	if session.connection == nil {
-		return nil
-	}
-	err := session.connection.Close()
-	session.connection = nil
+		err = session.connection.Close()
+		if session.reading {
+			<-session.done
+		}
+	})
 	return err
 }
 

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 	"github.com/gorilla/websocket"
@@ -44,17 +44,18 @@ func realtimeTTSEndpoint(baseURL string) (string, error) {
 	return parsed.String(), nil
 }
 
-func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
+func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	ctx context.Context,
 	text string,
-) ([]byte, error) {
-	if synthesizer == nil || ctx == nil {
-		return nil, errors.New("Qianwen realtime TTS is unavailable")
+	consume func([]byte) error,
+) error {
+	if synthesizer == nil || ctx == nil || consume == nil {
+		return errors.New("Qianwen realtime TTS is unavailable")
 	}
 	if err := protocol.ValidateSynthesisRequest(
 		protocol.SynthesisRequest{Text: text},
 	); err != nil {
-		return nil, err
+		return err
 	}
 	callContext, cancel := context.WithTimeout(ctx, synthesizer.timeout)
 	defer cancel()
@@ -70,7 +71,7 @@ func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
 		defer response.Body.Close()
 	}
 	if err != nil {
-		return nil, speechTransportError(
+		return speechTransportError(
 			protocol.SpeechOperationSynthesis,
 			callContext,
 			err,
@@ -83,7 +84,7 @@ func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
 	}
 	taskID, err := newRealtimeTaskID()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if err := connection.WriteJSON(map[string]any{
 		"header": map[string]any{
@@ -94,16 +95,16 @@ func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
 			"function": "SpeechSynthesizer", "model": synthesizer.model,
 			"parameters": map[string]any{
 				"text_type": "PlainText", "voice": synthesizer.voice,
-				"format": "wav", "sample_rate": ttsOutputSampleRate,
+				"format": "pcm", "sample_rate": agentconversation.AssistantSpeechSampleRate,
 				"volume": 50, "rate": 1, "pitch": 1, "enable_ssml": false,
 			},
 			"input": map[string]any{},
 		},
 	}); err != nil {
-		return nil, err
+		return err
 	}
 	if err := waitForSpeechRealtimeEvent(connection, taskID, "task-started"); err != nil {
-		return nil, err
+		return err
 	}
 	if err := connection.WriteJSON(map[string]any{
 		"header": map[string]any{
@@ -111,7 +112,7 @@ func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
 		},
 		"payload": map[string]any{"input": map[string]any{"text": strings.TrimSpace(text)}},
 	}); err != nil {
-		return nil, err
+		return err
 	}
 	if err := connection.WriteJSON(map[string]any{
 		"header": map[string]any{
@@ -119,35 +120,40 @@ func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
 		},
 		"payload": map[string]any{"input": map[string]any{}},
 	}); err != nil {
-		return nil, err
+		return err
 	}
-	var audio bytes.Buffer
+	var audioBytes int64
 	for {
 		messageType, payload, readErr := connection.ReadMessage()
 		if readErr != nil {
-			return nil, readErr
+			return readErr
 		}
 		switch messageType {
 		case websocket.BinaryMessage:
-			if len(payload) == 0 ||
-				int64(audio.Len()+len(payload)) > platformmedia.MaxAudioBytes {
-				return nil, errors.New("Qianwen realtime TTS audio exceeds the accepted size")
+			if len(payload) == 0 || audioBytes+int64(len(payload)) > platformmedia.MaxAudioBytes {
+				return errors.New("Qianwen realtime TTS audio exceeds the accepted size")
 			}
-			_, _ = audio.Write(payload)
+			audioBytes += int64(len(payload))
+			if err := consume(payload); err != nil {
+				return err
+			}
 		case websocket.TextMessage:
 			event, eventErr := decodeSpeechRealtimeEvent(payload, taskID)
 			if eventErr != nil {
-				return nil, eventErr
+				return eventErr
 			}
 			switch event {
 			case "result-generated":
 			case "task-finished":
-				return normalizeRealtimeWAV(audio.Bytes())
+				if audioBytes == 0 {
+					return errors.New("Qianwen realtime TTS returned no audio")
+				}
+				return nil
 			default:
-				return nil, fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
+				return fmt.Errorf("Qianwen realtime TTS returned unexpected event %q", event)
 			}
 		default:
-			return nil, errors.New("Qianwen realtime TTS returned an invalid frame")
+			return errors.New("Qianwen realtime TTS returned an invalid frame")
 		}
 	}
 }
@@ -184,25 +190,6 @@ func decodeSpeechRealtimeEvent(payload []byte, taskID string) (string, error) {
 		return "", errors.New("Qianwen realtime TTS event type is missing")
 	}
 	return envelope.Header.Event, nil
-}
-
-func normalizeRealtimeWAV(audio []byte) ([]byte, error) {
-	if len(audio) < 44 || int64(len(audio)) > platformmedia.MaxAudioBytes {
-		return nil, errors.New("Qianwen realtime TTS returned invalid WAV audio")
-	}
-	normalized, err := normalizeProviderWAVSizeMarkers(
-		bytes.NewReader(audio),
-		int64(len(audio)),
-	)
-	if err != nil {
-		return nil, err
-	}
-	result, err := io.ReadAll(io.LimitReader(normalized, platformmedia.MaxAudioBytes+1))
-	if err != nil || len(result) != len(audio) || string(result[:4]) != "RIFF" ||
-		string(result[8:12]) != "WAVE" {
-		return nil, errors.New("Qianwen realtime TTS returned malformed WAV audio")
-	}
-	return result, nil
 }
 
 func newRealtimeTaskID() (string, error) {

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
@@ -1,13 +1,13 @@
 package qianwen
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -15,7 +15,7 @@ import (
 func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 	t.Parallel()
 	const apiKey = "test-realtime-tts-key"
-	wav := ttsTestWAV(20 * time.Millisecond)
+	chunks := [][]byte{{1, 2, 3, 4}, {5, 6, 7, 8}}
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -56,7 +56,7 @@ func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 		if run.Header.Action != "run-task" ||
 			run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
 			run.Payload.Parameters.Voice != "loongeva_v3.6" ||
-			run.Payload.Parameters.Format != "wav" ||
+			run.Payload.Parameters.Format != "pcm" ||
 			run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
 			t.Errorf("unexpected run-task: %#v", run)
 			return
@@ -105,9 +105,11 @@ func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 			t.Errorf("unexpected finish-task: %s", finishPayload)
 			return
 		}
-		if err := connection.WriteMessage(websocket.BinaryMessage, wav); err != nil {
-			t.Errorf("write audio: %v", err)
-			return
+		for _, chunk := range chunks {
+			if err := connection.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
+				t.Errorf("write audio: %v", err)
+				return
+			}
 		}
 		if err := connection.WriteJSON(map[string]any{
 			"header": map[string]any{
@@ -124,14 +126,21 @@ func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 		return nil, nil
 	}), apiKey, "")
 	synthesizer.realtimeEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
-	result, err := synthesizer.synthesizeRealtimeWAV(
+	var received [][]byte
+	err := synthesizer.streamRealtimePCM(
 		context.Background(),
 		" Speak this sentence. ",
+		func(chunk []byte) error {
+			received = append(received, bytes.Clone(chunk))
+			return nil
+		},
 	)
 	if err != nil {
 		t.Fatalf("synthesize realtime: %v", err)
 	}
-	if string(result[:4]) != "RIFF" || string(result[8:12]) != "WAVE" {
-		t.Fatalf("result is not WAV: %q", result[:12])
+	if len(received) != len(chunks) ||
+		!bytes.Equal(received[0], chunks[0]) ||
+		!bytes.Equal(received[1], chunks[1]) {
+		t.Fatalf("received chunks = %#v", received)
 	}
 }

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
@@ -1,0 +1,137 @@
+package qianwen
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
+	t.Parallel()
+	const apiKey = "test-realtime-tts-key"
+	wav := ttsTestWAV(20 * time.Millisecond)
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		if request.Header.Get(authorizationHeaderName) != "Bearer "+apiKey {
+			t.Errorf("authorization header was not forwarded")
+		}
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer connection.Close()
+		_, runPayload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read run-task: %v", err)
+			return
+		}
+		var run struct {
+			Header struct {
+				Action string `json:"action"`
+				TaskID string `json:"task_id"`
+			} `json:"header"`
+			Payload struct {
+				Model      string `json:"model"`
+				Parameters struct {
+					Voice      string `json:"voice"`
+					Format     string `json:"format"`
+					SampleRate int    `json:"sample_rate"`
+				} `json:"parameters"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(runPayload, &run); err != nil {
+			t.Errorf("decode run-task: %v", err)
+			return
+		}
+		if run.Header.Action != "run-task" ||
+			run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
+			run.Payload.Parameters.Voice != "loongeva_v3.6" ||
+			run.Payload.Parameters.Format != "wav" ||
+			run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
+			t.Errorf("unexpected run-task: %#v", run)
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{
+			"header": map[string]any{
+				"task_id": run.Header.TaskID, "event": "task-started",
+			},
+		}); err != nil {
+			t.Errorf("write task-started: %v", err)
+			return
+		}
+		_, continuePayload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read continue-task: %v", err)
+			return
+		}
+		var continued struct {
+			Header struct {
+				Action string `json:"action"`
+			} `json:"header"`
+			Payload struct {
+				Input struct {
+					Text string `json:"text"`
+				} `json:"input"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(continuePayload, &continued); err != nil ||
+			continued.Header.Action != "continue-task" ||
+			continued.Payload.Input.Text != "Speak this sentence." {
+			t.Errorf("unexpected continue-task: %s", continuePayload)
+			return
+		}
+		_, finishPayload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read finish-task: %v", err)
+			return
+		}
+		var finished struct {
+			Header struct {
+				Action string `json:"action"`
+			} `json:"header"`
+		}
+		if err := json.Unmarshal(finishPayload, &finished); err != nil ||
+			finished.Header.Action != "finish-task" {
+			t.Errorf("unexpected finish-task: %s", finishPayload)
+			return
+		}
+		if err := connection.WriteMessage(websocket.BinaryMessage, wav); err != nil {
+			t.Errorf("write audio: %v", err)
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{
+			"header": map[string]any{
+				"task_id": run.Header.TaskID, "event": "task-finished",
+			},
+		}); err != nil {
+			t.Errorf("write task-finished: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	synthesizer := mustSynthesizer(t, doerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("realtime synthesis must not use HTTP generation")
+		return nil, nil
+	}), apiKey, "")
+	synthesizer.realtimeEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	result, err := synthesizer.synthesizeRealtimeWAV(
+		context.Background(),
+		" Speak this sentence. ",
+	)
+	if err != nil {
+		t.Fatalf("synthesize realtime: %v", err)
+	}
+	if string(result[:4]) != "RIFF" || string(result[8:12]) != "WAVE" {
+		t.Fatalf("result is not WAV: %q", result[:12])
+	}
+}

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
+func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
 	t.Parallel()
 	const apiKey = "test-realtime-tts-key"
 	chunks := [][]byte{{1, 2, 3, 4}, {5, 6, 7, 8}}
+	texts := []string{"Speak this sentence.", "Then speak this one."}
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -30,93 +31,95 @@ func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 			return
 		}
 		defer connection.Close()
-		_, runPayload, err := connection.ReadMessage()
-		if err != nil {
-			t.Errorf("read run-task: %v", err)
-			return
-		}
-		var run struct {
-			Header struct {
-				Action string `json:"action"`
-				TaskID string `json:"task_id"`
-			} `json:"header"`
-			Payload struct {
-				Model      string `json:"model"`
-				Parameters struct {
-					Voice      string `json:"voice"`
-					Format     string `json:"format"`
-					SampleRate int    `json:"sample_rate"`
-				} `json:"parameters"`
-			} `json:"payload"`
-		}
-		if err := json.Unmarshal(runPayload, &run); err != nil {
-			t.Errorf("decode run-task: %v", err)
-			return
-		}
-		if run.Header.Action != "run-task" ||
-			run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
-			run.Payload.Parameters.Voice != "loongeva_v3.6" ||
-			run.Payload.Parameters.Format != "pcm" ||
-			run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
-			t.Errorf("unexpected run-task: %#v", run)
-			return
-		}
-		if err := connection.WriteJSON(map[string]any{
-			"header": map[string]any{
-				"task_id": run.Header.TaskID, "event": "task-started",
-			},
-		}); err != nil {
-			t.Errorf("write task-started: %v", err)
-			return
-		}
-		_, continuePayload, err := connection.ReadMessage()
-		if err != nil {
-			t.Errorf("read continue-task: %v", err)
-			return
-		}
-		var continued struct {
-			Header struct {
-				Action string `json:"action"`
-			} `json:"header"`
-			Payload struct {
-				Input struct {
-					Text string `json:"text"`
-				} `json:"input"`
-			} `json:"payload"`
-		}
-		if err := json.Unmarshal(continuePayload, &continued); err != nil ||
-			continued.Header.Action != "continue-task" ||
-			continued.Payload.Input.Text != "Speak this sentence." {
-			t.Errorf("unexpected continue-task: %s", continuePayload)
-			return
-		}
-		_, finishPayload, err := connection.ReadMessage()
-		if err != nil {
-			t.Errorf("read finish-task: %v", err)
-			return
-		}
-		var finished struct {
-			Header struct {
-				Action string `json:"action"`
-			} `json:"header"`
-		}
-		if err := json.Unmarshal(finishPayload, &finished); err != nil ||
-			finished.Header.Action != "finish-task" {
-			t.Errorf("unexpected finish-task: %s", finishPayload)
-			return
-		}
-		for _, chunk := range chunks {
-			if err := connection.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
-				t.Errorf("write audio: %v", err)
+		for _, expectedText := range texts {
+			_, runPayload, err := connection.ReadMessage()
+			if err != nil {
+				t.Errorf("read run-task: %v", err)
 				return
 			}
-		}
-		if err := connection.WriteJSON(map[string]any{
-			"header": map[string]any{
-				"task_id": run.Header.TaskID, "event": "task-finished",
-			},
-		}); err != nil {
-			t.Errorf("write task-finished: %v", err)
+			var run struct {
+				Header struct {
+					Action string `json:"action"`
+					TaskID string `json:"task_id"`
+				} `json:"header"`
+				Payload struct {
+					Model      string `json:"model"`
+					Parameters struct {
+						Voice      string `json:"voice"`
+						Format     string `json:"format"`
+						SampleRate int    `json:"sample_rate"`
+					} `json:"parameters"`
+				} `json:"payload"`
+			}
+			if err := json.Unmarshal(runPayload, &run); err != nil {
+				t.Errorf("decode run-task: %v", err)
+				return
+			}
+			if run.Header.Action != "run-task" ||
+				run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
+				run.Payload.Parameters.Voice != "loongeva_v3.6" ||
+				run.Payload.Parameters.Format != "pcm" ||
+				run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
+				t.Errorf("unexpected run-task: %#v", run)
+				return
+			}
+			if err := connection.WriteJSON(map[string]any{
+				"header": map[string]any{
+					"task_id": run.Header.TaskID, "event": "task-started",
+				},
+			}); err != nil {
+				t.Errorf("write task-started: %v", err)
+				return
+			}
+			_, continuePayload, err := connection.ReadMessage()
+			if err != nil {
+				t.Errorf("read continue-task: %v", err)
+				return
+			}
+			var continued struct {
+				Header struct {
+					Action string `json:"action"`
+				} `json:"header"`
+				Payload struct {
+					Input struct {
+						Text string `json:"text"`
+					} `json:"input"`
+				} `json:"payload"`
+			}
+			if err := json.Unmarshal(continuePayload, &continued); err != nil ||
+				continued.Header.Action != "continue-task" ||
+				continued.Payload.Input.Text != expectedText {
+				t.Errorf("unexpected continue-task: %s", continuePayload)
+				return
+			}
+			_, finishPayload, err := connection.ReadMessage()
+			if err != nil {
+				t.Errorf("read finish-task: %v", err)
+				return
+			}
+			var finished struct {
+				Header struct {
+					Action string `json:"action"`
+				} `json:"header"`
+			}
+			if err := json.Unmarshal(finishPayload, &finished); err != nil ||
+				finished.Header.Action != "finish-task" {
+				t.Errorf("unexpected finish-task: %s", finishPayload)
+				return
+			}
+			for _, chunk := range chunks {
+				if err := connection.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
+					t.Errorf("write audio: %v", err)
+					return
+				}
+			}
+			if err := connection.WriteJSON(map[string]any{
+				"header": map[string]any{
+					"task_id": run.Header.TaskID, "event": "task-finished",
+				},
+			}); err != nil {
+				t.Errorf("write task-finished: %v", err)
+			}
 		}
 	}))
 	defer server.Close()
@@ -127,20 +130,23 @@ func TestRealtimeSynthesisUsesDocumentedWebSocketSequence(t *testing.T) {
 	}), apiKey, "")
 	synthesizer.realtimeEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
 	var received [][]byte
-	err := synthesizer.streamRealtimePCM(
-		context.Background(),
-		" Speak this sentence. ",
-		func(chunk []byte) error {
+	session, err := synthesizer.openRealtimeSpeech(context.Background())
+	if err != nil {
+		t.Fatalf("open realtime synthesis: %v", err)
+	}
+	defer session.Close()
+	for _, text := range texts {
+		err = session.StreamSegment(text, func(chunk []byte) error {
 			received = append(received, bytes.Clone(chunk))
 			return nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("synthesize realtime: %v", err)
+		})
+		if err != nil {
+			t.Fatalf("synthesize realtime: %v", err)
+		}
 	}
-	if len(received) != len(chunks) ||
+	if len(received) != len(chunks)*len(texts) ||
 		!bytes.Equal(received[0], chunks[0]) ||
-		!bytes.Equal(received[1], chunks[1]) {
+		!bytes.Equal(received[len(received)-1], chunks[1]) {
 		t.Fatalf("received chunks = %#v", received)
 	}
 }

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
@@ -8,15 +8,16 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
 
-func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
+func TestRealtimeSynthesisStreamsTextThroughOneDocumentedTask(t *testing.T) {
 	t.Parallel()
 	const apiKey = "test-realtime-tts-key"
 	chunks := [][]byte{{1, 2, 3, 4}, {5, 6, 7, 8}}
-	texts := []string{"Speak this sentence.", "Then speak this one."}
+	texts := []string{"Speak this ", "sentence."}
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -31,46 +32,46 @@ func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
 			return
 		}
 		defer connection.Close()
-		for _, expectedText := range texts {
-			_, runPayload, err := connection.ReadMessage()
-			if err != nil {
-				t.Errorf("read run-task: %v", err)
-				return
-			}
-			var run struct {
-				Header struct {
-					Action string `json:"action"`
-					TaskID string `json:"task_id"`
-				} `json:"header"`
-				Payload struct {
-					Model      string `json:"model"`
-					Parameters struct {
-						Voice      string `json:"voice"`
-						Format     string `json:"format"`
-						SampleRate int    `json:"sample_rate"`
-					} `json:"parameters"`
-				} `json:"payload"`
-			}
-			if err := json.Unmarshal(runPayload, &run); err != nil {
-				t.Errorf("decode run-task: %v", err)
-				return
-			}
-			if run.Header.Action != "run-task" ||
-				run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
-				run.Payload.Parameters.Voice != "loongeva_v3.6" ||
-				run.Payload.Parameters.Format != "pcm" ||
-				run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
-				t.Errorf("unexpected run-task: %#v", run)
-				return
-			}
-			if err := connection.WriteJSON(map[string]any{
-				"header": map[string]any{
-					"task_id": run.Header.TaskID, "event": "task-started",
-				},
-			}); err != nil {
-				t.Errorf("write task-started: %v", err)
-				return
-			}
+		_, runPayload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read run-task: %v", err)
+			return
+		}
+		var run struct {
+			Header struct {
+				Action string `json:"action"`
+				TaskID string `json:"task_id"`
+			} `json:"header"`
+			Payload struct {
+				Model      string `json:"model"`
+				Parameters struct {
+					Voice      string `json:"voice"`
+					Format     string `json:"format"`
+					SampleRate int    `json:"sample_rate"`
+				} `json:"parameters"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(runPayload, &run); err != nil {
+			t.Errorf("decode run-task: %v", err)
+			return
+		}
+		if run.Header.Action != "run-task" ||
+			run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
+			run.Payload.Parameters.Voice != "loongeva_v3.6" ||
+			run.Payload.Parameters.Format != "pcm" ||
+			run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
+			t.Errorf("unexpected run-task: %#v", run)
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{
+			"header": map[string]any{
+				"task_id": run.Header.TaskID, "event": "task-started",
+			},
+		}); err != nil {
+			t.Errorf("write task-started: %v", err)
+			return
+		}
+		for index, expectedText := range texts {
 			_, continuePayload, err := connection.ReadMessage()
 			if err != nil {
 				t.Errorf("read continue-task: %v", err)
@@ -79,6 +80,7 @@ func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
 			var continued struct {
 				Header struct {
 					Action string `json:"action"`
+					TaskID string `json:"task_id"`
 				} `json:"header"`
 				Payload struct {
 					Input struct {
@@ -88,38 +90,40 @@ func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
 			}
 			if err := json.Unmarshal(continuePayload, &continued); err != nil ||
 				continued.Header.Action != "continue-task" ||
+				continued.Header.TaskID != run.Header.TaskID ||
 				continued.Payload.Input.Text != expectedText {
 				t.Errorf("unexpected continue-task: %s", continuePayload)
 				return
 			}
-			_, finishPayload, err := connection.ReadMessage()
-			if err != nil {
-				t.Errorf("read finish-task: %v", err)
+			if err := connection.WriteMessage(
+				websocket.BinaryMessage,
+				chunks[index],
+			); err != nil {
+				t.Errorf("write audio: %v", err)
 				return
 			}
-			var finished struct {
-				Header struct {
-					Action string `json:"action"`
-				} `json:"header"`
-			}
-			if err := json.Unmarshal(finishPayload, &finished); err != nil ||
-				finished.Header.Action != "finish-task" {
-				t.Errorf("unexpected finish-task: %s", finishPayload)
-				return
-			}
-			for _, chunk := range chunks {
-				if err := connection.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
-					t.Errorf("write audio: %v", err)
-					return
-				}
-			}
-			if err := connection.WriteJSON(map[string]any{
-				"header": map[string]any{
-					"task_id": run.Header.TaskID, "event": "task-finished",
-				},
-			}); err != nil {
-				t.Errorf("write task-finished: %v", err)
-			}
+		}
+		_, finishPayload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read finish-task: %v", err)
+			return
+		}
+		var finished struct {
+			Header struct {
+				Action string `json:"action"`
+			} `json:"header"`
+		}
+		if err := json.Unmarshal(finishPayload, &finished); err != nil ||
+			finished.Header.Action != "finish-task" {
+			t.Errorf("unexpected finish-task: %s", finishPayload)
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{
+			"header": map[string]any{
+				"task_id": run.Header.TaskID, "event": "task-finished",
+			},
+		}); err != nil {
+			t.Errorf("write task-finished: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -129,24 +133,32 @@ func TestRealtimeSynthesisReusesDocumentedWebSocketSession(t *testing.T) {
 		return nil, nil
 	}), apiKey, "")
 	synthesizer.realtimeEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
-	var received [][]byte
-	session, err := synthesizer.openRealtimeSpeech(context.Background())
+	received := make(chan []byte, len(chunks))
+	session, err := synthesizer.openRealtimeSpeech(
+		context.Background(),
+		func(chunk []byte) error {
+			received <- bytes.Clone(chunk)
+			return nil
+		},
+	)
 	if err != nil {
 		t.Fatalf("open realtime synthesis: %v", err)
 	}
 	defer session.Close()
-	for _, text := range texts {
-		err = session.StreamSegment(text, func(chunk []byte) error {
-			received = append(received, bytes.Clone(chunk))
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("synthesize realtime: %v", err)
+	for index, text := range texts {
+		if err := session.AppendText(text); err != nil {
+			t.Fatalf("append realtime text: %v", err)
+		}
+		select {
+		case chunk := <-received:
+			if !bytes.Equal(chunk, chunks[index]) {
+				t.Fatalf("received chunk = %#v", chunk)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("realtime audio did not arrive before task completion")
 		}
 	}
-	if len(received) != len(chunks)*len(texts) ||
-		!bytes.Equal(received[0], chunks[0]) ||
-		!bytes.Equal(received[len(received)-1], chunks[1]) {
-		t.Fatalf("received chunks = %#v", received)
+	if err := session.Finish(); err != nil {
+		t.Fatalf("finish realtime synthesis: %v", err)
 	}
 }


### PR DESCRIPTION
## 功能描述

让 Agent 语音回复在文本生成期间按完整句段开始合成与播放，不再等待整条文本完成，同时保留完成后的整段重播。

## 实现思路

- 在 Agent Conversation 边界提供受认证的实时语音 WebSocket。
- 将文本增量按稳定句段送入实时 TTS，终态补齐剩余文本。
- 移动端收到首段 PCM 后立即播放，并按顺序衔接后续音频。
- 开始录音、切换 Thread 或离开页面时停止播放并清理队列。
- 完成后继续使用正式 Message 的整段语音接口进行手动重播。

## 验证

- go test -count=1 ./internal/agent/conversation/... ./internal/providers/qianwen/... ./internal/bootstrap/...
- dart format --output=none --set-exit-if-changed lib test
- flutter analyze --no-pub
- flutter test --no-pub test/agent/agent_assistant_speech_stream_test.dart test/agent/agent_voice_flow_test.dart test/agent/wire_agent_voice_client_test.dart
- git diff --check upstream/dev...HEAD

Closes #442