### PR TITLE
fix(mobile): 微调统一数字人练习舞台

### DIFF
--- a/mobile/lib/features/coaching/practice/practice_stage.dart
+++ b/mobile/lib/features/coaching/practice/practice_stage.dart
@@ -3,8 +3,8 @@ import 'package:speakup/design/speak_up_design.dart';
 
 /// Responsive shell shared by avatar-led practice experiences.
 ///
-/// The avatar occupies the leading 44% of the available space: above the
-/// content in portrait and to its left in landscape.
+/// The avatar occupies 34% of the available height in portrait and the
+/// leading 44% of the available width in landscape.
 class PracticeStageLayout extends StatelessWidget {
   const PracticeStageLayout({
     required this.avatar,
@@ -38,7 +38,7 @@ class PracticeStageLayout extends StatelessWidget {
           children: [
             SizedBox(
               key: avatarRegionKey,
-              height: constraints.maxHeight * 0.44,
+              height: constraints.maxHeight * 0.34,
               child: avatar,
             ),
             Expanded(child: content),
@@ -57,12 +57,9 @@ class PracticeAvatarStage extends StatelessWidget {
     required this.onExit,
     this.surfaceBuilder,
     this.statusLabel,
-    this.subtitle,
     this.exitInFlight = false,
     this.exitButtonKey,
     this.statusKey,
-    this.subtitleKey,
-    this.subtitleTextKey,
     super.key,
   });
 
@@ -71,12 +68,9 @@ class PracticeAvatarStage extends StatelessWidget {
   final VoidCallback onExit;
   final WidgetBuilder? surfaceBuilder;
   final String? statusLabel;
-  final String? subtitle;
   final bool exitInFlight;
   final Key? exitButtonKey;
   final Key? statusKey;
-  final Key? subtitleKey;
-  final Key? subtitleTextKey;
 
   @override
   Widget build(BuildContext context) {
@@ -174,36 +168,6 @@ class PracticeAvatarStage extends StatelessWidget {
               ],
             ),
           ),
-          if (subtitle case final text?)
-            Positioned(
-              left: 16,
-              right: 16,
-              bottom: 14,
-              child: Container(
-                key: subtitleKey,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 15,
-                  vertical: 11,
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.58),
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Text(
-                  text,
-                  key: subtitleTextKey,
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 15,
-                    height: 1.35,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ),
-            ),
         ],
       ),
     );

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
@@ -27,7 +26,7 @@ class ScenarioPracticePage extends StatefulWidget {
   const ScenarioPracticePage({
     required this.practiceController,
     this.avatarSurfaceBuilder,
-    this.avatarStatusLabel = '正在准备画面',
+    this.avatarStatusLabel,
     this.onBeforeStartRecording,
     this.onBeforeSubmitText,
     this.onReplayQuestion,
@@ -472,18 +471,9 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                         ? null
                         : widget.avatarSurfaceBuilder,
                     statusLabel: widget.avatarStatusLabel,
-                    subtitle:
-                        widget.practiceController.practiceExperience ==
-                            PracticeExperience.interview
-                        ? null
-                        : _latestAssistantMessage(
-                            widget.practiceController.practiceMessages,
-                          )?.text,
                     exitInFlight: _exitInFlight,
                     exitButtonKey: const Key('scenario-exit'),
                     statusKey: const Key('scenario-avatar-status'),
-                    subtitleKey: const Key('scenario-live-subtitle'),
-                    subtitleTextKey: const Key('scenario-live-subtitle-text'),
                     onExit: _requestExit,
                   ),
                   content: _ConversationPanel(
@@ -1048,15 +1038,6 @@ String _scenarioFeedbackSourceKey(
   PracticeController controller,
   PracticeMessage message,
 ) => 'practice:${controller.practiceSessionId}:${message.id}';
-
-PracticeMessage? _latestAssistantMessage(List<PracticeMessage> messages) {
-  for (final message in messages.reversed) {
-    if (message.role == PracticeMessageRole.assistant) {
-      return message;
-    }
-  }
-  return null;
-}
 
 bool _canTriggerScenarioReplay(PracticeController controller) {
   if (controller.isBusy) {

--- a/mobile/test/coaching/practice/practice_stage_test.dart
+++ b/mobile/test/coaching/practice/practice_stage_test.dart
@@ -30,7 +30,7 @@ void main() {
     expect(find.byKey(const Key('custom-content')), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const Key('avatar-region'))).height,
-      closeTo(844 * 0.44, 0.1),
+      closeTo(844 * 0.34, 0.1),
     );
 
     await pumpAt(const Size(844, 390));
@@ -41,7 +41,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('avatar stage accepts a surface and shared chrome content', (
+  testWidgets('avatar stage accepts a surface and shared chrome', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -55,10 +55,8 @@ void main() {
           surfaceBuilder: (_) =>
               const ColoredBox(key: Key('custom-surface'), color: Colors.green),
           statusLabel: 'Connected',
-          subtitle: 'Try answering in one complete sentence.',
           exitButtonKey: const Key('custom-exit'),
           statusKey: const Key('custom-status'),
-          subtitleKey: const Key('custom-subtitle'),
           onExit: () {},
         ),
       ),
@@ -68,13 +66,8 @@ void main() {
     expect(find.byKey(const Key('custom-fallback')), findsNothing);
     expect(find.text('Custom practice'), findsOneWidget);
     expect(find.text('Connected'), findsOneWidget);
-    expect(
-      find.text('Try answering in one complete sentence.'),
-      findsOneWidget,
-    );
     expect(find.byKey(const Key('custom-exit')), findsOneWidget);
     expect(find.byKey(const Key('custom-status')), findsOneWidget);
-    expect(find.byKey(const Key('custom-subtitle')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 }

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -379,6 +379,35 @@ void main() {
     expect(find.byKey(const Key('practice-page')), findsNothing);
   });
 
+  testWidgets('routes a scenario to the static avatar without loading status', (
+    tester,
+  ) async {
+    final practiceController = await _scenarioPracticeController();
+    addTearDown(practiceController.dispose);
+
+    await tester.pumpWidget(
+      SpeakUpApp.preview(practiceController: practiceController),
+    );
+    await tester.pumpAndSettle();
+
+    Navigator.of(
+      tester.element(find.byType(SpeakUpShell)),
+    ).pushNamed(AppRoutes.practice);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('scenario-practice-page')), findsOneWidget);
+    expect(
+      find.byKey(const Key('scenario-avatar-placeholder')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('scenario-avatar-status')), findsNothing);
+    expect(find.text('正在准备画面'), findsNothing);
+    expect(
+      find.byKey(const Key('scenario-record')).hitTestable(),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('routes interview practice through avatar with Tips', (
     tester,
   ) async {

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -47,14 +47,14 @@ void main() {
     expect(find.byKey(const Key('scenario-practice-page')), findsOneWidget);
     expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
     expect(find.text('画面已连接'), findsOneWidget);
-    expect(find.byKey(const Key('scenario-live-subtitle')), findsOneWidget);
+    expect(find.byKey(const Key('scenario-live-subtitle')), findsNothing);
     expect(
       find.byKey(const Key('scenario-toggle-conversation-text')),
       findsNothing,
     );
     expect(
       tester.getSize(find.byKey(const Key('scenario-avatar-region'))).height,
-      closeTo(844 * 0.44, 0.1),
+      closeTo(844 * 0.34, 0.1),
     );
     expect(find.byKey(const Key('scenario-conversation-history')), findsOne);
     expect(find.textContaining('评分'), findsNothing);
@@ -62,9 +62,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('keeps scenario text and avatar subtitle visible', (
-    tester,
-  ) async {
+  testWidgets('keeps scenario text in the conversation panel', (tester) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
@@ -82,7 +80,9 @@ void main() {
       find.byKey(const Key('scenario-toggle-conversation-text')),
       findsNothing,
     );
-    expect(find.byKey(const Key('scenario-live-subtitle')), findsOneWidget);
+    expect(find.byKey(const Key('scenario-live-subtitle')), findsNothing);
+    expect(find.byKey(const Key('scenario-avatar-status')), findsNothing);
+    expect(find.text('正在准备画面'), findsNothing);
     final staticAvatar = tester.widget<Image>(
       find.byKey(const Key('scenario-avatar-placeholder')),
     );
@@ -91,7 +91,7 @@ void main() {
       (staticAvatar.image as AssetImage).assetName,
       'assets/images/scenes/static-avatar-van-gogh.jpg',
     );
-    expect(find.text(question), findsNWidgets(2));
+    expect(find.text(question), findsOneWidget);
     final messageBubble = find.byKey(
       Key('practice-message-${questionMessage.id}'),
     );


### PR DESCRIPTION
## 功能描述
- 竖屏数字人区域由 44%% 调整为 34%%，横屏继续保持 44%%。
- 删除数字人画面内与对话区重复的字幕。
- 模拟器静态头像降级路径不再永久显示“正在准备画面”。

## 实现思路
- 继续复用 #534 抽取的 PracticeStageLayout 与 PracticeAvatarStage。
- 删除共享舞台不再使用的 subtitle 参数和场景页旧辅助方法。
- 实时数字人状态仍由 ScenarioPracticeSession 状态机控制；静态 fallback 不伪装连接状态。

## 可复现测试
1. cd mobile && flutter analyze
2. cd mobile && flutter test test/coaching/practice/practice_stage_test.dart test/coaching/practice/scenario_practice_test.dart test/coaching/practice/scenario_practice_session_test.dart test/coaching/preparation/practice_lifecycle_flow_test.dart
3. make dev-ios-simulator
4. 进入任意场景练习，确认静态头像无常驻准备状态、画面无重复字幕、对话区仍展示题目。

## 本地结果
- Flutter analyze 通过。
- 相关 31 项测试通过。
- 已从最新 upstream/dev 使用真实后端、模拟器禁用数字人的配置启动验证。

Closes #539