### PR TITLE
fix(ielts): return insufficient-evidence report for unscoreable mock

### DIFF
--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -25,15 +25,16 @@ const (
 	IELTSSpeakingShadowPromptVersion         = "ielts-speaking-full-mock-shadow-prompt/v5"
 	IELTSSpeakingShadowRubricVersion         = "ielts-speaking-public-band-rubric/v2"
 
-	ieltsMaximumProviderPayload = 64 * 1024
-	ieltsMaximumFindingText     = 2048
-	ieltsMaximumFindings        = 3
-	ieltsMaximumAnchors         = 4
-	ieltsMaximumOccurrence      = 16
-	ieltsMaximumQuestions       = 64
-	ieltsMinimumEnglishWords    = 10
-	ieltsMinimumEnglishTurns    = 3
-	ieltsMinimumAcousticMS      = 3000
+	ieltsMaximumProviderPayload     = 64 * 1024
+	ieltsMaximumFindingText         = 2048
+	ieltsMaximumFindings            = 3
+	ieltsMaximumAnchors             = 4
+	ieltsMaximumOccurrence          = 16
+	ieltsMaximumQuestions           = 64
+	ieltsMinimumEnglishWords        = 10
+	ieltsMinimumEnglishTurns        = 3
+	ieltsMinimumEnglishWordsPerTurn = 3
+	ieltsMinimumAcousticMS          = 3000
 )
 
 var ErrInvalidIELTSSpeakingShadow = errors.New(
@@ -598,6 +599,8 @@ func prepareIELTSSpeakingShadow(
 				if cjkCount > 0 {
 					language = ieltsLanguageMixed
 				}
+			}
+			if wordCount >= ieltsMinimumEnglishWordsPerTurn {
 				englishTurns++
 				englishWords += wordCount
 			}

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
@@ -143,6 +143,35 @@ func TestIELTSSpeakingShadowRejectsChineseOnlySessionAsUnscoreable(
 	}
 }
 
