### PR TITLE
feat(evaluation): project IELTS practice report sections

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -2030,6 +2030,132 @@ components:
         - PART_1
         - PART_2
         - PART_3
+    IeltsSpeakingPracticeReport:
+      type: object
+      additionalProperties: false
+      description: |
+        Canonical section projection for one IELTS standalone practice
+        FormalReport. It groups only questions, evidence and findings that
+        belong to the frozen Part assignment; scores remain in the parent
+        EvaluationFormalReport and no full-mock Overall Band is inferred.
+      required:
+        - schema_version
+        - report_scope
+        - available_sections
+        - questions
+        - section_reviews
+      properties:
+        schema_version:
+          type: string
+          const: ielts-speaking-practice-report/v1
+        report_scope:
+          type: string
+          enum:
+            - PART_1
+            - PART_2_3
+            - PART_3
+        available_sections:
+          type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/IeltsSpeakingPartId'
+        questions:
+          type: array
+          minItems: 1
+          maxItems: 64
+          items:
+            $ref: '#/components/schemas/IeltsSpeakingPracticeQuestionReview'
+        section_reviews:
+          type: array
+          minItems: 1
+          maxItems: 2
+          items:
+            $ref: '#/components/schemas/IeltsSpeakingPartReview'
+      oneOf:
+        - properties:
+            report_scope:
+              const: PART_1
+            available_sections:
+              prefixItems:
+                - const: PART_1
+              items: false
+            section_reviews:
+              prefixItems:
+                - $ref: '#/components/schemas/IeltsSpeakingPartOneReview'
+              items: false
+        - properties:
+            report_scope:
+              const: PART_2_3
+            available_sections:
+              prefixItems:
+                - const: PART_2
+                - const: PART_3
+              items: false
+            section_reviews:
+              prefixItems:
+                - $ref: '#/components/schemas/IeltsSpeakingPartTwoReview'
+                - $ref: '#/components/schemas/IeltsSpeakingPartThreeReview'
+              items: false
+        - properties:
+            report_scope:
+              const: PART_3
+            available_sections:
+              prefixItems:
+                - const: PART_3
+              items: false
+            section_reviews:
+              prefixItems:
+                - $ref: '#/components/schemas/IeltsSpeakingPartThreeReview'
+              items: false
+    IeltsSpeakingPracticeQuestionReview:
+      type: object
+      additionalProperties: false
+      required:
+        - question_id
+        - part_id
+        - index
+        - question_text
+        - evidence_ref_ids
+      properties:
+        question_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        part_id:
+          $ref: '#/components/schemas/IeltsSpeakingPartId'
+        index:
+          type: integer
+          minimum: 1
+          maximum: 64
+        question_text:
+          $ref: '#/components/schemas/IeltsSpeakingReportSourceText'
+        confirmed_transcript:
+          $ref: '#/components/schemas/IeltsSpeakingReportSourceText'
+        response_turn_id:
+          $ref: '#/components/schemas/StableIdentifier'
+        evidence_ref_ids:
+          type: array
+          maxItems: 1
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/StableIdentifier'
+      allOf:
+        - if:
+            required:
+              - response_turn_id
+          then:
+            required:
+              - confirmed_transcript
+            properties:
+              evidence_ref_ids:
+                minItems: 1
+          else:
+            properties:
+              evidence_ref_ids:
+                maxItems: 0
+            not:
+              required:
+                - confirmed_transcript
     IeltsSpeakingPartReviews:
       type: array
       minItems: 3

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -432,6 +432,8 @@ components:
       $ref: ./modules/evaluation.yaml#/components/schemas/IeltsSpeakingReportEnvelope
     IeltsSpeakingReport:
       $ref: ./modules/evaluation.yaml#/components/schemas/IeltsSpeakingReport
+    IeltsSpeakingPracticeReport:
+      $ref: ./modules/evaluation.yaml#/components/schemas/IeltsSpeakingPracticeReport
     Evaluation:
       $ref: ./modules/evaluation.yaml#/components/schemas/Evaluation
     SceneEvaluationResult:

