### PR TITLE
[codex] 修复首题生成失败遗留僵尸练习

### DIFF
--- a/api/common/errors.yaml
+++ b/api/common/errors.yaml
@@ -70,6 +70,7 @@ components:
         - resource_processing
         - idempotency_key_conflict
         - provider_unavailable
+        - practice_activation_failed
         - quota_exhausted
         - voice_capacity_exhausted
         - scene_not_found
@@ -174,6 +175,7 @@ components:
         evaluation_retryable_failure: 503
         rate_limited: 429
         provider_unavailable: 503
+        practice_activation_failed: 503
         quota_exhausted: 503
         voice_capacity_exhausted: 503
         job_target_analysis_failed: 503

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -59,6 +59,7 @@ final class PracticeController extends ChangeNotifier
   final PracticeClientIdFactory _clientIdFactory;
   final Duration _recordingLimit;
   String? _practiceSessionId;
+  String? _discardedActivationSessionId;
   PracticeExperience? _practiceExperience;
   SceneCategory? _practiceSceneCategory;
   PracticeMode? _practiceMode;
@@ -109,6 +110,7 @@ final class PracticeController extends ChangeNotifier
   int _mediaGeneration = 0;
   Future<void>? _mediaOperation;
   String? get practiceSessionId => _practiceSessionId;
+  String? get discardedActivationSessionId => _discardedActivationSessionId;
   PracticeExperience? get practiceExperience => _practiceExperience;
   SceneCategory? get practiceSceneCategory => _practiceSceneCategory;
   PracticeMode? get practiceMode => _practiceMode;
@@ -359,6 +361,12 @@ final class PracticeController extends ChangeNotifier
       }
       _activeScene = scene;
       _applyPracticeSnapshot(snapshot);
+    } on PracticeClientException catch (error) {
+      if (_isOperationCurrent(fence) &&
+          error.errorCode == 'practice_activation_failed') {
+        _discardedActivationSessionId = sessionId;
+      }
+      rethrow;
     } finally {
       if (_isCurrent(epoch)) {
         _setBusy(false);
@@ -397,6 +405,12 @@ final class PracticeController extends ChangeNotifier
       }
       _activeScene = scene;
       _applyPracticeSnapshot(snapshot);
+    } on PracticeClientException catch (error) {
+      if (_isOperationCurrent(fence) &&
+          error.errorCode == 'practice_activation_failed') {
+        _discardedActivationSessionId = sessionId;
+      }
+      rethrow;
     } finally {
       if (_isCurrent(epoch)) {
         _setBusy(false);
@@ -1864,6 +1878,7 @@ final class PracticeController extends ChangeNotifier
     _practiceGeneration++;
     _pendingPracticeAudio = null;
     _practiceSessionId = null;
+    _discardedActivationSessionId = null;
     _practiceExperience = null;
     _practiceSceneCategory = null;
     _practiceMode = null;
@@ -1984,6 +1999,9 @@ final class PracticeController extends ChangeNotifier
       );
     }
     final previousSessionId = _practiceSessionId;
+    if (snapshot != null) {
+      _discardedActivationSessionId = null;
+    }
     _cancelRecordingLimit();
     _practiceGeneration++;
     _candidate = null;

