### PR TITLE
feat(practice): 为 IELTS 分段练习开放翻译与 Tips

### DIFF
--- a/server/internal/coaching/practice/execution_policy.go
+++ b/server/internal/coaching/practice/execution_policy.go
@@ -210,8 +210,15 @@ func resolveSessionPolicyRegistration(
 		return standard, true
 	case IELTSSpeakingPart1SessionPolicy,
 		IELTSSpeakingPart2SessionPolicy,
-		IELTSSpeakingPart3SessionPolicy,
-		IELTSSpeakingFullMockSessionPolicy:
+		IELTSSpeakingPart3SessionPolicy:
+		return sessionPolicyRegistration{
+			completionMode:             CompletionModeTurnLimited,
+			turnsFromBlueprints:        true,
+			questionTranslationAllowed: true,
+			questionTipsAllowed:        true,
+			speechFeedbackAllowed:      true,
+		}, true
+	case IELTSSpeakingFullMockSessionPolicy:
 		return sessionPolicyRegistration{
 			completionMode:        CompletionModeTurnLimited,
 			turnsFromBlueprints:   true,

--- a/server/internal/coaching/practice/execution_policy_test.go
+++ b/server/internal/coaching/practice/execution_policy_test.go
@@ -117,3 +117,40 @@ func TestResolveSessionPolicyFreezesIELTSBlueprintCount(t *testing.T) {
 		t.Fatalf("IELTS policy = %#v", policy)
 	}
 }
+
+func TestResolveSessionPolicyAllowsReadAidsOnlyForIELTSSectionPractice(
+	t *testing.T,
+) {
+	t.Parallel()
+	prompt := ScenePrompt{TurnBlueprints: []string{"question"}}
+	tests := []struct {
+		name      string
+		reference string
+		mode      PracticeMode
+		wantAids  bool
+	}{
+		{"part 1", IELTSSpeakingPart1SessionPolicy, PracticeModePart1, true},
+		{"part 2", IELTSSpeakingPart2SessionPolicy, PracticeModePart2, true},
+		{"part 3", IELTSSpeakingPart3SessionPolicy, PracticeModePart3, true},
+		{"full mock", IELTSSpeakingFullMockSessionPolicy, PracticeModeFullMock, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, err := ResolveSessionPolicy(
+				test.reference,
+				prompt,
+				PracticeOption{
+					Mode: test.mode, SuggestedDurationSeconds: 300,
+				},
+				0,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if policy.QuestionTranslationAllowed != test.wantAids ||
+				policy.QuestionTipsAllowed != test.wantAids {
+				t.Fatalf("IELTS read aids policy = %#v", policy)
+			}
+		})
+	}
+}

--- a/server/internal/coaching/practice/session_application_test.go
+++ b/server/internal/coaching/practice/session_application_test.go
@@ -84,6 +84,8 @@ func TestSessionApplicationCopiesFrozenIELTSAssignmentFromPlan(t *testing.T) {
 	plan.SessionPolicy.MaxEffectiveTurns = len(blueprints)
 	plan.SessionPolicy.CoverageCheckpointTurn = len(blueprints)
 	plan.SessionPolicy.MaxFollowUpsPerQuestion = 0
+	plan.SessionPolicy.QuestionTranslationAllowed = true
+	plan.SessionPolicy.QuestionTipsAllowed = true
 	plan.SessionPolicy.SpeechFeedbackAllowed = true
 	plan.IELTSAssignment = &IELTSAssignment{
 		BankID: "ielts-bank-1",


### PR DESCRIPTION
## 功能描述

- IELTS Part 1、Part 2、Part 3 分段练习开放题目翻译与 Tips。
- IELTS Full Mock 继续关闭翻译与 Tips，保持完整模考无辅助。
- 不改变题量、顺序、计时、录音、评分或报告流程。

## 实现思路

- 将 IELTS 分段练习与 Full Mock 的 Session Policy 注册拆开。
- 仅为 Part 1/2/3 设置 question_translation_allowed=true 和 question_tips_allowed=true。
- 复用现有 Practice 翻译与 Question Tip API，不新增接口或抽象。
- 已基于包含 #553 的最新 upstream/dev 重放提交，不修改实时语音链路。
- 补充政策解析测试，并更新 Session Application 冻结政策测试。

## 可复现测试

- `make check-go`
- `make check-api`
- `git diff --check upstream/dev...HEAD`

Closes #548
Milestone: MS3（#9）