### PR TITLE
feat(ielts): 接入逐题答案准备与个性化润色

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_answer_preparation.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_answer_preparation.dart
@@ -1,0 +1,97 @@
+final class IeltsAnswerQuestionReference {
+  const IeltsAnswerQuestionReference({
+    required this.bankId,
+    required this.part,
+    required this.sourceId,
+    required this.questionPosition,
+  });
+
+  final String bankId;
+  final String part;
+  final String sourceId;
+  final int questionPosition;
+
+  Map<String, Object> toJson() => <String, Object>{
+    'bank_id': bankId,
+    'part': part,
+    'source_id': sourceId,
+    'question_position': questionPosition,
+  };
+}
+
+enum IeltsAnswerPreparationStatus { draft, generating, ready, failed }
+
+final class IeltsAnswerPreparation {
+  const IeltsAnswerPreparation({
+    required this.id,
+    required this.question,
+    required this.personalPoints,
+    required this.targetBand,
+    required this.status,
+    required this.version,
+    required this.generationRevision,
+    required this.answer,
+    required this.outline,
+    required this.usefulExpressions,
+    required this.speechText,
+  });
+
+  final String id;
+  final IeltsAnswerQuestionReference question;
+  final List<String> personalPoints;
+  final double targetBand;
+  final IeltsAnswerPreparationStatus status;
+  final int version;
+  final int generationRevision;
+  final String? answer;
+  final List<String> outline;
+  final List<String> usefulExpressions;
+  final String? speechText;
+}
+
+enum IeltsAnswerPreparationFailureKind {
+  authenticationRequired,
+  invalidRequest,
+  notFound,
+  conflict,
+  generationFailed,
+  network,
+  invalidResponse,
+  server,
+}
+
+final class IeltsAnswerPreparationException implements Exception {
+  const IeltsAnswerPreparationException({
+    required this.kind,
+    this.statusCode,
+    this.retryable = false,
+  });
+
+  final IeltsAnswerPreparationFailureKind kind;
+  final int? statusCode;
+  final bool retryable;
+}
+
+abstract interface class IeltsAnswerPreparationClient {
+  Future<IeltsAnswerPreparation> create({
+    required IeltsAnswerQuestionReference question,
+    required List<String> personalPoints,
+    required double targetBand,
+  });
+
+  Future<IeltsAnswerPreparation> get(String id);
+
+  Future<IeltsAnswerPreparation> update({
+    required String id,
+    required int expectedVersion,
+    required List<String> personalPoints,
+    required double targetBand,
+  });
+
+  Future<IeltsAnswerPreparation> generate({
+    required String id,
+    required int expectedVersion,
+  });
+
+  Future<void> delete({required String id, required int expectedVersion});
+}

--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
 import 'package:speakup/features/coaching/preparation/preparation_catalog_components.dart';
