### PR TITLE
feat(ielts): add Part 2 and Part 3 answer preparation

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -259,22 +259,40 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
           mode: item.mode,
           title: item.title,
           subtitle: item.subtitle,
-          questions: item.questions,
+          questions: item.mode == PracticeMode.part2
+              ? const <String>[]
+              : item.questions,
           cueCard: item.cueCard,
-          answerPreparationClient: item.mode == PracticeMode.part1
-              ? widget.controller.answerPreparationClient
+          answerPreparationClient: widget.controller.answerPreparationClient,
+          cueCardQuestionReference: item.mode == PracticeMode.part2
+              ? IeltsAnswerQuestionReference(
+                  bankId: bank.bankId,
+                  part: 'PART_2',
+                  sourceId: item.id,
+                  questionPosition: 1,
+                )
               : null,
-          questionReferences: item.mode == PracticeMode.part1
-              ? [
-                  for (var index = 0; index < item.questions.length; index++)
-                    IeltsAnswerQuestionReference(
-                      bankId: bank.bankId,
-                      part: 'PART_1',
-                      sourceId: item.id,
-                      questionPosition: index + 1,
-                    ),
-                ]
-              : const [],
+          questionReferences: switch (item.mode) {
+            PracticeMode.part1 => [
+              for (var index = 0; index < item.questions.length; index++)
+                IeltsAnswerQuestionReference(
+                  bankId: bank.bankId,
+                  part: 'PART_1',
+                  sourceId: item.id,
+                  questionPosition: index + 1,
+                ),
+            ],
+            PracticeMode.part3 => [
+              for (var index = 0; index < item.questions.length; index++)
+                IeltsAnswerQuestionReference(
+                  bankId: bank.bankId,
+                  part: 'PART_3',
+                  sourceId: item.id,
+                  questionPosition: index + 1,
+                ),
+            ],
+            _ => const [],
+          },
           onStart: scene == null
               ? null
               : () {

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -18,6 +18,7 @@ class IeltsSetDetailPage extends StatefulWidget {
     this.cueCard,
     this.promptSpeaker,
     this.answerPreparationClient,
+    this.cueCardQuestionReference,
     this.questionReferences = const <IeltsAnswerQuestionReference>[],
     super.key,
   });
@@ -30,6 +31,7 @@ class IeltsSetDetailPage extends StatefulWidget {
   final VoidCallback? onStart;
   final PracticePromptSpeaker? promptSpeaker;
   final IeltsAnswerPreparationClient? answerPreparationClient;
+  final IeltsAnswerQuestionReference? cueCardQuestionReference;
   final List<IeltsAnswerQuestionReference> questionReferences;
 
   @override
@@ -42,6 +44,7 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   int? _speakingQuestionIndex;
   int? _speakingAnswerIndex;
   int? _expandedQuestionIndex;
+  bool _cueCardAnswerExpanded = false;
   final Map<int, IeltsAnswerPreparation> _preparations = {};
   final Set<int> _generatingQuestionIndexes = {};
   final Map<int, String> _answerErrors = {};
@@ -66,20 +69,35 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
     super.initState();
     _ownsPromptSpeaker = widget.promptSpeaker == null;
     _promptSpeaker = widget.promptSpeaker ?? SystemPracticePromptSpeaker();
-    if (widget.mode == PracticeMode.part1 && _canPrepareAnswers) {
+    if (_canPrepareQuestionAnswers) {
       _expandedQuestionIndex = 0;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          unawaited(_ensureExample(0));
+          unawaited(_ensureExample(0, widget.questionReferences[0]));
+        }
+      });
+    } else if (_canPrepareCueCardAnswer) {
+      _cueCardAnswerExpanded = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          unawaited(_ensureExample(0, widget.cueCardQuestionReference!));
         }
       });
     }
   }
 
-  bool get _canPrepareAnswers =>
-      widget.mode == PracticeMode.part1 &&
+  bool get _canPrepareQuestionAnswers =>
+      (widget.mode == PracticeMode.part1 ||
+          widget.mode == PracticeMode.part3) &&
       widget.answerPreparationClient != null &&
+      widget.questions.isNotEmpty &&
       widget.questionReferences.length == widget.questions.length;
+
+  bool get _canPrepareCueCardAnswer =>
+      widget.mode == PracticeMode.part2 &&
+      widget.cueCard != null &&
+      widget.answerPreparationClient != null &&
+      widget.cueCardQuestionReference != null;
 
   int _startAnswerRequest(int index) {
     final request = (_answerRequests[index] ?? 0) + 1;
@@ -181,7 +199,10 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
     }
   }
 
