### PR TITLE
feat(ielts): 接入统一数字人练习舞台

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -469,18 +469,17 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     final launchController = widget.preparationLaunchController;
     if (_practiceController.practiceExperience ==
         PracticeExperience.ieltsSpeaking) {
-      return IeltsSpeakingMockPage(
-        controller: _practiceController,
-        onExitRequested: launchController?.parkCurrentPractice,
-        ieltsController: widget.ieltsPreparationController,
-        completedReportBuilder: widget.ieltsSpeakingReportController == null
-            ? null
-            : (_, practiceSessionId) => IeltsSpeakingSessionReportPanel(
-                practiceSessionId: practiceSessionId,
-                controller: widget.ieltsSpeakingReportController!,
-              ),
-        speechFeedbackController: widget.speechFeedbackController,
-      );
+      final factory = widget.avatarControllerFactory;
+      if (factory != null && _practiceController.canUseAvatar) {
+        return PracticeAvatarSession(
+          practiceController: _practiceController,
+          avatarControllerFactory: factory,
+          surfaceKey: const Key('ielts-avatar-surface'),
+          builder: (_, avatar) =>
+              _buildIeltsPracticePage(launchController, avatar: avatar),
+        );
+      }
+      return _buildIeltsPracticePage(launchController);
     }
     final experience = _practiceController.practiceExperience;
     if (experience == PracticeExperience.interview ||
@@ -516,6 +515,30 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       speechFeedbackController: widget.speechFeedbackController,
       onExitRequested: launchController?.parkCurrentPractice,
       onContinueWithAgent: launchController?.completeAndContinueWithAgent,
+    );
+  }
+
+  Widget _buildIeltsPracticePage(
+    PreparationLaunchController? launchController, {
+    PracticeAvatarSessionView? avatar,
+  }) {
+    return IeltsSpeakingMockPage(
+      controller: _practiceController,
+      onExitRequested: launchController?.parkCurrentPractice,
+      ieltsController: widget.ieltsPreparationController,
+      completedReportBuilder: widget.ieltsSpeakingReportController == null
+          ? null
+          : (_, practiceSessionId) => IeltsSpeakingSessionReportPanel(
+              practiceSessionId: practiceSessionId,
+              controller: widget.ieltsSpeakingReportController!,
+            ),
+      speechFeedbackController: widget.speechFeedbackController,
+      avatarSurfaceBuilder: avatar?.surfaceBuilder,
+      avatarStatusLabel: avatar?.statusLabel,
+      onBeforeUserTurn: avatar?.interruptForUserTurn,
+      onReplayQuestionWithAvatar: avatar?.onReplayQuestion,
+      avatarReplayLoading: avatar?.replayLoading ?? false,
+      avatarReplayPlaying: avatar?.replayPlaying ?? false,
     );
   }
 }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:speakup/features/coaching/ielts/ielts_assignment.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/voice_capture_control.dart';
@@ -17,6 +18,8 @@ import 'package:speakup/features/coaching/ielts/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
+import 'package:speakup/features/coaching/practice/practice_stage.dart';
+import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 
@@ -65,6 +68,12 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.completedReportBuilder,
     this.speechFeedbackController,
     this.examinerSpeaker,
+    this.avatarSurfaceBuilder,
+    this.avatarStatusLabel,
+    this.onBeforeUserTurn,
+    this.onReplayQuestionWithAvatar,
+    this.avatarReplayLoading = false,
+    this.avatarReplayPlaying = false,
     this.now = DateTime.now,
     super.key,
   });
@@ -76,6 +85,12 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final IeltsCompletedReportBuilder? completedReportBuilder;
   final SpeechFeedbackController? speechFeedbackController;
   final PracticePromptSpeaker? examinerSpeaker;
+  final WidgetBuilder? avatarSurfaceBuilder;
+  final String? avatarStatusLabel;
+  final Future<void> Function()? onBeforeUserTurn;
+  final Future<void> Function()? onReplayQuestionWithAvatar;
+  final bool avatarReplayLoading;
+  final bool avatarReplayPlaying;
   final DateTime Function() now;
 
   @override
@@ -86,6 +101,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   late final IeltsMockProgressStore _progressStore;
   late final PracticePromptSpeaker _examinerSpeaker;
   late final bool _ownsExaminerSpeaker;
+  final ScrollController _conversationScrollController = ScrollController();
   final TextEditingController _notesController = TextEditingController();
   final TextEditingController _convertedAnswerController =
       TextEditingController();
@@ -93,6 +109,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   IeltsMockProgress? _progress;
   Timer? _ticker;
+  Timer? _recordingTicker;
+  int _recordingSeconds = 0;
   Timer? _part2TranscriptionRetryTimer;
   Timer? _bufferedPart3RecordingLimitTimer;
   Future<void>? _bufferedPart3StartFuture;
@@ -120,7 +138,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       PracticeRecordingState.idle;
   RecordedPracticeAudio? _bufferedPart3Audio;
   bool _flushingBufferedPart3Audio = false;
-  final Set<String> _revealedQuestionIds = <String>{};
+  final Map<String, String> _questionTranslations = <String, String>{};
+  PracticePromptSpeaker? _ownedTipSpeaker;
+  String? _visibleTipQuestionId;
   String? _autoNarratedQuestionId;
   String? _autoNarratedQuestionText;
   String? _playingQuestionId;
@@ -129,6 +149,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   final Set<PracticeMode> _recordedCompletions = <PracticeMode>{};
   final Map<String, String> _feedbackSources = <String, String>{};
   bool _feedbackRebuildScheduled = false;
+  int _observedMessageCount = 0;
+  int _observedCompletedTurns = 0;
+  bool _preserveCompletedConversation = false;
+  bool _showCompletionSheet = false;
 
   IeltsPracticeSelection? get _selection {
     final sessionId = widget.controller.practiceSessionId;
@@ -271,6 +295,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     await _stopQuestionNarration();
+    final beforeUserTurn = widget.onBeforeUserTurn;
+    if (beforeUserTurn != null) {
+      await beforeUserTurn();
+    }
+    if (!mounted || _progress?.phase != IeltsMockPhase.part3) {
+      return;
+    }
     try {
       await widget.controller.recorder.start();
       if (!mounted || _progress?.phase != IeltsMockPhase.part3) {
@@ -285,12 +316,14 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       setState(() {
         _bufferedPart3RecordingState = PracticeRecordingState.recording;
       });
+      _syncRecordingTimer();
     } on Object {
       if (mounted) {
         setState(() {
           _bufferedPart3RecordingState = PracticeRecordingState.idle;
           _answerLanguageError = '暂时无法开始录音，请重新尝试。';
         });
+        _syncRecordingTimer();
       }
     }
   }
@@ -309,6 +342,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     setState(() {
       _bufferedPart3RecordingState = PracticeRecordingState.transcribing;
     });
+    _syncRecordingTimer();
     try {
       final audio = await widget.controller.recorder.stop();
       if (!mounted) {
@@ -323,6 +357,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
           _bufferedPart3RecordingState = PracticeRecordingState.idle;
           _answerLanguageError = '录音保存失败，请重新录音。';
         });
+        _syncRecordingTimer();
       }
     }
   }
@@ -338,6 +373,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     final audio = _bufferedPart3Audio;
     _bufferedPart3Audio = null;
     _bufferedPart3RecordingState = PracticeRecordingState.idle;
+    _syncRecordingTimer();
     try {
       if (state == PracticeRecordingState.starting ||
           state == PracticeRecordingState.recording) {
@@ -368,6 +404,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (accepted) {
       _bufferedPart3Audio = null;
       _bufferedPart3RecordingState = PracticeRecordingState.idle;
+      _syncRecordingTimer();
     }
     _flushingBufferedPart3Audio = false;
     if (mounted) {
@@ -382,11 +419,17 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _ownsExaminerSpeaker = widget.examinerSpeaker == null;
     _examinerSpeaker = widget.examinerSpeaker ?? SystemPracticePromptSpeaker();
     _now = widget.now().toUtc();
+    _observedMessageCount = widget.controller.practiceMessages.length;
+    _observedCompletedTurns = widget.controller.completedTurns;
     widget.controller.addListener(_handleControllerState);
     widget.speechFeedbackController?.addListener(_handleSpeechFeedbackState);
     _notesController.addListener(_saveNotes);
     _syncSpeechFeedbackSources();
+    _syncRecordingTimer();
     unawaited(_restoreProgress());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _jumpToLatestMessage();
+    });
   }
 
   @override
