### PR TITLE
fix(ielts): restore acoustic finalization budget

### DIFF
--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -141,6 +141,7 @@ func TestIELTSSpeakingShadowWorkerRetriesPendingAcoustics(
 ) {
 	t.Parallel()
 	claim := validIELTSSpeakingShadowClaim(t)
+	claim.AttemptCount = 7
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:      claim,
 		acquired:   true,
@@ -170,12 +171,51 @@ func TestIELTSSpeakingShadowWorkerRetriesPendingAcoustics(
 	}
 }
 
+func TestIELTSSpeakingShadowWorkerUsesReadyAcousticsWithinWaitBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := validIELTSSpeakingShadowClaim(t)
+	claim.AttemptCount = 7
+	repository := &ieltsShadowRuntimeRepositoryStub{
+		claim:    claim,
+		acquired: true,
+	}
+	provider := &ieltsProviderStub{}
+	worker, err := NewIELTSSpeakingShadowWorker(
+		repository,
+		NewIELTSSpeakingShadowEngineWithAcoustics(
+			provider,
+			&ieltsAcousticSourceStub{},
+		),
+		validIELTSSpeakingShadowRuntimeConfiguration(),
+	)
+	if err != nil {
+		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+	}
+	sweep, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ProcessPending: %v", err)
+	}
+	if sweep.Completed != 1 || provider.calls != 1 ||
+		repository.completeCalls != 1 || repository.failCalls != 0 ||
+		len(provider.input.AssessableCriteria) != 4 ||
+		repository.result.Criteria[3].EstimatedBand == nil {
+		t.Fatalf(
+			"sweep = %#v; provider calls = %d; repository = %#v",
+			sweep,
+			provider.calls,
+			repository,
+		)
+	}
+}
+
 func TestIELTSSpeakingShadowWorkerFallsBackAfterAcousticWaitExhaustion(
 	t *testing.T,
 ) {
 	t.Parallel()
 	claim := validIELTSSpeakingShadowClaim(t)
-	claim.AttemptCount = 3
+	claim.AttemptCount = 8
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:    claim,
 		acquired: true,
@@ -204,45 +244,54 @@ func TestIELTSSpeakingShadowWorkerFallsBackAfterAcousticWaitExhaustion(
 	}
 }
 
