### PR TITLE
feat(speech): 接入七牛实时 ASR Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,15 @@ REVIEW_HISTORY_CURSOR_SIGNING_KEY=
 # Enabling it sends a real request and may incur charges.
 QIANWEN_LIVE_TEST=0
 
-# Server-only Qianwen ASR. The first media boundary accepts only mono/stereo
-# 16-bit PCM WAV at 8-48 kHz, up to 60 seconds and 7.4 MB. No original upload
-# is retained after the caller closes its managed temporary audio.
-SPEECH_RECOGNITION_PROVIDER=qianwen
+# Server-only ASR. Qiniu consumes 16 kHz mono 16-bit PCM over WebSocket. The
+# upload boundary still rejects unvalidated WAV input, oversized recordings,
+# and recordings longer than 120 seconds. QINIU_AI_API_KEY is never exposed to
+# Flutter. Keep the Qianwen fields only when explicitly selecting qianwen.
+SPEECH_RECOGNITION_PROVIDER=qiniu
+QINIU_ASR_BASE_URL=wss://api.qnaigc.com/v1/voice/asr
+QINIU_ASR_MODEL=asr
+QINIU_ASR_TIMEOUT=90s
+QINIU_AI_API_KEY=
 QIANWEN_ASR_BASE_URL=https://dashscope.aliyuncs.com/api/v1
 QIANWEN_ASR_MODEL=fun-asr-realtime
 QIANWEN_ASR_TIMEOUT=90s
@@ -74,6 +79,10 @@ VOICE_AUDIO_READ_TIMEOUT=15s
 # either live flag sends a real Provider request and may incur charges.
 QIANWEN_ASR_LIVE_TEST=0
 QIANWEN_ASR_LIVE_TEST_AUDIO=
+QINIU_ASR_LIVE_TEST=0
+QINIU_ASR_LIVE_TEST_AUDIO_EN=
+QINIU_ASR_LIVE_TEST_AUDIO_ZH=
+QINIU_ASR_LIVE_TEST_AUDIO_MIXED=
 QIANWEN_TTS_LIVE_TEST=0
 
 # iFlytek streaming ISE pronunciation evaluation (server only).

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SHELL := /bin/bash
 	check-go-format \
 	check-go-vet \
 	check-go-test \
+	check-qiniu-asr-live \
 	check-oss-live \
 	check-resume-ocr-live \
 	check-api \
@@ -30,6 +31,7 @@ help:
 		'  make check          Run Flutter, Go, API, and deterministic smoke checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
 		'  make check-go       Run Go format, vet, and test checks' \
+		'  make check-qiniu-asr-live Run Qiniu ASR against English, Chinese, and mixed WAV fixtures' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
@@ -70,6 +72,34 @@ check-go-vet: check-go-format
 
 check-go-test: check-go-vet
 	cd server && go test -count=1 ./...