@@ -396,14 +439,20 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (controllerChanged) {
       oldWidget.controller.removeListener(_handleControllerState);
       widget.controller.addListener(_handleControllerState);
+      _observedMessageCount = widget.controller.practiceMessages.length;
+      _observedCompletedTurns = widget.controller.completedTurns;
+      _preserveCompletedConversation = false;
+      _showCompletionSheet = false;
       _questionNarrationGeneration++;
       _autoNarratedQuestionId = null;
       _autoNarratedQuestionText = null;
       _playingQuestionId = null;
       _questionNarrationErrorId = null;
-      _revealedQuestionIds.clear();
+      _questionTranslations.clear();
+      _visibleTipQuestionId = null;
       unawaited(_stopExaminerSpeakerSafely());
       unawaited(_restoreProgress());
+      _syncRecordingTimer();
     }
     if (oldWidget.speechFeedbackController != widget.speechFeedbackController) {
       oldWidget.speechFeedbackController?.removeListener(
@@ -427,15 +476,20 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     unawaited(widget.controller.cancelRecording());
     _notesController.removeListener(_saveNotes);
     _notesController.dispose();
+    _conversationScrollController.dispose();
     _convertedAnswerController.dispose();
     _convertedAnswerFocusNode.dispose();
     _ticker?.cancel();
+    _recordingTicker?.cancel();
     _part2TranscriptionRetryTimer?.cancel();
     _bufferedPart3RecordingLimitTimer?.cancel();
     unawaited(_discardBufferedPart3Recording());
     unawaited(_stopExaminerSpeakerSafely());
     if (_ownsExaminerSpeaker) {
       unawaited(_examinerSpeaker.dispose());
+    }
+    if (_ownedTipSpeaker case final speaker?) {
+      unawaited(speaker.dispose());
     }
     super.dispose();
   }
@@ -654,9 +708,31 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _removeSpeechFeedbackSources(widget.speechFeedbackController);
       _progress = null;
       _loading = false;
+      _observedMessageCount = 0;
+      _observedCompletedTurns = 0;
+      _preserveCompletedConversation = false;
+      _showCompletionSheet = false;
       setState(() {});
       return;
     }
+    final messageCount = widget.controller.practiceMessages.length;
+    final shouldFollowConversation = messageCount != _observedMessageCount;
+    _observedMessageCount = messageCount;
+    final completedTurns = widget.controller.completedTurns;
+    final turnLimit = widget.controller.turnLimit;
+    final justCompletedSession =
+        turnLimit > 0 &&
+        _observedCompletedTurns < turnLimit &&
+        completedTurns >= turnLimit;
+    _observedCompletedTurns = completedTurns;
+    if (justCompletedSession) {
+      _preserveCompletedConversation = true;
+      _showCompletionSheet = true;
+    }
+    if (_visibleTipQuestionId != widget.controller.currentQuestion?.id) {
+      _visibleTipQuestionId = null;
+    }
+    _syncRecordingTimer();
     _syncSpeechFeedbackSources();
     _confirmPendingTranscript();
     if ((_progress?.phase == IeltsMockPhase.part2Speaking ||
@@ -682,8 +758,35 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     _recordCompletedParts();
     setState(() {});
+    if (shouldFollowConversation) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _scrollToLatestMessage();
+      });
+    }
     _scheduleQuestionNarration();
     _flushBufferedPart3Audio();
