### PR TITLE
feat(mobile): 收敛 IELTS 口语报告页与雷达图

### DIFF
--- a/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
@@ -60,83 +60,22 @@ class _IeltsSpeakingSessionReportPanelState
 }
 
 class IeltsSpeakingReportPanel extends StatefulWidget {
-  const IeltsSpeakingReportPanel({
-    required this.controller,
-    this.onRepracticeQuestion,
-    super.key,
-  });
+  const IeltsSpeakingReportPanel({required this.controller, super.key});
 
   final IeltsSpeakingReportController controller;
-  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion;
 
   @override
   State<IeltsSpeakingReportPanel> createState() =>
       _IeltsSpeakingReportPanelState();
 }
 
-class IeltsSpeakingReadyReportView extends StatefulWidget {
-  const IeltsSpeakingReadyReportView({
-    required this.report,
-    this.onRepracticeQuestion,
-    super.key,
-  });
+class IeltsSpeakingReadyReportView extends StatelessWidget {
+  const IeltsSpeakingReadyReportView({required this.report, super.key});
 
   final IeltsSpeakingReport report;
-  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion;
 
   @override
-  State<IeltsSpeakingReadyReportView> createState() =>
-      _IeltsSpeakingReadyReportViewState();
-}
-
-class _IeltsSpeakingReadyReportViewState
-    extends State<IeltsSpeakingReadyReportView> {
-  var _selectedIndex = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    const parts = <IeltsSpeakingPartId>[
-      IeltsSpeakingPartId.part1,
-      IeltsSpeakingPartId.part2,
-      IeltsSpeakingPartId.part3,
-    ];
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: Row(
-            key: const Key('ielts-speaking-report-scope-tabs'),
-            children: [
-              for (var index = 0; index < 4; index++) ...[
-                if (index > 0) const SizedBox(width: 8),
-                ChoiceChip(
-                  key: Key('ielts-speaking-report-scope-$index'),
-                  label: Text(index == 0 ? '总览' : _partLabel(parts[index - 1])),
-                  selected: _selectedIndex == index,
-                  onSelected: (_) => setState(() => _selectedIndex = index),
-                ),
-              ],
-            ],
-          ),
-        ),
-        const SizedBox(height: SpeakUpDesign.space16),
-        if (_selectedIndex == 0)
-          _ReadyReport(
-            report: widget.report,
-            onRepracticeQuestion: widget.onRepracticeQuestion,
-          )
-        else
-          _IeltsPartReport(
-            report: widget.report,
-            partId: parts[_selectedIndex - 1],
-            onRepracticeQuestion: widget.onRepracticeQuestion,
-          ),
-      ],
-    );
-  }
+  Widget build(BuildContext context) => _ReadyReport(report: report);
 }
 
 class _IeltsSpeakingReportPanelState extends State<IeltsSpeakingReportPanel> {
@@ -185,7 +124,6 @@ class _IeltsSpeakingReportPanelState extends State<IeltsSpeakingReportPanel> {
       IeltsSpeakingReportEvaluationStatus.running => const _GeneratingReport(),
       IeltsSpeakingReportEvaluationStatus.ready => IeltsSpeakingReadyReportView(
         report: envelope.report!,
-        onRepracticeQuestion: widget.onRepracticeQuestion,
       ),
       IeltsSpeakingReportEvaluationStatus.failed => const _GeneratingReport(
         message: '报告正在自动恢复，无需重新操作',
@@ -270,11 +208,9 @@ class _GeneratingReport extends StatelessWidget {
 }
 
 class _ReadyReport extends StatelessWidget {
-  const _ReadyReport({required this.report, this.onRepracticeQuestion});
+  const _ReadyReport({required this.report});
 
   final IeltsSpeakingReport report;
-  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion;
 
   @override
   Widget build(BuildContext context) {
@@ -307,11 +243,6 @@ class _ReadyReport extends StatelessWidget {
         const _ReportSectionTitle(title: '改进建议'),
         const SizedBox(height: SpeakUpDesign.space12),
         _TargetPlan(report: report),
-        const SizedBox(height: SpeakUpDesign.space24),
-        _QuestionReviews(
-          report: report,
-          onRepracticeQuestion: onRepracticeQuestion,
-        ),
       ],
     );
   }
@@ -330,29 +261,17 @@ class _ReportHeader extends StatelessWidget {
       label: 'IELTS 口语模考报告摘要',
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: SpeakUpDesign.primaryMuted,
+          color: SpeakUpDesign.surfaceMuted,
           borderRadius: BorderRadius.circular(SpeakUpDesign.radiusMedia),
+          border: Border.all(color: SpeakUpDesign.border),
         ),
         child: Padding(
           padding: const EdgeInsets.all(SpeakUpDesign.space20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                'IELTS Speaking',
-                style: SpeakUpDesign.pageTitle.copyWith(
-                  color: SpeakUpDesign.primary,
-                  fontStyle: FontStyle.italic,
-                ),
-              ),
-              Text(
-                'Test Report',
-                style: SpeakUpDesign.pageTitle.copyWith(
-                  color: const Color(0xFF2A6D7E),
-                  fontStyle: FontStyle.italic,
-                ),
-              ),
-              const SizedBox(height: SpeakUpDesign.space20),
+              const Text('本次模考', style: SpeakUpDesign.cardTitle),
+              const SizedBox(height: SpeakUpDesign.space12),
               _SummaryLine(label: 'Part 1', value: summary.part1Topic),
               const SizedBox(height: SpeakUpDesign.space8),
               _SummaryLine(label: 'Part 2&3', value: summary.part2Topic),
@@ -430,51 +349,37 @@ class _OverallScore extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final band = report.speakingOverallBand;
-    return Container(
+    return Card(
       key: Key(
         band == null
             ? 'ielts-speaking-overall-unavailable'
             : 'ielts-speaking-overall-available',
-      ),
-      decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [SpeakUpDesign.primary, Color(0xFF2A6D7E)],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusMedia),
       ),
       child: Padding(
         padding: const EdgeInsets.all(SpeakUpDesign.space20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              '口语总分',
-              style: SpeakUpDesign.cardTitle.copyWith(color: Colors.white),
-            ),
-            const SizedBox(height: SpeakUpDesign.space8),
-            Text(
-              band == null ? '暂不可用' : _bandLabel(band),
-              style: SpeakUpDesign.pageTitle.copyWith(
-                color: Colors.white,
-                fontSize: band == null ? 26 : 48,
-              ),
-            ),
-            const SizedBox(height: SpeakUpDesign.space12),
-            Container(
-              padding: const EdgeInsets.all(SpeakUpDesign.space16),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.94),
-                borderRadius: BorderRadius.circular(
-                  SpeakUpDesign.radiusControl,
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Text('口语总分', style: SpeakUpDesign.cardTitle),
+                const SizedBox(width: SpeakUpDesign.space8),
+                Text(
+                  band == null ? '暂不可用' : _bandLabel(band),
+                  style: SpeakUpDesign.pageTitle.copyWith(
+                    color: SpeakUpDesign.ink,
+                    fontSize: band == null ? 24 : 42,
+                  ),
                 ),
-              ),
-              child: Text(
-                report.speakingOverallExplanation,
-                style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
-              ),
+                const Spacer(),
+                Text('0–9 分练习估分', style: SpeakUpDesign.meta),
+              ],
             ),
+            const SizedBox(height: SpeakUpDesign.space16),
+            const Divider(height: 1),
+            const SizedBox(height: SpeakUpDesign.space16),
+            Text(report.speakingOverallExplanation, style: SpeakUpDesign.body),
           ],
         ),
       ),