+
+check-qiniu-asr-live:
+	@set -euo pipefail; \
+	required=(SPEECH_RECOGNITION_PROVIDER QINIU_ASR_BASE_URL QINIU_ASR_MODEL QINIU_AI_API_KEY QINIU_ASR_LIVE_TEST QINIU_ASR_LIVE_TEST_AUDIO_EN QINIU_ASR_LIVE_TEST_AUDIO_ZH QINIU_ASR_LIVE_TEST_AUDIO_MIXED); \
+	missing=(); \
+	for name in "$${required[@]}"; do \
+		if [[ -z "$${!name:-}" ]]; then missing+=("$$name"); fi; \
+	done; \
+	if (( $${#missing[@]} > 0 )); then \
+		printf '%s\n' 'This live test intentionally does not load or execute .env.'; \
+		printf 'Export the required Qiniu ASR variables before running this target. Missing:'; \
+		printf ' %s' "$${missing[@]}"; \
+		printf '\n'; \
+		exit 1; \
+	fi; \
+	if [[ "$${SPEECH_RECOGNITION_PROVIDER}" != "qiniu" ]]; then \
+		printf '%s\n' 'Set and export SPEECH_RECOGNITION_PROVIDER=qiniu.'; \
+		exit 1; \
+	fi; \
+	if [[ "$${QINIU_ASR_LIVE_TEST}" != "1" ]]; then \
+		printf '%s\n' 'Set and export QINIU_ASR_LIVE_TEST=1 to opt in to billable ASR calls.'; \
+		exit 1; \
+	fi; \
+	$(MAKE) --no-print-directory check-qiniu-asr-live-go
+
+.PHONY: check-qiniu-asr-live-go
+check-qiniu-asr-live-go:
+	cd server && go test -count=1 -run '^TestLiveQiniuSpeechRecognition$$' ./internal/providers/qiniu
 
 check-oss-live:
 	@set -euo pipefail; \

--- a/server/internal/bootstrap/provider_selection_test.go
+++ b/server/internal/bootstrap/provider_selection_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 )
 
+func TestProviderSelectionRegistersQiniuASR(t *testing.T) {
+	t.Setenv("SPEECH_RECOGNITION_PROVIDER", config.SpeechProviderQiniu)
+	t.Setenv("QINIU_ASR_BASE_URL", "wss://api.qnaigc.com/v1/voice/asr")
+	t.Setenv("QINIU_ASR_MODEL", "asr")
+	t.Setenv("QINIU_ASR_TIMEOUT", "30s")
+	t.Setenv("QINIU_AI_API_KEY", "qiniu-test-key")
+
+	configuration, err := config.LoadSpeechRecognition()
+	if err != nil {
+		t.Fatalf("load Qiniu ASR configuration: %v", err)
+	}
+	agent, err := NewAgentSpeechRecognizer(configuration)
+	if err != nil || agent == nil {
+		t.Fatalf("Qiniu Agent recognizer = %T, %v", agent, err)
+	}
+	practice, err := NewPracticeSpeechRecognizer(configuration)
+	if err != nil || practice == nil {
+		t.Fatalf("Qiniu Practice recognizer = %T, %v", practice, err)
+	}
+}
+
 func TestProviderSelectionRejectsUnregisteredImplementations(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/bootstrap/voice.go
+++ b/server/internal/bootstrap/voice.go
@@ -13,6 +13,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qiniu"
 	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -57,19 +58,30 @@ type AgentImageConfiguration struct {
 func NewAgentSpeechRecognizer(
 	configuration config.SpeechRecognitionConfig,
 ) (agentvoice.StreamingSpeechRecognizer, error) {
-	if configuration.Provider != config.SpeechProviderQianwen {
+	switch configuration.Provider {
+	case config.SpeechProviderQianwen:
+		return qianwen.NewAgentVoiceRecognizer(
+			qianwen.ASRConfig{
+				BaseURL: configuration.BaseURL,
+				Model:   configuration.Model,
+				Timeout: configuration.Timeout,
+			},
+			configuration.APIKey.Reveal(),
+		)
+	case config.SpeechProviderQiniu:
+		return qiniu.NewAgentVoiceRecognizer(
+			qiniu.ASRConfig{
+				BaseURL: configuration.BaseURL,
+				Model:   configuration.Model,
+				Timeout: configuration.Timeout,
+			},
+			configuration.APIKey.Reveal(),
+		)
+	default:
 		return nil, errors.New(
 			"bootstrap: speech recognition provider is not registered",
 		)
 	}
-	return qianwen.NewAgentVoiceRecognizer(
-		qianwen.ASRConfig{
-			BaseURL: configuration.BaseURL,
-			Model:   configuration.Model,
-			Timeout: configuration.Timeout,
-		},
-		configuration.APIKey.Reveal(),
-	)
 }
 
 // NewAgentSpeechSynthesizer selects the Agent Voice TTS implementation.
@@ -98,19 +110,30 @@ func NewAgentSpeechSynthesizer(
 func NewPracticeSpeechRecognizer(
 	configuration config.SpeechRecognitionConfig,
 ) (practicevoice.SpeechRecognizer, error) {
-	if configuration.Provider != config.SpeechProviderQianwen {
+	switch configuration.Provider {
+	case config.SpeechProviderQianwen:
+		return qianwen.NewPracticeVoiceRecognizer(
+			qianwen.ASRConfig{
+				BaseURL: configuration.BaseURL,
+				Model:   configuration.Model,
+				Timeout: configuration.Timeout,
+			},
+			configuration.APIKey.Reveal(),
+		)
+	case config.SpeechProviderQiniu:
+		return qiniu.NewPracticeVoiceRecognizer(
+			qiniu.ASRConfig{
+				BaseURL: configuration.BaseURL,
+				Model:   configuration.Model,
+				Timeout: configuration.Timeout,
+			},
+			configuration.APIKey.Reveal(),
+		)
+	default:
 		return nil, errors.New(
 			"bootstrap: Practice speech recognition provider is not registered",
 		)
 	}
-	return qianwen.NewPracticeVoiceRecognizer(
-		qianwen.ASRConfig{
-			BaseURL: configuration.BaseURL,
-			Model:   configuration.Model,
-			Timeout: configuration.Timeout,
-		},
-		configuration.APIKey.Reveal(),
-	)
 }
 
 // NewPracticeSpeechSynthesizer selects the Practice Voice TTS adapter.

--- a/server/internal/platform/config/speech.go
+++ b/server/internal/platform/config/speech.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 const (
 	SpeechProviderQianwen = "qianwen"
+	SpeechProviderQiniu   = "qiniu"
 
 	defaultASRTimeout    = 90 * time.Second
 	defaultTTSTimeout    = 60 * time.Second
@@ -36,23 +36,31 @@ type SpeechSynthesisConfig struct {
 }
 
 func LoadSpeechRecognition() (SpeechRecognitionConfig, error) {
-	provider, err := requiredQianwenProvider("SPEECH_RECOGNITION_PROVIDER")
+	provider, err := requiredSpeechProvider(
+		"SPEECH_RECOGNITION_PROVIDER",
+		SpeechProviderQianwen,
+		SpeechProviderQiniu,
+	)
 	if err != nil {
 		return SpeechRecognitionConfig{}, err
 	}
-	baseURL, err := requiredEnvironment("QIANWEN_ASR_BASE_URL")
+	prefix := "QIANWEN_ASR"
+	if provider == SpeechProviderQiniu {
+		prefix = "QINIU_ASR"
+	}
+	baseURL, err := requiredEnvironment(prefix + "_BASE_URL")
 	if err != nil {
 		return SpeechRecognitionConfig{}, err
 	}
-	model, err := requiredEnvironment("QIANWEN_ASR_MODEL")
+	model, err := requiredEnvironment(prefix + "_MODEL")
 	if err != nil {
 		return SpeechRecognitionConfig{}, err
 	}
-	timeout, err := speechTimeoutOrDefault("QIANWEN_ASR_TIMEOUT", defaultASRTimeout)
+	timeout, err := speechTimeoutOrDefault(prefix+"_TIMEOUT", defaultASRTimeout)
 	if err != nil {
 		return SpeechRecognitionConfig{}, err
 	}
-	apiKey, err := loadDashScopeAPIKey()
+	apiKey, err := loadSpeechAPIKey(provider)
 	if err != nil {
 		return SpeechRecognitionConfig{}, err
 	}
@@ -107,14 +115,20 @@ func LoadSpeechSynthesis() (SpeechSynthesisConfig, error) {
 }
 
 func requiredQianwenProvider(name string) (string, error) {
+	return requiredSpeechProvider(name, SpeechProviderQianwen)
+}
+
+func requiredSpeechProvider(name string, allowed ...string) (string, error) {
 	provider := strings.ToLower(strings.TrimSpace(os.Getenv(name)))
 	if provider == "" {
 		return "", fmt.Errorf("%s is required", name)
 	}
-	if provider != SpeechProviderQianwen {
-		return "", fmt.Errorf("%s is not supported", name)
+	for _, candidate := range allowed {
+		if provider == candidate {
+			return provider, nil
+		}
 	}
-	return provider, nil
+	return "", fmt.Errorf("%s is not supported", name)
 }
 
 func requiredEnvironment(name string) (string, error) {
@@ -126,14 +140,28 @@ func requiredEnvironment(name string) (string, error) {
 }
 
 func loadDashScopeAPIKey() (Secret, error) {
-	apiKey := strings.TrimSpace(os.Getenv("DASHSCOPE_API_KEY"))
+	return loadProviderAPIKey("DASHSCOPE_API_KEY")
+}
+
+func loadSpeechAPIKey(provider string) (Secret, error) {
+	if provider == SpeechProviderQiniu {
+		return loadProviderAPIKey("QINIU_AI_API_KEY")
+	}
+	return loadDashScopeAPIKey()
+}
+
+func loadProviderAPIKey(name string) (Secret, error) {
+	apiKey := strings.TrimSpace(os.Getenv(name))
 	if apiKey == "" {
-		return Secret{}, errors.New("DASHSCOPE_API_KEY is required")
+		return Secret{}, fmt.Errorf("%s is required", name)
 	}
 	if strings.IndexFunc(apiKey, func(r rune) bool {
 		return r < 0x21 || r == 0x7f
 	}) >= 0 {
-		return Secret{}, errors.New("DASHSCOPE_API_KEY contains whitespace or control characters")
+		return Secret{}, fmt.Errorf(
+			"%s contains whitespace or control characters",
+			name,
+		)
 	}
 	return Secret{value: apiKey}, nil
 }

--- a/server/internal/platform/config/speech_test.go
+++ b/server/internal/platform/config/speech_test.go
@@ -22,6 +22,46 @@ func TestLoadSpeechRecognition(t *testing.T) {
 	}
 }
 
+func TestLoadSpeechRecognitionReadsQiniuConfiguration(t *testing.T) {
+	setQiniuASREnvironment(t)
+	t.Setenv("QINIU_ASR_TIMEOUT", "75s")
+
+	cfg, err := LoadSpeechRecognition()
+	if err != nil {
+		t.Fatalf("load Qiniu speech recognition: %v", err)
+	}
+	if cfg.Provider != SpeechProviderQiniu ||
+		cfg.BaseURL != "wss://api.qnaigc.com/v1/voice/asr" ||
+		cfg.Model != "asr" ||
+		cfg.Timeout != 75*time.Second ||
+		cfg.APIKey.Reveal() != "qiniu-test-secret" {
+		t.Fatalf("unexpected Qiniu speech recognition config: %#v", cfg)
+	}
+}
+
+func TestLoadSpeechRecognitionRejectsIncompleteQiniuConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "missing base URL", key: "QINIU_ASR_BASE_URL", value: ""},
+		{name: "missing model", key: "QINIU_ASR_MODEL", value: ""},
+		{name: "invalid timeout", key: "QINIU_ASR_TIMEOUT", value: "soon"},
+		{name: "missing API key", key: "QINIU_AI_API_KEY", value: ""},
+		{name: "API key whitespace", key: "QINIU_AI_API_KEY", value: "secret value"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setQiniuASREnvironment(t)
+			t.Setenv(test.key, test.value)
+			if _, err := LoadSpeechRecognition(); err == nil {
+				t.Fatal("expected Qiniu ASR configuration error")
+			}
+		})
+	}
+}
+
 func TestLoadSpeechSynthesis(t *testing.T) {
 	setSpeechEnvironment(t)
 	t.Setenv("QIANWEN_TTS_TIMEOUT", "45s")
@@ -131,4 +171,13 @@ func setSpeechEnvironment(t *testing.T) {
 	t.Setenv("QIANWEN_TTS_TIMEOUT", "")
 	t.Setenv("QIANWEN_TTS_TEMP_DIRECTORY", "")
 	t.Setenv("DASHSCOPE_API_KEY", "test-secret-value")
+}
+
+func setQiniuASREnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("SPEECH_RECOGNITION_PROVIDER", SpeechProviderQiniu)
+	t.Setenv("QINIU_ASR_BASE_URL", "wss://api.qnaigc.com/v1/voice/asr")
+	t.Setenv("QINIU_ASR_MODEL", "asr")
+	t.Setenv("QINIU_ASR_TIMEOUT", "")
+	t.Setenv("QINIU_AI_API_KEY", "qiniu-test-secret")
 }

--- a/server/internal/providers/qiniu/asr.go
+++ b/server/internal/providers/qiniu/asr.go
@@ -1,0 +1,530 @@
+package qiniu
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	qiniuASREndpoint     = "wss://api.qnaigc.com/v1/voice/asr"
+	qiniuASRModel        = "asr"
+	qiniuASRSampleRate   = 16_000
+	qiniuASRChunkBytes   = 6_400
+	qiniuASRMaxFrameSize = 1 << 20
+	qiniuASRMaxTimeout   = 5 * time.Minute
+	qiniuASRMaxPCMBytes  = int64(platformmedia.MaxAudioDuration/time.Second) *
+		qiniuASRSampleRate * 2
+)
+
+type ASRConfig struct {
+	BaseURL string
+	Model   string
+	Timeout time.Duration
+}
+
+type websocketDialer interface {
+	DialContext(context.Context, string, http.Header) (
+		*websocket.Conn,
+		*http.Response,
+		error,
+	)
+}
+
+type asrClient struct {
+	endpoint string
+	model    string
+	timeout  time.Duration
+	apiKey   providerSecret
+	dialer   websocketDialer
+}
+
+type asrResult struct {
+	id           string
+	transcript   string
+	audioSeconds int
+}
+
+type asrUpdate struct {
+	transcript string
+	final      bool
+}
+
+type asrObserver func(context.Context, asrUpdate) error
+
+type asrErrorKind string
+
+const (
+	asrErrorInvalidRequest  asrErrorKind = "invalid_request"
+	asrErrorConfiguration   asrErrorKind = "configuration"
+	asrErrorAuthentication  asrErrorKind = "authentication"
+	asrErrorAuthorization   asrErrorKind = "authorization"
+	asrErrorQuota           asrErrorKind = "quota_exhausted"
+	asrErrorRateLimited     asrErrorKind = "rate_limited"
+	asrErrorTimeout         asrErrorKind = "timeout"
+	asrErrorUnavailable     asrErrorKind = "provider_unavailable"
+	asrErrorInvalidResponse asrErrorKind = "invalid_response"
+	asrErrorCancelled       asrErrorKind = "cancelled"
+)
+
+type asrError struct {
+	kind       asrErrorKind
+	statusCode int
+	requestID  string
+	cause      error
+}
+
+func (failure *asrError) Error() string {
+	if failure == nil {
+		return "Qiniu ASR failed"
+	}
+	return "Qiniu ASR failed: " + string(failure.kind)
+}
+
+func (failure *asrError) Unwrap() error {
+	if failure == nil {
+		return nil
+	}
+	return failure.cause
+}
+
+func newASR(config ASRConfig, apiKey string) (*asrClient, error) {
+	return newASRWithDialer(config, apiKey, websocket.DefaultDialer)
+}
+
+func newASRWithDialer(
+	config ASRConfig,
+	apiKey string,
+	dialer websocketDialer,
+) (*asrClient, error) {
+	endpoint, err := normalizeASREndpoint(config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	model := strings.TrimSpace(config.Model)
+	if model != qiniuASRModel {
+		return nil, errors.New("Qiniu ASR model must be asr")
+	}
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" || strings.IndexFunc(apiKey, func(character rune) bool {
+		return character < 0x21 || character == 0x7f
+	}) >= 0 {
+		return nil, errors.New("Qiniu AI API key is invalid")
+	}
+	if config.Timeout <= 0 || config.Timeout > qiniuASRMaxTimeout {
+		return nil, fmt.Errorf(
+			"Qiniu ASR timeout must be greater than zero and at most %s",
+			qiniuASRMaxTimeout,
+		)
+	}
+	if dialer == nil {
+		return nil, errors.New("Qiniu ASR WebSocket dialer is required")
+	}
+	return &asrClient{
+		endpoint: endpoint,
+		model:    model,
+		timeout:  config.Timeout,
+		apiKey:   newProviderSecret(apiKey),
+		dialer:   dialer,
+	}, nil
+}
+
+func normalizeASREndpoint(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.String() != qiniuASREndpoint ||
+		parsed.Scheme != "wss" || parsed.Host != "api.qnaigc.com" ||
+		parsed.Path != "/v1/voice/asr" || parsed.User != nil ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New(
+			"Qiniu ASR base URL must be wss://api.qnaigc.com/v1/voice/asr",
+		)
+	}
+	return parsed.String(), nil
+}
+
+func (client *asrClient) String() string {
+	if client == nil {
+		return "QiniuASR(<nil>)"
+	}
+	return fmt.Sprintf(
+		"QiniuASR(model=%q, timeout=%s, api_key=[REDACTED])",
+		client.model,
+		client.timeout,
+	)
+}
+
+func (client *asrClient) GoString() string { return client.String() }
+
+func (client *asrClient) transcribeWAV(
+	ctx context.Context,
+	source platformmedia.AudioSource,
+	observer asrObserver,
+) (asrResult, error) {
+	if ctx == nil {
+		return asrResult{}, invalidASRRequest("transcription context is required")
+	}
+	if err := platformmedia.ValidateAudioSource(source); err != nil {
+		return asrResult{}, &asrError{
+			kind:  asrErrorInvalidRequest,
+			cause: errors.New("audio source is invalid"),
+		}
+	}
+	if source.SampleRate() != qiniuASRSampleRate {
+		return asrResult{}, invalidASRRequest(
+			"Qiniu ASR requires 16000 Hz mono PCM audio",
+		)
+	}
+	reader, err := source.Open()
+	if err != nil {
+		return asrResult{}, invalidASRRequest("open audio source")
+	}
+	defer reader.Close()
+	data, err := readExactBounded(reader, source.Size(), platformmedia.MaxAudioBytes)
+	if err != nil {
+		return asrResult{}, invalidASRRequest("read audio source")
+	}
+	pcm, err := extractPCM16MonoWAV(data)
+	if err != nil {
+		return asrResult{}, invalidASRRequest("audio WAV is incompatible")
+	}
+	defer clearBytes(pcm)
+	return client.transcribePCM(ctx, bytes.NewReader(pcm), qiniuASRSampleRate, observer)
+}
+
+func (client *asrClient) transcribePCM(
+	ctx context.Context,
+	pcm io.Reader,
+	sampleRate int,
+	observer asrObserver,
+) (asrResult, error) {
+	if ctx == nil || pcm == nil || sampleRate != qiniuASRSampleRate {
+		return asrResult{}, invalidASRRequest(
+			"Qiniu ASR requires a context and 16000 Hz PCM audio",
+		)
+	}
+	callContext, cancel := context.WithTimeout(ctx, client.timeout)
+	defer cancel()
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+client.apiKey.reveal())
+	connection, response, err := client.dialer.DialContext(
+		callContext,
+		client.endpoint,
+		header,
+	)
+	if err != nil {
+		return asrResult{}, dialASRError(callContext, response, err)
+	}
+	defer connection.Close()
+	if deadline, ok := callContext.Deadline(); ok {
+		_ = connection.SetReadDeadline(deadline)
+		_ = connection.SetWriteDeadline(deadline)
+	}
+	connection.SetReadLimit(qiniuASRMaxFrameSize)
+	requestID, err := newASRRequestID()
+	if err != nil {
+		return asrResult{}, &asrError{
+			kind:  asrErrorConfiguration,
+			cause: errors.New("create Qiniu ASR request identifier"),
+		}
+	}
+	configuration, err := encodeASRConfiguration(requestID, client.model)
+	if err != nil {
+		return asrResult{}, &asrError{
+			kind:  asrErrorConfiguration,
+			cause: errors.New("encode Qiniu ASR configuration"),
+		}
+	}
+	if err := connection.WriteMessage(websocket.BinaryMessage, configuration); err != nil {
+		return asrResult{}, transportASRError(callContext, err)
+	}
+
+	type readResult struct {
+		requestID  string
+		transcript string
+		err        error
+	}
+	readResults := make(chan readResult, 1)
+	go func() {
+		responseID, transcript, readErr := collectASRResponses(
+			callContext,
+			connection,
+			observer,
+		)
+		readResults <- readResult{
+			requestID:  responseID,
+			transcript: transcript,
+			err:        readErr,
+		}
+	}()
+
+	audioBytes, err := streamPCMFrames(connection, pcm)
+	if err != nil {
+		_ = connection.Close()
+		return asrResult{}, transportASRError(callContext, err)
+	}
+	var completed readResult
+	select {
+	case completed = <-readResults:
+	case <-callContext.Done():
+		return asrResult{}, transportASRError(callContext, callContext.Err())
+	}
+	if completed.err != nil {
+		return asrResult{}, completed.err
+	}
+	if completed.requestID == "" {
+		completed.requestID = requestID
+	}
+	return asrResult{
+		id:           completed.requestID,
+		transcript:   completed.transcript,
+		audioSeconds: audioDurationSeconds(audioBytes),
+	}, nil
+}
+
+func streamPCMFrames(
+	connection *websocket.Conn,
+	reader io.Reader,
+) (int64, error) {
+	limited := &io.LimitedReader{R: reader, N: qiniuASRMaxPCMBytes + 1}
+	current := make([]byte, qiniuASRChunkBytes)
+	next := make([]byte, qiniuASRChunkBytes)
+	currentCount, err := readPCMChunk(limited, current)
+	if err != nil {
+		return 0, err
+	}
+	if currentCount == 0 {
+		return 0, errors.New("Qiniu ASR PCM input is empty")
+	}
+	sequence := int32(2)
+	var total int64
+	for {
+		if total+int64(currentCount) > qiniuASRMaxPCMBytes {
+			return total, errors.New("Qiniu ASR PCM input exceeds the accepted duration")
+		}
+		nextCount, readErr := readPCMChunk(limited, next)
+		if readErr != nil {
+			return total, readErr
+		}
+		final := nextCount == 0
+		if final && (total+int64(currentCount))%2 != 0 {
+			return total, errors.New("Qiniu ASR PCM input must contain 16-bit samples")
+		}
+		frameSequence := sequence
+		if final {
+			frameSequence = -sequence
+		}
+		frame, encodeErr := encodeASRAudioFrame(
+			frameSequence,
+			current[:currentCount],
+			final,
+		)
+		if encodeErr != nil {
+			return total, encodeErr
+		}
+		if writeErr := connection.WriteMessage(websocket.BinaryMessage, frame); writeErr != nil {
+			return total, writeErr
+		}
+		total += int64(currentCount)
+		if final {
+			return total, nil
+		}
+		current, next = next, current
+		currentCount = nextCount
+		sequence++
+	}
+}
+
+func readPCMChunk(reader io.Reader, buffer []byte) (int, error) {
+	read := 0
+	for read < len(buffer) {
+		count, err := reader.Read(buffer[read:])
+		read += count
+		if err == io.EOF {
+			return read, nil
+		}
+		if err != nil {
+			return read, err
+		}
+		if count == 0 {
+			return read, io.ErrNoProgress
+		}
+	}
+	return read, nil
+}
+
+func readExactBounded(reader io.Reader, expected int64, maximum int64) ([]byte, error) {
+	if expected <= 0 || expected > maximum {
+		return nil, errors.New("audio size is outside the accepted range")
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, expected+1))
+	if err != nil || int64(len(data)) != expected {
+		return nil, errors.New("audio size does not match its metadata")
+	}
+	return data, nil
+}
+
+func extractPCM16MonoWAV(wav []byte) ([]byte, error) {
+	if len(wav) < 44 || string(wav[:4]) != "RIFF" ||
+		string(wav[8:12]) != "WAVE" ||
+		int(binary.LittleEndian.Uint32(wav[4:8]))+8 != len(wav) {
+		return nil, errors.New("invalid WAV container")
+	}
+	var formatValid bool
+	var pcm []byte
+	for offset := 12; offset+8 <= len(wav); {
+		chunkSize := int(binary.LittleEndian.Uint32(wav[offset+4 : offset+8]))
+		start := offset + 8
+		end := start + chunkSize
+		if chunkSize < 0 || end < start || end > len(wav) {
+			return nil, errors.New("invalid WAV chunk")
+		}
+		switch string(wav[offset : offset+4]) {
+		case "fmt ":
+			if chunkSize < 16 || binary.LittleEndian.Uint16(wav[start:start+2]) != 1 ||
+				binary.LittleEndian.Uint16(wav[start+2:start+4]) != 1 ||
+				binary.LittleEndian.Uint32(wav[start+4:start+8]) != qiniuASRSampleRate ||
+				binary.LittleEndian.Uint16(wav[start+14:start+16]) != 16 {
+				return nil, errors.New("WAV must be 16000 Hz mono 16-bit PCM")
+			}
+			formatValid = true
+		case "data":
+			if pcm != nil {
+				return nil, errors.New("WAV contains multiple data chunks")
+			}
+			pcm = wav[start:end]
+		}
+		offset = end + chunkSize%2
+	}
+	if !formatValid || len(pcm) == 0 || len(pcm)%2 != 0 {
+		return nil, errors.New("WAV PCM data is missing or invalid")
+	}
+	return pcm, nil
+}
+
+func audioDurationSeconds(bytes int64) int {
+	bytesPerSecond := int64(qiniuASRSampleRate * 2)
+	return int((bytes + bytesPerSecond - 1) / bytesPerSecond)
+}
+
+func newASRRequestID() (string, error) {
+	identifier := make([]byte, 16)
+	if _, err := rand.Read(identifier); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(identifier), nil
+}
+
+func invalidASRRequest(message string) *asrError {
+	return &asrError{
+		kind:  asrErrorInvalidRequest,
+		cause: errors.New(message),
+	}
+}
+
+func dialASRError(
+	ctx context.Context,
+	response *http.Response,
+	cause error,
+) *asrError {
+	statusCode := 0
+	requestID := ""
+	if response != nil {
+		statusCode = response.StatusCode
+		requestID = sanitizeASRIdentifier(response.Header.Get("X-Request-Id"))
+	}
+	return &asrError{
+		kind:       classifyASRError(ctx, statusCode, cause),
+		statusCode: statusCode,
+		requestID:  requestID,
+		cause:      safeTransportCause(ctx, cause),
+	}
+}
+
+func transportASRError(ctx context.Context, cause error) *asrError {
+	return &asrError{
+		kind:  classifyASRError(ctx, 0, cause),
+		cause: safeTransportCause(ctx, cause),
+	}
+}
+
+func classifyASRError(
+	ctx context.Context,
+	statusCode int,
+	cause error,
+) asrErrorKind {
+	if ctx != nil {
+		switch ctx.Err() {
+		case context.Canceled:
+			return asrErrorCancelled
+		case context.DeadlineExceeded:
+			return asrErrorTimeout
+		}
+	}
+	if errors.Is(cause, context.Canceled) {
+		return asrErrorCancelled
+	}
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return asrErrorTimeout
+	}
+	var networkError net.Error
+	if errors.As(cause, &networkError) && networkError.Timeout() {
+		return asrErrorTimeout
+	}
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return asrErrorAuthentication
+	case http.StatusPaymentRequired:
+		return asrErrorQuota
+	case http.StatusForbidden:
+		return asrErrorAuthorization
+	case http.StatusTooManyRequests:
+		return asrErrorRateLimited
+	default:
+		return asrErrorUnavailable
+	}
+}
+
+func safeTransportCause(ctx context.Context, cause error) error {
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(cause, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return errors.New("Qiniu ASR transport failed")
+}
+
+func sanitizeASRIdentifier(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" || len(value) > 128 || strings.IndexFunc(value, func(character rune) bool {
+		return !(character >= 'a' && character <= 'z') &&
+			!(character >= 'A' && character <= 'Z') &&
+			!(character >= '0' && character <= '9') &&
+			character != '-' && character != '_'
+	}) >= 0 {
+		return ""
+	}
+	return value
+}
+
+func clearBytes(data []byte) {
+	for index := range data {
+		data[index] = 0
+	}
+}

