### PR TITLE
fix(evaluation): stabilize IELTS report scoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ AGENT_CONTEXT_MAX_CHARACTERS=12000
 
 QINIU_AI_BASE_URL=https://api.qnaigc.com/v1
 QINIU_AI_MODEL=moonshotai/kimi-k2.6
+# Evaluation stays independent from the latency-oriented Agent model above;
+# this model passed the opt-in strict IELTS contract check. Replace it only
+# after the candidate also passes that check within the provider timeout.
+QINIU_AI_EVALUATION_MODEL=qwen3-30b-a3b-instruct-2507
 QINIU_AI_SPEECH_FEEDBACK_MODEL=gemini-2.5-flash
 QINIU_AI_TIMEOUT=60s
 QINIU_AI_MAX_OUTPUT_TOKENS=8192

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -119,6 +119,7 @@ jobs:
           TEXT_GENERATION_PROVIDER: qianwen
           QIANWEN_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           QIANWEN_MODEL: qwen-ci-readiness-not-invoked
+          QIANWEN_EVALUATION_MODEL: qwen-ci-readiness-not-invoked
           QIANWEN_SPEECH_FEEDBACK_MODEL: qwen-ci-readiness-not-invoked
           EMBEDDING_PROVIDER: qianwen
           QIANWEN_EMBEDDING_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ check-go-test: check-go-vet
 
 check-qiniu-llm-live:
 	@set -euo pipefail; \
