### PR TITLE
style(ielts): 统一答案阅读与展开区域

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:speakup/design/conversation_bubble_surface.dart';
 import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
@@ -780,7 +779,7 @@ class _QuestionAnswerPanel extends StatelessWidget {
     return Container(
       key: Key('ielts-answer-panel-${index + 1}'),
       width: double.infinity,
-      padding: const EdgeInsets.fromLTRB(28, 16, 0, 20),
+      padding: const EdgeInsets.fromLTRB(0, 16, 0, 20),
       decoration: const BoxDecoration(
         border: Border(bottom: BorderSide(color: PreparationDesign.border)),
       ),
@@ -804,47 +803,57 @@ class _QuestionAnswerPanel extends StatelessWidget {
               ),
             )
           else if (ready) ...[
-            Text(
-              personalized ? '我的表达' : '示例回答',
-              style: PreparationDesign.label.copyWith(
-                color: PreparationDesign.inkSecondary,
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: PreparationDesign.surfaceMuted,
+                borderRadius: BorderRadius.circular(
+                  PreparationDesign.radiusCard,
+                ),
               ),
-            ),
-            const SizedBox(height: 6),
-            ConversationBubbleSurface(
-              isUser: false,
-              maxWidth: double.infinity,
-              padding: const EdgeInsets.symmetric(vertical: 6),
-              child: Text(preparation!.answer!, style: PreparationDesign.body),
-            ),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              children: [
-                TextButton.icon(
-                  key: Key('ielts-speak-answer-${index + 1}'),
-                  onPressed: onSpeak,
-                  icon: Icon(
-                    speaking ? Icons.stop_rounded : Icons.volume_up_outlined,
-                    size: 18,
-                  ),
-                  label: Text(speaking ? '停止' : '播放'),
-                  style: TextButton.styleFrom(
-                    backgroundColor: PreparationDesign.surfaceMuted,
-                    foregroundColor: PreparationDesign.ink,
-                  ),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            personalized ? '我的表达' : '示例回答',
+                            style: PreparationDesign.label.copyWith(
+                              color: PreparationDesign.inkSecondary,
+                            ),
+                          ),
+                        ),
+                        TextButton.icon(
+                          key: Key('ielts-speak-answer-${index + 1}'),
+                          onPressed: onSpeak,
+                          icon: Icon(
+                            speaking
+                                ? Icons.stop_rounded
+                                : Icons.volume_up_outlined,
+                            size: 18,
+                          ),
+                          label: Text(speaking ? '停止' : '播放'),
+                          style: _answerActionStyle,
+                        ),
+                        TextButton.icon(
+                          key: Key('ielts-polish-answer-${index + 1}'),
+                          onPressed: onPrepare,
+                          icon: const Icon(
+                            Icons.auto_awesome_outlined,
+                            size: 18,
+                          ),
+                          label: Text(personalized ? '重新润色' : '润色'),
+                          style: _answerActionStyle,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    _ExpandableAnswerText(text: preparation!.answer!),
+                  ],
                 ),
-                TextButton.icon(
-                  key: Key('ielts-polish-answer-${index + 1}'),
-                  onPressed: onPrepare,
-                  icon: const Icon(Icons.auto_awesome_outlined, size: 18),
-                  label: Text(personalized ? '重新润色' : '润色'),
-                  style: TextButton.styleFrom(
-                    backgroundColor: PreparationDesign.surfaceMuted,
-                    foregroundColor: PreparationDesign.ink,
-                  ),
-                ),
-              ],
+              ),
             ),
           ] else
             TextButton.icon(
@@ -866,6 +875,72 @@ class _QuestionAnswerPanel extends StatelessWidget {
       ),
     );
   }
