### PR TITLE
style(ielts): 收紧 Part 2 朗读与作答舞台

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1734,6 +1734,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
               ? _buildAnimatedPhase(progress)
               : PracticeStageLayout(
                   avatarRegionKey: const Key('ielts-avatar-region'),
+                  portraitAvatarFraction: switch (stagePhase) {
+                    IeltsMockPhase.part2Intro ||
+                    IeltsMockPhase.part2CueCard ||
+                    IeltsMockPhase.part2Preparation ||
+                    IeltsMockPhase.part2Speaking => 0.40,
+                    _ => 0.34,
+                  },
                   avatar: PracticeAvatarStage(
                     title: _stageTitle(stagePhase),
                     fallback: const PracticeAvatarFallback(
@@ -3155,47 +3162,46 @@ class _Part2CueCardReading extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
+    return SizedBox.expand(
       key: const Key('ielts-mock-part-2-cue-card-reading'),
-      padding: const EdgeInsets.fromLTRB(20, 24, 20, 28),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Text(
-            'Listen to the examiner',
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.sectionTitle,
-          ),
-          const SizedBox(height: 18),
-          _CueCard(question: question),
-          const SizedBox(height: 18),
-          if (narrationBusy)
-            const Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                SizedBox.square(
-                  dimension: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-                SizedBox(width: 10),
-                Text('考官正在朗读 Cue Card…'),
-              ],
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 28),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Listen to the examiner',
+              style: SpeakUpDesign.sectionTitle,
             ),
-          if (errorMessage != null) ...[
-            Text(
-              errorMessage!,
-              key: const Key('ielts-part2-narration-error'),
-              textAlign: TextAlign.center,
-              style: SpeakUpDesign.meta.copyWith(color: SpeakUpDesign.error),
-            ),
-            const SizedBox(height: 10),
-            FilledButton(
-              key: const Key('ielts-part2-retry-narration'),
-              onPressed: narrationBusy ? null : onRetry,
-              child: const Text('重新播放 Cue Card'),
-            ),
+            const SizedBox(height: 16),
+            _CueCard(question: question),
+            const SizedBox(height: 16),
+            if (narrationBusy)
+              const Row(
+                children: [
+                  SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  SizedBox(width: 10),
+                  Text('考官正在朗读 Cue Card…'),
+                ],
+              ),
+            if (errorMessage != null) ...[
+              Text(
+                errorMessage!,
+                key: const Key('ielts-part2-narration-error'),
+                style: SpeakUpDesign.meta.copyWith(color: SpeakUpDesign.error),
+              ),
+              const SizedBox(height: 10),
+              FilledButton(
+                key: const Key('ielts-part2-retry-narration'),
+                onPressed: narrationBusy ? null : onRetry,
+                child: const Text('重新播放 Cue Card'),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }
@@ -3228,98 +3234,108 @@ class _Part2LongTurn extends StatelessWidget {
   Widget build(BuildContext context) {
     final minutes = secondsRemaining ~/ 60;
     final seconds = (secondsRemaining % 60).toString().padLeft(2, '0');
-    return SingleChildScrollView(
+    return SizedBox.expand(
       key: const Key('ielts-mock-part-2-long-turn'),
-      padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            '$minutes:$seconds',
-            key: Key(
-              speaking
-                  ? 'ielts-mock-speaking-countdown'
-                  : 'ielts-mock-preparation-countdown',
-            ),
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.pageTitle.copyWith(fontSize: 44),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            speaking ? '作答时间 · 已自动开始录音' : '准备时间 · 阅读题目并记录要点',
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.body,
-          ),
-          if (!speaking) ...[
-            const SizedBox(height: 18),
-            _CueCard(question: question),
-            const SizedBox(height: 14),
-            TextField(
-              key: const Key('ielts-mock-notes'),
-              controller: notesController,
-              minLines: 2,
-              maxLines: 4,
-              maxLength: 4000,
-              decoration: const InputDecoration(
-                hintText: '在这里记录要点…',
-                counterText: '',
-                alignLabelWithHint: true,
+      child: speaking
+          ? Padding(
+              padding: const EdgeInsets.fromLTRB(20, 24, 20, 28),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _Part2RecordingStatus(
+                    state: recordingState,
+                    secondsRemaining: secondsRemaining,
+                  ),
+                  const SizedBox(height: 20),
+                  const Divider(height: 1, color: SpeakUpDesign.border),
+                  const SizedBox(height: 18),
+                  const Text('我的小抄', style: SpeakUpDesign.meta),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: Text(
+                        notes.isEmpty ? '准备阶段未记录要点。' : notes,
+                        style: notes.isEmpty
+                            ? SpeakUpDesign.body
+                            : const TextStyle(
+                                color: SpeakUpDesign.ink,
+                                fontSize: 18,
+                                height: 1.5,
+                              ),
+                      ),
+                    ),
+                  ),
+                  if (errorMessage != null) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: SpeakUpDesign.error),
+                    ),
+                  ],
+                  if (recordingState == PracticeRecordingState.idle &&
+                      errorMessage != null) ...[
+                    const SizedBox(height: 20),
+                    FilledButton(
+                      key: const Key('ielts-mock-finish-speaking'),
+                      onPressed: busy ? null : onPressed,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(52),
+                        backgroundColor: SpeakUpDesign.ink,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: const Text('重新录音 →'),
+                    ),
+                  ],
+                ],
+              ),
+            )
+          : SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 10, 20, 28),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    '$minutes:$seconds',
+                    key: const Key('ielts-mock-preparation-countdown'),
+                    textAlign: TextAlign.center,
+                    style: SpeakUpDesign.pageTitle.copyWith(fontSize: 44),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    '准备时间 · 阅读题目并记录要点',
+                    textAlign: TextAlign.center,
+                    style: SpeakUpDesign.body,
+                  ),
+                  const SizedBox(height: 18),
+                  _CueCard(question: question),
+                  const SizedBox(height: 14),
+                  TextField(
+                    key: const Key('ielts-mock-notes'),
+                    controller: notesController,
+                    minLines: 2,
+                    maxLines: 4,
+                    maxLength: 4000,
+                    decoration: const InputDecoration(
+                      hintText: '在这里记录要点…',
+                      counterText: '',
+                      alignLabelWithHint: true,
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  FilledButton(
+                    key: const Key('ielts-mock-start-speaking'),
+                    onPressed: busy ? null : onPressed,
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(52),
+                      backgroundColor: SpeakUpDesign.ink,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('提前开始作答 →'),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(height: 18),
-            FilledButton(
-              key: const Key('ielts-mock-start-speaking'),
-              onPressed: busy ? null : onPressed,
-              style: FilledButton.styleFrom(
-                minimumSize: const Size.fromHeight(52),
-                backgroundColor: SpeakUpDesign.ink,
-                foregroundColor: Colors.white,
-              ),
-              child: const Text('提前开始作答 →'),
-            ),
-          ] else ...[
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: const Color(0xFFFAFAF9),
-                borderRadius: BorderRadius.circular(18),
-              ),
-              child: Text(
-                notes.isEmpty ? '准备阶段未记录要点。' : notes,
-                textAlign: TextAlign.center,
-                style: SpeakUpDesign.body,
-              ),
-            ),
-            const SizedBox(height: 20),
-            _Part2RecordingStatus(
-              state: recordingState,
-              elapsedSeconds: 120 - secondsRemaining,
-            ),
-            if (errorMessage != null) ...[
-              const SizedBox(height: 16),
-              Text(
-                errorMessage!,
-                textAlign: TextAlign.center,
-                style: const TextStyle(color: SpeakUpDesign.error),
-              ),
-            ],
-            if (recordingState == PracticeRecordingState.idle &&
-                errorMessage != null) ...[
-              const SizedBox(height: 20),
-              FilledButton(
-                key: const Key('ielts-mock-finish-speaking'),
-                onPressed: busy ? null : onPressed,
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(52),
-                  backgroundColor: SpeakUpDesign.ink,
-                  foregroundColor: Colors.white,
-                ),
-                child: const Text('重新录音 →'),
-              ),
-            ],
-          ],
-        ],
-      ),
     );
   }
 }
