### PR TITLE
fix(mobile): restore iOS integration testability

### DIFF
--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -332,15 +332,15 @@ void main() {
 
     final interviewHub = find.byKey(const Key('practice-hub-interview'));
     final examHub = find.byKey(const Key('practice-hub-exam'));
-    final roleplayHub = find.byKey(const Key('practice-hub-roleplay'));
+    final workplaceHub = find.byKey(const Key('practice-hub-workplace'));
     await _waitForPreparationTarget(
       tester,
       target: interviewHub,
-      operation: 'load the three practice hubs',
+      operation: 'load the four practice hubs',
       timeout: const Duration(seconds: 30),
     );
     expect(examHub, findsOneWidget);
-    expect(roleplayHub, findsOneWidget);
+    expect(workplaceHub, findsOneWidget);
 
     await _scrollPreparationIntoView(tester, interviewHub);
     await tester.tap(interviewHub);
@@ -353,12 +353,12 @@ void main() {
     await tester.tap(find.byKey(const Key('preparation-back-to-families')));
     await tester.pumpAndSettle();
 
-    await _scrollPreparationIntoView(tester, roleplayHub);
-    await tester.tap(roleplayHub);
+    await _scrollPreparationIntoView(tester, workplaceHub);
+    await tester.tap(workplaceHub);
     await _waitForPreparationTarget(
       tester,
-      target: find.byKey(const Key('practice-hub-title-roleplay')),
-      operation: 'open the roleplay hub',
+      target: find.byKey(const Key('practice-hub-title-workplace')),
+      operation: 'open the workplace hub',
       timeout: const Duration(seconds: 10),
     );
     await tester.tap(find.byKey(const Key('preparation-back-to-families')));

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -368,24 +368,13 @@ void main() {
     await tester.tap(examHub);
     await tester.pump();
 
-    final part1 = find.byKey(
-      const Key('catalog-scene-scn_ielts_speaking_part_1'),
+    final questionSet = find.byKey(
+      const Key('ielts-part1-set-p1-topic-001'),
     );
-    await _waitForPreparationTarget(
-      tester,
-      target: part1,
-      operation: 'load the IELTS Part 1 entry',
-      timeout: const Duration(seconds: 30),
-    );
-    await _scrollPreparationIntoView(tester, part1);
-    await tester.tap(part1);
-    await tester.pump();
-
-    final questionSet = find.byKey(const Key('ielts-part1-set-p1-001'));
     await _waitForPreparationTarget(
       tester,
       target: questionSet,
-      operation: 'load the first IELTS Part 1 question set',
+      operation: 'load the first IELTS Part 1 question topic',
       timeout: const Duration(seconds: 30),
     );
     await _scrollPreparationIntoView(tester, questionSet);

--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -68,9 +68,7 @@ class PlatformNavigationBar extends StatelessWidget {
                       child: GestureDetector(
                         key: destination.key,
                         behavior: HitTestBehavior.opaque,
-                        onTap: () => unawaited(
-                          onDestinationSelected(index),
-                        ),
+                        onTap: () => unawaited(onDestinationSelected(index)),
                       ),
                     ),
                 ],

--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -46,10 +46,37 @@ class PlatformNavigationBar extends StatelessWidget {
       return SizedBox(
         key: const Key('primary-navigation'),
         height: contentHeight + MediaQuery.viewPaddingOf(context).bottom,
-        child: _NativeIosTabBar(
-          destinations: destinations,
-          selectedIndex: selectedIndex,
-          onDestinationSelected: onDestinationSelected,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: _NativeIosTabBar(
+                destinations: destinations,
+                selectedIndex: selectedIndex,
+                onDestinationSelected: onDestinationSelected,
+              ),
+            ),
+            // A native UITabBar platform view is opaque to the Flutter widget
+            // tree, so widget tests and integration tests cannot locate or tap
+            // its items. Overlay a transparent Flutter hit target per item,
+            // reusing each destination's key and forwarding to the same
+            // selection callback the native view would invoke.
+            Positioned.fill(
+              child: Row(
+                children: [
+                  for (final (index, destination) in destinations.indexed)
+                    Expanded(
+                      child: GestureDetector(
+                        key: destination.key,
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => unawaited(
+                          onDestinationSelected(index),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
         ),
       );
     }

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -4,8 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/platform_navigation_bar.dart';
 
 void main() {
-  testWidgets('iOS native tab bar exposes destination keys and forwards taps',
-      (tester) async {
+  testWidgets('iOS native tab bar exposes destination keys and forwards taps', (
+    tester,
+  ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
     final destinations = <PlatformNavigationDestination>[

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/platform_navigation_bar.dart';
+
+void main() {
+  testWidgets('iOS native tab bar exposes destination keys and forwards taps',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    final destinations = <PlatformNavigationDestination>[
+      PlatformNavigationDestination(
+        label: 'SpeakUp',
+        icon: Icons.chat_bubble_outline_rounded,
+        selectedIcon: Icons.chat_bubble_rounded,
+        iosSystemImage: 'bubble.left',
+        iosSelectedSystemImage: 'bubble.left.fill',
+        key: const Key('primary-tab-agent'),
+      ),
+      PlatformNavigationDestination(
+        label: '训练',
+        icon: Icons.grid_view_rounded,
+        selectedIcon: Icons.dashboard_rounded,
+        iosSystemImage: 'square.grid.2x2',
+        iosSelectedSystemImage: 'square.grid.2x2.fill',
+        key: const Key('primary-tab-scenes'),
+      ),
+      PlatformNavigationDestination(
+        label: '复盘',
+        icon: Icons.fact_check_outlined,
+        selectedIcon: Icons.fact_check_rounded,
+        iosSystemImage: 'checklist',
+        iosSelectedSystemImage: 'checkmark.square.fill',
+        key: const Key('primary-tab-review'),
+      ),
+      PlatformNavigationDestination(
+        label: '我的',
+        icon: Icons.person_outline_rounded,
+        selectedIcon: Icons.person_rounded,
+        iosSystemImage: 'person',
+        iosSelectedSystemImage: 'person.fill',
+        key: const Key('primary-tab-profile'),
+      ),
+    ];
+
+    try {
+      final selectedIndexes = <int>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            bottomNavigationBar: PlatformNavigationBar(
+              destinations: destinations,
+              selectedIndex: 0,
+              onDestinationSelected: (index) async {
+                selectedIndexes.add(index);
+                return index;
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('primary-tab-scenes')), findsOneWidget);
+      expect(find.byKey(const Key('primary-tab-profile')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('primary-tab-scenes')));
+      await tester.pump();
+      expect(selectedIndexes, [1]);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}


### PR DESCRIPTION
## 目标

恢复 iOS 集成测试的可测试性。iOS 底部导航栏是原生 UITabBar（平台视图），对 Flutter widget 树不可见，导致 `find.byKey(Key('primary-tab-*'))` 在 iOS 上失效；同时 e2e 测试仍引用已被「四入口拆分」和「IELTS 目录重建」废弃的 key。

## 改动

1. `mobile/lib/app/platform_navigation_bar.dart`：在原生 UITabBar 上方叠加透明的 Flutter 命中目标，复用每个 destination 的 key 并转发到同一选择回调，使 widget 树查找与点击在 iOS 上可用；真实交互与视觉状态不变。
2. `mobile/integration_test/real_agent_e2e_test.dart`：
   - 更新为四入口结构（`practice-hub-workplace` 取代已废弃的 `practice-hub-roleplay`）。
   - IELTS Part 1 改为直接等待话题网格卡 `ielts-part1-set-p1-topic-001`（移除废弃的 `catalog-scene-scn_ielts_speaking_part_1` 入口层）。
3. 新增 widget 测试 `mobile/test/app/platform_navigation_bar_ios_test.dart`，覆盖 iOS 分支的 key 暴露与点击转发。

## 验证

- `flutter analyze` 通过。
- `flutter test test/app/platform_navigation_bar_ios_test.dart test/main_wiring_test.dart test/speak_up_app_test.dart` 通过。
- `make test-ios-simulator-scenes`（真实后端 + iOS 26.5 模拟器）可完成注册/登录/场景导航/进入 IELTS Part 1 并创建练习会话。

## 已知后续

- `real_agent_e2e_test.dart` 中场景测试段仍引用已废弃的 roleplay 目录 key（`roleplay-filter-*`、`scn_daily_hotel_checkin_issue`）。该段不在 `make test-ios-simulator-scenes` 目标内，作为后续维护项处理。
