### PR TITLE
[MS3][iOS][回归] 恢复 Liquid Glass 底部导航原生点击

### DIFF
--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -46,35 +46,10 @@ class PlatformNavigationBar extends StatelessWidget {
       return SizedBox(
         key: const Key('primary-navigation'),
         height: contentHeight + MediaQuery.viewPaddingOf(context).bottom,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: _NativeIosTabBar(
-                destinations: destinations,
-                selectedIndex: selectedIndex,
-                onDestinationSelected: onDestinationSelected,
-              ),
-            ),
-            // A native UITabBar platform view is opaque to the Flutter widget
-            // tree, so widget tests and integration tests cannot locate or tap
-            // its items. Overlay a transparent Flutter hit target per item,
-            // reusing each destination's key and forwarding to the same
-            // selection callback the native view would invoke.
-            Positioned.fill(
-              child: Row(
-                children: [
-                  for (final (index, destination) in destinations.indexed)
-                    Expanded(
-                      child: GestureDetector(
-                        key: destination.key,
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => unawaited(onDestinationSelected(index)),
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ],
+        child: _NativeIosTabBar(
+          destinations: destinations,
+          selectedIndex: selectedIndex,
+          onDestinationSelected: onDestinationSelected,
         ),
       );
     }

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/platform_navigation_bar.dart';
 
 void main() {
-  testWidgets('iOS native tab bar exposes destination keys and forwards taps', (
+  testWidgets('iOS leaves touch handling to the native tab bar', (
     tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
@@ -45,28 +45,33 @@ void main() {
     ];
 
     try {
-      final selectedIndexes = <int>[];
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             bottomNavigationBar: PlatformNavigationBar(
               destinations: destinations,
               selectedIndex: 0,
-              onDestinationSelected: (index) async {
-                selectedIndexes.add(index);
-                return index;
-              },
+              onDestinationSelected: (index) async => index,
             ),
           ),
         ),
       );
 
-      expect(find.byKey(const Key('primary-tab-scenes')), findsOneWidget);
-      expect(find.byKey(const Key('primary-tab-profile')), findsOneWidget);
-
-      await tester.tap(find.byKey(const Key('primary-tab-scenes')));
-      await tester.pump();
-      expect(selectedIndexes, [1]);
+      expect(find.byType(UiKitView), findsOneWidget);
+      expect(find.byType(GestureDetector), findsNothing);
+      final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
+      expect(platformView.viewType, 'speakup/native_tab_bar');
+      expect(platformView.creationParams, <String, Object>{
+        'selectedIndex': 0,
+        'items': <Map<String, String>>[
+          for (final destination in destinations)
+            <String, String>{
+              'label': destination.label,
+              'systemImage': destination.iosSystemImage,
+              'selectedSystemImage': destination.iosSelectedSystemImage,
+            },
+        ],
+      });
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/platform_navigation_bar.dart';
 
 void main() {
-  testWidgets('iOS leaves touch handling to the native tab bar', (
+  testWidgets('iOS delegates touches and forwards native tab selection', (
     tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    int? selectedIndex;
 
     final destinations = <PlatformNavigationDestination>[
       PlatformNavigationDestination(
@@ -51,7 +53,10 @@ void main() {
             bottomNavigationBar: PlatformNavigationBar(
               destinations: destinations,
               selectedIndex: 0,
-              onDestinationSelected: (index) async => index,
+              onDestinationSelected: (index) async {
+                selectedIndex = index;
+                return index;
+              },
             ),
           ),
         ),
@@ -72,6 +77,19 @@ void main() {
             },
         ],
       });
+
+      platformView.onPlatformViewCreated?.call(7);
+      final response = await tester.binding.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'speakup/native_tab_bar/7',
+            const StandardMethodCodec().encodeMethodCall(
+              const MethodCall('onSelected', 2),
+            ),
+            null,
+          );
+
+      expect(selectedIndex, 2);
+      expect(const StandardMethodCodec().decodeEnvelope(response!), 2);
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }


### PR DESCRIPTION
## 功能描述

修复 iOS Liquid Glass 底部导航视觉正常但无法连续点击切换的问题。保留系统原生 `UITabBar` 外观和 SF Symbols，仅移除覆盖在原生平台视图上方的透明 Flutter 点击层。

## 根因与实现

此前 `UiKitView` 上方叠加了一行透明 `GestureDetector`，用于让 Flutter 测试查找 Tab key；该合成层与原生 `UITabBar` 争夺真实触摸事件，使 `UITabBarDelegate.tabBar(_:didSelect:)` 无法稳定收到点击。

修复后的权威链路：

用户点击原生 UITabBar → UITabBarDelegate → MethodChannel → SpeakUpShell 导航状态。

Android 的 Flutter NavigationBar 和业务离开检查均未修改。

## Apple 规范

- [Tab bars](https://developer.apple.com/design/human-interface-guidelines/tab-bars)：iOS Tab Bar 浮于内容上方并使用 Liquid Glass，所有 Tab 应保持可用。
- [UITabBarDelegate](https://developer.apple.com/documentation/uikit/uitabbardelegate/tabbar(_:didselect:))：用户选择由原生 delegate 回调。

## 验证

- `flutter test test/app/platform_navigation_bar_ios_test.dart test/speak_up_app_test.dart`（26 项通过）
- `flutter analyze`（通过）
- `git diff --check`（通过）

Closes #490