### PR TITLE
feat(ielts): 优化专项完成页报告入口与行动层级

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -2012,7 +2012,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       IeltsMockPhase.part2Preparation ||
       IeltsMockPhase.part2Speaking => 'IELTS · Part 2',
       IeltsMockPhase.part3Intro || IeltsMockPhase.part3 => 'IELTS · Part 3',
-      IeltsMockPhase.complete => 'IELTS 口语报告',
+      IeltsMockPhase.complete =>
+        _mode == PracticeMode.fullMock ? 'IELTS 口语报告' : '练习完成',
       _ => 'IELTS Speaking',
     };
     return AppBar(
@@ -2021,7 +2022,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       centerTitle: true,
       leading: IconButton(
         key: const Key('ielts-mock-exit'),
-        tooltip: '退出模考',
+        tooltip:
+            phase == IeltsMockPhase.complete && _mode != PracticeMode.fullMock
+            ? '返回题单'
+            : '退出模考',
         onPressed: _exitInFlight ? null : _requestExit,
         icon: const Icon(Icons.chevron_left_rounded),
       ),
@@ -2159,14 +2163,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
               )
             : _SectionPracticeComplete(
                 mode: _mode,
+                completedAnswerCount: widget.controller.completedTurns,
                 reportStatusController: widget.reportStatusController,
                 onOpenReport: _openReadyReport,
                 onNext: () =>
                     _finishSection(IeltsPracticeCompletionAction.next),
                 onRetry: () =>
                     _finishSection(IeltsPracticeCompletionAction.retry),
-                onList: () =>
-                    _finishSection(IeltsPracticeCompletionAction.list),
               ),
     };
   }
