### PR TITLE
[Mobile] 统一四类练习二级页英文标题

### DIFF
--- a/mobile/lib/design/speak_up_components.dart
+++ b/mobile/lib/design/speak_up_components.dart
@@ -236,6 +236,8 @@ class SpeakUpNavigationHeader extends StatelessWidget {
     this.onBack,
     this.backButtonKey,
     this.titleKey,
+    this.titleStyle,
+    this.semanticLabel,
     this.trailing,
     super.key,
   });
@@ -244,6 +246,8 @@ class SpeakUpNavigationHeader extends StatelessWidget {
   final VoidCallback? onBack;
   final Key? backButtonKey;
   final Key? titleKey;
+  final TextStyle? titleStyle;
+  final String? semanticLabel;
   final Widget? trailing;
 
   @override
@@ -255,10 +259,12 @@ class SpeakUpNavigationHeader extends StatelessWidget {
         Expanded(
           child: Semantics(
             header: true,
+            label: semanticLabel,
+            excludeSemantics: semanticLabel != null,
             child: Text(
               title,
               key: titleKey,
-              style: Theme.of(context).textTheme.titleLarge,
+              style: titleStyle ?? Theme.of(context).textTheme.titleLarge,
             ),
           ),
         ),

--- a/mobile/lib/design/speak_up_design.dart
+++ b/mobile/lib/design/speak_up_design.dart
@@ -48,6 +48,17 @@ abstract final class SpeakUpDesign {
     height: 1,
   );
 
+  static const secondaryDisplayTitle = TextStyle(
+    color: ink,
+    fontFamily: 'Georgia',
+    fontFamilyFallback: ['serif'],
+    fontSize: 34,
+    fontWeight: FontWeight.w600,
+    fontStyle: FontStyle.italic,
+    height: 1.05,
+    letterSpacing: -0.4,
+  );
+
   static const sectionTitle = TextStyle(
     color: ink,
     fontSize: 20,

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_components.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/interview/interview_catalog.dart';
@@ -671,17 +672,7 @@ class _PreparationPageState extends State<PreparationPage> {
         top: 8,
       ),
       children: [
-        SpeakUpNavigationHeader(
-          title: _practiceHubLabel(hub),
-          backButtonKey: const Key('preparation-back-to-families'),
-          titleKey: Key('practice-hub-title-${hub.name}'),
-          onBack: () => setState(() => _selectedHub = null),
-          trailing: hub == _PracticeHub.interview
-              ? InterviewCatalogCreateButton(
-                  onPressed: widget.onOpenJobPreparation,
-                )
-              : null,
-        ),
+        _buildHubHeader(hub),
         SizedBox(height: hub == _PracticeHub.interview ? 20 : 16),
         if (hub == _PracticeHub.interview)
           InterviewCatalog(
@@ -740,17 +731,7 @@ class _PreparationPageState extends State<PreparationPage> {
           top: 8,
         ),
         children: [
-          SpeakUpNavigationHeader(
-            title: _practiceHubLabel(selectedHub),
-            backButtonKey: const Key('preparation-back-to-families'),
-            titleKey: Key('practice-hub-title-${selectedHub.name}'),
-            onBack: () => setState(() => _selectedHub = null),
-            trailing: selectedHub == _PracticeHub.interview
-                ? InterviewCatalogCreateButton(
-                    onPressed: widget.onOpenJobPreparation,
-                  )
-                : null,
-          ),
+          _buildHubHeader(selectedHub),
           SizedBox(height: selectedHub == _PracticeHub.interview ? 20 : 16),
           const PreparationCatalogEmpty(message: '连接场景服务后即可查看练习。'),
         ],
@@ -782,6 +763,20 @@ class _PreparationPageState extends State<PreparationPage> {
           Expanded(child: _buildPracticeHubCarousel()),
         ],
       ),
+    );
+  }
+
+  Widget _buildHubHeader(_PracticeHub hub) {
+    return SpeakUpNavigationHeader(
+      title: _practiceHubDisplayTitle(hub),
+      semanticLabel: _practiceHubLabel(hub),
+      titleStyle: SpeakUpDesign.secondaryDisplayTitle,
+      backButtonKey: const Key('preparation-back-to-families'),
+      titleKey: Key('practice-hub-title-${hub.name}'),
+      onBack: () => setState(() => _selectedHub = null),
+      trailing: hub == _PracticeHub.interview
+          ? InterviewCatalogCreateButton(onPressed: widget.onOpenJobPreparation)
+          : null,
     );
   }
 }
@@ -1199,6 +1194,15 @@ String _practiceHubLabel(_PracticeHub hub) {
     _PracticeHub.ielts => 'IELTS 口语',
     _PracticeHub.workplace => '职场英语',
     _PracticeHub.life => '生活与旅行',
+  };
+}
+
+String _practiceHubDisplayTitle(_PracticeHub hub) {
+  return switch (hub) {
+    _PracticeHub.interview => 'Interview',
+    _PracticeHub.ielts => 'IELTS',
+    _PracticeHub.workplace => 'Workplace',
+    _PracticeHub.life => 'Travel',
   };
 }
 

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -1,6 +1,7 @@
 import '../../support/scene_fixtures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/preparation/preparation.dart';
 import 'package:speakup/features/coaching/scene/scene_client.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
