### PR TITLE
fix(agent): 恢复首页 AI 流式朗读

### DIFF
--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -156,7 +156,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         ? audioController?.errorMessage
         : null;
     final actions = <Widget>[];
-    if (audioController != null) {
+    if (audioController != null && message.role == AgentMessageRole.assistant) {
       actions.addAll([
         TextButton.icon(
           key: Key('agent-assistant-tts-${message.id}'),

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -7,6 +7,14 @@ import 'package:speakup/features/agent/conversation/agent_message_image_client.d
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 
 typedef ConversationClientIdFactory = String Function(String scope);
+typedef ConversationAssistantStreamStarted =
+    Future<void> Function(String transientMessageId);
+typedef ConversationAssistantStreamDelta =
+    void Function(String transientMessageId, String delta);
+typedef ConversationAssistantStreamCompleted =
+    void Function(String transientMessageId, AgentMessage message);
+typedef ConversationAssistantStreamFailed =
+    void Function(String transientMessageId);
 
 /// Owns the focused Agent Thread, committed Messages, and text Run lifecycle.
 ///
@@ -15,11 +23,19 @@ final class ConversationController extends ChangeNotifier {
   ConversationController({
     required this.client,
     this.messageImageClient,
+    this.onAssistantStreamStarted,
+    this.onAssistantStreamDelta,
+    this.onAssistantStreamCompleted,
+    this.onAssistantStreamFailed,
     ConversationClientIdFactory? clientIdFactory,
   }) : _clientIdFactory = clientIdFactory ?? _createSecureClientId;
 
   final AgentClient client;
   final AgentMessageImageClient? messageImageClient;
+  final ConversationAssistantStreamStarted? onAssistantStreamStarted;
+  final ConversationAssistantStreamDelta? onAssistantStreamDelta;
+  final ConversationAssistantStreamCompleted? onAssistantStreamCompleted;
+  final ConversationAssistantStreamFailed? onAssistantStreamFailed;
   final ConversationClientIdFactory _clientIdFactory;
 
   String? _threadId;
@@ -887,8 +903,10 @@ final class ConversationController extends ChangeNotifier {
               assistantID = canonicalTransientID;
               assistantText = '';
             }
+            await _startAssistantStream(assistantID);
           case AgentAssistantDelta(:final delta):
             pending.write(delta);
+            _appendAssistantStream(assistantID, delta);
             frameTimer ??= Timer(const Duration(milliseconds: 16), flushDelta);
           case AgentRunCompleted(:final assistantMessageId):
             completedAssistantMessageID = assistantMessageId;
@@ -898,15 +916,14 @@ final class ConversationController extends ChangeNotifier {
                 .where((message) => message.id == assistantID)
                 .firstOrNull;
             if (current != null) {
-              replaceMessage(
-                assistantID,
-                current.copyWith(
-                  id: assistantMessageId,
-                  text: assistantText,
-                  isStreaming: false,
-                  hasFailed: false,
-                ),
+              final completed = current.copyWith(
+                id: assistantMessageId,
+                text: assistantText,
+                isStreaming: false,
+                hasFailed: false,
               );
+              replaceMessage(assistantID, completed);
+              _completeAssistantStream(assistantID, completed);
             }
           case AgentRunFailed(:final kind, :final retryable):
             throw AgentClientException(
@@ -935,6 +952,7 @@ final class ConversationController extends ChangeNotifier {
       );
     } catch (error) {
       if (_isOperationCurrent(fence)) {
+        _failAssistantStream(assistantID);
         frameTimer?.cancel();
         flushDelta();
         final current = _messages
@@ -960,6 +978,45 @@ final class ConversationController extends ChangeNotifier {
       if (_isOperationCurrent(fence)) {
         _setBusy(false);
       }
+    }
+  }
+
+  Future<void> _startAssistantStream(String transientMessageId) async {
+    final callback = onAssistantStreamStarted;
+    if (callback == null) {
+      return;
+    }
+    try {
+      await callback(transientMessageId);
+    } catch (_) {
+      _failAssistantStream(transientMessageId);
+    }
+  }
+
+  void _appendAssistantStream(String transientMessageId, String delta) {
+    try {
+      onAssistantStreamDelta?.call(transientMessageId, delta);
+    } catch (_) {
+      _failAssistantStream(transientMessageId);
+    }
+  }
+
+  void _completeAssistantStream(
+    String transientMessageId,
+    AgentMessage message,
+  ) {
+    try {
+      onAssistantStreamCompleted?.call(transientMessageId, message);
+    } catch (_) {
+      _failAssistantStream(transientMessageId);
+    }
+  }
+
+  void _failAssistantStream(String transientMessageId) {
+    try {
+      onAssistantStreamFailed?.call(transientMessageId);
+    } catch (_) {
+      // Speech presentation cannot change the authoritative text Run result.
     }
   }
 

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -924,6 +924,7 @@ final class ConversationController extends ChangeNotifier {
               );
               replaceMessage(assistantID, completed);
               _completeAssistantStream(assistantID, completed);
+              assistantID = assistantMessageId;
             }
           case AgentRunFailed(:final kind, :final retryable):
             throw AgentClientException(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -281,12 +281,27 @@ ProductionAppDependencies createProductionAppDependencies({
         apiTransport: practiceMediaTransport,
         signedAudioTransport: signedAudioTransport,
       );
+  late final AgentMessageAudioController messageAudioController;
   final conversationController = ConversationController(
     client: agentClient,
     messageImageClient: agentImageClient,
+    onAssistantStreamStarted: (transientMessageId) => messageAudioController
+        .startLiveAssistantSpeech(transientMessageId: transientMessageId),
+    onAssistantStreamDelta: (transientMessageId, delta) =>
+        messageAudioController.appendLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          delta: delta,
+        ),
+    onAssistantStreamCompleted: (transientMessageId, message) =>
+        messageAudioController.completeLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          message: message,
+        ),
+    onAssistantStreamFailed: (transientMessageId) => messageAudioController
+        .failLiveAssistantSpeech(transientMessageId: transientMessageId),
   );
   final GoalActivationClient goalActivationClient = goalClient;
-  final messageAudioController = AgentMessageAudioController(
+  messageAudioController = AgentMessageAudioController(
     conversationController: conversationController,
     client: agentVoiceClient,
     audioPlayer: agentMessageAudioPlayer ?? AudioplayersAgentAudioPlayer(),

--- a/mobile/test/agent/agent_assistant_speech_stream_test.dart
+++ b/mobile/test/agent/agent_assistant_speech_stream_test.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
+import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 
@@ -28,6 +30,39 @@ void main() {
       controller.dispose();
       conversation.dispose();
     });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Column(
+          children: [
+            AgentMessageBubble(
+              message: const AgentMessage(
+                id: 'plain-user-text',
+                role: AgentMessageRole.user,
+                text: 'I want to practice.',
+              ),
+              messageAudioController: controller,
+            ),
+            AgentMessageBubble(
+              message: const AgentMessage(
+                id: 'assistant-text',
+                role: AgentMessageRole.assistant,
+                text: 'Let us begin.',
+              ),
+              messageAudioController: controller,
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(
+      find.byKey(const Key('agent-assistant-tts-plain-user-text')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('agent-assistant-tts-assistant-text')),
+      findsOneWidget,
+    );
 
     conversation.commitComposerMessages(const <AgentMessage>[
       AgentMessage(

--- a/mobile/test/agent/agent_streaming_test.dart
+++ b/mobile/test/agent/agent_streaming_test.dart
@@ -124,6 +124,60 @@ void main() {
     expect(controller.messages.last.hasFailed, isTrue);
   });
 
+  test(
+    'stops committed assistant speech when the stream fails after completion',
+    () async {
+      final client = _StreamingAgentClient();
+      final speechEvents = <String>[];
+      final controller = ConversationController(
+        client: client,
+        clientIdFactory: (_) => 'stream-completed-failure-message',
+        onAssistantStreamStarted: (messageId) async {
+          speechEvents.add('start:$messageId');
+        },
+        onAssistantStreamDelta: (messageId, delta) {
+          speechEvents.add('delta:$messageId:$delta');
+        },
+        onAssistantStreamCompleted: (messageId, message) {
+          speechEvents.add('complete:$messageId:${message.id}');
+        },
+        onAssistantStreamFailed: (messageId) {
+          speechEvents.add('fail:$messageId');
+        },
+      );
+      addTearDown(controller.dispose);
+      await controller.initialize();
+
+      expect(await controller.sendText('Please continue.'), isTrue);
+      client.events
+        ..add(const AgentAssistantStarted(runId: 'run-completed-failure'))
+        ..add(
+          const AgentAssistantDelta(
+            runId: 'run-completed-failure',
+            delta: 'The response is complete.',
+          ),
+        )
+        ..add(
+          const AgentRunCompleted(
+            runId: 'run-completed-failure',
+            assistantMessageId: 'assistant-completed-failure',
+          ),
+        )
+        ..addError(StateError('Stream failed after completion.'));
+      await client.events.close();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(speechEvents, <String>[
+        'start:stream-run-completed-failure',
+        'delta:stream-run-completed-failure:The response is complete.',
+        'complete:stream-run-completed-failure:assistant-completed-failure',
+        'fail:assistant-completed-failure',
+      ]);
+      expect(controller.messages.last.id, 'assistant-completed-failure');
+      expect(controller.messages.last.hasFailed, isTrue);
+    },
+  );
+
   test('speech presentation failure does not fail the text stream', () async {
     final client = _StreamingAgentClient();
     final controller = ConversationController(

--- a/mobile/test/agent/agent_streaming_test.dart
+++ b/mobile/test/agent/agent_streaming_test.dart
@@ -15,9 +15,22 @@ void main() {
     'publishes input immediately and coalesces canonical stream deltas',
     () async {
       final client = _StreamingAgentClient();
+      final speechEvents = <String>[];
       final controller = ConversationController(
         client: client,
         clientIdFactory: (_) => 'stream-client-message',
+        onAssistantStreamStarted: (messageId) async {
+          speechEvents.add('start:$messageId');
+        },
+        onAssistantStreamDelta: (messageId, delta) {
+          speechEvents.add('delta:$messageId:$delta');
+        },
+        onAssistantStreamCompleted: (messageId, message) {
+          speechEvents.add('complete:$messageId:${message.id}:${message.text}');
+        },
+        onAssistantStreamFailed: (messageId) {
+          speechEvents.add('fail:$messageId');
+        },
       );
       addTearDown(controller.dispose);
       await controller.initialize();
@@ -61,8 +74,91 @@ void main() {
         'assistant-1',
       ]);
       expect(controller.messages.last.isStreaming, isFalse);
+      expect(speechEvents, <String>[
+        'start:stream-run-1',
+        'delta:stream-run-1:你',
+        'delta:stream-run-1:好，**小花**。',
+        'complete:stream-run-1:assistant-1:你好，**小花**。',
+      ]);
     },
   );
+
+  test('stops assistant speech when the text stream fails', () async {
+    final client = _StreamingAgentClient();
+    final speechEvents = <String>[];
+    final controller = ConversationController(
+      client: client,
+      clientIdFactory: (_) => 'stream-failure-message',
+      onAssistantStreamStarted: (messageId) async {
+        speechEvents.add('start:$messageId');
+      },
+      onAssistantStreamDelta: (messageId, delta) {
+        speechEvents.add('delta:$messageId:$delta');
+      },
+      onAssistantStreamFailed: (messageId) {
+        speechEvents.add('fail:$messageId');
+      },
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    expect(await controller.sendText('Please help me.'), isTrue);
+    client.events
+      ..add(const AgentAssistantStarted(runId: 'run-failed'))
+      ..add(const AgentAssistantDelta(runId: 'run-failed', delta: 'I can help'))
+      ..add(
+        const AgentRunFailed(
+          runId: 'run-failed',
+          kind: 'provider_unavailable',
+          retryable: true,
+        ),
+      );
+    await client.events.close();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(speechEvents, <String>[
+      'start:stream-run-failed',
+      'delta:stream-run-failed:I can help',
+      'fail:stream-run-failed',
+    ]);
+    expect(controller.messages.last.hasFailed, isTrue);
+  });
+
+  test('speech presentation failure does not fail the text stream', () async {
+    final client = _StreamingAgentClient();
+    final controller = ConversationController(
+      client: client,
+      clientIdFactory: (_) => 'stream-speech-failure-message',
+      onAssistantStreamStarted: (_) async {
+        throw StateError('Audio output unavailable.');
+      },
+    );
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    expect(await controller.sendText('Please continue.'), isTrue);
+    client.events
+      ..add(const AgentAssistantStarted(runId: 'run-text-success'))
+      ..add(
+        const AgentAssistantDelta(
+          runId: 'run-text-success',
+          delta: 'The text still succeeds.',
+        ),
+      )
+      ..add(
+        const AgentRunCompleted(
+          runId: 'run-text-success',
+          assistantMessageId: 'assistant-text-success',
+        ),
+      );
+    await client.events.close();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.errorMessage, isNull);
+    expect(controller.messages.last.id, 'assistant-text-success');
+    expect(controller.messages.last.text, 'The text still succeeds.');
+    expect(controller.messages.last.hasFailed, isFalse);
+  });
 
   test(
     'loads the trusted handoff immediately after stream completion',


### PR DESCRIPTION
## 功能描述
- 恢复首页普通文本 Run 的 AI 流式朗读生命周期
- AI 文本 delta 到达时同步送入现有实时 TTS/PCM 播放链路
- 普通用户文字消息不再展示无效的“朗读/倍速”操作
- TTS 展示层异常与权威文本 Run 隔离，避免语音故障误判文本失败

## 实现思路
- 由 `ConversationController` 暴露 assistant stream started/delta/completed/failed 回调
- 在现有 `AgentMessageAudioController` 中复用实时语音合成与 PCM 播放能力
- 完成时将 transient message ID 平滑迁移为持久化 message ID
- 不新增第二套播放器或静默兜底

## 可复现测试
1. 启动真实后端：`make dev-ios-simulator`
2. 在首页录音并发送，确认用户转写气泡不展示朗读/倍速
3. 确认 AI 回复逐步显示且自动朗读，回复完成后仍可手动重播
4. 连续发两轮并切换会话，确认旧实时播放正确取消

已执行：
- `flutter analyze --no-pub`
- `flutter test --no-pub test/agent/agent_streaming_test.dart test/agent/agent_assistant_speech_stream_test.dart test/agent/agent_message_bubble_test.dart test/main_wiring_test.dart`（22/22）
- `git diff --check`
- iOS Simulator + 真实后端人工验证
- 运行日志验证：首音频早于文本 Run 完成约 206ms，227 字回复分为 16 个文本块，TTS 0 失败

本地模型 A/B 说明：模型选择仅通过未提交的本地 `.env` 验证，不包含在本 PR 中。

Closes #580
