### PR TITLE
feat(ielts): 统一完整模考生命周期流程

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -165,6 +165,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (_mode != PracticeMode.fullMock && _mode != PracticeMode.part2) {
       return true;
     }
+    if (_part2ResponseAlreadyConfirmed) {
+      return true;
+    }
     final questionId = _part2QuestionId;
     if (questionId != null &&
         widget.controller.currentQuestion?.id != questionId) {
@@ -249,6 +252,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   int get _part1Total =>
       _assignment.part(IeltsSpeakingPart.part1)?.turnBlueprints.length ?? 0;
+
+  int get _part2Total =>
+      _assignment.part(IeltsSpeakingPart.part2)?.turnBlueprints.length ?? 0;
 
   int get _part3Total =>
       _assignment.part(IeltsSpeakingPart.part3)?.turnBlueprints.length ?? 0;
@@ -1594,23 +1600,14 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     final shouldExit =
         fromCompletion ||
         _progress?.phase == IeltsMockPhase.complete ||
-        await showDialog<bool>(
+        await showModalBottomSheet<bool>(
               context: context,
-              builder: (context) => AlertDialog(
-                title: const Text('Exit mock test?'),
-                content: const Text(
-                  'Your completed answers are saved. You can continue from the latest safe step later.',
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(context, false),
-                    child: const Text('Stay'),
-                  ),
-                  FilledButton(
-                    onPressed: () => Navigator.pop(context, true),
-                    child: const Text('Save & exit'),
-                  ),
-                ],
+              useSafeArea: true,
+              backgroundColor: Colors.transparent,
+              barrierColor: const Color(0x66000000),
+              builder: (sheetContext) => _MockExitSheet(
+                onContinue: () => Navigator.pop(sheetContext, false),
+                onSaveAndExit: () => Navigator.pop(sheetContext, true),
               ),
             ) ==
             true;
@@ -1712,10 +1709,14 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     final complete = progress.phase == IeltsMockPhase.complete;
     final showCompletionPage = complete && !_preserveCompletedConversation;
+    final completionSheet = _completionSheet(progress);
     final stagePhase = complete && _preserveCompletedConversation
         ? (_mode == PracticeMode.part1
               ? IeltsMockPhase.part1
               : IeltsMockPhase.part3)
+        : _mode == PracticeMode.fullMock &&
+              progress.phase == IeltsMockPhase.part1Complete
+        ? IeltsMockPhase.part1
         : progress.phase;
     return PopScope<Object?>(
       canPop: _exitApproved,
@@ -1757,7 +1758,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                             _buildRecorderDock(),
                         ],
                       ),
-                      if (_showCompletionSheet) ...[
+                      if (completionSheet != null) ...[
                         const Positioned.fill(
                           child: ModalBarrier(
                             dismissible: false,
@@ -1767,19 +1768,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                         ),
                         Align(
                           alignment: Alignment.bottomCenter,
-                          child: _SectionCompletionSheet(
-                            title: _completionTitle,
-                            message:
-                                '${widget.controller.completedTurns} 道回答已保存',
-                            primaryLabel: _mode == PracticeMode.fullMock
-                                ? '查看模考报告'
-                                : '查看本组复盘',
-                            secondaryLabel: _mode == PracticeMode.fullMock
-                                ? '返回训练'
-                                : '返回题单',
-                            onPrimary: _openCompletedReview,
-                            onSecondary: _leaveCompletedPractice,
-                          ),
+                          child: completionSheet,
                         ),
                       ],
                     ],
@@ -1791,6 +1780,26 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   Widget _buildAnimatedPhase(IeltsMockProgress progress) {
+    if (_mode == PracticeMode.fullMock &&
+        progress.phase == IeltsMockPhase.part1Complete) {
+      return _conversationPhase(
+        key: const Key('ielts-mock-part-1'),
+        partLabel: 'Part 1',
+        completed: _part1Total,
+        total: _part1Total,
+        sectionStart: _partStart(IeltsSpeakingPart.part1),
+        messages: _sectionMessages(
+          _partStart(IeltsSpeakingPart.part1),
+          _part1Total,
+          includeCurrentQuestion: false,
+        ),
+      );
+    }
+    if (_mode == PracticeMode.fullMock &&
+        progress.phase == IeltsMockPhase.part2Complete &&
+        _part2TurnConfirmed) {
+      return const SizedBox.expand(key: Key('ielts-mock-part-2-complete'));
+    }
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),
       child:
@@ -1799,6 +1808,43 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
           ? _completedConversationPhase()
           : _buildPhase(progress),
     );
+  }
+
+  Widget? _completionSheet(IeltsMockProgress progress) {
+    if (_showCompletionSheet) {
+      return _SectionCompletionSheet(
+        title: _completionTitle,
+        message: '${widget.controller.completedTurns} 道回答已保存',
+        primaryLabel: _mode == PracticeMode.fullMock ? '查看模考报告' : '查看本组复盘',
+        secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
+        onPrimary: _openCompletedReview,
+        onSecondary: _leaveCompletedPractice,
+      );
+    }
+    if (_mode != PracticeMode.fullMock) {
+      return null;
+    }
+    if (progress.phase == IeltsMockPhase.part1Complete) {
+      return _SectionCompletionSheet(
+        title: 'Part 1 已完成',
+        message: '$_part1Total 道回答已保存',
+        primaryLabel: '进入 Part 2',
+        secondaryLabel: '保存并退出',
+        onPrimary: () => unawaited(_beginPart2Intro()),
+        onSecondary: () => unawaited(_requestExit(fromCompletion: true)),
+      );
+    }
+    if (progress.phase == IeltsMockPhase.part2Complete && _part2TurnConfirmed) {
+      return _SectionCompletionSheet(
+        title: 'Part 2 已完成',
+        message: '$_part2Total 道回答已保存',
+        primaryLabel: '继续 Part 3',
+        secondaryLabel: '保存并退出',
+        onPrimary: () => unawaited(_continueFromPart2()),
+        onSecondary: () => unawaited(_requestExit(fromCompletion: true)),
+      );
+    }
+    return null;
   }
 
   String get _completionTitle => switch (_mode) {
@@ -2080,7 +2126,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             messages: messages ?? _sectionMessages(sectionStart, completed),
             controller: widget.controller,
             scrollController: _conversationScrollController,
-            bottomPadding: _showCompletionSheet ? 292 : 28,
+            bottomPadding: _completionOverlayVisible ? 292 : 28,
             speechFeedbackController: widget.speechFeedbackController,
             playingQuestionId:
                 widget.avatarReplayLoading || widget.avatarReplayPlaying
@@ -2117,14 +2163,23 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     );
   }
 