--- a/mobile/lib/features/coaching/preparation/practice_plan_handoff_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_plan_handoff_controller.dart
@@ -137,7 +137,22 @@ final class PracticePlanHandoffController extends ChangeNotifier {
       return false;
     } on Object {
       if (_isCurrent(generation)) {
-        _errorMessage = workspaceController.errorMessage ?? '练习暂时无法开始，请重试当前确认。';
+        final discardedSessionId =
+            practiceController.discardedActivationSessionId;
+        final cleaned =
+            discardedSessionId != null &&
+            workspaceController.currentSessionId == discardedSessionId &&
+            await workspaceController.parkCurrentPractice();
+        if (!_isCurrent(generation)) {
+          return false;
+        }
+        if (cleaned) {
+          _attempt = null;
+          _errorMessage = 'AI 出题服务暂时不可用，未开始的练习已清理，请重试。';
+        } else {
+          _errorMessage =
+              workspaceController.errorMessage ?? '练习暂时无法开始，请重试当前确认。';
+        }
       }
       return false;
     } finally {

--- a/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
@@ -438,6 +438,12 @@ final class PracticeWorkspaceController extends ChangeNotifier {
           (current.goalId == null ||
               conversationController.activeGoalId == current.goalId) &&
           !practiceController.hasActivePractice;
+      final failedActivationWasFocused =
+          current.isCommitted &&
+          conversationController.threadId == current.practiceThreadId &&
+          practiceController.discardedActivationSessionId ==
+              current.sessionId &&
+          !practiceController.hasActivePractice;
       if (!await _prepareToLeavePractice()) {
         return false;
       }
@@ -449,7 +455,7 @@ final class PracticeWorkspaceController extends ChangeNotifier {
         _setError('暂时无法返回原来的首页对话，请稍后重试。');
         return false;
       }
-      if (terminalPracticeWasFocused) {
+      if (terminalPracticeWasFocused || failedActivationWasFocused) {
         _current = null;
         notifyListeners();
         try {
@@ -872,6 +878,9 @@ final class PracticeWorkspaceController extends ChangeNotifier {
         scene: record.scene!,
       );
     } on Object {
+      if (practiceController.discardedActivationSessionId == record.sessionId) {
+        return _PracticeResumeVerification.terminal;
+      }
       return _PracticeResumeVerification.unavailable;
     }
     if (conversationController.threadId != record.practiceThreadId ||

--- a/mobile/test/coaching/practice/formal_practice_activation_test.dart
+++ b/mobile/test/coaching/practice/formal_practice_activation_test.dart
@@ -100,6 +100,60 @@ void main() {
     expect(controller.practiceSessionId, _sessionId);
   });
 
+  test(
+    'marks a server-discarded failed activation for workspace cleanup',
+    () async {
+      final practice = _ActivationPracticeClient(
+        snapshot: _snapshot(turnLimit: 6),
+        activationError: const PracticeClientException(
+          kind: PracticeClientFailureKind.server,
+          statusCode: 503,
+          errorCode: 'practice_activation_failed',
+          retryable: true,
+        ),
+      );
+      final controller = PracticeController(client: practice);
+      addTearDown(controller.dispose);
+
+      await expectLater(
+        controller.activateCreatedPractice(
+          scene: _scene,
+          sessionId: _sessionId,
+          planId: _planId,
+          practiceMode: PracticeMode.fullSimulation,
+          turnLimit: 6,
+          clientOperationId: _voiceKey,
+        ),
+        throwsA(isA<PracticeClientException>()),
+      );
+
+      expect(controller.discardedActivationSessionId, _sessionId);
+      expect(controller.practiceSessionId, isNull);
+    },
+  );
+
+  test('marks a discarded legacy activation during restore', () async {
+    final practice = _ActivationPracticeClient(
+      snapshot: _snapshot(turnLimit: 6),
+      restoreError: const PracticeClientException(
+        kind: PracticeClientFailureKind.server,
+        statusCode: 503,
+        errorCode: 'practice_activation_failed',
+        retryable: true,
+      ),
+    );
+    final controller = PracticeController(client: practice);
+    addTearDown(controller.dispose);
+
+    await expectLater(
+      controller.restoreCreatedPractice(sessionId: _sessionId, scene: _scene),
+      throwsA(isA<PracticeClientException>()),
+    );
+
+    expect(controller.discardedActivationSessionId, _sessionId);
+    expect(controller.practiceSessionId, isNull);
+  });
+
   test('rejects activation of a different formal Session response', () async {
     final practice = _ActivationPracticeClient(
       snapshot: PracticeSessionSnapshot(
@@ -299,11 +353,15 @@ final class _ActivationPracticeClient
     required this.snapshot,
     this.failFirstStart = false,
     this.activationCompleter,
+    this.activationError,
+    this.restoreError,
   });
 
   final PracticeSessionSnapshot snapshot;
   final bool failFirstStart;
   final Completer<PracticeSessionSnapshot>? activationCompleter;
+  final Object? activationError;
+  final Object? restoreError;
   int activationCalls = 0;
   int clearCalls = 0;
   final activationKeys = <String>[];
@@ -318,7 +376,12 @@ final class _ActivationPracticeClient
   @override
   Future<PracticeSessionSnapshot> restorePractice({
     required String sessionId,
-  }) async => snapshot;
+  }) async {
+    if (restoreError case final error?) {
+      throw error;
+    }
+    return snapshot;
+  }
 
   @override
   Future<PracticeSessionSnapshot> activatePractice({
@@ -327,6 +390,9 @@ final class _ActivationPracticeClient
   }) {
     activationCalls++;
     activationKeys.add(clientOperationId);
+    if (activationError case final error?) {
+      throw error;
+    }
     if (failFirstStart && activationCalls == 1) {
       throw const PracticeClientException(
         kind: PracticeClientFailureKind.network,

--- a/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
@@ -14,6 +14,8 @@ import 'package:speakup/features/coaching/preparation/preparation_launch_models.
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
 import '../../support/scene_fixtures.dart';
@@ -250,19 +252,52 @@ void main() {
       expect(harness.practice.practiceSessionId, isNull);
     },
   );
+
+  test(
+    'cleans the committed workspace after the server discards activation',
+    () async {
+      final harness = await _createHarness(
+        practiceClient: _DiscardedActivationPracticeClient(),
+      );
+      addTearDown(harness.dispose);
+      final plan = _plan(sourceThreadId: harness.conversation.threadId!);
+      final controller = PracticePlanHandoffController(
+        conversationController: harness.conversation,
+        practiceController: harness.practice,
+        workspaceController: harness.workspace,
+        readPlan: (_) async => plan,
+        confirmPlan:
+            ({required plan, required input, required idempotencyKey}) async =>
+                _bootstrap(plan),
+        idFactory: _fixedId,
+      );
+      addTearDown(controller.dispose);
+
+      expect(await controller.confirm(_handoff(plan)), isFalse);
+
+      expect(harness.workspace.currentLease, isNull);
+      expect(harness.workspace.currentSessionId, isNull);
+      expect(controller.errorMessage, contains('已清理'));
+    },
+  );
 }
 
-Future<_Harness> _createHarness({AgentClient? client}) async {
+Future<_Harness> _createHarness({
+  AgentClient? client,
+  PracticeClient? practiceClient,
+}) async {
   final conversation = ConversationController(
     client: client ?? FakeAgentClient(),
   );
   final composer = ComposerController(conversationController: conversation);
   final practice = PracticeController(
-    client: FakePracticeClient(
-      practiceExperience: PracticeExperience.interview,
-      sceneCategory: SceneCategory.interviewProfessional,
-      turnLimit: 3,
-    ),
+    client:
+        practiceClient ??
+        FakePracticeClient(
+          practiceExperience: PracticeExperience.interview,
+          sceneCategory: SceneCategory.interviewProfessional,
+          turnLimit: 3,
+        ),
   );
   await conversation.initialize();
   final workspace = PracticeWorkspaceController(
@@ -277,6 +312,24 @@ Future<_Harness> _createHarness({AgentClient? client}) async {
     practice: practice,
     workspace: workspace,
   );
+}
+
+final class _DiscardedActivationPracticeClient implements PracticeClient {
+  @override
+  Future<PracticeSessionSnapshot> activatePractice({
+    required String sessionId,
+    required String clientOperationId,
+  }) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.server,
+      statusCode: 503,
+      errorCode: 'practice_activation_failed',
+      retryable: true,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 PracticePlan _plan({required String sourceThreadId}) {

--- a/server/internal/coaching/practice/postgres/context.go
+++ b/server/internal/coaching/practice/postgres/context.go
@@ -439,6 +439,13 @@ func (r *Repository) ActivateSession(
 			  AND plan_id = $3
 			  AND status = 'starting'
 			  AND version = $4
+			  AND EXISTS (
+			      SELECT 1
+			      FROM practice_questions AS question
+			      WHERE question.owner_user_id = practice_sessions.owner_user_id
+			        AND question.practice_session_id = practice_sessions.session_id
+			        AND question.sequence = 1
+			  )
 		`, actor.UserID, sessionID, planID, bootstrap.Session.Version)
 		if err != nil {
 			return practice.SessionBootstrap{},

--- a/server/internal/coaching/practice/postgres/context_integration_test.go
+++ b/server/internal/coaching/practice/postgres/context_integration_test.go
@@ -240,6 +240,84 @@ func TestContextRepositoryRejectsArchivedPlanAndConflictsByPlan(t *testing.T) {
 	}
 }
 
+func TestContextRepositoryRequiresInitialQuestionBeforeActivation(t *testing.T) {
+	repository, pool := newContextRepository(t)
+	owner := contextOwnerA()
+	seedContextOwner(t, pool, &owner)
+	plan := createContextPlan(
+		t,
+		pool,
+		preparationpostgres.NewPostgresPlanRepository(pool),
+		owner,
+		"plan-question-before-activation",
+	)
+	created, replayed, err := repository.CreateSession(
+		context.Background(),
+		owner.Actor,
+		contextSessionCommand(
+			owner,
+			plan,
+			"session-question-before-activation",
+			"snapshot-question-before-activation",
+			"session-question-before-activation-key",
+		),
+	)
+	if err != nil || replayed {
+		t.Fatalf("CreateSession = (%#v,%t,%v)", created, replayed, err)
+	}
+	intent := practice.IdempotencyIntent{
+		Method:             "POST",
+		CanonicalPath:      "/v1/practice-sessions/" + created.Session.ID + "/voice-activation",
+		Key:                "voice-activation-question-required",
+		PayloadFingerprint: sha256.Sum256(nil),
+	}
+	if _, err := repository.ActivateSession(
+		context.Background(),
+		owner.Actor,
+		created.Session.ID,
+		created.Session.PlanID,
+		intent,
+	); !errors.Is(err, practice.ErrConflict) {
+		t.Fatalf("activation without initial question error = %v", err)
+	}
+
+	var facilitatorID, learnerID string
+	for _, participant := range created.Snapshot.Participants {
+		switch participant.Role {
+		case "FACILITATOR":
+			facilitatorID = participant.ID
+		case "LEARNER":
+			learnerID = participant.ID
+		}
+	}
+	if facilitatorID == "" || learnerID == "" {
+		t.Fatalf("session participants = %#v", created.Snapshot.Participants)
+	}
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO practice_questions (
+			owner_user_id, question_id, practice_session_id,
+			speaker_participant_id, addressee_participant_ids,
+			objective_id, question_type, content, sequence, created_at
+		)
+		VALUES ($1, 'question-initial', $2, $3, ARRAY[$4]::text[],
+		        'objective-initial', 'PRIMARY', 'Tell me about yourself.', 1,
+		        transaction_timestamp())
+	`, owner.Actor.UserID, created.Session.ID, facilitatorID, learnerID); err != nil {
+		t.Fatalf("insert initial question: %v", err)
+	}
+	activated, err := repository.ActivateSession(
+		context.Background(),
+		owner.Actor,
+		created.Session.ID,
+		created.Session.PlanID,
+		intent,
+	)
+	if err != nil || activated.Session.Status != practice.SessionInProgress ||
+		activated.Session.Version != created.Session.Version+1 {
+		t.Fatalf("ActivateSession = (%#v,%v)", activated, err)
+	}
+}
+
 func TestContextRepositoryCompletesUserControlledSessionIdempotently(
 	t *testing.T,
 ) {

--- a/server/internal/coaching/practice/voice/http/errors_test.go
+++ b/server/internal/coaching/practice/voice/http/errors_test.go
@@ -73,3 +73,27 @@ func TestProviderErrorUsesPracticeVoiceContract(t *testing.T) {
 		})
 	}
 }
+
+func TestActivationErrorReportsDiscardedEmptySession(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	handler := Handler{errors: httpresponse.NewRenderer(
+		func() string { return "test-correlation" },
+	)}
+	handler.write(context, mapError(practicevoice.NewActivationError(
+		practicevoice.NewProviderError(
+			practicevoice.ProviderOperationQuestionGeneration,
+			practicevoice.ProviderErrorUnavailable,
+			"provider-request",
+			nil,
+		),
+	)))
+
+	body := recorder.Body.String()
+	if recorder.Code != http.StatusServiceUnavailable ||
+		!strings.Contains(body, `"code":"practice_activation_failed"`) ||
+		!strings.Contains(body, `"retryable":true`) {
+		t.Fatalf("activation response = %d %s", recorder.Code, body)
+	}
+}

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -534,9 +534,20 @@ func ConfirmedTurnResponse(turn practice.Turn) gin.H {
 }
 
 func mapError(err error) error {
+	var activationFailure *practicevoice.ActivationError
 	var providerFailure *practicevoice.ProviderError
 	var translationFailure *sharedtranslation.ProviderError
 	switch {
+	case errors.As(err, &activationFailure):
+		retryable := false
+		if errors.As(err, &providerFailure) {
+			retryable = providerFailure.Retryable()
+		}
+		return apperror.New(
+			apperror.Unavailable, "practice_activation_failed",
+			"Practice could not start because the question provider failed; the empty session was discarded.",
+			apperror.WithRetryable(retryable), apperror.WithCause(err),
+		)
 	case errors.Is(err, practicevoice.ErrInvalidRequest),
 		errors.Is(err, practicevoice.ErrInvalidContext),
 		errors.Is(err, practicevoice.ErrVoiceRoundInvalid):

--- a/server/internal/coaching/practice/voice/provider.go
+++ b/server/internal/coaching/practice/voice/provider.go
@@ -51,6 +51,28 @@ type ProviderError struct {
 	cause     error
 }
 
+// ActivationError reports that initial question generation failed and the
+// zero-turn Session was safely moved to a terminal state. Callers may discard
+// their provisional workspace and start a fresh Session.
+type ActivationError struct {
+	cause error
+}
+
+func NewActivationError(cause error) *ActivationError {
+	return &ActivationError{cause: cause}
+}
+
+func (err *ActivationError) Error() string {
+	return "practice activation failed and was rolled back"
+}
+
+func (err *ActivationError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.cause
+}
+
 func NewProviderError(
 	operation ProviderOperation,
 	kind ProviderErrorKind,

--- a/server/internal/coaching/practice/voice/session_adapter.go
+++ b/server/internal/coaching/practice/voice/session_adapter.go
@@ -3,6 +3,8 @@ package voice
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -37,19 +39,24 @@ type sessionRepository interface {
 		string,
 		practice.IdempotencyIntent,
 	) (practice.SessionBootstrap, error)
+	TransitionSession(
+		context.Context,
+		practice.Actor,
+		practice.TransitionSessionCommand,
+	) (practice.Session, bool, error)
 }
 
-func (adapter *sessionAdapter) Start(
+func (adapter *sessionAdapter) PrepareStart(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	sessionID string,
 	idempotencyKey string,
-) (Session, error) {
+) (Session, bool, error) {
 	if adapter == nil || adapter.repository == nil ||
 		!actor.Valid() ||
 		strings.TrimSpace(sessionID) == "" ||
 		strings.TrimSpace(idempotencyKey) == "" {
-		return Session{}, ErrInvalidRequest
+		return Session{}, false, ErrInvalidRequest
 	}
 	practiceActor := practiceActor(actor)
 	intent := practice.IdempotencyIntent{
@@ -65,13 +72,14 @@ func (adapter *sessionAdapter) Start(
 		intent,
 	)
 	if err != nil {
-		return Session{}, mapPracticeError(err)
+		return Session{}, false, mapPracticeError(err)
 	}
 	if found {
 		if replayed.Session.ID != sessionID {
-			return Session{}, ErrIdempotencyConflict
+			return Session{}, false, ErrIdempotencyConflict
 		}
-		return mapPracticeSession(replayed, actor.UserID)
+		session, mapErr := mapPracticeSession(replayed, actor.UserID)
+		return session, true, mapErr
 	}
 	session, err := adapter.repository.GetSession(
 		ctx,
@@ -79,10 +87,10 @@ func (adapter *sessionAdapter) Start(
 		sessionID,
 	)
 	if err != nil {
-		return Session{}, mapPracticeError(err)
+		return Session{}, false, mapPracticeError(err)
 	}
 	if session.ID != sessionID || strings.TrimSpace(session.PlanID) == "" {
-		return Session{}, ErrInvalidContext
+		return Session{}, false, ErrInvalidContext
 	}
 	snapshot, err := adapter.repository.GetSessionSnapshot(
 		ctx,
@@ -90,7 +98,7 @@ func (adapter *sessionAdapter) Start(
 		sessionID,
 	)
 	if err != nil {
-		return Session{}, mapPracticeError(err)
+		return Session{}, false, mapPracticeError(err)
 	}
 	if _, err := mapPracticeSession(
 		practice.SessionBootstrap{
@@ -99,23 +107,97 @@ func (adapter *sessionAdapter) Start(
 		},
 		actor.UserID,
 	); err != nil {
-		return Session{}, err
+		return Session{}, false, err
+	}
+	mapped, err := mapPracticeSession(
+		practice.SessionBootstrap{Session: session, Snapshot: snapshot},
+		actor.UserID,
+	)
+	return mapped, false, err
+}
+
+func (adapter *sessionAdapter) CommitStart(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	sessionID string,
+	planID string,
+	idempotencyKey string,
+) (Session, error) {
+	if adapter == nil || adapter.repository == nil || !actor.Valid() ||
+		strings.TrimSpace(sessionID) == "" ||
+		strings.TrimSpace(planID) == "" ||
+		strings.TrimSpace(idempotencyKey) == "" {
+		return Session{}, ErrInvalidRequest
+	}
+	practiceActor := practiceActor(actor)
+	intent := practice.IdempotencyIntent{
+		Method: "POST",
+		CanonicalPath: "/v1/practice-sessions/" + sessionID +
+			"/voice-activation",
+		Key:                idempotencyKey,
+		PayloadFingerprint: sha256.Sum256(nil),
 	}
 	activated, err := adapter.repository.ActivateSession(
 		ctx,
 		practiceActor,
 		sessionID,
-		session.PlanID,
+		planID,
 		intent,
 	)
 	if err != nil {
 		return Session{}, mapPracticeError(err)
 	}
 	if activated.Session.ID != sessionID ||
-		activated.Session.PlanID != session.PlanID {
+		activated.Session.PlanID != planID {
 		return Session{}, ErrInvalidContext
 	}
 	return mapPracticeSession(activated, actor.UserID)
+}
+
+func (adapter *sessionAdapter) AbortStart(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	session Session,
+	idempotencyKey string,
+) error {
+	if adapter == nil || adapter.repository == nil || !actor.Valid() ||
+		session.ID == "" || session.SessionVersion < 1 ||
+		(session.Status != "starting" && session.Status != "in_progress") ||
+		session.EffectiveTurns != 0 ||
+		strings.TrimSpace(idempotencyKey) == "" {
+		return ErrInvalidRequest
+	}
+	payload, err := json.Marshal(struct {
+		ExpectedSessionVersion int `json:"expected_session_version"`
+	}{ExpectedSessionVersion: session.SessionVersion})
+	if err != nil {
+		return err
+	}
+	keyFingerprint := sha256.Sum256([]byte(idempotencyKey))
+	intent := practice.IdempotencyIntent{
+		Method:             "POST",
+		CanonicalPath:      "/v1/practice-sessions/" + session.ID + "/end-early",
+		Key:                "voice-activation-abort-" + hex.EncodeToString(keyFingerprint[:]),
+		PayloadFingerprint: sha256.Sum256(payload),
+	}
+	ended, _, err := adapter.repository.TransitionSession(
+		ctx,
+		practiceActor(actor),
+		practice.TransitionSessionCommand{
+			SessionID:              session.ID,
+			ExpectedSessionVersion: session.SessionVersion,
+			Transition:             practice.SessionEndEarly,
+			Intent:                 intent,
+		},
+	)
+	if err != nil {
+		return mapPracticeError(err)
+	}
+	if ended.ID != session.ID || ended.Status != practice.SessionEndedEarly ||
+		ended.EffectiveTurns != 0 {
+		return ErrInvalidContext
+	}
+	return nil
 }
 
 func (adapter *sessionAdapter) GetByID(

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
@@ -45,12 +46,25 @@ type Session struct {
 }
 
 type SessionPort interface {
-	Start(
+	PrepareStart(
 		context.Context,
 		requestcontext.Actor,
 		string,
 		string,
+	) (Session, bool, error)
+	CommitStart(
+		context.Context,
+		requestcontext.Actor,
+		string,
+		string,
+		string,
 	) (Session, error)
+	AbortStart(
+		context.Context,
+		requestcontext.Actor,
+		Session,
+		string,
+	) error
 	GetByID(
 		context.Context,
 		requestcontext.Actor,
@@ -232,7 +246,7 @@ func (application *SessionApplication) Start(
 		strings.TrimSpace(idempotencyKey) == "" {
 		return SessionState{}, ErrInvalidRequest
 	}
-	session, err := application.sessions.Start(
+	session, replayed, err := application.sessions.PrepareStart(
 		ctx,
 		actor,
 		sessionID,
@@ -244,7 +258,46 @@ func (application *SessionApplication) Start(
 	if session.ID != sessionID {
 		return SessionState{}, ErrInvalidContext
 	}
-	return application.state(ctx, actor, session)
+	if replayed || session.Status == "in_progress" {
+		state, stateErr := application.state(ctx, actor, session)
+		return application.recoverFailedEmptyActivation(
+			ctx,
+			actor,
+			session,
+			idempotencyKey,
+			state,
+			stateErr,
+		)
+	}
+	if session.Status != "starting" || session.EffectiveTurns != 0 {
+		return SessionState{}, ErrConflict
+	}
+	state, err := application.stateBeforeActivation(ctx, actor, session)
+	if err != nil {
+		return application.recoverFailedEmptyActivation(
+			ctx,
+			actor,
+			session,
+			idempotencyKey,
+			SessionState{},
+			err,
+		)
+	}
+	activated, err := application.sessions.CommitStart(
+		ctx,
+		actor,
+		sessionID,
+		session.PlanID,
+		idempotencyKey,
+	)
+	if err != nil {
+		return SessionState{}, err
+	}
+	if activated.ID != sessionID || activated.Status != "in_progress" {
+		return SessionState{}, ErrInvalidContext
+	}
+	state.Session = activated
+	return state, nil
 }
 
 func (application *SessionApplication) Resume(
@@ -263,7 +316,49 @@ func (application *SessionApplication) Resume(
 	if session.ID != sessionID {
 		return SessionState{}, ErrInvalidContext
 	}
-	return application.state(ctx, actor, session)
+	state, stateErr := application.state(ctx, actor, session)
+	return application.recoverFailedEmptyActivation(
+		ctx,
+		actor,
+		session,
+		"voice-resume-"+session.ID,
+		state,
+		stateErr,
+	)
+}
+
+func (application *SessionApplication) recoverFailedEmptyActivation(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	session Session,
+	idempotencyKey string,
+	state SessionState,
+	stateErr error,
+) (SessionState, error) {
+	if stateErr == nil {
+		return state, nil
+	}
+	var providerFailure *ProviderError
+	if session.EffectiveTurns != 0 ||
+		(session.Status != "starting" && session.Status != "in_progress") ||
+		!errors.As(stateErr, &providerFailure) {
+		return SessionState{}, stateErr
+	}
+	abortCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		5*time.Second,
+	)
+	abortErr := application.sessions.AbortStart(
+		abortCtx,
+		actor,
+		session,
+		idempotencyKey,
+	)
+	cancel()
+	if abortErr != nil {
+		return SessionState{}, stateErr
+	}
+	return SessionState{}, NewActivationError(stateErr)
 }
 
 func (application *SessionApplication) Transcribe(
@@ -358,6 +453,23 @@ func (application *SessionApplication) state(
 	actor requestcontext.Actor,
 	session Session,
 ) (SessionState, error) {
+	return application.buildState(ctx, actor, session, false)
+}
+
+func (application *SessionApplication) stateBeforeActivation(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	session Session,
+) (SessionState, error) {
+	return application.buildState(ctx, actor, session, true)
+}
+
+func (application *SessionApplication) buildState(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	session Session,
+	allowStarting bool,
+) (SessionState, error) {
 	if session.ID == "" ||
 		session.PlanID == "" ||
 		session.SceneID == "" ||
@@ -367,7 +479,7 @@ func (application *SessionApplication) state(
 		session.SessionVersion < 1 ||
 		session.EffectiveTurns < 0 ||
 		!validVoiceProgress(session) ||
-		!validVoiceSessionLifecycle(session) ||
+		!validVoiceSessionLifecycle(session, allowStarting) ||
 		session.FacilitatorParticipantID == "" ||
 		session.LearnerParticipantID == "" ||
 		session.FacilitatorParticipantID == session.LearnerParticipantID {
@@ -547,10 +659,13 @@ func validVoiceScenePrompt(session Session) bool {
 		len(prompt.TurnBlueprints) > 0
 }
 
-func validVoiceSessionLifecycle(session Session) bool {
+func validVoiceSessionLifecycle(session Session, allowStarting bool) bool {
 	turnAvailable := session.CompletionMode == practice.CompletionModeUserControlled ||
 		session.EffectiveTurns < session.TurnLimit
 	switch session.Status {
+	case "starting":
+		return allowStarting && !session.Completed &&
+			session.EffectiveTurns == 0
 	case "in_progress":
 		return !session.Completed && turnAvailable
 	case "paused":

--- a/server/internal/coaching/practice/voice/session_application_test.go
+++ b/server/internal/coaching/practice/voice/session_application_test.go
@@ -146,13 +146,223 @@ func TestSessionStartReturnsQuestionFromFrozenSession(t *testing.T) {
 
 type sessionPortStub struct{ session Session }
 
-func (p sessionPortStub) Start(
+func (p sessionPortStub) PrepareStart(
 	context.Context,
 	requestcontext.Actor,
 	string,
 	string,
+) (Session, bool, error) {
+	return p.session, false, nil
+}
+
+func TestSessionStartPersistsQuestionBeforeActivation(t *testing.T) {
+	starting := sessionFixture()
+	starting.Status = "starting"
+	starting.SessionVersion = 1
+	activated := starting
+	activated.Status = "in_progress"
+	activated.SessionVersion = 2
+	port := &activationSessionPortStub{
+		prepared:  starting,
+		activated: activated,
+	}
+	questions := &activationQuestionPortStub{sessionPort: port}
+	application := sessionApplicationFixture(t, port, questions)
+
+	state, err := application.Start(
+		context.Background(), roundActor(), starting.ID, "start-1",
+	)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !questions.called || !port.committed || port.aborted ||
+		state.Session.Status != "in_progress" || state.Question == nil {
+		t.Fatalf(
+			"questions.called=%t committed=%t aborted=%t state=%#v",
+			questions.called, port.committed, port.aborted, state,
+		)
+	}
+}
+
+func TestSessionStartAbortsEmptySessionAfterProviderFailure(t *testing.T) {
+	starting := sessionFixture()
+	starting.Status = "starting"
+	port := &activationSessionPortStub{prepared: starting}
+	providerFailure := NewProviderError(
+		ProviderOperationQuestionGeneration,
+		ProviderErrorUnavailable,
+		"request-1",
+		errors.New("provider unavailable"),
+	)
+	application := sessionApplicationFixture(
+		t,
+		port,
+		&activationQuestionPortStub{err: providerFailure},
+	)
+
+	_, err := application.Start(
+		context.Background(), roundActor(), starting.ID, "start-1",
+	)
+	var activationFailure *ActivationError
+	if !errors.As(err, &activationFailure) ||
+		!errors.Is(err, providerFailure) || !port.aborted || port.committed {
+		t.Fatalf(
+			"error=%v aborted=%t committed=%t",
+			err, port.aborted, port.committed,
+		)
+	}
+}
+
+func TestSessionResumeDiscardsLegacyEmptyActivationAfterProviderFailure(
+	t *testing.T,
+) {
+	legacy := sessionFixture()
+	legacy.Status = "in_progress"
+	legacy.EffectiveTurns = 0
+	port := &activationSessionPortStub{prepared: legacy}
+	providerFailure := NewProviderError(
+		ProviderOperationQuestionGeneration,
+		ProviderErrorUnavailable,
+		"request-legacy",
+		errors.New("provider unavailable"),
+	)
+	application := sessionApplicationFixture(
+		t,
+		port,
+		&activationQuestionPortStub{err: providerFailure},
+	)
+
+	_, err := application.Resume(
+		context.Background(), roundActor(), legacy.ID,
+	)
+	var activationFailure *ActivationError
+	if !errors.As(err, &activationFailure) || !port.aborted {
+		t.Fatalf("Resume error=%v aborted=%t", err, port.aborted)
+	}
+}
+
+func sessionApplicationFixture(
+	t *testing.T,
+	sessions SessionPort,
+	questions QuestionPort,
+) *SessionApplication {
+	t.Helper()
+	candidate := roundCandidate()
+	orchestrator, err := NewRoundOrchestrator(
+		&roundVoice{candidate: candidate, turn: roundTurn(candidate)},
+		roundPractice{},
+	)
+	if err != nil {
+		t.Fatalf("NewRoundOrchestrator: %v", err)
+	}
+	application, err := NewSessionApplication(
+		sessions,
+		questions,
+		checkpointPortStub{},
+		orchestrator,
+	)
+	if err != nil {
+		t.Fatalf("NewSessionApplication: %v", err)
+	}
+	return application
+}
+
+type activationSessionPortStub struct {
+	prepared  Session
+	activated Session
+	committed bool
+	aborted   bool
+}
+
+func (stub *activationSessionPortStub) PrepareStart(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	string,
+) (Session, bool, error) {
+	return stub.prepared, false, nil
+}
+
+func (stub *activationSessionPortStub) CommitStart(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	string,
+	string,
+) (Session, error) {
+	stub.committed = true
+	return stub.activated, nil
+}
+
+func (stub *activationSessionPortStub) AbortStart(
+	_ context.Context,
+	_ requestcontext.Actor,
+	session Session,
+	_ string,
+) error {
+	stub.aborted =
+		(session.Status == "starting" || session.Status == "in_progress") &&
+			session.EffectiveTurns == 0
+	return nil
+}
+
+func (stub *activationSessionPortStub) GetByID(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (Session, error) {
+	return stub.prepared, nil
+}
+
+type activationQuestionPortStub struct {
+	sessionPort *activationSessionPortStub
+	called      bool
+	err         error
+}
+
+func (stub *activationQuestionPortStub) EnsureQuestion(
+	_ context.Context,
+	_ requestcontext.Actor,
+	session Session,
+	sequence int,
+) (practice.Question, error) {
+	stub.called = true
+	if stub.sessionPort != nil && stub.sessionPort.committed {
+		return practice.Question{}, errors.New("question generated after activation")
+	}
+	if stub.err != nil {
+		return practice.Question{}, stub.err
+	}
+	return questionPortStub{}.EnsureQuestion(
+		context.Background(), roundActor(), session, sequence,
+	)
+}
+
+func (*activationQuestionPortStub) GetQuestion(
+	context.Context,
+	requestcontext.Actor,
+	string,
+) (practice.Question, error) {
+	return practice.Question{}, ErrNotFound
+}
+
+func (p sessionPortStub) CommitStart(
+	context.Context,
+	requestcontext.Actor,
+	string,
+	string,
+	string,
 ) (Session, error) {
 	return p.session, nil
+}
+
+func (sessionPortStub) AbortStart(
+	context.Context,
+	requestcontext.Actor,
+	Session,
+	string,
+) error {
+	return nil
 }
 
 func (p sessionPortStub) GetByID(

--- a/server/internal/coaching/practice/voice/turn_policy_test.go
+++ b/server/internal/coaching/practice/voice/turn_policy_test.go
@@ -229,7 +229,7 @@ func TestSessionAdapterRejectsUnknownPolicyBeforeActivation(t *testing.T) {
 	)
 	repository := &turnPolicySessionRepository{bootstrap: bootstrap}
 
-	_, err := (&sessionAdapter{repository: repository}).Start(
+	_, _, err := (&sessionAdapter{repository: repository}).PrepareStart(
 		context.Background(),
 		persistenceRequestActor(),
 		bootstrap.Session.ID,
@@ -455,6 +455,14 @@ func (repository *turnPolicySessionRepository) ActivateSession(
 ) (practice.SessionBootstrap, error) {
 	repository.activateCalls++
 	return repository.bootstrap, nil
+}
+
+func (repository *turnPolicySessionRepository) TransitionSession(
+	context.Context,
+	practice.Actor,
+	practice.TransitionSessionCommand,
+) (practice.Session, bool, error) {
+	return practice.Session{}, false, nil
 }
 
 type turnPolicyQuestionRepository struct {

--- a/server/internal/platform/httpresponse/error.go
+++ b/server/internal/platform/httpresponse/error.go
@@ -235,6 +235,7 @@ var canonicalHTTPStatusByCode = map[string]int{
 	"evaluation_policy_violation":             http.StatusUnprocessableEntity,
 	"rate_limited":                            http.StatusTooManyRequests,
 	"provider_unavailable":                    http.StatusServiceUnavailable,
+	"practice_activation_failed":              http.StatusServiceUnavailable,
 	"quota_exhausted":                         http.StatusServiceUnavailable,
 	"voice_capacity_exhausted":                http.StatusServiceUnavailable,
 	"job_target_analysis_failed":              http.StatusServiceUnavailable,


### PR DESCRIPTION
## 功能描述

修复首题生成 Provider 返回 503 后遗留零回合 `in_progress` 会话，导致 Flutter 后续进入任意练习场景都被“无法核验当前练习”持续阻塞的问题。同时兼容清理修复上线前已经存在的同类僵尸会话。

Closes #571

## 根因

原来的 Voice 激活先把 Practice Session 从 `starting` 提交为 `in_progress`，然后才生成并保存第一题。外部 Provider 失败时数据库状态已经提交，Flutter 也已经保存 committed Workspace，最终留下没有题目的活动会话。后续恢复会再次触发首题生成并返回 503，Workspace 因无法核验而拒绝创建新练习。

## 实现思路

- 将 Voice 激活拆成 prepare / question / commit 三段：先读取并校验冻结会话，在数据库事务外生成首题，首题持久化成功后才提交 `starting -> in_progress`。
- 在 PostgreSQL 激活更新条件中强制要求 sequence=1 的第一题已经存在，建立服务端不变量，避免业务层顺序退化后再次产生空的 `in_progress` 会话。
- 首题 Provider 失败时，用稳定幂等键把零回合 `starting` 会话安全转为 `ended_early`，并返回新增的 `practice_activation_failed` 503 契约错误。
- 恢复旧版遗留的 `in_progress + 0 回合` 会话时执行同样补偿，使已有僵尸会话能够自愈。
- Flutter 识别该专用错误，标记服务端已丢弃的会话；Practice Workspace 返回原对话、删除本地 committed 记录，下一次重试会创建干净的新会话。
- 保留普通网络错误的原有幂等重试行为，不把外部 AI 调用放进长数据库事务。

## 可复现验证

1. 让首题 Question Provider 对 `voice-activation` 返回 503。
2. 确认接口返回 `practice_activation_failed`，对应零回合 Session 为 `ended_early`，而不是没有题目的 `in_progress`。
3. 在 Flutter 中确认失败后返回场景列表，再次启动其他场景；本地 Workspace 不再被旧 Session 阻塞。
4. 使用旧版遗留的 `in_progress + 0 回合 + 无第一题` Session 调用 `voice-state`，确认服务端安全终止它，Flutter 清理本地记录。

## 测试与检查

- `npm run check`（OpenAPI、安全、WebSocket、Fixture、Evaluation、SpeechFeedback 契约全部通过）
- `go vet ./...` 通过
- `go test -count=1 ./...`：本次涉及的 Practice/Voice/Postgres/Bootstrap/Smoke 等包全部通过；仅仓库既有 Windows 权限断言 `TestCaptureTemporaryAudioValidatesAndRemovesPCMWAV` 失败（实际 0666，测试期望 Unix 0600），与本 PR 无关
- PostgreSQL 临时数据库集成测试 `TestContextRepositoryRequiresInitialQuestionBeforeActivation` 通过
- `flutter analyze --no-pub` 通过
- `flutter test --no-pub` 全量 824 项通过

## 范围说明

- 未修改练习轮数、题库内容、评分流程或页面视觉结构。
- 未删除现有有效练习数据。
- TTS 失败仍保持文字题目可用的既有降级行为。
