### PR TITLE
fix(ielts): tighten prepared answer length

### DIFF
--- a/server/internal/coaching/scene/ielts/answer_preparation.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation.go
@@ -327,9 +327,9 @@ func validGenerationLength(part PracticeMode, result AnswerGenerationResult) boo
 	case PracticeModePart1:
 		maximumWords = 75
 	case PracticeModePart2:
-		maximumWords = 280
+		maximumWords = 240
 	case PracticeModePart3:
-		maximumWords = 130
+		maximumWords = 95
 	default:
 		return false
 	}
@@ -381,7 +381,7 @@ func validIdempotencyKey(value string) bool {
 }
 
 func GenerationSystemPrompt() string {
-	return `Return one JSON object with exactly answer, outline, useful_expressions, and speech_text. When personal_points is non-empty, personalize only from those learner-supplied facts and never invent biography, names, places, achievements, or opinions. When personal_points is empty, produce a clearly generic sample answer without specific biographical claims. Produce natural spoken English suitable for the requested IELTS band. answer and speech_text are strings; outline and useful_expressions are non-empty arrays of strings. Do not return markdown.`
+	return `Return one JSON object with exactly answer, outline, useful_expressions, and speech_text. When personal_points is non-empty, personalize only from those learner-supplied facts and never invent biography, names, places, achievements, or opinions. When personal_points is empty, produce a clearly generic sample answer without specific biographical claims. Produce natural conversational English suitable for the requested IELTS band, not a written essay. Use target_band to control linguistic complexity, not answer length. Follow the supplied structure, do not restate the question, and do not add headings or bullet points to answer or speech_text. answer and speech_text are strings; outline and useful_expressions are non-empty arrays of strings. Do not return markdown.`
 }
 
 func GenerationUserPrompt(request AnswerGenerationRequest) string {
@@ -407,9 +407,9 @@ func answerTiming(part PracticeMode) struct {
 	case PracticeModePart1:
 		return struct{ seconds, words, structure string }{"20-30", "35-55", "2-4 sentences: direct answer, reason, brief example"}
 	case PracticeModePart2:
-		return struct{ seconds, words, structure string }{"90-120", "180-240", "structured long turn covering the cue-card points with a clear opening and closing"}
+		return struct{ seconds, words, structure string }{"80-110", "160-220", "one coherent long turn: address every cue-card point naturally, connect details instead of answering mechanically, and use a short opening and natural ending"}
 	case PracticeModePart3:
-		return struct{ seconds, words, structure string }{"35-50", "75-110", "4-6 sentences: position, explanation, example or comparison, conclusion"}
+		return struct{ seconds, words, structure string }{"25-40", "50-80", "3-5 sentences answering this question only: direct position, one or two connected reasons, and a relevant example, comparison, consequence, or exception when useful; discuss the issue generally and avoid an essay-style introduction or conclusion"}
 	default:
 		return struct{ seconds, words, structure string }{}
 	}

--- a/server/internal/coaching/scene/ielts/answer_preparation_test.go
+++ b/server/internal/coaching/scene/ielts/answer_preparation_test.go
@@ -114,13 +114,40 @@ func TestAnswerGenerationLengthCapsLikelySpeakingTime(t *testing.T) {
 		!validGenerationLength(PracticeModePart3, short) {
 		t.Fatal("short answer should fit every part")
 	}
-	words := make([]string, 76)
-	for index := range words {
-		words[index] = "word"
+	for _, test := range []struct {
+		name  string
+		part  PracticeMode
+		words int
+	}{
+		{name: "Part 1", part: PracticeModePart1, words: 76},
+		{name: "Part 2", part: PracticeModePart2, words: 241},
+		{name: "Part 3", part: PracticeModePart3, words: 96},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			words := make([]string, test.words)
+			for index := range words {
+				words[index] = "word"
+			}
+			tooLong := strings.Join(words, " ")
+			if validGenerationLength(test.part, AnswerGenerationResult{Answer: tooLong, SpeechText: tooLong}) {
+				t.Fatalf("%s answer with %d words should be rejected", test.name, test.words)
+			}
+		})
 	}
-	tooLong := strings.Join(words, " ")
-	if validGenerationLength(PracticeModePart1, AnswerGenerationResult{Answer: tooLong, SpeechText: tooLong}) {
-		t.Fatal("Part 1 answer above 75 words should be rejected")
+}
+
+func TestAnswerTimingKeepsPartSpecificSpokenTargets(t *testing.T) {
+	part1 := answerTiming(PracticeModePart1)
+	if part1.seconds != "20-30" || part1.words != "35-55" {
+		t.Fatalf("Part 1 timing changed: %#v", part1)
+	}
+	part2 := answerTiming(PracticeModePart2)
+	if part2.seconds != "80-110" || part2.words != "160-220" || !strings.Contains(part2.structure, "every cue-card point") {
+		t.Fatalf("Part 2 timing = %#v", part2)
+	}
+	part3 := answerTiming(PracticeModePart3)
+	if part3.seconds != "25-40" || part3.words != "50-80" || !strings.Contains(part3.structure, "avoid an essay-style") {
+		t.Fatalf("Part 3 timing = %#v", part3)
 	}
 }
 


### PR DESCRIPTION
## 功能描述
- Part 2 自定义答案目标调整为 160–220 词、约 80–110 秒
- Part 3 单题调整为 50–80 词、约 25–40 秒、3–5 句
- 明确生成自然口语而非作文，Part 3 避免作文式开头与结尾
- Part 2 保持连贯长回答并覆盖 Cue Card 要点，不逐项机械作答

## 实现思路
- 仅调整既有 Part 级提示词与服务端长度门禁，不修改 API 或数据结构
- Part 2 硬上限从 280 收紧至 240 词；Part 3 从 130 收紧至 95 词
- Part 1 的目标和 75 词硬上限保持不变

## 可复现测试
- `go test ./internal/coaching/scene/ielts ./internal/providers/qianwen`（通过）
- `make check-go`（通过）
- `git diff --check`（通过）

Closes #576

Milestone: MS3