@@ -113,6 +114,53 @@ void main() {
     expect(find.text('进度与风险汇报'), findsNothing);
   });
 
+  testWidgets('uses English display titles for all four practice hubs', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _HubFixtureClient());
+    addTearDown(controller.dispose);
+    await _pumpHub(tester, controller);
+
+    for (final hub in const [
+      (
+        entry: Key('practice-hub-interview'),
+        titleKey: Key('practice-hub-title-interview'),
+        title: 'Interview',
+        semanticLabel: '英文面试',
+      ),
+      (
+        entry: Key('practice-hub-exam'),
+        titleKey: Key('practice-hub-title-ielts'),
+        title: 'IELTS',
+        semanticLabel: 'IELTS 口语',
+      ),
+      (
+        entry: Key('practice-hub-workplace'),
+        titleKey: Key('practice-hub-title-workplace'),
+        title: 'Workplace',
+        semanticLabel: '职场英语',
+      ),
+      (
+        entry: Key('practice-hub-life'),
+        titleKey: Key('practice-hub-title-life'),
+        title: 'Travel',
+        semanticLabel: '生活与旅行',
+      ),
+    ]) {
+      await _openModule(tester, hub.entry);
+
+      final title = tester.widget<Text>(find.byKey(hub.titleKey));
+      expect(title.data, hub.title);
+      expect(title.style, SpeakUpDesign.secondaryDisplayTitle);
+      expect(find.bySemanticsLabel(hub.semanticLabel), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const Key('preparation-back-to-families')).hitTestable(),
+      );
+      await tester.pumpAndSettle();
+    }
+  });
+
   testWidgets(
     'opens IELTS from one scene with four server-defined practice options',
     (tester) async {
@@ -161,7 +209,7 @@ void main() {
 
     await _openModule(tester, const Key('practice-hub-workplace'));
 
-    expect(find.text('职场英语'), findsOneWidget);
+    expect(find.text('Workplace'), findsOneWidget);
     expect(find.text('进度与风险汇报'), findsOneWidget);
     expect(find.text('酒店入住与问题处理'), findsNothing);
     expect(find.byKey(const Key('scenario-filter-workplace')), findsNothing);
@@ -175,7 +223,7 @@ void main() {
     await tester.pumpAndSettle();
     await _openModule(tester, const Key('practice-hub-life'));
 
-    expect(find.text('生活与旅行'), findsOneWidget);
+    expect(find.text('Travel'), findsOneWidget);
     expect(find.text('酒店入住与问题处理'), findsOneWidget);
     expect(find.text('餐厅点餐'), findsOneWidget);
     expect(find.text('进度与风险汇报'), findsNothing);


### PR DESCRIPTION
## 功能描述

统一四类练习二级页的顶部标题：返回按钮与英文标题保持同一行，分别显示 Interview、IELTS、Workplace、Travel，并使用更正式的编辑型衬线样式。

## 实现思路

- 扩展现有导航标题组件，允许页面传入标题样式与本地化语义标签。
- 为二级页增加独立的正式英文标题样式，不影响首页 Allura 品牌标题。
- 四类场景复用同一个标题构建入口，场景内容与业务逻辑保持不变。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/coaching/preparation/preparation_hub_test.dart
```

结果：分析无问题，13 项相关 Widget 测试全部通过。已在 iOS 模拟器连接真实后端验证，数字人禁用；用户已确认视觉效果。

Closes #518