### PR TITLE
fix(ielts): 复用同题已有答案准备记录

### DIFF
--- a/server/internal/coaching/scene/ielts/answer_preparation_postgres.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_postgres.go
@@ -77,12 +77,25 @@ func (store *PostgresStore) Create(ctx context.Context, actor requestcontext.Act
 		return replay, found, err
 	}
 	points, _ := json.Marshal(command.Request.PersonalPoints)
-	_, err = tx.Exec(ctx, `INSERT INTO ielts_answer_preparations (owner_user_id, answer_preparation_id, bank_id, part, source_id, question_position, question_prompt, personal_points, target_band) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, actor.UserID, command.ID, command.Question.Reference.BankID, command.Question.Reference.Part, command.Question.Reference.SourceID, command.Question.Reference.QuestionPosition, command.Question.Prompt, points, command.Request.TargetBand)
+	tag, err := tx.Exec(ctx, `INSERT INTO ielts_answer_preparations (owner_user_id, answer_preparation_id, bank_id, part, source_id, question_position, question_prompt, personal_points, target_band) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (owner_user_id, bank_id, part, source_id, question_position) DO NOTHING`, actor.UserID, command.ID, command.Question.Reference.BankID, command.Question.Reference.Part, command.Question.Reference.SourceID, command.Question.Reference.QuestionPosition, command.Question.Prompt, points, command.Request.TargetBand)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return AnswerPreparation{}, false, ErrAnswerPreparationConflict
 		}
 		return AnswerPreparation{}, false, answerDatabaseError(err)
+	}
+	if tag.RowsAffected() == 0 {
+		existing, err := getAnswerPreparationByQuestion(ctx, tx, actor.UserID, command.Question.Reference)
+		if err != nil {
+			return AnswerPreparation{}, false, err
+		}
+		if err := persistAnswerMutation(ctx, tx, actor.UserID, command.Intent, existing.ID, existing, false); err != nil {
+			return AnswerPreparation{}, false, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return AnswerPreparation{}, false, answerDatabaseError(err)
+		}
+		return existing, true, nil
 	}
 	created, err := getAnswerPreparation(ctx, tx, actor.UserID, command.ID)
 	if err != nil {
@@ -303,6 +316,15 @@ type answerQueryer interface {
 
 func getAnswerPreparation(ctx context.Context, query answerQueryer, owner, id string) (AnswerPreparation, error) {
 	row := query.QueryRow(ctx, `SELECT `+answerPreparationColumns+` FROM ielts_answer_preparations WHERE owner_user_id=$1 AND answer_preparation_id=$2`, owner, id)
+	return scanAnswerPreparation(row)
+}
+
+func getAnswerPreparationByQuestion(ctx context.Context, query answerQueryer, owner string, reference QuestionReference) (AnswerPreparation, error) {
+	row := query.QueryRow(ctx, `SELECT `+answerPreparationColumns+` FROM ielts_answer_preparations WHERE owner_user_id=$1 AND bank_id=$2 AND part=$3 AND source_id=$4 AND question_position=$5`, owner, reference.BankID, reference.Part, reference.SourceID, reference.QuestionPosition)
+	return scanAnswerPreparation(row)
+}
+
+func scanAnswerPreparation(row pgx.Row) (AnswerPreparation, error) {
 	var value AnswerPreparation
 	var points, outline, expressions []byte
 	err := row.Scan(&value.ID, &value.Question.Reference.BankID, &value.Question.Reference.Part, &value.Question.Reference.SourceID, &value.Question.Reference.QuestionPosition, &value.Question.Prompt, &points, &value.TargetBand, &value.Status, &value.Answer, &outline, &expressions, &value.SpeechText, &value.FailureCode, &value.Version, &value.GenerationRevision, &value.CreatedAt, &value.UpdatedAt)

--- a/server/internal/coaching/scene/ielts/answer_preparation_postgres_integration_test.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_postgres_integration_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,7 +29,7 @@ func TestPostgresAnswerPreparationsEnforceIdentityIdempotencyVersionAndCleanup(t
 			t.Fatalf("insert identity: %v", err)
 		}
 	}
-	if _, err := pool.Exec(ctx, `INSERT INTO ielts_question_bank_versions(bank_id,schema_version,season_code,season_label,season_start,season_end,region,source_cutoff) VALUES('bank-2026',3,'2026-05-08','season','2026-05-01','2026-08-31','mainland',now()); INSERT INTO ielts_part1_topics(bank_id,topic_id,title_zh,title_en,release_status,display_order) VALUES('bank-2026','p1-topic-001','音乐','Music','new',1); INSERT INTO ielts_part1_questions(bank_id,topic_id,question_position,prompt) VALUES('bank-2026','p1-topic-001',1,'Do you enjoy music?'); UPDATE ielts_question_bank_versions SET status='published',published_at=now() WHERE bank_id='bank-2026'`); err != nil {
+	if _, err := pool.Exec(ctx, `INSERT INTO ielts_question_bank_versions(bank_id,schema_version,season_code,season_label,season_start,season_end,region,source_cutoff) VALUES('bank-2026',3,'2026-05-08','season','2026-05-01','2026-08-31','mainland',now()); INSERT INTO ielts_part1_topics(bank_id,topic_id,title_zh,title_en,release_status,display_order) VALUES('bank-2026','p1-topic-001','音乐','Music','new',1); INSERT INTO ielts_part1_questions(bank_id,topic_id,question_position,prompt) VALUES('bank-2026','p1-topic-001',1,'Do you enjoy music?'),('bank-2026','p1-topic-001',2,'Do you play music?'); UPDATE ielts_question_bank_versions SET status='published',published_at=now() WHERE bank_id='bank-2026'`); err != nil {
 		t.Fatalf("insert question: %v", err)
 	}
 	store, _ := NewPostgresStore(pool)
@@ -40,6 +42,36 @@ func TestPostgresAnswerPreparationsEnforceIdentityIdempotencyVersionAndCleanup(t
 	restored, replayed, err := service.Create(ctx, owner, "create-key-1", request)
 	if err != nil || !replayed || restored.ID != created.ID {
 		t.Fatalf("replay = %#v replay=%t err=%v", restored, replayed, err)
+	}
+	existingRequest := request
+	existingRequest.PersonalPoints = nil
+	existing, replayed, err := service.Create(ctx, owner, "create-key-existing", existingRequest)
+	if err != nil || !replayed || existing.ID != created.ID || existing.PersonalPoints[0] != "I play piano" {
+		t.Fatalf("existing = %#v replay=%t err=%v", existing, replayed, err)
+	}
+	concurrentService, _ := NewAnswerPreparationService(store, store, &answerGeneratorStub{}, SecureAnswerPreparationIDGenerator{})
+	concurrentRequest := request
+	concurrentRequest.Question.QuestionPosition = 2
+	type createResult struct {
+		value    AnswerPreparation
+		replayed bool
+		err      error
+	}
+	results := make([]createResult, 2)
+	start := make(chan struct{})
+	var group sync.WaitGroup
+	for index := range results {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			<-start
+			results[index].value, results[index].replayed, results[index].err = concurrentService.Create(ctx, owner, fmt.Sprintf("create-key-concurrent-%d", index), concurrentRequest)
+		}(index)
+	}
+	close(start)
+	group.Wait()
+	if results[0].err != nil || results[1].err != nil || results[0].value.ID != results[1].value.ID || results[0].replayed == results[1].replayed {
+		t.Fatalf("concurrent Create = %#v", results)
 	}
 	changed := request
 	changed.TargetBand = 7
@@ -71,6 +103,9 @@ func TestPostgresAnswerPreparationsEnforceIdentityIdempotencyVersionAndCleanup(t
 	}
 	if _, err := service.Delete(ctx, owner, created.ID, "delete-key-1", ready.Version); err != nil {
 		t.Fatalf("idempotent Delete: %v", err)
+	}
+	if _, err := service.Delete(ctx, owner, results[0].value.ID, "delete-key-concurrent", results[0].value.Version); err != nil {
+		t.Fatalf("delete concurrent Create result: %v", err)
 	}
 	var count int
 	if err := pool.QueryRow(ctx, `SELECT count(*) FROM ielts_answer_preparation_idempotency WHERE owner_user_id=$1 AND resource_id IS NOT NULL`, owner.UserID).Scan(&count); err != nil || count != 0 {


### PR DESCRIPTION
## 功能描述

重复进入同一道 IELTS 题目时，答案准备 Create 不再因为题目唯一约束返回冲突，而是复用当前用户已有的准备记录。

## 实现思路

- INSERT 使用题目唯一键 ON CONFLICT DO NOTHING。
- 未插入新行时按用户与题目引用读取已有记录。
- 将已有资源写入本次 Idempotency-Key 结果后提交。
- 并发请求中仅一个创建新记录，另一个稳定复用。

## 可复现测试

1. 配置真实本地 PostgreSQL。
2. 运行：cd server && go test ./internal/coaching/scene/ielts
3. 测试覆盖普通创建、同题重复创建、并发创建、版本更新、生成、删除及幂等清理。

## 关联 Issue

Closes #536