@@ -243,6 +244,10 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
   }
 
   Future<void> _open(_CatalogItem item) async {
+    final bank = widget.controller.questionBank;
+    if (bank == null) {
+      return;
+    }
     final scene = ieltsSceneForMode(widget.scenes, item.mode);
     final selection = IeltsPracticeSelection(
       part1SetId: item.mode == PracticeMode.part1 ? item.id : null,
@@ -256,6 +261,16 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
           subtitle: item.subtitle,
           questions: item.questions,
           cueCard: item.cueCard,
+          answerPreparationClient: widget.controller.answerPreparationClient,
+          questionReferences: [
+            for (var index = 0; index < item.questions.length; index++)
+              IeltsAnswerQuestionReference(
+                bankId: bank.bankId,
+                part: item.mode == PracticeMode.part1 ? 'PART_1' : 'PART_3',
+                sourceId: item.id,
+                questionPosition: index + 1,
+              ),
+          ],
           onStart: scene == null
               ? null
               : () {

--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -261,16 +261,20 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
           subtitle: item.subtitle,
           questions: item.questions,
           cueCard: item.cueCard,
-          answerPreparationClient: widget.controller.answerPreparationClient,
-          questionReferences: [
-            for (var index = 0; index < item.questions.length; index++)
-              IeltsAnswerQuestionReference(
-                bankId: bank.bankId,
-                part: item.mode == PracticeMode.part1 ? 'PART_1' : 'PART_3',
-                sourceId: item.id,
-                questionPosition: index + 1,
-              ),
-          ],
+          answerPreparationClient: item.mode == PracticeMode.part1
+              ? widget.controller.answerPreparationClient
+              : null,
+          questionReferences: item.mode == PracticeMode.part1
+              ? [
+                  for (var index = 0; index < item.questions.length; index++)
+                    IeltsAnswerQuestionReference(
+                      bankId: bank.bankId,
+                      part: 'PART_1',
+                      sourceId: item.id,
+                      questionPosition: index + 1,
+                    ),
+                ]
+              : const [],
           onStart: scene == null
               ? null
               : () {

--- a/mobile/lib/features/coaching/ielts/ielts_preparation_controller.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_preparation_controller.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_practice_history_store.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -31,10 +32,12 @@ final class IeltsPracticeNavigationRequest {
 final class IeltsPreparationController extends ChangeNotifier {
   IeltsPreparationController({
     required this.client,
+    this.answerPreparationClient,
     this.historyStore = const NullIeltsPracticeHistoryStore(),
   });
 
   final IeltsQuestionBankClient client;
+  final IeltsAnswerPreparationClient? answerPreparationClient;
   final IeltsPracticeHistoryStore historyStore;
 
   IeltsQuestionBank? _questionBank;

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:speakup/design/conversation_bubble_surface.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/preparation/preparation_design.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
-class IeltsSetDetailPage extends StatelessWidget {
+class IeltsSetDetailPage extends StatefulWidget {
   const IeltsSetDetailPage({
     required this.mode,
     required this.title,
@@ -11,6 +16,9 @@ class IeltsSetDetailPage extends StatelessWidget {
     required this.questions,
     required this.onStart,
     this.cueCard,
+    this.promptSpeaker,
+    this.answerPreparationClient,
+    this.questionReferences = const <IeltsAnswerQuestionReference>[],
     super.key,
   });
 
@@ -20,18 +28,240 @@ class IeltsSetDetailPage extends StatelessWidget {
   final List<String> questions;
   final IeltsCueCard? cueCard;
   final VoidCallback? onStart;
+  final PracticePromptSpeaker? promptSpeaker;
+  final IeltsAnswerPreparationClient? answerPreparationClient;
+  final List<IeltsAnswerQuestionReference> questionReferences;
 
-  String get _partLabel => switch (mode) {
+  @override
+  State<IeltsSetDetailPage> createState() => _IeltsSetDetailPageState();
+}
+
+class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
+  late final PracticePromptSpeaker _promptSpeaker;
+  late final bool _ownsPromptSpeaker;
+  int? _speakingQuestionIndex;
+  int? _speakingAnswerIndex;
+  int? _expandedQuestionIndex;
+  int? _generatingQuestionIndex;
+  final Map<int, IeltsAnswerPreparation> _preparations = {};
+  String? _speechError;
+  String? _answerError;
+  int _speechRequest = 0;
+
+  String get _partLabel => switch (widget.mode) {
     PracticeMode.part1 => 'Part 1',
     PracticeMode.part2 => 'Part 2',
     PracticeMode.part3 => 'Part 3',
     _ => throw StateError('IELTS set details require a section mode.'),
   };
 
-  String get _questionsTitle => switch (mode) {
-    PracticeMode.part2 => '同组 Part 3 · ${questions.length} 题',
-    _ => '$_partLabel · ${questions.length} 题',
+  String get _questionsTitle => switch (widget.mode) {
+    PracticeMode.part2 => '同组 Part 3 · ${widget.questions.length} 题',
+    _ => '$_partLabel · ${widget.questions.length} 题',
   };
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsPromptSpeaker = widget.promptSpeaker == null;
+    _promptSpeaker = widget.promptSpeaker ?? SystemPracticePromptSpeaker();
+    if (widget.mode == PracticeMode.part1 && _canPrepareAnswers) {
+      _expandedQuestionIndex = 0;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          unawaited(_ensureExample(0));
+        }
+      });
+    }
+  }
+
+  bool get _canPrepareAnswers =>
+      widget.answerPreparationClient != null &&
+      widget.questionReferences.length == widget.questions.length;
+
+  @override
+  void dispose() {
+    _speechRequest++;
+    if (_ownsPromptSpeaker) {
+      unawaited(_promptSpeaker.dispose());
+    } else {
+      unawaited(_promptSpeaker.stop());
+    }
+    super.dispose();
+  }
+
+  Future<void> _toggleQuestionSpeech(int index) async {
+    final request = ++_speechRequest;
+    final wasSpeaking = _speakingQuestionIndex == index;
+
+    try {
+      await _promptSpeaker.stop();
+      if (!mounted || request != _speechRequest) {
+        return;
+      }
+      if (wasSpeaking) {
+        setState(() {
+          _speakingQuestionIndex = null;
+          _speechError = null;
+        });
+        return;
+      }
+
+      setState(() {
+        _speakingQuestionIndex = index;
+        _speakingAnswerIndex = null;
+        _speechError = null;
+      });
+      await _promptSpeaker.speak(widget.questions[index]);
+      if (mounted && request == _speechRequest) {
+        setState(() => _speakingQuestionIndex = null);
+      }
+    } catch (_) {
+      if (mounted && request == _speechRequest) {
+        setState(() {
+          _speakingQuestionIndex = null;
+          _speechError = '题目朗读失败，请稍后重试。';
+        });
+      }
+    }
+  }
+
+  Future<void> _toggleAnswerSpeech(int index, String text) async {
+    final request = ++_speechRequest;
+    final wasSpeaking = _speakingAnswerIndex == index;
+    try {
+      await _promptSpeaker.stop();
+      if (!mounted || request != _speechRequest) {
+        return;
+      }
+      if (wasSpeaking) {
+        setState(() {
+          _speakingAnswerIndex = null;
+          _speechError = null;
+        });
+        return;
+      }
+      setState(() {
+        _speakingQuestionIndex = null;
+        _speakingAnswerIndex = index;
+        _speechError = null;
+      });
+      await _promptSpeaker.speak(text);
+      if (mounted && request == _speechRequest) {
+        setState(() => _speakingAnswerIndex = null);
+      }
+    } catch (_) {
+      if (mounted && request == _speechRequest) {
+        setState(() {
+          _speakingAnswerIndex = null;
+          _speechError = '答案朗读失败，请稍后重试。';
+        });
+      }
+    }
+  }
+
+  Future<void> _prepareAnswer(int index) async {
+    final points = await showModalBottomSheet<List<String>>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: PreparationDesign.surface,
+      builder: (_) => const _PolishExperienceSheet(),
+    );
+    if (points == null || !mounted) {
+      return;
+    }
+    setState(() {
+      _generatingQuestionIndex = index;
+      _answerError = null;
+    });
+    try {
+      final existing = _preparations[index];
+      var draft =
+          existing ??
+          await widget.answerPreparationClient!.create(
+            question: widget.questionReferences[index],
+            personalPoints: points,
+            targetBand: 7,
+          );
+      if (draft.status != IeltsAnswerPreparationStatus.draft ||
+          !_samePersonalPoints(draft.personalPoints, points) ||
+          draft.targetBand != 7) {
+        draft = await widget.answerPreparationClient!.update(
+          id: draft.id,
+          expectedVersion: draft.version,
+          personalPoints: points,
+          targetBand: 7,
+        );
+      }
+      final ready = await widget.answerPreparationClient!.generate(
+        id: draft.id,
+        expectedVersion: draft.version,
+      );
+      if (mounted) {
+        setState(() {
+          _preparations[index] = ready;
+          _answerError = null;
+        });
+      }
+    } on IeltsAnswerPreparationException catch (error) {
+      if (mounted) {
+        setState(() => _answerError = _answerFailureMessage(error));
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _answerError = '暂时无法生成答案，请稍后重试。');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _generatingQuestionIndex = null);
+      }
+    }
+  }
+
+  Future<void> _ensureExample(int index) async {
+    if (_preparations.containsKey(index) || _generatingQuestionIndex == index) {
+      return;
+    }
+    setState(() {
+      _generatingQuestionIndex = index;
+      _answerError = null;
+    });
+    try {
+      final draft = await widget.answerPreparationClient!.create(
+        question: widget.questionReferences[index],
+        personalPoints: const [],
+        targetBand: 7,
+      );
+      if (draft.status == IeltsAnswerPreparationStatus.ready) {
+        if (mounted) {
+          setState(() {
+            _preparations[index] = draft;
+            _answerError = null;
+          });
+        }
+        return;
+      }
+      final example = await widget.answerPreparationClient!.generate(
+        id: draft.id,
+        expectedVersion: draft.version,
+      );
+      if (mounted) {
+        setState(() {
+          _preparations[index] = example;
+          _answerError = null;
+        });
+      }
+    } on IeltsAnswerPreparationException catch (error) {
+      if (mounted) {
+        setState(() => _answerError = _answerFailureMessage(error));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _generatingQuestionIndex = null);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -68,47 +298,98 @@ class IeltsSetDetailPage extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (mode == PracticeMode.part1)
+                    if (widget.mode == PracticeMode.part1)
                       _PartOneHeader(
-                        title: title,
-                        subtitle: subtitle,
-                        questionCount: questions.length,
+                        title: widget.title,
+                        subtitle: widget.subtitle,
+                        questionCount: widget.questions.length,
                       )
                     else ...[
                       _PartBadge(label: _partLabel),
                       const SizedBox(height: 14),
                       Text(
-                        title,
+                        widget.title,
                         key: const Key('ielts-set-detail-title'),
                         style: PreparationDesign.pageTitle,
                       ),
-                      if (cueCard == null && subtitle.isNotEmpty) ...[
+                      if (widget.subtitle.isNotEmpty) ...[
                         const SizedBox(height: 8),
                         Text(
-                          subtitle,
+                          widget.subtitle,
                           key: const Key('ielts-set-detail-subtitle'),
                           style: PreparationDesign.body,
                         ),
                       ],
                       const SizedBox(height: 28),
                     ],
-                    if (cueCard case final value?) ...[
+                    if (widget.cueCard case final value?) ...[
                       _CueCardContent(cueCard: value),
-                      if (questions.isNotEmpty) const SizedBox(height: 30),
+                      if (widget.questions.isNotEmpty)
+                        const SizedBox(height: 30),
                     ],
-                    if (questions.isNotEmpty) ...[
-                      if (mode != PracticeMode.part1) ...[
+                    if (widget.questions.isNotEmpty) ...[
+                      if (widget.mode != PracticeMode.part1) ...[
                         Text(
                           _questionsTitle,
                           style: PreparationDesign.sectionTitle,
                         ),
                         const SizedBox(height: 8),
                       ],
-                      for (var index = 0; index < questions.length; index++)
+                      for (
+                        var index = 0;
+                        index < widget.questions.length;
+                        index++
+                      ) ...[
                         _QuestionRow(
                           index: index + 1,
-                          question: questions[index],
+                          question: widget.questions[index],
+                          speaking: _speakingQuestionIndex == index,
+                          onSpeak: () => _toggleQuestionSpeech(index),
+                          expanded: _expandedQuestionIndex == index,
+                          onToggle: _canPrepareAnswers
+                              ? () {
+                                  final opening =
+                                      _expandedQuestionIndex != index;
+                                  setState(() {
+                                    _expandedQuestionIndex = opening
+                                        ? index
+                                        : null;
+                                    _answerError = null;
+                                  });
+                                  if (opening) {
+                                    unawaited(_ensureExample(index));
+                                  }
+                                }
+                              : null,
                         ),
+                        if (_canPrepareAnswers &&
+                            _expandedQuestionIndex == index)
+                          _QuestionAnswerPanel(
+                            index: index,
+                            preparation: _preparations[index],
+                            generating: _generatingQuestionIndex == index,
+                            errorMessage: _answerError,
+                            speaking: _speakingAnswerIndex == index,
+                            onPrepare: () => _prepareAnswer(index),
+                            onRetry: () => _ensureExample(index),
+                            onSpeak: _preparations[index]?.speechText == null
+                                ? null
+                                : () => _toggleAnswerSpeech(
+                                    index,
+                                    _preparations[index]!.speechText!,
+                                  ),
+                          ),
+                      ],
+                      if (_speechError case final message?) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          message,
+                          key: const Key('ielts-set-detail-speech-error'),
+                          style: PreparationDesign.body.copyWith(
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                        ),
+                      ],
                     ],
                   ],
                 ),
@@ -130,7 +411,7 @@ class IeltsSetDetailPage extends StatelessWidget {
                 ),
                 child: FilledButton(
                   key: const Key('ielts-set-detail-start'),
-                  onPressed: onStart,
+                  onPressed: widget.onStart,
                   style: FilledButton.styleFrom(
                     minimumSize: const Size.fromHeight(52),
                     backgroundColor: PreparationDesign.ink,
@@ -138,9 +419,9 @@ class IeltsSetDetailPage extends StatelessWidget {
                     textStyle: PreparationDesign.cardTitle,
                   ),
                   child: Text(
-                    onStart == null
+                    widget.onStart == null
                         ? '练习暂不可用'
-                        : mode == PracticeMode.part1
+                        : widget.mode == PracticeMode.part1
                         ? '开始整组练习'
                         : '开始 $_partLabel',
                   ),
@@ -152,6 +433,18 @@ class IeltsSetDetailPage extends StatelessWidget {
       ),
     );
   }
+}
+
+bool _samePersonalPoints(List<String> left, List<String> right) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 class _PartOneHeader extends StatelessWidget {
@@ -267,10 +560,21 @@ class _CueCardContent extends StatelessWidget {
 }
 
 class _QuestionRow extends StatelessWidget {
-  const _QuestionRow({required this.index, required this.question});
+  const _QuestionRow({
+    required this.index,
+    required this.question,
+    required this.speaking,
+    required this.onSpeak,
+    required this.expanded,
+    required this.onToggle,
+  });
 
   final int index;
   final String question;
+  final bool speaking;
+  final VoidCallback onSpeak;
+  final bool expanded;
+  final VoidCallback? onToggle;
 
   @override
   Widget build(BuildContext context) => Container(
@@ -300,7 +604,240 @@ class _QuestionRow extends StatelessWidget {
             ),
           ),
         ),
+        const SizedBox(width: 10),
+        IconButton.outlined(
+          key: Key('ielts-set-detail-speak-$index'),
+          tooltip: speaking ? '停止播放第 $index 题' : '听考官读第 $index 题',
+          onPressed: onSpeak,
+          icon: Icon(
+            speaking ? Icons.stop_rounded : Icons.volume_up_outlined,
+            size: 22,
+          ),
+          style: IconButton.styleFrom(
+            minimumSize: const Size.square(44),
+            side: const BorderSide(color: PreparationDesign.border),
+          ),
+        ),
+        if (onToggle != null) ...[
+          const SizedBox(width: 2),
+          IconButton(
+            key: Key('ielts-set-detail-expand-$index'),
+            tooltip: expanded ? '收起第 $index 题' : '展开第 $index 题',
+            onPressed: onToggle,
+            icon: Icon(
+              expanded
+                  ? Icons.keyboard_arrow_up_rounded
+                  : Icons.keyboard_arrow_down_rounded,
+            ),
+          ),
+        ],
       ],
     ),
   );
 }
+
+class _QuestionAnswerPanel extends StatelessWidget {
+  const _QuestionAnswerPanel({
+    required this.index,
+    required this.preparation,
+    required this.generating,
+    required this.errorMessage,
+    required this.speaking,
+    required this.onPrepare,
+    required this.onRetry,
+    required this.onSpeak,
+  });
+
+  final int index;
+  final IeltsAnswerPreparation? preparation;
+  final bool generating;
+  final String? errorMessage;
+  final bool speaking;
+  final VoidCallback onPrepare;
+  final VoidCallback onRetry;
+  final VoidCallback? onSpeak;
+
+  @override
+  Widget build(BuildContext context) {
+    final ready = preparation?.status == IeltsAnswerPreparationStatus.ready;
+    final personalized = ready && preparation!.personalPoints.isNotEmpty;
+    return Container(
+      key: Key('ielts-answer-panel-${index + 1}'),
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(28, 16, 0, 20),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: PreparationDesign.border)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Tip：先直接回答，再补一个原因或小例子。', style: PreparationDesign.label),
+          const SizedBox(height: 12),
+          if (generating)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 20),
+              child: Row(
+                children: [
+                  SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  SizedBox(width: 10),
+                  Text('正在准备表达…', style: PreparationDesign.body),
+                ],
+              ),
+            )
+          else if (ready) ...[
+            Text(
+              personalized ? '我的表达' : '示例回答',
+              style: PreparationDesign.label.copyWith(
+                color: PreparationDesign.inkSecondary,
+              ),
+            ),
+            const SizedBox(height: 6),
+            ConversationBubbleSurface(
+              isUser: false,
+              maxWidth: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Text(preparation!.answer!, style: PreparationDesign.body),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                TextButton.icon(
+                  key: Key('ielts-speak-answer-${index + 1}'),
+                  onPressed: onSpeak,
+                  icon: Icon(
+                    speaking ? Icons.stop_rounded : Icons.volume_up_outlined,
+                    size: 18,
+                  ),
+                  label: Text(speaking ? '停止' : '播放'),
+                  style: TextButton.styleFrom(
+                    backgroundColor: PreparationDesign.surfaceMuted,
+                    foregroundColor: PreparationDesign.ink,
+                  ),
+                ),
+                TextButton.icon(
+                  key: Key('ielts-polish-answer-${index + 1}'),
+                  onPressed: onPrepare,
+                  icon: const Icon(Icons.auto_awesome_outlined, size: 18),
+                  label: Text(personalized ? '重新润色' : '润色'),
+                  style: TextButton.styleFrom(
+                    backgroundColor: PreparationDesign.surfaceMuted,
+                    foregroundColor: PreparationDesign.ink,
+                  ),
+                ),
+              ],
+            ),
+          ] else
+            TextButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('重新加载示例'),
+            ),
+          if (errorMessage case final message?) ...[
+            const SizedBox(height: 10),
+            Text(
+              message,
+              key: const Key('ielts-answer-error'),
+              style: PreparationDesign.body.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PolishExperienceSheet extends StatefulWidget {
+  const _PolishExperienceSheet();
+
+  @override
+  State<_PolishExperienceSheet> createState() => _PolishExperienceSheetState();
+}
+
+class _PolishExperienceSheetState extends State<_PolishExperienceSheet> {
+  final _controller = TextEditingController();
+  bool _showValidation = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final points = _controller.text
+        .split('\n')
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .take(12)
+        .toList(growable: false);
+    if (points.isEmpty) {
+      setState(() => _showValidation = true);
+      return;
+    }
+    Navigator.of(context).pop(points);
+  }
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: EdgeInsets.fromLTRB(
+      24,
+      20,
+      24,
+      20 + MediaQuery.viewInsetsOf(context).bottom,
+    ),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('润色成我的表达', style: PreparationDesign.sectionTitle),
+        const SizedBox(height: 8),
+        Text(
+          '写下真实经历或想法，每行一个要点。',
+          style: PreparationDesign.body.copyWith(
+            color: PreparationDesign.inkSecondary,
+          ),
+        ),
+        const SizedBox(height: 14),
+        TextField(
+          key: const Key('ielts-polish-experience'),
+          controller: _controller,
+          autofocus: true,
+          minLines: 3,
+          maxLines: 6,
+          maxLength: 1500,
+          decoration: InputDecoration(
+            hintText: '例如：我通勤时喜欢听轻快的音乐，它让我更有精神。',
+            errorText: _showValidation ? '请先写一条真实经历或想法。' : null,
+            border: const OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        FilledButton(
+          key: const Key('ielts-polish-generate'),
+          onPressed: _submit,
+          style: FilledButton.styleFrom(
+            minimumSize: const Size.fromHeight(50),
+            backgroundColor: PreparationDesign.ink,
+            foregroundColor: Colors.white,
+          ),
+          child: const Text('生成我的表达'),
+        ),
+      ],
+    ),
+  );
+}
+
+String _answerFailureMessage(IeltsAnswerPreparationException error) =>
+    switch (error.kind) {
+      IeltsAnswerPreparationFailureKind.authenticationRequired => '登录后才能定制答案。',
+      IeltsAnswerPreparationFailureKind.generationFailed => '这次生成没有成功，请重试一次。',
+      IeltsAnswerPreparationFailureKind.conflict => '答案已在其他页面更新，请重新进入后再试。',
+      IeltsAnswerPreparationFailureKind.network => '网络连接失败，请检查网络后重试。',
+      _ => '暂时无法生成答案，请稍后重试。',
+    };

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -42,10 +42,11 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   int? _speakingQuestionIndex;
   int? _speakingAnswerIndex;
   int? _expandedQuestionIndex;
-  int? _generatingQuestionIndex;
   final Map<int, IeltsAnswerPreparation> _preparations = {};
+  final Set<int> _generatingQuestionIndexes = {};
+  final Map<int, String> _answerErrors = {};
+  final Map<int, int> _answerRequests = {};
   String? _speechError;
-  String? _answerError;
   int _speechRequest = 0;
 
   String get _partLabel => switch (widget.mode) {
@@ -76,8 +77,28 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   }
 
   bool get _canPrepareAnswers =>
+      widget.mode == PracticeMode.part1 &&
       widget.answerPreparationClient != null &&
       widget.questionReferences.length == widget.questions.length;
+
+  int _startAnswerRequest(int index) {
+    final request = (_answerRequests[index] ?? 0) + 1;
+    setState(() {
+      _answerRequests[index] = request;
+      _generatingQuestionIndexes.add(index);
+      _answerErrors.remove(index);
+    });
+    return request;
+  }
+
+  bool _isCurrentAnswerRequest(int index, int request) =>
+      mounted && _answerRequests[index] == request;
+
+  void _finishAnswerRequest(int index, int request) {
+    if (_isCurrentAnswerRequest(index, request)) {
+      setState(() => _generatingQuestionIndexes.remove(index));
+    }
+  }
 
   @override
   void dispose() {
@@ -171,10 +192,10 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
     if (points == null || !mounted) {
       return;
     }
-    setState(() {
-      _generatingQuestionIndex = index;
-      _answerError = null;
-    });
+    if (_generatingQuestionIndexes.contains(index)) {
+      return;
+    }
+    final request = _startAnswerRequest(index);
     try {
       final existing = _preparations[index];
       var draft =
@@ -198,35 +219,31 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
         id: draft.id,
         expectedVersion: draft.version,
       );
-      if (mounted) {
+      if (_isCurrentAnswerRequest(index, request)) {
         setState(() {
           _preparations[index] = ready;
-          _answerError = null;
+          _answerErrors.remove(index);
         });
       }
     } on IeltsAnswerPreparationException catch (error) {
-      if (mounted) {
-        setState(() => _answerError = _answerFailureMessage(error));
+      if (_isCurrentAnswerRequest(index, request)) {
+        setState(() => _answerErrors[index] = _answerFailureMessage(error));
       }
     } catch (_) {
-      if (mounted) {
-        setState(() => _answerError = '暂时无法生成答案，请稍后重试。');
+      if (_isCurrentAnswerRequest(index, request)) {
+        setState(() => _answerErrors[index] = '暂时无法生成答案，请稍后重试。');
       }
     } finally {
-      if (mounted) {
-        setState(() => _generatingQuestionIndex = null);
-      }
+      _finishAnswerRequest(index, request);
     }
   }
 
   Future<void> _ensureExample(int index) async {
-    if (_preparations.containsKey(index) || _generatingQuestionIndex == index) {
+    if (_preparations.containsKey(index) ||
+        _generatingQuestionIndexes.contains(index)) {
       return;
     }
-    setState(() {
-      _generatingQuestionIndex = index;
-      _answerError = null;
-    });
+    final request = _startAnswerRequest(index);
     try {
       final draft = await widget.answerPreparationClient!.create(
         question: widget.questionReferences[index],
@@ -234,10 +251,10 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
         targetBand: 7,
       );
       if (draft.status == IeltsAnswerPreparationStatus.ready) {
-        if (mounted) {
+        if (_isCurrentAnswerRequest(index, request)) {
           setState(() {
             _preparations[index] = draft;
-            _answerError = null;
+            _answerErrors.remove(index);
           });
         }
         return;
@@ -246,20 +263,18 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
         id: draft.id,
         expectedVersion: draft.version,
       );
-      if (mounted) {
+      if (_isCurrentAnswerRequest(index, request)) {
         setState(() {
           _preparations[index] = example;
-          _answerError = null;
+          _answerErrors.remove(index);
         });
       }
     } on IeltsAnswerPreparationException catch (error) {
-      if (mounted) {
-        setState(() => _answerError = _answerFailureMessage(error));
+      if (_isCurrentAnswerRequest(index, request)) {
+        setState(() => _answerErrors[index] = _answerFailureMessage(error));
       }
     } finally {
-      if (mounted) {
-        setState(() => _generatingQuestionIndex = null);
-      }
+      _finishAnswerRequest(index, request);
     }
   }
 
@@ -354,7 +369,7 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                                     _expandedQuestionIndex = opening
                                         ? index
                                         : null;
-                                    _answerError = null;
+                                    _answerErrors.remove(index);
                                   });
                                   if (opening) {
                                     unawaited(_ensureExample(index));
@@ -367,8 +382,10 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                           _QuestionAnswerPanel(
                             index: index,
                             preparation: _preparations[index],
-                            generating: _generatingQuestionIndex == index,
-                            errorMessage: _answerError,
+                            generating: _generatingQuestionIndexes.contains(
+                              index,
+                            ),
+                            errorMessage: _answerErrors[index],
                             speaking: _speakingAnswerIndex == index,
                             onPrepare: () => _prepareAnswer(index),
                             onRetry: () => _ensureExample(index),

--- a/mobile/lib/features/coaching/ielts/wire_ielts_answer_preparation_client.dart
+++ b/mobile/lib/features/coaching/ielts/wire_ielts_answer_preparation_client.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+final class WireIeltsAnswerPreparationClient
+    implements IeltsAnswerPreparationClient {
+  factory WireIeltsAnswerPreparationClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    IdentityHttpTransport? transport,
+    Duration requestTimeout = const Duration(seconds: 45),
+  }) {
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'requestTimeout');
+    }
+    return WireIeltsAnswerPreparationClient._(
+      baseUri,
+      SessionAuthenticatedHttpTransport(
+        transport: transport ?? IoIdentityHttpTransport(),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: baseUri,
+      ),
+      requestTimeout,
+    );
+  }
+
+  WireIeltsAnswerPreparationClient._(
+    this._baseUri,
+    this._transport,
+    this._requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  final Uri _baseUri;
+  final IdentityHttpTransport _transport;
+  final Duration _requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+
+  @override
+  Future<IeltsAnswerPreparation> create({
+    required IeltsAnswerQuestionReference question,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) async {
+    final response = await _send(
+      'POST',
+      '/v1/ielts-speaking/answer-preparations',
+      body: <String, Object>{
+        'question': question.toJson(),
+        'personal_points': personalPoints,
+        'target_band': targetBand,
+      },
+      idempotencyKey: _newIdempotencyKey('create'),
+    );
+    if (response.statusCode != HttpStatus.created &&
+        response.statusCode != HttpStatus.ok) {
+      throw _statusFailure(response.statusCode);
+    }
+    return _decodePreparation(response.body);
+  }
+
+  @override
+  Future<IeltsAnswerPreparation> get(String id) async {
+    final response = await _send(
+      'GET',
+      '/v1/ielts-speaking/answer-preparations/${Uri.encodeComponent(id)}',
+    );
+    if (response.statusCode != HttpStatus.ok) {
+      throw _statusFailure(response.statusCode);
+    }
+    return _decodePreparation(response.body);
+  }
+
+  @override
+  Future<IeltsAnswerPreparation> update({
+    required String id,
+    required int expectedVersion,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) async {
+    final response = await _send(
+      'PATCH',
+      '/v1/ielts-speaking/answer-preparations/${Uri.encodeComponent(id)}',
+      body: <String, Object>{
+        'expected_version': expectedVersion,
+        'personal_points': personalPoints,
+        'target_band': targetBand,
+      },
+      idempotencyKey: _newIdempotencyKey('update'),
+    );
+    if (response.statusCode != HttpStatus.ok) {
+      throw _statusFailure(response.statusCode);
+    }
+    return _decodePreparation(response.body);
+  }
+
+  @override
+  Future<IeltsAnswerPreparation> generate({
+    required String id,
+    required int expectedVersion,
+  }) async {
+    final response = await _send(
+      'POST',
+      '/v1/ielts-speaking/answer-preparations/${Uri.encodeComponent(id)}/generations',
+      body: <String, Object>{'expected_version': expectedVersion},
+      idempotencyKey: _newIdempotencyKey('generate'),
+    );
+    if (response.statusCode != HttpStatus.ok) {
+      throw _statusFailure(response.statusCode);
+    }
+    return _decodePreparation(response.body);
+  }
+
+  @override
+  Future<void> delete({
+    required String id,
+    required int expectedVersion,
+  }) async {
+    final response = await _send(
+      'DELETE',
+      '/v1/ielts-speaking/answer-preparations/${Uri.encodeComponent(id)}?expected_version=$expectedVersion',
+      idempotencyKey: _newIdempotencyKey('delete'),
+    );
+    if (response.statusCode != HttpStatus.noContent) {
+      throw _statusFailure(response.statusCode);
+    }
+  }
+
+  Future<IdentityHttpResponse> _send(
+    String method,
+    String path, {
+    Map<String, Object>? body,
+    String? idempotencyKey,
+  }) async {
+    final uri = _baseUri.resolve(path);
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(uri);
+    try {
+      return await _transport
+          .send(
+            method: method,
+            uri: uri,
+            headers: <String, String>{
+              HttpHeaders.acceptHeader: 'application/json',
+              if (body != null)
+                HttpHeaders.contentTypeHeader: 'application/json',
+              'Idempotency-Key': ?idempotencyKey,
+            },
+            body: body == null ? null : jsonEncode(body),
+          )
+          .timeout(_requestTimeout);
+    } on StateError {
+      throw const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.authenticationRequired,
+      );
+    } on TimeoutException {
+      throw const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.network,
+        retryable: true,
+      );
+    } on IOException {
+      throw const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.network,
+        retryable: true,
+      );
+    }
+  }
+}
+
+IeltsAnswerPreparation _decodePreparation(String body) {
+  try {
+    final root = jsonDecode(body);
+    if (root is! Map<String, Object?>) {
+      throw const FormatException();
+    }
+    final questionObject = root['question'];
+    if (questionObject is! Map<String, Object?>) {
+      throw const FormatException();
+    }
+    final referenceObject = questionObject['reference'];
+    if (referenceObject is! Map<String, Object?>) {
+      throw const FormatException();
+    }
+    final status = IeltsAnswerPreparationStatus.values.byName(
+      _string(root, 'status'),
+    );
+    return IeltsAnswerPreparation(
+      id: _string(root, 'answer_preparation_id'),
+      question: IeltsAnswerQuestionReference(
+        bankId: _string(referenceObject, 'bank_id'),
+        part: _string(referenceObject, 'part'),
+        sourceId: _string(referenceObject, 'source_id'),
+        questionPosition: _integer(referenceObject, 'question_position'),
+      ),
+      personalPoints: _strings(root, 'personal_points'),
+      targetBand: _number(root, 'target_band').toDouble(),
+      status: status,
+      version: _integer(root, 'version'),
+      generationRevision: _integer(root, 'generation_revision'),
+      answer: _optionalString(root, 'answer'),
+      outline: _optionalStrings(root, 'outline'),
+      usefulExpressions: _optionalStrings(root, 'useful_expressions'),
+      speechText: _optionalString(root, 'speech_text'),
+    );
+  } on Object {
+    throw const IeltsAnswerPreparationException(
+      kind: IeltsAnswerPreparationFailureKind.invalidResponse,
+    );
+  }
+}
+
+String _string(Map<String, Object?> object, String key) {
+  final value = object[key];
+  if (value is! String || value.trim().isEmpty) {
+    throw const FormatException();
+  }
+  return value;
+}
+
+String? _optionalString(Map<String, Object?> object, String key) {
+  if (!object.containsKey(key)) {
+    return null;
+  }
+  return _string(object, key);
+}
+
+int _integer(Map<String, Object?> object, String key) {
+  final value = object[key];
+  if (value is! int || value < 0) {
+    throw const FormatException();
+  }
+  return value;
+}
+
+num _number(Map<String, Object?> object, String key) {
+  final value = object[key];
+  if (value is! num) {
+    throw const FormatException();
+  }
+  return value;
+}
+
+List<String> _strings(Map<String, Object?> object, String key) {
+  final value = object[key];
+  if (value is! List<Object?>) {
+    throw const FormatException();
+  }
+  return value
+      .map((item) {
+        if (item is! String || item.trim().isEmpty) {
+          throw const FormatException();
+        }
+        return item;
+      })
+      .toList(growable: false);
+}
+
+List<String> _optionalStrings(Map<String, Object?> object, String key) =>
+    object.containsKey(key) ? _strings(object, key) : const <String>[];
+
+IeltsAnswerPreparationException _statusFailure(int statusCode) =>
+    switch (statusCode) {
+      HttpStatus.unauthorized => const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.authenticationRequired,
+        statusCode: HttpStatus.unauthorized,
+      ),
+      HttpStatus.badRequest => const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.invalidRequest,
+        statusCode: HttpStatus.badRequest,
+      ),
+      HttpStatus.notFound => const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.notFound,
+        statusCode: HttpStatus.notFound,
+      ),
+      HttpStatus.conflict => const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.conflict,
+        statusCode: HttpStatus.conflict,
+      ),
+      HttpStatus.badGateway => const IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.generationFailed,
+        statusCode: HttpStatus.badGateway,
+        retryable: true,
+      ),
+      >= 500 => IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.server,
+        statusCode: statusCode,
+        retryable: true,
+      ),
+      _ => IeltsAnswerPreparationException(
+        kind: IeltsAnswerPreparationFailureKind.invalidResponse,
+        statusCode: statusCode,
+      ),
+    };
+
+String _newIdempotencyKey(String operation) {
+  final random = Random.secure();
+  final bytes = List<int>.generate(18, (_) => random.nextInt(256));
+  return 'ielts_${operation}_${base64Url.encode(bytes).replaceAll('=', '')}';
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_wire_client.dart';
+import 'package:speakup/features/coaching/ielts/wire_ielts_answer_preparation_client.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/review/wire_interview_report_client.dart';
@@ -144,6 +145,7 @@ ProductionAppDependencies createProductionAppDependencies({
   IdentityHttpTransport? reviewHistoryTransport,
   IdentityHttpTransport? interviewReportTransport,
   IdentityHttpTransport? ieltsSpeakingReportTransport,
+  IdentityHttpTransport? ieltsAnswerPreparationTransport,
   IdentityHttpTransport? speechFeedbackTransport,
   PracticeWireTransport? practiceTransport,
   PracticeMediaWireTransport? practiceMediaTransport,
@@ -368,6 +370,18 @@ ProductionAppDependencies createProductionAppDependencies({
         },
     transport: ieltsSpeakingReportTransport,
   );
+  final ieltsAnswerPreparationClient = WireIeltsAnswerPreparationClient(
+    baseUri: baseUri,
+    credentialProvider: () => authController.currentCredential,
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) {
+          return authController.invalidateSession(
+            expectedSessionToken: expectedSessionToken,
+            expectedGeneration: expectedGeneration,
+          );
+        },
+    transport: ieltsAnswerPreparationTransport,
+  );
   final ieltsSpeakingReportController = IeltsSpeakingReportController(
     client: ieltsSpeakingReportClient,
   );
@@ -390,6 +404,7 @@ ProductionAppDependencies createProductionAppDependencies({
   );
   final ieltsPreparationController = IeltsPreparationController(
     client: ieltsQuestionBankClient,
+    answerPreparationClient: ieltsAnswerPreparationClient,
     historyStore: const SecureIeltsPracticeHistoryStore(),
   );
   final practiceWorkspaceController = PracticeWorkspaceController(

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -7,10 +7,12 @@ import 'package:speakup/features/coaching/scene/scene_client.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 
 void main() {
   testWidgets('shows exactly the four product-level practice entries', (
@@ -299,10 +301,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('ielts-set-detail-cue-card')), findsOneWidget);
-    expect(
-      find.text('Describe a skill you would like to learn'),
-      findsOneWidget,
-    );
+    expect(find.text('Describe a skill you would like to learn'), findsWidgets);
     expect(find.text('What'), findsOneWidget);
     expect(find.text('Benefit'), findsOneWidget);
     expect(find.text('同组 Part 3 · 5 题'), findsOneWidget);
@@ -322,6 +321,118 @@ void main() {
 
     expect(selectedMode, PracticeMode.part2);
     expect(selectedSet, const IeltsPracticeSelection(topicGroupId: 'p23-001'));
+  });
+
+  testWidgets('reads an IELTS question with the configured system speaker', (
+    tester,
+  ) async {
+    final speaker = _DetailPromptSpeaker();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Do you enjoy music?', 'Do you sing?'],
+          onStart: () {},
+          promptSpeaker: speaker,
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const Key('ielts-set-detail-speak-1')).hitTestable(),
+    );
+    await tester.pump();
+
+    expect(speaker.spoken, ['Do you enjoy music?']);
+    expect(speaker.stopCalls, 1);
+    expect(
+      find.byKey(const Key('ielts-set-detail-speech-error')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('shows an example and polishes it from the experience drawer', (
+    tester,
+  ) async {
+    final client = _AnswerPreparationClient();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Do you prefer sad or happy music?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: client,
+          onStart: () {},
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tip：先直接回答，再补一个原因或小例子。'), findsOneWidget);
+    expect(find.text('示例回答'), findsOneWidget);
+    expect(find.text('播放'), findsOneWidget);
+    expect(find.text('润色'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ielts-polish-answer-1')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('ielts-polish-experience')),
+      'I listen to upbeat music on my commute.',
+    );
+    await tester.tap(find.byKey(const Key('ielts-polish-generate')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('It gives me energy on my commute.'), findsOneWidget);
+    expect(find.text('我的表达'), findsOneWidget);
+    expect(find.text('重新润色'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('reuses an existing answer when reopening a question', (
+    tester,
+  ) async {
+    final client = _AnswerPreparationClient(
+      existingAnswer: 'I already have a saved answer.',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Do you prefer sad or happy music?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: client,
+          onStart: () {},
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('I already have a saved answer.'), findsOneWidget);
+    expect(find.text('答案已在其他页面更新，请重新进入后再试。'), findsNothing);
+    expect(client.createCalls, 1);
+    expect(client.generateCalls, 0);
   });
 
   testWidgets('keeps the detail action reachable on a narrow large-text view', (
@@ -627,6 +738,138 @@ Future<void> _showModule(WidgetTester tester, Key key) async {
     await tester.pumpAndSettle();
   }
   expect(entry, findsOneWidget);
+}
+
+final class _DetailPromptSpeaker implements PracticePromptSpeaker {
+  final List<String> spoken = <String>[];
+  int stopCalls = 0;
+
+  @override
+  Future<void> speak(String text) async {
+    spoken.add(text);
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
+  _AnswerPreparationClient({this.existingAnswer});
+
+  final String? existingAnswer;
+  List<String> _personalPoints = const [];
+  int createCalls = 0;
+  int generateCalls = 0;
+
+  @override
+  Future<IeltsAnswerPreparation> create({
+    required IeltsAnswerQuestionReference question,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) async {
+    createCalls++;
+    if (existingAnswer case final answer?) {
+      return IeltsAnswerPreparation(
+        id: 'ielts_answer_00000000000000000000000000000000',
+        question: question,
+        personalPoints: const [],
+        targetBand: targetBand,
+        status: IeltsAnswerPreparationStatus.ready,
+        version: 3,
+        generationRevision: 1,
+        answer: answer,
+        outline: const ['Preference', 'Reason'],
+        usefulExpressions: const ['saved answer'],
+        speechText: answer,
+      );
+    }
+    _personalPoints = personalPoints;
+    return IeltsAnswerPreparation(
+      id: 'ielts_answer_00000000000000000000000000000000',
+      question: question,
+      personalPoints: personalPoints,
+      targetBand: targetBand,
+      status: IeltsAnswerPreparationStatus.draft,
+      version: 1,
+      generationRevision: 0,
+      answer: null,
+      outline: const [],
+      usefulExpressions: const [],
+      speechText: null,
+    );
+  }
+
+  @override
+  Future<IeltsAnswerPreparation> generate({
+    required String id,
+    required int expectedVersion,
+  }) async {
+    generateCalls++;
+    final personalized = _personalPoints.isNotEmpty;
+    final answer = personalized
+        ? 'It gives me energy on my commute.'
+        : 'I usually prefer happy music because it lifts my mood.';
+    return IeltsAnswerPreparation(
+      id: 'ielts_answer_00000000000000000000000000000000',
+      question: const IeltsAnswerQuestionReference(
+        bankId: 'bank-1',
+        part: 'PART_1',
+        sourceId: 'music',
+        questionPosition: 1,
+      ),
+      personalPoints: _personalPoints,
+      targetBand: 7,
+      status: IeltsAnswerPreparationStatus.ready,
+      version: personalized ? 5 : 3,
+      generationRevision: personalized ? 2 : 1,
+      answer: answer,
+      outline: const ['Preference', 'Reason'],
+      usefulExpressions: const ['lifts my mood'],
+      speechText: answer,
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String id,
+    required int expectedVersion,
+  }) async {}
+
+  @override
+  Future<IeltsAnswerPreparation> get(String id) => throw UnimplementedError();
+
+  @override
+  Future<IeltsAnswerPreparation> update({
+    required String id,
+    required int expectedVersion,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) async {
+    _personalPoints = personalPoints;
+    return IeltsAnswerPreparation(
+      id: id,
+      question: const IeltsAnswerQuestionReference(
+        bankId: 'bank-1',
+        part: 'PART_1',
+        sourceId: 'music',
+        questionPosition: 1,
+      ),
+      personalPoints: personalPoints,
+      targetBand: targetBand,
+      status: IeltsAnswerPreparationStatus.draft,
+      version: expectedVersion + 1,
+      generationRevision: 1,
+      answer: null,
+      outline: const [],
+      usefulExpressions: const [],
+      speechText: null,
+    );
+  }
 }
 
 final class _HubFixtureClient implements SceneClient {

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../../support/scene_fixtures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -435,6 +437,77 @@ void main() {
     expect(client.generateCalls, 0);
   });
 
+  testWidgets('keeps answer preparation limited to Part 1', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part3,
+          title: 'Watches',
+          subtitle: 'Part 3',
+          questions: const ['Why do people wear expensive watches?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_3',
+              sourceId: 'watches',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: _AnswerPreparationClient(),
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-set-detail-expand-1')), findsNothing);
+    expect(find.byKey(const Key('ielts-answer-panel-1')), findsNothing);
+  });
+
+  testWidgets('tracks answer loading independently for each question', (
+    tester,
+  ) async {
+    final client = _DelayedAnswerPreparationClient();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Question one?', 'Question two?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 2,
+            ),
+          ],
+          answerPreparationClient: client,
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-set-detail-expand-2')));
+    await tester.pump();
+
+    client.complete(1);
+    await tester.pump();
+    expect(find.text('正在准备表达…'), findsOneWidget);
+
+    client.complete(2);
+    await tester.pump();
+    expect(find.text('Example for question 2.'), findsOneWidget);
+    expect(find.text('正在准备表达…'), findsNothing);
+  });
+
   testWidgets('keeps the detail action reachable on a narrow large-text view', (
     tester,
   ) async {
@@ -870,6 +943,67 @@ final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
       speechText: null,
     );
   }
+}
+
+final class _DelayedAnswerPreparationClient
+    implements IeltsAnswerPreparationClient {
+  final Map<int, Completer<IeltsAnswerPreparation>> _creates = {};
+
+  void complete(int position) {
+    final question = IeltsAnswerQuestionReference(
+      bankId: 'bank-1',
+      part: 'PART_1',
+      sourceId: 'music',
+      questionPosition: position,
+    );
+    _creates[position]!.complete(
+      IeltsAnswerPreparation(
+        id: 'ielts_answer_$position',
+        question: question,
+        personalPoints: const [],
+        targetBand: 7,
+        status: IeltsAnswerPreparationStatus.ready,
+        version: 1,
+        generationRevision: 1,
+        answer: 'Example for question $position.',
+        outline: const [],
+        usefulExpressions: const [],
+        speechText: 'Example for question $position.',
+      ),
+    );
+  }
+
+  @override
+  Future<IeltsAnswerPreparation> create({
+    required IeltsAnswerQuestionReference question,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) {
+    final completer = Completer<IeltsAnswerPreparation>();
+    _creates[question.questionPosition] = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<void> delete({required String id, required int expectedVersion}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<IeltsAnswerPreparation> generate({
+    required String id,
+    required int expectedVersion,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<IeltsAnswerPreparation> get(String id) => throw UnimplementedError();
+
+  @override
+  Future<IeltsAnswerPreparation> update({
+    required String id,
+    required int expectedVersion,
+    required List<String> personalPoints,
+    required double targetBand,
+  }) => throw UnimplementedError();
 }
 
 final class _HubFixtureClient implements SceneClient {

--- a/mobile/test/coaching/preparation/wire_ielts_answer_preparation_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_ielts_answer_preparation_client_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
+import 'package:speakup/features/coaching/ielts/wire_ielts_answer_preparation_client.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+
+void main() {
+  test('creates and decodes an IELTS answer preparation', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.created, _preparationJson(status: 'ready')),
+    ]);
+    final client = _client(transport);
+
+    final preparation = await client.create(
+      question: _question,
+      personalPoints: const <String>['I listen on my commute.'],
+      targetBand: 7,
+    );
+
+    expect(preparation.status, IeltsAnswerPreparationStatus.ready);
+    expect(
+      preparation.answer,
+      'I prefer happy music because it lifts my mood.',
+    );
+    expect(preparation.question.sourceId, 'music');
+    expect(transport.calls, hasLength(1));
+    final call = transport.calls.single;
+    expect(call.method, 'POST');
+    expect(call.uri.path, '/v1/ielts-speaking/answer-preparations');
+    expect(
+      call.headers[HttpHeaders.authorizationHeader],
+      'Bearer sess_account-a',
+    );
+    expect(call.headers['Idempotency-Key'], startsWith('ielts_create_'));
+    expect(jsonDecode(call.body!), <String, Object?>{
+      'question': _question.toJson(),
+      'personal_points': <String>['I listen on my commute.'],
+      'target_band': 7.0,
+    });
+  });
+
+  test('updates, generates, and deletes with explicit versions', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.ok, _preparationJson(status: 'draft', version: 2)),
+      _response(HttpStatus.ok, _preparationJson(status: 'ready', version: 3)),
+      const IdentityHttpResponse(statusCode: HttpStatus.noContent, body: ''),
+    ]);
+    final client = _client(transport);
+
+    final draft = await client.update(
+      id: _preparationId,
+      expectedVersion: 1,
+      personalPoints: const <String>['I listen while commuting.'],
+      targetBand: 7,
+    );
+    final ready = await client.generate(
+      id: draft.id,
+      expectedVersion: draft.version,
+    );
+    await client.delete(id: ready.id, expectedVersion: ready.version);
+
+    expect(transport.calls.map((call) => call.method), <String>[
+      'PATCH',
+      'POST',
+      'DELETE',
+    ]);
+    expect(
+      transport.calls[0].uri.path,
+      '/v1/ielts-speaking/answer-preparations/$_preparationId',
+    );
+    expect(jsonDecode(transport.calls[0].body!), <String, Object?>{
+      'expected_version': 1,
+      'personal_points': <String>['I listen while commuting.'],
+      'target_band': 7.0,
+    });
+    expect(
+      transport.calls[1].uri.path,
+      '/v1/ielts-speaking/answer-preparations/$_preparationId/generations',
+    );
+    expect(jsonDecode(transport.calls[1].body!), <String, Object?>{
+      'expected_version': 2,
+    });
+    expect(transport.calls[2].uri.queryParameters, <String, String>{
+      'expected_version': '3',
+    });
+    for (final call in transport.calls) {
+      expect(call.headers['Idempotency-Key'], isNotEmpty);
+    }
+  });
+
+  test('maps conflicts and rejects malformed responses', () async {
+    final conflictClient = _client(
+      _QueueTransport(<IdentityHttpResponse>[
+        const IdentityHttpResponse(statusCode: HttpStatus.conflict, body: '{}'),
+      ]),
+    );
+
+    await expectLater(
+      conflictClient.create(
+        question: _question,
+        personalPoints: const <String>[],
+        targetBand: 7,
+      ),
+      throwsA(
+        isA<IeltsAnswerPreparationException>().having(
+          (error) => error.kind,
+          'kind',
+          IeltsAnswerPreparationFailureKind.conflict,
+        ),
+      ),
+    );
+
+    final invalidClient = _client(
+      _QueueTransport(<IdentityHttpResponse>[
+        _response(HttpStatus.created, <String, Object?>{'status': 'draft'}),
+      ]),
+    );
+    await expectLater(
+      invalidClient.create(
+        question: _question,
+        personalPoints: const <String>[],
+        targetBand: 7,
+      ),
+      throwsA(
+        isA<IeltsAnswerPreparationException>().having(
+          (error) => error.kind,
+          'kind',
+          IeltsAnswerPreparationFailureKind.invalidResponse,
+        ),
+      ),
+    );
+  });
+}
+
+WireIeltsAnswerPreparationClient _client(IdentityHttpTransport transport) {
+  const credential = AuthSessionCredential(
+    sessionToken: 'sess_account-a',
+    generation: 1,
+  );
+  return WireIeltsAnswerPreparationClient(
+    baseUri: Uri.parse('https://api.speak-up.top'),
+    credentialProvider: () => credential,
+    invalidateSession:
+        ({required expectedSessionToken, required expectedGeneration}) async {},
+    transport: transport,
+  );
+}
+
+Map<String, Object?> _preparationJson({
+  required String status,
+  int version = 1,
+}) => <String, Object?>{
+  'answer_preparation_id': _preparationId,
+  'question': <String, Object?>{'reference': _question.toJson()},
+  'personal_points': <String>[],
+  'target_band': 7,
+  'status': status,
+  'version': version,
+  'generation_revision': status == 'ready' ? 1 : 0,
+  if (status == 'ready') ...<String, Object?>{
+    'answer': 'I prefer happy music because it lifts my mood.',
+    'outline': <String>['Preference', 'Reason'],
+    'useful_expressions': <String>['lifts my mood'],
+    'speech_text': 'I prefer happy music because it lifts my mood.',
+  },
+};
+
+IdentityHttpResponse _response(int status, Map<String, Object?> body) =>
+    IdentityHttpResponse(statusCode: status, body: jsonEncode(body));
+
+final class _Call {
+  const _Call({
+    required this.method,
+    required this.uri,
+    required this.headers,
+    this.body,
+  });
+
+  final String method;
+  final Uri uri;
+  final Map<String, String> headers;
+  final String? body;
+}
+
+final class _QueueTransport implements IdentityHttpTransport {
+  _QueueTransport(this.responses);
+
+  final List<IdentityHttpResponse> responses;
+  final List<_Call> calls = <_Call>[];
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    calls.add(
+      _Call(
+        method: method,
+        uri: uri,
+        headers: Map<String, String>.of(headers),
+        body: body,
+      ),
+    );
+    return responses.removeAt(0);
+  }
+}
+
+const _preparationId = 'ielts_answer_00000000000000000000000000000000';
+const _question = IeltsAnswerQuestionReference(
+  bankId: 'bank-1',
+  part: 'PART_1',
+  sourceId: 'music',
+  questionPosition: 1,
+);


### PR DESCRIPTION
## 功能描述

IELTS Part 1 题组详情支持逐题准备答案：题目朗读、展开示例、简洁 Tip、答案播放，以及通过个人经历抽屉生成个性化表达。

## 实现思路

- 为答案准备 API 增加严格 Wire Client 与移动端模型。
- IeltsPreparationController 注入答案准备客户端，并为题目传递稳定引用。
- Part 1 首题自动加载示例，其余题目按展开状态加载。
- 复用系统题目朗读能力；答案区提供播放、润色与重新润色状态。
- 保留 Part 2/3 和开始整组练习的原有流程。

## 可复现测试

1. 运行：cd mobile && flutter analyze
2. 运行：cd mobile && flutter test test/coaching/preparation/preparation_hub_test.dart test/coaching/preparation/wire_ielts_answer_preparation_client_test.dart test/main_wiring_test.dart
3. 从最新 dev 启动真实本地后端与 iOS 模拟器。
4. 进入训练 → IELTS → 任一 Part 1 题组。
5. 确认首题展示 Tip、英文示例、播放与润色入口；其他题可展开加载。
6. 输入个人经历生成表达，再次进入仍能读取已有答案。

本地结果：flutter analyze 通过；相关 Flutter 测试 26 项全部通过；iOS 模拟器已由用户实际操作确认。

## 依赖

- 依赖后端重复创建修复 #537。

## 关联 Issue

Closes #535