--- a/server/internal/providers/qiniu/asr_adapters.go
+++ b/server/internal/providers/qiniu/asr_adapters.go
@@ -1,0 +1,273 @@
+package qiniu
+
+import (
+	"context"
+	"errors"
+
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
+)
+
+const qiniuProviderName = "qiniu"
+
+type AgentVoiceRecognizer struct {
+	client *asrClient
+}
+
+func NewAgentVoiceRecognizer(
+	configuration ASRConfig,
+	apiKey string,
+) (*AgentVoiceRecognizer, error) {
+	client, err := newASR(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentVoiceRecognizer{client: client}, nil
+}
+
+func (recognizer *AgentVoiceRecognizer) Transcribe(
+	ctx context.Context,
+	request agentvoice.TranscriptionRequest,
+) (agentvoice.TranscriptionResult, error) {
+	return recognizer.transcribe(ctx, request, nil)
+}
+
+func (recognizer *AgentVoiceRecognizer) TranscribeStream(
+	ctx context.Context,
+	request agentvoice.TranscriptionRequest,
+	observer agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	if observer == nil {
+		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
+			agentvoice.SpeechOperationTranscription,
+			agentvoice.ErrorConfiguration,
+			0,
+			"",
+			"",
+			errors.New("Qiniu Agent Voice transcription observer is required"),
+		)
+	}
+	return recognizer.transcribe(
+		ctx,
+		request,
+		func(ctx context.Context, update asrUpdate) error {
+			return observer.OnTranscriptionUpdate(
+				ctx,
+				agentvoice.TranscriptionUpdate{
+					Transcript: update.transcript,
+					Final:      update.final,
+				},
+			)
+		},
+	)
+}
+
+func (recognizer *AgentVoiceRecognizer) transcribe(
+	ctx context.Context,
+	request agentvoice.TranscriptionRequest,
+	observer asrObserver,
+) (agentvoice.TranscriptionResult, error) {
+	if recognizer == nil || recognizer.client == nil {
+		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
+			agentvoice.SpeechOperationTranscription,
+			agentvoice.ErrorConfiguration,
+			0,
+			"",
+			"",
+			errors.New("Qiniu Agent Voice recognizer is required"),
+		)
+	}
+	if err := agentvoice.ValidateTranscriptionRequest(request); err != nil {
+		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
+			agentvoice.SpeechOperationTranscription,
+			agentvoice.ErrorInvalidRequest,
+			0,
+			"",
+			"",
+			errors.New("Agent Voice transcription request is invalid"),
+		)
+	}
+	result, err := recognizer.client.transcribeWAV(ctx, request.Audio, observer)
+	if err != nil {
+		return agentvoice.TranscriptionResult{}, mapAgentASRError(err)
+	}
+	return agentvoice.TranscriptionResult{
+		ID:         result.id,
+		Provider:   qiniuProviderName,
+		Model:      recognizer.client.model,
+		Transcript: result.transcript,
+		Usage: agentvoice.SpeechUsage{
+			AudioSeconds: result.audioSeconds,
+		},
+	}, nil
+}
+
+type PracticeVoiceRecognizer struct {
+	client *asrClient
+}
+
+func NewPracticeVoiceRecognizer(
+	configuration ASRConfig,
+	apiKey string,
+) (*PracticeVoiceRecognizer, error) {
+	client, err := newASR(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &PracticeVoiceRecognizer{client: client}, nil
+}
+
+func (recognizer *PracticeVoiceRecognizer) Transcribe(
+	ctx context.Context,
+	request practicevoice.TranscriptionRequest,
+) (practicevoice.TranscriptionResult, error) {
+	if recognizer == nil || recognizer.client == nil {
+		return practicevoice.TranscriptionResult{}, practicevoice.NewProviderError(
+			practicevoice.ProviderOperationTranscription,
+			practicevoice.ProviderErrorConfiguration,
+			"",
+			errors.New("Qiniu Practice Voice recognizer is required"),
+		)
+	}
+	result, err := recognizer.client.transcribeWAV(ctx, request.Audio, nil)
+	if err != nil {
+		return practicevoice.TranscriptionResult{}, mapPracticeASRError(err)
+	}
+	return practiceTranscriptionResult(recognizer.client.model, result), nil
+}
+
+func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
+	ctx context.Context,
+	request practicevoice.StreamingTranscriptionRequest,
+	observer practicevoice.TranscriptionObserver,
+) (practicevoice.TranscriptionResult, error) {
+	if recognizer == nil || recognizer.client == nil || observer == nil {
+		return practicevoice.TranscriptionResult{}, practicevoice.NewProviderError(
+			practicevoice.ProviderOperationTranscription,
+			practicevoice.ProviderErrorConfiguration,
+			"",
+			errors.New("Qiniu streaming Practice Voice recognizer is required"),
+		)
+	}
+	result, err := recognizer.client.transcribePCM(
+		ctx,
+		request.PCM,
+		request.SampleRate,
+		func(ctx context.Context, update asrUpdate) error {
+			return observer.OnTranscriptionUpdate(
+				ctx,
+				practicevoice.TranscriptionUpdate{
+					Transcript: update.transcript,
+					Final:      update.final,
+				},
+			)
+		},
+	)
+	if err != nil {
+		return practicevoice.TranscriptionResult{}, mapPracticeASRError(err)
+	}
+	return practiceTranscriptionResult(recognizer.client.model, result), nil
+}
+
+func practiceTranscriptionResult(
+	model string,
+	result asrResult,
+) practicevoice.TranscriptionResult {
+	return practicevoice.TranscriptionResult{
+		ID:         result.id,
+		Provider:   qiniuProviderName,
+		Model:      model,
+		Transcript: result.transcript,
+		Usage: practicevoice.SpeechUsage{
+			AudioSeconds: result.audioSeconds,
+		},
+	}
+}
+
+func mapAgentASRError(err error) error {
+	failure := asASRError(err)
+	return agentvoice.NewSpeechError(
+		agentvoice.SpeechOperationTranscription,
+		mapAgentASRErrorKind(failure.kind),
+		failure.statusCode,
+		"",
+		failure.requestID,
+		failure,
+	)
+}
+
+func mapAgentASRErrorKind(kind asrErrorKind) agentvoice.ErrorKind {
+	switch kind {
+	case asrErrorInvalidRequest:
+		return agentvoice.ErrorInvalidRequest
+	case asrErrorConfiguration:
+		return agentvoice.ErrorConfiguration
+	case asrErrorAuthentication:
+		return agentvoice.ErrorAuthentication
+	case asrErrorAuthorization:
+		return agentvoice.ErrorAuthorization
+	case asrErrorQuota:
+		return agentvoice.ErrorQuotaExhausted
+	case asrErrorRateLimited:
+		return agentvoice.ErrorRateLimited
+	case asrErrorTimeout:
+		return agentvoice.ErrorTimeout
+	case asrErrorInvalidResponse:
+		return agentvoice.ErrorInvalidResponse
+	case asrErrorCancelled:
+		return agentvoice.ErrorCancelled
+	default:
+		return agentvoice.ErrorProviderUnavailable
+	}
+}
+
+func mapPracticeASRError(err error) error {
+	failure := asASRError(err)
+	return practicevoice.NewProviderError(
+		practicevoice.ProviderOperationTranscription,
+		mapPracticeASRErrorKind(failure.kind),
+		failure.requestID,
+		failure,
+	)
+}
+
+func mapPracticeASRErrorKind(kind asrErrorKind) practicevoice.ProviderErrorKind {
+	switch kind {
+	case asrErrorInvalidRequest:
+		return practicevoice.ProviderErrorInvalidRequest
+	case asrErrorConfiguration:
+		return practicevoice.ProviderErrorConfiguration
+	case asrErrorAuthentication:
+		return practicevoice.ProviderErrorAuthentication
+	case asrErrorAuthorization:
+		return practicevoice.ProviderErrorAuthorization
+	case asrErrorQuota:
+		return practicevoice.ProviderErrorQuotaExhausted
+	case asrErrorRateLimited:
+		return practicevoice.ProviderErrorRateLimited
+	case asrErrorTimeout:
+		return practicevoice.ProviderErrorTimeout
+	case asrErrorInvalidResponse:
+		return practicevoice.ProviderErrorInvalidResponse
+	case asrErrorCancelled:
+		return practicevoice.ProviderErrorCancelled
+	default:
+		return practicevoice.ProviderErrorUnavailable
+	}
+}
+
+func asASRError(err error) *asrError {
+	var failure *asrError
+	if errors.As(err, &failure) {
+		return failure
+	}
+	return &asrError{
+		kind:  asrErrorUnavailable,
+		cause: errors.New("Qiniu ASR failed"),
+	}
+}
+
+var (
+	_ agentvoice.StreamingSpeechRecognizer    = (*AgentVoiceRecognizer)(nil)
+	_ practicevoice.StreamingSpeechRecognizer = (*PracticeVoiceRecognizer)(nil)
+)

