### PR TITLE
feat(agent): 首页提供无持久化实时转写

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -335,6 +335,95 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads/{thread_id}/voice-transcriptions/realtime:
+    parameters:
+      - $ref: '#/components/parameters/AgentThreadId'
+    get:
+      tags:
+        - Agent
+      summary: Stream one non-persistent Agent voice transcription
+      description: |
+        Upgrade to a Thread-scoped WebSocket that sends mono PCM s16le frames
+        directly to the configured realtime speech recognizer. The server
+        authenticates the Bearer Session, resolves Thread ownership, and
+        validates `Sec-WebSocket-Protocol` before upgrading. The accepted
+        connection is bound to that Actor and Thread; switching accounts
+        requires closing it and authenticating a new connection.
+
+        The client first sends `start` with an 8-128 character idempotency key
+        and `sample_rate=16000`, then binary PCM frames, followed by `finish` or
+        `cancel`. At most 1,920,000 PCM bytes are accepted. The server emits
+        `transcription.started`, zero or more `transcription.updated`, and one
+        `transcription.completed` or `transcription.failed` terminal event.
+        Idempotency keys validate the live attempt only; this ephemeral stream
+        does not persist or replay a prior result.
+
+        This operation never creates a Voice Candidate, Agent Message, audio
+        attachment, transcript evidence, or object-storage entry. After
+        `transcription.completed`, clients submit edited text through the
+        existing Agent Run endpoint.
+      operationId: streamAgentVoiceTranscription
+      parameters:
+        - name: Sec-WebSocket-Protocol
+          in: header
+          required: true
+          description: Required Agent voice input subprotocol.
+          schema:
+            type: string
+            const: speakup.voice-input.v1
+      responses:
+        '101':
+          description: WebSocket protocol upgrade accepted.
+          headers:
+            Sec-WebSocket-Protocol:
+              description: Negotiated Agent voice input protocol.
+              schema:
+                type: string
+                const: speakup.voice-input.v1
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+      x-websocket-client-text-frame-schema:
+        $ref: ../websocket/agent-voice-transcription.schema.json#/$defs/ClientTextFrame
+      x-websocket-event-schema:
+        $ref: ../websocket/agent-voice-transcription.schema.json#/$defs/ServerEvent
+      x-websocket-security:
+        credential_location: authorization_header
+        header: Authorization
+        scheme: Bearer
+        other_credential_locations_allowed: false
+        production_transport: wss
+        local_loopback_transport: ws
+        pre_upgrade:
+          validation_order:
+            - session
+            - actor
+            - resource_ownership
+            - subprotocol
+            - upgrade
+          authentication_failure:
+            http_status: 401
+            error_code: authentication_required
+          resource_not_visible:
+            http_status: 404
+            error_code: resource_not_found
+        reconnect:
+          reauthenticate: true
+        connection_binding:
+          actor_fields:
+            - user_id
+            - session_id
+          target_field: thread_id
+          target_switch_allowed: false
+        subprotocol:
+          allowed:
+            - speakup.voice-input.v1
+          carries_credentials: false
   /v1/agent-threads/{thread_id}/voice-message-candidates:
     parameters:
       - $ref: '#/components/parameters/AgentThreadId'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -131,6 +131,8 @@ paths:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-image-assets~1{image_asset_id}
   /v1/agent-threads/{thread_id}/voice-message-candidates:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1voice-message-candidates
+  /v1/agent-threads/{thread_id}/voice-transcriptions/realtime:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1voice-transcriptions~1realtime
   /v1/agent-voice-message-candidates/{candidate_id}:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-voice-message-candidates~1{candidate_id}
   /v1/agent-voice-message-candidates/{candidate_id}/retries:

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "check": "npm run lint:openapi && npm run validate:security && npm run validate:websocket && npm run validate:fixture && npm run validate:evaluation && npm run validate:speech-feedback",
     "lint:openapi": "redocly lint openapi.yaml --config redocly.yaml",
     "validate:security": "node scripts/validate-security.mjs",
-    "validate:websocket": "node scripts/validate-events.mjs",
+    "validate:websocket": "node scripts/validate-events.mjs && node scripts/validate-agent-voice-transcription.mjs",
     "validate:fixture": "node scripts/validate-main-flow.mjs",
     "validate:evaluation": "node scripts/validate-evaluation.mjs",
     "validate:speech-feedback": "node scripts/validate-speech-feedback.mjs"

--- a/api/scripts/validate-agent-voice-transcription.mjs
+++ b/api/scripts/validate-agent-voice-transcription.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const schema = JSON.parse(
+  await readFile(
+    resolve(
+      apiDirectory,
+      'websocket/agent-voice-transcription.schema.json',
+    ),
+    { encoding: 'utf8' },
+  ),
+);
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+ajv.addSchema(schema);
+const compileDefinition = (name) =>
+  ajv.compile({ $ref: `${schema.$id}#/$defs/${name}` });
+const validateClient = compileDefinition('ClientTextFrame');
+const validateServer = compileDefinition('ServerEvent');
+
+const validClientFrames = [
+  { type: 'start', idempotency_key: 'voice-input-1', sample_rate: 16000 },
+  { type: 'start', idempotency_key: '实时转写幂等键值', sample_rate: 16000 },
+  { type: 'finish' },
+  { type: 'cancel' },
+];
+const validServerEvents = [
+  { type: 'transcription.started', data: {} },
+  {
+    type: 'transcription.updated',
+    data: { transcript: 'I would', final: false },
+  },
+  {
+    type: 'transcription.completed',
+    data: { transcript: 'I would like to practice.', final: true },
+  },
+  {
+    type: 'transcription.failed',
+    data: { kind: 'timeout', retryable: true },
+  },
+];
+for (const frame of validClientFrames) {
+  assert.equal(validateClient(frame), true, ajv.errorsText(validateClient.errors));
+}
+for (const event of validServerEvents) {
+  assert.equal(validateServer(event), true, ajv.errorsText(validateServer.errors));
+}
+
+const invalidClientFrames = [
+  { type: 'start', idempotency_key: 'short', sample_rate: 16000 },
+  { type: 'start', idempotency_key: '🙂🙂', sample_rate: 16000 },
+  { type: 'start', idempotency_key: ' voice-input-1 ', sample_rate: 16000 },
+  { type: 'start', idempotency_key: 'voice-input-1', sample_rate: 8000 },
+  { type: 'finish', transcript: 'client-controlled' },
+  { type: 'unknown' },
+];
+const invalidServerEvents = [
+  {
+    type: 'transcription.updated',
+    data: { transcript: 'Not final.', final: true },
+  },
+  {
+    type: 'transcription.completed',
+    data: { transcript: 'Still partial.', final: false },
+  },
+  { type: 'candidate.ready', data: {} },
+  {
+    type: 'transcription.failed',
+    data: { kind: 'timeout', retryable: true, provider_payload: 'forbidden' },
+  },
+];
+for (const frame of invalidClientFrames) {
+  assert.equal(validateClient(frame), false, `accepted client frame ${frame.type}`);
+}
+for (const event of invalidServerEvents) {
+  assert.equal(validateServer(event), false, `accepted server event ${event.type}`);
+}
+
+console.log(
+  `Validated ${validClientFrames.length} Agent transcription controls, ` +
+    `${validServerEvents.length} server events, and ` +
+    `${invalidClientFrames.length + invalidServerEvents.length} rejections.`,
+);

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -1152,6 +1152,49 @@ assert.equal(
 );
 assert.equal(websocketParameters.after_sequence?.in, 'query');
 
+const agentVoiceTranscription = requireOperation(
+  'GET /v1/agent-threads/{thread_id}/voice-transcriptions/realtime',
+);
+assert.deepEqual(
+  agentVoiceTranscription.security ?? openApi.security,
+  bearerSecurity,
+  'Agent voice transcription must derive the Actor from BearerSession.',
+);
+const agentVoiceSecurity = agentVoiceTranscription['x-websocket-security'];
+assert.equal(agentVoiceSecurity?.credential_location, 'authorization_header');
+assert.equal(agentVoiceSecurity?.other_credential_locations_allowed, false);
+assert.deepEqual(agentVoiceSecurity?.pre_upgrade?.validation_order, [
+  'session',
+  'actor',
+  'resource_ownership',
+  'subprotocol',
+  'upgrade',
+]);
+assert.deepEqual(agentVoiceSecurity?.connection_binding, {
+  actor_fields: ['user_id', 'session_id'],
+  target_field: 'thread_id',
+  target_switch_allowed: false,
+});
+assert.deepEqual(agentVoiceSecurity?.subprotocol?.allowed, [
+  'speakup.voice-input.v1',
+]);
+const agentVoiceParameters = Object.fromEntries(
+  (agentVoiceTranscription.parameters ?? []).map((parameterValue) => {
+    const parameter = resolveLocalReference(parameterValue);
+    return [parameter.name, parameter];
+  }),
+);
+assert.equal(
+  agentVoiceParameters['Sec-WebSocket-Protocol']?.required,
+  true,
+);
+assert.equal(
+  resolveLocalReference(
+    agentVoiceParameters['Sec-WebSocket-Protocol']?.schema,
+  )?.const,
+  'speakup.voice-input.v1',
+);
+
 const interviewReport = requireOperation(
   'GET /v1/practice-sessions/{practice_session_id}/interview-report',
 );