-  List<PracticeMessage> _sectionMessages(int sectionStart, int completed) {
+  List<PracticeMessage> _sectionMessages(
+    int sectionStart,
+    int completed, {
+    bool includeCurrentQuestion = true,
+  }) {
     final relevantCount =
-        completed * 2 + (widget.controller.currentQuestion == null ? 0 : 1);
+        completed * 2 +
+        (includeCurrentQuestion && widget.controller.currentQuestion != null
+            ? 1
+            : 0);
+    final currentQuestionId = widget.controller.currentQuestion?.id;
     final all = widget.controller.practiceMessages
         .where(
           (message) =>
-              message.role == PracticeMessageRole.assistant ||
-              message.role == PracticeMessageRole.user,
+              (message.role == PracticeMessageRole.assistant ||
+                  message.role == PracticeMessageRole.user) &&
+              (includeCurrentQuestion || message.id != currentQuestionId),
         )
         .toList(growable: false);
     if (all.length <= relevantCount) {
@@ -2164,6 +2219,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   String? _currentCueCard() =>
       _assignment.part(IeltsSpeakingPart.part2)?.cueCard;
+
+  bool get _completionOverlayVisible {
+    final progress = _progress;
+    return _showCompletionSheet ||
+        (_mode == PracticeMode.fullMock &&
+            (progress?.phase == IeltsMockPhase.part1Complete ||
+                (progress?.phase == IeltsMockPhase.part2Complete &&
+                    _part2TurnConfirmed)));
+  }
 }
 
 class _SectionProgress extends StatelessWidget {
@@ -2791,6 +2855,65 @@ class _SectionCompletionSheet extends StatelessWidget {
                     minimumSize: const Size.fromHeight(44),
                   ),
                   child: Text(secondaryLabel),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MockExitSheet extends StatelessWidget {
+  const _MockExitSheet({required this.onContinue, required this.onSaveAndExit});
+
+  final VoidCallback onContinue;
+  final VoidCallback onSaveAndExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+        child: Material(
+          key: const Key('ielts-mock-exit-sheet'),
+          color: SpeakUpDesign.surface,
+          borderRadius: BorderRadius.circular(28),
+          clipBehavior: Clip.antiAlias,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 28, 24, 22),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  '退出模拟考试？',
+                  style: SpeakUpDesign.pageTitle.copyWith(fontSize: 26),
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  key: const Key('ielts-mock-continue-answering'),
+                  onPressed: onContinue,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(54),
+                    backgroundColor: const Color(0xFFF4F4F6),
+                    foregroundColor: SpeakUpDesign.ink,
+                    elevation: 0,
+                  ),
+                  child: const Text('继续答题'),
+                ),
+                const SizedBox(height: 12),
+                FilledButton(
+                  key: const Key('ielts-mock-save-and-exit'),
+                  onPressed: onSaveAndExit,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(54),
+                    backgroundColor: SpeakUpDesign.ink,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('保存并退出'),
                 ),
               ],
             ),

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -353,6 +353,28 @@ class _PreparationPageState extends State<PreparationPage> {
     PreparationController controller,
     SceneDefinition scene,
   ) async {
+    final launch = widget.launchController;
+    if (launch?.hasResumablePractice ?? false) {
+      final action = await _chooseExistingPracticeAction(
+        currentTitle: launch?.resumablePracticeTitle,
+        nextTitle: scene.name,
+        startingFullMock: true,
+      );
+      if (!mounted || action == null) {
+        return;
+      }
+      if (action == _ExistingPracticeAction.continuePractice) {
+        await _continueCurrentPractice();
+        return;
+      }
+      await _startSceneDirectly(
+        controller,
+        scene,
+        practiceMode: PracticeMode.fullMock,
+        forceReplaceCurrentPractice: true,
+      );
+      return;
+    }
     await _startSceneDirectly(
       controller,
       scene,
@@ -363,6 +385,7 @@ class _PreparationPageState extends State<PreparationPage> {
   Future<_ExistingPracticeAction?> _chooseExistingPracticeAction({
     required String? currentTitle,
     required String nextTitle,
+    bool startingFullMock = false,
   }) async {
     final activeTitle = currentTitle ?? '上次练习';
     return showModalBottomSheet<_ExistingPracticeAction>(
@@ -383,13 +406,16 @@ class _PreparationPageState extends State<PreparationPage> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '开始新的练习？',
+                        startingFullMock ? '开始新的模考？' : '开始新的练习？',
                         style: Theme.of(context).textTheme.titleLarge,
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        '你正在练“$activeTitle”。开始“$nextTitle”后，'
-                        '当前进度将结束。',
+                        startingFullMock
+                            ? '你还有未完成的“$activeTitle”。可以继续当前进度，'
+                                  '或结束它并开始新的完整模考。'
+                            : '你正在练“$activeTitle”。开始“$nextTitle”后，'
+                                  '当前进度将结束。',
                         style: Theme.of(context).textTheme.bodyMedium,
                       ),
                     ],
@@ -409,14 +435,14 @@ class _PreparationPageState extends State<PreparationPage> {
               onPressed: () => Navigator.of(
                 context,
               ).pop(_ExistingPracticeAction.continuePractice),
-              child: Text('继续“$activeTitle”'),
+              child: Text(startingFullMock ? '继续上次练习' : '继续“$activeTitle”'),
             ),
             const SizedBox(height: 8),
             OutlinedButton(
               key: const Key('replace-existing-practice'),
               onPressed: () =>
                   Navigator.of(context).pop(_ExistingPracticeAction.replace),
-              child: Text('开始“$nextTitle”'),
+              child: Text(startingFullMock ? '开始新模考' : '开始“$nextTitle”'),
             ),
           ],
         ),

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -387,9 +387,13 @@ void main() {
       await tester.pump();
 
       expect(
-        find.byKey(const Key('ielts-mock-part-1-complete')),
+        find.byKey(const Key('ielts-section-completion-sheet')),
         findsOneWidget,
       );
+      expect(find.text('Part 1 已完成'), findsOneWidget);
+      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+      expect(find.text(_question(9).text), findsNothing);
+      expect(find.textContaining('You should say:'), findsNothing);
       await tester.tap(find.text('进入 Part 2'));
       await tester.pump();
       expect(find.byKey(const Key('ielts-mock-part-2-intro')), findsOneWidget);
@@ -441,10 +445,12 @@ void main() {
       expect(controller.completedTurns, 9);
       expect(practice.confirmedQuestionIds, ['question-9']);
       expect(
-        find.byKey(const Key('ielts-mock-part-2-transition')),
+        find.byKey(const Key('ielts-section-completion-sheet')),
         findsOneWidget,
       );
-      await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
+      expect(find.text('Part 2 已完成'), findsOneWidget);
+      expect(find.text(_question(10).text), findsNothing);
+      await tester.tap(find.text('继续 Part 3'));
       await tester.pump();
       expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
       expect(
@@ -497,11 +503,12 @@ void main() {
 
       expect(controller.completedTurns, 9);
       expect(
-        find.byKey(const Key('ielts-mock-part-2-transition')),
+        find.byKey(const Key('ielts-section-completion-sheet')),
         findsOneWidget,
       );
+      expect(find.text('Part 2 已完成'), findsOneWidget);
       expect(controller.hasPendingPracticeAudio, isFalse);
-      await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
+      await tester.tap(find.text('继续 Part 3'));
       await tester.pump();
       expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
     },
@@ -789,7 +796,7 @@ void main() {
       ),
     );
     await tester.pump();
-    await tester.tap(find.byKey(const Key('ielts-mock-continue')));
+    await tester.tap(find.text('进入 Part 2'));
     await tester.pump();
     await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
     await tester.pump();
@@ -868,7 +875,7 @@ void main() {
       ),
     );
     await tester.pump();
-    await tester.tap(find.byKey(const Key('ielts-mock-continue')));
+    await tester.tap(find.text('进入 Part 2'));
     await tester.pump();
     await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
     await tester.pump();
@@ -1199,6 +1206,7 @@ void main() {
   testWidgets('the full-mock PracticeOption opens the three-part flow', (
     tester,
   ) async {
+    var parkCalls = 0;
     final practice = _IeltsPracticeClient(initialCompleted: 8);
     final controller = PracticeController(
       client: practice,
@@ -1212,13 +1220,29 @@ void main() {
         home: IeltsSpeakingMockPage(
           controller: controller,
           progressStore: _MemoryProgressStore(),
+          onExitRequested: () async {
+            parkCalls++;
+            return true;
+          },
         ),
       ),
     );
     await tester.pump();
 
-    expect(find.byKey(const Key('ielts-mock-part-1-complete')), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('Part 1 已完成'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+    expect(find.text(_question(9).text), findsNothing);
+    expect(find.textContaining('You should say:'), findsNothing);
     expect(find.byKey(const Key('practice-page')), findsNothing);
+
+    await tester.tap(find.text('保存并退出'));
+    await tester.pumpAndSettle();
+    expect(parkCalls, 1);
+    expect(find.byKey(const Key('ielts-mock-exit-sheet')), findsNothing);
   });
 
   testWidgets(
@@ -1298,8 +1322,16 @@ void main() {
 
     await tester.tap(find.byKey(const Key('ielts-mock-exit')));
     await tester.pumpAndSettle();
-    expect(find.text('Exit mock test?'), findsOneWidget);
-    await tester.tap(find.text('Save & exit'));
+    expect(find.text('退出模拟考试？'), findsOneWidget);
+    await tester.tap(find.text('继续答题'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ielts-mock-page')), findsOneWidget);
+    expect(parkCalls, 0);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('ielts-mock-exit-sheet')), findsOneWidget);
+    await tester.tap(find.text('保存并退出'));
     await tester.pumpAndSettle();
 
     expect(parkCalls, 1);
@@ -1358,7 +1390,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('ielts-mock-exit')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Save & exit'));
+    await tester.tap(find.text('保存并退出'));
     await tester.pumpAndSettle();
 
     final request = preparation.takeNavigationRequest();
@@ -1403,6 +1435,83 @@ void main() {
       expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
       expect(find.text('Part 3 · Discussion'), findsOneWidget);
       expect(find.text('继续对应 Part 3'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Part 2 completion can be parked and resumed before entering Part 3',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 9, turnLimit: 10);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      final progressStore = _MemoryProgressStore();
+      var parkCalls = 0;
+      addTearDown(controller.dispose);
+      await _activatePractice(controller, practice, _ieltsScene);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                key: const Key('open-part-2-completion'),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => IeltsSpeakingMockPage(
+                      controller: controller,
+                      progressStore: progressStore,
+                      examinerSpeaker: _ImmediateExaminerSpeaker(),
+                      onExitRequested: () async {
+                        parkCalls++;
+                        return true;
+                      },
+                    ),
+                  ),
+                ),
+                child: const Text('Open Part 2 completion'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-part-2-completion')));
+      await tester.pumpAndSettle();
+      expect(find.text('Part 2 已完成'), findsOneWidget);
+
+      await tester.tap(find.text('保存并退出'));
+      await tester.pumpAndSettle();
+      expect(parkCalls, 1);
+      expect(find.byKey(const Key('open-part-2-completion')), findsOneWidget);
+
+      final resumedPractice = _IeltsPracticeClient(
+        initialCompleted: 9,
+        turnLimit: 10,
+      );
+      final resumedController = PracticeController(
+        client: resumedPractice,
+        recorder: _Recorder(),
+      );
+      addTearDown(resumedController.dispose);
+      await _activatePractice(resumedController, resumedPractice, _ieltsScene);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: resumedController,
+            progressStore: progressStore,
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Part 2 已完成'), findsOneWidget);
+
+      await tester.tap(find.text('继续 Part 3'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
+      expect(find.text('0/1'), findsOneWidget);
     },
   );
 
@@ -1486,10 +1595,11 @@ void main() {
     await tester.pump();
 
     expect(
-      find.byKey(const Key('ielts-mock-part-2-transition')),
+      find.byKey(const Key('ielts-section-completion-sheet')),
       findsOneWidget,
     );
-    await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
+    expect(find.text('Part 2 已完成'), findsOneWidget);
+    await tester.tap(find.text('继续 Part 3'));
     await tester.pumpAndSettle();
     expect(find.text('0/1'), findsOneWidget);
     expect(controller.recordingState, PracticeRecordingState.idle);

--- a/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
+++ b/mobile/test/coaching/preparation/practice_lifecycle_flow_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/coaching/preparation/preparation.dart';
 import 'package:speakup/features/coaching/preparation/practice_launch_record_store.dart';
 import 'package:speakup/features/coaching/preparation/practice_workspace_controller.dart';
 import 'package:speakup/features/coaching/scene/scene_client.dart';
@@ -13,6 +14,9 @@ import 'package:speakup/features/coaching/preparation/preparation_launch_client.
 import 'package:speakup/features/coaching/preparation/preparation_launch_controller.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
@@ -106,9 +110,13 @@ void main() {
       final preparationController = PreparationController(
         client: _LifecycleCatalogClient(),
       );
+      final ieltsController = IeltsPreparationController(
+        client: _LifecycleIeltsQuestionBankClient(),
+      );
       addTearDown(() {
         launchController.dispose();
         workspaceController.dispose();
+        ieltsController.dispose();
         preparationController.dispose();
         practiceController.dispose();
         conversationController.dispose();
@@ -281,8 +289,64 @@ void main() {
       expect(workspaceController.currentSceneId, _hotelScene.id);
       expect(conversationController.threads, hasLength(4));
       expect(launchClient.sessionIds, hasLength(2));
+
+      final hotelSessionId = practiceController.practiceSessionId!;
+      await _leavePractice(tester);
+      var preparationStarts = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PreparationPage(
+            practiceController: practiceController,
+            preparationController: preparationController,
+            ieltsController: ieltsController,
+            launchController: launchController,
+            onPracticeStarted: () => preparationStarts++,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await _openIeltsFullMock(tester);
+      expect(find.text('开始新的模考？'), findsOneWidget);
+      expect(find.text('继续上次练习'), findsOneWidget);
+      expect(find.text('开始新模考'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('continue-existing-practice')));
+      await tester.pumpAndSettle();
+      expect(preparationStarts, 1);
+      expect(practiceController.practiceSessionId, hotelSessionId);
+      expect(practiceClient.endedSessionIds, [firstSessionId]);
+
+      expect(await launchController.parkCurrentPractice(), isTrue);
+      await tester.pumpAndSettle();
+      await _openIeltsFullMock(tester);
+      await _tapVisible(
+        tester,
+        find.byKey(const Key('replace-existing-practice')),
+      );
+      for (var attempt = 0; attempt < 20 && preparationStarts < 2; attempt++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(preparationController.errorMessage, isNull);
+      expect(launchController.errorMessage, isNull);
+      expect(launchController.workspaceErrorMessage, isNull);
+      expect(launchClient.sessionIds, hasLength(3));
+      expect(practiceClient.endedSessionIds, [firstSessionId, hotelSessionId]);
+      expect(practiceController.practiceMode, PracticeMode.fullMock);
+      expect(workspaceController.currentSceneId, _ieltsSceneId);
+      expect(preparationStarts, 2);
     },
   );
+}
+
+Future<void> _openIeltsFullMock(WidgetTester tester) async {
+  await _showPracticeHub(tester, const Key('practice-hub-exam'));
+  await _tapVisible(
+    tester,
+    find.byKey(const Key('practice-hub-exam')).hitTestable(),
+  );
+  await _tapVisible(tester, find.byKey(const Key('ielts-mode-full')));
 }
 
 Future<void> _openScene(WidgetTester tester, SceneDefinition definition) async {
@@ -368,13 +432,14 @@ final class _LifecycleCatalogClient implements SceneClient {
     return switch (sceneId) {
       _progressSceneId => _progressDetail,
       _hotelSceneId => _hotelDetail,
+      _ieltsSceneId => _ieltsDetail,
       _ => throw StateError('Unknown lifecycle scene: $sceneId'),
     };
   }
 
   @override
   Future<List<SceneDefinition>> listScenes() async {
-    return <SceneDefinition>[_progressScene, _hotelScene];
+    return <SceneDefinition>[_progressScene, _hotelScene, _ieltsScene];
   }
 
   @override
@@ -382,8 +447,17 @@ final class _LifecycleCatalogClient implements SceneClient {
     return switch (sceneId) {
       _progressSceneId => <RoleDefinition>[_progressRole],
       _hotelSceneId => <RoleDefinition>[_hotelRole],
+      _ieltsSceneId => _ieltsDetail.roles,
       _ => throw StateError('Unknown lifecycle scene: $sceneId'),
     };
+  }
+}
+
+final class _LifecycleIeltsQuestionBankClient
+    implements IeltsQuestionBankClient {
+  @override
+  Future<IeltsQuestionBank> getQuestionBank() async {
+    throw StateError('Question-bank content is outside this lifecycle test.');
   }
 }
 
@@ -445,6 +519,7 @@ final class _LifecycleLaunchClient implements PreparationLaunchClient {
     final scene = switch (input.sceneId) {
       _progressSceneId => _progressDetail,
       _hotelSceneId => _hotelDetail,
+      _ieltsSceneId => _ieltsDetail,
       _ => throw StateError('Unknown lifecycle Scene.'),
     };
     if (snapshot == null || scene.version != input.sceneVersion) {
@@ -572,6 +647,15 @@ final class _LifecyclePracticeClient
       throw StateError('No exact lifecycle session was prepared.');
     }
     _nextStart = null;
+    final ieltsAssignment =
+        seed.scene.experience == PracticeExperience.ieltsSpeaking
+        ? testIeltsAssignment(
+            mode: seed.practiceMode,
+            part1QuestionCount: 1,
+            part3QuestionCount: 1,
+          )
+        : null;
+    final turnLimit = ieltsAssignment?.turnBlueprints.length ?? 3;
     final snapshot = PracticeSessionSnapshot(
       sessionId: seed.sessionId,
       planId: seed.planId,
@@ -581,8 +665,9 @@ final class _LifecyclePracticeClient
       practiceMode: seed.practiceMode,
       capabilities: testPracticeCapabilities,
       completedTurns: 0,
-      turnLimit: 3,
+      turnLimit: turnLimit,
       sessionCompleted: false,
+      ieltsAssignment: ieltsAssignment,
       currentQuestion: PracticeQuestion(
         id: 'question-${seed.sessionId}-1',
         sessionId: seed.sessionId,
@@ -704,6 +789,7 @@ final class _StartSeed {
 
 const _progressSceneId = 'scn_workplace_progress_risk_update';
 const _hotelSceneId = 'scn_daily_hotel_checkin_issue';
+const _ieltsSceneId = 'scn_ielts_speaking';
 
 final _progressScene = testScene(
   id: _progressSceneId,
@@ -722,6 +808,51 @@ final _hotelScene = testScene(
   version: 1,
   prompt: _hotelPrompt,
 );
+
+final _ieltsScene = testScene(
+  id: _ieltsSceneId,
+  experience: PracticeExperience.ieltsSpeaking,
+  category: SceneCategory.ieltsSpeaking,
+  name: 'IELTS 口语',
+  version: 1,
+  prompt: const ScenePrompt(
+    publicSceneBrief: '完成一轮 IELTS 口语模考。',
+    practiceGoal: '按 Part 1、Part 2、Part 3 完成作答。',
+    userRole: '考生',
+    aiRole: '考官',
+    personaSummary: '严格遵循 IELTS 口语流程。',
+    focusAreas: <String>['fluency'],
+    turnBlueprints: <String>['完成口语模考。'],
+  ),
+  practiceOptions: <PracticeOption>[
+    testPracticeOption(
+      id: 'option-ielts-full-mock',
+      sceneId: _ieltsSceneId,
+      mode: PracticeMode.fullMock,
+      displayName: '完整模考',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-1',
+      sceneId: _ieltsSceneId,
+      mode: PracticeMode.part1,
+      displayName: 'Part 1',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-2',
+      sceneId: _ieltsSceneId,
+      mode: PracticeMode.part2,
+      displayName: 'Part 2',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-3',
+      sceneId: _ieltsSceneId,
+      mode: PracticeMode.part3,
+      displayName: 'Part 3',
+    ),
+  ],
+);
+
+final _ieltsDetail = _ieltsScene;
 
 final _progressRole = testRole(
   id: 'role-project-stakeholder',

--- a/mobile/test/coaching/preparation/preparation_page_test.dart
+++ b/mobile/test/coaching/preparation/preparation_page_test.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/preparation/preparation.dart';
 import 'package:speakup/features/coaching/scene/scene_client.dart';
@@ -131,6 +134,70 @@ void main() {
     ]) {
       expect(await _showHub(tester, Key(hub)), findsOneWidget);
     }
+  });
+
+  testWidgets('full mock starts directly when no practice can be resumed', (
+    tester,
+  ) async {
+    final preparationController = PreparationController(
+      client: _FourFamilyClient(),
+    );
+    final ieltsController = IeltsPreparationController(
+      client: _UnavailableIeltsQuestionBankClient(),
+    );
+    final launchClient = _PageLaunchClient();
+    final launchController = PreparationLaunchController(
+      client: launchClient,
+      contextProvider: () => _pageContext,
+      threadIdProvider: () => _pageContext.threadId,
+      goalActivator:
+          ({
+            required threadId,
+            required selection,
+            required clientOperationId,
+          }) async => _pageContext,
+      voiceActivator:
+          ({
+            required context,
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+      idFactory: (scope) => '$scope-direct-full-mock',
+    );
+    var navigations = 0;
+    addTearDown(preparationController.dispose);
+    addTearDown(ieltsController.dispose);
+    addTearDown(launchController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: preparationController,
+          ieltsController: ieltsController,
+          launchController: launchController,
+          onPracticeStarted: () async {
+            navigations++;
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(launchController.hasResumablePractice, isFalse);
+    await _openFamily(tester, 'EXAM');
+    await tester.tap(find.byKey(const Key('ielts-mode-full')));
+    for (var attempt = 0; attempt < 20 && navigations == 0; attempt++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    expect(find.text('开始新的模考？'), findsNothing);
+    expect(launchClient.calls, ['profile', 'snapshot', 'plan', 'session']);
+    expect(
+      launchController.bootstrap?.session.practiceMode,
+      PracticeMode.fullMock,
+    );
+    expect(navigations, 1);
   });
 
   testWidgets('shows loading, failure retry, and empty states', (tester) async {
@@ -375,9 +442,8 @@ final class _MultiSceneClient implements SceneClient {
 
 final class _FourFamilyClient implements SceneClient {
   @override
-  Future<SceneDefinition> getScene(String sceneId) {
-    throw UnimplementedError();
-  }
+  Future<SceneDefinition> getScene(String sceneId) async =>
+      sceneId == _examScene.id ? _examScene : throw UnimplementedError();
 
   @override
   Future<List<SceneDefinition>> listScenes() async => [
@@ -390,6 +456,14 @@ final class _FourFamilyClient implements SceneClient {
   @override
   Future<List<RoleDefinition>> listRoles(String sceneId) {
     throw UnimplementedError();
+  }
+}
+
+final class _UnavailableIeltsQuestionBankClient
+    implements IeltsQuestionBankClient {
+  @override
+  Future<IeltsQuestionBank> getQuestionBank() {
+    throw StateError('Question-bank content is outside this launch test.');
   }
 }
 
@@ -474,6 +548,7 @@ final class _PageLaunchClient implements PreparationLaunchClient {
     final scene = switch (input.sceneId) {
       _sceneId => _detail,
       'scn_general_speaking' => _otherDetail,
+      'scn_ielts_speaking_test' => _examScene,
       _ => throw StateError('Unknown Page test Scene.'),
     };
     selection = PreparationLaunchSelection(
@@ -581,8 +656,34 @@ final _examScene = testScene(
   id: 'scn_ielts_speaking_test',
   experience: PracticeExperience.ieltsSpeaking,
   category: SceneCategory.ieltsSpeaking,
-  name: 'IELTS Speaking Part 2',
+  name: 'IELTS Speaking',
   version: 1,
+  practiceOptions: [
+    testPracticeOption(
+      id: 'option-ielts-full-mock',
+      sceneId: 'scn_ielts_speaking_test',
+      mode: PracticeMode.fullMock,
+      displayName: 'Full mock',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-1',
+      sceneId: 'scn_ielts_speaking_test',
+      mode: PracticeMode.part1,
+      displayName: 'Part 1',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-2',
+      sceneId: 'scn_ielts_speaking_test',
+      mode: PracticeMode.part2,
+      displayName: 'Part 2',
+    ),
+    testPracticeOption(
+      id: 'option-ielts-part-3',
+      sceneId: 'scn_ielts_speaking_test',
+      mode: PracticeMode.part3,
+      displayName: 'Part 3',
+    ),
+  ],
 );
 
 final _dailyScene = testScene(


### PR DESCRIPTION
## 功能描述

- 完整模考入口在存在可恢复练习时提供“继续上次练习 / 开始新模考”，没有可恢复练习时直接启动新模考。
- 完整模考 Part 1 完成后使用精简完成面板进入 Part 2 或保存退出。
- Part 2 确认提交后使用同一完成面板继续 Part 3 或保存退出；失败或仍在转写时保留原有重试流程。
- 顶部返回和系统返回统一使用中文底部面板：继续答题或保存并退出。
- 最终完成继续复用现有完成面板，提供查看报告和返回训练。

## 实现思路

1. 复用现有练习 Workspace 的恢复、暂存与替换能力，避免新建第二套模考会话状态。
2. 复用现有 SectionCompletionSheet，在冻结的 Part 1、Part 2 与最终完成边界展示对应操作。
3. Part 1 完成弹层隐藏控制器已预取的 Part 2 题目，用户确认后才进入下一阶段。
4. Part 2 仅在答案已经确认时展示完成弹层；转写中、失败或待重试仍使用原有处理状态。
5. 保存退出先执行现有 park 回调，再离开路由；恢复后保持在相同安全边界。

## 可复现测试

```bash
cd mobile
flutter test \
  test/coaching/practice/ielts_mock_practice_test.dart \
  test/coaching/preparation/preparation_page_test.dart \
  test/coaching/preparation/practice_lifecycle_flow_test.dart \
  test/review/turn_feedback_page_integration_test.dart

flutter analyze \
  lib/features/coaching/ielts/ielts_mock_practice.dart \
  lib/features/coaching/preparation/preparation.dart \
  test/coaching/practice/ielts_mock_practice_test.dart \
  test/coaching/preparation/practice_lifecycle_flow_test.dart \
  test/coaching/preparation/preparation_page_test.dart

git diff --check upstream/dev...HEAD
```

本分支执行结果：45 个相关测试通过；定向 analyze 无问题；diff-check 通过。

人工复现：

1. 使用真实后端运行 `make dev-ios-simulator`。
2. 无历史练习时点击 IELTS 完整模考入口，确认直接开始。
3. 暂存一场练习后再次点击入口，分别验证继续与开始新模考。
4. 完成 Part 1、Part 2，验证分段完成面板及保存退出后恢复。
5. 分别使用顶部返回与系统返回手势，验证两者展示同一退出面板。

Closes #585