--- a/server/internal/providers/qiniu/asr_live_test.go
+++ b/server/internal/providers/qiniu/asr_live_test.go
@@ -1,0 +1,95 @@
+package qiniu
+
+import (
+	"context"
+	"os"
+	"testing"
+	"unicode/utf8"
+
+	platformconfig "github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+)
+
+func TestLiveQiniuSpeechRecognition(t *testing.T) {
+	if os.Getenv("QINIU_ASR_LIVE_TEST") != "1" {
+		t.Skip(
+			"set QINIU_ASR_LIVE_TEST=1 and export the Qiniu ASR variables " +
+				"to run; real requests may incur charges",
+		)
+	}
+	configuration, err := platformconfig.LoadSpeechRecognition()
+	if err != nil {
+		t.Fatalf("load Qiniu ASR configuration: %v", err)
+	}
+	if configuration.Provider != platformconfig.SpeechProviderQiniu {
+		t.Fatalf("speech recognition provider = %q, want qiniu", configuration.Provider)
+	}
+	client, err := newASR(ASRConfig{
+		BaseURL: configuration.BaseURL,
+		Model:   configuration.Model,
+		Timeout: configuration.Timeout,
+	}, configuration.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create Qiniu ASR client: %v", err)
+	}
+	fixtures := []struct {
+		name        string
+		environment string
+	}{
+		{name: "english", environment: "QINIU_ASR_LIVE_TEST_AUDIO_EN"},
+		{name: "chinese", environment: "QINIU_ASR_LIVE_TEST_AUDIO_ZH"},
+		{name: "mixed", environment: "QINIU_ASR_LIVE_TEST_AUDIO_MIXED"},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			path := os.Getenv(fixture.environment)
+			if path == "" {
+				t.Fatalf("%s is required for live acceptance", fixture.environment)
+			}
+			audio := captureQiniuLiveAudio(t, path)
+			defer audio.Close()
+			result, err := client.transcribeWAV(context.Background(), audio, nil)
+			if err != nil {
+				t.Fatalf("live Qiniu ASR failed: %v", err)
+			}
+			if result.transcript == "" {
+				t.Fatal("live Qiniu ASR returned an empty transcript")
+			}
+			t.Logf(
+				"Qiniu ASR success: language_case=%s request_id=%s "+
+					"transcript_nonempty=true transcript_characters=%d "+
+					"audio_seconds=%d fixture_bytes=%d",
+				fixture.name,
+				result.id,
+				utf8.RuneCountInString(result.transcript),
+				result.audioSeconds,
+				audio.Size(),
+			)
+		})
+	}
+}
+
+func captureQiniuLiveAudio(
+	t *testing.T,
+	path string,
+) platformmedia.ManagedAudioSource {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open Qiniu ASR live fixture: %v", err)
+	}
+	defer file.Close()
+	audio, err := platformmedia.CaptureTemporaryAudio(
+		t.TempDir(),
+		platformmedia.ContentTypeWAV,
+		file,
+	)
+	if err != nil {
+		t.Fatalf("validate Qiniu ASR live fixture: %v", err)
+	}
+	if audio.SampleRate() != qiniuASRSampleRate {
+		audio.Close()
+		t.Fatalf("Qiniu ASR live fixture sample rate = %d, want %d", audio.SampleRate(), qiniuASRSampleRate)
+	}
+	return audio
+}