--- a/api/websocket/agent-voice-transcription.schema.json
+++ b/api/websocket/agent-voice-transcription.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speak-up.top/api/schemas/websocket/agent-voice-transcription.schema.json",
+  "title": "Agent ephemeral voice transcription",
+  "description": "Client text controls and server events for one authenticated, non-persistent Agent voice transcription WebSocket.",
+  "$defs": {
+    "ClientTextFrame": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/StartFrame"
+        },
+        {
+          "$ref": "#/$defs/FinishFrame"
+        },
+        {
+          "$ref": "#/$defs/CancelFrame"
+        }
+      ]
+    },
+    "StartFrame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "idempotency_key", "sample_rate"],
+      "properties": {
+        "type": {
+          "const": "start"
+        },
+        "idempotency_key": {
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 128,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$"
+        },
+        "sample_rate": {
+          "const": 16000
+        }
+      }
+    },
+    "FinishFrame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "finish"
+        }
+      }
+    },
+    "CancelFrame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "cancel"
+        }
+      }
+    },
+    "ServerEvent": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/TranscriptionStarted"
+        },
+        {
+          "$ref": "#/$defs/TranscriptionUpdated"
+        },
+        {
+          "$ref": "#/$defs/TranscriptionCompleted"
+        },
+        {
+          "$ref": "#/$defs/TranscriptionFailed"
+        }
+      ]
+    },
+    "TranscriptionStarted": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "transcription.started"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    },
+    "TranscriptionUpdated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "transcription.updated"
+        },
+        "data": {
+          "$ref": "#/$defs/PartialTranscript"
+        }
+      }
+    },
+    "TranscriptionCompleted": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "transcription.completed"
+        },
+        "data": {
+          "$ref": "#/$defs/FinalTranscript"
+        }
+      }
+    },
+    "TranscriptionFailed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "transcription.failed"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "retryable"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "minLength": 1
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "PartialTranscript": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transcript", "final"],
+      "properties": {
+        "transcript": {
+          "type": "string",
+          "minLength": 1
+        },
+        "final": {
+          "const": false
+        }
+      }
+    },
+    "FinalTranscript": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transcript", "final"],
+      "properties": {
+        "transcript": {
+          "type": "string",
+          "minLength": 1
+        },
+        "final": {
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/server/internal/agent/input/voice/http/ephemeral_realtime.go
+++ b/server/internal/agent/input/voice/http/ephemeral_realtime.go
@@ -1,0 +1,377 @@
+package voicehttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var (
+	errEphemeralAudioCapacity = errors.New(
+		"agent ephemeral transcription audio exceeds the accepted size",
+	)
+	errEphemeralInvalidAudio = errors.New(
+		"agent ephemeral transcription audio is invalid",
+	)
+	errEphemeralInvalidFrame = errors.New(
+		"agent ephemeral transcription frame is invalid",
+	)
+)
+
+type EphemeralTranscriptionHandler struct {
+	recognizer  agentvoice.PCMStreamingSpeechRecognizer
+	threads     ThreadReader
+	readTimeout time.Duration
+	errors      *httpresponse.Renderer
+}
+
+func NewEphemeralTranscriptionHandler(
+	recognizer agentvoice.PCMStreamingSpeechRecognizer,
+	threads ThreadReader,
+	readTimeout time.Duration,
+	errorRenderer *httpresponse.Renderer,
+) (*EphemeralTranscriptionHandler, error) {
+	if recognizer == nil || threads == nil || readTimeout < 0 {
+		return nil, errors.New(
+			"agent ephemeral transcription: HTTP dependencies are required",
+		)
+	}
+	if readTimeout == 0 {
+		readTimeout = defaultReadTimeout
+	}
+	if errorRenderer == nil {
+		errorRenderer = httpresponse.NewRenderer(nil)
+	}
+	return &EphemeralTranscriptionHandler{
+		recognizer:  recognizer,
+		threads:     threads,
+		readTimeout: readTimeout,
+		errors:      errorRenderer,
+	}, nil
+}
+
+func (handler *EphemeralTranscriptionHandler) RegisterRoutes(
+	routes gin.IRoutes,
+) {
+	routes.GET(
+		"/v1/agent-threads/:thread_id/voice-transcriptions/realtime",
+		handler.transcribeRealtime,
+	)
+}
+
+func (handler *EphemeralTranscriptionHandler) transcribeRealtime(
+	c *gin.Context,
+) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	if _, err := handler.threads.GetThread(
+		c.Request.Context(), actor, c.Param("thread_id"),
+	); err != nil {
+		handler.write(c, mapThreadError(err))
+		return
+	}
+	if !containsWebSocketProtocol(
+		websocket.Subprotocols(c.Request),
+		voiceInputWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := (&websocket.Upgrader{
+		Subprotocols: []string{voiceInputWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	connection.SetReadLimit(platformmedia.MaxAudioBytes)
+	if err := connection.SetReadDeadline(
+		time.Now().Add(handler.readTimeout),
+	); err != nil {
+		return
+	}
+	events := &ephemeralTranscriptionWriter{
+		connection: connection,
+		timeout:    handler.readTimeout,
+	}
+	start, err := readEphemeralStart(connection)
+	if err != nil {
+		_ = events.fail("invalid_request", false)
+		return
+	}
+	if err := events.write("transcription.started", gin.H{}); err != nil {
+		return
+	}
+
+	streamContext, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+	reader, writer := io.Pipe()
+	type transcriptionResult struct {
+		result agentvoice.TranscriptionResult
+		err    error
+	}
+	completed := make(chan transcriptionResult, 1)
+	go func() {
+		defer reader.Close()
+		result, transcribeErr := handler.recognizer.TranscribePCMStream(
+			streamContext,
+			agentvoice.PCMTranscriptionRequest{
+				PCM: reader, SampleRate: start.SampleRate,
+			},
+			events,
+		)
+		completed <- transcriptionResult{result: result, err: transcribeErr}
+	}()
+
+	streamed := make(chan error, 1)
+	go func() {
+		streamed <- streamEphemeralPCM(
+			connection,
+			writer,
+			handler.readTimeout,
+		)
+	}()
+	var streamErr error
+	var transcription transcriptionResult
+	select {
+	case streamErr = <-streamed:
+		if streamErr != nil {
+			cancel()
+			_ = writer.CloseWithError(streamErr)
+		} else {
+			_ = writer.Close()
+		}
+		transcription = <-completed
+	case transcription = <-completed:
+		cancel()
+		if transcription.err != nil {
+			_ = writer.CloseWithError(transcription.err)
+		} else {
+			_ = writer.Close()
+		}
+	}
+	if streamErr != nil {
+		kind, retryable, localFailure := ephemeralStreamFailure(streamErr)
+		if !localFailure && transcription.err != nil {
+			kind, retryable = ephemeralProviderFailure(transcription.err)
+		}
+		_ = events.fail(kind, retryable)
+		return
+	}
+	if transcription.err != nil {
+		kind, retryable := ephemeralProviderFailure(transcription.err)
+		_ = events.fail(kind, retryable)
+		return
+	}
+	transcript := strings.TrimSpace(transcription.result.Transcript)
+	if transcript == "" {
+		_ = events.fail("invalid_response", true)
+		return
+	}
+	_ = events.complete(gin.H{
+		"transcript": transcript,
+		"final":      true,
+	})
+}
+
+func readEphemeralStart(
+	connection *websocket.Conn,
+) (realtimeStartFrame, error) {
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.TextMessage {
+		return realtimeStartFrame{}, errEphemeralInvalidFrame
+	}
+	var frame realtimeStartFrame
+	if err := decodeEphemeralTextFrame(payload, &frame); err != nil ||
+		frame.Type != "start" ||
+		frame.IdempotencyKey != strings.TrimSpace(frame.IdempotencyKey) ||
+		utf8.RuneCountInString(frame.IdempotencyKey) < 8 ||
+		utf8.RuneCountInString(frame.IdempotencyKey) > 128 ||
+		frame.SampleRate != 16_000 {
+		return realtimeStartFrame{}, errEphemeralInvalidFrame
+	}
+	return frame, nil
+}
+
+func streamEphemeralPCM(
+	connection *websocket.Conn,
+	destination io.Writer,
+	readTimeout time.Duration,
+) error {
+	written := 0
+	for {
+		if err := connection.SetReadDeadline(
+			time.Now().Add(readTimeout),
+		); err != nil {
+			return err
+		}
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			return err
+		}
+		switch messageType {
+		case websocket.BinaryMessage:
+			if len(payload) == 0 {
+				return errEphemeralInvalidAudio
+			}
+			if written+len(payload) > maxRealtimePCMBytes {
+				return errEphemeralAudioCapacity
+			}
+			if _, err := destination.Write(payload); err != nil {
+				return err
+			}
+			written += len(payload)
+		case websocket.TextMessage:
+			var frame realtimeControlFrame
+			if err := decodeEphemeralTextFrame(payload, &frame); err != nil {
+				return errEphemeralInvalidFrame
+			}
+			switch frame.Type {
+			case "finish":
+				if written == 0 || written%2 != 0 {
+					return errEphemeralInvalidAudio
+				}
+				return nil
+			case "cancel":
+				return context.Canceled
+			default:
+				return errEphemeralInvalidFrame
+			}
+		default:
+			return errEphemeralInvalidFrame
+		}
+	}
+}
+
+func decodeEphemeralTextFrame(payload []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return errEphemeralInvalidFrame
+	}
+	return nil
+}
+
+type ephemeralTranscriptionWriter struct {
+	connection *websocket.Conn
+	timeout    time.Duration
+	mutex      sync.Mutex
+	terminal   bool
+}
+
+func (writer *ephemeralTranscriptionWriter) OnTranscriptionUpdate(
+	_ context.Context,
+	update agentvoice.TranscriptionUpdate,
+) error {
+	transcript := strings.TrimSpace(update.Transcript)
+	if update.Final || transcript == "" {
+		return nil
+	}
+	return writer.write("transcription.updated", gin.H{
+		"transcript": transcript,
+		"final":      false,
+	})
+}
+
+func (writer *ephemeralTranscriptionWriter) write(
+	event string,
+	data any,
+) error {
+	writer.mutex.Lock()
+	defer writer.mutex.Unlock()
+	if writer.terminal {
+		return nil
+	}
+	return writer.writeLocked(event, data)
+}
+
+func (writer *ephemeralTranscriptionWriter) complete(data any) error {
+	return writer.writeTerminal("transcription.completed", data)
+}
+
+func (writer *ephemeralTranscriptionWriter) fail(
+	kind string,
+	retryable bool,
+) error {
+	return writer.writeTerminal("transcription.failed", gin.H{
+		"kind": kind, "retryable": retryable,
+	})
+}
+
+func (writer *ephemeralTranscriptionWriter) writeTerminal(
+	event string,
+	data any,
+) error {
+	writer.mutex.Lock()
+	defer writer.mutex.Unlock()
+	if writer.terminal {
+		return nil
+	}
+	writer.terminal = true
+	return writer.writeLocked(event, data)
+}
+
+func (writer *ephemeralTranscriptionWriter) writeLocked(
+	event string,
+	data any,
+) error {
+	if err := writer.connection.SetWriteDeadline(
+		time.Now().Add(writer.timeout),
+	); err != nil {
+		return err
+	}
+	return writer.connection.WriteJSON(gin.H{"type": event, "data": data})
+}
+
+func ephemeralStreamFailure(err error) (string, bool, bool) {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "cancelled", false, true
+	case errors.Is(err, errEphemeralAudioCapacity):
+		return "audio_capacity", false, true
+	case errors.Is(err, errEphemeralInvalidAudio):
+		return "invalid_audio", false, true
+	case errors.Is(err, errEphemeralInvalidFrame):
+		return "invalid_request", false, true
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return "timeout", true, true
+	}
+	return "stream_interrupted", true, false
+}
+
+func ephemeralProviderFailure(err error) (string, bool) {
+	var speechError *agentvoice.SpeechError
+	if errors.As(err, &speechError) {
+		return string(speechError.Kind), speechError.Retryable()
+	}
+	return "stream_interrupted", true
+}
+
+func (handler *EphemeralTranscriptionHandler) write(
+	c *gin.Context,
+	err error,
+) {
+	writeHTTPError(c, handler.errors, err)
+}

--- a/server/internal/agent/input/voice/http/ephemeral_realtime_test.go
+++ b/server/internal/agent/input/voice/http/ephemeral_realtime_test.go
@@ -1,0 +1,668 @@
+package voicehttp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const ephemeralTestThreadID = "10000000-0000-4000-8000-000000000001"
+
+func TestEphemeralTranscriptionStreamsBeforeFinishWithoutVoicePersistence(
+	t *testing.T,
+) {
+	recognizer := newEphemeralTestRecognizer()
+	legacy := &voiceInputHTTPApplication{}
+	server := httptest.NewServer(newEphemeralHTTPTestRouter(
+		t,
+		recognizer,
+		&ephemeralThreadReader{},
+		legacy,
+		time.Second,
+	))
+	defer server.Close()
+
+	connection := dialEphemeralTranscription(
+		t,
+		server.URL,
+		ephemeralTestThreadID,
+		"Bearer voice-token-a",
+		voiceInputWebSocketProtocol,
+	)
+	defer connection.Close()
+	writeEphemeralStart(t, connection, "ephemeral-voice-1", 16_000)
+	started := readEphemeralEvent(t, connection)
+	var startedData map[string]any
+	if err := json.Unmarshal(started.Data, &startedData); err != nil ||
+		started.Type != "transcription.started" || len(startedData) != 0 {
+		t.Fatalf("started event = %#v", started)
+	}
+
+	pcm := make([]byte, 3_200)
+	if err := connection.WriteMessage(websocket.BinaryMessage, pcm); err != nil {
+		t.Fatalf("write PCM: %v", err)
+	}
+	// The client has deliberately not sent finish yet. Receiving this event
+	// proves the provider consumes the live io.Pipe instead of a buffered WAV.
+	updated := readEphemeralEvent(t, connection)
+	assertEphemeralTranscriptEvent(
+		t,
+		updated,
+		"transcription.updated",
+		"partial transcript",
+		false,
+	)
+	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
+		t.Fatalf("write finish: %v", err)
+	}
+	completed := readEphemeralEvent(t, connection)
+	assertEphemeralTranscriptEvent(
+		t,
+		completed,
+		"transcription.completed",
+		"completed transcript",
+		true,
+	)
+	if recognizer.Calls() != 1 || recognizer.Bytes() != int64(len(pcm)) {
+		t.Fatalf(
+			"recognizer calls = %d bytes = %d",
+			recognizer.Calls(),
+			recognizer.Bytes(),
+		)
+	}
+	if legacy.streamCalls != 0 || legacy.uploadBytes != 0 ||
+		legacy.confirmCalls != 0 || legacy.deleteCandidateCalls != 0 {
+		t.Fatalf("durable Voice application was called: %#v", legacy)
+	}
+}
+
+func TestEphemeralTranscriptionRejectsAuthenticationOwnershipAndProtocol(
+	t *testing.T,
+) {
+	recognizer := newEphemeralTestRecognizer()
+	threads := &ephemeralThreadReader{}
+	server := httptest.NewServer(newEphemeralHTTPTestRouter(
+		t,
+		recognizer,
+		threads,
+		nil,
+		time.Second,
+	))
+	defer server.Close()
+	endpoint := ephemeralWebSocketEndpoint(server.URL, ephemeralTestThreadID)
+
+	tests := []struct {
+		name       string
+		token      string
+		protocols  []string
+		wantStatus int
+	}{
+		{"authentication", "", []string{voiceInputWebSocketProtocol}, http.StatusUnauthorized},
+		{"ownership", "Bearer voice-token-b", []string{voiceInputWebSocketProtocol}, http.StatusNotFound},
+		{"missing protocol", "Bearer voice-token-a", nil, http.StatusBadRequest},
+		{"wrong protocol", "Bearer voice-token-a", []string{"speakup.other.v1"}, http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header := http.Header{}
+			if test.token != "" {
+				header.Set("Authorization", test.token)
+			}
+			connection, response, err := (&websocket.Dialer{
+				Subprotocols: test.protocols,
+			}).Dial(endpoint, header)
+			if connection != nil {
+				_ = connection.Close()
+			}
+			if err == nil || response == nil ||
+				response.StatusCode != test.wantStatus {
+				t.Fatalf(
+					"dial error = %v status = %#v, want %d",
+					err,
+					response,
+					test.wantStatus,
+				)
+			}
+		})
+	}
+	if recognizer.Calls() != 0 {
+		t.Fatalf("recognizer calls = %d", recognizer.Calls())
+	}
+}
+
+func TestEphemeralTranscriptionValidatesStartAndAudioCapacity(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		key        string
+		sampleRate int
+		raw        string
+	}{
+		{name: "idempotency key", key: "short", sampleRate: 16_000},
+		{name: "unicode idempotency key", key: "🙂🙂", sampleRate: 16_000},
+		{name: "padded idempotency key", key: " ephemeral-voice-2 ", sampleRate: 16_000},
+		{name: "sample rate", key: "ephemeral-voice-2", sampleRate: 8_000},
+		{
+			name: "concatenated JSON",
+			raw: `{"type":"start","idempotency_key":"ephemeral-voice-2",` +
+				`"sample_rate":16000}{"type":"finish"}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			recognizer := newEphemeralTestRecognizer()
+			server := httptest.NewServer(newEphemeralHTTPTestRouter(
+				t,
+				recognizer,
+				&ephemeralThreadReader{},
+				nil,
+				time.Second,
+			))
+			defer server.Close()
+			connection := dialEphemeralTranscription(
+				t,
+				server.URL,
+				ephemeralTestThreadID,
+				"Bearer voice-token-a",
+				voiceInputWebSocketProtocol,
+			)
+			defer connection.Close()
+			if test.raw == "" {
+				writeEphemeralStart(t, connection, test.key, test.sampleRate)
+			} else if err := connection.WriteMessage(
+				websocket.TextMessage,
+				[]byte(test.raw),
+			); err != nil {
+				t.Fatal(err)
+			}
+			assertEphemeralFailure(
+				t,
+				readEphemeralEvent(t, connection),
+				"invalid_request",
+				false,
+			)
+			if recognizer.Calls() != 0 {
+				t.Fatalf("recognizer calls = %d", recognizer.Calls())
+			}
+		})
+	}
+
+	recognizer := newEphemeralTestRecognizer()
+	server := httptest.NewServer(newEphemeralHTTPTestRouter(
+		t,
+		recognizer,
+		&ephemeralThreadReader{},
+		nil,
+		time.Second,
+	))
+	defer server.Close()
+	connection := dialEphemeralTranscription(
+		t,
+		server.URL,
+		ephemeralTestThreadID,
+		"Bearer voice-token-a",
+		voiceInputWebSocketProtocol,
+	)
+	defer connection.Close()
+	writeEphemeralStart(t, connection, "ephemeral-voice-3", 16_000)
+	if event := readEphemeralEvent(t, connection); event.Type != "transcription.started" {
+		t.Fatalf("started event = %#v", event)
+	}
+	if err := connection.WriteMessage(
+		websocket.BinaryMessage,
+		make([]byte, maxRealtimePCMBytes+2),
+	); err != nil {
+		t.Fatalf("write oversized PCM: %v", err)
+	}
+	assertEphemeralFailure(
+		t,
+		readEphemeralEvent(t, connection),
+		"audio_capacity",
+		false,
+	)
+	waitForEphemeralRecognizerStop(t, recognizer)
+}
+
+func TestEphemeralTranscriptionReturnsProviderFailure(t *testing.T) {
+	recognizer := failingEphemeralRecognizer{}
+	server := httptest.NewServer(newEphemeralHTTPTestRouter(
+		t,
+		recognizer,
+		&ephemeralThreadReader{},
+		nil,
+		time.Second,
+	))
+	defer server.Close()
+	connection := dialEphemeralTranscription(
+		t,
+		server.URL,
+		ephemeralTestThreadID,
+		"Bearer voice-token-a",
+		voiceInputWebSocketProtocol,
+	)
+	defer connection.Close()
+	writeEphemeralStart(t, connection, "ephemeral-provider", 16_000)
+	if event := readEphemeralEvent(t, connection); event.Type != "transcription.started" {
+		t.Fatalf("started event = %#v", event)
+	}
+	// A provider can reject the request before the client sends its first PCM
+	// frame. The failure must not be delayed until the client read timeout.
+	assertEphemeralFailure(
+		t,
+		readEphemeralEvent(t, connection),
+		"provider_unavailable",
+		true,
+	)
+}
+
+func TestEphemeralTranscriptionCancelsDisconnectsAndTimesOut(t *testing.T) {
+	t.Run("cancel", func(t *testing.T) {
+		recognizer := newEphemeralTestRecognizer()
+		server := httptest.NewServer(newEphemeralHTTPTestRouter(
+			t,
+			recognizer,
+			&ephemeralThreadReader{},
+			nil,
+			time.Second,
+		))
+		defer server.Close()
+		connection := dialEphemeralTranscription(
+			t,
+			server.URL,
+			ephemeralTestThreadID,
+			"Bearer voice-token-a",
+			voiceInputWebSocketProtocol,
+		)
+		defer connection.Close()
+		writeEphemeralStart(t, connection, "ephemeral-cancel", 16_000)
+		_ = readEphemeralEvent(t, connection)
+		if err := connection.WriteMessage(
+			websocket.BinaryMessage,
+			make([]byte, 320),
+		); err != nil {
+			t.Fatal(err)
+		}
+		_ = readEphemeralEvent(t, connection)
+		if err := connection.WriteJSON(map[string]string{"type": "cancel"}); err != nil {
+			t.Fatal(err)
+		}
+		assertEphemeralFailure(
+			t,
+			readEphemeralEvent(t, connection),
+			"cancelled",
+			false,
+		)
+		waitForEphemeralRecognizerStop(t, recognizer)
+	})
+
+	t.Run("disconnect", func(t *testing.T) {
+		recognizer := newEphemeralTestRecognizer()
+		server := httptest.NewServer(newEphemeralHTTPTestRouter(
+			t,
+			recognizer,
+			&ephemeralThreadReader{},
+			nil,
+			time.Second,
+		))
+		defer server.Close()
+		connection := dialEphemeralTranscription(
+			t,
+			server.URL,
+			ephemeralTestThreadID,
+			"Bearer voice-token-a",
+			voiceInputWebSocketProtocol,
+		)
+		writeEphemeralStart(t, connection, "ephemeral-disconnect", 16_000)
+		_ = readEphemeralEvent(t, connection)
+		if err := connection.WriteMessage(
+			websocket.BinaryMessage,
+			make([]byte, 320),
+		); err != nil {
+			t.Fatal(err)
+		}
+		_ = readEphemeralEvent(t, connection)
+		if err := connection.Close(); err != nil {
+			t.Fatal(err)
+		}
+		waitForEphemeralRecognizerStop(t, recognizer)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		recognizer := newEphemeralTestRecognizer()
+		server := httptest.NewServer(newEphemeralHTTPTestRouter(
+			t,
+			recognizer,
+			&ephemeralThreadReader{},
+			nil,
+			50*time.Millisecond,
+		))
+		defer server.Close()
+		connection := dialEphemeralTranscription(
+			t,
+			server.URL,
+			ephemeralTestThreadID,
+			"Bearer voice-token-a",
+			voiceInputWebSocketProtocol,
+		)
+		defer connection.Close()
+		writeEphemeralStart(t, connection, "ephemeral-timeout", 16_000)
+		_ = readEphemeralEvent(t, connection)
+		assertEphemeralFailure(
+			t,
+			readEphemeralEvent(t, connection),
+			"timeout",
+			true,
+		)
+		waitForEphemeralRecognizerStop(t, recognizer)
+	})
+}
+
+type ephemeralEvent struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+func dialEphemeralTranscription(
+	t *testing.T,
+	baseURL string,
+	threadID string,
+	token string,
+	protocol string,
+) *websocket.Conn {
+	t.Helper()
+	header := http.Header{"Authorization": []string{token}}
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{protocol},
+	}).Dial(ephemeralWebSocketEndpoint(baseURL, threadID), header)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial ephemeral transcription: %v", err)
+	}
+	if connection.Subprotocol() != voiceInputWebSocketProtocol {
+		t.Fatalf("subprotocol = %q", connection.Subprotocol())
+	}
+	return connection
+}
+
+func ephemeralWebSocketEndpoint(baseURL string, threadID string) string {
+	return "ws" + strings.TrimPrefix(baseURL, "http") +
+		"/v1/agent-threads/" + threadID +
+		"/voice-transcriptions/realtime"
+}
+
+func writeEphemeralStart(
+	t *testing.T,
+	connection *websocket.Conn,
+	key string,
+	sampleRate int,
+) {
+	t.Helper()
+	if err := connection.WriteJSON(map[string]any{
+		"type": "start", "idempotency_key": key, "sample_rate": sampleRate,
+	}); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+}
+
+func readEphemeralEvent(
+	t *testing.T,
+	connection *websocket.Conn,
+) ephemeralEvent {
+	t.Helper()
+	if err := connection.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var event ephemeralEvent
+	if err := connection.ReadJSON(&event); err != nil {
+		t.Fatalf("read ephemeral event: %v", err)
+	}
+	return event
+}
+
+func assertEphemeralTranscriptEvent(
+	t *testing.T,
+	event ephemeralEvent,
+	eventType string,
+	transcript string,
+	final bool,
+) {
+	t.Helper()
+	var data struct {
+		Transcript string `json:"transcript"`
+		Final      bool   `json:"final"`
+	}
+	if err := json.Unmarshal(event.Data, &data); err != nil ||
+		event.Type != eventType || data.Transcript != transcript ||
+		data.Final != final {
+		t.Fatalf("event = %#v data = %#v err = %v", event, data, err)
+	}
+}
+
+func assertEphemeralFailure(
+	t *testing.T,
+	event ephemeralEvent,
+	kind string,
+	retryable bool,
+) {
+	t.Helper()
+	var data struct {
+		Kind      string `json:"kind"`
+		Retryable bool   `json:"retryable"`
+	}
+	if err := json.Unmarshal(event.Data, &data); err != nil ||
+		event.Type != "transcription.failed" || data.Kind != kind ||
+		data.Retryable != retryable {
+		t.Fatalf("failure = %#v data = %#v err = %v", event, data, err)
+	}
+}
+
+func newEphemeralHTTPTestRouter(
+	t *testing.T,
+	recognizer agentvoice.PCMStreamingSpeechRecognizer,
+	threads ThreadReader,
+	legacy Application,
+	readTimeout time.Duration,
+) http.Handler {
+	t.Helper()
+	renderer := httpresponse.NewRenderer(
+		func() string { return "corr_agent_ephemeral_transcription" },
+	)
+	handler, err := NewEphemeralTranscriptionHandler(
+		recognizer,
+		threads,
+		readTimeout,
+		renderer,
+	)
+	if err != nil {
+		t.Fatalf("new ephemeral transcription handler: %v", err)
+	}
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		var actor requestcontext.Actor
+		switch c.GetHeader("Authorization") {
+		case "Bearer voice-token-a":
+			actor = requestcontext.Actor{UserID: "user-a", SessionID: "session-a"}
+		case "Bearer voice-token-b":
+			actor = requestcontext.Actor{UserID: "user-b", SessionID: "session-b"}
+		}
+		if actor.Valid() {
+			c.Request = c.Request.WithContext(
+				requestcontext.WithActor(c.Request.Context(), actor),
+			)
+		}
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	if legacy != nil {
+		legacyHandler, legacyErr := NewHandler(
+			legacy,
+			threads,
+			readTimeout,
+			renderer,
+		)
+		if legacyErr != nil {
+			t.Fatalf("new legacy voice handler: %v", legacyErr)
+		}
+		legacyHandler.RegisterRoutes(router)
+	}
+	return router
+}
+
+type ephemeralThreadReader struct {
+	calls atomic.Int64
+}
+
+func (reader *ephemeralThreadReader) GetThread(
+	_ context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) (agentconversation.Thread, error) {
+	reader.calls.Add(1)
+	if actor.UserID != "user-a" || threadID != ephemeralTestThreadID {
+		return agentconversation.Thread{}, agentconversation.ErrNotFound
+	}
+	return agentconversation.Thread{
+		ID: threadID, OwnerID: actor.UserID,
+	}, nil
+}
+
+type ephemeralTestRecognizer struct {
+	calls   atomic.Int64
+	bytes   atomic.Int64
+	stopped chan struct{}
+	once    sync.Once
+}
+
+type failingEphemeralRecognizer struct{}
+
+func (failingEphemeralRecognizer) TranscribePCMStream(
+	context.Context,
+	agentvoice.PCMTranscriptionRequest,
+	agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
+		agentvoice.SpeechOperationTranscription,
+		agentvoice.ErrorProviderUnavailable,
+		0,
+		"",
+		"",
+		errors.New("provider unavailable"),
+	)
+}
+
+func newEphemeralTestRecognizer() *ephemeralTestRecognizer {
+	return &ephemeralTestRecognizer{stopped: make(chan struct{})}
+}
+
+func (recognizer *ephemeralTestRecognizer) TranscribePCMStream(
+	ctx context.Context,
+	request agentvoice.PCMTranscriptionRequest,
+	observer agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	recognizer.calls.Add(1)
+	defer recognizer.once.Do(func() { close(recognizer.stopped) })
+	if request.PCM == nil || request.SampleRate != 16_000 || observer == nil {
+		return agentvoice.TranscriptionResult{}, errors.New(
+			"ephemeral test recognizer received invalid input",
+		)
+	}
+	first := make([]byte, 512)
+	read, err := request.PCM.Read(first)
+	if read > 0 {
+		recognizer.bytes.Add(int64(read))
+		if updateErr := observer.OnTranscriptionUpdate(
+			ctx,
+			agentvoice.TranscriptionUpdate{Transcript: "partial transcript"},
+		); updateErr != nil {
+			return agentvoice.TranscriptionResult{}, updateErr
+		}
+	}
+	if err != nil {
+		return agentvoice.TranscriptionResult{}, ephemeralRecognizerError(ctx, err)
+	}
+	copied, err := io.Copy(io.Discard, io.TeeReader(
+		request.PCM,
+		writerFunc(func(data []byte) (int, error) {
+			recognizer.bytes.Add(int64(len(data)))
+			return len(data), nil
+		}),
+	))
+	_ = copied
+	if err != nil {
+		return agentvoice.TranscriptionResult{}, ephemeralRecognizerError(ctx, err)
+	}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		agentvoice.TranscriptionUpdate{
+			Transcript: "completed transcript", Final: true,
+		},
+	); err != nil {
+		return agentvoice.TranscriptionResult{}, err
+	}
+	return agentvoice.TranscriptionResult{
+		ID: "ephemeral-result-1", Provider: "fake", Model: "fake-realtime",
+		Transcript: "completed transcript",
+	}, nil
+}
+
+func (recognizer *ephemeralTestRecognizer) Calls() int64 {
+	return recognizer.calls.Load()
+}
+
+func (recognizer *ephemeralTestRecognizer) Bytes() int64 {
+	return recognizer.bytes.Load()
+}
+
+func ephemeralRecognizerError(ctx context.Context, err error) error {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return agentvoice.NewSpeechError(
+			agentvoice.SpeechOperationTranscription,
+			agentvoice.ErrorCancelled,
+			0,
+			"",
+			"",
+			context.Canceled,
+		)
+	}
+	return err
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (write writerFunc) Write(data []byte) (int, error) {
+	return write(data)
+}
+
+func waitForEphemeralRecognizerStop(
+	t *testing.T,
+	recognizer *ephemeralTestRecognizer,
+) {
+	t.Helper()
+	select {
+	case <-recognizer.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("ephemeral recognizer did not stop")
+	}
+}
+
+var (
+	_ agentvoice.PCMStreamingSpeechRecognizer = (*ephemeralTestRecognizer)(nil)
+	_ agentvoice.PCMStreamingSpeechRecognizer = failingEphemeralRecognizer{}
+	_ ThreadReader                            = (*ephemeralThreadReader)(nil)
+)

--- a/server/internal/agent/input/voice/http/handler.go
+++ b/server/internal/agent/input/voice/http/handler.go
@@ -471,6 +471,14 @@ func providerUnavailable(cause error) error {
 }
 
 func (handler *Handler) write(c *gin.Context, err error) {
+	writeHTTPError(c, handler.errors, err)
+}
+
+func writeHTTPError(
+	c *gin.Context,
+	renderer *httpresponse.Renderer,
+	err error,
+) {
 	if appError, ok := apperror.From(err); ok {
 		if appError.Category() == apperror.Unauthenticated {
 			c.Header("WWW-Authenticate", "Bearer")
@@ -481,7 +489,7 @@ func (handler *Handler) write(c *gin.Context, err error) {
 			c.Header("Retry-After", "1")
 		}
 	}
-	handler.errors.Write(c, err)
+	renderer.Write(c, err)
 }
 
 func invalidRequest(cause error) error {

--- a/server/internal/agent/input/voice/http/realtime.go
+++ b/server/internal/agent/input/voice/http/realtime.go
@@ -77,7 +77,10 @@ func (handler *Handler) uploadRealtime(c *gin.Context) {
 		writeRealtimeFailure(connection, "invalid_audio", false)
 		return
 	}
-	observer := &realtimeTranscriptionWriter{connection: connection}
+	observer := &realtimeTranscriptionWriter{
+		connection: connection,
+		timeout:    handler.readTimeout,
+	}
 	if err := observer.write("transcription.started", gin.H{}); err != nil {
 		return
 	}
@@ -188,6 +191,7 @@ func pcm16MonoWAV(pcm []byte, sampleRate int) ([]byte, error) {
 
 type realtimeTranscriptionWriter struct {
 	connection *websocket.Conn
+	timeout    time.Duration
 }
 
 func (writer *realtimeTranscriptionWriter) OnTranscriptionUpdate(
@@ -204,6 +208,11 @@ func (writer *realtimeTranscriptionWriter) write(
 	event string,
 	data any,
 ) error {
+	if err := writer.connection.SetWriteDeadline(
+		time.Now().Add(writer.timeout),
+	); err != nil {
+		return err
+	}
 	return writer.connection.WriteJSON(gin.H{"type": event, "data": data})
 }
 

--- a/server/internal/agent/input/voice/speech_provider.go
+++ b/server/internal/agent/input/voice/speech_provider.go
@@ -3,6 +3,7 @@ package voice
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"unicode/utf8"
 
@@ -24,6 +25,22 @@ type StreamingSpeechRecognizer interface {
 		TranscriptionRequest,
 		TranscriptionObserver,
 	) (TranscriptionResult, error)
+}
+
+// PCMStreamingSpeechRecognizer consumes live PCM frames without requiring a
+// durable AudioSource. Callers retain ownership of the stream and cancel it
+// when the client disconnects or abandons transcription.
+type PCMStreamingSpeechRecognizer interface {
+	TranscribePCMStream(
+		context.Context,
+		PCMTranscriptionRequest,
+		TranscriptionObserver,
+	) (TranscriptionResult, error)
+}
+
+type PCMTranscriptionRequest struct {
+	PCM        io.Reader
+	SampleRate int
 }
 
 type TranscriptionObserver interface {

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -146,6 +146,7 @@ func buildIdentityAgentComposition(
 			"bootstrap: Agent Run dependencies are required",
 		)
 	}
+	realtimeRecognizer := agentRealtimePCMRecognizer(voiceConfigurations)
 	// 1. 装配身份、Goal 与 Conversation 主链。
 	identityContext, err := buildIdentityComposition(
 		database,
@@ -482,6 +483,19 @@ func buildIdentityAgentComposition(
 		translationHTTP,
 		runHTTP,
 	}
+	if realtimeRecognizer != nil {
+		ephemeralHTTP, ephemeralHTTPErr :=
+			agentvoicehttp.NewEphemeralTranscriptionHandler(
+				realtimeRecognizer,
+				agentService,
+				voiceConfigurations[0].AudioReadTimeout,
+				errorRenderer,
+			)
+		if ephemeralHTTPErr != nil {
+			return nil, ephemeralHTTPErr
+		}
+		registrars = append(registrars, ephemeralHTTP)
+	}
 	if agentImages != nil {
 		imageHTTP, imageHTTPErr := agentimagehttp.NewHandler(
 			agentImages,
@@ -562,6 +576,16 @@ func buildIdentityAgentComposition(
 		titleProcessor:      titleProcessor,
 		ids:                 ids,
 	}, nil
+}
+
+func agentRealtimePCMRecognizer(
+	configurations []VoiceConfiguration,
+) agentvoice.PCMStreamingSpeechRecognizer {
+	if len(configurations) != 1 || configurations[0].Recognizer == nil {
+		return nil
+	}
+	recognizer, _ := configurations[0].Recognizer.(agentvoice.PCMStreamingSpeechRecognizer)
+	return recognizer
 }
 
 func buildAgentImageApplication(

--- a/server/internal/bootstrap/agent_voice_bootstrap_test.go
+++ b/server/internal/bootstrap/agent_voice_bootstrap_test.go
@@ -15,6 +15,31 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 )
 
+func TestAgentRealtimePCMRecognizerUsesAvailableCapability(t *testing.T) {
+	recognizer := newTestSpeechRecognizer(agentvoice.TranscriptionResult{
+		Transcript: "available",
+	})
+	configured := agentRealtimePCMRecognizer([]VoiceConfiguration{{
+		Recognizer: recognizer,
+	}})
+	if configured != recognizer {
+		t.Fatalf("configured realtime recognizer = %T", configured)
+	}
+
+	configured = agentRealtimePCMRecognizer([]VoiceConfiguration{{
+		Recognizer: durableOnlyAgentSpeechRecognizer{
+			StreamingSpeechRecognizer: recognizer,
+		},
+	}})
+	if configured != nil {
+		t.Fatalf("missing realtime capability = %T", configured)
+	}
+}
+
+type durableOnlyAgentSpeechRecognizer struct {
+	agentvoice.StreamingSpeechRecognizer
+}
+
 func TestBuildAgentVoiceInputApplicationRequiresExplicitEnablementAndStore(
 	t *testing.T,
 ) {
@@ -234,6 +259,11 @@ func TestProductionAgentVoiceCompositionRegistersAllRoutes(t *testing.T) {
 		{
 			http.MethodGet,
 			"/v1/agent-threads/" + resourceID +
+				"/voice-transcriptions/realtime",
+		},
+		{
+			http.MethodGet,
+			"/v1/agent-threads/" + resourceID +
 				"/voice-message-candidates/realtime",
 		},
 		{
@@ -279,6 +309,92 @@ func TestProductionAgentVoiceCompositionRegistersAllRoutes(t *testing.T) {
 				response.Code,
 			)
 		}
+	}
+}
+
+func TestAgentEphemeralTranscriptionRegistersWithoutObjectStorage(t *testing.T) {
+	pool := voiceIntegrationDatabase(t)
+	textGenerator := &voiceTextGenerator{}
+	configuration := VoiceConfiguration{
+		Recognizer: newTestSpeechRecognizer(
+			agentvoice.TranscriptionResult{
+				ID:         "ephemeral-asr-result",
+				Provider:   "fake",
+				Model:      "fake-asr-v1",
+				Transcript: "An ephemeral transcript.",
+			},
+		),
+		Synthesizer:            newFailingTestSpeechSynthesizer(context.Canceled),
+		TemporaryAudio:         newVoiceTestVault(t),
+		AudioStagedTTL:         time.Hour,
+		ASRLease:               5 * time.Second,
+		AudioReadTimeout:       time.Second,
+		ReviewHistoryCursorKey: make([]byte, 32),
+	}
+	configuration.PracticeRecognizer = practiceVoiceRecognizerAdapter{
+		recognizer: configuration.Recognizer,
+	}
+	configuration.PracticeSynthesizer = practiceVoiceSynthesizerAdapter{
+		synthesizer: configuration.Synthesizer,
+	}
+	configuration.QuestionGenerator = practiceVoiceQuestionGeneratorAdapter{
+		generator: textGenerator,
+	}
+	composition, err := buildIdentityAgentComposition(
+		context.Background(),
+		pool,
+		nil,
+		"",
+		testAgentModelProviders(textGenerator),
+		agentrun.Configuration{
+			Provider:           "fake",
+			Model:              "fake-text-v1",
+			MaxOutputTokens:    256,
+			MaxInputCharacters: 12000,
+		},
+		emptyBootstrapMemorySearcher{},
+		nil,
+		nil,
+		nil,
+		nil,
+		configuration,
+	)
+	if err != nil {
+		t.Fatalf("build composition without object storage: %v", err)
+	}
+	if composition.agentVoiceReclaimer != nil {
+		t.Fatal("ephemeral transcription constructed durable Voice storage")
+	}
+	router := NewRouterWithReadinessAndRoutes(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pool,
+		[]RouteRegistrar{
+			composition.identity.module,
+			composition.agentModule,
+		},
+	)
+	const threadID = "20000000-0000-4000-8000-000000000001"
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/agent-threads/"+threadID+"/voice-transcriptions/realtime",
+		nil,
+	)
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("ephemeral route status = %d", response.Code)
+	}
+
+	legacy := httptest.NewRecorder()
+	legacyRequest := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/agent-threads/"+threadID+
+			"/voice-message-candidates/realtime",
+		nil,
+	)
+	router.ServeHTTP(legacy, legacyRequest)
+	if legacy.Code != http.StatusNotFound {
+		t.Fatalf("durable Voice route without storage status = %d", legacy.Code)
 	}
 }
 

--- a/server/internal/bootstrap/provider_fakes_test.go
+++ b/server/internal/bootstrap/provider_fakes_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"io"
 
 	agentsummary "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation/summary"
 	agenttitle "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation/title"
@@ -186,6 +187,31 @@ func (recognizer *testSpeechRecognizer) TranscribeStream(
 	return result, nil
 }
 
+func (recognizer *testSpeechRecognizer) TranscribePCMStream(
+	ctx context.Context,
+	request agentvoice.PCMTranscriptionRequest,
+	observer agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	if request.PCM == nil || request.SampleRate != 16_000 || observer == nil {
+		return agentvoice.TranscriptionResult{}, errors.New(
+			"test realtime PCM transcription input is invalid",
+		)
+	}
+	pcm, err := io.ReadAll(request.PCM)
+	if err != nil || len(pcm) == 0 {
+		return agentvoice.TranscriptionResult{}, errors.New(
+			"read test realtime PCM transcription input",
+		)
+	}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		agentvoice.TranscriptionUpdate{Transcript: recognizer.result.Transcript},
+	); err != nil {
+		return agentvoice.TranscriptionResult{}, err
+	}
+	return recognizer.result, nil
+}
+
 type failingTestSpeechSynthesizer struct {
 	err error
 }
@@ -208,6 +234,7 @@ func (synthesizer *failingTestSpeechSynthesizer) Synthesize(
 }
 
 var (
-	_ agentvoice.StreamingSpeechRecognizer = (*testSpeechRecognizer)(nil)
-	_ agentvoice.SpeechSynthesizer         = (*failingTestSpeechSynthesizer)(nil)
+	_ agentvoice.StreamingSpeechRecognizer    = (*testSpeechRecognizer)(nil)
+	_ agentvoice.PCMStreamingSpeechRecognizer = (*testSpeechRecognizer)(nil)
+	_ agentvoice.SpeechSynthesizer            = (*failingTestSpeechSynthesizer)(nil)
 )

--- a/server/internal/bootstrap/voice_integration_test.go
+++ b/server/internal/bootstrap/voice_integration_test.go
@@ -30,6 +30,7 @@ import (
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/migration"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/gorilla/websocket"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -37,6 +38,234 @@ import (
 var testReviewHistoryCursorKey = []byte(
 	"0123456789abcdef0123456789abcdef",
 )
+
+func TestAgentEphemeralTranscriptionDoesNotPersistVoiceState(t *testing.T) {
+	tests := []struct {
+		name            string
+		email           string
+		withObjectStore bool
+	}{
+		{
+			name:  "OSS disabled",
+			email: "ephemeral-agent-voice-no-oss@example.com",
+		},
+		{
+			name:            "ObjectStore remains untouched",
+			email:           "ephemeral-agent-voice-store@example.com",
+			withObjectStore: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testAgentEphemeralTranscriptionDoesNotPersistVoiceState(t, test.email, test.withObjectStore)
+		})
+	}
+}
+
+func testAgentEphemeralTranscriptionDoesNotPersistVoiceState(
+	t *testing.T,
+	email string,
+	withObjectStore bool,
+) {
+	pool := voiceIntegrationDatabase(t)
+	text := &voiceTextGenerator{}
+	recognizer := &voiceRecognizer{}
+	var objects *voiceObjectStore
+	var recordingStore objectstore.Store
+	if withObjectStore {
+		objects = newVoiceObjectStore()
+		recordingStore = objects
+	}
+	catalog, err := scene.NewPostgresCatalog(
+		pool,
+		scoring.NewEvaluationPolicyRegistry(),
+	)
+	if err != nil {
+		t.Fatalf("build Preparation catalog: %v", err)
+	}
+	server := newVoiceProductionIntegrationServer(
+		t,
+		pool,
+		catalog,
+		text,
+		VoiceConfiguration{
+			Recognizer: recognizer,
+			Synthesizer: newFailingTestSpeechSynthesizer(
+				errors.New("tts unavailable"),
+			),
+			TemporaryAudio:         newVoiceTestVault(t),
+			ObjectStore:            recordingStore,
+			AudioStagedTTL:         time.Hour,
+			ASRLease:               5 * time.Second,
+			ReviewHistoryCursorKey: testReviewHistoryCursorKey,
+		},
+	)
+	token := registerAndLoginVoiceUser(
+		t,
+		server.URL,
+		email,
+	)
+	threadID := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodPost,
+		"/v1/agent-threads",
+		`{}`,
+		"",
+		http.StatusCreated,
+	)["thread_id"].(string)
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/agent-threads/" + threadID +
+		"/voice-transcriptions/realtime"
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{"speakup.voice-input.v1"},
+	}).Dial(
+		endpoint,
+		http.Header{"Authorization": []string{"Bearer " + token}},
+	)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial ephemeral transcription status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial ephemeral transcription: %v", err)
+	}
+	defer connection.Close()
+	if err := connection.WriteJSON(map[string]any{
+		"type": "start", "idempotency_key": "ephemeral-bootstrap-1",
+		"sample_rate": 16_000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var event struct {
+		Type string `json:"type"`
+	}
+	if err := connection.ReadJSON(&event); err != nil ||
+		event.Type != "transcription.started" {
+		t.Fatalf("started event = %#v err = %v", event, err)
+	}
+	if err := connection.WriteMessage(
+		websocket.BinaryMessage,
+		make([]byte, 3_200),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.ReadJSON(&event); err != nil ||
+		event.Type != "transcription.updated" {
+		t.Fatalf("updated event = %#v err = %v", event, err)
+	}
+	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.ReadJSON(&event); err != nil ||
+		event.Type != "transcription.completed" {
+		t.Fatalf("completed event = %#v err = %v", event, err)
+	}
+	assertNoAgentVoicePersistence(t, pool, objects)
+
+	voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodPost,
+		"/v1/agent-threads/"+threadID+"/runs",
+		`{
+			"client_message_id":"ephemeral-text-1",
+			"content":"Confirmed answer number 1."
+		}`,
+		"",
+		http.StatusCreated,
+	)
+	messages := voiceJSONRequest(
+		t,
+		server.URL,
+		token,
+		http.MethodGet,
+		"/v1/agent-threads/"+threadID+"/messages",
+		"",
+		"",
+		http.StatusOK,
+	)["messages"].([]any)
+	foundTextInput := false
+	for _, raw := range messages {
+		message := raw.(map[string]any)
+		if message["role"] != "user" {
+			continue
+		}
+		foundTextInput = true
+		if message["content"] != "Confirmed answer number 1." {
+			t.Fatalf("user Message = %#v", message)
+		}
+		if _, found := message["audio"]; found {
+			t.Fatalf("text Message gained audio: %#v", message)
+		}
+		if _, found := message["modality"]; found {
+			t.Fatalf("text Message exposed non-text modality: %#v", message)
+		}
+	}
+	if !foundTextInput {
+		t.Fatalf("text input was not persisted: %#v", messages)
+	}
+	var modality string
+	if err := pool.QueryRow(
+		context.Background(),
+		`SELECT modality
+		   FROM agent_messages
+		  WHERE thread_id = $1
+		    AND role = 'user'
+		    AND content = $2`,
+		threadID,
+		"Confirmed answer number 1.",
+	).Scan(&modality); err != nil {
+		t.Fatalf("read confirmed text Message modality: %v", err)
+	}
+	if modality != "text" {
+		t.Fatalf("confirmed Message modality = %q", modality)
+	}
+	assertNoAgentVoicePersistence(t, pool, objects)
+}
+
+func assertNoAgentVoicePersistence(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	objects *voiceObjectStore,
+) {
+	t.Helper()
+	for _, table := range []string{
+		"agent_voice_candidates",
+		"agent_message_audios",
+		"agent_voice_transcript_evidence",
+		"practice_audio_assets",
+	} {
+		var count int
+		if err := pool.QueryRow(
+			context.Background(),
+			"SELECT count(*) FROM "+table,
+		).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows = %d", table, count)
+		}
+	}
+	if objects == nil {
+		return
+	}
+	objects.mu.Lock()
+	defer objects.mu.Unlock()
+	if len(objects.objects) != 0 {
+		t.Fatalf("ObjectStore entries = %d", len(objects.objects))
+	}
+	if objects.putCalls != 0 || objects.signedGetCalls != 0 ||
+		objects.deleteCalls != 0 {
+		t.Fatalf(
+			"ObjectStore calls: put=%d signed_get=%d delete=%d",
+			objects.putCalls,
+			objects.signedGetCalls,
+			objects.deleteCalls,
+		)
+	}
+}
 
 func TestVoiceInterviewFollowUpTextAnswerKeepsEffectiveTurn(t *testing.T) {
 	pool := voiceIntegrationDatabase(t)
@@ -1984,9 +2213,48 @@ func (recognizer *voiceRecognizer) TranscribeStream(
 	return result, nil
 }
 
+func (recognizer *voiceRecognizer) TranscribePCMStream(
+	ctx context.Context,
+	request agentvoice.PCMTranscriptionRequest,
+	observer agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	if request.PCM == nil || request.SampleRate != 16_000 || observer == nil {
+		return agentvoice.TranscriptionResult{}, errors.New(
+			"test realtime PCM transcription input is invalid",
+		)
+	}
+	first := make([]byte, 1024)
+	read, err := request.PCM.Read(first)
+	if err != nil || read == 0 {
+		return agentvoice.TranscriptionResult{}, errors.New(
+			"read test realtime PCM transcription input",
+		)
+	}
+	call := recognizer.calls.Add(1)
+	result := agentvoice.TranscriptionResult{
+		ID:         fmt.Sprintf("asr-result-%d", call),
+		Provider:   "fake",
+		Model:      "fake-asr-v1",
+		Transcript: fmt.Sprintf("Confirmed answer number %d.", call),
+	}
+	if err := observer.OnTranscriptionUpdate(
+		ctx,
+		agentvoice.TranscriptionUpdate{Transcript: result.Transcript},
+	); err != nil {
+		return agentvoice.TranscriptionResult{}, err
+	}
+	if _, err := io.Copy(io.Discard, request.PCM); err != nil {
+		return agentvoice.TranscriptionResult{}, err
+	}
+	return result, nil
+}
+
 type voiceObjectStore struct {
-	mu      sync.Mutex
-	objects map[string][]byte
+	mu             sync.Mutex
+	objects        map[string][]byte
+	putCalls       int
+	signedGetCalls int
+	deleteCalls    int
 }
 
 func newVoiceObjectStore() *voiceObjectStore {
@@ -1999,6 +2267,7 @@ func (store *voiceObjectStore) Put(
 ) (objectstore.PutResult, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	store.putCalls++
 	audio, err := io.ReadAll(request.Body)
 	if err != nil || int64(len(audio)) != request.Size {
 		return objectstore.PutResult{}, objectstore.ErrInvalidObject
@@ -2019,6 +2288,7 @@ func (store *voiceObjectStore) SignedGet(
 ) (objectstore.SignedGetResult, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	store.signedGetCalls++
 	if _, found := store.objects[key]; !found {
 		return objectstore.SignedGetResult{},
 			objectstore.ErrOperationFailed
@@ -2036,6 +2306,7 @@ func (store *voiceObjectStore) Delete(
 ) error {
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	store.deleteCalls++
 	delete(store.objects, key)
 	return nil
 }

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -13,6 +13,10 @@ type AgentVoiceRecognizer struct {
 	recognizer *speechRecognizer
 }
 
+type agentRealtimeVoiceRecognizer struct {
+	*AgentVoiceRecognizer
+}
+
 func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 	ctx context.Context,
 	consume func([]byte) error,
@@ -28,12 +32,18 @@ func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 func NewAgentVoiceRecognizer(
 	configuration ASRConfig,
 	apiKey string,
-) (*AgentVoiceRecognizer, error) {
+) (agentvoice.StreamingSpeechRecognizer, error) {
 	recognizer, err := newSpeechRecognizer(configuration, apiKey)
 	if err != nil {
 		return nil, err
 	}
-	return &AgentVoiceRecognizer{recognizer: recognizer}, nil
+	agentRecognizer := &AgentVoiceRecognizer{recognizer: recognizer}
+	if recognizer.model == "fun-asr-realtime" {
+		return &agentRealtimeVoiceRecognizer{
+			AgentVoiceRecognizer: agentRecognizer,
+		}, nil
+	}
+	return agentRecognizer, nil
 }
 
 func (recognizer *AgentVoiceRecognizer) Transcribe(
@@ -81,6 +91,38 @@ func (recognizer *AgentVoiceRecognizer) TranscribeStream(
 	result, err := recognizer.recognizer.TranscribeStream(
 		ctx,
 		protocol.TranscriptionRequest{Audio: request.Audio},
+		agentVoiceTranscriptionObserver{observer: observer},
+	)
+	if err != nil {
+		return agentvoice.TranscriptionResult{}, mapAgentVoiceError(
+			err,
+			agentvoice.SpeechOperationTranscription,
+		)
+	}
+	return agentVoiceTranscriptionResult(result), nil
+}
+
+func (recognizer *agentRealtimeVoiceRecognizer) TranscribePCMStream(
+	ctx context.Context,
+	request agentvoice.PCMTranscriptionRequest,
+	observer agentvoice.TranscriptionObserver,
+) (agentvoice.TranscriptionResult, error) {
+	if recognizer == nil || recognizer.AgentVoiceRecognizer == nil ||
+		recognizer.recognizer == nil || observer == nil ||
+		recognizer.recognizer.model != "fun-asr-realtime" {
+		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
+			agentvoice.SpeechOperationTranscription,
+			agentvoice.ErrorConfiguration,
+			0,
+			"",
+			"",
+			errors.New("qianwen: realtime Agent Voice recognizer is required"),
+		)
+	}
+	result, err := recognizer.recognizer.transcribeRealtimePCM(
+		ctx,
+		request.PCM,
+		request.SampleRate,
 		agentVoiceTranscriptionObserver{observer: observer},
 	)
 	if err != nil {
@@ -235,6 +277,8 @@ func mapAgentVoiceErrorKind(kind protocol.ErrorKind) agentvoice.ErrorKind {
 
 var (
 	_ agentvoice.StreamingSpeechRecognizer         = (*AgentVoiceRecognizer)(nil)
+	_ agentvoice.StreamingSpeechRecognizer         = (*agentRealtimeVoiceRecognizer)(nil)
+	_ agentvoice.PCMStreamingSpeechRecognizer      = (*agentRealtimeVoiceRecognizer)(nil)
 	_ agentvoice.SpeechSynthesizer                 = (*AgentVoiceSynthesizer)(nil)
 	_ agentconversation.AssistantSpeechSynthesizer = (*AgentVoiceSynthesizer)(nil)
 )

--- a/server/internal/providers/qianwen/speech_recognizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime.go
@@ -141,6 +141,10 @@ func (recognizer *speechRecognizer) transcribeRealtimeAudio(
 		)
 	}
 	defer connection.Close()
+	stopCancellationClose := context.AfterFunc(callContext, func() {
+		_ = connection.Close()
+	})
+	defer stopCancellationClose()
 	if deadline, ok := callContext.Deadline(); ok {
 		_ = connection.SetReadDeadline(deadline)
 		_ = connection.SetWriteDeadline(deadline)
@@ -188,6 +192,14 @@ func (recognizer *speechRecognizer) transcribeRealtimeAudio(
 			err:        readErr,
 		}
 	}()
+	readCompleted := false
+	defer func() {
+		if readCompleted {
+			return
+		}
+		_ = connection.Close()
+		<-readResults
+	}()
 	if err := streamRealtimeASRAudio(connection, audio.open); err != nil {
 		_ = connection.Close()
 		return protocol.TranscriptionResult{}, realtimeASRTransportError(callContext, err)
@@ -204,6 +216,7 @@ func (recognizer *speechRecognizer) transcribeRealtimeAudio(
 	var completed readResult
 	select {
 	case completed = <-readResults:
+		readCompleted = true
 	case <-callContext.Done():
 		return protocol.TranscriptionResult{}, realtimeASRTransportError(
 			callContext,

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -9,10 +9,40 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 	"github.com/gorilla/websocket"
 )
+
+func TestAgentVoiceRecognizerExposesRealtimePCMCapabilityOnlyForRealtime(
+	t *testing.T,
+) {
+	t.Parallel()
+	for _, test := range []struct {
+		model string
+		want  bool
+	}{
+		{model: "fun-asr-realtime", want: true},
+		{model: "fun-asr-flash-2026-06-15", want: false},
+	} {
+		t.Run(test.model, func(t *testing.T) {
+			recognizer, err := NewAgentVoiceRecognizer(ASRConfig{
+				BaseURL: "https://dashscope.aliyuncs.com/api/v1",
+				Model:   test.model,
+				Timeout: time.Second,
+			}, "test-api-key")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, got := recognizer.(agentvoice.PCMStreamingSpeechRecognizer)
+			if got != test.want {
+				t.Fatalf("PCM capability = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
 
 func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 	t.Parallel()
@@ -219,5 +249,69 @@ func TestRealtimeEndpointDerivesFromDashScopeHTTPBase(t *testing.T) {
 	got := realtimeASREndpoint("https://dashscope.aliyuncs.com/api/v1")
 	if got != "wss://dashscope.aliyuncs.com/api-ws/v1/inference/?heartbeat=true" {
 		t.Fatalf("endpoint = %q", got)
+	}
+}
+
+func TestRealtimeTranscribeClosesProviderConnectionOnCancellation(t *testing.T) {
+	providerConnected := make(chan struct{})
+	providerClosed := make(chan struct{})
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer connection.Close()
+		if _, _, err := connection.ReadMessage(); err != nil {
+			t.Errorf("read run-task: %v", err)
+			return
+		}
+		close(providerConnected)
+		if _, _, err := connection.ReadMessage(); err == nil {
+			t.Error("provider connection remained open after cancellation")
+		}
+		close(providerClosed)
+	}))
+	defer server.Close()
+
+	recognizer := mustRecognizer(t, doerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("realtime recognition must not use HTTP generation")
+		return nil, nil
+	}), "test-realtime-key")
+	recognizer.model = "fun-asr-realtime"
+	recognizer.wsEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := recognizer.transcribeRealtimePCM(
+			ctx,
+			bytes.NewReader([]byte{1, 2}),
+			16_000,
+			nil,
+		)
+		result <- err
+	}()
+	select {
+	case <-providerConnected:
+	case <-time.After(time.Second):
+		t.Fatal("provider did not accept the realtime task")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("cancelled realtime transcription succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled realtime transcription did not return")
+	}
+	select {
+	case <-providerClosed:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled realtime transcription did not close provider")
 	}
 }


### PR DESCRIPTION
## 功能描述

- 新增 Thread 鉴权的首页临时实时转写 WebSocket。
- PCM 直接流入实时 ASR，录音结束前即可返回 partial transcript。
- 转写过程不创建 Candidate、MessageAudio、TranscriptEvidence 或录音资产，也不调用对象存储。
- OSS 关闭时仍注册临时转写路由，并保留历史 Voice Message 相关旧路由。

## 实现思路

- 冻结 voice-transcriptions/realtime 的 start、PCM、finish、cancel 与 transcription.started/updated/completed/failed 契约。
- 为 Agent 识别器增加最小 PCM streaming capability，由 Qianwen realtime 模型显式实现；不支持 PCM 的模型在启动阶段明确失败。
- 使用 io.Pipe 边收边识别，串行化 WebSocket 写入，并在取消、断线、超限和 Provider 提前失败时关闭流与终态。
- OpenAPI 与 WebSocket schema 同步记录鉴权、所有权和零持久化边界。

## 可复现测试

- make check-go
- make check-api
- go test -race ./internal/agent/input/voice/http ./internal/providers/qianwen
- TEST_DATABASE_URL=postgres://xe3_esl:local-development-only@127.0.0.1:5432/xe3_esl?sslmode=disable go test ./internal/bootstrap -run TestAgentEphemeralTranscriptionDoesNotPersistVoiceState -count=1
- git diff --check upstream/dev...HEAD

Closes #563
关联 #542