@@ -3010,19 +3013,19 @@ class _MockExitSheet extends StatelessWidget {
 class _SectionPracticeComplete extends StatelessWidget {
   const _SectionPracticeComplete({
     required this.mode,
+    required this.completedAnswerCount,
     required this.reportStatusController,
     required this.onOpenReport,
     required this.onNext,
     required this.onRetry,
-    required this.onList,
   });
 
   final PracticeMode mode;
+  final int completedAnswerCount;
   final PracticeReportStatusController? reportStatusController;
   final Future<void> Function() onOpenReport;
   final VoidCallback onNext;
   final VoidCallback onRetry;
-  final VoidCallback onList;
 
   @override
   Widget build(BuildContext context) {
@@ -3035,44 +3038,61 @@ class _SectionPracticeComplete extends StatelessWidget {
         'Non-IELTS mode in IELTS practice.',
       ),
     };
-    return SingleChildScrollView(
-      key: Key('ielts-section-practice-complete-${mode.name}'),
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 520),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            _CompactCompletionHeader(
-              title: '$part 已完成',
-              message: '回答已保存，可离开本页等待复盘生成。',
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        key: Key('ielts-section-practice-complete-${mode.name}'),
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 32),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: 520,
+              minHeight: math.max(0, constraints.maxHeight - 56),
             ),
-            const SizedBox(height: 20),
-            PracticeReportStatusCard(
-              controller: reportStatusController,
-              onOpenReport: onOpenReport,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _CompactCompletionHeader(
+                      title: '$part 已完成',
+                      message: '$completedAnswerCount 道回答已保存',
+                    ),
+                    const SizedBox(height: 24),
+                    PracticeReportStatusCard(
+                      controller: reportStatusController,
+                      onOpenReport: onOpenReport,
+                    ),
+                  ],
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 40),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text('继续练习', style: SpeakUpDesign.cardTitle),
+                      const SizedBox(height: 12),
+                      OutlinedButton(
+                        key: const Key('ielts-section-next-action'),
+                        onPressed: onNext,
+                        style: OutlinedButton.styleFrom(
+                          minimumSize: const Size.fromHeight(52),
+                        ),
+                        child: const Text('练习下一套'),
+                      ),
+                      const SizedBox(height: 4),
+                      TextButton(
+                        key: const Key('ielts-section-retry-action'),
+                        onPressed: onRetry,
+                        child: const Text('再练本套'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            OutlinedButton(
-              key: const Key('ielts-section-next-action'),
-              onPressed: onNext,
-              style: OutlinedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-              ),
-              child: const Text('下一套未练习'),
-            ),
-            const SizedBox(height: 6),
-            TextButton(
-              key: const Key('ielts-section-retry-action'),
-              onPressed: onRetry,
-              child: const Text('再练本套'),
-            ),
-            TextButton(
-              key: const Key('ielts-section-list-action'),
-              onPressed: onList,
-              child: const Text('返回套题列表'),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/coaching/review/practice_report_status_view.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_view.dart
@@ -54,8 +54,9 @@ class PracticeReportStatusCard extends StatelessWidget {
       return const _ReportStatusSurface(
         key: Key('ielts-completion-report-loading'),
         icon: Icons.sync_rounded,
-        title: '正在读取复盘状态',
-        message: '你可以直接返回训练，不会影响后台处理。',
+        loading: true,
+        title: '复盘生成中',
+        message: '可以先离开，生成完成后可在复盘页查看。',
       );
     }
     return switch (status.evaluationStatus) {
@@ -63,10 +64,9 @@ class PracticeReportStatusCard extends StatelessWidget {
       PracticeReportEvaluationStatus.running => _ReportStatusSurface(
         key: const Key('ielts-completion-report-generating'),
         icon: Icons.schedule_rounded,
-        title: status.evaluationStatus == PracticeReportEvaluationStatus.queued
-            ? '报告已进入队列'
-            : '报告生成中',
-        message: value.errorMessage ?? '可先返回训练，完成后可在复盘页查看。',
+        loading: true,
+        title: '复盘生成中',
+        message: value.errorMessage ?? '可以先离开，生成完成后可在复盘页查看。',
         action: value.errorMessage == null
             ? null
             : TextButton(
@@ -82,8 +82,12 @@ class PracticeReportStatusCard extends StatelessWidget {
         icon: Icons.description_outlined,
         title: status.scoreability == EvaluationReportScoreability.insufficient
             ? '复盘已生成 · 证据不足'
-            : '复盘已生成',
-        message: value.errorMessage ?? status.summary!,
+            : '专项复盘已生成',
+        message:
+            value.errorMessage ??
+            (status.scoreability == EvaluationReportScoreability.insufficient
+                ? status.summary!
+                : '查看本次表现、主要问题和下一步练习建议。'),
         action: FilledButton(
           key: const Key('ielts-completion-report-open'),
           onPressed: value.isLoadingReadyReport
@@ -93,7 +97,7 @@ class PracticeReportStatusCard extends StatelessWidget {
             value.isLoadingReadyReport
                 ? '正在打开…'
                 : value.errorMessage == null
-                ? '查看复盘'
+                ? '查看本次复盘'
                 : '重试打开',
           ),
         ),
@@ -101,7 +105,7 @@ class PracticeReportStatusCard extends StatelessWidget {
       PracticeReportEvaluationStatus.failed => _ReportStatusSurface(
         key: const Key('ielts-completion-report-failed'),
         icon: Icons.error_outline_rounded,
-        title: '报告生成失败',
+        title: '复盘生成失败',
         message:
             value.errorMessage ??
             _failureMessage(
@@ -137,6 +141,7 @@ class _ReportStatusSurface extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.message,
+    this.loading = false,
     this.action,
     super.key,
   });
@@ -144,6 +149,7 @@ class _ReportStatusSurface extends StatelessWidget {
   final IconData icon;
   final String title;
   final String message;
+  final bool loading;
   final Widget? action;
 
   @override
@@ -160,7 +166,19 @@ class _ReportStatusSurface extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(icon, size: 22, color: SpeakUpDesign.ink),
+              if (loading)
+                Semantics(
+                  label: '正在生成复盘',
+                  child: const SizedBox.square(
+                    dimension: 22,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.2,
+                      color: SpeakUpDesign.ink,
+                    ),
+                  ),
+                )
+              else
+                Icon(icon, size: 22, color: SpeakUpDesign.ink),
               const SizedBox(width: 10),
               Expanded(child: Text(title, style: SpeakUpDesign.cardTitle)),
             ],

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1532,7 +1532,15 @@ void main() {
     await tester.pumpAndSettle();
     await _answerCurrentShortQuestion(tester, controller);
 
-    await tester.tap(find.byKey(const Key('ielts-section-list-action')));
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump();
+
+    expect(find.text('练习完成'), findsOneWidget);
+    expect(find.text('4 道回答已保存'), findsOneWidget);
+    expect(find.text('练习下一套'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-section-list-action')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
     await tester.pumpAndSettle();
 
     final request = preparation.takeNavigationRequest();

--- a/mobile/test/review/practice_report_status_test.dart
+++ b/mobile/test/review/practice_report_status_test.dart
@@ -493,7 +493,8 @@ void main() {
       find.byKey(const Key('ielts-completion-report-generating')),
       findsOneWidget,
     );
-    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('复盘生成中'), findsOneWidget);
 
     client.status = _status(PracticeReportEvaluationStatus.ready);
     await controller.retry();
@@ -502,7 +503,8 @@ void main() {
       find.byKey(const Key('ielts-completion-report-ready')),
       findsOneWidget,
     );
-    expect(find.text('复盘已生成'), findsOneWidget);
+    expect(find.text('专项复盘已生成'), findsOneWidget);
+    expect(find.text('查看本次复盘'), findsOneWidget);
 
     client.status = _status(
       PracticeReportEvaluationStatus.ready,
@@ -567,7 +569,8 @@ void main() {
       findsOneWidget,
     );
     await tester.tap(find.byKey(const Key('ielts-completion-report-retry')));
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump();
 
     expect(client.regenerationCalls, 1);
     expect(client.statusCalls, 2);


### PR DESCRIPTION
## 功能描述

- 将 IELTS 专项完成状态与异步复盘状态拆分展示
- 复盘生成期间显示明确的加载动画与可离开说明
- 复盘就绪后突出“查看本次复盘”主操作
- 精简完成页行动层级，移除与顶部返回重复的题单入口

## 实现思路

- 专项完成页标题统一为“练习完成”，并展示已保存回答数
- 报告状态卡分别呈现生成中、已生成、证据不足和失败状态
- 生成中状态使用可访问的 CircularProgressIndicator
- 使用受限宽度与上下分区布局，将继续练习操作稳定放在页面下方
- 保留完整模考原有标题与流程，不改变后端报告契约

## 可复现测试

1. `cd mobile && flutter test test/review/practice_report_status_test.dart test/coaching/practice/ielts_mock_practice_test.dart`
   - 64 tests passed
2. `cd mobile && flutter analyze`
   - No issues found
3. `IOS_SIMULATOR_ID=05F528B2-656E-4451-ACBA-415353BCEBD1 make dev-ios-simulator`
   - iOS 26.5 真后端启动验证，数字人禁用

Closes #610