### PR TITLE
[MS3] 开放式场景支持无限练习与主动复盘

### DIFF
--- a/api/examples/mock-main-flow.json
+++ b/api/examples/mock-main-flow.json
@@ -17,6 +17,7 @@
     "created_at": "2026-07-23T10:03:00Z"
   },
   "session_policy": {
+    "completion_mode": "TURN_LIMITED",
     "suggested_duration_seconds": 900,
     "min_effective_turns": 4,
     "max_effective_turns": 6,

--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -1297,8 +1297,9 @@ components:
           readOnly: true
         max_effective_turns:
           type: integer
-          minimum: 1
+          minimum: 0
           maximum: 100
+          description: Zero for a learner-completed, open-ended Practice.
           readOnly: true
         executable_status:
           type: string

--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -877,6 +877,7 @@ components:
         - session_version
         - effective_turns
         - turn_limit
+        - completion_mode
         - session_completed
         - practice_capabilities
       properties:
@@ -910,8 +911,14 @@ components:
           minimum: 0
         turn_limit:
           type: integer
-          minimum: 1
+          minimum: 0
           maximum: 64
+          description: Zero when completion_mode is USER_CONTROLLED.
+        completion_mode:
+          type: string
+          enum:
+            - TURN_LIMITED
+            - USER_CONTROLLED
         session_completed:
           type: boolean
           description: |
@@ -928,13 +935,12 @@ components:
           $ref: '#/components/schemas/ConfirmedVoiceTurn'
         turn_history:
           type: array
-          maxItems: 256
           description: |
             Confirmed `EFFECTIVE` turns ordered by Question sequence. A
             `PRIMARY` Turn advances `effective_turns`; a `FOLLOW_UP` Turn keeps
-            the previous value. With the protocol safety limit of 64 primary
-            Questions and three follow-ups per Question, the projection is
-            bounded to 256 entries.
+            the previous value. USER_CONTROLLED Sessions may continue until
+            the learner explicitly completes them, so this projection has no
+            fixed round-count bound.
             `RETRY` turns are intentionally excluded so same-question practice
             cannot change the Session's current Question, latest effective
             checkpoint, or `effective_turns` history invariant. This projection
@@ -944,6 +950,22 @@ components:
           items:
             $ref: '#/components/schemas/VoiceTurnHistoryEntry'
       allOf:
+        - if:
+            properties:
+              completion_mode:
+                const: USER_CONTROLLED
+            required:
+              - completion_mode
+          then:
+            properties:
+              turn_limit:
+                type: integer
+                const: 0
+          else:
+            properties:
+              turn_limit:
+                type: integer
+                minimum: 1
         - if:
             properties:
               practice_experience:

--- a/api/modules/practice.yaml
+++ b/api/modules/practice.yaml
@@ -218,6 +218,40 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/complete:
+    post:
+      tags:
+        - Practice
+      summary: Complete a user-controlled practice session for Review
+      operationId: completePracticeSession
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionLifecycleCommand'
+            example:
+              expected_session_version: 8
+      responses:
+        '200':
+          description: The completed Session; repeating the same intent returns this state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PracticeSession'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/practice-sessions/{practice_session_id}/snapshot:
     get:
       tags:

--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -608,9 +608,12 @@ components:
       type: object
       additionalProperties: false
       description: |
-        The effective-Turn budget frozen into a PracticePlan revision. Invalid
-        input and technical failures do not advance the budget.
+        The completion behavior frozen into a PracticePlan revision. A
+        TURN_LIMITED policy completes at max_effective_turns. A
+        USER_CONTROLLED policy uses max_effective_turns 0 and completes only
+        after the learner explicitly requests completion.
       required:
+        - completion_mode
         - suggested_duration_seconds
         - min_effective_turns
         - max_effective_turns
@@ -623,6 +626,11 @@ components:
         - avatar_allowed
         - speech_feedback_allowed
       properties:
+        completion_mode:
+          type: string
+          enum:
+            - TURN_LIMITED
+            - USER_CONTROLLED
         suggested_duration_seconds:
           type: integer
           minimum: 1
@@ -631,7 +639,7 @@ components:
           minimum: 1
         max_effective_turns:
           type: integer
-          minimum: 1
+          minimum: 0
           maximum: 64
         coverage_checkpoint_turn:
           type: integer
@@ -655,6 +663,26 @@ components:
           type: boolean
         speech_feedback_allowed:
           type: boolean
+      allOf:
+        - if:
+            properties:
+              completion_mode:
+                const: USER_CONTROLLED
+            required:
+              - completion_mode
+          then:
+            properties:
+              max_effective_turns:
+                type: integer
+                const: 0
+              coverage_checkpoint_turn:
+                type: integer
+                const: 1
+          else:
+            properties:
+              max_effective_turns:
+                type: integer
+                minimum: 1
     IELTSPracticeSelection:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -219,6 +219,8 @@ paths:
     $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1pause
   /v1/practice-sessions/{practice_session_id}/resume:
     $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1resume
+  /v1/practice-sessions/{practice_session_id}/complete:
+    $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1complete
   /v1/practice-sessions/{practice_session_id}/end-early:
     $ref: ./modules/practice.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1end-early
   /v1/practice-sessions/{practice_session_id}/bootstrap:

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -1638,12 +1638,12 @@ assert.ok(
 );
 assert.ok(
   voiceSessionState?.properties?.turn_history,
-  'VoiceSessionState must expose the bounded cold-start Turn history.',
+  'VoiceSessionState must expose the cold-start Turn history.',
 );
 assert.equal(
   voiceSessionState.properties.turn_history.maxItems,
-  256,
-  'Turn history must allow 64 primary Questions with three follow-ups each.',
+  undefined,
+  'User-controlled Turn history must not impose a fixed round-count bound.',
 );
 assert.equal(
   voiceSessionState.properties.turn_limit.maximum,

--- a/mobile/lib/features/agent/handoff/agent_handoff_codec.dart
+++ b/mobile/lib/features/agent/handoff/agent_handoff_codec.dart
@@ -89,13 +89,13 @@ ConfirmPracticePlanHandoff _decodeConfirmPracticePlanHandoff(Object? value) {
       .map((role) => _string(role, 1, 200))
       .toList(growable: false);
   final minTurns = _integer(object['min_effective_turns'], 1, 100);
-  final maxTurns = _integer(object['max_effective_turns'], 1, 100);
+  final maxTurns = _integer(object['max_effective_turns'], 0, 100);
   if (_string(object['type'], 1, 64) != 'confirm_practice_plan' ||
       !_practiceExperiences.contains(practiceExperience) ||
       !_sceneCategories.contains(sceneCategory) ||
       !_practiceModes.contains(practiceMode) ||
       roles.toSet().length != roles.length ||
-      maxTurns < minTurns ||
+      (maxTurns != 0 && maxTurns < minTurns) ||
       object['executable_status'] != 'ready') {
     _rejectHandoffPayload();
   }

--- a/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
+++ b/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
@@ -35,8 +35,10 @@ final class PracticePlanHandoffCard extends StatelessWidget {
           Text('角色：${handoff.roles.join('、')}', style: SpeakUpDesign.body),
           Text('范围：${handoff.practiceScope}', style: SpeakUpDesign.body),
           Text(
-            '预计 $minutes 分钟 · '
-            '${handoff.minEffectiveTurns}–${handoff.maxEffectiveTurns} 轮',
+            handoff.maxEffectiveTurns == 0
+                ? '预计 $minutes 分钟'
+                : '预计 $minutes 分钟 · '
+                      '${handoff.minEffectiveTurns}–${handoff.maxEffectiveTurns} 轮',
             style: SpeakUpDesign.meta,
           ),
           const SizedBox(height: 8),

--- a/mobile/lib/features/coaching/practice/practice_client.dart
+++ b/mobile/lib/features/coaching/practice/practice_client.dart
@@ -44,6 +44,14 @@ abstract interface class PracticeLifecycleClient {
   });
 }
 
+abstract interface class PracticeCompletionClient {
+  Future<PracticeSessionLifecycle> complete({
+    required String sessionId,
+    required int expectedSessionVersion,
+    required String idempotencyKey,
+  });
+}
+
 abstract interface class PracticeQuestionTranslationClient {
   Future<PracticeQuestionTranslation> translateQuestion({
     required String questionId,
@@ -89,7 +97,10 @@ abstract interface class PracticeSpeechFeedbackRetryClient {
 }
 
 final class FakePracticeClient
-    implements PracticeClient, PracticeLifecycleClient {
+    implements
+        PracticeClient,
+        PracticeLifecycleClient,
+        PracticeCompletionClient {
   FakePracticeClient({
     this.delay = Duration.zero,
     this.practiceExperience = PracticeExperience.interview,
@@ -103,11 +114,14 @@ final class FakePracticeClient
       speechFeedbackAllowed: false,
     ),
     this.turnLimit = 3,
+    this.completionMode = PracticeCompletionMode.turnLimited,
     this.ieltsAssignment,
     PracticeSessionSnapshot? initialSnapshot,
   }) : _snapshot = initialSnapshot {
-    if (turnLimit < 1 ||
-        turnLimit > practiceTurnSafetyLimit ||
+    if ((completionMode == PracticeCompletionMode.turnLimited &&
+            (turnLimit < 1 || turnLimit > practiceTurnSafetyLimit)) ||
+        (completionMode == PracticeCompletionMode.userControlled &&
+            turnLimit != 0) ||
         (practiceExperience == PracticeExperience.ieltsSpeaking) !=
             (ieltsAssignment != null) ||
         (ieltsAssignment != null &&
@@ -123,6 +137,7 @@ final class FakePracticeClient
   final PracticeMode practiceMode;
   final PracticeCapabilities capabilities;
   final int turnLimit;
+  final PracticeCompletionMode completionMode;
   final IeltsPracticeAssignment? ieltsAssignment;
   int _generation = 0;
   int _messageSequence = 0;
@@ -174,6 +189,7 @@ final class FakePracticeClient
       sessionVersion: 1,
       completedTurns: 0,
       turnLimit: turnLimit,
+      completionMode: completionMode,
       sessionCompleted: false,
       ieltsAssignment: ieltsAssignment,
       currentQuestion: PracticeQuestion(
@@ -237,7 +253,9 @@ final class FakePracticeClient
     }
     final completedTurns = snapshot.completedTurns + 1;
     final nextSessionVersion = snapshot.sessionVersion + 1;
-    final completed = completedTurns == snapshot.turnLimit;
+    final completed =
+        snapshot.completionMode == PracticeCompletionMode.turnLimited &&
+        completedTurns == snapshot.turnLimit;
     final nextQuestion = completed
         ? null
         : PracticeQuestion(
@@ -260,6 +278,7 @@ final class FakePracticeClient
       ),
       completedTurns: completedTurns,
       turnLimit: snapshot.turnLimit,
+      completionMode: snapshot.completionMode,
       sessionCompleted: completed,
       practiceExperience: snapshot.practiceExperience,
       sceneCategory: snapshot.sceneCategory,
@@ -279,6 +298,7 @@ final class FakePracticeClient
       sessionVersion: nextSessionVersion,
       completedTurns: completedTurns,
       turnLimit: snapshot.turnLimit,
+      completionMode: snapshot.completionMode,
       sessionCompleted: completed,
       currentQuestion: nextQuestion,
     );
@@ -304,6 +324,45 @@ final class FakePracticeClient
     return PracticeSessionLifecycle(
       sessionId: sessionId,
       status: PracticeSessionLifecycleStatus.endedEarly,
+      version: expectedSessionVersion + 1,
+    );
+  }
+
+  @override
+  Future<PracticeSessionLifecycle> complete({
+    required String sessionId,
+    required int expectedSessionVersion,
+    required String idempotencyKey,
+  }) async {
+    final generation = _generation;
+    await _wait(generation);
+    final snapshot = _snapshot;
+    if (snapshot == null ||
+        snapshot.sessionId != sessionId ||
+        snapshot.sessionVersion != expectedSessionVersion ||
+        snapshot.completionMode != PracticeCompletionMode.userControlled ||
+        snapshot.completedTurns < 1 ||
+        idempotencyKey.trim().isEmpty) {
+      throw StateError('Fake practice cannot be completed.');
+    }
+    _snapshot = PracticeSessionSnapshot(
+      sessionId: snapshot.sessionId,
+      planId: snapshot.planId,
+      practiceExperience: snapshot.practiceExperience,
+      sceneCategory: snapshot.sceneCategory,
+      practiceMode: snapshot.practiceMode,
+      capabilities: snapshot.capabilities,
+      sessionVersion: expectedSessionVersion + 1,
+      completedTurns: snapshot.completedTurns,
+      turnLimit: snapshot.turnLimit,
+      completionMode: snapshot.completionMode,
+      sessionCompleted: true,
+      currentTurn: snapshot.currentTurn,
+      turnHistory: snapshot.turnHistory,
+    );
+    return PracticeSessionLifecycle(
+      sessionId: sessionId,
+      status: PracticeSessionLifecycleStatus.completed,
       version: expectedSessionVersion + 1,
     );
   }

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -66,6 +66,7 @@ final class PracticeController extends ChangeNotifier
   PracticeCapabilities? _practiceCapabilities;
   int? _practiceSessionVersion;
   String? _endPracticeClientId;
+  String? _completePracticeClientId;
   PracticeQuestion? _currentQuestion;
   PracticeQuestionTip? _questionTip;
   String? _questionTipRequestId;
@@ -85,6 +86,7 @@ final class PracticeController extends ChangeNotifier
   String? _errorMessage;
   int _completedTurns = 0;
   int _turnLimit = 0;
+  PracticeCompletionMode _completionMode = PracticeCompletionMode.turnLimited;
   bool _sessionCompleted = false;
   int _epoch = 0;
   int _practiceGeneration = 0;
@@ -214,10 +216,19 @@ final class PracticeController extends ChangeNotifier
   String? get errorMessage => _errorMessage;
   int get completedTurns => _completedTurns;
   int get turnLimit => _turnLimit;
+  PracticeCompletionMode get completionMode => _completionMode;
+  bool get canCompleteActivePractice =>
+      _completionMode == PracticeCompletionMode.userControlled &&
+      _completedTurns > 0 &&
+      hasActivePractice &&
+      !isBusy &&
+      !_disposed &&
+      _recordingState == PracticeRecordingState.idle;
   bool get isFinalSubmission =>
       _recordingState == PracticeRecordingState.submitting &&
       _speechFeedbackRetry == null &&
       !_sessionCompleted &&
+      _completionMode == PracticeCompletionMode.turnLimited &&
       _turnLimit > 0 &&
       _completedTurns + 1 == _turnLimit;
   bool get isBusy =>
@@ -300,7 +311,7 @@ final class PracticeController extends ChangeNotifier
         planId.trim().isEmpty ||
         scene.id.trim().isEmpty ||
         scene.name.trim().isEmpty ||
-        turnLimit < 1 ||
+        turnLimit < 0 ||
         turnLimit > practiceTurnSafetyLimit ||
         clientOperationId.trim().isEmpty ||
         isBusy ||
@@ -594,6 +605,65 @@ final class PracticeController extends ChangeNotifier
                 error.kind == PracticeClientFailureKind.authenticationRequired
             ? '登录状态已失效，请重新登录后继续。'
             : '暂时无法结束当前练习，进度仍已保留，可以重试。';
+      }
+      return false;
+    } finally {
+      if (_isCurrent(fence.epoch)) {
+        _setBusy(false);
+      }
+    }
+  }
+
+  Future<bool> completeActivePractice() async {
+    final practice = client;
+    final lifecycle = practice is PracticeCompletionClient
+        ? practice as PracticeCompletionClient
+        : null;
+    final sessionId = _practiceSessionId;
+    final sessionVersion = _practiceSessionVersion;
+    if (lifecycle == null ||
+        sessionId == null ||
+        sessionVersion == null ||
+        !canCompleteActivePractice) {
+      return false;
+    }
+    final fence = _captureOperationFence(practiceSessionId: sessionId);
+    final operationId = _completePracticeClientId ??= _newClientId(
+      'practice-complete',
+    );
+    _setBusy(true);
+    _errorMessage = null;
+    try {
+      await stopPracticeAudio();
+      if (!_isOperationCurrent(fence)) {
+        return false;
+      }
+      final result = await lifecycle.complete(
+        sessionId: sessionId,
+        expectedSessionVersion: sessionVersion,
+        idempotencyKey: operationId,
+      );
+      if (!_isOperationCurrent(fence) ||
+          result.sessionId != sessionId ||
+          result.status != PracticeSessionLifecycleStatus.completed ||
+          result.version <= sessionVersion) {
+        throw StateError(
+          'Practice completion response did not match the session.',
+        );
+      }
+      _practiceSessionVersion = result.version;
+      _sessionCompleted = true;
+      _currentQuestion = null;
+      _recordingState = PracticeRecordingState.completed;
+      _completePracticeClientId = null;
+      return true;
+    } catch (error) {
+      if (_isOperationCurrent(fence)) {
+        _errorMessage =
+            error is PracticeClientException &&
+                error.kind == PracticeClientFailureKind.authenticationRequired
+            ? '登录状态已失效，请重新登录后继续。'
+            : '暂时无法完成当前练习，进度仍已保留，可以重试。';
       }
       return false;
     } finally {
@@ -1529,9 +1599,11 @@ final class PracticeController extends ChangeNotifier
     _practiceCapabilities = confirmation.capabilities;
     _completedTurns = confirmation.completedTurns;
     _turnLimit = confirmation.turnLimit;
+    _completionMode = confirmation.completionMode;
     _sessionCompleted = confirmation.sessionCompleted;
     _practiceSessionVersion = confirmation.sessionVersion;
     _endPracticeClientId = null;
+    _completePracticeClientId = null;
     _currentQuestion = confirmation.nextQuestion;
     _clearQuestionTip();
     final audioAssetId = confirmation.audioAssetId;
@@ -1691,6 +1763,7 @@ final class PracticeController extends ChangeNotifier
     _practiceCapabilities = null;
     _practiceSessionVersion = null;
     _endPracticeClientId = null;
+    _completePracticeClientId = null;
     _currentQuestion = null;
     _clearQuestionTip();
     _candidate = null;
@@ -1704,6 +1777,7 @@ final class PracticeController extends ChangeNotifier
     _errorMessage = null;
     _completedTurns = 0;
     _turnLimit = 0;
+    _completionMode = PracticeCompletionMode.turnLimited;
     _sessionCompleted = false;
     _recordings = const <PracticeRecordingReference>[];
     _playingMediaKey = null;
@@ -1822,11 +1896,13 @@ final class PracticeController extends ChangeNotifier
       _practiceCapabilities = null;
       _practiceSessionVersion = null;
       _endPracticeClientId = null;
+      _completePracticeClientId = null;
       _currentQuestion = null;
       _clearQuestionTip();
       _activeScene = null;
       _completedTurns = 0;
       _turnLimit = 0;
+      _completionMode = PracticeCompletionMode.turnLimited;
       _sessionCompleted = false;
       _recordings = const <PracticeRecordingReference>[];
       _practiceMessages = const <PracticeMessage>[];
@@ -1851,6 +1927,7 @@ final class PracticeController extends ChangeNotifier
     _clearQuestionTip();
     _completedTurns = snapshot.completedTurns;
     _turnLimit = snapshot.turnLimit;
+    _completionMode = snapshot.completionMode;
     _sessionCompleted = snapshot.sessionCompleted;
     final currentTurn = snapshot.currentTurn;
     final audioAssetId = currentTurn?.audioAssetId;
@@ -2089,9 +2166,12 @@ final class PracticeController extends ChangeNotifier
     if (snapshot.sessionId.trim().isEmpty ||
         snapshot.planId.trim().isEmpty ||
         snapshot.completedTurns < 0 ||
-        snapshot.turnLimit < 1 ||
-        snapshot.turnLimit > practiceTurnSafetyLimit ||
-        snapshot.completedTurns > snapshot.turnLimit ||
+        (snapshot.completionMode == PracticeCompletionMode.turnLimited &&
+            (snapshot.turnLimit < 1 ||
+                snapshot.turnLimit > practiceTurnSafetyLimit ||
+                snapshot.completedTurns > snapshot.turnLimit)) ||
+        (snapshot.completionMode == PracticeCompletionMode.userControlled &&
+            snapshot.turnLimit != 0) ||
         snapshot.sessionVersion < 1 ||
         (snapshot.practiceExperience == PracticeExperience.ieltsSpeaking) !=
             (snapshot.ieltsAssignment != null) ||
@@ -2250,9 +2330,13 @@ final class PracticeController extends ChangeNotifier
             confirmation.candidateId != expectedCandidateId) ||
         confirmation.answer.text != expectedAnswer ||
         confirmation.completedTurns < 1 ||
-        confirmation.turnLimit < 1 ||
-        confirmation.turnLimit > practiceTurnSafetyLimit ||
-        confirmation.completedTurns > confirmation.turnLimit ||
+        confirmation.completionMode != _completionMode ||
+        (confirmation.completionMode == PracticeCompletionMode.turnLimited &&
+            (confirmation.turnLimit < 1 ||
+                confirmation.turnLimit > practiceTurnSafetyLimit ||
+                confirmation.completedTurns > confirmation.turnLimit)) ||
+        (confirmation.completionMode == PracticeCompletionMode.userControlled &&
+            confirmation.turnLimit != 0) ||
         confirmation.sessionVersion < 1 ||
         (!confirmation.sessionCompleted && confirmation.nextQuestion == null) ||
         (confirmation.nextQuestion != null &&

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -30,6 +30,17 @@ enum PracticeRecordingState {
   completed,
 }
 
+enum PracticeCompletionMode {
+  turnLimited,
+  userControlled;
+
+  static PracticeCompletionMode? fromWireValue(String value) => switch (value) {
+    'TURN_LIMITED' => PracticeCompletionMode.turnLimited,
+    'USER_CONTROLLED' => PracticeCompletionMode.userControlled,
+    _ => null,
+  };
+}
+
 final class PracticeCapabilities {
   const PracticeCapabilities({
     required this.retryAllowed,
@@ -133,6 +144,7 @@ final class PracticeSessionSnapshot {
     required this.sessionVersion,
     required this.completedTurns,
     required this.turnLimit,
+    this.completionMode = PracticeCompletionMode.turnLimited,
     required this.sessionCompleted,
     this.ieltsAssignment,
     this.currentQuestion,
@@ -149,6 +161,7 @@ final class PracticeSessionSnapshot {
   final int sessionVersion;
   final int completedTurns;
   final int turnLimit;
+  final PracticeCompletionMode completionMode;
   final bool sessionCompleted;
   final IeltsPracticeAssignment? ieltsAssignment;
   final PracticeQuestion? currentQuestion;
@@ -240,6 +253,7 @@ final class PracticeTurnConfirmation {
     required this.answer,
     required this.completedTurns,
     required this.turnLimit,
+    this.completionMode = PracticeCompletionMode.turnLimited,
     required this.sessionCompleted,
     required this.practiceExperience,
     required this.sceneCategory,
@@ -258,6 +272,7 @@ final class PracticeTurnConfirmation {
   final PracticeMessage answer;
   final int completedTurns;
   final int turnLimit;
+  final PracticeCompletionMode completionMode;
   final bool sessionCompleted;
   final PracticeExperience practiceExperience;
   final SceneCategory sceneCategory;

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -35,6 +35,7 @@ final class PracticeWireEndpoints {
         '{question_id}/tips',
     this.confirm = '/v1/transcription-candidates/{candidate_id}/confirmations',
     this.endEarly = '/v1/practice-sessions/{practice_session_id}/end-early',
+    this.complete = '/v1/practice-sessions/{practice_session_id}/complete',
     this.retryRequest = '/v1/feedback-items/{feedback_item_id}/retry-requests',
     this.retryRequestStatus = '/v1/retry-requests/{retry_request_id}',
     this.retryConfirmation =
@@ -50,6 +51,7 @@ final class PracticeWireEndpoints {
   final String questionTip;
   final String confirm;
   final String endEarly;
+  final String complete;
   final String retryRequest;
   final String retryRequestStatus;
   final String retryConfirmation;
@@ -83,6 +85,9 @@ final class PracticeWireEndpoints {
 
   String endEarlyPath(String sessionId) =>
       endEarly.replaceAll('{practice_session_id}', _pathSegment(sessionId));
+
+  String completePath(String sessionId) =>
+      complete.replaceAll('{practice_session_id}', _pathSegment(sessionId));
 
   String retryRequestPath(String feedbackItemId) => retryRequest.replaceAll(
     '{feedback_item_id}',
@@ -145,6 +150,7 @@ final class WirePracticeClient
     implements
         PracticeClient,
         PracticeLifecycleClient,
+        PracticeCompletionClient,
         PracticeSpeechFeedbackRetryClient,
         PracticeQuestionTipClient,
         PracticeQuestionTranslationClient {
@@ -538,6 +544,42 @@ final class WirePracticeClient
     });
   }
 
+  @override
+  Future<PracticeSessionLifecycle> complete({
+    required String sessionId,
+    required int expectedSessionVersion,
+    required String idempotencyKey,
+  }) {
+    return _run((generation) async {
+      _requireOpaqueId(sessionId);
+      _requireClientId(idempotencyKey);
+      if (expectedSessionVersion < 1) {
+        throw const PracticeClientException(
+          kind: PracticeClientFailureKind.invalidRequest,
+        );
+      }
+      final response = await _sendJson(
+        generation: generation,
+        method: 'POST',
+        path: _endpoints.completePath(sessionId),
+        body: <String, Object?>{
+          'expected_session_version': expectedSessionVersion,
+        },
+        extraHeaders: <String, String>{'Idempotency-Key': idempotencyKey},
+      );
+      _requireStatus(response, const {HttpStatus.ok});
+      final lifecycle = _decodeSessionLifecycle(
+        response.body,
+        expectedSessionId: sessionId,
+      );
+      if (lifecycle.status != PracticeSessionLifecycleStatus.completed ||
+          lifecycle.version <= expectedSessionVersion) {
+        throw _invalidResponse();
+      }
+      return lifecycle;
+    });
+  }
+
   Future<PracticeWireResponse> _sendJson({
     required int generation,
     required String method,
@@ -799,6 +841,7 @@ PracticeSessionSnapshot _decodeSessionState(
       'current_question',
       'current_turn',
       'turn_history',
+      'completion_mode',
     },
   );
   final sessionId = _string(root, 'practice_session_id');
@@ -831,6 +874,11 @@ PracticeSessionSnapshot _decodeSessionState(
   final sessionVersion = _integer(root, 'session_version');
   final effectiveTurns = _integer(root, 'effective_turns');
   final turnLimit = _integer(root, 'turn_limit');
+  final completionMode = root.containsKey('completion_mode')
+      ? PracticeCompletionMode.fromWireValue(
+          _string(root, 'completion_mode', maxLength: 32),
+        )
+      : PracticeCompletionMode.turnLimited;
   final completed = _boolean(root, 'session_completed');
   final terminal =
       sessionStatus == PracticeSessionLifecycleStatus.completed ||
@@ -866,9 +914,13 @@ PracticeSessionSnapshot _decodeSessionState(
       sessionVersion < 1 ||
       completed != terminal ||
       effectiveTurns < 0 ||
-      turnLimit < 1 ||
-      turnLimit > practiceTurnSafetyLimit ||
-      effectiveTurns > turnLimit ||
+      completionMode == null ||
+      (completionMode == PracticeCompletionMode.turnLimited &&
+          (turnLimit < 1 ||
+              turnLimit > practiceTurnSafetyLimit ||
+              effectiveTurns > turnLimit)) ||
+      (completionMode == PracticeCompletionMode.userControlled &&
+          turnLimit != 0) ||
       (practiceExperience == PracticeExperience.ieltsSpeaking) !=
           (ieltsAssignment != null) ||
       (ieltsAssignment != null &&
@@ -906,6 +958,7 @@ PracticeSessionSnapshot _decodeSessionState(
     sessionVersion: sessionVersion,
     completedTurns: effectiveTurns,
     turnLimit: turnLimit,
+    completionMode: completionMode,
     sessionCompleted: completed,
     ieltsAssignment: ieltsAssignment,
     currentQuestion: question,
@@ -923,9 +976,7 @@ IeltsPracticeAssignment _decodeIeltsAssignment(Object? value) {
 }
 
 List<PracticeTurnExchange> _decodeTurnHistory(Object? value) {
-  if (value is! List<Object?> ||
-      value.isEmpty ||
-      value.length > practiceTurnSafetyLimit) {
+  if (value is! List<Object?> || value.isEmpty) {
     throw _invalidResponse();
   }
   final exchanges = <PracticeTurnExchange>[];
@@ -1386,6 +1437,7 @@ PracticeTurnConfirmation _confirmationFromState(
     ),
     completedTurns: state.completedTurns,
     turnLimit: state.turnLimit,
+    completionMode: state.completionMode,
     sessionCompleted: state.sessionCompleted,
     practiceExperience: state.practiceExperience,
     sceneCategory: state.sceneCategory,

--- a/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
@@ -1212,9 +1212,7 @@ final class _StoredPracticeWorkspace {
           (goalId != null && goalId is! String) ||
           (sessionId != null && sessionId is! String) ||
           (completedTurns != null &&
-              (completedTurns is! int ||
-                  completedTurns < 0 ||
-                  completedTurns > practiceTurnSafetyLimit)) ||
+              (completedTurns is! int || completedTurns < 0)) ||
           !_validOpaqueId(accountId) ||
           !_validOperationId(operationId) ||
           !_validOpaqueId(practiceThreadId) ||

--- a/mobile/lib/features/coaching/preparation/preparation_models.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_models.dart
@@ -175,6 +175,7 @@ final class PracticeObjective {
 
 final class PreparationSessionPolicy {
   const PreparationSessionPolicy({
+    this.completionMode = PreparationCompletionMode.turnLimited,
     required this.suggestedDurationSeconds,
     required this.minEffectiveTurns,
     required this.maxEffectiveTurns,
@@ -188,6 +189,7 @@ final class PreparationSessionPolicy {
     required this.speechFeedbackAllowed,
   });
 
+  final PreparationCompletionMode completionMode;
   final int suggestedDurationSeconds;
   final int minEffectiveTurns;
   final int maxEffectiveTurns;
@@ -199,6 +201,18 @@ final class PreparationSessionPolicy {
   final bool questionTipsAllowed;
   final bool avatarAllowed;
   final bool speechFeedbackAllowed;
+}
+
+enum PreparationCompletionMode {
+  turnLimited,
+  userControlled;
+
+  static PreparationCompletionMode? fromWireValue(String value) =>
+      switch (value) {
+        'TURN_LIMITED' => PreparationCompletionMode.turnLimited,
+        'USER_CONTROLLED' => PreparationCompletionMode.userControlled,
+        _ => null,
+      };
 }
 
 enum PracticePlanStatus { ready, archived }

--- a/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_wire_codec.dart
@@ -392,9 +392,16 @@ PreparationSessionPolicy decodePreparationSessionPolicy(Object? value) {
       'avatar_allowed',
       'speech_feedback_allowed',
     },
+    optional: const <String>{'completion_mode'},
   );
+  final completionMode = object['completion_mode'] == null
+      ? PreparationCompletionMode.turnLimited
+      : PreparationCompletionMode.fromWireValue(
+          _text(object['completion_mode'], maximumBytes: 32),
+        );
   final minimum = _version(object['min_effective_turns']);
-  final maximum = _version(object['max_effective_turns']);
+  final maximumValue = object['max_effective_turns'];
+  final maximum = maximumValue is int ? maximumValue : -1;
   final checkpoint = _version(object['coverage_checkpoint_turn']);
   final followUps = object['max_follow_ups_per_question'];
   final rule = _text(object['early_completion_rule'], maximumBytes: 128);
@@ -403,8 +410,12 @@ PreparationSessionPolicy decodePreparationSessionPolicy(Object? value) {
   final questionTipsAllowed = object['question_tips_allowed'];
   final avatarAllowed = object['avatar_allowed'];
   final speechFeedbackAllowed = object['speech_feedback_allowed'];
-  if (minimum > checkpoint ||
-      checkpoint > maximum ||
+  if (completionMode == null ||
+      maximum < 0 ||
+      (completionMode == PreparationCompletionMode.turnLimited &&
+          (maximum < 1 || minimum > checkpoint || checkpoint > maximum)) ||
+      (completionMode == PreparationCompletionMode.userControlled &&
+          (maximum != 0 || checkpoint != 1)) ||
       followUps is! int ||
       followUps < 0 ||
       followUps > 3 ||
@@ -417,6 +428,7 @@ PreparationSessionPolicy decodePreparationSessionPolicy(Object? value) {
     throw const PreparationWireFormatException();
   }
   return PreparationSessionPolicy(
+    completionMode: completionMode,
     suggestedDurationSeconds: _version(object['suggested_duration_seconds']),
     minEffectiveTurns: minimum,
     maxEffectiveTurns: maximum,

--- a/mobile/lib/features/coaching/preparation/wire_preparation_launch_client.dart
+++ b/mobile/lib/features/coaching/preparation/wire_preparation_launch_client.dart
@@ -765,6 +765,7 @@ bool _sameSessionPolicy(
   PreparationSessionPolicy left,
   PreparationSessionPolicy right,
 ) =>
+    left.completionMode == right.completionMode &&
     left.suggestedDurationSeconds == right.suggestedDurationSeconds &&
     left.minEffectiveTurns == right.minEffectiveTurns &&
     left.maxEffectiveTurns == right.maxEffectiveTurns &&

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -320,6 +320,45 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       ..showSnackBar(const SnackBar(content: Text('练习正在完成，请稍后重试。')));
   }
 
+  Future<void> _requestUserControlledCompletion() async {
+    final controller = widget.practiceController;
+    if (!mounted || !controller.canCompleteActivePractice) {
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('结束练习并复盘？'),
+        content: const Text('结束后将保存本次对话，并进入评分与复盘。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('继续练习'),
+          ),
+          FilledButton(
+            key: const Key('scenario-confirm-completion'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('结束并复盘'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+    final completed = await controller.completeActivePractice();
+    if (!mounted) {
+      return;
+    }
+    if (completed) {
+      await _completePractice();
+      return;
+    }
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(const SnackBar(content: Text('练习暂时无法结束，请稍后重试。')));
+  }
+
   Future<void> _submitText() async {
     await _runBoundedUserTurnAction(widget.onBeforeSubmitText);
     if (!mounted) {
@@ -470,6 +509,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                       onSpeakTip: _speakQuestionTip,
                       visibleTipQuestionId: _visibleTipQuestionId,
                       onPracticeCompleted: _completePractice,
+                      onCompleteRequested: _requestUserControlledCompletion,
                     );
                     if (landscape) {
                       return Row(
@@ -691,6 +731,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.onSpeakTip,
     required this.visibleTipQuestionId,
     required this.onPracticeCompleted,
+    required this.onCompleteRequested,
   });
 
   final PracticeController controller;
@@ -713,6 +754,7 @@ class _ConversationPanel extends StatelessWidget {
   final Future<void> Function() onSpeakTip;
   final String? visibleTipQuestionId;
   final VoidCallback onPracticeCompleted;
+  final VoidCallback onCompleteRequested;
 
   @override
   Widget build(BuildContext context) {
@@ -727,6 +769,7 @@ class _ConversationPanel extends StatelessWidget {
             onReplayQuestion: onReplayQuestion,
             replayLoading: replayLoading,
             replayPlaying: replayPlaying,
+            onCompleteRequested: onCompleteRequested,
           ),
           Expanded(
             child: messages.isEmpty
@@ -840,6 +883,7 @@ class _ConversationHeader extends StatelessWidget {
     required this.onReplayQuestion,
     required this.replayLoading,
     required this.replayPlaying,
+    required this.onCompleteRequested,
   });
 
   final PracticeController controller;
@@ -847,13 +891,14 @@ class _ConversationHeader extends StatelessWidget {
   final ScenarioAsyncAction? onReplayQuestion;
   final bool replayLoading;
   final bool replayPlaying;
+  final VoidCallback onCompleteRequested;
 
   @override
   Widget build(BuildContext context) {
     final current =
         (controller.completedTurns +
                 (controller.currentQuestion?.isFollowUp == true ? 0 : 1))
-            .clamp(1, controller.turnLimit);
+            .clamp(1, controller.turnLimit == 0 ? 1 : controller.turnLimit);
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
       decoration: const BoxDecoration(
@@ -862,16 +907,27 @@ class _ConversationHeader extends StatelessWidget {
       child: Row(
         children: [
           const Expanded(child: Text('对话', style: SpeakUpDesign.cardTitle)),
-          Flexible(
-            child: Text(
-              '第 $current 轮 · 共 ${controller.turnLimit} 轮',
-              key: const Key('scenario-turn-progress'),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.end,
-              style: SpeakUpDesign.meta,
+          if (controller.completionMode ==
+              PracticeCompletionMode.userControlled)
+            TextButton.icon(
+              key: const Key('scenario-complete-practice'),
+              onPressed: controller.canCompleteActivePractice
+                  ? onCompleteRequested
+                  : null,
+              icon: const Icon(Icons.stop_circle_outlined, size: 18),
+              label: const Text('结束练习并复盘'),
+            )
+          else
+            Flexible(
+              child: Text(
+                '第 $current 轮 · 共 ${controller.turnLimit} 轮',
+                key: const Key('scenario-turn-progress'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+                style: SpeakUpDesign.meta,
+              ),
             ),
-          ),
           if (controller.practiceCapabilities?.questionTipsAllowed ??
               false) ...[
             const SizedBox(width: 8),

--- a/mobile/test/agent/agent_handoff_codec_test.dart
+++ b/mobile/test/agent/agent_handoff_codec_test.dart
@@ -13,6 +13,16 @@ void main() {
     expect(handoff.roles, <String>['面试官']);
   });
 
+  test('decodes an open-ended PracticePlan handoff', () {
+    final payload = _validHandoff()..['max_effective_turns'] = 0;
+    final handoff =
+        decodeAgentHandoffs(<Object?>[payload]).single
+            as ConfirmPracticePlanHandoff;
+
+    expect(handoff.minEffectiveTurns, 3);
+    expect(handoff.maxEffectiveTurns, 0);
+  });
+
   test('rejects malformed or ambiguous handoff payloads', () {
     final unknownField = _validHandoff()..['unexpected'] = true;
     final invalidScene = _validHandoff()..['practice_experience'] = 'UNKNOWN';

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -271,6 +271,45 @@ void main() {
     expect(selected, same(handoff));
   });
 
+  testWidgets('does not show a round count for an open-ended handoff', (
+    tester,
+  ) async {
+    const handoff = ConfirmPracticePlanHandoff(
+      label: '确认并开始练习',
+      practicePlanId: '10000000-0000-4000-8000-000000000002',
+      planRevision: 1,
+      target: 'Travel English Practice',
+      sceneName: '酒店入住',
+      practiceExperience: 'LIFE_AND_TRAVEL',
+      sceneCategory: 'LIFE_TRAVEL',
+      practiceMode: 'FULL_SIMULATION',
+      roles: <String>['前台'],
+      practiceScope: '开放对话',
+      suggestedDuration: Duration(minutes: 10),
+      minEffectiveTurns: 1,
+      maxEffectiveTurns: 0,
+      executableStatus: 'ready',
+      confirmationPrompt: '请确认是否开始练习。',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AgentMessageBubble(
+            message: const AgentMessage(
+              id: 'assistant-open-practice',
+              role: AgentMessageRole.assistant,
+              text: '旅行场景已创建。',
+              handoffs: <AgentHandoff>[handoff],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('预计 10 分钟'), findsOneWidget);
+    expect(find.textContaining('轮'), findsNothing);
+  });
+
   testWidgets('loads, caches, and toggles an assistant translation', (
     tester,
   ) async {

--- a/mobile/test/coaching/practice/practice_controller_lifecycle_test.dart
+++ b/mobile/test/coaching/practice/practice_controller_lifecycle_test.dart
@@ -102,6 +102,48 @@ void main() {
     expect(client.restoreCalls, 0);
   });
 
+  test(
+    'user-controlled Practice continues past three Turns and completes on request',
+    () async {
+      final scene = testScene(
+        id: 'daily-open-practice',
+        experience: PracticeExperience.lifeAndTravel,
+        category: SceneCategory.lifeDaily,
+        name: 'Daily open practice',
+      );
+      final client = FakePracticeClient(
+        practiceExperience: scene.experience,
+        sceneCategory: scene.category,
+        completionMode: PracticeCompletionMode.userControlled,
+        turnLimit: 0,
+      );
+      final controller = PracticeController(client: client);
+      addTearDown(controller.dispose);
+
+      await controller.activateCreatedPractice(
+        scene: scene,
+        sessionId: 'session-user-controlled',
+        planId: testPracticePlanId('session-user-controlled'),
+        practiceMode: scene.practiceOptions.first.mode,
+        turnLimit: 0,
+        clientOperationId: 'activate-user-controlled',
+      );
+
+      expect(controller.canCompleteActivePractice, isFalse);
+      for (var turn = 1; turn <= 4; turn++) {
+        expect(await controller.submitPracticeText('Answer $turn'), isTrue);
+        expect(controller.completedTurns, turn);
+        expect(controller.recordingState, PracticeRecordingState.idle);
+        expect(controller.currentQuestion, isNotNull);
+      }
+
+      expect(controller.canCompleteActivePractice, isTrue);
+      expect(await controller.completeActivePractice(), isTrue);
+      expect(controller.recordingState, PracticeRecordingState.completed);
+      expect(controller.currentQuestion, isNull);
+    },
+  );
+
   test('restores and continues from the authoritative 2 of 3', () async {
     final scene = testScenes.first;
     final practice = _CountingPracticeClient(

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -97,6 +97,56 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('hides round progress and lets open scenarios finish manually', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final scene = testScene(
+      id: 'daily-open-practice',
+      experience: PracticeExperience.lifeAndTravel,
+      category: SceneCategory.lifeTravel,
+      name: 'Open travel practice',
+    );
+    final controller = PracticeController(
+      client: FakePracticeClient(
+        practiceExperience: scene.experience,
+        sceneCategory: scene.category,
+        completionMode: PracticeCompletionMode.userControlled,
+        turnLimit: 0,
+      ),
+    );
+    addTearDown(controller.dispose);
+    await controller.activateCreatedPractice(
+      scene: scene,
+      sessionId: 'session-open-scenario',
+      planId: testPracticePlanId('session-open-scenario'),
+      practiceMode: scene.practiceOptions.first.mode,
+      turnLimit: 0,
+      clientOperationId: 'activate-open-scenario',
+    );
+    await controller.submitPracticeText('I would like to check in.');
+
+    await tester.pumpWidget(
+      MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('scenario-turn-progress')), findsNothing);
+    expect(find.byKey(const Key('scenario-complete-practice')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('scenario-complete-practice')));
+    await tester.pumpAndSettle();
+    expect(find.text('结束练习并复盘？'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('scenario-confirm-completion')));
+    await tester.pumpAndSettle();
+
+    expect(controller.recordingState, PracticeRecordingState.completed);
+    expect(controller.currentQuestion, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('hides the duplicate avatar subtitle for interviews', (
     tester,
   ) async {

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -201,6 +201,10 @@ void main() {
       endpoints.endEarlyPath(opaque),
       '/v1/practice-sessions/$encoded/end-early',
     );
+    expect(
+      endpoints.completePath(opaque),
+      '/v1/practice-sessions/$encoded/complete',
+    );
   });
 
   test('decodes one bounded Simplified Chinese question translation', () async {
@@ -528,6 +532,53 @@ void main() {
     expect(lifecycle.version, 4);
     transport.expectDone();
   });
+
+  test(
+    'completes a user-controlled session with its current version',
+    () async {
+      final transport = _Transport([
+        _Step(
+          method: 'POST',
+          path: '/v1/practice-sessions/$_sessionId/complete',
+          verify: (request) {
+            expect(jsonDecode(request.jsonBody!), {
+              'expected_session_version': 8,
+            });
+            expect(
+              request.headers['Idempotency-Key'],
+              'complete-practice-operation',
+            );
+          },
+          response: _json(HttpStatus.ok, {
+            'practice_session_id': _sessionId,
+            'practice_plan_id': 'plan-1',
+            'plan_revision': 1,
+            'practice_experience': 'LIFE_AND_TRAVEL',
+            'scene_category': 'LIFE_TRAVEL',
+            'practice_mode': 'FULL_SIMULATION',
+            'evaluation_policy_ref': 'scenario.shadow.evaluation.v1',
+            'snapshot_id': 'snapshot-1',
+            'practice_session_status': 'completed',
+            'session_version': 9,
+            'started_at': '2026-07-25T09:00:01Z',
+            'ended_at': '2026-07-25T09:10:00Z',
+            'end_reason': 'USER_COMPLETED',
+            'created_at': _timestamp,
+          }),
+        ),
+      ]);
+
+      final lifecycle = await _client(transport).complete(
+        sessionId: _sessionId,
+        expectedSessionVersion: 8,
+        idempotencyKey: 'complete-practice-operation',
+      );
+
+      expect(lifecycle.status, PracticeSessionLifecycleStatus.completed);
+      expect(lifecycle.version, 9);
+      transport.expectDone();
+    },
+  );
 
   test('a practice 401 invalidates the captured Session generation', () async {
     final transport = _Transport([

--- a/server/internal/agent/handoff/model.go
+++ b/server/internal/agent/handoff/model.go
@@ -65,7 +65,8 @@ func Validate(item Item) error {
 		!validText(item.PracticeScope, 200) ||
 		item.SuggestedDurationSeconds < 1 ||
 		item.MinEffectiveTurns < 1 ||
-		item.MaxEffectiveTurns < item.MinEffectiveTurns ||
+		(item.MaxEffectiveTurns != 0 &&
+			item.MaxEffectiveTurns < item.MinEffectiveTurns) ||
 		item.MaxEffectiveTurns > 100 ||
 		item.ExecutableStatus != PracticePlanReadyStatus ||
 		!validText(item.ConfirmationPrompt, 300) ||

--- a/server/internal/agent/handoff/model_test.go
+++ b/server/internal/agent/handoff/model_test.go
@@ -25,6 +25,12 @@ func TestConfirmPracticePlanRequiresExactExecutablePlan(t *testing.T) {
 	if _, err := NewConfirmPracticePlan(invalid); !errors.Is(err, ErrInvalid) {
 		t.Fatalf("duplicate roles error = %v, want ErrInvalid", err)
 	}
+
+	openEnded := validConfirmPracticePlan()
+	openEnded.MaxEffectiveTurns = 0
+	if _, err := NewConfirmPracticePlan(openEnded); err != nil {
+		t.Fatalf("open-ended plan error = %v", err)
+	}
 }
 
 func TestCloneItemsDoesNotShareRoles(t *testing.T) {

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -650,10 +650,22 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 	}
 	var completedAudioAssetID string
 	var thirdTurnID string
+	var thirdSessionVersion int
 	for result := range results {
 		if result["effective_turns"] != float64(3) ||
-			result["session_completed"] != true {
+			result["session_completed"] != false ||
+			result["completion_mode"] != "USER_CONTROLLED" ||
+			result["turn_limit"] != float64(0) ||
+			result["current_question"] == nil {
 			t.Errorf("unexpected third-round state: %#v", result)
+		}
+		sessionVersion, _ := result["session_version"].(float64)
+		if sessionVersion < 1 {
+			t.Errorf("third-round response has no Session version: %#v", result)
+		} else if thirdSessionVersion == 0 {
+			thirdSessionVersion = int(sessionVersion)
+		} else if thirdSessionVersion != int(sessionVersion) {
+			t.Errorf("concurrent confirmations returned different Session versions")
 		}
 		turn := result["current_turn"].(map[string]any)
 		if turn["candidate_id"] != candidate["candidate_id"] {
@@ -676,6 +688,41 @@ func TestVoiceProductionCompositionBearerConcurrencyAndRestart(
 		} else if completedAudioAssetID != currentAudioAssetID {
 			t.Errorf("concurrent confirmations returned different AudioAssets")
 		}
+	}
+	completePath := "/v1/practice-sessions/" + sessionID + "/complete"
+	completeBody := fmt.Sprintf(
+		`{"expected_session_version":%d}`,
+		thirdSessionVersion,
+	)
+	completedSession := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodPost,
+		completePath,
+		completeBody,
+		"complete-user-controlled-session-0001",
+		http.StatusOK,
+	)
+	if completedSession["practice_session_status"] != "completed" ||
+		completedSession["session_version"] != float64(thirdSessionVersion+1) ||
+		completedSession["end_reason"] != "USER_COMPLETED" {
+		t.Fatalf("manual Practice completion = %#v", completedSession)
+	}
+	replayedCompletion := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodPost,
+		completePath,
+		completeBody,
+		"complete-user-controlled-session-0001",
+		http.StatusOK,
+	)
+	if replayedCompletion["practice_session_status"] != "completed" ||
+		replayedCompletion["session_version"] !=
+			completedSession["session_version"] {
+		t.Fatalf("manual Practice completion replay = %#v", replayedCompletion)
 	}
 	completedState := voiceJSONRequest(
 		t,

--- a/server/internal/coaching/evaluation/evidence/postgres_integration_test.go
+++ b/server/internal/coaching/evaluation/evidence/postgres_integration_test.go
@@ -827,6 +827,7 @@ func installEvidenceAuthorities(
 			len(practiceContext.Participants),
 		),
 		SessionPolicy: practice.SessionPolicy{
+			CompletionMode: practice.CompletionModeTurnLimited,
 			SuggestedDurationSeconds: practiceContext.TaskContext.
 				SuggestedDurationSeconds,
 			MinEffectiveTurns:       minEffectiveTurns,

--- a/server/internal/coaching/evaluation/evidence/source.go
+++ b/server/internal/coaching/evaluation/evidence/source.go
@@ -987,6 +987,9 @@ func validCompletedEvidenceSession(
 	session practice.Session,
 	snapshot practice.SessionSnapshot,
 ) bool {
+	completionMode := practice.NormalizeCompletionMode(
+		snapshot.SessionPolicy.CompletionMode,
+	)
 	option, optionErr := snapshot.SceneSelection.PracticeOption()
 	if session.ID != practiceSessionID ||
 		session.Status != practice.SessionCompleted ||
@@ -1011,10 +1014,16 @@ func validCompletedEvidenceSession(
 		!validIdentifier(snapshot.Preparation.ID) ||
 		!validIdentifier(snapshot.Preparation.SourceProfileID) ||
 		snapshot.Preparation.SourceVersion < 1 ||
-		snapshot.SessionPolicy.MaxEffectiveTurns < session.EffectiveTurns ||
 		snapshot.SessionPolicy.MinEffectiveTurns < 1 ||
-		snapshot.SessionPolicy.MinEffectiveTurns >
-			snapshot.SessionPolicy.MaxEffectiveTurns ||
+		(completionMode == practice.CompletionModeTurnLimited &&
+			(snapshot.SessionPolicy.MaxEffectiveTurns < session.EffectiveTurns ||
+				snapshot.SessionPolicy.MinEffectiveTurns >
+					snapshot.SessionPolicy.MaxEffectiveTurns)) ||
+		(completionMode == practice.CompletionModeUserControlled &&
+			(snapshot.SessionPolicy.MaxEffectiveTurns != 0 ||
+				snapshot.SessionPolicy.CoverageCheckpointTurn != 1)) ||
+		(completionMode != practice.CompletionModeTurnLimited &&
+			completionMode != practice.CompletionModeUserControlled) ||
 		option.EvaluationPolicyRef != session.EvaluationPolicyRef {
 		return false
 	}

--- a/server/internal/coaching/evaluation/evidence/source_test.go
+++ b/server/internal/coaching/evaluation/evidence/source_test.go
@@ -673,7 +673,7 @@ func newEvidenceSourceFixture(t *testing.T) *evidenceSourceFixture {
 			EffectiveTurns:      2,
 			StartedAt:           &started,
 			EndedAt:             &ended,
-			EndReason:           "COVERAGE_SATISFIED_AT_CHECKPOINT",
+			EndReason:           "USER_COMPLETED",
 			CreatedAt:           started,
 		},
 		snapshot: practice.SessionSnapshot{
@@ -800,9 +800,10 @@ func newEvidenceSourceFixture(t *testing.T) *evidenceSourceFixture {
 				},
 			},
 			SessionPolicy: practice.SessionPolicy{
+				CompletionMode:           practice.CompletionModeUserControlled,
 				SuggestedDurationSeconds: 300,
 				MinEffectiveTurns:        1,
-				MaxEffectiveTurns:        3,
+				MaxEffectiveTurns:        0,
 				CoverageCheckpointTurn:   1,
 				MaxFollowUpsPerQuestion:  1,
 				EarlyCompletionRule: practice.

--- a/server/internal/coaching/practice/api/session_http.go
+++ b/server/internal/coaching/practice/api/session_http.go
@@ -81,6 +81,10 @@ func (h *Handler) RegisterRoutes(routes gin.IRoutes) {
 		h.resumeSession,
 	)
 	routes.POST(
+		"/v1/practice-sessions/:practice_session_id/complete",
+		h.completeSession,
+	)
+	routes.POST(
 		"/v1/practice-sessions/:practice_session_id/end-early",
 		h.endSessionEarly,
 	)
@@ -205,6 +209,10 @@ func (h *Handler) pauseSession(c *gin.Context) {
 
 func (h *Handler) resumeSession(c *gin.Context) {
 	h.transitionSession(c, practice.SessionResume)
+}
+
+func (h *Handler) completeSession(c *gin.Context) {
+	h.transitionSession(c, practice.SessionComplete)
 }
 
 func (h *Handler) endSessionEarly(c *gin.Context) {

--- a/server/internal/coaching/practice/api/session_http_test.go
+++ b/server/internal/coaching/practice/api/session_http_test.go
@@ -40,6 +40,50 @@ func TestSessionHTTPRegistersOnlyPracticeSessionRoutes(t *testing.T) {
 	if _, exists := paths["POST /v1/practice-plans/:practice_plan_id/practice-sessions"]; !exists {
 		t.Fatal("Practice Session create route missing")
 	}
+	if _, exists := paths["POST /v1/practice-sessions/:practice_session_id/complete"]; !exists {
+		t.Fatal("Practice Session complete route missing")
+	}
+}
+
+func TestSessionHTTPCompletesUserControlledSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var gotTransition practice.SessionTransition
+	application := contextHTTPApplicationStub{
+		transitionSession: func(
+			_ context.Context,
+			actor requestcontext.Actor,
+			sessionID string,
+			key string,
+			expectedVersion int,
+			transition practice.SessionTransition,
+		) (practice.Session, bool, error) {
+			if actor.UserID != "user-1" || sessionID != "session-1" ||
+				key != "complete-session-0001" || expectedVersion != 8 {
+				t.Fatal("TransitionSession received altered trusted input")
+			}
+			gotTransition = transition
+			return practice.Session{
+				ID: "session-1", Status: practice.SessionCompleted, Version: 9,
+			}, false, nil
+		},
+	}
+	response := serveContextHTTPRequest(
+		t,
+		contextHTTPRouter(t, application),
+		http.MethodPost,
+		"/v1/practice-sessions/session-1/complete",
+		`{"expected_session_version":8}`,
+		"complete-session-0001",
+	)
+	if response.Code != http.StatusOK ||
+		gotTransition != practice.SessionComplete {
+		t.Fatalf(
+			"status=%d transition=%q body=%s",
+			response.Code,
+			gotTransition,
+			response.Body.String(),
+		)
+	}
 }
 
 func TestSessionHTTPCreateSessionForwardsOnlyExecutablePlanInputs(t *testing.T) {
@@ -165,6 +209,14 @@ type contextHTTPApplicationStub struct {
 		string,
 		practice.CreateSessionRequest,
 	) (practice.SessionBootstrap, bool, error)
+	transitionSession func(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		string,
+		int,
+		practice.SessionTransition,
+	) (practice.Session, bool, error)
 }
 
 func (s contextHTTPApplicationStub) CreateSession(
@@ -197,14 +249,19 @@ func (contextHTTPApplicationStub) GetSessionSnapshot(
 	return practice.SessionSnapshot{}, errors.New("unexpected GetSessionSnapshot")
 }
 
-func (contextHTTPApplicationStub) TransitionSession(
-	context.Context,
-	requestcontext.Actor,
-	string,
-	string,
-	int,
-	practice.SessionTransition,
+func (s contextHTTPApplicationStub) TransitionSession(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+	key string,
+	expectedVersion int,
+	transition practice.SessionTransition,
 ) (practice.Session, bool, error) {
+	if s.transitionSession != nil {
+		return s.transitionSession(
+			ctx, actor, sessionID, key, expectedVersion, transition,
+		)
+	}
 	return practice.Session{}, false,
 		errors.New("unexpected TransitionSession")
 }

--- a/server/internal/coaching/practice/execution_policy.go
+++ b/server/internal/coaching/practice/execution_policy.go
@@ -45,6 +45,7 @@ type TurnPolicy struct {
 }
 
 type sessionPolicyRegistration struct {
+	completionMode             CompletionMode
 	minEffectiveTurns          int
 	maxEffectiveTurns          int
 	coverageCheckpointTurn     int
@@ -112,6 +113,7 @@ func ValidSessionPolicy(
 		return false
 	}
 	return policy.SuggestedDurationSeconds == expected.SuggestedDurationSeconds &&
+		NormalizeCompletionMode(policy.CompletionMode) == expected.CompletionMode &&
 		policy.MinEffectiveTurns == expected.MinEffectiveTurns &&
 		policy.MaxEffectiveTurns == expected.MaxEffectiveTurns &&
 		policy.CoverageCheckpointTurn == expected.CoverageCheckpointTurn &&
@@ -170,6 +172,7 @@ func resolveSessionPolicyRegistration(
 	reference string,
 ) (sessionPolicyRegistration, bool) {
 	standard := sessionPolicyRegistration{
+		completionMode:          CompletionModeTurnLimited,
 		minEffectiveTurns:       4,
 		maxEffectiveTurns:       6,
 		coverageCheckpointTurn:  4,
@@ -190,6 +193,10 @@ func resolveSessionPolicyRegistration(
 		DailyHotelCheckinIssueSessionPolicy,
 		WorkplacePracticeSessionPolicy,
 		WorkplaceProgressRiskUpdateSessionPolicy:
+		standard.completionMode = CompletionModeUserControlled
+		standard.minEffectiveTurns = 1
+		standard.maxEffectiveTurns = 0
+		standard.coverageCheckpointTurn = 1
 		standard.retryAllowed = true
 		standard.avatarAllowed = true
 		standard.speechFeedbackAllowed = true
@@ -206,6 +213,7 @@ func resolveSessionPolicyRegistration(
 		IELTSSpeakingPart3SessionPolicy,
 		IELTSSpeakingFullMockSessionPolicy:
 		return sessionPolicyRegistration{
+			completionMode:        CompletionModeTurnLimited,
 			turnsFromBlueprints:   true,
 			speechFeedbackAllowed: true,
 		}, true
@@ -234,21 +242,28 @@ func buildSessionPolicy(
 		registration.minEffectiveTurns = blueprintCount
 		registration.maxEffectiveTurns = blueprintCount
 		registration.coverageCheckpointTurn = blueprintCount
-	} else if mode == PracticeModeFocus {
+	} else if mode == PracticeModeFocus &&
+		registration.completionMode == CompletionModeTurnLimited {
 		registration.minEffectiveTurns = 1
 		registration.maxEffectiveTurns = 3
 		registration.coverageCheckpointTurn = 1
-	} else if mode != PracticeModeFullSimulation {
+	} else if mode != PracticeModeFullSimulation &&
+		mode != PracticeModeFocus {
 		return SessionPolicy{}, false
 	}
 	if requestedMaxEffectiveTurns > 0 {
-		if requestedMaxEffectiveTurns < registration.minEffectiveTurns ||
+		if registration.completionMode == CompletionModeUserControlled {
+			requestedMaxEffectiveTurns = 0
+		} else if requestedMaxEffectiveTurns < registration.minEffectiveTurns ||
 			requestedMaxEffectiveTurns > registration.maxEffectiveTurns {
 			return SessionPolicy{}, false
 		}
-		registration.maxEffectiveTurns = requestedMaxEffectiveTurns
+		if requestedMaxEffectiveTurns > 0 {
+			registration.maxEffectiveTurns = requestedMaxEffectiveTurns
+		}
 	}
 	return SessionPolicy{
+		CompletionMode:             registration.completionMode,
 		SuggestedDurationSeconds:   suggestedDurationSeconds,
 		MinEffectiveTurns:          registration.minEffectiveTurns,
 		MaxEffectiveTurns:          registration.maxEffectiveTurns,

--- a/server/internal/coaching/practice/execution_policy_test.go
+++ b/server/internal/coaching/practice/execution_policy_test.go
@@ -17,17 +17,19 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 	tests := []struct {
 		name        string
 		reference   string
+		completion  CompletionMode
+		maxTurns    int
 		retry       bool
 		translation bool
 		followUps   int
 		wantErr     error
 	}{
-		{"daily", DailyPracticeSessionPolicy, true, false, 1, nil},
-		{"workplace", WorkplacePracticeSessionPolicy, true, false, 1, nil},
-		{"interview", InterviewPracticeSessionPolicy, false, true, 3, nil},
-		{"interview deep dive", InterviewProjectDeepDiveSessionPolicy, false, true, 3, nil},
-		{"exam", ExamPracticeSessionPolicy, false, false, 1, nil},
-		{"unknown", "unknown.practice.session.v1", false, false, 0, ErrExecutionPolicyNotFound},
+		{"daily", DailyPracticeSessionPolicy, CompletionModeUserControlled, 0, true, false, 1, nil},
+		{"workplace", WorkplacePracticeSessionPolicy, CompletionModeUserControlled, 0, true, false, 1, nil},
+		{"interview", InterviewPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
+		{"interview deep dive", InterviewProjectDeepDiveSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
+		{"exam", ExamPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, false, 1, nil},
+		{"unknown", "unknown.practice.session.v1", "", 0, false, false, 0, ErrExecutionPolicyNotFound},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -38,7 +40,9 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 				}
 				return
 			}
-			if err != nil || policy.RetryAllowed != test.retry ||
+			if err != nil || policy.CompletionMode != test.completion ||
+				policy.MaxEffectiveTurns != test.maxTurns ||
+				policy.RetryAllowed != test.retry ||
 				policy.QuestionTranslationAllowed != test.translation ||
 				policy.MaxFollowUpsPerQuestion != test.followUps ||
 				!ValidSessionPolicy(

--- a/server/internal/coaching/practice/plan_projection.go
+++ b/server/internal/coaching/practice/plan_projection.go
@@ -248,10 +248,25 @@ type EarlyCompletionRule string
 
 const EarlyCompletionCoverageSatisfiedAfterCheckpoint EarlyCompletionRule = "COVERAGE_SATISFIED_AFTER_CHECKPOINT"
 
+type CompletionMode string
+
+const (
+	CompletionModeTurnLimited    CompletionMode = "TURN_LIMITED"
+	CompletionModeUserControlled CompletionMode = "USER_CONTROLLED"
+)
+
+func NormalizeCompletionMode(value CompletionMode) CompletionMode {
+	if value == "" {
+		return CompletionModeTurnLimited
+	}
+	return value
+}
+
 // SessionPolicy is Practice's frozen progression policy. RetryAllowed is a
 // concrete value projected once at Session creation; runtime code never
 // infers it again from Scene family or model.
 type SessionPolicy struct {
+	CompletionMode             CompletionMode      `json:"completion_mode"`
 	SuggestedDurationSeconds   int                 `json:"suggested_duration_seconds"`
 	MinEffectiveTurns          int                 `json:"min_effective_turns"`
 	MaxEffectiveTurns          int                 `json:"max_effective_turns"`

--- a/server/internal/coaching/practice/planpolicy/resolver.go
+++ b/server/internal/coaching/practice/planpolicy/resolver.go
@@ -63,6 +63,7 @@ func (*Resolver) ResolveSessionPolicy(
 		}
 	}
 	return preparation.SessionPolicy{
+		CompletionMode:           preparation.CompletionMode(policy.CompletionMode),
 		SuggestedDurationSeconds: policy.SuggestedDurationSeconds,
 		MinEffectiveTurns:        policy.MinEffectiveTurns,
 		MaxEffectiveTurns:        policy.MaxEffectiveTurns,

--- a/server/internal/coaching/practice/planpolicy/resolver_test.go
+++ b/server/internal/coaching/practice/planpolicy/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
 )
 
@@ -27,8 +28,10 @@ func TestResolverFreezesCompleteRegisteredPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !policy.RetryAllowed || policy.MinEffectiveTurns != 4 ||
-		policy.MaxEffectiveTurns != 6 || policy.CoverageCheckpointTurn != 4 ||
+	if !policy.RetryAllowed ||
+		policy.CompletionMode != preparation.CompletionModeUserControlled ||
+		policy.MinEffectiveTurns != 1 || policy.MaxEffectiveTurns != 0 ||
+		policy.CoverageCheckpointTurn != 1 ||
 		policy.MaxFollowUpsPerQuestion != 1 {
 		t.Fatalf("resolved policy = %#v", policy)
 	}

--- a/server/internal/coaching/practice/postgres/context.go
+++ b/server/internal/coaching/practice/postgres/context.go
@@ -550,6 +550,26 @@ func (r *Repository) TransitionSession(
 	if session.Version != command.ExpectedSessionVersion {
 		return practice.Session{}, false, practice.ErrConflict
 	}
+	if command.Transition == practice.SessionComplete {
+		if session.EffectiveTurns < 1 {
+			return practice.Session{}, false, practice.ErrConflict
+		}
+		var snapshotDocument []byte
+		if err := tx.QueryRow(ctx, `
+			SELECT snapshot_document
+			FROM practice_session_snapshots
+			WHERE owner_user_id = $1 AND session_id = $2
+		`, actor.UserID, command.SessionID).Scan(&snapshotDocument); err != nil {
+			return practice.Session{}, false, classifyContextWriteError(
+				"read completion policy", err,
+			)
+		}
+		snapshot, err := decodeContextSnapshot(snapshotDocument)
+		if err != nil || snapshot.SessionPolicy.CompletionMode !=
+			practice.CompletionModeUserControlled {
+			return practice.Session{}, false, practice.ErrConflict
+		}
+	}
 	nextStatus, allowed := contextTransitionStatus(
 		session.Status,
 		command.Transition,
@@ -560,10 +580,14 @@ func (r *Repository) TransitionSession(
 	startedAtExpression := "started_at"
 	completedAtExpression := "NULL"
 	endReasonExpression := "NULL"
-	if command.Transition == practice.SessionEndEarly {
+	if command.Transition == practice.SessionEndEarly ||
+		command.Transition == practice.SessionComplete {
 		startedAtExpression = "COALESCE(started_at, transaction_timestamp())"
 		completedAtExpression = "transaction_timestamp()"
 		endReasonExpression = "'USER_ENDED'"
+		if command.Transition == practice.SessionComplete {
+			endReasonExpression = "'USER_COMPLETED'"
+		}
 	}
 	query := fmt.Sprintf(`
 		UPDATE practice_sessions
@@ -1182,6 +1206,7 @@ func validTransitionCommand(
 		command.ExpectedSessionVersion > 0 && validContextIntent(command.Intent) &&
 		(command.Transition == practice.SessionPause ||
 			command.Transition == practice.SessionResume ||
+			command.Transition == practice.SessionComplete ||
 			command.Transition == practice.SessionEndEarly)
 }
 
@@ -1196,6 +1221,10 @@ func contextTransitionStatus(
 	case practice.SessionResume:
 		return practice.SessionInProgress,
 			current == practice.SessionPaused
+	case practice.SessionComplete:
+		return practice.SessionCompleted,
+			current == practice.SessionInProgress ||
+				current == practice.SessionPaused
 	case practice.SessionEndEarly:
 		return practice.SessionEndedEarly,
 			current == practice.SessionStarting ||

--- a/server/internal/coaching/practice/postgres/context.go
+++ b/server/internal/coaching/practice/postgres/context.go
@@ -626,6 +626,80 @@ func (r *Repository) TransitionSession(
 	if err != nil {
 		return practice.Session{}, false, err
 	}
+	if command.Transition == practice.SessionComplete {
+		var finalTurnID string
+		err := tx.QueryRow(ctx, `
+			SELECT turn_id
+			FROM practice_turn_results
+			WHERE owner_user_id = $1
+			  AND session_id = $2
+			  AND round_number = $3
+		`, actor.UserID, command.SessionID, session.EffectiveTurns).Scan(
+			&finalTurnID,
+		)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return practice.Session{}, false, practice.ErrConflict
+		}
+		if err != nil {
+			return practice.Session{}, false,
+				fmt.Errorf("read final Practice Turn: %w", err)
+		}
+		completionToken := fmt.Sprintf(
+			"practice-session:%s:completed:v%d",
+			command.SessionID,
+			session.Version,
+		)
+		tag, err := tx.Exec(ctx, `
+			UPDATE practice_turn_results
+			SET completed = true,
+			    completion_token = $4
+			WHERE owner_user_id = $1
+			  AND session_id = $2
+			  AND turn_id = $3
+			  AND completed = false
+			  AND completion_token = ''
+		`, actor.UserID, command.SessionID, finalTurnID, completionToken)
+		if err != nil {
+			return practice.Session{}, false,
+				classifyContextWriteError(
+					"complete final Practice Turn result",
+					err,
+				)
+		}
+		if tag.RowsAffected() != 1 {
+			return practice.Session{}, false, practice.ErrConflict
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE practice_turns
+			SET session_completed = true
+			WHERE owner_user_id = $1
+			  AND practice_session_id = $2
+			  AND turn_id = $3
+			  AND effective_turns = $4
+			  AND session_completed = false
+		`, actor.UserID, command.SessionID, finalTurnID,
+			session.EffectiveTurns); err != nil {
+			return practice.Session{}, false,
+				classifyContextWriteError(
+					"complete final Practice Turn projection",
+					err,
+				)
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO practice_completed (
+				owner_user_id, session_id, final_turn_id,
+				session_version, completion_token
+			)
+			VALUES ($1, $2, $3, $4, $5)
+		`, actor.UserID, command.SessionID, finalTurnID,
+			session.Version, completionToken); err != nil {
+			return practice.Session{}, false,
+				classifyContextWriteError(
+					"record user-controlled Practice completion",
+					err,
+				)
+		}
+	}
 	if err := saveContextIdempotency(
 		ctx,
 		tx,

--- a/server/internal/coaching/practice/postgres/context_integration_test.go
+++ b/server/internal/coaching/practice/postgres/context_integration_test.go
@@ -290,6 +290,19 @@ func TestContextRepositoryCompletesUserControlledSessionIdempotently(
 	`, owner.Actor.UserID, created.Session.ID, startedVersion); err != nil {
 		t.Fatalf("start user-controlled Session fixture: %v", err)
 	}
+	turnFingerprint := sha256.Sum256([]byte("turn-user-complete-payload"))
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO practice_turn_results (
+			owner_user_id, session_id, turn_id, payload_fingerprint,
+			round_number, effective_turns, session_version,
+			completed, completion_token
+		)
+		VALUES ($1, $2, 'turn-user-complete', $3, 1, 1, $4, false, '')
+	`, owner.Actor.UserID, created.Session.ID,
+		turnFingerprint[:],
+		startedVersion); err != nil {
+		t.Fatalf("insert user-controlled final Turn fixture: %v", err)
+	}
 	completeIntent := practice.IdempotencyIntent{
 		Method:        "POST",
 		CanonicalPath: "/v1/practice-sessions/" + created.Session.ID + "/complete",
@@ -346,6 +359,51 @@ func TestContextRepositoryCompletesUserControlledSessionIdempotently(
 	}
 	if resourceKind != string(practice.SessionComplete) {
 		t.Fatalf("completion resource kind = %q", resourceKind)
+	}
+	var finalTurnID, completionToken, deliveryStatus string
+	var completionVersion int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT final_turn_id, session_version, completion_token, delivery_status
+		FROM practice_completed
+		WHERE owner_user_id = $1 AND session_id = $2
+	`, owner.Actor.UserID, completed.ID).Scan(
+		&finalTurnID,
+		&completionVersion,
+		&completionToken,
+		&deliveryStatus,
+	); err != nil {
+		t.Fatalf("read completion handoff: %v", err)
+	}
+	if finalTurnID != "turn-user-complete" ||
+		completionVersion != completed.Version || completionToken == "" ||
+		deliveryStatus != "PENDING" {
+		t.Fatalf(
+			"completion handoff = (%q,%d,%q,%q)",
+			finalTurnID,
+			completionVersion,
+			completionToken,
+			deliveryStatus,
+		)
+	}
+	var turnCompleted bool
+	var turnCompletionToken string
+	if err := pool.QueryRow(context.Background(), `
+		SELECT completed, completion_token
+		FROM practice_turn_results
+		WHERE owner_user_id = $1 AND session_id = $2 AND turn_id = $3
+	`, owner.Actor.UserID, completed.ID, finalTurnID).Scan(
+		&turnCompleted,
+		&turnCompletionToken,
+	); err != nil {
+		t.Fatalf("read completed final Turn result: %v", err)
+	}
+	if !turnCompleted || turnCompletionToken != completionToken {
+		t.Fatalf(
+			"final Turn completion = (%t,%q), want token %q",
+			turnCompleted,
+			turnCompletionToken,
+			completionToken,
+		)
 	}
 }
 

--- a/server/internal/coaching/practice/postgres/context_integration_test.go
+++ b/server/internal/coaching/practice/postgres/context_integration_test.go
@@ -240,6 +240,115 @@ func TestContextRepositoryRejectsArchivedPlanAndConflictsByPlan(t *testing.T) {
 	}
 }
 
+func TestContextRepositoryCompletesUserControlledSessionIdempotently(
+	t *testing.T,
+) {
+	repository, pool := newContextRepository(t)
+	owner := contextOwnerA()
+	seedContextOwner(t, pool, &owner)
+	plan := createContextPlanForExperience(
+		t,
+		pool,
+		preparationpostgres.NewPostgresPlanRepository(pool),
+		owner,
+		"plan-user-complete",
+		scene.PracticeExperienceLifeAndTravel,
+	)
+	command := contextSessionCommand(
+		owner,
+		plan,
+		"session-user-complete",
+		"snapshot-user-complete",
+		"session-user-complete-key",
+	)
+	created, replayed, err := repository.CreateSession(
+		context.Background(),
+		owner.Actor,
+		command,
+	)
+	if err != nil || replayed {
+		t.Fatalf("CreateSession = (%#v,%t,%v)", created, replayed, err)
+	}
+	if created.Snapshot.SessionPolicy.CompletionMode !=
+		practice.CompletionModeUserControlled {
+		t.Fatalf(
+			"completion mode = %q, want %q",
+			created.Snapshot.SessionPolicy.CompletionMode,
+			practice.CompletionModeUserControlled,
+		)
+	}
+
+	startedVersion := created.Session.Version + 1
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE practice_sessions
+		SET status = 'in_progress',
+		    version = $3,
+		    effective_turns = 1,
+		    started_at = transaction_timestamp(),
+		    updated_at = transaction_timestamp()
+		WHERE owner_user_id = $1 AND session_id = $2
+	`, owner.Actor.UserID, created.Session.ID, startedVersion); err != nil {
+		t.Fatalf("start user-controlled Session fixture: %v", err)
+	}
+	completeIntent := practice.IdempotencyIntent{
+		Method:        "POST",
+		CanonicalPath: "/v1/practice-sessions/" + created.Session.ID + "/complete",
+		Key:           "session-complete-key",
+		PayloadFingerprint: sha256.Sum256(
+			[]byte("session-complete-payload"),
+		),
+	}
+	completeCommand := practice.TransitionSessionCommand{
+		SessionID:              created.Session.ID,
+		ExpectedSessionVersion: startedVersion,
+		Transition:             practice.SessionComplete,
+		Intent:                 completeIntent,
+	}
+	completed, replayed, err := repository.TransitionSession(
+		context.Background(),
+		owner.Actor,
+		completeCommand,
+	)
+	if err != nil || replayed || completed.Status != practice.SessionCompleted ||
+		completed.Version != startedVersion+1 ||
+		completed.EndReason != "USER_COMPLETED" {
+		t.Fatalf("complete Session = (%#v,%t,%v)", completed, replayed, err)
+	}
+
+	replayedSession, replayed, err := repository.TransitionSession(
+		context.Background(),
+		owner.Actor,
+		completeCommand,
+	)
+	if err != nil || !replayed || replayedSession.ID != completed.ID ||
+		replayedSession.Status != completed.Status ||
+		replayedSession.Version != completed.Version ||
+		replayedSession.EndReason != completed.EndReason {
+		t.Fatalf(
+			"replay complete Session = (%#v,%t,%v), want %#v",
+			replayedSession,
+			replayed,
+			err,
+			completed,
+		)
+	}
+	var resourceKind string
+	if err := pool.QueryRow(context.Background(), `
+		SELECT resource_kind
+		FROM practice_idempotency_records
+		WHERE owner_user_id = $1
+		  AND canonical_path = $2
+		  AND idempotency_key = $3
+	`, owner.Actor.UserID, completeIntent.CanonicalPath, completeIntent.Key).Scan(
+		&resourceKind,
+	); err != nil {
+		t.Fatalf("read completion idempotency record: %v", err)
+	}
+	if resourceKind != string(practice.SessionComplete) {
+		t.Fatalf("completion resource kind = %q", resourceKind)
+	}
+}
+
 func TestContextRepositoryPersistsCanonicalParticipantRoles(t *testing.T) {
 	repository, pool := newContextRepository(t)
 	owner := contextOwnerA()
@@ -425,6 +534,25 @@ func createContextPlan(
 	planID string,
 ) preparation.PracticePlan {
 	t.Helper()
+	return createContextPlanForExperience(
+		t,
+		pool,
+		repository,
+		owner,
+		planID,
+		"",
+	)
+}
+
+func createContextPlanForExperience(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	repository *preparationpostgres.PostgresPlanRepository,
+	owner contextOwnerFixture,
+	planID string,
+	experience scene.PracticeExperience,
+) preparation.PracticePlan {
+	t.Helper()
 	catalog, err := scene.NewPostgresCatalog(
 		pool,
 		scoring.NewEvaluationPolicyRegistry(),
@@ -437,6 +565,19 @@ func createContextPlan(
 		t.Fatalf("ListActive Scenes = (%d,%v)", len(definitions), err)
 	}
 	definition := definitions[0]
+	if experience != "" {
+		found := false
+		for _, candidate := range definitions {
+			if candidate.Experience == experience {
+				definition = candidate
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("seeded Scenes lack experience %q", experience)
+		}
+	}
 	if len(definition.Roles) == 0 || len(definition.PracticeOptions) == 0 {
 		t.Fatal("seeded Scene lacks selectable roles/options")
 	}

--- a/server/internal/coaching/practice/postgres/context_voice.go
+++ b/server/internal/coaching/practice/postgres/context_voice.go
@@ -126,12 +126,21 @@ func (r *Repository) advanceTurnInTransaction(
 	}
 
 	snapshot, err := decodeContextSnapshot(snapshotDocument)
+	completionMode := practice.NormalizeCompletionMode(
+		snapshot.SessionPolicy.CompletionMode,
+	)
 	if err != nil ||
 		snapshot.ID != snapshotID ||
 		snapshot.SessionID != command.SessionID ||
 		snapshot.SessionPolicy.MaxEffectiveTurns != turnLimit ||
-		turnLimit < 1 || turnLimit > practice.MaxPracticeTurns ||
-		effectiveTurns < 0 || effectiveTurns > turnLimit {
+		effectiveTurns < 0 ||
+		(completionMode != practice.CompletionModeTurnLimited &&
+			completionMode != practice.CompletionModeUserControlled) ||
+		(completionMode == practice.CompletionModeTurnLimited &&
+			(turnLimit < 1 || turnLimit > practice.MaxPracticeTurns ||
+				effectiveTurns > turnLimit)) ||
+		(completionMode == practice.CompletionModeUserControlled &&
+			turnLimit != 0) {
 		return practice.TurnResult{}, practice.ErrConflict
 	}
 	option, err := snapshot.SceneSelection.PracticeOption()
@@ -162,7 +171,8 @@ func (r *Repository) advanceTurnInTransaction(
 		// paused and unknown lifecycle states cannot consume a Turn.
 		return practice.TurnResult{}, practice.ErrConflict
 	}
-	if effectiveTurns >= turnLimit {
+	if completionMode == practice.CompletionModeTurnLimited &&
+		effectiveTurns >= turnLimit {
 		return practice.TurnResult{}, practice.ErrSessionCompleted
 	}
 
@@ -173,7 +183,9 @@ func (r *Repository) advanceTurnInTransaction(
 	if round < 1 {
 		return practice.TurnResult{}, practice.ErrConflict
 	}
-	completed := command.CountsTowardTurnLimit && round == turnLimit
+	completed := completionMode ==
+		practice.CompletionModeTurnLimited &&
+		command.CountsTowardTurnLimit && round == turnLimit
 	nextVersion := version + 1
 	completionToken := ""
 	if completed {

--- a/server/internal/coaching/practice/preparationsource/reader.go
+++ b/server/internal/coaching/practice/preparationsource/reader.go
@@ -188,6 +188,9 @@ func projectSessionPolicy(
 		return practice.SessionPolicy{}, practice.ErrConflict
 	}
 	projected := practice.SessionPolicy{
+		CompletionMode: practice.NormalizeCompletionMode(
+			practice.CompletionMode(policy.CompletionMode),
+		),
 		SuggestedDurationSeconds: policy.SuggestedDurationSeconds,
 		MinEffectiveTurns:        policy.MinEffectiveTurns,
 		MaxEffectiveTurns:        policy.MaxEffectiveTurns,

--- a/server/internal/coaching/practice/preparationsource/reader_test.go
+++ b/server/internal/coaching/practice/preparationsource/reader_test.go
@@ -32,6 +32,10 @@ func TestProjectConfirmedPlanFreezesRetryFromPolicyRefNotSceneMetadata(
 	plan.SceneSelection.Scene.PracticeOptions[0].SessionPolicyRef =
 		practice.InterviewPracticeSessionPolicy
 	plan.SessionPolicy.RetryAllowed = false
+	plan.SessionPolicy.CompletionMode = preparation.CompletionModeTurnLimited
+	plan.SessionPolicy.MinEffectiveTurns = 4
+	plan.SessionPolicy.MaxEffectiveTurns = 6
+	plan.SessionPolicy.CoverageCheckpointTurn = 4
 	plan.SessionPolicy.MaxFollowUpsPerQuestion = 3
 	plan.SessionPolicy.QuestionTranslationAllowed = true
 	plan.SessionPolicy.QuestionTipsAllowed = true
@@ -170,10 +174,11 @@ func confirmedPlanFixture() preparation.PracticePlan {
 			PracticeOptionID: "option-selected",
 		},
 		SessionPolicy: preparation.SessionPolicy{
+			CompletionMode:           preparation.CompletionModeUserControlled,
 			SuggestedDurationSeconds: 600,
-			MinEffectiveTurns:        4,
-			MaxEffectiveTurns:        6,
-			CoverageCheckpointTurn:   4,
+			MinEffectiveTurns:        1,
+			MaxEffectiveTurns:        0,
+			CoverageCheckpointTurn:   1,
 			MaxFollowUpsPerQuestion:  1,
 			EarlyCompletionRule: preparation.
 				EarlyCompletionCoverageSatisfiedAfterCheckpoint,

--- a/server/internal/coaching/practice/session.go
+++ b/server/internal/coaching/practice/session.go
@@ -86,6 +86,7 @@ type SessionTransition string
 const (
 	SessionPause    SessionTransition = "pause"
 	SessionResume   SessionTransition = "resume"
+	SessionComplete SessionTransition = "complete"
 	SessionEndEarly SessionTransition = "end_early"
 )
 

--- a/server/internal/coaching/practice/session_application.go
+++ b/server/internal/coaching/practice/session_application.go
@@ -452,6 +452,8 @@ func contextTransitionWireAction(
 		return "pause", true
 	case SessionResume:
 		return "resume", true
+	case SessionComplete:
+		return "complete", true
 	case SessionEndEarly:
 		return "end-early", true
 	default:

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -383,6 +383,7 @@ func SessionStateResponse(state practicevoice.SessionState) gin.H {
 		"session_version":         state.Session.SessionVersion,
 		"effective_turns":         state.Session.EffectiveTurns,
 		"turn_limit":              state.Session.TurnLimit,
+		"completion_mode":         state.Session.CompletionMode,
 		"session_completed": state.Session.Completed ||
 			state.Session.Status == string(practice.SessionEndedEarly),
 		"practice_capabilities": gin.H{

--- a/server/internal/coaching/practice/voice/question.go
+++ b/server/internal/coaching/practice/voice/question.go
@@ -221,7 +221,9 @@ func questionGenerationRequest(
 	sequence int,
 ) (QuestionGenerationRequest, error) {
 	prompt := session.Prompt
-	if sequence < 1 || sequence > session.TurnLimit ||
+	if sequence < 1 ||
+		(session.CompletionMode == practice.CompletionModeTurnLimited &&
+			sequence > session.TurnLimit) ||
 		strings.TrimSpace(session.PracticeExperience) == "" ||
 		strings.TrimSpace(session.SceneCategory) == "" ||
 		strings.TrimSpace(session.PracticeMode) == "" ||
@@ -297,10 +299,17 @@ func questionGenerationRequest(
 			fmt.Sprintf("Previous learner response: %s", answer),
 		)
 	}
-	contextParts = append(
-		contextParts,
-		fmt.Sprintf("This is turn %d of at most %d.", sequence, session.TurnLimit),
-	)
+	if session.CompletionMode == practice.CompletionModeTurnLimited {
+		contextParts = append(
+			contextParts,
+			fmt.Sprintf("This is turn %d of at most %d.", sequence, session.TurnLimit),
+		)
+	} else {
+		contextParts = append(
+			contextParts,
+			fmt.Sprintf("This is turn %d. Continue naturally until the learner chooses to finish.", sequence),
+		)
+	}
 	return QuestionGenerationRequest{
 		SystemPrompt: systemPrompt,
 		UserPrompt:   strings.Join(contextParts, "\n"),

--- a/server/internal/coaching/practice/voice/question_test.go
+++ b/server/internal/coaching/practice/voice/question_test.go
@@ -1,0 +1,37 @@
+package voice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+)
+
+func TestQuestionGenerationRequestAllowsUserControlledTurnsPastBlueprints(t *testing.T) {
+	t.Parallel()
+	session := Session{
+		PracticeExperience: string(practice.PracticeExperienceLifeAndTravel),
+		SceneCategory:      "LIFE_TRAVEL",
+		PracticeMode:       string(practice.PracticeModeFullSimulation),
+		TurnLimit:          0,
+		CompletionMode:     practice.CompletionModeUserControlled,
+		Prompt: practice.ScenePrompt{
+			PublicSceneBrief: "Check in at a hotel.",
+			PracticeGoal:     "Complete the check-in conversation.",
+			UserRole:         "Guest",
+			AIRole:           "Receptionist",
+			PersonaSummary:   "Professional and helpful.",
+			FocusAreas:       []string{"check_in"},
+			TurnBlueprints:   []string{"Confirm the booking."},
+		},
+	}
+
+	request, err := questionGenerationRequest(session, 65)
+	if err != nil {
+		t.Fatalf("questionGenerationRequest() error = %v", err)
+	}
+	if !strings.Contains(request.UserPrompt, "This is turn 65") ||
+		!strings.Contains(request.UserPrompt, "learner chooses to finish") {
+		t.Fatalf("user prompt = %q", request.UserPrompt)
+	}
+}

--- a/server/internal/coaching/practice/voice/round_orchestrator.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator.go
@@ -287,8 +287,7 @@ func validVoiceTurnCheckpoint(turn practice.Turn) bool {
 		turn.TranscriptID == "" ||
 		turn.EvidenceVersion < 1 ||
 		strings.TrimSpace(turn.AnswerText) == "" ||
-		turn.EffectiveTurns < 0 ||
-		turn.EffectiveTurns > practice.MaxPracticeTurns {
+		turn.EffectiveTurns < 0 {
 		return false
 	}
 	return turn.EffectiveTurns > 0

--- a/server/internal/coaching/practice/voice/session_adapter.go
+++ b/server/internal/coaching/practice/voice/session_adapter.go
@@ -203,20 +203,23 @@ func mapPracticeSession(
 		return Session{}, ErrInvalidContext
 	}
 	result := Session{
-		ID:                         session.ID,
-		PlanID:                     session.PlanID,
-		SceneID:                    selection.Scene.ID,
-		SceneVersion:               selection.Scene.Version,
-		PracticeExperience:         string(snapshot.Experience),
-		SceneCategory:              string(snapshot.Category),
-		PracticeMode:               string(snapshot.PracticeMode),
-		TurnPolicyRef:              option.TurnPolicyRef,
-		Prompt:                     cloneScenePrompt(selection.Scene.Prompt),
-		ScenarioContext:            cloneScenarioPreparationContext(snapshot.Preparation.ScenarioContext),
-		IELTSAssignment:            cloneIELTSAssignment(snapshot.IELTSAssignment),
-		SessionVersion:             session.Version,
-		EffectiveTurns:             session.EffectiveTurns,
-		TurnLimit:                  snapshot.SessionPolicy.MaxEffectiveTurns,
+		ID:                 session.ID,
+		PlanID:             session.PlanID,
+		SceneID:            selection.Scene.ID,
+		SceneVersion:       selection.Scene.Version,
+		PracticeExperience: string(snapshot.Experience),
+		SceneCategory:      string(snapshot.Category),
+		PracticeMode:       string(snapshot.PracticeMode),
+		TurnPolicyRef:      option.TurnPolicyRef,
+		Prompt:             cloneScenePrompt(selection.Scene.Prompt),
+		ScenarioContext:    cloneScenarioPreparationContext(snapshot.Preparation.ScenarioContext),
+		IELTSAssignment:    cloneIELTSAssignment(snapshot.IELTSAssignment),
+		SessionVersion:     session.Version,
+		EffectiveTurns:     session.EffectiveTurns,
+		TurnLimit:          snapshot.SessionPolicy.MaxEffectiveTurns,
+		CompletionMode: practice.NormalizeCompletionMode(
+			snapshot.SessionPolicy.CompletionMode,
+		),
 		MaxFollowUpsPerQuestion:    snapshot.SessionPolicy.MaxFollowUpsPerQuestion,
 		QuestionTranslationAllowed: snapshot.SessionPolicy.QuestionTranslationAllowed,
 		QuestionTipsAllowed:        snapshot.SessionPolicy.QuestionTipsAllowed,
@@ -294,14 +297,15 @@ func mapPracticeSession(
 	if result.FacilitatorParticipantID == "" ||
 		result.LearnerParticipantID == "" ||
 		len(facilitatorRoles) != len(selectedRoles) ||
-		result.TurnLimit < 1 ||
-		result.TurnLimit > practice.MaxPracticeTurns ||
-		result.EffectiveTurns < 0 ||
-		result.EffectiveTurns > result.TurnLimit ||
+		result.EffectiveTurns < 0 || !validVoiceProgress(result) ||
 		(result.Status == string(
 			practice.SessionCompleted,
 		)) != result.Completed ||
-		!validPersistedSessionLifecycle(session, result.TurnLimit) {
+		!validPersistedSessionLifecycle(
+			session,
+			result.TurnLimit,
+			result.CompletionMode,
+		) {
 		return Session{}, ErrInvalidContext
 	}
 	return result, nil
@@ -345,12 +349,19 @@ func cloneIELTSAssignment(
 func validPersistedSessionLifecycle(
 	session practice.Session,
 	turnLimit int,
+	completionMode practice.CompletionMode,
 ) bool {
-	if turnLimit < 1 || turnLimit > practice.MaxPracticeTurns ||
-		session.EffectiveTurns < 0 ||
-		session.EffectiveTurns > turnLimit {
+	if session.EffectiveTurns < 0 ||
+		(completionMode == practice.CompletionModeUserControlled && turnLimit != 0) ||
+		(completionMode == practice.CompletionModeTurnLimited &&
+			(turnLimit < 1 || turnLimit > practice.MaxPracticeTurns ||
+				session.EffectiveTurns > turnLimit)) ||
+		(completionMode != practice.CompletionModeUserControlled &&
+			completionMode != practice.CompletionModeTurnLimited) {
 		return false
 	}
+	turnAvailable := completionMode == practice.CompletionModeUserControlled ||
+		session.EffectiveTurns < turnLimit
 	switch session.Status {
 	case practice.SessionStarting:
 		return session.EffectiveTurns == 0 &&
@@ -359,7 +370,7 @@ func validPersistedSessionLifecycle(
 			session.EndReason == ""
 	case practice.SessionInProgress,
 		practice.SessionPaused:
-		return session.EffectiveTurns < turnLimit &&
+		return turnAvailable &&
 			session.StartedAt != nil &&
 			session.EndedAt == nil &&
 			session.EndReason == ""
@@ -369,7 +380,7 @@ func validPersistedSessionLifecycle(
 			session.EndedAt != nil &&
 			strings.TrimSpace(session.EndReason) != ""
 	case practice.SessionEndedEarly:
-		return session.EffectiveTurns < turnLimit &&
+		return turnAvailable &&
 			session.StartedAt != nil &&
 			session.EndedAt != nil &&
 			strings.TrimSpace(session.EndReason) != ""

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -31,6 +31,7 @@ type Session struct {
 	SessionVersion             int
 	EffectiveTurns             int
 	TurnLimit                  int
+	CompletionMode             practice.CompletionMode
 	MaxFollowUpsPerQuestion    int
 	QuestionTranslationAllowed bool
 	QuestionTipsAllowed        bool
@@ -350,10 +351,8 @@ func (application *SessionApplication) state(
 		!validVoiceTurnPolicy(session.TurnPolicyRef) ||
 		!validVoiceScenePrompt(session) ||
 		session.SessionVersion < 1 ||
-		session.TurnLimit < 1 ||
-		session.TurnLimit > practice.MaxPracticeTurns ||
 		session.EffectiveTurns < 0 ||
-		session.EffectiveTurns > session.TurnLimit ||
+		!validVoiceProgress(session) ||
 		!validVoiceSessionLifecycle(session) ||
 		session.FacilitatorParticipantID == "" ||
 		session.LearnerParticipantID == "" ||
@@ -535,20 +534,32 @@ func validVoiceScenePrompt(session Session) bool {
 }
 
 func validVoiceSessionLifecycle(session Session) bool {
+	turnAvailable := session.CompletionMode == practice.CompletionModeUserControlled ||
+		session.EffectiveTurns < session.TurnLimit
 	switch session.Status {
 	case "in_progress":
-		return !session.Completed &&
-			session.EffectiveTurns < session.TurnLimit
+		return !session.Completed && turnAvailable
 	case "paused":
-		return !session.Completed &&
-			session.EffectiveTurns < session.TurnLimit
+		return !session.Completed && turnAvailable
 	case "completed":
-		return session.Completed &&
-			session.EffectiveTurns > 0 &&
-			session.EffectiveTurns <= session.TurnLimit
+		return session.Completed && session.EffectiveTurns > 0 &&
+			(session.CompletionMode == practice.CompletionModeUserControlled ||
+				session.EffectiveTurns <= session.TurnLimit)
 	case "ended_early":
-		return !session.Completed &&
-			session.EffectiveTurns < session.TurnLimit
+		return !session.Completed && turnAvailable
+	default:
+		return false
+	}
+}
+
+func validVoiceProgress(session Session) bool {
+	switch session.CompletionMode {
+	case practice.CompletionModeUserControlled:
+		return session.TurnLimit == 0
+	case practice.CompletionModeTurnLimited:
+		return session.TurnLimit > 0 &&
+			session.TurnLimit <= practice.MaxPracticeTurns &&
+			session.EffectiveTurns <= session.TurnLimit
 	default:
 		return false
 	}

--- a/server/internal/coaching/practice/voice/session_application_test.go
+++ b/server/internal/coaching/practice/voice/session_application_test.go
@@ -230,6 +230,7 @@ func sessionFixture() Session {
 		},
 		SessionVersion:             1,
 		TurnLimit:                  3,
+		CompletionMode:             practice.CompletionModeTurnLimited,
 		MaxFollowUpsPerQuestion:    1,
 		QuestionTranslationAllowed: true,
 		Status:                     "in_progress",

--- a/server/internal/coaching/preparation/plan.go
+++ b/server/internal/coaching/preparation/plan.go
@@ -28,6 +28,20 @@ type EarlyCompletionRule string
 
 const EarlyCompletionCoverageSatisfiedAfterCheckpoint EarlyCompletionRule = "COVERAGE_SATISFIED_AFTER_CHECKPOINT"
 
+type CompletionMode string
+
+const (
+	CompletionModeTurnLimited    CompletionMode = "TURN_LIMITED"
+	CompletionModeUserControlled CompletionMode = "USER_CONTROLLED"
+)
+
+func NormalizeCompletionMode(value CompletionMode) CompletionMode {
+	if value == "" {
+		return CompletionModeTurnLimited
+	}
+	return value
+}
+
 // GoalSnapshot freezes only the Goal identity needed to explain why a Plan
 // was created. Goal remains optional and owns its live lifecycle separately.
 type GoalSnapshot struct {
@@ -40,6 +54,7 @@ type GoalSnapshot struct {
 // revision. Objectives are held once on PracticePlan rather than duplicated
 // inside this value.
 type SessionPolicy struct {
+	CompletionMode             CompletionMode      `json:"completion_mode"`
 	SuggestedDurationSeconds   int                 `json:"suggested_duration_seconds"`
 	MinEffectiveTurns          int                 `json:"min_effective_turns"`
 	MaxEffectiveTurns          int                 `json:"max_effective_turns"`

--- a/server/internal/coaching/preparation/service/plan.go
+++ b/server/internal/coaching/preparation/service/plan.go
@@ -1072,15 +1072,24 @@ func ValidPracticeObjectives(objectives []PracticeObjective) bool {
 }
 
 func validStoredSessionPolicy(policy SessionPolicy) bool {
-	return policy.SuggestedDurationSeconds > 0 &&
-		policy.MinEffectiveTurns > 0 &&
+	completionMode := NormalizeCompletionMode(policy.CompletionMode)
+	if policy.SuggestedDurationSeconds < 1 ||
+		policy.MinEffectiveTurns < 1 ||
+		policy.CoverageCheckpointTurn < 1 ||
+		policy.MaxFollowUpsPerQuestion < 0 ||
+		policy.EarlyCompletionRule !=
+			EarlyCompletionCoverageSatisfiedAfterCheckpoint {
+		return false
+	}
+	if completionMode == CompletionModeUserControlled {
+		return policy.MaxEffectiveTurns == 0 &&
+			policy.CoverageCheckpointTurn == 1
+	}
+	return completionMode == CompletionModeTurnLimited &&
 		policy.MaxEffectiveTurns >= policy.MinEffectiveTurns &&
 		policy.MaxEffectiveTurns <= maxPlanEffectiveTurns &&
-		policy.CoverageCheckpointTurn > 0 &&
 		policy.CoverageCheckpointTurn <= policy.MaxEffectiveTurns &&
-		policy.MaxFollowUpsPerQuestion >= 0 &&
-		policy.EarlyCompletionRule ==
-			EarlyCompletionCoverageSatisfiedAfterCheckpoint
+		policy.MaxEffectiveTurns > 0
 }
 
 func ValidStoredSessionPolicy(policy SessionPolicy) bool {

--- a/server/migrations/000082_user_controlled_practice_sessions.down.sql
+++ b/server/migrations/000082_user_controlled_practice_sessions.down.sql
@@ -1,0 +1,114 @@
+BEGIN;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM preparation_practice_plan_revisions
+        WHERE session_policy ->> 'completion_mode' = 'USER_CONTROLLED'
+    ) OR EXISTS (
+        SELECT 1 FROM practice_session_snapshots
+        WHERE turn_limit = 0
+           OR snapshot_document -> 'session_policy' ->> 'completion_mode' =
+              'USER_CONTROLLED'
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot remove user-controlled Practice policy while dependent Plans or Sessions exist.'
+            USING ERRCODE = '55000';
+    END IF;
+END;
+$$;
+
+ALTER TABLE practice_session_snapshots
+    DROP CONSTRAINT practice_session_snapshots_turn_limit_check,
+    ADD CONSTRAINT practice_session_snapshots_turn_limit_check
+        CHECK (turn_limit > 0);
+
+ALTER TABLE practice_idempotency_records
+    DROP CONSTRAINT practice_idempotency_resource_check,
+    ADD CONSTRAINT practice_idempotency_resource_check
+        CHECK (
+            resource_kind IN (
+                'session',
+                'pause',
+                'resume',
+                'end_early'
+            )
+            AND btrim(resource_id) <> ''
+        );
+
+ALTER TABLE practice_session_snapshots
+    DISABLE TRIGGER practice_session_snapshots_immutable;
+
+UPDATE practice_session_snapshots
+SET snapshot_document = snapshot_document #- '{session_policy,completion_mode}'
+WHERE snapshot_document -> 'session_policy' ? 'completion_mode';
+
+ALTER TABLE practice_session_snapshots
+    ENABLE TRIGGER practice_session_snapshots_immutable;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DISABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+UPDATE preparation_practice_plan_revisions
+SET session_policy = session_policy - 'completion_mode'
+WHERE session_policy ? 'completion_mode';
+
+ALTER TABLE preparation_practice_plan_revisions
+    ENABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+CREATE OR REPLACE FUNCTION preparation_plan_session_policy_is_valid_v1(
+    payload jsonb
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+    IF payload IS NULL
+       OR jsonb_typeof(payload) <> 'object'
+       OR NOT payload ?& ARRAY[
+           'suggested_duration_seconds', 'min_effective_turns',
+           'max_effective_turns', 'coverage_checkpoint_turn',
+           'max_follow_ups_per_question', 'early_completion_rule',
+           'retry_allowed', 'question_translation_allowed',
+           'question_tips_allowed', 'avatar_allowed',
+           'speech_feedback_allowed'
+       ]
+       OR payload - ARRAY[
+           'suggested_duration_seconds', 'min_effective_turns',
+           'max_effective_turns', 'coverage_checkpoint_turn',
+           'max_follow_ups_per_question', 'early_completion_rule',
+           'retry_allowed', 'question_translation_allowed',
+           'question_tips_allowed', 'avatar_allowed',
+           'speech_feedback_allowed'
+       ] <> '{}'::jsonb
+       OR jsonb_typeof(payload -> 'suggested_duration_seconds') <> 'number'
+       OR jsonb_typeof(payload -> 'min_effective_turns') <> 'number'
+       OR jsonb_typeof(payload -> 'max_effective_turns') <> 'number'
+       OR jsonb_typeof(payload -> 'coverage_checkpoint_turn') <> 'number'
+       OR jsonb_typeof(payload -> 'max_follow_ups_per_question') <> 'number'
+       OR jsonb_typeof(payload -> 'retry_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'question_translation_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'question_tips_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'avatar_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'speech_feedback_allowed') <> 'boolean'
+       OR payload ->> 'suggested_duration_seconds' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'min_effective_turns' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'max_effective_turns' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'coverage_checkpoint_turn' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'max_follow_ups_per_question' !~ '^[0-9]{1,9}$'
+       OR (payload ->> 'min_effective_turns')::integer >
+           (payload ->> 'max_effective_turns')::integer
+       OR (payload ->> 'coverage_checkpoint_turn')::integer >
+           (payload ->> 'max_effective_turns')::integer
+       OR (payload ->> 'max_effective_turns')::integer > 64
+       OR jsonb_typeof(payload -> 'early_completion_rule') <> 'string'
+       OR payload ->> 'early_completion_rule' <>
+           'COVERAGE_SATISFIED_AFTER_CHECKPOINT' THEN
+        RETURN false;
+    END IF;
+    RETURN true;
+END;
+$$;
+
+COMMIT;

--- a/server/migrations/000082_user_controlled_practice_sessions.up.sql
+++ b/server/migrations/000082_user_controlled_practice_sessions.up.sql
@@ -1,0 +1,116 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION preparation_plan_session_policy_is_valid_v1(
+    payload jsonb
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    completion_mode text;
+BEGIN
+    IF payload IS NULL
+       OR jsonb_typeof(payload) <> 'object'
+       OR NOT payload ?& ARRAY[
+           'suggested_duration_seconds', 'min_effective_turns',
+           'max_effective_turns', 'coverage_checkpoint_turn',
+           'max_follow_ups_per_question', 'early_completion_rule',
+           'retry_allowed', 'question_translation_allowed',
+           'question_tips_allowed', 'avatar_allowed',
+           'speech_feedback_allowed'
+       ]
+       OR payload - ARRAY[
+           'completion_mode', 'suggested_duration_seconds',
+           'min_effective_turns', 'max_effective_turns',
+           'coverage_checkpoint_turn', 'max_follow_ups_per_question',
+           'early_completion_rule', 'retry_allowed',
+           'question_translation_allowed', 'question_tips_allowed',
+           'avatar_allowed', 'speech_feedback_allowed'
+       ] <> '{}'::jsonb
+       OR jsonb_typeof(payload -> 'suggested_duration_seconds') <> 'number'
+       OR jsonb_typeof(payload -> 'min_effective_turns') <> 'number'
+       OR jsonb_typeof(payload -> 'max_effective_turns') <> 'number'
+       OR jsonb_typeof(payload -> 'coverage_checkpoint_turn') <> 'number'
+       OR jsonb_typeof(payload -> 'max_follow_ups_per_question') <> 'number'
+       OR jsonb_typeof(payload -> 'retry_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'question_translation_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'question_tips_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'avatar_allowed') <> 'boolean'
+       OR jsonb_typeof(payload -> 'speech_feedback_allowed') <> 'boolean'
+       OR (payload ? 'completion_mode'
+           AND jsonb_typeof(payload -> 'completion_mode') <> 'string')
+       OR payload ->> 'suggested_duration_seconds' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'min_effective_turns' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'max_effective_turns' !~ '^(0|[1-9][0-9]{0,8})$'
+       OR payload ->> 'coverage_checkpoint_turn' !~ '^[1-9][0-9]{0,8}$'
+       OR payload ->> 'max_follow_ups_per_question' !~ '^[0-9]{1,9}$'
+       OR jsonb_typeof(payload -> 'early_completion_rule') <> 'string'
+       OR payload ->> 'early_completion_rule' <>
+           'COVERAGE_SATISFIED_AFTER_CHECKPOINT' THEN
+        RETURN false;
+    END IF;
+
+    completion_mode := COALESCE(payload ->> 'completion_mode', 'TURN_LIMITED');
+    IF completion_mode = 'USER_CONTROLLED' THEN
+        RETURN (payload ->> 'max_effective_turns')::integer = 0
+            AND (payload ->> 'coverage_checkpoint_turn')::integer = 1;
+    END IF;
+    IF completion_mode <> 'TURN_LIMITED' THEN
+        RETURN false;
+    END IF;
+    RETURN (payload ->> 'min_effective_turns')::integer <=
+               (payload ->> 'max_effective_turns')::integer
+        AND (payload ->> 'coverage_checkpoint_turn')::integer <=
+               (payload ->> 'max_effective_turns')::integer
+        AND (payload ->> 'max_effective_turns')::integer BETWEEN 1 AND 64;
+END;
+$$;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DISABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+UPDATE preparation_practice_plan_revisions
+SET session_policy = jsonb_set(
+    session_policy, '{completion_mode}', '"TURN_LIMITED"'::jsonb, true
+)
+WHERE NOT session_policy ? 'completion_mode';
+
+ALTER TABLE preparation_practice_plan_revisions
+    ENABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+ALTER TABLE practice_session_snapshots
+    DISABLE TRIGGER practice_session_snapshots_immutable;
+
+UPDATE practice_session_snapshots
+SET snapshot_document = jsonb_set(
+    snapshot_document,
+    '{session_policy,completion_mode}',
+    '"TURN_LIMITED"'::jsonb,
+    true
+)
+WHERE NOT (snapshot_document -> 'session_policy') ? 'completion_mode';
+
+ALTER TABLE practice_session_snapshots
+    ENABLE TRIGGER practice_session_snapshots_immutable;
+
+ALTER TABLE practice_session_snapshots
+    DROP CONSTRAINT practice_session_snapshots_turn_limit_check,
+    ADD CONSTRAINT practice_session_snapshots_turn_limit_check
+        CHECK (turn_limit >= 0);
+
+ALTER TABLE practice_idempotency_records
+    DROP CONSTRAINT practice_idempotency_resource_check,
+    ADD CONSTRAINT practice_idempotency_resource_check
+        CHECK (
+            resource_kind IN (
+                'session',
+                'pause',
+                'resume',
+                'complete',
+                'end_early'
+            )
+            AND btrim(resource_id) <> ''
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -67,4 +67,5 @@ import "embed"
 //go:embed 000079_preparation_plan_typed_context.*.sql
 //go:embed 000080_ielts_versioned_question_bank.*.sql
 //go:embed 000081_restore_interview_follow_ups.*.sql
+//go:embed 000082_user_controlled_practice_sessions.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

- 将职场英语、生活与旅行场景改为用户主动结束，不再受固定三轮限制。
- 开放式场景隐藏轮次总数，提供“结束练习并复盘”操作；暂停仍保持可恢复语义。
- 英语面试与 IELTS 继续使用固定轮次策略，不改变既有完成行为。
- 保留现有 Review 实现边界，只让有效的用户主动完成会话进入后续复盘证据链。

## 实现思路

- 在 Preparation、Practice Runtime、Agent handoff 与 OpenAPI 契约中增加 `completion_mode`，区分 `TURN_LIMITED` 和 `USER_CONTROLLED`。
- 为用户控制模式使用 `max_effective_turns = 0`，取消问题生成和客户端恢复路径中的固定上限。
- 新增 `POST /v1/practice-sessions/{practice_session_id}/complete`，按 Session version 与 Idempotency-Key 完成会话并记录 `USER_COMPLETED`。
- 新增 82 号迁移，兼容历史固定轮次快照，并允许 `complete` 幂等记录；up/down 迁移保持对称。
- Flutter 场景页隐藏开放式轮次展示，增加确认式结束入口，并沿用既有完成回调进入复盘流程。

## 可复现测试

```bash
cd server
go test ./...

go test -count=1 ./internal/platform/migration

TEST_DATABASE_URL="$DATABASE_URL" go test -count=1 \
  ./internal/coaching/practice/postgres \
  -run TestContextRepositoryCompletesUserControlledSessionIdempotently -v

cd ../api
npm run check

cd ../mobile
flutter analyze --no-pub \
  lib \
  test/agent/agent_handoff_codec_test.dart \
  test/agent/agent_message_bubble_test.dart \
  test/coaching/practice \
  test/coaching/preparation

flutter test --no-pub \
  test/agent/agent_handoff_codec_test.dart \
  test/agent/agent_message_bubble_test.dart \
  test/coaching/practice/practice_controller_lifecycle_test.dart \
  test/coaching/practice/scenario_practice_test.dart \
  test/coaching/practice/wire_practice_client_test.dart
```

手工验证：新建职场英语或生活与旅行练习，连续完成四轮以上，确认页面不显示轮次总数且不会自动结束；点击“结束练习并复盘”后 Session 进入 `completed / USER_COMPLETED`。新建面试或 IELTS 练习，确认仍按固定轮次完成。

说明：当前 `upstream/dev` 的全目录 `flutter analyze --no-pub` 会扫描 `mobile/vendor/avatar_kit/example`，该上游示例缺少 `shared_preferences` 依赖；本 PR 涉及的 `lib/` 与测试目录定向 Analyzer 已通过。

Closes #482
