### PR TITLE
[MS3][前端] 优化主导航的对话与复盘图标语义

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -84,10 +84,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   static const _destinations = [
     PlatformNavigationDestination(
       label: 'SpeakUp',
-      icon: Icons.chat_bubble_outline_rounded,
-      selectedIcon: Icons.chat_bubble_rounded,
-      iosSystemImage: 'bubble.left',
-      iosSelectedSystemImage: 'bubble.left.fill',
+      icon: Icons.mic_none_rounded,
+      selectedIcon: Icons.mic_rounded,
+      iosSystemImage: 'waveform.circle',
+      iosSelectedSystemImage: 'waveform.circle.fill',
       key: Key('primary-tab-agent'),
     ),
     PlatformNavigationDestination(
@@ -100,10 +100,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     ),
     PlatformNavigationDestination(
       label: '复盘',
-      icon: Icons.fact_check_outlined,
-      selectedIcon: Icons.fact_check_rounded,
-      iosSystemImage: 'checklist',
-      iosSelectedSystemImage: 'checkmark.square.fill',
+      icon: Icons.insights_outlined,
+      selectedIcon: Icons.insights_rounded,
+      iosSystemImage: 'chart.bar',
+      iosSelectedSystemImage: 'chart.bar.fill',
       key: Key('primary-tab-review'),
     ),
     PlatformNavigationDestination(

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,6 +20,69 @@ import 'package:speakup/features/coaching/review/interview_report_controller.dar
 import 'package:speakup/features/coaching/review/review.dart';
 
 void main() {
+  testWidgets('uses voice and analysis icons for Material navigation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp.preview());
+    final navigation = find.byKey(const Key('primary-navigation'));
+
+    expect(
+      find.descendant(of: navigation, matching: find.byIcon(Icons.mic_rounded)),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: navigation,
+        matching: find.byIcon(Icons.insights_outlined),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('primary-tab-review')));
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(
+        of: navigation,
+        matching: find.byIcon(Icons.mic_none_rounded),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: navigation,
+        matching: find.byIcon(Icons.insights_rounded),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+    'passes voice and analysis SF Symbols to the native iOS tab bar',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(const SpeakUpApp.preview());
+
+        final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
+        final parameters =
+            platformView.creationParams! as Map<Object?, Object?>;
+        final items = parameters['items']! as List<Object?>;
+        expect(items[0], <String, String>{
+          'label': 'SpeakUp',
+          'systemImage': 'waveform.circle',
+          'selectedSystemImage': 'waveform.circle.fill',
+        });
+        expect(items[2], <String, String>{
+          'label': '复盘',
+          'systemImage': 'chart.bar',
+          'selectedSystemImage': 'chart.bar.fill',
+        });
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
   testWidgets('starts on the Agent home with four primary navigation entries', (
     tester,
   ) async {

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -69,10 +69,7 @@ void main() {
     final navigation = find.byKey(const Key('primary-navigation'));
     expect(navigation, findsOneWidget);
     expect(
-      find.descendant(
-        of: navigation,
-        matching: find.byIcon(Icons.chat_bubble_rounded),
-      ),
+      find.descendant(of: navigation, matching: find.byIcon(Icons.mic_rounded)),
       findsOneWidget,
     );
     expect(find.byType(BackdropFilter), findsNothing);


### PR DESCRIPTION
## 功能描述
- 将 SpeakUp 导航图标从普通消息气泡调整为语音入口。
- 将复盘图标从待办清单调整为训练数据分析。

## 实现思路
- iOS 沿用原生 UITabBar 和 SF Symbols：`waveform.circle` / `waveform.circle.fill`、`chart.bar` / `chart.bar.fill`。
- Android 沿用 Material NavigationBar：麦克风与 Insights 的未选中/选中系统图标。
- 不修改导航结构、标签、路由或平台桥接，不新增依赖和自绘资源。

## 验证方式
- `cd mobile && flutter analyze lib/app/speak_up_shell.dart`
- `cd mobile && flutter test test/speak_up_app_test.dart test/app/platform_navigation_bar_ios_test.dart`
- iOS 26.5 模拟器检查原生选中填充状态与四个入口点击。

Closes #507