### PR TITLE
[Backend] 修复七牛 Kodo 表单上传缺少文件名

### DIFF
--- a/server/internal/platform/objectstore/kodostore/client.go
+++ b/server/internal/platform/objectstore/kodostore/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -179,6 +180,7 @@ func (client *Client) Put(
 			UpToken:     uptoken.NewSigner(policy, client.credentials),
 			BucketName:  client.bucket,
 			ObjectName:  &objectName,
+			FileName:    path.Base(request.Key),
 			ContentType: request.ContentType,
 			Metadata: map[string]string{
 				"sha256": request.ChecksumSHA256,

--- a/server/internal/platform/objectstore/kodostore/client_test.go
+++ b/server/internal/platform/objectstore/kodostore/client_test.go
@@ -105,6 +105,7 @@ func TestClientPutSignAndDelete(t *testing.T) {
 			t.Fatalf("uploaded body = %q, %v", body, err)
 		}
 		if *options.ObjectName != key ||
+			options.FileName != "asset_test.wav" ||
 			options.ContentType != "audio/wav" ||
 			options.Metadata["sha256"] != checksum {
 			t.Fatalf("upload options = %#v", options)


### PR DESCRIPTION
## 功能描述

- 修复七牛 Kodo 表单上传缺少文件名导致 Put 在 SDK 本地失败的问题。
- 从已经过对象 Key 校验的路径末段传递 `FileName`，不改变对象 Key、内容类型或元数据。

## 实现思路

七牛 Go SDK v7 的 `PostObject` 表单构建要求 `File.Name` 非空。适配器继续以完整对象 Key 作为 `ObjectName`，仅将 `path.Base(request.Key)` 作为 multipart 文件名。

## 可复现测试

```bash
make check-go-test
```

完整 Go vet 与测试本地通过。真实 Kodo 验收结果：

- 修复前：Put 在 SDK 表单构建阶段失败。
- 修复后：真实私有空间上传成功。
- 后续签名下载仍被当前七牛测试域名的 TLS 证书不匹配阻塞；空间仅绑定该测试域名，需绑定有效的自定义 HTTPS 域名后才能完成端到端验收。
- 失败测试上传的临时对象已确认删除。

Closes #560
