### PR TITLE
fix(interview): cancel preparation and restore avatar route

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -477,7 +477,8 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       );
     }
     final experience = _practiceController.practiceExperience;
-    if (experience == PracticeExperience.workplace ||
+    if (experience == PracticeExperience.interview ||
+        experience == PracticeExperience.workplace ||
         experience == PracticeExperience.lifeAndTravel) {
       final factory = widget.avatarControllerFactory;
       if (factory != null) {

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -435,9 +435,13 @@ class _PreparationPageState extends State<PreparationPage> {
     }
   }
 
-  void _handleBack(PreparationController? controller) {
+  Future<void> _handleBack(PreparationController? controller) async {
     final launch = widget.launchController;
-    if (launch?.isNavigationLocked ?? false) {
+    if (launch?.isStarting ?? false) {
+      if (!await launch!.cancelCurrentPreparation() || !mounted) {
+        return;
+      }
+    } else if (launch?.isNavigationLocked ?? false) {
       return;
     }
     if (controller?.selectedScene != null) {
@@ -456,7 +460,7 @@ class _PreparationPageState extends State<PreparationPage> {
       setState(() => _selectedHub = null);
       return;
     }
-    Navigator.of(context).maybePop();
+    await Navigator.of(context).maybePop();
   }
 
   @override
@@ -470,7 +474,7 @@ class _PreparationPageState extends State<PreparationPage> {
       canPop: !navigationLocked && !hasInternalRoute,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) {
-          _handleBack(controller);
+          unawaited(_handleBack(controller));
         }
       },
       child: Scaffold(
@@ -485,9 +489,11 @@ class _PreparationPageState extends State<PreparationPage> {
                 leading: IconButton(
                   key: const Key('preparation-route-back-button'),
                   tooltip: '返回',
-                  onPressed: navigationLocked
+                  onPressed:
+                      navigationLocked &&
+                          !(widget.launchController?.isStarting ?? false)
                       ? null
-                      : () => _handleBack(controller),
+                      : () => unawaited(_handleBack(controller)),
                   icon: const Icon(Icons.arrow_back_rounded),
                 ),
               )
@@ -516,7 +522,7 @@ class _PreparationPageState extends State<PreparationPage> {
           ),
           scene: selectedScene,
           hasPrimaryNavigation: !widget.showBackButton,
-          onBack: () => _handleBack(controller),
+          onBack: () => unawaited(_handleBack(controller)),
           onSubmit: _submitScenarioPreparation,
         );
       }
@@ -525,7 +531,7 @@ class _PreparationPageState extends State<PreparationPage> {
         scene: selectedScene,
         launchController: widget.launchController,
         hasPrimaryNavigation: !widget.showBackButton,
-        onBack: () => _handleBack(controller),
+        onBack: () => unawaited(_handleBack(controller)),
         onRetry: _retryLaunch,
       );
     }
@@ -841,7 +847,10 @@ class _SceneLaunchStatus extends StatelessWidget {
             child: IconButton(
               key: const Key('preparation-back-to-catalog'),
               tooltip: '取消并返回',
-              onPressed: navigationLocked ? null : onBack,
+              onPressed:
+                  navigationLocked && !(launchController?.isStarting ?? false)
+                  ? null
+                  : onBack,
               icon: const Icon(Icons.arrow_back_rounded),
               color: PreparationDesign.ink,
               style: IconButton.styleFrom(

--- a/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
@@ -101,6 +101,28 @@ final class PreparationLaunchController extends ChangeNotifier {
         await workspace.parkCurrentPractice();
   }
 
+  /// Cancels a preparation launch that has not produced a usable practice.
+  ///
+  /// The launch epoch is invalidated first so late profile/plan/session
+  /// responses cannot restore the preparation screen after the user leaves.
+  /// An in-flight launch parks its workspace from the launcher's finally block
+  /// once the current workspace operation has completed.
+  Future<bool> cancelCurrentPreparation() async {
+    if (_disposed) {
+      return false;
+    }
+    final workspace = workspaceController;
+    final wasStarting = isStarting;
+    _invalidateAttempt();
+    if (wasStarting) {
+      return true;
+    }
+    if (workspace?.currentLease == null) {
+      return true;
+    }
+    return workspace!.parkCurrentPractice();
+  }
+
   Future<bool> completeAndContinueWithAgent() async {
     final workspace = workspaceController;
     return workspace != null && await workspace.completeAndContinueWithAgent();
@@ -449,7 +471,6 @@ final class PreparationLaunchController extends ChangeNotifier {
     } finally {
       var safelyParked = workspace == null;
       if (!launchSucceeded &&
-          _isCurrent(operationEpoch) &&
           workspace != null &&
           workspace.currentLease?.operationId == attempt.workspaceOperationId) {
         final parked = await workspace.parkCurrentPractice();

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -379,6 +379,44 @@ void main() {
     expect(find.byKey(const Key('practice-page')), findsNothing);
   });
 
+  testWidgets('routes interview practice through avatar with Tips', (
+    tester,
+  ) async {
+    final practiceController = await _interviewPracticeController();
+    addTearDown(practiceController.dispose);
+    final renderer = FakeAvatarRenderer();
+    final tokenClient = FakeAvatarSessionTokenClient();
+    var factoryCalls = 0;
+
+    await tester.pumpWidget(
+      SpeakUpApp.preview(
+        practiceController: practiceController,
+        avatarControllerFactory: () {
+          factoryCalls++;
+          return AvatarController(
+            renderer: renderer,
+            tokenClient: tokenClient,
+            fallbackPlayback: (_) async {},
+            fallbackStop: () async {},
+            delay: (_) async {},
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Navigator.of(
+      tester.element(find.byType(SpeakUpShell)),
+    ).pushNamed(AppRoutes.practice);
+    await tester.pumpAndSettle();
+
+    expect(factoryCalls, 1);
+    expect(find.byKey(const Key('scenario-practice-page')), findsOneWidget);
+    expect(find.byKey(const Key('scenario-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('scenario-question-tip')), findsOneWidget);
+    expect(find.byKey(const Key('practice-page')), findsNothing);
+  });
+
   testWidgets('loads each assistant WAV once and sends it only to the avatar', (
     tester,
   ) async {
@@ -465,6 +503,47 @@ Future<PracticeController> _scenarioPracticeController() async {
       id: 'question-daily-travel-1',
       sessionId: sessionId,
       text: 'Where would you like to go?',
+    ),
+  );
+  final controller = PracticeController(
+    client: _SnapshotPracticeClient(snapshot),
+  );
+  await _activateCreatedPractice(controller, scene, snapshot);
+  return controller;
+}
+
+Future<PracticeController> _interviewPracticeController() async {
+  final scene = testScene(
+    id: 'interview-avatar',
+    experience: PracticeExperience.interview,
+    category: SceneCategory.interviewProfessional,
+    name: '英文自我介绍',
+    prompt: const ScenePrompt(
+      publicSceneBrief: 'Practice a concise interview introduction.',
+      practiceGoal: 'Introduce professional experience clearly.',
+      userRole: 'Candidate',
+      aiRole: 'Interviewer',
+      personaSummary: 'Professional and attentive.',
+      focusAreas: <String>['clarity'],
+      turnBlueprints: <String>['Ask for an introduction.'],
+    ),
+  );
+  const sessionId = 'session-interview-avatar';
+  final snapshot = PracticeSessionSnapshot(
+    sessionId: sessionId,
+    planId: 'plan-interview-avatar',
+    practiceExperience: scene.experience,
+    sceneCategory: scene.category,
+    practiceMode: PracticeMode.fullSimulation,
+    capabilities: testPracticeCapabilities,
+    sessionVersion: 1,
+    completedTurns: 0,
+    turnLimit: 3,
+    sessionCompleted: false,
+    currentQuestion: const PracticeQuestion(
+      id: 'question-interview-avatar-1',
+      sessionId: sessionId,
+      text: 'Could you introduce yourself?',
     ),
   );
   final controller = PracticeController(

--- a/mobile/test/coaching/preparation/preparation_launch_controller_test.dart
+++ b/mobile/test/coaching/preparation/preparation_launch_controller_test.dart
@@ -428,6 +428,50 @@ void main() {
     },
   );
 
+  test('cancel fences an in-flight preparation completion', () async {
+    final profile = Completer<PreparationProfile>();
+    final client = _LaunchClient(profileCompleter: profile);
+    var activated = false;
+    final controller = PreparationLaunchController(
+      client: client,
+      contextProvider: () => _context,
+      threadIdProvider: () => _threadId,
+      goalActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => _context,
+      voiceActivator:
+          ({
+            required context,
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {
+            activated = true;
+          },
+      idFactory: (scope) => '$scope-cancel-key',
+    );
+    addTearDown(controller.dispose);
+    controller.updateBackgroundSummary(_background);
+
+    final start = controller.start(_selection);
+    expect(controller.isStarting, isTrue);
+    await Future<void>.delayed(Duration.zero);
+    expect(client.calls, ['profile']);
+
+    expect(await controller.cancelCurrentPreparation(), isTrue);
+    expect(controller.isStarting, isFalse);
+    expect(controller.bootstrap, isNull);
+    expect(controller.errorMessage, isNull);
+
+    profile.complete(_profile);
+    expect(await start, isFalse);
+    expect(client.calls, ['profile']);
+    expect(activated, isFalse);
+  });
+
   test(
     'selection changes cannot orphan a Session while launch is pending',
     () async {

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -241,6 +241,84 @@ void main() {
       ),
     );
   });
+
+  testWidgets('back cancels a pending preparation and clears launch status', (
+    tester,
+  ) async {
+    final preparationController = PreparationController(
+      client: _FixtureClient(),
+    );
+    await preparationController.loadIfNeeded();
+    await preparationController.selectScene(_scene);
+    expect(preparationController.selectRecommendedConfiguration(), isTrue);
+    final profile = Completer<PreparationProfile>();
+    final launchClient = _PageLaunchClient(profileCompleter: profile);
+    var navigations = 0;
+    final launchController = PreparationLaunchController(
+      client: launchClient,
+      contextProvider: () => _pageContext,
+      threadIdProvider: () => _pageContext.threadId,
+      goalActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => _pageContext,
+      voiceActivator:
+          ({
+            required context,
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+      idFactory: (scope) => '$scope-cancel-widget-key',
+    );
+    launchController.updateBackgroundSummary(
+      'Backend engineer preparing a technical interview.',
+    );
+    addTearDown(preparationController.dispose);
+    addTearDown(launchController.dispose);
+
+    final start = launchController.start(
+      PreparationLaunchSelection.fromCatalog(
+        scene: preparationController.detail!,
+        role: preparationController.selectedRole!,
+        option: preparationController.selectedOption!,
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: preparationController,
+          launchController: launchController,
+          onPracticeStarted: () => navigations++,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('正在准备练习…'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('preparation-back-to-catalog')));
+    await tester.pump();
+
+    expect(find.text('正在准备练习…'), findsNothing);
+    expect(find.byKey(const Key('preparation-launch-progress')), findsNothing);
+    expect(preparationController.selectedScene, isNull);
+
+    profile.complete(
+      PreparationProfile(
+        id: 'profile-1',
+        userId: 'user-1',
+        backgroundSummary: 'Backend engineer preparing a technical interview.',
+        version: 1,
+        updatedAt: DateTime.utc(2026, 7, 26),
+      ),
+    );
+    expect(await start, isFalse);
+    await tester.pumpAndSettle();
+    expect(navigations, 0);
+    expect(find.text('正在准备练习…'), findsNothing);
+  });
 }
 
 class _FixtureClient implements SceneClient {
@@ -312,7 +390,8 @@ final class _ControlledListClient implements SceneClient {
 }
 
 final class _PageLaunchClient implements PreparationLaunchClient {
-  _PageLaunchClient();
+  _PageLaunchClient({this.profileCompleter});
+  final Completer<PreparationProfile>? profileCompleter;
   final calls = <String>[];
   PreparationLaunchSelection? selection;
   CreatePreparationProfileInput? lastProfileInput;
@@ -328,7 +407,7 @@ final class _PageLaunchClient implements PreparationLaunchClient {
   }) async {
     calls.add('profile');
     lastProfileInput = input;
-    return PreparationProfile(
+    final result = PreparationProfile(
       id: 'profile-1',
       userId: 'user-1',
       backgroundSummary: input.backgroundSummary,
@@ -336,6 +415,7 @@ final class _PageLaunchClient implements PreparationLaunchClient {
       version: 1,
       updatedAt: DateTime.utc(2026, 7, 26),
     );
+    return profileCompleter?.future ?? result;
   }
 
   @override


### PR DESCRIPTION
## 功能描述

修复 Issue #481 的英文模拟面试链路：

- 准备面试启动中允许返回，立即使本次启动失效，避免迟到响应重新显示“正在准备练习…”。
- 模拟面试在生产路由中接入已有数字人会话组件，恢复数字人、Tips、朗读和录音交互。
- 保留预览模式普通面试页面和其他练习体验的既有分流。

## 实现思路

- PreparationLaunchController 增加取消入口，使用启动 epoch fence 过滤迟到 Profile/Plan/Session 响应；未完成启动的 workspace 在异步收尾时按 operation ID 暂存。
- PreparationPage 的返回按钮和 PopScope 在启动中调用取消逻辑并回到方案列表。
- 生产路由将 PracticeExperience.interview 与 workplace、lifeAndTravel 一样交给 ScenarioPracticeSession，由现有 AvatarControllerFactory 提供数字人。
- 增加控制器、准备页和面试数字人路由回归测试。

## 可复现测试

- make check-flutter
- flutter test --no-pub test/coaching/preparation/preparation_launch_controller_test.dart
- flutter test --no-pub test/coaching/preparation/preparation_page_test.dart
- flutter test --no-pub test/coaching/practice/scenario_practice_session_test.dart
- flutter test --no-pub test/speak_up_app_test.dart

## 关联

Closes #481
Related to #423
