### PR TITLE
[Mobile] 消除正式练习启动时训练首页闪回

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -404,8 +404,11 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             onOpenInterviewPlan: widget.jobPreparationController == null
                 ? null
                 : (planId) => unawaited(_openSavedInterviewPlan(planId)),
-            onPracticeStarted: () => _navigatorKey.currentState
-                ?.pushReplacementNamed(AppRoutes.practice),
+            onPracticeStarted: () async {
+              await _navigatorKey.currentState?.pushReplacementNamed(
+                AppRoutes.practice,
+              );
+            },
           ),
           AppRoutes.jobPreparation
               when widget.jobPreparationController != null =>
@@ -413,8 +416,11 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
               controller: widget.jobPreparationController!,
               catalogController: widget.preparationController,
               resumeController: widget.resumeController,
-              onPracticeStarted: () => _navigatorKey.currentState
-                  ?.pushReplacementNamed(AppRoutes.practice),
+              onPracticeStarted: () async {
+                await _navigatorKey.currentState?.pushReplacementNamed(
+                  AppRoutes.practice,
+                );
+              },
               onPlanCreated: () => _navigatorKey.currentState?.pop(),
             ),
           AppRoutes.practice => _buildPracticePage(),

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -254,9 +254,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       ..showSnackBar(SnackBar(content: Text(message)));
   }
 
-  void _openPractice() {
-    unawaited(_openPracticeRoute());
-  }
+  Future<void> _openPractice() => _openPracticeRoute();
 
   Future<void> _confirmAgentHandoff(AgentHandoff handoff) async {
     final controller = widget.practicePlanHandoffController;

--- a/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
@@ -334,6 +334,20 @@ final class PracticeWorkspaceController extends ChangeNotifier {
       _setError('没有可以继续的练习。');
       return false;
     }
+    final activeScene = practiceController.scene;
+    if (practiceController.hasActivePractice &&
+        conversationController.threadId == current.practiceThreadId &&
+        practiceController.practiceSessionId == current.sessionId &&
+        (current.goalId == null ||
+            conversationController.activeGoalId == current.goalId) &&
+        activeScene?.id == current.scene!.id &&
+        activeScene?.version == current.scene!.version) {
+      if (_errorMessage != null) {
+        _errorMessage = null;
+        notifyListeners();
+      }
+      return true;
+    }
     final accountGeneration = _accountGeneration;
     final operationGeneration = ++_operationGeneration;
     _beginOperation();

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -26,6 +26,8 @@ enum _PracticeHub { interview, ielts, workplace, life }
 
 enum _ExistingPracticeAction { continuePractice, replace }
 
+typedef PracticeStartedCallback = FutureOr<void> Function();
+
 class PreparationPage extends StatefulWidget {
   const PreparationPage({
     this.showBackButton = false,
@@ -52,7 +54,7 @@ class PreparationPage extends StatefulWidget {
   final VoidCallback? onOpenJobPreparation;
   final ValueChanged<String>? onOpenInterviewPlan;
   final VoidCallback? onSceneSelected;
-  final VoidCallback? onPracticeStarted;
+  final PracticeStartedCallback? onPracticeStarted;
 
   @override
   State<PreparationPage> createState() => _PreparationPageState();
@@ -224,13 +226,16 @@ class _PreparationPageState extends State<PreparationPage> {
           ieltsSelection,
         );
       }
+      await widget.onPracticeStarted?.call();
+      if (!mounted) {
+        return;
+      }
       catalog.showSceneList();
       setState(() {
         _selectedHub = null;
         _launchingIeltsSelection = null;
         _scenarioFormVisible = false;
       });
-      widget.onPracticeStarted?.call();
     }
   }
 
@@ -250,13 +255,16 @@ class _PreparationPageState extends State<PreparationPage> {
           );
         }
       }
+      await widget.onPracticeStarted?.call();
+      if (!mounted) {
+        return;
+      }
       catalog?.showSceneList();
       setState(() {
         _selectedHub = null;
         _launchingIeltsSelection = null;
         _scenarioFormVisible = false;
       });
-      widget.onPracticeStarted?.call();
     }
   }
 