--- a/server/internal/coaching/evaluation/report/general_scene.go
+++ b/server/internal/coaching/evaluation/report/general_scene.go
@@ -17,11 +17,27 @@ func ProjectGeneralSceneFormalReport(
 	}
 	summary := "本次练习已形成场景沟通评估，可按优先行动继续复练。"
 	scoreability := ReportScoreabilityProvisional
+	if result.SceneType == evaluation.SceneIELTSSpeaking {
+		summary = "本次 IELTS 专项练习已形成分段复盘，可按对应 Part 继续练习。"
+	}
 	if result.ScoreabilityStatus == scoring.GeneralSceneScoreabilityInsufficient {
 		summary = "本次练习的有效证据不足，暂不形成能力结论。"
+		if result.SceneType == evaluation.SceneIELTSSpeaking {
+			summary = "本次 IELTS 专项练习的有效证据不足，暂不形成能力结论。"
+		}
 		scoreability = ReportScoreabilityInsufficient
 	}
-	detail, err := json.Marshal(result)
+	detailSchema := scoring.GeneralSceneSchemaVersion
+	var detailValue any = result
+	if result.SceneType == evaluation.SceneIELTSSpeaking {
+		practiceDetail, err := ProjectIELTSSpeakingPracticeReport(snapshot, result)
+		if err != nil {
+			return FormalReport{}, err
+		}
+		detailSchema = practiceDetail.SchemaVersion
+		detailValue = practiceDetail
+	}
+	detail, err := json.Marshal(detailValue)
 	if err != nil {
 		return FormalReport{}, evaluation.ErrInvalidRequest
 	}
