### PR TITLE
feat(ielts): redesign section and full mock reports

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -36,6 +36,7 @@ import 'package:speakup/features/coaching/review/interview_report_controller.dar
 import 'package:speakup/features/coaching/review/interview_report_view.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/resume/resume_controller.dart';
@@ -57,6 +58,7 @@ class SpeakUpApp extends StatelessWidget {
     this.avatarControllerFactory,
     this.interviewReportController,
     this.ieltsSpeakingReportController,
+    this.practiceReportStatusController,
     this.speechFeedbackController,
     this.resumeController,
     super.key,
@@ -78,6 +80,7 @@ class SpeakUpApp extends StatelessWidget {
     this.avatarControllerFactory,
     this.interviewReportController,
     this.ieltsSpeakingReportController,
+    this.practiceReportStatusController,
     this.speechFeedbackController,
     this.resumeController,
     super.key,
@@ -99,6 +102,7 @@ class SpeakUpApp extends StatelessWidget {
   final AvatarControllerFactory? avatarControllerFactory;
   final InterviewReportController? interviewReportController;
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
+  final PracticeReportStatusController? practiceReportStatusController;
   final SpeechFeedbackController? speechFeedbackController;
   final ResumeController? resumeController;
   final bool _allowFakePreview;
@@ -126,6 +130,7 @@ class SpeakUpApp extends StatelessWidget {
               avatarControllerFactory: avatarControllerFactory,
               interviewReportController: interviewReportController,
               ieltsSpeakingReportController: ieltsSpeakingReportController,
+              practiceReportStatusController: practiceReportStatusController,
               speechFeedbackController: speechFeedbackController,
               resumeController: resumeController,
               allowFakePreview: _allowFakePreview,
@@ -149,6 +154,7 @@ class SpeakUpApp extends StatelessWidget {
                 avatarControllerFactory: avatarControllerFactory,
                 interviewReportController: interviewReportController,
                 ieltsSpeakingReportController: ieltsSpeakingReportController,
+                practiceReportStatusController: practiceReportStatusController,
                 speechFeedbackController: speechFeedbackController,
                 resumeController: resumeController,
                 allowFakePreview: _allowFakePreview,
@@ -176,6 +182,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.avatarControllerFactory,
     this.interviewReportController,
     this.ieltsSpeakingReportController,
+    this.practiceReportStatusController,
     this.speechFeedbackController,
     this.resumeController,
     required this.allowFakePreview,
@@ -197,6 +204,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final AvatarControllerFactory? avatarControllerFactory;
   final InterviewReportController? interviewReportController;
   final IeltsSpeakingReportController? ieltsSpeakingReportController;
+  final PracticeReportStatusController? practiceReportStatusController;
   final SpeechFeedbackController? speechFeedbackController;
   final ResumeController? resumeController;
   final bool allowFakePreview;
@@ -529,6 +537,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       controller: _practiceController,
       onExitRequested: launchController?.parkCurrentPractice,
       ieltsController: widget.ieltsPreparationController,
+      reportStatusController: widget.practiceReportStatusController,
       completedReportBuilder: widget.ieltsSpeakingReportController == null
           ? null
           : (_, practiceSessionId) => IeltsSpeakingSessionReportPanel(

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -22,6 +22,13 @@ import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
+import 'package:speakup/features/coaching/review/evaluation_report_presentation.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_view.dart';
+import 'package:speakup/features/coaching/review/review.dart';
+import 'package:speakup/features/coaching/review/review_history_client.dart';
 
 const _part2IntroNarration =
     'You will have one minute to prepare and up to two minutes to speak. '
@@ -66,6 +73,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.progressStore,
     this.ieltsController,
     this.completedReportBuilder,
+    this.reportStatusController,
     this.speechFeedbackController,
     this.examinerSpeaker,
     this.avatarSurfaceBuilder,
@@ -83,6 +91,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final IeltsMockProgressStore? progressStore;
   final IeltsPreparationController? ieltsController;
   final IeltsCompletedReportBuilder? completedReportBuilder;
+  final PracticeReportStatusController? reportStatusController;
   final SpeechFeedbackController? speechFeedbackController;
   final PracticePromptSpeaker? examinerSpeaker;
   final WidgetBuilder? avatarSurfaceBuilder;
@@ -466,6 +475,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         oldWidget.speechFeedbackController != widget.speechFeedbackController) {
       _syncSpeechFeedbackSources();
     }
+    if (oldWidget.reportStatusController != widget.reportStatusController) {
+      final sessionId = oldWidget.reportStatusController?.practiceSessionId;
+      if (sessionId != null) {
+        oldWidget.reportStatusController?.cancel(sessionId);
+      }
+      _syncCompletionReport();
+    }
   }
 
   @override
@@ -491,6 +507,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     if (_ownedTipSpeaker case final speaker?) {
       unawaited(speaker.dispose());
+    }
+    final reportSessionId = widget.reportStatusController?.practiceSessionId;
+    if (reportSessionId != null) {
+      widget.reportStatusController?.cancel(reportSessionId);
     }
     super.dispose();
   }
@@ -547,6 +567,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       setState(() => _part2RetryNeeded = true);
     }
     _recordCompletedParts();
+    _syncCompletionReport();
     unawaited(_resumePart2Narration(restored.phase));
     _scheduleQuestionNarration();
   }
@@ -758,6 +779,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       }
     }
     _recordCompletedParts();
+    _syncCompletionReport();
     setState(() {});
     if (shouldFollowConversation) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1145,6 +1167,19 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _syncTicker();
     await _progressStore.write(value);
     _scheduleQuestionNarration();
+    _syncCompletionReport();
+  }
+
+  void _syncCompletionReport() {
+    final reportController = widget.reportStatusController;
+    final sessionId = widget.controller.practiceSessionId;
+    if (_progress?.phase != IeltsMockPhase.complete ||
+        reportController == null ||
+        sessionId == null ||
+        reportController.practiceSessionId == sessionId) {
+      return;
+    }
+    unawaited(reportController.load(sessionId));
   }
 
   void _syncTicker() {
@@ -1772,8 +1807,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                             message:
                                 '${widget.controller.completedTurns} 道回答已保存',
                             primaryLabel: _mode == PracticeMode.fullMock
-                                ? '查看模考报告'
-                                : '查看本组复盘',
+                                ? '查看报告状态'
+                                : '查看专项复盘',
                             secondaryLabel: _mode == PracticeMode.fullMock
                                 ? '返回训练'
                                 : '返回题单',
@@ -1830,17 +1865,50 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _openCompletedReview() {
+    setState(() {
+      _showCompletionSheet = false;
+      _preserveCompletedConversation = false;
+    });
+  }
+
+  Future<void> _openReadyReport() async {
+    final statusController = widget.reportStatusController;
+    final sessionId = widget.controller.practiceSessionId;
+    if (statusController == null || sessionId == null) return;
+    final report = await statusController.loadReadyReport();
+    if (!mounted || report == null) return;
     if (_mode == PracticeMode.fullMock) {
-      setState(() {
-        _showCompletionSheet = false;
-        _preserveCompletedConversation = false;
-      });
+      try {
+        final detail = decodeIeltsSpeakingReportDetail(report.detail);
+        await Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => _CompletedReportPage(
+              title: evaluationReportTitle(report),
+              child: IeltsSpeakingReadyReportView(report: detail),
+            ),
+          ),
+        );
+      } on IeltsSpeakingReportDecodeException {
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(const SnackBar(content: Text('报告内容暂时无法识别，请稍后重试。')));
+        }
+      }
       return;
     }
-    setState(() => _showCompletionSheet = false);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _scrollToLatestMessage();
-    });
+    final item = ReviewHistoryItem(
+      review: presentEvaluationReport(report),
+      report: report,
+      practiceSessionId: report.practiceSessionId,
+      createdAt: report.createdAt,
+      completedAt: report.createdAt,
+    );
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => ReviewReportDetailPage(item: item),
+      ),
+    );
   }
 
   void _leaveCompletedPractice() {
@@ -2027,11 +2095,17 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                 totalQuestionCount: _assignment.turnBlueprints.length,
                 part1AnswerCount: _part1Total,
                 part3AnswerCount: _part3Total,
-                report: _completedReport(),
+                report: widget.reportStatusController == null
+                    ? _completedReport()
+                    : null,
+                reportStatusController: widget.reportStatusController,
+                onOpenReport: _openReadyReport,
                 onPressed: () => _requestExit(fromCompletion: true),
               )
             : _SectionPracticeComplete(
                 mode: _mode,
+                reportStatusController: widget.reportStatusController,
+                onOpenReport: _openReadyReport,
                 onNext: () =>
                     _finishSection(IeltsPracticeCompletionAction.next),
                 onRetry: () =>
@@ -2804,12 +2878,16 @@ class _SectionCompletionSheet extends StatelessWidget {
 class _SectionPracticeComplete extends StatelessWidget {
   const _SectionPracticeComplete({
     required this.mode,
+    required this.reportStatusController,
+    required this.onOpenReport,
     required this.onNext,
     required this.onRetry,
     required this.onList,
   });
 
   final PracticeMode mode;
+  final PracticeReportStatusController? reportStatusController;
+  final Future<void> Function() onOpenReport;
   final VoidCallback onNext;
   final VoidCallback onRetry;
   final VoidCallback onList;
@@ -2825,105 +2903,44 @@ class _SectionPracticeComplete extends StatelessWidget {
         'Non-IELTS mode in IELTS practice.',
       ),
     };
-    return _SectionActionLayout(
+    return SingleChildScrollView(
       key: Key('ielts-section-practice-complete-${mode.name}'),
-      title: '$part 已完成',
-      message: '本套练习已完成，进度已保存。',
-      primaryLabel: '下一套未练习',
-      onPrimary: onNext,
-      onNext: null,
-      onRetry: onRetry,
-      onList: onList,
-    );
-  }
-}
-
-class _SectionActionLayout extends StatelessWidget {
-  const _SectionActionLayout({
-    required this.title,
-    required this.message,
-    required this.primaryLabel,
-    required this.onPrimary,
-    required this.onNext,
-    required this.onRetry,
-    required this.onList,
-    super.key,
-  });
-
-  final String title;
-  final String message;
-  final String primaryLabel;
-  final VoidCallback onPrimary;
-  final VoidCallback? onNext;
-  final VoidCallback onRetry;
-  final VoidCallback onList;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(20),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 520),
-          child: Column(
-            children: [
-              ClipOval(
-                child: Image.asset(
-                  'assets/images/scenes/ielts-complete-orb.png',
-                  width: 80,
-                  height: 80,
-                  fit: BoxFit.cover,
-                  filterQuality: FilterQuality.high,
-                  semanticLabel: 'Section complete',
-                ),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _CompactCompletionHeader(
+              title: '$part 已完成',
+              message: '回答已保存，可离开本页等待复盘生成。',
+            ),
+            const SizedBox(height: 20),
+            PracticeReportStatusCard(
+              controller: reportStatusController,
+              onOpenReport: onOpenReport,
+            ),
+            const SizedBox(height: 20),
+            OutlinedButton(
+              key: const Key('ielts-section-next-action'),
+              onPressed: onNext,
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size.fromHeight(50),
               ),
-              const SizedBox(height: 24),
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                style: SpeakUpDesign.pageTitle.copyWith(fontSize: 26),
-              ),
-              const SizedBox(height: 10),
-              Text(
-                message,
-                textAlign: TextAlign.center,
-                style: SpeakUpDesign.body,
-              ),
-              const SizedBox(height: 30),
-              FilledButton(
-                key: const Key('ielts-section-primary-action'),
-                onPressed: onPrimary,
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(52),
-                  backgroundColor: SpeakUpDesign.ink,
-                  foregroundColor: Colors.white,
-                ),
-                child: Text(primaryLabel),
-              ),
-              if (onNext case final callback?) ...[
-                const SizedBox(height: 10),
-                OutlinedButton(
-                  key: const Key('ielts-section-next-action'),
-                  onPressed: callback,
-                  style: OutlinedButton.styleFrom(
-                    minimumSize: const Size.fromHeight(48),
-                  ),
-                  child: const Text('下一套未练习'),
-                ),
-              ],
-              const SizedBox(height: 10),
-              TextButton(
-                key: const Key('ielts-section-retry-action'),
-                onPressed: onRetry,
-                child: const Text('再练本套'),
-              ),
-              TextButton(
-                key: const Key('ielts-section-list-action'),
-                onPressed: onList,
-                child: const Text('返回套题列表'),
-              ),
-            ],
-          ),
+              child: const Text('下一套未练习'),
+            ),
+            const SizedBox(height: 6),
+            TextButton(
+              key: const Key('ielts-section-retry-action'),
+              onPressed: onRetry,
+              child: const Text('再练本套'),
+            ),
+            TextButton(
+              key: const Key('ielts-section-list-action'),
+              onPressed: onList,
+              child: const Text('返回套题列表'),
+            ),
+          ],
         ),
       ),
     );
@@ -3418,6 +3435,8 @@ class _MockComplete extends StatelessWidget {
     required this.part1AnswerCount,
     required this.part3AnswerCount,
     required this.onPressed,
+    required this.reportStatusController,
+    required this.onOpenReport,
     this.report,
   });
 
