### PR TITLE
[Backend] 接入七牛 AI 文本生成 Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,10 @@ DASHSCOPE_API_KEY=
 # TEXT_GENERATION_PROVIDER=qiniu. The API key is independent from Kodo AK/SK;
 # never expose it to Flutter. Keep the base URL on the official /v1 endpoint.
 QINIU_AI_BASE_URL=https://api.qnaigc.com/v1
-QINIU_AI_MODEL=
-QINIU_AI_SPEECH_FEEDBACK_MODEL=
+# Gemini 2.5 Flash is the documented multimodal/tool-calling example and
+# covers the current text, JSON, tool, and image-input business contracts.
+QINIU_AI_MODEL=gemini-2.5-flash
+QINIU_AI_SPEECH_FEEDBACK_MODEL=gemini-2.5-flash
 QINIU_AI_TIMEOUT=60s
 QINIU_AI_MAX_OUTPUT_TOKENS=8192
 QINIU_AI_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgres://xe3_esl:local-development-only@127.0.0.1:5432/xe3_esl?sslmode=disable
 MIGRATION_ENV=local
 
-# Server-only Qianwen text generation. Never expose DASHSCOPE_API_KEY to Flutter.
+# Server-only text generation. Select qianwen or qiniu; never expose either
+# provider API key to Flutter. Qianwen settings follow.
 # Keep the Base URL, API key, and explicitly selected model in the same Alibaba
 # Cloud region. Real-provider tests may incur charges under the cloud account's
 # current billing configuration.
@@ -21,7 +22,18 @@ QIANWEN_MAX_OUTPUT_TOKENS=8192
 AGENT_CONTEXT_MAX_CHARACTERS=12000
 DASHSCOPE_API_KEY=
 
-# Required Agent Memory semantic index. Uses the same server-only API key.
+# Server-only Qiniu AI text generation. Select it with
+# TEXT_GENERATION_PROVIDER=qiniu. The API key is independent from Kodo AK/SK;
+# never expose it to Flutter. Keep the base URL on the official /v1 endpoint.
+QINIU_AI_BASE_URL=https://api.qnaigc.com/v1
+QINIU_AI_MODEL=
+QINIU_AI_SPEECH_FEEDBACK_MODEL=
+QINIU_AI_TIMEOUT=60s
+QINIU_AI_MAX_OUTPUT_TOKENS=8192
+QINIU_AI_API_KEY=
+
+# Required Agent Memory semantic index. Qiniu does not currently expose a text
+# embedding model, so this remains on Qianwen and uses DASHSCOPE_API_KEY.
 EMBEDDING_PROVIDER=qianwen
 QIANWEN_EMBEDDING_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 QIANWEN_EMBEDDING_MODEL=text-embedding-v4
@@ -36,6 +48,7 @@ REVIEW_HISTORY_CURSOR_SIGNING_KEY=
 # Explicit opt-in for a local real-provider test; public CI leaves this disabled.
 # Enabling it sends a real request and may incur charges.
 QIANWEN_LIVE_TEST=0
+QINIU_LLM_LIVE_TEST=0
 
 # Server-only Qianwen ASR. The first media boundary accepts only mono/stereo
 # 16-bit PCM WAV at 8-48 kHz, up to 60 seconds and 7.4 MB. No original upload

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SHELL := /bin/bash
 	check-go-format \
 	check-go-vet \
 	check-go-test \
+	check-qiniu-llm-live \
 	check-oss-live \
 	check-resume-ocr-live \
 	check-api \
@@ -30,6 +31,7 @@ help:
 		'  make check          Run Flutter, Go, API, and deterministic smoke checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
 		'  make check-go       Run Go format, vet, and test checks' \
+		'  make check-qiniu-llm-live Run the real Qiniu text generation smoke test' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
@@ -70,6 +72,34 @@ check-go-vet: check-go-format
 
 check-go-test: check-go-vet
 	cd server && go test -count=1 ./...