@@ -43,7 +59,7 @@ func ProjectGeneralSceneFormalReport(
 		Summary:            summary,
 		Dimensions:         dimensions,
 		PriorityActions:    actions,
-		DetailSchema:       scoring.GeneralSceneSchemaVersion,
+		DetailSchema:       detailSchema,
 		Detail:             detail,
 	}
 	if !formal.Valid() {

--- a/server/internal/coaching/evaluation/report/ielts_practice.go
+++ b/server/internal/coaching/evaluation/report/ielts_practice.go
@@ -1,0 +1,418 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
+)
+
+const IELTSSpeakingPracticeReportSchemaVersion = "ielts-speaking-practice-report/v1"
+
+type IELTSSpeakingPracticeReportScope string
+
+const (
+	IELTSSpeakingPracticeReportPart1  IELTSSpeakingPracticeReportScope = "PART_1"
+	IELTSSpeakingPracticeReportPart23 IELTSSpeakingPracticeReportScope = "PART_2_3"
+	IELTSSpeakingPracticeReportPart3  IELTSSpeakingPracticeReportScope = "PART_3"
+)
+
+type IELTSSpeakingPracticeReport struct {
+	SchemaVersion     string                                  `json:"schema_version"`
+	ReportScope       IELTSSpeakingPracticeReportScope        `json:"report_scope"`
+	AvailableSections []scoring.IELTSPart                     `json:"available_sections"`
+	Questions         []IELTSSpeakingPracticeReportQuestion   `json:"questions"`
+	SectionReviews    []IELTSSpeakingPracticeReportPartReview `json:"section_reviews"`
+}
+
+type IELTSSpeakingPracticeReportQuestion struct {
+	QuestionID          string            `json:"question_id"`
+	PartID              scoring.IELTSPart `json:"part_id"`
+	Index               int               `json:"index"`
+	QuestionText        string            `json:"question_text"`
+	ConfirmedTranscript string            `json:"confirmed_transcript,omitempty"`
+	ResponseTurnID      string            `json:"response_turn_id,omitempty"`
+	EvidenceRefIDs      []string          `json:"evidence_ref_ids"`
+}
+
+type IELTSSpeakingPracticeReportPartReview struct {
+	PartID                   scoring.IELTSPart `json:"part_id"`
+	QuestionIndexes          []int             `json:"question_indexes"`
+	EvidenceRefIDs           []string          `json:"evidence_ref_ids"`
+	StrengthFindingIDs       []string          `json:"strength_finding_ids"`
+	ImprovementFindingIDs    []string          `json:"improvement_finding_ids"`
+	UpgradeExampleFindingIDs []string          `json:"upgrade_example_finding_ids"`
+}
+
+func ProjectIELTSSpeakingPracticeReport(
+	snapshot evidence.EvidenceSnapshot,
+	result scoring.GeneralSceneResult,
+) (IELTSSpeakingPracticeReport, error) {
+	if err := scoring.ValidateGeneralSceneResult(snapshot, result); err != nil {
+		return IELTSSpeakingPracticeReport{}, err
+	}
+	if snapshot.SceneType != evaluation.SceneIELTSSpeaking ||
+		result.SceneType != evaluation.SceneIELTSSpeaking {
+		return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+	}
+	var payload evidence.SnapshotPayload
+	decoder := json.NewDecoder(bytes.NewReader(snapshot.Payload))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&payload) != nil || ensureJSONEOF(decoder) != nil {
+		return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+	}
+	parts, scope, ok := ieltsPracticeQuestionParts(payload.PracticeContext)
+	if !ok || len(parts) != len(payload.OpportunityManifest) {
+		return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+	}
+	turns := make(map[string]evidence.ConfirmedTurn, len(payload.ConfirmedTurns))
+	refs := make(map[string]evidence.Ref, len(payload.EvidenceRefs))
+	for _, turn := range payload.ConfirmedTurns {
+		turns[turn.TurnID] = turn
+	}
+	for _, ref := range payload.EvidenceRefs {
+		refs[ref.TurnID] = ref
+	}
+	available := ieltsPracticeAvailableSections(parts)
+	report := IELTSSpeakingPracticeReport{
+		SchemaVersion:     IELTSSpeakingPracticeReportSchemaVersion,
+		ReportScope:       scope,
+		AvailableSections: available,
+		Questions: make(
+			[]IELTSSpeakingPracticeReportQuestion,
+			len(payload.OpportunityManifest),
+		),
+		SectionReviews: make(
+			[]IELTSSpeakingPracticeReportPartReview,
+			len(available),
+		),
+	}
+	refParts := make(map[string]scoring.IELTSPart, len(payload.EvidenceRefs))
+	for index, opportunity := range payload.OpportunityManifest {
+		if opportunity.Sequence != index+1 {
+			return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+		}
+		question := IELTSSpeakingPracticeReportQuestion{
+			QuestionID:     opportunity.QuestionID,
+			PartID:         parts[index],
+			Index:          index + 1,
+			QuestionText:   opportunity.QuestionText,
+			EvidenceRefIDs: []string{},
+		}
+		if opportunity.ResponseTurnID != "" {
+			turn, turnOK := turns[opportunity.ResponseTurnID]
+			ref, refOK := refs[opportunity.ResponseTurnID]
+			if !turnOK || !refOK || turn.QuestionID != opportunity.QuestionID ||
+				turn.Sequence != opportunity.Sequence {
+				return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+			}
+			question.ConfirmedTranscript = turn.Transcript.Text
+			question.ResponseTurnID = turn.TurnID
+			question.EvidenceRefIDs = []string{ref.EvidenceRefID}
+			refParts[ref.EvidenceRefID] = parts[index]
+		}
+		report.Questions[index] = question
+	}
+	for index, part := range available {
+		report.SectionReviews[index] = ieltsPracticePartReview(
+			part,
+			report.Questions,
+			result.Dimensions,
+			refParts,
+		)
+	}
+	if !report.Valid() {
+		return IELTSSpeakingPracticeReport{}, evaluation.ErrInvalidRequest
+	}
+	return report, nil
+}
+
+func (report IELTSSpeakingPracticeReport) Valid() bool {
+	expectedSections := expectedIELTSPracticeSections(report.ReportScope)
+	if report.SchemaVersion != IELTSSpeakingPracticeReportSchemaVersion ||
+		expectedSections == nil ||
+		!slices.Equal(report.AvailableSections, expectedSections) ||
+		len(report.Questions) == 0 || len(report.Questions) > 64 ||
+		!validIELTSPracticeQuestionSequence(report.Questions, expectedSections) ||
+		len(report.SectionReviews) != len(expectedSections) {
+		return false
+	}
+	seenQuestions := make(map[string]struct{}, len(report.Questions))
+	seenTurns := make(map[string]struct{}, len(report.Questions))
+	seenRefs := make(map[string]struct{}, len(report.Questions))
+	for index, question := range report.Questions {
+		if !slices.Contains(expectedSections, question.PartID) ||
+			question.Index != index+1 || !validIdentifier(question.QuestionID) ||
+			!validReportText(question.QuestionText, reportMaximumInputString) ||
+			question.EvidenceRefIDs == nil || len(question.EvidenceRefIDs) > 1 {
+			return false
+		}
+		if _, duplicate := seenQuestions[question.QuestionID]; duplicate {
+			return false
+		}
+		seenQuestions[question.QuestionID] = struct{}{}
+		if question.ResponseTurnID == "" {
+			if question.ConfirmedTranscript != "" || len(question.EvidenceRefIDs) != 0 {
+				return false
+			}
+			continue
+		}
+		if !validIdentifier(question.ResponseTurnID) ||
+			!validReportText(question.ConfirmedTranscript, reportMaximumInputString) ||
+			len(question.EvidenceRefIDs) != 1 ||
+			!validIdentifier(question.EvidenceRefIDs[0]) {
+			return false
+		}
+		if _, duplicate := seenTurns[question.ResponseTurnID]; duplicate {
+			return false
+		}
+		if _, duplicate := seenRefs[question.EvidenceRefIDs[0]]; duplicate {
+			return false
+		}
+		seenTurns[question.ResponseTurnID] = struct{}{}
+		seenRefs[question.EvidenceRefIDs[0]] = struct{}{}
+	}
+	for index, review := range report.SectionReviews {
+		if review.PartID != expectedSections[index] ||
+			review.EvidenceRefIDs == nil ||
+			!slices.Equal(
+				review.QuestionIndexes,
+				ieltsPracticeQuestionIndexes(report.Questions, review.PartID),
+			) ||
+			!slices.Equal(
+				review.EvidenceRefIDs,
+				ieltsPracticeEvidenceRefs(report.Questions, review.PartID),
+			) ||
+			!validStringList(review.StrengthFindingIDs, 64) ||
+			!validStringList(review.ImprovementFindingIDs, 64) ||
+			!validStringList(review.UpgradeExampleFindingIDs, 64) {
+			return false
+		}
+	}
+	return true
+}
+
+func ieltsPracticeQuestionParts(
+	context evidence.PracticeContext,
+) ([]scoring.IELTSPart, IELTSSpeakingPracticeReportScope, bool) {
+	assignment := context.IELTSAssignment
+	if context.PracticeExperience != "IELTS_SPEAKING" || assignment == nil ||
+		context.EvaluationPolicyRef !=
+			scoring.IELTSSpeakingPracticeEvaluationPolicyRef ||
+		assignment.Mode != context.PracticeMode ||
+		!validIdentifier(assignment.BankID) ||
+		strings.TrimSpace(assignment.Season) == "" ||
+		strings.TrimSpace(assignment.Season) != assignment.Season ||
+		len(assignment.Parts) == 0 {
+		return nil, "", false
+	}
+	var scope IELTSSpeakingPracticeReportScope
+	expected := []scoring.IELTSPart{}
+	switch context.PracticeMode {
+	case "PART_1":
+		scope = IELTSSpeakingPracticeReportPart1
+		expected = []scoring.IELTSPart{scoring.IELTSPart1}
+	case "PART_2":
+		scope = IELTSSpeakingPracticeReportPart23
+		expected = []scoring.IELTSPart{scoring.IELTSPart2, scoring.IELTSPart3}
+	case "PART_3":
+		scope = IELTSSpeakingPracticeReportPart3
+		expected = []scoring.IELTSPart{scoring.IELTSPart3}
+	default:
+		return nil, "", false
+	}
+	if len(assignment.Parts) != len(expected) {
+		return nil, "", false
+	}
+	parts := make([]scoring.IELTSPart, 0, len(context.TaskBlueprints))
+	blueprints := make([]string, 0, len(context.TaskBlueprints))
+	for index, assignmentPart := range assignment.Parts {
+		part := scoring.IELTSPart(assignmentPart.Part)
+		if part != expected[index] || !validIdentifier(assignmentPart.SourceID) ||
+			len(assignmentPart.TurnBlueprints) == 0 {
+			return nil, "", false
+		}
+		for _, blueprint := range assignmentPart.TurnBlueprints {
+			if strings.TrimSpace(blueprint) == "" || strings.TrimSpace(blueprint) != blueprint {
+				return nil, "", false
+			}
+			parts = append(parts, part)
+			blueprints = append(blueprints, blueprint)
+		}
+	}
+	if !validIELTSPracticeAssignmentDetails(scope, assignment.Parts) {
+		return nil, "", false
+	}
+	if !slices.Equal(blueprints, context.TaskBlueprints) {
+		return nil, "", false
+	}
+	return parts, scope, true
+}
+
+func validIELTSPracticeAssignmentDetails(
+	scope IELTSSpeakingPracticeReportScope,
+	parts []evidence.IELTSAssignmentPart,
+) bool {
+	switch scope {
+	case IELTSSpeakingPracticeReportPart1:
+		return len(parts) == 1 && parts[0].TopicTitle == "" && parts[0].CueCard == ""
+	case IELTSSpeakingPracticeReportPart23:
+		return len(parts) == 2 &&
+			parts[0].SourceID == parts[1].SourceID &&
+			strings.TrimSpace(parts[0].TopicTitle) != "" &&
+			strings.TrimSpace(parts[0].TopicTitle) == parts[0].TopicTitle &&
+			parts[0].TopicTitle == parts[1].TopicTitle &&
+			strings.TrimSpace(parts[0].CueCard) != "" &&
+			strings.TrimSpace(parts[0].CueCard) == parts[0].CueCard &&
+			parts[1].CueCard == "" && len(parts[0].TurnBlueprints) == 1
+	case IELTSSpeakingPracticeReportPart3:
+		return len(parts) == 1 &&
+			strings.TrimSpace(parts[0].TopicTitle) != "" &&
+			strings.TrimSpace(parts[0].TopicTitle) == parts[0].TopicTitle &&
+			parts[0].CueCard == ""
+	default:
+		return false
+	}
+}
+
+func expectedIELTSPracticeSections(
+	scope IELTSSpeakingPracticeReportScope,
+) []scoring.IELTSPart {
+	switch scope {
+	case IELTSSpeakingPracticeReportPart1:
+		return []scoring.IELTSPart{scoring.IELTSPart1}
+	case IELTSSpeakingPracticeReportPart23:
+		return []scoring.IELTSPart{scoring.IELTSPart2, scoring.IELTSPart3}
+	case IELTSSpeakingPracticeReportPart3:
+		return []scoring.IELTSPart{scoring.IELTSPart3}
+	default:
+		return nil
+	}
+}
+
+func ieltsPracticeAvailableSections(parts []scoring.IELTSPart) []scoring.IELTSPart {
+	sections := make([]scoring.IELTSPart, 0, len(parts))
+	for _, part := range parts {
+		if len(sections) == 0 || sections[len(sections)-1] != part {
+			sections = append(sections, part)
+		}
+	}
+	return sections
+}
+
+func ieltsPracticePartReview(
+	part scoring.IELTSPart,
+	questions []IELTSSpeakingPracticeReportQuestion,
+	dimensions []scoring.GeneralSceneDimensionResult,
+	refParts map[string]scoring.IELTSPart,
+) IELTSSpeakingPracticeReportPartReview {
+	review := IELTSSpeakingPracticeReportPartReview{
+		PartID:                   part,
+		QuestionIndexes:          ieltsPracticeQuestionIndexes(questions, part),
+		EvidenceRefIDs:           []string{},
+		StrengthFindingIDs:       []string{},
+		ImprovementFindingIDs:    []string{},
+		UpgradeExampleFindingIDs: []string{},
+	}
+	for _, question := range questions {
+		if question.PartID == part {
+			review.EvidenceRefIDs = append(review.EvidenceRefIDs, question.EvidenceRefIDs...)
+		}
+	}
+	for _, dimension := range dimensions {
+		appendIELTSPracticeFindingIDs(
+			&review.StrengthFindingIDs,
+			dimension.Strengths,
+			part,
+			refParts,
+		)
+		appendIELTSPracticeFindingIDs(
+			&review.ImprovementFindingIDs,
+			dimension.Improvements,
+			part,
+			refParts,
+		)
+		appendIELTSPracticeFindingIDs(
+			&review.UpgradeExampleFindingIDs,
+			dimension.Examples,
+			part,
+			refParts,
+		)
+	}
+	return review
+}
+
+func appendIELTSPracticeFindingIDs(
+	target *[]string,
+	findings []scoring.GeneralSceneFinding,
+	part scoring.IELTSPart,
+	refParts map[string]scoring.IELTSPart,
+) {
+	for _, finding := range findings {
+		if len(finding.Evidence) == 0 {
+			continue
+		}
+		belongs := true
+		for _, item := range finding.Evidence {
+			if refParts[item.EvidenceRefID] != part {
+				belongs = false
+				break
+			}
+		}
+		if belongs {
+			*target = append(*target, finding.ID)
+		}
+	}
+}
+
+func ieltsPracticeQuestionIndexes(
+	questions []IELTSSpeakingPracticeReportQuestion,
+	part scoring.IELTSPart,
+) []int {
+	indexes := make([]int, 0, len(questions))
+	for _, question := range questions {
+		if question.PartID == part {
+			indexes = append(indexes, question.Index)
+		}
+	}
+	return indexes
+}
+
+func ieltsPracticeEvidenceRefs(
+	questions []IELTSSpeakingPracticeReportQuestion,
+	part scoring.IELTSPart,
+) []string {
+	refs := make([]string, 0, len(questions))
+	for _, question := range questions {
+		if question.PartID == part {
+			refs = append(refs, question.EvidenceRefIDs...)
+		}
+	}
+	return refs
+}
+
+func validIELTSPracticeQuestionSequence(
+	questions []IELTSSpeakingPracticeReportQuestion,
+	sections []scoring.IELTSPart,
+) bool {
+	if len(questions) == 0 || len(sections) == 0 ||
+		questions[0].PartID != sections[0] {
+		return false
+	}
+	sectionIndex := 0
+	for _, question := range questions[1:] {
+		if question.PartID == sections[sectionIndex] {
+			continue
+		}
+		if sectionIndex+1 >= len(sections) ||
+			question.PartID != sections[sectionIndex+1] {
+			return false
+		}
+		sectionIndex++
+	}
+	return sectionIndex == len(sections)-1
+}