-  Future<void> _prepareAnswer(int index) async {
+  Future<void> _prepareAnswer(
+    int index,
+    IeltsAnswerQuestionReference question,
+  ) async {
     final points = await showModalBottomSheet<List<String>>(
       context: context,
       isScrollControlled: true,
@@ -201,7 +222,7 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
       var draft =
           existing ??
           await widget.answerPreparationClient!.create(
-            question: widget.questionReferences[index],
+            question: question,
             personalPoints: points,
             targetBand: 7,
           );
@@ -238,7 +259,10 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
     }
   }
 
-  Future<void> _ensureExample(int index) async {
+  Future<void> _ensureExample(
+    int index,
+    IeltsAnswerQuestionReference question,
+  ) async {
     if (_preparations.containsKey(index) ||
         _generatingQuestionIndexes.contains(index)) {
       return;
@@ -246,7 +270,7 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
     final request = _startAnswerRequest(index);
     try {
       final draft = await widget.answerPreparationClient!.create(
-        question: widget.questionReferences[index],
+        question: question,
         personalPoints: const [],
         targetBand: 7,
       );
@@ -339,6 +363,60 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                     ],
                     if (widget.cueCard case final value?) ...[
                       _CueCardContent(cueCard: value),
+                      if (_canPrepareCueCardAnswer) ...[
+                        const SizedBox(height: 8),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton.icon(
+                            key: const Key('ielts-cue-card-answer-toggle'),
+                            onPressed: () {
+                              setState(() {
+                                _cueCardAnswerExpanded =
+                                    !_cueCardAnswerExpanded;
+                              });
+                              if (_cueCardAnswerExpanded) {
+                                unawaited(
+                                  _ensureExample(
+                                    0,
+                                    widget.cueCardQuestionReference!,
+                                  ),
+                                );
+                              }
+                            },
+                            icon: Icon(
+                              _cueCardAnswerExpanded
+                                  ? Icons.keyboard_arrow_up_rounded
+                                  : Icons.keyboard_arrow_down_rounded,
+                            ),
+                            label: Text(
+                              _cueCardAnswerExpanded ? '收起答案' : '示例与自定义答案',
+                            ),
+                          ),
+                        ),
+                        if (_cueCardAnswerExpanded)
+                          _QuestionAnswerPanel(
+                            index: 0,
+                            tipText: _answerTip,
+                            preparation: _preparations[0],
+                            generating: _generatingQuestionIndexes.contains(0),
+                            errorMessage: _answerErrors[0],
+                            speaking: _speakingAnswerIndex == 0,
+                            onPrepare: () => _prepareAnswer(
+                              0,
+                              widget.cueCardQuestionReference!,
+                            ),
+                            onRetry: () => _ensureExample(
+                              0,
+                              widget.cueCardQuestionReference!,
+                            ),
+                            onSpeak: _preparations[0]?.speechText == null
+                                ? null
+                                : () => _toggleAnswerSpeech(
+                                    0,
+                                    _preparations[0]!.speechText!,
+                                  ),
+                          ),
+                      ],
                       if (widget.questions.isNotEmpty)
                         const SizedBox(height: 30),
                     ],
@@ -361,7 +439,7 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                           speaking: _speakingQuestionIndex == index,
                           onSpeak: () => _toggleQuestionSpeech(index),
                           expanded: _expandedQuestionIndex == index,
-                          onToggle: _canPrepareAnswers
+                          onToggle: _canPrepareQuestionAnswers
                               ? () {
                                   final opening =
                                       _expandedQuestionIndex != index;
@@ -372,23 +450,35 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                                     _answerErrors.remove(index);
                                   });
                                   if (opening) {
-                                    unawaited(_ensureExample(index));
+                                    unawaited(
+                                      _ensureExample(
+                                        index,
+                                        widget.questionReferences[index],
+                                      ),
+                                    );
                                   }
                                 }
                               : null,
                         ),
-                        if (_canPrepareAnswers &&
+                        if (_canPrepareQuestionAnswers &&
                             _expandedQuestionIndex == index)
                           _QuestionAnswerPanel(
                             index: index,
+                            tipText: _answerTip,
                             preparation: _preparations[index],
                             generating: _generatingQuestionIndexes.contains(
                               index,
                             ),
                             errorMessage: _answerErrors[index],
                             speaking: _speakingAnswerIndex == index,
-                            onPrepare: () => _prepareAnswer(index),
-                            onRetry: () => _ensureExample(index),
+                            onPrepare: () => _prepareAnswer(
+                              index,
+                              widget.questionReferences[index],
+                            ),
+                            onRetry: () => _ensureExample(
+                              index,
+                              widget.questionReferences[index],
+                            ),
                             onSpeak: _preparations[index]?.speechText == null
                                 ? null
                                 : () => _toggleAnswerSpeech(
@@ -450,6 +540,13 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
       ),
     );
   }