+
+check-qiniu-llm-live:
+	@set -euo pipefail; \
+	required=(TEXT_GENERATION_PROVIDER QINIU_AI_BASE_URL QINIU_AI_MODEL QINIU_AI_SPEECH_FEEDBACK_MODEL QINIU_AI_API_KEY QINIU_LLM_LIVE_TEST); \
+	missing=(); \
+	for name in "$${required[@]}"; do \
+		if [[ -z "$${!name:-}" ]]; then missing+=("$$name"); fi; \
+	done; \
+	if (( $${#missing[@]} > 0 )); then \
+		printf '%s\n' 'This target intentionally does not load or execute .env.'; \
+		printf 'Export the required Qiniu AI variables before running this target. Missing:'; \
+		printf ' %s' "$${missing[@]}"; \
+		printf '\n'; \
+		exit 1; \
+	fi; \
+	if [[ "$${TEXT_GENERATION_PROVIDER}" != "qiniu" ]]; then \
+		printf '%s\n' 'Set and export TEXT_GENERATION_PROVIDER=qiniu.'; \
+		exit 1; \
+	fi; \
+	if [[ "$${QINIU_LLM_LIVE_TEST}" != "1" ]]; then \
+		printf '%s\n' 'Set and export QINIU_LLM_LIVE_TEST=1 to opt in to billable requests.'; \
+		exit 1; \
+	fi; \
+	$(MAKE) --no-print-directory check-qiniu-llm-live-go
+
+.PHONY: check-qiniu-llm-live-go
+check-qiniu-llm-live-go:
+	cd server && go test -count=1 -run '^TestLiveQiniuTextGeneration$$' ./internal/providers/qiniu
 
 check-oss-live:
 	@set -euo pipefail; \

--- a/server/internal/bootstrap/text_generation.go
+++ b/server/internal/bootstrap/text_generation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene/ielts"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qiniu"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/fieldextractor"
 	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 )
@@ -28,6 +29,21 @@ type AgentModelProviders struct {
 }
 
 func NewAgentModelProviders(
+	configuration config.TextGenerationConfig,
+) (AgentModelProviders, error) {
+	switch configuration.Provider {
+	case config.TextProviderQianwen:
+		return newQianwenAgentModelProviders(configuration)
+	case config.TextProviderQiniu:
+		return newQiniuAgentModelProviders(configuration)
+	default:
+		return AgentModelProviders{}, errors.New(
+			"bootstrap: text generation provider is not registered",
+		)
+	}
+}
+
+func newQianwenAgentModelProviders(
 	configuration config.TextGenerationConfig,
 ) (AgentModelProviders, error) {
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
@@ -63,9 +79,49 @@ func NewAgentModelProviders(
 	}, nil
 }
 
+func newQiniuAgentModelProviders(
+	configuration config.TextGenerationConfig,
+) (AgentModelProviders, error) {
+	providerConfig, apiKey, err := qiniuTextProvider(configuration)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	runGenerator, err := qiniu.NewAgentRunGenerator(providerConfig, apiKey)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	memoryGenerator, err := qiniu.NewMemoryGenerator(providerConfig, apiKey)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	summaryGenerator, err := qiniu.NewSummaryGenerator(providerConfig, apiKey)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	titleGenerator, err := qiniu.NewTitleGenerator(providerConfig, apiKey)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	translator, err := qiniu.NewTranslator(providerConfig, apiKey)
+	if err != nil {
+		return AgentModelProviders{}, err
+	}
+	return AgentModelProviders{
+		Run: runGenerator, Memory: memoryGenerator, Summary: summaryGenerator,
+		Title: titleGenerator, Translation: translator,
+	}, nil
+}
+
 func NewPreparationJobTargetGenerator(
 	configuration config.TextGenerationConfig,
 ) (preparation.JobTargetGenerator, error) {
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewPreparationJobTargetGenerator(providerConfig, apiKey)
+	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
@@ -76,6 +132,13 @@ func NewPreparationJobTargetGenerator(
 func NewIELTSAnswerPreparationGenerator(
 	configuration config.TextGenerationConfig,
 ) (ielts.AnswerPreparationGenerator, error) {
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewIELTSAnswerPreparationGenerator(providerConfig, apiKey)
+	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
@@ -86,6 +149,13 @@ func NewIELTSAnswerPreparationGenerator(
 func NewEvaluationScoringGenerator(
 	configuration config.TextGenerationConfig,
 ) (scoring.TextGenerator, error) {
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewEvaluationScoringGenerator(providerConfig, apiKey)
+	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
@@ -96,6 +166,14 @@ func NewEvaluationScoringGenerator(
 func NewEvaluationSpeechFeedbackGenerator(
 	configuration config.TextGenerationConfig,
 ) (speechfeedback.TextGenerator, error) {
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		providerConfig.Model = configuration.SpeechFeedbackModel
+		return qiniu.NewEvaluationSpeechFeedbackGenerator(providerConfig, apiKey)
+	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
@@ -107,6 +185,13 @@ func NewEvaluationSpeechFeedbackGenerator(
 func NewResumeFieldGenerator(
 	configuration config.TextGenerationConfig,
 ) (fieldextractor.Generator, error) {
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewResumeFieldGenerator(providerConfig, apiKey)
+	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
@@ -116,6 +201,23 @@ func NewResumeFieldGenerator(
 		return nil, err
 	}
 	return generator, nil
+}
+
+func qiniuTextProvider(
+	configuration config.TextGenerationConfig,
+) (qiniu.TextConfig, string, error) {
+	if configuration.Provider != config.TextProviderQiniu {
+		return qiniu.TextConfig{}, "", errors.New(
+			"bootstrap: text generation provider is not registered",
+		)
+	}
+	return qiniu.TextConfig{
+		Provider:        qiniu.TextProviderName,
+		BaseURL:         configuration.BaseURL,
+		Model:           configuration.Model,
+		Timeout:         configuration.Timeout,
+		MaxOutputTokens: configuration.MaxOutputTokens,
+	}, configuration.APIKey.Reveal(), nil
 }
 
 func qianwenTextProvider(

--- a/server/internal/bootstrap/text_generation_test.go
+++ b/server/internal/bootstrap/text_generation_test.go
@@ -41,6 +41,49 @@ func TestNewAgentAndPreparationGeneratorsRegisterConfiguredQianwen(
 	}
 }
 
+func TestTextGenerationCompositionRegistersConfiguredQiniu(t *testing.T) {
+	setBootstrapQiniuTextGenerationEnvironment(t, "server-only-qiniu-key")
+
+	configuration, err := config.LoadTextGeneration()
+	if err != nil {
+		t.Fatalf("load Qiniu text generation configuration: %v", err)
+	}
+	providers, err := NewAgentModelProviders(configuration)
+	if err != nil {
+		t.Fatalf("register Qiniu Agent model providers: %v", err)
+	}
+	if providers.Run == nil || providers.Memory == nil || providers.Summary == nil ||
+		providers.Title == nil || providers.Translation == nil {
+		t.Fatalf("Qiniu Agent model providers are incomplete: %#v", providers)
+	}
+	generators := []struct {
+		name string
+		new  func() (any, error)
+	}{
+		{name: "preparation", new: func() (any, error) {
+			return NewPreparationJobTargetGenerator(configuration)
+		}},
+		{name: "ielts answer", new: func() (any, error) {
+			return NewIELTSAnswerPreparationGenerator(configuration)
+		}},
+		{name: "evaluation", new: func() (any, error) {
+			return NewEvaluationScoringGenerator(configuration)
+		}},
+		{name: "speech feedback", new: func() (any, error) {
+			return NewEvaluationSpeechFeedbackGenerator(configuration)
+		}},
+		{name: "resume", new: func() (any, error) {
+			return NewResumeFieldGenerator(configuration)
+		}},
+	}
+	for _, generator := range generators {
+		created, createErr := generator.new()
+		if createErr != nil || created == nil {
+			t.Fatalf("register Qiniu %s generator = %T, %v", generator.name, created, createErr)
+		}
+	}
+}
+
 func TestNewResumeFieldGeneratorRejectsInsufficientBudget(t *testing.T) {
 	setBootstrapTextGenerationEnvironment(t, "server-only-test-key")
 
@@ -133,4 +176,16 @@ func setBootstrapTextGenerationEnvironment(t *testing.T, apiKey string) {
 	t.Setenv("QIANWEN_MAX_OUTPUT_TOKENS", "")
 	t.Setenv("AGENT_CONTEXT_MAX_CHARACTERS", "")
 	t.Setenv("DASHSCOPE_API_KEY", apiKey)
+}
+
+func setBootstrapQiniuTextGenerationEnvironment(t *testing.T, apiKey string) {
+	t.Helper()
+	t.Setenv("TEXT_GENERATION_PROVIDER", config.TextProviderQiniu)
+	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
+	t.Setenv("QINIU_AI_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_TIMEOUT", "")
+	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "")
+	t.Setenv("QINIU_AI_API_KEY", apiKey)
+	t.Setenv("AGENT_CONTEXT_MAX_CHARACTERS", "")
 }

--- a/server/internal/bootstrap/text_generation_test.go
+++ b/server/internal/bootstrap/text_generation_test.go
@@ -75,6 +75,12 @@ func TestTextGenerationCompositionRegistersConfiguredQiniu(t *testing.T) {
 		{name: "resume", new: func() (any, error) {
 			return NewResumeFieldGenerator(configuration)
 		}},
+		{name: "Practice Voice question", new: func() (any, error) {
+			return NewPracticeQuestionGenerator(configuration)
+		}},
+		{name: "Practice Voice answer Tip", new: func() (any, error) {
+			return NewPracticeAnswerTipGenerator(configuration)
+		}},
 	}
 	for _, generator := range generators {
 		created, createErr := generator.new()
@@ -139,6 +145,20 @@ func TestExplicitModelPortsRejectUnregisteredProviderWithoutFallback(
 	if generator, err := NewResumeFieldGenerator(configuration); err == nil || generator != nil {
 		t.Fatalf(
 			"unregistered provider returned Resume port=%T error=%v",
+			generator,
+			err,
+		)
+	}
+	if generator, err := NewPracticeQuestionGenerator(configuration); err == nil || generator != nil {
+		t.Fatalf(
+			"unregistered provider returned Practice question port=%T error=%v",
+			generator,
+			err,
+		)
+	}
+	if generator, err := NewPracticeAnswerTipGenerator(configuration); err == nil || generator != nil {
+		t.Fatalf(
+			"unregistered provider returned Practice answer Tip port=%T error=%v",
 			generator,
 			err,
 		)

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -13,6 +13,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qiniu"
 	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -139,40 +140,36 @@ func NewPracticeSpeechSynthesizer(
 func NewPracticeQuestionGenerator(
 	configuration config.TextGenerationConfig,
 ) (practicevoice.QuestionGenerator, error) {
-	if configuration.Provider != config.TextProviderQianwen {
-		return nil, errors.New(
-			"bootstrap: Practice question provider is not registered",
-		)
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewPracticeVoiceQuestionGenerator(providerConfig, apiKey)
 	}
-	return qianwen.NewPracticeVoiceQuestionGenerator(
-		qianwen.TextConfig{
-			BaseURL:         configuration.BaseURL,
-			Model:           configuration.Model,
-			Timeout:         configuration.Timeout,
-			MaxOutputTokens: configuration.MaxOutputTokens,
-		},
-		configuration.APIKey.Reveal(),
-	)
+	providerConfig, apiKey, err := qianwenTextProvider(configuration)
+	if err != nil {
+		return nil, err
+	}
+	return qianwen.NewPracticeVoiceQuestionGenerator(providerConfig, apiKey)
 }
 
 // NewPracticeAnswerTipGenerator selects the Practice Voice Tip adapter.
 func NewPracticeAnswerTipGenerator(
 	configuration config.TextGenerationConfig,
 ) (practicevoice.AnswerTipGenerator, error) {
-	if configuration.Provider != config.TextProviderQianwen {
-		return nil, errors.New(
-			"bootstrap: Practice answer Tip provider is not registered",
-		)
+	if configuration.Provider == config.TextProviderQiniu {
+		providerConfig, apiKey, err := qiniuTextProvider(configuration)
+		if err != nil {
+			return nil, err
+		}
+		return qiniu.NewPracticeVoiceAnswerTipGenerator(providerConfig, apiKey)
 	}
-	return qianwen.NewPracticeVoiceAnswerTipGenerator(
-		qianwen.TextConfig{
-			BaseURL:         configuration.BaseURL,
-			Model:           configuration.Model,
-			Timeout:         configuration.Timeout,
-			MaxOutputTokens: configuration.MaxOutputTokens,
-		},
-		configuration.APIKey.Reveal(),
-	)
+	providerConfig, apiKey, err := qianwenTextProvider(configuration)
+	if err != nil {
+		return nil, err
+	}
+	return qianwen.NewPracticeVoiceAnswerTipGenerator(providerConfig, apiKey)
 }
 
 // buildProductionVoiceApplication constructs infrastructure and delegates all

--- a/server/internal/platform/config/text_generation.go
+++ b/server/internal/platform/config/text_generation.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	TextProviderQianwen = "qianwen"
+	TextProviderQiniu   = "qiniu"
 
 	defaultTextTimeout         = 60 * time.Second
 	defaultTextMaxOutputTokens = 8192
@@ -62,49 +63,66 @@ func LoadTextGeneration() (TextGenerationConfig, error) {
 	if provider == "" {
 		return TextGenerationConfig{}, errors.New("TEXT_GENERATION_PROVIDER is required")
 	}
-	if provider != TextProviderQianwen {
+	if provider != TextProviderQianwen && provider != TextProviderQiniu {
 		return TextGenerationConfig{}, errors.New("TEXT_GENERATION_PROVIDER is not supported")
 	}
 
-	baseURL := strings.TrimSpace(os.Getenv("QIANWEN_BASE_URL"))
-	if baseURL == "" {
-		return TextGenerationConfig{}, errors.New("QIANWEN_BASE_URL is required")
+	prefix := "QIANWEN"
+	apiKeyName := "DASHSCOPE_API_KEY"
+	if provider == TextProviderQiniu {
+		prefix = "QINIU_AI"
+		apiKeyName = "QINIU_AI_API_KEY"
 	}
-	model := strings.TrimSpace(os.Getenv("QIANWEN_MODEL"))
+	baseURLName := prefix + "_BASE_URL"
+	modelName := prefix + "_MODEL"
+	speechFeedbackModelName := prefix + "_SPEECH_FEEDBACK_MODEL"
+	timeoutName := prefix + "_TIMEOUT"
+	maxOutputTokensName := prefix + "_MAX_OUTPUT_TOKENS"
+
+	baseURL := strings.TrimSpace(os.Getenv(baseURLName))
+	if baseURL == "" {
+		return TextGenerationConfig{}, fmt.Errorf("%s is required", baseURLName)
+	}
+	model := strings.TrimSpace(os.Getenv(modelName))
 	if model == "" {
-		return TextGenerationConfig{}, errors.New("QIANWEN_MODEL is required")
+		return TextGenerationConfig{}, fmt.Errorf("%s is required", modelName)
 	}
 	speechFeedbackModel := strings.TrimSpace(
-		os.Getenv("QIANWEN_SPEECH_FEEDBACK_MODEL"),
+		os.Getenv(speechFeedbackModelName),
 	)
 	if speechFeedbackModel == "" {
-		return TextGenerationConfig{}, errors.New(
-			"QIANWEN_SPEECH_FEEDBACK_MODEL is required",
+		return TextGenerationConfig{}, fmt.Errorf(
+			"%s is required",
+			speechFeedbackModelName,
 		)
 	}
-	apiKey := strings.TrimSpace(os.Getenv("DASHSCOPE_API_KEY"))
+	apiKey := strings.TrimSpace(os.Getenv(apiKeyName))
 	if apiKey == "" {
-		return TextGenerationConfig{}, errors.New("DASHSCOPE_API_KEY is required")
+		return TextGenerationConfig{}, fmt.Errorf("%s is required", apiKeyName)
 	}
 	if strings.IndexFunc(apiKey, func(r rune) bool {
 		return r < 0x21 || r == 0x7f
 	}) >= 0 {
-		return TextGenerationConfig{}, errors.New("DASHSCOPE_API_KEY contains whitespace or control characters")
+		return TextGenerationConfig{}, fmt.Errorf(
+			"%s contains whitespace or control characters",
+			apiKeyName,
+		)
 	}
 
-	timeout, err := durationOrDefault("QIANWEN_TIMEOUT", defaultTextTimeout)
+	timeout, err := durationOrDefault(timeoutName, defaultTextTimeout)
 	if err != nil {
 		return TextGenerationConfig{}, err
 	}
 	if timeout <= 0 || timeout > maximumTextTimeout {
 		return TextGenerationConfig{}, fmt.Errorf(
-			"QIANWEN_TIMEOUT must be greater than zero and at most %s",
+			"%s must be greater than zero and at most %s",
+			timeoutName,
 			maximumTextTimeout,
 		)
 	}
 
 	maxOutputTokens, err := positiveIntOrDefault(
-		"QIANWEN_MAX_OUTPUT_TOKENS",
+		maxOutputTokensName,
 		defaultTextMaxOutputTokens,
 	)
 	if err != nil {
@@ -112,7 +130,8 @@ func LoadTextGeneration() (TextGenerationConfig, error) {
 	}
 	if maxOutputTokens > maximumTextOutputTokens {
 		return TextGenerationConfig{}, fmt.Errorf(
-			"QIANWEN_MAX_OUTPUT_TOKENS must be at most %d",
+			"%s must be at most %d",
+			maxOutputTokensName,
 			maximumTextOutputTokens,
 		)
 	}

--- a/server/internal/platform/config/text_generation_test.go
+++ b/server/internal/platform/config/text_generation_test.go
@@ -59,6 +59,57 @@ func TestLoadTextGenerationUsesSafeOperationalDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadTextGenerationReadsQiniuConfiguration(t *testing.T) {
+	t.Setenv("TEXT_GENERATION_PROVIDER", TextProviderQiniu)
+	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
+	t.Setenv("QINIU_AI_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_TIMEOUT", "45s")
+	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "768")
+	t.Setenv("QINIU_AI_API_KEY", "qiniu-test-secret")
+	t.Setenv("AGENT_CONTEXT_MAX_CHARACTERS", "24000")
+
+	cfg, err := LoadTextGeneration()
+	if err != nil {
+		t.Fatalf("load Qiniu text generation config: %v", err)
+	}
+	if cfg.Provider != TextProviderQiniu ||
+		cfg.BaseURL != "https://api.qnaigc.com/v1" ||
+		cfg.Model != "gemini-2.5-flash" ||
+		cfg.SpeechFeedbackModel != "gemini-2.5-flash" ||
+		cfg.Timeout != 45*time.Second ||
+		cfg.MaxOutputTokens != 768 ||
+		cfg.MaxContextChars != 24000 ||
+		cfg.APIKey.Reveal() != "qiniu-test-secret" {
+		t.Fatalf("unexpected Qiniu text generation config: %#v", cfg)
+	}
+}
+
+func TestLoadTextGenerationRejectsUnsafeQiniuConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "missing base URL", key: "QINIU_AI_BASE_URL", value: ""},
+		{name: "missing model", key: "QINIU_AI_MODEL", value: ""},
+		{name: "missing feedback model", key: "QINIU_AI_SPEECH_FEEDBACK_MODEL", value: ""},
+		{name: "missing API key", key: "QINIU_AI_API_KEY", value: ""},
+		{name: "API key whitespace", key: "QINIU_AI_API_KEY", value: "secret value"},
+		{name: "invalid timeout", key: "QINIU_AI_TIMEOUT", value: "soon"},
+		{name: "invalid output budget", key: "QINIU_AI_MAX_OUTPUT_TOKENS", value: "many"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setRequiredQiniuTextGenerationEnvironment(t)
+			t.Setenv(test.key, test.value)
+			if _, err := LoadTextGeneration(); err == nil {
+				t.Fatal("expected Qiniu configuration error")
+			}
+		})
+	}
+}
+
 func TestLoadTextGenerationRejectsUnsafeOrIncompleteConfiguration(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -142,4 +193,16 @@ func setRequiredTextGenerationEnvironment(t *testing.T) {
 	t.Setenv("QIANWEN_MAX_OUTPUT_TOKENS", "")
 	t.Setenv("AGENT_CONTEXT_MAX_CHARACTERS", "")
 	t.Setenv("DASHSCOPE_API_KEY", "test-secret-value")
+}
+
+func setRequiredQiniuTextGenerationEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("TEXT_GENERATION_PROVIDER", TextProviderQiniu)
+	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
+	t.Setenv("QINIU_AI_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
+	t.Setenv("QINIU_AI_TIMEOUT", "")
+	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "")
+	t.Setenv("QINIU_AI_API_KEY", "qiniu-test-secret")
+	t.Setenv("AGENT_CONTEXT_MAX_CHARACTERS", "")
 }

--- a/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
+++ b/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
@@ -1,0 +1,195 @@
+package qianwen
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+func TestQiniuGenerateUsesOfficialMultimodalJSONContract(t *testing.T) {
+	const apiKey = "qiniu-test-key"
+	var payload map[string]json.RawMessage
+	generator := mustQiniuGenerator(t, doerFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != "https://api.qnaigc.com/v1/chat/completions" {
+			t.Fatalf("Qiniu request URL = %q", request.URL.String())
+		}
+		if request.Header.Get(authorizationHeaderName) != "Bearer "+apiKey {
+			t.Fatal("Qiniu authorization header was not set")
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode Qiniu request: %v", err)
+		}
+		return jsonResponse(http.StatusOK, `{
+			"id":"chatcmpl-qiniu-1",
+			"model":"gemini-2.5-flash",
+			"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"summary\":\"safe\"}"}}],
+			"usage":{"prompt_tokens":12,"completion_tokens":6,"total_tokens":18}
+		}`), nil
+	}), apiKey)
+
+	result, err := generator.Generate(context.Background(), protocol.TextRequest{
+		Messages: []protocol.TextMessage{{
+			Role: protocol.TextRoleUser,
+			ContentParts: []protocol.ContentPart{
+				{Kind: protocol.ContentPartText, Text: "Read the image."},
+				{Kind: protocol.ContentPartImageURL, ImageURL: "https://private.example.com/image.jpg?token=ephemeral"},
+			},
+		}},
+		ResponseFormat: protocol.TextResponseFormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("Qiniu Generate() error = %v", err)
+	}
+	if result.Provider != qiniuProviderName || result.Model != "gemini-2.5-flash" ||
+		result.Content != `{"summary":"safe"}` || result.Usage.TotalTokens != 18 {
+		t.Fatalf("Qiniu result = %#v", result)
+	}
+	if _, exists := payload["enable_thinking"]; exists {
+		t.Fatal("Qiniu request included the DashScope-only enable_thinking field")
+	}
+	if string(payload["response_format"]) != `{"type":"json_object"}` {
+		t.Fatalf("Qiniu response_format = %s", payload["response_format"])
+	}
+	var messages []struct {
+		Content []struct {
+			Type     string `json:"type"`
+			Text     string `json:"text"`
+			ImageURL *struct {
+				URL string `json:"url"`
+			} `json:"image_url"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(payload["messages"], &messages); err != nil ||
+		len(messages) != 1 || len(messages[0].Content) != 2 ||
+		messages[0].Content[0].Text != "Read the image." ||
+		messages[0].Content[1].ImageURL == nil ||
+		messages[0].Content[1].ImageURL.URL == "" {
+		t.Fatalf("Qiniu multimodal messages = %#v, %v", messages, err)
+	}
+}
+
+func TestQiniuGenerateMapsToolCallsAndLineage(t *testing.T) {
+	generator := mustQiniuGenerator(t, doerFunc(func(request *http.Request) (*http.Response, error) {
+		var payload chatCompletionRequest
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.Tools) != 1 || payload.Tools[0].Function.Name != "review_search_v1" {
+			t.Fatalf("Qiniu tools = %#v", payload.Tools)
+		}
+		return jsonResponse(http.StatusOK, `{
+			"id":"chatcmpl-qiniu-tool",
+			"model":"gemini-2.5-flash",
+			"choices":[{"finish_reason":"tool_calls","message":{"role":"assistant","content":"","tool_calls":[{
+				"id":"call_qiniu_1","type":"function","function":{"name":"review_search_v1","arguments":"{\"query\":\"IELTS\"}"}
+			}]}}],
+			"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}
+		}`), nil
+	}), "qiniu-test-key")
+
+	result, err := generator.Generate(context.Background(), toolRequest())
+	if err != nil {
+		t.Fatalf("Qiniu tool Generate() error = %v", err)
+	}
+	if result.Provider != qiniuProviderName || result.FinishReason != "tool_calls" ||
+		len(result.ToolCalls) != 1 || result.ToolCalls[0].Name != "review.search.v1" {
+		t.Fatalf("Qiniu tool result = %#v", result)
+	}
+}
+
+func TestQiniuGenerateStreamRequiresUsageAndReportsLineage(t *testing.T) {
+	var payload map[string]json.RawMessage
+	generator := mustQiniuGenerator(t, doerFunc(func(request *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		return streamResponse(
+			`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[{"delta":{"role":"assistant","content":"Hello"}}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[{"delta":{"content":" there"},"finish_reason":"stop"}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}` + "\n\n" +
+				"data: [DONE]\n\n",
+		), nil
+	}), "qiniu-test-key")
+	var deltas []string
+	result, err := generator.GenerateStream(
+		context.Background(),
+		validRequest(),
+		protocol.TextDeltaObserverFunc(func(_ context.Context, delta string) error {
+			deltas = append(deltas, delta)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Qiniu GenerateStream() error = %v", err)
+	}
+	if result.Provider != qiniuProviderName || result.Content != "Hello there" ||
+		result.Usage.TotalTokens != 7 || strings.Join(deltas, "") != "Hello there" {
+		t.Fatalf("Qiniu stream result = %#v, deltas=%#v", result, deltas)
+	}
+	if _, exists := payload["enable_thinking"]; exists {
+		t.Fatal("Qiniu stream included the DashScope-only enable_thinking field")
+	}
+	if string(payload["stream_options"]) != `{"include_usage":true}` {
+		t.Fatalf("Qiniu stream_options = %s", payload["stream_options"])
+	}
+}
+
+func TestQiniuErrorsAreBoundedAndClassified(t *testing.T) {
+	const sensitive = "prompt and key must not leak"
+	generator := mustQiniuGenerator(t, doerFunc(func(*http.Request) (*http.Response, error) {
+		response := jsonResponse(http.StatusPaymentRequired, fmt.Sprintf(
+			`{"error":{"type":"quota_exceeded_error","message":%q}}`,
+			sensitive,
+		))
+		response.Header.Set("X-Request-Id", "request-qiniu-1")
+		return response, nil
+	}), "qiniu-test-key")
+	_, err := generator.Generate(context.Background(), validRequest())
+	var generationError *protocol.GenerationError
+	if !errors.As(err, &generationError) ||
+		generationError.Kind != protocol.ErrorQuotaExhausted ||
+		generationError.RequestID != "request-qiniu-1" ||
+		strings.Contains(fmt.Sprint(err), sensitive) {
+		t.Fatalf("Qiniu status error = %#v, %v", generationError, err)
+	}
+}
+
+func TestQiniuTextConfigRejectsNonOfficialEndpoints(t *testing.T) {
+	invalid := []TextConfig{
+		{Provider: qiniuProviderName, BaseURL: "https://example.com/v1", Model: "gemini-2.5-flash"},
+		{Provider: qiniuProviderName, BaseURL: "http://api.qnaigc.com/v1", Model: "gemini-2.5-flash"},
+		{Provider: qiniuProviderName, BaseURL: "https://api.qnaigc.com/v1/chat/completions", Model: "gemini-2.5-flash"},
+		{Provider: qiniuProviderName, BaseURL: "https://api.qnaigc.com/v1", Model: "../unsafe"},
+	}
+	for _, configuration := range invalid {
+		configuration.Timeout = time.Second
+		configuration.MaxOutputTokens = 512
+		if client, err := newWithClient(configuration, "qiniu-test-key", doerFunc(
+			func(*http.Request) (*http.Response, error) {
+				return &http.Response{Body: io.NopCloser(strings.NewReader(""))}, nil
+			},
+		)); err == nil || client != nil {
+			t.Fatalf("unsafe Qiniu config created client=%#v error=%v", client, err)
+		}
+	}
+}
+
+func mustQiniuGenerator(t *testing.T, client httpDoer, apiKey string) *textClient {
+	t.Helper()
+	generator, err := newWithClient(TextConfig{
+		Provider: qiniuProviderName, BaseURL: "https://api.qnaigc.com/v1",
+		Model: "gemini-2.5-flash", Timeout: time.Second, MaxOutputTokens: 512,
+	}, apiKey, client)
+	if err != nil {
+		t.Fatalf("new Qiniu generator: %v", err)
+	}
+	return generator
+}

--- a/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
+++ b/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
@@ -113,8 +113,7 @@ func TestQiniuGenerateStreamRequiresUsageAndReportsLineage(t *testing.T) {
 		}
 		return streamResponse(
 			`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[{"delta":{"role":"assistant","content":"Hello"}}]}` + "\n\n" +
-				`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[{"delta":{"content":" there"},"finish_reason":"stop"}]}` + "\n\n" +
-				`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}` + "\n\n" +
+				`data: {"id":"chatcmpl-qiniu-stream","model":"gemini-2.5-flash","choices":[{"delta":{"content":" there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}` + "\n\n" +
 				"data: [DONE]\n\n",
 		), nil
 	}), "qiniu-test-key")

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -644,8 +644,9 @@ func decodeCompletionStream(
 		if completionID == "" || model == "" {
 			return protocol.TextResult{}, errors.New("Qianwen stream has invalid completion identity")
 		}
-		if chunk.Usage != nil {
-			if sawUsage || len(chunk.Choices) != 0 ||
+		usageInChunk := chunk.Usage != nil
+		if usageInChunk {
+			if sawUsage || len(chunk.Choices) > 1 ||
 				chunk.Usage.PromptTokens == nil ||
 				chunk.Usage.CompletionTokens == nil ||
 				chunk.Usage.TotalTokens == nil {
@@ -665,7 +666,9 @@ func decodeCompletionStream(
 				return protocol.TextResult{}, errors.New("Qianwen stream has invalid token usage")
 			}
 			sawUsage = true
-			continue
+			if len(chunk.Choices) == 0 {
+				continue
+			}
 		}
 		// Official OpenAI-compatible examples consume chunks by state: choice
 		// chunks carry deltas, while the final empty-choice chunk carries usage.
@@ -673,10 +676,13 @@ func decodeCompletionStream(
 		if len(chunk.Choices) == 0 {
 			continue
 		}
-		if sawUsage || len(chunk.Choices) != 1 {
+		if (sawUsage && !usageInChunk) || len(chunk.Choices) != 1 {
 			return protocol.TextResult{}, errors.New("Qianwen stream must contain exactly one choice")
 		}
 		choice := chunk.Choices[0]
+		if usageInChunk && choice.FinishReason == nil {
+			return protocol.TextResult{}, errors.New("Qianwen stream has invalid final usage")
+		}
 		if choice.Delta.Role != "" &&
 			choice.Delta.Role != string(protocol.TextRoleAssistant) {
 			return protocol.TextResult{}, errors.New("Qianwen stream has an invalid delta role")

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -19,8 +19,10 @@ import (
 
 const (
 	providerName            = "qianwen"
+	qiniuProviderName       = "qiniu"
 	chatCompletionsPath     = "/chat/completions"
 	compatibleBasePath      = "/compatible-mode/v1"
+	qiniuCompatibleBasePath = "/v1"
 	maxResponseBytes        = 2 << 20
 	maxErrorResponseBytes   = 64 << 10
 	maxTimeout              = 5 * time.Minute
@@ -34,6 +36,10 @@ const (
 )
 
 type TextConfig struct {
+	// Provider is empty for the native Qianwen adapter. The Qiniu wrapper sets
+	// it explicitly so both providers can share the audited OpenAI-compatible
+	// wire implementation without changing the business ports.
+	Provider        string
 	BaseURL         string
 	Model           string
 	Timeout         time.Duration
@@ -41,6 +47,8 @@ type TextConfig struct {
 }
 
 type textClient struct {
+	provider        string
+	providerLabel   string
 	endpoint        string
 	model           string
 	timeout         time.Duration
@@ -54,7 +62,8 @@ func (generator *textClient) String() string {
 		return "QianwenGenerator(<nil>)"
 	}
 	return fmt.Sprintf(
-		"QianwenGenerator(model=%q, timeout=%s, max_output_tokens=%d, api_key=[REDACTED])",
+		"%sGenerator(model=%q, timeout=%s, max_output_tokens=%d, api_key=[REDACTED])",
+		generator.providerLabel,
 		generator.model,
 		generator.timeout,
 		generator.maxOutputTokens,
@@ -80,15 +89,19 @@ func newTextClient(config TextConfig, apiKey string) (*textClient, error) {
 }
 
 func newWithClient(config TextConfig, apiKey string, client httpDoer) (*textClient, error) {
-	baseURL, err := normalizeBaseURL(config.BaseURL)
+	settings, err := textProviderSettingsFor(config.Provider)
 	if err != nil {
 		return nil, err
 	}
-	model, err := normalizeModel(config.Model)
+	baseURL, err := normalizeTextBaseURL(config.BaseURL, settings)
 	if err != nil {
 		return nil, err
 	}
-	apiKey, err = normalizeAPIKey(apiKey)
+	model, err := normalizeModel(config.Model, settings)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, err = normalizeTextAPIKey(apiKey, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +119,8 @@ func newWithClient(config TextConfig, apiKey string, client httpDoer) (*textClie
 	}
 
 	return &textClient{
+		provider:        settings.name,
+		providerLabel:   settings.label,
 		endpoint:        baseURL + chatCompletionsPath,
 		model:           model,
 		timeout:         config.Timeout,
@@ -148,63 +163,11 @@ func (generator *textClient) Generate(
 		)
 	}
 
-	payload := chatCompletionRequest{
-		Model:          generator.model,
-		Messages:       make([]chatMessage, 0, len(request.Messages)),
-		Tools:          make([]chatTool, 0, len(request.Tools)),
-		Stream:         false,
-		EnableThinking: false,
-		MaxTokens:      generator.maxOutputTokens,
-	}
-	if request.ResponseFormat == protocol.TextResponseFormatJSON {
-		payload.ResponseFormat = &chatResponseFormat{
-			Type: string(protocol.TextResponseFormatJSON),
-		}
-	}
-	toolChoice, err := providerToolChoice(request.ToolChoice, internalToProvider)
+	payload, err := generator.providerRequest(request, internalToProvider)
 	if err != nil {
 		return protocol.TextResult{}, protocol.NewGenerationError(
-			protocol.ErrorInvalidRequest,
-			0,
-			"",
-			"",
-			err,
+			protocol.ErrorInvalidRequest, 0, "", "", err,
 		)
-	}
-	payload.ToolChoice = toolChoice
-	for _, message := range request.Messages {
-		providerMessage := chatMessage{
-			Role:       string(message.Role),
-			ToolCallID: message.ToolCallID,
-			ToolCalls:  make([]chatToolCall, 0, len(message.ToolCalls)),
-		}
-		if len(message.ContentParts) != 0 {
-			providerMessage.Content = providerContentParts(message.ContentParts)
-		} else if message.Content != "" {
-			providerMessage.Content = message.Content
-		}
-		for index, call := range message.ToolCalls {
-			providerMessage.ToolCalls = append(providerMessage.ToolCalls, chatToolCall{
-				ID:    call.ID,
-				Type:  "function",
-				Index: index,
-				Function: chatFunctionCall{
-					Name:      internalToProvider[call.Name],
-					Arguments: string(call.Arguments),
-				},
-			})
-		}
-		payload.Messages = append(payload.Messages, providerMessage)
-	}
-	for _, definition := range request.Tools {
-		payload.Tools = append(payload.Tools, chatTool{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        internalToProvider[definition.Name],
-				Description: definition.Description,
-				Parameters:  definition.InputSchema,
-			},
-		})
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -289,7 +252,7 @@ func (generator *textClient) Generate(
 			errors.New("decode Qianwen response"),
 		)
 	}
-	result, err := completion.result(providerToInternal)
+	result, err := completion.result(generator.provider, providerToInternal)
 	if err != nil {
 		return protocol.TextResult{}, protocol.NewGenerationError(
 			protocol.ErrorInvalidResponse,
@@ -398,6 +361,7 @@ func (generator *textClient) GenerateStream(
 	result, err := decodeCompletionStream(
 		callContext,
 		response.Body,
+		generator.provider,
 		providerToInternal,
 		observer,
 	)
@@ -431,12 +395,15 @@ func (generator *textClient) providerRequest(
 	internalToProvider map[string]string,
 ) (chatCompletionRequest, error) {
 	payload := chatCompletionRequest{
-		Model:          generator.model,
-		Messages:       make([]chatMessage, 0, len(request.Messages)),
-		Tools:          make([]chatTool, 0, len(request.Tools)),
-		Stream:         false,
-		EnableThinking: false,
-		MaxTokens:      generator.maxOutputTokens,
+		Model:     generator.model,
+		Messages:  make([]chatMessage, 0, len(request.Messages)),
+		Tools:     make([]chatTool, 0, len(request.Tools)),
+		Stream:    false,
+		MaxTokens: generator.maxOutputTokens,
+	}
+	if generator.provider == providerName {
+		disabled := false
+		payload.EnableThinking = &disabled
 	}
 	if request.ResponseFormat == protocol.TextResponseFormatJSON {
 		payload.ResponseFormat = &chatResponseFormat{
@@ -450,9 +417,14 @@ func (generator *textClient) providerRequest(
 	payload.ToolChoice = toolChoice
 	for _, message := range request.Messages {
 		providerMessage := chatMessage{
-			Role: string(message.Role), Content: message.Content,
+			Role:       string(message.Role),
 			ToolCallID: message.ToolCallID,
 			ToolCalls:  make([]chatToolCall, 0, len(message.ToolCalls)),
+		}
+		if len(message.ContentParts) != 0 {
+			providerMessage.Content = providerContentParts(message.ContentParts)
+		} else if message.Content != "" {
+			providerMessage.Content = message.Content
 		}
 		for index, call := range message.ToolCalls {
 			providerMessage.ToolCalls = append(providerMessage.ToolCalls, chatToolCall{
@@ -484,7 +456,7 @@ type chatCompletionRequest struct {
 	ToolChoice     any                 `json:"tool_choice,omitempty"`
 	Stream         bool                `json:"stream"`
 	StreamOptions  *chatStreamOptions  `json:"stream_options,omitempty"`
-	EnableThinking bool                `json:"enable_thinking"`
+	EnableThinking *bool               `json:"enable_thinking,omitempty"`
 	ResponseFormat *chatResponseFormat `json:"response_format,omitempty"`
 	// The current compatibility overview lists max_completion_tokens as
 	// silently ignored. The endpoint-specific Chat API still honors the
@@ -618,6 +590,7 @@ type streamToolCall struct {
 func decodeCompletionStream(
 	ctx context.Context,
 	body io.Reader,
+	provider string,
 	providerToInternal map[string]string,
 	observer protocol.TextDeltaObserver,
 ) (protocol.TextResult, error) {
@@ -661,7 +634,7 @@ func decodeCompletionStream(
 			return protocol.TextResult{}, errors.New("decode Qianwen stream event")
 		}
 		chunkID := sanitizeIdentifier(chunk.ID)
-		chunkModel, _ := normalizeModel(chunk.Model)
+		chunkModel, _ := normalizeReturnedModel(chunk.Model)
 		if completionID == "" {
 			completionID = chunkID
 			model = chunkModel
@@ -780,7 +753,7 @@ func decodeCompletionStream(
 		return protocol.TextResult{}, errors.New("Qianwen stream ended before completion")
 	}
 	result := protocol.TextResult{
-		ID: completionID, Provider: providerName, Model: model,
+		ID: completionID, Provider: provider, Model: model,
 		Content: content.String(), FinishReason: finishReason,
 		Usage: protocol.TokenUsage{
 			InputTokens: usage.prompt, OutputTokens: usage.completion,
@@ -826,13 +799,14 @@ func normalizedVisibleDelta(started bool, value string) (string, string) {
 }
 
 func (response chatCompletionResponse) result(
+	provider string,
 	providerToInternal map[string]string,
 ) (protocol.TextResult, error) {
 	id := sanitizeIdentifier(response.ID)
 	if id == "" {
 		return protocol.TextResult{}, errors.New("Qianwen response has no valid completion ID")
 	}
-	model, err := normalizeModel(response.Model)
+	model, err := normalizeReturnedModel(response.Model)
 	if err != nil {
 		return protocol.TextResult{}, errors.New("Qianwen response has no valid model")
 	}
@@ -906,7 +880,7 @@ func (response chatCompletionResponse) result(
 
 	return protocol.TextResult{
 		ID:           id,
-		Provider:     providerName,
+		Provider:     provider,
 		Model:        model,
 		Content:      content,
 		ToolCalls:    toolCalls,
@@ -1030,6 +1004,10 @@ func decodeStatusError(response *http.Response) error {
 
 func classifyStatus(statusCode int, providerCode string) protocol.ErrorKind {
 	normalizedCode := strings.ToLower(providerCode)
+	if statusCode == http.StatusPaymentRequired ||
+		strings.Contains(normalizedCode, "quota_exceeded") {
+		return protocol.ErrorQuotaExhausted
+	}
 	if strings.Contains(normalizedCode, "allocationquota.freetieronly") {
 		return protocol.ErrorQuotaExhausted
 	}
@@ -1093,32 +1071,66 @@ func readBounded(reader io.Reader, limit int64) ([]byte, error) {
 	return body, nil
 }
 
-func normalizeBaseURL(raw string) (string, error) {
+type textProviderSettings struct {
+	name     string
+	label    string
+	basePath string
+}
+
+func textProviderSettingsFor(provider string) (textProviderSettings, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", providerName:
+		return textProviderSettings{
+			name: providerName, label: "Qianwen", basePath: compatibleBasePath,
+		}, nil
+	case qiniuProviderName:
+		return textProviderSettings{
+			name: qiniuProviderName, label: "Qiniu", basePath: qiniuCompatibleBasePath,
+		}, nil
+	default:
+		return textProviderSettings{}, errors.New("text provider is not supported")
+	}
+}
+
+func normalizeTextBaseURL(raw string, settings textProviderSettings) (string, error) {
 	raw = strings.TrimSpace(raw)
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return "", errors.New("Qianwen base URL is invalid")
+		return "", fmt.Errorf("%s base URL is invalid", settings.label)
 	}
 	if parsed.Scheme != "https" ||
 		parsed.User != nil ||
 		parsed.RawQuery != "" ||
 		parsed.Fragment != "" ||
 		parsed.Port() != "" {
-		return "", errors.New("Qianwen base URL must be a credential-free HTTPS URL")
+		return "", fmt.Errorf(
+			"%s base URL must be a credential-free HTTPS URL",
+			settings.label,
+		)
 	}
 	host := strings.ToLower(parsed.Hostname())
-	if !isOfficialHost(host) {
-		return "", errors.New("Qianwen base URL must use an official Alibaba Cloud endpoint")
+	if !isOfficialTextHost(host, settings) {
+		return "", fmt.Errorf(
+			"%s base URL must use an official provider endpoint",
+			settings.label,
+		)
 	}
-	if strings.TrimRight(parsed.EscapedPath(), "/") != compatibleBasePath {
-		return "", fmt.Errorf("Qianwen base URL path must be %s", compatibleBasePath)
+	if strings.TrimRight(parsed.EscapedPath(), "/") != settings.basePath {
+		return "", fmt.Errorf(
+			"%s base URL path must be %s",
+			settings.label,
+			settings.basePath,
+		)
 	}
-	parsed.Path = compatibleBasePath
+	parsed.Path = settings.basePath
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
 }
 
-func isOfficialHost(host string) bool {
+func isOfficialTextHost(host string, settings textProviderSettings) bool {
+	if settings.name == qiniuProviderName {
+		return host == "api.qnaigc.com"
+	}
 	switch host {
 	case "dashscope.aliyuncs.com",
 		"dashscope-intl.aliyuncs.com",
@@ -1130,36 +1142,75 @@ func isOfficialHost(host string) bool {
 	}
 }
 
-func normalizeModel(raw string) (string, error) {
-	model := strings.TrimSpace(raw)
-	if len(model) == 0 || len(model) > maxProviderIdentifier {
-		return "", errors.New("Qianwen model is required and must not exceed 128 characters")
+func normalizeModel(raw string, settings textProviderSettings) (string, error) {
+	model, err := normalizeReturnedModel(raw)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%s model is required and contains only supported characters",
+			settings.label,
+		)
 	}
-	if !strings.HasPrefix(strings.ToLower(model), "qwen") {
+	if settings.name == providerName &&
+		!strings.HasPrefix(strings.ToLower(model), "qwen") {
 		return "", errors.New("Qianwen adapter only accepts Qwen model IDs")
-	}
-	for _, value := range model {
-		if !((value >= 'a' && value <= 'z') ||
-			(value >= 'A' && value <= 'Z') ||
-			(value >= '0' && value <= '9') ||
-			value == '-' || value == '_' || value == '.') {
-			return "", errors.New("Qianwen model contains unsupported characters")
-		}
 	}
 	return model, nil
 }
 
-func normalizeAPIKey(raw string) (string, error) {
+func normalizeReturnedModel(raw string) (string, error) {
+	model := strings.TrimSpace(raw)
+	if len(model) == 0 || len(model) > maxProviderIdentifier {
+		return "", errors.New("provider model is required and must not exceed 128 characters")
+	}
+	for index, value := range model {
+		if !((value >= 'a' && value <= 'z') ||
+			(value >= 'A' && value <= 'Z') ||
+			(value >= '0' && value <= '9') ||
+			value == '-' || value == '_' || value == '.' || value == '/' ||
+			value == ':') {
+			return "", errors.New("provider model contains unsupported characters")
+		}
+		if value == '/' && (index == 0 || index == len(model)-1) {
+			return "", errors.New("provider model contains an invalid separator")
+		}
+	}
+	if strings.Contains(model, "//") || strings.Contains(model, "..") {
+		return "", errors.New("provider model contains an invalid sequence")
+	}
+	return model, nil
+}
+
+func normalizeTextAPIKey(raw string, settings textProviderSettings) (string, error) {
 	apiKey := strings.TrimSpace(raw)
 	if apiKey == "" {
-		return "", errors.New("Qianwen API key is required")
+		return "", fmt.Errorf("%s API key is required", settings.label)
 	}
 	for _, value := range apiKey {
 		if unicode.IsSpace(value) || unicode.IsControl(value) {
-			return "", errors.New("Qianwen API key contains whitespace or control characters")
+			return "", fmt.Errorf(
+				"%s API key contains whitespace or control characters",
+				settings.label,
+			)
 		}
 	}
 	return apiKey, nil
+}
+
+// These Qianwen-only helpers remain shared by the existing embedding and
+// speech adapters. Text generation uses the provider-aware variants above.
+func normalizeBaseURL(raw string) (string, error) {
+	settings, _ := textProviderSettingsFor(providerName)
+	return normalizeTextBaseURL(raw, settings)
+}
+
+func normalizeAPIKey(raw string) (string, error) {
+	settings, _ := textProviderSettingsFor(providerName)
+	return normalizeTextAPIKey(raw, settings)
+}
+
+func isOfficialHost(host string) bool {
+	settings, _ := textProviderSettingsFor(providerName)
+	return isOfficialTextHost(host, settings)
 }
 
 func rawIdentifier(raw json.RawMessage) string {

--- a/server/internal/providers/qiniu/text.go
+++ b/server/internal/providers/qiniu/text.go
@@ -21,6 +21,8 @@ type IELTSAnswerPreparationGenerator = qianwen.IELTSAnswerPreparationGenerator
 type EvaluationScoringGenerator = qianwen.EvaluationScoringGenerator
 type EvaluationSpeechFeedbackGenerator = qianwen.EvaluationSpeechFeedbackGenerator
 type ResumeFieldGenerator = qianwen.ResumeFieldGenerator
+type PracticeVoiceQuestionGenerator = qianwen.PracticeVoiceQuestionGenerator
+type PracticeVoiceAnswerTipGenerator = qianwen.PracticeVoiceAnswerTipGenerator
 
 func NewAgentRunGenerator(
 	configuration TextConfig,
@@ -102,6 +104,26 @@ func NewResumeFieldGenerator(
 	apiKey string,
 ) (*ResumeFieldGenerator, error) {
 	return qianwen.NewResumeFieldGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewPracticeVoiceQuestionGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*PracticeVoiceQuestionGenerator, error) {
+	return qianwen.NewPracticeVoiceQuestionGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
+}
+
+func NewPracticeVoiceAnswerTipGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*PracticeVoiceAnswerTipGenerator, error) {
+	return qianwen.NewPracticeVoiceAnswerTipGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
 }
 
 func qiniuTextConfig(configuration TextConfig) TextConfig {

--- a/server/internal/providers/qiniu/text.go
+++ b/server/internal/providers/qiniu/text.go
@@ -1,0 +1,110 @@
+// Package qiniu adapts Qiniu AI services to the application's provider ports.
+package qiniu
+
+import "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
+
+const TextProviderName = "qiniu"
+
+// Qiniu's Chat Completions endpoint is OpenAI-compatible. The established
+// Qianwen text adapters own the provider-neutral business mappings, while the
+// TextConfig provider selector activates Qiniu-specific endpoint, model, wire,
+// lineage, and error behavior in the shared audited compatibility client.
+type TextConfig = qianwen.TextConfig
+
+type AgentRunGenerator = qianwen.AgentRunGenerator
+type MemoryGenerator = qianwen.MemoryGenerator
+type SummaryGenerator = qianwen.SummaryGenerator
+type TitleGenerator = qianwen.TitleGenerator
+type Translator = qianwen.Translator
+type PreparationJobTargetGenerator = qianwen.PreparationJobTargetGenerator
+type IELTSAnswerPreparationGenerator = qianwen.IELTSAnswerPreparationGenerator
+type EvaluationScoringGenerator = qianwen.EvaluationScoringGenerator
+type EvaluationSpeechFeedbackGenerator = qianwen.EvaluationSpeechFeedbackGenerator
+type ResumeFieldGenerator = qianwen.ResumeFieldGenerator
+
+func NewAgentRunGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*AgentRunGenerator, error) {
+	return qianwen.NewAgentRunGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewMemoryGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*MemoryGenerator, error) {
+	return qianwen.NewMemoryGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewSummaryGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*SummaryGenerator, error) {
+	return qianwen.NewSummaryGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewTitleGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*TitleGenerator, error) {
+	return qianwen.NewTitleGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewTranslator(
+	configuration TextConfig,
+	apiKey string,
+) (*Translator, error) {
+	return qianwen.NewTranslator(qiniuTextConfig(configuration), apiKey)
+}
+
+func NewPreparationJobTargetGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*PreparationJobTargetGenerator, error) {
+	return qianwen.NewPreparationJobTargetGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
+}
+
+func NewIELTSAnswerPreparationGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*IELTSAnswerPreparationGenerator, error) {
+	return qianwen.NewIELTSAnswerPreparationGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
+}
+
+func NewEvaluationScoringGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*EvaluationScoringGenerator, error) {
+	return qianwen.NewEvaluationScoringGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
+}
+
+func NewEvaluationSpeechFeedbackGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*EvaluationSpeechFeedbackGenerator, error) {
+	return qianwen.NewEvaluationSpeechFeedbackGenerator(
+		qiniuTextConfig(configuration),
+		apiKey,
+	)
+}
+
+func NewResumeFieldGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*ResumeFieldGenerator, error) {
+	return qianwen.NewResumeFieldGenerator(qiniuTextConfig(configuration), apiKey)
+}
+
+func qiniuTextConfig(configuration TextConfig) TextConfig {
+	configuration.Provider = TextProviderName
+	return configuration
+}

--- a/server/internal/providers/qiniu/text_live_test.go
+++ b/server/internal/providers/qiniu/text_live_test.go
@@ -1,0 +1,63 @@
+package qiniu
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
+	platformconfig "github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+)
+
+func TestLiveQiniuTextGeneration(t *testing.T) {
+	if os.Getenv("QINIU_LLM_LIVE_TEST") != "1" {
+		t.Skip("set QINIU_LLM_LIVE_TEST=1 with the Qiniu AI environment variables; the real request may incur charges")
+	}
+	configuration, err := platformconfig.LoadTextGeneration()
+	if err != nil {
+		t.Fatalf("load Qiniu text generation config: %v", err)
+	}
+	if configuration.Provider != platformconfig.TextProviderQiniu {
+		t.Fatalf("TEXT_GENERATION_PROVIDER = %q, want qiniu", configuration.Provider)
+	}
+	generator, err := NewAgentRunGenerator(TextConfig{
+		BaseURL: configuration.BaseURL, Model: configuration.Model,
+		Timeout: configuration.Timeout, MaxOutputTokens: configuration.MaxOutputTokens,
+	}, configuration.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create Qiniu text generator: %v", err)
+	}
+
+	request := agentrun.TextRequest{Messages: []agentrun.TextMessage{{
+		Role: agentrun.TextRoleUser, Content: "Reply with one short English greeting.",
+	}}}
+	result, err := generator.Generate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("live Qiniu text generation failed: %v", err)
+	}
+	if result.Provider != TextProviderName || result.Model != configuration.Model ||
+		strings.TrimSpace(result.Content) == "" || result.ID == "" ||
+		result.Usage.TotalTokens <= 0 {
+		t.Fatalf("invalid live Qiniu result: %#v", result)
+	}
+
+	var streamed strings.Builder
+	streamResult, err := generator.GenerateStream(
+		context.Background(),
+		request,
+		agentrun.TextDeltaObserverFunc(func(_ context.Context, delta string) error {
+			streamed.WriteString(delta)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("live Qiniu streaming generation failed: %v", err)
+	}
+	if streamResult.Provider != TextProviderName ||
+		streamResult.Model != configuration.Model ||
+		streamResult.Content == "" || streamResult.Content != streamed.String() ||
+		streamResult.Usage.TotalTokens <= 0 {
+		t.Fatalf("invalid live Qiniu stream result: %#v", streamResult)
+	}
+}

--- a/server/internal/providers/qiniu/text_test.go
+++ b/server/internal/providers/qiniu/text_test.go
@@ -1,0 +1,50 @@
+package qiniu
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTextConstructorsUseQiniuCompatibilityBoundary(t *testing.T) {
+	configuration := TextConfig{
+		BaseURL: "https://api.qnaigc.com/v1", Model: "gemini-2.5-flash",
+		Timeout: time.Second, MaxOutputTokens: 8192,
+	}
+	constructors := []struct {
+		name string
+		new  func() (any, error)
+	}{
+		{name: "agent run", new: func() (any, error) { return NewAgentRunGenerator(configuration, "qiniu-key") }},
+		{name: "memory", new: func() (any, error) { return NewMemoryGenerator(configuration, "qiniu-key") }},
+		{name: "summary", new: func() (any, error) { return NewSummaryGenerator(configuration, "qiniu-key") }},
+		{name: "title", new: func() (any, error) { return NewTitleGenerator(configuration, "qiniu-key") }},
+		{name: "translation", new: func() (any, error) { return NewTranslator(configuration, "qiniu-key") }},
+		{name: "preparation", new: func() (any, error) { return NewPreparationJobTargetGenerator(configuration, "qiniu-key") }},
+		{name: "IELTS answer", new: func() (any, error) { return NewIELTSAnswerPreparationGenerator(configuration, "qiniu-key") }},
+		{name: "evaluation", new: func() (any, error) { return NewEvaluationScoringGenerator(configuration, "qiniu-key") }},
+		{name: "speech feedback", new: func() (any, error) { return NewEvaluationSpeechFeedbackGenerator(configuration, "qiniu-key") }},
+		{name: "resume", new: func() (any, error) { return NewResumeFieldGenerator(configuration, "qiniu-key") }},
+	}
+	for _, constructor := range constructors {
+		created, err := constructor.new()
+		if err != nil || created == nil {
+			t.Fatalf("Qiniu %s constructor = %T, %v", constructor.name, created, err)
+		}
+	}
+}
+
+func TestTextConstructorRejectsUnsafeEndpointWithoutLeakingAPIKey(t *testing.T) {
+	const apiKey = "must-never-appear"
+	generator, err := NewAgentRunGenerator(TextConfig{
+		BaseURL: "https://example.com/v1", Model: "gemini-2.5-flash",
+		Timeout: time.Second, MaxOutputTokens: 512,
+	}, apiKey)
+	if err == nil || generator != nil {
+		t.Fatalf("unsafe Qiniu endpoint returned generator=%T error=%v", generator, err)
+	}
+	if strings.Contains(fmt.Sprint(err), apiKey) || !strings.Contains(fmt.Sprint(err), "Qiniu") {
+		t.Fatalf("unsafe Qiniu endpoint error = %q", err)
+	}
+}


### PR DESCRIPTION
## 功能描述

- 新增七牛 AI 文本生成 Provider，通过 `TEXT_GENERATION_PROVIDER=qiniu` 显式选择。
- 默认使用已实测可用的 `gemini-2.5-flash`，覆盖 Agent Run、Memory、Summary、Title、Translation、Preparation、IELTS、Evaluation、Speech Feedback 与 Resume 字段生成。
- 支持非流式、SSE 流式、工具调用、结构化 JSON、图片 URL 输入和 token usage，结果记录 `provider=qiniu` 与实际模型。
- 保留现有千问 Provider；Embedding 继续使用千问，因为七牛当前没有文本向量模型。

七牛官方文档：[实时推理接入点](https://developer.qiniu.com/aitokenapi/13379/real-time-ai-interface-api)、[Chat Completions 参数](https://developer.qiniu.com/aitokenapi/13390/chat-completions)。

## 实现思路

- 复用现有经过边界与错误测试的 OpenAI-compatible wire 实现，由七牛薄适配器显式激活七牛 endpoint、模型规则、payload 与 provider lineage。
- 七牛仅允许官方 `https://api.qnaigc.com/v1`；API Key 保持服务端 Secret。
- 兼容七牛把 token usage 放在最后一个 choice 数据块的 SSE 格式，同时继续支持独立 usage 数据块；两种格式都保持严格的结束标志、token 与身份校验。
- 七牛请求不发送 DashScope 专属 `enable_thinking` 字段。
- 对响应大小、异常 SSE、缺字段、模型不一致、token 超限、402/429/5xx 和取消沿用严格失败及脱敏映射，不做隐式重试或 Provider 回退。

## 可复现测试

```bash
make check-go-test
make check-qiniu-llm-live
```

- 完整 Go vet 与测试通过。
- 使用受限 API Key 对 `gemini-2.5-flash` 完成真实非流式和 SSE 流式调用，均通过项目适配层验收。
- 新增测试覆盖 Qiniu 非流式、SSE、tools、JSON、image URL、usage、lineage、官方 endpoint 和错误脱敏。

真实调用需要自行导出 `QINIU_AI_*` 配置并显式设置 `QINIU_LLM_LIVE_TEST=1`；测试入口不会读取 `.env`。

Closes #550
