### PR TITLE
feat(agent): use voice as realtime text input

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_message_image_client.dart';
@@ -230,6 +231,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     final previewVoiceClient = widget.allowFakePreview
         ? FakeAgentVoiceClient()
         : null;
+    final previewVoiceInputClient = widget.allowFakePreview
+        ? FakeAgentVoiceInputClient()
+        : null;
     final injectedController = widget.conversationController;
     if (injectedController == null && !widget.allowFakePreview) {
       throw StateError(
@@ -269,8 +273,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
         injectedComposerController ??
         ComposerController(
           conversationController: _conversationController,
-          voiceClient: previewVoiceClient,
-          onAssistantCommitted: _messageAudioController?.playCommittedAssistant,
+          voiceInputClient: previewVoiceInputClient,
         );
     final injectedPracticeController = widget.practiceController;
     if (injectedPracticeController == null && !widget.allowFakePreview) {

--- a/mobile/lib/design/voice_composer_dock.dart
+++ b/mobile/lib/design/voice_composer_dock.dart
@@ -24,6 +24,9 @@ class VoiceComposerDock extends StatelessWidget {
     this.directTapToSend = false,
     this.liveTranscript,
     this.liveTranscriptKey,
+    this.tapRecordingLabel,
+    this.holdRecordingLabel,
+    this.capturingSemanticsLabel,
     super.key,
   });
 
@@ -44,6 +47,9 @@ class VoiceComposerDock extends StatelessWidget {
   final bool directTapToSend;
   final String? liveTranscript;
   final Key? liveTranscriptKey;
+  final String? tapRecordingLabel;
+  final String? holdRecordingLabel;
+  final String? capturingSemanticsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -55,9 +61,11 @@ class VoiceComposerDock extends StatelessWidget {
       (_, VoiceCaptureReleaseIntent.cancel, _) => '松开取消',
       (_, VoiceCaptureReleaseIntent.convertToText, _) => '松开转文字',
       (VoiceCapturePhase.recording, _, true) =>
-        upwardCancelOnly ? '点击发送 · 上滑取消' : '点击发送 · 左取消 · 右转文字',
+        tapRecordingLabel ??
+            (upwardCancelOnly ? '点击发送 · 上滑取消' : '点击发送 · 左取消 · 右转文字'),
       (VoiceCapturePhase.recording, _, false) =>
-        upwardCancelOnly ? '上滑取消 · 松开发送' : '松开发送 · 左取消 · 右转文字',
+        holdRecordingLabel ??
+            (upwardCancelOnly ? '上滑取消 · 松开发送' : '松开发送 · 左取消 · 右转文字'),
       _ => enabled ? '点击或长按说话' : '暂时无法录音',
     };
     final stateColor = capture.cancelArmed
@@ -141,7 +149,9 @@ class VoiceComposerDock extends StatelessWidget {
           )
         : capture.wrapTarget(
             key: recordKey,
-            semanticsLabel: capturing ? '发送语音' : '开始录音',
+            semanticsLabel: capturing
+                ? capturingSemanticsLabel ?? '发送语音'
+                : '开始录音',
             child: targetContent,
           );
     return Row(

--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -9,8 +9,7 @@ import 'package:speakup/design/voice_composer_dock.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
 import 'package:speakup/features/agent/composer/pending_image_strip.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_composer.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 
 typedef AgentComposerAction = FutureOr<void> Function();
 
@@ -43,7 +42,7 @@ class AgentComposer extends StatefulWidget {
   final String? acceptedUserMessageId;
   final String? acceptedUserMessageText;
   final AgentComposerAction? onStartVoice;
-  final AgentVoiceController? voiceController;
+  final AgentVoiceInputController? voiceController;
   final bool voiceEnabled;
   final Future<bool> Function(String)? onSubmitText;
   final bool enabled;
@@ -124,7 +123,7 @@ class _AgentComposerState extends State<AgentComposer> {
   void _handleTextChanged() {
     if (!_suppressControllerNotifications) {
       final voice = widget.voiceController;
-      if (voice?.state == AgentVoiceComposerState.awaitingConfirmation) {
+      if (voice?.state == AgentVoiceInputState.editing) {
         voice?.updateTranscript(_controller.text);
       }
       setState(() {});
@@ -136,7 +135,7 @@ class _AgentComposerState extends State<AgentComposer> {
       return;
     }
     final voice = widget.voiceController;
-    if (voice?.state == AgentVoiceComposerState.awaitingConfirmation &&
+    if (voice?.state == AgentVoiceInputState.editing &&
         _controller.text != voice?.editedTranscript) {
       _suppressControllerNotifications = true;
       _controller.value = TextEditingValue(
@@ -147,7 +146,7 @@ class _AgentComposerState extends State<AgentComposer> {
       );
       _suppressControllerNotifications = false;
     }
-    if (voice?.state == AgentVoiceComposerState.awaitingConfirmation) {
+    if (voice?.state == AgentVoiceInputState.editing) {
       _textMode = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
@@ -179,15 +178,7 @@ class _AgentComposerState extends State<AgentComposer> {
     if (voice == null) {
       return;
     }
-    await voice.stopRecordingAndUpload();
-    if (!mounted || !voice.canConfirm) {
-      return;
-    }
-    await voice.confirm();
-    if (!mounted || voice.editedTranscript.isNotEmpty) {
-      return;
-    }
-    _replaceComposerText(_draftBeforeVoice);
+    await voice.stopRecording();
   }
 
   Future<void> _convertVoiceToText() async {
@@ -195,14 +186,12 @@ class _AgentComposerState extends State<AgentComposer> {
     if (voice == null) {
       return;
     }
-    await voice.stopRecordingAndUpload();
+    await voice.stopRecording();
   }
 
   Future<void> _cancelVoice() async {
     final voice = widget.voiceController;
-    if (voice == null ||
-        voice.state == AgentVoiceComposerState.confirming ||
-        voice.state == AgentVoiceComposerState.awaitingAssistant) {
+    if (voice == null) {
       return;
     }
     await voice.cancel();
@@ -246,9 +235,19 @@ class _AgentComposerState extends State<AgentComposer> {
   Future<void> _submitConvertedText() async {
     final voice = widget.voiceController;
     final text = _controller.text.trim();
+    final imageUploadPending = widget.pendingImages.any(
+      (image) => image.state == AgentPendingImageState.uploading,
+    );
+    final imageUploadFailed = widget.pendingImages.any(
+      (image) => image.state == AgentPendingImageState.failed,
+    );
     if (voice == null ||
-        !voice.canConfirm ||
+        !voice.canSubmitTranscript ||
         text.isEmpty ||
+        !widget.enabled ||
+        widget.isBusy ||
+        imageUploadPending ||
+        imageUploadFailed ||
         _textSubmissionInFlight ||
         widget.onSubmitText == null) {
       return;
@@ -353,24 +352,16 @@ class _AgentComposerState extends State<AgentComposer> {
   @override
   Widget build(BuildContext context) {
     final voice = widget.voiceController;
-    final voiceState = voice?.state ?? AgentVoiceComposerState.idle;
-    final starting = voiceState == AgentVoiceComposerState.starting;
-    final recording = voiceState == AgentVoiceComposerState.recording;
-    final confirmingText =
-        voiceState == AgentVoiceComposerState.awaitingConfirmation;
-    final voiceProgress =
-        voiceState == AgentVoiceComposerState.uploading ||
-        voiceState == AgentVoiceComposerState.transcribing ||
-        voiceState == AgentVoiceComposerState.confirming ||
-        voiceState == AgentVoiceComposerState.awaitingAssistant;
-    final voiceSubmissionInFlight =
-        voiceState == AgentVoiceComposerState.confirming ||
-        voiceState == AgentVoiceComposerState.awaitingAssistant;
-    final voiceFailure = voiceState == AgentVoiceComposerState.failed;
+    final voiceState = voice?.state ?? AgentVoiceInputState.idle;
+    final starting = voiceState == AgentVoiceInputState.starting;
+    final recording = voiceState == AgentVoiceInputState.recording;
+    final editingVoiceDraft = voiceState == AgentVoiceInputState.editing;
+    final voiceProgress = voiceState == AgentVoiceInputState.completing;
+    final voiceFailure = voiceState == AgentVoiceInputState.failed;
     final capturePhase = switch (voiceState) {
-      AgentVoiceComposerState.idle => VoiceCapturePhase.idle,
-      AgentVoiceComposerState.starting => VoiceCapturePhase.starting,
-      AgentVoiceComposerState.recording => VoiceCapturePhase.recording,
+      AgentVoiceInputState.idle => VoiceCapturePhase.idle,
+      AgentVoiceInputState.starting => VoiceCapturePhase.starting,
+      AgentVoiceInputState.recording => VoiceCapturePhase.recording,
       _ => VoiceCapturePhase.busy,
     };
     final voiceCaptureEnabled =
@@ -381,7 +372,7 @@ class _AgentComposerState extends State<AgentComposer> {
             widget.enabled &&
             !widget.isBusy);
     final showTextComposer =
-        confirmingText ||
+        editingVoiceDraft ||
         (_textMode &&
             !starting &&
             !recording &&
@@ -434,11 +425,10 @@ class _AgentComposerState extends State<AgentComposer> {
                     state: voiceState,
                     message: voiceFailure
                         ? voice?.errorMessage ?? '语音识别失败'
-                        : voiceState == AgentVoiceComposerState.transcribing &&
-                              voice?.liveTranscript.trim().isNotEmpty == true
+                        : voice?.liveTranscript.trim().isNotEmpty == true
                         ? voice!.liveTranscript
                         : agentComposerVoiceStateLabel(voiceState),
-                    canCancel: !voiceSubmissionInFlight,
+                    canCancel: true,
                     canRetry: voiceFailure && voice?.canRetry == true,
                     onCancel: _cancelVoice,
                     onRetry: voice?.retry,
@@ -448,20 +438,28 @@ class _AgentComposerState extends State<AgentComposer> {
                     controller: _controller,
                     focusNode: _focusNode,
                     keyboardVisible: widget.keyboardVisible,
-                    enabled: confirmingText || widget.enabled,
-                    confirmingConvertedText: confirmingText,
+                    enabled: editingVoiceDraft || widget.enabled,
+                    confirmingConvertedText: editingVoiceDraft,
                     submitting: _textSubmissionInFlight,
-                    canSubmitConvertedText: voice?.canConfirm == true,
+                    canSubmitConvertedText:
+                        voice?.canSubmitTranscript == true &&
+                        widget.onSubmitText != null &&
+                        widget.enabled &&
+                        !widget.isBusy &&
+                        !imageUploadPending &&
+                        !imageUploadFailed,
                     canSubmitText:
                         widget.onSubmitText != null &&
                         widget.enabled &&
                         !widget.isBusy &&
                         !imageUploadPending &&
                         !imageUploadFailed,
-                    onReturnToVoice: confirmingText
+                    onReturnToVoice: editingVoiceDraft
                         ? _cancelVoice
                         : _showVoiceComposer,
-                    onSubmit: confirmingText ? _submitConvertedText : _submit,
+                    onSubmit: editingVoiceDraft
+                        ? _submitConvertedText
+                        : _submit,
                   )
                 : AgentComposerVoiceDock(
                     capture: capture,
@@ -474,6 +472,7 @@ class _AgentComposerState extends State<AgentComposer> {
                         widget.onTakePhoto != null,
                     onAddImages: _showImageSource,
                     onShowText: _showTextComposer,
+                    liveTranscript: voice?.liveTranscript,
                   ),
           ),
         ),
@@ -526,7 +525,7 @@ class _AgentTextDock extends StatelessWidget {
       ),
       fieldKey: const Key('agent-composer-field'),
       submitKey: Key(
-        confirmingConvertedText ? 'agent-voice-confirm' : 'agent-send-button',
+        confirmingConvertedText ? 'agent-voice-text-send' : 'agent-send-button',
       ),
       returnTooltip: confirmingConvertedText ? '取消转文字' : '切换到语音输入',
       returnIcon: confirmingConvertedText

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -2,11 +2,9 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
@@ -23,34 +21,14 @@ final class ComposerController extends ChangeNotifier {
     required this.conversationController,
     this.imageClient,
     this.imagePicker,
-    AgentVoiceClient? voiceClient,
+    AgentVoiceInputClient? voiceInputClient,
     AgentVoiceRecorder? voiceRecorder,
-    AgentAudioPlayer? draftAudioPlayer,
-    this.onAssistantCommitted,
-    this.onAssistantStreamStarted,
-    this.onAssistantStreamDelta,
-    this.onAssistantStreamCompleted,
-    this.onAssistantStreamFailed,
     ComposerClientIdFactory? clientIdFactory,
   }) : _clientIdFactory = clientIdFactory ?? _createSecureComposerId {
-    if (voiceClient != null) {
-      if ((voiceRecorder == null) != (draftAudioPlayer == null)) {
-        throw ArgumentError(
-          'Agent voice recorder and audio player must be injected together.',
-        );
-      }
-      _voiceController = AgentVoiceController(
-        client: voiceClient,
-        recorder: voiceRecorder ?? FakeAgentVoiceRecorder(),
-        audioPlayer: draftAudioPlayer ?? FakeAgentAudioPlayer(),
-        onMessagesCommitted: conversationController.commitComposerMessages,
-        onStreamMessageChanged:
-            conversationController.changeComposerStreamMessage,
-        onAssistantCommitted: onAssistantCommitted,
-        onAssistantStreamStarted: onAssistantStreamStarted,
-        onAssistantStreamDelta: onAssistantStreamDelta,
-        onAssistantStreamCompleted: onAssistantStreamCompleted,
-        onAssistantStreamFailed: onAssistantStreamFailed,
+    if (voiceInputClient != null) {
+      _voiceController = AgentVoiceInputController(
+        client: voiceInputClient,
+        recorder: voiceRecorder ?? FakeAgentVoiceStreamingRecorder(),
         idFactory: _newId,
       )..addListener(_relayVoiceState);
     }
@@ -61,14 +39,9 @@ final class ComposerController extends ChangeNotifier {
   final ConversationController conversationController;
   final AgentImageClient? imageClient;
   final AgentImagePicker? imagePicker;
-  final AgentVoiceAssistantCommitted? onAssistantCommitted;
-  final AgentVoiceAssistantStreamStarted? onAssistantStreamStarted;
-  final AgentVoiceAssistantStreamDelta? onAssistantStreamDelta;
-  final AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted;
-  final AgentVoiceAssistantStreamFailed? onAssistantStreamFailed;
   final ComposerClientIdFactory _clientIdFactory;
 
-  AgentVoiceController? _voiceController;
+  AgentVoiceInputController? _voiceController;
   List<AgentPendingImage> _pendingImages = const <AgentPendingImage>[];
   String? _imageErrorMessage;
   bool _imageSelectionInFlight = false;
@@ -79,7 +52,7 @@ final class ComposerController extends ChangeNotifier {
   bool _departureInFlight = false;
   String? _boundThreadId;
 
-  AgentVoiceController? get voiceController => _voiceController;
+  AgentVoiceInputController? get voiceController => _voiceController;
   bool get supportsAgentVoice => _voiceController != null;
   bool get supportsAgentImages => imageClient != null && imagePicker != null;
   List<AgentPendingImage> get pendingImages =>
@@ -145,7 +118,7 @@ final class ComposerController extends ChangeNotifier {
   }
 
   Future<void> _startAgentVoiceRecording(
-    AgentVoiceController voice,
+    AgentVoiceInputController voice,
     int generation,
   ) async {
     await conversationController.initialize();
@@ -436,14 +409,8 @@ final class ComposerController extends ChangeNotifier {
       if (voice == null) {
         return true;
       }
-      switch (voice.state) {
-        case AgentVoiceComposerState.confirming ||
-            AgentVoiceComposerState.awaitingAssistant:
-          return false;
-        case AgentVoiceComposerState.idle:
-          break;
-        default:
-          await voice.cancel();
+      if (voice.state != AgentVoiceInputState.idle) {
+        await voice.cancel();
       }
       return !_disposed && !voice.hasActiveWorkflow;
     } finally {
@@ -465,7 +432,7 @@ final class ComposerController extends ChangeNotifier {
       notifyListeners();
     }
     await Future.wait([
-      if (_voiceController case final AgentVoiceController voice)
+      if (_voiceController case final AgentVoiceInputController voice)
         voice.clearPrivateState(),
       for (final asset in stagedAssets)
         imageClient?.deleteImage(imageAssetId: asset.id).catchError((_) {}) ??
@@ -486,7 +453,7 @@ final class ComposerController extends ChangeNotifier {
 
   bool _isCurrent(int generation) => !_disposed && generation == _generation;
 
-  bool _isVoiceStartCurrent(AgentVoiceController voice, int generation) =>
+  bool _isVoiceStartCurrent(AgentVoiceInputController voice, int generation) =>
       !_disposed &&
       !_departureInFlight &&
       generation == _voiceStartGeneration &&

--- a/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/design/voice_composer_dock.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 
 class AgentComposerVoiceDock extends StatelessWidget {
   const AgentComposerVoiceDock({
@@ -16,6 +16,7 @@ class AgentComposerVoiceDock extends StatelessWidget {
     required this.canAddImages,
     required this.onAddImages,
     required this.onShowText,
+    this.liveTranscript,
     super.key,
   });
 
@@ -27,6 +28,7 @@ class AgentComposerVoiceDock extends StatelessWidget {
   final bool canAddImages;
   final FutureOr<void> Function() onAddImages;
   final VoidCallback onShowText;
+  final String? liveTranscript;
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +44,11 @@ class AgentComposerVoiceDock extends StatelessWidget {
       durationKey: const Key('agent-voice-recording-duration'),
       showTextKey: const Key('agent-show-text-composer'),
       onShowText: onShowText,
+      liveTranscript: liveTranscript,
+      liveTranscriptKey: const Key('agent-voice-live-transcript'),
+      tapRecordingLabel: '点击转文字 · 上滑取消',
+      holdRecordingLabel: '上滑取消 · 松开转文字',
+      capturingSemanticsLabel: '停止录音并转文字',
       leading: IconButton(
         key: const Key('agent-image-picker-button'),
         tooltip: '添加图片',
@@ -66,7 +73,7 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
     super.key,
   });
 
-  final AgentVoiceComposerState state;
+  final AgentVoiceInputState state;
   final String message;
   final bool canCancel;
   final bool canRetry;
@@ -75,7 +82,7 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final failed = state == AgentVoiceComposerState.failed;
+    final failed = state == AgentVoiceInputState.failed;
     if (!failed) {
       return SizedBox(
         height: 48,
@@ -164,13 +171,10 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
   }
 }
 
-String agentComposerVoiceStateLabel(AgentVoiceComposerState state) {
+String agentComposerVoiceStateLabel(AgentVoiceInputState state) {
   return switch (state) {
-    AgentVoiceComposerState.starting => '正在打开麦克风…',
-    AgentVoiceComposerState.uploading => '正在处理语音…',
-    AgentVoiceComposerState.transcribing => '正在转写…',
-    AgentVoiceComposerState.confirming => '已识别，SpeakUp 正在回复…',
-    AgentVoiceComposerState.awaitingAssistant => 'SpeakUp 正在回复…',
+    AgentVoiceInputState.starting => '正在打开麦克风…',
+    AgentVoiceInputState.completing => '正在整理识别文字…',
     _ => '正在处理…',
   };
 }

--- a/mobile/lib/features/agent/composer/voice/agent_voice_input_client.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_input_client.dart
@@ -1,0 +1,125 @@
+import 'dart:typed_data';
+
+import 'package:speakup/features/agent/conversation/agent_client.dart';
+
+sealed class AgentVoiceInputEvent {
+  const AgentVoiceInputEvent();
+}
+
+final class AgentVoiceInputStarted extends AgentVoiceInputEvent {
+  const AgentVoiceInputStarted();
+}
+
+final class AgentVoiceInputUpdated extends AgentVoiceInputEvent {
+  const AgentVoiceInputUpdated(this.transcript);
+
+  final String transcript;
+}
+
+final class AgentVoiceInputCompleted extends AgentVoiceInputEvent {
+  const AgentVoiceInputCompleted(this.transcript);
+
+  final String transcript;
+}
+
+final class AgentVoiceInputFailed extends AgentVoiceInputEvent {
+  const AgentVoiceInputFailed({required this.kind, required this.retryable});
+
+  final String kind;
+  final bool retryable;
+}
+
+abstract interface class AgentVoiceInputClient {
+  Stream<AgentVoiceInputEvent> transcribeRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  });
+
+  Future<void> clearAccountState();
+
+  Future<void> dispose();
+}
+
+final class AgentVoiceInputFailure implements Exception {
+  const AgentVoiceInputFailure({required this.kind, required this.retryable});
+
+  final String kind;
+  final bool retryable;
+}
+
+/// Explicit preview/test provider for ephemeral Agent voice-to-text input.
+final class FakeAgentVoiceInputClient implements AgentVoiceInputClient {
+  FakeAgentVoiceInputClient({
+    this.partialTranscript = 'I explained the problem and the trade-off',
+    this.completedTranscript =
+        'I explained the problem, the trade-off, and the result clearly.',
+  });
+
+  final String partialTranscript;
+  final String completedTranscript;
+  int _accountGeneration = 0;
+  bool _disposed = false;
+
+  @override
+  Stream<AgentVoiceInputEvent> transcribeRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) async* {
+    if (_disposed) {
+      throw const AgentClientOperationCancelled();
+    }
+    if (threadId.trim().isEmpty ||
+        idempotencyKey.length < 8 ||
+        idempotencyKey.length > 128 ||
+        partialTranscript.trim().isEmpty ||
+        completedTranscript.trim().isEmpty) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.invalidRequest,
+      );
+    }
+    final generation = _accountGeneration;
+    yield const AgentVoiceInputStarted();
+    var receivedAudio = false;
+    await for (final chunk in audioChunks) {
+      _requireCurrent(generation);
+      if (chunk.isEmpty) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.invalidRequest,
+        );
+      }
+      if (!receivedAudio) {
+        receivedAudio = true;
+        yield AgentVoiceInputUpdated(partialTranscript);
+      }
+    }
+    _requireCurrent(generation);
+    if (!receivedAudio) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.invalidRequest,
+      );
+    }
+    yield AgentVoiceInputCompleted(completedTranscript);
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _accountGeneration++;
+  }
+
+  void _requireCurrent(int generation) {
+    if (_disposed || generation != _accountGeneration) {
+      throw const AgentClientOperationCancelled();
+    }
+  }
+}

--- a/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
@@ -1,0 +1,712 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:speakup/features/agent/conversation/agent_client.dart';
+
+import 'agent_voice_input_client.dart';
+import 'agent_voice_recording.dart';
+
+typedef AgentVoiceInputIdFactory = String Function(String scope);
+typedef AgentVoiceInputClock = DateTime Function();
+
+enum AgentVoiceInputState {
+  idle,
+  starting,
+  recording,
+  completing,
+  editing,
+  failed,
+}
+
+/// Owns ephemeral microphone input until it becomes an editable text draft.
+///
+/// This controller never creates a voice candidate, MessageAudio, or Message.
+/// The edited transcript is submitted through the ordinary text composer.
+final class AgentVoiceInputController extends ChangeNotifier
+    with WidgetsBindingObserver {
+  AgentVoiceInputController({
+    required this.client,
+    required this.recorder,
+    required this.idFactory,
+    this.clock = DateTime.now,
+    this.recordingLimit = const Duration(seconds: 58),
+    this.completionTimeout = const Duration(seconds: 75),
+  }) {
+    if (recordingLimit <= Duration.zero ||
+        recordingLimit > const Duration(seconds: 60) ||
+        completionTimeout <= Duration.zero) {
+      throw ArgumentError('Agent voice input configuration is invalid.');
+    }
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  final AgentVoiceInputClient client;
+  final AgentVoiceRecorder recorder;
+  final AgentVoiceInputIdFactory idFactory;
+  final AgentVoiceInputClock clock;
+  final Duration recordingLimit;
+  final Duration completionTimeout;
+
+  String? _threadId;
+  AgentVoiceInputState _state = AgentVoiceInputState.idle;
+  String _liveTranscript = '';
+  String _editedTranscript = '';
+  String? _errorMessage;
+  bool _canRetry = false;
+  DateTime? _recordingStartedAt;
+  Duration _recordingElapsed = Duration.zero;
+  Timer? _recordingTicker;
+  Timer? _recordingLimitTimer;
+  StreamSubscription<AgentVoiceInputEvent>? _eventSubscription;
+  Completer<_AgentVoiceInputTerminal>? _terminal;
+  Future<void>? _operation;
+  Future<void>? _workflowCleanup;
+  Future<void>? _cleanupFuture;
+  int _workflowGeneration = 0;
+  int _accountEpoch = 0;
+  bool _backgrounded = false;
+  bool _disposed = false;
+
+  String? get threadId => _threadId;
+  AgentVoiceInputState get state => _state;
+  String get liveTranscript => _liveTranscript;
+  String get editedTranscript => _editedTranscript;
+  String? get errorMessage => _errorMessage;
+  Duration get recordingElapsed => _recordingElapsed;
+  bool get canRetry => _canRetry;
+  bool get hasActiveWorkflow =>
+      _state != AgentVoiceInputState.idle ||
+      _workflowCleanup != null ||
+      _cleanupFuture != null;
+  bool get canStartRecording =>
+      !_disposed &&
+      !_backgrounded &&
+      _workflowCleanup == null &&
+      _cleanupFuture == null &&
+      _threadId != null &&
+      _state == AgentVoiceInputState.idle;
+  bool get canStopRecording => _state == AgentVoiceInputState.recording;
+  bool get canSubmitTranscript =>
+      _state == AgentVoiceInputState.editing &&
+      _editedTranscript.trim().isNotEmpty &&
+      utf8.encode(_editedTranscript.trim()).length <= 16384;
+
+  Future<void> bindThread(String? threadId) async {
+    if (threadId == _threadId) {
+      await _workflowCleanup;
+      return;
+    }
+    _threadId = threadId;
+    await _cancelWorkflow();
+  }
+
+  Future<void> startRecording() {
+    if (!canStartRecording || _operation != null) {
+      return Future<void>.value();
+    }
+    final fence = _newFence();
+    _state = AgentVoiceInputState.starting;
+    _liveTranscript = '';
+    _editedTranscript = '';
+    _errorMessage = null;
+    _canRetry = false;
+    notifyListeners();
+    late final Future<void> operation;
+    operation = _startRecording(fence).whenComplete(() {
+      if (identical(_operation, operation)) {
+        _operation = null;
+      }
+    });
+    _operation = operation;
+    return operation;
+  }
+
+  Future<void> _startRecording(_AgentVoiceInputFence fence) async {
+    final streamingRecorder = recorder;
+    if (streamingRecorder is! AgentVoiceEphemeralStreamingRecorder) {
+      _showFailure(
+        fence,
+        const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        ),
+      );
+      return;
+    }
+    try {
+      final chunks =
+          await (streamingRecorder as AgentVoiceEphemeralStreamingRecorder)
+              .startAudioStream();
+      if (!_isCurrent(fence)) {
+        await _discardCurrentBestEffort();
+        return;
+      }
+      final terminal = Completer<_AgentVoiceInputTerminal>();
+      _terminal = terminal;
+      final events = client.transcribeRealtime(
+        threadId: fence.threadId,
+        audioChunks: chunks,
+        idempotencyKey: _newId('voice-input'),
+      );
+      late final StreamSubscription<AgentVoiceInputEvent> subscription;
+      subscription = events.listen(
+        (event) => _handleEvent(fence, event),
+        onError: (Object error, StackTrace stackTrace) {
+          _completeTerminal(
+            terminal,
+            _AgentVoiceInputTerminal.failure(error, stackTrace),
+          );
+          if (_isCurrent(fence) &&
+              (_state == AgentVoiceInputState.starting ||
+                  _state == AgentVoiceInputState.recording)) {
+            unawaited(_abortCaptureAfterFailure(fence, error));
+          }
+        },
+        onDone: () {
+          if (!terminal.isCompleted) {
+            const error = AgentClientException(
+              kind: AgentClientFailureKind.network,
+              retryable: true,
+            );
+            _completeTerminal(
+              terminal,
+              const _AgentVoiceInputTerminal.failure(error, StackTrace.empty),
+            );
+            if (_isCurrent(fence) &&
+                (_state == AgentVoiceInputState.starting ||
+                    _state == AgentVoiceInputState.recording)) {
+              unawaited(_abortCaptureAfterFailure(fence, error));
+            }
+          }
+        },
+        cancelOnError: false,
+      );
+      _eventSubscription = subscription;
+      if (!_isCurrent(fence)) {
+        _completeTerminal(terminal, const _AgentVoiceInputTerminal.cancelled());
+        Future<void>? subscriptionCancellation;
+        try {
+          subscriptionCancellation = subscription.cancel();
+        } catch (_) {
+          // Recorder cleanup below still releases the stale capture.
+        }
+        await _discardCurrentBestEffort();
+        try {
+          await subscriptionCancellation;
+        } catch (_) {
+          // The generation fence already made this stream unobservable.
+        }
+        return;
+      }
+      _state = AgentVoiceInputState.recording;
+      _recordingElapsed = Duration.zero;
+      _startRecordingTimers(fence);
+      notifyListeners();
+    } catch (error) {
+      await _discardCurrentBestEffort();
+      _showFailure(fence, error);
+    }
+  }
+
+  void _handleEvent(_AgentVoiceInputFence fence, AgentVoiceInputEvent event) {
+    if (!_isCurrent(fence)) {
+      return;
+    }
+    switch (event) {
+      case AgentVoiceInputStarted():
+        return;
+      case AgentVoiceInputUpdated(:final transcript):
+        _liveTranscript = transcript;
+        notifyListeners();
+      case AgentVoiceInputCompleted(:final transcript):
+        _liveTranscript = transcript;
+        _completeTerminal(
+          _terminal,
+          _AgentVoiceInputTerminal.completed(transcript),
+        );
+        notifyListeners();
+      case AgentVoiceInputFailed(:final kind, :final retryable):
+        final failure = AgentVoiceInputFailure(
+          kind: kind,
+          retryable: retryable,
+        );
+        _completeTerminal(
+          _terminal,
+          _AgentVoiceInputTerminal.serverFailure(failure, StackTrace.current),
+        );
+        if (_state == AgentVoiceInputState.starting ||
+            _state == AgentVoiceInputState.recording) {
+          unawaited(_abortCaptureAfterFailure(fence, failure));
+        }
+    }
+  }
+
+  Future<void> stopRecording() {
+    if (_state == AgentVoiceInputState.completing) {
+      return _operation ?? Future<void>.value();
+    }
+    if (!canStopRecording || _operation != null) {
+      return Future<void>.value();
+    }
+    final fence = _captureFence();
+    _cancelRecordingTimers();
+    _state = AgentVoiceInputState.completing;
+    notifyListeners();
+    late final Future<void> operation;
+    operation = _stopRecording(fence).whenComplete(() {
+      if (identical(_operation, operation)) {
+        _operation = null;
+      }
+    });
+    _operation = operation;
+    return operation;
+  }
+
+  Future<void> _stopRecording(_AgentVoiceInputFence fence) async {
+    String? completedTranscript;
+    Object? failure;
+    var serverTerminal = false;
+    final terminal = _terminal;
+    final subscription = _eventSubscription;
+    try {
+      final streamingRecorder = recorder;
+      if (streamingRecorder is! AgentVoiceEphemeralStreamingRecorder ||
+          terminal == null) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        );
+      }
+      await (streamingRecorder as AgentVoiceEphemeralStreamingRecorder)
+          .stopAudioStreamAndDiscard();
+      if (!_isCurrent(fence)) {
+        return;
+      }
+      final result = await terminal.future.timeout(completionTimeout);
+      serverTerminal = result.serverTerminal;
+      if (!_isCurrent(fence) || result.cancelled) {
+        return;
+      }
+      if (result.error case final error?) {
+        Error.throwWithStackTrace(error, result.stackTrace!);
+      }
+      final transcript = result.transcript!.trim();
+      if (transcript.isEmpty) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.invalidResponse,
+        );
+      }
+      completedTranscript = transcript;
+    } catch (error) {
+      failure = error;
+    } finally {
+      _completeTerminal(terminal, const _AgentVoiceInputTerminal.cancelled());
+      if (identical(_eventSubscription, subscription)) {
+        _eventSubscription = null;
+      }
+      if (identical(_terminal, terminal)) {
+        _terminal = null;
+      }
+      if (!serverTerminal) {
+        _cancelSubscriptionWithoutWaiting(subscription);
+      }
+      await _discardCurrentBestEffort();
+    }
+    if (!_isCurrent(fence)) {
+      return;
+    }
+    if (failure case final error?) {
+      _showFailure(fence, error);
+      return;
+    }
+    final transcript = completedTranscript!;
+    _liveTranscript = transcript;
+    _editedTranscript = transcript;
+    _state = AgentVoiceInputState.editing;
+    _errorMessage = null;
+    _canRetry = false;
+    notifyListeners();
+  }
+
+  Future<void> _abortCaptureAfterFailure(
+    _AgentVoiceInputFence fence,
+    Object error,
+  ) async {
+    if (!_isCurrent(fence)) {
+      return;
+    }
+    _workflowGeneration++;
+    final cleanupFence = _captureFence();
+    _cancelRecordingTimers();
+    final subscription = _eventSubscription;
+    _eventSubscription = null;
+    _terminal = null;
+    _liveTranscript = '';
+    _editedTranscript = '';
+    _state = AgentVoiceInputState.completing;
+    _errorMessage = null;
+    _canRetry = false;
+    notifyListeners();
+    await _discardCurrentBestEffort();
+    _cancelSubscriptionWithoutWaiting(subscription);
+    if (!_isCurrent(cleanupFence)) {
+      return;
+    }
+    _state = AgentVoiceInputState.failed;
+    _errorMessage = _failureMessage(error);
+    _canRetry = _isRetryable(error);
+    notifyListeners();
+  }
+
+  Future<void> cancel() => _cancelWorkflow();
+
+  Future<void> _cancelWorkflow() {
+    final existing = _workflowCleanup;
+    if (existing != null) {
+      return existing;
+    }
+    _workflowGeneration++;
+    _cancelRecordingTimers();
+    final terminal = _terminal;
+    final subscription = _eventSubscription;
+    final operation = _operation;
+    _terminal = null;
+    _eventSubscription = null;
+    _resetPresentation();
+    _completeTerminal(terminal, const _AgentVoiceInputTerminal.cancelled());
+    late final Future<void> cleanup;
+    cleanup =
+        Future<void>.microtask(() async {
+          Future<void>? subscriptionCancellation;
+          try {
+            subscriptionCancellation = subscription?.cancel();
+          } catch (_) {
+            // Closing the recorder below still fences and releases the workflow.
+          }
+          await _discardCurrentBestEffort();
+          try {
+            await subscriptionCancellation;
+          } catch (_) {
+            // Recorder cleanup already released the local capture.
+          }
+          try {
+            await operation;
+          } catch (_) {
+            // The generation fence already made the stale operation unobservable.
+          }
+          await _discardCurrentBestEffort();
+        }).whenComplete(() {
+          if (identical(_workflowCleanup, cleanup)) {
+            _workflowCleanup = null;
+            if (!_disposed) {
+              notifyListeners();
+            }
+          }
+        });
+    _workflowCleanup = cleanup;
+    if (!_disposed) {
+      notifyListeners();
+    }
+    return cleanup;
+  }
+
+  void updateTranscript(String value) {
+    if (_state != AgentVoiceInputState.editing || value == _editedTranscript) {
+      return;
+    }
+    _editedTranscript = value;
+    notifyListeners();
+  }
+
+  Future<void> retry() async {
+    if (!_canRetry || _state != AgentVoiceInputState.failed) {
+      return;
+    }
+    final operation = _operation;
+    if (operation != null) {
+      try {
+        await operation;
+      } catch (_) {
+        // The visible failure already describes the completed operation.
+      }
+    }
+    await _workflowCleanup;
+    if (!_canRetry || _state != AgentVoiceInputState.failed) {
+      return;
+    }
+    _resetPresentation();
+    notifyListeners();
+    await startRecording();
+  }
+
+  Future<void> clearPrivateState() async {
+    final existing = _cleanupFuture;
+    if (existing != null) {
+      await existing;
+      return;
+    }
+    _accountEpoch++;
+    _threadId = null;
+    final cleanup = () async {
+      await _cancelWorkflow();
+      await Future.wait<void>([
+        Future<void>.sync(recorder.clearAccountState),
+        Future<void>.sync(client.clearAccountState),
+      ]);
+    }();
+    _cleanupFuture = cleanup;
+    try {
+      await cleanup;
+    } finally {
+      if (identical(_cleanupFuture, cleanup)) {
+        _cleanupFuture = null;
+      }
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_disposed) {
+      return;
+    }
+    if (state == AppLifecycleState.resumed) {
+      _backgrounded = false;
+      return;
+    }
+    if (_backgrounded) {
+      return;
+    }
+    _backgrounded = true;
+    unawaited(_cancelWorkflow());
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    WidgetsBinding.instance.removeObserver(this);
+    _accountEpoch++;
+    _workflowGeneration++;
+    _cancelRecordingTimers();
+    final terminal = _terminal;
+    final subscription = _eventSubscription;
+    final operation = _operation;
+    final workflowCleanup = _workflowCleanup;
+    _terminal = null;
+    _eventSubscription = null;
+    _completeTerminal(terminal, const _AgentVoiceInputTerminal.cancelled());
+    unawaited(() async {
+      Future<void>? subscriptionCancellation;
+      try {
+        subscriptionCancellation = subscription?.cancel();
+      } catch (_) {
+        // Recorder cleanup remains authoritative during disposal.
+      }
+      await _discardCurrentBestEffort();
+      try {
+        await subscriptionCancellation;
+      } catch (_) {
+        // Recorder cleanup already released the local capture.
+      }
+      await workflowCleanup;
+      try {
+        await operation;
+      } catch (_) {
+        // The disposed fence makes the operation unobservable.
+      }
+      await _discardCurrentBestEffort();
+      await client.dispose();
+    }());
+    super.dispose();
+  }
+
+  void _startRecordingTimers(_AgentVoiceInputFence fence) {
+    _cancelRecordingTimers();
+    _recordingStartedAt = clock();
+    _recordingTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!_isCurrent(fence) || _state != AgentVoiceInputState.recording) {
+        _cancelRecordingTimers();
+        return;
+      }
+      final startedAt = _recordingStartedAt;
+      if (startedAt != null) {
+        final elapsed = clock().difference(startedAt);
+        _recordingElapsed = elapsed.isNegative ? Duration.zero : elapsed;
+        notifyListeners();
+      }
+    });
+    _recordingLimitTimer = Timer(recordingLimit, () {
+      if (_isCurrent(fence) && _state == AgentVoiceInputState.recording) {
+        unawaited(stopRecording());
+      }
+    });
+  }
+
+  void _cancelRecordingTimers() {
+    _recordingTicker?.cancel();
+    _recordingLimitTimer?.cancel();
+    _recordingTicker = null;
+    _recordingLimitTimer = null;
+    _recordingStartedAt = null;
+  }
+
+  void _showFailure(_AgentVoiceInputFence fence, Object error) {
+    if (!_isCurrent(fence)) {
+      return;
+    }
+    _cancelRecordingTimers();
+    _liveTranscript = '';
+    _editedTranscript = '';
+    _state = AgentVoiceInputState.failed;
+    _errorMessage = _failureMessage(error);
+    _canRetry = _isRetryable(error);
+    notifyListeners();
+  }
+
+  void _resetPresentation() {
+    _state = AgentVoiceInputState.idle;
+    _liveTranscript = '';
+    _editedTranscript = '';
+    _errorMessage = null;
+    _canRetry = false;
+    _recordingElapsed = Duration.zero;
+  }
+
+  _AgentVoiceInputFence _newFence() {
+    final threadId = _threadId;
+    if (threadId == null) {
+      throw StateError('Agent voice input requires a focused Thread.');
+    }
+    return _AgentVoiceInputFence(
+      accountEpoch: _accountEpoch,
+      generation: ++_workflowGeneration,
+      threadId: threadId,
+    );
+  }
+
+  _AgentVoiceInputFence _captureFence() {
+    final threadId = _threadId;
+    if (threadId == null) {
+      throw StateError('Agent voice input requires a focused Thread.');
+    }
+    return _AgentVoiceInputFence(
+      accountEpoch: _accountEpoch,
+      generation: _workflowGeneration,
+      threadId: threadId,
+    );
+  }
+
+  bool _isCurrent(_AgentVoiceInputFence fence) =>
+      !_disposed &&
+      fence.accountEpoch == _accountEpoch &&
+      fence.generation == _workflowGeneration &&
+      fence.threadId == _threadId;
+
+  String _newId(String scope) {
+    final id = idFactory(scope);
+    if (id.length < 8 || id.length > 128) {
+      throw StateError('Agent voice input identity is invalid.');
+    }
+    return id;
+  }
+
+  Future<void> _discardCurrentBestEffort() async {
+    try {
+      await recorder.discardCurrent();
+    } catch (_) {
+      // Cleanup remains fenced even if the platform cannot remove the file.
+    }
+  }
+
+  void _cancelSubscriptionWithoutWaiting(
+    StreamSubscription<AgentVoiceInputEvent>? subscription,
+  ) {
+    if (subscription == null) {
+      return;
+    }
+    unawaited(subscription.cancel().catchError((_) {}));
+  }
+
+  bool _isRetryable(Object error) => switch (error) {
+    AgentVoiceInputFailure(:final retryable) => retryable,
+    AgentClientException(:final kind, :final retryable) =>
+      retryable ||
+          kind == AgentClientFailureKind.network ||
+          kind == AgentClientFailureKind.rateLimited ||
+          kind == AgentClientFailureKind.server,
+    AgentVoiceRecordingException(:final kind) =>
+      kind != AgentVoiceRecordingFailureKind.permissionDenied,
+    TimeoutException() => true,
+    _ => false,
+  };
+
+  String _failureMessage(Object error) => switch (error) {
+    AgentVoiceRecordingException(
+      kind: AgentVoiceRecordingFailureKind.permissionDenied,
+    ) =>
+      '请允许使用麦克风后再试。',
+    AgentVoiceRecordingException(
+      kind: AgentVoiceRecordingFailureKind.emptyAudio,
+    ) =>
+      '没有检测到语音，请重试。',
+    AgentClientException(kind: AgentClientFailureKind.authenticationRequired) =>
+      '登录状态已失效，请重新登录。',
+    AgentClientException(kind: AgentClientFailureKind.network) ||
+    TimeoutException() => '语音识别连接中断，请重试。',
+    AgentVoiceInputFailure() => '语音识别失败，请重试。',
+    _ => '暂时无法识别语音，请重试。',
+  };
+
+  static void _completeTerminal(
+    Completer<_AgentVoiceInputTerminal>? terminal,
+    _AgentVoiceInputTerminal result,
+  ) {
+    if (terminal != null && !terminal.isCompleted) {
+      terminal.complete(result);
+    }
+  }
+}
+
+final class _AgentVoiceInputFence {
+  const _AgentVoiceInputFence({
+    required this.accountEpoch,
+    required this.generation,
+    required this.threadId,
+  });
+
+  final int accountEpoch;
+  final int generation;
+  final String threadId;
+}
+
+final class _AgentVoiceInputTerminal {
+  const _AgentVoiceInputTerminal.completed(this.transcript)
+    : error = null,
+      stackTrace = null,
+      cancelled = false,
+      serverTerminal = true;
+
+  const _AgentVoiceInputTerminal.failure(this.error, this.stackTrace)
+    : transcript = null,
+      cancelled = false,
+      serverTerminal = false;
+
+  const _AgentVoiceInputTerminal.serverFailure(this.error, this.stackTrace)
+    : transcript = null,
+      cancelled = false,
+      serverTerminal = true;
+
+  const _AgentVoiceInputTerminal.cancelled()
+    : transcript = null,
+      error = null,
+      stackTrace = null,
+      cancelled = true,
+      serverTerminal = false;
+
+  final String? transcript;
+  final Object? error;
+  final StackTrace? stackTrace;
+  final bool cancelled;
+  final bool serverTerminal;
+}

--- a/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
@@ -27,6 +27,13 @@ abstract interface class AgentVoiceStreamingRecorder {
   Future<AgentVoiceLocalRecording> stopAudioStream();
 }
 
+/// Streams ephemeral voice input without materializing a local WAV file.
+abstract interface class AgentVoiceEphemeralStreamingRecorder {
+  Future<Stream<Uint8List>> startAudioStream();
+
+  Future<void> stopAudioStreamAndDiscard();
+}
+
 final class AgentVoiceRecordingException implements Exception {
   const AgentVoiceRecordingException(this.kind);
 
@@ -98,7 +105,10 @@ final class RecordNativeAgentVoiceRecorder implements NativeAgentVoiceRecorder {
 typedef AgentVoiceClock = DateTime Function();
 
 final class IosAgentVoiceRecorder
-    implements AgentVoiceRecorder, AgentVoiceStreamingRecorder {
+    implements
+        AgentVoiceRecorder,
+        AgentVoiceStreamingRecorder,
+        AgentVoiceEphemeralStreamingRecorder {
   IosAgentVoiceRecorder({
     NativeAgentVoiceRecorder? recorder,
     Future<Directory> Function()? temporaryDirectory,
@@ -116,6 +126,7 @@ final class IosAgentVoiceRecorder
   final Future<Directory> Function() _temporaryDirectory;
   final AgentVoiceClock _clock;
   final Random _random = Random.secure();
+  final Set<String> _pendingDeletionPaths = <String>{};
   String? _activePath;
   DateTime? _startedAt;
   Pcm16StreamCapture? _streamCapture;
@@ -127,6 +138,7 @@ final class IosAgentVoiceRecorder
         AgentVoiceRecordingFailureKind.alreadyRecording,
       );
     }
+    await _retryPendingDeletions();
     if (!await _recorder.hasPermission()) {
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.permissionDenied,
@@ -155,6 +167,7 @@ final class IosAgentVoiceRecorder
         AgentVoiceRecordingFailureKind.alreadyRecording,
       );
     }
+    await _retryPendingDeletions();
     if (!await _recorder.hasPermission()) {
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.permissionDenied,
@@ -290,12 +303,45 @@ final class IosAgentVoiceRecorder
   }
 
   @override
+  Future<void> stopAudioStreamAndDiscard() async {
+    final path = _activePath;
+    final startedAt = _startedAt;
+    final capture = _streamCapture;
+    if (path == null || startedAt == null || capture == null) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.notRecording,
+      );
+    }
+    _activePath = null;
+    _startedAt = null;
+    try {
+      await _recorder.stop();
+      await capture.finishAndDiscard();
+    } on Pcm16StreamCaptureException catch (error) {
+      await capture.cancel();
+      throw AgentVoiceRecordingException(_mapStreamFailure(error.kind));
+    } on AgentVoiceRecordingException {
+      await capture.cancel();
+      rethrow;
+    } catch (_) {
+      await capture.cancel();
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.unavailable,
+      );
+    } finally {
+      _clearStreamingState();
+      await _deletePath(path);
+    }
+  }
+
+  @override
   Future<void> discardCurrent() async {
     final path = _activePath;
     final capture = _streamCapture;
     _activePath = null;
     _startedAt = null;
     if (path == null) {
+      await _retryPendingDeletions();
       return;
     }
     await capture?.cancel();
@@ -334,6 +380,7 @@ final class IosAgentVoiceRecorder
   @override
   Future<void> clearAccountState() async {
     await discardCurrent();
+    await _retryPendingDeletions();
     final directory = await _managedDirectory(create: false);
     if (!await directory.exists()) {
       return;
@@ -379,15 +426,23 @@ final class IosAgentVoiceRecorder
   }
 
   Future<void> _deletePath(String path) async {
+    _pendingDeletionPaths.add(path);
     try {
       final file = File(path);
       if (await file.exists()) {
         await file.delete();
       }
+      _pendingDeletionPaths.remove(path);
     } on FileSystemException {
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.unavailable,
       );
+    }
+  }
+
+  Future<void> _retryPendingDeletions() async {
+    for (final path in _pendingDeletionPaths.toList(growable: false)) {
+      await _deletePath(path);
     }
   }
 }
@@ -455,6 +510,79 @@ final class FakeAgentVoiceRecorder implements AgentVoiceRecorder {
 
   @override
   Future<void> discard(AgentVoiceLocalRecording recording) async {}
+
+  @override
+  Future<void> clearAccountState() => discardCurrent();
+}
+
+final class FakeAgentVoiceStreamingRecorder
+    implements
+        AgentVoiceRecorder,
+        AgentVoiceStreamingRecorder,
+        AgentVoiceEphemeralStreamingRecorder {
+  FakeAgentVoiceStreamingRecorder({
+    AgentVoiceRecordingFailureKind? failure,
+    Duration recordingDuration = const Duration(seconds: 3),
+  }) : _recorder = FakeAgentVoiceRecorder(
+         failure: failure,
+         recordingDuration: recordingDuration,
+       );
+
+  final FakeAgentVoiceRecorder _recorder;
+  StreamController<Uint8List>? _audioChunks;
+
+  AgentVoiceRecordingFailureKind? get failure => _recorder.failure;
+
+  set failure(AgentVoiceRecordingFailureKind? value) {
+    _recorder.failure = value;
+  }
+
+  @override
+  Future<void> start() => _recorder.start();
+
+  @override
+  Future<Stream<Uint8List>> startAudioStream() async {
+    await _recorder.start();
+    final chunks = StreamController<Uint8List>();
+    _audioChunks = chunks;
+    scheduleMicrotask(() {
+      if (identical(_audioChunks, chunks) && !chunks.isClosed) {
+        chunks.add(Uint8List.fromList(const <int>[1, 0, 2, 0]));
+      }
+    });
+    return chunks.stream;
+  }
+
+  @override
+  Future<AgentVoiceLocalRecording> stop() => _recorder.stop();
+
+  @override
+  Future<AgentVoiceLocalRecording> stopAudioStream() async {
+    final chunks = _audioChunks;
+    _audioChunks = null;
+    await chunks?.close();
+    return _recorder.stop();
+  }
+
+  @override
+  Future<void> stopAudioStreamAndDiscard() async {
+    final chunks = _audioChunks;
+    _audioChunks = null;
+    await chunks?.close();
+    await _recorder.stop();
+  }
+
+  @override
+  Future<void> discardCurrent() async {
+    final chunks = _audioChunks;
+    _audioChunks = null;
+    await chunks?.close();
+    await _recorder.discardCurrent();
+  }
+
+  @override
+  Future<void> discard(AgentVoiceLocalRecording recording) =>
+      _recorder.discard(recording);
 
   @override
   Future<void> clearAccountState() => discardCurrent();

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -10,8 +10,7 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/agent/composer/agent_composer.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
 import 'package:speakup/features/agent/composer/pending_image_strip.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
@@ -107,7 +106,7 @@ class ConversationPage extends StatefulWidget {
   final Future<bool> Function(String)? onSubmitText;
   final VoidCallback? onRetryOperation;
   final VoidCallback? onLoadEarlierMessages;
-  final AgentVoiceController? voiceController;
+  final AgentVoiceInputController? voiceController;
   final AgentMessageAudioController? messageAudioController;
   final ConversationMessageTranslator? onTranslateMessage;
   final List<AgentPendingImage> pendingImages;
@@ -142,12 +141,7 @@ class ConversationPage extends StatefulWidget {
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
     final canCompose = hasFocusedThread || onCreateConversation != null;
-    final voiceShowsReplyProgress = switch (voiceController?.state) {
-      AgentVoiceComposerState.confirming ||
-      AgentVoiceComposerState.awaitingAssistant => true,
-      _ => false,
-    };
-    final replyPending = isBusy || voiceShowsReplyProgress;
+    final replyPending = isBusy;
     const topContentInset = 65.0;
     const topOverlayExtent = 76.0;
     final bottomOverlayExtent = composerBottom + composerHeight + 16;
@@ -285,7 +279,7 @@ class ConversationPage extends StatefulWidget {
                                   : null,
                             ),
                           ],
-                          if (isBusy && !voiceShowsReplyProgress) ...[
+                          if (isBusy) ...[
                             const SizedBox(height: 14),
                             Center(
                               child: Semantics(
@@ -591,14 +585,7 @@ class _ConversationPageState extends State<ConversationPage> {
       if (!mounted) {
         return;
       }
-      final keepLatestVisible = _isNearLatest();
-      final voiceState = widget.voiceController?.state;
       setState(() {});
-      if (voiceState == AgentVoiceComposerState.awaitingAssistant ||
-          (keepLatestVisible &&
-              voiceState == AgentVoiceComposerState.confirming)) {
-        _scheduleScrollToLatest();
-      }
     });
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -152,7 +152,6 @@ ProductionAppDependencies createProductionAppDependencies({
   PracticeMediaWireTransport? signedAudioTransport,
   PracticeRecorder? practiceRecorder,
   AgentVoiceRecorder? agentVoiceRecorder,
-  AgentAudioPlayer? agentComposerAudioPlayer,
   AgentAudioPlayer? agentMessageAudioPlayer,
   PracticeMediaClient? practiceMediaClient,
   PracticeAudioPlayer? practiceAudioPlayer,
@@ -297,24 +296,8 @@ ProductionAppDependencies createProductionAppDependencies({
     conversationController: conversationController,
     imageClient: agentImageClient,
     imagePicker: ImagePickerAgentImagePicker(),
-    voiceClient: agentVoiceClient,
+    voiceInputClient: agentVoiceClient,
     voiceRecorder: agentVoiceRecorder ?? IosAgentVoiceRecorder(),
-    draftAudioPlayer:
-        agentComposerAudioPlayer ?? AudioplayersAgentAudioPlayer(),
-    onAssistantStreamStarted: (transientMessageId) => messageAudioController
-        .startLiveAssistantSpeech(transientMessageId: transientMessageId),
-    onAssistantStreamDelta: (transientMessageId, delta) =>
-        messageAudioController.appendLiveAssistantSpeech(
-          transientMessageId: transientMessageId,
-          delta: delta,
-        ),
-    onAssistantStreamCompleted: (transientMessageId, message) =>
-        messageAudioController.completeLiveAssistantSpeech(
-          transientMessageId: transientMessageId,
-          message: message,
-        ),
-    onAssistantStreamFailed: (transientMessageId) => messageAudioController
-        .failLiveAssistantSpeech(transientMessageId: transientMessageId),
   );
   final practiceController = PracticeController(
     client: practiceClient,

--- a/mobile/lib/platform/audio/pcm16_stream_capture.dart
+++ b/mobile/lib/platform/audio/pcm16_stream_capture.dart
@@ -51,6 +51,28 @@ final class Pcm16StreamCapture {
   Future<Uint8List> finish({
     Duration timeout = const Duration(seconds: 2),
   }) async {
+    final pcm = await _takeValidatedPcm(timeout);
+    try {
+      return _pcm16MonoWav(pcm, sampleRate: sampleRate);
+    } finally {
+      pcm.fillRange(0, pcm.lengthInBytes, 0);
+    }
+  }
+
+  /// Finishes a streamed transcription without materializing local evidence.
+  Future<void> finishAndDiscard({
+    Duration timeout = const Duration(seconds: 2),
+  }) async {
+    Uint8List? pcm;
+    try {
+      pcm = await _takeValidatedPcm(timeout);
+    } finally {
+      _zero(pcm);
+      _discardBufferedPcm();
+    }
+  }
+
+  Future<Uint8List> _takeValidatedPcm(Duration timeout) async {
     try {
       await _done.future.timeout(timeout);
     } on TimeoutException {
@@ -68,11 +90,12 @@ final class Pcm16StreamCapture {
       );
     }
     if (pcm.lengthInBytes.isOdd || pcm.lengthInBytes > maximumPcmBytes) {
+      pcm.fillRange(0, pcm.lengthInBytes, 0);
       throw const Pcm16StreamCaptureException(
         Pcm16StreamCaptureFailureKind.invalidAudio,
       );
     }
-    return _pcm16MonoWav(pcm, sampleRate: sampleRate);
+    return pcm;
   }
 
   Future<void> cancel() async {
@@ -86,7 +109,7 @@ final class Pcm16StreamCapture {
       await _subscription?.cancel();
       _complete();
     }
-    _pcm.takeBytes();
+    _discardBufferedPcm();
   }
 
   void _handleChunk(Uint8List chunk) {
@@ -124,6 +147,7 @@ final class Pcm16StreamCapture {
     );
     await _subscription?.cancel();
     _complete();
+    _discardBufferedPcm();
   }
 
   void _fail(Pcm16StreamCaptureException failure) {
@@ -132,6 +156,7 @@ final class Pcm16StreamCapture {
     }
     _failure = failure;
     _output.addError(failure);
+    _discardBufferedPcm();
     final subscription = _subscription;
     if (subscription == null) {
       scheduleMicrotask(_complete);
@@ -148,6 +173,12 @@ final class Pcm16StreamCapture {
       _outputClosed = true;
       unawaited(_output.close());
     }
+  }
+
+  void _discardBufferedPcm() => _zero(_pcm.takeBytes());
+
+  static void _zero(Uint8List? bytes) {
+    bytes?.fillRange(0, bytes.lengthInBytes, 0);
   }
 }
 

--- a/mobile/lib/platform/audio/realtime_voice_input.dart
+++ b/mobile/lib/platform/audio/realtime_voice_input.dart
@@ -36,15 +36,23 @@ final class RealtimeVoiceInputTransport {
     required String idempotencyKey,
     required void Function() ensureCurrent,
     int maximumChunkBytes = 7_400_000,
+    Set<String> terminalEventTypes = const <String>{
+      'candidate.ready',
+      'candidate.failed',
+    },
   }) async* {
     if (idempotencyKey.length < 8 ||
         idempotencyKey.length > 128 ||
-        maximumChunkBytes < 1) {
+        maximumChunkBytes < 1 ||
+        terminalEventTypes.isEmpty ||
+        terminalEventTypes.any((type) => type.isEmpty || type.length > 64)) {
       throw ArgumentError('Realtime voice input configuration is invalid.');
     }
     SessionAuthenticatedWebSocketConnection? connection;
     StreamIterator<Uint8List>? chunks;
     Future<void>? sender;
+    final senderControl = _RealtimeVoiceInputSenderControl();
+    var receivedTerminalEvent = false;
     try {
       connection = await connector.connect(uri: uri);
       ensureCurrent();
@@ -61,17 +69,19 @@ final class RealtimeVoiceInputTransport {
         chunks: chunks,
         ensureCurrent: ensureCurrent,
         maximumChunkBytes: maximumChunkBytes,
+        control: senderControl,
       );
-      var receivedTerminalEvent = false;
       await for (final message in connection.socket) {
         ensureCurrent();
         final envelope = _decodeEnvelope(message);
         yield envelope;
-        if (envelope.type == 'candidate.ready' ||
-            envelope.type == 'candidate.failed') {
+        if (terminalEventTypes.contains(envelope.type)) {
           receivedTerminalEvent = true;
           break;
         }
+      }
+      if (receivedTerminalEvent) {
+        senderControl.stop();
       }
       await chunks.cancel();
       await sender;
@@ -96,6 +106,13 @@ final class RealtimeVoiceInputTransport {
         RealtimeVoiceInputFailureKind.invalidResponse,
       );
     } finally {
+      if (connection != null) {
+        if (receivedTerminalEvent) {
+          senderControl.stop();
+        } else {
+          senderControl.cancel(connection);
+        }
+      }
       await chunks?.cancel();
       if (sender != null) {
         try {
@@ -115,9 +132,13 @@ Future<void> _sendAudio({
   required StreamIterator<Uint8List> chunks,
   required void Function() ensureCurrent,
   required int maximumChunkBytes,
+  required _RealtimeVoiceInputSenderControl control,
 }) async {
   try {
     while (await chunks.moveNext()) {
+      if (control.stopped) {
+        return;
+      }
       ensureCurrent();
       final chunk = chunks.current;
       if (chunk.isEmpty || chunk.lengthInBytes > maximumChunkBytes) {
@@ -125,18 +146,48 @@ Future<void> _sendAudio({
       }
       connection.socket.add(chunk);
     }
+    if (control.stopped) {
+      return;
+    }
     ensureCurrent();
+    if (control.stopped) {
+      return;
+    }
     connection.socket.add(jsonEncode(const <String, String>{'type': 'finish'}));
   } catch (error, stackTrace) {
     try {
-      connection.socket.add(
-        jsonEncode(const <String, String>{'type': 'cancel'}),
-      );
+      control.cancel(connection);
       await connection.socket.close();
     } catch (_) {
       // Preserve the capture or account-fence failure that ended the stream.
     }
     Error.throwWithStackTrace(error, stackTrace);
+  }
+}
+
+final class _RealtimeVoiceInputSenderControl {
+  bool _stopped = false;
+  bool _cancelSent = false;
+
+  bool get stopped => _stopped;
+
+  void stop() {
+    _stopped = true;
+  }
+
+  void cancel(SessionAuthenticatedWebSocketConnection connection) {
+    _stopped = true;
+    if (_cancelSent) {
+      return;
+    }
+    _cancelSent = true;
+    try {
+      connection.socket.add(
+        jsonEncode(const <String, String>{'type': 'cancel'}),
+      );
+    } catch (_) {
+      // Closing the socket below still cancels the server-side workflow.
+    }
   }
 }
 

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -15,6 +15,7 @@ import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 
 final class AgentVoiceWireRequest {
@@ -75,6 +76,7 @@ final class WireAgentVoiceClient
         AgentVoiceClient,
         AgentVoiceStreamingClient,
         AgentVoiceRealtimeInputClient,
+        AgentVoiceInputClient,
         AgentMessageAudioClient,
         AgentAssistantSpeechClient {
   factory WireAgentVoiceClient({
@@ -329,6 +331,108 @@ final class WireAgentVoiceClient
         retryable: error.kind == RealtimeVoiceInputFailureKind.network,
       );
     } on AgentClientOperationCancelled {
+      rethrow;
+    } catch (_) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.network,
+        retryable: true,
+      );
+    }
+  }
+
+  @override
+  Stream<AgentVoiceInputEvent> transcribeRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) async* {
+    _requireUuid(threadId);
+    _requireClientIdentity(idempotencyKey, minimumLength: 8);
+    final generation = _accountGeneration;
+    final uri = realtimeVoiceWebSocketBaseUri(_baseUri).resolve(
+      '/v1/agent-threads/${Uri.encodeComponent(threadId)}/voice-transcriptions/realtime',
+    );
+    var phase = 0;
+    try {
+      final transport = RealtimeVoiceInputTransport(
+        connector: _realtimeConnector,
+      );
+      await for (final envelope in transport.stream(
+        uri: uri,
+        audioChunks: audioChunks,
+        idempotencyKey: idempotencyKey,
+        ensureCurrent: () => _requireGeneration(generation),
+        maximumChunkBytes: _maximumAudioBytes,
+        terminalEventTypes: const <String>{
+          'transcription.completed',
+          'transcription.failed',
+        },
+      )) {
+        final data = envelope.data;
+        switch (envelope.type) {
+          case 'transcription.started' when phase == 0:
+            _strictObject(
+              data,
+              allowed: const <String>{},
+              required: const <String>{},
+            );
+            phase = 1;
+            yield const AgentVoiceInputStarted();
+          case 'transcription.updated' when phase == 1:
+            final update = _strictObject(
+              data,
+              allowed: const <String>{'transcript', 'final'},
+              required: const <String>{'transcript', 'final'},
+            );
+            final transcript = _strictContent(update['transcript']);
+            if (_strictBool(update['final'])) {
+              throw const _InvalidVoiceResponse();
+            }
+            yield AgentVoiceInputUpdated(transcript);
+          case 'transcription.completed' when phase == 1:
+            final completed = _strictObject(
+              data,
+              allowed: const <String>{'transcript', 'final'},
+              required: const <String>{'transcript', 'final'},
+            );
+            final transcript = _strictContent(completed['transcript']);
+            if (!_strictBool(completed['final'])) {
+              throw const _InvalidVoiceResponse();
+            }
+            phase = 2;
+            yield AgentVoiceInputCompleted(transcript);
+          case 'transcription.failed' when phase == 1:
+            final failure = _strictObject(
+              data,
+              allowed: const <String>{'kind', 'retryable'},
+              required: const <String>{'kind', 'retryable'},
+            );
+            phase = 2;
+            yield AgentVoiceInputFailed(
+              kind: _strictString(failure['kind'], min: 1, max: 64),
+              retryable: _strictBool(failure['retryable']),
+            );
+          default:
+            throw const _InvalidVoiceResponse();
+        }
+      }
+      if (phase != 2) {
+        throw const _InvalidVoiceResponse();
+      }
+    } on _InvalidVoiceResponse {
+      throw _invalidResponse();
+    } on RealtimeVoiceInputException catch (error) {
+      throw AgentClientException(
+        kind: error.kind == RealtimeVoiceInputFailureKind.authenticationRequired
+            ? AgentClientFailureKind.authenticationRequired
+            : error.kind == RealtimeVoiceInputFailureKind.invalidResponse
+            ? AgentClientFailureKind.invalidResponse
+            : AgentClientFailureKind.network,
+        retryable: error.kind == RealtimeVoiceInputFailureKind.network,
+      );
+    } on AgentClientOperationCancelled {
+      rethrow;
+    } on AgentClientException {
       rethrow;
     } catch (_) {
       throw const AgentClientException(

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
@@ -349,8 +350,7 @@ _AgentHarness _agentHarness({PracticeClient? practiceClient}) {
     conversation: conversation,
     composer: ComposerController(
       conversationController: conversation,
-      voiceClient: voiceClient,
-      onAssistantCommitted: messageAudio.playCommittedAssistant,
+      voiceInputClient: FakeAgentVoiceInputClient(),
     ),
     messageAudio: messageAudio,
     practice: PracticeController(

--- a/mobile/test/agent/agent_voice_fence_test.dart
+++ b/mobile/test/agent/agent_voice_fence_test.dart
@@ -14,7 +14,6 @@ import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dar
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
 import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
-import 'package:speakup/features/agent/conversation/conversation.dart';
 
 void main() {
   test('production-capable recorder uses realtime input before stop', () async {
@@ -267,90 +266,6 @@ void main() {
     expect(controller.recording, isNull);
     expect(controller.candidate, isNotNull);
   });
-
-  testWidgets(
-    'committed voice Message appears before the pending Agent reply',
-    (tester) async {
-      final candidate = _readyCandidate(threadId: 'thread-a');
-      final confirmation = Completer<AgentVoiceConfirmation>();
-      final runResult = Completer<AgentVoiceRun>();
-      final pendingRun = AgentVoiceRun(
-        id: 'run-a',
-        threadId: 'thread-a',
-        inputMessageId: 'message-a',
-        status: AgentVoiceRunStatus.pending,
-      );
-      final completedRun = AgentVoiceRun(
-        id: 'run-a',
-        threadId: 'thread-a',
-        inputMessageId: 'message-a',
-        status: AgentVoiceRunStatus.completed,
-        assistantMessageId: 'assistant-a',
-      );
-      final client = _ControlledVoiceClient()
-        ..createResult = candidate
-        ..confirmCompleter = confirmation
-        ..getRunCompleter = runResult
-        ..messages['assistant-a'] = const AgentMessage(
-          id: 'assistant-a',
-          role: AgentMessageRole.assistant,
-          text: 'Assistant reply',
-        );
-      final committed = <AgentMessage>[];
-      final controller = _controller(client, committed);
-      addTearDown(controller.dispose);
-      await controller.bindThread('thread-a');
-      await tester.pumpWidget(
-        MaterialApp(
-          home: ConversationPage(
-            threadId: 'thread-a',
-            messages: committed,
-            onStartVoice: controller.startRecording,
-            voiceController: controller,
-            onSubmitText: (_) async => true,
-          ),
-        ),
-      );
-      await tester.tap(find.byKey(const Key('agent-show-text-composer')));
-      await tester.pump();
-      await tester.enterText(
-        find.byKey(const Key('agent-composer-field')),
-        'Unsent text before recording',
-      );
-      await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-voice-stop')));
-      await _pumpVoiceOperation(tester);
-      expect(controller.state, AgentVoiceComposerState.confirming);
-      expect(find.byKey(const Key('agent-voice-cancel')), findsNothing);
-      expect(find.text('Unsent text before recording'), findsNothing);
-
-      confirmation.complete(
-        _confirmation(
-          candidate: candidate,
-          text: candidate.transcript!.text,
-          run: pendingRun,
-        ),
-      );
-      await tester.pump();
-
-      expect(controller.state, AgentVoiceComposerState.awaitingAssistant);
-      expect(committed, hasLength(1));
-      expect(committed.single.role, AgentMessageRole.user);
-      expect(committed.single.modality, AgentMessageModality.voice);
-      expect(find.byKey(const Key('agent-message-message-a')), findsOneWidget);
-      expect(find.text('Assistant reply'), findsNothing);
-      expect(find.byKey(const Key('agent-voice-cancel')), findsNothing);
-      expect(find.byKey(const Key('agent-voice-state-label')), findsOneWidget);
-      expect(find.text('Unsent text before recording'), findsNothing);
-
-      runResult.complete(completedRun);
-      await _pumpVoiceOperation(tester);
-      expect(controller.state, AgentVoiceComposerState.idle);
-    },
-  );
 
   test('upload and ASR failures expose bounded retry states', () async {
     final uploadClient = _ControlledVoiceClient()

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -3,206 +3,391 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:speakup/features/agent/audio/agent_audio_player.dart';
+import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
-import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
-import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
-import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
-import 'package:speakup/design/speak_up_design.dart';
-import 'package:speakup/app/speak_up_app.dart';
-import 'package:speakup/features/agent/conversation/conversation.dart';
+import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 
 void main() {
-  test(
-    'Thread focus stays authoritative when voice cleanup needs a retry',
-    () async {
-      final player = _FailNextStopAgentAudioPlayer();
-      final recorder = _TrackingAgentVoiceRecorder();
+  testWidgets(
+    'home voice input shows partial text then sends an edited ordinary Message',
+    (tester) async {
+      final recorder = _TrackingStreamingRecorder();
       final conversationController = ConversationController(
         client: FakeAgentClient(),
       );
       final composerController = ComposerController(
         conversationController: conversationController,
-        voiceClient: FakeAgentVoiceClient(),
+        voiceInputClient: FakeAgentVoiceInputClient(),
         voiceRecorder: recorder,
-        draftAudioPlayer: player,
+        clientIdFactory: _sequentialIdFactory(),
       );
       addTearDown(() {
         composerController.dispose();
         conversationController.dispose();
       });
-      await conversationController.initialize();
-      await Future<void>.delayed(Duration.zero);
-      final oldThreadId = conversationController.threadId;
-      final voiceController = composerController.voiceController!;
 
-      player.failNextStop = true;
-      expect(await conversationController.createIndependentThread(), isTrue);
-      await Future<void>.delayed(Duration.zero);
+      await tester.pumpWidget(
+        SpeakUpApp.preview(
+          conversationController: conversationController,
+          composerController: composerController,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-      expect(conversationController.threadId, isNot(oldThreadId));
-      expect(voiceController.threadId, conversationController.threadId);
-      expect(voiceController.state, AgentVoiceComposerState.failed);
-      expect(voiceController.errorMessage, contains('语音播放未能停止'));
+      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+      await tester.pump();
+      await tester.pump();
 
-      await voiceController.retry();
+      expect(
+        composerController.voiceController?.state,
+        AgentVoiceInputState.recording,
+      );
+      expect(
+        find.byKey(const Key('agent-voice-live-transcript')),
+        findsOneWidget,
+      );
+      expect(find.text('点击转文字 · 上滑取消'), findsOneWidget);
+      expect(conversationController.messages, isEmpty);
 
-      expect(voiceController.state, AgentVoiceComposerState.recording);
-      expect(recorder.startCalls, 1);
-      await voiceController.cancel();
+      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+      await composerController.voiceController!.stopRecording();
+      await _pumpUntil(
+        tester,
+        () =>
+            composerController.voiceController?.state ==
+            AgentVoiceInputState.editing,
+      );
+
+      final field = find.byKey(const Key('agent-composer-field'));
+      expect(
+        composerController.voiceController?.state,
+        AgentVoiceInputState.editing,
+      );
+      expect(field, findsOneWidget);
+      expect(
+        tester.widget<TextField>(field).controller?.text,
+        'I explained the problem, the trade-off, and the result clearly.',
+      );
+      expect(conversationController.messages, isEmpty);
+
+      const edited = 'I explained the trade-off and measured the result.';
+      await tester.enterText(field, edited);
+      await tester.pump();
+      final send = find.byKey(const Key('agent-voice-text-send'));
+      expect(tester.widget<IconButton>(send).onPressed, isNotNull);
+      await tester.tap(send);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      final userMessages = conversationController.messages
+          .where((message) => message.role == AgentMessageRole.user)
+          .toList();
+      expect(userMessages, hasLength(1));
+      expect(userMessages.single.text, edited);
+      expect(userMessages.single.modality, AgentMessageModality.text);
+      expect(userMessages.single.audio, isNull);
+      expect(recorder.stopAudioStreamAndDiscardCalls, 1);
+      expect(recorder.discardedRecordings, 0);
+      expect(
+        conversationController.messages.where(
+          (message) => message.modality == AgentMessageModality.voice,
+        ),
+        isEmpty,
+      );
+      expect(
+        conversationController.messages.where(
+          (message) => message.role == AgentMessageRole.assistant,
+        ),
+        hasLength(1),
+      );
+      expect(
+        composerController.voiceController?.state,
+        AgentVoiceInputState.idle,
+      );
     },
   );
 
-  testWidgets('records, directly sends, and plays one Agent voice Message', (
-    tester,
-  ) async {
-    final client = FakeAgentClient();
-    final voiceClient = FakeAgentVoiceClient();
-    final assistantSpeech = _FlowAssistantSpeechClient();
-    final messagePlayer = FakeAgentAudioPlayer();
-    final conversationController = ConversationController(client: client);
-    final messageAudioController = AgentMessageAudioController(
-      conversationController: conversationController,
-      client: voiceClient,
-      audioPlayer: messagePlayer,
-      assistantSpeechClient: assistantSpeech,
-    );
-    final composerController = ComposerController(
-      conversationController: conversationController,
-      voiceClient: voiceClient,
-      onAssistantStreamStarted: (transientMessageId) => messageAudioController
-          .startLiveAssistantSpeech(transientMessageId: transientMessageId),
-      onAssistantStreamDelta: (transientMessageId, delta) =>
-          messageAudioController.appendLiveAssistantSpeech(
-            transientMessageId: transientMessageId,
-            delta: delta,
-          ),
-      onAssistantStreamCompleted: (transientMessageId, message) =>
-          messageAudioController.completeLiveAssistantSpeech(
-            transientMessageId: transientMessageId,
-            message: message,
-          ),
-      onAssistantStreamFailed: (transientMessageId) => messageAudioController
-          .failLiveAssistantSpeech(transientMessageId: transientMessageId),
-      clientIdFactory: _sequentialIdFactory(),
-    );
-    addTearDown(() {
-      composerController.dispose();
-      messageAudioController.dispose();
-      conversationController.dispose();
-    });
+  test(
+    'completed transcription discards PCM without creating a local WAV',
+    () async {
+      final recorder = _TrackingStreamingRecorder();
+      final controller = AgentVoiceInputController(
+        client: FakeAgentVoiceInputClient(),
+        recorder: recorder,
+        idFactory: _sequentialIdFactory(),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
 
-    await tester.pumpWidget(
-      SpeakUpApp.preview(
+      await controller.startRecording();
+      await Future<void>.delayed(Duration.zero);
+      expect(controller.liveTranscript, isNotEmpty);
+
+      await controller.stopRecording();
+
+      expect(controller.state, AgentVoiceInputState.editing);
+      expect(controller.canSubmitTranscript, isTrue);
+      expect(recorder.stopAudioStreamAndDiscardCalls, 1);
+      expect(recorder.stopAudioStreamCalls, 0);
+      expect(recorder.discardedRecordings, 0);
+      expect(recorder.hasCurrentRecording, isFalse);
+    },
+  );
+
+  test(
+    'local cleanup failure stays failed and retries retained cleanup',
+    () async {
+      final recorder = _TrackingStreamingRecorder()
+        ..failEphemeralCleanup = true;
+      final controller = AgentVoiceInputController(
+        client: FakeAgentVoiceInputClient(),
+        recorder: recorder,
+        idFactory: _sequentialIdFactory(),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+      await Future<void>.delayed(Duration.zero);
+
+      await controller.stopRecording();
+
+      expect(controller.state, AgentVoiceInputState.failed);
+      expect(controller.editedTranscript, isEmpty);
+      expect(controller.canSubmitTranscript, isFalse);
+      expect(controller.canRetry, isTrue);
+      expect(recorder.hasPendingCleanup, isTrue);
+
+      recorder
+        ..failEphemeralCleanup = false
+        ..allowPendingCleanup = true;
+      await controller.retry();
+
+      expect(recorder.hasPendingCleanup, isFalse);
+      expect(controller.state, AgentVoiceInputState.recording);
+    },
+  );
+
+  testWidgets(
+    'text send failure keeps the draft after local audio is deleted',
+    (tester) async {
+      final recorder = _TrackingStreamingRecorder();
+      final conversationController = ConversationController(
+        client: _FailingTextAgentClient(),
+      );
+      final composerController = ComposerController(
         conversationController: conversationController,
-        composerController: composerController,
-        messageAudioController: messageAudioController,
-      ),
-    );
-    await tester.pumpAndSettle();
+        voiceInputClient: FakeAgentVoiceInputClient(),
+        voiceRecorder: recorder,
+        clientIdFactory: _sequentialIdFactory(),
+      );
+      addTearDown(() {
+        composerController.dispose();
+        conversationController.dispose();
+      });
+      await tester.pumpWidget(
+        SpeakUpApp.preview(
+          conversationController: conversationController,
+          composerController: composerController,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await tester.pump();
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.recording,
-    );
-    expect(find.byKey(const Key('agent-composer-surface')), findsOneWidget);
-    expect(find.byKey(const Key('agent-voice-composer-panel')), findsNothing);
-    expect(find.byKey(const Key('agent-voice-stop')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+      await composerController.voiceController!.stopRecording();
+      await _pumpUntil(
+        tester,
+        () =>
+            composerController.voiceController?.state ==
+            AgentVoiceInputState.editing,
+      );
+      final field = find.byKey(const Key('agent-composer-field'));
+      const edited = 'Keep this voice-derived draft after failure.';
+      await tester.enterText(field, edited);
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('agent-voice-text-send')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
-    await tester.tap(find.byKey(const Key('agent-voice-stop')));
-    await _pumpVoiceOperation(tester);
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.idle,
-    );
-    expect(find.byKey(const Key('agent-composer-surface')), findsOneWidget);
-    expect(find.byKey(const Key('agent-voice-composer-panel')), findsNothing);
-    expect(find.text('试听'), findsNothing);
-    expect(find.text('重录'), findsNothing);
-    expect(find.text('上传并转写'), findsNothing);
+      expect(conversationController.messages, isEmpty);
+      expect(recorder.stopAudioStreamAndDiscardCalls, 1);
+      expect(recorder.discardedRecordings, 0);
+      expect(recorder.hasCurrentRecording, isFalse);
+      expect(
+        tester
+            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
+            .controller
+            ?.text,
+        edited,
+      );
+      expect(
+        composerController.voiceController?.state,
+        AgentVoiceInputState.idle,
+      );
+    },
+  );
 
-    final voiceMessages = conversationController.messages
-        .where((message) => message.modality == AgentMessageModality.voice)
-        .toList();
-    expect(voiceMessages, hasLength(1));
-    expect(
-      voiceMessages.single.text,
-      'I explained the problem, the trade-off, and the result clearly.',
-    );
-    expect(voiceMessages.single.audio?.isReadable, isTrue);
-    expect(
-      conversationController.messages.where(
-        (message) => message.role == AgentMessageRole.assistant,
-      ),
-      hasLength(1),
-    );
-    expect(find.byKey(const Key('agent-voice-composer-panel')), findsNothing);
+  test(
+    'Thread switch cleans capture and fences late transcription events',
+    () async {
+      final client = _ControlledVoiceInputClient();
+      final recorder = _TrackingStreamingRecorder();
+      final controller = AgentVoiceInputController(
+        client: client,
+        recorder: recorder,
+        idFactory: _sequentialIdFactory(),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+      client.events.add(const AgentVoiceInputStarted());
+      client.events.add(const AgentVoiceInputUpdated('Thread A partial'));
+      await Future<void>.delayed(Duration.zero);
+      expect(controller.liveTranscript, 'Thread A partial');
 
-    final assistant = conversationController.messages.singleWhere(
-      (message) => message.role == AgentMessageRole.assistant,
-    );
-    final assistantTts = find.byKey(Key('agent-assistant-tts-${assistant.id}'));
-    await tester.pumpAndSettle();
-    expect(assistantTts.hitTestable(), findsOneWidget);
-    expect(assistantSpeech.texts, <String>[
-      'That was clear. Add one measurable result to make the answer stronger.',
-    ]);
-    expect(messageAudioController.playingMessageId, assistant.id);
-    messagePlayer.complete();
-    await tester.pump();
-    expect(messageAudioController.playingMessageId, isNull);
-    await tester.tap(assistantTts);
-    await tester.pump();
-    expect(
-      find.byKey(Key('agent-assistant-text-${assistant.id}')),
-      findsOneWidget,
-    );
-    expect(messageAudioController.playingMessageId, assistant.id);
-    await tester.tap(find.byKey(Key('agent-assistant-speed-${assistant.id}')));
-    await tester.pump();
-    expect(messageAudioController.speechSpeed, 1.25);
+      await controller.bindThread('thread-b');
+      client.events.add(const AgentVoiceInputCompleted('Late Thread A text'));
+      await Future<void>.delayed(Duration.zero);
 
-    final voiceMessage = voiceMessages.single;
-    final voiceBubble = find.byKey(Key('agent-message-${voiceMessage.id}'));
-    final voiceDecoration =
-        tester.widget<Container>(voiceBubble).decoration! as BoxDecoration;
-    expect(voiceDecoration.color, SpeakUpDesign.primaryMuted);
-    expect(tester.getSize(voiceBubble).height, lessThan(220));
-    expect(
-      find.byKey(Key('agent-user-voice-play-${voiceMessage.id}')),
-      findsOneWidget,
+      expect(controller.threadId, 'thread-b');
+      expect(controller.state, AgentVoiceInputState.idle);
+      expect(controller.liveTranscript, isEmpty);
+      expect(controller.editedTranscript, isEmpty);
+      expect(recorder.discardCurrentCalls, greaterThan(0));
+      expect(recorder.hasCurrentRecording, isFalse);
+    },
+  );
+
+  test(
+    'failed realtime transcription cleans audio without creating a draft',
+    () async {
+      final client = _ControlledVoiceInputClient();
+      final recorder = _TrackingStreamingRecorder();
+      final controller = AgentVoiceInputController(
+        client: client,
+        recorder: recorder,
+        idFactory: _sequentialIdFactory(),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+
+      client.events.add(const AgentVoiceInputStarted());
+      client.events.add(
+        const AgentVoiceInputFailed(
+          kind: 'provider_unavailable',
+          retryable: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state, AgentVoiceInputState.failed);
+      expect(controller.canRetry, isTrue);
+      expect(controller.editedTranscript, isEmpty);
+      expect(recorder.hasCurrentRecording, isFalse);
+      expect(recorder.discardCurrentCalls, greaterThan(0));
+    },
+  );
+
+  test('account cleanup removes capture and fences late events', () async {
+    final client = _ControlledVoiceInputClient();
+    final recorder = _TrackingStreamingRecorder();
+    final controller = AgentVoiceInputController(
+      client: client,
+      recorder: recorder,
+      idFactory: _sequentialIdFactory(),
     );
-    expect(
-      find.byKey(Key('agent-user-voice-duration-${voiceMessage.id}')),
-      findsNothing,
-    );
-    expect(
-      find.byKey(Key('agent-user-voice-transcript-${voiceMessage.id}')),
-      findsOneWidget,
-    );
-    expect(
-      find.byKey(Key('agent-user-voice-delete-${voiceMessage.id}')),
-      findsNothing,
-    );
-    await composerController.voiceController?.cancel();
-    await tester.pump();
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+    await controller.startRecording();
+    client.events.add(const AgentVoiceInputUpdated('Private partial'));
+    await Future<void>.delayed(Duration.zero);
+
+    await controller.clearPrivateState();
+    client.events.add(const AgentVoiceInputCompleted('Late private text'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.threadId, isNull);
+    expect(controller.state, AgentVoiceInputState.idle);
+    expect(controller.liveTranscript, isEmpty);
+    expect(controller.editedTranscript, isEmpty);
+    expect(recorder.clearAccountStateCalls, greaterThan(0));
+    expect(recorder.hasCurrentRecording, isFalse);
   });
 
-  testWidgets('upward swipe cancels home recording', (tester) async {
-    final client = FakeAgentClient();
-    final voiceClient = FakeAgentVoiceClient();
-    final conversationController = ConversationController(client: client);
+  test('same-thread restart waits for cancellation cleanup', () async {
+    final gate = Completer<void>();
+    final recorder = _TrackingStreamingRecorder(discardGate: gate);
+    final controller = AgentVoiceInputController(
+      client: _ControlledVoiceInputClient(),
+      recorder: recorder,
+      idFactory: _sequentialIdFactory(),
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+    await controller.startRecording();
+
+    final cleanup = controller.cancel();
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.state, AgentVoiceInputState.idle);
+    expect(controller.canStartRecording, isFalse);
+
+    var rebound = false;
+    final rebind = controller.bindThread('thread-a').then((_) {
+      rebound = true;
+    });
+    await Future<void>.delayed(Duration.zero);
+    expect(rebound, isFalse);
+
+    gate.complete();
+    await cleanup;
+    await rebind;
+    expect(controller.canStartRecording, isTrue);
+    await controller.startRecording();
+    expect(controller.state, AgentVoiceInputState.recording);
+  });
+
+  test('dispose releases an active ephemeral capture', () async {
+    final client = _ControlledVoiceInputClient();
+    final recorder = _TrackingStreamingRecorder();
+    final controller = AgentVoiceInputController(
+      client: client,
+      recorder: recorder,
+      idFactory: _sequentialIdFactory(),
+    );
+    await controller.bindThread('thread-a');
+    await controller.startRecording();
+
+    controller.dispose();
+    for (var attempt = 0; attempt < 20 && client.disposeCalls == 0; attempt++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(client.disposeCalls, 1);
+    expect(recorder.discardCurrentCalls, greaterThan(0));
+    expect(recorder.hasCurrentRecording, isFalse);
+  });
+
+  testWidgets('upward swipe cancels capture and restores the typed draft', (
+    tester,
+  ) async {
+    final recorder = _TrackingStreamingRecorder();
+    final conversationController = ConversationController(
+      client: FakeAgentClient(),
+    );
     final composerController = ComposerController(
       conversationController: conversationController,
-      voiceClient: voiceClient,
+      voiceInputClient: FakeAgentVoiceInputClient(),
+      voiceRecorder: recorder,
       clientIdFactory: _sequentialIdFactory(),
     );
     addTearDown(() {
@@ -217,13 +402,17 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const Key('agent-composer-field')),
+      'Keep this draft',
+    );
+    await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
+    await tester.pump();
     final target = find.byKey(const Key('agent-mic-placeholder'));
     await tester.tap(target);
     await tester.pump();
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.recording,
-    );
 
     final gesture = await tester.startGesture(tester.getCenter(target));
     await gesture.moveBy(const Offset(0, -90));
@@ -231,449 +420,229 @@ void main() {
     expect(find.text('松开取消'), findsOneWidget);
     await gesture.up();
     await _pumpVoiceOperation(tester);
-
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.idle,
-    );
-    expect(find.byKey(const Key('agent-composer-field')), findsNothing);
-  });
-
-  testWidgets('recording elapsed time updates inside the original composer', (
-    tester,
-  ) async {
-    var now = DateTime.utc(2026, 7, 27, 9);
-    final voiceController = AgentVoiceController(
-      client: FakeAgentVoiceClient(),
-      recorder: FakeAgentVoiceRecorder(),
-      audioPlayer: FakeAgentAudioPlayer(),
-      onMessagesCommitted: (_) {},
-      idFactory: (scope) => '${scope}_1',
-      clock: () => now,
-    );
-    addTearDown(voiceController.dispose);
-    await voiceController.bindThread('thread-a');
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: ConversationPage(
-          onStartVoice: voiceController.startRecording,
-          voiceController: voiceController,
-          onSubmitText: (_) async => true,
-        ),
-      ),
-    );
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await tester.pump();
-
-    expect(voiceController.state, AgentVoiceComposerState.recording);
-    expect(find.byKey(const Key('agent-composer-surface')), findsOneWidget);
-    expect(find.byKey(const Key('agent-voice-composer-panel')), findsNothing);
-    expect(
-      tester
-          .widget<Text>(find.byKey(const Key('agent-voice-recording-duration')))
-          .data,
-      '0:00',
-    );
-
-    now = now.add(const Duration(seconds: 1));
-    await tester.pump(const Duration(seconds: 1));
+    await composerController.voiceController!.cancel();
 
     expect(
       tester
-          .widget<Text>(find.byKey(const Key('agent-voice-recording-duration')))
-          .data,
-      '0:01',
+          .widget<TextField>(find.byKey(const Key('agent-composer-field')))
+          .controller
+          ?.text,
+      'Keep this draft',
     );
-    await voiceController.cancel();
-    await tester.pump();
+    expect(conversationController.messages, isEmpty);
+    expect(recorder.discardCurrentCalls, greaterThan(0));
+    expect(recorder.hasCurrentRecording, isFalse);
   });
-
-  testWidgets('leaving the Agent tab cancels hands-free recording', (
-    tester,
-  ) async {
-    final client = FakeAgentClient();
-    final voiceClient = FakeAgentVoiceClient();
-    final conversationController = ConversationController(client: client);
-    final composerController = ComposerController(
-      conversationController: conversationController,
-      voiceClient: voiceClient,
-      clientIdFactory: _sequentialIdFactory(),
-    );
-    addTearDown(() {
-      composerController.dispose();
-      conversationController.dispose();
-    });
-    await tester.pumpWidget(
-      SpeakUpApp.preview(
-        conversationController: conversationController,
-        composerController: composerController,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await tester.pump();
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.recording,
-    );
-
-    await tester.tap(find.byKey(const Key('primary-tab-scenes')));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('scenes-page')), findsOneWidget);
-    expect(
-      composerController.voiceController?.state,
-      AgentVoiceComposerState.idle,
-    );
-    await tester.pump(const Duration(seconds: 60));
-    expect(
-      conversationController.messages.where(
-        (message) => message.modality == AgentMessageModality.voice,
-      ),
-      isEmpty,
-    );
-  });
-
-  test(
-    'leaving Agent while playback is stopping fences microphone start',
-    () async {
-      final player = _GatedAgentAudioPlayer();
-      final recorder = _TrackingAgentVoiceRecorder();
-      final client = FakeAgentClient();
-      final voiceClient = FakeAgentVoiceClient();
-      final conversationController = ConversationController(client: client);
-      final composerController = ComposerController(
-        conversationController: conversationController,
-        voiceClient: voiceClient,
-        voiceRecorder: recorder,
-        draftAudioPlayer: player,
-        clientIdFactory: _sequentialIdFactory(),
-      );
-      addTearDown(() {
-        composerController.dispose();
-        conversationController.dispose();
-      });
-      await conversationController.initialize();
-
-      final stop = player.blockNextStop();
-      final start = composerController.startAgentVoiceRecording();
-      await stop.entered.future;
-
-      final leave = composerController.prepareToLeave();
-      stop.release.complete();
-
-      await start;
-      expect(await leave, isTrue);
-      expect(recorder.startCalls, 0);
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceComposerState.idle,
-      );
-    },
-  );
-
-  testWidgets('composer drafts cannot cross the Thread boundary', (
-    tester,
-  ) async {
-    final voiceController = AgentVoiceController(
-      client: FakeAgentVoiceClient(),
-      recorder: FakeAgentVoiceRecorder(),
-      audioPlayer: FakeAgentAudioPlayer(),
-      onMessagesCommitted: (_) {},
-      idFactory: (scope) => '${scope}_1',
-    );
-    addTearDown(voiceController.dispose);
-    var threadId = 'thread-a';
-    late StateSetter update;
-    await voiceController.bindThread(threadId);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: StatefulBuilder(
-          builder: (context, setState) {
-            update = setState;
-            return ConversationPage(
-              threadId: threadId,
-              onStartVoice: voiceController.startRecording,
-              voiceController: voiceController,
-              onSubmitText: (_) async => true,
-            );
-          },
-        ),
-      ),
-    );
-    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
-    await tester.pump();
-    await tester.enterText(
-      find.byKey(const Key('agent-composer-field')),
-      'Thread A private draft',
-    );
-    await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await tester.pump();
-    expect(voiceController.state, AgentVoiceComposerState.recording);
-
-    await voiceController.bindThread('thread-b');
-    await voiceController.startRecording();
-    update(() => threadId = 'thread-b');
-    await tester.pump();
-
-    expect(voiceController.state, AgentVoiceComposerState.recording);
-    await voiceController.cancel();
-    await tester.pump();
-
-    await tester.tap(find.byKey(const Key('agent-show-text-composer')));
-    await tester.pump();
-    final field = find.byKey(const Key('agent-composer-field'));
-    expect(field, findsOneWidget);
-    expect(tester.widget<TextField>(field).controller?.text, isEmpty);
-    expect(find.text('Thread A private draft'), findsNothing);
-  });
-
-  testWidgets(
-    'microphone safely creates and focuses a Thread when none is focused',
-    (tester) async {
-      final client = FakeAgentClient();
-      final voiceClient = FakeAgentVoiceClient();
-      final conversationController = ConversationController(client: client);
-      final composerController = ComposerController(
-        conversationController: conversationController,
-        voiceClient: voiceClient,
-        clientIdFactory: _sequentialIdFactory(),
-      );
-      addTearDown(() {
-        composerController.dispose();
-        conversationController.dispose();
-      });
-      await conversationController.initialize();
-      final previousThreadId = conversationController.threadId;
-      await conversationController.clearFocusedThread();
-      expect(conversationController.threadId, isNull);
-
-      await tester.pumpWidget(
-        SpeakUpApp.preview(
-          conversationController: conversationController,
-          composerController: composerController,
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(
-        find.byKey(const Key('no-focused-conversation-home')),
-        findsNothing,
-      );
-      expect(find.byKey(const Key('agent-show-text-composer')), findsOneWidget);
-
-      await tester.tap(find.byKey(const Key('agent-show-text-composer')));
-      await tester.pump();
-      await tester.enterText(
-        find.byKey(const Key('agent-composer-field')),
-        'Keep this typed draft',
-      );
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-show-voice-composer')));
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await tester.pump();
-
-      expect(conversationController.threadId, isNotNull);
-      expect(conversationController.threadId, isNot(previousThreadId));
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceComposerState.recording,
-      );
-      await composerController.voiceController?.cancel();
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-show-text-composer')));
-      await tester.pump();
-      expect(
-        tester
-            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
-            .controller
-            ?.text,
-        'Keep this typed draft',
-      );
-    },
-  );
-
-  testWidgets(
-    'voice transcript stays in the original composer on narrow layouts',
-    (tester) async {
-      tester.view.physicalSize = const Size(320, 640);
-      tester.view.devicePixelRatio = 1;
-      tester.view.viewInsets = const FakeViewPadding(bottom: 240);
-      tester.platformDispatcher.textScaleFactorTestValue = 2;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-      addTearDown(tester.view.resetViewInsets);
-      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
-
-      final client = FakeAgentClient();
-      final voiceClient = FakeAgentVoiceClient();
-      final conversationController = ConversationController(client: client);
-      final composerController = ComposerController(
-        conversationController: conversationController,
-        voiceClient: voiceClient,
-        clientIdFactory: _sequentialIdFactory(),
-      );
-      addTearDown(() {
-        composerController.dispose();
-        conversationController.dispose();
-      });
-      await tester.pumpWidget(
-        SpeakUpApp.preview(
-          conversationController: conversationController,
-          composerController: composerController,
-        ),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await tester.pump();
-
-      final surface = find.byKey(const Key('agent-composer-surface'));
-      final stateLabel = find.byKey(const Key('agent-voice-state-label'));
-      final duration = find.byKey(const Key('agent-voice-recording-duration'));
-      final stop = find.byKey(const Key('agent-voice-stop'));
-      expect(stateLabel, findsOneWidget);
-      expect(duration, findsOneWidget);
-      expect(stop.hitTestable(), findsOneWidget);
-      expect(tester.getRect(stateLabel).left, greaterThanOrEqualTo(0));
-      expect(
-        tester.getRect(duration).right,
-        lessThanOrEqualTo(tester.getRect(surface).right),
-      );
-      expect(
-        tester.getRect(stop).right,
-        lessThanOrEqualTo(tester.getRect(surface).right),
-      );
-      expect(tester.takeException(), isNull);
-
-      expect(find.text('点击发送 · 上滑取消'), findsOneWidget);
-      expect(tester.takeException(), isNull);
-      await composerController.voiceController?.cancel();
-      await tester.pump();
-    },
-  );
 }
 
-final class _TrackingAgentVoiceRecorder implements AgentVoiceRecorder {
-  int startCalls = 0;
+final class _TrackingStreamingRecorder
+    implements
+        AgentVoiceRecorder,
+        AgentVoiceStreamingRecorder,
+        AgentVoiceEphemeralStreamingRecorder {
+  _TrackingStreamingRecorder({this.discardGate});
+
+  final Completer<void>? discardGate;
+  StreamController<Uint8List>? _chunks;
+  bool _recording = false;
+  int stopAudioStreamCalls = 0;
+  int stopAudioStreamAndDiscardCalls = 0;
+  int discardCurrentCalls = 0;
+  int discardedRecordings = 0;
+  int clearAccountStateCalls = 0;
+  bool failEphemeralCleanup = false;
+  bool allowPendingCleanup = false;
+  bool _pendingCleanup = false;
+
+  bool get hasCurrentRecording => _recording;
+  bool get hasPendingCleanup => _pendingCleanup;
 
   @override
   Future<void> start() async {
-    startCalls++;
-  }
-
-  @override
-  Future<AgentVoiceLocalRecording> stop() {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> discardCurrent() async {}
-
-  @override
-  Future<void> discard(AgentVoiceLocalRecording recording) async {}
-
-  @override
-  Future<void> clearAccountState() async {}
-}
-
-final class _GatedAgentAudioPlayer implements AgentAudioPlayer {
-  Completer<void>? _nextStopEntered;
-  Completer<void>? _nextStopGate;
-
-  ({Completer<void> entered, Completer<void> release}) blockNextStop() {
-    final entered = Completer<void>();
-    final release = Completer<void>();
-    _nextStopEntered = entered;
-    _nextStopGate = release;
-    return (entered: entered, release: release);
-  }
-
-  @override
-  Stream<Duration> get onPosition => const Stream<Duration>.empty();
-
-  @override
-  Stream<void> get onComplete => const Stream<void>.empty();
-
-  @override
-  Future<void> playFile(String path, {required double speed}) async {}
-
-  @override
-  Future<void> playWav(Uint8List bytes, {required double speed}) async {}
-
-  @override
-  Future<void> stop() async {
-    final entered = _nextStopEntered;
-    final gate = _nextStopGate;
-    _nextStopEntered = null;
-    _nextStopGate = null;
-    entered?.complete();
-    await gate?.future;
-  }
-
-  @override
-  Future<void> clearAccountState() async {}
-
-  @override
-  Future<void> dispose() async {}
-}
-
-final class _FailNextStopAgentAudioPlayer implements AgentAudioPlayer {
-  bool failNextStop = false;
-
-  @override
-  Stream<Duration> get onPosition => const Stream<Duration>.empty();
-
-  @override
-  Stream<void> get onComplete => const Stream<void>.empty();
-
-  @override
-  Future<void> playFile(String path, {required double speed}) async {}
-
-  @override
-  Future<void> playWav(Uint8List bytes, {required double speed}) async {}
-
-  @override
-  Future<void> stop() async {
-    if (failNextStop) {
-      failNextStop = false;
-      throw const AgentAudioPlaybackException();
+    if (_pendingCleanup) {
+      if (!allowPendingCleanup) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        );
+      }
+      _pendingCleanup = false;
     }
+    _recording = true;
   }
 
   @override
-  Future<void> clearAccountState() async {}
+  Future<Stream<Uint8List>> startAudioStream() async {
+    await start();
+    final chunks = StreamController<Uint8List>();
+    _chunks = chunks;
+    scheduleMicrotask(() {
+      if (identical(_chunks, chunks) && !chunks.isClosed) {
+        chunks.add(Uint8List.fromList(const <int>[1, 0, 2, 0]));
+      }
+    });
+    return chunks.stream;
+  }
 
   @override
-  Future<void> dispose() async {}
-}
-
-final class _FlowAssistantSpeechClient implements AgentAssistantSpeechClient {
-  final List<String> texts = <String>[];
+  Future<AgentVoiceLocalRecording> stop() async {
+    _recording = false;
+    return const AgentVoiceLocalRecording(
+      path: 'temporary-agent-input.wav',
+      contentType: 'audio/wav',
+      sizeBytes: 48,
+      duration: Duration(seconds: 1),
+    );
+  }
 
   @override
-  Stream<AgentAssistantSpeechAudioSegment> streamAssistantSpeech({
-    required String threadId,
-    required Stream<AgentAssistantSpeechTextSegment> segments,
-  }) async* {
-    await for (final segment in segments) {
-      texts.add(segment.text);
-      yield AgentAssistantSpeechAudioSegment(
-        sequence: segment.sequence,
-        chunkIndex: 1,
-        audio: Uint8List.fromList(<int>[1, 2, 3, 4]),
+  Future<AgentVoiceLocalRecording> stopAudioStream() async {
+    stopAudioStreamCalls++;
+    final chunks = _chunks;
+    _chunks = null;
+    await chunks?.close();
+    return stop();
+  }
+
+  @override
+  Future<void> stopAudioStreamAndDiscard() async {
+    stopAudioStreamAndDiscardCalls++;
+    final chunks = _chunks;
+    _chunks = null;
+    await chunks?.close();
+    _recording = false;
+    if (failEphemeralCleanup) {
+      _pendingCleanup = true;
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.unavailable,
       );
     }
+  }
+
+  @override
+  Future<void> discardCurrent() async {
+    discardCurrentCalls++;
+    if (_recording) {
+      await discardGate?.future;
+    }
+    final chunks = _chunks;
+    _chunks = null;
+    await chunks?.close();
+    _recording = false;
+    if (_pendingCleanup) {
+      if (!allowPendingCleanup) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        );
+      }
+      _pendingCleanup = false;
+    }
+  }
+
+  @override
+  Future<void> discard(AgentVoiceLocalRecording recording) async {
+    discardedRecordings++;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    clearAccountStateCalls++;
+    await discardCurrent();
+  }
+}
+
+final class _ControlledVoiceInputClient implements AgentVoiceInputClient {
+  final events = StreamController<AgentVoiceInputEvent>.broadcast();
+  StreamSubscription<Uint8List>? _audioSubscription;
+  int disposeCalls = 0;
+
+  @override
+  Stream<AgentVoiceInputEvent> transcribeRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) {
+    _audioSubscription = audioChunks.listen((_) {});
+    return events.stream;
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    await _audioSubscription?.cancel();
+    _audioSubscription = null;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+    await _audioSubscription?.cancel();
+    await events.close();
+  }
+}
+
+final class _FailingTextAgentClient implements AgentClient {
+  final _delegate = FakeAgentClient();
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<AgentThreadSummary> createThread() => _delegate.createThread();
+
+  @override
+  Future<void> clearFocusedThread() => _delegate.clearFocusedThread();
+
+  @override
+  Future<void> deleteThread({required String threadId}) =>
+      _delegate.deleteThread(threadId: threadId);
+
+  @override
+  Future<AgentThreadSnapshot?> getFocusedThread() =>
+      _delegate.getFocusedThread();
+
+  @override
+  Future<AgentThreadPage> listThreads({int pageSize = 20, String? cursor}) =>
+      _delegate.listThreads(pageSize: pageSize, cursor: cursor);
+
+  @override
+  Future<AgentMessagePage> listMessages({
+    required String threadId,
+    int pageSize = 50,
+    String? cursor,
+  }) => _delegate.listMessages(
+    threadId: threadId,
+    pageSize: pageSize,
+    cursor: cursor,
+  );
+
+  @override
+  Future<AgentThreadSnapshot> setFocusedThread({required String threadId}) =>
+      _delegate.setFocusedThread(threadId: threadId);
+
+  @override
+  Future<AgentExchange> sendText({
+    required String threadId,
+    required String text,
+    required String clientMessageId,
+    List<String> imageAssetIds = const <String>[],
+  }) {
+    throw const AgentClientException(
+      kind: AgentClientFailureKind.network,
+      retryable: true,
+    );
   }
 }
 
 Future<void> _pumpVoiceOperation(WidgetTester tester) async {
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump();
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempt = 0; attempt < 100 && !condition(); attempt++) {
+    await tester.pump(const Duration(milliseconds: 10));
+  }
+  await tester.pump();
 }
 
 String Function(String scope) _sequentialIdFactory() {

--- a/mobile/test/agent/agent_voice_recording_stream_test.dart
+++ b/mobile/test/agent/agent_voice_recording_stream_test.dart
@@ -38,6 +38,34 @@ void main() {
     },
   );
 
+  test('ephemeral streaming stop clears PCM without creating a WAV', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'agent-voice-ephemeral-recorder-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final native = _StreamingNativeRecorder();
+    final recorder = IosAgentVoiceRecorder(
+      recorder: native,
+      temporaryDirectory: () async => directory,
+    );
+
+    final stream = await recorder.startAudioStream();
+    final forwarded = stream.expand((chunk) => chunk).toList();
+    final pcm = Uint8List.fromList(<int>[0, 0, 1, 0]);
+    native.add(pcm);
+    await recorder.stopAudioStreamAndDiscard();
+
+    expect(await forwarded, <int>[0, 0, 1, 0]);
+    expect(pcm, <int>[0, 0, 0, 0]);
+    expect(
+      await directory
+          .list(recursive: true, followLinks: false)
+          .where((entity) => entity is File)
+          .toList(),
+      isEmpty,
+    );
+  });
+
   test('streaming stop failure cancels the native capture', () async {
     final directory = await Directory.systemTemp.createTemp(
       'agent-voice-stream-recorder-failure-',
@@ -52,6 +80,8 @@ void main() {
 
     final stream = await recorder.startAudioStream();
     final subscription = stream.listen((_) {}, onError: (_) {});
+    final pcm = Uint8List.fromList(<int>[1, 0, 2, 0]);
+    native.add(pcm);
 
     await expectLater(
       recorder.stopAudioStream(),
@@ -65,6 +95,7 @@ void main() {
     );
 
     expect(native.cancelCount, 1);
+    expect(pcm, <int>[0, 0, 0, 0]);
     await subscription.cancel();
   });
 }

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/providers/agent/wire_agent_voice_client.dart';
 import 'package:speakup/features/agent/handoff/agent_handoff.dart';
@@ -162,6 +163,252 @@ void main() {
       'type': 'finish',
     });
   });
+
+  test(
+    'decodes ephemeral voice-to-text events from the frozen endpoint',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final received = <Object>[];
+      final handled = Completer<void>();
+      server.listen((request) async {
+        expect(
+          request.uri.path,
+          '/v1/agent-threads/$_threadId/voice-transcriptions/realtime',
+        );
+        expect(
+          request.headers.value(HttpHeaders.authorizationHeader),
+          'Bearer sess_voice',
+        );
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (protocols) {
+            expect(protocols, contains('speakup.voice-input.v1'));
+            return 'speakup.voice-input.v1';
+          },
+        );
+        await for (final message in socket) {
+          received.add(message);
+          if (received.length == 1) {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.started',
+                'data': <String, Object>{},
+              }),
+            );
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.updated',
+                'data': <String, Object>{
+                  'transcript': 'Partial answer',
+                  'final': false,
+                },
+              }),
+            );
+          }
+          if (message is String &&
+              (jsonDecode(message) as Map<String, dynamic>)['type'] ==
+                  'finish') {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.completed',
+                'data': <String, Object>{
+                  'transcript': 'Completed answer',
+                  'final': true,
+                },
+              }),
+            );
+            await socket.close();
+            handled.complete();
+            break;
+          }
+        }
+      });
+      final client = WireAgentVoiceClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => _credential,
+        invalidateSession: _ignoreInvalidation,
+        apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      );
+      addTearDown(client.dispose);
+
+      final events = await client
+          .transcribeRealtime(
+            threadId: _threadId,
+            audioChunks: Stream<Uint8List>.value(
+              Uint8List.fromList(const <int>[1, 0, 2, 0]),
+            ),
+            idempotencyKey: 'voice_input_001',
+          )
+          .toList();
+      await handled.future;
+
+      expect(events, hasLength(3));
+      expect(events[0], isA<AgentVoiceInputStarted>());
+      expect(
+        (events[1] as AgentVoiceInputUpdated).transcript,
+        'Partial answer',
+      );
+      expect(
+        (events[2] as AgentVoiceInputCompleted).transcript,
+        'Completed answer',
+      );
+      expect(jsonDecode(received.first as String), <String, Object?>{
+        'type': 'start',
+        'idempotency_key': 'voice_input_001',
+        'sample_rate': 16000,
+      });
+      expect(received[1], <int>[1, 0, 2, 0]);
+      expect(jsonDecode(received.last as String), <String, Object?>{
+        'type': 'finish',
+      });
+    },
+  );
+
+  test(
+    'rejects a completed voice transcript unless final is exactly true',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final handled = Completer<void>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (_) => 'speakup.voice-input.v1',
+        );
+        await for (final message in socket) {
+          if (message is String &&
+              (jsonDecode(message) as Map<String, dynamic>)['type'] ==
+                  'start') {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.started',
+                'data': <String, Object>{},
+              }),
+            );
+          }
+          if (message is String &&
+              (jsonDecode(message) as Map<String, dynamic>)['type'] ==
+                  'finish') {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.completed',
+                'data': <String, Object>{
+                  'transcript': 'Not terminal',
+                  'final': false,
+                },
+              }),
+            );
+            await socket.close();
+            handled.complete();
+            break;
+          }
+        }
+      });
+      final client = WireAgentVoiceClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => _credential,
+        invalidateSession: _ignoreInvalidation,
+        apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.transcribeRealtime(
+          threadId: _threadId,
+          audioChunks: Stream<Uint8List>.value(
+            Uint8List.fromList(const <int>[1, 0]),
+          ),
+          idempotencyKey: 'voice_input_002',
+        ),
+        emitsInOrder(<Object>[
+          isA<AgentVoiceInputStarted>(),
+          emitsError(
+            isA<AgentClientException>().having(
+              (error) => error.kind,
+              'kind',
+              AgentClientFailureKind.invalidResponse,
+            ),
+          ),
+        ]),
+      );
+      await handled.future;
+    },
+  );
+
+  test(
+    'cancelling ephemeral transcription sends cancel instead of finish',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final receivedTypes = <String>[];
+      final handled = Completer<void>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (_) => 'speakup.voice-input.v1',
+        );
+        await for (final message in socket) {
+          if (message is! String) {
+            continue;
+          }
+          final type = (jsonDecode(message) as Map<String, dynamic>)['type'];
+          if (type is! String) {
+            continue;
+          }
+          receivedTypes.add(type);
+          if (type == 'start') {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.started',
+                'data': <String, Object>{},
+              }),
+            );
+          } else if (type == 'cancel') {
+            if (!handled.isCompleted) {
+              handled.complete();
+            }
+            await socket.close();
+            break;
+          }
+        }
+      });
+      final client = WireAgentVoiceClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => _credential,
+        invalidateSession: _ignoreInvalidation,
+        apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      );
+      addTearDown(client.dispose);
+      final audio = StreamController<Uint8List>();
+      addTearDown(audio.close);
+      final started = Completer<void>();
+      final subscription = client
+          .transcribeRealtime(
+            threadId: _threadId,
+            audioChunks: audio.stream,
+            idempotencyKey: 'voice_input_003',
+          )
+          .listen((event) {
+            if (event is AgentVoiceInputStarted && !started.isCompleted) {
+              started.complete();
+            }
+          });
+
+      await started.future.timeout(const Duration(seconds: 2));
+      await subscription.cancel();
+      await handled.future.timeout(const Duration(seconds: 2));
+
+      expect(
+        receivedTypes,
+        containsAllInOrder(const <String>['start', 'cancel']),
+      );
+      expect(receivedTypes, isNot(contains('finish')));
+    },
+  );
 
   test('confirms one voice Message with exact strict JSON', () async {
     final transport = _ScriptedVoiceTransport([

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -170,7 +170,6 @@ void main() {
       final practiceMediaClient = _TrackingPracticeMediaClient();
       final practiceAudioPlayer = _TrackingPracticeAudioPlayer();
       final agentVoiceRecorder = _TrackingAgentVoiceRecorder();
-      final agentComposerAudioPlayer = _TrackingAgentAudioPlayer();
       final agentMessageAudioPlayer = _TrackingAgentAudioPlayer();
       final dependencies = production.createProductionAppDependencies(
         baseUri: Uri.parse('https://api.speak-up.test'),
@@ -182,7 +181,6 @@ void main() {
         practiceTransport: _PracticeTransport(),
         practiceRecorder: practiceRecorder,
         agentVoiceRecorder: agentVoiceRecorder,
-        agentComposerAudioPlayer: agentComposerAudioPlayer,
         agentMessageAudioPlayer: agentMessageAudioPlayer,
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
@@ -224,10 +222,6 @@ void main() {
       expect(
         dependencies.composerController.voiceController?.recorder,
         same(agentVoiceRecorder),
-      );
-      expect(
-        dependencies.composerController.voiceController?.audioPlayer,
-        same(agentComposerAudioPlayer),
       );
       expect(
         dependencies.messageAudioController.audioPlayer,
@@ -306,7 +300,6 @@ void main() {
         isTrue,
       );
       expect(agentVoiceRecorder.clearCount, 0);
-      expect(agentComposerAudioPlayer.clearCount, 0);
       expect(agentMessageAudioPlayer.clearCount, 0);
 
       await dependencies.preparationController.loadIfNeeded();
@@ -378,8 +371,7 @@ void main() {
       expect(practiceRecorder.clearCount, 1);
       expect(practiceMediaClient.clearCount, 1);
       expect(practiceAudioPlayer.clearCount, 2);
-      expect(agentVoiceRecorder.clearCount, 2);
-      expect(agentComposerAudioPlayer.clearCount, 2);
+      expect(agentVoiceRecorder.clearCount, 1);
       expect(agentMessageAudioPlayer.clearCount, 2);
 
       reviewHistoryTransport.completeWithReview();
@@ -470,7 +462,6 @@ void main() {
       final practiceMediaClient = _TrackingPracticeMediaClient();
       final practiceAudioPlayer = _TrackingPracticeAudioPlayer();
       final agentVoiceRecorder = _TrackingAgentVoiceRecorder();
-      final agentComposerAudioPlayer = _TrackingAgentAudioPlayer();
       final agentMessageAudioPlayer = _TrackingAgentAudioPlayer();
       final launchRecordStore = _FailingPracticeLaunchRecordStore();
       final dependencies = production.createProductionAppDependencies(
@@ -480,7 +471,6 @@ void main() {
         practiceTransport: _PracticeTransport(),
         practiceRecorder: practiceRecorder,
         agentVoiceRecorder: agentVoiceRecorder,
-        agentComposerAudioPlayer: agentComposerAudioPlayer,
         agentMessageAudioPlayer: agentMessageAudioPlayer,
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
@@ -512,7 +502,6 @@ void main() {
       expect(dependencies.conversationController.threadId, isNull);
       expect(dependencies.conversationController.messages, isEmpty);
       expect(agentVoiceRecorder.clearCount, greaterThan(0));
-      expect(agentComposerAudioPlayer.clearCount, greaterThan(0));
       expect(agentMessageAudioPlayer.clearCount, greaterThan(0));
       expect(practiceRecorder.clearCount, greaterThan(0));
       expect(practiceMediaClient.clearCount, greaterThan(0));


### PR DESCRIPTION
## 功能描述
- 首页录音期间展示实时转写，停止后进入可编辑文字草稿
- 确认后复用普通文字消息与现有 AI 流式回复，不创建新的用户语音消息
- 首页录音不生成 WAV、不上传 OSS；练习证据与历史语音播放/删除保持不变

## 实现思路
- 新增首页专用临时转写控制器，严格消费 #568 冻结的 WebSocket 事件
- 取消、切换会话、退后台和退出登录均发送 cancel，并用会话栅栏隔离迟到事件
- 串行清理旧录音；PCM 在完成后清零，清理失败显式进入失败态
- 转写完成后回填现有文字编辑框，并走已有 text Message + Agent SSE

## 测试
- flutter analyze --no-pub
- 171 项 Agent、Practice realtime、录音组件及主装配相关测试全部通过
- 首页新流程 10/10、Wire 契约 11/11、录音流 3/3 通过
- git diff --check

## 依赖
- 合并顺序：先合并后端 PR #568，再合并本 PR

Closes #564
关联 #542