+func TestIELTSSpeakingShadowRejectsRepeatedShortAnswersAsUnscoreable(
+	t *testing.T,
+) {
+	snapshot := ieltsSpeakingSnapshotWithTranscript(
+		t,
+		"Yes, yes. 666 这是中文。",
+	)
+	provider := &ieltsProviderStub{}
+	result, err := NewIELTSSpeakingShadowEngine(provider).Evaluate(
+		context.Background(),
+		snapshot,
+	)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if provider.calls != 0 ||
+		result.Scoreability != IELTSSpeakingScoreabilityInsufficient ||
+		result.Gate != IELTSSpeakingGateBlocked ||
+		result.Provider != nil ||
+		!slices.Equal(result.ReasonCodes, []IELTSSpeakingReasonCode{
+			IELTSReasonInsufficientEvidence,
+		}) {
+		t.Fatalf("result = %#v; provider calls = %d", result, provider.calls)
+	}
+	if err := ValidateIELTSSpeakingShadowResult(snapshot, result); err != nil {
+		t.Fatalf("ValidateIELTSSpeakingShadowResult: %v", err)
+	}
+}
+
 func TestIELTSSpeakingShadowDoesNotCallProviderWithoutEveryFrozenAnswer(
 	t *testing.T,
 ) {

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -274,13 +274,13 @@ func (worker *IELTSSpeakingShadowWorker) recordFailure(
 	cause error,
 ) (IELTSSpeakingShadowRuntimeStatus, error) {
 	failure := classifyIELTSSpeakingShadowFailure(cause)
-	if failure.Code == "provider_invalid_json" ||
-		failure.Code == "provider_schema_mismatch" ||
-		failure.Code == "provider_invalid_response" {
+	if rejectionStage := ieltsProviderRejectionStage(cause); rejectionStage != "" {
 		slog.Warn(
 			"IELTS Speaking provider response rejected",
 			"failure_code",
 			failure.Code,
+			"rejection_stage",
+			rejectionStage,
 		)
 	}
 	status, err := worker.repository.FailIELTSSpeakingShadow(
@@ -297,6 +297,21 @@ func (worker *IELTSSpeakingShadowWorker) recordFailure(
 		return "", evaluation.ErrInvalidRequest
 	}
 	return status, nil
+}
+
+func ieltsProviderRejectionStage(cause error) string {
+	switch {
+	case errors.Is(cause, errIELTSSpeakingProviderInvalidJSON):
+		return "json_decode"
+	case errors.Is(cause, errIELTSSpeakingProviderSchemaMismatch):
+		return "schema_validation"
+	case errors.Is(cause, ErrInvalidIELTSSpeakingShadow):
+		return "semantic_validation"
+	case errors.Is(cause, evaluation.ErrInvalidRequest):
+		return "request_validation"
+	default:
+		return ""
+	}
 }
 
 func ieltsClaimMatchesRuntime(

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -1,9 +1,13 @@
 package scoring
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +48,52 @@ func TestIELTSSpeakingShadowWorkerCompletesEvidenceBoundResult(
 			repository.result,
 		) != nil {
 		t.Fatalf("repository = %#v", repository)
+	}
+}
+
+func TestIELTSSpeakingShadowWorkerCompletesInsufficientEvidenceResult(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := validIELTSSpeakingShadowClaim(t)
+	claim.Snapshot = ieltsSpeakingSnapshotWithTranscript(
+		t,
+		"Yes, yes. 666 这是中文。",
+	)
+	repository := &ieltsShadowRuntimeRepositoryStub{
+		claim:    claim,
+		acquired: true,
+	}
+	provider := &ieltsProviderStub{}
+	worker, err := NewIELTSSpeakingShadowWorker(
+		repository,
+		NewIELTSSpeakingShadowEngine(provider),
+		validIELTSSpeakingShadowRuntimeConfiguration(),
+	)
+	if err != nil {
+		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+	}
+	sweep, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if sweep != (IELTSSpeakingShadowSweepResult{
+		Claimed:   1,
+		Completed: 1,
+	}) || provider.calls != 0 || repository.completeCalls != 1 ||
+		repository.failCalls != 0 ||
+		repository.result.Scoreability !=
+			IELTSSpeakingScoreabilityInsufficient ||
+		ValidateIELTSSpeakingShadowResult(
+			claim.Snapshot,
+			repository.result,
+		) != nil {
+		t.Fatalf(
+			"sweep = %#v; provider calls = %d; repository = %#v",
+			sweep,
+			provider.calls,
+			repository,
+		)
 	}
 }
 
@@ -234,6 +284,55 @@ func TestIELTSSpeakingShadowWorkerFailsSchemaMismatchWithoutRetry(
 			sweep,
 			repository.failure,
 		)
+	}
+}
+
+func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
+	t *testing.T,
+) {
+	claim := validIELTSSpeakingShadowClaim(t)
+	prepared, err := prepareIELTSSpeakingShadow(claim.Snapshot)
+	if err != nil {
+		t.Fatalf("prepareIELTSSpeakingShadow: %v", err)
+	}
+	payload := validIELTSProviderPayload(prepared.input)
+	anchor := &payload.Criteria[0].Strengths[0].Evidence[0]
+	anchor.EvidenceRefID = "missing-evidence-ref"
+	anchor.Quote = "I explain"
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	repository := &ieltsShadowRuntimeRepositoryStub{
+		claim:      claim,
+		acquired:   true,
+		failStatus: IELTSSpeakingShadowRuntimeFailed,
+	}
+	worker, err := NewIELTSSpeakingShadowWorker(
+		repository,
+		NewIELTSSpeakingShadowEngine(&ieltsProviderStub{payload: raw}),
+		validIELTSSpeakingShadowRuntimeConfiguration(),
+	)
+	if err != nil {
+		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+	}
+
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	sweep, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	logged := output.String()
+	if sweep.Failed != 1 ||
+		!strings.Contains(logged, `"failure_code":"provider_invalid_response"`) ||
+		!strings.Contains(logged, `"rejection_stage":"semantic_validation"`) ||
+		strings.Contains(logged, "I explain") {
+		t.Fatalf("sweep = %#v; log = %s", sweep, logged)
 	}
 }
 


### PR DESCRIPTION
## 功能描述

修复 IELTS 完整模考在回答主要为重复短答、数字或中文时仍调用评分模型，最终因歧义证据锚点显示报告生成失败的问题。

## 实现思路

- 复用现有评估流程的最小有效回答标准：每个回答至少包含 3 个英文词，才计入可评分英文回合与总词数。
- 全部题目已回答但英语证据不足时，直接生成 INSUFFICIENT_EVIDENCE 的受约束结果，不调用 LLM；Worker 正常完成为 READY。
- Provider 拒绝日志增加安全稳定的 rejection_stage，只记录校验阶段与既有失败码，不记录回答或 Provider 原文。
- 补充重复短答、中英混合、Worker READY 和安全日志回归测试。

## 可复现测试

1. 将全部回答设为 Yes, yes. 666 加中文，确认 Provider 调用次数为 0，结果为 INSUFFICIENT/BLOCKED 且可通过完整结果校验。
2. 让 Provider 返回歧义证据锚点，确认日志包含 provider_invalid_response 与 semantic_validation，且不包含回答原文。
3. 已通过：go test ./internal/coaching/evaluation/scoring -run IELTSSpeaking -count=1
4. 已通过：make check-go（Go 格式、vet、全仓 Go 测试）。

## 关联 Issue

Closes #607