@@ -3327,44 +3343,49 @@ class _Part2LongTurn extends StatelessWidget {
 class _Part2RecordingStatus extends StatelessWidget {
   const _Part2RecordingStatus({
     required this.state,
-    required this.elapsedSeconds,
+    required this.secondsRemaining,
   });
 
   final PracticeRecordingState state;
-  final int elapsedSeconds;
+  final int secondsRemaining;
 
   @override
   Widget build(BuildContext context) {
     final recording =
         state == PracticeRecordingState.starting ||
         state == PracticeRecordingState.recording;
-    final minutes = (elapsedSeconds.clamp(0, 120) ~/ 60).toString();
-    final seconds = (elapsedSeconds.clamp(0, 120) % 60).toString().padLeft(
+    final minutes = (secondsRemaining.clamp(0, 120) ~/ 60).toString();
+    final seconds = (secondsRemaining.clamp(0, 120) % 60).toString().padLeft(
       2,
       '0',
     );
     final label = switch (state) {
       PracticeRecordingState.starting => '正在打开麦克风…',
-      PracticeRecordingState.recording => '录音中·$minutes:$seconds',
+      PracticeRecordingState.recording => '录音中',
       PracticeRecordingState.transcribing => '正在识别你的作答…',
       PracticeRecordingState.awaitingConfirmation => '正在提交作答…',
       PracticeRecordingState.submitting => '正在进入下一环节…',
       _ => '等待录音',
     };
-    final color = recording ? const Color(0xFF197782) : SpeakUpDesign.secondary;
+    final color = recording ? SpeakUpDesign.ink : SpeakUpDesign.secondary;
 
-    return Column(
+    return Row(
       key: const Key('ielts-part2-recording-status'),
       mainAxisSize: MainAxisSize.min,
       children: [
+        Icon(Icons.graphic_eq_rounded, size: 26, color: color),
+        const SizedBox(width: 10),
+        Text(
+          '$minutes:$seconds',
+          key: const Key('ielts-mock-speaking-countdown'),
+          style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
+        ),
+        const SizedBox(width: 10),
         Text(
           label,
           key: const Key('ielts-part2-recording-label'),
-          textAlign: TextAlign.center,
-          style: SpeakUpDesign.cardTitle.copyWith(color: color),
+          style: SpeakUpDesign.body,
         ),
-        const SizedBox(height: 10),
-        Icon(Icons.graphic_eq_rounded, size: 42, color: color),
       ],
     );
   }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -3381,10 +3381,12 @@ class _Part2RecordingStatus extends StatelessWidget {
           style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
         ),
         const SizedBox(width: 10),
-        Text(
-          label,
-          key: const Key('ielts-part2-recording-label'),
-          style: SpeakUpDesign.body,
+        Flexible(
+          child: Text(
+            label,
+            key: const Key('ielts-part2-recording-label'),
+            style: SpeakUpDesign.body,
+          ),
         ),
       ],
     );

--- a/mobile/lib/features/coaching/practice/practice_stage.dart
+++ b/mobile/lib/features/coaching/practice/practice_stage.dart
@@ -10,12 +10,14 @@ class PracticeStageLayout extends StatelessWidget {
     required this.avatar,
     required this.content,
     this.avatarRegionKey,
+    this.portraitAvatarFraction = 0.34,
     super.key,
   });
 
   final Widget avatar;
   final Widget content;
   final Key? avatarRegionKey;
+  final double portraitAvatarFraction;
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +40,7 @@ class PracticeStageLayout extends StatelessWidget {
           children: [
             SizedBox(
               key: avatarRegionKey,
-              height: constraints.maxHeight * 0.34,
+              height: constraints.maxHeight * portraitAvatarFraction,
               child: avatar,
             ),
             Expanded(child: content),

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -305,7 +305,8 @@ void main() {
       expect(store.value?.phase, IeltsMockPhase.part2Speaking);
       expect(controller.recordingState, PracticeRecordingState.recording);
       expect(find.byKey(const Key('ielts-mock-cue-card')), findsNothing);
-      expect(find.textContaining('录音中·'), findsOneWidget);
+      expect(find.text('录音中'), findsOneWidget);
+      expect(find.text('我的小抄'), findsOneWidget);
       expect(find.byKey(const Key('ielts-mock-finish-speaking')), findsNothing);
     },
   );
@@ -428,7 +429,8 @@ void main() {
         find.byKey(const Key('ielts-part2-recording-status')),
         findsOneWidget,
       );
-      expect(find.textContaining('录音中·'), findsOneWidget);
+      expect(find.text('录音中'), findsOneWidget);
+      expect(find.text('我的小抄'), findsOneWidget);
       expect(
         find.text('online course, weekly practice, useful at work'),
         findsOneWidget,

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -364,6 +364,63 @@ void main() {
     },
   );
 
+  testWidgets('Part 2 recording status fits 320px with 2x text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final now = DateTime.utc(2026, 8, 4, 9);
+    final startGate = Completer<void>();
+    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 6);
+    final recorder = _Recorder()..startGate = startGate;
+    final controller = PracticeController(client: practice, recorder: recorder);
+    final store = _MemoryProgressStore(
+      IeltsMockProgress(
+        sessionId: _sessionId,
+        phase: IeltsMockPhase.part2Speaking,
+        startedAt: now,
+        speakingDeadline: now.add(const Duration(seconds: 120)),
+      ),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part2,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(320, 1000),
+            textScaler: TextScaler.linear(2),
+          ),
+          child: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: store,
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+            now: () => now,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(controller.recordingState, PracticeRecordingState.starting);
+    expect(find.text('正在打开麦克风…'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    startGate.complete();
+    await tester.pump();
+    await controller.cancelRecording();
+    await tester.pump();
+  });
+
   testWidgets(
     'Part 1 boundary enters prep, keeps notes, and submits the Part 2 long turn',
     (tester) async {
@@ -1843,10 +1900,12 @@ final class _IeltsPracticeClient
 final class _Recorder implements PracticeRecorder {
   bool recording = false;
   int startCalls = 0;
+  Completer<void>? startGate;
 
   @override
   Future<void> start() async {
     startCalls++;
+    await startGate?.future;
     recording = true;
   }
 

--- a/mobile/test/coaching/practice/practice_stage_test.dart
+++ b/mobile/test/coaching/practice/practice_stage_test.dart
@@ -41,6 +41,28 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('accepts a custom portrait avatar fraction', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: PracticeStageLayout(
+          avatarRegionKey: Key('avatar-region'),
+          portraitAvatarFraction: 0.40,
+          avatar: ColoredBox(color: Colors.blue),
+          content: ColoredBox(color: Colors.white),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byKey(const Key('avatar-region'))).height,
+      closeTo(844 * 0.40, 0.1),
+    );
+  });
+
   testWidgets('avatar stage accepts a surface and shared chrome', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 调整 IELTS Part 2 的数字人舞台与内容区比例
- Cue Card 朗读和准备阶段保持题目可见且内容顶部对齐
- 正式作答阶段隐藏题目与实时转写，仅展示录音状态、唯一倒计时和用户小抄
- 小抄较短时保持紧凑布局，剩余空间落在页面底部

## 实现思路

- 为现有 PracticeStageLayout 增加可选的竖屏舞台比例，默认行为不变
- Part 2 各阶段复用同一舞台组件并使用 40% 比例
- 将正式作答状态收敛为录音状态行和独立小抄阅读区，不新增视觉依赖

## 可复现测试

1. 运行 make dev-ios-simulator
2. 分别进入 IELTS Part 2 专项与完整模考的 Part 2
3. 确认朗读/准备阶段可见 Cue Card，内容顶部对齐
4. 开始作答后确认 Cue Card 与实时转写隐藏，只保留录音状态、倒计时与小抄

已执行：
- flutter test --no-pub test/coaching/practice/ielts_mock_practice_test.dart test/coaching/practice/practice_stage_test.dart（34/34）
- flutter analyze --no-pub
- git diff --check
- iPhone 16 Pro 模拟器人工确认

Closes #586