-func TestIELTSSpeakingShadowWorkerReservesProviderRetryAfterAcousticWait(
+func TestIELTSSpeakingShadowWorkerReservesProviderAttemptsAfterAcousticWait(
 	t *testing.T,
 ) {
 	t.Parallel()
-	claim := validIELTSSpeakingShadowClaim(t)
-	claim.AttemptCount = 2
-	repository := &ieltsShadowRuntimeRepositoryStub{
-		claim:      claim,
-		acquired:   true,
-		failStatus: IELTSSpeakingShadowRuntimePending,
-	}
-	provider := &ieltsProviderStub{err: context.DeadlineExceeded}
-	worker, err := NewIELTSSpeakingShadowWorker(
-		repository,
-		NewIELTSSpeakingShadowEngineWithAcoustics(
-			provider,
-			&ieltsAcousticSourceStub{
-				err: ErrIELTSSpeakingAcousticsPending,
-			},
-		),
-		validIELTSSpeakingShadowRuntimeConfiguration(),
-	)
-	if err != nil {
-		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
-	}
-	sweep, err := worker.ProcessPending(context.Background(), 1)
-	if err != nil {
-		t.Fatalf("ProcessPending: %v", err)
-	}
-	if sweep.Retried != 1 || provider.calls != 1 ||
-		repository.failCalls != 1 ||
-		repository.failure.Code != "provider_timeout" ||
-		!repository.failure.Retryable {
-		t.Fatalf(
-			"sweep = %#v; provider calls = %d; failure = %#v",
-			sweep,
-			provider.calls,
-			repository.failure,
+	for attempt := 8; attempt <= 10; attempt++ {
+		failStatus := IELTSSpeakingShadowRuntimePending
+		wantRetried, wantFailed := 1, 0
+		if attempt == 10 {
+			failStatus = IELTSSpeakingShadowRuntimeFailed
+			wantRetried, wantFailed = 0, 1
+		}
+		claim := validIELTSSpeakingShadowClaim(t)
+		claim.AttemptCount = attempt
+		repository := &ieltsShadowRuntimeRepositoryStub{
+			claim:      claim,
+			acquired:   true,
+			failStatus: failStatus,
+		}
+		provider := &ieltsProviderStub{err: context.DeadlineExceeded}
+		worker, err := NewIELTSSpeakingShadowWorker(
+			repository,
+			NewIELTSSpeakingShadowEngineWithAcoustics(
+				provider,
+				&ieltsAcousticSourceStub{
+					err: ErrIELTSSpeakingAcousticsPending,
+				},
+			),
+			validIELTSSpeakingShadowRuntimeConfiguration(),
 		)
+		if err != nil {
+			t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+		}
+		sweep, err := worker.ProcessPending(context.Background(), 1)
+		if err != nil {
+			t.Fatalf("ProcessPending: %v", err)
+		}
+		if sweep.Retried != wantRetried || sweep.Failed != wantFailed ||
+			provider.calls != 1 || repository.failCalls != 1 ||
+			repository.failure.Code != "provider_timeout" ||
+			!repository.failure.Retryable {
+			t.Fatalf(
+				"attempt = %d; sweep = %#v; provider calls = %d; failure = %#v",
+				attempt,
+				sweep,
+				provider.calls,
+				repository.failure,
+			)
+		}
 	}
 }
 
@@ -412,7 +461,7 @@ func (failure ieltsGenerationFailureStub) Retryable() bool {
 
 func validIELTSSpeakingShadowRuntimeConfiguration() IELTSSpeakingShadowRuntimeConfiguration {
 	return IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     3,
+		MaxAttempts:     10,
 		LeaseDuration:   time.Minute,
 		StrategyRef:     IELTSSpeakingShadowStrategyRef,
 		PipelineVersion: IELTSSpeakingShadowPipelineVersion,

--- a/server/internal/coaching/evaluation/scoring/runtime.go
+++ b/server/internal/coaching/evaluation/scoring/runtime.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	runtimeLeaseDuration = 60 * time.Second
-	runtimeRetryDelay    = 5 * time.Second
-	runtimeMaxAttempts   = 3
+	runtimeLeaseDuration    = 60 * time.Second
+	runtimeRetryDelay       = 5 * time.Second
+	runtimeMaxAttempts      = 3
+	ieltsRuntimeMaxAttempts = 10
 )
 
 type Configuration struct {
@@ -412,7 +413,7 @@ func ieltsRuntimeConfiguration(
 		return IELTSSpeakingShadowRuntimeConfiguration{}, err
 	}
 	result := IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     configuration.maxAttempts,
+		MaxAttempts:     ieltsRuntimeMaxAttempts,
 		LeaseDuration:   configuration.leaseDuration,
 		StrategyRef:     IELTSSpeakingShadowStrategyRef,
 		PipelineVersion: IELTSSpeakingShadowPipelineVersion,

--- a/server/internal/coaching/evaluation/scoring/runtime_test.go
+++ b/server/internal/coaching/evaluation/scoring/runtime_test.go
@@ -24,6 +24,9 @@ func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	if firstInterview != secondInterview || !firstInterview.Valid() {
 		t.Fatalf("interview runtime configuration is unstable: %#v %#v", firstInterview, secondInterview)
 	}
+	if firstInterview.MaxAttempts != runtimeMaxAttempts {
+		t.Fatalf("interview max attempts = %d", firstInterview.MaxAttempts)
+	}
 
 	firstIELTS, err := ieltsRuntimeConfiguration(configuration)
 	if err != nil {
@@ -36,7 +39,7 @@ func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	if firstIELTS != secondIELTS || !firstIELTS.Valid() {
 		t.Fatalf("IELTS runtime configuration is unstable: %#v %#v", firstIELTS, secondIELTS)
 	}
-	if firstIELTS.MaxAttempts != runtimeMaxAttempts {
+	if firstIELTS.MaxAttempts != 10 {
 		t.Fatalf("IELTS max attempts = %d", firstIELTS.MaxAttempts)
 	}
 
@@ -50,6 +53,28 @@ func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	}
 	if firstGeneral != secondGeneral || !firstGeneral.Valid() {
 		t.Fatalf("general runtime configuration is unstable: %#v %#v", firstGeneral, secondGeneral)
+	}
+	if firstGeneral.MaxAttempts != runtimeMaxAttempts {
+		t.Fatalf("general max attempts = %d", firstGeneral.MaxAttempts)
+	}
+}
+
+func TestIELTSAcousticWaitBudgetPreservesProviderAttempts(t *testing.T) {
+	t.Parallel()
+	configuration, err := NewConfiguration("qiniu", "qwen-plus", 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ielts, err := ieltsRuntimeConfiguration(configuration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitAttempts := ieltsAcousticWaitAttemptLimit(ielts.MaxAttempts)
+	if waitAttempts != 7 {
+		t.Fatalf("IELTS acoustic wait attempts = %d", waitAttempts)
+	}
+	if providerAttempts := ielts.MaxAttempts - waitAttempts; providerAttempts < ieltsProviderAttemptReserve {
+		t.Fatalf("IELTS provider attempts = %d", providerAttempts)
 	}
 }
 


### PR DESCRIPTION
## 功能描述

恢复 IELTS Speaking 完整模考独立的声学定稿等待预算，避免讯飞 ISE 正常处理中仅等待约 1 秒就提前生成 text-only 报告，同时不挤占评分 Provider 的重试机会。

## 实现思路

- 通用 Interview/General Scene 继续使用 3 次预算。
- FULL_MOCK 单独恢复 10 次 durable job budget。
- attempt 1–7 用于等待声学证据；持久化退避累计约 127 秒。
- attempt 8 开始若声学仍 pending，则诚实降级 text-only；attempt 8–10 完整保留给评分 Provider。
- 不引入内存计时器，不伪造 PR 分数，不改变通用场景。

## 可复现测试

```bash
make check-go
```

结果：gofmt、全仓 `go vet ./...`、`go test -count=1 ./...` 通过。

定向回归：

```bash
cd server
go test ./internal/coaching/evaluation/scoring -count=1
```

覆盖：

- attempt 7 仍等待声学；
- 等待窗口内 READY 可进入四维输入；
- attempt 8 声学仍 pending 时 text-only 定稿；
- attempt 8/9/10 均可用于 Provider，最后一次耗尽后才 FAILED；
- Interview/General Scene 的 3 次预算不变。

## 范围说明

不修改讯飞协议、SpeechFeedback 执行 timeout、评分结果校验或移动端 UI。

Closes #615