### PR TITLE
feat(practice): 支持实时语音转写候选答案

### DIFF
--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -1682,9 +1682,29 @@ func (adapter practiceVoiceRecognizerAdapter) Transcribe(
 
 func (adapter practiceVoiceRecognizerAdapter) TranscribeStream(
 	ctx context.Context,
-	request practicevoice.TranscriptionRequest,
+	request practicevoice.StreamingTranscriptionRequest,
 	observer practicevoice.TranscriptionObserver,
 ) (practicevoice.TranscriptionResult, error) {
+	if request.PCM == nil || request.SampleRate != 16_000 {
+		return practicevoice.TranscriptionResult{}, errors.New(
+			"streaming test PCM is required",
+		)
+	}
+	if _, err := io.Copy(
+		io.Discard,
+		io.LimitReader(request.PCM, platformmedia.MaxAudioBytes),
+	); err != nil {
+		return practicevoice.TranscriptionResult{}, err
+	}
+	audio, err := platformmedia.CaptureTemporaryAudio(
+		"",
+		platformmedia.ContentTypeWAV,
+		bytes.NewReader(testWAV()),
+	)
+	if err != nil {
+		return practicevoice.TranscriptionResult{}, err
+	}
+	defer audio.Close()
 	recognizer, ok := adapter.recognizer.(agentvoice.StreamingSpeechRecognizer)
 	if !ok {
 		return practicevoice.TranscriptionResult{}, errors.New(
@@ -1693,7 +1713,7 @@ func (adapter practiceVoiceRecognizerAdapter) TranscribeStream(
 	}
 	result, err := recognizer.TranscribeStream(
 		ctx,
-		agentvoice.TranscriptionRequest{Audio: request.Audio},
+		agentvoice.TranscriptionRequest{Audio: audio},
 		practiceVoiceTranscriptionObserverAdapter{observer: observer},
 	)
 	return practicevoice.TranscriptionResult{

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -1680,6 +1680,47 @@ func (adapter practiceVoiceRecognizerAdapter) Transcribe(
 	}, err
 }
 
+func (adapter practiceVoiceRecognizerAdapter) TranscribeStream(
+	ctx context.Context,
+	request practicevoice.TranscriptionRequest,
+	observer practicevoice.TranscriptionObserver,
+) (practicevoice.TranscriptionResult, error) {
+	recognizer, ok := adapter.recognizer.(agentvoice.StreamingSpeechRecognizer)
+	if !ok {
+		return practicevoice.TranscriptionResult{}, errors.New(
+			"streaming test recognizer is required",
+		)
+	}
+	result, err := recognizer.TranscribeStream(
+		ctx,
+		agentvoice.TranscriptionRequest{Audio: request.Audio},
+		practiceVoiceTranscriptionObserverAdapter{observer: observer},
+	)
+	return practicevoice.TranscriptionResult{
+		ID:         result.ID,
+		Provider:   result.Provider,
+		Model:      result.Model,
+		Transcript: result.Transcript,
+	}, err
+}
+
+type practiceVoiceTranscriptionObserverAdapter struct {
+	observer practicevoice.TranscriptionObserver
+}
+
+func (adapter practiceVoiceTranscriptionObserverAdapter) OnTranscriptionUpdate(
+	ctx context.Context,
+	update agentvoice.TranscriptionUpdate,
+) error {
+	return adapter.observer.OnTranscriptionUpdate(
+		ctx,
+		practicevoice.TranscriptionUpdate{
+			Transcript: update.Transcript,
+			Final:      update.Final,
+		},
+	)
+}
+
 type practiceVoiceSynthesizerAdapter struct {
 	synthesizer agentvoice.SpeechSynthesizer
 }

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -1,6 +1,7 @@
 package voicehttp
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -20,6 +21,58 @@ import (
 
 const defaultReadTimeout = 15 * time.Second
 
+type Application interface {
+	Start(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		string,
+	) (practicevoice.SessionState, error)
+	Resume(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (practicevoice.SessionState, error)
+	Transcribe(
+		context.Context,
+		requestcontext.Actor,
+		practicevoice.TranscribeVoiceCommand,
+	) (practicevoice.TranscriptionCandidate, error)
+	TranscribeStream(
+		context.Context,
+		requestcontext.Actor,
+		practicevoice.TranscribeVoiceCommand,
+		practicevoice.TranscriptionObserver,
+	) (practicevoice.TranscriptionCandidate, error)
+	SubmitText(
+		context.Context,
+		requestcontext.Actor,
+		practicevoice.SubmitTextAnswerCommand,
+	) (practicevoice.SessionState, error)
+	Confirm(
+		context.Context,
+		requestcontext.Actor,
+		practicevoice.ConfirmVoiceTurnCommand,
+	) (practicevoice.SessionState, error)
+	QuestionSpeech(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (practicevoice.QuestionSpeech, error)
+	QuestionTranslation(
+		context.Context,
+		requestcontext.Actor,
+		string,
+	) (practicevoice.QuestionTranslation, error)
+	EnsureQuestionTip(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		string,
+		string,
+	) (practicevoice.QuestionTipResult, error)
+}
+
 type Options struct {
 	AudioReadTimeout  time.Duration
 	SameQuestionRetry *practicevoice.SameQuestionRetryApplication
@@ -27,7 +80,7 @@ type Options struct {
 }
 
 type Handler struct {
-	application *practicevoice.SessionApplication
+	application Application
 	retry       *practicevoice.SameQuestionRetryApplication
 	audioAssets AudioAssetHTTPService
 	readTimeout time.Duration
@@ -35,7 +88,7 @@ type Handler struct {
 }
 
 func NewHandler(
-	application *practicevoice.SessionApplication,
+	application Application,
 	options Options,
 	errorRenderer *httpresponse.Renderer,
 ) (*Handler, error) {
@@ -69,6 +122,10 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 	routes.POST(
 		"/v1/voice-practice-sessions/:practice_session_id/questions/:question_id/transcription-candidates",
 		handler.transcribeCandidate,
+	)
+	routes.GET(
+		"/v1/voice-practice-sessions/:practice_session_id/questions/:question_id/transcription-candidates/realtime",
+		handler.transcribeCandidateRealtime,
 	)
 	routes.POST(
 		"/v1/voice-practice-sessions/:practice_session_id/questions/:question_id/text-answers",

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -41,7 +41,7 @@ type Application interface {
 	TranscribeStream(
 		context.Context,
 		requestcontext.Actor,
-		practicevoice.TranscribeVoiceCommand,
+		practicevoice.TranscribeVoiceStreamCommand,
 		practicevoice.TranscriptionObserver,
 	) (practicevoice.TranscriptionCandidate, error)
 	SubmitText(

--- a/server/internal/coaching/practice/voice/http/realtime.go
+++ b/server/internal/coaching/practice/voice/http/realtime.go
@@ -3,9 +3,9 @@ package voicehttp
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"time"
 
@@ -79,40 +79,58 @@ func (handler *Handler) transcribeCandidateRealtime(c *gin.Context) {
 		writePracticeRealtimeFailure(connection, "invalid_request", false)
 		return
 	}
-	pcm, err := readPracticeRealtimePCM(connection, handler.readTimeout)
-	if err != nil {
-		writePracticeRealtimeFailure(connection, "stream_interrupted", true)
-		return
-	}
-	wav, err := practicePCM16MonoWAV(pcm, start.SampleRate)
-	if err != nil {
-		writePracticeRealtimeFailure(connection, "invalid_audio", false)
-		return
-	}
 	observer := &practiceRealtimeTranscriptionWriter{connection: connection}
 	if err := observer.write("transcription.started", gin.H{}); err != nil {
 		return
 	}
-	candidate, err := handler.application.TranscribeStream(
-		c.Request.Context(),
-		actor,
-		practicevoice.TranscribeVoiceCommand{
-			SessionID:      sessionID,
-			QuestionID:     questionID,
-			IdempotencyKey: start.IdempotencyKey,
-			ContentType:    platformmedia.ContentTypeWAV,
-			Audio:          bytes.NewReader(wav),
-		},
-		observer,
+	streamContext, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+	reader, writer := io.Pipe()
+	type transcriptionResult struct {
+		candidate practicevoice.TranscriptionCandidate
+		err       error
+	}
+	result := make(chan transcriptionResult, 1)
+	go func() {
+		defer reader.Close()
+		candidate, transcribeErr := handler.application.TranscribeStream(
+			streamContext,
+			actor,
+			practicevoice.TranscribeVoiceStreamCommand{
+				SessionID:      sessionID,
+				QuestionID:     questionID,
+				IdempotencyKey: start.IdempotencyKey,
+				PCM:            reader,
+				SampleRate:     start.SampleRate,
+			},
+			observer,
+		)
+		result <- transcriptionResult{candidate: candidate, err: transcribeErr}
+	}()
+	streamErr := streamPracticeRealtimePCM(
+		connection,
+		writer,
+		handler.readTimeout,
 	)
-	if err != nil {
-		kind, retryable := practiceRealtimeFailure(err)
+	if streamErr != nil {
+		cancel()
+		_ = writer.CloseWithError(streamErr)
+	} else {
+		_ = writer.Close()
+	}
+	completed := <-result
+	if completed.err != nil {
+		kind, retryable := practiceRealtimeFailure(completed.err)
 		writePracticeRealtimeFailure(connection, kind, retryable)
+		return
+	}
+	if streamErr != nil {
+		writePracticeRealtimeFailure(connection, "stream_interrupted", true)
 		return
 	}
 	_ = observer.write(
 		"candidate.ready",
-		gin.H{"candidate": TranscriptionCandidateResponse(candidate)},
+		gin.H{"candidate": TranscriptionCandidateResponse(completed.candidate)},
 	)
 }
 
@@ -137,76 +155,60 @@ func readPracticeRealtimeStart(
 	return frame, nil
 }
 
-func readPracticeRealtimePCM(
+func streamPracticeRealtimePCM(
 	connection *websocket.Conn,
+	destination io.Writer,
 	readTimeout time.Duration,
-) ([]byte, error) {
-	var pcm bytes.Buffer
+) error {
+	written := 0
 	for {
 		if err := connection.SetReadDeadline(
 			time.Now().Add(readTimeout),
 		); err != nil {
-			return nil, err
+			return err
 		}
 		messageType, payload, err := connection.ReadMessage()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		switch messageType {
 		case websocket.BinaryMessage:
 			if len(payload) == 0 ||
-				pcm.Len()+len(payload) > maxPracticeRealtimePCMBytes {
-				return nil,
-					errors.New("practice voice realtime audio exceeds the accepted size")
+				written+len(payload) > maxPracticeRealtimePCMBytes {
+				return errors.New(
+					"practice voice realtime audio exceeds the accepted size",
+				)
 			}
-			_, _ = pcm.Write(payload)
+			if _, err := destination.Write(payload); err != nil {
+				return err
+			}
+			written += len(payload)
 		case websocket.TextMessage:
 			var frame practiceRealtimeControlFrame
 			decoder := json.NewDecoder(bytes.NewReader(payload))
 			decoder.DisallowUnknownFields()
 			if err := decoder.Decode(&frame); err != nil {
-				return nil, err
+				return err
 			}
 			switch frame.Type {
 			case "finish":
-				if pcm.Len() == 0 || pcm.Len()%2 != 0 {
-					return nil,
-						errors.New("practice voice realtime audio is incomplete")
+				if written == 0 || written%2 != 0 {
+					return errors.New(
+						"practice voice realtime audio is incomplete",
+					)
 				}
-				return pcm.Bytes(), nil
+				return nil
 			case "cancel":
-				return nil, context.Canceled
+				return context.Canceled
 			default:
-				return nil,
-					errors.New("practice voice realtime control frame is invalid")
+				return errors.New(
+					"practice voice realtime control frame is invalid",
+				)
 			}
 		default:
-			return nil,
-				errors.New("practice voice realtime frame type is invalid")
+			return errors.New("practice voice realtime frame type is invalid")
 		}
 	}
-}
-
-func practicePCM16MonoWAV(pcm []byte, sampleRate int) ([]byte, error) {
-	if len(pcm) == 0 || len(pcm)%2 != 0 || sampleRate != 16_000 {
-		return nil, errors.New("practice voice realtime PCM is invalid")
-	}
-	result := make([]byte, 44+len(pcm))
-	copy(result[0:4], "RIFF")
-	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
-	copy(result[8:12], "WAVE")
-	copy(result[12:16], "fmt ")
-	binary.LittleEndian.PutUint32(result[16:20], 16)
-	binary.LittleEndian.PutUint16(result[20:22], 1)
-	binary.LittleEndian.PutUint16(result[22:24], 1)
-	binary.LittleEndian.PutUint32(result[24:28], uint32(sampleRate))
-	binary.LittleEndian.PutUint32(result[28:32], uint32(sampleRate*2))
-	binary.LittleEndian.PutUint16(result[32:34], 2)
-	binary.LittleEndian.PutUint16(result[34:36], 16)
-	copy(result[36:40], "data")
-	binary.LittleEndian.PutUint32(result[40:44], uint32(len(pcm)))
-	copy(result[44:], pcm)
-	return result, nil
 }
 
 type practiceRealtimeTranscriptionWriter struct {

--- a/server/internal/coaching/practice/voice/http/realtime.go
+++ b/server/internal/coaching/practice/voice/http/realtime.go
@@ -17,7 +17,10 @@ import (
 )
 
 const practiceVoiceInputWebSocketProtocol = "speakup.voice-input.v1"
-const maxPracticeRealtimePCMBytes = 16_000 * 2 * 120
+
+// This is a transport-capacity boundary, not an IELTS answer timer. The
+// Practice flow owns any exam-specific timing and stops capture accordingly.
+const maxPracticeRealtimePCMBytes = int(platformmedia.MaxAudioBytes) - 44
 
 type practiceRealtimeStartFrame struct {
 	Type           string `json:"type"`

--- a/server/internal/coaching/practice/voice/http/realtime.go
+++ b/server/internal/coaching/practice/voice/http/realtime.go
@@ -1,0 +1,275 @@
+package voicehttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const practiceVoiceInputWebSocketProtocol = "speakup.voice-input.v1"
+const maxPracticeRealtimePCMBytes = 16_000 * 2 * 60
+
+type practiceRealtimeStartFrame struct {
+	Type           string `json:"type"`
+	IdempotencyKey string `json:"idempotency_key"`
+	SampleRate     int    `json:"sample_rate"`
+}
+
+type practiceRealtimeControlFrame struct {
+	Type string `json:"type"`
+}
+
+func (handler *Handler) transcribeCandidateRealtime(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	sessionID := c.Param("practice_session_id")
+	questionID := c.Param("question_id")
+	state, err := handler.application.Resume(
+		c.Request.Context(),
+		actor,
+		sessionID,
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	if state.Session.ID != sessionID || state.Question == nil ||
+		state.Question.ID != questionID {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	if !containsPracticeWebSocketProtocol(
+		websocket.Subprotocols(c.Request),
+		practiceVoiceInputWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := (&websocket.Upgrader{
+		Subprotocols: []string{practiceVoiceInputWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	connection.SetReadLimit(platformmedia.MaxAudioBytes)
+	if err := connection.SetReadDeadline(
+		time.Now().Add(handler.readTimeout),
+	); err != nil {
+		return
+	}
+	start, err := readPracticeRealtimeStart(connection)
+	if err != nil {
+		writePracticeRealtimeFailure(connection, "invalid_request", false)
+		return
+	}
+	pcm, err := readPracticeRealtimePCM(connection, handler.readTimeout)
+	if err != nil {
+		writePracticeRealtimeFailure(connection, "stream_interrupted", true)
+		return
+	}
+	wav, err := practicePCM16MonoWAV(pcm, start.SampleRate)
+	if err != nil {
+		writePracticeRealtimeFailure(connection, "invalid_audio", false)
+		return
+	}
+	observer := &practiceRealtimeTranscriptionWriter{connection: connection}
+	if err := observer.write("transcription.started", gin.H{}); err != nil {
+		return
+	}
+	candidate, err := handler.application.TranscribeStream(
+		c.Request.Context(),
+		actor,
+		practicevoice.TranscribeVoiceCommand{
+			SessionID:      sessionID,
+			QuestionID:     questionID,
+			IdempotencyKey: start.IdempotencyKey,
+			ContentType:    platformmedia.ContentTypeWAV,
+			Audio:          bytes.NewReader(wav),
+		},
+		observer,
+	)
+	if err != nil {
+		kind, retryable := practiceRealtimeFailure(err)
+		writePracticeRealtimeFailure(connection, kind, retryable)
+		return
+	}
+	_ = observer.write(
+		"candidate.ready",
+		gin.H{"candidate": TranscriptionCandidateResponse(candidate)},
+	)
+}
+
+func readPracticeRealtimeStart(
+	connection *websocket.Conn,
+) (practiceRealtimeStartFrame, error) {
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage {
+		return practiceRealtimeStartFrame{},
+			errors.New("practice voice realtime start frame is required")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var frame practiceRealtimeStartFrame
+	if err := decoder.Decode(&frame); err != nil ||
+		frame.Type != "start" ||
+		!validPracticeRealtimeIdempotencyKey(frame.IdempotencyKey) ||
+		frame.SampleRate != 16_000 {
+		return practiceRealtimeStartFrame{},
+			errors.New("practice voice realtime start frame is invalid")
+	}
+	return frame, nil
+}
+
+func readPracticeRealtimePCM(
+	connection *websocket.Conn,
+	readTimeout time.Duration,
+) ([]byte, error) {
+	var pcm bytes.Buffer
+	for {
+		if err := connection.SetReadDeadline(
+			time.Now().Add(readTimeout),
+		); err != nil {
+			return nil, err
+		}
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			return nil, err
+		}
+		switch messageType {
+		case websocket.BinaryMessage:
+			if len(payload) == 0 ||
+				pcm.Len()+len(payload) > maxPracticeRealtimePCMBytes {
+				return nil,
+					errors.New("practice voice realtime audio exceeds the accepted size")
+			}
+			_, _ = pcm.Write(payload)
+		case websocket.TextMessage:
+			var frame practiceRealtimeControlFrame
+			decoder := json.NewDecoder(bytes.NewReader(payload))
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&frame); err != nil {
+				return nil, err
+			}
+			switch frame.Type {
+			case "finish":
+				if pcm.Len() == 0 || pcm.Len()%2 != 0 {
+					return nil,
+						errors.New("practice voice realtime audio is incomplete")
+				}
+				return pcm.Bytes(), nil
+			case "cancel":
+				return nil, context.Canceled
+			default:
+				return nil,
+					errors.New("practice voice realtime control frame is invalid")
+			}
+		default:
+			return nil,
+				errors.New("practice voice realtime frame type is invalid")
+		}
+	}
+}
+
+func practicePCM16MonoWAV(pcm []byte, sampleRate int) ([]byte, error) {
+	if len(pcm) == 0 || len(pcm)%2 != 0 || sampleRate != 16_000 {
+		return nil, errors.New("practice voice realtime PCM is invalid")
+	}
+	result := make([]byte, 44+len(pcm))
+	copy(result[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
+	copy(result[8:12], "WAVE")
+	copy(result[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(result[16:20], 16)
+	binary.LittleEndian.PutUint16(result[20:22], 1)
+	binary.LittleEndian.PutUint16(result[22:24], 1)
+	binary.LittleEndian.PutUint32(result[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(result[28:32], uint32(sampleRate*2))
+	binary.LittleEndian.PutUint16(result[32:34], 2)
+	binary.LittleEndian.PutUint16(result[34:36], 16)
+	copy(result[36:40], "data")
+	binary.LittleEndian.PutUint32(result[40:44], uint32(len(pcm)))
+	copy(result[44:], pcm)
+	return result, nil
+}
+
+type practiceRealtimeTranscriptionWriter struct {
+	connection *websocket.Conn
+}
+
+func (writer *practiceRealtimeTranscriptionWriter) OnTranscriptionUpdate(
+	_ context.Context,
+	update practicevoice.TranscriptionUpdate,
+) error {
+	return writer.write("transcription.updated", gin.H{
+		"transcript": update.Transcript,
+		"final":      update.Final,
+	})
+}
+
+func (writer *practiceRealtimeTranscriptionWriter) write(
+	event string,
+	data any,
+) error {
+	return writer.connection.WriteJSON(gin.H{"type": event, "data": data})
+}
+
+func writePracticeRealtimeFailure(
+	connection *websocket.Conn,
+	kind string,
+	retryable bool,
+) {
+	_ = connection.WriteJSON(gin.H{
+		"type": "candidate.failed",
+		"data": gin.H{"kind": kind, "retryable": retryable},
+	})
+}
+
+func practiceRealtimeFailure(err error) (string, bool) {
+	var providerError *practicevoice.ProviderError
+	if errors.As(err, &providerError) {
+		return string(providerError.Kind), providerError.Retryable()
+	}
+	switch {
+	case errors.Is(err, practicevoice.ErrVoiceRoundInvalid):
+		return "invalid_audio", false
+	case errors.Is(err, practicevoice.ErrVoiceRoundCapacity):
+		return "audio_capacity", false
+	case errors.Is(err, practicevoice.ErrVoiceRoundConflict):
+		return "idempotency_conflict", false
+	case errors.Is(err, practicevoice.ErrVoiceRoundProcessing):
+		return "processing", true
+	default:
+		return "stream_interrupted", true
+	}
+}
+
+func containsPracticeWebSocketProtocol(
+	protocols []string,
+	required string,
+) bool {
+	for _, protocol := range protocols {
+		if protocol == required {
+			return true
+		}
+	}
+	return false
+}
+
+func validPracticeRealtimeIdempotencyKey(value string) bool {
+	value = strings.TrimSpace(value)
+	return len(value) >= 8 && len(value) <= 128
+}

--- a/server/internal/coaching/practice/voice/http/realtime.go
+++ b/server/internal/coaching/practice/voice/http/realtime.go
@@ -17,7 +17,7 @@ import (
 )
 
 const practiceVoiceInputWebSocketProtocol = "speakup.voice-input.v1"
-const maxPracticeRealtimePCMBytes = 16_000 * 2 * 60
+const maxPracticeRealtimePCMBytes = 16_000 * 2 * 120
 
 type practiceRealtimeStartFrame struct {
 	Type           string `json:"type"`

--- a/server/internal/coaching/practice/voice/http/realtime_test.go
+++ b/server/internal/coaching/practice/voice/http/realtime_test.go
@@ -1,0 +1,346 @@
+package voicehttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+func TestPracticeRealtimeVoiceInputUsesCurrentQuestionAndDurableCandidate(
+	t *testing.T,
+) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	question := practice.Question{
+		ID:        "question-1",
+		SessionID: "session-1",
+		Content:   "Tell me about yourself.",
+	}
+	application := &practiceRealtimeHTTPApplication{
+		state: practicevoice.SessionState{
+			Session:  practicevoice.Session{ID: "session-1"},
+			Question: &question,
+		},
+		candidate: practicevoice.TranscriptionCandidate{
+			ID:                      "candidate-1",
+			SessionID:               "session-1",
+			QuestionID:              "question-1",
+			RespondentParticipantID: "learner-1",
+			TranscriptID:            "transcript-1",
+			EvidenceVersion:         1,
+			Transcript:              "A complete practice answer.",
+			CreatedAt:               now,
+		},
+	}
+	server := httptest.NewServer(newPracticeRealtimeHTTPRouter(t, application))
+	defer server.Close()
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/voice-practice-sessions/session-1/questions/question-1/" +
+		"transcription-candidates/realtime"
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{practiceVoiceInputWebSocketProtocol},
+	}).Dial(
+		endpoint,
+		http.Header{"Authorization": []string{"Bearer voice-token-a"}},
+	)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial realtime Practice Voice: %v", err)
+	}
+	defer connection.Close()
+	if connection.Subprotocol() != practiceVoiceInputWebSocketProtocol {
+		t.Fatalf("subprotocol = %q", connection.Subprotocol())
+	}
+	if err := connection.WriteJSON(map[string]any{
+		"type":            "start",
+		"idempotency_key": "practice-voice-realtime-1",
+		"sample_rate":     16_000,
+	}); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+	if err := connection.WriteMessage(
+		websocket.BinaryMessage,
+		make([]byte, 3_200),
+	); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
+		t.Fatalf("write finish: %v", err)
+	}
+	var events []struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	for len(events) < 4 {
+		_, payload, readErr := connection.ReadMessage()
+		if readErr != nil {
+			t.Fatalf("read event %d: %v", len(events), readErr)
+		}
+		var event struct {
+			Type string          `json:"type"`
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(payload, &event); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		events = append(events, event)
+	}
+	wantTypes := []string{
+		"transcription.started",
+		"transcription.updated",
+		"transcription.updated",
+		"candidate.ready",
+	}
+	for index, want := range wantTypes {
+		if events[index].Type != want {
+			t.Fatalf("events = %#v", events)
+		}
+	}
+	var ready struct {
+		Candidate map[string]any `json:"candidate"`
+	}
+	if err := json.Unmarshal(events[3].Data, &ready); err != nil {
+		t.Fatalf("decode ready candidate: %v", err)
+	}
+	if ready.Candidate["candidate_id"] != "candidate-1" ||
+		ready.Candidate["transcript"] != "A complete practice answer." ||
+		application.streamSessionID != "session-1" ||
+		application.streamQuestionID != "question-1" ||
+		application.streamKey != "practice-voice-realtime-1" ||
+		application.streamBytes != 3_244 {
+		t.Fatalf("ready = %#v, application = %#v", ready, application)
+	}
+}
+
+func TestPracticeRealtimeVoiceInputRejectsUnauthorizedOrNonCurrentQuestion(
+	t *testing.T,
+) {
+	question := practice.Question{ID: "question-1", SessionID: "session-1"}
+	application := &practiceRealtimeHTTPApplication{
+		state: practicevoice.SessionState{
+			Session:  practicevoice.Session{ID: "session-1"},
+			Question: &question,
+		},
+	}
+	server := httptest.NewServer(newPracticeRealtimeHTTPRouter(t, application))
+	defer server.Close()
+	base := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/voice-practice-sessions/session-1/questions/"
+	for _, test := range []struct {
+		name       string
+		questionID string
+		token      string
+		wantStatus int
+	}{
+		{name: "unauthorized", questionID: "question-1", wantStatus: http.StatusUnauthorized},
+		{name: "non-current", questionID: "question-2", token: "voice-token-a", wantStatus: http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			header := http.Header{}
+			if test.token != "" {
+				header.Set("Authorization", "Bearer "+test.token)
+			}
+			_, response, err := (&websocket.Dialer{
+				Subprotocols: []string{practiceVoiceInputWebSocketProtocol},
+			}).Dial(
+				base+test.questionID+"/transcription-candidates/realtime",
+				header,
+			)
+			if err == nil || response == nil || response.StatusCode != test.wantStatus {
+				t.Fatalf("dial response = %#v, err = %v", response, err)
+			}
+			_ = response.Body.Close()
+		})
+	}
+}
+
+func TestPracticeRealtimeFailureUsesStableSafeCategory(t *testing.T) {
+	providerFailure := practicevoice.NewProviderError(
+		practicevoice.ProviderOperationTranscription,
+		practicevoice.ProviderErrorAuthentication,
+		"private-provider-request",
+		errors.New("private provider payload"),
+	)
+	for _, test := range []struct {
+		name          string
+		err           error
+		wantKind      string
+		wantRetryable bool
+	}{
+		{
+			name:     "provider authentication",
+			err:      providerFailure,
+			wantKind: "authentication",
+		},
+		{
+			name:          "live reservation",
+			err:           practicevoice.ErrVoiceRoundProcessing,
+			wantKind:      "processing",
+			wantRetryable: true,
+		},
+		{
+			name:     "idempotency conflict",
+			err:      practicevoice.ErrVoiceRoundConflict,
+			wantKind: "idempotency_conflict",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			kind, retryable := practiceRealtimeFailure(test.err)
+			if kind != test.wantKind || retryable != test.wantRetryable {
+				t.Fatalf("failure = (%q, %t)", kind, retryable)
+			}
+		})
+	}
+}
+
+func newPracticeRealtimeHTTPRouter(
+	t *testing.T,
+	application Application,
+) http.Handler {
+	t.Helper()
+	handler, err := NewHandler(
+		application,
+		Options{},
+		httpresponse.NewRenderer(
+			func() string { return "corr_practice_voice_realtime" },
+		),
+	)
+	if err != nil {
+		t.Fatalf("new Practice Voice HTTP handler: %v", err)
+	}
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		if c.GetHeader("Authorization") == "Bearer voice-token-a" {
+			actor := requestcontext.Actor{
+				UserID: "user-a", SessionID: "auth-session-a",
+			}
+			c.Request = c.Request.WithContext(
+				requestcontext.WithActor(c.Request.Context(), actor),
+			)
+		}
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	return router
+}
+
+type practiceRealtimeHTTPApplication struct {
+	state            practicevoice.SessionState
+	candidate        practicevoice.TranscriptionCandidate
+	streamSessionID  string
+	streamQuestionID string
+	streamKey        string
+	streamBytes      int
+}
+
+func (application *practiceRealtimeHTTPApplication) Start(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	string,
+) (practicevoice.SessionState, error) {
+	return application.state, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) Resume(
+	_ context.Context,
+	actor requestcontext.Actor,
+	_ string,
+) (practicevoice.SessionState, error) {
+	if actor.UserID != "user-a" {
+		return practicevoice.SessionState{}, practicevoice.ErrNotFound
+	}
+	return application.state, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) Transcribe(
+	context.Context,
+	requestcontext.Actor,
+	practicevoice.TranscribeVoiceCommand,
+) (practicevoice.TranscriptionCandidate, error) {
+	return application.candidate, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) TranscribeStream(
+	ctx context.Context,
+	_ requestcontext.Actor,
+	command practicevoice.TranscribeVoiceCommand,
+	observer practicevoice.TranscriptionObserver,
+) (practicevoice.TranscriptionCandidate, error) {
+	body, err := io.ReadAll(command.Audio)
+	if err != nil {
+		return practicevoice.TranscriptionCandidate{}, err
+	}
+	application.streamSessionID = command.SessionID
+	application.streamQuestionID = command.QuestionID
+	application.streamKey = command.IdempotencyKey
+	application.streamBytes = len(body)
+	for _, update := range []practicevoice.TranscriptionUpdate{
+		{Transcript: "A complete", Final: false},
+		{Transcript: "A complete practice answer.", Final: true},
+	} {
+		if err := observer.OnTranscriptionUpdate(ctx, update); err != nil {
+			return practicevoice.TranscriptionCandidate{}, err
+		}
+	}
+	return application.candidate, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) SubmitText(
+	context.Context,
+	requestcontext.Actor,
+	practicevoice.SubmitTextAnswerCommand,
+) (practicevoice.SessionState, error) {
+	return application.state, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) Confirm(
+	context.Context,
+	requestcontext.Actor,
+	practicevoice.ConfirmVoiceTurnCommand,
+) (practicevoice.SessionState, error) {
+	return application.state, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) QuestionSpeech(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (practicevoice.QuestionSpeech, error) {
+	return practicevoice.QuestionSpeech{}, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) QuestionTranslation(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (practicevoice.QuestionTranslation, error) {
+	return practicevoice.QuestionTranslation{}, nil
+}
+
+func (application *practiceRealtimeHTTPApplication) EnsureQuestionTip(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	string,
+	string,
+) (practicevoice.QuestionTipResult, error) {
+	return practicevoice.QuestionTipResult{}, nil
+}
+
+var _ Application = (*practiceRealtimeHTTPApplication)(nil)

--- a/server/internal/coaching/practice/voice/http/realtime_test.go
+++ b/server/internal/coaching/practice/voice/http/realtime_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func TestPracticeRealtimeVoiceInputUsesCurrentQuestionAndDurableCandidate(
+func TestPracticeRealtimeVoiceInputStreamsBeforeFinishAndPersistsCandidate(
 	t *testing.T,
 ) {
 	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
@@ -72,32 +72,44 @@ func TestPracticeRealtimeVoiceInputUsesCurrentQuestionAndDurableCandidate(
 	}); err != nil {
 		t.Fatalf("write start: %v", err)
 	}
+	type realtimeEvent struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	readEvent := func() realtimeEvent {
+		t.Helper()
+		_, payload, readErr := connection.ReadMessage()
+		if readErr != nil {
+			t.Fatalf("read realtime event: %v", readErr)
+		}
+		var event realtimeEvent
+		if err := json.Unmarshal(payload, &event); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		return event
+	}
+	events := []realtimeEvent{readEvent()}
 	if err := connection.WriteMessage(
 		websocket.BinaryMessage,
 		make([]byte, 3_200),
 	); err != nil {
 		t.Fatalf("write audio: %v", err)
 	}
+	if err := connection.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set live update deadline: %v", err)
+	}
+	events = append(events, readEvent())
+	if events[1].Type != "transcription.updated" {
+		t.Fatalf("event before finish = %#v", events[1])
+	}
 	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
 		t.Fatalf("write finish: %v", err)
 	}
-	var events []struct {
-		Type string          `json:"type"`
-		Data json.RawMessage `json:"data"`
+	if err := connection.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set completion deadline: %v", err)
 	}
 	for len(events) < 4 {
-		_, payload, readErr := connection.ReadMessage()
-		if readErr != nil {
-			t.Fatalf("read event %d: %v", len(events), readErr)
-		}
-		var event struct {
-			Type string          `json:"type"`
-			Data json.RawMessage `json:"data"`
-		}
-		if err := json.Unmarshal(payload, &event); err != nil {
-			t.Fatalf("decode event: %v", err)
-		}
-		events = append(events, event)
+		events = append(events, readEvent())
 	}
 	wantTypes := []string{
 		"transcription.started",
@@ -121,7 +133,8 @@ func TestPracticeRealtimeVoiceInputUsesCurrentQuestionAndDurableCandidate(
 		application.streamSessionID != "session-1" ||
 		application.streamQuestionID != "question-1" ||
 		application.streamKey != "practice-voice-realtime-1" ||
-		application.streamBytes != 3_244 {
+		application.streamBytes != 3_200 ||
+		application.streamSampleRate != 16_000 {
 		t.Fatalf("ready = %#v, application = %#v", ready, application)
 	}
 }
@@ -246,6 +259,7 @@ type practiceRealtimeHTTPApplication struct {
 	streamQuestionID string
 	streamKey        string
 	streamBytes      int
+	streamSampleRate int
 }
 
 func (application *practiceRealtimeHTTPApplication) Start(
@@ -279,24 +293,36 @@ func (application *practiceRealtimeHTTPApplication) Transcribe(
 func (application *practiceRealtimeHTTPApplication) TranscribeStream(
 	ctx context.Context,
 	_ requestcontext.Actor,
-	command practicevoice.TranscribeVoiceCommand,
+	command practicevoice.TranscribeVoiceStreamCommand,
 	observer practicevoice.TranscriptionObserver,
 ) (practicevoice.TranscriptionCandidate, error) {
-	body, err := io.ReadAll(command.Audio)
+	firstFrame := make([]byte, 3_200)
+	if _, err := io.ReadFull(command.PCM, firstFrame); err != nil {
+		return practicevoice.TranscriptionCandidate{}, err
+	}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		practicevoice.TranscriptionUpdate{Transcript: "A complete"},
+	); err != nil {
+		return practicevoice.TranscriptionCandidate{}, err
+	}
+	remainder, err := io.ReadAll(command.PCM)
 	if err != nil {
 		return practicevoice.TranscriptionCandidate{}, err
 	}
 	application.streamSessionID = command.SessionID
 	application.streamQuestionID = command.QuestionID
 	application.streamKey = command.IdempotencyKey
-	application.streamBytes = len(body)
-	for _, update := range []practicevoice.TranscriptionUpdate{
-		{Transcript: "A complete", Final: false},
-		{Transcript: "A complete practice answer.", Final: true},
-	} {
-		if err := observer.OnTranscriptionUpdate(ctx, update); err != nil {
-			return practicevoice.TranscriptionCandidate{}, err
-		}
+	application.streamBytes = len(firstFrame) + len(remainder)
+	application.streamSampleRate = command.SampleRate
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		practicevoice.TranscriptionUpdate{
+			Transcript: "A complete practice answer.",
+			Final:      true,
+		},
+	); err != nil {
+		return practicevoice.TranscriptionCandidate{}, err
 	}
 	return application.candidate, nil
 }

--- a/server/internal/coaching/practice/voice/provider.go
+++ b/server/internal/coaching/practice/voice/provider.go
@@ -2,6 +2,7 @@ package voice
 
 import (
 	"context"
+	"io"
 
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 )
@@ -115,9 +116,17 @@ type StreamingSpeechRecognizer interface {
 	SpeechRecognizer
 	TranscribeStream(
 		context.Context,
-		TranscriptionRequest,
+		StreamingTranscriptionRequest,
 		TranscriptionObserver,
 	) (TranscriptionResult, error)
+}
+
+// StreamingTranscriptionRequest carries the PCM frames that arrive during a
+// live capture. The durable Practice recording is assembled and validated by
+// VoiceRoundService after the stream ends.
+type StreamingTranscriptionRequest struct {
+	PCM        io.Reader
+	SampleRate int
 }
 
 type TranscriptionObserver interface {

--- a/server/internal/coaching/practice/voice/provider.go
+++ b/server/internal/coaching/practice/voice/provider.go
@@ -109,6 +109,26 @@ type SpeechRecognizer interface {
 	) (TranscriptionResult, error)
 }
 
+// StreamingSpeechRecognizer exposes provider-authored transcript snapshots;
+// the final TranscriptionResult remains the only durable result.
+type StreamingSpeechRecognizer interface {
+	SpeechRecognizer
+	TranscribeStream(
+		context.Context,
+		TranscriptionRequest,
+		TranscriptionObserver,
+	) (TranscriptionResult, error)
+}
+
+type TranscriptionObserver interface {
+	OnTranscriptionUpdate(context.Context, TranscriptionUpdate) error
+}
+
+type TranscriptionUpdate struct {
+	Transcript string
+	Final      bool
+}
+
 type SynthesisRequest struct {
 	Text string
 }

--- a/server/internal/coaching/practice/voice/round_orchestrator.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator.go
@@ -19,6 +19,13 @@ type RoundPort interface {
 		string,
 		TranscribeVoiceCommand,
 	) (TranscriptionCandidate, error)
+	TranscribeStream(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		TranscribeVoiceCommand,
+		TranscriptionObserver,
+	) (TranscriptionCandidate, error)
 	GetTranscriptionCandidate(
 		context.Context,
 		requestcontext.Actor,
@@ -123,6 +130,35 @@ func (orchestrator *RoundOrchestrator) Transcribe(
 		actor,
 		participantID,
 		command,
+	)
+}
+
+func (orchestrator *RoundOrchestrator) TranscribeStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command TranscribeVoiceCommand,
+	observer TranscriptionObserver,
+) (TranscriptionCandidate, error) {
+	if err := validateVoiceActor(ctx, actor); err != nil || observer == nil {
+		return TranscriptionCandidate{}, ErrInvalidRequest
+	}
+	participantID, err := orchestrator.practice.ResolveActorParticipant(
+		ctx,
+		actor,
+		command.SessionID,
+	)
+	if err != nil {
+		return TranscriptionCandidate{}, err
+	}
+	if strings.TrimSpace(participantID) == "" {
+		return TranscriptionCandidate{}, ErrInvalidContext
+	}
+	return orchestrator.rounds.TranscribeStream(
+		ctx,
+		actor,
+		participantID,
+		command,
+		observer,
 	)
 }
 

--- a/server/internal/coaching/practice/voice/round_orchestrator.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator.go
@@ -23,7 +23,7 @@ type RoundPort interface {
 		context.Context,
 		requestcontext.Actor,
 		string,
-		TranscribeVoiceCommand,
+		TranscribeVoiceStreamCommand,
 		TranscriptionObserver,
 	) (TranscriptionCandidate, error)
 	GetTranscriptionCandidate(
@@ -136,7 +136,7 @@ func (orchestrator *RoundOrchestrator) Transcribe(
 func (orchestrator *RoundOrchestrator) TranscribeStream(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	command TranscribeVoiceCommand,
+	command TranscribeVoiceStreamCommand,
 	observer TranscriptionObserver,
 ) (TranscriptionCandidate, error) {
 	if err := validateVoiceActor(ctx, actor); err != nil || observer == nil {

--- a/server/internal/coaching/practice/voice/round_orchestrator_test.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator_test.go
@@ -82,7 +82,7 @@ func (c *roundVoice) TranscribeStream(
 	context.Context,
 	requestcontext.Actor,
 	string,
-	TranscribeVoiceCommand,
+	TranscribeVoiceStreamCommand,
 	TranscriptionObserver,
 ) (TranscriptionCandidate, error) {
 	return c.candidate, nil

--- a/server/internal/coaching/practice/voice/round_orchestrator_test.go
+++ b/server/internal/coaching/practice/voice/round_orchestrator_test.go
@@ -78,6 +78,16 @@ func (c *roundVoice) Transcribe(
 	return c.candidate, nil
 }
 
+func (c *roundVoice) TranscribeStream(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	TranscribeVoiceCommand,
+	TranscriptionObserver,
+) (TranscriptionCandidate, error) {
+	return c.candidate, nil
+}
+
 func (c *roundVoice) GetTranscriptionCandidate(
 	context.Context,
 	requestcontext.Actor,

--- a/server/internal/coaching/practice/voice/round_service.go
+++ b/server/internal/coaching/practice/voice/round_service.go
@@ -366,6 +366,41 @@ func (service *VoiceRoundService) Transcribe(
 	respondentParticipantID string,
 	command TranscribeVoiceCommand,
 ) (candidate TranscriptionCandidate, returnErr error) {
+	return service.transcribe(
+		ctx,
+		actor,
+		respondentParticipantID,
+		command,
+		nil,
+	)
+}
+
+func (service *VoiceRoundService) TranscribeStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	respondentParticipantID string,
+	command TranscribeVoiceCommand,
+	observer TranscriptionObserver,
+) (candidate TranscriptionCandidate, returnErr error) {
+	if observer == nil {
+		return TranscriptionCandidate{}, ErrVoiceRoundInvalid
+	}
+	return service.transcribe(
+		ctx,
+		actor,
+		respondentParticipantID,
+		command,
+		observer,
+	)
+}
+
+func (service *VoiceRoundService) transcribe(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	respondentParticipantID string,
+	command TranscribeVoiceCommand,
+	observer TranscriptionObserver,
+) (candidate TranscriptionCandidate, returnErr error) {
 	if err := validateVoiceContext(ctx, actor); err != nil ||
 		strings.TrimSpace(respondentParticipantID) == "" ||
 		strings.TrimSpace(command.SessionID) == "" ||
@@ -482,10 +517,27 @@ func (service *VoiceRoundService) Transcribe(
 	}
 
 	startedAt := service.now()
-	result, err := service.recognizer.Transcribe(
-		ctx,
-		TranscriptionRequest{Audio: source},
-	)
+	request := TranscriptionRequest{Audio: source}
+	var result TranscriptionResult
+	if observer == nil {
+		result, err = service.recognizer.Transcribe(ctx, request)
+	} else {
+		streamingRecognizer, ok := service.recognizer.(StreamingSpeechRecognizer)
+		if !ok {
+			err = NewProviderError(
+				ProviderOperationTranscription,
+				ProviderErrorConfiguration,
+				"",
+				errors.New("practice voice: streaming recognizer is required"),
+			)
+		} else {
+			result, err = streamingRecognizer.TranscribeStream(
+				ctx,
+				request,
+				observer,
+			)
+		}
+	}
 	if err != nil {
 		attempt := safeAttempt(
 			err,

--- a/server/internal/coaching/practice/voice/round_service.go
+++ b/server/internal/coaching/practice/voice/round_service.go
@@ -366,32 +366,7 @@ func (service *VoiceRoundService) Transcribe(
 	respondentParticipantID string,
 	command TranscribeVoiceCommand,
 ) (candidate TranscriptionCandidate, returnErr error) {
-	return service.transcribe(
-		ctx,
-		actor,
-		respondentParticipantID,
-		command,
-		nil,
-	)
-}
-
-func (service *VoiceRoundService) TranscribeStream(
-	ctx context.Context,
-	actor requestcontext.Actor,
-	respondentParticipantID string,
-	command TranscribeVoiceCommand,
-	observer TranscriptionObserver,
-) (candidate TranscriptionCandidate, returnErr error) {
-	if observer == nil {
-		return TranscriptionCandidate{}, ErrVoiceRoundInvalid
-	}
-	return service.transcribe(
-		ctx,
-		actor,
-		respondentParticipantID,
-		command,
-		observer,
-	)
+	return service.transcribe(ctx, actor, respondentParticipantID, command)
 }
 
 func (service *VoiceRoundService) transcribe(
@@ -399,7 +374,6 @@ func (service *VoiceRoundService) transcribe(
 	actor requestcontext.Actor,
 	respondentParticipantID string,
 	command TranscribeVoiceCommand,
-	observer TranscriptionObserver,
 ) (candidate TranscriptionCandidate, returnErr error) {
 	if err := validateVoiceContext(ctx, actor); err != nil ||
 		strings.TrimSpace(respondentParticipantID) == "" ||
@@ -518,49 +492,41 @@ func (service *VoiceRoundService) transcribe(
 
 	startedAt := service.now()
 	request := TranscriptionRequest{Audio: source}
-	var result TranscriptionResult
-	if observer == nil {
-		result, err = service.recognizer.Transcribe(ctx, request)
-	} else {
-		streamingRecognizer, ok := service.recognizer.(StreamingSpeechRecognizer)
-		if !ok {
-			err = NewProviderError(
-				ProviderOperationTranscription,
-				ProviderErrorConfiguration,
-				"",
-				errors.New("practice voice: streaming recognizer is required"),
-			)
-		} else {
-			result, err = streamingRecognizer.TranscribeStream(
-				ctx,
-				request,
-				observer,
-			)
-		}
-	}
+	result, err := service.recognizer.Transcribe(ctx, request)
 	if err != nil {
-		attempt := safeAttempt(
-			err,
-			ProviderOperationTranscription,
-			service.now().Sub(startedAt),
-			service.now(),
-		)
-		persistenceContext, cancel := voicePersistenceContext(ctx)
-		saveErr := service.store.FailTranscription(
-			persistenceContext,
+		if saveErr := service.failTranscription(
+			ctx,
 			actor,
-			FailTranscriptionCommand{
-				ReservationID: reservation.ID,
-				LeaseToken:    reservation.LeaseToken,
-				Attempt:       attempt,
-			},
-		)
-		cancel()
-		if saveErr != nil {
+			reservation,
+			err,
+			startedAt,
+		); saveErr != nil {
 			return TranscriptionCandidate{}, saveErr
 		}
 		return TranscriptionCandidate{}, err
 	}
+	return service.completeTranscription(
+		ctx,
+		actor,
+		reservation,
+		result,
+		startedAt,
+		command.SessionID,
+		command.QuestionID,
+		respondentParticipantID,
+	)
+}
+
+func (service *VoiceRoundService) completeTranscription(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	reservation TranscriptionReservation,
+	result TranscriptionResult,
+	startedAt time.Time,
+	sessionID string,
+	questionID string,
+	respondentParticipantID string,
+) (TranscriptionCandidate, error) {
 	transcript := strings.TrimSpace(result.Transcript)
 	if !validTranscriptionResult(result, transcript) {
 		attempt := SafeProcessingAttempt{
@@ -588,7 +554,7 @@ func (service *VoiceRoundService) transcribe(
 		return TranscriptionCandidate{}, ErrVoiceRoundInvalid
 	}
 	persistenceContext, cancel := voicePersistenceContext(ctx)
-	candidate, err = service.store.CompleteTranscription(
+	candidate, err := service.store.CompleteTranscription(
 		persistenceContext,
 		actor,
 		CompleteTranscriptionCommand{
@@ -611,13 +577,39 @@ func (service *VoiceRoundService) transcribe(
 	}
 	if !validTranscriptionCandidate(
 		candidate,
-		command.SessionID,
-		command.QuestionID,
+		sessionID,
+		questionID,
 		respondentParticipantID,
 	) {
 		return TranscriptionCandidate{}, ErrVoiceRoundConflict
 	}
 	return candidate, nil
+}
+
+func (service *VoiceRoundService) failTranscription(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	reservation TranscriptionReservation,
+	err error,
+	startedAt time.Time,
+) error {
+	attempt := safeAttempt(
+		err,
+		ProviderOperationTranscription,
+		service.now().Sub(startedAt),
+		service.now(),
+	)
+	persistenceContext, cancel := voicePersistenceContext(ctx)
+	defer cancel()
+	return service.store.FailTranscription(
+		persistenceContext,
+		actor,
+		FailTranscriptionCommand{
+			ReservationID: reservation.ID,
+			LeaseToken:    reservation.LeaseToken,
+			Attempt:       attempt,
+		},
+	)
 }
 
 type ConfirmVoiceTurnCommand struct {

--- a/server/internal/coaching/practice/voice/round_service_realtime.go
+++ b/server/internal/coaching/practice/voice/round_service_realtime.go
@@ -1,0 +1,316 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const maxRealtimePCMBytes = platformmedia.MaxAudioBytes - 44
+
+type TranscribeVoiceStreamCommand struct {
+	SessionID      string
+	QuestionID     string
+	IdempotencyKey string
+	PCM            io.Reader
+	SampleRate     int
+}
+
+func (service *VoiceRoundService) TranscribeStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	respondentParticipantID string,
+	command TranscribeVoiceStreamCommand,
+	observer TranscriptionObserver,
+) (candidate TranscriptionCandidate, returnErr error) {
+	if err := validateVoiceContext(ctx, actor); err != nil ||
+		strings.TrimSpace(respondentParticipantID) == "" ||
+		strings.TrimSpace(command.SessionID) == "" ||
+		strings.TrimSpace(command.QuestionID) == "" ||
+		strings.TrimSpace(command.IdempotencyKey) == "" ||
+		command.PCM == nil || command.SampleRate != 16_000 || observer == nil {
+		return TranscriptionCandidate{}, ErrVoiceRoundInvalid
+	}
+	question, err := service.store.GetVoiceQuestion(
+		ctx,
+		actor,
+		command.SessionID,
+		command.QuestionID,
+	)
+	if err != nil {
+		return TranscriptionCandidate{}, err
+	}
+	if !validVoiceQuestion(
+		question,
+		command.SessionID,
+		command.QuestionID,
+		respondentParticipantID,
+	) {
+		return TranscriptionCandidate{}, ErrVoiceRoundNotFound
+	}
+
+	// A live request must acquire its idempotency lease before its final audio
+	// hash exists. Bind the key to the immutable PCM/session scope; the key
+	// itself identifies this recording attempt.
+	reservation, err := service.store.ReserveTranscription(
+		ctx,
+		actor,
+		ReserveTranscriptionCommand{
+			SessionID:               command.SessionID,
+			QuestionID:              command.QuestionID,
+			RespondentParticipantID: respondentParticipantID,
+			IdempotencyKey:          command.IdempotencyKey,
+			InputFingerprint: realtimeVoiceInputFingerprint(
+				command.SessionID,
+				command.QuestionID,
+				command.SampleRate,
+			),
+		},
+	)
+	if err != nil {
+		return TranscriptionCandidate{}, err
+	}
+	switch reservation.Status {
+	case TranscriptionCompleted:
+		if !validTranscriptionCandidate(
+			reservation.Candidate,
+			command.SessionID,
+			command.QuestionID,
+			respondentParticipantID,
+		) {
+			return TranscriptionCandidate{}, ErrVoiceRoundConflict
+		}
+		if err := drainRealtimePCM(command.PCM, command.SampleRate); err != nil {
+			return TranscriptionCandidate{}, err
+		}
+		return reservation.Candidate, nil
+	case TranscriptionProcessing:
+		if strings.TrimSpace(reservation.ID) == "" ||
+			reservation.LeaseToken != "" {
+			return TranscriptionCandidate{}, ErrVoiceRoundConflict
+		}
+		if err := drainRealtimePCM(command.PCM, command.SampleRate); err != nil {
+			return TranscriptionCandidate{}, err
+		}
+		return TranscriptionCandidate{}, ErrVoiceRoundProcessing
+	case TranscriptionReserved:
+		if strings.TrimSpace(reservation.ID) == "" ||
+			strings.TrimSpace(reservation.LeaseToken) == "" {
+			return TranscriptionCandidate{}, ErrVoiceRoundConflict
+		}
+	default:
+		return TranscriptionCandidate{}, ErrVoiceRoundConflict
+	}
+
+	streamingRecognizer, ok := service.recognizer.(StreamingSpeechRecognizer)
+	if !ok {
+		err = NewProviderError(
+			ProviderOperationTranscription,
+			ProviderErrorConfiguration,
+			"",
+			errors.New("practice voice: streaming recognizer is required"),
+		)
+		if saveErr := service.failTranscription(
+			ctx,
+			actor,
+			reservation,
+			err,
+			service.now(),
+		); saveErr != nil {
+			return TranscriptionCandidate{}, saveErr
+		}
+		return TranscriptionCandidate{}, err
+	}
+
+	startedAt := service.now()
+	var pcm bytes.Buffer
+	result, err := streamingRecognizer.TranscribeStream(
+		ctx,
+		StreamingTranscriptionRequest{
+			PCM: io.TeeReader(
+				io.LimitReader(command.PCM, maxRealtimePCMBytes+1),
+				&pcm,
+			),
+			SampleRate: command.SampleRate,
+		},
+		observer,
+	)
+	defer clear(pcm.Bytes())
+	if err != nil {
+		if saveErr := service.failTranscription(
+			ctx,
+			actor,
+			reservation,
+			err,
+			startedAt,
+		); saveErr != nil {
+			return TranscriptionCandidate{}, saveErr
+		}
+		return TranscriptionCandidate{}, err
+	}
+
+	metadata, source, err := service.captureRealtimePCM(
+		ctx,
+		actor,
+		pcm.Bytes(),
+		command.SampleRate,
+	)
+	if err != nil {
+		invalidAudio := NewProviderError(
+			ProviderOperationTranscription,
+			ProviderErrorInvalidRequest,
+			result.ID,
+			err,
+		)
+		if saveErr := service.failTranscription(
+			ctx,
+			actor,
+			reservation,
+			invalidAudio,
+			startedAt,
+		); saveErr != nil {
+			return TranscriptionCandidate{}, saveErr
+		}
+		return TranscriptionCandidate{}, err
+	}
+	defer func() {
+		if cleanupErr := service.vault.Delete(actor, metadata.ID); cleanupErr != nil {
+			candidate = TranscriptionCandidate{}
+			returnErr = errors.Join(returnErr, cleanupErr)
+		}
+	}()
+	if service.recordings != nil {
+		if _, err := service.stageRecording(
+			ctx,
+			actor,
+			reservation.ID,
+			source,
+		); err != nil {
+			return TranscriptionCandidate{}, err
+		}
+	}
+	return service.completeTranscription(
+		ctx,
+		actor,
+		reservation,
+		result,
+		startedAt,
+		command.SessionID,
+		command.QuestionID,
+		respondentParticipantID,
+	)
+}
+
+func realtimeVoiceInputFingerprint(
+	sessionID string,
+	questionID string,
+	sampleRate int,
+) string {
+	hash := sha256.New()
+	_, _ = io.WriteString(
+		hash,
+		"conversation.voice-stream/v1\x00"+
+			sessionID+"\x00"+questionID+"\x00pcm-s16le-mono\x00"+
+			strconv.Itoa(sampleRate),
+	)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func drainRealtimePCM(input io.Reader, sampleRate int) error {
+	pcm, err := readRealtimePCM(input, sampleRate)
+	clear(pcm)
+	return err
+}
+
+func readRealtimePCM(input io.Reader, sampleRate int) ([]byte, error) {
+	if input == nil || sampleRate != 16_000 {
+		return nil, ErrVoiceRoundInvalid
+	}
+	pcm, err := io.ReadAll(io.LimitReader(input, maxRealtimePCMBytes+1))
+	if err != nil {
+		clear(pcm)
+		return nil, err
+	}
+	if len(pcm) == 0 || len(pcm)%2 != 0 {
+		clear(pcm)
+		return nil, ErrVoiceRoundInvalid
+	}
+	if int64(len(pcm)) > maxRealtimePCMBytes {
+		clear(pcm)
+		return nil, ErrVoiceRoundCapacity
+	}
+	return pcm, nil
+}
+
+func (service *VoiceRoundService) captureRealtimePCM(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	pcm []byte,
+	sampleRate int,
+) (
+	platformmedia.TemporaryAudioMetadata,
+	platformmedia.AudioSource,
+	error,
+) {
+	wav, err := pcm16MonoWAV(pcm, sampleRate)
+	if err != nil {
+		return platformmedia.TemporaryAudioMetadata{}, nil, err
+	}
+	metadata, err := service.vault.Capture(
+		ctx,
+		actor,
+		platformmedia.ContentTypeWAV,
+		bytes.NewReader(wav),
+	)
+	clear(wav)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return platformmedia.TemporaryAudioMetadata{}, nil, contextErr
+		}
+		if errors.Is(err, platformmedia.ErrTemporaryAudioCapacity) {
+			return platformmedia.TemporaryAudioMetadata{}, nil,
+				ErrVoiceRoundCapacity
+		}
+		return platformmedia.TemporaryAudioMetadata{}, nil,
+			ErrVoiceRoundInvalid
+	}
+	source, err := service.vault.Source(actor, metadata.ID)
+	if err != nil {
+		_ = service.vault.Delete(actor, metadata.ID)
+		return platformmedia.TemporaryAudioMetadata{}, nil,
+			ErrVoiceRoundInvalid
+	}
+	return metadata, source, nil
+}
+
+func pcm16MonoWAV(pcm []byte, sampleRate int) ([]byte, error) {
+	if len(pcm) == 0 || len(pcm)%2 != 0 ||
+		int64(len(pcm)) > maxRealtimePCMBytes || sampleRate != 16_000 {
+		return nil, ErrVoiceRoundInvalid
+	}
+	result := make([]byte, 44+len(pcm))
+	copy(result[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(result[4:8], uint32(len(result)-8))
+	copy(result[8:12], "WAVE")
+	copy(result[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(result[16:20], 16)
+	binary.LittleEndian.PutUint16(result[20:22], 1)
+	binary.LittleEndian.PutUint16(result[22:24], 1)
+	binary.LittleEndian.PutUint32(result[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(result[28:32], uint32(sampleRate*2))
+	binary.LittleEndian.PutUint16(result[32:34], 2)
+	binary.LittleEndian.PutUint16(result[34:36], 16)
+	copy(result[36:40], "data")
+	binary.LittleEndian.PutUint32(result[40:44], uint32(len(pcm)))
+	copy(result[44:], pcm)
+	return result, nil
+}

--- a/server/internal/coaching/practice/voice/round_service_test.go
+++ b/server/internal/coaching/practice/voice/round_service_test.go
@@ -132,26 +132,57 @@ func TestVoiceRoundStreamsProviderSnapshotsAndPersistsFinalCandidate(
 	if err != nil {
 		t.Fatalf("new service: %v", err)
 	}
-	command := func() TranscribeVoiceCommand {
-		return TranscribeVoiceCommand{
+	command := func(pcm io.Reader) TranscribeVoiceStreamCommand {
+		return TranscribeVoiceStreamCommand{
 			SessionID:      "session-1",
 			QuestionID:     "question-1",
 			IdempotencyKey: "transcribe-stream-question-1",
-			ContentType:    platformmedia.ContentTypeWAV,
-			Audio:          bytes.NewReader(voiceTestWAV()),
+			PCM:            pcm,
+			SampleRate:     16_000,
 		}
 	}
-	observer := &voiceTestTranscriptionObserver{}
-	candidate, err := service.TranscribeStream(
-		context.Background(),
-		voiceTestActor("a"),
-		"participant-a",
-		command(),
-		observer,
-	)
-	if err != nil {
-		t.Fatalf("stream transcription: %v", err)
+	observer := &voiceTestTranscriptionObserver{
+		observed: make(chan TranscriptionUpdate, 2),
 	}
+	reader, writer := io.Pipe()
+	type streamResult struct {
+		candidate TranscriptionCandidate
+		err       error
+	}
+	completed := make(chan streamResult, 1)
+	go func() {
+		candidate, streamErr := service.TranscribeStream(
+			context.Background(),
+			voiceTestActor("a"),
+			"participant-a",
+			command(reader),
+			observer,
+		)
+		completed <- streamResult{candidate: candidate, err: streamErr}
+	}()
+	pcm := voiceTestPCM()
+	if _, err := writer.Write(pcm[:320]); err != nil {
+		t.Fatalf("write first live PCM frame: %v", err)
+	}
+	select {
+	case update := <-observer.observed:
+		if update.Transcript != "A complete" || update.Final {
+			t.Fatalf("live update before stream end = %#v", update)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no transcription update before the PCM stream ended")
+	}
+	if _, err := writer.Write(pcm[320:]); err != nil {
+		t.Fatalf("write remaining live PCM: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close live PCM: %v", err)
+	}
+	result := <-completed
+	if result.err != nil {
+		t.Fatalf("stream transcription: %v", result.err)
+	}
+	candidate := result.candidate
 	if candidate.Transcript != "A complete streaming answer." ||
 		candidate.ProviderRequestID != "asr-stream-request" ||
 		recognizer.streamCalls != 1 || recognizer.transcribeCalls != 0 {
@@ -169,7 +200,7 @@ func TestVoiceRoundStreamsProviderSnapshotsAndPersistsFinalCandidate(
 		context.Background(),
 		voiceTestActor("a"),
 		"participant-a",
-		command(),
+		command(bytes.NewReader(voiceTestPCM())),
 		replayObserver,
 	)
 	if err != nil || replayed.ID != candidate.ID ||
@@ -212,12 +243,12 @@ func TestVoiceRoundStreamingRequiresStreamingRecognizer(t *testing.T) {
 		context.Background(),
 		voiceTestActor("a"),
 		"participant-a",
-		TranscribeVoiceCommand{
+		TranscribeVoiceStreamCommand{
 			SessionID:      "session-1",
 			QuestionID:     "question-1",
 			IdempotencyKey: "transcribe-stream-question-1",
-			ContentType:    platformmedia.ContentTypeWAV,
-			Audio:          bytes.NewReader(voiceTestWAV()),
+			PCM:            bytes.NewReader(voiceTestPCM()),
+			SampleRate:     16_000,
 		},
 		&voiceTestTranscriptionObserver{},
 	)
@@ -1343,20 +1374,34 @@ func (recognizer *streamingVoiceTestRecognizer) Transcribe(
 
 func (recognizer *streamingVoiceTestRecognizer) TranscribeStream(
 	ctx context.Context,
-	request TranscriptionRequest,
+	request StreamingTranscriptionRequest,
 	observer TranscriptionObserver,
 ) (TranscriptionResult, error) {
 	recognizer.streamCalls++
-	if err := platformmedia.ValidateAudioSource(request.Audio); err != nil {
+	if request.PCM == nil || request.SampleRate != 16_000 {
+		return TranscriptionResult{}, ErrVoiceRoundInvalid
+	}
+	first := make([]byte, 320)
+	if _, err := io.ReadFull(request.PCM, first); err != nil {
 		return TranscriptionResult{}, err
 	}
-	for _, update := range []TranscriptionUpdate{
-		{Transcript: "A complete", Final: false},
-		{Transcript: "A complete streaming answer.", Final: true},
-	} {
-		if err := observer.OnTranscriptionUpdate(ctx, update); err != nil {
-			return TranscriptionResult{}, err
-		}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		TranscriptionUpdate{Transcript: "A complete"},
+	); err != nil {
+		return TranscriptionResult{}, err
+	}
+	if _, err := io.Copy(io.Discard, request.PCM); err != nil {
+		return TranscriptionResult{}, err
+	}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		TranscriptionUpdate{
+			Transcript: "A complete streaming answer.",
+			Final:      true,
+		},
+	); err != nil {
+		return TranscriptionResult{}, err
 	}
 	return TranscriptionResult{
 		ID:         "asr-stream-request",
@@ -1367,7 +1412,8 @@ func (recognizer *streamingVoiceTestRecognizer) TranscribeStream(
 }
 
 type voiceTestTranscriptionObserver struct {
-	updates []TranscriptionUpdate
+	updates  []TranscriptionUpdate
+	observed chan TranscriptionUpdate
 }
 
 func (observer *voiceTestTranscriptionObserver) OnTranscriptionUpdate(
@@ -1375,6 +1421,9 @@ func (observer *voiceTestTranscriptionObserver) OnTranscriptionUpdate(
 	update TranscriptionUpdate,
 ) error {
 	observer.updates = append(observer.updates, update)
+	if observer.observed != nil {
+		observer.observed <- update
+	}
 	return nil
 }
 
@@ -1564,4 +1613,8 @@ func voiceTestWAV() []byte {
 	_ = binary.Write(buffer, binary.LittleEndian, uint32(dataSize))
 	buffer.Write(make([]byte, dataSize))
 	return buffer.Bytes()
+}
+
+func voiceTestPCM() []byte {
+	return make([]byte, 3_200)
 }

--- a/server/internal/coaching/practice/voice/round_service_test.go
+++ b/server/internal/coaching/practice/voice/round_service_test.go
@@ -105,6 +105,130 @@ func TestVoiceRoundTranscriptionAndConfirmationAreIdempotent(t *testing.T) {
 	}
 }
 
+func TestVoiceRoundStreamsProviderSnapshotsAndPersistsFinalCandidate(
+	t *testing.T,
+) {
+	store := newVoiceTestStore()
+	store.addQuestion("question-1")
+	recognizer := &streamingVoiceTestRecognizer{}
+	vault, err := platformmedia.NewTemporaryAudioVault(
+		platformmedia.TemporaryAudioVaultConfig{
+			ScratchDirectory: t.TempDir(),
+			Lifetime:         time.Minute,
+			MaxItems:         1,
+			MaxBytes:         platformmedia.MaxAudioBytes,
+		},
+	)
+	if err != nil {
+		t.Fatalf("new vault: %v", err)
+	}
+	t.Cleanup(func() { _ = vault.Close() })
+	service, err := NewVoiceRoundService(
+		store,
+		vault,
+		recognizer,
+		&voiceTestSynthesizer{},
+	)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	command := func() TranscribeVoiceCommand {
+		return TranscribeVoiceCommand{
+			SessionID:      "session-1",
+			QuestionID:     "question-1",
+			IdempotencyKey: "transcribe-stream-question-1",
+			ContentType:    platformmedia.ContentTypeWAV,
+			Audio:          bytes.NewReader(voiceTestWAV()),
+		}
+	}
+	observer := &voiceTestTranscriptionObserver{}
+	candidate, err := service.TranscribeStream(
+		context.Background(),
+		voiceTestActor("a"),
+		"participant-a",
+		command(),
+		observer,
+	)
+	if err != nil {
+		t.Fatalf("stream transcription: %v", err)
+	}
+	if candidate.Transcript != "A complete streaming answer." ||
+		candidate.ProviderRequestID != "asr-stream-request" ||
+		recognizer.streamCalls != 1 || recognizer.transcribeCalls != 0 {
+		t.Fatalf("candidate = %#v, recognizer = %#v", candidate, recognizer)
+	}
+	wantUpdates := []TranscriptionUpdate{
+		{Transcript: "A complete", Final: false},
+		{Transcript: "A complete streaming answer.", Final: true},
+	}
+	if !reflect.DeepEqual(observer.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", observer.updates, wantUpdates)
+	}
+	replayObserver := &voiceTestTranscriptionObserver{}
+	replayed, err := service.TranscribeStream(
+		context.Background(),
+		voiceTestActor("a"),
+		"participant-a",
+		command(),
+		replayObserver,
+	)
+	if err != nil || replayed.ID != candidate.ID ||
+		recognizer.streamCalls != 1 || len(replayObserver.updates) != 0 {
+		t.Fatalf(
+			"replay = %#v, err = %v, calls = %d, updates = %#v",
+			replayed,
+			err,
+			recognizer.streamCalls,
+			replayObserver.updates,
+		)
+	}
+}
+
+func TestVoiceRoundStreamingRequiresStreamingRecognizer(t *testing.T) {
+	store := newVoiceTestStore()
+	store.addQuestion("question-1")
+	vault, err := platformmedia.NewTemporaryAudioVault(
+		platformmedia.TemporaryAudioVaultConfig{
+			ScratchDirectory: t.TempDir(),
+			Lifetime:         time.Minute,
+			MaxItems:         1,
+			MaxBytes:         platformmedia.MaxAudioBytes,
+		},
+	)
+	if err != nil {
+		t.Fatalf("new vault: %v", err)
+	}
+	t.Cleanup(func() { _ = vault.Close() })
+	service, err := NewVoiceRoundService(
+		store,
+		vault,
+		&voiceTestRecognizer{},
+		&voiceTestSynthesizer{},
+	)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	_, err = service.TranscribeStream(
+		context.Background(),
+		voiceTestActor("a"),
+		"participant-a",
+		TranscribeVoiceCommand{
+			SessionID:      "session-1",
+			QuestionID:     "question-1",
+			IdempotencyKey: "transcribe-stream-question-1",
+			ContentType:    platformmedia.ContentTypeWAV,
+			Audio:          bytes.NewReader(voiceTestWAV()),
+		},
+		&voiceTestTranscriptionObserver{},
+	)
+	var providerError *ProviderError
+	if !errors.As(err, &providerError) ||
+		providerError.Kind != ProviderErrorConfiguration ||
+		providerError.Retryable() {
+		t.Fatalf("streaming error = %#v", err)
+	}
+}
+
 func TestVoiceRoundTextAnswerUsesDurableCandidateWithoutASR(t *testing.T) {
 	store := newVoiceTestStore()
 	store.addQuestion("question-1")
@@ -1202,6 +1326,56 @@ func (store *voiceTestStore) replaceTurn(turn practice.Turn) {
 type voiceTestRecognizer struct {
 	calls int
 	err   error
+}
+
+type streamingVoiceTestRecognizer struct {
+	streamCalls     int
+	transcribeCalls int
+}
+
+func (recognizer *streamingVoiceTestRecognizer) Transcribe(
+	_ context.Context,
+	request TranscriptionRequest,
+) (TranscriptionResult, error) {
+	recognizer.transcribeCalls++
+	return TranscriptionResult{}, platformmedia.ValidateAudioSource(request.Audio)
+}
+
+func (recognizer *streamingVoiceTestRecognizer) TranscribeStream(
+	ctx context.Context,
+	request TranscriptionRequest,
+	observer TranscriptionObserver,
+) (TranscriptionResult, error) {
+	recognizer.streamCalls++
+	if err := platformmedia.ValidateAudioSource(request.Audio); err != nil {
+		return TranscriptionResult{}, err
+	}
+	for _, update := range []TranscriptionUpdate{
+		{Transcript: "A complete", Final: false},
+		{Transcript: "A complete streaming answer.", Final: true},
+	} {
+		if err := observer.OnTranscriptionUpdate(ctx, update); err != nil {
+			return TranscriptionResult{}, err
+		}
+	}
+	return TranscriptionResult{
+		ID:         "asr-stream-request",
+		Provider:   "fake",
+		Model:      "fake-streaming-asr-v1",
+		Transcript: "A complete streaming answer.",
+	}, nil
+}
+
+type voiceTestTranscriptionObserver struct {
+	updates []TranscriptionUpdate
+}
+
+func (observer *voiceTestTranscriptionObserver) OnTranscriptionUpdate(
+	_ context.Context,
+	update TranscriptionUpdate,
+) error {
+	observer.updates = append(observer.updates, update)
+	return nil
 }
 
 type cancelingVoiceRecognizer struct {

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -277,7 +277,7 @@ func (application *SessionApplication) Transcribe(
 func (application *SessionApplication) TranscribeStream(
 	ctx context.Context,
 	actor requestcontext.Actor,
-	command TranscribeVoiceCommand,
+	command TranscribeVoiceStreamCommand,
 	observer TranscriptionObserver,
 ) (TranscriptionCandidate, error) {
 	return application.orchestrator.TranscribeStream(

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -274,6 +274,20 @@ func (application *SessionApplication) Transcribe(
 	return application.orchestrator.Transcribe(ctx, actor, command)
 }
 
+func (application *SessionApplication) TranscribeStream(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	command TranscribeVoiceCommand,
+	observer TranscriptionObserver,
+) (TranscriptionCandidate, error) {
+	return application.orchestrator.TranscribeStream(
+		ctx,
+		actor,
+		command,
+		observer,
+	)
+}
+
 func (application *SessionApplication) Confirm(
 	ctx context.Context,
 	actor requestcontext.Actor,

--- a/server/internal/providers/qianwen/practice_voice.go
+++ b/server/internal/providers/qianwen/practice_voice.go
@@ -56,6 +56,59 @@ func (recognizer *PracticeVoiceRecognizer) Transcribe(
 	}, nil
 }
 
+func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
+	ctx context.Context,
+	request practicevoice.TranscriptionRequest,
+	observer practicevoice.TranscriptionObserver,
+) (practicevoice.TranscriptionResult, error) {
+	if recognizer == nil || recognizer.recognizer == nil || observer == nil ||
+		recognizer.recognizer.model != "fun-asr-realtime" {
+		return practicevoice.TranscriptionResult{},
+			practicevoice.NewProviderError(
+				practicevoice.ProviderOperationTranscription,
+				practicevoice.ProviderErrorConfiguration,
+				"",
+				errors.New("Qianwen streaming Practice Voice recognizer is required"),
+			)
+	}
+	result, err := recognizer.recognizer.TranscribeStream(
+		ctx,
+		protocol.TranscriptionRequest{Audio: request.Audio},
+		practiceVoiceTranscriptionObserver{observer: observer},
+	)
+	if err != nil {
+		return practicevoice.TranscriptionResult{},
+			mapPracticeVoiceError(
+				err,
+				practicevoice.ProviderOperationTranscription,
+			)
+	}
+	return practicevoice.TranscriptionResult{
+		ID:         result.ID,
+		Provider:   result.Provider,
+		Model:      result.Model,
+		Transcript: result.Transcript,
+		Usage:      mapPracticeVoiceUsage(result.Usage),
+	}, nil
+}
+
+type practiceVoiceTranscriptionObserver struct {
+	observer practicevoice.TranscriptionObserver
+}
+
+func (observer practiceVoiceTranscriptionObserver) OnTranscriptionUpdate(
+	ctx context.Context,
+	update protocol.TranscriptionUpdate,
+) error {
+	return observer.observer.OnTranscriptionUpdate(
+		ctx,
+		practicevoice.TranscriptionUpdate{
+			Transcript: update.Transcript,
+			Final:      update.Final,
+		},
+	)
+}
+
 type PracticeVoiceSynthesizer struct {
 	synthesizer *speechSynthesizer
 }
@@ -264,8 +317,8 @@ func mapPracticeVoiceErrorKind(kind protocol.ErrorKind) practicevoice.ProviderEr
 }
 
 var (
-	_ practicevoice.SpeechRecognizer   = (*PracticeVoiceRecognizer)(nil)
-	_ practicevoice.SpeechSynthesizer  = (*PracticeVoiceSynthesizer)(nil)
-	_ practicevoice.QuestionGenerator  = (*PracticeVoiceQuestionGenerator)(nil)
-	_ practicevoice.AnswerTipGenerator = (*PracticeVoiceAnswerTipGenerator)(nil)
+	_ practicevoice.StreamingSpeechRecognizer = (*PracticeVoiceRecognizer)(nil)
+	_ practicevoice.SpeechSynthesizer         = (*PracticeVoiceSynthesizer)(nil)
+	_ practicevoice.QuestionGenerator         = (*PracticeVoiceQuestionGenerator)(nil)
+	_ practicevoice.AnswerTipGenerator        = (*PracticeVoiceAnswerTipGenerator)(nil)
 )

--- a/server/internal/providers/qianwen/practice_voice.go
+++ b/server/internal/providers/qianwen/practice_voice.go
@@ -58,7 +58,7 @@ func (recognizer *PracticeVoiceRecognizer) Transcribe(
 
 func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
 	ctx context.Context,
-	request practicevoice.TranscriptionRequest,
+	request practicevoice.StreamingTranscriptionRequest,
 	observer practicevoice.TranscriptionObserver,
 ) (practicevoice.TranscriptionResult, error) {
 	if recognizer == nil || recognizer.recognizer == nil || observer == nil ||
@@ -71,9 +71,10 @@ func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
 				errors.New("Qianwen streaming Practice Voice recognizer is required"),
 			)
 	}
-	result, err := recognizer.recognizer.TranscribeStream(
+	result, err := recognizer.recognizer.transcribeRealtimePCM(
 		ctx,
-		protocol.TranscriptionRequest{Audio: request.Audio},
+		request.PCM,
+		request.SampleRate,
 		practiceVoiceTranscriptionObserver{observer: observer},
 	)
 	if err != nil {

--- a/server/internal/providers/qianwen/practice_voice_test.go
+++ b/server/internal/providers/qianwen/practice_voice_test.go
@@ -85,7 +85,7 @@ func TestPracticeVoiceAdaptersRejectMissingProvider(t *testing.T) {
 	}
 	if _, err := recognizer.TranscribeStream(
 		context.Background(),
-		practicevoice.TranscriptionRequest{},
+		practicevoice.StreamingTranscriptionRequest{},
 		&practiceVoiceObserverRecorder{},
 	); !isPracticeVoiceConfigurationError(err) {
 		t.Fatalf("streaming recognizer error = %v", err)
@@ -148,7 +148,7 @@ func TestPracticeVoiceStreamingRejectsNonRealtimeModel(t *testing.T) {
 	}
 	_, err := recognizer.TranscribeStream(
 		context.Background(),
-		practicevoice.TranscriptionRequest{},
+		practicevoice.StreamingTranscriptionRequest{},
 		&practiceVoiceObserverRecorder{},
 	)
 	if !isPracticeVoiceConfigurationError(err) {

--- a/server/internal/providers/qianwen/practice_voice_test.go
+++ b/server/internal/providers/qianwen/practice_voice_test.go
@@ -83,6 +83,13 @@ func TestPracticeVoiceAdaptersRejectMissingProvider(t *testing.T) {
 	); !isPracticeVoiceConfigurationError(err) {
 		t.Fatalf("recognizer error = %v", err)
 	}
+	if _, err := recognizer.TranscribeStream(
+		context.Background(),
+		practicevoice.TranscriptionRequest{},
+		&practiceVoiceObserverRecorder{},
+	); !isPracticeVoiceConfigurationError(err) {
+		t.Fatalf("streaming recognizer error = %v", err)
+	}
 
 	var synthesizer *PracticeVoiceSynthesizer
 	if _, err := synthesizer.Synthesize(
@@ -115,6 +122,50 @@ func TestPracticeVoiceAdaptersRejectMissingProvider(t *testing.T) {
 	); !isPracticeVoiceConfigurationError(err) {
 		t.Fatalf("Tip generator error = %v", err)
 	}
+}
+
+func TestPracticeVoiceStreamingObserverMapsProviderSnapshot(t *testing.T) {
+	recorder := &practiceVoiceObserverRecorder{}
+	adapter := practiceVoiceTranscriptionObserver{observer: recorder}
+	if err := adapter.OnTranscriptionUpdate(
+		context.Background(),
+		protocol.TranscriptionUpdate{
+			Transcript: "An answer in progress.",
+			Final:      true,
+		},
+	); err != nil {
+		t.Fatalf("observe update: %v", err)
+	}
+	if recorder.update.Transcript != "An answer in progress." ||
+		!recorder.update.Final {
+		t.Fatalf("mapped update = %#v", recorder.update)
+	}
+}
+
+func TestPracticeVoiceStreamingRejectsNonRealtimeModel(t *testing.T) {
+	recognizer := &PracticeVoiceRecognizer{
+		recognizer: &speechRecognizer{model: "fun-asr-flash-2026-06-15"},
+	}
+	_, err := recognizer.TranscribeStream(
+		context.Background(),
+		practicevoice.TranscriptionRequest{},
+		&practiceVoiceObserverRecorder{},
+	)
+	if !isPracticeVoiceConfigurationError(err) {
+		t.Fatalf("non-realtime model error = %v", err)
+	}
+}
+
+type practiceVoiceObserverRecorder struct {
+	update practicevoice.TranscriptionUpdate
+}
+
+func (recorder *practiceVoiceObserverRecorder) OnTranscriptionUpdate(
+	_ context.Context,
+	update practicevoice.TranscriptionUpdate,
+) error {
+	recorder.update = update
+	return nil
 }
 
 func isTranslationConfigurationError(err error) bool {

--- a/server/internal/providers/qianwen/speech_recognizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime.go
@@ -39,6 +39,12 @@ type realtimeASREvent struct {
 	} `json:"payload"`
 }
 
+type realtimeASRAudio struct {
+	format     string
+	sampleRate int
+	open       func() (io.ReadCloser, error)
+}
+
 func (recognizer *speechRecognizer) transcribeRealtime(
 	ctx context.Context,
 	request protocol.TranscriptionRequest,
@@ -64,6 +70,51 @@ func (recognizer *speechRecognizer) transcribeRealtime(
 			err,
 		)
 	}
+	return recognizer.transcribeRealtimeAudio(
+		ctx,
+		realtimeASRAudio{
+			format:     "wav",
+			sampleRate: request.Audio.SampleRate(),
+			open:       request.Audio.Open,
+		},
+		observer,
+	)
+}
+
+func (recognizer *speechRecognizer) transcribeRealtimePCM(
+	ctx context.Context,
+	pcm io.Reader,
+	sampleRate int,
+	observer protocol.TranscriptionObserver,
+) (protocol.TranscriptionResult, error) {
+	if ctx == nil || pcm == nil || sampleRate < 8_000 || sampleRate > 48_000 {
+		return protocol.TranscriptionResult{}, protocol.NewSpeechError(
+			protocol.SpeechOperationTranscription,
+			protocol.ErrorInvalidRequest,
+			0,
+			"",
+			"",
+			errors.New("realtime PCM transcription input is invalid"),
+		)
+	}
+	return recognizer.transcribeRealtimeAudio(
+		ctx,
+		realtimeASRAudio{
+			format:     "pcm",
+			sampleRate: sampleRate,
+			open: func() (io.ReadCloser, error) {
+				return io.NopCloser(pcm), nil
+			},
+		},
+		observer,
+	)
+}
+
+func (recognizer *speechRecognizer) transcribeRealtimeAudio(
+	ctx context.Context,
+	audio realtimeASRAudio,
+	observer protocol.TranscriptionObserver,
+) (protocol.TranscriptionResult, error) {
 	callContext, cancel := context.WithTimeout(ctx, recognizer.timeout)
 	defer cancel()
 	header := http.Header{}
@@ -106,7 +157,7 @@ func (recognizer *speechRecognizer) transcribeRealtime(
 			"task_group": "audio", "task": "asr", "function": "recognition",
 			"model": recognizer.model,
 			"parameters": map[string]any{
-				"format": "wav", "sample_rate": request.Audio.SampleRate(),
+				"format": audio.format, "sample_rate": audio.sampleRate,
 				"max_sentence_silence": 400,
 			},
 			"input": map[string]any{},
@@ -137,7 +188,7 @@ func (recognizer *speechRecognizer) transcribeRealtime(
 			err:        readErr,
 		}
 	}()
-	if err := streamRealtimeASRAudio(connection, request.Audio); err != nil {
+	if err := streamRealtimeASRAudio(connection, audio.open); err != nil {
 		_ = connection.Close()
 		return protocol.TranscriptionResult{}, realtimeASRTransportError(callContext, err)
 	}
@@ -186,9 +237,9 @@ func waitForRealtimeASRStart(connection *websocket.Conn, taskID string) error {
 
 func streamRealtimeASRAudio(
 	connection *websocket.Conn,
-	source interface{ Open() (io.ReadCloser, error) },
+	open func() (io.ReadCloser, error),
 ) error {
-	reader, err := source.Open()
+	reader, err := open()
 	if err != nil {
 		return err
 	}

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -18,6 +18,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 	t.Parallel()
 	const apiKey = "test-realtime-key"
 	audio := bytes.Repeat([]byte{1, 2, 3, 4}, realtimeASRChunkBytes)
+	formats := make(chan string, 2)
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -56,11 +57,11 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		}
 		if run.Header.Action != "run-task" ||
 			run.Payload.Model != "fun-asr-realtime" ||
-			run.Payload.Parameters.Format != "wav" ||
 			run.Payload.Parameters.SampleRate != 16_000 {
 			t.Errorf("unexpected run-task: %#v", run)
 			return
 		}
+		formats <- run.Payload.Parameters.Format
 		if err := connection.WriteJSON(map[string]any{
 			"header": map[string]any{
 				"task_id": run.Header.TaskID, "event": "task-started",
@@ -157,6 +158,9 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transcribe realtime: %v", err)
 	}
+	if format := <-formats; format != "wav" {
+		t.Fatalf("validated source format = %q, want wav", format)
+	}
 	if result.Transcript != "I practice English for interviews." ||
 		result.Model != "fun-asr-realtime" ||
 		result.Usage.AudioSeconds != 4 {
@@ -167,6 +171,25 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		!updates[len(updates)-1].Final ||
 		updates[len(updates)-1].Transcript != result.Transcript {
 		t.Fatalf("stream updates = %#v", updates)
+	}
+
+	pcmObserver := &recordingTranscriptionObserver{}
+	pcmResult, err := recognizer.transcribeRealtimePCM(
+		context.Background(),
+		bytes.NewReader(audio),
+		16_000,
+		pcmObserver,
+	)
+	if err != nil {
+		t.Fatalf("transcribe realtime PCM: %v", err)
+	}
+	if format := <-formats; format != "pcm" {
+		t.Fatalf("live capture format = %q, want pcm", format)
+	}
+	pcmUpdates := pcmObserver.Updates()
+	if pcmResult.Transcript != result.Transcript || len(pcmUpdates) == 0 ||
+		!pcmUpdates[len(pcmUpdates)-1].Final {
+		t.Fatalf("PCM result = %#v, updates = %#v", pcmResult, pcmUpdates)
 	}
 }
 


### PR DESCRIPTION
## 功能描述
- 为当前 Practice Session / Question 新增实时语音 WebSocket 入口。
- 沿用 `speakup.voice-input.v1` 帧与 `transcription.started / transcription.updated / candidate.ready / candidate.failed` 事件。
- 最终结果继续写入现有 TranscriptionCandidate、录音证据与确认答案流程。
- 保留原完整 WAV 上传接口；实时识别能力不可用时明确失败，不静默降级。

## 实现思路
- 在 Practice Voice 边界增加 StreamingSpeechRecognizer 与 TranscriptionObserver。
- RoundService 复用原有音频校验、幂等预留、证据保存和候选完成逻辑，仅替换识别调用方式。
- Qianwen 适配器桥接现有 realtime ASR 更新，并限定真实 realtime 模型。
- HTTP 层在升级前校验登录用户、Session 与当前 Question，再接收 PCM16 并输出稳定事件。

## 可复现测试
- `cd server && go test ./...`
- `cd server && go vet ./...`
- `make check-api`
- WebSocket 测试覆盖鉴权、当前 Question、事件顺序、PCM→WAV、稳定失败类别与最终候选。
- RoundService 测试覆盖流式快照、最终持久化、重复幂等和禁止静默降级。

Closes #543
Related to #542