### PR TITLE
feat(practice): 复用首页实时语音链路

### DIFF
--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -501,6 +501,7 @@ class PracticeRecordingComposer extends StatelessWidget {
     required this.phase,
     required this.keyPrefix,
     this.elapsed,
+    this.transcript = '',
     this.upwardCancelOnly = false,
     super.key,
   });
@@ -509,6 +510,7 @@ class PracticeRecordingComposer extends StatelessWidget {
   final VoiceCapturePhase phase;
   final String keyPrefix;
   final Duration? elapsed;
+  final String transcript;
   final bool upwardCancelOnly;
 
   @override
@@ -522,6 +524,8 @@ class PracticeRecordingComposer extends StatelessWidget {
       stopRecordingKey: Key('$keyPrefix-stop-recording'),
       stateLabelKey: Key('$keyPrefix-voice-state-label'),
       durationKey: Key('$keyPrefix-voice-target-duration'),
+      liveTranscript: transcript,
+      liveTranscriptKey: Key('$keyPrefix-live-transcript'),
       upwardCancelOnly: upwardCancelOnly,
     );
   }
@@ -559,42 +563,6 @@ class PracticeLoadingComposer extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class PracticeTranscribingComposer extends StatelessWidget {
-  const PracticeTranscribingComposer({
-    required this.label,
-    required this.transcript,
-    required this.keyPrefix,
-    super.key,
-  });
-
-  final String label;
-  final String transcript;
-  final String keyPrefix;
-
-  @override
-  Widget build(BuildContext context) {
-    final visibleTranscript = transcript.trim();
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        PracticeLoadingComposer(label: label),
-        if (visibleTranscript.isNotEmpty) ...[
-          const SizedBox(height: 4),
-          Text(
-            visibleTranscript,
-            key: Key('$keyPrefix-live-transcript'),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.body,
-          ),
-        ],
-      ],
     );
   }
 }

--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -563,6 +563,42 @@ class PracticeLoadingComposer extends StatelessWidget {
   }
 }
 
