### PR TITLE
refactor(mobile): 抽取统一数字人练习舞台

### DIFF
--- a/mobile/lib/features/coaching/practice/practice_stage.dart
+++ b/mobile/lib/features/coaching/practice/practice_stage.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+/// Responsive shell shared by avatar-led practice experiences.
+///
+/// The avatar occupies the leading 44% of the available space: above the
+/// content in portrait and to its left in landscape.
+class PracticeStageLayout extends StatelessWidget {
+  const PracticeStageLayout({
+    required this.avatar,
+    required this.content,
+    this.avatarRegionKey,
+    super.key,
+  });
+
+  final Widget avatar;
+  final Widget content;
+  final Key? avatarRegionKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final landscape = constraints.maxWidth > constraints.maxHeight;
+        if (landscape) {
+          return Row(
+            children: [
+              SizedBox(
+                key: avatarRegionKey,
+                width: constraints.maxWidth * 0.44,
+                child: avatar,
+              ),
+              Expanded(child: content),
+            ],
+          );
+        }
+        return Column(
+          children: [
+            SizedBox(
+              key: avatarRegionKey,
+              height: constraints.maxHeight * 0.44,
+              child: avatar,
+            ),
+            Expanded(child: content),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Shared visual surface for an avatar-led practice experience.
+class PracticeAvatarStage extends StatelessWidget {
+  const PracticeAvatarStage({
+    required this.title,
+    required this.fallback,
+    required this.onExit,
+    this.surfaceBuilder,
+    this.statusLabel,
+    this.subtitle,
+    this.exitInFlight = false,
+    this.exitButtonKey,
+    this.statusKey,
+    this.subtitleKey,
+    this.subtitleTextKey,
+    super.key,
+  });
+
+  final String title;
+  final Widget fallback;
+  final VoidCallback onExit;
+  final WidgetBuilder? surfaceBuilder;
+  final String? statusLabel;
+  final String? subtitle;
+  final bool exitInFlight;
+  final Key? exitButtonKey;
+  final Key? statusKey;
+  final Key? subtitleKey;
+  final Key? subtitleTextKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: const Color(0xFFE5E9E5),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (surfaceBuilder case final builder?)
+            builder(context)
+          else
+            fallback,
+          const Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Color(0x33000000),
+                      Colors.transparent,
+                      Color(0x4D000000),
+                    ],
+                    stops: [0, 0.45, 1],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 12,
+            right: 12,
+            top: 10,
+            child: Row(
+              children: [
+                IconButton.filledTonal(
+                  key: exitButtonKey,
+                  tooltip: '返回',
+                  onPressed: exitInFlight ? null : onExit,
+                  icon: exitInFlight
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.arrow_back_rounded),
+                  style: IconButton.styleFrom(
+                    backgroundColor: Colors.white.withValues(alpha: 0.9),
+                    foregroundColor: SpeakUpDesign.ink,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      shadows: [
+                        Shadow(color: Color(0x66000000), blurRadius: 8),
+                      ],
+                    ),
+                  ),
+                ),
+                if (statusLabel case final label?)
+                  Flexible(
+                    child: Semantics(
+                      liveRegion: true,
+                      child: Container(
+                        key: statusKey,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 7,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.46),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (subtitle case final text?)
+            Positioned(
+              left: 16,
+              right: 16,
+              bottom: 14,
+              child: Container(
+                key: subtitleKey,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 15,
+                  vertical: 11,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.58),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  text,
+                  key: subtitleTextKey,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    height: 1.35,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -11,6 +11,7 @@ import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart'
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
+import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 
@@ -461,230 +462,60 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
         body: SafeArea(
           child: scene == null
               ? const Center(child: Text('请先选择一个情景开始对话。'))
-              : LayoutBuilder(
-                  builder: (context, constraints) {
-                    final landscape =
-                        constraints.maxWidth > constraints.maxHeight;
-                    final avatar = _AvatarStage(
-                      scene: scene,
-                      surfaceBuilder:
-                          _exitApproved ||
-                              !widget.practiceController.canUseAvatar
-                          ? null
-                          : widget.avatarSurfaceBuilder,
-                      statusLabel: widget.avatarStatusLabel,
-                      latestAssistantMessage:
-                          widget.practiceController.practiceExperience ==
-                              PracticeExperience.interview
-                          ? null
-                          : _latestAssistantMessage(
-                              widget.practiceController.practiceMessages,
-                            ),
-                      exitInFlight: _exitInFlight,
-                      onExit: _requestExit,
-                    );
-                    final conversation = _ConversationPanel(
-                      controller: widget.practiceController,
-                      scrollController: _conversationScrollController,
-                      textController: _textController,
-                      textFocusNode: _textFocusNode,
-                      textMode: _textMode,
-                      recordingSeconds: _recordingSeconds,
-                      previewMode: widget.previewMode,
-                      onBeforeStartRecording: _beforeStartRecording,
-                      onReplayQuestion: widget.onReplayQuestion,
-                      speechFeedbackController: widget.speechFeedbackController,
-                      replayLoading: widget.replayLoading,
-                      replayPlaying: widget.replayPlaying,
-                      onToggleTextMode: _toggleTextMode,
-                      onSubmitText: _submitText,
-                      onTranslateQuestion:
-                          widget.practiceController.canTranslateQuestion &&
-                              widget.practiceController.client
-                                  is PracticeQuestionTranslationClient
-                          ? _translateQuestion
-                          : null,
-                      onShowTip: _showQuestionTip,
-                      onHideTip: _hideQuestionTip,
-                      onSpeakTip: _speakQuestionTip,
-                      visibleTipQuestionId: _visibleTipQuestionId,
-                      onPracticeCompleted: _completePractice,
-                      onCompleteRequested: _requestUserControlledCompletion,
-                    );
-                    if (landscape) {
-                      return Row(
-                        children: [
-                          SizedBox(
-                            key: const Key('scenario-avatar-region'),
-                            width: constraints.maxWidth * 0.44,
-                            child: avatar,
-                          ),
-                          Expanded(child: conversation),
-                        ],
-                      );
-                    }
-                    return Column(
-                      children: [
-                        SizedBox(
-                          key: const Key('scenario-avatar-region'),
-                          height: constraints.maxHeight * 0.44,
-                          child: avatar,
-                        ),
-                        Expanded(child: conversation),
-                      ],
-                    );
-                  },
+              : PracticeStageLayout(
+                  avatarRegionKey: const Key('scenario-avatar-region'),
+                  avatar: PracticeAvatarStage(
+                    title: scene.name,
+                    fallback: const _AvatarPlaceholder(),
+                    surfaceBuilder:
+                        _exitApproved || !widget.practiceController.canUseAvatar
+                        ? null
+                        : widget.avatarSurfaceBuilder,
+                    statusLabel: widget.avatarStatusLabel,
+                    subtitle:
+                        widget.practiceController.practiceExperience ==
+                            PracticeExperience.interview
+                        ? null
+                        : _latestAssistantMessage(
+                            widget.practiceController.practiceMessages,
+                          )?.text,
+                    exitInFlight: _exitInFlight,
+                    exitButtonKey: const Key('scenario-exit'),
+                    statusKey: const Key('scenario-avatar-status'),
+                    subtitleKey: const Key('scenario-live-subtitle'),
+                    subtitleTextKey: const Key('scenario-live-subtitle-text'),
+                    onExit: _requestExit,
+                  ),
+                  content: _ConversationPanel(
+                    controller: widget.practiceController,
+                    scrollController: _conversationScrollController,
+                    textController: _textController,
+                    textFocusNode: _textFocusNode,
+                    textMode: _textMode,
+                    recordingSeconds: _recordingSeconds,
+                    previewMode: widget.previewMode,
+                    onBeforeStartRecording: _beforeStartRecording,
+                    onReplayQuestion: widget.onReplayQuestion,
+                    speechFeedbackController: widget.speechFeedbackController,
+                    replayLoading: widget.replayLoading,
+                    replayPlaying: widget.replayPlaying,
+                    onToggleTextMode: _toggleTextMode,
+                    onSubmitText: _submitText,
+                    onTranslateQuestion:
+                        widget.practiceController.canTranslateQuestion &&
+                            widget.practiceController.client
+                                is PracticeQuestionTranslationClient
+                        ? _translateQuestion
+                        : null,
+                    onShowTip: _showQuestionTip,
+                    onHideTip: _hideQuestionTip,
+                    onSpeakTip: _speakQuestionTip,
+                    visibleTipQuestionId: _visibleTipQuestionId,
+                    onPracticeCompleted: _completePractice,
+                    onCompleteRequested: _requestUserControlledCompletion,
+                  ),
                 ),
         ),
-      ),
-    );
-  }
-}
-
-class _AvatarStage extends StatelessWidget {
-  const _AvatarStage({
-    required this.scene,
-    required this.surfaceBuilder,
-    required this.statusLabel,
-    required this.latestAssistantMessage,
-    required this.exitInFlight,
-    required this.onExit,
-  });
-
-  final SceneDefinition scene;
-  final ScenarioAvatarSurfaceBuilder? surfaceBuilder;
-  final String? statusLabel;
-  final PracticeMessage? latestAssistantMessage;
-  final bool exitInFlight;
-  final VoidCallback onExit;
-
-  @override
-  Widget build(BuildContext context) {
-    return ColoredBox(
-      color: const Color(0xFFE5E9E5),
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          if (surfaceBuilder case final builder?)
-            builder(context)
-          else
-            const _AvatarPlaceholder(),
-          const Positioned.fill(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Color(0x33000000),
-                      Colors.transparent,
-                      Color(0x4D000000),
-                    ],
-                    stops: [0, 0.45, 1],
-                  ),
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            left: 12,
-            right: 12,
-            top: 10,
-            child: Row(
-              children: [
-                IconButton.filledTonal(
-                  key: const Key('scenario-exit'),
-                  tooltip: '返回',
-                  onPressed: exitInFlight ? null : onExit,
-                  icon: exitInFlight
-                      ? const SizedBox.square(
-                          dimension: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.arrow_back_rounded),
-                  style: IconButton.styleFrom(
-                    backgroundColor: Colors.white.withValues(alpha: 0.9),
-                    foregroundColor: SpeakUpDesign.ink,
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    scene.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      shadows: [
-                        Shadow(color: Color(0x66000000), blurRadius: 8),
-                      ],
-                    ),
-                  ),
-                ),
-                if (statusLabel case final label?)
-                  Flexible(
-                    child: Semantics(
-                      liveRegion: true,
-                      child: Container(
-                        key: const Key('scenario-avatar-status'),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 7,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withValues(alpha: 0.46),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          label,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-          if (latestAssistantMessage case final message?)
-            Positioned(
-              left: 16,
-              right: 16,
-              bottom: 14,
-              child: Container(
-                key: const Key('scenario-live-subtitle'),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 15,
-                  vertical: 11,
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.58),
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Text(
-                  message.text,
-                  key: const Key('scenario-live-subtitle-text'),
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 15,
-                    height: 1.35,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ),
-            ),
-        ],
       ),
     );
   }

--- a/mobile/test/coaching/practice/practice_stage_test.dart
+++ b/mobile/test/coaching/practice/practice_stage_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/practice_stage.dart';
+
+void main() {
+  testWidgets('lays out arbitrary practice content in portrait and landscape', (
+    tester,
+  ) async {
+    Future<void> pumpAt(Size size) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1;
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PracticeStageLayout(
+            avatarRegionKey: Key('avatar-region'),
+            avatar: ColoredBox(key: Key('custom-avatar'), color: Colors.blue),
+            content: ColoredBox(
+              key: Key('custom-content'),
+              color: Colors.white,
+            ),
+          ),
+        ),
+      );
+    }
+
+    addTearDown(tester.view.reset);
+
+    await pumpAt(const Size(390, 844));
+    expect(find.byKey(const Key('custom-avatar')), findsOneWidget);
+    expect(find.byKey(const Key('custom-content')), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const Key('avatar-region'))).height,
+      closeTo(844 * 0.44, 0.1),
+    );
+
+    await pumpAt(const Size(844, 390));
+    expect(
+      tester.getSize(find.byKey(const Key('avatar-region'))).width,
+      closeTo(844 * 0.44, 0.1),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('avatar stage accepts a surface and shared chrome content', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarStage(
+          title: 'Custom practice',
+          fallback: const ColoredBox(
+            key: Key('custom-fallback'),
+            color: Colors.grey,
+          ),
+          surfaceBuilder: (_) =>
+              const ColoredBox(key: Key('custom-surface'), color: Colors.green),
+          statusLabel: 'Connected',
+          subtitle: 'Try answering in one complete sentence.',
+          exitButtonKey: const Key('custom-exit'),
+          statusKey: const Key('custom-status'),
+          subtitleKey: const Key('custom-subtitle'),
+          onExit: () {},
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('custom-surface')), findsOneWidget);
+    expect(find.byKey(const Key('custom-fallback')), findsNothing);
+    expect(find.text('Custom practice'), findsOneWidget);
+    expect(find.text('Connected'), findsOneWidget);
+    expect(
+      find.text('Try answering in one complete sentence.'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('custom-exit')), findsOneWidget);
+    expect(find.byKey(const Key('custom-status')), findsOneWidget);
+    expect(find.byKey(const Key('custom-subtitle')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## 功能描述

- 抽取可复用的 `PracticeStageLayout`，统一竖屏上方数字人/下方内容与横屏左侧数字人/右侧内容布局。
- 抽取 `PracticeAvatarStage`，共享返回、标题、连接状态、实时字幕、真实 surface 与静态降级画面外壳。
- 让现有面试、职场、生活旅行的 `ScenarioPracticePage` 使用共享舞台，为后续 IELTS 接入提供复用边界。

## 实现思路

- 只移动稳定的展示布局，不抽取场景专属的 Tips、翻译、完成和作答状态。
- 保留 44% 数字人区域、全部视觉参数和现有 Widget Key，避免行为与自动化回归。
- 通过 Widget 插槽接收任意业务内容；后续 IELTS 继续保留自己的 Part 2 计时和考试状态机。

## 可复现测试

```bash
make check-flutter-analyze
cd mobile
flutter test --no-pub \
  test/coaching/practice/practice_stage_test.dart \
  test/coaching/practice/scenario_practice_test.dart \
  test/coaching/practice/scenario_practice_session_test.dart \
  test/coaching/preparation/practice_lifecycle_flow_test.dart
make dev-ios-simulator
```

结果：Flutter 格式化与分析通过；相关测试 30 项通过；已在最新 `upstream/dev`（包含 #529、#530）、真实后端、模拟器禁用数字人的配置下启动验证。

Closes #531