@@ -3426,6 +3445,8 @@ class _MockComplete extends StatelessWidget {
   final int part1AnswerCount;
   final int part3AnswerCount;
   final VoidCallback onPressed;
+  final PracticeReportStatusController? reportStatusController;
+  final Future<void> Function() onOpenReport;
   final Widget? report;
 
   @override
@@ -3436,33 +3457,23 @@ class _MockComplete extends StatelessWidget {
       key: const Key('ielts-mock-complete'),
       padding: const EdgeInsets.fromLTRB(20, 28, 20, 32),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Icon(
-            Icons.check_circle_rounded,
-            size: 88,
-            color: SpeakUpDesign.success,
+          _CompactCompletionHeader(
+            title: '模考已完成',
+            message: '$totalQuestionCount 道回答已保存，报告将在后台生成。',
           ),
-          const SizedBox(height: 22),
-          Text(
-            '模考已完成',
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.pageTitle.copyWith(fontSize: 28),
-          ),
-          const SizedBox(height: 10),
-          Text(
-            '$totalQuestionCount 道题已全部作答，正在整理你的口语报告。',
-            textAlign: TextAlign.center,
-            style: SpeakUpDesign.body,
+          const SizedBox(height: 20),
+          PracticeReportStatusCard(
+            controller: reportStatusController,
+            onOpenReport: onOpenReport,
           ),
           if (report case final reportPanel?) ...[
-            const SizedBox(height: 24),
+            const SizedBox(height: 20),
             reportPanel,
           ],
-          const SizedBox(height: 28),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text('本次模考', style: SpeakUpDesign.sectionTitle),
-          ),
+          const SizedBox(height: 24),
+          Text('本次模考', style: SpeakUpDesign.sectionTitle),
           const SizedBox(height: 12),
           Container(
             padding: const EdgeInsets.all(18),
@@ -3497,6 +3508,66 @@ class _MockComplete extends StatelessWidget {
             child: const Text('返回训练'),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _CompactCompletionHeader extends StatelessWidget {
+  const _CompactCompletionHeader({required this.title, required this.message});
+
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 42,
+          height: 42,
+          decoration: BoxDecoration(
+            color: SpeakUpDesign.success.withValues(alpha: 0.12),
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(Icons.check_rounded, color: SpeakUpDesign.success),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: SpeakUpDesign.pageTitle.copyWith(fontSize: 26),
+              ),
+              const SizedBox(height: 4),
+              Text(message, style: SpeakUpDesign.body),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CompletedReportPage extends StatelessWidget {
+  const _CompletedReportPage({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 40),
+          child: child,
+        ),
       ),
     );
   }

--- a/mobile/lib/features/coaching/review/evaluation_report_presentation.dart
+++ b/mobile/lib/features/coaching/review/evaluation_report_presentation.dart
@@ -43,7 +43,13 @@ ReviewSummary presentEvaluationReport(EvaluationReport report) {
 String evaluationReportTitle(EvaluationReport report) {
   final base = switch (report.sceneType) {
     EvaluationReportSceneType.interview => '面试复盘',
-    EvaluationReportSceneType.ieltsSpeaking => 'IELTS 口语复盘',
+    EvaluationReportSceneType.ieltsSpeaking => switch (report.practiceMode) {
+      'PART_1' => 'Part 1 专项复盘',
+      'PART_2' => 'Part 2 + Part 3 联合复盘',
+      'PART_3' => 'Part 3 专项复盘',
+      'FULL_MOCK' => 'IELTS 口语模考报告',
+      _ => 'IELTS 口语复盘',
+    },
     EvaluationReportSceneType.overseasDailyLife => '日常英语复盘',
     EvaluationReportSceneType.overseasWorkplace => '职场英语复盘',
   };

--- a/mobile/lib/features/coaching/review/ielts_practice_report.dart
+++ b/mobile/lib/features/coaching/review/ielts_practice_report.dart
@@ -1,0 +1,54 @@
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+
+final class IeltsPracticeReportDetail {
+  const IeltsPracticeReportDetail({
+    required this.reportScope,
+    required this.availableSections,
+    required this.questions,
+    required this.sectionReviews,
+  });
+
+  final PracticeReportScope reportScope;
+  final List<IeltsSpeakingPartId> availableSections;
+  final List<IeltsPracticeReportQuestion> questions;
+  final List<IeltsPracticeSectionReview> sectionReviews;
+}
+
+final class IeltsPracticeReportQuestion {
+  const IeltsPracticeReportQuestion({
+    required this.questionId,
+    required this.partId,
+    required this.index,
+    required this.questionText,
+    required this.evidenceRefIds,
+    this.confirmedTranscript,
+    this.responseTurnId,
+  });
+
+  final String questionId;
+  final IeltsSpeakingPartId partId;
+  final int index;
+  final String questionText;
+  final String? confirmedTranscript;
+  final String? responseTurnId;
+  final List<String> evidenceRefIds;
+}
+
+final class IeltsPracticeSectionReview {
+  const IeltsPracticeSectionReview({
+    required this.partId,
+    required this.questionIndexes,
+    required this.evidenceRefIds,
+    required this.strengthFindingIds,
+    required this.improvementFindingIds,
+    required this.upgradeExampleFindingIds,
+  });
+
+  final IeltsSpeakingPartId partId;
+  final List<int> questionIndexes;
+  final List<String> evidenceRefIds;
+  final List<String> strengthFindingIds;
+  final List<String> improvementFindingIds;
+  final List<String> upgradeExampleFindingIds;
+}

--- a/mobile/lib/features/coaching/review/ielts_practice_report_decoder.dart
+++ b/mobile/lib/features/coaching/review/ielts_practice_report_decoder.dart
@@ -1,0 +1,275 @@
+import 'dart:convert';
+
+import 'package:speakup/features/coaching/review/ielts_practice_report.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+
+final class IeltsPracticeReportDecodeException implements Exception {
+  const IeltsPracticeReportDecodeException();
+
+  @override
+  String toString() => 'IeltsPracticeReportDecodeException';
+}
+
+IeltsPracticeReportDetail decodeIeltsPracticeReportDetail(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{
+      'schema_version',
+      'report_scope',
+      'available_sections',
+      'questions',
+      'section_reviews',
+    },
+  );
+  if (root['schema_version'] != 'ielts-speaking-practice-report/v1') {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final scope = _scope(root['report_scope']);
+  if (scope == PracticeReportScope.fullMock) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final rawSections = root['available_sections'];
+  if (rawSections is! List<Object?> || rawSections.isEmpty) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final sections = rawSections.map(_part).toList(growable: false);
+  if (sections.toSet().length != sections.length ||
+      !_sameValues(sections, _expectedParts(scope))) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+
+  final rawQuestions = root['questions'];
+  if (rawQuestions is! List<Object?> ||
+      rawQuestions.isEmpty ||
+      rawQuestions.length > 64) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final questions = rawQuestions.map(_question).toList(growable: false);
+  final questionIds = <String>{};
+  final turnIds = <String>{};
+  final evidenceRefIds = <String>{};
+  for (var index = 0; index < questions.length; index++) {
+    final question = questions[index];
+    if (!sections.contains(question.partId) ||
+        !questionIds.add(question.questionId) ||
+        question.index != index + 1 ||
+        (question.responseTurnId != null &&
+            !turnIds.add(question.responseTurnId!)) ||
+        question.evidenceRefIds.any((refId) => !evidenceRefIds.add(refId))) {
+      throw const IeltsPracticeReportDecodeException();
+    }
+  }
+  if (!_hasCanonicalPartSequence(questions, sections)) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+
+  final rawReviews = root['section_reviews'];
+  if (rawReviews is! List<Object?> || rawReviews.length != sections.length) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final reviews = rawReviews.map(_sectionReview).toList(growable: false);
+  if (!_sameValues(
+    reviews.map((review) => review.partId).toList(growable: false),
+    sections,
+  )) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  for (final review in reviews) {
+    final partQuestions = questions
+        .where((question) => question.partId == review.partId)
+        .toList(growable: false);
+    if (!_sameValues(
+          review.questionIndexes,
+          partQuestions.map((question) => question.index).toList(),
+        ) ||
+        !_sameValues(review.evidenceRefIds, <String>[
+          for (final question in partQuestions) ...question.evidenceRefIds,
+        ])) {
+      throw const IeltsPracticeReportDecodeException();
+    }
+  }
+
+  return IeltsPracticeReportDetail(
+    reportScope: scope,
+    availableSections: List<IeltsSpeakingPartId>.unmodifiable(sections),
+    questions: List<IeltsPracticeReportQuestion>.unmodifiable(questions),
+    sectionReviews: List<IeltsPracticeSectionReview>.unmodifiable(reviews),
+  );
+}
+
+IeltsPracticeReportQuestion _question(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{
+      'question_id',
+      'part_id',
+      'index',
+      'question_text',
+      'evidence_ref_ids',
+    },
+    optional: const <String>{'confirmed_transcript', 'response_turn_id'},
+  );
+  final evidenceRefs = _identifiers(root['evidence_ref_ids'], maximum: 1);
+  final hasTranscript = root.containsKey('confirmed_transcript');
+  final hasTurn = root.containsKey('response_turn_id');
+  if (hasTranscript != hasTurn ||
+      (hasTurn && evidenceRefs.length != 1) ||
+      (!hasTurn && evidenceRefs.isNotEmpty)) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return IeltsPracticeReportQuestion(
+    questionId: _identifier(root['question_id']),
+    partId: _part(root['part_id']),
+    index: _positiveInt(root['index']),
+    questionText: _text(root['question_text'], maxBytes: 16384),
+    confirmedTranscript: hasTranscript
+        ? _text(root['confirmed_transcript'], maxBytes: 16384)
+        : null,
+    responseTurnId: hasTurn ? _identifier(root['response_turn_id']) : null,
+    evidenceRefIds: evidenceRefs,
+  );
+}
+
+IeltsPracticeSectionReview _sectionReview(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{
+      'part_id',
+      'question_indexes',
+      'evidence_ref_ids',
+      'strength_finding_ids',
+      'improvement_finding_ids',
+      'upgrade_example_finding_ids',
+    },
+  );
+  return IeltsPracticeSectionReview(
+    partId: _part(root['part_id']),
+    questionIndexes: _positiveInts(root['question_indexes']),
+    evidenceRefIds: _identifiers(root['evidence_ref_ids']),
+    strengthFindingIds: _identifiers(root['strength_finding_ids']),
+    improvementFindingIds: _identifiers(root['improvement_finding_ids']),
+    upgradeExampleFindingIds: _identifiers(root['upgrade_example_finding_ids']),
+  );
+}
+
+List<IeltsSpeakingPartId> _expectedParts(PracticeReportScope scope) =>
+    switch (scope) {
+      PracticeReportScope.part1 => const <IeltsSpeakingPartId>[
+        IeltsSpeakingPartId.part1,
+      ],
+      PracticeReportScope.part2And3 => const <IeltsSpeakingPartId>[
+        IeltsSpeakingPartId.part2,
+        IeltsSpeakingPartId.part3,
+      ],
+      PracticeReportScope.part3 => const <IeltsSpeakingPartId>[
+        IeltsSpeakingPartId.part3,
+      ],
+      PracticeReportScope.fullMock =>
+        throw const IeltsPracticeReportDecodeException(),
+    };
+
+PracticeReportScope _scope(Object? value) => switch (value) {
+  'PART_1' => PracticeReportScope.part1,
+  'PART_2_3' => PracticeReportScope.part2And3,
+  'PART_3' => PracticeReportScope.part3,
+  'FULL_MOCK' => PracticeReportScope.fullMock,
+  _ => throw const IeltsPracticeReportDecodeException(),
+};
+
+IeltsSpeakingPartId _part(Object? value) => switch (value) {
+  'PART_1' => IeltsSpeakingPartId.part1,
+  'PART_2' => IeltsSpeakingPartId.part2,
+  'PART_3' => IeltsSpeakingPartId.part3,
+  _ => throw const IeltsPracticeReportDecodeException(),
+};
+
+Map<String, Object?> _exactObject(
+  Object? value, {
+  required Set<String> required,
+  Set<String> optional = const <String>{},
+}) {
+  if (value is! Map<String, Object?>) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final allowed = <String>{...required, ...optional};
+  if (!value.keys.toSet().containsAll(required) ||
+      value.keys.any((key) => !allowed.contains(key))) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return value;
+}
+
+String _identifier(Object? value) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.length > 128 ||
+      !RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]*$').hasMatch(value)) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return value;
+}
+
+String _text(Object? value, {required int maxBytes}) {
+  if (value is! String ||
+      value.trim() != value ||
+      value.isEmpty ||
+      utf8.encode(value).length > maxBytes) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return value;
+}
+
+int _positiveInt(Object? value) {
+  if (value is! int || value < 1) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return value;
+}
+
+List<int> _positiveInts(Object? value) {
+  if (value is! List<Object?>) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final result = value.map(_positiveInt).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return result;
+}
+
+List<String> _identifiers(Object? value, {int maximum = 64}) {
+  if (value is! List<Object?> || value.length > maximum) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final result = value.map(_identifier).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return result;
+}
+
+bool _sameValues<T>(List<T> left, List<T> right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+bool _hasCanonicalPartSequence(
+  List<IeltsPracticeReportQuestion> questions,
+  List<IeltsSpeakingPartId> sections,
+) {
+  if (questions.first.partId != sections.first) return false;
+  var sectionIndex = 0;
+  for (final question in questions.skip(1)) {
+    if (question.partId == sections[sectionIndex]) continue;
+    sectionIndex++;
+    if (sectionIndex >= sections.length ||
+        question.partId != sections[sectionIndex]) {
+      return false;
+    }
+  }
+  return sectionIndex == sections.length - 1;
+}

--- a/mobile/lib/features/coaching/review/ielts_speaking_report_decoder.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_decoder.dart
@@ -81,6 +81,14 @@ IeltsSpeakingReportEnvelope decodeIeltsSpeakingReport(Object? value) {
   );
 }
 
+IeltsSpeakingReport decodeIeltsSpeakingReportDetail(Object? value) {
+  try {
+    return _report(value);
+  } on FormatException {
+    throw const IeltsSpeakingReportDecodeException();
+  }
+}
+
 IeltsSpeakingReport _report(Object? value) {
   final root = _exactObject(
     value,

--- a/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
@@ -75,6 +75,70 @@ class IeltsSpeakingReportPanel extends StatefulWidget {
       _IeltsSpeakingReportPanelState();
 }
 
+class IeltsSpeakingReadyReportView extends StatefulWidget {
+  const IeltsSpeakingReadyReportView({
+    required this.report,
+    this.onRepracticeQuestion,
+    super.key,
+  });
+
+  final IeltsSpeakingReport report;
+  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
+  onRepracticeQuestion;
+
+  @override
+  State<IeltsSpeakingReadyReportView> createState() =>
+      _IeltsSpeakingReadyReportViewState();
+}
+
+class _IeltsSpeakingReadyReportViewState
+    extends State<IeltsSpeakingReadyReportView> {
+  var _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    const parts = <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part1,
+      IeltsSpeakingPartId.part2,
+      IeltsSpeakingPartId.part3,
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            key: const Key('ielts-speaking-report-scope-tabs'),
+            children: [
+              for (var index = 0; index < 4; index++) ...[
+                if (index > 0) const SizedBox(width: 8),
+                ChoiceChip(
+                  key: Key('ielts-speaking-report-scope-$index'),
+                  label: Text(index == 0 ? '总览' : _partLabel(parts[index - 1])),
+                  selected: _selectedIndex == index,
+                  onSelected: (_) => setState(() => _selectedIndex = index),
+                ),
+              ],
+            ],
+          ),
+        ),
+        const SizedBox(height: SpeakUpDesign.space16),
+        if (_selectedIndex == 0)
+          _ReadyReport(
+            report: widget.report,
+            onRepracticeQuestion: widget.onRepracticeQuestion,
+          )
+        else
+          _IeltsPartReport(
+            report: widget.report,
+            partId: parts[_selectedIndex - 1],
+            onRepracticeQuestion: widget.onRepracticeQuestion,
+          ),
+      ],
+    );
+  }
+}
+
 class _IeltsSpeakingReportPanelState extends State<IeltsSpeakingReportPanel> {
   @override
   void initState() {
@@ -119,7 +183,7 @@ class _IeltsSpeakingReportPanelState extends State<IeltsSpeakingReportPanel> {
     return switch (envelope.evaluationStatus) {
       IeltsSpeakingReportEvaluationStatus.queued ||
       IeltsSpeakingReportEvaluationStatus.running => const _GeneratingReport(),
-      IeltsSpeakingReportEvaluationStatus.ready => _ReadyReport(
+      IeltsSpeakingReportEvaluationStatus.ready => IeltsSpeakingReadyReportView(
         report: envelope.report!,
         onRepracticeQuestion: widget.onRepracticeQuestion,
       ),
@@ -979,6 +1043,102 @@ class _CriterionFeedback extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _IeltsPartReport extends StatelessWidget {
+  const _IeltsPartReport({
+    required this.report,
+    required this.partId,
+    this.onRepracticeQuestion,
+  });
+
+  final IeltsSpeakingReport report;
+  final IeltsSpeakingPartId partId;
+  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
+  onRepracticeQuestion;
+
+  @override
+  Widget build(BuildContext context) {
+    final part = report.partReviews.firstWhere((item) => item.id == partId);
+    final questions = report.questions
+        .where((question) => question.partId == partId)
+        .toList(growable: false);
+    final findings = <({String label, String id})>[
+      for (final id in part.strengthFindingIds) (label: '做得好', id: id),
+      for (final id in part.improvementFindingIds) (label: '可改进', id: id),
+      for (final id in part.upgradeExampleFindingIds) (label: '提升表达', id: id),
+    ];
+    return Column(
+      key: Key('ielts-speaking-report-${partId.name}'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(SpeakUpDesign.space20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      '${_partLabel(partId)} 复盘',
+                      style: SpeakUpDesign.sectionTitle,
+                    ),
+                    const Spacer(),
+                    Text('${questions.length} 题', style: SpeakUpDesign.meta),
+                  ],
+                ),
+                if (findings.isEmpty) ...[
+                  const SizedBox(height: SpeakUpDesign.space12),
+                  Text('本部分暂无可用的分段反馈。', style: SpeakUpDesign.meta),
+                ],
+                for (final item in findings) ...[
+                  const SizedBox(height: SpeakUpDesign.space16),
+                  Text(item.label, style: SpeakUpDesign.label),
+                  const SizedBox(height: SpeakUpDesign.space4),
+                  Text(
+                    report.finding(item.id)!.message,
+                    style: SpeakUpDesign.body,
+                  ),
+                  if (report.finding(item.id)!.suggestion
+                      case final suggestion?) ...[
+                    const SizedBox(height: SpeakUpDesign.space4),
+                    Text('建议：$suggestion', style: SpeakUpDesign.meta),
+                  ],
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: SpeakUpDesign.space12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(SpeakUpDesign.space20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('本段题目', style: SpeakUpDesign.cardTitle),
+                const SizedBox(height: SpeakUpDesign.space12),
+                for (var index = 0; index < questions.length; index++) ...[
+                  if (index > 0) ...[
+                    const SizedBox(height: SpeakUpDesign.space12),
+                    const Divider(height: 1),
+                    const SizedBox(height: SpeakUpDesign.space12),
+                  ],
+                  _RepracticeQuestion(
+                    question: questions[index],
+                    onPressed: onRepracticeQuestion == null
+                        ? null
+                        : () => onRepracticeQuestion!(questions[index]),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/coaching/review/practice_report_status.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status.dart
@@ -1,0 +1,58 @@
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+
+enum PracticeReportScope { part1, part2And3, part3, fullMock }
+
+enum PracticeReportEvaluationStatus { queued, running, ready, failed }
+
+final class PracticeReportRef {
+  const PracticeReportRef({required this.reportId, required this.href});
+
+  final String reportId;
+  final String href;
+}
+
+final class PracticeReportStableFailure {
+  const PracticeReportStableFailure({
+    required this.reasonCode,
+    required this.retryable,
+  });
+
+  final String reasonCode;
+  final bool retryable;
+}
+
+final class PracticeReportStatus {
+  const PracticeReportStatus({
+    required this.practiceSessionId,
+    required this.practiceMode,
+    required this.reportScope,
+    required this.availableSections,
+    required this.detailSchema,
+    required this.evaluationStatus,
+    required this.statusUrl,
+    this.evaluationId,
+    this.evaluationRevisionId,
+    this.revision,
+    this.reportRef,
+    this.scoreability,
+    this.summary,
+    this.stableFailure,
+  });
+
+  final String practiceSessionId;
+  final PracticeMode practiceMode;
+  final PracticeReportScope reportScope;
+  final List<IeltsSpeakingPartId> availableSections;
+  final String detailSchema;
+  final PracticeReportEvaluationStatus evaluationStatus;
+  final String statusUrl;
+  final String? evaluationId;
+  final String? evaluationRevisionId;
+  final int? revision;
+  final PracticeReportRef? reportRef;
+  final EvaluationReportScoreability? scoreability;
+  final String? summary;
+  final PracticeReportStableFailure? stableFailure;
+}

--- a/mobile/lib/features/coaching/review/practice_report_status_client.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_client.dart
@@ -1,0 +1,40 @@
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+
+enum PracticeReportStatusFailureKind {
+  authenticationRequired,
+  invalidRequest,
+  notFound,
+  conflict,
+  network,
+  server,
+  invalidResponse,
+  superseded,
+}
+
+final class PracticeReportStatusException implements Exception {
+  const PracticeReportStatusException({
+    required this.kind,
+    this.statusCode,
+    this.retryable = false,
+  });
+
+  final PracticeReportStatusFailureKind kind;
+  final int? statusCode;
+  final bool retryable;
+
+  @override
+  String toString() => 'PracticeReportStatusException(kind: ${kind.name})';
+}
+
+abstract interface class PracticeReportStatusClient {
+  Future<PracticeReportStatus> getStatus(String practiceSessionId);
+
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef);
+
+  Future<void> clearAccountState();
+}
+
+abstract interface class PracticeReportRegenerationClient {
+  Future<void> regenerateReport(PracticeReportStatus status);
+}

--- a/mobile/lib/features/coaching/review/practice_report_status_controller.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_controller.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_client.dart';
+
+final class PracticeReportStatusController extends ChangeNotifier {
+  PracticeReportStatusController({
+    required this.client,
+    this.pollInterval = const Duration(seconds: 2),
+    this.maximumPollAttempts = 30,
+  }) {
+    if (pollInterval < Duration.zero) {
+      throw ArgumentError.value(pollInterval, 'pollInterval');
+    }
+    if (maximumPollAttempts < 1) {
+      throw ArgumentError.value(maximumPollAttempts, 'maximumPollAttempts');
+    }
+  }
+
+  final PracticeReportStatusClient client;
+  final Duration pollInterval;
+  final int maximumPollAttempts;
+
+  String? _practiceSessionId;
+  PracticeReportStatus? _status;
+  EvaluationReport? _readyReport;
+  String? _errorMessage;
+  bool _loading = false;
+  bool _regenerating = false;
+  bool _loadingReadyReport = false;
+  bool _retryAllowed = false;
+  bool _disposed = false;
+  int _generation = 0;
+
+  String? get practiceSessionId => _practiceSessionId;
+  PracticeReportStatus? get status => _status;
+  EvaluationReport? get readyReport => _readyReport;
+  String? get errorMessage => _errorMessage;
+  bool get isLoading => _loading;
+  bool get isRegenerating => _regenerating;
+  bool get isLoadingReadyReport => _loadingReadyReport;
+  bool get canRetry => !_loading && _errorMessage != null && _retryAllowed;
+  bool get canRegenerate {
+    final currentStatus = _status;
+    return !_loading &&
+        !_regenerating &&
+        currentStatus?.evaluationStatus ==
+            PracticeReportEvaluationStatus.failed &&
+        currentStatus?.stableFailure?.retryable == true &&
+        currentStatus?.evaluationId != null &&
+        currentStatus?.reportScope == PracticeReportScope.fullMock &&
+        client is PracticeReportRegenerationClient;
+  }
+
+  Future<void> load(String practiceSessionId) async {
+    if (_disposed || practiceSessionId.isEmpty) return;
+    final generation = ++_generation;
+    _practiceSessionId = practiceSessionId;
+    _status = null;
+    _readyReport = null;
+    _errorMessage = null;
+    _loading = true;
+    _regenerating = false;
+    _loadingReadyReport = false;
+    _retryAllowed = false;
+    notifyListeners();
+
+    for (var attempt = 0; attempt < maximumPollAttempts; attempt++) {
+      try {
+        final status = await client.getStatus(practiceSessionId);
+        if (!_isCurrent(generation, practiceSessionId)) return;
+        _status = status;
+        _errorMessage = null;
+        final pending =
+            status.evaluationStatus == PracticeReportEvaluationStatus.queued ||
+            status.evaluationStatus == PracticeReportEvaluationStatus.running;
+        if (!pending) {
+          _loading = false;
+          notifyListeners();
+          return;
+        }
+        notifyListeners();
+        if (attempt + 1 < maximumPollAttempts) {
+          await Future<void>.delayed(pollInterval);
+          if (!_isCurrent(generation, practiceSessionId)) return;
+        }
+      } on PracticeReportStatusException catch (error) {
+        if (!_isCurrent(generation, practiceSessionId)) return;
+        if (error.kind == PracticeReportStatusFailureKind.superseded) return;
+        if (error.retryable && attempt + 1 < maximumPollAttempts) {
+          await Future<void>.delayed(pollInterval);
+          if (!_isCurrent(generation, practiceSessionId)) return;
+          continue;
+        }
+        _loading = false;
+        _retryAllowed = error.retryable;
+        _errorMessage = _messageFor(error);
+        notifyListeners();
+        return;
+      } on Object {
+        if (!_isCurrent(generation, practiceSessionId)) return;
+        _loading = false;
+        _retryAllowed = true;
+        _errorMessage = '复盘状态暂时无法加载，请稍后重试。';
+        notifyListeners();
+        return;
+      }
+    }
+    if (_isCurrent(generation, practiceSessionId)) {
+      _loading = false;
+      _retryAllowed = true;
+      _errorMessage = '报告仍在后台生成，可稍后到复盘页查看。';
+      notifyListeners();
+    }
+  }
+
+  Future<void> retry() {
+    final sessionId = _practiceSessionId;
+    if (sessionId == null) return Future<void>.value();
+    return load(sessionId);
+  }
+
+  Future<void> regenerate() async {
+    final sessionId = _practiceSessionId;
+    final currentStatus = _status;
+    if (!canRegenerate ||
+        sessionId == null ||
+        currentStatus == null ||
+        client is! PracticeReportRegenerationClient) {
+      return;
+    }
+    final regenerationClient = client as PracticeReportRegenerationClient;
+    final generation = _generation;
+    _regenerating = true;
+    _errorMessage = null;
+    _retryAllowed = false;
+    notifyListeners();
+    try {
+      await regenerationClient.regenerateReport(currentStatus);
+      if (!_isCurrent(generation, sessionId)) return;
+      _regenerating = false;
+      await load(sessionId);
+    } on PracticeReportStatusException catch (error) {
+      if (!_isCurrent(generation, sessionId) ||
+          error.kind == PracticeReportStatusFailureKind.superseded) {
+        return;
+      }
+      _regenerating = false;
+      _retryAllowed = error.retryable;
+      _errorMessage = _regenerationMessageFor(error);
+      notifyListeners();
+    } on Object {
+      if (!_isCurrent(generation, sessionId)) return;
+      _regenerating = false;
+      _retryAllowed = true;
+      _errorMessage = '报告暂时无法重新生成，请稍后重试。';
+      notifyListeners();
+    }
+  }
+
+  Future<EvaluationReport?> loadReadyReport() async {
+    final sessionId = _practiceSessionId;
+    final currentStatus = _status;
+    final reportRef = currentStatus?.reportRef;
+    if (_disposed ||
+        sessionId == null ||
+        currentStatus == null ||
+        currentStatus.evaluationStatus !=
+            PracticeReportEvaluationStatus.ready ||
+        reportRef == null) {
+      return null;
+    }
+    final cached = _readyReport;
+    if (cached != null) return cached;
+    final generation = _generation;
+    _loadingReadyReport = true;
+    _errorMessage = null;
+    _retryAllowed = false;
+    notifyListeners();
+    try {
+      final report = await client.getReadyReport(reportRef);
+      if (!_isCurrent(generation, sessionId)) return null;
+      if (report.practiceSessionId != sessionId ||
+          report.evaluationId != currentStatus.evaluationId ||
+          report.evaluationRevisionId != currentStatus.evaluationRevisionId ||
+          report.revision != currentStatus.revision ||
+          report.practiceMode != currentStatus.practiceMode.wireValue ||
+          report.scoreability != currentStatus.scoreability ||
+          report.detailSchema != currentStatus.detailSchema) {
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.invalidResponse,
+        );
+      }
+      _readyReport = report;
+      return report;
+    } on PracticeReportStatusException catch (error) {
+      if (_isCurrent(generation, sessionId) &&
+          error.kind != PracticeReportStatusFailureKind.superseded) {
+        _retryAllowed = error.retryable;
+        _errorMessage = _readyReportMessageFor(error);
+      }
+      return null;
+    } on Object {
+      if (_isCurrent(generation, sessionId)) {
+        _retryAllowed = true;
+        _errorMessage = '报告暂时无法加载，请稍后重试。';
+      }
+      return null;
+    } finally {
+      if (_isCurrent(generation, sessionId)) {
+        _loadingReadyReport = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  void cancel(String practiceSessionId) {
+    if (_practiceSessionId != practiceSessionId) return;
+    _generation++;
+    _practiceSessionId = null;
+    _status = null;
+    _readyReport = null;
+    _errorMessage = null;
+    _loading = false;
+    _regenerating = false;
+    _loadingReadyReport = false;
+    _retryAllowed = false;
+    notifyListeners();
+  }
+
+  Future<void> clearPrivateState() async {
+    _generation++;
+    _practiceSessionId = null;
+    _status = null;
+    _readyReport = null;
+    _errorMessage = null;
+    _loading = false;
+    _regenerating = false;
+    _loadingReadyReport = false;
+    _retryAllowed = false;
+    await client.clearAccountState();
+    if (!_disposed) notifyListeners();
+  }
+
+  bool _isCurrent(int generation, String practiceSessionId) =>
+      !_disposed &&
+      generation == _generation &&
+      _practiceSessionId == practiceSessionId;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _generation++;
+    super.dispose();
+  }
+}
+
+String _messageFor(PracticeReportStatusException error) => switch (error.kind) {
+  PracticeReportStatusFailureKind.authenticationRequired => '登录状态已失效，请重新登录。',
+  PracticeReportStatusFailureKind.invalidRequest ||
+  PracticeReportStatusFailureKind.invalidResponse => '复盘状态响应无法识别，请稍后重试。',
+  PracticeReportStatusFailureKind.notFound => '复盘任务尚未就绪，请稍后重试。',
+  PracticeReportStatusFailureKind.conflict => '报告正在处理中，请稍后刷新状态。',
+  PracticeReportStatusFailureKind.network ||
+  PracticeReportStatusFailureKind.server => '复盘状态暂时无法加载，请稍后重试。',
+  PracticeReportStatusFailureKind.superseded => '',
+};
+
+String _readyReportMessageFor(PracticeReportStatusException error) =>
+    switch (error.kind) {
+      PracticeReportStatusFailureKind.authenticationRequired =>
+        '登录状态已失效，请重新登录。',
+      PracticeReportStatusFailureKind.invalidRequest ||
+      PracticeReportStatusFailureKind.invalidResponse => '报告内容暂时无法识别，请稍后重试。',
+      PracticeReportStatusFailureKind.notFound => '报告文件尚未就绪，请稍后重试。',
+      PracticeReportStatusFailureKind.conflict => '报告正在处理中，请稍后重试。',
+      PracticeReportStatusFailureKind.network ||
+      PracticeReportStatusFailureKind.server => '报告暂时无法加载，请稍后重试。',
+      PracticeReportStatusFailureKind.superseded => '',
+    };
+
+String _regenerationMessageFor(PracticeReportStatusException error) =>
+    switch (error.kind) {
+      PracticeReportStatusFailureKind.authenticationRequired =>
+        '登录状态已失效，请重新登录。',
+      PracticeReportStatusFailureKind.invalidRequest => '当前报告无法重新生成，请返回训练后重试。',
+      PracticeReportStatusFailureKind.notFound => '原报告已不存在，无法重新生成。',
+      PracticeReportStatusFailureKind.conflict => '报告正在处理中，请稍后刷新状态。',
+      PracticeReportStatusFailureKind.network ||
+      PracticeReportStatusFailureKind.server => '重新生成请求未完成，请检查网络后重试。',
+      PracticeReportStatusFailureKind.invalidResponse => '重新生成响应无法识别，请稍后重试。',
+      PracticeReportStatusFailureKind.superseded => '',
+    };

--- a/mobile/lib/features/coaching/review/practice_report_status_decoder.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_decoder.dart
@@ -1,0 +1,289 @@
+import 'dart:convert';
+
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+
+final class PracticeReportStatusDecodeException implements Exception {
+  const PracticeReportStatusDecodeException();
+
+  @override
+  String toString() => 'PracticeReportStatusDecodeException';
+}
+
+PracticeReportStatus decodePracticeReportStatusJson(String body) {
+  try {
+    return decodePracticeReportStatus(jsonDecode(body));
+  } on FormatException {
+    throw const PracticeReportStatusDecodeException();
+  }
+}
+
+PracticeReportStatus decodePracticeReportStatus(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{
+      'practice_session_id',
+      'practice_mode',
+      'report_scope',
+      'available_sections',
+      'detail_schema',
+      'evaluation_status',
+      'status_url',
+    },
+    optional: const <String>{
+      'evaluation_id',
+      'evaluation_revision_id',
+      'revision',
+      'report_ref',
+      'scoreability_status',
+      'summary',
+      'stable_failure',
+    },
+  );
+  final sessionId = _identifier(root['practice_session_id']);
+  final modeValue = root['practice_mode'];
+  final mode = modeValue is String
+      ? PracticeMode.fromWireValue(modeValue)
+      : null;
+  if (mode != PracticeMode.part1 &&
+      mode != PracticeMode.part2 &&
+      mode != PracticeMode.part3 &&
+      mode != PracticeMode.fullMock) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final scope = _scope(root['report_scope']);
+  final expectedScope = switch (mode!) {
+    PracticeMode.part1 => PracticeReportScope.part1,
+    PracticeMode.part2 => PracticeReportScope.part2And3,
+    PracticeMode.part3 => PracticeReportScope.part3,
+    PracticeMode.fullMock => PracticeReportScope.fullMock,
+    _ => throw const PracticeReportStatusDecodeException(),
+  };
+  if (scope != expectedScope) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final rawSections = root['available_sections'];
+  if (rawSections is! List<Object?> || rawSections.length > 4) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final sections = rawSections.map(_part).toList(growable: false);
+  if (sections.toSet().length != sections.length ||
+      !_sameParts(sections, _expectedParts(mode))) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final detailSchema = _text(root['detail_schema'], maxBytes: 128);
+  final status = _status(root['evaluation_status']);
+  final validDetailSchema = mode == PracticeMode.fullMock
+      ? detailSchema == 'ielts-speaking-report/v1'
+      : detailSchema == 'ielts-speaking-practice-report/v1' ||
+            status == PracticeReportEvaluationStatus.ready &&
+                detailSchema == 'general-scene-evaluation/v1';
+  if (!validDetailSchema) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final statusUrl = root['status_url'];
+  if (statusUrl != '/v1/practice-sessions/$sessionId/report') {
+    throw const PracticeReportStatusDecodeException();
+  }
+
+  final hasEvaluationId = root.containsKey('evaluation_id');
+  final hasEvaluationRevisionId = root.containsKey('evaluation_revision_id');
+  final hasRevision = root.containsKey('revision');
+  if (hasEvaluationId != hasEvaluationRevisionId ||
+      hasEvaluationId != hasRevision) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final evaluationId = hasEvaluationId ? _uuid(root['evaluation_id']) : null;
+  final evaluationRevisionId = hasEvaluationId
+      ? _uuid(root['evaluation_revision_id'])
+      : null;
+  final revision = hasEvaluationId ? _positiveInt(root['revision']) : null;
+  if ((status == PracticeReportEvaluationStatus.running ||
+          status == PracticeReportEvaluationStatus.ready) &&
+      evaluationId == null) {
+    throw const PracticeReportStatusDecodeException();
+  }
+
+  final hasReportRef = root.containsKey('report_ref');
+  final hasScoreability = root.containsKey('scoreability_status');
+  final hasSummary = root.containsKey('summary');
+  final hasFailure = root.containsKey('stable_failure');
+  PracticeReportRef? reportRef;
+  EvaluationReportScoreability? scoreability;
+  String? summary;
+  PracticeReportStableFailure? failure;
+  switch (status) {
+    case PracticeReportEvaluationStatus.queued:
+    case PracticeReportEvaluationStatus.running:
+      if (hasReportRef || hasScoreability || hasSummary || hasFailure) {
+        throw const PracticeReportStatusDecodeException();
+      }
+    case PracticeReportEvaluationStatus.ready:
+      if (!hasReportRef || !hasScoreability || !hasSummary || hasFailure) {
+        throw const PracticeReportStatusDecodeException();
+      }
+      reportRef = _reportRef(root['report_ref']);
+      scoreability = switch (root['scoreability_status']) {
+        'PROVISIONAL' => EvaluationReportScoreability.provisional,
+        'INSUFFICIENT' => EvaluationReportScoreability.insufficient,
+        _ => throw const PracticeReportStatusDecodeException(),
+      };
+      summary = _text(root['summary'], maxBytes: 4096);
+    case PracticeReportEvaluationStatus.failed:
+      if (hasReportRef || hasScoreability || hasSummary || !hasFailure) {
+        throw const PracticeReportStatusDecodeException();
+      }
+      failure = _stableFailure(root['stable_failure']);
+  }
+
+  return PracticeReportStatus(
+    practiceSessionId: sessionId,
+    practiceMode: mode,
+    reportScope: scope,
+    availableSections: List<IeltsSpeakingPartId>.unmodifiable(sections),
+    detailSchema: detailSchema,
+    evaluationStatus: status,
+    statusUrl: statusUrl as String,
+    evaluationId: evaluationId,
+    evaluationRevisionId: evaluationRevisionId,
+    revision: revision,
+    reportRef: reportRef,
+    scoreability: scoreability,
+    summary: summary,
+    stableFailure: failure,
+  );
+}
+
+PracticeReportRef _reportRef(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{'report_id', 'href'},
+  );
+  final reportId = _uuid(root['report_id']);
+  if (root['href'] != '/v1/evaluation-reports/$reportId') {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return PracticeReportRef(reportId: reportId, href: root['href']! as String);
+}
+
+PracticeReportStableFailure _stableFailure(Object? value) {
+  final root = _exactObject(
+    value,
+    required: const <String>{'reason_code', 'retryable'},
+  );
+  final reasonCode = root['reason_code'];
+  final retryable = root['retryable'];
+  if (reasonCode is! String ||
+      !RegExp(r'^[A-Z][A-Z0-9_]{0,63}$').hasMatch(reasonCode) ||
+      retryable is! bool) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return PracticeReportStableFailure(
+    reasonCode: reasonCode,
+    retryable: retryable,
+  );
+}
+
+PracticeReportScope _scope(Object? value) => switch (value) {
+  'PART_1' => PracticeReportScope.part1,
+  'PART_2_3' => PracticeReportScope.part2And3,
+  'PART_3' => PracticeReportScope.part3,
+  'FULL_MOCK' => PracticeReportScope.fullMock,
+  _ => throw const PracticeReportStatusDecodeException(),
+};
+
+IeltsSpeakingPartId _part(Object? value) => switch (value) {
+  'PART_1' => IeltsSpeakingPartId.part1,
+  'PART_2' => IeltsSpeakingPartId.part2,
+  'PART_3' => IeltsSpeakingPartId.part3,
+  _ => throw const PracticeReportStatusDecodeException(),
+};
+
+List<IeltsSpeakingPartId> _expectedParts(PracticeMode mode) => switch (mode) {
+  PracticeMode.part1 => const <IeltsSpeakingPartId>[IeltsSpeakingPartId.part1],
+  PracticeMode.part2 => const <IeltsSpeakingPartId>[
+    IeltsSpeakingPartId.part2,
+    IeltsSpeakingPartId.part3,
+  ],
+  PracticeMode.part3 => const <IeltsSpeakingPartId>[IeltsSpeakingPartId.part3],
+  PracticeMode.fullMock => const <IeltsSpeakingPartId>[
+    IeltsSpeakingPartId.part1,
+    IeltsSpeakingPartId.part2,
+    IeltsSpeakingPartId.part3,
+  ],
+  _ => throw const PracticeReportStatusDecodeException(),
+};
+
+bool _sameParts(
+  List<IeltsSpeakingPartId> left,
+  List<IeltsSpeakingPartId> right,
+) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+PracticeReportEvaluationStatus _status(Object? value) => switch (value) {
+  'QUEUED' => PracticeReportEvaluationStatus.queued,
+  'RUNNING' => PracticeReportEvaluationStatus.running,
+  'READY' => PracticeReportEvaluationStatus.ready,
+  'FAILED' => PracticeReportEvaluationStatus.failed,
+  _ => throw const PracticeReportStatusDecodeException(),
+};
+
+Map<String, Object?> _exactObject(
+  Object? value, {
+  required Set<String> required,
+  Set<String> optional = const <String>{},
+}) {
+  if (value is! Map<String, Object?>) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  final allowed = <String>{...required, ...optional};
+  if (!value.keys.toSet().containsAll(required) ||
+      value.keys.any((key) => !allowed.contains(key))) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return value;
+}
+
+String _identifier(Object? value) {
+  if (value is! String ||
+      value.isEmpty ||
+      value.length > 128 ||
+      !RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]*$').hasMatch(value)) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return value;
+}
+
+String _uuid(Object? value) {
+  if (value is! String ||
+      !RegExp(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+      ).hasMatch(value)) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return value;
+}
+
+int _positiveInt(Object? value) {
+  if (value is! int || value < 1) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return value;
+}
+
+String _text(Object? value, {required int maxBytes}) {
+  if (value is! String ||
+      value.trim() != value ||
+      value.isEmpty ||
+      utf8.encode(value).length > maxBytes) {
+    throw const PracticeReportStatusDecodeException();
+  }
+  return value;
+}

--- a/mobile/lib/features/coaching/review/practice_report_status_view.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_view.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
+
+class PracticeReportStatusCard extends StatelessWidget {
+  const PracticeReportStatusCard({
+    required this.controller,
+    required this.onOpenReport,
+    super.key,
+  });
+
+  final PracticeReportStatusController? controller;
+  final Future<void> Function() onOpenReport;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = controller;
+    if (value == null) {
+      return const _ReportStatusSurface(
+        key: Key('ielts-completion-report-unavailable'),
+        icon: Icons.info_outline_rounded,
+        title: '复盘状态暂不可用',
+        message: '回答已保存，可稍后到复盘页查看。',
+      );
+    }
+    return AnimatedBuilder(
+      animation: value,
+      builder: (context, _) => _buildStatus(value),
+    );
+  }
+
+  Widget _buildStatus(PracticeReportStatusController value) {
+    final status = value.status;
+    if (status == null) {
+      if (value.errorMessage case final message?) {
+        return _ReportStatusSurface(
+          key: const Key('ielts-completion-report-load-failed'),
+          icon: Icons.error_outline_rounded,
+          title: '暂时无法读取复盘状态',
+          message: message,
+          action: value.canRetry
+              ? TextButton(
+                  key: const Key('ielts-completion-report-retry'),
+                  onPressed: () => unawaited(value.retry()),
+                  child: const Text('重试'),
+                )
+              : null,
+        );
+      }
+      return const _ReportStatusSurface(
+        key: Key('ielts-completion-report-loading'),
+        icon: Icons.sync_rounded,
+        title: '正在读取复盘状态',
+        message: '你可以直接返回训练，不会影响后台处理。',
+      );
+    }
+    return switch (status.evaluationStatus) {
+      PracticeReportEvaluationStatus.queued ||
+      PracticeReportEvaluationStatus.running => _ReportStatusSurface(
+        key: const Key('ielts-completion-report-generating'),
+        icon: Icons.schedule_rounded,
+        title: status.evaluationStatus == PracticeReportEvaluationStatus.queued
+            ? '报告已进入队列'
+            : '报告生成中',
+        message: value.errorMessage ?? '可先返回训练，完成后可在复盘页查看。',
+        action: value.errorMessage == null
+            ? null
+            : TextButton(
+                key: const Key('ielts-completion-report-retry'),
+                onPressed: value.canRetry
+                    ? () => unawaited(value.retry())
+                    : null,
+                child: const Text('刷新状态'),
+              ),
+      ),
+      PracticeReportEvaluationStatus.ready => _ReportStatusSurface(
+        key: const Key('ielts-completion-report-ready'),
+        icon: Icons.description_outlined,
+        title: status.scoreability == EvaluationReportScoreability.insufficient
+            ? '复盘已生成 · 证据不足'
+            : '复盘已生成',
+        message: value.errorMessage ?? status.summary!,
+        action: FilledButton(
+          key: const Key('ielts-completion-report-open'),
+          onPressed: value.isLoadingReadyReport
+              ? null
+              : () => unawaited(onOpenReport()),
+          child: Text(
+            value.isLoadingReadyReport
+                ? '正在打开…'
+                : value.errorMessage == null
+                ? '查看复盘'
+                : '重试打开',
+          ),
+        ),
+      ),
+      PracticeReportEvaluationStatus.failed => _ReportStatusSurface(
+        key: const Key('ielts-completion-report-failed'),
+        icon: Icons.error_outline_rounded,
+        title: '报告生成失败',
+        message:
+            value.errorMessage ??
+            _failureMessage(
+              status.stableFailure!.reasonCode,
+              canRegenerate: value.canRegenerate || value.isRegenerating,
+            ),
+        action: value.canRegenerate || value.isRegenerating
+            ? TextButton(
+                key: const Key('ielts-completion-report-retry'),
+                onPressed: value.isRegenerating
+                    ? null
+                    : () => unawaited(value.regenerate()),
+                child: Text(value.isRegenerating ? '正在重试…' : '重试生成'),
+              )
+            : null,
+      ),
+    };
+  }
+}
+
+String _failureMessage(String reasonCode, {required bool canRegenerate}) {
+  if (!canRegenerate) {
+    return '本次报告未能生成，回答已保存，可返回题单再练或稍后查看。';
+  }
+  return switch (reasonCode.toLowerCase()) {
+    'provider_timeout' || 'evaluation_timeout' => '报告生成超时，可以重新生成。',
+    _ => '系统暂时无法完成本次报告，可以重新生成。',
+  };
+}
+
+class _ReportStatusSurface extends StatelessWidget {
+  const _ReportStatusSurface({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.action,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.canvas,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: SpeakUpDesign.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 22, color: SpeakUpDesign.ink),
+              const SizedBox(width: 10),
+              Expanded(child: Text(title, style: SpeakUpDesign.cardTitle)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(message, style: SpeakUpDesign.body),
+          if (action case final actionWidget?) ...[
+            const SizedBox(height: 12),
+            SizedBox(width: double.infinity, child: actionWidget),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -8,11 +8,20 @@ import 'package:flutter/scheduler.dart';
 import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/evaluation_report_presentation.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/ielts_practice_report.dart';
+import 'package:speakup/features/coaching/review/ielts_practice_report_decoder.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
 import 'package:speakup/features/coaching/review/review_history_client.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
+
+const _ieltsSpeakingReportSchema = 'ielts-speaking-report/v1';
+const _ieltsSpeakingPracticeReportSchema = 'ielts-speaking-practice-report/v1';
+const _legacyGeneralSceneReportSchema = 'general-scene-evaluation/v1';
 
 class ReviewPage extends StatefulWidget {
   const ReviewPage({
@@ -106,8 +115,7 @@ class _ReviewPageState extends State<ReviewPage> {
     final historyController = widget.historyController;
     if (reportController == null || historyController == null) return;
     final readyReports = historyController.items.where(
-      (item) =>
-          item.report.sceneType == EvaluationReportSceneType.ieltsSpeaking,
+      (item) => _isFullMockIeltsReport(item.report),
     );
     if (readyReports.isEmpty) {
       final previousSessionId = _abilitySessionId;
@@ -141,44 +149,38 @@ class _ReviewPageState extends State<ReviewPage> {
   }
 
   void _openDetail(ReviewHistoryItem item) {
-    if (item.report.sceneType == EvaluationReportSceneType.ieltsSpeaking &&
-        widget.ieltsSpeakingReportController != null) {
+    if (_isFullMockIeltsReport(item.report)) {
       _openIeltsReport(item);
       return;
     }
     unawaited(
       Navigator.of(context).push<void>(
-        MaterialPageRoute<void>(builder: (_) => _ReviewDetailPage(item: item)),
+        MaterialPageRoute<void>(
+          builder: (_) => ReviewReportDetailPage(item: item),
+        ),
       ),
     );
   }
 
   void _openIeltsReport(ReviewHistoryItem item) {
-    final controller = widget.ieltsSpeakingReportController;
-    if (controller == null) {
-      return;
-    }
-    unawaited(() async {
-      controller.removeListener(_rebuild);
-      try {
-        await Navigator.of(context).push<void>(
+    try {
+      final detail = decodeIeltsSpeakingReportDetail(item.report.detail);
+      unawaited(
+        Navigator.of(context).push<void>(
           MaterialPageRoute<void>(
-            builder: (_) => _IeltsReportDetailPage(
-              practiceSessionId: item.practiceSessionId,
-              controller: controller,
-              cancelOnDispose: false,
-            ),
+            builder: (_) => _IeltsReportDetailPage(report: detail),
           ),
-        );
-      } finally {
-        await Future<void>.delayed(Duration.zero);
-        if (mounted &&
-            identical(controller, widget.ieltsSpeakingReportController)) {
-          controller.addListener(_rebuild);
-          _syncAbilityReport(force: true);
-        }
-      }
-    }());
+        ),
+      );
+    } on IeltsSpeakingReportDecodeException {
+      unawaited(
+        Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => ReviewReportDetailPage(item: item),
+          ),
+        ),
+      );
+    }
   }
 
   void _openHistory() {
@@ -300,6 +302,19 @@ class _ReviewPageState extends State<ReviewPage> {
     return report;
   }
 }
+
+bool _isFullMockIeltsReport(EvaluationReport report) =>
+    report.sceneType == EvaluationReportSceneType.ieltsSpeaking &&
+    report.practiceMode == 'FULL_MOCK' &&
+    report.detailSchema == _ieltsSpeakingReportSchema;
+
+bool _isIeltsSectionReport(EvaluationReport report) =>
+    report.sceneType == EvaluationReportSceneType.ieltsSpeaking &&
+    (report.practiceMode == 'PART_1' ||
+        report.practiceMode == 'PART_2' ||
+        report.practiceMode == 'PART_3') &&
+    (report.detailSchema == _ieltsSpeakingPracticeReportSchema ||
+        report.detailSchema == _legacyGeneralSceneReportSchema);
 
 class _ReviewHistoryPage extends StatelessWidget {
   const _ReviewHistoryPage({
@@ -670,35 +685,10 @@ class _EmptyReview extends StatelessWidget {
   }
 }
 
-class _IeltsReportDetailPage extends StatefulWidget {
-  const _IeltsReportDetailPage({
-    required this.practiceSessionId,
-    required this.controller,
-    this.cancelOnDispose = true,
-  });
+class _IeltsReportDetailPage extends StatelessWidget {
+  const _IeltsReportDetailPage({required this.report});
 
-  final String practiceSessionId;
-  final IeltsSpeakingReportController controller;
-  final bool cancelOnDispose;
-
-  @override
-  State<_IeltsReportDetailPage> createState() => _IeltsReportDetailPageState();
-}
-
-class _IeltsReportDetailPageState extends State<_IeltsReportDetailPage> {
-  @override
-  void initState() {
-    super.initState();
-    unawaited(widget.controller.load(widget.practiceSessionId));
-  }
-
-  @override
-  void dispose() {
-    if (widget.cancelOnDispose) {
-      widget.controller.cancel(widget.practiceSessionId);
-    }
-    super.dispose();
-  }
+  final IeltsSpeakingReport report;
 
   @override
   Widget build(BuildContext context) {
@@ -708,28 +698,36 @@ class _IeltsReportDetailPageState extends State<_IeltsReportDetailPage> {
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 40),
-          child: IeltsSpeakingReportPanel(controller: widget.controller),
+          child: IeltsSpeakingReadyReportView(report: report),
         ),
       ),
     );
   }
 }
 
-class _ReviewDetailPage extends StatelessWidget {
-  const _ReviewDetailPage({required this.item});
+class ReviewReportDetailPage extends StatelessWidget {
+  const ReviewReportDetailPage({required this.item, super.key});
 
   final ReviewHistoryItem item;
 
   @override
   Widget build(BuildContext context) {
     final report = item.report;
+    final sectionDetail = _decodeSectionDetail(report);
+    final expectsSectionDetail =
+        report.sceneType == EvaluationReportSceneType.ieltsSpeaking &&
+        report.detailSchema == _ieltsSpeakingPracticeReportSchema;
     final findings = report.dimensions
         .expand((dimension) => dimension.improvements)
         .toList(growable: false);
     return Scaffold(
       key: const Key('review-detail-page'),
       appBar: AppBar(
-        title: const Text('复盘详情'),
+        title: Text(
+          _isIeltsSectionReport(report)
+              ? evaluationReportTitle(report)
+              : '复盘详情',
+        ),
         leading: IconButton(
           key: const Key('review-detail-back'),
           tooltip: '返回复盘历史',
@@ -743,20 +741,37 @@ class _ReviewDetailPage extends StatelessWidget {
           key: const Key('review-detail-content'),
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 48),
           children: [
-            _ReviewDetailHeader(item: item),
-            const SizedBox(height: 12),
-            _ReviewDetailSection(
-              key: const Key('review-detail-summary'),
-              title: '整体表现',
-              body: report.summary,
-            ),
+            if (sectionDetail != null)
+              _IeltsSectionDetailHeader(item: item)
+            else ...[
+              _ReviewDetailHeader(item: item),
+              const SizedBox(height: 12),
+              _ReviewDetailSection(
+                key: const Key('review-detail-summary'),
+                title: '整体表现',
+                body: report.summary,
+              ),
+            ],
             if (report.scoreability ==
                 EvaluationReportScoreability.insufficient) ...[
               const SizedBox(height: 12),
               const _ReviewStatusNotice(),
             ],
-            const SizedBox(height: 12),
-            _ReviewDimensions(dimensions: report.dimensions),
+            if (sectionDetail != null) ...[
+              const SizedBox(height: 12),
+              _IeltsSectionReport(report: report, detail: sectionDetail),
+            ] else if (expectsSectionDetail) ...[
+              const SizedBox(height: 12),
+              const _ReviewDetailSection(
+                key: Key('ielts-section-detail-invalid'),
+                title: '分段复盘暂不可用',
+                body: '专项报告的分段数据无法识别，下方仍保留本次练习的通用反馈。',
+              ),
+            ],
+            if (report.dimensions.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _ReviewDimensions(dimensions: report.dimensions),
+            ],
             if (findings.isNotEmpty) ...[
               const SizedBox(height: 12),
               _ReviewFindings(report: report, findings: findings),
@@ -805,6 +820,40 @@ class _ReviewDetailHeader extends StatelessWidget {
   }
 }
 
+class _IeltsSectionDetailHeader extends StatelessWidget {
+  const _IeltsSectionDetailHeader({required this.item});
+
+  final ReviewHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('review-detail-summary'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 6,
+          children: [
+            _StatusLabel(label: _statusLabel(item.report)),
+            Text(_detailDateLabel(item.completedAt), style: SpeakUpDesign.meta),
+          ],
+        ),
+        const SizedBox(height: 14),
+        Text(
+          item.review.title,
+          key: const Key('review-detail-title'),
+          style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
+        ),
+        const SizedBox(height: 10),
+        Text(item.report.summary, style: SpeakUpDesign.body),
+        const SizedBox(height: 18),
+        const Divider(height: 1),
+      ],
+    );
+  }
+}
+
 class _ReviewDetailSection extends StatelessWidget {
   const _ReviewDetailSection({
     required this.title,
@@ -832,6 +881,248 @@ class _ReviewDetailSection extends StatelessWidget {
     );
   }
 }
+
+IeltsPracticeReportDetail? _decodeSectionDetail(EvaluationReport report) {
+  if (report.sceneType != EvaluationReportSceneType.ieltsSpeaking ||
+      report.detailSchema != _ieltsSpeakingPracticeReportSchema) {
+    return null;
+  }
+  try {
+    final detail = decodeIeltsPracticeReportDetail(report.detail);
+    if (!_sectionDetailMatchesPracticeMode(report.practiceMode, detail)) {
+      throw const IeltsPracticeReportDecodeException();
+    }
+    final strengthIds = <String>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.strengths) finding.id,
+    };
+    final improvementIds = <String>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.improvements) finding.id,
+    };
+    final exampleIds = <String>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.recommendedExamples) finding.id,
+    };
+    for (final section in detail.sectionReviews) {
+      if (!strengthIds.containsAll(section.strengthFindingIds) ||
+          !improvementIds.containsAll(section.improvementFindingIds) ||
+          !exampleIds.containsAll(section.upgradeExampleFindingIds)) {
+        throw const IeltsPracticeReportDecodeException();
+      }
+    }
+    return detail;
+  } on IeltsPracticeReportDecodeException {
+    return null;
+  }
+}
+
+bool _sectionDetailMatchesPracticeMode(
+  String practiceMode,
+  IeltsPracticeReportDetail detail,
+) => switch (practiceMode) {
+  'PART_1' =>
+    detail.reportScope == PracticeReportScope.part1 &&
+        _matchesParts(detail.availableSections, const <IeltsSpeakingPartId>[
+          IeltsSpeakingPartId.part1,
+        ]),
+  'PART_2' =>
+    detail.reportScope == PracticeReportScope.part2And3 &&
+        _matchesParts(detail.availableSections, const <IeltsSpeakingPartId>[
+          IeltsSpeakingPartId.part2,
+          IeltsSpeakingPartId.part3,
+        ]),
+  'PART_3' =>
+    detail.reportScope == PracticeReportScope.part3 &&
+        _matchesParts(detail.availableSections, const <IeltsSpeakingPartId>[
+          IeltsSpeakingPartId.part3,
+        ]),
+  _ => false,
+};
+
+bool _matchesParts(
+  List<IeltsSpeakingPartId> actual,
+  List<IeltsSpeakingPartId> expected,
+) {
+  if (actual.length != expected.length) return false;
+  for (var index = 0; index < actual.length; index++) {
+    if (actual[index] != expected[index]) return false;
+  }
+  return true;
+}
+
+class _IeltsSectionReport extends StatelessWidget {
+  const _IeltsSectionReport({required this.report, required this.detail});
+
+  final EvaluationReport report;
+  final IeltsPracticeReportDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final strengths = <String, EvaluationReportFinding>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.strengths) finding.id: finding,
+    };
+    final improvements = <String, EvaluationReportFinding>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.improvements) finding.id: finding,
+    };
+    final examples = <String, EvaluationReportFinding>{
+      for (final dimension in report.dimensions)
+        for (final finding in dimension.recommendedExamples)
+          finding.id: finding,
+    };
+    return Column(
+      key: const Key('ielts-section-report'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('分段复盘', style: SpeakUpDesign.sectionTitle),
+        const SizedBox(height: 6),
+        for (var index = 0; index < detail.sectionReviews.length; index++) ...[
+          if (index > 0) const Divider(height: 33),
+          _IeltsSectionCard(
+            section: detail.sectionReviews[index],
+            questions: detail.questions
+                .where(
+                  (question) =>
+                      question.partId == detail.sectionReviews[index].partId,
+                )
+                .toList(growable: false),
+            strengths: strengths,
+            improvements: improvements,
+            examples: examples,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _IeltsSectionCard extends StatelessWidget {
+  const _IeltsSectionCard({
+    required this.section,
+    required this.questions,
+    required this.strengths,
+    required this.improvements,
+    required this.examples,
+  });
+
+  final IeltsPracticeSectionReview section;
+  final List<IeltsPracticeReportQuestion> questions;
+  final Map<String, EvaluationReportFinding> strengths;
+  final Map<String, EvaluationReportFinding> improvements;
+  final Map<String, EvaluationReportFinding> examples;
+
+  @override
+  Widget build(BuildContext context) {
+    final answered = questions
+        .where((question) => question.confirmedTranscript != null)
+        .length;
+    return Padding(
+      key: Key('ielts-section-${section.partId.name}'),
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                _ieltsPartLabel(section.partId),
+                style: SpeakUpDesign.cardTitle,
+              ),
+              const Spacer(),
+              Text(
+                '$answered/${questions.length} 题已回答',
+                style: SpeakUpDesign.meta,
+              ),
+            ],
+          ),
+          if (section.strengthFindingIds.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionFindingGroup(
+              title: '做得好',
+              ids: section.strengthFindingIds,
+              findings: strengths,
+            ),
+          ],
+          if (section.improvementFindingIds.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionFindingGroup(
+              title: '可改进',
+              ids: section.improvementFindingIds,
+              findings: improvements,
+            ),
+          ],
+          if (section.upgradeExampleFindingIds.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionFindingGroup(
+              title: '提升表达',
+              ids: section.upgradeExampleFindingIds,
+              findings: examples,
+            ),
+          ],
+          const SizedBox(height: 16),
+          const Divider(height: 1),
+          const SizedBox(height: 14),
+          Text('本段题目', style: SpeakUpDesign.label),
+          for (final question in questions) ...[
+            const SizedBox(height: 10),
+            Text(
+              '${question.index}. ${question.questionText}',
+              style: SpeakUpDesign.body,
+            ),
+            if (question.confirmedTranscript case final transcript?) ...[
+              const SizedBox(height: 3),
+              Text(
+                transcript,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: SpeakUpDesign.meta,
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionFindingGroup extends StatelessWidget {
+  const _SectionFindingGroup({
+    required this.title,
+    required this.ids,
+    required this.findings,
+  });
+
+  final String title;
+  final List<String> ids;
+  final Map<String, EvaluationReportFinding> findings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: SpeakUpDesign.label),
+        for (final id in ids) ...[
+          const SizedBox(height: 5),
+          Text('• ${findings[id]!.message}', style: SpeakUpDesign.body),
+          if (findings[id]!.suggestion case final suggestion?)
+            Padding(
+              padding: const EdgeInsets.only(left: 13, top: 3),
+              child: Text('建议：$suggestion', style: SpeakUpDesign.meta),
+            ),
+        ],
+      ],
+    );
+  }
+}
+
+String _ieltsPartLabel(IeltsSpeakingPartId partId) => switch (partId) {
+  IeltsSpeakingPartId.part1 => 'Part 1',
+  IeltsSpeakingPartId.part2 => 'Part 2',
+  IeltsSpeakingPartId.part3 => 'Part 3',
+};
 
 class _ReviewStatusNotice extends StatelessWidget {
   const _ReviewStatusNotice();
@@ -995,6 +1286,10 @@ String _dimensionLabel(String key) {
         'LEXICAL_RESOURCE': '词汇资源',
         'GRAMMATICAL_RANGE_ACCURACY': '语法范围与准确性',
         'PRONUNCIATION': '发音',
+        'TASK_ACHIEVEMENT': '任务达成',
+        'CLARITY_COHERENCE': '清晰度与连贯性',
+        'LANGUAGE_CONTROL': '语言运用',
+        'INTERACTION': '互动表现',
       }[key] ??
       key.toLowerCase().replaceAll('_', ' ');
 }

--- a/mobile/lib/features/coaching/review/wire_practice_report_status_client.dart
+++ b/mobile/lib/features/coaching/review/wire_practice_report_status_client.dart
@@ -1,0 +1,370 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report_decoder.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_client.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_decoder.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+import 'package:speakup/identity/network/transport_security.dart';
+
+final class WirePracticeReportStatusClient
+    implements PracticeReportStatusClient, PracticeReportRegenerationClient {
+  factory WirePracticeReportStatusClient({
+    required Uri baseUri,
+    required AuthSessionCredentialProvider credentialProvider,
+    required AuthSessionInvalidator invalidateSession,
+    IdentityHttpTransport? transport,
+    Duration requestTimeout = const Duration(seconds: 15),
+  }) {
+    if (requestTimeout <= Duration.zero) {
+      throw ArgumentError.value(requestTimeout, 'requestTimeout');
+    }
+    final rawTransport =
+        transport ?? _IoPracticeReportStatusHttpTransport(requestTimeout);
+    return WirePracticeReportStatusClient._(
+      baseUri,
+      SessionAuthenticatedHttpTransport(
+        transport: rawTransport,
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: baseUri,
+      ),
+      requestTimeout,
+    );
+  }
+
+  WirePracticeReportStatusClient._(
+    this._baseUri,
+    this._transport,
+    this._requestTimeout,
+  ) : _trustedOrigin = TrustedIdentityHttpOrigin(_baseUri);
+
+  final Uri _baseUri;
+  final IdentityHttpTransport _transport;
+  final Duration _requestTimeout;
+  final TrustedIdentityHttpOrigin _trustedOrigin;
+  int _accountGeneration = 0;
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async {
+    if (!_validPracticeSessionId(practiceSessionId)) {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.invalidRequest,
+      );
+    }
+    final response = await _get(
+      '/v1/practice-sessions/${Uri.encodeComponent(practiceSessionId)}/report',
+    );
+    switch (response.statusCode) {
+      case HttpStatus.ok:
+        try {
+          final result = decodePracticeReportStatusJson(response.body);
+          if (result.practiceSessionId != practiceSessionId) {
+            throw const PracticeReportStatusDecodeException();
+          }
+          return result;
+        } on PracticeReportStatusDecodeException {
+          throw const PracticeReportStatusException(
+            kind: PracticeReportStatusFailureKind.invalidResponse,
+          );
+        }
+      case HttpStatus.unauthorized:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.authenticationRequired,
+          statusCode: HttpStatus.unauthorized,
+        );
+      case HttpStatus.badRequest:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.invalidRequest,
+          statusCode: HttpStatus.badRequest,
+        );
+      case HttpStatus.notFound:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.notFound,
+          statusCode: HttpStatus.notFound,
+          retryable: true,
+        );
+      case HttpStatus.conflict:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.conflict,
+          statusCode: HttpStatus.conflict,
+          retryable: true,
+        );
+      default:
+        throw _unexpectedStatus(response.statusCode);
+    }
+  }
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) async {
+    if (!_validReportRef(reportRef)) {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.invalidRequest,
+      );
+    }
+    final response = await _get(reportRef.href);
+    switch (response.statusCode) {
+      case HttpStatus.ok:
+        try {
+          final value = jsonDecode(response.body);
+          final report = decodeEvaluationReport(value);
+          if (report.id != reportRef.reportId) {
+            throw const EvaluationReportDecodeException();
+          }
+          return report;
+        } on FormatException {
+          throw const PracticeReportStatusException(
+            kind: PracticeReportStatusFailureKind.invalidResponse,
+          );
+        } on EvaluationReportDecodeException {
+          throw const PracticeReportStatusException(
+            kind: PracticeReportStatusFailureKind.invalidResponse,
+          );
+        }
+      case HttpStatus.unauthorized:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.authenticationRequired,
+          statusCode: HttpStatus.unauthorized,
+        );
+      case HttpStatus.notFound:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.notFound,
+          statusCode: HttpStatus.notFound,
+          retryable: true,
+        );
+      default:
+        throw _unexpectedStatus(response.statusCode);
+    }
+  }
+
+  @override
+  Future<void> regenerateReport(PracticeReportStatus status) async {
+    final evaluationId = status.evaluationId;
+    if (status.evaluationStatus != PracticeReportEvaluationStatus.failed ||
+        status.stableFailure?.retryable != true ||
+        status.practiceMode != PracticeMode.fullMock ||
+        evaluationId == null ||
+        !_validEvaluationId(evaluationId)) {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.invalidRequest,
+      );
+    }
+    final response = await _request(
+      '/v1/evaluations/${Uri.encodeComponent(evaluationId)}/re-evaluate',
+      method: 'POST',
+      body: jsonEncode(<String, Object>{
+        'channels': const <String>['SCENE'],
+        'scene_strategy_ref': 'ielts-speaking-full-mock-shadow/v1',
+        'pipeline_version': 'evaluation-pipeline-shadow/v1',
+      }),
+    );
+    switch (response.statusCode) {
+      case HttpStatus.ok:
+      case HttpStatus.accepted:
+        return;
+      case HttpStatus.unauthorized:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.authenticationRequired,
+          statusCode: HttpStatus.unauthorized,
+        );
+      case HttpStatus.badRequest:
+      case HttpStatus.unprocessableEntity:
+        throw PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.invalidRequest,
+          statusCode: response.statusCode,
+        );
+      case HttpStatus.notFound:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.notFound,
+          statusCode: HttpStatus.notFound,
+        );
+      case HttpStatus.conflict:
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.conflict,
+          statusCode: HttpStatus.conflict,
+          retryable: true,
+        );
+      default:
+        throw _unexpectedStatus(response.statusCode);
+    }
+  }
+
+  Future<IdentityHttpResponse> _get(String path) => _request(path);
+
+  Future<IdentityHttpResponse> _request(
+    String path, {
+    String method = 'GET',
+    String? body,
+  }) async {
+    final generation = _accountGeneration;
+    final uri = _baseUri.replace(path: path, query: null, fragment: null);
+    _trustedOrigin.validateResourceUri(uri);
+    validateNoSessionCredentialInUri(uri);
+    try {
+      final response = await _transport
+          .send(
+            method: method,
+            uri: uri,
+            headers: <String, String>{
+              HttpHeaders.acceptHeader: 'application/json',
+              if (body != null)
+                HttpHeaders.contentTypeHeader: 'application/json',
+            },
+            body: body,
+          )
+          .timeout(_requestTimeout);
+      if (generation != _accountGeneration) {
+        throw const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.superseded,
+        );
+      }
+      return response;
+    } on AuthSessionSupersededException {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.superseded,
+      );
+    } on StateError {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.authenticationRequired,
+        statusCode: HttpStatus.unauthorized,
+      );
+    } on TimeoutException {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.network,
+        retryable: true,
+      );
+    } on SocketException {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.network,
+        retryable: true,
+      );
+    } on HttpException {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.network,
+        retryable: true,
+      );
+    } on IOException {
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.network,
+        retryable: true,
+      );
+    }
+  }
+
+  @override
+  Future<void> clearAccountState() async {
+    _accountGeneration++;
+  }
+}
+
+PracticeReportStatusException _unexpectedStatus(int statusCode) {
+  if (statusCode >= 500) {
+    return PracticeReportStatusException(
+      kind: PracticeReportStatusFailureKind.server,
+      statusCode: statusCode,
+      retryable: true,
+    );
+  }
+  return PracticeReportStatusException(
+    kind: PracticeReportStatusFailureKind.invalidResponse,
+    statusCode: statusCode,
+  );
+}
+
+bool _validPracticeSessionId(String value) =>
+    value.isNotEmpty &&
+    value.length <= 128 &&
+    value == value.trim() &&
+    RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]*$').hasMatch(value);
+
+bool _validEvaluationId(String value) => RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+).hasMatch(value);
+
+bool _validReportRef(PracticeReportRef ref) =>
+    RegExp(
+      r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    ).hasMatch(ref.reportId) &&
+    ref.href == '/v1/evaluation-reports/${ref.reportId}';
+
+final class _IoPracticeReportStatusHttpTransport
+    implements IdentityHttpTransport {
+  const _IoPracticeReportStatusHttpTransport(this._requestTimeout);
+
+  final Duration _requestTimeout;
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    final client = HttpClient()..connectionTimeout = _requestTimeout;
+    HttpClientRequest? request;
+    try {
+      final operation = () async {
+        request = await client.openUrl(method, uri);
+        request!.followRedirects = false;
+        headers.forEach(request!.headers.set);
+        if (body != null) {
+          request!.add(utf8.encode(body));
+        }
+        final response = await request!.close();
+        if (response.contentLength > _maximumResponseBytes) {
+          request!.abort();
+          throw const PracticeReportStatusException(
+            kind: PracticeReportStatusFailureKind.invalidResponse,
+          );
+        }
+        final bytes = await _readBoundedResponse(response, request!);
+        late final String responseBody;
+        try {
+          responseBody = utf8.decode(bytes, allowMalformed: false);
+        } on FormatException {
+          throw const PracticeReportStatusException(
+            kind: PracticeReportStatusFailureKind.invalidResponse,
+          );
+        }
+        return IdentityHttpResponse(
+          statusCode: response.statusCode,
+          body: responseBody,
+          headers: const <String, String>{},
+        );
+      }();
+      return await operation.timeout(_requestTimeout);
+    } on TimeoutException {
+      request?.abort();
+      rethrow;
+    } finally {
+      client.close(force: true);
+    }
+  }
+}
+
+Future<Uint8List> _readBoundedResponse(
+  HttpClientResponse response,
+  HttpClientRequest request,
+) async {
+  final builder = BytesBuilder(copy: false);
+  var count = 0;
+  await for (final chunk in response) {
+    count += chunk.length;
+    if (count > _maximumResponseBytes) {
+      request.abort();
+      throw const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.invalidResponse,
+      );
+    }
+    builder.add(chunk);
+  }
+  return builder.takeBytes();
+}
+
+const _maximumResponseBytes = 2 * 1024 * 1024;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -43,6 +43,8 @@ import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/review/interview_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_wire_client.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
+import 'package:speakup/features/coaching/review/wire_practice_report_status_client.dart';
 import 'package:speakup/features/coaching/ielts/wire_ielts_answer_preparation_client.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -83,6 +85,8 @@ void main() {
           : null,
       interviewReportController: dependencies.interviewReportController,
       ieltsSpeakingReportController: dependencies.ieltsSpeakingReportController,
