### PR TITLE
feat(ielts): add question set detail page

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
+import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
 import 'package:speakup/features/coaching/preparation/preparation_catalog_components.dart';
 import 'package:speakup/features/coaching/preparation/preparation_design.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -167,7 +170,7 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
           ),
           itemBuilder: (context, index) => _IeltsTopicCard(
             item: items[index],
-            onPressed: () => _open(items[index]),
+            onPressed: () => unawaited(_open(items[index])),
           ),
         ),
     ];
@@ -187,6 +190,7 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
             release: topic.releaseStatus,
             tags: topic.tagCodes,
             imagePath: _topicImageFor(topic.tagCodes, topic.id),
+            questions: topic.questions,
             searchable:
                 '${topic.titleZh} ${topic.titleEn} ${topic.questions.join(' ')}',
           ),
@@ -204,6 +208,8 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
             release: group.releaseStatus,
             tags: [group.cueCardType, ...group.tagCodes],
             imagePath: _topicImageFor(group.tagCodes, '${group.id}-part2'),
+            questions: group.part3Questions,
+            cueCard: group.cueCard,
             searchable:
                 '${group.title} ${group.cueCard.prompt} ${group.cueCard.points.join(' ')} ${group.part3Questions.join(' ')}',
           ),
@@ -219,6 +225,7 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
             release: group.releaseStatus,
             tags: [group.cueCardType, ...group.tagCodes],
             imagePath: _topicImageFor(group.tagCodes, '${group.id}-part3'),
+            questions: group.part3Questions,
             searchable:
                 '${group.title} ${group.cueCard.prompt} ${group.part3Questions.join(' ')}',
           ),
@@ -235,15 +242,27 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
         .toList(growable: false);
   }
 
-  void _open(_CatalogItem item) {
+  Future<void> _open(_CatalogItem item) async {
     final scene = ieltsSceneForMode(widget.scenes, item.mode);
-    if (scene == null) return;
-    widget.onSelectionPressed(
-      scene,
-      item.mode,
-      IeltsPracticeSelection(
-        part1SetId: item.mode == PracticeMode.part1 ? item.id : null,
-        topicGroupId: item.mode == PracticeMode.part1 ? null : item.id,
+    final selection = IeltsPracticeSelection(
+      part1SetId: item.mode == PracticeMode.part1 ? item.id : null,
+      topicGroupId: item.mode == PracticeMode.part1 ? null : item.id,
+    );
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => IeltsSetDetailPage(
+          mode: item.mode,
+          title: item.title,
+          subtitle: item.subtitle,
+          questions: item.questions,
+          cueCard: item.cueCard,
+          onStart: scene == null
+              ? null
+              : () {
+                  Navigator.of(context).pop();
+                  widget.onSelectionPressed(scene, item.mode, selection);
+                },
+        ),
       ),
     );
   }
@@ -422,7 +441,9 @@ final class _CatalogItem {
     required this.release,
     required this.tags,
     required this.imagePath,
+    required this.questions,
     required this.searchable,
+    this.cueCard,
   });
   final String id;
   final PracticeMode mode;
@@ -431,6 +452,8 @@ final class _CatalogItem {
   final String release;
   final List<String> tags;
   final String? imagePath;
+  final List<String> questions;
+  final IeltsCueCard? cueCard;
   final String searchable;
 }
 

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -82,7 +82,7 @@ class IeltsSetDetailPage extends StatelessWidget {
                         key: const Key('ielts-set-detail-title'),
                         style: PreparationDesign.pageTitle,
                       ),
