### PR TITLE
[Mobile] 收紧语音气泡操作区间距

### DIFF
--- a/mobile/lib/design/conversation_bubble_surface.dart
+++ b/mobile/lib/design/conversation_bubble_surface.dart
@@ -8,6 +8,7 @@ class ConversationBubbleSurface extends StatelessWidget {
     this.bubbleKey,
     this.maxWidth = 340,
     this.margin = EdgeInsets.zero,
+    this.padding,
     this.semanticsLabel,
     super.key,
   });
@@ -17,6 +18,7 @@ class ConversationBubbleSurface extends StatelessWidget {
   final Key? bubbleKey;
   final double maxWidth;
   final EdgeInsetsGeometry margin;
+  final EdgeInsetsGeometry? padding;
   final String? semanticsLabel;
 
   @override
@@ -25,9 +27,11 @@ class ConversationBubbleSurface extends StatelessWidget {
       key: bubbleKey,
       constraints: BoxConstraints(maxWidth: maxWidth),
       margin: margin,
-      padding: isUser
-          ? const EdgeInsets.fromLTRB(14, 11, 12, 11)
-          : const EdgeInsets.fromLTRB(2, 7, 12, 9),
+      padding:
+          padding ??
+          (isUser
+              ? const EdgeInsets.fromLTRB(14, 11, 12, 11)
+              : const EdgeInsets.fromLTRB(2, 7, 12, 9)),
       decoration: BoxDecoration(
         color: isUser ? SpeakUpDesign.primaryMuted : Colors.transparent,
         borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),

--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -31,6 +31,7 @@ class InlineLanguageFeedback extends StatefulWidget {
     this.suggestionLoading = false,
     this.suggestionPlaying = false,
     this.optimizeIconOnly = false,
+    this.onExpandedChanged,
     this.foregroundColor = SpeakUpDesign.primary,
     this.textColor = SpeakUpDesign.ink,
     super.key,
@@ -46,6 +47,7 @@ class InlineLanguageFeedback extends StatefulWidget {
   final bool suggestionLoading;
   final bool suggestionPlaying;
   final bool optimizeIconOnly;
+  final ValueChanged<bool>? onExpandedChanged;
   final Color foregroundColor;
   final Color textColor;
 
@@ -65,7 +67,9 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
   }
 
   void _toggle() {
-    setState(() => _expanded = !_expanded);
+    final expanded = !_expanded;
+    setState(() => _expanded = expanded);
+    widget.onExpandedChanged?.call(expanded);
   }
 
   @override

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -114,6 +114,9 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
       bubbleKey: Key('agent-message-${message.id}'),
       isUser: isUser,
       margin: const EdgeInsets.only(bottom: 7),
+      padding: isUser && message.modality == AgentMessageModality.voice
+          ? const EdgeInsets.fromLTRB(14, 11, 12, 0)
+          : null,
       child: message.handoffs.isEmpty
           ? primaryContent
           : Column(
@@ -312,7 +315,6 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           key: Key('agent-user-voice-transcript-${message.id}'),
           style: TextStyle(color: foreground, fontSize: 16, height: 1.45),
         ),
-        const SizedBox(height: 10),
         InlineLanguageFeedback(
           leading: _VoicePlaybackAction(
             key: Key('agent-user-voice-play-${message.id}'),

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -39,6 +39,7 @@ final class AgentMessageBubble extends StatefulWidget {
 
 class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   late _AgentMessageAudioSnapshot _audioSnapshot;
+  bool _languageFeedbackExpanded = false;
 
   @override
   void initState() {
@@ -50,6 +51,10 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   @override
   void didUpdateWidget(covariant AgentMessageBubble oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.message.id != widget.message.id ||
+        (widget.correction == null && widget.polish == null)) {
+      _languageFeedbackExpanded = false;
+    }
     if (oldWidget.messageAudioController != widget.messageAudioController) {
       oldWidget.messageAudioController?.removeListener(_handleAudioController);
       widget.messageAudioController?.addListener(_handleAudioController);
@@ -101,6 +106,10 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   Widget build(BuildContext context) {
     final message = widget.message;
     final isUser = message.role == AgentMessageRole.user;
+    final voiceNeedsBottomInset =
+        isUser &&
+        message.modality == AgentMessageModality.voice &&
+        (_languageFeedbackExpanded || _audioSnapshot.error != null);
     const foreground = SpeakUpDesign.ink;
     final primaryContent = switch (message.modality) {
       AgentMessageModality.voice => _buildUserVoice(context, foreground),
@@ -115,7 +124,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
       isUser: isUser,
       margin: const EdgeInsets.only(bottom: 7),
       padding: isUser && message.modality == AgentMessageModality.voice
-          ? const EdgeInsets.fromLTRB(14, 11, 12, 0)
+          ? EdgeInsets.fromLTRB(14, 11, 12, voiceNeedsBottomInset ? 11 : 0)
           : null,
       child: message.handoffs.isEmpty
           ? primaryContent
@@ -328,6 +337,12 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           correction: widget.correction,
           polish: widget.polish,
           optimizeIconOnly: true,
+          onExpandedChanged: (expanded) {
+            if (_languageFeedbackExpanded == expanded) {
+              return;
+            }
+            setState(() => _languageFeedbackExpanded = expanded);
+          },
           suggestionLoading: previewLoading,
           suggestionPlaying: previewPlaying,
           onSpeakSuggestion: audioController == null

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -189,6 +189,10 @@ void main() {
     await tester.tap(find.byKey(const Key('inline-language-optimize')));
     await tester.pump();
 
+    final expandedBubble = tester.widget<Container>(
+      find.byKey(const Key('agent-message-user-voice-polish')),
+    );
+    expect(expandedBubble.padding, const EdgeInsets.fromLTRB(14, 11, 12, 11));
     expect(find.text('纠错'), findsOneWidget);
     expect(find.text('更自然的表达'), findsOneWidget);
     expect(find.text('This plan sounds good.'), findsOneWidget);

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -220,6 +220,61 @@ void main() {
     );
   });
 
+  testWidgets('keeps voice actions compact without shrinking tap targets', (
+    tester,
+  ) async {
+    const message = AgentMessage(
+      id: 'user-voice-spacing',
+      role: AgentMessageRole.user,
+      text: 'Can you help me study knowledge about AI?',
+      modality: AgentMessageModality.voice,
+      audio: AgentMessageAudio(
+        id: 'audio-spacing',
+        status: AgentMessageAudioStatus.readable,
+        contentType: 'audio/mp4',
+        sizeBytes: 128,
+        duration: Duration(seconds: 3),
+        playbackPath: '/v1/agent-audio/audio-spacing/playback',
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: const [
+              AgentMessageBubble(
+                message: message,
+                correction: InlineLanguageSuggestion(
+                  originalText: 'study knowledge about AI',
+                  text: 'learn about AI',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final bubble = find.byKey(const Key('agent-message-user-voice-spacing'));
+    final transcript = find.byKey(
+      const Key('agent-user-voice-transcript-user-voice-spacing'),
+    );
+    final playback = find.byKey(
+      const Key('agent-user-voice-play-user-voice-spacing'),
+    );
+    final optimize = find.byKey(const Key('inline-language-optimize'));
+    final transcriptRect = tester.getRect(transcript);
+    final playbackRect = tester.getRect(playback);
+
+    expect(playbackRect.top, transcriptRect.bottom);
+    expect(
+      tester.widget<Container>(bubble).padding,
+      const EdgeInsets.fromLTRB(14, 11, 12, 0),
+    );
+    expect(tester.getSize(playback), const Size.square(44));
+    expect(tester.getSize(optimize), const Size.square(40));
+  });
+
   testWidgets('renders and dispatches a practice plan handoff', (tester) async {
     const handoff = ConfirmPracticePlanHandoff(
       label: '确认并开始练习',


### PR DESCRIPTION
## 功能描述

- 收紧用户语音气泡正文与播放、优化图标之间的纵向间距
- 移除操作区底部的额外留白
- 保持原有横向布局、44px 播放点击区和业务行为

## 实现思路

- 为共享气泡表面增加可选 padding，仅由用户语音气泡覆盖默认值
- 普通文本气泡、助手消息和练习气泡继续沿用原有间距
- 增加 Widget 回归断言，覆盖正文间距、气泡 padding 与点击区域

## 验证方式

- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/agent/agent_message_bubble_test.dart`（11 项通过）
- iOS 模拟器连接真实后端验证；模拟器数字人禁用，OSS 仅在忽略提交的本地 `.env` 临时禁用

Closes #512