-	required=(TEXT_GENERATION_PROVIDER QINIU_AI_BASE_URL QINIU_AI_MODEL QINIU_AI_SPEECH_FEEDBACK_MODEL QINIU_AI_API_KEY QINIU_LLM_LIVE_TEST); \
+	required=(TEXT_GENERATION_PROVIDER QINIU_AI_BASE_URL QINIU_AI_MODEL QINIU_AI_EVALUATION_MODEL QINIU_AI_SPEECH_FEEDBACK_MODEL QINIU_AI_API_KEY QINIU_LLM_LIVE_TEST); \
 	missing=(); \
 	for name in "$${required[@]}"; do \
 		if [[ -z "$${!name:-}" ]]; then missing+=("$$name"); fi; \

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -250,7 +250,7 @@ func run() int {
 
 	evaluationConfiguration, err := scoring.NewConfiguration(
 		textConfig.Provider,
-		textConfig.Model,
+		textConfig.EvaluationModel,
 		textConfig.MaxOutputTokens,
 	)
 	if err != nil {

--- a/server/internal/bootstrap/text_generation.go
+++ b/server/internal/bootstrap/text_generation.go
@@ -154,12 +154,14 @@ func NewEvaluationScoringGenerator(
 		if err != nil {
 			return nil, err
 		}
+		providerConfig.Model = configuration.EvaluationModel
 		return qiniu.NewEvaluationScoringGenerator(providerConfig, apiKey)
 	}
 	providerConfig, apiKey, err := qianwenTextProvider(configuration)
 	if err != nil {
 		return nil, err
 	}
+	providerConfig.Model = configuration.EvaluationModel
 	return qianwen.NewEvaluationScoringGenerator(providerConfig, apiKey)
 }
 

--- a/server/internal/bootstrap/text_generation_test.go
+++ b/server/internal/bootstrap/text_generation_test.go
@@ -191,6 +191,7 @@ func setBootstrapTextGenerationEnvironment(t *testing.T, apiKey string) {
 		"https://dashscope.aliyuncs.com/compatible-mode/v1",
 	)
 	t.Setenv("QIANWEN_MODEL", "qwen3.5-flash")
+	t.Setenv("QIANWEN_EVALUATION_MODEL", "qwen-plus")
 	t.Setenv("QIANWEN_SPEECH_FEEDBACK_MODEL", "qwen3.5-flash")
 	t.Setenv("QIANWEN_TIMEOUT", "")
 	t.Setenv("QIANWEN_MAX_OUTPUT_TOKENS", "")
@@ -203,6 +204,7 @@ func setBootstrapQiniuTextGenerationEnvironment(t *testing.T, apiKey string) {
 	t.Setenv("TEXT_GENERATION_PROVIDER", config.TextProviderQiniu)
 	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
 	t.Setenv("QINIU_AI_MODEL", "moonshotai/kimi-k2.6")
+	t.Setenv("QINIU_AI_EVALUATION_MODEL", "qwen3-30b-a3b-instruct-2507")
 	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
 	t.Setenv("QINIU_AI_TIMEOUT", "")
 	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "")

--- a/server/internal/coaching/evaluation/api/application.go
+++ b/server/internal/coaching/evaluation/api/application.go
@@ -792,7 +792,9 @@ func interviewShadowFailure(
 	code string,
 ) EvaluationFailure {
 	switch code {
-	case "provider_invalid_response":
+	case "provider_invalid_json",
+		"provider_schema_mismatch",
+		"provider_invalid_response":
 		return EvaluationFailure{
 			ReasonCode: ReasonPolicyViolation,
 		}

--- a/server/internal/coaching/evaluation/api/application_test.go
+++ b/server/internal/coaching/evaluation/api/application_test.go
@@ -393,6 +393,14 @@ func TestInterviewShadowFailureDerivesStableRetryability(t *testing.T) {
 		wantRetryable bool
 	}{
 		{
+			code:   "provider_invalid_json",
+			reason: ReasonPolicyViolation,
+		},
+		{
+			code:   "provider_schema_mismatch",
+			reason: ReasonPolicyViolation,
+		},
+		{
 			code:   "provider_invalid_response",
 			reason: ReasonPolicyViolation,
 		},

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -40,6 +40,16 @@ var ErrInvalidIELTSSpeakingShadow = errors.New(
 	"evaluation: invalid IELTS Speaking shadow",
 )
 
+var errIELTSSpeakingProviderInvalidJSON = fmt.Errorf(
+	"evaluation: IELTS Speaking provider returned invalid JSON: %w",
+	ErrInvalidIELTSSpeakingShadow,
+)
+
+var errIELTSSpeakingProviderSchemaMismatch = fmt.Errorf(
+	"evaluation: IELTS Speaking provider response schema mismatch: %w",
+	ErrInvalidIELTSSpeakingShadow,
+)
+
 var ErrIELTSSpeakingAcousticsPending = errors.New(
 	"evaluation: IELTS Speaking acoustics pending",
 )
@@ -925,6 +935,12 @@ func normalizeIELTSSpeakingProviderResult(
 		)
 	}
 	var payload ieltsProviderPayload
+	if !json.Valid(generated.Payload) {
+		return IELTSSpeakingShadowResult{}, fmt.Errorf(
+			"provider JSON: %w",
+			errIELTSSpeakingProviderInvalidJSON,
+		)
+	}
 	decoder := json.NewDecoder(bytes.NewReader(generated.Payload))
 	decoder.DisallowUnknownFields()
 	if decoder.Decode(&payload) != nil ||
@@ -934,7 +950,7 @@ func normalizeIELTSSpeakingProviderResult(
 		len(payload.Criteria) != len(prepared.input.AssessableCriteria) {
 		return IELTSSpeakingShadowResult{}, fmt.Errorf(
 			"provider JSON shape: %w",
-			ErrInvalidIELTSSpeakingShadow,
+			errIELTSSpeakingProviderSchemaMismatch,
 		)
 	}
 	byCriterion := make(
@@ -946,12 +962,14 @@ func normalizeIELTSSpeakingProviderResult(
 		if criterion.CriterionID != expected {
 			return IELTSSpeakingShadowResult{}, fmt.Errorf(
 				"provider criterion order: %w",
-				ErrInvalidIELTSSpeakingShadow,
+				errIELTSSpeakingProviderSchemaMismatch,
 			)
 		}
 		if _, duplicate := byCriterion[criterion.CriterionID]; duplicate {
-			return IELTSSpeakingShadowResult{},
-				ErrInvalidIELTSSpeakingShadow
+			return IELTSSpeakingShadowResult{}, fmt.Errorf(
+				"provider duplicate criterion: %w",
+				errIELTSSpeakingProviderSchemaMismatch,
+			)
 		}
 		byCriterion[criterion.CriterionID] = criterion
 	}

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
@@ -218,6 +218,59 @@ func TestIELTSSpeakingShadowRejectsProviderGateAndNumericScore(
 	}
 }
 
+func TestIELTSSpeakingShadowClassifiesProviderJSONContractFailures(
+	t *testing.T,
+) {
+	t.Parallel()
+	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	prepared, err := prepareIELTSSpeakingShadow(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		payload []byte
+		want    error
+	}{
+		{
+			name:    "invalid JSON",
+			payload: []byte(`{"schema_version":`),
+			want:    errIELTSSpeakingProviderInvalidJSON,
+		},
+		{
+			name: "unknown field",
+			payload: []byte(`{"schema_version":"` +
+				IELTSSpeakingShadowProviderSchemaVersion +
+				`","criteria":[],"unexpected":true}`),
+			want: errIELTSSpeakingProviderSchemaMismatch,
+		},
+		{
+			name: "wrong schema version",
+			payload: []byte(
+				`{"schema_version":"wrong","criteria":[]}`,
+			),
+			want: errIELTSSpeakingProviderSchemaMismatch,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, normalizeErr := normalizeIELTSSpeakingProviderResult(
+				prepared,
+				IELTSSpeakingShadowProviderResult{
+					Payload:   test.payload,
+					Provider:  "provider",
+					Model:     "model",
+					RequestID: "request-1",
+				},
+			)
+			if !errors.Is(normalizeErr, test.want) ||
+				!errors.Is(normalizeErr, ErrInvalidIELTSSpeakingShadow) {
+				t.Fatalf("normalize error = %v", normalizeErr)
+			}
+		})
+	}
+}
+
 func TestIELTSSpeakingShadowRejectsNonFullMockEvaluationPolicy(t *testing.T) {
 	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
 	var payload evidence.SnapshotPayload

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -273,17 +273,20 @@ func (worker *IELTSSpeakingShadowWorker) recordFailure(
 	claim IELTSSpeakingShadowClaim,
 	cause error,
 ) (IELTSSpeakingShadowRuntimeStatus, error) {
-	if errors.Is(cause, ErrInvalidIELTSSpeakingShadow) {
+	failure := classifyIELTSSpeakingShadowFailure(cause)
+	if failure.Code == "provider_invalid_json" ||
+		failure.Code == "provider_schema_mismatch" ||
+		failure.Code == "provider_invalid_response" {
 		slog.Warn(
 			"IELTS Speaking provider response rejected",
-			"validation_error",
-			cause,
+			"failure_code",
+			failure.Code,
 		)
 	}
 	status, err := worker.repository.FailIELTSSpeakingShadow(
 		ctx,
 		claim,
-		classifyIELTSSpeakingShadowFailure(cause),
+		failure,
 		worker.configuration,
 	)
 	if err != nil {
@@ -316,11 +319,21 @@ func classifyIELTSSpeakingShadowFailure(
 			Code:      "acoustics_pending",
 			Retryable: true,
 		}
+	case errors.Is(cause, errIELTSSpeakingProviderInvalidJSON):
+		return IELTSSpeakingShadowFailure{
+			Code:      "provider_invalid_json",
+			Retryable: false,
+		}
+	case errors.Is(cause, errIELTSSpeakingProviderSchemaMismatch):
+		return IELTSSpeakingShadowFailure{
+			Code:      "provider_schema_mismatch",
+			Retryable: false,
+		}
 	case errors.Is(cause, ErrInvalidIELTSSpeakingShadow),
 		errors.Is(cause, evaluation.ErrInvalidRequest):
 		return IELTSSpeakingShadowFailure{
 			Code:      "provider_invalid_response",
-			Retryable: errors.Is(cause, ErrInvalidIELTSSpeakingShadow),
+			Retryable: false,
 		}
 	case errors.Is(cause, context.Canceled):
 		return IELTSSpeakingShadowFailure{
@@ -337,6 +350,9 @@ func classifyIELTSSpeakingShadowFailure(
 	if errors.As(cause, &generationError) {
 		code := strings.ToLower(generationError.StableCategory())
 		code = strings.NewReplacer("-", "_", " ", "_").Replace(code)
+		if code == "timeout" {
+			code = "provider_timeout"
+		}
 		if !durableSceneJobFailureCodePattern.MatchString(code) {
 			code = "provider_error"
 		}

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
-	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"testing"
 	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 )
 
 func TestIELTSSpeakingShadowWorkerCompletesEvidenceBoundResult(
@@ -195,12 +196,11 @@ func TestIELTSSpeakingShadowWorkerReservesProviderRetryAfterAcousticWait(
 	}
 }
 
-func TestIELTSSpeakingShadowWorkerFailsAfterInvalidProviderPayloadExhaustion(
+func TestIELTSSpeakingShadowWorkerFailsSchemaMismatchWithoutRetry(
 	t *testing.T,
 ) {
 	t.Parallel()
 	claim := validIELTSSpeakingShadowClaim(t)
-	claim.AttemptCount = 3
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:      claim,
 		acquired:   true,
@@ -224,8 +224,8 @@ func TestIELTSSpeakingShadowWorkerFailsAfterInvalidProviderPayloadExhaustion(
 	}
 	if sweep.Failed != 1 ||
 		repository.failCalls != 1 ||
-		repository.failure.Code != "provider_invalid_response" ||
-		!repository.failure.Retryable ||
+		repository.failure.Code != "provider_schema_mismatch" ||
+		repository.failure.Retryable ||
 		repository.completeCalls != 0 ||
 		repository.result.Provider != nil ||
 		len(repository.result.Criteria) != 0 {
@@ -235,6 +235,80 @@ func TestIELTSSpeakingShadowWorkerFailsAfterInvalidProviderPayloadExhaustion(
 			repository.failure,
 		)
 	}
+}
+
+func TestClassifyIELTSSpeakingShadowFailureUsesStableProviderCodes(
+	t *testing.T,
+) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		cause     error
+		code      string
+		retryable bool
+	}{
+		{
+			name:  "invalid JSON",
+			cause: errIELTSSpeakingProviderInvalidJSON,
+			code:  "provider_invalid_json",
+		},
+		{
+			name:  "schema mismatch",
+			cause: errIELTSSpeakingProviderSchemaMismatch,
+			code:  "provider_schema_mismatch",
+		},
+		{
+			name:  "semantic response rejection",
+			cause: ErrInvalidIELTSSpeakingShadow,
+			code:  "provider_invalid_response",
+		},
+		{
+			name:  "invalid request",
+			cause: evaluation.ErrInvalidRequest,
+			code:  "provider_invalid_response",
+		},
+		{
+			name:      "timeout",
+			cause:     context.DeadlineExceeded,
+			code:      "provider_timeout",
+			retryable: true,
+		},
+		{
+			name: "provider timeout category",
+			cause: ieltsGenerationFailureStub{
+				category:  "timeout",
+				retryable: true,
+			},
+			code:      "provider_timeout",
+			retryable: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failure := classifyIELTSSpeakingShadowFailure(test.cause)
+			if failure.Code != test.code ||
+				failure.Retryable != test.retryable {
+				t.Fatalf("failure = %#v", failure)
+			}
+		})
+	}
+}
+
+type ieltsGenerationFailureStub struct {
+	category  string
+	retryable bool
+}
+
+func (failure ieltsGenerationFailureStub) Error() string {
+	return "provider generation failed"
+}
+
+func (failure ieltsGenerationFailureStub) StableCategory() string {
+	return failure.category
+}
+
+func (failure ieltsGenerationFailureStub) Retryable() bool {
+	return failure.retryable
 }
 
 func validIELTSSpeakingShadowRuntimeConfiguration() IELTSSpeakingShadowRuntimeConfiguration {

--- a/server/internal/coaching/evaluation/scoring/runtime.go
+++ b/server/internal/coaching/evaluation/scoring/runtime.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	runtimeLeaseDuration    = 60 * time.Second
-	runtimeRetryDelay       = 5 * time.Second
-	runtimeMaxAttempts      = 3
-	ieltsRuntimeMaxAttempts = 10
+	runtimeLeaseDuration = 60 * time.Second
+	runtimeRetryDelay    = 5 * time.Second
+	runtimeMaxAttempts   = 3
 )
 
 type Configuration struct {
@@ -413,7 +412,7 @@ func ieltsRuntimeConfiguration(
 		return IELTSSpeakingShadowRuntimeConfiguration{}, err
 	}
 	result := IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     ieltsRuntimeMaxAttempts,
+		MaxAttempts:     configuration.maxAttempts,
 		LeaseDuration:   configuration.leaseDuration,
 		StrategyRef:     IELTSSpeakingShadowStrategyRef,
 		PipelineVersion: IELTSSpeakingShadowPipelineVersion,

--- a/server/internal/coaching/evaluation/scoring/runtime_test.go
+++ b/server/internal/coaching/evaluation/scoring/runtime_test.go
@@ -36,7 +36,7 @@ func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	if firstIELTS != secondIELTS || !firstIELTS.Valid() {
 		t.Fatalf("IELTS runtime configuration is unstable: %#v %#v", firstIELTS, secondIELTS)
 	}
-	if firstIELTS.MaxAttempts != ieltsRuntimeMaxAttempts {
+	if firstIELTS.MaxAttempts != runtimeMaxAttempts {
 		t.Fatalf("IELTS max attempts = %d", firstIELTS.MaxAttempts)
 	}
 

--- a/server/internal/platform/config/text_generation.go
+++ b/server/internal/platform/config/text_generation.go
@@ -29,6 +29,7 @@ type TextGenerationConfig struct {
 	Provider            string
 	BaseURL             string
 	Model               string
+	EvaluationModel     string
 	SpeechFeedbackModel string
 	Timeout             time.Duration
 	MaxOutputTokens     int
@@ -77,6 +78,7 @@ func LoadTextGeneration() (TextGenerationConfig, error) {
 	}
 	baseURLName := prefix + "_BASE_URL"
 	modelName := prefix + "_MODEL"
+	evaluationModelName := prefix + "_EVALUATION_MODEL"
 	speechFeedbackModelName := prefix + "_SPEECH_FEEDBACK_MODEL"
 	timeoutName := prefix + "_TIMEOUT"
 	maxOutputTokensName := prefix + "_MAX_OUTPUT_TOKENS"
@@ -90,6 +92,13 @@ func LoadTextGeneration() (TextGenerationConfig, error) {
 		return TextGenerationConfig{}, fmt.Errorf(
 			"%s must be a valid model ID",
 			modelName,
+		)
+	}
+	evaluationModel := os.Getenv(evaluationModelName)
+	if !modelid.Valid(evaluationModel) {
+		return TextGenerationConfig{}, fmt.Errorf(
+			"%s must be a valid model ID",
+			evaluationModelName,
 		)
 	}
 	speechFeedbackModel := os.Getenv(speechFeedbackModelName)
@@ -158,6 +167,7 @@ func LoadTextGeneration() (TextGenerationConfig, error) {
 		Provider:            provider,
 		BaseURL:             baseURL,
 		Model:               model,
+		EvaluationModel:     evaluationModel,
 		SpeechFeedbackModel: speechFeedbackModel,
 		Timeout:             timeout,
 		MaxOutputTokens:     maxOutputTokens,

--- a/server/internal/platform/config/text_generation_test.go
+++ b/server/internal/platform/config/text_generation_test.go
@@ -21,6 +21,7 @@ func TestLoadTextGeneration(t *testing.T) {
 	if cfg.Provider != TextProviderQianwen ||
 		cfg.BaseURL != "https://dashscope.aliyuncs.com/compatible-mode/v1" ||
 		cfg.Model != "qwen-test-model" ||
+		cfg.EvaluationModel != "qwen-test-evaluation-model" ||
 		cfg.SpeechFeedbackModel != "qwen-test-feedback-model" ||
 		cfg.Timeout != 45*time.Second ||
 		cfg.MaxOutputTokens != 768 ||
@@ -63,6 +64,7 @@ func TestLoadTextGenerationReadsQiniuConfiguration(t *testing.T) {
 	t.Setenv("TEXT_GENERATION_PROVIDER", TextProviderQiniu)
 	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
 	t.Setenv("QINIU_AI_MODEL", "moonshotai/kimi-k2.6")
+	t.Setenv("QINIU_AI_EVALUATION_MODEL", "qwen3-30b-a3b-instruct-2507")
 	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
 	t.Setenv("QINIU_AI_TIMEOUT", "45s")
 	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "768")
@@ -76,6 +78,7 @@ func TestLoadTextGenerationReadsQiniuConfiguration(t *testing.T) {
 	if cfg.Provider != TextProviderQiniu ||
 		cfg.BaseURL != "https://api.qnaigc.com/v1" ||
 		cfg.Model != "moonshotai/kimi-k2.6" ||
+		cfg.EvaluationModel != "qwen3-30b-a3b-instruct-2507" ||
 		cfg.SpeechFeedbackModel != "gemini-2.5-flash" ||
 		cfg.Timeout != 45*time.Second ||
 		cfg.MaxOutputTokens != 768 ||
@@ -96,6 +99,8 @@ func TestLoadTextGenerationRejectsUnsafeQiniuConfiguration(t *testing.T) {
 		{name: "model with leading whitespace", key: "QINIU_AI_MODEL", value: " moonshotai/kimi-k2.6"},
 		{name: "model with repeated separator", key: "QINIU_AI_MODEL", value: "moonshotai//kimi-k2.6"},
 		{name: "model with traversal", key: "QINIU_AI_MODEL", value: "moonshotai/../kimi-k2.6"},
+		{name: "missing evaluation model", key: "QINIU_AI_EVALUATION_MODEL", value: ""},
+		{name: "invalid evaluation model", key: "QINIU_AI_EVALUATION_MODEL", value: "qwen//qwen3.5-plus"},
 		{name: "missing feedback model", key: "QINIU_AI_SPEECH_FEEDBACK_MODEL", value: ""},
 		{name: "invalid feedback model", key: "QINIU_AI_SPEECH_FEEDBACK_MODEL", value: "gemini//2.5-flash"},
 		{name: "missing API key", key: "QINIU_AI_API_KEY", value: ""},
@@ -124,6 +129,8 @@ func TestLoadTextGenerationRejectsUnsafeOrIncompleteConfiguration(t *testing.T) 
 		{name: "unsupported provider", key: "TEXT_GENERATION_PROVIDER", value: "fake"},
 		{name: "missing base URL", key: "QIANWEN_BASE_URL", value: ""},
 		{name: "missing model", key: "QIANWEN_MODEL", value: ""},
+		{name: "missing evaluation model", key: "QIANWEN_EVALUATION_MODEL", value: ""},
+		{name: "invalid evaluation model", key: "QIANWEN_EVALUATION_MODEL", value: "qwen//evaluation"},
 		{name: "missing speech feedback model", key: "QIANWEN_SPEECH_FEEDBACK_MODEL", value: ""},
 		{name: "missing API key", key: "DASHSCOPE_API_KEY", value: ""},
 		{name: "API key whitespace", key: "DASHSCOPE_API_KEY", value: "secret value"},
@@ -192,6 +199,7 @@ func setRequiredTextGenerationEnvironment(t *testing.T) {
 	t.Setenv("TEXT_GENERATION_PROVIDER", "qianwen")
 	t.Setenv("QIANWEN_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1")
 	t.Setenv("QIANWEN_MODEL", "qwen-test-model")
+	t.Setenv("QIANWEN_EVALUATION_MODEL", "qwen-test-evaluation-model")
 	t.Setenv("QIANWEN_SPEECH_FEEDBACK_MODEL", "qwen-test-feedback-model")
 	t.Setenv("QIANWEN_TIMEOUT", "")
 	t.Setenv("QIANWEN_MAX_OUTPUT_TOKENS", "")
@@ -204,6 +212,7 @@ func setRequiredQiniuTextGenerationEnvironment(t *testing.T) {
 	t.Setenv("TEXT_GENERATION_PROVIDER", TextProviderQiniu)
 	t.Setenv("QINIU_AI_BASE_URL", "https://api.qnaigc.com/v1")
 	t.Setenv("QINIU_AI_MODEL", "moonshotai/kimi-k2.6")
+	t.Setenv("QINIU_AI_EVALUATION_MODEL", "qwen3-30b-a3b-instruct-2507")
 	t.Setenv("QINIU_AI_SPEECH_FEEDBACK_MODEL", "gemini-2.5-flash")
 	t.Setenv("QINIU_AI_TIMEOUT", "")
 	t.Setenv("QINIU_AI_MAX_OUTPUT_TOKENS", "")

--- a/server/internal/providers/qianwen/business_generation_test.go
+++ b/server/internal/providers/qianwen/business_generation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation/summary"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/memory"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/resume/fieldextractor"
@@ -25,6 +26,24 @@ func TestBusinessGeneratorsMapOwnedRequests(t *testing.T) {
 		responseFormat protocol.TextResponseFormat
 		generate       func(*textClient) (string, string, string, error)
 	}{
+		{
+			name:           "Evaluation JSON",
+			systemPrompt:   "evaluate frozen evidence",
+			userPrompt:     "sanitized evidence payload",
+			responseFormat: protocol.TextResponseFormatJSON,
+			generate: func(client *textClient) (string, string, string, error) {
+				result, err := (&EvaluationScoringGenerator{
+					generator: client,
+				}).Generate(
+					context.Background(),
+					scoring.TextGenerationRequest{
+						SystemPrompt: "evaluate frozen evidence",
+						UserPrompt:   "sanitized evidence payload",
+					},
+				)
+				return result.Provider, result.Model, result.Content, err
+			},
+		},
 		{
 			name:           "Memory JSON",
 			systemPrompt:   "extract durable memory",

--- a/server/internal/providers/qiniu/text_live_test.go
+++ b/server/internal/providers/qiniu/text_live_test.go
@@ -1,14 +1,18 @@
 package qiniu
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	platformconfig "github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 )
 
@@ -145,7 +149,58 @@ func TestLiveQiniuAgentContracts(t *testing.T) {
 	}
 }
 
+func TestLiveQiniuIELTSEvaluationContract(t *testing.T) {
+	configuration := liveQiniuConfiguration(t)
+	generator, err := NewEvaluationScoringGenerator(TextConfig{
+		BaseURL: configuration.BaseURL, Model: configuration.EvaluationModel,
+		Timeout: configuration.Timeout, MaxOutputTokens: configuration.MaxOutputTokens,
+	}, configuration.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create Qiniu Evaluation generator: %v", err)
+	}
+	result, err := generator.Generate(
+		context.Background(),
+		scoring.TextGenerationRequest{
+			SystemPrompt: scoring.IELTSSpeakingShadowSystemContract,
+			UserPrompt:   liveIELTSEvaluationEvidence,
+		},
+	)
+	if err != nil {
+		t.Fatalf("live Qiniu IELTS Evaluation failed: %v", err)
+	}
+	if result.Provider != TextProviderName ||
+		result.Model != configuration.EvaluationModel ||
+		strings.TrimSpace(result.RequestID) == "" {
+		t.Fatalf(
+			"invalid IELTS Evaluation lineage: provider=%q model=%q request_id_present=%t",
+			result.Provider,
+			result.Model,
+			strings.TrimSpace(result.RequestID) != "",
+		)
+	}
+	if err := validateLiveIELTSEvaluationPayload([]byte(result.Content)); err != nil {
+		t.Fatalf("live Qiniu IELTS contract rejected: %v", err)
+	}
+	t.Logf(
+		"Qiniu IELTS Evaluation model=%s passed strict sanitized contract",
+		configuration.EvaluationModel,
+	)
+}
+
 func liveQiniuAgentGenerator(t *testing.T) (*AgentRunGenerator, string) {
+	t.Helper()
+	configuration := liveQiniuConfiguration(t)
+	generator, err := NewAgentRunGenerator(TextConfig{
+		BaseURL: configuration.BaseURL, Model: configuration.Model,
+		Timeout: configuration.Timeout, MaxOutputTokens: configuration.MaxOutputTokens,
+	}, configuration.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create Qiniu text generator: %v", err)
+	}
+	return generator, configuration.Model
+}
+
+func liveQiniuConfiguration(t *testing.T) platformconfig.TextGenerationConfig {
 	t.Helper()
 	if os.Getenv("QINIU_LLM_LIVE_TEST") != "1" {
 		t.Skip("set QINIU_LLM_LIVE_TEST=1 with the Qiniu AI environment variables; the real request may incur charges")
@@ -157,17 +212,198 @@ func liveQiniuAgentGenerator(t *testing.T) (*AgentRunGenerator, string) {
 	if configuration.Provider != platformconfig.TextProviderQiniu {
 		t.Fatalf("TEXT_GENERATION_PROVIDER = %q, want qiniu", configuration.Provider)
 	}
-	generator, err := NewAgentRunGenerator(TextConfig{
-		BaseURL: configuration.BaseURL, Model: configuration.Model,
-		Timeout: configuration.Timeout, MaxOutputTokens: configuration.MaxOutputTokens,
-	}, configuration.APIKey.Reveal())
-	if err != nil {
-		t.Fatalf("create Qiniu text generator: %v", err)
-	}
-	return generator, configuration.Model
+	return configuration
 }
 
 func valueString(value any) string {
 	text, _ := value.(string)
 	return text
+}
+
+type liveIELTSEvaluationPayload struct {
+	SchemaVersion string                         `json:"schema_version"`
+	Criteria      []liveIELTSEvaluationCriterion `json:"criteria"`
+}
+
+type liveIELTSEvaluationCriterion struct {
+	CriterionID      scoring.IELTSCriterion       `json:"criterion_id"`
+	RubricDescriptor string                       `json:"rubric_descriptor,omitempty"`
+	Strengths        []liveIELTSEvaluationFinding `json:"strengths"`
+	Improvements     []liveIELTSEvaluationFinding `json:"improvements"`
+	UpgradeExamples  []liveIELTSEvaluationFinding `json:"upgrade_examples"`
+}
+
+type liveIELTSEvaluationFinding struct {
+	TemplateID string                      `json:"template_id"`
+	Suggestion string                      `json:"suggestion,omitempty"`
+	Evidence   []liveIELTSEvaluationAnchor `json:"evidence"`
+}
+
+type liveIELTSEvaluationAnchor struct {
+	EvidenceRefID string `json:"evidence_ref_id"`
+	Quote         string `json:"quote"`
+	Occurrence    int    `json:"occurrence"`
+}
+
+const liveIELTSEvaluationEvidence = `{
+  "schema_version":"ielts-speaking-full-mock-shadow-provider/v2",
+  "prompt_version":"ielts-speaking-full-mock-shadow-prompt/v5",
+  "rubric_version":"ielts-speaking-public-band-rubric/v2",
+  "scene_type":"IELTS_SPEAKING",
+  "practice_mode":"FULL_MOCK",
+  "rubric_descriptors":[
+    {"criterion_id":"IELTS_LR","descriptors":[{"descriptor_id":"LR_PRACTICE_BAND_6","band":6,"description":"Uses enough vocabulary to discuss topics at length."}]},
+    {"criterion_id":"IELTS_GRA","descriptors":[{"descriptor_id":"GRA_PRACTICE_BAND_6","band":6,"description":"Uses a mix of simple and complex structures."}]}
+  ],
+  "assessable_criteria":["IELTS_FC","IELTS_LR","IELTS_GRA"],
+  "questions":[
+    {"question_id":"question-1","part_id":"PART_1","index":1,"question_text":"What kind of music do you enjoy?","response":{"turn_id":"turn-1","evidence_ref_id":"evidence-1","confirmed_transcript":"I enjoy calm jazz because it helps me concentrate after a busy day.","recording_duration_ms":9000,"english_word_count":13,"cjk_character_count":0,"language_evidence":"ENGLISH"}},
+    {"question_id":"question-2","part_id":"PART_2","index":2,"question_text":"Describe a useful skill you learned.","response":{"turn_id":"turn-2","evidence_ref_id":"evidence-2","confirmed_transcript":"I learned to cook at university, and regular practice made me more confident.","recording_duration_ms":10000,"english_word_count":13,"cjk_character_count":0,"language_evidence":"ENGLISH"}},
+    {"question_id":"question-3","part_id":"PART_3","index":3,"question_text":"Why do adults continue learning?","response":{"turn_id":"turn-3","evidence_ref_id":"evidence-3","confirmed_transcript":"Adults keep learning because work changes quickly and new skills bring satisfaction.","recording_duration_ms":10000,"english_word_count":12,"cjk_character_count":0,"language_evidence":"ENGLISH"}}
+  ]
+}`
+
+func validateLiveIELTSEvaluationPayload(raw []byte) error {
+	var payload liveIELTSEvaluationPayload
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return io.ErrUnexpectedEOF
+	}
+	expected := [...]scoring.IELTSCriterion{
+		scoring.IELTSCriterionFC,
+		scoring.IELTSCriterionLR,
+		scoring.IELTSCriterionGRA,
+	}
+	if payload.SchemaVersion != scoring.IELTSSpeakingShadowProviderSchemaVersion ||
+		len(payload.Criteria) != len(expected) {
+		return errLiveIELTSEvaluationSchema
+	}
+	descriptors := map[scoring.IELTSCriterion]string{
+		scoring.IELTSCriterionLR:  "LR_PRACTICE_BAND_6",
+		scoring.IELTSCriterionGRA: "GRA_PRACTICE_BAND_6",
+	}
+	transcripts := map[string]string{
+		"evidence-1": "I enjoy calm jazz because it helps me concentrate after a busy day.",
+		"evidence-2": "I learned to cook at university, and regular practice made me more confident.",
+		"evidence-3": "Adults keep learning because work changes quickly and new skills bring satisfaction.",
+	}
+	for index, criterion := range payload.Criteria {
+		criterionID := expected[index]
+		if criterion.CriterionID != criterionID ||
+			!validLiveIELTSRubricDescriptor(
+				criterionID,
+				criterion.RubricDescriptor,
+				descriptors[criterionID],
+			) ||
+			!validLiveIELTSFindings(criterionID, "strength", criterion.Strengths, transcripts) ||
+			!validLiveIELTSFindings(criterionID, "improvement", criterion.Improvements, transcripts) ||
+			!validLiveIELTSFindings(criterionID, "upgrade", criterion.UpgradeExamples, transcripts) ||
+			len(criterion.Strengths)+len(criterion.Improvements) == 0 {
+			return errLiveIELTSEvaluationSchema
+		}
+	}
+	return nil
+}
+
+func validLiveIELTSRubricDescriptor(
+	criterion scoring.IELTSCriterion,
+	descriptor string,
+	expected string,
+) bool {
+	if criterion != scoring.IELTSCriterionFC {
+		return descriptor == expected
+	}
+	if descriptor == "" {
+		return true
+	}
+	const prefix = "FC_PRACTICE_BAND_"
+	return strings.HasPrefix(descriptor, prefix) &&
+		len(descriptor) == len(prefix)+1 &&
+		descriptor[len(prefix)] >= '1' && descriptor[len(prefix)] <= '9'
+}
+
+func TestValidLiveIELTSRubricDescriptor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		criterion  scoring.IELTSCriterion
+		descriptor string
+		expected   string
+		valid      bool
+	}{
+		{name: "text-only FC omitted", criterion: scoring.IELTSCriterionFC, valid: true},
+		{name: "text-only FC known band", criterion: scoring.IELTSCriterionFC, descriptor: "FC_PRACTICE_BAND_6", valid: true},
+		{name: "text-only FC unknown band", criterion: scoring.IELTSCriterionFC, descriptor: "FC_PRACTICE_BAND_10"},
+		{name: "text-only FC arbitrary", criterion: scoring.IELTSCriterionFC, descriptor: "FC_UNTRUSTED"},
+		{name: "LR selected descriptor", criterion: scoring.IELTSCriterionLR, descriptor: "LR_PRACTICE_BAND_6", expected: "LR_PRACTICE_BAND_6", valid: true},
+		{name: "LR descriptor outside input", criterion: scoring.IELTSCriterionLR, descriptor: "LR_PRACTICE_BAND_7", expected: "LR_PRACTICE_BAND_6"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := validLiveIELTSRubricDescriptor(
+				test.criterion,
+				test.descriptor,
+				test.expected,
+			); got != test.valid {
+				t.Fatalf("valid = %t, want %t", got, test.valid)
+			}
+		})
+	}
+}
+
+var errLiveIELTSEvaluationSchema = errors.New(
+	"IELTS Evaluation response did not match the strict contract",
+)
+
+func validLiveIELTSFindings(
+	criterion scoring.IELTSCriterion,
+	kind string,
+	findings []liveIELTSEvaluationFinding,
+	transcripts map[string]string,
+) bool {
+	if findings == nil || len(findings) > 3 {
+		return false
+	}
+	prefix := strings.ToLower(strings.TrimPrefix(string(criterion), "IELTS_"))
+	wantTemplate := "ielts." + prefix + "." + kind + ".v1"
+	for _, finding := range findings {
+		if finding.TemplateID != wantTemplate || len(finding.Evidence) == 0 ||
+			len(finding.Evidence) > 4 ||
+			(kind == "strength" && finding.Suggestion != "") {
+			return false
+		}
+		for _, anchor := range finding.Evidence {
+			transcript, ok := transcripts[anchor.EvidenceRefID]
+			if !ok || strings.TrimSpace(anchor.Quote) == "" ||
+				anchor.Occurrence < 1 ||
+				nthLiveIELTSOccurrence(
+					transcript,
+					anchor.Quote,
+					anchor.Occurrence,
+				) < 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func nthLiveIELTSOccurrence(text string, quote string, occurrence int) int {
+	start := 0
+	for current := 1; current <= occurrence; current++ {
+		relative := strings.Index(text[start:], quote)
+		if relative < 0 {
+			return -1
+		}
+		start += relative
+		if current == occurrence {
+			return start
+		}
+		start += len(quote)
+	}
+	return -1
 }


### PR DESCRIPTION
## 功能描述

- 将 IELTS Evaluation 模型与首页 Agent 模型解耦
- 为非法 JSON、schema 不匹配和 Provider 超时提供脱敏稳定终态
- 将无意义的 10 次长重试收紧为最多 3 次，避免报告长期伪装为生成中

## 实现思路

- 七牛 Evaluation 默认使用 `qwen3-30b-a3b-instruct-2507`，首页 `moonshotai/kimi-k2.6` 不变
- 继续使用 `json_object` 加服务端严格解码，不虚构 Provider 未声明的 JSON Schema 能力
- 不放宽 IELTS rubric、证据锚点、评分门禁或幂等语义
- Provider 拒绝日志只记录稳定失败码，不记录回答或模型正文

## 模型选型实测

同一脱敏 IELTS 严格契约和 60 秒上限：

- 两个 Plus 候选超时
- 27B 新候选返回 invalid_response
- `qwen3-30b-a3b-instruct-2507` 约 5–8 秒，连续 3 次严格契约通过

## 可复现测试

- `make check-go`
- `make check-api`
- `QINIU_LLM_LIVE_TEST=1 go test ./internal/providers/qiniu -run TestLiveQiniuIELTSEvaluationContract -count=2 -v`
- `git diff --check`

部署前需显式补充 `QINIU_AI_EVALUATION_MODEL=qwen3-30b-a3b-instruct-2507`。

Closes #593