@@ -650,7 +555,7 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
   const IeltsSpeakingScoreRadar({
     required this.criteria,
     this.semanticsKey = const Key('ielts-speaking-score-radar'),
-    this.height = 300,
+    this.height = 320,
     this.profileMode = false,
     super.key,
   });
@@ -670,18 +575,61 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
       byId[IeltsSpeakingCriterionId.lexicalResource],
     ];
     final values = ordered
-        .map((item) => (item?.estimatedBand ?? 0).toDouble())
+        .map((item) => item?.estimatedBand?.toDouble())
         .toList(growable: false);
-    final semanticLabel = ordered
-        .whereType<IeltsSpeakingCriterion>()
+    return FourAxisScoreRadar(
+      axes: <FourAxisRadarAxis>[
+        FourAxisRadarAxis(label: '流利与连贯', value: values[0]),
+        FourAxisRadarAxis(label: '发音', value: values[1]),
+        FourAxisRadarAxis(label: '语法', value: values[2]),
+        FourAxisRadarAxis(label: '词汇', value: values[3]),
+      ],
+      maximum: 9,
+      semanticsKey: semanticsKey,
+      semanticsPrefix: 'IELTS 口语四维雷达图',
+      height: height,
+      emphasized: profileMode,
+    );
+  }
+}
+
+final class FourAxisRadarAxis {
+  const FourAxisRadarAxis({required this.label, required this.value});
+
+  final String label;
+  final double? value;
+}
+
+class FourAxisScoreRadar extends StatelessWidget {
+  const FourAxisScoreRadar({
+    required this.axes,
+    required this.maximum,
+    required this.semanticsKey,
+    required this.semanticsPrefix,
+    this.height = 300,
+    this.emphasized = false,
+    super.key,
+  }) : assert(axes.length == 4),
+       assert(maximum > 0);
+
+  final List<FourAxisRadarAxis> axes;
+  final double maximum;
+  final Key semanticsKey;
+  final String semanticsPrefix;
+  final double height;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    final semanticLabel = axes
         .map(
-          (item) =>
-              '${_criterionChineseLabel(item.id)} ${item.estimatedBand ?? '未评分'}分',
+          (axis) =>
+              '${axis.label} ${axis.value == null ? '未评分' : _radarScoreLabel(axis.value!)}分',
         )
         .join('，');
     return Semantics(
       key: semanticsKey,
-      label: 'IELTS 口语四维雷达图，$semanticLabel',
+      label: '$semanticsPrefix，$semanticLabel',
       child: SizedBox(
         height: height,
         child: Stack(
@@ -689,113 +637,87 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
           children: [
             Positioned.fill(
               child: Padding(
-                padding: const EdgeInsets.all(48),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 72,
+                  vertical: 56,
+                ),
                 child: CustomPaint(
-                  painter: _RadarPainter(values, emphasized: profileMode),
+                  painter: _FourAxisRadarPainter(
+                    axes.map((axis) => axis.value).toList(growable: false),
+                    maximum: maximum,
+                    emphasized: emphasized,
+                  ),
                 ),
               ),
             ),
-            _radarLabel(
-              alignment: Alignment.topCenter,
-              label: '流利与连贯',
-              score: ordered[0]?.estimatedBand,
-            ),
-            _radarLabel(
+            _FourAxisRadarLabel(alignment: Alignment.topCenter, axis: axes[0]),
+            _FourAxisRadarLabel(
               alignment: Alignment.centerRight,
-              label: '发音',
-              score: ordered[1]?.estimatedBand,
+              axis: axes[1],
             ),
-            _radarLabel(
+            _FourAxisRadarLabel(
               alignment: Alignment.bottomCenter,
-              label: '语法',
-              score: ordered[2]?.estimatedBand,
+              axis: axes[2],
             ),
-            _radarLabel(
-              alignment: Alignment.centerLeft,
-              label: '词汇',
-              score: ordered[3]?.estimatedBand,
-            ),
+            _FourAxisRadarLabel(alignment: Alignment.centerLeft, axis: axes[3]),
           ],
         ),
       ),
     );
   }
+}
 