--- a/server/internal/providers/qiniu/asr_test.go
+++ b/server/internal/providers/qiniu/asr_test.go
@@ -1,0 +1,468 @@
+package qiniu
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/gorilla/websocket"
+)
+
+func TestQiniuASRUsesBinaryProtocolAndStreamsSnapshots(t *testing.T) {
+	t.Parallel()
+	const apiKey = "qiniu-asr-test-key"
+	pcm := bytes.Repeat([]byte{1, 2, 3, 4}, qiniuASRChunkBytes/4+25)
+	serverErrors := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			serverErrors <- err
+			return
+		}
+		defer connection.Close()
+		if request.Header.Get("Authorization") != "Bearer "+apiKey {
+			serverErrors <- errors.New("authorization header is invalid")
+			return
+		}
+		configuration, err := readTestASRFrame(connection)
+		if err != nil {
+			serverErrors <- err
+			return
+		}
+		if configuration.messageType != asrMessageConfiguration ||
+			configuration.flags != asrFlagSequence || configuration.sequence != 1 ||
+			configuration.serialization != asrJSON ||
+			configuration.compression != asrGZIP {
+			serverErrors <- fmt.Errorf("unexpected configuration frame: %#v", configuration)
+			return
+		}
+		var config asrConfiguration
+		if err := json.Unmarshal(configuration.payload, &config); err != nil {
+			serverErrors <- err
+			return
+		}
+		if config.User.UID == "" || config.Audio.SampleRate != qiniuASRSampleRate ||
+			config.Audio.Bits != 16 || config.Audio.Channel != 1 ||
+			config.Audio.Format != "pcm" || config.Audio.Codec != "raw" ||
+			config.Request.ModelName != qiniuASRModel || !config.Request.EnablePunc {
+			serverErrors <- fmt.Errorf("unexpected ASR configuration: %#v", config)
+			return
+		}
+
+		var received bytes.Buffer
+		for expectedSequence := int32(2); ; expectedSequence++ {
+			frame, readErr := readTestASRFrame(connection)
+			if readErr != nil {
+				serverErrors <- readErr
+				return
+			}
+			if frame.messageType != asrMessageAudio || frame.compression != asrGZIP ||
+				frame.serialization != 0 {
+				serverErrors <- fmt.Errorf("unexpected audio frame: %#v", frame)
+				return
+			}
+			received.Write(frame.payload)
+			if frame.flags == asrFlagFinal {
+				if frame.sequence != -expectedSequence {
+					serverErrors <- fmt.Errorf("final sequence = %d", frame.sequence)
+					return
+				}
+				break
+			}
+			if frame.flags != asrFlagSequence || frame.sequence != expectedSequence {
+				serverErrors <- fmt.Errorf("audio sequence = %d", frame.sequence)
+				return
+			}
+		}
+		if !bytes.Equal(received.Bytes(), pcm) {
+			serverErrors <- errors.New("received PCM differs from source")
+			return
+		}
+		if err := writeTestASRResponse(
+			connection,
+			2,
+			asrFlagSequence,
+			"qiniu-request-1",
+			"I practice",
+		); err != nil {
+			serverErrors <- err
+			return
+		}
+		if err := writeTestASRResponse(
+			connection,
+			-3,
+			asrFlagFinal,
+			"qiniu-request-1",
+			"I practice English.",
+		); err != nil {
+			serverErrors <- err
+			return
+		}
+		serverErrors <- nil
+	}))
+	defer server.Close()
+
+	client := mustTestASRClient(t, apiKey)
+	client.endpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	var updates []asrUpdate
+	result, err := client.transcribePCM(
+		context.Background(),
+		bytes.NewReader(pcm),
+		qiniuASRSampleRate,
+		func(_ context.Context, update asrUpdate) error {
+			updates = append(updates, update)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("transcribe PCM: %v", err)
+	}
+	if serverErr := <-serverErrors; serverErr != nil {
+		t.Fatalf("test server: %v", serverErr)
+	}
+	if result.id != "qiniu-request-1" ||
+		result.transcript != "I practice English." ||
+		result.audioSeconds != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(updates) != 2 || updates[0].transcript != "I practice" ||
+		updates[0].final || !updates[1].final ||
+		updates[1].transcript != result.transcript {
+		t.Fatalf("updates = %#v", updates)
+	}
+}
+
+func TestQiniuAgentAdapterAcceptsValidatedWAV(t *testing.T) {
+	t.Parallel()
+	pcm := bytes.Repeat([]byte{1, 2}, qiniuASRSampleRate)
+	server := newFinalASRTestServer(t, pcm, "你好，English。")
+	defer server.Close()
+	client := mustTestASRClient(t, "adapter-key")
+	client.endpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	recognizer := &AgentVoiceRecognizer{client: client}
+	result, err := recognizer.Transcribe(
+		context.Background(),
+		agentvoice.TranscriptionRequest{Audio: newTestAudioSource(pcm)},
+	)
+	if err != nil {
+		t.Fatalf("transcribe WAV: %v", err)
+	}
+	if result.Provider != qiniuProviderName || result.Model != qiniuASRModel ||
+		result.Transcript != "你好，English。" || result.Usage.AudioSeconds != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestQiniuASRRejectsUnsafeConfigurationAndRedactsSecret(t *testing.T) {
+	t.Parallel()
+	tests := []ASRConfig{
+		{BaseURL: "ws://api.qnaigc.com/v1/voice/asr", Model: qiniuASRModel, Timeout: time.Second},
+		{BaseURL: qiniuASREndpoint + "?key=secret", Model: qiniuASRModel, Timeout: time.Second},
+		{BaseURL: qiniuASREndpoint, Model: "other", Timeout: time.Second},
+		{BaseURL: qiniuASREndpoint, Model: qiniuASRModel, Timeout: 0},
+	}
+	for _, config := range tests {
+		if client, err := newASR(config, "safe-key"); err == nil || client != nil {
+			t.Fatalf("unsafe config accepted: %#v", config)
+		}
+	}
+	if client, err := newASR(testASRConfig(), "unsafe key"); err == nil || client != nil {
+		t.Fatal("unsafe API key was accepted")
+	}
+	client := mustTestASRClient(t, "do-not-print-this-key")
+	for _, output := range []string{client.String(), fmt.Sprintf("%#v", client)} {
+		if strings.Contains(output, "do-not-print-this-key") ||
+			!strings.Contains(output, "[REDACTED]") {
+			t.Fatalf("unsafe client rendering: %q", output)
+		}
+	}
+}
+
+func TestDecodeQiniuASRResponseRejectsMalformedFrames(t *testing.T) {
+	t.Parallel()
+	validPayload, err := json.Marshal(map[string]any{
+		"reqid":  "request-1",
+		"result": map[string]any{"text": "hello"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed, err := gzipASRPayload(validPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := encodeASRFrame(
+		asrMessageResponse,
+		asrFlagFinal,
+		asrJSON,
+		asrGZIP,
+		-2,
+		compressed,
+	)
+	malformed := [][]byte{
+		{},
+		{0x11, 0x91, 0x11, 0},
+		append([]byte(nil), valid[:len(valid)-1]...),
+		encodeASRFrame(asrMessageResponse, asrFlagFinal, asrJSON, 0, 2, validPayload),
+	}
+	for _, frame := range malformed {
+		if _, err := decodeASRResponseFrame(frame); err == nil {
+			t.Fatalf("malformed response accepted: %x", frame)
+		}
+	}
+	decoded, err := decodeASRResponseFrame(valid)
+	if err != nil || !decoded.final || decoded.text != "hello" {
+		t.Fatalf("decoded response = %#v, %v", decoded, err)
+	}
+}
+
+func TestQiniuASRErrorMappingDoesNotExposeProviderPayload(t *testing.T) {
+	t.Parallel()
+	secretPayload := "provider-secret-audio-transcript"
+	failure := invalidASRResponse(secretPayload)
+	mapped := mapAgentASRError(failure)
+	if strings.Contains(mapped.Error(), secretPayload) ||
+		strings.Contains(fmt.Sprintf("%v", mapped), secretPayload) {
+		t.Fatalf("mapped error exposed provider payload: %v", mapped)
+	}
+	var speechError *agentvoice.SpeechError
+	if !errors.As(mapped, &speechError) || speechError.Kind != agentvoice.ErrorInvalidResponse {
+		t.Fatalf("mapped error = %#v", mapped)
+	}
+}
+
+func TestQiniuASRMapsCancellationAndTimeout(t *testing.T) {
+	t.Parallel()
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		for {
+			if _, _, err := connection.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	client := mustTestASRClient(t, "timeout-key")
+	client.endpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	client.timeout = 50 * time.Millisecond
+	_, err := client.transcribePCM(
+		context.Background(),
+		bytes.NewReader([]byte{1, 2}),
+		qiniuASRSampleRate,
+		nil,
+	)
+	var timeoutFailure *asrError
+	if !errors.As(err, &timeoutFailure) || timeoutFailure.kind != asrErrorTimeout {
+		t.Fatalf("timeout error = %#v", err)
+	}
+
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = client.transcribePCM(
+		cancelledContext,
+		bytes.NewReader([]byte{1, 2}),
+		qiniuASRSampleRate,
+		nil,
+	)
+	var cancelledFailure *asrError
+	if !errors.As(err, &cancelledFailure) ||
+		cancelledFailure.kind != asrErrorCancelled {
+		t.Fatalf("cancellation error = %#v", err)
+	}
+}
+
+type testASRFrame struct {
+	messageType   byte
+	flags         byte
+	serialization byte
+	compression   byte
+	sequence      int32
+	payload       []byte
+}
+
+func readTestASRFrame(connection *websocket.Conn) (testASRFrame, error) {
+	messageType, raw, err := connection.ReadMessage()
+	if err != nil {
+		return testASRFrame{}, err
+	}
+	if messageType != websocket.BinaryMessage || len(raw) < 12 || raw[0] != 0x11 {
+		return testASRFrame{}, errors.New("invalid client ASR frame")
+	}
+	payloadSize := int(binary.BigEndian.Uint32(raw[8:12]))
+	if payloadSize != len(raw)-12 {
+		return testASRFrame{}, errors.New("invalid client ASR payload size")
+	}
+	payload := raw[12:]
+	compression := raw[2] & 0x0f
+	if compression == asrGZIP {
+		payload, err = gunzipASRPayload(payload)
+		if err != nil {
+			return testASRFrame{}, err
+		}
+	}
+	return testASRFrame{
+		messageType:   raw[1] >> 4,
+		flags:         raw[1] & 0x0f,
+		serialization: raw[2] >> 4,
+		compression:   compression,
+		sequence:      int32(binary.BigEndian.Uint32(raw[4:8])),
+		payload:       payload,
+	}, nil
+}
+
+func writeTestASRResponse(
+	connection *websocket.Conn,
+	sequence int32,
+	flags byte,
+	requestID string,
+	text string,
+) error {
+	payload, err := json.Marshal(map[string]any{
+		"reqid":  requestID,
+		"result": map[string]any{"text": text},
+	})
+	if err != nil {
+		return err
+	}
+	compressed, err := gzipASRPayload(payload)
+	if err != nil {
+		return err
+	}
+	return connection.WriteMessage(
+		websocket.BinaryMessage,
+		encodeASRFrame(
+			asrMessageResponse,
+			flags,
+			asrJSON,
+			asrGZIP,
+			sequence,
+			compressed,
+		),
+	)
+}
+
+func newFinalASRTestServer(
+	t *testing.T,
+	expectedPCM []byte,
+	transcript string,
+) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	return httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer connection.Close()
+		if _, err := readTestASRFrame(connection); err != nil {
+			t.Errorf("read config: %v", err)
+			return
+		}
+		var received bytes.Buffer
+		for {
+			frame, err := readTestASRFrame(connection)
+			if err != nil {
+				t.Errorf("read audio: %v", err)
+				return
+			}
+			received.Write(frame.payload)
+			if frame.flags == asrFlagFinal {
+				break
+			}
+		}
+		if !bytes.Equal(received.Bytes(), expectedPCM) {
+			t.Error("WAV PCM extraction differs from expected bytes")
+			return
+		}
+		if err := writeTestASRResponse(
+			connection,
+			-2,
+			asrFlagFinal,
+			"adapter-request",
+			transcript,
+		); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+}
+
+type testAudioSource struct {
+	data []byte
+}
+
+func newTestAudioSource(pcm []byte) *testAudioSource {
+	dataSize := len(pcm)
+	wav := make([]byte, 44+dataSize)
+	copy(wav[:4], "RIFF")
+	binary.LittleEndian.PutUint32(wav[4:8], uint32(len(wav)-8))
+	copy(wav[8:12], "WAVE")
+	copy(wav[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(wav[16:20], 16)
+	binary.LittleEndian.PutUint16(wav[20:22], 1)
+	binary.LittleEndian.PutUint16(wav[22:24], 1)
+	binary.LittleEndian.PutUint32(wav[24:28], qiniuASRSampleRate)
+	binary.LittleEndian.PutUint32(wav[28:32], qiniuASRSampleRate*2)
+	binary.LittleEndian.PutUint16(wav[32:34], 2)
+	binary.LittleEndian.PutUint16(wav[34:36], 16)
+	copy(wav[36:40], "data")
+	binary.LittleEndian.PutUint32(wav[40:44], uint32(dataSize))
+	copy(wav[44:], pcm)
+	return &testAudioSource{data: wav}
+}
+
+func (source *testAudioSource) Open() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(source.data)), nil
+}
+
+func (source *testAudioSource) MediaType() string { return platformmedia.ContentTypeWAV }
+func (source *testAudioSource) Size() int64       { return int64(len(source.data)) }
+func (source *testAudioSource) Duration() time.Duration {
+	return time.Duration(len(source.data)-44) * time.Second /
+		time.Duration(qiniuASRSampleRate*2)
+}
+func (source *testAudioSource) SampleRate() int { return qiniuASRSampleRate }
+
+func testASRConfig() ASRConfig {
+	return ASRConfig{
+		BaseURL: qiniuASREndpoint,
+		Model:   qiniuASRModel,
+		Timeout: 5 * time.Second,
+	}
+}
+
+func mustTestASRClient(t *testing.T, apiKey string) *asrClient {
+	t.Helper()
+	client, err := newASR(testASRConfig(), apiKey)
+	if err != nil {
+		t.Fatalf("new ASR client: %v", err)
+	}
+	return client
+}

--- a/server/internal/providers/qiniu/asr_wire.go
+++ b/server/internal/providers/qiniu/asr_wire.go
@@ -1,0 +1,309 @@
+package qiniu
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	asrMessageConfiguration = 0x1
+	asrMessageAudio         = 0x2
+	asrMessageResponse      = 0x9
+	asrMessageError         = 0xf
+
+	asrFlagSequence = 0x1
+	asrFlagFinal    = 0x3
+	asrJSON         = 0x1
+	asrGZIP         = 0x1
+)
+
+type asrConfiguration struct {
+	User struct {
+		UID string `json:"uid"`
+	} `json:"user"`
+	Audio struct {
+		Format     string `json:"format"`
+		SampleRate int    `json:"sample_rate"`
+		Bits       int    `json:"bits"`
+		Channel    int    `json:"channel"`
+		Codec      string `json:"codec"`
+	} `json:"audio"`
+	Request struct {
+		ModelName  string `json:"model_name"`
+		EnablePunc bool   `json:"enable_punc"`
+	} `json:"request"`
+}
+
+type asrResponse struct {
+	RequestID string `json:"reqid"`
+	Result    struct {
+		Text string `json:"text"`
+	} `json:"result"`
+}
+
+func encodeASRConfiguration(requestID string, model string) ([]byte, error) {
+	configuration := asrConfiguration{}
+	configuration.User.UID = requestID
+	configuration.Audio.Format = "pcm"
+	configuration.Audio.SampleRate = qiniuASRSampleRate
+	configuration.Audio.Bits = 16
+	configuration.Audio.Channel = 1
+	configuration.Audio.Codec = "raw"
+	configuration.Request.ModelName = model
+	configuration.Request.EnablePunc = true
+	payload, err := json.Marshal(configuration)
+	if err != nil {
+		return nil, err
+	}
+	compressed, err := gzipASRPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+	return encodeASRFrame(
+		asrMessageConfiguration,
+		asrFlagSequence,
+		asrJSON,
+		asrGZIP,
+		1,
+		compressed,
+	), nil
+}
+
+func encodeASRAudioFrame(sequence int32, pcm []byte, final bool) ([]byte, error) {
+	compressed, err := gzipASRPayload(pcm)
+	if err != nil {
+		return nil, err
+	}
+	flags := byte(asrFlagSequence)
+	if final {
+		flags = asrFlagFinal
+	}
+	return encodeASRFrame(
+		asrMessageAudio,
+		flags,
+		0,
+		asrGZIP,
+		sequence,
+		compressed,
+	), nil
+}
+
+func encodeASRFrame(
+	messageType byte,
+	flags byte,
+	serialization byte,
+	compression byte,
+	sequence int32,
+	payload []byte,
+) []byte {
+	frame := make([]byte, 12+len(payload))
+	frame[0] = 0x11
+	frame[1] = messageType<<4 | flags
+	frame[2] = serialization<<4 | compression
+	binary.BigEndian.PutUint32(frame[4:8], uint32(sequence))
+	binary.BigEndian.PutUint32(frame[8:12], uint32(len(payload)))
+	copy(frame[12:], payload)
+	return frame
+}
+
+func collectASRResponses(
+	ctx context.Context,
+	connection *websocket.Conn,
+	observer asrObserver,
+) (string, string, error) {
+	var (
+		latestText      string
+		latestRequestID string
+		lastSequence    int64
+		finalEmitted    bool
+	)
+	for {
+		messageType, frame, err := connection.ReadMessage()
+		if err != nil {
+			return "", "", transportASRError(ctx, err)
+		}
+		if messageType != websocket.BinaryMessage || len(frame) > qiniuASRMaxFrameSize {
+			return "", "", invalidASRResponse("Qiniu ASR response frame is invalid")
+		}
+		decoded, err := decodeASRResponseFrame(frame)
+		if err != nil {
+			return "", "", err
+		}
+		if decoded.requestID != "" {
+			latestRequestID = decoded.requestID
+		}
+		absoluteSequence := int64(decoded.sequence)
+		if absoluteSequence < 0 {
+			absoluteSequence = -absoluteSequence
+		}
+		if absoluteSequence <= lastSequence {
+			return "", "", invalidASRResponse(
+				"Qiniu ASR response sequence is not increasing",
+			)
+		}
+		lastSequence = absoluteSequence
+		text := strings.TrimSpace(decoded.text)
+		if text != "" && text != latestText {
+			latestText = text
+			if observer != nil {
+				if err := observer(ctx, asrUpdate{
+					transcript: latestText,
+					final:      decoded.final,
+				}); err != nil {
+					return "", "", &asrError{
+						kind:  asrErrorCancelled,
+						cause: errors.New("Qiniu ASR observer rejected an update"),
+					}
+				}
+				finalEmitted = decoded.final
+			}
+		}
+		if decoded.final {
+			if latestText == "" {
+				return "", "", invalidASRResponse(
+					"Qiniu ASR final response has no transcript",
+				)
+			}
+			if observer != nil && !finalEmitted {
+				if err := observer(ctx, asrUpdate{
+					transcript: latestText,
+					final:      true,
+				}); err != nil {
+					return "", "", &asrError{
+						kind:  asrErrorCancelled,
+						cause: errors.New("Qiniu ASR observer rejected the final update"),
+					}
+				}
+			}
+			return latestRequestID, latestText, nil
+		}
+	}
+}
+
+type decodedASRResponse struct {
+	sequence  int32
+	requestID string
+	text      string
+	final     bool
+}
+
+func decodeASRResponseFrame(frame []byte) (decodedASRResponse, error) {
+	if len(frame) < 4 {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response header is incomplete",
+		)
+	}
+	version := frame[0] >> 4
+	headerWords := int(frame[0] & 0x0f)
+	headerSize := headerWords * 4
+	messageType := frame[1] >> 4
+	flags := frame[1] & 0x0f
+	serialization := frame[2] >> 4
+	compression := frame[2] & 0x0f
+	if version != 1 || headerWords < 1 || headerSize > len(frame) ||
+		serialization != asrJSON || (compression != 0 && compression != asrGZIP) {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response header is unsupported",
+		)
+	}
+	payload := frame[headerSize:]
+	if messageType == asrMessageError {
+		return decodedASRResponse{}, &asrError{
+			kind:  asrErrorUnavailable,
+			cause: errors.New("Qiniu ASR returned a provider error"),
+		}
+	}
+	if messageType != asrMessageResponse ||
+		(flags != asrFlagSequence && flags != asrFlagFinal) ||
+		len(payload) < 8 {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response message is invalid",
+		)
+	}
+	sequence := int32(binary.BigEndian.Uint32(payload[:4]))
+	payloadSize := int(binary.BigEndian.Uint32(payload[4:8]))
+	payload = payload[8:]
+	if payloadSize < 0 || payloadSize != len(payload) {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response payload size is invalid",
+		)
+	}
+	if compression == asrGZIP {
+		var err error
+		payload, err = gunzipASRPayload(payload)
+		if err != nil {
+			return decodedASRResponse{}, invalidASRResponse(
+				"Qiniu ASR response compression is invalid",
+			)
+		}
+	}
+	var response asrResponse
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response JSON is invalid",
+		)
+	}
+	requestID := sanitizeASRIdentifier(response.RequestID)
+	if response.RequestID != "" && requestID == "" {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response request identifier is invalid",
+		)
+	}
+	final := flags == asrFlagFinal || sequence < 0
+	if final && sequence >= 0 {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR final response sequence is invalid",
+		)
+	}
+	if !final && sequence <= 0 {
+		return decodedASRResponse{}, invalidASRResponse(
+			"Qiniu ASR response sequence is invalid",
+		)
+	}
+	return decodedASRResponse{
+		sequence:  sequence,
+		requestID: requestID,
+		text:      response.Result.Text,
+		final:     final,
+	}, nil
+}
+
+func gzipASRPayload(payload []byte) ([]byte, error) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return compressed.Bytes(), nil
+}
+
+func gunzipASRPayload(payload []byte) ([]byte, error) {
+	reader, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	decoded, err := io.ReadAll(io.LimitReader(reader, qiniuASRMaxFrameSize+1))
+	if err != nil || len(decoded) > qiniuASRMaxFrameSize {
+		return nil, errors.New("Qiniu ASR response exceeds the accepted limit")
+	}
+	return decoded, nil
+}
+
+func invalidASRResponse(message string) *asrError {
+	return &asrError{
+		kind:  asrErrorInvalidResponse,
+		cause: errors.New(message),
+	}
+}