+  }
+
+  void _jumpToLatestMessage() {
+    if (!mounted || !_conversationScrollController.hasClients) {
+      return;
+    }
+    _conversationScrollController.jumpTo(
+      _conversationScrollController.position.maxScrollExtent,
+    );
+  }
+
+  void _scrollToLatestMessage() {
+    if (!mounted || !_conversationScrollController.hasClients) {
+      return;
+    }
+    unawaited(
+      _conversationScrollController.animateTo(
+        _conversationScrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOutCubic,
+      ),
+    );
   }
 
   void _syncSpeechFeedbackSources() {
@@ -764,6 +867,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     _autoNarratedQuestionId = questionId;
     _autoNarratedQuestionText = questionText;
+    if (preview == null &&
+        widget.controller.currentQuestion?.speechPath != null &&
+        widget.onReplayQuestionWithAvatar != null) {
+      return;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _progress?.phase != phase) {
         return;
@@ -774,6 +882,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   Future<void> _playQuestionNarration(String questionId, String text) async {
     final currentQuestion = widget.controller.currentQuestion;
+    final replayWithAvatar = widget.onReplayQuestionWithAvatar;
+    if (currentQuestion?.id == questionId &&
+        currentQuestion?.speechPath != null &&
+        replayWithAvatar != null) {
+      await replayWithAvatar();
+      return;
+    }
     if (_progress?.phase == IeltsMockPhase.part1 &&
         currentQuestion?.id == questionId &&
         widget.controller.canUsePracticeAudio) {
@@ -827,12 +942,73 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
   }
 
-  void _toggleQuestionTranscript(String questionId) {
-    setState(() {
-      if (!_revealedQuestionIds.add(questionId)) {
-        _revealedQuestionIds.remove(questionId);
+  Future<String> _translateQuestion(PracticeMessage message) async {
+    final cached = _questionTranslations[message.id];
+    if (cached != null) {
+      return cached;
+    }
+    final client = widget.controller.client;
+    if (client is! PracticeQuestionTranslationClient) {
+      throw StateError('Question translation is unavailable.');
+    }
+    final translationClient = client as PracticeQuestionTranslationClient;
+    final translation = await translationClient.translateQuestion(
+      questionId: message.id,
+    );
+    if (translation.questionId != message.id) {
+      throw StateError('Question translation does not match the message.');
+    }
+    _questionTranslations[message.id] = translation.content;
+    return translation.content;
+  }
+
+  Future<void> _showQuestionTip() async {
+    final tip = await widget.controller.requestQuestionTip();
+    if (!mounted ||
+        tip == null ||
+        widget.controller.currentQuestion?.id != tip.questionId) {
+      return;
+    }
+    setState(() => _visibleTipQuestionId = tip.questionId);
+  }
+
+  Future<void> _speakQuestionTip() async {
+    final tip = widget.controller.questionTip;
+    if (tip == null || _visibleTipQuestionId != tip.questionId) {
+      return;
+    }
+    final speaker = _ownedTipSpeaker ??= SystemPracticePromptSpeaker();
+    await speaker.speak(tip.content);
+  }
+
+  void _hideQuestionTip() {
+    if (_visibleTipQuestionId == null) {
+      return;
+    }
+    setState(() => _visibleTipQuestionId = null);
+    unawaited(_ownedTipSpeaker?.stop());
+  }
+
+  void _syncRecordingTimer() {
+    final recording =
+        widget.controller.recordingState == PracticeRecordingState.recording ||
+        _bufferedPart3RecordingState == PracticeRecordingState.recording;
+    if (recording) {
+      if (_recordingTicker != null) {
+        return;
       }
-    });
+      _recordingSeconds = 0;
+      _recordingTicker = Timer.periodic(const Duration(seconds: 1), (timer) {
+        if (!mounted) {
+          return;
+        }
+        setState(() => _recordingSeconds = timer.tick);
+      });
+      return;
+    }
+    _recordingTicker?.cancel();
+    _recordingTicker = null;
+    _recordingSeconds = 0;
   }
 
   void _recordCompletedParts() {
@@ -1134,6 +1310,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         return;
       }
     }
+    final beforeUserTurn = widget.onBeforeUserTurn;
+    if (beforeUserTurn != null) {
+      await beforeUserTurn();
+      if (!mounted) {
+        return;
+      }
+    }
     _startingPart2Recording = true;
     _part2DeadlineHandled = false;
     _part2RetryNeeded = false;
@@ -1251,13 +1434,24 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     await _beginPart3();
   }
 
-  Future<void> _startShortRecording() {
+  Future<void> _startShortRecording() async {
     _conversionRequested = false;
+    _hideQuestionTip();
     if (_answerLanguageError != null) {
       setState(() => _answerLanguageError = null);
     }
-    unawaited(_stopQuestionNarration());
-    return widget.controller.startRecording();
+    final beforeUserTurn = widget.onBeforeUserTurn;
+    if (beforeUserTurn == null) {
+      unawaited(_stopQuestionNarration());
+      await widget.controller.startRecording();
+      return;
+    }
+    await _stopQuestionNarration();
+    await beforeUserTurn();
+    if (!mounted) {
+      return;
+    }
+    await widget.controller.startRecording();
   }
 
   Future<void> _sendShortVoice() async {
@@ -1319,6 +1513,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       });
       return;
     }
+    final beforeUserTurn = widget.onBeforeUserTurn;
+    if (beforeUserTurn != null) {
+      await beforeUserTurn();
+      if (!mounted) {
+        return;
+      }
+    }
     setState(() => _convertedAnswerSubmitting = true);
     final submitted = await widget.controller.submitPracticeText(text);
     if (!mounted) {
@@ -1342,6 +1543,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _openTextAnswer() {
+    unawaited(widget.onBeforeUserTurn?.call());
     setState(() {
       _answerLanguageError = null;
       _convertedAnswerMode = true;
@@ -1504,6 +1706,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         body: Center(child: CircularProgressIndicator()),
       );
     }
+    final complete = progress.phase == IeltsMockPhase.complete;
+    final showCompletionPage = complete && !_preserveCompletedConversation;
+    final stagePhase = complete && _preserveCompletedConversation
+        ? (_mode == PracticeMode.part1
+              ? IeltsMockPhase.part1
+              : IeltsMockPhase.part3)
+        : progress.phase;
     return PopScope<Object?>(
       canPop: _exitApproved,
       onPopInvokedWithResult: (didPop, _) {
@@ -1514,51 +1723,178 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       child: Scaffold(
         key: const Key('ielts-mock-page'),
         backgroundColor: SpeakUpDesign.surface,
-        appBar: _buildAppBar(progress.phase),
+        appBar: showCompletionPage ? _buildAppBar(progress.phase) : null,
         body: SafeArea(
-          top: false,
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 220),
-            child: _buildPhase(progress),
-          ),
+          top: !showCompletionPage,
+          child: showCompletionPage
+              ? _buildAnimatedPhase(progress)
+              : PracticeStageLayout(
+                  avatarRegionKey: const Key('ielts-avatar-region'),
+                  avatar: PracticeAvatarStage(
+                    title: _stageTitle(stagePhase),
+                    fallback: const PracticeAvatarFallback(
+                      semanticLabel: 'IELTS 考官静态画面',
+                      imageKey: Key('ielts-avatar-placeholder'),
+                    ),
+                    surfaceBuilder: widget.avatarSurfaceBuilder,
+                    statusLabel: widget.avatarSurfaceBuilder == null
+                        ? null
+                        : widget.avatarStatusLabel,
+                    exitInFlight: _exitInFlight,
+                    exitButtonKey: const Key('ielts-mock-exit'),
+                    onExit: _requestExit,
+                  ),
+                  content: Stack(
+                    children: [
+                      Column(
+                        children: [
+                          Expanded(child: _buildAnimatedPhase(progress)),
+                          if (_usesShortAnswerRecorder(progress.phase))
+                            _buildRecorderDock(),
+                        ],
+                      ),
+                      if (_showCompletionSheet) ...[
+                        const Positioned.fill(
+                          child: ModalBarrier(
+                            dismissible: false,
+                            color: Color(0x14000000),
+                            semanticsLabel: '练习完成',
+                          ),
+                        ),
+                        Align(
+                          alignment: Alignment.bottomCenter,
+                          child: _SectionCompletionSheet(
+                            title: _completionTitle,
+                            message:
+                                '${widget.controller.completedTurns} 道回答已保存',
+                            primaryLabel: _mode == PracticeMode.fullMock
+                                ? '查看模考报告'
+                                : '查看本组复盘',
+                            secondaryLabel: _mode == PracticeMode.fullMock
+                                ? '返回训练'
+                                : '返回题单',
+                            onPrimary: _openCompletedReview,
+                            onSecondary: _leaveCompletedPractice,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
         ),
-        bottomNavigationBar:
-            progress.phase == IeltsMockPhase.part1 ||
-                progress.phase == IeltsMockPhase.part3
-            ? _RecorderDock(
-                controller: widget.controller,
-                stateOverride: _usesBufferedPart3Recorder
-                    ? _bufferedPart3RecordingState
-                    : null,
-                enabledOverride: _usesBufferedPart3Recorder
-                    ? _bufferedPart3RecordingState ==
-                          PracticeRecordingState.idle
-                    : null,
-                allowTextAnswer: !_usesBufferedPart3Recorder,
-                validationMessage: _answerLanguageError,
-                convertedAnswerController: _convertedAnswerController,
-                convertedAnswerFocusNode: _convertedAnswerFocusNode,
-                convertedAnswerMode: _convertedAnswerMode,
-                convertedAnswerSubmitting: _convertedAnswerSubmitting,
-                onStart: _usesBufferedPart3Recorder
-                    ? _startBufferedPart3Recording
-                    : _startShortRecording,
-                onSendVoice: _usesBufferedPart3Recorder
-                    ? _stopBufferedPart3Recording
-                    : _sendShortVoice,
-                onConvertToText: _usesBufferedPart3Recorder
-                    ? _stopBufferedPart3Recording
-                    : _convertShortVoice,
-                onCancelRecording: _usesBufferedPart3Recorder
-                    ? _discardBufferedPart3Recording
-                    : _cancelShortVoice,
-                onSubmitConvertedAnswer: _submitConvertedAnswer,
-                onCancelConvertedAnswer: _cancelConvertedAnswer,
-                onOpenTextAnswer: _openTextAnswer,
-              )
-            : null,
       ),
     );
+  }
+
+  Widget _buildAnimatedPhase(IeltsMockProgress progress) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 220),
+      child:
+          progress.phase == IeltsMockPhase.complete &&
+              _preserveCompletedConversation
+          ? _completedConversationPhase()
+          : _buildPhase(progress),
+    );
+  }
+
+  String get _completionTitle => switch (_mode) {
+    PracticeMode.part1 => 'Part 1 已完成',
+    PracticeMode.part2 => 'Part 2 + Part 3 已完成',
+    PracticeMode.part3 => 'Part 3 已完成',
+    PracticeMode.fullMock => '口语模考已完成',
+    PracticeMode.fullSimulation ||
+    PracticeMode.focus => throw StateError('Non-IELTS mode in IELTS practice.'),
+  };
+
+  Widget _completedConversationPhase() {
+    if (_mode == PracticeMode.part1) {
+      return _conversationPhase(
+        key: const Key('ielts-mock-part-1'),
+        partLabel: 'Part 1',
+        completed: _part1Total,
+        total: _part1Total,
+        sectionStart: _partStart(IeltsSpeakingPart.part1),
+      );
+    }
+    return _conversationPhase(
+      key: const Key('ielts-mock-part-3'),
+      partLabel: 'Part 3 · Discussion',
+      completed: _part3Total,
+      total: _part3Total,
+      sectionStart: _part3Start,
+    );
+  }
+
+  void _openCompletedReview() {
+    if (_mode == PracticeMode.fullMock) {
+      setState(() {
+        _showCompletionSheet = false;
+        _preserveCompletedConversation = false;
+      });
+      return;
+    }
+    setState(() => _showCompletionSheet = false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollToLatestMessage();
+    });
+  }
+
+  void _leaveCompletedPractice() {
+    if (_mode == PracticeMode.fullMock) {
+      unawaited(_requestExit(fromCompletion: true));
+      return;
+    }
+    unawaited(_finishSection(IeltsPracticeCompletionAction.list));
+  }
+
+  bool _usesShortAnswerRecorder(IeltsMockPhase phase) =>
+      phase == IeltsMockPhase.part1 || phase == IeltsMockPhase.part3;
+
+  Widget _buildRecorderDock() {
+    return _RecorderDock(
+      controller: widget.controller,
+      recordingSeconds: _recordingSeconds,
+      stateOverride: _usesBufferedPart3Recorder
+          ? _bufferedPart3RecordingState
+          : null,
+      enabledOverride: _usesBufferedPart3Recorder
+          ? _bufferedPart3RecordingState == PracticeRecordingState.idle
+          : null,
+      allowTextAnswer: !_usesBufferedPart3Recorder,
+      validationMessage: _answerLanguageError,
+      convertedAnswerController: _convertedAnswerController,
+      convertedAnswerFocusNode: _convertedAnswerFocusNode,
+      convertedAnswerMode: _convertedAnswerMode,
+      convertedAnswerSubmitting: _convertedAnswerSubmitting,
+      onStart: _usesBufferedPart3Recorder
+          ? _startBufferedPart3Recording
+          : _startShortRecording,
+      onSendVoice: _usesBufferedPart3Recorder
+          ? _stopBufferedPart3Recording
+          : _sendShortVoice,
+      onConvertToText: _usesBufferedPart3Recorder
+          ? _stopBufferedPart3Recording
+          : _convertShortVoice,
+      onCancelRecording: _usesBufferedPart3Recorder
+          ? _discardBufferedPart3Recording
+          : _cancelShortVoice,
+      onSubmitConvertedAnswer: _submitConvertedAnswer,
+      onCancelConvertedAnswer: _cancelConvertedAnswer,
+      onOpenTextAnswer: _openTextAnswer,
+    );
+  }
+
+  String _stageTitle(IeltsMockPhase phase) {
+    return switch (phase) {
+      IeltsMockPhase.part1 => 'IELTS · Part 1',
+      IeltsMockPhase.part2Intro ||
+      IeltsMockPhase.part2CueCard ||
+      IeltsMockPhase.part2Preparation ||
+      IeltsMockPhase.part2Speaking ||
+      IeltsMockPhase.part2Complete => 'IELTS · Part 2',
+      IeltsMockPhase.part3Intro || IeltsMockPhase.part3 => 'IELTS · Part 3',
+      _ => 'IELTS Speaking',
+    };
   }
 
   PreferredSizeWidget? _buildAppBar(IeltsMockPhase phase) {
@@ -1739,15 +2075,28 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
           child: _ExamConversation(
             messages: messages ?? _sectionMessages(sectionStart, completed),
             controller: widget.controller,
+            scrollController: _conversationScrollController,
+            bottomPadding: _showCompletionSheet ? 292 : 28,
             speechFeedbackController: widget.speechFeedbackController,
-            revealedQuestionIds: _revealedQuestionIds,
-            playingQuestionId: _playingQuestionId,
+            playingQuestionId:
+                widget.avatarReplayLoading || widget.avatarReplayPlaying
+                ? widget.controller.questionId
+                : _playingQuestionId,
             narrationErrorQuestionId: _questionNarrationErrorId,
             mediaPlayingQuestionId: widget.controller.isQuestionAudioPlaying
                 ? widget.controller.questionId
                 : null,
             onPlayQuestion: _playQuestionNarration,
-            onToggleTranscript: _toggleQuestionTranscript,
+            onTranslateQuestion:
+                widget.controller.canTranslateQuestion &&
+                    widget.controller.client
+                        is PracticeQuestionTranslationClient
+                ? _translateQuestion
+                : null,
+            visibleTipQuestionId: _visibleTipQuestionId,
+            onShowTip: _showQuestionTip,
+            onHideTip: _hideQuestionTip,
+            onSpeakTip: _speakQuestionTip,
           ),
         ),
         if (widget.controller.errorMessage case final error?)
@@ -1765,7 +2114,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   List<PracticeMessage> _sectionMessages(int sectionStart, int completed) {
-    final relevantCount = completed * 2 + 1;
+    final relevantCount =
+        completed * 2 + (widget.controller.currentQuestion == null ? 0 : 1);
     final all = widget.controller.practiceMessages
         .where(
           (message) =>
@@ -1853,30 +2203,41 @@ class _ExamConversation extends StatelessWidget {
   const _ExamConversation({
     required this.messages,
     required this.controller,
-    required this.revealedQuestionIds,
+    required this.scrollController,
+    required this.bottomPadding,
     required this.playingQuestionId,
     required this.narrationErrorQuestionId,
     required this.mediaPlayingQuestionId,
     required this.onPlayQuestion,
-    required this.onToggleTranscript,
+    required this.onTranslateQuestion,
+    required this.visibleTipQuestionId,
+    required this.onShowTip,
+    required this.onHideTip,
+    required this.onSpeakTip,
     this.speechFeedbackController,
   });
 
   final List<PracticeMessage> messages;
   final PracticeController controller;
-  final Set<String> revealedQuestionIds;
+  final ScrollController scrollController;
+  final double bottomPadding;
   final String? playingQuestionId;
   final String? narrationErrorQuestionId;
   final String? mediaPlayingQuestionId;
   final Future<void> Function(String questionId, String text) onPlayQuestion;
-  final ValueChanged<String> onToggleTranscript;
+  final Future<String> Function(PracticeMessage message)? onTranslateQuestion;
+  final String? visibleTipQuestionId;
+  final VoidCallback onShowTip;
+  final VoidCallback onHideTip;
+  final Future<void> Function() onSpeakTip;
   final SpeechFeedbackController? speechFeedbackController;
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       key: const Key('ielts-mock-conversation'),
-      padding: const EdgeInsets.fromLTRB(20, 26, 20, 28),
+      controller: scrollController,
+      padding: EdgeInsets.fromLTRB(20, 26, 20, bottomPadding),
       itemCount: messages.length,
       itemBuilder: (context, index) {
         final message = messages[index];
@@ -1894,29 +2255,68 @@ class _ExamConversation extends StatelessWidget {
                 SpeechFeedbackScoreabilityStatus.insufficient
             ? null
             : candidateProjection;
+        final currentQuestion = message.id == controller.questionId;
+        final playing =
+            playingQuestionId == message.id ||
+            mediaPlayingQuestionId == message.id;
+        final tipsAvailable =
+            currentQuestion &&
+            (controller.practiceCapabilities?.questionTipsAllowed ?? false);
+        final tip = controller.questionTip;
+        final showTip =
+            assistant &&
+            tip != null &&
+            tip.questionId == message.id &&
+            tip.questionId == visibleTipQuestionId;
+        final tipError = currentQuestion
+            ? controller.questionTipErrorMessage
+            : null;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Padding(
               padding: const EdgeInsets.only(bottom: 12),
-              child: assistant
-                  ? _ExaminerQuestionBubble(
-                      message: message,
-                      playing:
-                          playingQuestionId == message.id ||
-                          mediaPlayingQuestionId == message.id,
-                      transcriptVisible: revealedQuestionIds.contains(
-                        message.id,
-                      ),
-                      playbackFailed: narrationErrorQuestionId == message.id,
-                      onPlay: () => onPlayQuestion(message.id, message.text),
-                      onToggleTranscript: () => onToggleTranscript(message.id),
-                    )
-                  : PracticeMessageBubble(
-                      message: message,
-                      feedbackProjection: projection,
-                    ),
+              child: PracticeMessageBubble(
+                message: message,
+                feedbackProjection: projection,
+                onTranslate: assistant ? onTranslateQuestion : null,
+                actions: assistant
+                    ? _IeltsQuestionActions(
+                        messageId: message.id,
+                        playing: playing,
+                        playbackFailed: narrationErrorQuestionId == message.id,
+                        tipsAvailable: tipsAvailable,
+                        tipLoading:
+                            currentQuestion && controller.isQuestionTipLoading,
+                        tipEnabled:
+                            currentQuestion && controller.canRequestQuestionTip,
+                        onPlay: () => onPlayQuestion(message.id, message.text),
+                        onShowTip: onShowTip,
+                      )
+                    : null,
+              ),
             ),
+            if (showTip)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: QuestionTipCard(
+                  content: tip.content,
+                  onClose: onHideTip,
+                  onSpeak: onSpeakTip,
+                ),
+              ),
+            if (assistant && tipError != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                child: Text(
+                  tipError,
+                  key: const Key('ielts-question-tip-error'),
+                  style: const TextStyle(
+                    color: SpeakUpDesign.error,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
           ],
         );
       },
@@ -1924,105 +2324,81 @@ class _ExamConversation extends StatelessWidget {
   }
 }
 
-class _ExaminerQuestionBubble extends StatelessWidget {
-  const _ExaminerQuestionBubble({
-    required this.message,
+class _IeltsQuestionActions extends StatelessWidget {
+  const _IeltsQuestionActions({
+    required this.messageId,
     required this.playing,
-    required this.transcriptVisible,
     required this.playbackFailed,
+    required this.tipsAvailable,
+    required this.tipLoading,
+    required this.tipEnabled,
     required this.onPlay,
-    required this.onToggleTranscript,
+    required this.onShowTip,
   });
 
-  final PracticeMessage message;
+  final String messageId;
   final bool playing;
-  final bool transcriptVisible;
   final bool playbackFailed;
+  final bool tipsAvailable;
+  final bool tipLoading;
+  final bool tipEnabled;
   final VoidCallback onPlay;
-  final VoidCallback onToggleTranscript;
+  final VoidCallback onShowTip;
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 340),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Material(
-              key: ValueKey('ielts-question-voice-${message.id}'),
-              color: SpeakUpDesign.surfaceMuted,
-              borderRadius: BorderRadius.circular(22),
-              child: InkWell(
-                borderRadius: BorderRadius.circular(22),
-                onTap: onPlay,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        playing
-                            ? Icons.stop_circle_outlined
-                            : Icons.play_circle_outline_rounded,
-                        color: SpeakUpDesign.primary,
-                      ),
-                      const SizedBox(width: 10),
-                      Icon(
-                        Icons.graphic_eq_rounded,
-                        color: SpeakUpDesign.primary,
-                        size: 34,
-                      ),
-                      const SizedBox(width: 10),
-                      Flexible(
-                        child: Text(
-                          playing ? 'Examiner is speaking…' : 'Examiner voice',
-                          style: SpeakUpDesign.body.copyWith(
-                            color: SpeakUpDesign.primary,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextButton.icon(
+          key: ValueKey('ielts-question-voice-$messageId'),
+          onPressed: onPlay,
+          style: TextButton.styleFrom(
+            foregroundColor: SpeakUpDesign.primary,
+            backgroundColor: SpeakUpDesign.surfaceMuted,
+            minimumSize: const Size(0, 32),
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            visualDensity: VisualDensity.compact,
+            textStyle: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
             ),
-            TextButton.icon(
-              key: ValueKey('ielts-question-transcript-toggle-${message.id}'),
-              onPressed: onToggleTranscript,
-              icon: Icon(
-                transcriptVisible
-                    ? Icons.visibility_off_outlined
-                    : Icons.visibility_outlined,
-                size: 18,
-              ),
-              label: Text(transcriptVisible ? 'Hide English' : 'Show English'),
-            ),
-            if (playbackFailed)
-              const Padding(
-                padding: EdgeInsets.only(left: 12, bottom: 8),
-                child: Text(
-                  'Playback failed. Tap the voice bubble to retry.',
-                  style: TextStyle(color: SpeakUpDesign.error, fontSize: 12),
-                ),
-              ),
-            if (transcriptVisible)
-              Container(
-                key: ValueKey('ielts-question-transcript-${message.id}'),
-                margin: const EdgeInsets.only(bottom: 4),
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  color: SpeakUpDesign.surface,
-                  border: Border.all(color: SpeakUpDesign.border),
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Text(message.text, style: SpeakUpDesign.body),
-              ),
-          ],
+          ),
+          icon: Icon(
+            playing ? Icons.stop_rounded : Icons.volume_up_outlined,
+            size: 17,
+          ),
+          label: Text(
+            playing
+                ? '停止朗读'
+                : playbackFailed
+                ? '重试朗读'
+                : '朗读',
+          ),
         ),
-      ),
+        if (tipsAvailable)
+          TextButton.icon(
+            key: ValueKey('ielts-question-tip-$messageId'),
+            onPressed: tipEnabled ? onShowTip : null,
+            style: TextButton.styleFrom(
+              foregroundColor: SpeakUpDesign.primary,
+              minimumSize: const Size(0, 32),
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              visualDensity: VisualDensity.compact,
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            icon: tipLoading
+                ? const SizedBox.square(
+                    dimension: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.lightbulb_outline_rounded, size: 17),
+            label: Text(tipLoading ? '生成中' : 'Tips'),
+          ),
+      ],
     );
   }
 }
@@ -2035,6 +2411,7 @@ String _ieltsFeedbackSourceKey(
 class _RecorderDock extends StatelessWidget {
   const _RecorderDock({
     required this.controller,
+    required this.recordingSeconds,
     required this.stateOverride,
     required this.enabledOverride,
     required this.allowTextAnswer,
@@ -2053,6 +2430,7 @@ class _RecorderDock extends StatelessWidget {
   });
 
   final PracticeController controller;
+  final int recordingSeconds;
   final PracticeRecordingState? stateOverride;
   final bool? enabledOverride;
   final bool allowTextAnswer;
@@ -2110,6 +2488,7 @@ class _RecorderDock extends StatelessWidget {
                 phase: phase,
                 capture: capture,
                 transcript: controller.transcript ?? '',
+                recordingSeconds: recordingSeconds,
                 allowTextAnswer: allowTextAnswer,
                 onShowText: onOpenTextAnswer,
               );
@@ -2143,6 +2522,7 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
     required this.phase,
     required this.capture,
     required this.transcript,
+    required this.recordingSeconds,
     required this.allowTextAnswer,
     required this.onShowText,
   });
@@ -2150,6 +2530,7 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
   final VoiceCapturePhase phase;
   final VoiceCaptureView capture;
   final String transcript;
+  final int recordingSeconds;
   final bool allowTextAnswer;
   final VoidCallback onShowText;
 
@@ -2158,7 +2539,7 @@ class _IeltsVoiceCaptureDock extends StatelessWidget {
     return VoiceComposerDock(
       capture: capture,
       phase: phase,
-      elapsed: Duration.zero,
+      elapsed: Duration(seconds: recordingSeconds),
       enabled: true,
       recordKey: const Key('ielts-mock-record'),
       stopRecordingKey: const Key('ielts-mock-stop-recording'),
@@ -2300,6 +2681,115 @@ class _CompletionStep extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCompletionSheet extends StatelessWidget {
+  const _SectionCompletionSheet({
+    required this.title,
+    required this.message,
+    required this.primaryLabel,
+    required this.secondaryLabel,
+    required this.onPrimary,
+    required this.onSecondary,
+  });
+
+  final String title;
+  final String message;
+  final String primaryLabel;
+  final String secondaryLabel;
+  final VoidCallback onPrimary;
+  final VoidCallback onSecondary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560),
+        child: Material(
+          key: const Key('ielts-section-completion-sheet'),
+          color: SpeakUpDesign.surface,
+          elevation: 12,
+          shadowColor: const Color(0x26000000),
+          borderRadius: BorderRadius.circular(28),
+          clipBehavior: Clip.antiAlias,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Container(
+                    width: 42,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: SpeakUpDesign.border,
+                      borderRadius: BorderRadius.circular(99),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 18),
+                Center(
+                  child: Container(
+                    width: 52,
+                    height: 52,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(color: SpeakUpDesign.ink, width: 2),
+                    ),
+                    child: const Icon(
+                      Icons.check_rounded,
+                      size: 34,
+                      color: SpeakUpDesign.ink,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: SpeakUpDesign.pageTitle.copyWith(fontSize: 24),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: SpeakUpDesign.body.copyWith(
+                    color: SpeakUpDesign.secondary,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                FilledButton(
+                  key: const Key('ielts-section-review-action'),
+                  onPressed: onPrimary,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(54),
+                    backgroundColor: SpeakUpDesign.ink,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                  child: Text(primaryLabel),
+                ),
+                const SizedBox(height: 4),
+                TextButton(
+                  key: const Key('ielts-section-list-action'),
+                  onPressed: onSecondary,
+                  style: TextButton.styleFrom(
+                    foregroundColor: SpeakUpDesign.ink,
+                    minimumSize: const Size.fromHeight(44),
+                  ),
+                  child: Text(secondaryLabel),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -294,6 +294,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       await _startShortRecording();
       return;
     }
+    await _stopQuestionTipSpeech();
     await _stopQuestionNarration();
     final beforeUserTurn = widget.onBeforeUserTurn;
     if (beforeUserTurn != null) {
@@ -986,7 +987,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     setState(() => _visibleTipQuestionId = null);
-    unawaited(_ownedTipSpeaker?.stop());
+    unawaited(_stopQuestionTipSpeech());
+  }
+
+  Future<void> _stopQuestionTipSpeech() async {
+    try {
+      await _ownedTipSpeaker?.stop();
+    } on Object {
+      // Recording must remain usable if platform TTS cannot stop cleanly.
+    }
   }
 
   void _syncRecordingTimer() {
@@ -1436,18 +1445,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   Future<void> _startShortRecording() async {
     _conversionRequested = false;
-    _hideQuestionTip();
+    await _stopQuestionTipSpeech();
     if (_answerLanguageError != null) {
       setState(() => _answerLanguageError = null);
     }
-    final beforeUserTurn = widget.onBeforeUserTurn;
-    if (beforeUserTurn == null) {
-      unawaited(_stopQuestionNarration());
-      await widget.controller.startRecording();
-      return;
-    }
     await _stopQuestionNarration();
-    await beforeUserTurn();
+    final beforeUserTurn = widget.onBeforeUserTurn;
+    await beforeUserTurn?.call();
     if (!mounted) {
       return;
     }

--- a/mobile/lib/features/coaching/practice/practice_stage.dart
+++ b/mobile/lib/features/coaching/practice/practice_stage.dart
@@ -173,3 +173,29 @@ class PracticeAvatarStage extends StatelessWidget {
     );
   }
 }
+
+/// Shared static fallback shown when a live avatar surface is unavailable.
+class PracticeAvatarFallback extends StatelessWidget {
+  const PracticeAvatarFallback({
+    required this.semanticLabel,
+    this.imageKey,
+    super.key,
+  });
+
+  final String semanticLabel;
+  final Key? imageKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      image: true,
+      child: Image.asset(
+        'assets/images/scenes/static-avatar-van-gogh.jpg',
+        key: imageKey,
+        fit: BoxFit.cover,
+        alignment: Alignment.center,
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coaching/practice/question_tip_sheet.dart
+++ b/mobile/lib/features/coaching/practice/question_tip_sheet.dart
@@ -107,8 +107,6 @@ class _QuestionTipCardState extends State<QuestionTipCard> {
                     : const Icon(Icons.volume_up_outlined, size: 18),
                 label: Text(_speaking ? '正在朗读' : '朗读'),
               ),
-              const Spacer(),
-              const Text('可边看边说', style: SpeakUpDesign.meta),
             ],
           ),
           if (_speechError case final message?) ...[

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -465,7 +465,10 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                   avatarRegionKey: const Key('scenario-avatar-region'),
                   avatar: PracticeAvatarStage(
                     title: scene.name,
-                    fallback: const _AvatarPlaceholder(),
+                    fallback: const PracticeAvatarFallback(
+                      semanticLabel: '情景对话静态角色画面',
+                      imageKey: Key('scenario-avatar-placeholder'),
+                    ),
                     surfaceBuilder:
                         _exitApproved || !widget.practiceController.canUseAvatar
                         ? null
@@ -506,24 +509,6 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                   ),
                 ),
         ),
-      ),
-    );
-  }
-}
-
-class _AvatarPlaceholder extends StatelessWidget {
-  const _AvatarPlaceholder();
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: '情景对话静态角色画面',
-      image: true,
-      child: Image.asset(
-        'assets/images/scenes/static-avatar-van-gogh.jpg',
-        key: const Key('scenario-avatar-placeholder'),
-        fit: BoxFit.cover,
-        alignment: Alignment.center,
       ),
     );
   }

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -10,12 +10,52 @@ import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.da
 
 typedef AvatarControllerFactory = AvatarController Function();
 
+typedef PracticeAvatarSessionBuilder =
+    Widget Function(BuildContext context, PracticeAvatarSessionView avatar);
+
+final class PracticeAvatarSessionView {
+  const PracticeAvatarSessionView({
+    required this.surfaceBuilder,
+    required this.statusLabel,
+    required this.interruptForUserTurn,
+    required this.onReplayQuestion,
+    required this.replayLoading,
+    required this.replayPlaying,
+  });
+
+  final WidgetBuilder surfaceBuilder;
+  final String? statusLabel;
+  final Future<void> Function() interruptForUserTurn;
+  final Future<void> Function()? onReplayQuestion;
+  final bool replayLoading;
+  final bool replayPlaying;
+}
+
+/// Owns one avatar connection while the supplied practice page owns its UI.
+class PracticeAvatarSession extends StatefulWidget {
+  const PracticeAvatarSession({
+    required this.practiceController,
+    required this.avatarControllerFactory,
+    required this.builder,
+    required this.surfaceKey,
+    super.key,
+  });
+
+  final PracticeController practiceController;
+  final AvatarControllerFactory avatarControllerFactory;
+  final PracticeAvatarSessionBuilder builder;
+  final Key surfaceKey;
+
+  @override
+  State<PracticeAvatarSession> createState() => _PracticeAvatarSessionState();
+}
+
 /// Owns one avatar connection for one scenario practice route.
 ///
 /// The product shell remains vendor-neutral: this coordinator only knows the
 /// AvatarController boundary, while the composition root chooses Spatius (or a
 /// future provider).
-class ScenarioPracticeSession extends StatefulWidget {
+class ScenarioPracticeSession extends StatelessWidget {
   const ScenarioPracticeSession({
     required this.practiceController,
     required this.avatarControllerFactory,
@@ -32,11 +72,29 @@ class ScenarioPracticeSession extends StatefulWidget {
   final Future<bool> Function()? onExitRequested;
 
   @override
-  State<ScenarioPracticeSession> createState() =>
-      _ScenarioPracticeSessionState();
+  Widget build(BuildContext context) {
+    return PracticeAvatarSession(
+      practiceController: practiceController,
+      avatarControllerFactory: avatarControllerFactory,
+      surfaceKey: const Key('scenario-avatar-surface'),
+      builder: (context, avatar) => ScenarioPracticePage(
+        practiceController: practiceController,
+        avatarSurfaceBuilder: avatar.surfaceBuilder,
+        avatarStatusLabel: avatar.statusLabel,
+        onBeforeStartRecording: avatar.interruptForUserTurn,
+        onBeforeSubmitText: avatar.interruptForUserTurn,
+        onReplayQuestion: avatar.onReplayQuestion,
+        onPracticeCompleted: onPracticeCompleted,
+        speechFeedbackController: speechFeedbackController,
+        replayLoading: avatar.replayLoading,
+        replayPlaying: avatar.replayPlaying,
+        onExitRequested: onExitRequested,
+      ),
+    );
+  }
 }
 
-class _ScenarioPracticeSessionState extends State<ScenarioPracticeSession>
+class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     with WidgetsBindingObserver {
   static const _avatarReadinessTimeout = Duration(seconds: 15);
   static const _userTurnInterruptBudget = Duration(milliseconds: 500);
@@ -83,7 +141,7 @@ class _ScenarioPracticeSessionState extends State<ScenarioPracticeSession>
   }
 
   @override
-  void didUpdateWidget(covariant ScenarioPracticeSession oldWidget) {
+  void didUpdateWidget(covariant PracticeAvatarSession oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.practiceController == widget.practiceController) {
       return;
@@ -553,25 +611,21 @@ class _ScenarioPracticeSessionState extends State<ScenarioPracticeSession>
 
   @override
   Widget build(BuildContext context) {
-    return ScenarioPracticePage(
-      practiceController: widget.practiceController,
-      avatarSurfaceBuilder: (_) => _hasLiveAvatarController
-          ? _avatarController.buildSurface(
-              key: const Key('scenario-avatar-surface'),
-            )
-          : const SizedBox.expand(key: Key('scenario-avatar-surface')),
-      avatarStatusLabel: _avatarStatusLabel,
-      onBeforeStartRecording: _interruptForUserTurn,
-      onBeforeSubmitText: _interruptForUserTurn,
-      onReplayQuestion:
-          widget.practiceController.currentQuestion?.speechPath == null
-          ? null
-          : _replayQuestion,
-      onPracticeCompleted: widget.onPracticeCompleted,
-      speechFeedbackController: widget.speechFeedbackController,
-      replayLoading: _replayLoading,
-      replayPlaying: _isAvatarSpeaking,
-      onExitRequested: widget.onExitRequested,
+    return widget.builder(
+      context,
+      PracticeAvatarSessionView(
+        surfaceBuilder: (_) => _hasLiveAvatarController
+            ? _avatarController.buildSurface(key: widget.surfaceKey)
+            : SizedBox.expand(key: widget.surfaceKey),
+        statusLabel: _avatarStatusLabel,
+        interruptForUserTurn: _interruptForUserTurn,
+        onReplayQuestion:
+            widget.practiceController.currentQuestion?.speechPath == null
+            ? null
+            : _replayQuestion,
+        replayLoading: _replayLoading,
+        replayPlaying: _isAvatarSpeaking,
+      ),
     );
   }
 

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -28,6 +28,57 @@ import 'package:speakup/features/coaching/review/ielts_speaking_report_controlle
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 
 void main() {
+  testWidgets('Part 1 keeps Tips visible while recording', (tester) async {
+    const capabilities = PracticeCapabilities(
+      retryAllowed: false,
+      questionTranslationAllowed: false,
+      questionTipsAllowed: true,
+      avatarAllowed: false,
+      speechFeedbackAllowed: false,
+    );
+    final practice = _IeltsPracticeClient(
+      initialCompleted: 0,
+      capabilities: capabilities,
+    );
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('ielts-question-tip-question-1')),
+    );
+    await tester.pump();
+    expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
+    expect(find.text('可边看边说'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    await tester.pump();
+
+    expect(controller.recordingState, PracticeRecordingState.recording);
+    expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
+    await controller.cancelRecording();
+    await tester.pump();
+  });
+
   testWidgets(
     'Part 1 uses the shared avatar, conversation, and composer stage',
     (tester) async {
@@ -848,6 +899,7 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
         ),
       ),
     );
@@ -1336,6 +1388,7 @@ void main() {
           home: IeltsSpeakingMockPage(
             controller: controller,
             progressStore: _MemoryProgressStore(),
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
           ),
         ),
       );
@@ -1374,6 +1427,7 @@ void main() {
           home: IeltsSpeakingMockPage(
             controller: controller,
             progressStore: _MemoryProgressStore(),
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
           ),
         ),
       );
@@ -1383,12 +1437,7 @@ void main() {
       await tester.pump();
       expect(find.text('0/1'), findsOneWidget);
 
-      await tester.tap(find.byKey(const Key('ielts-mock-record')));
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('ielts-mock-record')));
-      await tester.pump();
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 220));
+      await _answerCurrentShortQuestion(tester, controller);
 
       expect(controller.completedTurns, 1);
       expect(find.text('Answer 1'), findsOneWidget);
@@ -1430,6 +1479,7 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
         ),
       ),
     );
@@ -1565,7 +1615,15 @@ Future<void> _answerCurrentShortQuestion(
 ) async {
   final completedTurns = controller.completedTurns;
   await tester.tap(find.byKey(const Key('ielts-mock-record')));
-  await tester.pump();
+  for (
+    var attempt = 0;
+    attempt < 20 &&
+        controller.recordingState != PracticeRecordingState.recording;
+    attempt++
+  ) {
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+  expect(controller.recordingState, PracticeRecordingState.recording);
   await tester.tap(find.byKey(const Key('ielts-mock-record')));
   for (
     var attempt = 0;
@@ -1613,12 +1671,14 @@ final class _UnusedQuestionBankClient implements IeltsQuestionBankClient {
   }
 }
 
-final class _IeltsPracticeClient implements PracticeClient {
+final class _IeltsPracticeClient
+    implements PracticeClient, PracticeQuestionTipClient {
   _IeltsPracticeClient({
     required this.initialCompleted,
     this.turnLimit = 14,
     this.transcriptionFailuresRemaining = 0,
     this.transcriptionText,
+    this.capabilities = _practiceCapabilities,
   }) : completed = initialCompleted;
 
   final int initialCompleted;
@@ -1627,6 +1687,7 @@ final class _IeltsPracticeClient implements PracticeClient {
   final int turnLimit;
   int transcriptionFailuresRemaining;
   final String? transcriptionText;
+  final PracticeCapabilities capabilities;
   int completed;
   SceneDefinition? activeScene;
   PracticeMode activeMode = PracticeMode.fullMock;
@@ -1661,7 +1722,7 @@ final class _IeltsPracticeClient implements PracticeClient {
       practiceExperience: scene.experience,
       sceneCategory: scene.category,
       practiceMode: activeMode,
-      capabilities: _practiceCapabilities,
+      capabilities: capabilities,
       sessionVersion: completed + 1,
       completedTurns: completed,
       turnLimit: turnLimit,
@@ -1747,7 +1808,7 @@ final class _IeltsPracticeClient implements PracticeClient {
       practiceExperience: scene.experience,
       sceneCategory: scene.category,
       practiceMode: activeMode,
-      capabilities: _practiceCapabilities,
+      capabilities: capabilities,
       sessionVersion: completed + 1,
       nextQuestion: done ? null : _question(completed + 1),
     );
@@ -1762,6 +1823,19 @@ final class _IeltsPracticeClient implements PracticeClient {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<PracticeQuestionTip> ensureQuestionTip({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+  }) async => PracticeQuestionTip(
+    id: 'tip-$questionId',
+    sessionId: sessionId,
+    questionId: questionId,
+    content: 'Give a direct answer and one short reason.',
+    createdAt: DateTime.utc(2026, 8, 10),
+  );
 }
 
 final class _Recorder implements PracticeRecorder {

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -28,6 +28,37 @@ import 'package:speakup/features/coaching/review/ielts_speaking_report_controlle
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 
 void main() {
+  testWidgets(
+    'Part 1 uses the shared avatar, conversation, and composer stage',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await _activatePractice(controller, practice, _ieltsScene);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const Key('ielts-avatar-region')), findsOneWidget);
+      expect(find.byKey(const Key('ielts-avatar-placeholder')), findsOneWidget);
+      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-mock-record')).hitTestable(),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgets('Part 1 prefers the shared practice question voice', (
     tester,
   ) async {
@@ -62,7 +93,7 @@ void main() {
   });
 
   testWidgets(
-    'Part 1 auto-plays voice bubbles and reveals English only on request',
+    'Part 1 auto-plays and keeps examiner text visible in shared bubbles',
     (tester) async {
       final speaker = _ImmediateExaminerSpeaker();
       final practice = _IeltsPracticeClient(initialCompleted: 0);
@@ -90,18 +121,7 @@ void main() {
         find.byKey(const Key('ielts-question-voice-question-1')),
         findsOneWidget,
       );
-      expect(find.text(_question(1).text), findsNothing);
-
-      await tester.tap(
-        find.byKey(const Key('ielts-question-transcript-toggle-question-1')),
-      );
-      await tester.pump();
-
       expect(find.text(_question(1).text), findsOneWidget);
-      expect(
-        find.byKey(const Key('ielts-question-transcript-question-1')),
-        findsOneWidget,
-      );
 
       await tester.tap(find.byKey(const Key('ielts-mock-record')));
       await tester.pump();
@@ -112,11 +132,11 @@ void main() {
       await tester.pump();
 
       expect(speaker.spoken.last, _question(2).text);
-      expect(find.text(_question(2).text), findsNothing);
+      expect(find.text(_question(2).text), findsOneWidget);
     },
   );
 
-  testWidgets('Part 3 starts with an auto-playing hidden-text voice bubble', (
+  testWidgets('Part 3 starts with an auto-playing visible text bubble', (
     tester,
   ) async {
     final speaker = _ImmediateExaminerSpeaker();
@@ -160,7 +180,7 @@ void main() {
       find.byKey(const Key('ielts-question-voice-question-1')),
       findsOneWidget,
     );
-    expect(find.text(_question(1).text), findsNothing);
+    expect(find.text(_question(1).text), findsOneWidget);
   });
 
   testWidgets(
@@ -837,9 +857,18 @@ void main() {
       tester.getCenter(find.byKey(const Key('ielts-mock-record'))),
     );
     await tester.pump(const Duration(milliseconds: 220));
+    await tester.pump(const Duration(seconds: 1));
     expect(
       tester.getSize(find.byKey(const Key('ielts-mock-stop-recording'))).height,
       48,
+    );
+    expect(
+      tester
+          .widget<Text>(
+            find.byKey(const Key('ielts-mock-voice-target-duration')),
+          )
+          .data,
+      '0:01',
     );
     expect(find.byKey(const Key('ielts-mock-voice-targets')), findsNothing);
     await gesture.moveBy(const Offset(0, -90));
@@ -968,9 +997,95 @@ void main() {
     expect(reportController.isLoading, isFalse);
   });
 
-  testWidgets('section completion never requests the full-mock report', (
-    tester,
-  ) async {
+  testWidgets(
+    'Part 1 completion keeps the final answer visible before section review',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 4);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      final preparation = IeltsPreparationController(
+        client: _UnusedQuestionBankClient(),
+      );
+      final reportClient = _PendingReportClient();
+      final reportController = IeltsSpeakingReportController(
+        client: reportClient,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(preparation.dispose);
+      addTearDown(reportController.dispose);
+      await _activatePractice(
+        controller,
+        practice,
+        _ieltsScene,
+        mode: PracticeMode.part1,
+      );
+      expect(controller.errorMessage, isNull);
+      expect(controller.practiceSessionId, _sessionId);
+      await preparation.beginSession(
+        _sessionId,
+        PracticeMode.part1,
+        const IeltsPracticeSelection(part1SetId: 'p1-set-02'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+            ieltsController: preparation,
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+            completedReportBuilder: (_, practiceSessionId) =>
+                IeltsSpeakingSessionReportPanel(
+                  practiceSessionId: practiceSessionId,
+                  controller: reportController,
+                ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      for (var turn = 0; turn < 4; turn++) {
+        await _answerCurrentShortQuestion(tester, controller);
+      }
+
+      expect(controller.completedTurns, 4);
+      final conversation = tester
+          .widget<ListView>(find.byKey(const Key('ielts-mock-conversation')))
+          .controller!;
+      expect(
+        conversation.position.pixels,
+        closeTo(conversation.position.maxScrollExtent, 0.5),
+      );
+      expect(find.text('Answer 4'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('Part 1 已完成'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part1')),
+        findsNothing,
+      );
+      expect(reportClient.started.isCompleted, isFalse);
+      expect(reportController.practiceSessionId, isNull);
+
+      await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsNothing,
+      );
+      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+      expect(find.text('Answer 4'), findsOneWidget);
+      expect(reportClient.started.isCompleted, isFalse);
+      expect(reportController.practiceSessionId, isNull);
+    },
+  );
+
+  testWidgets('Part 1 completion returns to the section list', (tester) async {
     final practice = _IeltsPracticeClient(initialCompleted: 3, turnLimit: 4);
     final controller = PracticeController(
       client: practice,
@@ -979,21 +1094,14 @@ void main() {
     final preparation = IeltsPreparationController(
       client: _UnusedQuestionBankClient(),
     );
-    final reportClient = _PendingReportClient();
-    final reportController = IeltsSpeakingReportController(
-      client: reportClient,
-    );
     addTearDown(controller.dispose);
     addTearDown(preparation.dispose);
-    addTearDown(reportController.dispose);
     await _activatePractice(
       controller,
       practice,
       _ieltsScene,
       mode: PracticeMode.part1,
     );
-    expect(controller.errorMessage, isNull);
-    expect(controller.practiceSessionId, _sessionId);
     await preparation.beginSession(
       _sessionId,
       PracticeMode.part1,
@@ -1002,34 +1110,38 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        home: IeltsSpeakingMockPage(
-          controller: controller,
-          progressStore: _MemoryProgressStore(),
-          ieltsController: preparation,
-          completedReportBuilder: (_, practiceSessionId) =>
-              IeltsSpeakingSessionReportPanel(
-                practiceSessionId: practiceSessionId,
-                controller: reportController,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              key: const Key('open-section-completion'),
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<IeltsPracticeRouteResult>(
+                  builder: (_) => IeltsSpeakingMockPage(
+                    controller: controller,
+                    progressStore: _MemoryProgressStore(),
+                    ieltsController: preparation,
+                    examinerSpeaker: _ImmediateExaminerSpeaker(),
+                    onExitRequested: () async => true,
+                  ),
+                ),
               ),
+              child: const Text('Open section completion'),
+            ),
+          ),
         ),
       ),
     );
-    await tester.pump();
+    await tester.tap(find.byKey(const Key('open-section-completion')));
+    await tester.pumpAndSettle();
+    await _answerCurrentShortQuestion(tester, controller);
 
-    await tester.tap(find.byKey(const Key('ielts-mock-record')));
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('ielts-mock-record')));
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 220));
+    await tester.tap(find.byKey(const Key('ielts-section-list-action')));
+    await tester.pumpAndSettle();
 
-    expect(controller.completedTurns, 4);
-    expect(
-      find.byKey(const Key('ielts-section-practice-complete-part1')),
-      findsOneWidget,
-    );
-    expect(reportClient.started.isCompleted, isFalse);
-    expect(reportController.practiceSessionId, isNull);
+    final request = preparation.takeNavigationRequest();
+    expect(request?.mode, PracticeMode.part1);
+    expect(request?.selection, isNull);
+    expect(find.byKey(const Key('open-section-completion')), findsOneWidget);
   });
 
   testWidgets('the full-mock PracticeOption opens the three-part flow', (
@@ -1241,49 +1353,66 @@ void main() {
     },
   );
 
-  testWidgets('one-question Part 3 section completes after its original item', (
-    tester,
-  ) async {
-    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
-    final controller = PracticeController(
-      client: practice,
-      recorder: _Recorder(),
-    );
-    addTearDown(controller.dispose);
-    await _activatePractice(
-      controller,
-      practice,
-      _ieltsScene,
-      mode: PracticeMode.part3,
-    );
+  testWidgets(
+    'one-question Part 3 shows its final answer before section review',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await _activatePractice(
+        controller,
+        practice,
+        _ieltsScene,
+        mode: PracticeMode.part3,
+      );
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: IeltsSpeakingMockPage(
-          controller: controller,
-          progressStore: _MemoryProgressStore(),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+          ),
         ),
-      ),
-    );
-    await tester.pump();
+      );
+      await tester.pump();
 
-    await tester.tap(find.byKey(const Key('ielts-part3-start')));
-    await tester.pump();
-    expect(find.text('0/1'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('ielts-part3-start')));
+      await tester.pump();
+      expect(find.text('0/1'), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('ielts-mock-record')));
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('ielts-mock-record')));
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 220));
+      await tester.tap(find.byKey(const Key('ielts-mock-record')));
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('ielts-mock-record')));
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 220));
 
-    expect(controller.completedTurns, 1);
-    expect(
-      find.byKey(const Key('ielts-section-practice-complete-part3')),
-      findsOneWidget,
-    );
-  });
+      expect(controller.completedTurns, 1);
+      expect(find.text('Answer 1'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('Part 3 已完成'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part3')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsNothing,
+      );
+      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+      expect(find.text('Answer 1'), findsOneWidget);
+    },
+  );
 
   testWidgets('full mock completes after a single original Part 3 question', (
     tester,
@@ -1344,6 +1473,16 @@ void main() {
     }
 
     expect(controller.completedTurns, 10);
+    expect(find.text('Answer 10'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('ielts-mock-complete')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump(const Duration(milliseconds: 220));
+
     expect(find.byKey(const Key('ielts-mock-complete')), findsOneWidget);
     expect(find.text('1 题'), findsOneWidget);
   });
@@ -1418,6 +1557,30 @@ Future<void> _activatePractice(
     turnLimit: practice.turnLimit,
     clientOperationId: 'activate-${scene.id}',
   );
+}
+
+Future<void> _answerCurrentShortQuestion(
+  WidgetTester tester,
+  PracticeController controller,
+) async {
+  final completedTurns = controller.completedTurns;
+  await tester.tap(find.byKey(const Key('ielts-mock-record')));
+  await tester.pump();
+  await tester.tap(find.byKey(const Key('ielts-mock-record')));
+  for (
+    var attempt = 0;
+    attempt < 20 && controller.completedTurns == completedTurns;
+    attempt++
+  ) {
+    if (controller.recordingState ==
+        PracticeRecordingState.awaitingConfirmation) {
+      await controller.confirmTranscript();
+    }
+    await tester.pump(const Duration(milliseconds: 20));
+  }
+  await tester.pump(const Duration(milliseconds: 220));
+  await tester.pump(const Duration(milliseconds: 220));
+  expect(controller.completedTurns, completedTurns + 1);
 }
 
 final class _MemoryProgressStore implements IeltsMockProgressStore {


### PR DESCRIPTION
## 功能描述

- 将 IELTS Part 1、Part 2、Part 3 接入统一 Practice 数字人舞台，同时保留既有考试状态机。
- 复用统一考官消息、翻译、Tips、录音与完成操作；Part 2 的 Cue Card、准备/作答计时和笔记保持不变。
- 仅在 Practice 能力允许时创建数字人会话，否则直接展示静态角色画面。
- 兼容已合入 #553 的实时转写：录音中同时展示持续转写文本与实际录音时长。

## 实现思路

- 将场景练习已有的数字人生命周期协调抽成可注入页面内容的 `PracticeAvatarSession`，IELTS 与 Scenario 共用同一连接、打断和重播边界。
- 在共享舞台补充可复用静态角色画面，并删除 Scenario 内被取代的重复占位实现。
- IELTS 页面只重组舞台、会话列表和底部作答区；冻结题单、Turn/Answer 确认、Completion Handoff、Evaluation、Report 与 Review 链路不变。
- 分支已更新到最新 `upstream/dev`；与 #553 重叠的改动由主线提供，本 PR 仅保留 #532 的录音计时与舞台语义。

## 可复现测试

在 `mobile` 目录执行：

```bash
flutter analyze --no-pub
flutter test --no-pub \
  test/speak_up_app_test.dart \
  test/coaching/practice/ielts_mock_practice_test.dart \
  test/coaching/practice/ielts_mock_progress_store_test.dart \
  test/coaching/practice/practice_stage_test.dart \
  test/coaching/practice/scenario_practice_session_test.dart
flutter test --no-pub \
  test/coaching/practice/practice_realtime_controller_test.dart \
  test/design/practice_conversation_components_test.dart
```

结果：Flutter analyze 通过；83 项定向测试全部通过。

另已通过：

```bash
dart format --output=none --set-exit-if-changed <本 PR 的 7 个 Dart 文件>
git diff --check upstream/dev...HEAD
```

Closes #532
Related to #531 and #553