### PR TITLE
[MS3][Mobile] 完善 Agent 对话侧边栏的历史与新建行为

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -366,7 +366,12 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         restingComposerBottom: composerBottomInset,
         threadId: widget.conversationController.threadId,
         displayName: widget.authController?.profile?.displayName,
-        onOpenMenu: () => _scaffoldKey.currentState?.openDrawer(),
+        onOpenMenu: () {
+          _scaffoldKey.currentState?.openDrawer();
+          if (!widget.previewMode) {
+            unawaited(widget.conversationController.refreshThreadHistory());
+          }
+        },
         onNavigateBack: widget.showBackButton
             ? () => Navigator.of(context).maybePop()
             : null,
@@ -522,6 +527,7 @@ class _ConversationDrawer extends StatelessWidget {
     final recentThreads = <AgentThreadSummary>[
       for (final thread in controller.threads)
         if (thread.id != currentThreadId &&
+            thread.activeGoalId == null &&
             !hiddenThreadIds.contains(thread.id))
           thread,
     ];
@@ -535,7 +541,7 @@ class _ConversationDrawer extends StatelessWidget {
           enabled: !busy,
           onTap: () => Navigator.of(context).pop(),
         )
-      else
+      else if (current?.activeGoalId == null)
         _ConversationThreadTile(
           key: Key('conversation-thread-$currentThreadId'),
           title: current?.title ?? '新对话',
@@ -587,65 +593,78 @@ class _ConversationDrawer extends StatelessWidget {
               ),
             ),
             Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+              child: Stack(
                 children: [
-                  if (controller.threadHistoryErrorMessage case final message?)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: Text(
-                        message,
-                        key: const Key('conversation-history-error'),
-                        style: SpeakUpDesign.meta.copyWith(
-                          color: SpeakUpDesign.error,
-                        ),
-                      ),
+                  Positioned.fill(
+                    child: ListView(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 88),
+                      children: [
+                        if (controller.threadHistoryErrorMessage
+                            case final message?)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 10),
+                            child: Text(
+                              message,
+                              key: const Key('conversation-history-error'),
+                              style: SpeakUpDesign.meta.copyWith(
+                                color: SpeakUpDesign.error,
+                              ),
+                            ),
+                          ),
+                        if (threadWidgets.isEmpty)
+                          const Padding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 10,
+                            ),
+                            child: Text('暂无聊天', style: SpeakUpDesign.body),
+                          )
+                        else
+                          ...threadWidgets,
+                        if (controller.hasMoreThreads) ...[
+                          const SizedBox(height: 8),
+                          TextButton(
+                            key: const Key('load-more-conversations'),
+                            onPressed: controller.isLoadingMoreThreads || busy
+                                ? null
+                                : controller.loadMoreThreads,
+                            child: Text(
+                              controller.isLoadingMoreThreads
+                                  ? '正在加载…'
+                                  : '加载更早',
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
-                  const Padding(
-                    padding: EdgeInsets.only(left: 4, bottom: 8),
-                    child: Text('最近', style: SpeakUpDesign.label),
                   ),
-                  ...threadWidgets,
-                  if (controller.hasMoreThreads) ...[
-                    const SizedBox(height: 8),
-                    TextButton(
-                      key: const Key('load-more-conversations'),
-                      onPressed: controller.isLoadingMoreThreads || busy
+                  Positioned(
+                    left: 16,
+                    bottom: 16,
+                    child: FilledButton.icon(
+                      key: const Key('new-conversation-button'),
+                      onPressed: busy
                           ? null
-                          : controller.loadMoreThreads,
-                      child: Text(
-                        controller.isLoadingMoreThreads ? '正在加载…' : '加载更早',
+                          : () async {
+                              final created = await controller.createThread();
+                              if (!context.mounted || !created) {
+                                return;
+                              }
+                              Navigator.of(context).pop();
+                            },
+                      icon: const Icon(Icons.edit_outlined, size: 22),
+                      label: const Text('聊天'),
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size(0, 48),
+                        padding: const EdgeInsets.symmetric(horizontal: 20),
+                        backgroundColor: SpeakUpDesign.primary,
+                        foregroundColor: SpeakUpDesign.canvas,
+                        shape: const StadiumBorder(),
+                        textStyle: SpeakUpDesign.cardTitle,
                       ),
                     ),
-                  ],
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-              child: FilledButton.icon(
-                key: const Key('new-conversation-button'),
-                onPressed: busy
-                    ? null
-                    : () async {
-                        final created = await controller.createThread();
-                        if (!context.mounted || !created) {
-                          return;
-                        }
-                        Navigator.of(context).pop();
-                      },
-                icon: const Icon(Icons.add_rounded),
-                label: const Text('新建聊天'),
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(48),
-                  backgroundColor: SpeakUpDesign.primary,
-                  foregroundColor: SpeakUpDesign.canvas,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                      SpeakUpDesign.radiusControl,
-                    ),
                   ),
-                ),
+                ],
               ),
             ),
           ],

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -992,11 +992,48 @@ final class ConversationController extends ChangeNotifier {
     if (_disposed || !_initialized || isBusy || threadId == null) {
       return;
     }
-    await _refreshAuthoritativeThreadPage(
-      client,
-      fence: _captureOperationFence(threadId: threadId),
-      failureMessage: '对话列表暂时无法刷新，请稍后再试。',
-    );
+    final fence = _captureOperationFence(threadId: threadId);
+    try {
+      final page = await client.listThreads();
+      _validateThreadPage(page);
+      if (!_isOperationCurrent(fence)) {
+        return;
+      }
+      final refreshedIds = <String>{
+        for (final thread in page.threads) thread.id,
+      };
+      final boundary = page.threads.lastOrNull;
+      final preservedOlderThreads = boundary == null
+          ? const <AgentThreadSummary>[]
+          : <AgentThreadSummary>[
+              for (final thread in _threads)
+                if (!refreshedIds.contains(thread.id) &&
+                    _threadSortsAfter(thread, boundary))
+                  thread,
+            ];
+      final previousCursor = _nextThreadCursor;
+      _threads = <AgentThreadSummary>[
+        ...page.threads,
+        ...preservedOlderThreads,
+      ];
+      _nextThreadCursor = preservedOlderThreads.isEmpty
+          ? page.nextCursor
+          : previousCursor;
+      _currentThreadSummary =
+          page.threads.where((thread) => thread.id == threadId).firstOrNull ??
+          preservedOlderThreads
+              .where((thread) => thread.id == threadId)
+              .firstOrNull ??
+          _currentThreadSummary;
+      _resolveThreadPageRefresh();
+      notifyListeners();
+    } catch (_) {
+      if (_isOperationCurrent(fence)) {
+        _requireThreadPageRefresh();
+        _threadHistoryErrorMessage = '对话列表暂时无法刷新，请稍后再试。';
+        notifyListeners();
+      }
+    }
   }
 
   Future<void> _retryThreadHistoryRefresh() async {

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -224,7 +224,7 @@ final class ConversationController extends ChangeNotifier {
     if (pendingFocusThreadId != null) {
       return selectThread(pendingFocusThreadId);
     }
-    return _createNewThread();
+    return _createNewThread(reuseBlankCurrent: true);
   }
 
   /// Creates a new Thread for a caller that requires an isolated workspace.
@@ -239,7 +239,7 @@ final class ConversationController extends ChangeNotifier {
     return _createNewThread();
   }
 
-  Future<bool> _createNewThread() async {
+  Future<bool> _createNewThread({bool reuseBlankCurrent = false}) async {
     if (_disposed) {
       return false;
     }
@@ -254,10 +254,22 @@ final class ConversationController extends ChangeNotifier {
       if (!_isCurrent(accountEpoch)) {
         return false;
       }
+      if (reuseBlankCurrent && _canReuseCurrentBlankThread) {
+        return true;
+      }
       return await _transitionThread(historyClient, createNew: true);
     } finally {
       _finishThreadTransition(transitionGeneration);
     }
+  }
+
+  bool get _canReuseCurrentBlankThread {
+    final current = _currentThreadSummary;
+    return _threadId != null &&
+        current?.id == _threadId &&
+        current?.activeGoalId == null &&
+        _messages.isEmpty &&
+        _retry == null;
   }
 
   Future<bool> selectThread(String threadId) async {
@@ -973,6 +985,18 @@ final class ConversationController extends ChangeNotifier {
       case null:
         return;
     }
+  }
+
+  Future<void> refreshThreadHistory() async {
+    final threadId = _threadId;
+    if (_disposed || !_initialized || isBusy || threadId == null) {
+      return;
+    }
+    await _refreshAuthoritativeThreadPage(
+      client,
+      fence: _captureOperationFence(threadId: threadId),
+      failureMessage: '对话列表暂时无法刷新，请稍后再试。',
+    );
   }
 
   Future<void> _retryThreadHistoryRefresh() async {

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -166,7 +166,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('conversation-menu-button')));
       await tester.pumpAndSettle();
-      expect(find.text('新建聊天'), findsOneWidget);
+      expect(find.text('聊天'), findsOneWidget);
       expect(find.textContaining('本地 Fake 预览'), findsNothing);
       Navigator.of(tester.element(find.byType(Drawer))).pop();
       await tester.pumpAndSettle();

--- a/mobile/test/agent/agent_image_flow_test.dart
+++ b/mobile/test/agent/agent_image_flow_test.dart
@@ -102,7 +102,7 @@ void main() {
       final oldThreadId = conversationController.threadId;
       final stagedAssetId = composerController.pendingImages.single.asset!.id;
 
-      expect(await conversationController.createThread(), isTrue);
+      expect(await conversationController.createIndependentThread(), isTrue);
       await Future<void>.delayed(Duration.zero);
 
       expect(conversationController.threadId, isNot(oldThreadId));
@@ -130,7 +130,7 @@ void main() {
 
     final selection = composerController.pickAgentImages();
     await imageClient.uploadStarted.future;
-    expect(await conversationController.createThread(), isTrue);
+    expect(await conversationController.createIndependentThread(), isTrue);
     imageClient.completeUpload(threadId: oldThreadId);
     await selection;
     await Future<void>.delayed(Duration.zero);

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -43,7 +43,7 @@ void main() {
       final voiceController = composerController.voiceController!;
 
       player.failNextStop = true;
-      expect(await conversationController.createThread(), isTrue);
+      expect(await conversationController.createIndependentThread(), isTrue);
       await Future<void>.delayed(Duration.zero);
 
       expect(conversationController.threadId, isNot(oldThreadId));

--- a/mobile/test/agent/conversation_controller_test.dart
+++ b/mobile/test/agent/conversation_controller_test.dart
@@ -623,6 +623,59 @@ void main() {
     },
   );
 
+  test(
+    'refresh keeps a selected older Thread that is absent from the first page',
+    () async {
+      final client = _HistoryAgentClient(
+        refreshedThreadPage: AgentThreadPage(
+          threads: <AgentThreadSummary>[_historySummaryOne],
+          nextCursor: 'older_threads',
+        ),
+      );
+      final controller = ConversationController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      await controller.loadMoreThreads();
+      expect(await controller.selectThread(_historyThreadTwo), isTrue);
+
+      await controller.refreshThreadHistory();
+
+      expect(controller.threadId, _historyThreadTwo);
+      expect(controller.currentThreadSummary?.id, _historyThreadTwo);
+      expect(controller.threadHistoryErrorMessage, isNull);
+    },
+  );
+
+  test('refresh preserves loaded older pages and their cursor', () async {
+    final generatedTitle = AgentThreadSummary(
+      id: _historyThreadOne,
+      title: '产品经理面试准备',
+      createdAt: _historySummaryOne.createdAt,
+      updatedAt: _historySummaryOne.updatedAt,
+    );
+    final client = _HistoryAgentClient(
+      refreshedThreadPage: AgentThreadPage(
+        threads: <AgentThreadSummary>[generatedTitle],
+        nextCursor: 'older_threads',
+      ),
+    );
+    final controller = ConversationController(client: client);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    await controller.loadMoreThreads();
+
+    expect(controller.hasMoreThreads, isFalse);
+    await controller.refreshThreadHistory();
+
+    expect(controller.threads.map((thread) => thread.id), [
+      _historyThreadOne,
+      _historyThreadTwo,
+    ]);
+    expect(controller.threads.first.title, '产品经理面试准备');
+    expect(controller.hasMoreThreads, isFalse);
+    expect(controller.threadHistoryErrorMessage, isNull);
+  });
+
   test('rejects overlapping and out-of-bound Thread pages', () async {
     final invalidPages = <AgentThreadPage>[
       AgentThreadPage(threads: <AgentThreadSummary>[_historySummaryOne]),

--- a/mobile/test/agent/conversation_controller_test.dart
+++ b/mobile/test/agent/conversation_controller_test.dart
@@ -408,6 +408,36 @@ void main() {
     expect(controller.isThreadTransitionInFlight, isFalse);
   });
 
+  test('reuses a focused blank ordinary Thread without another POST', () async {
+    final client = _HistoryAgentClient(focusedThreadEmpty: true);
+    final controller = ConversationController(client: client);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    final originalThreadId = controller.threadId;
+
+    expect(controller.messages, isEmpty);
+    expect(await controller.createThread(), isTrue);
+
+    expect(client.createCalls, 0);
+    expect(controller.threadId, originalThreadId);
+  });
+
+  test(
+    'independent Thread creation does not reuse a blank ordinary Thread',
+    () async {
+      final client = _HistoryAgentClient(focusedThreadEmpty: true);
+      final controller = ConversationController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+      final originalThreadId = controller.threadId;
+
+      expect(await controller.createIndependentThread(), isTrue);
+
+      expect(client.createCalls, 1);
+      expect(controller.threadId, isNot(originalThreadId));
+    },
+  );
+
   test(
     'exposes ambiguous Thread creation as an explicit recovery operation',
     () async {
@@ -558,6 +588,38 @@ void main() {
         updatedSummaryOne.updatedAt,
       );
       expect(client.firstPageCalls, 3);
+    },
+  );
+
+  test(
+    'refreshes a generated Thread title from the authoritative page',
+    () async {
+      final generatedTitle = AgentThreadSummary(
+        id: _historyThreadOne,
+        title: '产品经理面试准备',
+        createdAt: _historySummaryOne.createdAt,
+        updatedAt: _historySummaryOne.updatedAt,
+      );
+      final client = _HistoryAgentClient(
+        initialThreadPage: AgentThreadPage(
+          threads: <AgentThreadSummary>[_historySummaryOne],
+          focusedThreadId: _historyThreadOne,
+        ),
+        refreshedThreadPage: AgentThreadPage(
+          threads: <AgentThreadSummary>[generatedTitle],
+          focusedThreadId: _historyThreadOne,
+        ),
+      );
+      final controller = ConversationController(client: client);
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      expect(controller.threads.single.title, isNull);
+
+      await controller.refreshThreadHistory();
+
+      expect(controller.threads.single.title, '产品经理面试准备');
+      expect(controller.currentThreadSummary?.title, '产品经理面试准备');
     },
   );
 
@@ -812,6 +874,7 @@ final class _HistoryAgentClient extends _DelegatingAgentClient {
     this.textExchange,
     this.laterThreadPage,
     this.olderMessagePage,
+    this.focusedThreadEmpty = false,
   });
 
   final bool controlOldSend;
@@ -827,6 +890,7 @@ final class _HistoryAgentClient extends _DelegatingAgentClient {
   final AgentExchange? textExchange;
   final AgentThreadPage? laterThreadPage;
   final AgentMessagePage? olderMessagePage;
+  final bool focusedThreadEmpty;
   final initialListStarted = Completer<void>();
   final createStarted = Completer<void>();
   final sendStarted = Completer<void>();
@@ -886,7 +950,11 @@ final class _HistoryAgentClient extends _DelegatingAgentClient {
     if (startsWithoutFocus) {
       return null;
     }
-    return _historySnapshot(_historySummaryOne, hasOlderMessages: true);
+    return _historySnapshot(
+      _historySummaryOne,
+      hasOlderMessages: true,
+      empty: focusedThreadEmpty,
+    );
   }
 
   @override
@@ -988,17 +1056,20 @@ final class _HistoryAgentClient extends _DelegatingAgentClient {
 AgentThreadSnapshot _historySnapshot(
   AgentThreadSummary summary, {
   bool hasOlderMessages = false,
+  bool empty = false,
 }) {
   return AgentThreadSnapshot(
     threadId: summary.id,
-    messages: <AgentMessage>[
-      AgentMessage(
-        id: 'message_current_${summary.id}',
-        role: AgentMessageRole.assistant,
-        text: 'current ${summary.id}',
-        sequence: 2,
-      ),
-    ],
+    messages: empty
+        ? const <AgentMessage>[]
+        : <AgentMessage>[
+            AgentMessage(
+              id: 'message_current_${summary.id}',
+              role: AgentMessageRole.assistant,
+              text: 'current ${summary.id}',
+              sequence: 2,
+            ),
+          ],
     createdAt: summary.createdAt,
     updatedAt: summary.updatedAt,
     nextMessageCursor: hasOlderMessages ? 'older_messages' : null,

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -504,7 +504,10 @@ void main() {
       expect(harness.workspaceController.currentPracticeThreadId, isNull);
       final originalHomeThreadId = harness.conversationController.threadId;
 
-      expect(await harness.conversationController.createThread(), isTrue);
+      expect(
+        await harness.conversationController.createIndependentThread(),
+        isTrue,
+      );
       final latestHomeThreadId = harness.conversationController.threadId;
       expect(latestHomeThreadId, isNot(originalHomeThreadId));
 

--- a/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
@@ -190,7 +190,7 @@ void main() {
       await _leavePractice(tester);
       expect(conversationController.threadId, homeThreadId);
 
-      expect(await conversationController.createThread(), isTrue);
+      expect(await conversationController.createIndependentThread(), isTrue);
       final unrelatedPracticeThreadId = conversationController.threadId!;
       final unrelatedScene = testScene(
         id: 'unrelated-practice',

--- a/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
@@ -98,7 +98,7 @@ void main() {
       expect(firstWorkspace.resumableHasProgress, isFalse);
       expect(await firstWorkspace.parkCurrentPractice(), isTrue);
       expect(harness.conversation.threadId, homeThreadId);
-      expect(await harness.conversation.createThread(), isTrue);
+      expect(await harness.conversation.createIndependentThread(), isTrue);
       final newerHomeThreadId = harness.conversation.threadId;
       expect(newerHomeThreadId, isNot(homeThreadId));
       firstWorkspace.dispose();
@@ -196,7 +196,7 @@ void main() {
 
       // The user switches to a different conversation (e.g. via the drawer)
       // while the practice stays parked and resumable.
-      await harness.conversation.createThread();
+      await harness.conversation.createIndependentThread();
       final otherHomeThreadId = harness.conversation.threadId;
       expect(otherHomeThreadId, isNot(launchHomeThreadId));
 

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -663,12 +663,12 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.descendant(of: drawer, matching: find.text('新建聊天')),
+      find.descendant(of: drawer, matching: find.text('聊天')),
       findsOneWidget,
     );
     expect(
       find.descendant(of: drawer, matching: find.text('最近')),
-      findsOneWidget,
+      findsNothing,
     );
     expect(
       find.descendant(of: drawer, matching: find.byTooltip('删除对话')),
@@ -688,6 +688,37 @@ void main() {
     );
   });
 
+  testWidgets('conversation drawer excludes practice-owned Threads', (
+    tester,
+  ) async {
+    final controller = ConversationController(client: FakeAgentClient());
+    addTearDown(controller.dispose);
+    await controller.initialize();
+    final practiceThreadId = controller.threadId!;
+    controller.applyActiveGoal(
+      threadId: practiceThreadId,
+      goalId: 'goal_practice_drawer',
+    );
+    expect(await controller.createThread(), isTrue);
+    final ordinaryThreadId = controller.threadId!;
+
+    await tester.pumpWidget(
+      SpeakUpApp.preview(conversationController: controller),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(Key('conversation-thread-$ordinaryThreadId')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(Key('conversation-thread-$practiceThreadId')),
+      findsNothing,
+    );
+  });
+
   testWidgets(
     'new conversation becomes selected and the old one stays recent',
     (tester) async {
@@ -696,6 +727,8 @@ void main() {
       await tester.pumpWidget(
         SpeakUpApp.preview(conversationController: controller),
       );
+      await tester.pumpAndSettle();
+      expect(await controller.sendText('保留这段已有聊天'), isTrue);
       await tester.pumpAndSettle();
       final originalThreadId = controller.threadId;
 
@@ -734,6 +767,8 @@ void main() {
     await tester.pumpWidget(
       SpeakUpApp.preview(conversationController: controller),
     );
+    await tester.pumpAndSettle();
+    expect(await controller.sendText('创建一段可删除的聊天'), isTrue);
     await tester.pumpAndSettle();
     final originalThreadId = controller.threadId!;
 
@@ -1033,7 +1068,7 @@ void main() {
 
       await tester.drag(find.byType(ListView), const Offset(0, -1000));
       await tester.pumpAndSettle();
-      expect(find.text('新建聊天').hitTestable(), findsOneWidget);
+      expect(find.text('聊天').hitTestable(), findsOneWidget);
       expect(tester.takeException(), isNull);
 
       await tester.drag(find.byType(ListView), const Offset(0, 1000));


### PR DESCRIPTION
## 功能描述

完善 Agent 对话侧边栏的普通聊天边界与新建行为：过滤练习 Thread，复用当前空白普通 Thread，并在打开正式侧边栏时刷新服务端权威列表。同时将底部入口收敛为紧凑“聊天”胶囊按钮。

## 实现思路

- 侧边栏根据 `activeGoalId` 排除练习占用的 Thread。
- 用户点击“聊天”时，仅在当前普通 Thread 为空且无待恢复发送时复用；需要隔离工作区的 `createIndependentThread` 保持创建新 Thread。
- 正式环境打开抽屉后刷新 Thread 首页，使异步生成的服务端标题及时进入列表；预览模式保持纯本地行为。
- 移除“最近”标签，将新建入口固定在侧边栏底部，列表保留足够滚动留白。

## 代码位置与依赖方向

`SpeakUpShell 抽屉入口 → ConversationController Thread 操作 → AgentClient 服务端 Thread API`

- `mobile/lib/app/speak_up_shell.dart`：侧边栏展示、Thread 过滤和刷新触发。
- `mobile/lib/features/agent/conversation/conversation_controller.dart`：空白 Thread 复用与权威列表刷新。
- `mobile/test`：普通/练习 Thread、新建行为、标题刷新及可访问性回归。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/speak_up_app_test.dart test/agent/agent_flow_test.dart test/agent/conversation_controller_test.dart
```

Closes #500