--- a/server/internal/providers/qiniu/secret.go
+++ b/server/internal/providers/qiniu/secret.go
@@ -1,0 +1,27 @@
+package qiniu
+
+import "encoding/json"
+
+type providerSecret struct {
+	value string
+}
+
+func newProviderSecret(value string) providerSecret {
+	return providerSecret{value: value}
+}
+
+func (secret providerSecret) reveal() string {
+	return secret.value
+}
+
+func (providerSecret) String() string {
+	return "[REDACTED]"
+}
+
+func (providerSecret) GoString() string {
+	return "qiniu.providerSecret([REDACTED])"
+}
+
+func (providerSecret) MarshalJSON() ([]byte, error) {
+	return json.Marshal("[REDACTED]")
+}


### PR DESCRIPTION
## 功能描述

- 为 Agent Voice 与 Practice Voice 新增七牛实时 ASR Provider
- 支持 16 kHz 单声道 16-bit PCM/WAV、分片发送、增量文本、最终文本、用量时长、超时与取消
- 保留讯飞 ISE 发音评分链路，不用普通 ASR 替代声学评分
- 默认示例配置切换为七牛 ASR；Qianwen ASR 仍可显式选择

## 实现思路

- 在组合根按 `SPEECH_RECOGNITION_PROVIDER` 显式注册 qianwen/qiniu，不做静默回退
- 严格实现七牛 WebSocket 二进制协议：Bearer 鉴权、gzip 配置/音频帧、递增序号、最终负序号、响应边界与顺序校验
- Agent 整段 WAV 与 Practice 实时 PCM 共用同一协议核心，并分别映射现有稳定错误契约
- 错误不携带原始 Provider 正文、音频、转写文本或凭据；客户端与 Secret 的字符串表示均脱敏
- 增加显式真实验收入口，要求英文、中文、中英混合三份 16 kHz PCM WAV

## 可复现测试

- `make check-go`
- `make check-api`
- `make check-smoke`
- `cd server && go test -race ./internal/providers/qiniu ./internal/bootstrap ./internal/platform/config`
- `make check-qiniu-asr-live` 未运行：当前环境没有七牛 AI API Key 和三语真实音频；该目标不会读取 `.env`，需显式导出变量并可能产生费用

## 待真实 Provider 验收

七牛当前公开导航中的 ASR/TTS 接入说明页面返回 404，因此本 PR 保持 Draft。合入前需用真实账号运行三语音频测试，确认 `wss://api.qnaigc.com/v1/voice/asr` 的最终帧语义、文本结果和计费权限。

Closes #552