### PR TITLE
fix(ielts): retry semantic report responses

### DIFF
--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -344,8 +344,12 @@ func classifyIELTSSpeakingShadowFailure(
 			Code:      "provider_schema_mismatch",
 			Retryable: false,
 		}
-	case errors.Is(cause, ErrInvalidIELTSSpeakingShadow),
-		errors.Is(cause, evaluation.ErrInvalidRequest):
+	case errors.Is(cause, ErrInvalidIELTSSpeakingShadow):
+		return IELTSSpeakingShadowFailure{
+			Code:      "provider_invalid_response",
+			Retryable: true,
+		}
+	case errors.Is(cause, evaluation.ErrInvalidRequest):
 		return IELTSSpeakingShadowFailure{
 			Code:      "provider_invalid_response",
 			Retryable: false,

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -287,6 +287,63 @@ func TestIELTSSpeakingShadowWorkerFailsSchemaMismatchWithoutRetry(
 	}
 }
 
+func TestIELTSSpeakingShadowWorkerRetriesSemanticRejectionThenCompletes(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := validIELTSSpeakingShadowClaim(t)
+	repository := &ieltsShadowRuntimeRepositoryStub{
+		claim:      claim,
+		acquired:   true,
+		failStatus: IELTSSpeakingShadowRuntimePending,
+	}
+	provider := &ieltsSemanticRetryProviderStub{}
+	worker, err := NewIELTSSpeakingShadowWorker(
+		repository,
+		NewIELTSSpeakingShadowEngine(provider),
+		validIELTSSpeakingShadowRuntimeConfiguration(),
+	)
+	if err != nil {
+		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+	}
+
+	first, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("first ProcessPending: %v", err)
+	}
+	if first.Retried != 1 || repository.failCalls != 1 ||
+		repository.failure.Code != "provider_invalid_response" ||
+		!repository.failure.Retryable || repository.completeCalls != 0 {
+		t.Fatalf(
+			"first sweep = %#v; failure = %#v; repository = %#v",
+			first,
+			repository.failure,
+			repository,
+		)
+	}
+
+	repository.claim.AttemptCount = 2
+	repository.claim.FencingToken++
+	repository.acquired = true
+	second, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("second ProcessPending: %v", err)
+	}
+	if second.Completed != 1 || provider.calls != 2 ||
+		repository.completeCalls != 1 || repository.failCalls != 1 ||
+		ValidateIELTSSpeakingShadowResult(
+			claim.Snapshot,
+			repository.result,
+		) != nil {
+		t.Fatalf(
+			"second sweep = %#v; provider calls = %d; repository = %#v",
+			second,
+			provider.calls,
+			repository,
+		)
+	}
+}
+
 func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
 	t *testing.T,
 ) {
@@ -307,7 +364,7 @@ func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:      claim,
 		acquired:   true,
-		failStatus: IELTSSpeakingShadowRuntimeFailed,
+		failStatus: IELTSSpeakingShadowRuntimePending,
 	}
 	worker, err := NewIELTSSpeakingShadowWorker(
 		repository,
@@ -328,7 +385,7 @@ func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
 		t.Fatalf("ProcessPending: %v", err)
 	}
 	logged := output.String()
-	if sweep.Failed != 1 ||
+	if sweep.Retried != 1 || !repository.failure.Retryable ||
 		!strings.Contains(logged, `"failure_code":"provider_invalid_response"`) ||
 		!strings.Contains(logged, `"rejection_stage":"semantic_validation"`) ||
 		strings.Contains(logged, "I explain") {
@@ -357,9 +414,10 @@ func TestClassifyIELTSSpeakingShadowFailureUsesStableProviderCodes(
 			code:  "provider_schema_mismatch",
 		},
 		{
-			name:  "semantic response rejection",
-			cause: ErrInvalidIELTSSpeakingShadow,
-			code:  "provider_invalid_response",
+			name:      "semantic response rejection",
+			cause:     ErrInvalidIELTSSpeakingShadow,
+			code:      "provider_invalid_response",
+			retryable: true,
 		},
 		{
 			name:  "invalid request",
@@ -391,6 +449,24 @@ func TestClassifyIELTSSpeakingShadowFailureUsesStableProviderCodes(
 			}
 		})
 	}
+}
+
+type ieltsSemanticRetryProviderStub struct {
+	calls int
+}
+
+func (provider *ieltsSemanticRetryProviderStub) AnalyzeIELTSSpeaking(
+	_ context.Context,
+	input IELTSSpeakingShadowProviderInput,
+) (IELTSSpeakingShadowProviderResult, error) {
+	provider.calls++
+	payload := validIELTSProviderPayload(input)
+	if provider.calls == 1 {
+		payload.Criteria[0].Strengths[0].Evidence[0].EvidenceRefID =
+			"missing-evidence-ref"
+		payload.Criteria[0].Strengths[0].Evidence[0].Quote = "I explain"
+	}
+	return ieltsProviderResult(nil, payload), nil
 }
 
 type ieltsGenerationFailureStub struct {


### PR DESCRIPTION
## 功能描述

修复 IELTS Speaking 完整模考在评分 Provider 首次返回格式合规但语义/evidence-anchor 不合约响应时，attempt 1 直接终态失败的问题。

## 实现思路

- 保持 JSON 解码、schema 和最终严格语义校验不变。
- 将 `ErrInvalidIELTSSpeakingShadow` 单独归类为可重试的 `provider_invalid_response`，使用现有最大 3 次 durable job 预算。
- `provider_invalid_json`、`provider_schema_mismatch` 与 `evaluation.ErrInvalidRequest` 仍不可重试。
- 回归覆盖首次语义拒绝后第二次合法响应进入 READY，并验证日志不泄露转写文本。

## 可复现测试

```bash
make check-go
```

结果：Go format、vet、全量 `go test -count=1 ./...` 通过。

```bash
cd server
QINIU_LLM_LIVE_TEST=1 go test ./internal/providers/qiniu \
  -run "^TestLiveQiniuIELTSEvaluationContract$" -count=1 -v
```

结果：真实 Qiniu Evaluation 模型通过 strict sanitized contract（测试前按本地安全方式导出已有凭据，未提交或输出凭据）。

定向红绿回归：

```bash
cd server
go test ./internal/coaching/evaluation/scoring \
  -run "TestIELTSSpeakingShadowWorkerRetriesSemanticRejectionThenCompletes|TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage|TestClassifyIELTSSpeakingShadowFailureUsesStableProviderCodes" \
  -count=1
```

## 范围说明

不修改移动端录音/ASR、讯飞 ISE、声学等待预算，也不放宽评分合同或生成兜底分数。

Closes #613