### PR TITLE
[Backend] 建立 IELTS 逐题答案准备与个性化生成契约

### DIFF
--- a/api/modules/ielts.yaml
+++ b/api/modules/ielts.yaml
@@ -17,7 +17,98 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/BadRequest
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/ielts-speaking/answer-preparations:
+    post:
+      tags: [IELTS Speaking]
+      summary: Create or restore an actor-owned answer preparation
+      description: Creates one preparation for a stable bank/part/source/position locator. The prompt is resolved and snapshotted by the server; question text is never accepted as identity. AI output is a personal practice aid, not an official or scored answer.
+      operationId: createIeltsAnswerPreparation
+      parameters: [{$ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreateIeltsAnswerPreparationRequest'}
+      responses:
+        '201': {description: Created preparation., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        '200': {description: Idempotently restored preparation., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        '409': {$ref: ../common/errors.yaml#/components/responses/Conflict}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}:
+    parameters:
+      - {$ref: '#/components/parameters/AnswerPreparationId'}
+    get:
+      tags: [IELTS Speaking]
+      summary: Get an actor-owned answer preparation
+      operationId: getIeltsAnswerPreparation
+      responses:
+        '200': {description: Current preparation., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
+    patch:
+      tags: [IELTS Speaking]
+      summary: Replace personal points and target band
+      description: Requires the current version. A successful edit returns the resource to draft and removes obsolete generated fields.
+      operationId: updateIeltsAnswerPreparation
+      parameters: [{$ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey}]
+      requestBody:
+        required: true
+        content: {application/json: {schema: {$ref: '#/components/schemas/UpdateIeltsAnswerPreparationRequest'}}}
+      responses:
+        '200': {description: Updated or idempotently restored preparation., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        '409': {$ref: ../common/errors.yaml#/components/responses/Conflict}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
+    delete:
+      tags: [IELTS Speaking]
+      summary: Delete an actor-owned answer preparation
+      operationId: deleteIeltsAnswerPreparation
+      parameters:
+        - {$ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey}
+        - name: expected_version
+          in: query
+          required: true
+          schema: {type: integer, minimum: 1}
+      responses:
+        '204': {description: Deleted or idempotently replayed.}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        '409': {$ref: ../common/errors.yaml#/components/responses/Conflict}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}/generations:
+    post:
+      tags: [IELTS Speaking]
+      summary: Generate or regenerate a personalized practice answer
+      description: Uses only the question and learner-supplied points. Provider failures persist failed with retryable semantics; the operation never creates or advances a Practice Session or Turn.
+      operationId: generateIeltsAnswerPreparation
+      parameters:
+        - {$ref: '#/components/parameters/AnswerPreparationId'}
+        - {$ref: ../common/parameters.yaml#/components/parameters/IdempotencyKey}
+      requestBody:
+        required: true
+        content: {application/json: {schema: {$ref: '#/components/schemas/GenerateIeltsAnswerPreparationRequest'}}}
+      responses:
+        '200': {description: Ready result or matching idempotent replay., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        '409': {$ref: ../common/errors.yaml#/components/responses/Conflict}
+        '502': {description: Generation failed; response is the persisted failed resource and a fresh idempotency key may retry., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
 components:
+  parameters:
+    AnswerPreparationId:
+      name: answer_preparation_id
+      in: path
+      required: true
+      schema: {type: string, pattern: '^ielts_answer_[0-9a-f]{32}$'}
   schemas:
     ResourceId:
       type: string
@@ -104,6 +195,7 @@ components:
         questions:
           type: array
           minItems: 2
+          description: Ordered questions. The stable answer-preparation question_position is the one-based array position within this topic and bank_id.
           items: {type: string, minLength: 1}
     IeltsTopicGroup:
       type: object
@@ -128,6 +220,7 @@ components:
           type: array
           minItems: 1
           maxItems: 6
+          description: Ordered questions. The stable answer-preparation question_position is the one-based array position within this topic group and bank_id.
           items: {type: string, minLength: 1}
     IeltsPart2CueCard:
       type: object
@@ -139,3 +232,63 @@ components:
           type: array
           minItems: 3
           items: {type: string, minLength: 1}
+    IeltsQuestionReference:
+      type: object
+      additionalProperties: false
+      required: [bank_id, part, source_id, question_position]
+      properties:
+        bank_id: {$ref: '#/components/schemas/ResourceId'}
+        part: {type: string, enum: [PART_1, PART_2, PART_3]}
+        source_id: {$ref: '#/components/schemas/ResourceId'}
+        question_position:
+          type: integer
+          minimum: 1
+          description: One-based position within the source. Part 2 Cue Cards always use 1.
+    IeltsResolvedQuestion:
+      type: object
+      additionalProperties: false
+      required: [reference, prompt]
+      properties:
+        reference: {$ref: '#/components/schemas/IeltsQuestionReference'}
+        prompt: {type: string, minLength: 1, maxLength: 2048}
+    IeltsAnswerPreparation:
+      type: object
+      additionalProperties: false
+      required: [answer_preparation_id, question, personal_points, target_band, status, version, generation_revision, created_at, updated_at]
+      properties:
+        answer_preparation_id: {type: string, pattern: '^ielts_answer_[0-9a-f]{32}$'}
+        question: {$ref: '#/components/schemas/IeltsResolvedQuestion'}
+        personal_points: {type: array, maxItems: 12, items: {type: string, minLength: 1, maxLength: 500}}
+        target_band: {type: number, minimum: 4, maximum: 9, multipleOf: 0.5}
+        status: {type: string, enum: [draft, generating, ready, failed]}
+        answer: {type: string, minLength: 1}
+        outline: {type: array, minItems: 1, maxItems: 12, items: {type: string, minLength: 1}}
+        useful_expressions: {type: array, minItems: 1, maxItems: 16, items: {type: string, minLength: 1}}
+        speech_text: {type: string, minLength: 1}
+        failure_code: {type: string, enum: [provider_error, invalid_provider_response]}
+        version: {type: integer, minimum: 1}
+        generation_revision: {type: integer, minimum: 0}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+    CreateIeltsAnswerPreparationRequest:
+      type: object
+      additionalProperties: false
+      required: [question, personal_points, target_band]
+      properties:
+        question: {$ref: '#/components/schemas/IeltsQuestionReference'}
+        personal_points: {type: array, maxItems: 12, items: {type: string, minLength: 1, maxLength: 500}}
+        target_band: {type: number, minimum: 4, maximum: 9, multipleOf: 0.5}
+    UpdateIeltsAnswerPreparationRequest:
+      type: object
+      additionalProperties: false
+      required: [expected_version, personal_points, target_band]
+      properties:
+        expected_version: {type: integer, minimum: 1}
+        personal_points: {type: array, maxItems: 12, items: {type: string, minLength: 1, maxLength: 500}}
+        target_band: {type: number, minimum: 4, maximum: 9, multipleOf: 0.5}
+    GenerateIeltsAnswerPreparationRequest:
+      type: object
+      additionalProperties: false
+      required: [expected_version]
+      properties:
+        expected_version: {type: integer, minimum: 1}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34,7 +34,7 @@ tags:
   - name: Scene
     description: Versioned training Scenes, roles, and practice options.
   - name: IELTS Speaking
-    description: Published IELTS Speaking question-bank resources.
+    description: Published question-bank resources and actor-owned answer preparation.
   - name: Preparation
     description: User materials, immutable snapshots, and versioned practice plans.
   - name: Practice
@@ -103,6 +103,12 @@ paths:
     $ref: ./modules/scene.yaml#/paths/~1v1~1scenes
   /v1/ielts-speaking/question-bank:
     $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1question-bank
+  /v1/ielts-speaking/answer-preparations:
+    $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}:
+    $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations~1{answer_preparation_id}
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}/generations:
+    $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations~1{answer_preparation_id}~1generations
   /v1/goals:
     $ref: ./modules/goal.yaml#/paths/~1v1~1goals
   /v1/goals/{goal_id}:
@@ -352,6 +358,10 @@ components:
       $ref: ./modules/ielts.yaml#/components/schemas/IeltsTopicGroup
     IeltsPart2CueCard:
       $ref: ./modules/ielts.yaml#/components/schemas/IeltsPart2CueCard
+    IeltsQuestionReference:
+      $ref: ./modules/ielts.yaml#/components/schemas/IeltsQuestionReference
+    IeltsAnswerPreparation:
+      $ref: ./modules/ielts.yaml#/components/schemas/IeltsAnswerPreparation
     PreparationProfile:
       $ref: ./modules/preparation.yaml#/components/schemas/PreparationProfile
     PreparationSnapshot:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -58,6 +58,12 @@ func run() int {
 		logger.Error("Preparation job target generation startup failed")
 		return 1
 	}
+	ieltsAnswerGenerator, err :=
+		bootstrap.NewIELTSAnswerPreparationGenerator(textConfig)
+	if err != nil {
+		logger.Error("IELTS answer preparation generation startup failed")
+		return 1
+	}
 	evaluationScoringGenerator, err :=
 		bootstrap.NewEvaluationScoringGenerator(textConfig)
 	if err != nil {
@@ -207,6 +213,23 @@ func run() int {
 	ieltsQuestionBank, err := ielts.NewPostgresStore(databasePool.Native())
 	if err != nil {
 		logger.Error("IELTS question bank startup failed", slog.Any("error", err))
+		return 1
+	}
+	ieltsAnswerService, err := ielts.NewAnswerPreparationService(
+		ieltsQuestionBank,
+		ieltsQuestionBank,
+		ieltsAnswerGenerator,
+		ielts.SecureAnswerPreparationIDGenerator{},
+	)
+	if err != nil {
+		logger.Error("IELTS answer preparation startup failed")
+		return 1
+	}
+	ieltsAnswerHTTP, err := ielts.NewAnswerPreparationHTTPHandler(
+		ieltsAnswerService,
+	)
+	if err != nil {
+		logger.Error("IELTS answer preparation HTTP startup failed")
 		return 1
 	}
 
@@ -458,6 +481,7 @@ func run() int {
 	}
 	protectedRegistrars := []bootstrap.ProtectedRouteRegistrar{
 		avatarHTTP,
+		ieltsAnswerHTTP,
 		evaluationComposition.HTTPHandler(),
 		speechFeedbackComposition.HTTPHandler(),
 		speechFeedbackComposition.RetryHTTPHandler(),

--- a/server/internal/bootstrap/text_generation.go
+++ b/server/internal/bootstrap/text_generation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene/ielts"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/fieldextractor"
@@ -70,6 +71,16 @@ func NewPreparationJobTargetGenerator(
 		return nil, err
 	}
 	return qianwen.NewPreparationJobTargetGenerator(providerConfig, apiKey)
+}
+
+func NewIELTSAnswerPreparationGenerator(
+	configuration config.TextGenerationConfig,
+) (ielts.AnswerPreparationGenerator, error) {
+	providerConfig, apiKey, err := qianwenTextProvider(configuration)
+	if err != nil {
+		return nil, err
+	}
+	return qianwen.NewIELTSAnswerPreparationGenerator(providerConfig, apiKey)
 }
 
 func NewEvaluationScoringGenerator(

--- a/server/internal/coaching/scene/ielts/answer_preparation.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation.go
@@ -1,0 +1,416 @@
+package ielts
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+var (
+	ErrAnswerPreparationInvalid             = errors.New("ielts: invalid answer preparation request")
+	ErrAnswerPreparationNotFound            = errors.New("ielts: answer preparation not found")
+	ErrAnswerPreparationConflict            = errors.New("ielts: answer preparation version conflict")
+	ErrAnswerPreparationIdempotencyConflict = errors.New("ielts: answer preparation idempotency conflict")
+	ErrAnswerPreparationRepository          = errors.New("ielts: answer preparation repository failure")
+	ErrAnswerPreparationGeneration          = errors.New("ielts: answer preparation generation failed")
+)
+
+type AnswerPreparationStatus string
+
+const (
+	AnswerPreparationDraft      AnswerPreparationStatus = "draft"
+	AnswerPreparationGenerating AnswerPreparationStatus = "generating"
+	AnswerPreparationReady      AnswerPreparationStatus = "ready"
+	AnswerPreparationFailed     AnswerPreparationStatus = "failed"
+)
+
+type QuestionReference struct {
+	BankID           string       `json:"bank_id"`
+	Part             PracticeMode `json:"part"`
+	SourceID         string       `json:"source_id"`
+	QuestionPosition int          `json:"question_position"`
+}
+
+type ResolvedQuestion struct {
+	Reference QuestionReference `json:"reference"`
+	Prompt    string            `json:"prompt"`
+}
+
+type AnswerPreparation struct {
+	ID                 string                  `json:"answer_preparation_id"`
+	Question           ResolvedQuestion        `json:"question"`
+	PersonalPoints     []string                `json:"personal_points"`
+	TargetBand         float64                 `json:"target_band"`
+	Status             AnswerPreparationStatus `json:"status"`
+	Answer             string                  `json:"answer,omitempty"`
+	Outline            []string                `json:"outline,omitempty"`
+	UsefulExpressions  []string                `json:"useful_expressions,omitempty"`
+	SpeechText         string                  `json:"speech_text,omitempty"`
+	FailureCode        string                  `json:"failure_code,omitempty"`
+	Version            int                     `json:"version"`
+	GenerationRevision int                     `json:"generation_revision"`
+	CreatedAt          time.Time               `json:"created_at"`
+	UpdatedAt          time.Time               `json:"updated_at"`
+}
+
+type CreateAnswerPreparationRequest struct {
+	Question       QuestionReference `json:"question"`
+	PersonalPoints []string          `json:"personal_points"`
+	TargetBand     float64           `json:"target_band"`
+}
+
+type UpdateAnswerPreparationRequest struct {
+	ExpectedVersion int      `json:"expected_version"`
+	PersonalPoints  []string `json:"personal_points"`
+	TargetBand      float64  `json:"target_band"`
+}
+
+type GenerateAnswerPreparationRequest struct {
+	ExpectedVersion int `json:"expected_version"`
+}
+
+type MutationIntent struct {
+	Method      string
+	Path        string
+	Key         string
+	Fingerprint [sha256.Size]byte
+}
+
+type CreateAnswerPreparationCommand struct {
+	ID       string
+	Question ResolvedQuestion
+	Request  CreateAnswerPreparationRequest
+	Intent   MutationIntent
+}
+
+type UpdateAnswerPreparationCommand struct {
+	ID      string
+	Request UpdateAnswerPreparationRequest
+	Intent  MutationIntent
+}
+
+type BeginAnswerGenerationCommand struct {
+	ID      string
+	Request GenerateAnswerPreparationRequest
+	Intent  MutationIntent
+}
+
+type CompleteAnswerGenerationCommand struct {
+	ID                 string
+	GeneratingVersion  int
+	GenerationRevision int
+	Result             AnswerGenerationResult
+}
+
+type FailAnswerGenerationCommand struct {
+	ID                 string
+	GeneratingVersion  int
+	GenerationRevision int
+	FailureCode        string
+}
+
+type DeleteAnswerPreparationCommand struct {
+	ID              string
+	ExpectedVersion int
+	Intent          MutationIntent
+}
+
+type AnswerPreparationRepository interface {
+	Create(context.Context, requestcontext.Actor, CreateAnswerPreparationCommand) (AnswerPreparation, bool, error)
+	Get(context.Context, requestcontext.Actor, string) (AnswerPreparation, error)
+	Update(context.Context, requestcontext.Actor, UpdateAnswerPreparationCommand) (AnswerPreparation, bool, error)
+	BeginGeneration(context.Context, requestcontext.Actor, BeginAnswerGenerationCommand) (AnswerPreparation, bool, error)
+	CompleteGeneration(context.Context, requestcontext.Actor, CompleteAnswerGenerationCommand) (AnswerPreparation, error)
+	FailGeneration(context.Context, requestcontext.Actor, FailAnswerGenerationCommand) error
+	Delete(context.Context, requestcontext.Actor, DeleteAnswerPreparationCommand) (bool, error)
+}
+
+type AnswerQuestionResolver interface {
+	ResolveAnswerQuestion(context.Context, QuestionReference) (ResolvedQuestion, error)
+}
+
+type AnswerGenerationRequest struct {
+	Part           PracticeMode
+	Question       string
+	PersonalPoints []string
+	TargetBand     float64
+}
+
+type AnswerGenerationResult struct {
+	RequestID         string
+	Provider          string
+	Model             string
+	Answer            string
+	Outline           []string
+	UsefulExpressions []string
+	SpeechText        string
+}
+
+type AnswerPreparationGenerator interface {
+	GenerateAnswerPreparation(context.Context, AnswerGenerationRequest) (AnswerGenerationResult, error)
+}
+
+type AnswerPreparationIDGenerator interface {
+	NewAnswerPreparationID() (string, error)
+}
+
+type AnswerPreparationService struct {
+	repository AnswerPreparationRepository
+	questions  AnswerQuestionResolver
+	generator  AnswerPreparationGenerator
+	ids        AnswerPreparationIDGenerator
+}
+
+func NewAnswerPreparationService(repository AnswerPreparationRepository, questions AnswerQuestionResolver, generator AnswerPreparationGenerator, ids AnswerPreparationIDGenerator) (*AnswerPreparationService, error) {
+	if repository == nil || questions == nil || generator == nil || ids == nil {
+		return nil, ErrAnswerPreparationInvalid
+	}
+	return &AnswerPreparationService{repository: repository, questions: questions, generator: generator, ids: ids}, nil
+}
+
+func (service *AnswerPreparationService) Create(ctx context.Context, actor requestcontext.Actor, key string, request CreateAnswerPreparationRequest) (AnswerPreparation, bool, error) {
+	if ctx == nil || !actor.Valid() || !validCreateAnswerPreparation(request) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	intent, err := answerMutationIntent("POST", "/v1/ielts-speaking/answer-preparations", key, request)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	question, err := service.questions.ResolveAnswerQuestion(ctx, request.Question)
+	if err != nil {
+		if errors.Is(err, ErrQuestionSetNotFound) {
+			return AnswerPreparation{}, false, ErrAnswerPreparationNotFound
+		}
+		return AnswerPreparation{}, false, err
+	}
+	id, err := service.ids.NewAnswerPreparationID()
+	if err != nil {
+		return AnswerPreparation{}, false, ErrAnswerPreparationRepository
+	}
+	request.PersonalPoints = normalizeStrings(request.PersonalPoints)
+	return service.repository.Create(ctx, actor, CreateAnswerPreparationCommand{ID: id, Question: question, Request: request, Intent: intent})
+}
+
+func (service *AnswerPreparationService) Get(ctx context.Context, actor requestcontext.Actor, id string) (AnswerPreparation, error) {
+	if ctx == nil || !actor.Valid() || !validAnswerPreparationID(id) {
+		return AnswerPreparation{}, ErrAnswerPreparationInvalid
+	}
+	return service.repository.Get(ctx, actor, id)
+}
+
+func (service *AnswerPreparationService) Update(ctx context.Context, actor requestcontext.Actor, id, key string, request UpdateAnswerPreparationRequest) (AnswerPreparation, bool, error) {
+	if ctx == nil || !actor.Valid() || !validAnswerPreparationID(id) || !validUpdateAnswerPreparation(request) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	request.PersonalPoints = normalizeStrings(request.PersonalPoints)
+	intent, err := answerMutationIntent("PATCH", "/v1/ielts-speaking/answer-preparations/"+id, key, request)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	return service.repository.Update(ctx, actor, UpdateAnswerPreparationCommand{ID: id, Request: request, Intent: intent})
+}
+
+func (service *AnswerPreparationService) Generate(ctx context.Context, actor requestcontext.Actor, id, key string, request GenerateAnswerPreparationRequest) (AnswerPreparation, bool, error) {
+	if ctx == nil || !actor.Valid() || !validAnswerPreparationID(id) || request.ExpectedVersion < 1 {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	intent, err := answerMutationIntent("POST", "/v1/ielts-speaking/answer-preparations/"+id+"/generations", key, request)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	preparation, replayed, err := service.repository.BeginGeneration(ctx, actor, BeginAnswerGenerationCommand{ID: id, Request: request, Intent: intent})
+	if err != nil {
+		return preparation, replayed, err
+	}
+	if replayed {
+		if preparation.Status == AnswerPreparationFailed {
+			return preparation, true, ErrAnswerPreparationGeneration
+		}
+		return preparation, true, nil
+	}
+	if preparation.Status != AnswerPreparationGenerating {
+		return AnswerPreparation{}, false, ErrAnswerPreparationConflict
+	}
+	result, generationErr := service.generator.GenerateAnswerPreparation(ctx, AnswerGenerationRequest{Part: preparation.Question.Reference.Part, Question: preparation.Question.Prompt, PersonalPoints: preparation.PersonalPoints, TargetBand: preparation.TargetBand})
+	if generationErr != nil || !validGenerationResult(result) || !validGenerationLength(preparation.Question.Reference.Part, result) {
+		failureCode := "provider_error"
+		if generationErr == nil {
+			failureCode = "invalid_provider_response"
+		}
+		failureCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		_ = service.repository.FailGeneration(failureCtx, actor, FailAnswerGenerationCommand{ID: id, GeneratingVersion: preparation.Version, GenerationRevision: preparation.GenerationRevision, FailureCode: failureCode})
+		return AnswerPreparation{}, false, ErrAnswerPreparationGeneration
+	}
+	ready, err := service.repository.CompleteGeneration(ctx, actor, CompleteAnswerGenerationCommand{ID: id, GeneratingVersion: preparation.Version, GenerationRevision: preparation.GenerationRevision, Result: normalizeGenerationResult(result)})
+	return ready, false, err
+}
+
+func (service *AnswerPreparationService) Delete(ctx context.Context, actor requestcontext.Actor, id, key string, expectedVersion int) (bool, error) {
+	if ctx == nil || !actor.Valid() || !validAnswerPreparationID(id) || expectedVersion < 1 {
+		return false, ErrAnswerPreparationInvalid
+	}
+	payload := struct {
+		ExpectedVersion int `json:"expected_version"`
+	}{expectedVersion}
+	intent, err := answerMutationIntent("DELETE", "/v1/ielts-speaking/answer-preparations/"+id, key, payload)
+	if err != nil {
+		return false, err
+	}
+	return service.repository.Delete(ctx, actor, DeleteAnswerPreparationCommand{ID: id, ExpectedVersion: expectedVersion, Intent: intent})
+}
+
+func answerMutationIntent(method, path, key string, payload any) (MutationIntent, error) {
+	if !validIdempotencyKey(key) {
+		return MutationIntent{}, ErrAnswerPreparationInvalid
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return MutationIntent{}, ErrAnswerPreparationInvalid
+	}
+	return MutationIntent{Method: method, Path: path, Key: key, Fingerprint: sha256.Sum256(encoded)}, nil
+}
+
+func validCreateAnswerPreparation(request CreateAnswerPreparationRequest) bool {
+	return validQuestionReference(request.Question) && validPersonalPoints(request.PersonalPoints) && validTargetBand(request.TargetBand)
+}
+
+func validUpdateAnswerPreparation(request UpdateAnswerPreparationRequest) bool {
+	return request.ExpectedVersion >= 1 && validPersonalPoints(request.PersonalPoints) && validTargetBand(request.TargetBand)
+}
+
+func validQuestionReference(reference QuestionReference) bool {
+	if !validStableID(reference.BankID) || !validStableID(reference.SourceID) || reference.QuestionPosition < 1 {
+		return false
+	}
+	switch reference.Part {
+	case PracticeModePart1, PracticeModePart3:
+		return true
+	case PracticeModePart2:
+		return reference.QuestionPosition == 1
+	default:
+		return false
+	}
+}
+
+func validPersonalPoints(points []string) bool {
+	if len(points) > 12 {
+		return false
+	}
+	for _, point := range points {
+		trimmed := strings.TrimSpace(point)
+		if trimmed == "" || !utf8.ValidString(trimmed) || utf8.RuneCountInString(trimmed) > 500 {
+			return false
+		}
+	}
+	return true
+}
+
+func validTargetBand(band float64) bool {
+	return band >= 4 && band <= 9 && band*2 == float64(int(band*2))
+}
+
+func validGenerationResult(result AnswerGenerationResult) bool {
+	return validGeneratedText(result.Answer, 6000) && validGeneratedText(result.SpeechText, 6000) && validGeneratedList(result.Outline, 12, 500) && validGeneratedList(result.UsefulExpressions, 16, 300)
+}
+
+func validGenerationLength(part PracticeMode, result AnswerGenerationResult) bool {
+	var maximumWords int
+	switch part {
+	case PracticeModePart1:
+		maximumWords = 75
+	case PracticeModePart2:
+		maximumWords = 280
+	case PracticeModePart3:
+		maximumWords = 130
+	default:
+		return false
+	}
+	return len(strings.Fields(result.Answer)) <= maximumWords &&
+		len(strings.Fields(result.SpeechText)) <= maximumWords
+}
+
+func validGeneratedText(value string, max int) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && utf8.ValidString(value) && utf8.RuneCountInString(value) <= max
+}
+
+func validGeneratedList(values []string, maxItems, maxRunes int) bool {
+	if len(values) == 0 || len(values) > maxItems {
+		return false
+	}
+	for _, value := range values {
+		if !validGeneratedText(value, maxRunes) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeStrings(values []string) []string {
+	result := make([]string, len(values))
+	for index, value := range values {
+		result[index] = strings.TrimSpace(value)
+	}
+	return result
+}
+
+func normalizeGenerationResult(result AnswerGenerationResult) AnswerGenerationResult {
+	result.Answer = strings.TrimSpace(result.Answer)
+	result.SpeechText = strings.TrimSpace(result.SpeechText)
+	result.Outline = normalizeStrings(result.Outline)
+	result.UsefulExpressions = normalizeStrings(result.UsefulExpressions)
+	return result
+}
+
+func validStableID(value string) bool {
+	return value == strings.TrimSpace(value) && value != "" && utf8.ValidString(value) && len(value) <= 128
+}
+func validAnswerPreparationID(value string) bool {
+	return strings.HasPrefix(value, "ielts_answer_") && validStableID(value)
+}
+func validIdempotencyKey(value string) bool {
+	return value == strings.TrimSpace(value) && len(value) >= 8 && len(value) <= 128 && !strings.ContainsAny(value, " \t\r\n")
+}
+
+func GenerationSystemPrompt() string {
+	return `Return one JSON object with exactly answer, outline, useful_expressions, and speech_text. When personal_points is non-empty, personalize only from those learner-supplied facts and never invent biography, names, places, achievements, or opinions. When personal_points is empty, produce a clearly generic sample answer without specific biographical claims. Produce natural spoken English suitable for the requested IELTS band. answer and speech_text are strings; outline and useful_expressions are non-empty arrays of strings. Do not return markdown.`
+}
+
+func GenerationUserPrompt(request AnswerGenerationRequest) string {
+	timing := answerTiming(request.Part)
+	payload, _ := json.Marshal(struct {
+		Part           PracticeMode `json:"part"`
+		Question       string       `json:"question"`
+		PersonalPoints []string     `json:"personal_points"`
+		TargetBand     float64      `json:"target_band"`
+		TargetSeconds  string       `json:"target_seconds"`
+		TargetWords    string       `json:"target_words"`
+		Structure      string       `json:"structure"`
+	}{request.Part, request.Question, request.PersonalPoints, request.TargetBand, timing.seconds, timing.words, timing.structure})
+	return fmt.Sprintf("Create an IELTS Speaking answer preparation that fits the stated timing. Keep answer and speech_text within target_words; do not pad with repetition.\n%s", payload)
+}
+
+func answerTiming(part PracticeMode) struct {
+	seconds   string
+	words     string
+	structure string
+} {
+	switch part {
+	case PracticeModePart1:
+		return struct{ seconds, words, structure string }{"20-30", "35-55", "2-4 sentences: direct answer, reason, brief example"}
+	case PracticeModePart2:
+		return struct{ seconds, words, structure string }{"90-120", "180-240", "structured long turn covering the cue-card points with a clear opening and closing"}
+	case PracticeModePart3:
+		return struct{ seconds, words, structure string }{"35-50", "75-110", "4-6 sentences: position, explanation, example or comparison, conclusion"}
+	default:
+		return struct{ seconds, words, structure string }{}
+	}
+}

--- a/server/internal/coaching/scene/ielts/answer_preparation_http.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_http.go
@@ -1,0 +1,213 @@
+package ielts
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const maxAnswerPreparationBody = 32 * 1024
+
+type AnswerPreparationHTTPHandler struct{ service *AnswerPreparationService }
+
+func NewAnswerPreparationHTTPHandler(service *AnswerPreparationService) (*AnswerPreparationHTTPHandler, error) {
+	if service == nil {
+		return nil, ErrAnswerPreparationInvalid
+	}
+	return &AnswerPreparationHTTPHandler{service: service}, nil
+}
+
+func (handler *AnswerPreparationHTTPHandler) RegisterRoutes(routes gin.IRoutes) {
+	routes.POST("/v1/ielts-speaking/answer-preparations", handler.create)
+	routes.GET("/v1/ielts-speaking/answer-preparations/:answer_preparation_id", handler.get)
+	routes.PATCH("/v1/ielts-speaking/answer-preparations/:answer_preparation_id", handler.update)
+	routes.POST("/v1/ielts-speaking/answer-preparations/:answer_preparation_id/generations", handler.generate)
+	routes.DELETE("/v1/ielts-speaking/answer-preparations/:answer_preparation_id", handler.delete)
+}
+
+func (handler *AnswerPreparationHTTPHandler) create(c *gin.Context) {
+	actor, key, ok := answerWriteContext(c)
+	if !ok {
+		return
+	}
+	var request CreateAnswerPreparationRequest
+	if !decodeAnswerJSON(c, &request) {
+		writeAnswerError(c, ErrAnswerPreparationInvalid)
+		return
+	}
+	value, replayed, err := handler.service.Create(c.Request.Context(), actor, key, request)
+	if err != nil {
+		writeAnswerError(c, err)
+		return
+	}
+	status := http.StatusCreated
+	if replayed {
+		status = http.StatusOK
+	}
+	c.JSON(status, value)
+}
+
+func (handler *AnswerPreparationHTTPHandler) get(c *gin.Context) {
+	setAnswerPrivateHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		writeAnswerAuthentication(c)
+		return
+	}
+	value, err := handler.service.Get(c.Request.Context(), actor, c.Param("answer_preparation_id"))
+	if err != nil {
+		writeAnswerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, value)
+}
+
+func (handler *AnswerPreparationHTTPHandler) update(c *gin.Context) {
+	actor, key, ok := answerWriteContext(c)
+	if !ok {
+		return
+	}
+	var request UpdateAnswerPreparationRequest
+	if !decodeAnswerJSON(c, &request) {
+		writeAnswerError(c, ErrAnswerPreparationInvalid)
+		return
+	}
+	value, _, err := handler.service.Update(c.Request.Context(), actor, c.Param("answer_preparation_id"), key, request)
+	if err != nil {
+		writeAnswerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, value)
+}
+
+func (handler *AnswerPreparationHTTPHandler) generate(c *gin.Context) {
+	actor, key, ok := answerWriteContext(c)
+	if !ok {
+		return
+	}
+	var request GenerateAnswerPreparationRequest
+	if !decodeAnswerJSON(c, &request) {
+		writeAnswerError(c, ErrAnswerPreparationInvalid)
+		return
+	}
+	value, _, err := handler.service.Generate(c.Request.Context(), actor, c.Param("answer_preparation_id"), key, request)
+	if err != nil {
+		if errors.Is(err, ErrAnswerPreparationGeneration) {
+			failed, getErr := handler.service.Get(c.Request.Context(), actor, c.Param("answer_preparation_id"))
+			if getErr == nil {
+				c.JSON(http.StatusBadGateway, failed)
+				return
+			}
+		}
+		writeAnswerError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, value)
+}
+
+func (handler *AnswerPreparationHTTPHandler) delete(c *gin.Context) {
+	actor, key, ok := answerWriteContext(c)
+	if !ok {
+		return
+	}
+	expectedVersion, err := strconv.Atoi(c.Query("expected_version"))
+	if err != nil || expectedVersion < 1 {
+		writeAnswerError(c, ErrAnswerPreparationInvalid)
+		return
+	}
+	_, err = handler.service.Delete(c.Request.Context(), actor, c.Param("answer_preparation_id"), key, expectedVersion)
+	if err != nil {
+		writeAnswerError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func answerWriteContext(c *gin.Context) (requestcontext.Actor, string, bool) {
+	setAnswerPrivateHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		writeAnswerAuthentication(c)
+		return requestcontext.Actor{}, "", false
+	}
+	values := c.Request.Header.Values("Idempotency-Key")
+	if len(values) != 1 || !validIdempotencyKey(values[0]) {
+		writeAnswerError(c, ErrAnswerPreparationInvalid)
+		return requestcontext.Actor{}, "", false
+	}
+	return actor, values[0], true
+}
+
+func decodeAnswerJSON(c *gin.Context, target any) bool {
+	mediaType, params, err := mime.ParseMediaType(c.GetHeader("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	if charset, exists := params["charset"]; exists && !strings.EqualFold(charset, "utf-8") {
+		return false
+	}
+	body := http.MaxBytesReader(c.Writer, c.Request.Body, maxAnswerPreparationBody)
+	raw, err := io.ReadAll(body)
+	if err != nil || !utf8.Valid(raw) || len(bytes.TrimSpace(raw)) == 0 {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(target) != nil {
+		return false
+	}
+	var trailing any
+	return errors.Is(decoder.Decode(&trailing), io.EOF)
+}
+
+func writeAnswerError(c *gin.Context, err error) {
+	status, code, retryable := http.StatusInternalServerError, "internal_error", false
+	switch {
+	case errors.Is(err, ErrAnswerPreparationInvalid):
+		status, code = http.StatusBadRequest, "invalid_request"
+	case errors.Is(err, ErrAnswerPreparationNotFound):
+		status, code = http.StatusNotFound, "answer_preparation_not_found"
+	case errors.Is(err, ErrAnswerPreparationConflict):
+		status, code = http.StatusConflict, "answer_preparation_version_conflict"
+	case errors.Is(err, ErrAnswerPreparationIdempotencyConflict):
+		status, code = http.StatusConflict, "idempotency_key_conflict"
+	case errors.Is(err, ErrAnswerPreparationGeneration):
+		status, code, retryable = http.StatusBadGateway, "answer_preparation_generation_failed", true
+	}
+	c.JSON(status, gin.H{"error": gin.H{"code": code, "message": answerErrorMessage(code), "retryable": retryable, "correlation_id": newCorrelationID()}})
+}
+
+func answerErrorMessage(code string) string {
+	switch code {
+	case "invalid_request":
+		return "Request is invalid."
+	case "answer_preparation_not_found":
+		return "Answer preparation was not found."
+	case "answer_preparation_version_conflict":
+		return "Answer preparation version conflicts with this operation."
+	case "idempotency_key_conflict":
+		return "Idempotency key conflicts with the original request."
+	case "answer_preparation_generation_failed":
+		return "Answer preparation generation failed and can be retried."
+	default:
+		return "Internal server error."
+	}
+}
+
+func writeAnswerAuthentication(c *gin.Context) {
+	c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "authentication_required", "message": "Authentication is required.", "retryable": false, "correlation_id": newCorrelationID()}})
+}
+func setAnswerPrivateHeaders(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+}

--- a/server/internal/coaching/scene/ielts/answer_preparation_http_test.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_http_test.go
@@ -1,0 +1,68 @@
+package ielts
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+func TestAnswerPreparationHTTPRequiresActorAndIdempotencyKey(t *testing.T) {
+	router := answerPreparationTestRouter(t, false)
+	request := httptest.NewRequest(http.MethodPost, "/v1/ielts-speaking/answer-preparations", bytes.NewBufferString(`{"question":{"bank_id":"bank","part":"PART_1","source_id":"topic","question_position":1},"personal_points":[],"target_band":6.5}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	router = answerPreparationTestRouter(t, true)
+	request = httptest.NewRequest(http.MethodPost, "/v1/ielts-speaking/answer-preparations", bytes.NewBufferString(`{"question":{"bank_id":"bank","part":"PART_1","source_id":"topic","question_position":1},"personal_points":[],"target_band":6.5}`))
+	request.Header.Set("Content-Type", "application/json")
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("missing key status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestAnswerPreparationHTTPRejectsUnknownFields(t *testing.T) {
+	router := answerPreparationTestRouter(t, true)
+	request := httptest.NewRequest(http.MethodPost, "/v1/ielts-speaking/answer-preparations", bytes.NewBufferString(`{"question":{"bank_id":"bank","part":"PART_1","source_id":"topic","question_position":1},"personal_points":[],"target_band":6.5,"owner_user_id":"attacker"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Idempotency-Key", "create-key-1")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("unknown owner status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func answerPreparationTestRouter(t *testing.T, authenticated bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	if authenticated {
+		router.Use(func(c *gin.Context) {
+			actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+			c.Request = c.Request.WithContext(requestcontext.WithActor(c.Request.Context(), actor))
+			c.Next()
+		})
+	}
+	repository := &answerRepositoryStub{}
+	service, err := NewAnswerPreparationService(repository, answerQuestionStub{}, &answerGeneratorStub{}, answerIDStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewAnswerPreparationHTTPHandler(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.RegisterRoutes(router)
+	return router
+}

--- a/server/internal/coaching/scene/ielts/answer_preparation_postgres.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_postgres.go
@@ -1,0 +1,396 @@
+package ielts
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const answerPreparationColumns = `answer_preparation_id, bank_id, part, source_id,
+       question_position, question_prompt, personal_points, target_band, status,
+       COALESCE(answer, ''), COALESCE(outline, '[]'::jsonb),
+       COALESCE(useful_expressions, '[]'::jsonb), COALESCE(speech_text, ''),
+       COALESCE(failure_code, ''), version, generation_revision, created_at, updated_at`
+
+type SecureAnswerPreparationIDGenerator struct{}
+
+func (SecureAnswerPreparationIDGenerator) NewAnswerPreparationID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return "ielts_answer_" + hex.EncodeToString(value[:]), nil
+}
+
+func (store *PostgresStore) ResolveAnswerQuestion(ctx context.Context, reference QuestionReference) (ResolvedQuestion, error) {
+	if store == nil || store.database == nil || ctx == nil || !validQuestionReference(reference) {
+		return ResolvedQuestion{}, ErrAnswerPreparationInvalid
+	}
+	var prompt string
+	var err error
+	switch reference.Part {
+	case PracticeModePart1:
+		err = store.database.QueryRow(ctx, `SELECT prompt FROM ielts_part1_questions WHERE bank_id=$1 AND topic_id=$2 AND question_position=$3`, reference.BankID, reference.SourceID, reference.QuestionPosition).Scan(&prompt)
+	case PracticeModePart2:
+		var pointsJSON []byte
+		err = store.database.QueryRow(ctx, `SELECT cue_card_prompt, cue_card_points FROM ielts_part23_groups WHERE bank_id=$1 AND topic_group_id=$2`, reference.BankID, reference.SourceID).Scan(&prompt, &pointsJSON)
+		if err == nil {
+			var points []string
+			if json.Unmarshal(pointsJSON, &points) != nil {
+				return ResolvedQuestion{}, ErrAnswerPreparationRepository
+			}
+			prompt = formatCueCard(Part2CueCard{Prompt: prompt, Points: points})
+		}
+	case PracticeModePart3:
+		err = store.database.QueryRow(ctx, `SELECT prompt FROM ielts_part3_questions WHERE bank_id=$1 AND topic_group_id=$2 AND question_position=$3`, reference.BankID, reference.SourceID, reference.QuestionPosition).Scan(&prompt)
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ResolvedQuestion{}, ErrQuestionSetNotFound
+	}
+	if err != nil {
+		return ResolvedQuestion{}, fmt.Errorf("%w: resolve answer question", ErrAnswerPreparationRepository)
+	}
+	return ResolvedQuestion{Reference: reference, Prompt: prompt}, nil
+}
+
+func (store *PostgresStore) Create(ctx context.Context, actor requestcontext.Actor, command CreateAnswerPreparationCommand) (AnswerPreparation, bool, error) {
+	if !validStoreActor(actor) || !validAnswerPreparationID(command.ID) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveAnswerOwner(ctx, tx, actor.UserID); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if replay, found, err := replayAnswerMutation(ctx, tx, actor.UserID, command.Intent); err != nil || found {
+		return replay, found, err
+	}
+	points, _ := json.Marshal(command.Request.PersonalPoints)
+	_, err = tx.Exec(ctx, `INSERT INTO ielts_answer_preparations (owner_user_id, answer_preparation_id, bank_id, part, source_id, question_position, question_prompt, personal_points, target_band) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, actor.UserID, command.ID, command.Question.Reference.BankID, command.Question.Reference.Part, command.Question.Reference.SourceID, command.Question.Reference.QuestionPosition, command.Question.Prompt, points, command.Request.TargetBand)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return AnswerPreparation{}, false, ErrAnswerPreparationConflict
+		}
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	created, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := persistAnswerMutation(ctx, tx, actor.UserID, command.Intent, command.ID, created, false); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	return created, false, nil
+}
+
+func (store *PostgresStore) Get(ctx context.Context, actor requestcontext.Actor, id string) (AnswerPreparation, error) {
+	if !validStoreActor(actor) || !validAnswerPreparationID(id) {
+		return AnswerPreparation{}, ErrAnswerPreparationInvalid
+	}
+	return getAnswerPreparation(ctx, store.database, actor.UserID, id)
+}
+
+func (store *PostgresStore) Update(ctx context.Context, actor requestcontext.Actor, command UpdateAnswerPreparationCommand) (AnswerPreparation, bool, error) {
+	if !validStoreActor(actor) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveAnswerOwner(ctx, tx, actor.UserID); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if replay, found, err := replayAnswerMutation(ctx, tx, actor.UserID, command.Intent); err != nil || found {
+		return replay, found, err
+	}
+	points, _ := json.Marshal(command.Request.PersonalPoints)
+	tag, err := tx.Exec(ctx, `UPDATE ielts_answer_preparations SET personal_points=$4, target_band=$5, status='draft', answer=NULL, outline=NULL, useful_expressions=NULL, speech_text=NULL, failure_code=NULL, version=version+1, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND answer_preparation_id=$2 AND version=$3 AND status <> 'generating'`, actor.UserID, command.ID, command.Request.ExpectedVersion, points, command.Request.TargetBand)
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return AnswerPreparation{}, false, classifyAnswerMiss(ctx, tx, actor.UserID, command.ID)
+	}
+	updated, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := persistAnswerMutation(ctx, tx, actor.UserID, command.Intent, command.ID, updated, false); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	return updated, false, nil
+}
+
+func (store *PostgresStore) BeginGeneration(ctx context.Context, actor requestcontext.Actor, command BeginAnswerGenerationCommand) (AnswerPreparation, bool, error) {
+	if !validStoreActor(actor) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveAnswerOwner(ctx, tx, actor.UserID); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if replay, found, err := replayAnswerMutation(ctx, tx, actor.UserID, command.Intent); err != nil || found {
+		return replay, found, err
+	}
+	tag, err := tx.Exec(ctx, `UPDATE ielts_answer_preparations SET status='generating', answer=NULL, outline=NULL, useful_expressions=NULL, speech_text=NULL, provider=NULL, model=NULL, provider_request_id=NULL, failure_code=NULL, version=version+1, generation_revision=generation_revision+1, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND answer_preparation_id=$2 AND version=$3 AND status <> 'generating'`, actor.UserID, command.ID, command.Request.ExpectedVersion)
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return AnswerPreparation{}, false, classifyAnswerMiss(ctx, tx, actor.UserID, command.ID)
+	}
+	generating, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
+	if err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := persistAnswerMutation(ctx, tx, actor.UserID, command.Intent, command.ID, generating, true); err != nil {
+		return AnswerPreparation{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	return generating, false, nil
+}
+
+func (store *PostgresStore) CompleteGeneration(ctx context.Context, actor requestcontext.Actor, command CompleteAnswerGenerationCommand) (AnswerPreparation, error) {
+	if !validStoreActor(actor) || !validGenerationResult(command.Result) {
+		return AnswerPreparation{}, ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return AnswerPreparation{}, answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	outline, _ := json.Marshal(command.Result.Outline)
+	expressions, _ := json.Marshal(command.Result.UsefulExpressions)
+	tag, err := tx.Exec(ctx, `UPDATE ielts_answer_preparations SET status='ready', answer=$5, outline=$6, useful_expressions=$7, speech_text=$8, provider=$9, model=$10, provider_request_id=$11, failure_code=NULL, version=version+1, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND answer_preparation_id=$2 AND status='generating' AND version=$3 AND generation_revision=$4`, actor.UserID, command.ID, command.GeneratingVersion, command.GenerationRevision, command.Result.Answer, outline, expressions, command.Result.SpeechText, command.Result.Provider, command.Result.Model, command.Result.RequestID)
+	if err != nil {
+		return AnswerPreparation{}, answerDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return AnswerPreparation{}, ErrAnswerPreparationConflict
+	}
+	ready, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
+	if err != nil {
+		return AnswerPreparation{}, err
+	}
+	if _, err := tx.Exec(ctx, `UPDATE ielts_answer_preparation_idempotency SET pending=false, response=$3, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND resource_id=$2 AND pending`, actor.UserID, command.ID, mustJSON(ready)); err != nil {
+		return AnswerPreparation{}, answerDatabaseError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AnswerPreparation{}, answerDatabaseError(err)
+	}
+	return ready, nil
+}
+
+func (store *PostgresStore) FailGeneration(ctx context.Context, actor requestcontext.Actor, command FailAnswerGenerationCommand) error {
+	if !validStoreActor(actor) || command.FailureCode == "" {
+		return ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	tag, err := tx.Exec(ctx, `UPDATE ielts_answer_preparations SET status='failed', failure_code=$5, version=version+1, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND answer_preparation_id=$2 AND status='generating' AND version=$3 AND generation_revision=$4`, actor.UserID, command.ID, command.GeneratingVersion, command.GenerationRevision, command.FailureCode)
+	if err != nil {
+		return answerDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrAnswerPreparationConflict
+	}
+	failed, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `UPDATE ielts_answer_preparation_idempotency SET pending=false, response=$3, updated_at=transaction_timestamp() WHERE owner_user_id=$1 AND resource_id=$2 AND pending`, actor.UserID, command.ID, mustJSON(failed)); err != nil {
+		return answerDatabaseError(err)
+	}
+	return tx.Commit(ctx)
+}
+
+func (store *PostgresStore) Delete(ctx context.Context, actor requestcontext.Actor, command DeleteAnswerPreparationCommand) (bool, error) {
+	if !validStoreActor(actor) {
+		return false, ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return false, answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveAnswerOwner(ctx, tx, actor.UserID); err != nil {
+		return false, err
+	}
+	if _, found, err := replayAnswerMutation(ctx, tx, actor.UserID, command.Intent); err != nil {
+		return false, err
+	} else if found {
+		return true, nil
+	}
+	tag, err := tx.Exec(ctx, `DELETE FROM ielts_answer_preparations WHERE owner_user_id=$1 AND answer_preparation_id=$2 AND version=$3 AND status <> 'generating'`, actor.UserID, command.ID, command.ExpectedVersion)
+	if err != nil {
+		return false, answerDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return false, classifyAnswerMiss(ctx, tx, actor.UserID, command.ID)
+	}
+	// A tombstone keeps DELETE idempotency after the resource and its resource-bound mutation records are removed.
+	if err := persistAnswerMutation(ctx, tx, actor.UserID, command.Intent, "", AnswerPreparation{}, false); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, answerDatabaseError(err)
+	}
+	return false, nil
+}
+
+// DeleteUserAnswerPreparations is the account-cleanup boundary. It serializes
+// with writes through the identity row and accepts only an identity already in
+// the deleting/deleted lifecycle.
+func (store *PostgresStore) DeleteUserAnswerPreparations(ctx context.Context, userID string) error {
+	if store == nil || store.database == nil || ctx == nil || strings.TrimSpace(userID) == "" {
+		return ErrAnswerPreparationInvalid
+	}
+	tx, err := store.database.Begin(ctx)
+	if err != nil {
+		return answerDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var status string
+	if err := tx.QueryRow(ctx, `SELECT account_status FROM identity_users WHERE id=$1 FOR UPDATE`, userID).Scan(&status); err != nil {
+		return ErrAnswerPreparationNotFound
+	}
+	if status != "deleting" && status != "deleted" {
+		return ErrAnswerPreparationConflict
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM ielts_answer_preparations WHERE owner_user_id=$1`, userID); err != nil {
+		return answerDatabaseError(err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM ielts_answer_preparation_idempotency WHERE owner_user_id=$1`, userID); err != nil {
+		return answerDatabaseError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return answerDatabaseError(err)
+	}
+	return nil
+}
+
+type answerQueryer interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func getAnswerPreparation(ctx context.Context, query answerQueryer, owner, id string) (AnswerPreparation, error) {
+	row := query.QueryRow(ctx, `SELECT `+answerPreparationColumns+` FROM ielts_answer_preparations WHERE owner_user_id=$1 AND answer_preparation_id=$2`, owner, id)
+	var value AnswerPreparation
+	var points, outline, expressions []byte
+	err := row.Scan(&value.ID, &value.Question.Reference.BankID, &value.Question.Reference.Part, &value.Question.Reference.SourceID, &value.Question.Reference.QuestionPosition, &value.Question.Prompt, &points, &value.TargetBand, &value.Status, &value.Answer, &outline, &expressions, &value.SpeechText, &value.FailureCode, &value.Version, &value.GenerationRevision, &value.CreatedAt, &value.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AnswerPreparation{}, ErrAnswerPreparationNotFound
+	}
+	if err != nil {
+		return AnswerPreparation{}, answerDatabaseError(err)
+	}
+	if json.Unmarshal(points, &value.PersonalPoints) != nil || json.Unmarshal(outline, &value.Outline) != nil || json.Unmarshal(expressions, &value.UsefulExpressions) != nil {
+		return AnswerPreparation{}, ErrAnswerPreparationRepository
+	}
+	return value, nil
+}
+
+func replayAnswerMutation(ctx context.Context, tx pgx.Tx, owner string, intent MutationIntent) (AnswerPreparation, bool, error) {
+	var fingerprint []byte
+	var response []byte
+	var pending bool
+	err := tx.QueryRow(ctx, `SELECT payload_fingerprint, response, pending FROM ielts_answer_preparation_idempotency WHERE owner_user_id=$1 AND method=$2 AND canonical_path=$3 AND idempotency_key=$4`, owner, intent.Method, intent.Path, intent.Key).Scan(&fingerprint, &response, &pending)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AnswerPreparation{}, false, nil
+	}
+	if err != nil {
+		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	if string(fingerprint) != string(intent.Fingerprint[:]) {
+		return AnswerPreparation{}, false, ErrAnswerPreparationIdempotencyConflict
+	}
+	if pending {
+		var resourceID string
+		if err := tx.QueryRow(ctx, `SELECT resource_id FROM ielts_answer_preparation_idempotency WHERE owner_user_id=$1 AND method=$2 AND canonical_path=$3 AND idempotency_key=$4`, owner, intent.Method, intent.Path, intent.Key).Scan(&resourceID); err != nil {
+			return AnswerPreparation{}, false, answerDatabaseError(err)
+		}
+		current, err := getAnswerPreparation(ctx, tx, owner, resourceID)
+		return current, true, err
+	}
+	if len(response) == 0 {
+		return AnswerPreparation{}, true, nil
+	}
+	var value AnswerPreparation
+	if json.Unmarshal(response, &value) != nil {
+		return AnswerPreparation{}, false, ErrAnswerPreparationRepository
+	}
+	return value, true, nil
+}
+
+func persistAnswerMutation(ctx context.Context, tx pgx.Tx, owner string, intent MutationIntent, resourceID string, value AnswerPreparation, pending bool) error {
+	var response any
+	if value.ID != "" {
+		response = mustJSON(value)
+	}
+	_, err := tx.Exec(ctx, `INSERT INTO ielts_answer_preparation_idempotency (owner_user_id, method, canonical_path, idempotency_key, payload_fingerprint, resource_id, pending, response) VALUES ($1,$2,$3,$4,$5,NULLIF($6,''),$7,$8)`, owner, intent.Method, intent.Path, intent.Key, intent.Fingerprint[:], resourceID, pending, response)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrAnswerPreparationIdempotencyConflict
+		}
+		return answerDatabaseError(err)
+	}
+	return nil
+}
+
+func classifyAnswerMiss(ctx context.Context, tx pgx.Tx, owner, id string) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM ielts_answer_preparations WHERE owner_user_id=$1 AND answer_preparation_id=$2)`, owner, id).Scan(&exists); err != nil {
+		return answerDatabaseError(err)
+	}
+	if exists {
+		return ErrAnswerPreparationConflict
+	}
+	return ErrAnswerPreparationNotFound
+}
+
+func lockActiveAnswerOwner(ctx context.Context, tx pgx.Tx, owner string) error {
+	var status string
+	if err := tx.QueryRow(ctx, `SELECT account_status FROM identity_users WHERE id=$1 FOR SHARE`, owner).Scan(&status); err != nil {
+		return ErrAnswerPreparationNotFound
+	}
+	if status != "active" {
+		return ErrAnswerPreparationConflict
+	}
+	return nil
+}
+
+func validStoreActor(actor requestcontext.Actor) bool { return actor.Valid() }
+func answerDatabaseError(error) error                 { return ErrAnswerPreparationRepository }
+func isUniqueViolation(err error) bool                { return strings.Contains(err.Error(), "SQLSTATE 23505") }
+func mustJSON(value any) []byte                       { encoded, _ := json.Marshal(value); return encoded }
+
+var _ AnswerQuestionResolver = (*PostgresStore)(nil)
+var _ AnswerPreparationRepository = (*PostgresStore)(nil)

--- a/server/internal/coaching/scene/ielts/answer_preparation_postgres_integration_test.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_postgres_integration_test.go
@@ -1,0 +1,173 @@
+package ielts
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+)
+
+func TestPostgresAnswerPreparationsEnforceIdentityIdempotencyVersionAndCleanup(t *testing.T) {
+	pool := answerPreparationTestDatabase(t)
+	ctx := context.Background()
+	owner := requestcontext.Actor{UserID: "11111111-1111-4111-8111-111111111111", SessionID: "session-owner"}
+	other := requestcontext.Actor{UserID: "22222222-2222-4222-8222-222222222222", SessionID: "session-other"}
+	for _, row := range []struct{ id, email string }{{owner.UserID, "owner@example.test"}, {other.UserID, "other@example.test"}} {
+		if _, err := pool.Exec(ctx, `INSERT INTO identity_users(id, canonical_email) VALUES($1,$2)`, row.id, row.email); err != nil {
+			t.Fatalf("insert identity: %v", err)
+		}
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO ielts_question_bank_versions(bank_id,schema_version,season_code,season_label,season_start,season_end,region,source_cutoff) VALUES('bank-2026',3,'2026-05-08','season','2026-05-01','2026-08-31','mainland',now()); INSERT INTO ielts_part1_topics(bank_id,topic_id,title_zh,title_en,release_status,display_order) VALUES('bank-2026','p1-topic-001','音乐','Music','new',1); INSERT INTO ielts_part1_questions(bank_id,topic_id,question_position,prompt) VALUES('bank-2026','p1-topic-001',1,'Do you enjoy music?'); UPDATE ielts_question_bank_versions SET status='published',published_at=now() WHERE bank_id='bank-2026'`); err != nil {
+		t.Fatalf("insert question: %v", err)
+	}
+	store, _ := NewPostgresStore(pool)
+	service, _ := NewAnswerPreparationService(store, store, &answerGeneratorStub{}, answerIDStub{})
+	request := CreateAnswerPreparationRequest{Question: QuestionReference{BankID: "bank-2026", Part: PracticeModePart1, SourceID: "p1-topic-001", QuestionPosition: 1}, PersonalPoints: []string{"I play piano"}, TargetBand: 6.5}
+	created, replayed, err := service.Create(ctx, owner, "create-key-1", request)
+	if err != nil || replayed {
+		t.Fatalf("Create = %#v replay=%t err=%v", created, replayed, err)
+	}
+	restored, replayed, err := service.Create(ctx, owner, "create-key-1", request)
+	if err != nil || !replayed || restored.ID != created.ID {
+		t.Fatalf("replay = %#v replay=%t err=%v", restored, replayed, err)
+	}
+	changed := request
+	changed.TargetBand = 7
+	if _, _, err := service.Create(ctx, owner, "create-key-1", changed); !errors.Is(err, ErrAnswerPreparationIdempotencyConflict) {
+		t.Fatalf("changed replay err=%v", err)
+	}
+	if _, err := service.Get(ctx, other, created.ID); !errors.Is(err, ErrAnswerPreparationNotFound) {
+		t.Fatalf("foreign Get err=%v", err)
+	}
+	updated, _, err := service.Update(ctx, owner, created.ID, "update-key-1", UpdateAnswerPreparationRequest{ExpectedVersion: created.Version, PersonalPoints: []string{"I study piano"}, TargetBand: 7})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if _, _, err := service.Update(ctx, owner, created.ID, "update-key-stale", UpdateAnswerPreparationRequest{ExpectedVersion: created.Version, PersonalPoints: []string{"stale"}, TargetBand: 7}); !errors.Is(err, ErrAnswerPreparationConflict) {
+		t.Fatalf("stale Update err=%v", err)
+	}
+	ready, _, err := service.Generate(ctx, owner, created.ID, "generate-key-1", GenerateAnswerPreparationRequest{ExpectedVersion: updated.Version})
+	if err != nil || ready.Status != AnswerPreparationReady {
+		t.Fatalf("Generate = %#v err=%v", ready, err)
+	}
+	if _, err := service.Get(ctx, other, created.ID); !errors.Is(err, ErrAnswerPreparationNotFound) {
+		t.Fatalf("foreign ready Get err=%v", err)
+	}
+	if _, err := service.Delete(ctx, other, created.ID, "delete-key-other", ready.Version); !errors.Is(err, ErrAnswerPreparationNotFound) {
+		t.Fatalf("foreign Delete err=%v", err)
+	}
+	if _, err := service.Delete(ctx, owner, created.ID, "delete-key-1", ready.Version); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := service.Delete(ctx, owner, created.ID, "delete-key-1", ready.Version); err != nil {
+		t.Fatalf("idempotent Delete: %v", err)
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM ielts_answer_preparation_idempotency WHERE owner_user_id=$1 AND resource_id IS NOT NULL`, owner.UserID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("resource-bound idempotency count=%d err=%v", count, err)
+	}
+}
+
+func TestPostgresAnswerQuestionResolverKeepsBankVersionInLocator(t *testing.T) {
+	pool := answerPreparationTestDatabase(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `INSERT INTO ielts_question_bank_versions(bank_id,schema_version,season_code,season_label,season_start,season_end,region,source_cutoff) VALUES('bank-old',3,'old','old','2026-01-01','2026-04-30','mainland',now()),('bank-new',3,'new','new','2026-05-01','2026-08-31','mainland',now()); INSERT INTO ielts_part1_topics(bank_id,topic_id,title_zh,title_en,release_status,display_order) VALUES('bank-old','topic','旧','Old','new',1),('bank-new','topic','新','New','new',1); INSERT INTO ielts_part1_questions(bank_id,topic_id,question_position,prompt) VALUES('bank-old','topic',1,'Old prompt?'),('bank-new','topic',1,'New prompt?'); INSERT INTO ielts_part23_groups(bank_id,topic_group_id,title_zh,release_status,cue_card_type,cue_card_prompt,cue_card_points,display_order) VALUES('bank-new','group','地点','new','place','Describe a place.','["where it is","why you like it","when you visit"]',1); INSERT INTO ielts_part3_questions(bank_id,topic_group_id,question_position,prompt) VALUES('bank-new','group',1,'Why do people like public places?'); UPDATE ielts_question_bank_versions SET status='published',published_at=now() WHERE bank_id='bank-old'; UPDATE ielts_question_bank_versions SET status='retired',retired_at=now() WHERE bank_id='bank-old'; UPDATE ielts_question_bank_versions SET status='published',published_at=now() WHERE bank_id='bank-new'`); err != nil {
+		t.Fatalf("fixtures: %v", err)
+	}
+	store, _ := NewPostgresStore(pool)
+	old, err := store.ResolveAnswerQuestion(ctx, QuestionReference{BankID: "bank-old", Part: PracticeModePart1, SourceID: "topic", QuestionPosition: 1})
+	if err != nil || old.Prompt != "Old prompt?" {
+		t.Fatalf("old=%#v err=%v", old, err)
+	}
+	newer, err := store.ResolveAnswerQuestion(ctx, QuestionReference{BankID: "bank-new", Part: PracticeModePart1, SourceID: "topic", QuestionPosition: 1})
+	if err != nil || newer.Prompt != "New prompt?" {
+		t.Fatalf("new=%#v err=%v", newer, err)
+	}
+	part2, err := store.ResolveAnswerQuestion(ctx, QuestionReference{BankID: "bank-new", Part: PracticeModePart2, SourceID: "group", QuestionPosition: 1})
+	if err != nil || !strings.Contains(part2.Prompt, "You should say:\n• where it is") {
+		t.Fatalf("Part 2=%#v err=%v", part2, err)
+	}
+	part3, err := store.ResolveAnswerQuestion(ctx, QuestionReference{BankID: "bank-new", Part: PracticeModePart3, SourceID: "group", QuestionPosition: 1})
+	if err != nil || part3.Prompt != "Why do people like public places?" {
+		t.Fatalf("Part 3=%#v err=%v", part3, err)
+	}
+}
+
+func TestPostgresAnswerPreparationAccountCleanupRejectsActiveAndRemovesDeletingOwner(t *testing.T) {
+	pool := answerPreparationTestDatabase(t)
+	ctx := context.Background()
+	userID := "33333333-3333-4333-8333-333333333333"
+	if _, err := pool.Exec(ctx, `INSERT INTO identity_users(id,canonical_email) VALUES($1,'cleanup@example.test')`, userID); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := NewPostgresStore(pool)
+	if err := store.DeleteUserAnswerPreparations(ctx, userID); !errors.Is(err, ErrAnswerPreparationConflict) {
+		t.Fatalf("active cleanup err=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE identity_users SET account_status='deleting' WHERE id=$1`, userID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteUserAnswerPreparations(ctx, userID); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if err := store.DeleteUserAnswerPreparations(ctx, userID); err != nil {
+		t.Fatalf("idempotent cleanup: %v", err)
+	}
+}
+
+func answerPreparationTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if raw == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, raw)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		t.Fatal(err)
+	}
+	schema := "ielts_answer_" + hex.EncodeToString(suffix[:])
+	identifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+identifier); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	config, err := pgxpool.ParseConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = identifier
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE")
+		admin.Close()
+	})
+	for _, name := range []string{"000002_identity_schema.up.sql", "000080_ielts_versioned_question_bank.up.sql", "000084_ielts_answer_preparations.up.sql"} {
+		content, err := migrations.Files.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(ctx, string(content)); err != nil {
+			t.Fatalf("apply %s: %v", name, err)
+		}
+	}
+	return pool
+}

--- a/server/internal/coaching/scene/ielts/answer_preparation_test.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_test.go
@@ -1,0 +1,144 @@
+package ielts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type answerRepositoryStub struct {
+	value AnswerPreparation
+	fail  bool
+}
+
+func (stub *answerRepositoryStub) Create(_ context.Context, _ requestcontext.Actor, command CreateAnswerPreparationCommand) (AnswerPreparation, bool, error) {
+	stub.value = AnswerPreparation{ID: command.ID, Question: command.Question, PersonalPoints: command.Request.PersonalPoints, TargetBand: command.Request.TargetBand, Status: AnswerPreparationDraft, Version: 1, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	return stub.value, false, nil
+}
+func (stub *answerRepositoryStub) Get(context.Context, requestcontext.Actor, string) (AnswerPreparation, error) {
+	return stub.value, nil
+}
+func (stub *answerRepositoryStub) Update(_ context.Context, _ requestcontext.Actor, command UpdateAnswerPreparationCommand) (AnswerPreparation, bool, error) {
+	if command.Request.ExpectedVersion != stub.value.Version {
+		return AnswerPreparation{}, false, ErrAnswerPreparationConflict
+	}
+	stub.value.PersonalPoints, stub.value.TargetBand, stub.value.Status = command.Request.PersonalPoints, command.Request.TargetBand, AnswerPreparationDraft
+	stub.value.Answer, stub.value.Outline, stub.value.UsefulExpressions, stub.value.SpeechText = "", nil, nil, ""
+	stub.value.Version++
+	return stub.value, false, nil
+}
+func (stub *answerRepositoryStub) BeginGeneration(_ context.Context, _ requestcontext.Actor, command BeginAnswerGenerationCommand) (AnswerPreparation, bool, error) {
+	if command.Request.ExpectedVersion != stub.value.Version {
+		return AnswerPreparation{}, false, ErrAnswerPreparationConflict
+	}
+	stub.value.Status, stub.value.Version, stub.value.GenerationRevision = AnswerPreparationGenerating, stub.value.Version+1, stub.value.GenerationRevision+1
+	return stub.value, false, nil
+}
+func (stub *answerRepositoryStub) CompleteGeneration(_ context.Context, _ requestcontext.Actor, command CompleteAnswerGenerationCommand) (AnswerPreparation, error) {
+	stub.value.Status, stub.value.Answer, stub.value.Outline = AnswerPreparationReady, command.Result.Answer, command.Result.Outline
+	stub.value.UsefulExpressions, stub.value.SpeechText = command.Result.UsefulExpressions, command.Result.SpeechText
+	stub.value.Version++
+	return stub.value, nil
+}
+func (stub *answerRepositoryStub) FailGeneration(_ context.Context, _ requestcontext.Actor, command FailAnswerGenerationCommand) error {
+	stub.fail = true
+	stub.value.Status, stub.value.FailureCode, stub.value.Version = AnswerPreparationFailed, command.FailureCode, stub.value.Version+1
+	return nil
+}
+func (stub *answerRepositoryStub) Delete(context.Context, requestcontext.Actor, DeleteAnswerPreparationCommand) (bool, error) {
+	return false, nil
+}
+
+type answerQuestionStub struct{}
+
+func (answerQuestionStub) ResolveAnswerQuestion(_ context.Context, reference QuestionReference) (ResolvedQuestion, error) {
+	return ResolvedQuestion{Reference: reference, Prompt: "Do you enjoy music?"}, nil
+}
+
+type answerGeneratorStub struct {
+	err     error
+	calls   int
+	request AnswerGenerationRequest
+}
+
+func (stub *answerGeneratorStub) GenerateAnswerPreparation(_ context.Context, request AnswerGenerationRequest) (AnswerGenerationResult, error) {
+	stub.calls++
+	stub.request = request
+	if stub.err != nil {
+		return AnswerGenerationResult{}, stub.err
+	}
+	return AnswerGenerationResult{Answer: "I enjoy music because it helps me relax.", Outline: []string{"preference", "reason"}, UsefulExpressions: []string{"helps me relax"}, SpeechText: "I enjoy music because it helps me relax."}, nil
+}
+
+type answerIDStub struct{}
+
+func (answerIDStub) NewAnswerPreparationID() (string, error) {
+	return "ielts_answer_0123456789abcdef0123456789abcdef", nil
+}
+
+func TestAnswerPreparationServiceCreatesStableQuestionAndGeneratesReadyResult(t *testing.T) {
+	repository := &answerRepositoryStub{}
+	generator := &answerGeneratorStub{}
+	service, err := NewAnswerPreparationService(repository, answerQuestionStub{}, generator, answerIDStub{})
+	if err != nil {
+		t.Fatalf("NewAnswerPreparationService: %v", err)
+	}
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	created, _, err := service.Create(context.Background(), actor, "create-key-1", CreateAnswerPreparationRequest{Question: QuestionReference{BankID: "bank-2026", Part: PracticeModePart1, SourceID: "p1-topic-001", QuestionPosition: 2}, PersonalPoints: []string{"  I play piano  "}, TargetBand: 6.5})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.Question.Reference.QuestionPosition != 2 || created.Question.Prompt != "Do you enjoy music?" || created.PersonalPoints[0] != "I play piano" {
+		t.Fatalf("created = %#v", created)
+	}
+	ready, _, err := service.Generate(context.Background(), actor, created.ID, "generate-key-1", GenerateAnswerPreparationRequest{ExpectedVersion: 1})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if ready.Status != AnswerPreparationReady || ready.Answer == "" || len(ready.Outline) == 0 || len(ready.UsefulExpressions) == 0 || ready.SpeechText == "" || generator.calls != 1 {
+		t.Fatalf("ready = %#v, calls=%d", ready, generator.calls)
+	}
+	if generator.request.Part != PracticeModePart1 {
+		t.Fatalf("generation part = %q", generator.request.Part)
+	}
+}
+
+func TestAnswerGenerationLengthCapsLikelySpeakingTime(t *testing.T) {
+	short := AnswerGenerationResult{Answer: "short answer", SpeechText: "short answer"}
+	if !validGenerationLength(PracticeModePart1, short) ||
+		!validGenerationLength(PracticeModePart2, short) ||
+		!validGenerationLength(PracticeModePart3, short) {
+		t.Fatal("short answer should fit every part")
+	}
+	words := make([]string, 76)
+	for index := range words {
+		words[index] = "word"
+	}
+	tooLong := strings.Join(words, " ")
+	if validGenerationLength(PracticeModePart1, AnswerGenerationResult{Answer: tooLong, SpeechText: tooLong}) {
+		t.Fatal("Part 1 answer above 75 words should be rejected")
+	}
+}
+
+func TestAnswerPreparationServicePersistsExplicitFailedState(t *testing.T) {
+	repository := &answerRepositoryStub{value: AnswerPreparation{ID: "ielts_answer_0123456789abcdef0123456789abcdef", Question: ResolvedQuestion{Prompt: "Question"}, Status: AnswerPreparationDraft, Version: 1, TargetBand: 6.5}}
+	generator := &answerGeneratorStub{err: errors.New("provider unavailable")}
+	service, _ := NewAnswerPreparationService(repository, answerQuestionStub{}, generator, answerIDStub{})
+	_, _, err := service.Generate(context.Background(), requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}, repository.value.ID, "generate-key-2", GenerateAnswerPreparationRequest{ExpectedVersion: 1})
+	if !errors.Is(err, ErrAnswerPreparationGeneration) || !repository.fail || repository.value.Status != AnswerPreparationFailed || repository.value.FailureCode != "provider_error" {
+		t.Fatalf("err=%v value=%#v", err, repository.value)
+	}
+}
+
+func TestAnswerPreparationServiceRejectsStaleEditWithoutOverwriting(t *testing.T) {
+	repository := &answerRepositoryStub{value: AnswerPreparation{ID: "ielts_answer_0123456789abcdef0123456789abcdef", PersonalPoints: []string{"new"}, Status: AnswerPreparationDraft, Version: 3}}
+	service, _ := NewAnswerPreparationService(repository, answerQuestionStub{}, &answerGeneratorStub{}, answerIDStub{})
+	_, _, err := service.Update(context.Background(), requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}, repository.value.ID, "update-key-1", UpdateAnswerPreparationRequest{ExpectedVersion: 2, PersonalPoints: []string{"stale"}, TargetBand: 7})
+	if !errors.Is(err, ErrAnswerPreparationConflict) || repository.value.PersonalPoints[0] != "new" {
+		t.Fatalf("err=%v value=%#v", err, repository.value)
+	}
+}

--- a/server/internal/providers/qianwen/ielts_answer_preparation.go
+++ b/server/internal/providers/qianwen/ielts_answer_preparation.go
@@ -1,0 +1,82 @@
+package qianwen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene/ielts"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+type IELTSAnswerPreparationGenerator struct {
+	generator *textClient
+}
+
+func NewIELTSAnswerPreparationGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*IELTSAnswerPreparationGenerator, error) {
+	generator, err := newTextClient(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &IELTSAnswerPreparationGenerator{generator: generator}, nil
+}
+
+func (generator *IELTSAnswerPreparationGenerator) GenerateAnswerPreparation(
+	ctx context.Context,
+	request ielts.AnswerGenerationRequest,
+) (ielts.AnswerGenerationResult, error) {
+	if generator == nil {
+		return ielts.AnswerGenerationResult{}, missingBusinessGenerator()
+	}
+	result, err := generateBusinessText(
+		ctx,
+		generator.generator,
+		ielts.GenerationSystemPrompt(),
+		ielts.GenerationUserPrompt(request),
+		protocol.TextResponseFormatJSON,
+	)
+	if err != nil {
+		return ielts.AnswerGenerationResult{}, err
+	}
+	var payload struct {
+		Answer            string   `json:"answer"`
+		Outline           []string `json:"outline"`
+		UsefulExpressions []string `json:"useful_expressions"`
+		SpeechText        string   `json:"speech_text"`
+	}
+	decoder := json.NewDecoder(bytes.NewBufferString(result.Content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return ielts.AnswerGenerationResult{}, invalidIELTSAnswerResponse(result.ID, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return ielts.AnswerGenerationResult{}, invalidIELTSAnswerResponse(result.ID, errors.New("qianwen: IELTS answer response contains trailing data"))
+	}
+	return ielts.AnswerGenerationResult{
+		RequestID:         result.ID,
+		Provider:          result.Provider,
+		Model:             result.Model,
+		Answer:            payload.Answer,
+		Outline:           payload.Outline,
+		UsefulExpressions: payload.UsefulExpressions,
+		SpeechText:        payload.SpeechText,
+	}, nil
+}
+
+func invalidIELTSAnswerResponse(requestID string, cause error) error {
+	return protocol.NewGenerationError(
+		protocol.ErrorInvalidResponse,
+		0,
+		"",
+		requestID,
+		cause,
+	)
+}
+
+var _ ielts.AnswerPreparationGenerator = (*IELTSAnswerPreparationGenerator)(nil)

--- a/server/internal/providers/qianwen/ielts_answer_preparation_test.go
+++ b/server/internal/providers/qianwen/ielts_answer_preparation_test.go
@@ -1,0 +1,80 @@
+package qianwen
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene/ielts"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+func TestIELTSAnswerPreparationGeneratorMapsOnlyOwnedMaterial(t *testing.T) {
+	t.Parallel()
+
+	request := ielts.AnswerGenerationRequest{
+		Part:           ielts.PracticeModePart1,
+		Question:       "Do you enjoy music?",
+		PersonalPoints: []string{"I play piano with my sister."},
+		TargetBand:     7.5,
+	}
+	var received chatCompletionRequest
+	client := mustBusinessGenerator(t, doerFunc(func(providerRequest *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(providerRequest.Body).Decode(&received); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		return jsonResponse(http.StatusOK, `{
+			"id":"chatcmpl-ielts-1",
+			"model":"qwen3.5-flash",
+			"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"answer\":\"Yes.\",\"outline\":[\"Preference\"],\"useful_expressions\":[\"a big part of my life\"],\"speech_text\":\"Yes.\"}"}}],
+			"usage":{"prompt_tokens":20,"completion_tokens":12,"total_tokens":32}
+		}`), nil
+	}))
+
+	result, err := (&IELTSAnswerPreparationGenerator{generator: client}).
+		GenerateAnswerPreparation(context.Background(), request)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if result.RequestID != "chatcmpl-ielts-1" ||
+		result.Provider != providerName || result.Model != "qwen3.5-flash" ||
+		result.Answer != "Yes." || result.SpeechText != "Yes." {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(received.Messages) != 2 ||
+		received.Messages[0].Content != ielts.GenerationSystemPrompt() ||
+		received.Messages[1].Content != ielts.GenerationUserPrompt(request) {
+		t.Fatalf("messages = %#v", received.Messages)
+	}
+	if received.ResponseFormat == nil ||
+		received.ResponseFormat.Type != string(protocol.TextResponseFormatJSON) {
+		t.Fatalf("response format = %#v", received.ResponseFormat)
+	}
+}
+
+func TestIELTSAnswerPreparationGeneratorRejectsUnknownOutputFields(t *testing.T) {
+	t.Parallel()
+
+	client := mustBusinessGenerator(t, doerFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{
+			"id":"chatcmpl-ielts-invalid",
+			"model":"qwen3.5-flash",
+			"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"answer\":\"Yes.\",\"outline\":[\"Preference\"],\"useful_expressions\":[\"often listen to\"],\"speech_text\":\"Yes.\",\"invented_fact\":\"x\"}"}}],
+			"usage":{"prompt_tokens":20,"completion_tokens":12,"total_tokens":32}
+		}`), nil
+	}))
+
+	_, err := (&IELTSAnswerPreparationGenerator{generator: client}).
+		GenerateAnswerPreparation(context.Background(), ielts.AnswerGenerationRequest{
+			Part:           ielts.PracticeModePart1,
+			Question:       "Do you enjoy music?",
+			PersonalPoints: []string{"I play piano."},
+			TargetBand:     7,
+		})
+	var failure *protocol.GenerationError
+	if !errors.As(err, &failure) || failure.Kind != protocol.ErrorInvalidResponse {
+		t.Fatalf("failure = %#v", err)
+	}
+}

--- a/server/migrations/000084_ielts_answer_preparations.down.sql
+++ b/server/migrations/000084_ielts_answer_preparations.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE IF EXISTS ielts_answer_preparation_idempotency;
+DROP TABLE IF EXISTS ielts_answer_preparations;
+
+COMMIT;

--- a/server/migrations/000084_ielts_answer_preparations.up.sql
+++ b/server/migrations/000084_ielts_answer_preparations.up.sql
@@ -1,0 +1,97 @@
+BEGIN;
+
+CREATE TABLE ielts_answer_preparations (
+    owner_user_id uuid NOT NULL REFERENCES identity_users(id) ON DELETE CASCADE,
+    answer_preparation_id text NOT NULL,
+    bank_id text NOT NULL REFERENCES ielts_question_bank_versions(bank_id),
+    part text NOT NULL,
+    source_id text NOT NULL,
+    question_position integer NOT NULL,
+    question_prompt text NOT NULL,
+    personal_points jsonb NOT NULL DEFAULT '[]'::jsonb,
+    target_band numeric(2,1) NOT NULL,
+    status text NOT NULL DEFAULT 'draft',
+    answer text,
+    outline jsonb,
+    useful_expressions jsonb,
+    speech_text text,
+    failure_code text,
+    provider text,
+    model text,
+    provider_request_id text,
+    version integer NOT NULL DEFAULT 1,
+    generation_revision integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (owner_user_id, answer_preparation_id),
+    UNIQUE (owner_user_id, bank_id, part, source_id, question_position),
+    CONSTRAINT ielts_answer_preparations_id_check CHECK (
+        answer_preparation_id ~ '^ielts_answer_[0-9a-f]{32}$'
+    ),
+    CONSTRAINT ielts_answer_preparations_locator_check CHECK (
+        part IN ('PART_1', 'PART_2', 'PART_3')
+        AND question_position > 0
+        AND (part <> 'PART_2' OR question_position = 1)
+        AND length(bank_id) BETWEEN 1 AND 128
+        AND length(source_id) BETWEEN 1 AND 128
+    ),
+    CONSTRAINT ielts_answer_preparations_prompt_check CHECK (
+        question_prompt = btrim(question_prompt)
+        AND length(question_prompt) BETWEEN 1 AND 2048
+    ),
+    CONSTRAINT ielts_answer_preparations_input_check CHECK (
+        jsonb_typeof(personal_points) = 'array'
+        AND jsonb_array_length(personal_points) <= 12
+        AND target_band BETWEEN 4.0 AND 9.0
+        AND mod(target_band * 2, 1) = 0
+    ),
+    CONSTRAINT ielts_answer_preparations_status_check CHECK (
+        status IN ('draft', 'generating', 'ready', 'failed')
+        AND (
+            (status IN ('draft', 'generating') AND failure_code IS NULL)
+            OR (status = 'ready' AND answer IS NOT NULL AND outline IS NOT NULL
+                AND useful_expressions IS NOT NULL AND speech_text IS NOT NULL
+                AND failure_code IS NULL)
+            OR (status = 'failed' AND failure_code IS NOT NULL)
+        )
+    ),
+    CONSTRAINT ielts_answer_preparations_generated_shape_check CHECK (
+        (outline IS NULL OR jsonb_typeof(outline) = 'array')
+        AND (useful_expressions IS NULL OR jsonb_typeof(useful_expressions) = 'array')
+    ),
+    CONSTRAINT ielts_answer_preparations_version_check CHECK (
+        version > 0 AND generation_revision >= 0 AND updated_at >= created_at
+    )
+);
+
+CREATE INDEX ielts_answer_preparations_owner_updated_idx
+    ON ielts_answer_preparations(owner_user_id, updated_at DESC);
+
+CREATE TABLE ielts_answer_preparation_idempotency (
+    owner_user_id uuid NOT NULL REFERENCES identity_users(id) ON DELETE CASCADE,
+    method text NOT NULL,
+    canonical_path text NOT NULL,
+    idempotency_key text NOT NULL,
+    payload_fingerprint bytea NOT NULL,
+    resource_id text,
+    pending boolean NOT NULL DEFAULT false,
+    response jsonb,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (owner_user_id, method, canonical_path, idempotency_key),
+    FOREIGN KEY (owner_user_id, resource_id)
+        REFERENCES ielts_answer_preparations(owner_user_id, answer_preparation_id)
+        ON DELETE CASCADE,
+    CONSTRAINT ielts_answer_preparation_idempotency_method_check
+        CHECK (method IN ('POST', 'PATCH', 'DELETE')),
+    CONSTRAINT ielts_answer_preparation_idempotency_key_check
+        CHECK (octet_length(idempotency_key) BETWEEN 8 AND 128
+               AND idempotency_key !~ '[[:space:]]'),
+    CONSTRAINT ielts_answer_preparation_idempotency_fingerprint_check
+        CHECK (octet_length(payload_fingerprint) = 32),
+    CONSTRAINT ielts_answer_preparation_idempotency_response_check
+        CHECK ((pending AND resource_id IS NOT NULL AND response IS NOT NULL)
+               OR (NOT pending AND (response IS NOT NULL OR resource_id IS NULL)))
+);
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -69,4 +69,5 @@ import "embed"
 //go:embed 000081_restore_interview_follow_ups.*.sql
 //go:embed 000082_user_controlled_practice_sessions.*.sql
 //go:embed 000083_agent_thread_titles.*.sql
+//go:embed 000084_ielts_answer_preparations.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

- 为 IELTS Part 1、Part 2 Cue Card 和 Part 3 题目建立包含 bank、part、source 与题序的稳定定位。
- 提供账号隔离的答案准备创建/恢复、读取、修改、生成、重生成和删除接口。
- 持久化 draft、generating、ready、failed 状态，以及个人要点、目标档位、答案、提纲、亮点表达和朗读文本。
- 生成结果遵守各 Part 的训练时长与字数目标，并在后端拒绝超过安全上限的回答。
- 保留幂等、版本冲突、越权隐藏、失败重试和账号清理语义。

## 实现思路

- 服务端只接受稳定题目引用，并从题库解析、快照真实题目文本。
- PostgreSQL 迁移保存资源与幂等响应；事务和版本号保护并发修改。
- 千问生成器使用严格 JSON 契约，个人要点非空时只使用用户提供的事实；空要点时返回不含具体传记声明的通用示例。
- 按 Part 将目标秒数、目标词数和回答结构传入生成提示词，同时验证 answer 与 speech_text 的硬性词数上限。
- 更新运行时 wiring、OpenAPI 与领域、HTTP、Provider、PostgreSQL 测试。

## 可复现测试

- make check-go
- TEST_DATABASE_URL=<postgres-url> go test -count=1 -run '^TestPostgresAnswer' ./internal/coaching/scene/ielts
- make check-api
- make check-smoke
- cd server && go build -o /tmp/xe3-issue525-server ./cmd/server
- 使用独立 PostgreSQL 完成 migrate up、status、重复 up、down-one、再次 up 与 status

Closes #525