+class PracticeTranscribingComposer extends StatelessWidget {
+  const PracticeTranscribingComposer({
+    required this.label,
+    required this.transcript,
+    required this.keyPrefix,
+    super.key,
+  });
+
+  final String label;
+  final String transcript;
+  final String keyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleTranscript = transcript.trim();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        PracticeLoadingComposer(label: label),
+        if (visibleTranscript.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Text(
+            visibleTranscript,
+            key: Key('$keyPrefix-live-transcript'),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: SpeakUpDesign.body,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
 class PracticePendingAudioComposer extends StatelessWidget {
   const PracticePendingAudioComposer({
     required this.keyPrefix,

--- a/mobile/lib/design/voice_composer_dock.dart
+++ b/mobile/lib/design/voice_composer_dock.dart
@@ -22,6 +22,8 @@ class VoiceComposerDock extends StatelessWidget {
     this.upwardCancelOnly = true,
     this.showTextAction = true,
     this.directTapToSend = false,
+    this.liveTranscript,
+    this.liveTranscriptKey,
     super.key,
   });
 
@@ -40,6 +42,8 @@ class VoiceComposerDock extends StatelessWidget {
   final bool upwardCancelOnly;
   final bool showTextAction;
   final bool directTapToSend;
+  final String? liveTranscript;
+  final Key? liveTranscriptKey;
 
   @override
   Widget build(BuildContext context) {
@@ -63,41 +67,63 @@ class VoiceComposerDock extends StatelessWidget {
         : capturing
         ? SpeakUpDesign.ink
         : SpeakUpDesign.secondary;
+    final visibleTranscript = capturing ? liveTranscript?.trim() ?? '' : '';
     final targetContent = ConstrainedBox(
       key: capturing ? stopRecordingKey : null,
       constraints: const BoxConstraints(minHeight: 48),
-      child: Row(
+      child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          if (capturing) ...[
-            Icon(Icons.graphic_eq_rounded, color: stateColor, size: 22),
-            const SizedBox(width: 9),
-          ],
-          Flexible(
-            child: Text(
-              label,
-              key: stateLabelKey,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: stateColor,
-                fontSize: 15,
-                fontWeight: FontWeight.w700,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (capturing) ...[
+                Icon(Icons.graphic_eq_rounded, color: stateColor, size: 22),
+                const SizedBox(width: 9),
+              ],
+              Flexible(
+                child: Text(
+                  label,
+                  key: stateLabelKey,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: stateColor,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
               ),
-            ),
+              if (phase == VoiceCapturePhase.recording) ...[
+                const SizedBox(width: 10),
+                Text(
+                  _formatDuration(elapsed),
+                  key: durationKey,
+                  style: const TextStyle(
+                    color: SpeakUpDesign.secondary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ],
           ),
-          if (phase == VoiceCapturePhase.recording) ...[
-            const SizedBox(width: 10),
-            Text(
-              _formatDuration(elapsed),
-              key: durationKey,
-              style: const TextStyle(
-                color: SpeakUpDesign.secondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
+          if (visibleTranscript.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 2, 12, 4),
+              child: Text(
+                visibleTranscript,
+                key: liveTranscriptKey,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: SpeakUpDesign.secondary,
+                  fontSize: 13,
+                  height: 1.3,
+                ),
               ),
             ),
-          ],
         ],
       ),
     );

--- a/mobile/lib/design/voice_composer_dock.dart
+++ b/mobile/lib/design/voice_composer_dock.dart
@@ -72,6 +72,7 @@ class VoiceComposerDock extends StatelessWidget {
       key: capturing ? stopRecordingKey : null,
       constraints: const BoxConstraints(minHeight: 48),
       child: Column(
+        mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Row(

--- a/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
+import 'package:speakup/platform/audio/pcm16_stream_capture.dart';
 
 import 'agent_voice_models.dart';
 
@@ -117,10 +118,7 @@ final class IosAgentVoiceRecorder
   final Random _random = Random.secure();
   String? _activePath;
   DateTime? _startedAt;
-  BytesBuilder? _activePCM;
-  StreamSubscription<Uint8List>? _pcmSubscription;
-  Completer<void>? _pcmDone;
-  StreamController<Uint8List>? _pcmOutput;
+  Pcm16StreamCapture? _streamCapture;
 
   @override
   Future<void> start() async {
@@ -166,42 +164,14 @@ final class IosAgentVoiceRecorder
     final path = '${directory.path}/${_newFileName()}';
     _activePath = path;
     _startedAt = _clock();
-    final pcm = BytesBuilder(copy: false);
-    final done = Completer<void>();
-    final output = StreamController<Uint8List>();
-    _activePCM = pcm;
-    _pcmDone = done;
-    _pcmOutput = output;
     try {
       final input = await _recorder.startPcm16Stream();
-      _pcmSubscription = input.listen(
-        (chunk) {
-          if (pcm.length + chunk.lengthInBytes > _maximumPCMBytes) {
-            output.addError(
-              const AgentVoiceRecordingException(
-                AgentVoiceRecordingFailureKind.invalidAudio,
-              ),
-            );
-            return;
-          }
-          pcm.add(chunk);
-          output.add(chunk);
-        },
-        onError: (Object error, StackTrace stackTrace) {
-          output.addError(error, stackTrace);
-          if (!done.isCompleted) {
-            done.completeError(error, stackTrace);
-          }
-        },
-        onDone: () {
-          output.close();
-          if (!done.isCompleted) {
-            done.complete();
-          }
-        },
-        cancelOnError: true,
+      final capture = Pcm16StreamCapture(
+        input: input,
+        maximumPcmBytes: _maximumPCMBytes,
       );
-      return output.stream;
+      _streamCapture = capture;
+      return capture.stream;
     } catch (_) {
       _clearStreamingState();
       _activePath = null;
@@ -281,9 +251,8 @@ final class IosAgentVoiceRecorder
   Future<AgentVoiceLocalRecording> stopAudioStream() async {
     final path = _activePath;
     final startedAt = _startedAt;
-    final pcm = _activePCM;
-    final done = _pcmDone;
-    if (path == null || startedAt == null || pcm == null || done == null) {
+    final capture = _streamCapture;
+    if (path == null || startedAt == null || capture == null) {
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.notRecording,
       );
@@ -292,14 +261,7 @@ final class IosAgentVoiceRecorder
     _startedAt = null;
     try {
       await _recorder.stop();
-      await done.future.timeout(const Duration(seconds: 2));
-      final pcmBytes = pcm.takeBytes();
-      if (pcmBytes.isEmpty || pcmBytes.lengthInBytes.isOdd) {
-        throw const AgentVoiceRecordingException(
-          AgentVoiceRecordingFailureKind.emptyAudio,
-        );
-      }
-      final wav = _pcm16MonoWav(pcmBytes, sampleRate: 16000);
+      final wav = await capture.finish();
       await File(path).writeAsBytes(wav, flush: true);
       final elapsed = _boundedRecordingDuration(startedAt);
       return AgentVoiceLocalRecording(
@@ -308,6 +270,9 @@ final class IosAgentVoiceRecorder
         sizeBytes: wav.lengthInBytes,
         duration: elapsed,
       );
+    } on Pcm16StreamCaptureException catch (error) {
+      await _deletePath(path);
+      throw AgentVoiceRecordingException(_mapStreamFailure(error.kind));
     } on AgentVoiceRecordingException {
       await _deletePath(path);
       rethrow;
@@ -324,18 +289,18 @@ final class IosAgentVoiceRecorder
   @override
   Future<void> discardCurrent() async {
     final path = _activePath;
+    final capture = _streamCapture;
     _activePath = null;
     _startedAt = null;
     if (path == null) {
       return;
     }
+    await capture?.cancel();
     try {
       await _recorder.stop();
     } catch (_) {
       // The owned path is still removed below.
     }
-    await _pcmSubscription?.cancel();
-    await _pcmOutput?.close();
     _clearStreamingState();
     await _deletePath(path);
   }
@@ -350,10 +315,7 @@ final class IosAgentVoiceRecorder
   }
 
   void _clearStreamingState() {
-    _activePCM = null;
-    _pcmSubscription = null;
-    _pcmDone = null;
-    _pcmOutput = null;
+    _streamCapture = null;
   }
 
   @override
@@ -427,25 +389,17 @@ final class IosAgentVoiceRecorder
   }
 }
 
-Uint8List _pcm16MonoWav(Uint8List pcm, {required int sampleRate}) {
-  final result = Uint8List(44 + pcm.lengthInBytes);
-  final data = ByteData.sublistView(result);
-  result.setRange(0, 4, 'RIFF'.codeUnits);
-  data.setUint32(4, result.lengthInBytes - 8, Endian.little);
-  result.setRange(8, 12, 'WAVE'.codeUnits);
-  result.setRange(12, 16, 'fmt '.codeUnits);
-  data.setUint32(16, 16, Endian.little);
-  data.setUint16(20, 1, Endian.little);
-  data.setUint16(22, 1, Endian.little);
-  data.setUint32(24, sampleRate, Endian.little);
-  data.setUint32(28, sampleRate * 2, Endian.little);
-  data.setUint16(32, 2, Endian.little);
-  data.setUint16(34, 16, Endian.little);
-  result.setRange(36, 40, 'data'.codeUnits);
-  data.setUint32(40, pcm.lengthInBytes, Endian.little);
-  result.setRange(44, result.lengthInBytes, pcm);
-  return result;
-}
+AgentVoiceRecordingFailureKind _mapStreamFailure(
+  Pcm16StreamCaptureFailureKind kind,
+) => switch (kind) {
+  Pcm16StreamCaptureFailureKind.emptyAudio =>
+    AgentVoiceRecordingFailureKind.emptyAudio,
+  Pcm16StreamCaptureFailureKind.invalidAudio =>
+    AgentVoiceRecordingFailureKind.invalidAudio,
+  Pcm16StreamCaptureFailureKind.unavailable ||
+  Pcm16StreamCaptureFailureKind.cancelled =>
+    AgentVoiceRecordingFailureKind.unavailable,
+};
 
 final class FakeAgentVoiceRecorder implements AgentVoiceRecorder {
   FakeAgentVoiceRecorder({

--- a/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
@@ -271,12 +271,15 @@ final class IosAgentVoiceRecorder
         duration: elapsed,
       );
     } on Pcm16StreamCaptureException catch (error) {
+      await capture.cancel();
       await _deletePath(path);
       throw AgentVoiceRecordingException(_mapStreamFailure(error.kind));
     } on AgentVoiceRecordingException {
+      await capture.cancel();
       await _deletePath(path);
       rethrow;
     } catch (_) {
+      await capture.cancel();
       await _deletePath(path);
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.unavailable,

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -2105,13 +2105,11 @@ class _RecorderDock extends StatelessWidget {
                 onCancel: onCancelConvertedAnswer,
               )
             : working
-            ? _IeltsRecorderWorkingState(
-                state: state,
-                transcript: controller.transcript ?? '',
-              )
+            ? _IeltsRecorderWorkingState(state: state)
             : _IeltsVoiceCaptureDock(
                 phase: phase,
                 capture: capture,
+                transcript: controller.transcript ?? '',
                 allowTextAnswer: allowTextAnswer,
                 onShowText: onOpenTextAnswer,
               );
@@ -2144,12 +2142,14 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
   const _IeltsVoiceCaptureDock({
     required this.phase,
     required this.capture,
+    required this.transcript,
     required this.allowTextAnswer,
     required this.onShowText,
   });
 
   final VoiceCapturePhase phase;
   final VoiceCaptureView capture;
+  final String transcript;
   final bool allowTextAnswer;
   final VoidCallback onShowText;
 
@@ -2164,6 +2164,8 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
       stopRecordingKey: const Key('ielts-mock-stop-recording'),
       stateLabelKey: const Key('ielts-mock-voice-state-label'),
       durationKey: const Key('ielts-mock-voice-target-duration'),
+      liveTranscript: transcript,
+      liveTranscriptKey: const Key('ielts-mock-live-transcript'),
       upwardCancelOnly: true,
       showTextAction: allowTextAnswer,
       directTapToSend: !allowTextAnswer,
@@ -2174,32 +2176,21 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
 }
 
 class _IeltsRecorderWorkingState extends StatelessWidget {
-  const _IeltsRecorderWorkingState({
-    required this.state,
-    required this.transcript,
-  });
+  const _IeltsRecorderWorkingState({required this.state});
 
   final PracticeRecordingState state;
-  final String transcript;
 
   @override
   Widget build(BuildContext context) {
     final label = switch (state) {
-      PracticeRecordingState.transcribing => 'Transcribing your answer…',
-      PracticeRecordingState.awaitingConfirmation => 'Submitting your answer…',
-      PracticeRecordingState.submitting => 'Answer sent. Agent is replying…',
-      _ => 'Working…',
+      PracticeRecordingState.transcribing => '正在识别你的回答…',
+      PracticeRecordingState.awaitingConfirmation => '正在提交你的回答…',
+      PracticeRecordingState.submitting => '回答已发送，正在进入下一题…',
+      _ => '正在处理…',
     };
-    final content = state == PracticeRecordingState.transcribing
-        ? PracticeTranscribingComposer(
-            label: label,
-            transcript: transcript,
-            keyPrefix: 'ielts-mock',
-          )
-        : PracticeLoadingComposer(label: label);
     return KeyedSubtree(
       key: const Key('ielts-mock-recorder-working'),
-      child: content,
+      child: PracticeLoadingComposer(label: label),
     );
   }
 }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -2105,7 +2105,10 @@ class _RecorderDock extends StatelessWidget {
                 onCancel: onCancelConvertedAnswer,
               )
             : working
-            ? _IeltsRecorderWorkingState(state: state)
+            ? _IeltsRecorderWorkingState(
+                state: state,
+                transcript: controller.transcript ?? '',
+              )
             : _IeltsVoiceCaptureDock(
                 phase: phase,
                 capture: capture,
@@ -2171,9 +2174,13 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
 }
 
 class _IeltsRecorderWorkingState extends StatelessWidget {
-  const _IeltsRecorderWorkingState({required this.state});
+  const _IeltsRecorderWorkingState({
+    required this.state,
+    required this.transcript,
+  });
 
   final PracticeRecordingState state;
+  final String transcript;
 
   @override
   Widget build(BuildContext context) {
@@ -2183,9 +2190,16 @@ class _IeltsRecorderWorkingState extends StatelessWidget {
       PracticeRecordingState.submitting => 'Answer sent. Agent is replying…',
       _ => 'Working…',
     };
+    final content = state == PracticeRecordingState.transcribing
+        ? PracticeTranscribingComposer(
+            label: label,
+            transcript: transcript,
+            keyPrefix: 'ielts-mock',
+          )
+        : PracticeLoadingComposer(label: label);
     return KeyedSubtree(
       key: const Key('ielts-mock-recorder-working'),
-      child: PracticeLoadingComposer(label: label),
+      child: content,
     );
   }
 }

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -855,11 +855,10 @@ class _RecordingPanelState extends State<_RecordingPanel> {
             phase: capturePhase,
             keyPrefix: 'practice',
             elapsed: Duration(seconds: widget.recordingSeconds),
-          ),
-          PracticeRecordingState.transcribing => PracticeTranscribingComposer(
-            label: '正在识别英文回答…',
             transcript: widget.controller.transcript ?? '',
-            keyPrefix: 'practice',
+          ),
+          PracticeRecordingState.transcribing => PracticeLoadingComposer(
+            label: '正在识别英文回答…',
           ),
           PracticeRecordingState.awaitingConfirmation =>
             PracticeTranscriptComposer(

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -856,8 +856,10 @@ class _RecordingPanelState extends State<_RecordingPanel> {
             keyPrefix: 'practice',
             elapsed: Duration(seconds: widget.recordingSeconds),
           ),
-          PracticeRecordingState.transcribing => const PracticeLoadingComposer(
+          PracticeRecordingState.transcribing => PracticeTranscribingComposer(
             label: '正在识别英文回答…',
+            transcript: widget.controller.transcript ?? '',
+            keyPrefix: 'practice',
           ),
           PracticeRecordingState.awaitingConfirmation =>
             PracticeTranscriptComposer(

--- a/mobile/lib/features/coaching/practice/ios_practice_recorder.dart
+++ b/mobile/lib/features/coaching/practice/ios_practice_recorder.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
+import 'package:speakup/platform/audio/pcm16_stream_capture.dart';
 
 abstract interface class NativePracticeRecorder {
   Future<bool> hasPermission();
@@ -13,7 +16,12 @@ abstract interface class NativePracticeRecorder {
   Future<String?> stop();
 }
 
-final class RecordNativePracticeRecorder implements NativePracticeRecorder {
+abstract interface class NativeStreamingPracticeRecorder {
+  Future<Stream<Uint8List>> startPcm16Stream();
+}
+
+final class RecordNativePracticeRecorder
+    implements NativePracticeRecorder, NativeStreamingPracticeRecorder {
   RecordNativePracticeRecorder([AudioRecorder? recorder])
     : _recorder = recorder ?? AudioRecorder();
 
@@ -39,10 +47,25 @@ final class RecordNativePracticeRecorder implements NativePracticeRecorder {
   }
 
   @override
+  Future<Stream<Uint8List>> startPcm16Stream() {
+    return _recorder.startStream(
+      const RecordConfig(
+        encoder: AudioEncoder.pcm16bits,
+        sampleRate: 16000,
+        numChannels: 1,
+        autoGain: false,
+        echoCancel: false,
+        noiseSuppress: false,
+      ),
+    );
+  }
+
+  @override
   Future<String?> stop() => _recorder.stop();
 }
 
-final class IosPracticeRecorder implements PracticeRecorder {
+final class IosPracticeRecorder
+    implements PracticeRecorder, PracticeStreamingRecorder {
   IosPracticeRecorder({
     NativePracticeRecorder? recorder,
     Future<Directory> Function()? temporaryDirectory,
@@ -51,11 +74,13 @@ final class IosPracticeRecorder implements PracticeRecorder {
 
   static const _managedDirectoryName = 'speakup-practice-audio';
   static const _minimumWavBytes = 45;
+  static const _maximumPcmBytes = 7400000 - 44;
 
   final NativePracticeRecorder _recorder;
   final Future<Directory> Function() _temporaryDirectory;
   final Random _random = Random.secure();
   String? _activePath;
+  Pcm16StreamCapture? _streamCapture;
 
   @override
   Future<void> start() async {
@@ -76,6 +101,46 @@ final class IosPracticeRecorder implements PracticeRecorder {
       await _recorder.startWav(path);
     } catch (_) {
       _activePath = null;
+      await _deletePath(path);
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.unavailable,
+      );
+    }
+  }
+
+  @override
+  Future<Stream<Uint8List>> startAudioStream() async {
+    if (_activePath != null) {
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.alreadyRecording,
+      );
+    }
+    if (!await _recorder.hasPermission()) {
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.permissionDenied,
+      );
+    }
+    final directory = await _managedDirectory();
+    final path = '${directory.path}/${_newFileName()}';
+    _activePath = path;
+    try {
+      final native = _recorder;
+      if (native is! NativeStreamingPracticeRecorder) {
+        throw const PracticeRecordingException(
+          PracticeRecordingFailureKind.unavailable,
+        );
+      }
+      final input = await (native as NativeStreamingPracticeRecorder)
+          .startPcm16Stream();
+      final capture = Pcm16StreamCapture(
+        input: input,
+        maximumPcmBytes: _maximumPcmBytes,
+      );
+      _streamCapture = capture;
+      return capture.stream;
+    } catch (_) {
+      _activePath = null;
+      _streamCapture = null;
       await _deletePath(path);
       throw const PracticeRecordingException(
         PracticeRecordingFailureKind.unavailable,
@@ -131,10 +196,44 @@ final class IosPracticeRecorder implements PracticeRecorder {
   }
 
   @override
+  Future<RecordedPracticeAudio> stopAudioStream() async {
+    final path = _activePath;
+    final capture = _streamCapture;
+    if (path == null || capture == null) {
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.notRecording,
+      );
+    }
+    _activePath = null;
+    _streamCapture = null;
+    try {
+      await _recorder.stop();
+      final wav = await capture.finish();
+      await File(path).writeAsBytes(wav, flush: true);
+      return RecordedPracticeAudio(
+        path: path,
+        contentType: 'audio/wav',
+        sizeBytes: wav.lengthInBytes,
+      );
+    } on Pcm16StreamCaptureException catch (error) {
+      await _deletePath(path);
+      throw PracticeRecordingException(_mapStreamFailure(error.kind));
+    } catch (_) {
+      await _deletePath(path);
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.unavailable,
+      );
+    }
+  }
+
+  @override
   Future<void> discardCurrent() async {
     final path = _activePath;
+    final capture = _streamCapture;
     _activePath = null;
+    _streamCapture = null;
     if (path != null) {
+      await capture?.cancel();
       try {
         await _recorder.stop();
       } catch (_) {
@@ -214,3 +313,15 @@ final class IosPracticeRecorder implements PracticeRecorder {
     }
   }
 }
+
+PracticeRecordingFailureKind _mapStreamFailure(
+  Pcm16StreamCaptureFailureKind kind,
+) => switch (kind) {
+  Pcm16StreamCaptureFailureKind.emptyAudio =>
+    PracticeRecordingFailureKind.emptyAudio,
+  Pcm16StreamCaptureFailureKind.invalidAudio =>
+    PracticeRecordingFailureKind.invalidAudio,
+  Pcm16StreamCaptureFailureKind.unavailable ||
+  Pcm16StreamCaptureFailureKind.cancelled =>
+    PracticeRecordingFailureKind.unavailable,
+};

--- a/mobile/lib/features/coaching/practice/ios_practice_recorder.dart
+++ b/mobile/lib/features/coaching/practice/ios_practice_recorder.dart
@@ -204,8 +204,6 @@ final class IosPracticeRecorder
         PracticeRecordingFailureKind.notRecording,
       );
     }
-    _activePath = null;
-    _streamCapture = null;
     try {
       await _recorder.stop();
       final wav = await capture.finish();
@@ -216,13 +214,18 @@ final class IosPracticeRecorder
         sizeBytes: wav.lengthInBytes,
       );
     } on Pcm16StreamCaptureException catch (error) {
+      await capture.cancel();
       await _deletePath(path);
       throw PracticeRecordingException(_mapStreamFailure(error.kind));
     } catch (_) {
+      await capture.cancel();
       await _deletePath(path);
       throw const PracticeRecordingException(
         PracticeRecordingFailureKind.unavailable,
       );
+    } finally {
+      _activePath = null;
+      _streamCapture = null;
     }
   }
 

--- a/mobile/lib/features/coaching/practice/practice_client.dart
+++ b/mobile/lib/features/coaching/practice/practice_client.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/ielts/ielts_assignment.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
@@ -34,6 +36,32 @@ abstract interface class PracticeClient {
     required String answerText,
     required String idempotencyKey,
   });
+}
+
+abstract interface class PracticeRealtimeTranscriptionClient {
+  Stream<PracticeTranscriptionEvent> transcribeRealtime({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+    required Stream<Uint8List> audioChunks,
+  });
+}
+
+sealed class PracticeTranscriptionEvent {
+  const PracticeTranscriptionEvent();
+}
+
+final class PracticeTranscriptUpdated extends PracticeTranscriptionEvent {
+  const PracticeTranscriptUpdated({required this.text, required this.isFinal});
+
+  final String text;
+  final bool isFinal;
+}
+
+final class PracticeCandidateCompleted extends PracticeTranscriptionEvent {
+  const PracticeCandidateCompleted(this.candidate);
+
+  final TranscriptionCandidate candidate;
 }
 
 abstract interface class PracticeLifecycleClient {

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -74,6 +74,8 @@ final class PracticeController extends ChangeNotifier
   bool _questionTipLoading = false;
   int _questionTipGeneration = 0;
   TranscriptionCandidate? _candidate;
+  String _liveTranscript = '';
+  Future<_RealtimePracticeCandidateResult>? _realtimeCandidate;
   _PendingPracticeAudio? _pendingPracticeAudio;
   String? _activeConfirmationId;
   String? _activeTextAnswer;
@@ -178,6 +180,8 @@ final class PracticeController extends ChangeNotifier
       clientTurnId: _newClientId('turn'),
     );
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _errorMessage = null;
@@ -211,8 +215,14 @@ final class PracticeController extends ChangeNotifier
   List<PracticeMessage> get practiceMessages =>
       List.unmodifiable(_practiceMessages);
   PracticeRecordingState get recordingState => _recordingState;
-  String? get transcript =>
-      _speechFeedbackRetryCandidate?.text ?? _candidate?.text;
+  String? get transcript {
+    final value =
+        _speechFeedbackRetryCandidate?.text ??
+        _candidate?.text ??
+        _liveTranscript;
+    return value.trim().isEmpty ? null : value;
+  }
+
   String? get errorMessage => _errorMessage;
   int get completedTurns => _completedTurns;
   int get turnLimit => _turnLimit;
@@ -539,6 +549,8 @@ final class PracticeController extends ChangeNotifier
       }
       await recorder.discardCurrent();
       _candidate = null;
+      _liveTranscript = '';
+      _realtimeCandidate = null;
       _activeConfirmationId = null;
       _activeTextAnswer = null;
       if (speechFeedbackRetry != null &&
@@ -814,6 +826,8 @@ final class PracticeController extends ChangeNotifier
     _speechFeedbackRetry = context;
     _speechFeedbackRetryCandidate = null;
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _errorMessage = null;
@@ -930,6 +944,8 @@ final class PracticeController extends ChangeNotifier
     }
     final generation = ++_practiceGeneration;
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _errorMessage = null;
@@ -962,9 +978,35 @@ final class PracticeController extends ChangeNotifier
           _recordingState != PracticeRecordingState.starting) {
         return;
       }
-      await recorder.start();
+      final realtimePractice = client is PracticeRealtimeTranscriptionClient
+          ? client as PracticeRealtimeTranscriptionClient
+          : null;
+      final streamingRecorder = recorder is PracticeStreamingRecorder
+          ? recorder as PracticeStreamingRecorder
+          : null;
+      final sessionId = fence.practiceSessionId;
+      final questionId = fence.questionId;
+      if (_speechFeedbackRetry == null &&
+          realtimePractice != null &&
+          streamingRecorder != null &&
+          sessionId != null &&
+          questionId != null) {
+        final chunks = await streamingRecorder.startAudioStream();
+        _realtimeCandidate = _collectRealtimeCandidate(
+          fence,
+          realtimePractice.transcribeRealtime(
+            sessionId: sessionId,
+            questionId: questionId,
+            idempotencyKey: _newClientId('turn'),
+            audioChunks: chunks,
+          ),
+        );
+      } else {
+        await recorder.start();
+      }
       if (!_isOperationCurrent(fence)) {
         await recorder.discardCurrent();
+        _realtimeCandidate = null;
         return;
       }
       _recordingState = PracticeRecordingState.recording;
@@ -977,6 +1019,7 @@ final class PracticeController extends ChangeNotifier
       });
     } on PracticeRecordingException catch (error) {
       if (_isOperationCurrent(fence)) {
+        _realtimeCandidate = null;
         final retry = _speechFeedbackRetry;
         if (retry == null) {
           _recordingState = PracticeRecordingState.idle;
@@ -990,6 +1033,7 @@ final class PracticeController extends ChangeNotifier
       }
     } catch (_) {
       if (_isOperationCurrent(fence)) {
+        _realtimeCandidate = null;
         final retry = _speechFeedbackRetry;
         if (retry == null) {
           _recordingState = PracticeRecordingState.idle;
@@ -1044,13 +1088,12 @@ final class PracticeController extends ChangeNotifier
       practiceSessionId: sessionId,
       questionId: question.id,
     );
-    final clientTurnId = _newClientId('turn');
     final operation = _stopRecording(
       practice: practice,
       sessionId: sessionId,
       question: question,
       fence: fence,
-      clientTurnId: clientTurnId,
+      clientTurnId: _newClientId('turn'),
     );
     _stopRecordingFuture = operation;
     return operation.whenComplete(() {
@@ -1075,6 +1118,8 @@ final class PracticeController extends ChangeNotifier
       return;
     }
     _practiceGeneration++;
+    _realtimeCandidate = null;
+    _liveTranscript = '';
     final speechFeedbackRetry = _speechFeedbackRetry;
     _cancelRecordingLimit();
     await _recorderStartFuture;
@@ -1103,10 +1148,15 @@ final class PracticeController extends ChangeNotifier
     required String clientTurnId,
   }) async {
     RecordedPracticeAudio? audio;
+    final realtime = _realtimeCandidate;
+    final usedRealtime =
+        realtime != null && recorder is PracticeStreamingRecorder;
     _recordingState = PracticeRecordingState.transcribing;
     notifyListeners();
     try {
-      final stopOperation = recorder.stop();
+      final stopOperation = usedRealtime
+          ? (recorder as PracticeStreamingRecorder).stopAudioStream()
+          : recorder.stop();
       _recorderStopFuture = stopOperation;
       try {
         audio = await stopOperation;
@@ -1118,26 +1168,56 @@ final class PracticeController extends ChangeNotifier
       if (!_isOperationCurrent(fence)) {
         return;
       }
-      final pending = _PendingPracticeAudio(
-        audio: audio,
-        sessionId: sessionId,
-        questionId: question.id,
-        clientTurnId: clientTurnId,
-      );
-      _pendingPracticeAudio = pending;
-      audio = null;
-      await _transcribePendingPracticeAudio(
-        practice: practice,
-        pending: pending,
-        fence: fence,
-      );
+      if (realtime != null) {
+        final result = await realtime;
+        if (identical(_realtimeCandidate, realtime)) {
+          _realtimeCandidate = null;
+        }
+        if (result.error case final error?) {
+          throw error;
+        }
+        final candidate = result.candidate;
+        if (candidate == null) {
+          throw StateError(
+            'Realtime Practice stream ended without a Candidate.',
+          );
+        }
+        if (!_isOperationCurrent(fence)) {
+          return;
+        }
+        _validateCandidate(candidate, sessionId, question.id);
+        _candidate = candidate;
+        _activeConfirmationId = null;
+        _activeTextAnswer = null;
+        _recordingState = PracticeRecordingState.awaitingConfirmation;
+        _errorMessage = null;
+      } else {
+        final pending = _PendingPracticeAudio(
+          audio: audio,
+          sessionId: sessionId,
+          questionId: question.id,
+          clientTurnId: clientTurnId,
+        );
+        _pendingPracticeAudio = pending;
+        audio = null;
+        await _transcribePendingPracticeAudio(
+          practice: practice,
+          pending: pending,
+          fence: fence,
+        );
+      }
     } catch (error) {
       if (_isOperationCurrent(fence)) {
         _candidate = null;
         _recordingState = PracticeRecordingState.idle;
-        _errorMessage = _transcriptionFailureMessage(error);
+        _errorMessage = usedRealtime
+            ? _realtimeTranscriptionFailureMessage(error)
+            : _transcriptionFailureMessage(error);
       }
     } finally {
+      if (identical(_realtimeCandidate, realtime)) {
+        _realtimeCandidate = null;
+      }
       if (audio != null) {
         try {
           await recorder.discard(audio);
@@ -1148,6 +1228,30 @@ final class PracticeController extends ChangeNotifier
     }
     if (_isOperationCurrent(fence)) {
       notifyListeners();
+    }
+  }
+
+  Future<_RealtimePracticeCandidateResult> _collectRealtimeCandidate(
+    _PracticeOperationFence fence,
+    Stream<PracticeTranscriptionEvent> events,
+  ) async {
+    TranscriptionCandidate? completed;
+    try {
+      await for (final event in events) {
+        if (!_isOperationCurrent(fence)) {
+          continue;
+        }
+        switch (event) {
+          case PracticeTranscriptUpdated(:final text):
+            _liveTranscript = text;
+            notifyListeners();
+          case PracticeCandidateCompleted(:final candidate):
+            completed = candidate;
+        }
+      }
+      return _RealtimePracticeCandidateResult(candidate: completed);
+    } catch (error) {
+      return _RealtimePracticeCandidateResult(error: error);
     }
   }
 
@@ -1358,6 +1462,8 @@ final class PracticeController extends ChangeNotifier
     _practiceGeneration++;
     final speechFeedbackRetry = _speechFeedbackRetry;
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     if (speechFeedbackRetry != null) {
@@ -1620,6 +1726,8 @@ final class PracticeController extends ChangeNotifier
       ];
     }
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _appendPracticeMessages([
@@ -1767,6 +1875,8 @@ final class PracticeController extends ChangeNotifier
     _currentQuestion = null;
     _clearQuestionTip();
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _speechFeedbackRetry = null;
@@ -1877,6 +1987,8 @@ final class PracticeController extends ChangeNotifier
     _cancelRecordingLimit();
     _practiceGeneration++;
     _candidate = null;
+    _liveTranscript = '';
+    _realtimeCandidate = null;
     _activeConfirmationId = null;
     _activeTextAnswer = null;
     _speechFeedbackRetry = null;
@@ -2081,6 +2193,14 @@ final class PracticeController extends ChangeNotifier
       }
     }
     return '没有识别出这一轮，录音已保留；可重试转写或删除。';
+  }
+
+  String _realtimeTranscriptionFailureMessage(Object error) {
+    if (error is PracticeClientException &&
+        error.kind == PracticeClientFailureKind.authenticationRequired) {
+      return '登录状态已失效，请重新登录。';
+    }
+    return '实时识别已中断，本轮没有提交，请重新录音。';
   }
 
   String _confirmationFailureMessage(Object error) {
@@ -2361,6 +2481,13 @@ final class PracticeController extends ChangeNotifier
   bool _canRetry(Object error) {
     return error is! PracticeClientException || error.retryable;
   }
+}
+
+final class _RealtimePracticeCandidateResult {
+  const _RealtimePracticeCandidateResult({this.candidate, this.error});
+
+  final TranscriptionCandidate? candidate;
+  final Object? error;
 }
 
 final class _PracticeOperationFence {

--- a/mobile/lib/features/coaching/practice/practice_recording.dart
+++ b/mobile/lib/features/coaching/practice/practice_recording.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 final class RecordedPracticeAudio {
   const RecordedPracticeAudio({
     required this.path,
@@ -20,6 +22,12 @@ abstract interface class PracticeRecorder {
   Future<void> discard(RecordedPracticeAudio audio);
 
   Future<void> clearAccountState();
+}
+
+abstract interface class PracticeStreamingRecorder {
+  Future<Stream<Uint8List>> startAudioStream();
+
+  Future<RecordedPracticeAudio> stopAudioStream();
 }
 
 final class PracticeRecordingException implements Exception {

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -10,7 +10,9 @@ import 'package:speakup/features/coaching/ielts/ielts_assignment_codec.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/bearer_authentication.dart';
+import 'package:speakup/identity/network/authenticated_web_socket.dart';
 import 'package:speakup/identity/network/transport_security.dart';
+import 'package:speakup/platform/audio/realtime_voice_input.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
@@ -27,6 +29,9 @@ final class PracticeWireEndpoints {
     this.transcribe =
         '/v1/voice-practice-sessions/{practice_session_id}/questions/'
         '{question_id}/transcription-candidates',
+    this.transcribeRealtime =
+        '/v1/voice-practice-sessions/{practice_session_id}/questions/'
+        '{question_id}/transcription-candidates/realtime',
     this.submitText =
         '/v1/voice-practice-sessions/{practice_session_id}/questions/'
         '{question_id}/text-answers',
@@ -47,6 +52,7 @@ final class PracticeWireEndpoints {
   final String voiceActivation;
   final String voiceState;
   final String transcribe;
+  final String transcribeRealtime;
   final String submitText;
   final String questionTip;
   final String confirm;
@@ -68,6 +74,11 @@ final class PracticeWireEndpoints {
   String transcribePath(String sessionId, String questionId) => transcribe
       .replaceAll('{practice_session_id}', _pathSegment(sessionId))
       .replaceAll('{question_id}', _pathSegment(questionId));
+
+  String transcribeRealtimePath(String sessionId, String questionId) =>
+      transcribeRealtime
+          .replaceAll('{practice_session_id}', _pathSegment(sessionId))
+          .replaceAll('{question_id}', _pathSegment(questionId));
 
   String confirmPath(String candidateId) =>
       confirm.replaceAll('{candidate_id}', _pathSegment(candidateId));
@@ -153,7 +164,8 @@ final class WirePracticeClient
         PracticeCompletionClient,
         PracticeSpeechFeedbackRetryClient,
         PracticeQuestionTipClient,
-        PracticeQuestionTranslationClient {
+        PracticeQuestionTranslationClient,
+        PracticeRealtimeTranscriptionClient {
   factory WirePracticeClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -161,6 +173,7 @@ final class WirePracticeClient
     PracticeWireTransport? transport,
     PracticeWireTransport Function()? transportFactory,
     PracticeWireEndpoints endpoints = const PracticeWireEndpoints(),
+    AuthenticatedWebSocketConnector? realtimeConnector,
     Duration jsonTimeout = const Duration(seconds: 30),
     Duration transcriptionTimeout = const Duration(seconds: 120),
   }) {
@@ -180,6 +193,16 @@ final class WirePracticeClient
       ownsTransport,
       createTransport,
       endpoints,
+      SessionAuthenticatedWebSocketConnector(
+        connector:
+            realtimeConnector ??
+            IoAuthenticatedWebSocketConnector(
+              protocols: const <String>[realtimeVoiceInputProtocol],
+            ),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: realtimeVoiceWebSocketBaseUri(baseUri),
+      ),
       jsonTimeout,
       transcriptionTimeout,
     );
@@ -194,6 +217,7 @@ final class WirePracticeClient
     this._ownsTransport,
     this._transportFactory,
     this._endpoints,
+    this._realtimeConnector,
     this._jsonTimeout,
     this._transcriptionTimeout,
   );
@@ -210,6 +234,7 @@ final class WirePracticeClient
   final bool _ownsTransport;
   final PracticeWireTransport Function() _transportFactory;
   final PracticeWireEndpoints _endpoints;
+  final SessionAuthenticatedWebSocketConnector _realtimeConnector;
   final Duration _jsonTimeout;
   final Duration _transcriptionTimeout;
 
@@ -290,6 +315,83 @@ final class WirePracticeClient
         expectedQuestionId: request.questionId,
       );
     });
+  }
+
+  @override
+  Stream<PracticeTranscriptionEvent> transcribeRealtime({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+    required Stream<Uint8List> audioChunks,
+  }) async* {
+    _requireOpaqueId(sessionId);
+    _requireOpaqueId(questionId);
+    _requireClientId(idempotencyKey);
+    final generation = _accountGeneration;
+    final uri = realtimeVoiceWebSocketBaseUri(
+      _baseUri,
+    ).resolve(_endpoints.transcribeRealtimePath(sessionId, questionId));
+    try {
+      final transport = RealtimeVoiceInputTransport(
+        connector: _realtimeConnector,
+      );
+      await for (final envelope in transport.stream(
+        uri: uri,
+        audioChunks: audioChunks,
+        idempotencyKey: idempotencyKey,
+        ensureCurrent: () => _requireGeneration(generation),
+        maximumChunkBytes: _maximumAudioBytes,
+      )) {
+        switch (envelope.type) {
+          case 'transcription.started':
+            if (envelope.data.isNotEmpty) {
+              throw _invalidResponse();
+            }
+          case 'transcription.updated':
+            final data = _exactObject(
+              envelope.data,
+              required: const {'transcript', 'final'},
+            );
+            yield PracticeTranscriptUpdated(
+              text: _string(data, 'transcript'),
+              isFinal: _boolean(data, 'final'),
+            );
+          case 'candidate.ready':
+            final data = _exactObject(
+              envelope.data,
+              required: const {'candidate'},
+            );
+            yield PracticeCandidateCompleted(
+              _decodeCandidate(
+                jsonEncode(data['candidate']),
+                expectedSessionId: sessionId,
+                expectedQuestionId: questionId,
+              ),
+            );
+          case 'candidate.failed':
+            final data = _exactObject(
+              envelope.data,
+              required: const {'kind', 'retryable'},
+            );
+            throw PracticeClientException(
+              kind: PracticeClientFailureKind.server,
+              errorCode: _string(data, 'kind', maxLength: 64),
+              retryable: _boolean(data, 'retryable'),
+            );
+          default:
+            throw _invalidResponse();
+        }
+      }
+    } on RealtimeVoiceInputException catch (error) {
+      throw PracticeClientException(
+        kind: error.kind == RealtimeVoiceInputFailureKind.authenticationRequired
+            ? PracticeClientFailureKind.authenticationRequired
+            : error.kind == RealtimeVoiceInputFailureKind.invalidResponse
+            ? PracticeClientFailureKind.invalidResponse
+            : PracticeClientFailureKind.network,
+        retryable: error.kind == RealtimeVoiceInputFailureKind.network,
+      );
+    }
   }
 
   @override

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -391,6 +391,13 @@ final class WirePracticeClient
             : PracticeClientFailureKind.network,
         retryable: error.kind == RealtimeVoiceInputFailureKind.network,
       );
+    } on PracticeClientOperationCancelled {
+      rethrow;
+    } catch (_) {
+      throw const PracticeClientException(
+        kind: PracticeClientFailureKind.network,
+        retryable: true,
+      );
     }
   }
 

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -954,8 +954,10 @@ class _ScenarioComposerState extends State<_ScenarioComposer> {
             seconds: widget.recordingSeconds,
             capture: capture,
           ),
-          PracticeRecordingState.transcribing => const PracticeLoadingComposer(
+          PracticeRecordingState.transcribing => PracticeTranscribingComposer(
             label: '正在识别你的回答…',
+            transcript: widget.controller.transcript ?? '',
+            keyPrefix: 'scenario',
           ),
           PracticeRecordingState.awaitingConfirmation =>
             PracticeTranscriptComposer(

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -953,11 +953,10 @@ class _ScenarioComposerState extends State<_ScenarioComposer> {
             phase: capturePhase,
             seconds: widget.recordingSeconds,
             capture: capture,
-          ),
-          PracticeRecordingState.transcribing => PracticeTranscribingComposer(
-            label: '正在识别你的回答…',
             transcript: widget.controller.transcript ?? '',
-            keyPrefix: 'scenario',
+          ),
+          PracticeRecordingState.transcribing => PracticeLoadingComposer(
+            label: '正在识别你的回答…',
           ),
           PracticeRecordingState.awaitingConfirmation =>
             PracticeTranscriptComposer(
@@ -1018,11 +1017,13 @@ class _RecordingComposer extends StatelessWidget {
     required this.phase,
     required this.seconds,
     required this.capture,
+    required this.transcript,
   });
 
   final VoiceCapturePhase phase;
   final int seconds;
   final VoiceCaptureView capture;
+  final String transcript;
 
   @override
   Widget build(BuildContext context) {
@@ -1031,6 +1032,7 @@ class _RecordingComposer extends StatelessWidget {
       phase: phase,
       keyPrefix: 'scenario',
       elapsed: Duration(seconds: seconds),
+      transcript: transcript,
       upwardCancelOnly: true,
     );
   }

--- a/mobile/lib/platform/audio/pcm16_stream_capture.dart
+++ b/mobile/lib/platform/audio/pcm16_stream_capture.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+enum Pcm16StreamCaptureFailureKind {
+  emptyAudio,
+  invalidAudio,
+  unavailable,
+  cancelled,
+}
+
+final class Pcm16StreamCaptureException implements Exception {
+  const Pcm16StreamCaptureException(this.kind);
+
+  final Pcm16StreamCaptureFailureKind kind;
+}
+
+/// Captures one native PCM16 stream while forwarding the same chunks to ASR.
+///
+/// The buffered bytes are converted to the local WAV evidence used by both the
+/// Agent composer and Practice. Domain-specific recorders keep ownership of
+/// permissions, file paths, limits, and user-facing errors.
+final class Pcm16StreamCapture {
+  Pcm16StreamCapture({
+    required Stream<Uint8List> input,
+    required this.maximumPcmBytes,
+    this.sampleRate = 16000,
+  }) {
+    if (maximumPcmBytes < 2 || sampleRate < 1) {
+      throw ArgumentError('PCM16 stream capture configuration is invalid.');
+    }
+    _output = StreamController<Uint8List>(onCancel: _handleOutputCancel);
+    _subscription = input.listen(
+      _handleChunk,
+      onError: _handleInputError,
+      onDone: _handleInputDone,
+      cancelOnError: true,
+    );
+  }
+
+  final int maximumPcmBytes;
+  final int sampleRate;
+  final BytesBuilder _pcm = BytesBuilder(copy: false);
+  final Completer<void> _done = Completer<void>();
+  late final StreamController<Uint8List> _output;
+  StreamSubscription<Uint8List>? _subscription;
+  Pcm16StreamCaptureException? _failure;
+  bool _outputClosed = false;
+
+  Stream<Uint8List> get stream => _output.stream;
+
+  Future<Uint8List> finish({
+    Duration timeout = const Duration(seconds: 2),
+  }) async {
+    try {
+      await _done.future.timeout(timeout);
+    } on TimeoutException {
+      throw const Pcm16StreamCaptureException(
+        Pcm16StreamCaptureFailureKind.unavailable,
+      );
+    }
+    if (_failure case final failure?) {
+      throw failure;
+    }
+    final pcm = _pcm.takeBytes();
+    if (pcm.isEmpty) {
+      throw const Pcm16StreamCaptureException(
+        Pcm16StreamCaptureFailureKind.emptyAudio,
+      );
+    }
+    if (pcm.lengthInBytes.isOdd || pcm.lengthInBytes > maximumPcmBytes) {
+      throw const Pcm16StreamCaptureException(
+        Pcm16StreamCaptureFailureKind.invalidAudio,
+      );
+    }
+    return _pcm16MonoWav(pcm, sampleRate: sampleRate);
+  }
+
+  Future<void> cancel() async {
+    if (!_done.isCompleted) {
+      _failure ??= const Pcm16StreamCaptureException(
+        Pcm16StreamCaptureFailureKind.cancelled,
+      );
+      if (!_outputClosed) {
+        _output.addError(_failure!);
+      }
+      await _subscription?.cancel();
+      _complete();
+    }
+    _pcm.takeBytes();
+  }
+
+  void _handleChunk(Uint8List chunk) {
+    if (_done.isCompleted) {
+      return;
+    }
+    if (chunk.isEmpty || _pcm.length + chunk.lengthInBytes > maximumPcmBytes) {
+      _fail(
+        const Pcm16StreamCaptureException(
+          Pcm16StreamCaptureFailureKind.invalidAudio,
+        ),
+      );
+      return;
+    }
+    _pcm.add(chunk);
+    _output.add(chunk);
+  }
+
+  void _handleInputError(Object _, StackTrace _) {
+    _fail(
+      const Pcm16StreamCaptureException(
+        Pcm16StreamCaptureFailureKind.unavailable,
+      ),
+    );
+  }
+
+  void _handleInputDone() => _complete();
+
+  Future<void> _handleOutputCancel() async {
+    if (_done.isCompleted) {
+      return;
+    }
+    _failure ??= const Pcm16StreamCaptureException(
+      Pcm16StreamCaptureFailureKind.cancelled,
+    );
+    await _subscription?.cancel();
+    _complete();
+  }
+
+  void _fail(Pcm16StreamCaptureException failure) {
+    if (_done.isCompleted) {
+      return;
+    }
+    _failure = failure;
+    _output.addError(failure);
+    final subscription = _subscription;
+    if (subscription == null) {
+      scheduleMicrotask(_complete);
+      return;
+    }
+    unawaited(subscription.cancel().whenComplete(_complete));
+  }
+
+  void _complete() {
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+    if (!_outputClosed) {
+      _outputClosed = true;
+      unawaited(_output.close());
+    }
+  }
+}
+
+Uint8List _pcm16MonoWav(Uint8List pcm, {required int sampleRate}) {
+  final result = Uint8List(44 + pcm.lengthInBytes);
+  final data = ByteData.sublistView(result);
+  result.setRange(0, 4, 'RIFF'.codeUnits);
+  data.setUint32(4, result.lengthInBytes - 8, Endian.little);
+  result.setRange(8, 12, 'WAVE'.codeUnits);
+  result.setRange(12, 16, 'fmt '.codeUnits);
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, 1, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, sampleRate * 2, Endian.little);
+  data.setUint16(32, 2, Endian.little);
+  data.setUint16(34, 16, Endian.little);
+  result.setRange(36, 40, 'data'.codeUnits);
+  data.setUint32(40, pcm.lengthInBytes, Endian.little);
+  result.setRange(44, result.lengthInBytes, pcm);
+  return result;
+}

--- a/mobile/lib/platform/audio/realtime_voice_input.dart
+++ b/mobile/lib/platform/audio/realtime_voice_input.dart
@@ -62,24 +62,29 @@ final class RealtimeVoiceInputTransport {
         ensureCurrent: ensureCurrent,
         maximumChunkBytes: maximumChunkBytes,
       );
+      var receivedTerminalEvent = false;
       await for (final message in connection.socket) {
         ensureCurrent();
         final envelope = _decodeEnvelope(message);
         yield envelope;
         if (envelope.type == 'candidate.ready' ||
             envelope.type == 'candidate.failed') {
-          return;
+          receivedTerminalEvent = true;
+          break;
         }
       }
       await chunks.cancel();
       await sender;
-      await connection.handleDisconnect(
-        closeCode: connection.socket.closeCode,
-        closeReason: connection.socket.closeReason,
-      );
-      throw const RealtimeVoiceInputException(
-        RealtimeVoiceInputFailureKind.network,
-      );
+      if (!receivedTerminalEvent) {
+        await connection.handleDisconnect(
+          closeCode: connection.socket.closeCode,
+          closeReason: connection.socket.closeReason,
+        );
+        throw const RealtimeVoiceInputException(
+          RealtimeVoiceInputFailureKind.network,
+        );
+      }
+      return;
     } on AuthenticatedWebSocketException catch (error) {
       throw RealtimeVoiceInputException(
         error.invalidatesAuthentication

--- a/mobile/lib/platform/audio/realtime_voice_input.dart
+++ b/mobile/lib/platform/audio/realtime_voice_input.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:speakup/identity/network/authenticated_web_socket.dart';
+
+const realtimeVoiceInputProtocol = 'speakup.voice-input.v1';
+
+enum RealtimeVoiceInputFailureKind {
+  authenticationRequired,
+  network,
+  invalidResponse,
+}
+
+final class RealtimeVoiceInputException implements Exception {
+  const RealtimeVoiceInputException(this.kind);
+
+  final RealtimeVoiceInputFailureKind kind;
+}
+
+final class RealtimeVoiceInputEnvelope {
+  const RealtimeVoiceInputEnvelope({required this.type, required this.data});
+
+  final String type;
+  final Map<String, Object?> data;
+}
+
+final class RealtimeVoiceInputTransport {
+  const RealtimeVoiceInputTransport({required this.connector});
+
+  final SessionAuthenticatedWebSocketConnector connector;
+
+  Stream<RealtimeVoiceInputEnvelope> stream({
+    required Uri uri,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+    required void Function() ensureCurrent,
+    int maximumChunkBytes = 7_400_000,
+  }) async* {
+    if (idempotencyKey.length < 8 ||
+        idempotencyKey.length > 128 ||
+        maximumChunkBytes < 1) {
+      throw ArgumentError('Realtime voice input configuration is invalid.');
+    }
+    SessionAuthenticatedWebSocketConnection? connection;
+    StreamIterator<Uint8List>? chunks;
+    Future<void>? sender;
+    try {
+      connection = await connector.connect(uri: uri);
+      ensureCurrent();
+      connection.socket.add(
+        jsonEncode(<String, Object>{
+          'type': 'start',
+          'idempotency_key': idempotencyKey,
+          'sample_rate': 16000,
+        }),
+      );
+      chunks = StreamIterator<Uint8List>(audioChunks);
+      sender = _sendAudio(
+        connection: connection,
+        chunks: chunks,
+        ensureCurrent: ensureCurrent,
+        maximumChunkBytes: maximumChunkBytes,
+      );
+      await for (final message in connection.socket) {
+        ensureCurrent();
+        final envelope = _decodeEnvelope(message);
+        yield envelope;
+        if (envelope.type == 'candidate.ready' ||
+            envelope.type == 'candidate.failed') {
+          return;
+        }
+      }
+      await chunks.cancel();
+      await sender;
+      await connection.handleDisconnect(
+        closeCode: connection.socket.closeCode,
+        closeReason: connection.socket.closeReason,
+      );
+      throw const RealtimeVoiceInputException(
+        RealtimeVoiceInputFailureKind.network,
+      );
+    } on AuthenticatedWebSocketException catch (error) {
+      throw RealtimeVoiceInputException(
+        error.invalidatesAuthentication
+            ? RealtimeVoiceInputFailureKind.authenticationRequired
+            : RealtimeVoiceInputFailureKind.network,
+      );
+    } on FormatException {
+      throw const RealtimeVoiceInputException(
+        RealtimeVoiceInputFailureKind.invalidResponse,
+      );
+    } finally {
+      await chunks?.cancel();
+      if (sender != null) {
+        try {
+          await sender;
+        } catch (_) {
+          // The active consumer already receives this failure above. A
+          // cancelled consumer only needs its socket and microphone released.
+        }
+      }
+      await connection?.socket.close();
+    }
+  }
+}
+
+Future<void> _sendAudio({
+  required SessionAuthenticatedWebSocketConnection connection,
+  required StreamIterator<Uint8List> chunks,
+  required void Function() ensureCurrent,
+  required int maximumChunkBytes,
+}) async {
+  try {
+    while (await chunks.moveNext()) {
+      ensureCurrent();
+      final chunk = chunks.current;
+      if (chunk.isEmpty || chunk.lengthInBytes > maximumChunkBytes) {
+        throw ArgumentError('Realtime voice input chunk is invalid.');
+      }
+      connection.socket.add(chunk);
+    }
+    ensureCurrent();
+    connection.socket.add(jsonEncode(const <String, String>{'type': 'finish'}));
+  } catch (error, stackTrace) {
+    try {
+      connection.socket.add(
+        jsonEncode(const <String, String>{'type': 'cancel'}),
+      );
+      await connection.socket.close();
+    } catch (_) {
+      // Preserve the capture or account-fence failure that ended the stream.
+    }
+    Error.throwWithStackTrace(error, stackTrace);
+  }
+}
+
+Uri realtimeVoiceWebSocketBaseUri(Uri baseUri) {
+  return baseUri.replace(
+    scheme: switch (baseUri.scheme) {
+      'https' => 'wss',
+      'http' => 'ws',
+      final scheme => throw ArgumentError.value(
+        scheme,
+        'baseUri',
+        'Realtime voice input requires HTTP or HTTPS.',
+      ),
+    },
+  );
+}
+
+RealtimeVoiceInputEnvelope _decodeEnvelope(Object? message) {
+  if (message is! String) {
+    throw const FormatException('Realtime voice event must be JSON text.');
+  }
+  final decoded = jsonDecode(message);
+  if (decoded is! Map<String, dynamic> ||
+      decoded.length != 2 ||
+      !decoded.containsKey('type') ||
+      !decoded.containsKey('data')) {
+    throw const FormatException('Realtime voice event envelope is invalid.');
+  }
+  final type = decoded['type'];
+  final data = decoded['data'];
+  if (type is! String ||
+      type.isEmpty ||
+      type.length > 64 ||
+      data is! Map<String, dynamic>) {
+    throw const FormatException('Realtime voice event payload is invalid.');
+  }
+  return RealtimeVoiceInputEnvelope(
+    type: type,
+    data: Map<String, Object?>.unmodifiable(data),
+  );
+}

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -328,6 +328,13 @@ final class WireAgentVoiceClient
             : AgentClientFailureKind.network,
         retryable: error.kind == RealtimeVoiceInputFailureKind.network,
       );
+    } on AgentClientOperationCancelled {
+      rethrow;
+    } catch (_) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
     }
   }
 

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -7,6 +7,7 @@ import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/bearer_authentication.dart';
 import 'package:speakup/identity/network/authenticated_web_socket.dart';
 import 'package:speakup/identity/network/transport_security.dart';
+import 'package:speakup/platform/audio/realtime_voice_input.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff_codec.dart';
 
@@ -112,7 +113,7 @@ final class WireAgentVoiceClient
         connector:
             realtimeConnector ??
             IoAuthenticatedWebSocketConnector(
-              protocols: const <String>[_voiceInputWebSocketProtocol],
+              protocols: const <String>[realtimeVoiceInputProtocol],
             ),
         credentialProvider: credentialProvider,
         invalidateSession: invalidateSession,
@@ -153,7 +154,6 @@ final class WireAgentVoiceClient
   static const _maximumAudioBytes = 7400000;
   static const _maximumPlaybackLifetime = Duration(minutes: 2);
   static const _maximumLocalClockSkew = Duration(seconds: 30);
-  static const _voiceInputWebSocketProtocol = 'speakup.voice-input.v1';
   static const _assistantSpeechWebSocketProtocol =
       'speakup.assistant-speech.v1';
 
@@ -296,74 +296,38 @@ final class WireAgentVoiceClient
     _requireUuid(threadId);
     _requireClientIdentity(idempotencyKey, minimumLength: 8);
     final generation = _accountGeneration;
-    final uri = _webSocketBaseUri(_baseUri).resolve(
+    final uri = realtimeVoiceWebSocketBaseUri(_baseUri).resolve(
       '/v1/agent-threads/${Uri.encodeComponent(threadId)}/voice-message-candidates/realtime',
     );
-    SessionAuthenticatedWebSocketConnection? connection;
     try {
-      connection = await _realtimeConnector.connect(uri: uri);
-      _requireGeneration(generation);
-      connection.socket.add(
-        jsonEncode(<String, Object>{
-          'type': 'start',
-          'idempotency_key': idempotencyKey,
-          'sample_rate': 16000,
-        }),
+      final transport = RealtimeVoiceInputTransport(
+        connector: _realtimeConnector,
       );
-      await for (final chunk in audioChunks) {
-        _requireGeneration(generation);
-        if (chunk.isEmpty || chunk.lengthInBytes > _maximumAudioBytes) {
-          throw const AgentClientException(
-            kind: AgentClientFailureKind.invalidRequest,
-          );
-        }
-        connection.socket.add(chunk);
-      }
-      connection.socket.add(
-        jsonEncode(const <String, String>{'type': 'finish'}),
-      );
-      await for (final message in connection.socket) {
-        _requireGeneration(generation);
-        if (message is! String) {
-          throw _invalidResponse();
-        }
-        final envelope = _strictObject(
-          jsonDecode(message),
-          allowed: const <String>{'type', 'data'},
-          required: const <String>{'type', 'data'},
-        );
-        final event = _strictString(envelope['type'], min: 1, max: 64);
+      await for (final envelope in transport.stream(
+        uri: uri,
+        audioChunks: audioChunks,
+        idempotencyKey: idempotencyKey,
+        ensureCurrent: () => _requireGeneration(generation),
+        maximumChunkBytes: _maximumAudioBytes,
+      )) {
         final decoded = _decodeTranscriptionEvent(
-          event,
-          jsonEncode(envelope['data']),
+          envelope.type,
+          jsonEncode(envelope.data),
           expectedThreadId: threadId,
         );
         if (decoded != null) {
           yield decoded;
         }
-        if (event == 'candidate.ready' || event == 'candidate.failed') {
-          return;
-        }
       }
-      await connection.handleDisconnect(
-        closeCode: connection.socket.closeCode,
-        closeReason: connection.socket.closeReason,
-      );
-      throw const AgentClientException(
-        kind: AgentClientFailureKind.network,
-        retryable: true,
-      );
-    } on AuthenticatedWebSocketException catch (error) {
+    } on RealtimeVoiceInputException catch (error) {
       throw AgentClientException(
-        kind: error.invalidatesAuthentication
+        kind: error.kind == RealtimeVoiceInputFailureKind.authenticationRequired
             ? AgentClientFailureKind.authenticationRequired
+            : error.kind == RealtimeVoiceInputFailureKind.invalidResponse
+            ? AgentClientFailureKind.invalidResponse
             : AgentClientFailureKind.network,
-        retryable: !error.invalidatesAuthentication,
+        retryable: error.kind == RealtimeVoiceInputFailureKind.network,
       );
-    } on FormatException {
-      throw _invalidResponse();
-    } finally {
-      await connection?.socket.close();
     }
   }
 

--- a/mobile/test/agent/agent_voice_recording_stream_test.dart
+++ b/mobile/test/agent/agent_voice_recording_stream_test.dart
@@ -37,10 +37,46 @@ void main() {
       expect(await File(recording.path).exists(), isFalse);
     },
   );
+
+  test('streaming stop failure cancels the native capture', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'agent-voice-stream-recorder-failure-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final native = _StreamingNativeRecorder()
+      ..stopError = StateError('stop failed');
+    final recorder = IosAgentVoiceRecorder(
+      recorder: native,
+      temporaryDirectory: () async => directory,
+    );
+
+    final stream = await recorder.startAudioStream();
+    final subscription = stream.listen((_) {}, onError: (_) {});
+
+    await expectLater(
+      recorder.stopAudioStream(),
+      throwsA(
+        isA<AgentVoiceRecordingException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentVoiceRecordingFailureKind.unavailable,
+        ),
+      ),
+    );
+
+    expect(native.cancelCount, 1);
+    await subscription.cancel();
+  });
 }
 
 final class _StreamingNativeRecorder implements NativeAgentVoiceRecorder {
-  final StreamController<Uint8List> _chunks = StreamController<Uint8List>();
+  _StreamingNativeRecorder() {
+    _chunks = StreamController<Uint8List>(onCancel: () => cancelCount++);
+  }
+
+  late final StreamController<Uint8List> _chunks;
+  Object? stopError;
+  int cancelCount = 0;
 
   void add(Uint8List chunk) => _chunks.add(chunk);
 
@@ -55,6 +91,9 @@ final class _StreamingNativeRecorder implements NativeAgentVoiceRecorder {
 
   @override
   Future<String?> stop() async {
+    if (stopError case final error?) {
+      throw error;
+    }
     await _chunks.close();
     return null;
   }

--- a/mobile/test/coaching/practice/ios_practice_recorder_test.dart
+++ b/mobile/test/coaching/practice/ios_practice_recorder_test.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/practice/ios_practice_recorder.dart';
@@ -98,6 +100,30 @@ void main() {
       expect(await unrelated.exists(), isTrue);
     },
   );
+
+  test('streaming recorder forwards PCM and retains a local WAV', () async {
+    final native = _StreamingNativeRecorder();
+    final recorder = IosPracticeRecorder(
+      recorder: native,
+      temporaryDirectory: () async => root,
+    );
+
+    final stream = await recorder.startAudioStream();
+    final forwarded = stream.expand((chunk) => chunk).toList();
+    native.add(Uint8List.fromList(<int>[0, 0, 1, 0]));
+    final audio = await recorder.stopAudioStream();
+
+    expect(await forwarded, <int>[0, 0, 1, 0]);
+    expect(audio.contentType, 'audio/wav');
+    expect(audio.sizeBytes, 48);
+    final bytes = await File(audio.path).readAsBytes();
+    expect(String.fromCharCodes(bytes.sublist(0, 4)), 'RIFF');
+    expect(String.fromCharCodes(bytes.sublist(8, 12)), 'WAVE');
+    expect(bytes.sublist(44), <int>[0, 0, 1, 0]);
+
+    await recorder.discard(audio);
+    expect(await File(audio.path).exists(), isFalse);
+  });
 }
 
 final class _NativeRecorder implements NativePracticeRecorder {
@@ -120,5 +146,27 @@ final class _NativeRecorder implements NativePracticeRecorder {
       throw error;
     }
     return stopResult ?? startedPath;
+  }
+}
+
+final class _StreamingNativeRecorder
+    implements NativePracticeRecorder, NativeStreamingPracticeRecorder {
+  final StreamController<Uint8List> _chunks = StreamController<Uint8List>();
+
+  void add(Uint8List chunk) => _chunks.add(chunk);
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> startWav(String path) => throw UnimplementedError();
+
+  @override
+  Future<Stream<Uint8List>> startPcm16Stream() async => _chunks.stream;
+
+  @override
+  Future<String?> stop() async {
+    await _chunks.close();
+    return null;
   }
 }

--- a/mobile/test/coaching/practice/ios_practice_recorder_test.dart
+++ b/mobile/test/coaching/practice/ios_practice_recorder_test.dart
@@ -124,6 +124,32 @@ void main() {
     await recorder.discard(audio);
     expect(await File(audio.path).exists(), isFalse);
   });
+
+  test('streaming stop failure cancels the native capture', () async {
+    final native = _StreamingNativeRecorder()
+      ..stopError = StateError('stop failed');
+    final recorder = IosPracticeRecorder(
+      recorder: native,
+      temporaryDirectory: () async => root,
+    );
+
+    final stream = await recorder.startAudioStream();
+    final subscription = stream.listen((_) {}, onError: (_) {});
+
+    await expectLater(
+      recorder.stopAudioStream(),
+      throwsA(
+        isA<PracticeRecordingException>().having(
+          (error) => error.kind,
+          'kind',
+          PracticeRecordingFailureKind.unavailable,
+        ),
+      ),
+    );
+
+    expect(native.cancelCount, 1);
+    await subscription.cancel();
+  });
 }
 
 final class _NativeRecorder implements NativePracticeRecorder {
@@ -151,7 +177,13 @@ final class _NativeRecorder implements NativePracticeRecorder {
 
 final class _StreamingNativeRecorder
     implements NativePracticeRecorder, NativeStreamingPracticeRecorder {
-  final StreamController<Uint8List> _chunks = StreamController<Uint8List>();
+  _StreamingNativeRecorder() {
+    _chunks = StreamController<Uint8List>(onCancel: () => cancelCount++);
+  }
+
+  late final StreamController<Uint8List> _chunks;
+  Object? stopError;
+  int cancelCount = 0;
 
   void add(Uint8List chunk) => _chunks.add(chunk);
 
@@ -166,6 +198,9 @@ final class _StreamingNativeRecorder
 
   @override
   Future<String?> stop() async {
+    if (stopError case final error?) {
+      throw error;
+    }
     await _chunks.close();
     return null;
   }

--- a/mobile/test/coaching/practice/practice_realtime_controller_test.dart
+++ b/mobile/test/coaching/practice/practice_realtime_controller_test.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_recording.dart';
+
+import '../../support/practice_fixtures.dart';
+import '../../support/scene_fixtures.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('realtime transcript becomes the existing confirmation draft', () async {
+    final client = _RealtimePracticeClient();
+    final recorder = _StreamingPracticeRecorder();
+    final controller = PracticeController(
+      client: client,
+      recorder: recorder,
+      clientIdFactory: (scope) => '$scope-realtime-001',
+    );
+    addTearDown(controller.dispose);
+    await _restore(controller);
+
+    await controller.startRecording();
+    expect(controller.recordingState, PracticeRecordingState.recording);
+    expect(recorder.streamingStarts, 1);
+    expect(recorder.legacyStarts, 0);
+
+    recorder.add(Uint8List.fromList(<int>[1, 2]));
+    await client.firstUpdate.future;
+    expect(controller.transcript, 'I led the migration');
+
+    final stopping = controller.stopRecording();
+    await client.captureFinished.future;
+    expect(controller.recordingState, PracticeRecordingState.transcribing);
+    expect(controller.transcript, 'I led the migration');
+
+    client.releaseCandidate.complete();
+    await stopping;
+
+    expect(
+      controller.recordingState,
+      PracticeRecordingState.awaitingConfirmation,
+    );
+    expect(controller.candidateId, 'candidate-realtime');
+    expect(controller.transcript, 'I led the migration safely.');
+    expect(client.legacyTranscriptions, 0);
+    expect(recorder.discarded, 1);
+  });
+
+  test(
+    'realtime failure is explicit and never falls back to WAV upload',
+    () async {
+      final client = _RealtimePracticeClient(failAfterCapture: true);
+      final recorder = _StreamingPracticeRecorder();
+      final controller = PracticeController(
+        client: client,
+        recorder: recorder,
+        clientIdFactory: (scope) => '$scope-realtime-002',
+      );
+      addTearDown(controller.dispose);
+      await _restore(controller);
+
+      await controller.startRecording();
+      recorder.add(Uint8List.fromList(<int>[1, 2]));
+      await client.firstUpdate.future;
+      await controller.stopRecording();
+
+      expect(controller.recordingState, PracticeRecordingState.idle);
+      expect(controller.candidateId, isNull);
+      expect(controller.hasPendingPracticeAudio, isFalse);
+      expect(controller.errorMessage, contains('请重新录音'));
+      expect(client.legacyTranscriptions, 0);
+      expect(recorder.discarded, 1);
+    },
+  );
+
+  test('account cleanup fences a late realtime Candidate', () async {
+    final client = _RealtimePracticeClient();
+    final recorder = _StreamingPracticeRecorder();
+    final controller = PracticeController(
+      client: client,
+      recorder: recorder,
+      clientIdFactory: (scope) => '$scope-realtime-003',
+    );
+    addTearDown(controller.dispose);
+    await _restore(controller);
+
+    await controller.startRecording();
+    recorder.add(Uint8List.fromList(<int>[1, 2]));
+    await client.firstUpdate.future;
+    await controller.clearPrivateState();
+    client.releaseCandidate.complete();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.practiceSessionId, isNull);
+    expect(controller.candidateId, isNull);
+    expect(controller.transcript, isNull);
+    expect(client.legacyTranscriptions, 0);
+  });
+
+  test(
+    'recording cancellation cannot apply a late realtime Candidate',
+    () async {
+      final client = _RealtimePracticeClient();
+      final recorder = _StreamingPracticeRecorder();
+      final controller = PracticeController(
+        client: client,
+        recorder: recorder,
+        clientIdFactory: (scope) => '$scope-realtime-004',
+      );
+      addTearDown(controller.dispose);
+      await _restore(controller);
+
+      await controller.startRecording();
+      recorder.add(Uint8List.fromList(<int>[1, 2]));
+      await client.firstUpdate.future;
+      await controller.cancelRecording();
+      client.releaseCandidate.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.recordingState, PracticeRecordingState.idle);
+      expect(controller.candidateId, isNull);
+      expect(controller.transcript, isNull);
+      expect(client.legacyTranscriptions, 0);
+    },
+  );
+}
+
+Future<void> _restore(PracticeController controller) {
+  return controller.restoreCreatedPractice(
+    sessionId: 'session-realtime',
+    scene: testScenes.first,
+  );
+}
+
+final class _RealtimePracticeClient
+    implements PracticeClient, PracticeRealtimeTranscriptionClient {
+  _RealtimePracticeClient({this.failAfterCapture = false});
+
+  final bool failAfterCapture;
+  final Completer<void> firstUpdate = Completer<void>();
+  final Completer<void> captureFinished = Completer<void>();
+  final Completer<void> releaseCandidate = Completer<void>();
+  int legacyTranscriptions = 0;
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<PracticeSessionSnapshot> restorePractice({
+    required String sessionId,
+  }) async {
+    return _snapshot();
+  }
+
+  @override
+  Future<PracticeSessionSnapshot> activatePractice({
+    required String sessionId,
+    required String clientOperationId,
+  }) async {
+    return _snapshot();
+  }
+
+  @override
+  Stream<PracticeTranscriptionEvent> transcribeRealtime({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+    required Stream<Uint8List> audioChunks,
+  }) async* {
+    var sentUpdate = false;
+    await for (final chunk in audioChunks) {
+      expect(chunk, isNotEmpty);
+      if (!sentUpdate) {
+        sentUpdate = true;
+        if (!firstUpdate.isCompleted) {
+          firstUpdate.complete();
+        }
+        yield const PracticeTranscriptUpdated(
+          text: 'I led the migration',
+          isFinal: false,
+        );
+      }
+    }
+    if (!captureFinished.isCompleted) {
+      captureFinished.complete();
+    }
+    if (failAfterCapture) {
+      throw const PracticeClientException(
+        kind: PracticeClientFailureKind.network,
+        retryable: true,
+      );
+    }
+    await releaseCandidate.future;
+    yield const PracticeTranscriptUpdated(
+      text: 'I led the migration safely.',
+      isFinal: true,
+    );
+    yield PracticeCandidateCompleted(
+      TranscriptionCandidate(
+        id: 'candidate-realtime',
+        sessionId: sessionId,
+        questionId: questionId,
+        text: 'I led the migration safely.',
+      ),
+    );
+  }
+
+  @override
+  Future<TranscriptionCandidate> transcribe(
+    PracticeTranscriptionRequest request,
+  ) async {
+    legacyTranscriptions++;
+    return TranscriptionCandidate(
+      id: 'candidate-legacy',
+      sessionId: request.sessionId,
+      questionId: request.questionId,
+      text: 'Legacy answer',
+    );
+  }
+
+  @override
+  Future<PracticeTurnConfirmation> confirm({
+    required String sessionId,
+    required String questionId,
+    required String candidateId,
+    required String idempotencyKey,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PracticeTurnConfirmation> submitText({
+    required String sessionId,
+    required String questionId,
+    required String answerText,
+    required String idempotencyKey,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+final class _StreamingPracticeRecorder
+    implements PracticeRecorder, PracticeStreamingRecorder {
+  final StreamController<Uint8List> _chunks = StreamController<Uint8List>();
+  int legacyStarts = 0;
+  int streamingStarts = 0;
+  int discarded = 0;
+  bool _closed = false;
+
+  void add(Uint8List chunk) => _chunks.add(chunk);
+
+  @override
+  Future<void> start() async {
+    legacyStarts++;
+  }
+
+  @override
+  Future<Stream<Uint8List>> startAudioStream() async {
+    streamingStarts++;
+    return _chunks.stream;
+  }
+
+  @override
+  Future<RecordedPracticeAudio> stop() async => _audio;
+
+  @override
+  Future<RecordedPracticeAudio> stopAudioStream() async {
+    await _close();
+    return _audio;
+  }
+
+  @override
+  Future<void> discardCurrent() => _close();
+
+  @override
+  Future<void> discard(RecordedPracticeAudio audio) async {
+    discarded++;
+  }
+
+  @override
+  Future<void> clearAccountState() => _close();
+
+  Future<void> _close() async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    await _chunks.close();
+  }
+}
+
+const _audio = RecordedPracticeAudio(
+  path: 'realtime-practice.wav',
+  contentType: 'audio/wav',
+  sizeBytes: 48,
+);
+
+PracticeSessionSnapshot _snapshot() {
+  return PracticeSessionSnapshot(
+    sessionId: 'session-realtime',
+    planId: 'plan-realtime',
+    practiceExperience: testScenes.first.experience,
+    sceneCategory: testScenes.first.category,
+    practiceMode: testScenes.first.practiceOptions.first.mode,
+    capabilities: testPracticeCapabilities,
+    sessionVersion: 1,
+    completedTurns: 0,
+    turnLimit: 2,
+    sessionCompleted: false,
+    currentQuestion: const PracticeQuestion(
+      id: 'question-realtime',
+      sessionId: 'session-realtime',
+      text: 'Tell me about a project.',
+      speechPath: '/v1/questions/question-realtime/speech',
+    ),
+  );
+}

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/ielts/ielts_assignment.dart';
 import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
@@ -179,6 +181,11 @@ void main() {
       endpoints.transcribePath(opaque, opaque),
       '/v1/voice-practice-sessions/$encoded/questions/'
       '$encoded/transcription-candidates',
+    );
+    expect(
+      endpoints.transcribeRealtimePath(opaque, opaque),
+      '/v1/voice-practice-sessions/$encoded/questions/'
+      '$encoded/transcription-candidates/realtime',
     );
     expect(
       endpoints.submitTextPath(opaque, opaque),
@@ -425,6 +432,116 @@ void main() {
 
     expect(candidate.id, _candidateId);
     transport.expectDone();
+  });
+
+  test('streams a Practice transcript before PCM capture finishes', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final handled = Completer<void>();
+    server.listen((request) async {
+      expect(
+        request.uri.path,
+        '/v1/voice-practice-sessions/$_sessionId/questions/'
+        '$_questionId/transcription-candidates/realtime',
+      );
+      expect(
+        request.headers.value(HttpHeaders.authorizationHeader),
+        'Bearer sess_practice',
+      );
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (protocols) => 'speakup.voice-input.v1',
+      );
+      var sentUpdate = false;
+      await for (final message in socket) {
+        if (message is List<int> && !sentUpdate) {
+          sentUpdate = true;
+          socket.add(
+            jsonEncode(<String, Object>{
+              'type': 'transcription.updated',
+              'data': <String, Object>{
+                'transcript': 'I led the migration',
+                'final': false,
+              },
+            }),
+          );
+        }
+        if (message is String &&
+            (jsonDecode(message) as Map<String, dynamic>)['type'] == 'finish') {
+          socket.add(
+            jsonEncode(<String, Object>{
+              'type': 'candidate.ready',
+              'data': <String, Object>{
+                'candidate': <String, Object>{
+                  'candidate_id': _candidateId,
+                  'practice_session_id': _sessionId,
+                  'question_id': _questionId,
+                  'respondent_participant_id': 'participant-user',
+                  'transcript_id': 'transcript-realtime',
+                  'evidence_version': 1,
+                  'transcript': 'I led the migration safely.',
+                  'created_at': _timestamp,
+                },
+              },
+            }),
+          );
+          await socket.close();
+          if (!handled.isCompleted) {
+            handled.complete();
+          }
+        }
+      }
+    });
+    final client = WirePracticeClient(
+      baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+      credentialProvider: () => _credential,
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: _Transport(const <_Step>[]),
+    );
+    final chunks = StreamController<Uint8List>();
+    final update = Completer<PracticeTranscriptUpdated>();
+    final events = <PracticeTranscriptionEvent>[];
+    final completed = Completer<void>();
+    final subscription = client
+        .transcribeRealtime(
+          sessionId: _sessionId,
+          questionId: _questionId,
+          idempotencyKey: 'turn-realtime-001',
+          audioChunks: chunks.stream,
+        )
+        .listen(
+          (event) {
+            events.add(event);
+            if (event case final PracticeTranscriptUpdated value) {
+              if (!update.isCompleted) {
+                update.complete(value);
+              }
+            }
+          },
+          onError: completed.completeError,
+          onDone: completed.complete,
+        );
+    addTearDown(subscription.cancel);
+
+    chunks.add(Uint8List.fromList(<int>[1, 2]));
+    final firstUpdate = await update.future.timeout(const Duration(seconds: 2));
+    expect(firstUpdate.text, 'I led the migration');
+    expect(completed.isCompleted, isFalse);
+
+    chunks.add(Uint8List.fromList(<int>[3, 4]));
+    await chunks.close();
+    await completed.future;
+    await handled.future;
+
+    expect(events.last, isA<PracticeCandidateCompleted>());
+    expect(
+      (events.last as PracticeCandidateCompleted).candidate.text,
+      'I led the migration safely.',
+    );
   });
 
   test('submits text through the combined durable answer route', () async {

--- a/mobile/test/design/practice_conversation_components_test.dart
+++ b/mobile/test/design/practice_conversation_components_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/practice_conversation_components.dart';
+
+void main() {
+  testWidgets('shared transcribing composer shows the live transcript', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PracticeTranscribingComposer(
+            label: '正在识别英文回答…',
+            transcript: 'I led the migration safely.',
+            keyPrefix: 'practice',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('正在识别英文回答…'), findsOneWidget);
+    expect(find.byKey(const Key('practice-live-transcript')), findsOneWidget);
+    expect(find.text('I led the migration safely.'), findsOneWidget);
+  });
+
+  testWidgets('shared transcribing composer hides an empty snapshot', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PracticeTranscribingComposer(
+            label: 'Transcribing your answer…',
+            transcript: '   ',
+            keyPrefix: 'ielts-mock',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Transcribing your answer…'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-live-transcript')), findsNothing);
+  });
+}

--- a/mobile/test/design/practice_conversation_components_test.dart
+++ b/mobile/test/design/practice_conversation_components_test.dart
@@ -1,44 +1,59 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
+import 'package:speakup/design/voice_capture_control.dart';
 
 void main() {
-  testWidgets('shared transcribing composer shows the live transcript', (
+  testWidgets('shared recording composer shows the live transcript', (
     tester,
   ) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
-          body: PracticeTranscribingComposer(
-            label: '正在识别英文回答…',
-            transcript: 'I led the migration safely.',
-            keyPrefix: 'practice',
+          body: VoiceCaptureControl(
+            phase: VoiceCapturePhase.recording,
+            onStart: () {},
+            onSendVoice: () {},
+            onConvertToText: () {},
+            onCancel: () {},
+            builder: (_, capture) => PracticeRecordingComposer(
+              capture: capture,
+              phase: VoiceCapturePhase.recording,
+              keyPrefix: 'practice',
+              transcript: 'I led the migration safely.',
+            ),
           ),
         ),
       ),
     );
 
-    expect(find.text('正在识别英文回答…'), findsOneWidget);
     expect(find.byKey(const Key('practice-live-transcript')), findsOneWidget);
     expect(find.text('I led the migration safely.'), findsOneWidget);
   });
 
-  testWidgets('shared transcribing composer hides an empty snapshot', (
+  testWidgets('shared recording composer hides an empty snapshot', (
     tester,
   ) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
-          body: PracticeTranscribingComposer(
-            label: 'Transcribing your answer…',
-            transcript: '   ',
-            keyPrefix: 'ielts-mock',
+          body: VoiceCaptureControl(
+            phase: VoiceCapturePhase.recording,
+            onStart: () {},
+            onSendVoice: () {},
+            onConvertToText: () {},
+            onCancel: () {},
+            builder: (_, capture) => PracticeRecordingComposer(
+              capture: capture,
+              phase: VoiceCapturePhase.recording,
+              keyPrefix: 'practice',
+              transcript: '   ',
+            ),
           ),
         ),
       ),
     );
 
-    expect(find.text('Transcribing your answer…'), findsOneWidget);
-    expect(find.byKey(const Key('ielts-mock-live-transcript')), findsNothing);
+    expect(find.byKey(const Key('practice-live-transcript')), findsNothing);
   });
 }


### PR DESCRIPTION
## 功能描述
- 将首页已有的 PCM16 实时语音输入链路复用到 Practice。
- 场景练习、面试与 IELTS 在识别阶段展示连续转写文本。
- 最终 Candidate 继续进入既有编辑、确认、Turn 与证据流程。
- 实时通道失败时明确报错，不静默回退到完整 WAV 上传。

## 实现思路
- 抽取首页与 Practice 共用的 PCM16 流式采集与 WebSocket 传输底座。
- 为 Practice 增加显式 realtime client/recorder capability，并由 Controller 协调音频上传和转写事件。
- 对取消、账号清理和题目切换做代际隔离，避免迟到 Candidate 污染当前练习。
- 复用统一的转写中组件，保留非实时测试与预览客户端原有行为。

## 可复现测试
在 `mobile` 目录执行：

```bash
flutter analyze --no-pub
flutter test --no-pub \
  test/coaching/practice/ios_practice_recorder_test.dart \
  test/coaching/practice/practice_realtime_controller_test.dart \
  test/coaching/practice/wire_practice_client_test.dart \
  test/design/practice_conversation_components_test.dart
```

结果：Flutter analyze 通过；33 项相关测试全部通过。

Closes #546