+
+  static final ButtonStyle _answerActionStyle = TextButton.styleFrom(
+    minimumSize: const Size(0, 40),
+    padding: const EdgeInsets.symmetric(horizontal: 8),
+    foregroundColor: PreparationDesign.ink,
+  );
+}
+
+class _ExpandableAnswerText extends StatefulWidget {
+  const _ExpandableAnswerText({required this.text});
+
+  final String text;
+
+  @override
+  State<_ExpandableAnswerText> createState() => _ExpandableAnswerTextState();
+}
+
+class _ExpandableAnswerTextState extends State<_ExpandableAnswerText> {
+  static const _collapsedLines = 6;
+  bool _expanded = false;
+
+  @override
+  void didUpdateWidget(covariant _ExpandableAnswerText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text) {
+      _expanded = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) {
+      final style = PreparationDesign.body;
+      final painter = TextPainter(
+        text: TextSpan(text: widget.text, style: style),
+        textDirection: Directionality.of(context),
+      )..layout(maxWidth: constraints.maxWidth);
+      final canExpand = painter.computeLineMetrics().length > _collapsedLines;
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            widget.text,
+            key: const Key('ielts-answer-body'),
+            maxLines: _expanded ? null : _collapsedLines,
+            overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+            style: style,
+          ),
+          if (canExpand) ...[
+            const SizedBox(height: 8),
+            TextButton(
+              key: const Key('ielts-answer-expand-body'),
+              onPressed: () => setState(() => _expanded = !_expanded),
+              style: TextButton.styleFrom(
+                minimumSize: const Size(0, 40),
+                padding: EdgeInsets.zero,
+                foregroundColor: PreparationDesign.ink,
+              ),
+              child: Text(_expanded ? '收起答案' : '查看完整答案'),
+            ),
+          ],
+        ],
+      );
+    },
+  );
 }
 
 class _PolishExperienceSheet extends StatefulWidget {

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -815,14 +815,16 @@ class _QuestionAnswerPanel extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Row(
+                    Wrap(
+                      alignment: WrapAlignment.spaceBetween,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: 8,
+                      runSpacing: 4,
                       children: [
-                        Expanded(
-                          child: Text(
-                            personalized ? '我的表达' : '示例回答',
-                            style: PreparationDesign.label.copyWith(
-                              color: PreparationDesign.inkSecondary,
-                            ),
+                        Text(
+                          personalized ? '我的表达' : '示例回答',
+                          style: PreparationDesign.label.copyWith(
+                            color: PreparationDesign.inkSecondary,
                           ),
                         ),
                         TextButton.icon(
@@ -911,6 +913,7 @@ class _ExpandableAnswerTextState extends State<_ExpandableAnswerText> {
       final painter = TextPainter(
         text: TextSpan(text: widget.text, style: style),
         textDirection: Directionality.of(context),
+        textScaler: MediaQuery.textScalerOf(context),
       )..layout(maxWidth: constraints.maxWidth);
       final canExpand = painter.computeLineMetrics().length > _collapsedLines;
 

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -490,6 +490,94 @@ void main() {
     expect(find.text('收起答案'), findsOneWidget);
   });
 
+  testWidgets('keeps IELTS answer actions usable at 320px and 3x text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Do you prefer sad or happy music?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: _AnswerPreparationClient(
+            existingAnswer: 'I prefer happy music because it lifts my mood.',
+            existingPersonalPoints: const ['I listen on my commute.'],
+          ),
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    for (final key in const [
+      Key('ielts-speak-answer-1'),
+      Key('ielts-polish-answer-1'),
+    ]) {
+      final action = find.byKey(key);
+      await tester.ensureVisible(action);
+      await tester.pumpAndSettle();
+      expect(action.hitTestable(), findsOneWidget);
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('offers answer expansion using the rendered text scale', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+    const scaledAnswer =
+        'I enjoy music because it helps me relax after work and gives me '
+        'something positive to focus on during my commute.';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part3,
+          title: 'Music',
+          subtitle: 'Part 3',
+          questions: const ['Why is music important?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_3',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: _AnswerPreparationClient(
+            existingAnswer: scaledAnswer,
+          ),
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('查看完整答案'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('shows answer preparation for Part 3 questions', (tester) async {
     final client = _AnswerPreparationClient();
     await tester.pumpWidget(
@@ -890,9 +978,13 @@ final class _DetailPromptSpeaker implements PracticePromptSpeaker {
 }
 
 final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
-  _AnswerPreparationClient({this.existingAnswer});
+  _AnswerPreparationClient({
+    this.existingAnswer,
+    this.existingPersonalPoints = const [],
+  });
 
   final String? existingAnswer;
+  final List<String> existingPersonalPoints;
   List<String> _personalPoints = const [];
   int createCalls = 0;
   int generateCalls = 0;
@@ -910,7 +1002,7 @@ final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {
       return IeltsAnswerPreparation(
         id: 'ielts_answer_00000000000000000000000000000000',
         question: question,
-        personalPoints: const [],
+        personalPoints: existingPersonalPoints,
         targetBand: targetBand,
         status: IeltsAnswerPreparationStatus.ready,
         version: 3,

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -441,6 +441,55 @@ void main() {
     expect(client.generateCalls, 0);
   });
 
+  testWidgets('collapses and expands a long IELTS answer', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    const longAnswer =
+        'I definitely lean towards happy music because it instantly boosts my '
+        'mood and energy levels. For instance, whenever I’m commuting to work, '
+        'I listen to upbeat pop songs to start my day on a positive note. It '
+        'just feels more motivating than melancholic tunes.';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part3,
+          title: 'Tall buildings',
+          subtitle: 'Describe a tall building',
+          questions: const ['Are there many tall buildings in your country?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_3',
+              sourceId: 'buildings',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: _AnswerPreparationClient(
+            existingAnswer: longAnswer,
+          ),
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<Text>(find.byKey(const Key('ielts-answer-body'))).maxLines,
+      6,
+    );
+    expect(find.text('查看完整答案'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ielts-answer-expand-body')));
+    await tester.pump();
+
+    expect(
+      tester.widget<Text>(find.byKey(const Key('ielts-answer-body'))).maxLines,
+      isNull,
+    );
+    expect(find.text('收起答案'), findsOneWidget);
+  });
+
   testWidgets('shows answer preparation for Part 3 questions', (tester) async {
     final client = _AnswerPreparationClient();
     await tester.pumpWidget(


### PR DESCRIPTION
## 功能描述

- 统一 IELTS Part 1、Part 2、Part 3 的答案阅读组件
- Tip 与答案区域使用完整内容宽度，移除多余缩进
- 示例回答与我的表达使用单层浅灰阅读区
- 播放与润色操作固定在阅读区顶部
- 长答案默认展示 6 行，并支持查看完整答案和再次收起

## 实现思路

- 继续复用现有 QuestionAnswerPanel，不为三个 Part 复制实现
- 将回答正文封装为最小的 ExpandableAnswerText 状态组件
- 使用实际排版行数决定是否展示展开按钮，短答案不出现多余操作

## 可复现测试

1. 运行 make dev-ios-simulator
2. 打开 IELTS Part 1、Part 2、Part 3 的任意题目详情并展开答案
3. 确认短答案正常展示，长答案默认 6 行且可展开/收起
4. 确认播放、润色操作始终位于答案区域顶部，固定开始按钮不遮挡操作

已执行：
- flutter test --no-pub test/coaching/preparation/preparation_hub_test.dart（23/23）
- flutter analyze --no-pub
- git diff --check
- iPhone 16 Pro 模拟器人工确认

Closes #587