-                      if (subtitle.isNotEmpty) ...[
+                      if (cueCard == null && subtitle.isNotEmpty) ...[
                         const SizedBox(height: 8),
                         Text(
                           subtitle,

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -1,0 +1,306 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/preparation/preparation_design.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+
+class IeltsSetDetailPage extends StatelessWidget {
+  const IeltsSetDetailPage({
+    required this.mode,
+    required this.title,
+    required this.subtitle,
+    required this.questions,
+    required this.onStart,
+    this.cueCard,
+    super.key,
+  });
+
+  final PracticeMode mode;
+  final String title;
+  final String subtitle;
+  final List<String> questions;
+  final IeltsCueCard? cueCard;
+  final VoidCallback? onStart;
+
+  String get _partLabel => switch (mode) {
+    PracticeMode.part1 => 'Part 1',
+    PracticeMode.part2 => 'Part 2',
+    PracticeMode.part3 => 'Part 3',
+    _ => throw StateError('IELTS set details require a section mode.'),
+  };
+
+  String get _questionsTitle => switch (mode) {
+    PracticeMode.part2 => '同组 Part 3 · ${questions.length} 题',
+    _ => '$_partLabel · ${questions.length} 题',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('ielts-set-detail'),
+      backgroundColor: PreparationDesign.canvas,
+      appBar: AppBar(
+        backgroundColor: PreparationDesign.canvas,
+        surfaceTintColor: Colors.transparent,
+        leading: IconButton(
+          key: const Key('ielts-set-detail-back'),
+          tooltip: '返回题库',
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back_rounded),
+        ),
+        title: Text(
+          'IELTS · $_partLabel',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: SafeArea(
+        top: false,
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                key: const Key('ielts-set-detail-scroll'),
+                padding: PreparationDesign.pagePadding(
+                  context,
+                  hasPrimaryNavigation: false,
+                  top: 12,
+                ).copyWith(bottom: 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (mode == PracticeMode.part1)
+                      _PartOneHeader(
+                        title: title,
+                        subtitle: subtitle,
+                        questionCount: questions.length,
+                      )
+                    else ...[
+                      _PartBadge(label: _partLabel),
+                      const SizedBox(height: 14),
+                      Text(
+                        title,
+                        key: const Key('ielts-set-detail-title'),
+                        style: PreparationDesign.pageTitle,
+                      ),
+                      if (subtitle.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          subtitle,
+                          key: const Key('ielts-set-detail-subtitle'),
+                          style: PreparationDesign.body,
+                        ),
+                      ],
+                      const SizedBox(height: 28),
+                    ],
+                    if (cueCard case final value?) ...[
+                      _CueCardContent(cueCard: value),
+                      if (questions.isNotEmpty) const SizedBox(height: 30),
+                    ],
+                    if (questions.isNotEmpty) ...[
+                      if (mode != PracticeMode.part1) ...[
+                        Text(
+                          _questionsTitle,
+                          style: PreparationDesign.sectionTitle,
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                      for (var index = 0; index < questions.length; index++)
+                        _QuestionRow(
+                          index: index + 1,
+                          question: questions[index],
+                        ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            DecoratedBox(
+              decoration: const BoxDecoration(
+                color: PreparationDesign.surface,
+                border: Border(
+                  top: BorderSide(color: PreparationDesign.border),
+                ),
+              ),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(
+                  PreparationDesign.horizontalInset(context),
+                  12,
+                  PreparationDesign.horizontalInset(context),
+                  12 + MediaQuery.viewPaddingOf(context).bottom,
+                ),
+                child: FilledButton(
+                  key: const Key('ielts-set-detail-start'),
+                  onPressed: onStart,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(52),
+                    backgroundColor: PreparationDesign.ink,
+                    foregroundColor: Colors.white,
+                    textStyle: PreparationDesign.cardTitle,
+                  ),
+                  child: Text(
+                    onStart == null
+                        ? '练习暂不可用'
+                        : mode == PracticeMode.part1
+                        ? '开始整组练习'
+                        : '开始 $_partLabel',
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PartOneHeader extends StatelessWidget {
+  const _PartOneHeader({
+    required this.title,
+    required this.subtitle,
+    required this.questionCount,
+  });
+
+  final String title;
+  final String subtitle;
+  final int questionCount;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    key: const Key('ielts-set-detail-topic'),
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Wrap(
+        crossAxisAlignment: WrapCrossAlignment.end,
+        spacing: 14,
+        runSpacing: 6,
+        children: [
+          Text(
+            title,
+            key: const Key('ielts-set-detail-title'),
+            style: PreparationDesign.pageTitle,
+          ),
+          if (subtitle.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Text(
+                subtitle,
+                key: const Key('ielts-set-detail-subtitle'),
+                style: PreparationDesign.sectionTitle.copyWith(
+                  color: PreparationDesign.inkSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+        ],
+      ),
+      const SizedBox(height: 8),
+      Text(
+        '$questionCount 题',
+        style: PreparationDesign.body.copyWith(
+          color: PreparationDesign.inkSecondary,
+        ),
+      ),
+      const SizedBox(height: 20),
+      const Divider(height: 1, color: PreparationDesign.border),
+      const SizedBox(height: 8),
+    ],
+  );
+}
+
+class _PartBadge extends StatelessWidget {
+  const _PartBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => DecoratedBox(
+    decoration: BoxDecoration(
+      color: PreparationDesign.surfaceMuted,
+      borderRadius: BorderRadius.circular(PreparationDesign.radiusControl),
+    ),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      child: Text(label.toUpperCase(), style: PreparationDesign.label),
+    ),
+  );
+}
+
+class _CueCardContent extends StatelessWidget {
+  const _CueCardContent({required this.cueCard});
+
+  final IeltsCueCard cueCard;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    key: const Key('ielts-set-detail-cue-card'),
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      const Text('Cue Card', style: PreparationDesign.sectionTitle),
+      const SizedBox(height: 10),
+      Text(
+        cueCard.prompt,
+        style: PreparationDesign.cardTitle.copyWith(fontSize: 18),
+      ),
+      if (cueCard.points.isNotEmpty) ...[
+        const SizedBox(height: 14),
+        const Text('You should say:', style: PreparationDesign.label),
+        const SizedBox(height: 6),
+        for (final point in cueCard.points)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(top: 7),
+                  child: Icon(Icons.circle, size: 5),
+                ),
+                const SizedBox(width: 10),
+                Expanded(child: Text(point, style: PreparationDesign.body)),
+              ],
+            ),
+          ),
+      ],
+    ],
+  );
+}
+
+class _QuestionRow extends StatelessWidget {
+  const _QuestionRow({required this.index, required this.question});
+
+  final int index;
+  final String question;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    key: Key('ielts-set-detail-question-$index'),
+    width: double.infinity,
+    padding: const EdgeInsets.symmetric(vertical: 12),
+    decoration: const BoxDecoration(
+      border: Border(bottom: BorderSide(color: PreparationDesign.border)),
+    ),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 28,
+          child: Text(
+            '$index',
+            style: PreparationDesign.label.copyWith(
+              color: PreparationDesign.inkSecondary,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            question,
+            style: PreparationDesign.body.copyWith(
+              color: PreparationDesign.ink,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -9,6 +9,8 @@ import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
+import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
+import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
 
 void main() {
   testWidgets('shows exactly the four product-level practice entries', (
@@ -202,6 +204,153 @@ void main() {
     expect(find.textContaining('对应 Part 2'), findsNothing);
     expect(find.textContaining('完成后继续同组 Part 3'), findsNothing);
     expect(find.byKey(const Key('ielts-part2-set-p23-001')), findsOneWidget);
+  });
+
+  testWidgets('opens Part 1 details before emitting the exact selection', (
+    tester,
+  ) async {
+    final ieltsController = IeltsPreparationController(
+      client: _HubQuestionBankClient(),
+    );
+    addTearDown(ieltsController.dispose);
+    SceneDefinition? selectedScene;
+    PracticeMode? selectedMode;
+    IeltsPracticeSelection? selectedSet;
+    await ieltsController.loadIfNeeded();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: IeltsCatalog(
+            controller: ieltsController,
+            scenes: _hubScenes,
+            onRetry: ieltsController.retryLoad,
+            onSelectionPressed: (scene, mode, selection) {
+              selectedScene = scene;
+              selectedMode = mode;
+              selectedSet = selection;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('ielts-part1-set-p1-topic-001')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-set-detail')), findsOneWidget);
+    expect(find.text('家乡'), findsOneWidget);
+    expect(find.text('Hometown'), findsOneWidget);
+    expect(find.text('Q1'), findsOneWidget);
+    expect(find.text('Q2'), findsOneWidget);
+    final topicBottom = tester.getBottomLeft(
+      find.byKey(const Key('ielts-set-detail-topic')),
+    );
+    final questionsTop = tester.getTopLeft(
+      find.byKey(const Key('ielts-set-detail-question-1')),
+    );
+    expect(topicBottom.dy, lessThanOrEqualTo(questionsTop.dy));
+    expect(find.byKey(const Key('ielts-set-detail-title')), findsOneWidget);
+    expect(find.text('开始整组练习'), findsOneWidget);
+    expect(selectedSet, isNull);
+
+    await tester.tap(find.byKey(const Key('ielts-set-detail-start')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-set-detail')), findsNothing);
+    expect(selectedScene?.id, 'scene_ielts_speaking');
+    expect(selectedMode, PracticeMode.part1);
+    expect(
+      selectedSet,
+      const IeltsPracticeSelection(part1SetId: 'p1-topic-001'),
+    );
+  });
+
+  testWidgets('shows the real Cue Card and linked Part 3 questions', (
+    tester,
+  ) async {
+    final ieltsController = IeltsPreparationController(
+      client: _HubQuestionBankClient(),
+    );
+    addTearDown(ieltsController.dispose);
+    await ieltsController.loadIfNeeded();
+    PracticeMode? selectedMode;
+    IeltsPracticeSelection? selectedSet;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: IeltsCatalog(
+            controller: ieltsController,
+            scenes: _hubScenes,
+            onRetry: ieltsController.retryLoad,
+            onSelectionPressed: (_, mode, selection) {
+              selectedMode = mode;
+              selectedSet = selection;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('ielts-part2-set-p23-001')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-set-detail-cue-card')), findsOneWidget);
+    expect(find.text('Describe a skill you would like to learn'), findsWidgets);
+    expect(find.text('What'), findsOneWidget);
+    expect(find.text('Benefit'), findsOneWidget);
+    expect(find.text('同组 Part 3 · 5 题'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-set-detail-question-5')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('ielts-set-detail-back')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ielts-part2-set-p23-001')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('ielts-part2-set-p23-001')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('ielts-set-detail-start')));
+    await tester.pumpAndSettle();
+
+    expect(selectedMode, PracticeMode.part2);
+    expect(selectedSet, const IeltsPracticeSelection(topicGroupId: 'p23-001'));
+  });
+
+  testWidgets('keeps the detail action reachable on a narrow large-text view', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 1.6;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part2,
+          title: _ieltsBank.topicGroups.single.title,
+          subtitle: _ieltsBank.topicGroups.single.cueCard.prompt,
+          cueCard: _ieltsBank.topicGroups.single.cueCard,
+          questions: _ieltsBank.topicGroups.single.part3Questions,
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('ielts-set-detail-start')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('ielts-set-detail-scroll')), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('keeps IELTS filters available in the compact catalog', (

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -299,7 +299,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('ielts-set-detail-cue-card')), findsOneWidget);
-    expect(find.text('Describe a skill you would like to learn'), findsWidgets);
+    expect(
+      find.text('Describe a skill you would like to learn'),
+      findsOneWidget,
+    );
     expect(find.text('What'), findsOneWidget);
     expect(find.text('Benefit'), findsOneWidget);
     expect(find.text('同组 Part 3 · 5 题'), findsOneWidget);


### PR DESCRIPTION
## 功能描述

- IELTS Part 1/2/3 题卡点击后先进入套题详情，不再立即创建练习。
- Part 1 展示话题与全部题目；Part 2 展示 Cue Card 及同组 Part 3；Part 3 展示全部题目。
- 支持返回题库，并通过底部主操作按原有 mode 与题组 ID 启动练习。
- 小屏、横屏和较大系统字体下详情内容可滚动且开始按钮可触达。

## 实现思路

- 将题库接口返回的真实题目与 Cue Card 直接传入详情页，不增加本地假数据或猜测字段。
- 详情页只负责预览与确认；点击开始后复用现有 `onSelectionPressed` 启动链和 `IeltsPracticeSelection` 契约。
- 用 Widget 测试覆盖详情打开前不发出选择、Part 1/2 精确 ID 传递、返回层级和窄屏大字体可用性。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/coaching/preparation/preparation_hub_test.dart
```

结果：Flutter analyze 无问题；17 项相关测试全部通过。

Closes #524