+      practiceReportStatusController:
+          dependencies.practiceReportStatusController,
       speechFeedbackController: dependencies.speechFeedbackController,
       resumeController: dependencies.resumeController,
     ),
@@ -107,6 +111,7 @@ final class ProductionAppDependencies {
     required this.avatarControllerFactory,
     required this.interviewReportController,
     required this.ieltsSpeakingReportController,
+    required this.practiceReportStatusController,
     required this.speechFeedbackController,
     required this.resumeController,
   });
@@ -127,6 +132,7 @@ final class ProductionAppDependencies {
   final AvatarControllerFactory avatarControllerFactory;
   final InterviewReportController interviewReportController;
   final IeltsSpeakingReportController ieltsSpeakingReportController;
+  final PracticeReportStatusController practiceReportStatusController;
   final SpeechFeedbackController speechFeedbackController;
   final ResumeController resumeController;
 }
@@ -145,6 +151,7 @@ ProductionAppDependencies createProductionAppDependencies({
   IdentityHttpTransport? reviewHistoryTransport,
   IdentityHttpTransport? interviewReportTransport,
   IdentityHttpTransport? ieltsSpeakingReportTransport,
+  IdentityHttpTransport? practiceReportStatusTransport,
   IdentityHttpTransport? ieltsAnswerPreparationTransport,
   IdentityHttpTransport? speechFeedbackTransport,
   PracticeWireTransport? practiceTransport,
@@ -383,6 +390,20 @@ ProductionAppDependencies createProductionAppDependencies({
   final ieltsSpeakingReportController = IeltsSpeakingReportController(
     client: ieltsSpeakingReportClient,
   );
+  final practiceReportStatusController = PracticeReportStatusController(
+    client: WirePracticeReportStatusClient(
+      baseUri: baseUri,
+      credentialProvider: () => authController.currentCredential,
+      invalidateSession:
+          ({required expectedSessionToken, required expectedGeneration}) {
+            return authController.invalidateSession(
+              expectedSessionToken: expectedSessionToken,
+              expectedGeneration: expectedGeneration,
+            );
+          },
+      transport: practiceReportStatusTransport,
+    ),
+  );
   final speechFeedbackController = SpeechFeedbackController(
     client: WireSpeechFeedbackClient(
       baseUri: baseUri,
@@ -570,6 +591,7 @@ ProductionAppDependencies createProductionAppDependencies({
     clearPrivateState: () => _runAllPrivateStateCleanups([
       interviewReportController.clearPrivateState,
       ieltsSpeakingReportController.clearPrivateState,
+      practiceReportStatusController.clearPrivateState,
       speechFeedbackController.clearPrivateState,
       resumeController.clearPrivateState,
       preparationLaunchController.clearPrivateState,
@@ -603,6 +625,7 @@ ProductionAppDependencies createProductionAppDependencies({
     avatarControllerFactory: createAvatarController,
     interviewReportController: interviewReportController,
     ieltsSpeakingReportController: ieltsSpeakingReportController,
+    practiceReportStatusController: practiceReportStatusController,
     speechFeedbackController: speechFeedbackController,
     resumeController: resumeController,
   );

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -22,10 +22,14 @@ import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_media.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_client.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_client.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
 
 void main() {
   testWidgets('Part 1 keeps Tips visible while recording', (tester) async {
@@ -1130,8 +1134,14 @@ void main() {
         find.byKey(const Key('ielts-section-completion-sheet')),
         findsNothing,
       );
-      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
-      expect(find.text('Answer 4'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part1')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ielts-completion-report-unavailable')),
+        findsOneWidget,
+      );
       expect(reportClient.started.isCompleted, isFalse);
       expect(reportController.practiceSessionId, isNull);
     },
@@ -1458,10 +1468,61 @@ void main() {
         find.byKey(const Key('ielts-section-completion-sheet')),
         findsNothing,
       );
-      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
-      expect(find.text('Answer 1'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part3')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ielts-completion-report-unavailable')),
+        findsOneWidget,
+      );
     },
   );
+
+  testWidgets('finishing a section starts the report status load immediately', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    final reportClient = _PracticeReportStatusClient();
+    final reportController = PracticeReportStatusController(
+      client: reportClient,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    addTearDown(reportController.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part3,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          reportStatusController: reportController,
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-part3-start')));
+    await tester.pump();
+
+    await _answerCurrentShortQuestion(tester, controller);
+    await tester.pump();
+
+    expect(reportClient.statusCalls, 1);
+    expect(reportClient.practiceSessionIds, <String>[_sessionId]);
+    expect(reportController.practiceSessionId, _sessionId);
+  });
 
   testWidgets('full mock completes after a single original Part 3 question', (
     tester,
@@ -1669,6 +1730,36 @@ final class _UnusedQuestionBankClient implements IeltsQuestionBankClient {
   Future<IeltsQuestionBank> getQuestionBank() {
     throw UnimplementedError();
   }
+}
+
+final class _PracticeReportStatusClient implements PracticeReportStatusClient {
+  int statusCalls = 0;
+  final List<String> practiceSessionIds = <String>[];
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async {
+    statusCalls++;
+    practiceSessionIds.add(practiceSessionId);
+    return PracticeReportStatus(
+      practiceSessionId: practiceSessionId,
+      practiceMode: PracticeMode.part3,
+      reportScope: PracticeReportScope.part3,
+      availableSections: const <IeltsSpeakingPartId>[IeltsSpeakingPartId.part3],
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      evaluationStatus: PracticeReportEvaluationStatus.running,
+      statusUrl: '/v1/practice-sessions/$practiceSessionId/report',
+      evaluationId: '7b000001-0000-4000-8000-000000000001',
+      evaluationRevisionId: 'a1000001-0000-4000-8000-000000000001',
+      revision: 1,
+    );
+  }
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> clearAccountState() async {}
 }
 
 final class _IeltsPracticeClient

--- a/mobile/test/review/ielts_report_routing_test.dart
+++ b/mobile/test/review/ielts_report_routing_test.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/evaluation_report_presentation.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_client.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/features/coaching/review/review.dart';
+import 'package:speakup/features/coaching/review/review_history_client.dart';
+import 'package:speakup/features/coaching/review/review_history_controller.dart';
+
+import 'ielts_speaking_report_fixture.dart';
+
+void main() {
+  testWidgets('IELTS section report stays on the generic detail route', (
+    tester,
+  ) async {
+    final item = _item(
+      practiceMode: 'PART_2',
+      detailSchema: 'ielts-speaking-practice-report/v1',
+    );
+    final history = ReviewHistoryController(client: _HistoryClient(item));
+    final fullMockClient = _PendingIeltsClient();
+    final fullMockController = IeltsSpeakingReportController(
+      client: fullMockClient,
+    );
+    addTearDown(history.dispose);
+    addTearDown(fullMockController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ReviewPage(
+          historyController: history,
+          ieltsSpeakingReportController: fullMockController,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('review-history-entry')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(Key('review-history-select-${item.review.id}')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
+    expect(find.text('Part 2 + Part 3 联合复盘'), findsWidgets);
+    expect(find.byKey(const Key('ielts-section-part2')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-section-part3')), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-speaking-report-detail-page')),
+      findsNothing,
+    );
+    expect(fullMockClient.calls, 0);
+  });
+
+  testWidgets('legacy IELTS section report keeps scoped generic detail', (
+    tester,
+  ) async {
+    final item = _item(
+      practiceMode: 'PART_2',
+      detailSchema: 'general-scene-evaluation/v1',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
+    expect(find.text('Part 2 + Part 3 联合复盘'), findsWidgets);
+    expect(find.byKey(const Key('review-detail-summary')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-section-report')), findsNothing);
+    expect(find.byKey(const Key('ielts-section-detail-invalid')), findsNothing);
+  });
+
+  testWidgets('section detail must match the outer practice mode', (
+    tester,
+  ) async {
+    final item = _item(
+      practiceMode: 'PART_1',
+      detailSchema: 'ielts-speaking-practice-report/v1',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-section-report')), findsNothing);
+    expect(
+      find.byKey(const Key('ielts-section-detail-invalid')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+    'full mock history opens its embedded report without refetching',
+    (tester) async {
+      final item = _item(
+        practiceMode: 'FULL_MOCK',
+        detailSchema: 'ielts-speaking-report/v1',
+      );
+      final history = ReviewHistoryController(client: _HistoryClient(item));
+      final fullMockClient = _PendingIeltsClient();
+      final fullMockController = IeltsSpeakingReportController(
+        client: fullMockClient,
+      );
+      addTearDown(history.dispose);
+      addTearDown(fullMockController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReviewPage(
+            historyController: history,
+            ieltsSpeakingReportController: fullMockController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(fullMockClient.calls, 1);
+      await tester.tap(find.byKey(const Key('review-history-entry')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(Key('review-history-select-${item.review.id}')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(
+        find.byKey(const Key('ielts-speaking-report-detail-page')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('review-detail-page')), findsNothing);
+      expect(
+        find.byKey(const Key('ielts-speaking-report-scope-tabs')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ielts-speaking-report-generating')),
+        findsNothing,
+      );
+      expect(fullMockClient.calls, 1);
+    },
+  );
+}
+
+ReviewHistoryItem _item({
+  required String practiceMode,
+  required String detailSchema,
+}) {
+  final createdAt = DateTime.utc(2026, 8, 11, 4);
+  final report = EvaluationReport(
+    id: '20000000-0000-4000-8000-000000000002',
+    evaluationId: '7b000001-0000-4000-8000-000000000001',
+    evaluationRevisionId: 'a1000001-0000-4000-8000-000000000001',
+    practiceSessionId: 'session_595',
+    revision: 1,
+    sceneType: EvaluationReportSceneType.ieltsSpeaking,
+    practiceExperience: 'IELTS_SPEAKING',
+    sceneCategory: 'IELTS_SPEAKING',
+    practiceMode: practiceMode,
+    scoreability: EvaluationReportScoreability.provisional,
+    summary: '本次练习已形成复盘。',
+    dimensions: const <EvaluationReportDimension>[],
+    priorityActions: const <EvaluationReportPriorityAction>[],
+    detailSchema: detailSchema,
+    detail: switch (detailSchema) {
+      'ielts-speaking-practice-report/v1' => _sectionDetail(),
+      'ielts-speaking-report/v1' =>
+        completeIeltsSpeakingReportContractFixture()['report']!
+            as Map<String, Object?>,
+      _ => <String, Object?>{'schema_version': detailSchema},
+    },
+    createdAt: createdAt,
+  );
+  return ReviewHistoryItem(
+    review: presentEvaluationReport(report),
+    report: report,
+    practiceSessionId: report.practiceSessionId,
+    createdAt: createdAt,
+    completedAt: createdAt,
+  );
+}
+
+Map<String, Object?> _sectionDetail() => <String, Object?>{
+  'schema_version': 'ielts-speaking-practice-report/v1',
+  'report_scope': 'PART_2_3',
+  'available_sections': <Object?>['PART_2', 'PART_3'],
+  'questions': <Object?>[
+    _sectionQuestion(part: 'PART_2', index: 1),
+    _sectionQuestion(part: 'PART_3', index: 2),
+  ],
+  'section_reviews': <Object?>[
+    _sectionReview(part: 'PART_2', index: 1),
+    _sectionReview(part: 'PART_3', index: 2),
+  ],
+};
+
+Map<String, Object?> _sectionQuestion({
+  required String part,
+  required int index,
+}) => <String, Object?>{
+  'question_id': 'question_$index',
+  'part_id': part,
+  'index': index,
+  'question_text': 'Question $index?',
+  'confirmed_transcript': 'Answer $index.',
+  'response_turn_id': 'turn_$index',
+  'evidence_ref_ids': <Object?>['evidence_$index'],
+};
+
+Map<String, Object?> _sectionReview({
+  required String part,
+  required int index,
+}) => <String, Object?>{
+  'part_id': part,
+  'question_indexes': <Object?>[index],
+  'evidence_ref_ids': <Object?>['evidence_$index'],
+  'strength_finding_ids': <Object?>[],
+  'improvement_finding_ids': <Object?>[],
+  'upgrade_example_finding_ids': <Object?>[],
+};
+
+final class _HistoryClient implements ReviewHistoryClient {
+  const _HistoryClient(this.item);
+
+  final ReviewHistoryItem item;
+
+  @override
+  Future<ReviewHistoryPage> list({String? cursor, int limit = 20}) async =>
+      ReviewHistoryPage(items: <ReviewHistoryItem>[item]);
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _PendingIeltsClient implements IeltsSpeakingReportClient {
+  int calls = 0;
+  final Completer<IeltsSpeakingReportEnvelope> pending =
+      Completer<IeltsSpeakingReportEnvelope>();
+
+  @override
+  Future<IeltsSpeakingReportEnvelope> getReport(String practiceSessionId) {
+    calls++;
+    return pending.future;
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+}

--- a/mobile/test/review/ielts_speaking_report_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_view_test.dart
@@ -111,6 +111,35 @@ void main() {
     expect(find.text('发音'), findsWidgets);
   });
 
+  testWidgets('full mock report switches between overall and three parts', (
+    tester,
+  ) async {
+    final controller = await _controllerFor('ready');
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_app(controller));
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('ielts-speaking-report-scope-tabs')),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('ielts-speaking-report-scope-2')));
+    await tester.pump();
+    expect(
+      find.byKey(const Key('ielts-speaking-report-part2')),
+      findsOneWidget,
+    );
+    expect(find.text('Part 2 复盘'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('ielts-speaking-report-scope-3')));
+    await tester.pump();
+    expect(
+      find.byKey(const Key('ielts-speaking-report-part3')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('same-question list starts the selected question directly', (
     tester,
   ) async {

--- a/mobile/test/review/practice_report_status_test.dart
+++ b/mobile/test/review/practice_report_status_test.dart
@@ -1,0 +1,943 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/ielts_practice_report_decoder.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_client.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_decoder.dart';
+import 'package:speakup/features/coaching/review/practice_report_status_view.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/features/coaching/review/wire_practice_report_status_client.dart';
+import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/identity_http_transport.dart';
+
+void main() {
+  test(
+    'wire client reads the authenticated by-session status endpoint',
+    () async {
+      final transport = _Transport(
+        IdentityHttpResponse(
+          statusCode: HttpStatus.ok,
+          body: jsonEncode(<String, Object?>{
+            ..._baseStatus(),
+            'evaluation_status': 'RUNNING',
+          }),
+        ),
+      );
+      final client = WirePracticeReportStatusClient(
+        baseUri: Uri.parse('https://api.speak-up.test'),
+        credentialProvider: () => const AuthSessionCredential(
+          sessionToken: 'sess_practice-report',
+          generation: 3,
+        ),
+        invalidateSession:
+            ({
+              required expectedSessionToken,
+              required expectedGeneration,
+            }) async {},
+        transport: transport,
+      );
+
+      final status = await client.getStatus('session_595');
+
+      expect(status.evaluationStatus, PracticeReportEvaluationStatus.running);
+      expect(transport.method, 'GET');
+      expect(
+        transport.uri,
+        Uri.parse(
+          'https://api.speak-up.test/v1/practice-sessions/session_595/report',
+        ),
+      );
+      expect(
+        transport.headers?[HttpHeaders.authorizationHeader],
+        'Bearer sess_practice-report',
+      );
+    },
+  );
+
+  test('wire client creates a FULL_MOCK replacement revision', () async {
+    final transport = _Transport(
+      const IdentityHttpResponse(statusCode: HttpStatus.accepted, body: '{}'),
+    );
+    final client = WirePracticeReportStatusClient(
+      baseUri: Uri.parse('https://api.speak-up.test'),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_practice-report',
+        generation: 3,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: transport,
+    );
+
+    await client.regenerateReport(
+      _status(
+        PracticeReportEvaluationStatus.failed,
+        practiceMode: PracticeMode.fullMock,
+        withEvaluationIdentity: true,
+      ),
+    );
+
+    expect(transport.method, 'POST');
+    expect(
+      transport.uri,
+      Uri.parse(
+        'https://api.speak-up.test/v1/evaluations/'
+        '7b000001-0000-4000-8000-000000000001/re-evaluate',
+      ),
+    );
+    expect(jsonDecode(transport.body!), <String, Object>{
+      'channels': <String>['SCENE'],
+      'scene_strategy_ref': 'ielts-speaking-full-mock-shadow/v1',
+      'pipeline_version': 'evaluation-pipeline-shadow/v1',
+    });
+  });
+
+  test('default IO transport sends the FULL_MOCK regeneration body', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final receivedBody = Completer<String>();
+    server.listen((request) async {
+      final body = await utf8.decoder.bind(request).join();
+      if (!receivedBody.isCompleted) {
+        receivedBody.complete(body);
+      }
+      request.response.statusCode = HttpStatus.accepted;
+      request.response.write('{}');
+      await request.response.close();
+    });
+    final client = WirePracticeReportStatusClient(
+      baseUri: Uri(
+        scheme: 'http',
+        host: InternetAddress.loopbackIPv4.address,
+        port: server.port,
+      ),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_practice-report',
+        generation: 3,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+    );
+
+    await HttpOverrides.runWithHttpOverrides<Future<void>>(
+      () => client.regenerateReport(
+        _status(
+          PracticeReportEvaluationStatus.failed,
+          practiceMode: PracticeMode.fullMock,
+          withEvaluationIdentity: true,
+        ),
+      ),
+      _RealHttpOverrides(),
+    );
+
+    expect(jsonDecode(await receivedBody.future), <String, Object>{
+      'channels': <String>['SCENE'],
+      'scene_strategy_ref': 'ielts-speaking-full-mock-shadow/v1',
+      'pipeline_version': 'evaluation-pipeline-shadow/v1',
+    });
+  });
+
+  test('wire client marks report status conflicts as retryable', () async {
+    final client = WirePracticeReportStatusClient(
+      baseUri: Uri.parse('https://api.speak-up.test'),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_practice-report',
+        generation: 3,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: _Transport(
+        const IdentityHttpResponse(statusCode: HttpStatus.conflict, body: '{}'),
+      ),
+    );
+
+    await expectLater(
+      client.getStatus('session_595'),
+      throwsA(
+        isA<PracticeReportStatusException>()
+            .having(
+              (error) => error.kind,
+              'kind',
+              PracticeReportStatusFailureKind.conflict,
+            )
+            .having((error) => error.retryable, 'retryable', isTrue),
+      ),
+    );
+  });
+
+  test('wire client rejects section regeneration before transport', () async {
+    final transport = _Transport(
+      const IdentityHttpResponse(statusCode: HttpStatus.accepted, body: '{}'),
+    );
+    final client = WirePracticeReportStatusClient(
+      baseUri: Uri.parse('https://api.speak-up.test'),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_practice-report',
+        generation: 3,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      transport: transport,
+    );
+
+    await expectLater(
+      client.regenerateReport(
+        _status(
+          PracticeReportEvaluationStatus.failed,
+          withEvaluationIdentity: true,
+        ),
+      ),
+      throwsA(isA<PracticeReportStatusException>()),
+    );
+    expect(transport.method, isNull);
+  });
+
+  test('decodes the frozen Part 2 + Part 3 READY contract', () {
+    final status = decodePracticeReportStatus(<String, Object?>{
+      ..._baseStatus(),
+      'evaluation_status': 'READY',
+      'report_ref': const <String, Object?>{
+        'report_id': '20000000-0000-4000-8000-000000000002',
+        'href': '/v1/evaluation-reports/20000000-0000-4000-8000-000000000002',
+      },
+      'scoreability_status': 'PROVISIONAL',
+      'summary': '已生成 Part 2 + Part 3 专项复盘。',
+    });
+
+    expect(status.practiceMode, PracticeMode.part2);
+    expect(status.reportScope, PracticeReportScope.part2And3);
+    expect(status.availableSections, const <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part2,
+      IeltsSpeakingPartId.part3,
+    ]);
+    expect(status.evaluationStatus, PracticeReportEvaluationStatus.ready);
+    expect(status.evaluationId, '7b000001-0000-4000-8000-000000000001');
+    expect(status.revision, 1);
+  });
+
+  test('accepts a legacy general-scene READY section report', () {
+    final status = decodePracticeReportStatus(<String, Object?>{
+      ..._baseStatus(),
+      'detail_schema': 'general-scene-evaluation/v1',
+      'evaluation_status': 'READY',
+      'report_ref': const <String, Object?>{
+        'report_id': '20000000-0000-4000-8000-000000000002',
+        'href': '/v1/evaluation-reports/20000000-0000-4000-8000-000000000002',
+      },
+      'scoreability_status': 'PROVISIONAL',
+      'summary': '历史专项复盘已生成。',
+    });
+
+    expect(status.detailSchema, 'general-scene-evaluation/v1');
+    expect(status.evaluationStatus, PracticeReportEvaluationStatus.ready);
+  });
+
+  test('rejects legacy general-scene schema while evaluation is running', () {
+    expect(
+      () => decodePracticeReportStatus(<String, Object?>{
+        ..._baseStatus(),
+        'detail_schema': 'general-scene-evaluation/v1',
+        'evaluation_status': 'RUNNING',
+      }),
+      throwsA(isA<PracticeReportStatusDecodeException>()),
+    );
+  });
+
+  test('requires the Evaluation identity for RUNNING and READY', () {
+    final missingIdentity =
+        <String, Object?>{..._baseStatus(), 'evaluation_status': 'RUNNING'}
+          ..remove('evaluation_id')
+          ..remove('evaluation_revision_id')
+          ..remove('revision');
+
+    expect(
+      () => decodePracticeReportStatus(missingIdentity),
+      throwsA(isA<PracticeReportStatusDecodeException>()),
+    );
+  });
+
+  test('accepts QUEUED before the Evaluation identity exists', () {
+    final queued =
+        <String, Object?>{..._baseStatus(), 'evaluation_status': 'QUEUED'}
+          ..remove('evaluation_id')
+          ..remove('evaluation_revision_id')
+          ..remove('revision');
+
+    expect(
+      decodePracticeReportStatus(queued).evaluationStatus,
+      PracticeReportEvaluationStatus.queued,
+    );
+  });
+
+  test('rejects a report scope that contradicts practice mode', () {
+    expect(
+      () => decodePracticeReportStatus(<String, Object?>{
+        ..._baseStatus(),
+        'report_scope': 'PART_1',
+        'evaluation_status': 'RUNNING',
+      }),
+      throwsA(isA<PracticeReportStatusDecodeException>()),
+    );
+  });
+
+  test('rejects report status sections outside server order', () {
+    expect(
+      () => decodePracticeReportStatus(<String, Object?>{
+        ..._baseStatus(),
+        'available_sections': <Object?>['PART_3', 'PART_2'],
+        'evaluation_status': 'RUNNING',
+      }),
+      throwsA(isA<PracticeReportStatusDecodeException>()),
+    );
+  });
+
+  test('decodes separate Part 2 and Part 3 practice report sections', () {
+    final detail = decodeIeltsPracticeReportDetail(_sectionDetail());
+
+    expect(detail.sectionReviews, hasLength(2));
+    expect(detail.sectionReviews.first.partId, IeltsSpeakingPartId.part2);
+    expect(detail.sectionReviews.last.partId, IeltsSpeakingPartId.part3);
+  });
+
+  test('rejects practice report sections outside server order', () {
+    final detail = _sectionDetail()
+      ..['available_sections'] = <Object?>['PART_3', 'PART_2']
+      ..['section_reviews'] = <Object?>[
+        _sectionReview(part: 'PART_3', index: 2),
+        _sectionReview(part: 'PART_2', index: 1),
+      ];
+
+    expect(
+      () => decodeIeltsPracticeReportDetail(detail),
+      throwsA(isA<IeltsPracticeReportDecodeException>()),
+    );
+  });
+
+  test('rejects practice report questions outside server sequence', () {
+    final detail = _sectionDetail()
+      ..['questions'] = <Object?>[
+        _sectionQuestion(part: 'PART_3', index: 2),
+        _sectionQuestion(part: 'PART_2', index: 1),
+      ];
+
+    expect(
+      () => decodeIeltsPracticeReportDetail(detail),
+      throwsA(isA<IeltsPracticeReportDecodeException>()),
+    );
+  });
+
+  test('rejects incomplete and duplicated response evidence links', () {
+    final incomplete = _sectionDetail();
+    final incompleteQuestion =
+        (incomplete['questions']! as List<Object?>).first
+            as Map<String, Object?>;
+    incompleteQuestion.remove('confirmed_transcript');
+
+    final duplicated = _sectionDetail();
+    final duplicatedQuestions = duplicated['questions']! as List<Object?>;
+    final duplicateQuestion = duplicatedQuestions.last as Map<String, Object?>;
+    duplicateQuestion['response_turn_id'] = 'turn_1';
+    duplicateQuestion['evidence_ref_ids'] = <Object?>['evidence_1'];
+    final duplicatedReviews = duplicated['section_reviews']! as List<Object?>;
+    (duplicatedReviews.last as Map<String, Object?>)['evidence_ref_ids'] =
+        <Object?>['evidence_1'];
+
+    for (final invalid in <Map<String, Object?>>[incomplete, duplicated]) {
+      expect(
+        () => decodeIeltsPracticeReportDetail(invalid),
+        throwsA(isA<IeltsPracticeReportDecodeException>()),
+      );
+    }
+  });
+
+  test('accepts an explicitly unanswered question without evidence', () {
+    final detail = _sectionDetail();
+    final questions = detail['questions']! as List<Object?>;
+    final unanswered = questions.last as Map<String, Object?>
+      ..remove('confirmed_transcript')
+      ..remove('response_turn_id')
+      ..['evidence_ref_ids'] = <Object?>[];
+    final reviews = detail['section_reviews']! as List<Object?>;
+    (reviews.last as Map<String, Object?>)['evidence_ref_ids'] = <Object?>[];
+
+    final decoded = decodeIeltsPracticeReportDetail(detail);
+
+    expect(unanswered['evidence_ref_ids'], isEmpty);
+    expect(decoded.questions.last.confirmedTranscript, isNull);
+    expect(decoded.questions.last.responseTurnId, isNull);
+  });
+
+  test(
+    'controller recovers from a retryable status failure within its bound',
+    () async {
+      final client = _ScriptedStatusClient(<Object>[
+        const PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.conflict,
+          retryable: true,
+        ),
+        _status(PracticeReportEvaluationStatus.ready),
+      ]);
+      final controller = PracticeReportStatusController(
+        client: client,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 3,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('session_595');
+
+      expect(client.statusCalls, 2);
+      expect(
+        controller.status?.evaluationStatus,
+        PracticeReportEvaluationStatus.ready,
+      );
+      expect(controller.errorMessage, isNull);
+    },
+  );
+
+  test(
+    'controller stops retryable status polling at the configured bound',
+    () async {
+      final client = _ScriptedStatusClient(const <Object>[
+        PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.conflict,
+          retryable: true,
+        ),
+      ]);
+      final controller = PracticeReportStatusController(
+        client: client,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 3,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('session_595');
+
+      expect(client.statusCalls, 3);
+      expect(controller.status, isNull);
+      expect(controller.errorMessage, '报告正在处理中，请稍后刷新状态。');
+      expect(controller.canRetry, isTrue);
+    },
+  );
+
+  test(
+    'controller does not poll or offer retry for a terminal status error',
+    () async {
+      final client = _ScriptedStatusClient(const <Object>[
+        PracticeReportStatusException(
+          kind: PracticeReportStatusFailureKind.authenticationRequired,
+        ),
+      ]);
+      final controller = PracticeReportStatusController(
+        client: client,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 3,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('session_595');
+
+      expect(client.statusCalls, 1);
+      expect(controller.canRetry, isFalse);
+    },
+  );
+
+  testWidgets('renders real running, ready, insufficient, and failed states', (
+    tester,
+  ) async {
+    final client = _StatusClient();
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    var opened = false;
+
+    Future<void> pumpCard() => tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: PracticeReportStatusCard(
+              controller: controller,
+              onOpenReport: () async => opened = true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    client.status = _status(PracticeReportEvaluationStatus.running);
+    await controller.load('session_595');
+    await pumpCard();
+    expect(
+      find.byKey(const Key('ielts-completion-report-generating')),
+      findsOneWidget,
+    );
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    client.status = _status(PracticeReportEvaluationStatus.ready);
+    await controller.retry();
+    await tester.pump();
+    expect(
+      find.byKey(const Key('ielts-completion-report-ready')),
+      findsOneWidget,
+    );
+    expect(find.text('复盘已生成'), findsOneWidget);
+
+    client.status = _status(
+      PracticeReportEvaluationStatus.ready,
+      scoreability: EvaluationReportScoreability.insufficient,
+    );
+    await controller.retry();
+    await tester.pump();
+    expect(
+      find.byKey(const Key('ielts-completion-report-ready')),
+      findsOneWidget,
+    );
+    expect(find.text('复盘已生成 · 证据不足'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ielts-completion-report-open')));
+    await tester.pump();
+    expect(opened, isTrue);
+
+    client.status = _status(PracticeReportEvaluationStatus.failed);
+    await controller.retry();
+    await tester.pump();
+    expect(
+      find.byKey(const Key('ielts-completion-report-failed')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('ielts-completion-report-retry')),
+      findsNothing,
+    );
+    expect(find.textContaining('EVALUATION_FAILED'), findsNothing);
+    expect(find.textContaining('回答已保存'), findsOneWidget);
+  });
+
+  testWidgets('retryable FULL_MOCK FAILED creates a new revision', (
+    tester,
+  ) async {
+    final client = _RegeneratingStatusClient(
+      _status(
+        PracticeReportEvaluationStatus.failed,
+        practiceMode: PracticeMode.fullMock,
+        withEvaluationIdentity: true,
+      ),
+    );
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load('session_595');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeReportStatusCard(
+            controller: controller,
+            onOpenReport: () async {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('ielts-completion-report-retry')),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('ielts-completion-report-retry')));
+    await tester.pumpAndSettle();
+
+    expect(client.regenerationCalls, 1);
+    expect(client.statusCalls, 2);
+    expect(
+      find.byKey(const Key('ielts-completion-report-generating')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('READY report loading failure stays visible and can be retried', (
+    tester,
+  ) async {
+    final client = _StatusClient()
+      ..status = _status(PracticeReportEvaluationStatus.ready)
+      ..readyReportError = const PracticeReportStatusException(
+        kind: PracticeReportStatusFailureKind.network,
+        retryable: true,
+      );
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load('session_595');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeReportStatusCard(
+            controller: controller,
+            onOpenReport: () async {
+              await controller.loadReadyReport();
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('ielts-completion-report-open')));
+    await tester.pumpAndSettle();
+
+    expect(client.readyReportCalls, 1);
+    expect(find.text('报告暂时无法加载，请稍后重试。'), findsOneWidget);
+    expect(find.text('重试打开'), findsOneWidget);
+  });
+
+  testWidgets('section FAILED with identity cannot regenerate', (tester) async {
+    final client = _RegeneratingStatusClient(
+      _status(
+        PracticeReportEvaluationStatus.failed,
+        withEvaluationIdentity: true,
+      ),
+    );
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load('session_595');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeReportStatusCard(
+            controller: controller,
+            onOpenReport: () async {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('ielts-completion-report-retry')),
+      findsNothing,
+    );
+    await controller.regenerate();
+    expect(client.regenerationCalls, 0);
+    expect(client.statusCalls, 1);
+  });
+
+  testWidgets('handoff FAILED without identity cannot regenerate', (
+    tester,
+  ) async {
+    final client = _RegeneratingStatusClient(
+      _status(PracticeReportEvaluationStatus.failed),
+    );
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load('session_595');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeReportStatusCard(
+            controller: controller,
+            onOpenReport: () async {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('ielts-completion-report-retry')),
+      findsNothing,
+    );
+    await controller.regenerate();
+    expect(client.regenerationCalls, 0);
+    expect(client.statusCalls, 1);
+  });
+
+  testWidgets('status card fits narrow screens with large text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final client = _StatusClient()
+      ..status = _status(PracticeReportEvaluationStatus.ready);
+    final controller = PracticeReportStatusController(
+      client: client,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    await controller.load('session_595');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: Scaffold(
+            body: SingleChildScrollView(
+              padding: const EdgeInsets.all(12),
+              child: PracticeReportStatusCard(
+                controller: controller,
+                onOpenReport: () async {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Map<String, Object?> _baseStatus() => <String, Object?>{
+  'practice_session_id': 'session_595',
+  'practice_mode': 'PART_2',
+  'report_scope': 'PART_2_3',
+  'available_sections': <Object?>['PART_2', 'PART_3'],
+  'detail_schema': 'ielts-speaking-practice-report/v1',
+  'evaluation_id': '7b000001-0000-4000-8000-000000000001',
+  'evaluation_revision_id': 'a1000001-0000-4000-8000-000000000001',
+  'revision': 1,
+  'status_url': '/v1/practice-sessions/session_595/report',
+};
+
+Map<String, Object?> _sectionDetail() => <String, Object?>{
+  'schema_version': 'ielts-speaking-practice-report/v1',
+  'report_scope': 'PART_2_3',
+  'available_sections': <Object?>['PART_2', 'PART_3'],
+  'questions': <Object?>[
+    _sectionQuestion(part: 'PART_2', index: 1),
+    _sectionQuestion(part: 'PART_3', index: 2),
+  ],
+  'section_reviews': <Object?>[
+    _sectionReview(part: 'PART_2', index: 1),
+    _sectionReview(part: 'PART_3', index: 2),
+  ],
+};
+
+Map<String, Object?> _sectionQuestion({
+  required String part,
+  required int index,
+}) => <String, Object?>{
+  'question_id': 'question_$index',
+  'part_id': part,
+  'index': index,
+  'question_text': 'Question $index?',
+  'confirmed_transcript': 'Answer $index.',
+  'response_turn_id': 'turn_$index',
+  'evidence_ref_ids': <Object?>['evidence_$index'],
+};
+
+Map<String, Object?> _sectionReview({
+  required String part,
+  required int index,
+}) => <String, Object?>{
+  'part_id': part,
+  'question_indexes': <Object?>[index],
+  'evidence_ref_ids': <Object?>['evidence_$index'],
+  'strength_finding_ids': <Object?>[],
+  'improvement_finding_ids': <Object?>[],
+  'upgrade_example_finding_ids': <Object?>[],
+};
+
+PracticeReportStatus _status(
+  PracticeReportEvaluationStatus evaluationStatus, {
+  EvaluationReportScoreability scoreability =
+      EvaluationReportScoreability.provisional,
+  PracticeMode practiceMode = PracticeMode.part2,
+  bool withEvaluationIdentity = false,
+}) {
+  final ready = evaluationStatus == PracticeReportEvaluationStatus.ready;
+  final failed = evaluationStatus == PracticeReportEvaluationStatus.failed;
+  final hasEvaluation = ready || withEvaluationIdentity;
+  final reportScope = switch (practiceMode) {
+    PracticeMode.part1 => PracticeReportScope.part1,
+    PracticeMode.part2 => PracticeReportScope.part2And3,
+    PracticeMode.part3 => PracticeReportScope.part3,
+    PracticeMode.fullMock => PracticeReportScope.fullMock,
+    _ => throw StateError('Unsupported test mode.'),
+  };
+  final sections = switch (practiceMode) {
+    PracticeMode.part1 => const <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part1,
+    ],
+    PracticeMode.part2 => const <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part2,
+      IeltsSpeakingPartId.part3,
+    ],
+    PracticeMode.part3 => const <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part3,
+    ],
+    PracticeMode.fullMock => const <IeltsSpeakingPartId>[
+      IeltsSpeakingPartId.part1,
+      IeltsSpeakingPartId.part2,
+      IeltsSpeakingPartId.part3,
+    ],
+    _ => throw StateError('Unsupported test mode.'),
+  };
+  return PracticeReportStatus(
+    practiceSessionId: 'session_595',
+    practiceMode: practiceMode,
+    reportScope: reportScope,
+    availableSections: sections,
+    detailSchema: practiceMode == PracticeMode.fullMock
+        ? 'ielts-speaking-report/v1'
+        : 'ielts-speaking-practice-report/v1',
+    evaluationStatus: evaluationStatus,
+    statusUrl: '/v1/practice-sessions/session_595/report',
+    evaluationId: hasEvaluation ? '7b000001-0000-4000-8000-000000000001' : null,
+    evaluationRevisionId: hasEvaluation
+        ? 'a1000001-0000-4000-8000-000000000001'
+        : null,
+    revision: hasEvaluation ? 1 : null,
+    reportRef: ready
+        ? const PracticeReportRef(
+            reportId: '20000000-0000-4000-8000-000000000002',
+            href: '/v1/evaluation-reports/20000000-0000-4000-8000-000000000002',
+          )
+        : null,
+    scoreability: ready ? scoreability : null,
+    summary: ready ? '复盘已生成。' : null,
+    stableFailure: failed
+        ? const PracticeReportStableFailure(
+            reasonCode: 'EVALUATION_FAILED',
+            retryable: true,
+          )
+        : null,
+  );
+}
+
+final class _StatusClient implements PracticeReportStatusClient {
+  PracticeReportStatus status = _status(PracticeReportEvaluationStatus.running);
+  Object? readyReportError;
+  int readyReportCalls = 0;
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async =>
+      status;
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) {
+    readyReportCalls++;
+    final error = readyReportError;
+    if (error != null) {
+      return Future<EvaluationReport>.error(error);
+    }
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _ScriptedStatusClient implements PracticeReportStatusClient {
+  _ScriptedStatusClient(this.results);
+
+  final List<Object> results;
+  int statusCalls = 0;
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async {
+    final index = statusCalls.clamp(0, results.length - 1);
+    statusCalls++;
+    final result = results[index];
+    if (result is PracticeReportStatusException) {
+      throw result;
+    }
+    return result as PracticeReportStatus;
+  }
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _RegeneratingStatusClient
+    implements PracticeReportStatusClient, PracticeReportRegenerationClient {
+  _RegeneratingStatusClient(this.status);
+
+  PracticeReportStatus status;
+  int statusCalls = 0;
+  int regenerationCalls = 0;
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async {
+    statusCalls++;
+    return status;
+  }
+
+  @override
+  Future<void> regenerateReport(PracticeReportStatus status) async {
+    regenerationCalls++;
+    this.status = _status(
+      PracticeReportEvaluationStatus.running,
+      practiceMode: status.practiceMode,
+      withEvaluationIdentity: true,
+    );
+  }
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> clearAccountState() async {}
+}
+
+final class _Transport implements IdentityHttpTransport {
+  _Transport(this.response);
+
+  final IdentityHttpResponse response;
+  String? method;
+  Uri? uri;
+  Map<String, String>? headers;
+  String? body;
+
+  @override
+  Future<IdentityHttpResponse> send({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    String? body,
+  }) async {
+    this.method = method;
+    this.uri = uri;
+    this.headers = headers;
+    this.body = body;
+    return response;
+  }
+}
+
+final class _RealHttpOverrides extends HttpOverrides {}

--- a/mobile/test/review/review_history_test.dart
+++ b/mobile/test/review/review_history_test.dart
@@ -899,7 +899,7 @@ void main() {
     );
     await tester.pumpAndSettle();
     await _expandHistory(tester);
-    expect(find.text('IELTS 口语复盘'), findsOneWidget);
+    expect(find.text('IELTS 口语模考报告'), findsOneWidget);
     await tester.tap(
       find.byKey(Key('review-history-select-${item.review.id}')),
     );


### PR DESCRIPTION
## 功能描述

- 为 Part 1、Part 2 + Part 3、Part 3 专项练习提供独立复盘页面。
- 为完整模考提供总览、Part 1、Part 2、Part 3 四个视图。
- 重做练习完成页：明确展示排队、生成中、已就绪、证据不足与失败状态，允许用户离开等待。
- 完整模考历史报告直接使用已经返回的正式报告，不再二次请求旧接口，避免长时间停留在加载页。

## 实现思路

- 复用现有 EvaluationReport 与 IELTS 正式报告组件，只新增专项报告的严格解码与分段展示。
- 统一使用按 Practice Session 查询的报告状态契约；仅完整模考失败且后端允许时提供真实重新生成操作。
- 严格校验练习模式、报告范围、Part 顺序、题号、Turn 与 Evidence 引用，拒绝串报告或不完整数据。
- 专项报告只展示证据与反馈，不伪造 Overall Band；完整模考才展示综合估分。

## 可复现测试

- cd mobile && flutter analyze --no-pub
- cd mobile && flutter test
- 关键报告、状态与路由测试通过
- 整合分支 Flutter 全量测试：870 项通过
- 使用真实后端运行 make dev-ios-simulator，iOS 模拟器数字人已禁用

## 依赖

- #597 专项报告后端投影
- #598 IELTS 评估可靠性
- #599 Practice Session 报告状态接口

Closes #595
