### PR TITLE
[MS3][Mobile] 让 Agent 消息内容使用完整屏幕视口

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -129,6 +129,9 @@ class ConversationPage extends StatefulWidget {
     required VoidCallback? onLoadEarlierMessages,
     required bool showJumpToLatest,
     required VoidCallback onJumpToLatest,
+    required double composerHeight,
+    required GlobalKey composerKey,
+    required VoidCallback onComposerSizeChanged,
   }) {
     final width = MediaQuery.sizeOf(context).width;
     final horizontalPadding = width >= 390 ? 20.0 : 16.0;
@@ -147,6 +150,8 @@ class ConversationPage extends StatefulWidget {
       _ => false,
     };
     final replyPending = isBusy || voiceShowsReplyProgress;
+    const topOverlayExtent = 76.0;
+    final bottomOverlayExtent = composerBottom + composerHeight + 16;
 
     return Scaffold(
       key: const Key('agent-home-page'),
@@ -158,232 +163,279 @@ class ConversationPage extends StatefulWidget {
           Positioned.fill(
             child: SafeArea(
               bottom: false,
-              child: Padding(
-                padding: EdgeInsets.only(bottom: composerBottom),
-                child: Column(
-                  children: [
-                    Padding(
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: SingleChildScrollView(
+                      key: const Key('agent-conversation-scroll'),
+                      controller: scrollController,
                       padding: EdgeInsets.fromLTRB(
                         horizontalPadding,
-                        12,
+                        topOverlayExtent,
                         horizontalPadding,
-                        8,
+                        bottomOverlayExtent,
                       ),
-                      child: _AgentTopBar(
-                        previewMode: previewMode,
-                        onOpenMenu: onOpenMenu,
-                        onNavigateBack: onNavigateBack,
-                        onCreateConversation: onCreateConversation,
-                        isBusy: isBusy,
-                      ),
-                    ),
-                    Expanded(
-                      child: SingleChildScrollView(
-                        controller: scrollController,
-                        padding: EdgeInsets.fromLTRB(
-                          horizontalPadding,
-                          8,
-                          horizontalPadding,
-                          0,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            SizedBox(
-                              height: hasFocusedThread && messages.isNotEmpty
-                                  ? 4
-                                  : width < 350
-                                  ? 16
-                                  : 24,
-                            ),
-                            if (messages.isEmpty) ...[
-                              _Greeting(displayName: displayName),
-                              if (displayName != null) ...[
-                                const SizedBox(height: 5),
-                                Text(
-                                  '今天想练什么？',
-                                  style: TextStyle(
-                                    color: SpeakUpDesign.ink,
-                                    fontSize: titleSize,
-                                    fontWeight: FontWeight.w600,
-                                    height: 1.12,
-                                    letterSpacing: -0.8,
-                                  ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(
+                            height: hasFocusedThread && messages.isNotEmpty
+                                ? 4
+                                : width < 350
+                                ? 16
+                                : 24,
+                          ),
+                          if (messages.isEmpty) ...[
+                            _Greeting(displayName: displayName),
+                            if (displayName != null) ...[
+                              const SizedBox(height: 5),
+                              Text(
+                                '今天想练什么？',
+                                style: TextStyle(
+                                  color: SpeakUpDesign.ink,
+                                  fontSize: titleSize,
+                                  fontWeight: FontWeight.w600,
+                                  height: 1.12,
+                                  letterSpacing: -0.8,
                                 ),
-                              ],
-                              SizedBox(height: emptyHomeActionGap),
-                              if (practiceAvailable)
-                                _QuickActions(
-                                  onCreatePlan: onCreatePlan,
-                                  onBrowseScenes: onBrowseScenes,
-                                  onContinuePractice: onContinuePractice,
-                                  onOpenReview: onOpenReview,
-                                )
-                              else
-                                const _PracticeUnavailableNotice(),
-                            ] else ...[
-                              if (activeSceneName case final sceneName?) ...[
-                                Row(
-                                  children: [
-                                    const Text(
-                                      '当前场景',
-                                      style: TextStyle(
-                                        color: SpeakUpDesign.secondary,
-                                        fontSize: 13,
-                                        fontWeight: FontWeight.w500,
+                              ),
+                            ],
+                            SizedBox(height: emptyHomeActionGap),
+                            if (practiceAvailable)
+                              _QuickActions(
+                                onCreatePlan: onCreatePlan,
+                                onBrowseScenes: onBrowseScenes,
+                                onContinuePractice: onContinuePractice,
+                                onOpenReview: onOpenReview,
+                              )
+                            else
+                              const _PracticeUnavailableNotice(),
+                          ] else ...[
+                            if (activeSceneName case final sceneName?) ...[
+                              Row(
+                                children: [
+                                  const Text(
+                                    '当前场景',
+                                    style: TextStyle(
+                                      color: SpeakUpDesign.secondary,
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Flexible(
+                                    child: Text(
+                                      sceneName,
+                                      key: const Key('agent-thread-title'),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(
+                                        color: SpeakUpDesign.ink,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w600,
                                       ),
                                     ),
-                                    const SizedBox(width: 8),
-                                    Flexible(
-                                      child: Text(
-                                        sceneName,
-                                        key: const Key('agent-thread-title'),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: const TextStyle(
-                                          color: SpeakUpDesign.ink,
-                                          fontSize: 14,
-                                          fontWeight: FontWeight.w600,
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                            ],
+                            if (hasEarlierMessages) ...[
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: TextButton.icon(
+                                  key: const Key('load-earlier-agent-messages'),
+                                  onPressed:
+                                      isLoadingEarlierMessages ||
+                                          onLoadEarlierMessages == null
+                                      ? null
+                                      : onLoadEarlierMessages,
+                                  icon: isLoadingEarlierMessages
+                                      ? const SizedBox.square(
+                                          dimension: 16,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        )
+                                      : const Icon(
+                                          Icons.history_rounded,
+                                          size: 18,
                                         ),
+                                  label: Text(
+                                    isLoadingEarlierMessages
+                                        ? '正在加载更早消息'
+                                        : '加载更早消息',
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                            ],
+                            _MessageList(
+                              messages: messages,
+                              suppressLoadingFeedback: replyPending,
+                              messageAudioController: messageAudioController,
+                              onTranslateMessage: onTranslateMessage,
+                              onHandoff: onMessageHandoff,
+                              onRefreshImage: onRefreshMessageImage,
+                              feedbackPresenter: feedbackPresenter,
+                              onSameThreadRepractice:
+                                  !isBusy && onStartVoice != null
+                                  ? () => unawaited(
+                                      Future<void>.sync(onStartVoice!),
+                                    )
+                                  : null,
+                            ),
+                          ],
+                          if (isBusy && !voiceShowsReplyProgress) ...[
+                            const SizedBox(height: 14),
+                            Center(
+                              child: Semantics(
+                                label: 'SpeakUp 正在处理',
+                                child: const Wrap(
+                                  key: Key('agent-operation-progress'),
+                                  alignment: WrapAlignment.center,
+                                  crossAxisAlignment: WrapCrossAlignment.center,
+                                  spacing: 10,
+                                  children: [
+                                    SizedBox.square(
+                                      dimension: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
                                       ),
+                                    ),
+                                    Text(
+                                      'SpeakUp 正在回复…',
+                                      style: SpeakUpDesign.meta,
                                     ),
                                   ],
                                 ),
-                                const SizedBox(height: 8),
-                              ],
-                              if (hasEarlierMessages) ...[
-                                Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: TextButton.icon(
-                                    key: const Key(
-                                      'load-earlier-agent-messages',
-                                    ),
-                                    onPressed:
-                                        isLoadingEarlierMessages ||
-                                            onLoadEarlierMessages == null
-                                        ? null
-                                        : onLoadEarlierMessages,
-                                    icon: isLoadingEarlierMessages
-                                        ? const SizedBox.square(
-                                            dimension: 16,
-                                            child: CircularProgressIndicator(
-                                              strokeWidth: 2,
-                                            ),
-                                          )
-                                        : const Icon(
-                                            Icons.history_rounded,
-                                            size: 18,
-                                          ),
-                                    label: Text(
-                                      isLoadingEarlierMessages
-                                          ? '正在加载更早消息'
-                                          : '加载更早消息',
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                              ],
-                              _MessageList(
-                                messages: messages,
-                                suppressLoadingFeedback: replyPending,
-                                messageAudioController: messageAudioController,
-                                onTranslateMessage: onTranslateMessage,
-                                onHandoff: onMessageHandoff,
-                                onRefreshImage: onRefreshMessageImage,
-                                feedbackPresenter: feedbackPresenter,
-                                onSameThreadRepractice:
-                                    !isBusy && onStartVoice != null
-                                    ? () => unawaited(
-                                        Future<void>.sync(onStartVoice!),
-                                      )
-                                    : null,
                               ),
-                            ],
-                            if (isBusy && !voiceShowsReplyProgress) ...[
-                              const SizedBox(height: 14),
-                              Center(
-                                child: Semantics(
-                                  label: 'SpeakUp 正在处理',
-                                  child: const Wrap(
-                                    key: Key('agent-operation-progress'),
-                                    alignment: WrapAlignment.center,
-                                    crossAxisAlignment:
-                                        WrapCrossAlignment.center,
-                                    spacing: 10,
-                                    children: [
-                                      SizedBox.square(
-                                        dimension: 18,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2,
-                                        ),
-                                      ),
-                                      Text(
-                                        'SpeakUp 正在回复…',
-                                        style: SpeakUpDesign.meta,
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ],
-                            if (errorMessage case final message?) ...[
-                              const SizedBox(height: 14),
-                              _InlineError(
-                                message: message,
-                                onRetry: onRetryOperation,
-                              ),
-                            ],
+                            ),
                           ],
+                          if (errorMessage case final message?) ...[
+                            const SizedBox(height: 14),
+                            _InlineError(
+                              message: message,
+                              onRetry: onRetryOperation,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    right: 0,
+                    height: topOverlayExtent + 28,
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        key: const Key('agent-top-overlay-scrim'),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              SpeakUpDesign.canvas,
+                              SpeakUpDesign.canvas.withValues(alpha: 0.94),
+                              SpeakUpDesign.canvas.withValues(alpha: 0),
+                            ],
+                            stops: const [0, 0.7, 1],
+                          ),
                         ),
                       ),
                     ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(
-                        horizontalPadding,
-                        16,
-                        horizontalPadding,
-                        0,
-                      ),
-                      child: AgentComposer(
-                        threadId: threadId,
-                        draftThreadRecoveryGeneration:
-                            draftThreadRecoveryGeneration,
-                        keyboardVisible: keyboardVisible,
-                        acceptedUserMessageId: acceptedUserMessage?.id,
-                        acceptedUserMessageText: acceptedUserMessage?.text,
-                        onStartVoice: onStartVoice,
-                        voiceController: voiceController,
-                        voiceEnabled: voiceController != null && !isBusy,
-                        onSubmitText: onSubmitText,
-                        enabled: canCompose,
-                        isBusy: isBusy,
-                        pendingImages: pendingImages,
-                        imageErrorMessage: imageErrorMessage,
-                        imageSelectionInFlight: imageSelectionInFlight,
-                        onPickImages: onPickImages,
-                        onTakePhoto: onTakePhoto,
-                        onRemovePendingImage: onRemovePendingImage,
-                        onRetryPendingImage: onRetryPendingImage,
+                  ),
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    height: bottomOverlayExtent + 52,
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        key: const Key('agent-bottom-overlay-scrim'),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              SpeakUpDesign.canvas.withValues(alpha: 0),
+                              SpeakUpDesign.canvas.withValues(alpha: 0.94),
+                              SpeakUpDesign.canvas,
+                            ],
+                            stops: const [0, 0.38, 1],
+                          ),
+                        ),
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                  Positioned(
+                    left: horizontalPadding,
+                    top: 12,
+                    right: horizontalPadding,
+                    child: _AgentTopBar(
+                      previewMode: previewMode,
+                      onOpenMenu: onOpenMenu,
+                      onNavigateBack: onNavigateBack,
+                      onCreateConversation: onCreateConversation,
+                      isBusy: isBusy,
+                    ),
+                  ),
+                  Positioned(
+                    left: horizontalPadding,
+                    right: horizontalPadding,
+                    bottom: composerBottom,
+                    child: NotificationListener<SizeChangedLayoutNotification>(
+                      onNotification: (_) {
+                        onComposerSizeChanged();
+                        return false;
+                      },
+                      child: SizeChangedLayoutNotifier(
+                        key: const Key('agent-composer-overlay'),
+                        child: KeyedSubtree(
+                          key: composerKey,
+                          child: AgentComposer(
+                            threadId: threadId,
+                            draftThreadRecoveryGeneration:
+                                draftThreadRecoveryGeneration,
+                            keyboardVisible: keyboardVisible,
+                            acceptedUserMessageId: acceptedUserMessage?.id,
+                            acceptedUserMessageText: acceptedUserMessage?.text,
+                            onStartVoice: onStartVoice,
+                            voiceController: voiceController,
+                            voiceEnabled: voiceController != null && !isBusy,
+                            onSubmitText: onSubmitText,
+                            enabled: canCompose,
+                            isBusy: isBusy,
+                            pendingImages: pendingImages,
+                            imageErrorMessage: imageErrorMessage,
+                            imageSelectionInFlight: imageSelectionInFlight,
+                            onPickImages: onPickImages,
+                            onTakePhoto: onTakePhoto,
+                            onRemovePendingImage: onRemovePendingImage,
+                            onRetryPendingImage: onRetryPendingImage,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (showJumpToLatest)
+                    Positioned(
+                      right: horizontalPadding,
+                      bottom: bottomOverlayExtent,
+                      child: FloatingActionButton.small(
+                        key: const Key('agent-jump-to-latest'),
+                        tooltip: '查看最新回复',
+                        onPressed: onJumpToLatest,
+                        backgroundColor: SpeakUpDesign.surface,
+                        foregroundColor: SpeakUpDesign.primary,
+                        child: const Icon(Icons.arrow_downward_rounded),
+                      ),
+                    ),
+                ],
               ),
             ),
           ),
-          if (showJumpToLatest)
-            Positioned(
-              right: horizontalPadding,
-              bottom: composerBottom + 92,
-              child: FloatingActionButton.small(
-                key: const Key('agent-jump-to-latest'),
-                tooltip: '查看最新回复',
-                onPressed: onJumpToLatest,
-                backgroundColor: SpeakUpDesign.surface,
-                foregroundColor: SpeakUpDesign.primary,
-                child: const Icon(Icons.arrow_downward_rounded),
-              ),
-            ),
         ],
       ),
     );
@@ -392,10 +444,13 @@ class ConversationPage extends StatefulWidget {
 
 class _ConversationPageState extends State<ConversationPage> {
   final ScrollController _scrollController = ScrollController();
+  final GlobalKey _composerKey = GlobalKey();
   _ConversationScrollAnchor? _earlierMessagesAnchor;
   int _scrollRequestGeneration = 0;
   bool _showJumpToLatest = false;
   bool _voiceRebuildScheduled = false;
+  bool _composerMeasurementScheduled = false;
+  double _composerHeight = 54;
 
   @override
   void initState() {
@@ -482,6 +537,28 @@ class _ConversationPageState extends State<ConversationPage> {
     if (_showJumpToLatest && _isNearLatest()) {
       setState(() => _showJumpToLatest = false);
     }
+  }
+
+  void _scheduleComposerMeasurement() {
+    if (_composerMeasurementScheduled) {
+      return;
+    }
+    _composerMeasurementScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _composerMeasurementScheduled = false;
+      if (!mounted) {
+        return;
+      }
+      final height = _composerKey.currentContext?.size?.height;
+      if (height == null || (height - _composerHeight).abs() < 0.5) {
+        return;
+      }
+      final keepLatestVisible = _isNearLatest();
+      setState(() => _composerHeight = height);
+      if (keepLatestVisible) {
+        _scheduleScrollToLatest();
+      }
+    });
   }
 
   void _setJumpToLatestVisible(bool value) {
@@ -594,6 +671,7 @@ class _ConversationPageState extends State<ConversationPage> {
 
   @override
   Widget build(BuildContext context) {
+    _scheduleComposerMeasurement();
     return widget._build(
       context,
       scrollController: _scrollController,
@@ -602,6 +680,9 @@ class _ConversationPageState extends State<ConversationPage> {
           : _handleLoadEarlierMessages,
       showJumpToLatest: _showJumpToLatest,
       onJumpToLatest: _scheduleScrollToLatest,
+      composerHeight: _composerHeight,
+      composerKey: _composerKey,
+      onComposerSizeChanged: _scheduleComposerMeasurement,
     );
   }
 }

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -596,12 +596,24 @@ void main() {
       final menuBefore = tester.getRect(menu);
       final createBefore = tester.getRect(create);
       final titleBefore = tester.getRect(fixedTitle);
-      final scroll = find.byType(SingleChildScrollView);
+      final scroll = find.byKey(const Key('agent-conversation-scroll'));
+      final scrollRect = tester.getRect(scroll);
+      final composerRect = tester.getRect(
+        find.byKey(const Key('agent-composer-surface')),
+      );
+      expect(scrollRect.top, lessThan(menuBefore.bottom));
+      expect(scrollRect.bottom, greaterThan(composerRect.bottom));
       final scrollController = tester
           .widget<SingleChildScrollView>(scroll)
           .controller!;
       final pixelsBefore = scrollController.position.pixels;
       expect(pixelsBefore, greaterThan(0));
+      expect(
+        tester
+            .getRect(find.byKey(const Key('agent-message-scroll-message-27')))
+            .bottom,
+        lessThanOrEqualTo(composerRect.top - 15),
+      );
 
       await tester.drag(scroll, const Offset(0, 360));
       await tester.pumpAndSettle();
@@ -612,6 +624,59 @@ void main() {
       expect(tester.getRect(fixedTitle), titleBefore);
     },
   );
+
+  testWidgets('keeps the latest Message clear of a growing composer', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    String? imageErrorMessage;
+    late StateSetter update;
+    final messages = List<AgentMessage>.generate(
+      16,
+      (index) => AgentMessage(
+        id: 'resized-composer-message-$index',
+        role: index.isEven ? AgentMessageRole.user : AgentMessageRole.assistant,
+        text: 'Message $index keeps the conversation scrollable.',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return ConversationPage(
+              messages: messages,
+              imageErrorMessage: imageErrorMessage,
+              onSubmitText: (_) async => true,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final composer = find.byKey(const Key('agent-composer-overlay'));
+    final initialComposerTop = tester.getRect(composer).top;
+
+    update(() {
+      imageErrorMessage = '图片上传失败，请重试后再发送这条消息。';
+    });
+    await tester.pumpAndSettle();
+
+    final grownComposerTop = tester.getRect(composer).top;
+    expect(grownComposerTop, lessThan(initialComposerTop));
+    expect(
+      tester
+          .getRect(
+            find.byKey(const Key('agent-message-resized-composer-message-15')),
+          )
+          .bottom,
+      lessThanOrEqualTo(grownComposerTop - 15),
+    );
+  });
 
   testWidgets('keeps available Agent actions above the composer on iPhone', (
     tester,


### PR DESCRIPTION
## 功能描述
- 让 Agent 消息滚动层覆盖完整安全区域，提升长对话可见范围
- 顶部操作、输入框和主导航保持悬浮，并通过渐隐层保证文本经过时仍清晰
- 根据输入框实际高度动态保留消息底部空间，图片或多行输入不会遮住最后一条消息

## 实现思路与代码位置
- 页面入口：`mobile/lib/features/agent/conversation/conversation.dart`
- 内容层：全屏 `Positioned.fill` 消息列表
- 浮层：顶部控制、动态高度 Composer、跳转到最新按钮及上下渐隐层
- 回归验证：`mobile/test/speak_up_app_test.dart` 覆盖浮层重叠关系及 Composer 增高场景

## 验证方式
- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/speak_up_app_test.dart`
- `cd mobile && flutter test`（764 项通过）
- iOS 模拟器以真实持久化对话完成视觉对比

Closes #502