### PR TITLE
[MS3][Mobile] 统一 Agent 回复加载状态

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -911,15 +911,19 @@ class _MessageList extends StatelessWidget {
       key: const Key('agent-message-list'),
       children: [
         for (final message in messages)
-          AgentMessageBubble(
-            message: message,
-            messageAudioController: messageAudioController,
-            onTranslate: onTranslateMessage,
-            onHandoff: onHandoff,
-            onRefreshImage: onRefreshImage,
-            correction: feedbackPresenter?.correctionFor(message),
-            polish: feedbackPresenter?.polishFor(message),
-          ),
+          if (!suppressLoadingFeedback ||
+              message.role != AgentMessageRole.assistant ||
+              !message.isStreaming ||
+              message.text.isNotEmpty)
+            AgentMessageBubble(
+              message: message,
+              messageAudioController: messageAudioController,
+              onTranslate: onTranslateMessage,
+              onHandoff: onHandoff,
+              onRefreshImage: onRefreshImage,
+              correction: feedbackPresenter?.correctionFor(message),
+              polish: feedbackPresenter?.polishFor(message),
+            ),
       ],
     );
   }

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -499,6 +499,32 @@ void main() {
     );
   });
 
+  testWidgets('a busy run shows only the page reply progress', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ConversationPage(
+          isBusy: true,
+          messages: <AgentMessage>[
+            AgentMessage(
+              id: 'user-message',
+              role: AgentMessageRole.user,
+              text: 'Help me prepare for an interview.',
+            ),
+            AgentMessage(
+              id: 'assistant-stream',
+              role: AgentMessageRole.assistant,
+              text: '',
+              isStreaming: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('agent-operation-progress')), findsOneWidget);
+    expect(find.byKey(const Key('agent-assistant-streaming')), findsNothing);
+  });
+
   testWidgets('older Message pagination is visible and accessible', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

Agent 请求进行中仅展示页面级“SpeakUp 正在回复…”状态，不再同时渲染空内容的流式 Assistant 气泡；流式消息一旦产生文本，仍按正常消息展示。

## 实现思路

- 在 Agent 消息列表中仅抑制“空文本 + streaming”的 Assistant 占位消息。
- 保留现有页面级进度、已产生内容的流式消息和其他消息渲染行为。
- 增加组件测试，锁定一次请求只出现一个可见加载状态。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/speak_up_app_test.dart
```

Closes #496
