### PR TITLE
fix(ielts): freeze Part 1 plan assignments without topic title

### DIFF
--- a/server/internal/coaching/preparation/service/plan_ielts_postgres_integration_test.go
+++ b/server/internal/coaching/preparation/service/plan_ielts_postgres_integration_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene/ielts"
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresIELTSResolverProducesPlanCompatibleAssignments(t *testing.T) {
+	pool := planIELTSTestDatabase(t)
+	importer, err := ielts.NewImporter(pool)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+	input, err := os.Open("../../../../data/ielts/2026-05-08-mainland.json")
+	if err != nil {
+		t.Fatalf("open current IELTS question bank: %v", err)
+	}
+	defer input.Close()
+	document, err := ielts.DecodeImportDocument(input)
+	if err != nil {
+		t.Fatalf("DecodeImportDocument: %v", err)
+	}
+	if _, err := importer.Import(context.Background(), document, true); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	resolver, err := ielts.NewPostgresStore(pool)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+
+	topicGroupID := document.TopicGroups[0].ID
+	assertCompatible := func(
+		t *testing.T,
+		mode scene.PracticeMode,
+		request *IELTSQuestionSelection,
+	) {
+		t.Helper()
+		selection := planIELTSSelectionFixture()
+		selection.Scene.PracticeOptions[0].Mode = mode
+		frozen, assignment, err := freezeIELTSAssignment(
+			context.Background(),
+			resolver,
+			selection,
+			request,
+		)
+		if err != nil {
+			t.Fatalf("freezeIELTSAssignment: %v", err)
+		}
+		if !ValidPlanIELTSAssignment(frozen, assignment) {
+			t.Fatalf("PostgreSQL assignment is incompatible with Plan contract: %#v", assignment)
+		}
+	}
+
+	t.Run("full mock assignment", func(t *testing.T) {
+		assertCompatible(t, scene.PracticeModeFullMock, nil)
+	})
+	for _, topic := range document.Part1Topics {
+		t.Run("Part 1 topic/"+topic.ID, func(t *testing.T) {
+			assertCompatible(
+				t,
+				scene.PracticeModePart1,
+				&IELTSQuestionSelection{Part1SetID: topic.ID},
+			)
+		})
+	}
+	for _, test := range []struct {
+		name    string
+		mode    scene.PracticeMode
+		request IELTSQuestionSelection
+	}{
+		{
+			name:    "Part 2",
+			mode:    scene.PracticeModePart2,
+			request: IELTSQuestionSelection{TopicGroupID: topicGroupID},
+		},
+		{
+			name:    "Part 3",
+			mode:    scene.PracticeModePart3,
+			request: IELTSQuestionSelection{TopicGroupID: topicGroupID},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assertCompatible(t, test.mode, &test.request)
+		})
+	}
+}
+
+func planIELTSTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	databaseURL := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open IELTS Plan test database: %v", err)
+	}
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		admin.Close()
+		t.Fatalf("create IELTS Plan schema suffix: %v", err)
+	}
+	schema := "ielts_plan_" + hex.EncodeToString(suffix[:])
+	identifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+identifier); err != nil {
+		admin.Close()
+		t.Fatalf("create IELTS Plan schema: %v", err)
+	}
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE")
+		admin.Close()
+		t.Fatalf("parse IELTS Plan database URL: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = identifier
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE")
+		admin.Close()
+		t.Fatalf("open isolated IELTS Plan pool: %v", err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if _, err := admin.Exec(cleanupCtx, "DROP SCHEMA "+identifier+" CASCADE"); err != nil {
+			t.Errorf("drop IELTS Plan schema: %v", err)
+		}
+		admin.Close()
+	})
+	migration, err := migrations.Files.ReadFile("000080_ielts_versioned_question_bank.up.sql")
+	if err != nil {
+		t.Fatalf("read IELTS question bank migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply IELTS question bank migration: %v", err)
+	}
+	return pool
+}

--- a/server/internal/coaching/scene/ielts/postgres.go
+++ b/server/internal/coaching/scene/ielts/postgres.go
@@ -522,7 +522,7 @@ func resolvePart1Topic(
 		return ResolvedPart{}, fmt.Errorf("%w: read Part 1 topic: %v", ErrQuestionBankUnavailable, err)
 	}
 	defer rows.Close()
-	part := ResolvedPart{Part: PracticeModePart1, SourceID: topicID, TopicTitle: title}
+	part := ResolvedPart{Part: PracticeModePart1, SourceID: topicID}
 	for rows.Next() {
 		var prompt string
 		if err := rows.Scan(&prompt); err != nil {


### PR DESCRIPTION
## 目标

Fixes #479 — 修正 IELTS Part 1 专项练习计划冻结结构，让 Part 1 专项卡能正常创建 Plan、Session 并进入真实练习。

## 现象与原因

- PostgreSQL 题库解析（`server/internal/coaching/scene/ielts/postgres.go`）为 Part 1 专项分配附带 `topic_title`。
- 既有 Plan 领域契约（`ValidPlanIELTSAssignment`，`server/internal/coaching/preparation/service/plan.go`）规定 Part 1 part 只冻结 `part`、`source_id`、`turn_blueprints`，`topic_title` 必须为空。
- 契约校验失败 → `POST /v1/practice-plans` 返回 `409 practice_plan_revision_conflict`，Part 1 专项无法创建 Plan/Session；完整模考与 Thread/Goal/Profile/Snapshot 链路正常。

## 改动

1. `server/internal/coaching/scene/ielts/postgres.go`：移除 Part 1 解析结果中的 `topic_title`，保留 topic 存在性校验与按序读取真实问题。
2. 新增 `server/internal/coaching/preparation/service/plan_ielts_postgres_integration_test.go`：导入发布题库到隔离 PostgreSQL schema，断言 FULL_MOCK、全部已发布 Part 1 话题、PART_2、PART_3 的冻结分配均通过 `ValidPlanIELTSAssignment`。

## 验证

- `go build ./...`、`go vet ./...` 通过。
- 新集成测试通过（38 个 Part 1 话题 + Part 2/3/模考），需要 `TEST_DATABASE_URL`：
  ```shell
  cd server && go test -count=1 -run TestPostgresIELTSResolverProducesPlanCompatibleAssignments ./internal/coaching/preparation/service
  ```
- `server/internal/coaching/scene/ielts/...` 与 `server/internal/coaching/preparation/...` 全部测试通过。
- 真实前后端 iOS 模拟器联调：`make test-ios-simulator-scenes` 成功完成注册/登录/进入 IELTS Part 1 话题并创建练习会话（见下方截图）。测试最后一步「退出对话框」的文案断言与当前 UI 不一致，属既有测试维护问题，另作处理。

- iOS 模拟器联调截图已捕获（IELTS Part 1 练习会话页面），需要时可随 PR 附件提供。
