### PR TITLE
[Mobile] 校准首条对话的顶部安全区

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -150,6 +150,7 @@ class ConversationPage extends StatefulWidget {
       _ => false,
     };
     final replyPending = isBusy || voiceShowsReplyProgress;
+    const topContentInset = 64.0;
     const topOverlayExtent = 76.0;
     final bottomOverlayExtent = composerBottom + composerHeight + 16;
 
@@ -171,7 +172,7 @@ class ConversationPage extends StatefulWidget {
                       controller: scrollController,
                       padding: EdgeInsets.fromLTRB(
                         horizontalPadding,
-                        topOverlayExtent,
+                        topContentInset,
                         horizontalPadding,
                         bottomOverlayExtent,
                       ),
@@ -327,7 +328,7 @@ class ConversationPage extends StatefulWidget {
                     left: 0,
                     top: 0,
                     right: 0,
-                    height: topOverlayExtent + 28,
+                    height: topOverlayExtent,
                     child: IgnorePointer(
                       child: DecoratedBox(
                         key: const Key('agent-top-overlay-scrim'),

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -150,7 +150,7 @@ class ConversationPage extends StatefulWidget {
       _ => false,
     };
     final replyPending = isBusy || voiceShowsReplyProgress;
-    const topContentInset = 64.0;
+    const topContentInset = 65.0;
     const topOverlayExtent = 76.0;
     final bottomOverlayExtent = composerBottom + composerHeight + 16;
 

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -693,7 +693,7 @@ void main() {
           messages: const [
             AgentMessage(
               id: 'first-message',
-              role: AgentMessageRole.user,
+              role: AgentMessageRole.assistant,
               text: 'The first message stays fully visible.',
             ),
           ],

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -681,6 +681,39 @@ void main() {
     },
   );
 
+  testWidgets('keeps the first message below the top overlay', (tester) async {
+    tester.view.physicalSize = const Size(390, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ConversationPage(
+          messages: const [
+            AgentMessage(
+              id: 'first-message',
+              role: AgentMessageRole.user,
+              text: 'The first message stays fully visible.',
+            ),
+          ],
+          onOpenMenu: () {},
+          onCreateConversation: () {},
+          onSubmitText: (_) async => true,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final overlayBottom = tester
+        .getRect(find.byKey(const Key('agent-top-overlay-scrim')))
+        .bottom;
+    final firstMessageTextTop = tester
+        .getRect(find.text('The first message stays fully visible.'))
+        .top;
+    expect(firstMessageTextTop, greaterThanOrEqualTo(overlayBottom));
+  });
+
   testWidgets('keeps the latest Message clear of a growing composer', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 缩短悬浮页头与首条消息之间的无效高度
- 保证消息正文位于顶部渐隐遮罩之外，不再发白或藏到 Logo 后面
- 保留全屏滚动层和内容经过悬浮页头下方的效果

## 实现思路

- 将内容初始 inset 与顶部遮罩高度拆分：气泡边缘可进入渐隐区，正文保持完整可见
- 不改变页头、气泡、输入框、导航栏及滚动到底部逻辑
- 增加短对话回归测试，直接校验首条正文与遮罩边界

## 验证方式

- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/speak_up_app_test.dart`（31 项通过）
- iOS 模拟器连接真实后端验证；模拟器数字人禁用，OSS 仅在忽略提交的本地 `.env` 临时禁用

Closes #513