@@ -421,14 +429,17 @@ class _PreparationPageState extends State<PreparationPage> {
     if (launch?.hasResumablePractice ?? false) {
       final resumed = await launch!.resumeCurrentPractice();
       if (resumed && mounted) {
+        await widget.onPracticeStarted?.call();
+        if (!mounted) {
+          return;
+        }
         widget.preparationController?.showSceneList();
         setState(() => _selectedHub = null);
-        widget.onPracticeStarted?.call();
       }
       return;
     }
     if (widget.practiceController?.hasActivePractice ?? false) {
-      widget.onPracticeStarted?.call();
+      await widget.onPracticeStarted?.call();
     } else if (widget.onSceneSelected case final callback?) {
       callback();
     } else if (widget.showBackButton) {

--- a/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
@@ -137,6 +137,7 @@ void main() {
       );
       expect(workspaceController.currentSessionId, firstSessionId);
       expect(conversationController.threads, hasLength(2));
+      expect(practiceClient.restoreCalls, 0);
 
       await _tapVisible(
         tester,
@@ -525,6 +526,7 @@ final class _LifecyclePracticeClient
   final Map<String, PracticeSessionSnapshot> _sessions =
       <String, PracticeSessionSnapshot>{};
   final List<String> endedSessionIds = <String>[];
+  int restoreCalls = 0;
   _StartSeed? _nextStart;
 
   PracticeSessionSnapshot? snapshotFor(String sessionId) =>
@@ -555,6 +557,7 @@ final class _LifecyclePracticeClient
   Future<PracticeSessionSnapshot> restorePractice({
     required String sessionId,
   }) async {
+    restoreCalls++;
     return _sessions[sessionId] ??
         (throw StateError('No exact lifecycle session was prepared.'));
   }

--- a/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
@@ -71,6 +71,42 @@ void main() {
     },
   );
 
+  test('active committed practice resumes without restoring again', () async {
+    final harness = await _createHarness();
+    final workspace = PracticeWorkspaceController(
+      conversationController: harness.conversation,
+      practiceController: harness.practiceController,
+      recordStore: _InspectableRecordStore(),
+    );
+    addTearDown(() {
+      workspace.dispose();
+      harness.dispose();
+    });
+    await workspace.activateAccount('account-1');
+    final launched = await _launchPractice(
+      harness: harness,
+      workspace: workspace,
+      operationId: 'launch-active-operation',
+      sceneId: 'interview-screening',
+      sceneTitle: '招聘初筛',
+      sessionId: 'practice-active-session',
+    );
+
+    expect(workspace.hasResumable, isTrue);
+    expect(harness.practiceController.hasActivePractice, isTrue);
+    expect(harness.practiceClient.restoreCalls, 0);
+
+    expect(await workspace.resumeCurrentPractice(), isTrue);
+
+    expect(harness.practiceClient.restoreCalls, 0);
+    expect(harness.conversation.threadId, launched.lease.practiceThreadId);
+    expect(harness.conversation.activeGoalId, launched.goal.id);
+    expect(
+      harness.practiceController.practiceSessionId,
+      'practice-active-session',
+    );
+  });
+
   test(
     'committed practice parks on home and resumes by exact identities',
     () async {
@@ -114,7 +150,9 @@ void main() {
       expect(restoredWorkspace.currentTitle, '招聘初筛');
       expect(restoredWorkspace.currentSceneId, 'interview-screening');
       expect(restoredWorkspace.hasResumable, isTrue);
+      expect(harness.practiceClient.restoreCalls, 0);
       expect(await restoredWorkspace.resumeCurrentPractice(), isTrue);
+      expect(harness.practiceClient.restoreCalls, 1);
       expect(harness.conversation.threadId, launched.lease.practiceThreadId);
       expect(harness.conversation.activeGoalId, launched.goal.id);
       expect(
@@ -1258,6 +1296,7 @@ final class _WorkspacePracticeClient
       <String, PracticeSessionSnapshot>{};
   final Map<String, String> _sessionsByThread = <String, String>{};
   final List<String> endedSessionIds = <String>[];
+  int restoreCalls = 0;
   int endFailures = 0;
   _StartSeed? _nextStart;
   Completer<PracticeTurnConfirmation>? _pendingTextSubmission;
@@ -1328,6 +1367,7 @@ final class _WorkspacePracticeClient
   Future<PracticeSessionSnapshot> restorePractice({
     required String sessionId,
   }) async {
+    restoreCalls++;
     return _sessions[sessionId] ??
         (throw StateError('No exact Practice Session was prepared.'));
   }

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -171,6 +171,7 @@ void main() {
     );
     final launchClient = _PageLaunchClient();
     var navigations = 0;
+    final practiceRoute = Completer<void>();
     final launchController = PreparationLaunchController(
       client: launchClient,
       contextProvider: () => _pageContext,
@@ -198,7 +199,10 @@ void main() {
         home: PreparationPage(
           preparationController: preparationController,
           launchController: launchController,
-          onPracticeStarted: () => navigations++,
+          onPracticeStarted: () {
+            navigations++;
+            return practiceRoute.future;
+          },
         ),
       ),
     );
@@ -239,10 +243,20 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
     await tester.tap(submit);
-    await tester.pumpAndSettle();
+    for (var attempt = 0; attempt < 20 && navigations == 0; attempt++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
 
     expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
     expect(navigations, 1);
+    expect(
+      find.byKey(const Key('preparation-scene-launch-status')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('preparation-catalog-list')), findsNothing);
+    practiceRoute.complete();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('preparation-catalog-list')), findsOneWidget);
     expect(launchClient.lastProfileInput?.kind, PreparationKind.scenario);
     expect(
       launchClient.lastProfileInput?.scenario,


### PR DESCRIPTION
## 功能描述

- 修复从 IELTS Part 1/Part 2/Part 3、完整模考及其他正式练习入口启动时，短暂闪回训练首页的问题。
- 保留真正停放后的继续练习与本地可恢复记录。

## 实现思路

- 当当前 thread、goal、session、scene 与已提交 workspace 完全一致且练习仍为 active 时，直接复用当前会话，不再重复请求 restore。
- 练习启动成功后，准备页保持当前启动状态，等待练习路由退出后再清理；路由转场期间不再暴露训练首页。
- 不改变 `hasResumable`、IELTS 冻结选题或练习模式契约。

## 可复现测试

- `cd mobile && flutter analyze --no-pub`
- `cd mobile && flutter test --no-pub test/coaching/preparation/preparation_page_test.dart test/coaching/preparation/practice_workspace_controller_test.dart test/coaching/preparation/practice_lifecycle_flow_test.dart`
- iOS Simulator：真实后端、数字人禁用；点击任意 IELTS Part 1，确认直接进入对应练习且不闪回训练首页。

Closes #522
