### PR TITLE
fix(interview): tighten plan catalog layout

### DIFF
--- a/mobile/lib/features/coaching/interview/interview_catalog.dart
+++ b/mobile/lib/features/coaching/interview/interview_catalog.dart
@@ -27,20 +27,6 @@ class InterviewCatalog extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Align(
-          alignment: Alignment.centerRight,
-          child: IconButton.filled(
-            key: const Key('create-interview-plan'),
-            tooltip: '创建模拟面试',
-            onPressed: onCreatePressed,
-            icon: const Icon(Icons.add_rounded),
-            style: IconButton.styleFrom(
-              backgroundColor: PreparationDesign.ink,
-              foregroundColor: Colors.white,
-            ),
-          ),
-        ),
-        const SizedBox(height: 12),
         if (loading && plans.isEmpty)
           const Center(child: CircularProgressIndicator())
         else if (errorMessage != null && plans.isEmpty)
@@ -93,6 +79,27 @@ class InterviewCatalog extends StatelessWidget {
   }
 }
 
+class InterviewCatalogCreateButton extends StatelessWidget {
+  const InterviewCatalogCreateButton({required this.onPressed, super.key});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton.filled(
+      key: const Key('create-interview-plan'),
+      tooltip: '创建模拟面试',
+      onPressed: onPressed,
+      icon: const Icon(Icons.add_rounded),
+      style: IconButton.styleFrom(
+        minimumSize: const Size(44, 44),
+        backgroundColor: PreparationDesign.ink,
+        foregroundColor: Colors.white,
+      ),
+    );
+  }
+}
+
 class _PlanCard extends StatelessWidget {
   const _PlanCard({
     required this.plan,
@@ -115,24 +122,24 @@ class _PlanCard extends StatelessWidget {
       child: InkWell(
         onTap: onPressed,
         child: Padding(
-          padding: const EdgeInsets.all(18),
-          child: Row(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: PreparationDesign.scenarioTint,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: const Icon(Icons.mic_none_rounded),
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
+              Row(
+                children: [
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      color: PreparationDesign.scenarioTint,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(Icons.mic_none_rounded),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
                       title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -140,30 +147,73 @@ class _PlanCard extends StatelessWidget {
                         fontWeight: FontWeight.w800,
                       ),
                     ),
-                    const SizedBox(height: 5),
-                    Text(
-                      '${plan.practiceScope} · 约 $minutes 分钟 · '
-                      '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: PreparationDesign.inkTertiary,
-                      ),
+                  ),
+                  IconButton(
+                    key: Key('delete-interview-plan-${plan.id}'),
+                    tooltip: '删除模拟面试',
+                    onPressed: onDelete,
+                    icon: const Icon(Icons.delete_outline_rounded),
+                  ),
+                  const Icon(Icons.chevron_right_rounded),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 56, top: 4),
+                child: Text(
+                  plan.practiceScope,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: PreparationDesign.inkSecondary),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 56, top: 10),
+                child: Wrap(
+                  spacing: 16,
+                  runSpacing: 8,
+                  children: [
+                    _PlanMeta(
+                      icon: Icons.schedule_rounded,
+                      label: '约 $minutes 分钟',
+                    ),
+                    _PlanMeta(
+                      icon: Icons.repeat_rounded,
+                      label:
+                          '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
                     ),
                   ],
                 ),
               ),
-              IconButton(
-                key: Key('delete-interview-plan-${plan.id}'),
-                tooltip: '删除模拟面试',
-                onPressed: onDelete,
-                icon: const Icon(Icons.delete_outline_rounded),
-              ),
-              const Icon(Icons.chevron_right_rounded),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+class _PlanMeta extends StatelessWidget {
+  const _PlanMeta({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: PreparationDesign.inkTertiary),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            label,
+            style: PreparationDesign.meta.copyWith(
+              color: PreparationDesign.inkTertiary,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -656,8 +656,13 @@ class _PreparationPageState extends State<PreparationPage> {
           backButtonKey: const Key('preparation-back-to-families'),
           titleKey: Key('practice-hub-title-${hub.name}'),
           onBack: () => setState(() => _selectedHub = null),
+          trailing: hub == _PracticeHub.interview
+              ? InterviewCatalogCreateButton(
+                  onPressed: widget.onOpenJobPreparation,
+                )
+              : null,
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: hub == _PracticeHub.interview ? 20 : 16),
         if (hub == _PracticeHub.interview)
           InterviewCatalog(
             plans: widget.jobPreparationController?.interviewPlans ?? const [],
@@ -720,8 +725,13 @@ class _PreparationPageState extends State<PreparationPage> {
             backButtonKey: const Key('preparation-back-to-families'),
             titleKey: Key('practice-hub-title-${selectedHub.name}'),
             onBack: () => setState(() => _selectedHub = null),
+            trailing: selectedHub == _PracticeHub.interview
+                ? InterviewCatalogCreateButton(
+                    onPressed: widget.onOpenJobPreparation,
+                  )
+                : null,
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: selectedHub == _PracticeHub.interview ? 20 : 16),
           const PreparationCatalogEmpty(message: '连接场景服务后即可查看练习。'),
         ],
       );

--- a/mobile/test/coaching/interview/interview_catalog_test.dart
+++ b/mobile/test/coaching/interview/interview_catalog_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_theme.dart';
+import 'package:speakup/features/coaching/interview/interview_catalog.dart';
+import 'package:speakup/features/coaching/preparation/preparation_models.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+
+void main() {
+  testWidgets('separates plan content and preserves card actions', (
+    tester,
+  ) async {
+    PracticePlanSummary? opened;
+    PracticePlanSummary? deleted;
+    final plan = _plan('plan-1');
+
+    await _pumpCatalog(
+      tester,
+      plans: [plan],
+      onPlanPressed: (value) => opened = value,
+      onPlanDeleted: (value) => deleted = value,
+    );
+
+    expect(find.text('Java Developer'), findsOneWidget);
+    expect(find.text('技术深挖'), findsOneWidget);
+    expect(find.text('约 15 分钟'), findsOneWidget);
+    expect(find.text('1–3 轮'), findsOneWidget);
+    expect(find.textContaining('技术深挖 ·'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('interview-plan-plan-1')));
+    await tester.pump();
+    expect(opened, same(plan));
+
+    await tester.tap(find.byKey(const Key('delete-interview-plan-plan-1')));
+    await tester.pumpAndSettle();
+    expect(find.text('删除模拟面试？'), findsOneWidget);
+    expect(deleted, isNull);
+
+    await tester.tap(find.byKey(const Key('confirm-delete-interview-plan')));
+    await tester.pumpAndSettle();
+    expect(deleted, same(plan));
+  });
+
+  testWidgets('renders loading, error, empty, and multiple plan states', (
+    tester,
+  ) async {
+    var retries = 0;
+
+    await _pumpCatalog(tester, loading: true);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await _pumpCatalog(
+      tester,
+      errorMessage: '方案加载失败',
+      onRetry: () => retries++,
+    );
+    expect(find.text('方案加载失败'), findsOneWidget);
+    await tester.tap(find.text('重试'));
+    expect(retries, 1);
+
+    await _pumpCatalog(tester);
+    expect(find.byKey(const Key('interview-plan-empty')), findsOneWidget);
+
+    await _pumpCatalog(tester, plans: [_plan('plan-1'), _plan('plan-2')]);
+    expect(find.byType(Card), findsNWidgets(2));
+  });
+
+  testWidgets('keeps plan metadata usable at 320px and 3x text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await _pumpCatalog(tester, plans: [_plan('plan-1')]);
+
+    for (final label in ['Java Developer', '技术深挖', '约 15 分钟', '1–3 轮']) {
+      final content = find.text(label);
+      await tester.ensureVisible(content);
+      await tester.pumpAndSettle();
+      expect(content, findsOneWidget);
+    }
+    expect(
+      find.byKey(const Key('delete-interview-plan-plan-1')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpCatalog(
+  WidgetTester tester, {
+  List<PracticePlanSummary> plans = const [],
+  bool loading = false,
+  String? errorMessage,
+  ValueChanged<PracticePlanSummary>? onPlanPressed,
+  ValueChanged<PracticePlanSummary>? onPlanDeleted,
+  VoidCallback? onRetry,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      theme: SpeakUpTheme.light,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: InterviewCatalog(
+            plans: plans,
+            loading: loading,
+            errorMessage: errorMessage,
+            onCreatePressed: () {},
+            onPlanPressed: onPlanPressed ?? (_) {},
+            onPlanDeleted: onPlanDeleted ?? (_) {},
+            onRetry: onRetry ?? () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+PracticePlanSummary _plan(String id) {
+  return PracticePlanSummary(
+    id: id,
+    revision: 1,
+    status: PracticePlanStatus.ready,
+    experience: PracticeExperience.interview,
+    sceneName: 'Technical interview',
+    practiceScope: '技术深挖',
+    jobTitle: 'Java Developer',
+    practiceObjectives: const ['清楚说明技术取舍'],
+    resumeUsed: true,
+    suggestedDurationSeconds: 900,
+    minEffectiveTurns: 1,
+    maxEffectiveTurns: 3,
+    createdAt: DateTime.utc(2026, 8, 7),
+    updatedAt: DateTime.utc(2026, 8, 7),
+  );
+}

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -54,8 +54,17 @@ void main() {
 
     expect(find.byKey(const Key('create-interview-plan')), findsOneWidget);
     expect(find.byKey(const Key('interview-plan-empty')), findsOneWidget);
+    final titleCenter = tester.getCenter(
+      find.byKey(const Key('practice-hub-title-interview')),
+    );
+    final createButton = find.byKey(const Key('create-interview-plan'));
+    final createCenter = tester.getCenter(createButton);
+    final createSize = tester.getSize(createButton);
+    expect((titleCenter.dy - createCenter.dy).abs(), lessThan(1));
+    expect(createSize.width, greaterThanOrEqualTo(44));
+    expect(createSize.height, greaterThanOrEqualTo(44));
 
-    await tester.tap(find.byKey(const Key('create-interview-plan')));
+    await tester.tap(createButton);
     await tester.pump();
 
     expect(opens, 1);


### PR DESCRIPTION
## 功能描述

收紧英文面试方案库首屏布局，将创建入口移入紧凑导航标题行，并重排方案卡片的信息层级。岗位、练习重点、预计时长和有效轮次现在独立展示，避免窄屏下轮次范围被含义割裂地换行。

## 实现思路

- 复用 `SpeakUpNavigationHeader.trailing` 承载原有创建按钮，保留 Widget Key、Tooltip、回调和 44px 最小触控区域。
- 让 `InterviewCatalog` 只负责加载、错误、空状态和方案列表，移除列表内部孤立的顶部创建按钮。
- 将方案卡片重排为岗位标题行、练习重点和可换行元信息区；时长与轮次使用独立图标和文本。
- 保留整卡进入、删除确认、进入指示及现有业务回调，不修改 API、数据模型或训练流程。
- 新增 InterviewCatalog Widget 测试，覆盖卡片进入、删除确认、加载/错误/空/多方案状态，以及 320px + 3 倍字体布局。

## 测试方式

1. `make check-flutter`
2. 预期：依赖锁文件检查、Dart 格式、Flutter analyze 和全部 754 项测试通过。
3. `flutter run -d C3F00DDB-A017-4A12-ABB7-234CB16B2037 --dart-define=SPEAKUP_API_BASE_URL=http://127.0.0.1:18080`
4. 预期：iPhone 17 Pro Simulator debug 构建、安装和 App 启动成功；本地后端 `/readyz` 返回数据库 ready。
5. 进入“训练 → 英文面试”，确认返回、标题和创建按钮同排；方案卡片分别显示岗位、练习重点、时长和轮次，进入与删除操作保持可用。

## 相关 Issue / 备注

Closes #478

Related to #449
Related to #474

- 仅修改 Flutter 面试方案库布局和相关 Widget 测试。
- iOS Simulator 使用仓库既有 AvatarKit stub；不影响真机 AvatarKit 配置。

## AI 辅助说明

使用 Codex 辅助定位页面组合边界、实现布局和补充回归测试。人工确认了依赖方向、交互回调、差异范围、320px/大字体失败用例及修复结果，并完成全量 Flutter 门禁和 iOS Simulator debug 构建。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
