### PR TITLE
refactor(mobile): 统一 Agent 与 Practice 消息渲染

### DIFF
--- a/mobile/lib/design/conversation_message_content.dart
+++ b/mobile/lib/design/conversation_message_content.dart
@@ -55,12 +55,13 @@ final class ConversationTextMessageContent extends StatelessWidget {
       maintainState: true,
       child: _messageText(),
     );
-    if (isUser || hasFailed) {
+    if (hasFailed) {
       return content;
     }
-    final translate = isStreaming ? null : onTranslate;
+    final translate = isUser || isStreaming ? null : onTranslate;
     final hasActions = leadingActions.isNotEmpty || translate != null;
-    if (!hasActions && mediaError == null) {
+    final visibleMediaError = isUser ? null : mediaError;
+    if (!hasActions && visibleMediaError == null) {
       return content;
     }
     return Column(
@@ -76,7 +77,7 @@ final class ConversationTextMessageContent extends StatelessWidget {
             onTranslate: translate,
             leadingActions: leadingActions,
           ),
-        if (mediaError case final error?) ...[
+        if (visibleMediaError case final error?) ...[
           const SizedBox(height: 3),
           Text(
             error,

--- a/mobile/lib/design/conversation_message_content.dart
+++ b/mobile/lib/design/conversation_message_content.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:speakup/design/message_translation.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+/// Text-message presentation shared by Agent and Practice conversations.
+///
+/// Business models, playback controllers, and network clients remain owned by
+/// their feature. Callers provide only presentation state and actions.
+final class ConversationTextMessageContent extends StatelessWidget {
+  const ConversationTextMessageContent({
+    required this.sourceId,
+    required this.text,
+    required this.isUser,
+    required this.translationButtonKey,
+    required this.translationContentKey,
+    required this.translationErrorKey,
+    this.isStreaming = false,
+    this.hasFailed = false,
+    this.textVisible = true,
+    this.textVisibilityKey,
+    this.textKey,
+    this.streamingKey,
+    this.onTranslate,
+    this.leadingActions = const <Widget>[],
+    this.mediaError,
+    this.mediaErrorKey,
+    super.key,
+  });
+
+  final String sourceId;
+  final String text;
+  final bool isUser;
+  final bool isStreaming;
+  final bool hasFailed;
+  final bool textVisible;
+  final Key? textVisibilityKey;
+  final Key? textKey;
+  final Key? streamingKey;
+  final Key translationButtonKey;
+  final Key translationContentKey;
+  final Key translationErrorKey;
+  final Future<String> Function()? onTranslate;
+  final List<Widget> leadingActions;
+  final String? mediaError;
+  final Key? mediaErrorKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Visibility(
+      key: textVisibilityKey,
+      visible: textVisible,
+      maintainAnimation: true,
+      maintainSize: true,
+      maintainState: true,
+      child: _messageText(),
+    );
+    if (isUser || hasFailed) {
+      return content;
+    }
+    final translate = isStreaming ? null : onTranslate;
+    final hasActions = leadingActions.isNotEmpty || translate != null;
+    if (!hasActions && mediaError == null) {
+      return content;
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        content,
+        if (hasActions)
+          MessageTranslationDisclosure(
+            sourceId: sourceId,
+            buttonKey: translationButtonKey,
+            contentKey: translationContentKey,
+            errorKey: translationErrorKey,
+            onTranslate: translate,
+            leadingActions: leadingActions,
+          ),
+        if (mediaError case final error?) ...[
+          const SizedBox(height: 3),
+          Text(
+            error,
+            key: mediaErrorKey,
+            style: const TextStyle(
+              color: SpeakUpDesign.error,
+              fontSize: 12,
+              height: 1.35,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _messageText() {
+    if (isUser) {
+      return Text(
+        text,
+        key: textKey,
+        style: const TextStyle(
+          color: SpeakUpDesign.ink,
+          fontSize: 15,
+          height: 1.45,
+        ),
+      );
+    }
+    if (isStreaming && text.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: SizedBox.square(
+          key: streamingKey,
+          dimension: 16,
+          child: const CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return ConversationAssistantMarkdown(
+      key: textKey,
+      data: text,
+      foreground: SpeakUpDesign.ink,
+    );
+  }
+}
+
+final class ConversationAssistantMarkdown extends StatelessWidget {
+  const ConversationAssistantMarkdown({
+    required this.data,
+    this.foreground = SpeakUpDesign.ink,
+    super.key,
+  });
+
+  final String data;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    final body = TextStyle(color: foreground, fontSize: 15, height: 1.48);
+    return MarkdownBody(
+      data: data,
+      selectable: true,
+      fitContent: true,
+      styleSheet: MarkdownStyleSheet(
+        a: body,
+        p: body,
+        pPadding: EdgeInsets.zero,
+        em: body.copyWith(fontStyle: FontStyle.italic),
+        strong: body.copyWith(fontWeight: FontWeight.w700),
+        code: body.copyWith(
+          fontFamily: 'monospace',
+          fontSize: 13.5,
+          backgroundColor: SpeakUpDesign.surfaceMuted,
+        ),
+        h1: body.copyWith(fontSize: 20, fontWeight: FontWeight.w700),
+        h2: body.copyWith(fontSize: 18, fontWeight: FontWeight.w700),
+        h3: body.copyWith(fontSize: 16, fontWeight: FontWeight.w700),
+        h4: body.copyWith(fontWeight: FontWeight.w700),
+        h5: body.copyWith(fontWeight: FontWeight.w700),
+        h6: body.copyWith(fontWeight: FontWeight.w700),
+        blockquote: body.copyWith(color: SpeakUpDesign.secondary),
+        listBullet: body,
+        listIndent: 20,
+        blockSpacing: 8,
+        blockquotePadding: const EdgeInsets.fromLTRB(10, 5, 8, 5),
+        blockquoteDecoration: const BoxDecoration(
+          color: SpeakUpDesign.surfaceMuted,
+          border: Border(
+            left: BorderSide(color: SpeakUpDesign.primary, width: 3),
+          ),
+        ),
+        codeblockPadding: const EdgeInsets.all(10),
+        codeblockDecoration: BoxDecoration(
+          color: SpeakUpDesign.surfaceMuted,
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+      imageBuilder: (uri, title, alt) => Text(
+        alt == null || alt.trim().isEmpty ? '[图片已隐藏]' : '[图片：$alt]',
+        style: body.copyWith(color: SpeakUpDesign.secondary),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:speakup/design/conversation_bubble_surface.dart';
-import 'package:speakup/design/message_translation.dart';
+import 'package:speakup/design/conversation_message_content.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff.dart';
@@ -117,7 +116,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         context,
         foreground,
       ),
-      AgentMessageModality.text => _buildTextMessage(context, foreground),
+      AgentMessageModality.text => _buildTextMessage(),
     };
     return ConversationBubbleSurface(
       bubbleKey: Key('agent-message-${message.id}'),
@@ -148,36 +147,9 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
     );
   }
 
-  Widget _buildTextMessage(BuildContext context, Color foreground) {
+  Widget _buildTextMessage() {
     final message = widget.message;
     final audioController = widget.messageAudioController;
-    if (message.role == AgentMessageRole.user) {
-      return Text(
-        message.text,
-        style: TextStyle(color: foreground, fontSize: 15, height: 1.45),
-      );
-    }
-    final markdown = _AssistantMarkdown(
-      key: Key('agent-assistant-text-${message.id}'),
-      data: message.text,
-      foreground: foreground,
-    );
-    if (message.isStreaming && message.text.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 6),
-        child: SizedBox.square(
-          key: Key('agent-assistant-streaming'),
-          dimension: 16,
-          child: CircularProgressIndicator(strokeWidth: 2),
-        ),
-      );
-    }
-    if (message.hasFailed) {
-      return markdown;
-    }
-    if (audioController == null && widget.onTranslate == null) {
-      return markdown;
-    }
     final loading = audioController?.loadingMessageId == message.id;
     final playing = audioController?.playingMessageId == message.id;
     final error = audioController?.errorMessageId == message.id
@@ -238,33 +210,27 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         ),
       ]);
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        markdown,
-        MessageTranslationDisclosure(
-          sourceId: message.id,
-          buttonKey: Key('agent-assistant-translate-${message.id}'),
-          contentKey: Key('agent-assistant-translation-${message.id}'),
-          errorKey: Key('agent-assistant-translation-error-${message.id}'),
-          onTranslate: widget.onTranslate == null || message.isStreaming
-              ? null
-              : () => widget.onTranslate!(message),
-          leadingActions: actions,
-        ),
-        if (error != null) ...[
-          const SizedBox(height: 3),
-          Text(
-            error,
-            key: Key('agent-message-media-error-${message.id}'),
-            style: const TextStyle(
-              color: SpeakUpDesign.error,
-              fontSize: 12,
-              height: 1.35,
-            ),
-          ),
-        ],
-      ],
+    return ConversationTextMessageContent(
+      sourceId: message.id,
+      text: message.text,
+      isUser: message.role == AgentMessageRole.user,
+      isStreaming: message.isStreaming,
+      hasFailed: message.hasFailed,
+      textKey: message.role == AgentMessageRole.assistant
+          ? Key('agent-assistant-text-${message.id}')
+          : null,
+      streamingKey: const Key('agent-assistant-streaming'),
+      translationButtonKey: Key('agent-assistant-translate-${message.id}'),
+      translationContentKey: Key('agent-assistant-translation-${message.id}'),
+      translationErrorKey: Key(
+        'agent-assistant-translation-error-${message.id}',
+      ),
+      onTranslate: widget.onTranslate == null
+          ? null
+          : () => widget.onTranslate!(message),
+      leadingActions: actions,
+      mediaError: error,
+      mediaErrorKey: Key('agent-message-media-error-${message.id}'),
     );
   }
 
@@ -466,65 +432,6 @@ class _MessageImageThumbnail extends StatelessWidget {
                 errorBuilder: (_, _, _) => placeholder,
               ),
             ),
-    );
-  }
-}
-
-class _AssistantMarkdown extends StatelessWidget {
-  const _AssistantMarkdown({
-    required this.data,
-    required this.foreground,
-    super.key,
-  });
-
-  final String data;
-  final Color foreground;
-
-  @override
-  Widget build(BuildContext context) {
-    final body = TextStyle(color: foreground, fontSize: 15, height: 1.48);
-    return MarkdownBody(
-      data: data,
-      selectable: true,
-      fitContent: true,
-      styleSheet: MarkdownStyleSheet(
-        a: body,
-        p: body,
-        pPadding: EdgeInsets.zero,
-        em: body.copyWith(fontStyle: FontStyle.italic),
-        strong: body.copyWith(fontWeight: FontWeight.w700),
-        code: body.copyWith(
-          fontFamily: 'monospace',
-          fontSize: 13.5,
-          backgroundColor: SpeakUpDesign.surfaceMuted,
-        ),
-        h1: body.copyWith(fontSize: 20, fontWeight: FontWeight.w700),
-        h2: body.copyWith(fontSize: 18, fontWeight: FontWeight.w700),
-        h3: body.copyWith(fontSize: 16, fontWeight: FontWeight.w700),
-        h4: body.copyWith(fontWeight: FontWeight.w700),
-        h5: body.copyWith(fontWeight: FontWeight.w700),
-        h6: body.copyWith(fontWeight: FontWeight.w700),
-        blockquote: body.copyWith(color: SpeakUpDesign.secondary),
-        listBullet: body,
-        listIndent: 20,
-        blockSpacing: 8,
-        blockquotePadding: const EdgeInsets.fromLTRB(10, 5, 8, 5),
-        blockquoteDecoration: const BoxDecoration(
-          color: SpeakUpDesign.surfaceMuted,
-          border: Border(
-            left: BorderSide(color: SpeakUpDesign.primary, width: 3),
-          ),
-        ),
-        codeblockPadding: const EdgeInsets.all(10),
-        codeblockDecoration: BoxDecoration(
-          color: SpeakUpDesign.surfaceMuted,
-          borderRadius: BorderRadius.circular(8),
-        ),
-      ),
-      imageBuilder: (uri, title, alt) => Text(
-        alt == null || alt.trim().isEmpty ? '[图片已隐藏]' : '[图片：$alt]',
-        style: body.copyWith(color: SpeakUpDesign.secondary),
-      ),
     );
   }
 }

--- a/mobile/lib/features/coaching/practice/practice_message_bubble.dart
+++ b/mobile/lib/features/coaching/practice/practice_message_bubble.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/conversation_bubble_surface.dart';
-import 'package:speakup/design/message_translation.dart';
+import 'package:speakup/design/conversation_message_content.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/evaluation/inline_speech_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
@@ -44,25 +44,27 @@ final class _PracticeMessageBubbleState extends State<PracticeMessageBubble> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Visibility(
-            key: Key('practice-message-text-${message.id}'),
-            visible: widget.messageTextVisible,
-            maintainAnimation: true,
-            maintainSize: true,
-            maintainState: true,
-            child: Text(
-              message.text,
-              style: TextStyle(color: SpeakUpDesign.ink, height: 1.45),
-            ),
-          ),
-          MessageTranslationDisclosure(
+          ConversationTextMessageContent(
             sourceId: message.id,
-            buttonKey: Key('practice-assistant-translate-${message.id}'),
-            contentKey: Key('practice-assistant-translation-${message.id}'),
-            errorKey: Key('practice-assistant-translation-error-${message.id}'),
+            text: message.text,
+            isUser: user,
+            textVisible: widget.messageTextVisible,
+            textVisibilityKey: Key('practice-message-text-${message.id}'),
+            translationButtonKey: Key(
+              'practice-assistant-translate-${message.id}',
+            ),
+            translationContentKey: Key(
+              'practice-assistant-translation-${message.id}',
+            ),
+            translationErrorKey: Key(
+              'practice-assistant-translation-error-${message.id}',
+            ),
             onTranslate: widget.onTranslate == null
                 ? null
                 : () => widget.onTranslate!(message),
+            leadingActions: widget.actions == null
+                ? const <Widget>[]
+                : <Widget>[widget.actions!],
           ),
           if (user && widget.feedbackProjection != null) ...[
             const SizedBox(height: SpeakUpDesign.space4),
@@ -70,10 +72,6 @@ final class _PracticeMessageBubbleState extends State<PracticeMessageBubble> {
               projection: widget.feedbackProjection,
               onRepractice: widget.onFeedbackRepractice,
             ),
-          ],
-          if (widget.actions != null) ...[
-            const SizedBox(height: 6),
-            widget.actions!,
           ],
         ],
       ),

--- a/mobile/test/coaching/practice/practice_message_bubble_test.dart
+++ b/mobile/test/coaching/practice/practice_message_bubble_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
+
+void main() {
+  testWidgets('uses the shared Markdown renderer for an assistant message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PracticeMessageBubble(
+            message: PracticeMessage(
+              id: 'practice-assistant',
+              role: PracticeMessageRole.assistant,
+              text: 'Try **one complete sentence**.',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final selectable = find.descendant(
+      of: find.byKey(const Key('practice-message-practice-assistant')),
+      matching: find.byType(SelectableText),
+    );
+    expect(selectable, findsWidgets);
+    expect(find.textContaining('one complete sentence'), findsOneWidget);
+    expect(find.textContaining('**'), findsNothing);
+  });
+
+  testWidgets('places a practice action beside the shared translation action', (
+    tester,
+  ) async {
+    var playbackCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeMessageBubble(
+            message: const PracticeMessage(
+              id: 'practice-actions',
+              role: PracticeMessageRole.assistant,
+              text: 'Tell me about your role.',
+            ),
+            onTranslate: (_) async => '介绍一下你的角色。',
+            actions: TextButton(
+              key: const Key('practice-play'),
+              onPressed: () => playbackCalls++,
+              child: const Text('播放'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('practice-play')));
+    await tester.tap(
+      find.byKey(const Key('practice-assistant-translate-practice-actions')),
+    );
+    await tester.pump();
+
+    expect(playbackCalls, 1);
+    expect(find.text('介绍一下你的角色。'), findsOneWidget);
+  });
+}

--- a/mobile/test/coaching/practice/practice_message_bubble_test.dart
+++ b/mobile/test/coaching/practice/practice_message_bubble_test.dart
@@ -63,4 +63,31 @@ void main() {
     expect(playbackCalls, 1);
     expect(find.text('介绍一下你的角色。'), findsOneWidget);
   });
+
+  testWidgets('keeps actions attached to a user message', (tester) async {
+    var actionCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeMessageBubble(
+            message: const PracticeMessage(
+              id: 'practice-user-actions',
+              role: PracticeMessageRole.user,
+              text: 'I led the migration.',
+            ),
+            actions: TextButton(
+              key: const Key('practice-user-action'),
+              onPressed: () => actionCalls++,
+              child: const Text('查看反馈'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('practice-user-action')));
+
+    expect(actionCalls, 1);
+    expect(find.text('查看反馈'), findsOneWidget);
+  });
 }

--- a/mobile/test/design/conversation_message_content_test.dart
+++ b/mobile/test/design/conversation_message_content_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/conversation_message_content.dart';
+
+void main() {
+  testWidgets('renders shared assistant Markdown without loading images', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ConversationTextMessageContent(
+            sourceId: 'assistant-1',
+            text: '**Clear answer**\n\n![diagram](https://example.com/a.png)',
+            isUser: false,
+            translationButtonKey: Key('translate'),
+            translationContentKey: Key('translation'),
+            translationErrorKey: Key('translation-error'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Clear answer'), findsOneWidget);
+    expect(find.text('[图片：diagram]'), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+
+  testWidgets('shows a streaming placeholder and withholds translation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ConversationTextMessageContent(
+            sourceId: 'assistant-stream',
+            text: '',
+            isUser: false,
+            isStreaming: true,
+            streamingKey: const Key('streaming'),
+            translationButtonKey: const Key('translate'),
+            translationContentKey: const Key('translation'),
+            translationErrorKey: const Key('translation-error'),
+            onTranslate: () async => '不应请求',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('streaming')), findsOneWidget);
+    expect(find.byKey(const Key('translate')), findsNothing);
+  });
+
+  testWidgets('hosts playback and translation in one shared action row', (
+    tester,
+  ) async {
+    var playbackCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ConversationTextMessageContent(
+            sourceId: 'assistant-actions',
+            text: 'How are you?',
+            isUser: false,
+            translationButtonKey: const Key('translate'),
+            translationContentKey: const Key('translation'),
+            translationErrorKey: const Key('translation-error'),
+            onTranslate: () async => '你好吗？',
+            leadingActions: [
+              TextButton(
+                key: const Key('play'),
+                onPressed: () => playbackCalls++,
+                child: const Text('播放'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('play')));
+    await tester.tap(find.byKey(const Key('translate')));
+    await tester.pump();
+
+    expect(playbackCalls, 1);
+    expect(find.text('你好吗？'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 功能描述
- 抽取 Agent 与 Practice 共用的文本消息内容层。
- Assistant 共用 Markdown、流式空态、翻译披露、媒体失败和操作行布局。
- User 消息继续按纯文本展示；Practice 的单轮反馈与业务动作仍保留在 Practice 边界。

## 实现思路
- 新增与业务模型无关的 `ConversationTextMessageContent` 和 `ConversationAssistantMarkdown`。
- AgentMessageBubble 与 PracticeMessageBubble 只负责各自状态/动作，正文渲染委托给共享组件。
- 删除 Agent 内原有私有 Markdown 重复实现，不把完整首页 Conversation 页面嵌入练习页。

## 可复现测试
- `cd mobile && flutter analyze --no-pub`
- 共享渲染、Agent 气泡、Practice 气泡、Scenario、IELTS 与 App 路由相关 93 项测试通过。
- 已在 #539 + #541 的真实后端 iOS 模拟器集成预览中验证页面渲染。

Closes #541
Related to #542