### PR TITLE
feat(agent): 语音识别完成后自动发送文字消息

### DIFF
--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -296,7 +296,9 @@ class _AgentComposerState extends State<AgentComposer> {
     final voiceState = voice?.state ?? AgentVoiceInputState.idle;
     final starting = voiceState == AgentVoiceInputState.starting;
     final recording = voiceState == AgentVoiceInputState.recording;
-    final voiceProgress = voiceState == AgentVoiceInputState.completing;
+    final voiceProgress =
+        voiceState == AgentVoiceInputState.completing ||
+        voiceState == AgentVoiceInputState.submitting;
     final voiceFailure = voiceState == AgentVoiceInputState.failed;
     final capturePhase = switch (voiceState) {
       AgentVoiceInputState.idle => VoiceCapturePhase.idle,
@@ -363,7 +365,7 @@ class _AgentComposerState extends State<AgentComposer> {
                         : voice?.liveTranscript.trim().isNotEmpty == true
                         ? voice!.liveTranscript
                         : agentComposerVoiceStateLabel(voiceState),
-                    canCancel: true,
+                    canCancel: voiceState != AgentVoiceInputState.submitting,
                     canRetry: voiceFailure && voice?.canRetry == true,
                     onCancel: _cancelVoice,
                     onRetry: voice?.retry,

--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -122,10 +122,6 @@ class _AgentComposerState extends State<AgentComposer> {
 
   void _handleTextChanged() {
     if (!_suppressControllerNotifications) {
-      final voice = widget.voiceController;
-      if (voice?.state == AgentVoiceInputState.editing) {
-        voice?.updateTranscript(_controller.text);
-      }
       setState(() {});
     }
   }
@@ -133,26 +129,6 @@ class _AgentComposerState extends State<AgentComposer> {
   void _handleVoiceChanged() {
     if (!mounted) {
       return;
-    }
-    final voice = widget.voiceController;
-    if (voice?.state == AgentVoiceInputState.editing &&
-        _controller.text != voice?.editedTranscript) {
-      _suppressControllerNotifications = true;
-      _controller.value = TextEditingValue(
-        text: voice!.editedTranscript,
-        selection: TextSelection.collapsed(
-          offset: voice.editedTranscript.length,
-        ),
-      );
-      _suppressControllerNotifications = false;
-    }
-    if (voice?.state == AgentVoiceInputState.editing) {
-      _textMode = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _focusNode.requestFocus();
-        }
-      });
     }
     setState(() {});
   }
@@ -230,41 +206,6 @@ class _AgentComposerState extends State<AgentComposer> {
   void _showVoiceComposer() {
     _focusNode.unfocus();
     setState(() => _textMode = false);
-  }
-
-  Future<void> _submitConvertedText() async {
-    final voice = widget.voiceController;
-    final text = _controller.text.trim();
-    final imageUploadPending = widget.pendingImages.any(
-      (image) => image.state == AgentPendingImageState.uploading,
-    );
-    final imageUploadFailed = widget.pendingImages.any(
-      (image) => image.state == AgentPendingImageState.failed,
-    );
-    if (voice == null ||
-        !voice.canSubmitTranscript ||
-        text.isEmpty ||
-        !widget.enabled ||
-        widget.isBusy ||
-        imageUploadPending ||
-        imageUploadFailed ||
-        _textSubmissionInFlight ||
-        widget.onSubmitText == null) {
-      return;
-    }
-    setState(() => _textSubmissionInFlight = true);
-    try {
-      await voice.cancel();
-      final sent = await widget.onSubmitText!(text);
-      if (mounted && sent) {
-        _controller.clear();
-        setState(() => _textMode = false);
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _textSubmissionInFlight = false);
-      }
-    }
   }
 
   Future<void> _submit() async {
@@ -355,7 +296,6 @@ class _AgentComposerState extends State<AgentComposer> {
     final voiceState = voice?.state ?? AgentVoiceInputState.idle;
     final starting = voiceState == AgentVoiceInputState.starting;
     final recording = voiceState == AgentVoiceInputState.recording;
-    final editingVoiceDraft = voiceState == AgentVoiceInputState.editing;
     final voiceProgress = voiceState == AgentVoiceInputState.completing;
     final voiceFailure = voiceState == AgentVoiceInputState.failed;
     final capturePhase = switch (voiceState) {
@@ -372,12 +312,7 @@ class _AgentComposerState extends State<AgentComposer> {
             widget.enabled &&
             !widget.isBusy);
     final showTextComposer =
-        editingVoiceDraft ||
-        (_textMode &&
-            !starting &&
-            !recording &&
-            !voiceProgress &&
-            !voiceFailure);
+        _textMode && !starting && !recording && !voiceProgress && !voiceFailure;
     final imageUploadPending = widget.pendingImages.any(
       (image) => image.state == AgentPendingImageState.uploading,
     );
@@ -438,28 +373,16 @@ class _AgentComposerState extends State<AgentComposer> {
                     controller: _controller,
                     focusNode: _focusNode,
                     keyboardVisible: widget.keyboardVisible,
-                    enabled: editingVoiceDraft || widget.enabled,
-                    confirmingConvertedText: editingVoiceDraft,
+                    enabled: widget.enabled,
                     submitting: _textSubmissionInFlight,
-                    canSubmitConvertedText:
-                        voice?.canSubmitTranscript == true &&
-                        widget.onSubmitText != null &&
-                        widget.enabled &&
-                        !widget.isBusy &&
-                        !imageUploadPending &&
-                        !imageUploadFailed,
                     canSubmitText:
                         widget.onSubmitText != null &&
                         widget.enabled &&
                         !widget.isBusy &&
                         !imageUploadPending &&
                         !imageUploadFailed,
-                    onReturnToVoice: editingVoiceDraft
-                        ? _cancelVoice
-                        : _showVoiceComposer,
-                    onSubmit: editingVoiceDraft
-                        ? _submitConvertedText
-                        : _submit,
+                    onReturnToVoice: _showVoiceComposer,
+                    onSubmit: _submit,
                   )
                 : AgentComposerVoiceDock(
                     capture: capture,
@@ -487,9 +410,7 @@ class _AgentTextDock extends StatelessWidget {
     required this.focusNode,
     required this.keyboardVisible,
     required this.enabled,
-    required this.confirmingConvertedText,
     required this.submitting,
-    required this.canSubmitConvertedText,
     required this.canSubmitText,
     required this.onReturnToVoice,
     required this.onSubmit,
@@ -499,9 +420,7 @@ class _AgentTextDock extends StatelessWidget {
   final FocusNode focusNode;
   final bool keyboardVisible;
   final bool enabled;
-  final bool confirmingConvertedText;
   final bool submitting;
-  final bool canSubmitConvertedText;
   final bool canSubmitText;
   final FutureOr<void> Function() onReturnToVoice;
   final FutureOr<void> Function() onSubmit;
@@ -512,30 +431,16 @@ class _AgentTextDock extends StatelessWidget {
       controller: controller,
       focusNode: focusNode,
       enabled: enabled,
-      canSubmit: confirmingConvertedText
-          ? canSubmitConvertedText
-          : canSubmitText,
+      canSubmit: canSubmitText,
       submitting: submitting,
       onReturn: onReturnToVoice,
       onSubmit: onSubmit,
-      returnKey: Key(
-        confirmingConvertedText
-            ? 'agent-voice-cancel'
-            : 'agent-show-voice-composer',
-      ),
+      returnKey: const Key('agent-show-voice-composer'),
       fieldKey: const Key('agent-composer-field'),
-      submitKey: Key(
-        confirmingConvertedText ? 'agent-voice-text-send' : 'agent-send-button',
-      ),
-      returnTooltip: confirmingConvertedText ? '取消转文字' : '切换到语音输入',
-      returnIcon: confirmingConvertedText
-          ? Icons.close_rounded
-          : Icons.mic_none_rounded,
-      hintText: enabled
-          ? confirmingConvertedText
-                ? '编辑识别文字后发送'
-                : '问问 SpeakUp'
-          : '暂时无法开始对话',
+      submitKey: const Key('agent-send-button'),
+      returnTooltip: '切换到语音输入',
+      returnIcon: Icons.mic_none_rounded,
+      hintText: enabled ? '问问 SpeakUp' : '暂时无法开始对话',
       maxLines: keyboardVisible ? 3 : 2,
       inputFormatters: <TextInputFormatter>[_agentContentFormatter],
     );

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -30,6 +30,7 @@ final class ComposerController extends ChangeNotifier {
         client: voiceInputClient,
         recorder: voiceRecorder ?? FakeAgentVoiceStreamingRecorder(),
         idFactory: _newId,
+        submitTranscript: sendText,
       )..addListener(_relayVoiceState);
     }
     conversationController.addListener(_syncConversationState);

--- a/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
@@ -175,6 +175,7 @@ String agentComposerVoiceStateLabel(AgentVoiceInputState state) {
   return switch (state) {
     AgentVoiceInputState.starting => '正在打开麦克风…',
     AgentVoiceInputState.completing => '正在整理识别文字…',
+    AgentVoiceInputState.submitting => '正在发送…',
     _ => '正在处理…',
   };
 }

--- a/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
@@ -10,7 +10,14 @@ typedef AgentVoiceInputIdFactory = String Function(String scope);
 typedef AgentVoiceInputClock = DateTime Function();
 typedef AgentVoiceInputSubmit = Future<bool> Function(String transcript);
 
-enum AgentVoiceInputState { idle, starting, recording, completing, failed }
+enum AgentVoiceInputState {
+  idle,
+  starting,
+  recording,
+  completing,
+  submitting,
+  failed,
+}
 
 /// Owns ephemeral microphone input until its transcript is submitted as text.
 ///
@@ -46,6 +53,7 @@ final class AgentVoiceInputController extends ChangeNotifier
   String? _threadId;
   AgentVoiceInputState _state = AgentVoiceInputState.idle;
   String _liveTranscript = '';
+  String? _pendingSubmitTranscript;
   String? _errorMessage;
   bool _canRetry = false;
   DateTime? _recordingStartedAt;
@@ -308,15 +316,39 @@ final class AgentVoiceInputController extends ChangeNotifier
     }
     final transcript = completedTranscript!;
     _liveTranscript = transcript;
+    _pendingSubmitTranscript = transcript;
+    await _submitPendingTranscript(fence);
+  }
+
+  Future<void> _submitPendingTranscript(_AgentVoiceInputFence fence) async {
+    final transcript = _pendingSubmitTranscript;
+    if (transcript == null || !_isCurrent(fence)) {
+      return;
+    }
+    _state = AgentVoiceInputState.submitting;
+    _errorMessage = null;
+    _canRetry = false;
+    notifyListeners();
+    bool submitted;
     try {
-      await submitTranscript(transcript);
+      submitted = await submitTranscript(transcript);
     } catch (error) {
       if (_isCurrent(fence)) {
-        _showFailure(fence, error);
+        _state = AgentVoiceInputState.failed;
+        _errorMessage = _submissionFailureMessage(error);
+        _canRetry = _isRetryable(error);
+        notifyListeners();
       }
       return;
     }
     if (!_isCurrent(fence)) {
+      return;
+    }
+    if (!submitted) {
+      _state = AgentVoiceInputState.failed;
+      _errorMessage = '消息未发送，请重试。';
+      _canRetry = true;
+      notifyListeners();
       return;
     }
     _resetPresentation();
@@ -418,6 +450,10 @@ final class AgentVoiceInputController extends ChangeNotifier
     }
     await _workflowCleanup;
     if (!_canRetry || _state != AgentVoiceInputState.failed) {
+      return;
+    }
+    if (_pendingSubmitTranscript != null) {
+      await _submitPendingTranscript(_captureFence());
       return;
     }
     _resetPresentation();
@@ -544,6 +580,7 @@ final class AgentVoiceInputController extends ChangeNotifier
     }
     _cancelRecordingTimers();
     _liveTranscript = '';
+    _pendingSubmitTranscript = null;
     _state = AgentVoiceInputState.failed;
     _errorMessage = _failureMessage(error);
     _canRetry = _isRetryable(error);
@@ -553,6 +590,7 @@ final class AgentVoiceInputController extends ChangeNotifier
   void _resetPresentation() {
     _state = AgentVoiceInputState.idle;
     _liveTranscript = '';
+    _pendingSubmitTranscript = null;
     _errorMessage = null;
     _canRetry = false;
     _recordingElapsed = Duration.zero;
@@ -641,6 +679,12 @@ final class AgentVoiceInputController extends ChangeNotifier
     TimeoutException() => '语音识别连接中断，请重试。',
     AgentVoiceInputFailure() => '语音识别失败，请重试。',
     _ => '暂时无法识别语音，请重试。',
+  };
+
+  String _submissionFailureMessage(Object error) => switch (error) {
+    AgentClientException(kind: AgentClientFailureKind.authenticationRequired) =>
+      '登录状态已失效，请重新登录。',
+    _ => '消息未发送，请重试。',
   };
 
   static void _completeTerminal(

--- a/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_input_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
@@ -9,26 +8,21 @@ import 'agent_voice_recording.dart';
 
 typedef AgentVoiceInputIdFactory = String Function(String scope);
 typedef AgentVoiceInputClock = DateTime Function();
+typedef AgentVoiceInputSubmit = Future<bool> Function(String transcript);
 
-enum AgentVoiceInputState {
-  idle,
-  starting,
-  recording,
-  completing,
-  editing,
-  failed,
-}
+enum AgentVoiceInputState { idle, starting, recording, completing, failed }
 
-/// Owns ephemeral microphone input until it becomes an editable text draft.
+/// Owns ephemeral microphone input until its transcript is submitted as text.
 ///
-/// This controller never creates a voice candidate, MessageAudio, or Message.
-/// The edited transcript is submitted through the ordinary text composer.
+/// This controller never creates a voice candidate or MessageAudio. The final
+/// transcript is submitted through the ordinary text-message workflow.
 final class AgentVoiceInputController extends ChangeNotifier
     with WidgetsBindingObserver {
   AgentVoiceInputController({
     required this.client,
     required this.recorder,
     required this.idFactory,
+    required this.submitTranscript,
     this.clock = DateTime.now,
     this.recordingLimit = const Duration(seconds: 58),
     this.completionTimeout = const Duration(seconds: 75),
@@ -44,6 +38,7 @@ final class AgentVoiceInputController extends ChangeNotifier
   final AgentVoiceInputClient client;
   final AgentVoiceRecorder recorder;
   final AgentVoiceInputIdFactory idFactory;
+  final AgentVoiceInputSubmit submitTranscript;
   final AgentVoiceInputClock clock;
   final Duration recordingLimit;
   final Duration completionTimeout;
@@ -51,7 +46,6 @@ final class AgentVoiceInputController extends ChangeNotifier
   String? _threadId;
   AgentVoiceInputState _state = AgentVoiceInputState.idle;
   String _liveTranscript = '';
-  String _editedTranscript = '';
   String? _errorMessage;
   bool _canRetry = false;
   DateTime? _recordingStartedAt;
@@ -71,7 +65,6 @@ final class AgentVoiceInputController extends ChangeNotifier
   String? get threadId => _threadId;
   AgentVoiceInputState get state => _state;
   String get liveTranscript => _liveTranscript;
-  String get editedTranscript => _editedTranscript;
   String? get errorMessage => _errorMessage;
   Duration get recordingElapsed => _recordingElapsed;
   bool get canRetry => _canRetry;
@@ -87,10 +80,6 @@ final class AgentVoiceInputController extends ChangeNotifier
       _threadId != null &&
       _state == AgentVoiceInputState.idle;
   bool get canStopRecording => _state == AgentVoiceInputState.recording;
-  bool get canSubmitTranscript =>
-      _state == AgentVoiceInputState.editing &&
-      _editedTranscript.trim().isNotEmpty &&
-      utf8.encode(_editedTranscript.trim()).length <= 16384;
 
   Future<void> bindThread(String? threadId) async {
     if (threadId == _threadId) {
@@ -108,7 +97,6 @@ final class AgentVoiceInputController extends ChangeNotifier
     final fence = _newFence();
     _state = AgentVoiceInputState.starting;
     _liveTranscript = '';
-    _editedTranscript = '';
     _errorMessage = null;
     _canRetry = false;
     notifyListeners();
@@ -320,10 +308,18 @@ final class AgentVoiceInputController extends ChangeNotifier
     }
     final transcript = completedTranscript!;
     _liveTranscript = transcript;
-    _editedTranscript = transcript;
-    _state = AgentVoiceInputState.editing;
-    _errorMessage = null;
-    _canRetry = false;
+    try {
+      await submitTranscript(transcript);
+    } catch (error) {
+      if (_isCurrent(fence)) {
+        _showFailure(fence, error);
+      }
+      return;
+    }
+    if (!_isCurrent(fence)) {
+      return;
+    }
+    _resetPresentation();
     notifyListeners();
   }
 
@@ -341,7 +337,6 @@ final class AgentVoiceInputController extends ChangeNotifier
     _eventSubscription = null;
     _terminal = null;
     _liveTranscript = '';
-    _editedTranscript = '';
     _state = AgentVoiceInputState.completing;
     _errorMessage = null;
     _canRetry = false;
@@ -407,14 +402,6 @@ final class AgentVoiceInputController extends ChangeNotifier
       notifyListeners();
     }
     return cleanup;
-  }
-
-  void updateTranscript(String value) {
-    if (_state != AgentVoiceInputState.editing || value == _editedTranscript) {
-      return;
-    }
-    _editedTranscript = value;
-    notifyListeners();
   }
 
   Future<void> retry() async {
@@ -557,7 +544,6 @@ final class AgentVoiceInputController extends ChangeNotifier
     }
     _cancelRecordingTimers();
     _liveTranscript = '';
-    _editedTranscript = '';
     _state = AgentVoiceInputState.failed;
     _errorMessage = _failureMessage(error);
     _canRetry = _isRetryable(error);
@@ -567,7 +553,6 @@ final class AgentVoiceInputController extends ChangeNotifier
   void _resetPresentation() {
     _state = AgentVoiceInputState.idle;
     _liveTranscript = '';
-    _editedTranscript = '';
     _errorMessage = null;
     _canRetry = false;
     _recordingElapsed = Duration.zero;

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -15,7 +15,7 @@ import 'package:speakup/features/agent/conversation/conversation_controller.dart
 
 void main() {
   testWidgets(
-    'home voice input shows partial text then sends an edited ordinary Message',
+    'home voice input shows partial text then auto-sends an ordinary Message',
     (tester) async {
       final recorder = _TrackingStreamingRecorder();
       final conversationController = ConversationController(
@@ -56,41 +56,23 @@ void main() {
       expect(conversationController.messages, isEmpty);
 
       await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await composerController.voiceController!.stopRecording();
       await _pumpUntil(
         tester,
-        () =>
-            composerController.voiceController?.state ==
-            AgentVoiceInputState.editing,
+        () => conversationController.messages.any(
+          (message) => message.role == AgentMessageRole.user,
+        ),
       );
 
-      final field = find.byKey(const Key('agent-composer-field'));
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceInputState.editing,
-      );
-      expect(field, findsOneWidget);
-      expect(
-        tester.widget<TextField>(field).controller?.text,
-        'I explained the problem, the trade-off, and the result clearly.',
-      );
-      expect(conversationController.messages, isEmpty);
-
-      const edited = 'I explained the trade-off and measured the result.';
-      await tester.enterText(field, edited);
-      await tester.pump();
-      final send = find.byKey(const Key('agent-voice-text-send'));
-      expect(tester.widget<IconButton>(send).onPressed, isNotNull);
-      await tester.tap(send);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
-      await tester.pump();
+      expect(find.byKey(const Key('agent-composer-field')), findsNothing);
 
       final userMessages = conversationController.messages
           .where((message) => message.role == AgentMessageRole.user)
           .toList();
       expect(userMessages, hasLength(1));
-      expect(userMessages.single.text, edited);
+      expect(
+        userMessages.single.text,
+        'I explained the problem, the trade-off, and the result clearly.',
+      );
       expect(userMessages.single.modality, AgentMessageModality.text);
       expect(userMessages.single.audio, isNull);
       expect(recorder.stopAudioStreamAndDiscardCalls, 1);
@@ -118,10 +100,15 @@ void main() {
     'completed transcription discards PCM without creating a local WAV',
     () async {
       final recorder = _TrackingStreamingRecorder();
+      final submitted = <String>[];
       final controller = AgentVoiceInputController(
         client: FakeAgentVoiceInputClient(),
         recorder: recorder,
         idFactory: _sequentialIdFactory(),
+        submitTranscript: (transcript) async {
+          submitted.add(transcript);
+          return true;
+        },
       );
       addTearDown(controller.dispose);
       await controller.bindThread('thread-a');
@@ -132,8 +119,10 @@ void main() {
 
       await controller.stopRecording();
 
-      expect(controller.state, AgentVoiceInputState.editing);
-      expect(controller.canSubmitTranscript, isTrue);
+      expect(controller.state, AgentVoiceInputState.idle);
+      expect(submitted, <String>[
+        'I explained the problem, the trade-off, and the result clearly.',
+      ]);
       expect(recorder.stopAudioStreamAndDiscardCalls, 1);
       expect(recorder.stopAudioStreamCalls, 0);
       expect(recorder.discardedRecordings, 0);
@@ -150,6 +139,7 @@ void main() {
         client: FakeAgentVoiceInputClient(),
         recorder: recorder,
         idFactory: _sequentialIdFactory(),
+        submitTranscript: (_) async => true,
       );
       addTearDown(controller.dispose);
       await controller.bindThread('thread-a');
@@ -159,8 +149,6 @@ void main() {
       await controller.stopRecording();
 
       expect(controller.state, AgentVoiceInputState.failed);
-      expect(controller.editedTranscript, isEmpty);
-      expect(controller.canSubmitTranscript, isFalse);
       expect(controller.canRetry, isTrue);
       expect(recorder.hasPendingCleanup, isTrue);
 
@@ -174,66 +162,51 @@ void main() {
     },
   );
 
-  testWidgets(
-    'text send failure keeps the draft after local audio is deleted',
-    (tester) async {
-      final recorder = _TrackingStreamingRecorder();
-      final conversationController = ConversationController(
-        client: _FailingTextAgentClient(),
-      );
-      final composerController = ComposerController(
+  testWidgets('automatic text send failure does not retain local audio', (
+    tester,
+  ) async {
+    final recorder = _TrackingStreamingRecorder();
+    final conversationController = ConversationController(
+      client: _FailingTextAgentClient(),
+    );
+    final composerController = ComposerController(
+      conversationController: conversationController,
+      voiceInputClient: FakeAgentVoiceInputClient(),
+      voiceRecorder: recorder,
+      clientIdFactory: _sequentialIdFactory(),
+    );
+    addTearDown(() {
+      composerController.dispose();
+      conversationController.dispose();
+    });
+    await tester.pumpWidget(
+      SpeakUpApp.preview(
         conversationController: conversationController,
-        voiceInputClient: FakeAgentVoiceInputClient(),
-        voiceRecorder: recorder,
-        clientIdFactory: _sequentialIdFactory(),
-      );
-      addTearDown(() {
-        composerController.dispose();
-        conversationController.dispose();
-      });
-      await tester.pumpWidget(
-        SpeakUpApp.preview(
-          conversationController: conversationController,
-          composerController: composerController,
-        ),
-      );
-      await tester.pumpAndSettle();
+        composerController: composerController,
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await composerController.voiceController!.stopRecording();
-      await _pumpUntil(
-        tester,
-        () =>
-            composerController.voiceController?.state ==
-            AgentVoiceInputState.editing,
-      );
-      final field = find.byKey(const Key('agent-composer-field'));
-      const edited = 'Keep this voice-derived draft after failure.';
-      await tester.enterText(field, edited);
-      await tester.pump();
-      await tester.tap(find.byKey(const Key('agent-voice-text-send')));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await _pumpUntil(
+      tester,
+      () =>
+          composerController.voiceController?.state ==
+          AgentVoiceInputState.idle,
+    );
 
-      expect(conversationController.messages, isEmpty);
-      expect(recorder.stopAudioStreamAndDiscardCalls, 1);
-      expect(recorder.discardedRecordings, 0);
-      expect(recorder.hasCurrentRecording, isFalse);
-      expect(
-        tester
-            .widget<TextField>(find.byKey(const Key('agent-composer-field')))
-            .controller
-            ?.text,
-        edited,
-      );
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceInputState.idle,
-      );
-    },
-  );
+    expect(conversationController.messages, isEmpty);
+    expect(recorder.stopAudioStreamAndDiscardCalls, 1);
+    expect(recorder.discardedRecordings, 0);
+    expect(recorder.hasCurrentRecording, isFalse);
+    expect(find.byKey(const Key('agent-composer-field')), findsNothing);
+    expect(
+      composerController.voiceController?.state,
+      AgentVoiceInputState.idle,
+    );
+  });
 
   test(
     'Thread switch cleans capture and fences late transcription events',
@@ -244,6 +217,7 @@ void main() {
         client: client,
         recorder: recorder,
         idFactory: _sequentialIdFactory(),
+        submitTranscript: (_) async => true,
       );
       addTearDown(controller.dispose);
       await controller.bindThread('thread-a');
@@ -260,7 +234,6 @@ void main() {
       expect(controller.threadId, 'thread-b');
       expect(controller.state, AgentVoiceInputState.idle);
       expect(controller.liveTranscript, isEmpty);
-      expect(controller.editedTranscript, isEmpty);
       expect(recorder.discardCurrentCalls, greaterThan(0));
       expect(recorder.hasCurrentRecording, isFalse);
     },
@@ -275,6 +248,7 @@ void main() {
         client: client,
         recorder: recorder,
         idFactory: _sequentialIdFactory(),
+        submitTranscript: (_) async => true,
       );
       addTearDown(controller.dispose);
       await controller.bindThread('thread-a');
@@ -292,7 +266,6 @@ void main() {
 
       expect(controller.state, AgentVoiceInputState.failed);
       expect(controller.canRetry, isTrue);
-      expect(controller.editedTranscript, isEmpty);
       expect(recorder.hasCurrentRecording, isFalse);
       expect(recorder.discardCurrentCalls, greaterThan(0));
     },
@@ -305,6 +278,7 @@ void main() {
       client: client,
       recorder: recorder,
       idFactory: _sequentialIdFactory(),
+      submitTranscript: (_) async => true,
     );
     addTearDown(controller.dispose);
     await controller.bindThread('thread-a');
@@ -319,7 +293,6 @@ void main() {
     expect(controller.threadId, isNull);
     expect(controller.state, AgentVoiceInputState.idle);
     expect(controller.liveTranscript, isEmpty);
-    expect(controller.editedTranscript, isEmpty);
     expect(recorder.clearAccountStateCalls, greaterThan(0));
     expect(recorder.hasCurrentRecording, isFalse);
   });
@@ -331,6 +304,7 @@ void main() {
       client: _ControlledVoiceInputClient(),
       recorder: recorder,
       idFactory: _sequentialIdFactory(),
+      submitTranscript: (_) async => true,
     );
     addTearDown(controller.dispose);
     await controller.bindThread('thread-a');
@@ -363,6 +337,7 @@ void main() {
       client: client,
       recorder: recorder,
       idFactory: _sequentialIdFactory(),
+      submitTranscript: (_) async => true,
     );
     await controller.bindThread('thread-a');
     await controller.startRecording();

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -9,6 +9,7 @@ import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.d
 import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_composer.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
@@ -130,6 +131,88 @@ void main() {
     },
   );
 
+  test('failed automatic send retains transcript and retries it', () async {
+    final recorder = _TrackingStreamingRecorder();
+    final submitted = <String>[];
+    var shouldSucceed = false;
+    final controller = AgentVoiceInputController(
+      client: FakeAgentVoiceInputClient(),
+      recorder: recorder,
+      idFactory: _sequentialIdFactory(),
+      submitTranscript: (transcript) async {
+        submitted.add(transcript);
+        return shouldSucceed;
+      },
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+
+    await controller.startRecording();
+    await Future<void>.delayed(Duration.zero);
+    await controller.stopRecording();
+
+    expect(controller.state, AgentVoiceInputState.failed);
+    expect(controller.canRetry, isTrue);
+    expect(
+      controller.liveTranscript,
+      'I explained the problem, the trade-off, and the result clearly.',
+    );
+
+    shouldSucceed = true;
+    await controller.retry();
+
+    expect(controller.state, AgentVoiceInputState.idle);
+    expect(submitted, hasLength(2));
+    expect(submitted.toSet(), hasLength(1));
+  });
+
+  test('automatic send cannot be cancelled after submission starts', () async {
+    final recorder = _TrackingStreamingRecorder();
+    final submission = Completer<bool>();
+    final controller = AgentVoiceInputController(
+      client: FakeAgentVoiceInputClient(),
+      recorder: recorder,
+      idFactory: _sequentialIdFactory(),
+      submitTranscript: (_) => submission.future,
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+    await controller.startRecording();
+    await Future<void>.delayed(Duration.zero);
+
+    final stopping = controller.stopRecording();
+    while (controller.state != AgentVoiceInputState.submitting) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(controller.liveTranscript, isNotEmpty);
+    submission.complete(true);
+    await stopping;
+    expect(controller.state, AgentVoiceInputState.idle);
+  });
+
+  testWidgets('submitting status does not expose a cancel action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AgentComposerVoiceStatusDock(
+            state: AgentVoiceInputState.submitting,
+            message: '正在发送…',
+            canCancel: false,
+            canRetry: false,
+            onCancel: () {},
+            onRetry: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('agent-voice-cancel')), findsNothing);
+    expect(find.text('正在发送…'), findsOneWidget);
+  });
+
   test(
     'local cleanup failure stays failed and retries retained cleanup',
     () async {
@@ -162,7 +245,7 @@ void main() {
     },
   );
 
-  testWidgets('automatic text send failure does not retain local audio', (
+  testWidgets('automatic text send failure retains text without local audio', (
     tester,
   ) async {
     final recorder = _TrackingStreamingRecorder();
@@ -194,17 +277,17 @@ void main() {
       tester,
       () =>
           composerController.voiceController?.state ==
-          AgentVoiceInputState.idle,
+          AgentVoiceInputState.failed,
     );
 
     expect(conversationController.messages, isEmpty);
     expect(recorder.stopAudioStreamAndDiscardCalls, 1);
     expect(recorder.discardedRecordings, 0);
     expect(recorder.hasCurrentRecording, isFalse);
-    expect(find.byKey(const Key('agent-composer-field')), findsNothing);
+    expect(find.text('消息未发送，请重试。'), findsOneWidget);
     expect(
-      composerController.voiceController?.state,
-      AgentVoiceInputState.idle,
+      composerController.voiceController?.liveTranscript,
+      'I explained the problem, the trade-off, and the result clearly.',
     );
   });
 


### PR DESCRIPTION
## 功能描述
- 首页语音输入结束并完成转写后，自动按普通文字消息发送
- 移除转写完成后的二次编辑/二次发送步骤
- 保留上滑取消、失败重试和已有文字草稿恢复行为
- 不上传录音到 OSS，不影响 Practice / IELTS 证据链

## 实现思路
- 将 `sendText` 作为转写完成回调注入语音控制器
- 最终转写成功后直接走现有文字发送链路
- 发送失败继续由会话控制器展示原有错误与重试入口

## 可复现测试
1. `cd mobile`
2. `flutter analyze --no-pub`
3. `flutter test --no-pub test/agent/agent_voice_flow_test.dart test/agent/agent_voice_fence_test.dart test/agent/agent_flow_test.dart`
4. 长按首页语音输入并说话，松手后确认转写内容自动成为普通文字消息
5. 上滑取消，确认不发送且恢复原文字草稿

Closes #570