+
+  String get _answerTip => switch (widget.mode) {
+    PracticeMode.part1 => 'Tip：先直接回答，再补一个原因或小例子。',
+    PracticeMode.part2 => 'Tip：围绕 Cue Card 要点组织开头、主体和结尾。',
+    PracticeMode.part3 => 'Tip：先表明观点，再解释并补充例子或比较。',
+    _ => throw StateError('IELTS answer preparation requires a section mode.'),
+  };
 }
 
 bool _samePersonalPoints(List<String> left, List<String> right) {
@@ -656,6 +753,7 @@ class _QuestionRow extends StatelessWidget {
 class _QuestionAnswerPanel extends StatelessWidget {
   const _QuestionAnswerPanel({
     required this.index,
+    required this.tipText,
     required this.preparation,
     required this.generating,
     required this.errorMessage,
@@ -666,6 +764,7 @@ class _QuestionAnswerPanel extends StatelessWidget {
   });
 
   final int index;
+  final String tipText;
   final IeltsAnswerPreparation? preparation;
   final bool generating;
   final String? errorMessage;
@@ -688,7 +787,7 @@ class _QuestionAnswerPanel extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('Tip：先直接回答，再补一个原因或小例子。', style: PreparationDesign.label),
+          Text(tipText, style: PreparationDesign.label),
           const SizedBox(height: 12),
           if (generating)
             const Padding(

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -271,11 +271,13 @@ void main() {
     );
   });
 
-  testWidgets('shows the real Cue Card and linked Part 3 questions', (
+  testWidgets('shows only the Part 2 Cue Card and its answer preparation', (
     tester,
   ) async {
+    final answers = _AnswerPreparationClient();
     final ieltsController = IeltsPreparationController(
       client: _HubQuestionBankClient(),
+      answerPreparationClient: answers,
     );
     addTearDown(ieltsController.dispose);
     await ieltsController.loadIfNeeded();
@@ -303,14 +305,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('ielts-set-detail-cue-card')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-answer-panel-1')), findsOneWidget);
+    expect(find.text('Tip：围绕 Cue Card 要点组织开头、主体和结尾。'), findsOneWidget);
+    expect(answers.createdQuestions.single.part, 'PART_2');
+    expect(answers.createdQuestions.single.sourceId, 'p23-001');
+    expect(answers.createdQuestions.single.questionPosition, 1);
     expect(find.text('Describe a skill you would like to learn'), findsWidgets);
     expect(find.text('What'), findsOneWidget);
     expect(find.text('Benefit'), findsOneWidget);
-    expect(find.text('同组 Part 3 · 5 题'), findsOneWidget);
-    expect(
-      find.byKey(const Key('ielts-set-detail-question-5')),
-      findsOneWidget,
-    );
+    expect(find.text('同组 Part 3 · 5 题'), findsNothing);
+    expect(find.byKey(const Key('ielts-set-detail-question-1')), findsNothing);
 
     await tester.tap(find.byKey(const Key('ielts-set-detail-back')));
     await tester.pumpAndSettle();
@@ -437,7 +441,8 @@ void main() {
     expect(client.generateCalls, 0);
   });
 
-  testWidgets('keeps answer preparation limited to Part 1', (tester) async {
+  testWidgets('shows answer preparation for Part 3 questions', (tester) async {
+    final client = _AnswerPreparationClient();
     await tester.pumpWidget(
       MaterialApp(
         home: IeltsSetDetailPage(
@@ -453,15 +458,19 @@ void main() {
               questionPosition: 1,
             ),
           ],
-          answerPreparationClient: _AnswerPreparationClient(),
+          answerPreparationClient: client,
           onStart: () {},
         ),
       ),
     );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('ielts-set-detail-expand-1')), findsNothing);
-    expect(find.byKey(const Key('ielts-answer-panel-1')), findsNothing);
+    expect(find.byKey(const Key('ielts-set-detail-expand-1')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-answer-panel-1')), findsOneWidget);
+    expect(find.text('Tip：先表明观点，再解释并补充例子或比较。'), findsOneWidget);
+    expect(client.createdQuestions.single.part, 'PART_3');
+    expect(client.createdQuestions.single.sourceId, 'watches');
+    expect(client.createdQuestions.single.questionPosition, 1);
   });
 
   testWidgets('tracks answer loading independently for each question', (
@@ -838,6 +847,7 @@ final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
   List<String> _personalPoints = const [];
   int createCalls = 0;
   int generateCalls = 0;
+  final List<IeltsAnswerQuestionReference> createdQuestions = [];
 
   @override
   Future<IeltsAnswerPreparation> create({
@@ -846,6 +856,7 @@ final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
     required double targetBand,
   }) async {
     createCalls++;
+    createdQuestions.add(question);
     if (existingAnswer case final answer?) {
       return IeltsAnswerPreparation(
         id: 'ielts_answer_00000000000000000000000000000000',


### PR DESCRIPTION
## 功能描述
- Part 2 详情页仅展示当前 Cue Card，并复用示例回答、朗读与定制答案面板
- Part 3 详情页为每道问题接入同一答案准备能力
- 保持 Part 1 现有行为，不在 Part 2 页面提前展示 Part 3 题目

## 实现思路
- 题库入口按 Part 传递冻结题库的 bank、source、position 引用
- Part 2 使用 Cue Card 的 PART_2 引用；Part 3 逐题使用 PART_3 引用
- 复用既有答案面板、生成、朗读和润色链路，不新增并行业务实现

## 可复现测试
- `flutter test --no-pub test/coaching/preparation/preparation_hub_test.dart`（22 项通过）
- `flutter analyze --no-pub`（通过）
- `git diff --check`（通过）
- iOS 模拟器真实后端验证：Part 2 不显示 Part 3 题目，Cue Card 定制答案入口可见

Closes #572

Milestone: MS3