--- a/server/internal/coaching/evaluation/report/ielts_practice_test.go
+++ b/server/internal/coaching/evaluation/report/ielts_practice_test.go
@@ -1,0 +1,206 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
+)
+
+func TestProjectIELTSSpeakingPracticeReportSeparatesPart2AndPart3(t *testing.T) {
+	t.Parallel()
+	snapshot := ieltsPracticeReportTestSnapshot(t, "PART_2")
+	result, err := scoring.NewGeneralSceneEngine(
+		&ieltsPracticeReportProvider{},
+	).Evaluate(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("evaluate IELTS practice fixture: %v", err)
+	}
+	formal, err := ProjectGeneralSceneFormalReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("project IELTS practice FormalReport: %v", err)
+	}
+	if formal.DetailSchema != IELTSSpeakingPracticeReportSchemaVersion {
+		t.Fatalf("detail schema = %q", formal.DetailSchema)
+	}
+	if formal.Summary != "本次 IELTS 专项练习已形成分段复盘，可按对应 Part 继续练习。" {
+		t.Fatalf("summary = %q", formal.Summary)
+	}
+	var detail IELTSSpeakingPracticeReport
+	if err := json.Unmarshal(formal.Detail, &detail); err != nil {
+		t.Fatalf("decode IELTS practice detail: %v", err)
+	}
+	if !detail.Valid() ||
+		detail.ReportScope != IELTSSpeakingPracticeReportPart23 ||
+		!slices.Equal(detail.AvailableSections, []scoring.IELTSPart{
+			scoring.IELTSPart2,
+			scoring.IELTSPart3,
+		}) || len(detail.SectionReviews) != 2 {
+		t.Fatalf("practice detail = %#v", detail)
+	}
+	part2 := detail.SectionReviews[0]
+	part3 := detail.SectionReviews[1]
+	if len(part2.QuestionIndexes) != 1 ||
+		len(part3.QuestionIndexes) != ieltsReportQuestionCount-
+			ieltsReportPart1QuestionCount-ieltsReportPart2QuestionCount ||
+		len(part2.StrengthFindingIDs) != len(result.Dimensions) ||
+		len(part2.ImprovementFindingIDs) != 0 ||
+		len(part2.UpgradeExampleFindingIDs) != 0 ||
+		len(part3.StrengthFindingIDs) != 0 ||
+		len(part3.ImprovementFindingIDs) != len(result.Dimensions) ||
+		len(part3.UpgradeExampleFindingIDs) != 0 {
+		t.Fatalf("section reviews = %#v", detail.SectionReviews)
+	}
+}
+
+func TestProjectIELTSSpeakingPracticeReportScopesStandaloneParts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mode    string
+		scope   IELTSSpeakingPracticeReportScope
+		section scoring.IELTSPart
+	}{
+		{mode: "PART_1", scope: IELTSSpeakingPracticeReportPart1, section: scoring.IELTSPart1},
+		{mode: "PART_3", scope: IELTSSpeakingPracticeReportPart3, section: scoring.IELTSPart3},
+	}
+	for _, test := range tests {
+		t.Run(test.mode, func(t *testing.T) {
+			snapshot := ieltsPracticeReportTestSnapshot(t, test.mode)
+			result, err := scoring.NewGeneralSceneEngine(
+				&ieltsPracticeReportProvider{},
+			).Evaluate(context.Background(), snapshot)
+			if err != nil {
+				t.Fatalf("evaluate IELTS practice fixture: %v", err)
+			}
+			detail, err := ProjectIELTSSpeakingPracticeReport(snapshot, result)
+			if err != nil {
+				t.Fatalf("project IELTS practice detail: %v", err)
+			}
+			if !detail.Valid() || detail.ReportScope != test.scope ||
+				!slices.Equal(detail.AvailableSections, []scoring.IELTSPart{test.section}) ||
+				len(detail.SectionReviews) != 1 {
+				t.Fatalf("practice detail = %#v", detail)
+			}
+		})
+	}
+}
+
+type ieltsPracticeReportProvider struct{}
+
+func (*ieltsPracticeReportProvider) AnalyzeGeneralScene(
+	_ context.Context,
+	input scoring.GeneralSceneProviderInput,
+) (scoring.GeneralSceneProviderResult, error) {
+	payload := generalSceneReportProviderPayload{
+		SchemaVersion: scoring.GeneralSceneProviderSchemaVersion,
+		Dimensions: make(
+			[]generalSceneReportProviderDimension,
+			0,
+			len(input.AssessableDimensions),
+		),
+	}
+	for index, dimension := range input.AssessableDimensions {
+		first := input.Opportunities[0].Response
+		last := input.Opportunities[len(input.Opportunities)-1].Response
+		if first == nil || last == nil {
+			panic("IELTS practice report fixture requires answered opportunities")
+		}
+		payload.Dimensions = append(payload.Dimensions,
+			generalSceneReportProviderDimension{
+				DimensionID: dimension,
+				Score:       60 + index*10,
+				Strengths: []generalSceneReportProviderFinding{{
+					TemplateID: string(dimension) + ":STRENGTH:v1",
+					Evidence: []generalSceneReportProviderAnchor{{
+						EvidenceRefID: first.EvidenceRefID,
+						Quote:         first.Transcript,
+						Occurrence:    1,
+					}},
+				}},
+				Improvements: []generalSceneReportProviderFinding{{
+					TemplateID: string(dimension) + ":IMPROVEMENT:v1",
+					Evidence: []generalSceneReportProviderAnchor{{
+						EvidenceRefID: last.EvidenceRefID,
+						Quote:         last.Transcript,
+						Occurrence:    1,
+					}},
+				}},
+				Examples: []generalSceneReportProviderFinding{{
+					TemplateID: string(dimension) + ":RECOMMENDED_EXAMPLE:v1",
+					Evidence: []generalSceneReportProviderAnchor{
+						{
+							EvidenceRefID: first.EvidenceRefID,
+							Quote:         first.Transcript,
+							Occurrence:    1,
+						},
+						{
+							EvidenceRefID: last.EvidenceRefID,
+							Quote:         last.Transcript,
+							Occurrence:    1,
+						},
+					},
+				}},
+			},
+		)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return scoring.GeneralSceneProviderResult{}, err
+	}
+	return scoring.GeneralSceneProviderResult{
+		Payload: raw, Provider: "provider", Model: "model", RequestID: "request-1",
+	}, nil
+}
+
+func ieltsPracticeReportTestSnapshot(
+	t *testing.T,
+	mode string,
+) evidence.EvidenceSnapshot {
+	t.Helper()
+	full := ieltsReportTestSnapshot(t, ieltsReportQuestionCount)
+	var payload evidence.SnapshotPayload
+	if err := json.Unmarshal(full.Payload, &payload); err != nil {
+		t.Fatalf("decode full IELTS fixture: %v", err)
+	}
+	start := 0
+	end := ieltsReportPart1QuestionCount
+	parts := payload.PracticeContext.IELTSAssignment.Parts[:1]
+	switch mode {
+	case "PART_1":
+	case "PART_2":
+		start = ieltsReportPart1QuestionCount
+		end = ieltsReportQuestionCount
+		parts = payload.PracticeContext.IELTSAssignment.Parts[1:]
+	case "PART_3":
+		start = ieltsReportPart1QuestionCount + ieltsReportPart2QuestionCount
+		end = ieltsReportQuestionCount
+		parts = payload.PracticeContext.IELTSAssignment.Parts[2:]
+	default:
+		t.Fatalf("unsupported IELTS practice mode %q", mode)
+	}
+	payload.PracticeContext.PracticeMode = mode
+	payload.PracticeContext.PracticeOption.Mode = mode
+	payload.PracticeContext.EvaluationPolicyRef =
+		scoring.IELTSSpeakingPracticeEvaluationPolicyRef
+	payload.PracticeContext.TaskBlueprints = slices.Clone(
+		payload.PracticeContext.TaskBlueprints[start:end],
+	)
+	payload.PracticeContext.IELTSAssignment.Mode = mode
+	payload.PracticeContext.IELTSAssignment.Parts = slices.Clone(parts)
+	payload.OpportunityManifest = slices.Clone(payload.OpportunityManifest[start:end])
+	payload.ConfirmedTurns = slices.Clone(payload.ConfirmedTurns[start:end])
+	payload.EvidenceRefs = slices.Clone(payload.EvidenceRefs[start:end])
+	payload.ProviderLineage.ASR = slices.Clone(payload.ProviderLineage.ASR[start:end])
+	payload.VersionManifest.TurnEvidence = slices.Clone(
+		payload.VersionManifest.TurnEvidence[start:end],
+	)
+	for index := range payload.OpportunityManifest {
+		payload.OpportunityManifest[index].Sequence = index + 1
+		payload.ConfirmedTurns[index].Sequence = index + 1
+	}
+	return rebuildReportTestSnapshot(t, payload, evaluation.SceneIELTSSpeaking)
+}


### PR DESCRIPTION
## 功能描述

- 为 IELTS Part 1、Part 2+3、Part 3 专项报告提供稳定的分段详情结构
- 按冻结题目分配关联确认转写、证据和改进项
- 保留完整模考报告的现有独立结构，专项报告不推导 Overall Band

## 实现思路

- 新增 `ielts-speaking-practice-report/v1` 详情 schema
- 从 Evidence Snapshot 的冻结 assignment 投影 Part 边界
- 仅把证据完全属于同一 Part 的 finding 归入该分段，跨 Part finding 不错误归属
- FormalReport 顶层维度仍是唯一评分来源，不制造分段分数

## 可复现测试

- `cd server && go test ./...`
- `cd server && go vet ./...`
- `make check-api-contracts`
- `git diff --check`

Closes #596