-  Widget _radarLabel({
-    required Alignment alignment,
-    required String label,
-    required int? score,
-  }) {
-    if (!profileMode) {
-      return _RadarLabel(alignment: alignment, label: label, score: score);
-    }
-    return _AbilityRadarLabel(alignment: alignment, label: label, score: score);
+class _FourAxisRadarLabel extends StatelessWidget {
+  const _FourAxisRadarLabel({required this.alignment, required this.axis});
+
+  final Alignment alignment;
+  final FourAxisRadarAxis axis;
+
+  @override
+  Widget build(BuildContext context) {
+    final score = Text(
+      axis.value == null ? '--' : _radarScoreLabel(axis.value!),
+      style: SpeakUpDesign.cardTitle.copyWith(
+        color: const Color(0xFF3679F5),
+        fontSize: 22,
+        height: 1,
+      ),
+    );
+    final label = Text(
+      axis.label,
+      maxLines: 1,
+      textAlign: TextAlign.center,
+      style: SpeakUpDesign.label.copyWith(
+        color: SpeakUpDesign.ink,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+    return Align(
+      alignment: alignment,
+      child: SizedBox(
+        width: 92,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [label, const SizedBox(height: 7), score],
+        ),
+      ),
+    );
   }
 }
 
-class _RadarLabel extends StatelessWidget {
-  const _RadarLabel({required this.alignment, required this.label, this.score});
+String _radarScoreLabel(double value) => value == value.roundToDouble()
+    ? value.toInt().toString()
+    : value.toStringAsFixed(1);
 
-  final Alignment alignment;
-  final String label;
-  final int? score;
-
-  @override
-  Widget build(BuildContext context) => Align(
-    alignment: alignment,
-    child: Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(label, style: SpeakUpDesign.label),
-        Text(
-          score?.toString() ?? '--',
-          style: SpeakUpDesign.cardTitle.copyWith(color: SpeakUpDesign.primary),
-        ),
-      ],
-    ),
-  );
-}
-
-class _AbilityRadarLabel extends StatelessWidget {
-  const _AbilityRadarLabel({
-    required this.alignment,
-    required this.label,
-    this.score,
+class _FourAxisRadarPainter extends CustomPainter {
+  const _FourAxisRadarPainter(
+    this.values, {
+    required this.maximum,
+    this.emphasized = false,
   });
 
-  final Alignment alignment;
-  final String label;
-  final int? score;
-
-  @override
-  Widget build(BuildContext context) => Align(
-    alignment: alignment,
-    child: Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          label,
-          maxLines: 1,
-          style: SpeakUpDesign.meta.copyWith(color: SpeakUpDesign.secondary),
-        ),
-        const SizedBox(height: 2),
-        Text(
-          score == null ? '--' : '${score!}.0',
-          style: SpeakUpDesign.cardTitle.copyWith(
-            color: SpeakUpDesign.ink,
-            fontSize: 20,
-            height: 1.1,
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
-class _RadarPainter extends CustomPainter {
-  const _RadarPainter(this.values, {this.emphasized = false});
-
-  final List<double> values;
+  final List<double?> values;
+  final double maximum;
   final bool emphasized;
 
   @override
@@ -803,53 +725,72 @@ class _RadarPainter extends CustomPainter {
     final center = size.center(Offset.zero);
     final radius = math.min(size.width, size.height) / 2;
     final grid = Paint()
-      ..color = SpeakUpDesign.border
+      ..color = const Color(0xFFDCE3F1)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1;
-    for (final level in [1 / 3, 2 / 3, 1.0]) {
-      canvas.drawPath(
-        _polygon(center, radius * level, const [1, 1, 1, 1]),
-        grid,
+      ..strokeWidth = 1.1;
+    final levels = <double>[1, 0.75, 0.5, 0.25];
+    for (final level in levels) {
+      final path = _polygon(center, radius, List<double>.filled(4, level));
+      canvas.drawPath(path, grid);
+    }
+    final outerPoints = _points(center, radius, const [1, 1, 1, 1]);
+    for (final point in outerPoints) {
+      canvas.drawLine(center, point, grid);
+      canvas.drawCircle(
+        point,
+        3,
+        Paint()
+          ..color = const Color(0xFFB8C5DC)
+          ..style = PaintingStyle.fill,
       );
     }
-    for (final point in _points(center, radius, const [1, 1, 1, 1])) {
-      canvas.drawLine(center, point, grid);
-    }
     final normalized = values
-        .map((value) => (value / 9).clamp(0.0, 1.0))
-        .toList();
-    final dataPath = _polygon(center, radius, normalized);
-    canvas.drawPath(
-      dataPath,
-      Paint()
-        ..color = (emphasized ? _abilityBlue : SpeakUpDesign.primary)
-            .withValues(alpha: emphasized ? 0.12 : 0.2)
-        ..style = PaintingStyle.fill,
-    );
-    canvas.drawPath(
-      dataPath,
-      Paint()
-        ..color = emphasized ? _abilityBlue : SpeakUpDesign.primary
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = emphasized ? 2.4 : 2.5,
-    );
-    if (emphasized) {
-      for (final point in _points(center, radius, normalized)) {
-        canvas.drawCircle(
-          point,
-          4.5,
-          Paint()
-            ..color = SpeakUpDesign.surface
-            ..style = PaintingStyle.fill,
-        );
-        canvas.drawCircle(
-          point,
-          2.8,
-          Paint()
-            ..color = _abilityBlue
-            ..style = PaintingStyle.fill,
-        );
+        .map(
+          (value) => value == null ? null : (value / maximum).clamp(0.0, 1.0),
+        )
+        .toList(growable: false);
+    if (normalized.every((value) => value != null)) {
+      final dataPath = _polygon(
+        center,
+        radius,
+        normalized.whereType<double>().toList(growable: false),
+      );
+      canvas.drawPath(
+        dataPath,
+        Paint()
+          ..color = const Color(
+            0xFF3679F5,
+          ).withValues(alpha: emphasized ? 0.18 : 0.14)
+          ..style = PaintingStyle.fill,
+      );
+      canvas.drawPath(
+        dataPath,
+        Paint()
+          ..color = const Color(0xFF3679F5)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = emphasized ? 2.8 : 2.4,
+      );
+    }
+    for (var index = 0; index < normalized.length; index++) {
+      final scale = normalized[index];
+      if (scale == null) {
+        continue;
       }
+      final point = _point(center, radius, index, scale);
+      canvas.drawCircle(
+        point,
+        emphasized ? 4.5 : 4,
+        Paint()
+          ..color = SpeakUpDesign.surface
+          ..style = PaintingStyle.fill,
+      );
+      canvas.drawCircle(
+        point,
+        emphasized ? 3.2 : 2.8,
+        Paint()
+          ..color = const Color(0xFF3679F5)
+          ..style = PaintingStyle.fill,
+      );
     }
   }
 
@@ -861,15 +802,26 @@ class _RadarPainter extends CustomPainter {
   }
 
   List<Offset> _points(Offset center, double radius, List<num> scales) => [
-    Offset(center.dx, center.dy - radius * scales[0]),
-    Offset(center.dx + radius * scales[1], center.dy),
-    Offset(center.dx, center.dy + radius * scales[2]),
-    Offset(center.dx - radius * scales[3], center.dy),
+    for (var index = 0; index < scales.length; index++)
+      _point(center, radius, index, scales[index]),
   ];
 
+  Offset _point(Offset center, double radius, int index, num scale) {
+    if (index < 0 || index > 3) {
+      throw ArgumentError.value(index, 'index');
+    }
+    final angle = -math.pi / 2 + (math.pi / 2 * index);
+    return Offset(
+      center.dx + math.cos(angle) * radius * scale,
+      center.dy + math.sin(angle) * radius * scale,
+    );
+  }
+
   @override
-  bool shouldRepaint(covariant _RadarPainter oldDelegate) =>
-      oldDelegate.values != values || oldDelegate.emphasized != emphasized;
+  bool shouldRepaint(covariant _FourAxisRadarPainter oldDelegate) =>
+      oldDelegate.values != values ||
+      oldDelegate.maximum != maximum ||
+      oldDelegate.emphasized != emphasized;
 }
 
 class _EvidenceStandard extends StatelessWidget {
@@ -1047,178 +999,6 @@ class _CriterionFeedback extends StatelessWidget {
   }
 }
 
-class _IeltsPartReport extends StatelessWidget {
-  const _IeltsPartReport({
-    required this.report,
-    required this.partId,
-    this.onRepracticeQuestion,
-  });
-
-  final IeltsSpeakingReport report;
-  final IeltsSpeakingPartId partId;
-  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion;
-
-  @override
-  Widget build(BuildContext context) {
-    final part = report.partReviews.firstWhere((item) => item.id == partId);
-    final questions = report.questions
-        .where((question) => question.partId == partId)
-        .toList(growable: false);
-    final findings = <({String label, String id})>[
-      for (final id in part.strengthFindingIds) (label: '做得好', id: id),
-      for (final id in part.improvementFindingIds) (label: '可改进', id: id),
-      for (final id in part.upgradeExampleFindingIds) (label: '提升表达', id: id),
-    ];
-    return Column(
-      key: Key('ielts-speaking-report-${partId.name}'),
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(SpeakUpDesign.space20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Text(
-                      '${_partLabel(partId)} 复盘',
-                      style: SpeakUpDesign.sectionTitle,
-                    ),
-                    const Spacer(),
-                    Text('${questions.length} 题', style: SpeakUpDesign.meta),
-                  ],
-                ),
-                if (findings.isEmpty) ...[
-                  const SizedBox(height: SpeakUpDesign.space12),
-                  Text('本部分暂无可用的分段反馈。', style: SpeakUpDesign.meta),
-                ],
-                for (final item in findings) ...[
-                  const SizedBox(height: SpeakUpDesign.space16),
-                  Text(item.label, style: SpeakUpDesign.label),
-                  const SizedBox(height: SpeakUpDesign.space4),
-                  Text(
-                    report.finding(item.id)!.message,
-                    style: SpeakUpDesign.body,
-                  ),
-                  if (report.finding(item.id)!.suggestion
-                      case final suggestion?) ...[
-                    const SizedBox(height: SpeakUpDesign.space4),
-                    Text('建议：$suggestion', style: SpeakUpDesign.meta),
-                  ],
-                ],
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: SpeakUpDesign.space12),
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(SpeakUpDesign.space20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('本段题目', style: SpeakUpDesign.cardTitle),
-                const SizedBox(height: SpeakUpDesign.space12),
-                for (var index = 0; index < questions.length; index++) ...[
-                  if (index > 0) ...[
-                    const SizedBox(height: SpeakUpDesign.space12),
-                    const Divider(height: 1),
-                    const SizedBox(height: SpeakUpDesign.space12),
-                  ],
-                  _RepracticeQuestion(
-                    question: questions[index],
-                    onPressed: onRepracticeQuestion == null
-                        ? null
-                        : () => onRepracticeQuestion!(questions[index]),
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _QuestionReviews extends StatelessWidget {
-  const _QuestionReviews({required this.report, this.onRepracticeQuestion});
-
-  final IeltsSpeakingReport report;
-  final Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      key: const Key('ielts-speaking-report-questions'),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('同题复练', style: SpeakUpDesign.cardTitle),
-            const SizedBox(height: 6),
-            Text(
-              '本次问到的 ${report.questions.length} 道题，可直接选择原题重新作答。',
-              style: SpeakUpDesign.meta,
-            ),
-            const SizedBox(height: 14),
-            for (var index = 0; index < report.questions.length; index++) ...[
-              if (index > 0) ...[
-                const SizedBox(height: 14),
-                const Divider(height: 1),
-                const SizedBox(height: 14),
-              ],
-              _RepracticeQuestion(
-                question: report.questions[index],
-                onPressed: onRepracticeQuestion == null
-                    ? null
-                    : () => onRepracticeQuestion!(report.questions[index]),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RepracticeQuestion extends StatelessWidget {
-  const _RepracticeQuestion({required this.question, this.onPressed});
-
-  final IeltsSpeakingQuestionReview question;
-  final Future<bool> Function()? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: Key('ielts-speaking-question-${question.index}'),
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          '${_partLabel(question.partId)} · 第 ${question.index} 题',
-          style: SpeakUpDesign.meta,
-        ),
-        const SizedBox(height: 4),
-        Text(question.questionText, style: SpeakUpDesign.label),
-        const SizedBox(height: 10),
-        Align(
-          alignment: Alignment.centerRight,
-          child: OutlinedButton.icon(
-            key: Key('ielts-speaking-repractice-${question.index}'),
-            onPressed: onPressed,
-            icon: const Icon(Icons.mic_none_rounded, size: 18),
-            label: const Text('直接重练'),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _TargetPlan extends StatelessWidget {
   const _TargetPlan({required this.report});
 
@@ -1294,15 +1074,7 @@ String _criterionEnglishLabel(IeltsSpeakingCriterionId criterion) =>
       IeltsSpeakingCriterionId.pronunciation => 'Pronunciation',
     };
 
-Color _criterionColor(IeltsSpeakingCriterionId criterion) =>
-    switch (criterion) {
-      IeltsSpeakingCriterionId.fluencyAndCoherence => const Color(0xFF7651C8),
-      IeltsSpeakingCriterionId.lexicalResource => const Color(0xFFDA633B),
-      IeltsSpeakingCriterionId.grammaticalRangeAndAccuracy => const Color(
-        0xFF3E8A5B,
-      ),
-      IeltsSpeakingCriterionId.pronunciation => const Color(0xFF3478C8),
-    };
+Color _criterionColor(IeltsSpeakingCriterionId _) => SpeakUpDesign.ink;
 
 IconData _criterionIcon(IeltsSpeakingCriterionId criterion) =>
     switch (criterion) {
@@ -1324,9 +1096,3 @@ String _durationLabel(int durationMs) {
 String _bandLabel(double band) => band == band.roundToDouble()
     ? band.toInt().toString()
     : band.toStringAsFixed(1);
-
-String _partLabel(IeltsSpeakingPartId part) => switch (part) {
-  IeltsSpeakingPartId.part1 => 'Part 1',
-  IeltsSpeakingPartId.part2 => 'Part 2',
-  IeltsSpeakingPartId.part3 => 'Part 3',
-};

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -714,19 +714,20 @@ class ReviewReportDetailPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final report = item.report;
     final sectionDetail = _decodeSectionDetail(report);
+    final isIeltsSectionReport = _isIeltsSectionReport(report);
     final expectsSectionDetail =
         report.sceneType == EvaluationReportSceneType.ieltsSpeaking &&
         report.detailSchema == _ieltsSpeakingPracticeReportSchema;
     final findings = report.dimensions
         .expand((dimension) => dimension.improvements)
         .toList(growable: false);
+    final priorityFeedback = _ieltsPriorityFeedback(report);
     return Scaffold(
       key: const Key('review-detail-page'),
       appBar: AppBar(
         title: Text(
-          _isIeltsSectionReport(report)
-              ? evaluationReportTitle(report)
-              : '复盘详情',
+          isIeltsSectionReport ? evaluationReportTitle(report) : '复盘详情',
+          key: isIeltsSectionReport ? const Key('review-detail-title') : null,
         ),
         leading: IconButton(
           key: const Key('review-detail-back'),
@@ -741,9 +742,7 @@ class ReviewReportDetailPage extends StatelessWidget {
           key: const Key('review-detail-content'),
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 48),
           children: [
-            if (sectionDetail != null)
-              _IeltsSectionDetailHeader(item: item)
-            else ...[
+            if (!isIeltsSectionReport) ...[
               _ReviewDetailHeader(item: item),
               const SizedBox(height: 12),
               _ReviewDetailSection(
@@ -757,6 +756,14 @@ class ReviewReportDetailPage extends StatelessWidget {
               const SizedBox(height: 12),
               const _ReviewStatusNotice(),
             ],
+            if (isIeltsSectionReport && report.dimensions.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _IeltsSectionPerformance(dimensions: report.dimensions),
+            ],
+            if (isIeltsSectionReport && priorityFeedback != null) ...[
+              const SizedBox(height: 12),
+              _IeltsPriorityFocus(feedback: priorityFeedback),
+            ],
             if (sectionDetail != null) ...[
               const SizedBox(height: 12),
               _IeltsSectionReport(report: report, detail: sectionDetail),
@@ -768,11 +775,16 @@ class ReviewReportDetailPage extends StatelessWidget {
                 body: '专项报告的分段数据无法识别，下方仍保留本次练习的通用反馈。',
               ),
             ],
-            if (report.dimensions.isNotEmpty) ...[
+            if (!isIeltsSectionReport && report.dimensions.isNotEmpty) ...[
               const SizedBox(height: 12),
               _ReviewDimensions(dimensions: report.dimensions),
             ],
-            if (findings.isNotEmpty) ...[
+            if (isIeltsSectionReport &&
+                sectionDetail == null &&
+                findings.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _IeltsDetailedFeedback(findings: findings),
+            ] else if (!isIeltsSectionReport && findings.isNotEmpty) ...[
               const SizedBox(height: 12),
               _ReviewFindings(report: report, findings: findings),
             ],
@@ -820,36 +832,120 @@ class _ReviewDetailHeader extends StatelessWidget {
   }
 }
 
-class _IeltsSectionDetailHeader extends StatelessWidget {
-  const _IeltsSectionDetailHeader({required this.item});
+class _IeltsSectionPerformance extends StatelessWidget {
+  const _IeltsSectionPerformance({required this.dimensions});
 
-  final ReviewHistoryItem item;
+  final List<EvaluationReportDimension> dimensions;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      key: const Key('review-detail-summary'),
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Wrap(
-          spacing: 8,
-          runSpacing: 6,
+    final usesPracticeScale = dimensions.every(
+      (dimension) =>
+          dimension.scale == EvaluationReportScoreScale.percentage100,
+    );
+    final byKey = {
+      for (final dimension in dimensions) dimension.key: dimension,
+    };
+    final ordered = <EvaluationReportDimension?>[
+      byKey['TASK_ACHIEVEMENT'],
+      byKey['CLARITY_COHERENCE'],
+      byKey['LANGUAGE_CONTROL'],
+      byKey['INTERACTION'],
+    ];
+    return Card(
+      key: const Key('review-detail-dimensions'),
+      child: Padding(
+        padding: const EdgeInsets.all(SpeakUpDesign.space20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _StatusLabel(label: _statusLabel(item.report)),
-            Text(_detailDateLabel(item.completedAt), style: SpeakUpDesign.meta),
+            Text('口语能力', style: SpeakUpDesign.sectionTitle),
+            const SizedBox(height: SpeakUpDesign.space20),
+            FourAxisScoreRadar(
+              axes: <FourAxisRadarAxis>[
+                FourAxisRadarAxis(label: '任务达成', value: ordered[0]?.score),
+                FourAxisRadarAxis(label: '清晰与连贯', value: ordered[1]?.score),
+                FourAxisRadarAxis(label: '语言运用', value: ordered[2]?.score),
+                FourAxisRadarAxis(label: '互动表现', value: ordered[3]?.score),
+              ],
+              maximum: usesPracticeScale ? 100 : 9,
+              semanticsKey: const Key('review-section-score-radar'),
+              semanticsPrefix: '专项练习四维雷达图',
+            ),
           ],
         ),
-        const SizedBox(height: 14),
-        Text(
-          item.review.title,
-          key: const Key('review-detail-title'),
-          style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
-        ),
-        const SizedBox(height: 10),
-        Text(item.report.summary, style: SpeakUpDesign.body),
-        const SizedBox(height: 18),
-        const Divider(height: 1),
-      ],
+      ),
+    );
+  }
+}
+
+typedef _IeltsPriorityFeedback = ({
+  String dimensionKey,
+  EvaluationReportFinding finding,
+});
+
+_IeltsPriorityFeedback? _ieltsPriorityFeedback(EvaluationReport report) {
+  for (final action in report.priorityActions) {
+    for (final dimension in report.dimensions) {
+      if (dimension.key != action.dimensionKey) continue;
+      for (final finding in <EvaluationReportFinding>[
+        ...dimension.improvements,
+        ...dimension.recommendedExamples,
+      ]) {
+        if (finding.id == action.findingId) {
+          return (dimensionKey: dimension.key, finding: finding);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+class _IeltsPriorityFocus extends StatelessWidget {
+  const _IeltsPriorityFocus({required this.feedback});
+
+  final _IeltsPriorityFeedback feedback;
+
+  @override
+  Widget build(BuildContext context) {
+    final finding = feedback.finding;
+    final suggestion = finding.suggestion;
+    final evidence = finding.evidence.firstOrNull?.originalExcerpt;
+    return Container(
+      key: const Key('review-detail-priority-focus'),
+      padding: const EdgeInsets.all(SpeakUpDesign.space20),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('下一步先练这个', style: SpeakUpDesign.cardTitle),
+          const SizedBox(height: SpeakUpDesign.space16),
+          Text(
+            _dimensionLabel(feedback.dimensionKey),
+            style: SpeakUpDesign.label.copyWith(color: SpeakUpDesign.secondary),
+          ),
+          const SizedBox(height: SpeakUpDesign.space4),
+          Text(
+            finding.message,
+            style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
+          ),
+          if (suggestion != null && suggestion != finding.message) ...[
+            const SizedBox(height: SpeakUpDesign.space16),
+            Text('下次这样说', style: SpeakUpDesign.label),
+            const SizedBox(height: SpeakUpDesign.space4),
+            Text(suggestion, style: SpeakUpDesign.body),
+          ],
+          if (evidence != null) ...[
+            const SizedBox(height: SpeakUpDesign.space16),
+            Text('本次回答', style: SpeakUpDesign.label),
+            const SizedBox(height: SpeakUpDesign.space4),
+            Text('“$evidence”', style: SpeakUpDesign.body),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -972,28 +1068,93 @@ class _IeltsSectionReport extends StatelessWidget {
         for (final finding in dimension.recommendedExamples)
           finding.id: finding,
     };
-    return Column(
+    return Card(
       key: const Key('ielts-section-report'),
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text('分段复盘', style: SpeakUpDesign.sectionTitle),
-        const SizedBox(height: 6),
-        for (var index = 0; index < detail.sectionReviews.length; index++) ...[
-          if (index > 0) const Divider(height: 33),
-          _IeltsSectionCard(
-            section: detail.sectionReviews[index],
-            questions: detail.questions
-                .where(
-                  (question) =>
-                      question.partId == detail.sectionReviews[index].partId,
-                )
-                .toList(growable: false),
-            strengths: strengths,
-            improvements: improvements,
-            examples: examples,
-          ),
+      clipBehavior: Clip.antiAlias,
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(
+          horizontal: SpeakUpDesign.space20,
+          vertical: SpeakUpDesign.space4,
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          SpeakUpDesign.space20,
+          0,
+          SpeakUpDesign.space20,
+          SpeakUpDesign.space20,
+        ),
+        title: Text('详细反馈', style: SpeakUpDesign.cardTitle),
+        subtitle: Text('评分依据与本次回答', style: SpeakUpDesign.meta),
+        children: [
+          for (
+            var index = 0;
+            index < detail.sectionReviews.length;
+            index++
+          ) ...[
+            if (index > 0) const Divider(height: 33),
+            _IeltsSectionCard(
+              section: detail.sectionReviews[index],
+              questions: detail.questions
+                  .where(
+                    (question) =>
+                        question.partId == detail.sectionReviews[index].partId,
+                  )
+                  .toList(growable: false),
+              strengths: strengths,
+              improvements: improvements,
+              examples: examples,
+            ),
+          ],
         ],
-      ],
+      ),
+    );
+  }
+}
+
+class _IeltsDetailedFeedback extends StatelessWidget {
+  const _IeltsDetailedFeedback({required this.findings});
+
+  final List<EvaluationReportFinding> findings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('review-detail-feedback'),
+      clipBehavior: Clip.antiAlias,
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(
+          horizontal: SpeakUpDesign.space20,
+          vertical: SpeakUpDesign.space4,
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(
+          SpeakUpDesign.space20,
+          0,
+          SpeakUpDesign.space20,
+          SpeakUpDesign.space20,
+        ),
+        title: Text('详细反馈', style: SpeakUpDesign.cardTitle),
+        subtitle: Text(
+          '查看全部 ${findings.length} 条建议',
+          style: SpeakUpDesign.meta,
+        ),
+        children: [
+          for (var index = 0; index < findings.length; index++) ...[
+            if (index > 0) const Divider(height: SpeakUpDesign.space24),
+            Column(
+              key: Key('review-feedback-${findings[index].id}'),
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(findings[index].message, style: SpeakUpDesign.body),
+                if (findings[index].suggestion case final suggestion?) ...[
+                  if (suggestion != findings[index].message) ...[
+                    const SizedBox(height: SpeakUpDesign.space8),
+                    Text('建议：$suggestion', style: SpeakUpDesign.body),
+                  ],
+                ],
+              ],
+            ),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -1267,13 +1428,15 @@ String _statusLabel(EvaluationReport report) =>
     : '已完成';
 
 String _scoreLabel(double value, EvaluationReportScoreScale scale) {
-  final formatted = value == value.roundToDouble()
-      ? value.toInt().toString()
-      : value.toStringAsFixed(1);
+  final formatted = _scoreValueLabel(value);
   return scale == EvaluationReportScoreScale.ieltsBand
       ? '$formatted / 9'
       : '$formatted / 100';
 }
+
+String _scoreValueLabel(double value) => value == value.roundToDouble()
+    ? value.toInt().toString()
+    : value.toStringAsFixed(1);
 
 String _dimensionLabel(String key) {
   return const <String, String>{

--- a/mobile/test/review/ielts_report_routing_test.dart
+++ b/mobile/test/review/ielts_report_routing_test.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/review/evaluation_report_presentation.
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_client.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
 import 'package:speakup/features/coaching/review/review.dart';
 import 'package:speakup/features/coaching/review/review_history_client.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
@@ -47,7 +48,9 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
-    expect(find.text('Part 2 + Part 3 联合复盘'), findsWidgets);
+    expect(find.byKey(const Key('review-detail-title')), findsOneWidget);
+    await tester.tap(find.text('详细反馈'));
+    await tester.pumpAndSettle();
     expect(find.byKey(const Key('ielts-section-part2')), findsOneWidget);
     expect(find.byKey(const Key('ielts-section-part3')), findsOneWidget);
     expect(
@@ -71,11 +74,94 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
-    expect(find.text('Part 2 + Part 3 联合复盘'), findsWidgets);
-    expect(find.byKey(const Key('review-detail-summary')), findsOneWidget);
+    expect(find.text('Part 2 + Part 3 联合复盘'), findsOneWidget);
+    expect(find.byKey(const Key('review-detail-summary')), findsNothing);
+    expect(find.text('整体表现'), findsNothing);
     expect(find.byKey(const Key('ielts-section-report')), findsNothing);
     expect(find.byKey(const Key('ielts-section-detail-invalid')), findsNothing);
   });
+
+  testWidgets(
+    'single Part report prioritizes summary, scores, and next action',
+    (tester) async {
+      const finding = EvaluationReportFinding(
+        id: 'improvement_task',
+        message: '交流目标表达不够清晰。',
+        suggestion: 'State the intended outcome first.',
+        evidence: <EvaluationReportEvidence>[
+          EvaluationReportEvidence(
+            evidenceRefId: 'evidence_1',
+            turnId: 'turn_1',
+            startUtf8Byte: 0,
+            endUtf8Byte: 8,
+            originalExcerpt: 'I think maybe...',
+          ),
+        ],
+      );
+      final item = _item(
+        practiceMode: 'PART_1',
+        detailSchema: 'general-scene-evaluation/v1',
+        summary: '回答基本完成，但交流目标表达不够清晰。',
+        dimensions: const <EvaluationReportDimension>[
+          EvaluationReportDimension(
+            key: 'TASK_ACHIEVEMENT',
+            score: 5,
+            scale: EvaluationReportScoreScale.percentage100,
+            coverage: 1,
+            confidence: 0.8,
+            reasonCodes: <String>[],
+            evidenceRefIds: <String>['evidence_1'],
+            strengths: <EvaluationReportFinding>[],
+            improvements: <EvaluationReportFinding>[finding],
+            recommendedExamples: <EvaluationReportFinding>[],
+          ),
+        ],
+        priorityActions: const <EvaluationReportPriorityAction>[
+          EvaluationReportPriorityAction(
+            dimensionKey: 'TASK_ACHIEVEMENT',
+            findingId: 'improvement_task',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: ReviewReportDetailPage(item: item)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('已完成'), findsNothing);
+      expect(find.text('本次表现'), findsNothing);
+      expect(find.text(item.report.summary), findsNothing);
+      expect(find.byKey(const Key('review-detail-dimensions')), findsOneWidget);
+      expect(
+        find.byKey(const Key('review-section-score-radar')),
+        findsOneWidget,
+      );
+      expect(find.byType(FourAxisScoreRadar), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.text('任务达成'), findsWidgets);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.textContaining('非 IELTS'), findsNothing);
+      await tester.drag(
+        find.byKey(const Key('review-detail-content')),
+        const Offset(0, -400),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const Key('review-detail-priority-focus')),
+        findsOneWidget,
+      );
+      expect(find.text('下一步先练这个'), findsOneWidget);
+      expect(find.text('State the intended outcome first.'), findsOneWidget);
+      expect(find.text('“I think maybe...”'), findsOneWidget);
+      await tester.drag(
+        find.byKey(const Key('review-detail-content')),
+        const Offset(0, -500),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('review-detail-feedback')), findsOneWidget);
+    },
+  );
 
   testWidgets('section detail must match the outer practice mode', (
     tester,
@@ -137,7 +223,7 @@ void main() {
       expect(find.byKey(const Key('review-detail-page')), findsNothing);
       expect(
         find.byKey(const Key('ielts-speaking-report-scope-tabs')),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.byKey(const Key('ielts-speaking-report-generating')),
@@ -151,6 +237,11 @@ void main() {
 ReviewHistoryItem _item({
   required String practiceMode,
   required String detailSchema,
+  String summary = '本次练习已形成复盘。',
+  List<EvaluationReportDimension> dimensions =
+      const <EvaluationReportDimension>[],
+  List<EvaluationReportPriorityAction> priorityActions =
+      const <EvaluationReportPriorityAction>[],
 }) {
   final createdAt = DateTime.utc(2026, 8, 11, 4);
   final report = EvaluationReport(
@@ -164,9 +255,9 @@ ReviewHistoryItem _item({
     sceneCategory: 'IELTS_SPEAKING',
     practiceMode: practiceMode,
     scoreability: EvaluationReportScoreability.provisional,
-    summary: '本次练习已形成复盘。',
-    dimensions: const <EvaluationReportDimension>[],
-    priorityActions: const <EvaluationReportPriorityAction>[],
+    summary: summary,
+    dimensions: dimensions,
+    priorityActions: priorityActions,
     detailSchema: detailSchema,
     detail: switch (detailSchema) {
       'ielts-speaking-practice-report/v1' => _sectionDetail(),

--- a/mobile/test/review/ielts_speaking_report_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_view_test.dart
@@ -57,7 +57,7 @@ void main() {
       find.byKey(const Key('ielts-speaking-band-grammaticalRangeAndAccuracy')),
       findsOneWidget,
     );
-    expect(find.text('IELTS Speaking'), findsOneWidget);
+    expect(find.text('本次模考'), findsOneWidget);
     expect(find.textContaining('Part 2&3'), findsOneWidget);
     expect(find.textContaining('共 14/14 题'), findsOneWidget);
     expect(find.textContaining('缺少可信发音工件'), findsOneWidget);
@@ -65,22 +65,24 @@ void main() {
       find.byKey(const Key('ielts-speaking-overall-unavailable')),
       findsOneWidget,
     );
+    expect(
+      tester.widget(
+        find.byKey(const Key('ielts-speaking-overall-unavailable')),
+      ),
+      isA<Card>(),
+    );
     expect(find.text('暂不可用'), findsOneWidget);
     expect(find.textContaining('非 IELTS 官方成绩'), findsOneWidget);
     expect(find.textContaining('距目标差值'), findsOneWidget);
     expect(find.byKey(const Key('ielts-speaking-score-radar')), findsOneWidget);
+    expect(find.byType(FourAxisScoreRadar), findsOneWidget);
     expect(
       find.byKey(const Key('ielts-speaking-evidence-standard')),
       findsOneWidget,
     );
     expect(find.text('部分练习报告'), findsNothing);
     expect(find.text('分 Part 复盘'), findsNothing);
-    expect(find.text('同题复练'), findsOneWidget);
-    expect(find.byKey(const Key('ielts-speaking-question-14')), findsOneWidget);
-    expect(
-      find.byKey(const Key('ielts-speaking-repractice-14')),
-      findsOneWidget,
-    );
+    expect(find.text('同题复练'), findsNothing);
     expect(find.textContaining('Band 0'), findsNothing);
   });
 
@@ -111,7 +113,7 @@ void main() {
     expect(find.text('发音'), findsWidgets);
   });
 
-  testWidgets('full mock report switches between overall and three parts', (
+  testWidgets('full mock report presents one continuous summary', (
     tester,
   ) async {
     final controller = await _controllerFor('ready');
@@ -122,48 +124,16 @@ void main() {
 
     expect(
       find.byKey(const Key('ielts-speaking-report-scope-tabs')),
-      findsOneWidget,
+      findsNothing,
     );
-    await tester.tap(find.byKey(const Key('ielts-speaking-report-scope-2')));
-    await tester.pump();
     expect(
-      find.byKey(const Key('ielts-speaking-report-part2')),
+      find.byKey(const Key('ielts-speaking-report-criteria')),
       findsOneWidget,
     );
-    expect(find.text('Part 2 复盘'), findsOneWidget);
-
-    await tester.tap(find.byKey(const Key('ielts-speaking-report-scope-3')));
-    await tester.pump();
     expect(
-      find.byKey(const Key('ielts-speaking-report-part3')),
-      findsOneWidget,
+      find.byKey(const Key('ielts-speaking-report-questions')),
+      findsNothing,
     );
-  });
-
-  testWidgets('same-question list starts the selected question directly', (
-    tester,
-  ) async {
-    final controller = await _controllerFor('ready');
-    addTearDown(controller.dispose);
-    IeltsSpeakingQuestionReview? selected;
-
-    await tester.pumpWidget(
-      _app(
-        controller,
-        onRepracticeQuestion: (question) async {
-          selected = question;
-          return true;
-        },
-      ),
-    );
-    await tester.pump();
-    final button = find.byKey(const Key('ielts-speaking-repractice-1'));
-    await tester.ensureVisible(button);
-    await tester.tap(button);
-    await tester.pump();
-
-    expect(selected?.index, 1);
-    expect(selected?.questionText, isNotEmpty);
   });
 
   testWidgets('renders insufficient evidence without a zero score', (
@@ -258,17 +228,10 @@ Future<IeltsSpeakingReportController> _controllerFor(String fixtureKey) async {
   return controller;
 }
 
-Widget _app(
-  IeltsSpeakingReportController controller, {
-  Future<bool> Function(IeltsSpeakingQuestionReview question)?
-  onRepracticeQuestion,
-}) => MaterialApp(
+Widget _app(IeltsSpeakingReportController controller) => MaterialApp(
   home: Scaffold(
     body: SingleChildScrollView(
-      child: IeltsSpeakingReportPanel(
-        controller: controller,
-        onRepracticeQuestion: onRepracticeQuestion,
-      ),
+      child: IeltsSpeakingReportPanel(controller: controller),
     ),
   ),
 );


### PR DESCRIPTION
## 功能描述

- 将完整 IELTS 口语模考报告收敛为连续总览，移除顶部分类与同题复练
- 重构专项报告的信息层级，删除重复摘要，优先展示四维能力与下一步行动
- 专项和完整模考共用四轴雷达图；专项保持 0–100 真实量尺，完整模考保持 0–9 IELTS Band
- 使用浅色多边形网格、蓝色数据轮廓、节点与半透明填充，并直接展示各维度裸分数

## 实现思路

- 抽取 FourAxisScoreRadar 和 FourAxisRadarAxis，统一四维数据排序、缺失分数语义与绘制逻辑
- 使用 CustomPainter 绘制四层网格、轴线、外圈节点和单系列数据面
- 专项详情调整为雷达图、优先建议、折叠详细反馈的连续结构
- 保留不足证据时不伪造 0 分的既有规则

## 可复现测试

1. cd mobile
2. flutter test test/review
3. flutter analyze
4. 使用 iPhone 16 Pro、iOS 26.5 模拟器打开历史报告中的 Part 1 专项复盘，确认雷达图无裁切或标签重叠
5. 打开完整 IELTS 口语模考报告，确认总分与四维雷达图保持 0–9 量尺

测试结果：Review 目录 158 项测试通过；Flutter 全量静态分析通过；iOS 26.5 真后端模拟器视觉验证通过，数字人禁用。

Closes #605