### PR TITLE
fix(evaluation): freeze IELTS acoustic evidence

### DIFF
--- a/mobile/lib/features/coaching/review/practice_report_status_controller.dart
+++ b/mobile/lib/features/coaching/review/practice_report_status_controller.dart
@@ -9,7 +9,7 @@ final class PracticeReportStatusController extends ChangeNotifier {
   PracticeReportStatusController({
     required this.client,
     this.pollInterval = const Duration(seconds: 2),
-    this.maximumPollAttempts = 30,
+    this.maximumPollAttempts = 150,
   }) {
     if (pollInterval < Duration.zero) {
       throw ArgumentError.value(pollInterval, 'pollInterval');

--- a/mobile/test/review/practice_report_status_test.dart
+++ b/mobile/test/review/practice_report_status_test.dart
@@ -415,6 +415,38 @@ void main() {
   );
 
   test(
+    'default polling budget outlives the acoustic validation barrier',
+    () async {
+      final client = _ScriptedStatusClient(<Object>[
+        for (var attempt = 0; attempt < 30; attempt++)
+          _status(
+            PracticeReportEvaluationStatus.queued,
+            practiceMode: PracticeMode.fullMock,
+            withEvaluationIdentity: true,
+          ),
+        _status(
+          PracticeReportEvaluationStatus.ready,
+          practiceMode: PracticeMode.fullMock,
+        ),
+      ]);
+      final controller = PracticeReportStatusController(
+        client: client,
+        pollInterval: Duration.zero,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('session_595');
+
+      expect(client.statusCalls, 31);
+      expect(
+        controller.status?.evaluationStatus,
+        PracticeReportEvaluationStatus.ready,
+      );
+      expect(controller.errorMessage, isNull);
+    },
+  );
+
+  test(
     'controller stops retryable status polling at the configured bound',
     () async {
       final client = _ScriptedStatusClient(const <Object>[

--- a/server/internal/coaching/evaluation/api/application.go
+++ b/server/internal/coaching/evaluation/api/application.go
@@ -369,7 +369,7 @@ func sessionReportResource(
 		resource.Revision = value.Revision.Number
 	}
 	switch state.Status {
-	case evaluation.StatusQueued:
+	case evaluation.StatusValidating, evaluation.StatusQueued:
 		if state.FormalReport != nil || state.Failure != nil {
 			return SessionReportResource{}, evaluation.ErrInvalidRequest
 		}
@@ -516,7 +516,8 @@ func ieltsSpeakingShadowAccepted(
 	}
 	if replayed {
 		switch value.Revision.Status {
-		case evaluation.StatusQueued,
+		case evaluation.StatusValidating,
+			evaluation.StatusQueued,
 			evaluation.StatusRunning,
 			evaluation.StatusReady,
 			evaluation.StatusFailed:
@@ -524,7 +525,8 @@ func ieltsSpeakingShadowAccepted(
 			return EvaluationAccepted{},
 				interviewShadowVersionConflictError()
 		}
-	} else if value.Revision.Status != evaluation.StatusQueued {
+	} else if value.Revision.Status != evaluation.StatusValidating &&
+		value.Revision.Status != evaluation.StatusQueued {
 		return EvaluationAccepted{},
 			interviewShadowVersionConflictError()
 	}
@@ -752,7 +754,7 @@ func ieltsSpeakingReportResource(
 		IsFinal:              false,
 	}
 	switch value.Revision.Status {
-	case evaluation.StatusQueued:
+	case evaluation.StatusValidating, evaluation.StatusQueued:
 		if state.Runtime.ModuleStatus !=
 			scoring.IELTSSpeakingShadowRuntimePending ||
 			state.Runtime.Result != nil ||

--- a/server/internal/coaching/evaluation/api/application_test.go
+++ b/server/internal/coaching/evaluation/api/application_test.go
@@ -761,14 +761,15 @@ func evaluationTestIELTSRuntimeConfiguration(
 ) scoring.IELTSSpeakingShadowRuntimeConfiguration {
 	t.Helper()
 	return scoring.IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     3,
-		LeaseDuration:   30 * time.Second,
-		StrategyRef:     scoring.IELTSSpeakingShadowStrategyRef,
-		PipelineVersion: scoring.IELTSSpeakingShadowPipelineVersion,
-		FullConfigHash:  sha256.Sum256([]byte("ielts-config")),
-		PromptVersion:   scoring.IELTSSpeakingShadowPromptVersion,
-		Provider:        "qianwen",
-		Model:           "qwen-plus",
+		MaxAttempts:          3,
+		LeaseDuration:        30 * time.Second,
+		AcousticWaitDuration: 15 * time.Second,
+		StrategyRef:          scoring.IELTSSpeakingShadowStrategyRef,
+		PipelineVersion:      scoring.IELTSSpeakingShadowPipelineVersion,
+		FullConfigHash:       sha256.Sum256([]byte("ielts-config")),
+		PromptVersion:        scoring.IELTSSpeakingShadowPromptVersion,
+		Provider:             "qianwen",
+		Model:                "qwen-plus",
 	}
 }
 

--- a/server/internal/coaching/evaluation/api/application_test.go
+++ b/server/internal/coaching/evaluation/api/application_test.go
@@ -247,6 +247,25 @@ func TestEvaluationHTTPApplicationReevaluatesIELTSSpeakingReport(
 	}
 }
 
+func TestIELTSSpeakingShadowAcceptedAllowsValidatingFreshAndReplay(
+	t *testing.T,
+) {
+	t.Parallel()
+	value := evaluationTestIELTSValue(evaluation.StatusValidating)
+	for _, replayed := range []bool{false, true} {
+		accepted, err := ieltsSpeakingShadowAccepted(value, replayed)
+		if err != nil || accepted.EvaluationStatus != evaluation.StatusValidating ||
+			accepted.Replayed != replayed {
+			t.Fatalf(
+				"replayed=%t accepted=%#v err=%v",
+				replayed,
+				accepted,
+				err,
+			)
+		}
+	}
+}
+
 func TestEvaluationHTTPApplicationRejectsReevaluationBeforeMutation(
 	t *testing.T,
 ) {
@@ -385,6 +404,38 @@ func TestEvaluationHTTPApplicationGetsOwnerScopedIELTSSpeakingReport(
 	}
 }
 
+func TestEvaluationHTTPApplicationProjectsValidatingIELTSSpeakingReport(
+	t *testing.T,
+) {
+	t.Parallel()
+	actor := requestcontext.Actor{
+		UserID:    "00000000-0000-4000-8000-000000000001",
+		SessionID: "session-authenticated",
+	}
+	application := &Application{
+		ieltsReports: &ieltsSpeakingReportReaderStub{
+			result: evaluationreport.IELTSSpeakingReadState{
+				Evaluation: evaluationTestIELTSValue(
+					evaluation.StatusValidating,
+				),
+				Runtime: scoring.IELTSSpeakingShadowReadState{
+					ModuleStatus: scoring.IELTSSpeakingShadowRuntimePending,
+				},
+			},
+		},
+		ieltsConfiguration: evaluationTestIELTSRuntimeConfiguration(t),
+	}
+	resource, err := application.GetIELTSSpeakingReport(
+		requestcontext.WithActor(context.Background(), actor),
+		actor,
+		"session_ielts_001",
+	)
+	if err != nil || resource.EvaluationStatus != evaluation.StatusValidating ||
+		resource.Report != nil || resource.StableFailure != nil {
+		t.Fatalf("validating resource=%#v err=%v", resource, err)
+	}
+}
+
 func TestEvaluationHTTPApplicationGetsOwnerScopedQueuedSessionReport(
 	t *testing.T,
 ) {
@@ -417,6 +468,38 @@ func TestEvaluationHTTPApplicationGetsOwnerScopedQueuedSessionReport(
 		resource.EvaluationStatus != evaluation.StatusQueued ||
 		len(resource.AvailableSections) != 2 {
 		t.Fatalf("reader=%#v resource=%#v", reader, resource)
+	}
+}
+
+func TestEvaluationHTTPApplicationProjectsValidatingFullMockSessionReport(
+	t *testing.T,
+) {
+	t.Parallel()
+	actor := requestcontext.Actor{
+		UserID:    "00000000-0000-4000-8000-000000000001",
+		SessionID: "session-authenticated",
+	}
+	value := evaluationTestIELTSValue(evaluation.StatusValidating)
+	application := &Application{
+		sessionReports: &sessionReportReaderStub{
+			result: evaluationreport.SessionReportReadState{
+				PracticeMode: "FULL_MOCK",
+				AvailableSections: []string{
+					"PART_1", "PART_2", "PART_3",
+				},
+				Status:     evaluation.StatusValidating,
+				Evaluation: &value,
+			},
+		},
+	}
+	resource, err := application.GetSessionReport(
+		requestcontext.WithActor(context.Background(), actor),
+		actor,
+		"session_ielts_001",
+	)
+	if err != nil || resource.EvaluationStatus != evaluation.StatusValidating ||
+		resource.ReportID != "" || resource.StableFailure != nil {
+		t.Fatalf("validating resource=%#v err=%v", resource, err)
 	}
 }
 

--- a/server/internal/coaching/evaluation/api/http.go
+++ b/server/internal/coaching/evaluation/api/http.go
@@ -62,8 +62,8 @@ type HTTPApplication interface {
 }
 
 // EvaluationAccepted is the immutable revision identity returned by a write.
-// Fresh writes must be genuinely QUEUED. Idempotent replays may expose the
-// persisted current state without requeuing work.
+// Fresh writes must be waiting for validation or genuinely queued. Idempotent
+// replays may expose the persisted current state without requeuing work.
 type EvaluationAccepted struct {
 	EvaluationID         string
 	EvaluationRevisionID string
@@ -519,7 +519,8 @@ func (accepted EvaluationAccepted) valid() bool {
 		if !validEvaluationStatus(accepted.EvaluationStatus) {
 			return false
 		}
-	} else if accepted.EvaluationStatus != evaluation.StatusQueued {
+	} else if accepted.EvaluationStatus != evaluation.StatusValidating &&
+		accepted.EvaluationStatus != evaluation.StatusQueued {
 		return false
 	}
 	if accepted.Revision == 1 {
@@ -687,7 +688,7 @@ func (resource SessionReportResource) response() sessionReportResponse {
 		ReportScope:          resource.ReportScope,
 		AvailableSections:    append([]string(nil), resource.AvailableSections...),
 		DetailSchema:         resource.DetailSchema,
-		EvaluationStatus:     resource.EvaluationStatus,
+		EvaluationStatus:     reportWireStatus(resource.EvaluationStatus),
 		EvaluationID:         resource.EvaluationID,
 		EvaluationRevisionID: resource.EvaluationRevisionID,
 		Revision:             resource.Revision,
@@ -725,6 +726,10 @@ func (resource SessionReportResource) valid() bool {
 		return false
 	}
 	switch resource.EvaluationStatus {
+	case evaluation.StatusValidating:
+		return hasEvaluation && resource.ReportID == "" &&
+			resource.ScoreabilityStatus == "" && resource.Summary == "" &&
+			resource.StableFailure == nil
 	case evaluation.StatusQueued:
 		return resource.ReportID == "" && resource.ScoreabilityStatus == "" &&
 			resource.Summary == "" && resource.StableFailure == nil
@@ -745,6 +750,13 @@ func (resource SessionReportResource) valid() bool {
 	default:
 		return false
 	}
+}
+
+func reportWireStatus(status evaluation.Status) evaluation.Status {
+	if status == evaluation.StatusValidating {
+		return evaluation.StatusQueued
+	}
+	return status
 }
 
 func validSessionReportShape(
@@ -810,7 +822,7 @@ func (resource IELTSSpeakingReportResource) response() ieltsSpeakingReportRespon
 		EvaluationID:         resource.EvaluationID,
 		EvaluationRevisionID: resource.EvaluationRevisionID,
 		Revision:             resource.Revision,
-		EvaluationStatus:     resource.EvaluationStatus,
+		EvaluationStatus:     reportWireStatus(resource.EvaluationStatus),
 		IsFinal:              resource.IsFinal,
 		StatusURL: "/v1/practice-sessions/" +
 			resource.PracticeSessionID +
@@ -829,7 +841,8 @@ func (resource IELTSSpeakingReportResource) valid() bool {
 		return false
 	}
 	switch resource.EvaluationStatus {
-	case evaluation.StatusQueued, evaluation.StatusRunning:
+	case evaluation.StatusValidating, evaluation.StatusQueued,
+		evaluation.StatusRunning:
 		return resource.Report == nil &&
 			resource.StableFailure == nil
 	case evaluation.StatusReady:

--- a/server/internal/coaching/evaluation/api/http_test.go
+++ b/server/internal/coaching/evaluation/api/http_test.go
@@ -288,6 +288,7 @@ func TestWriteEndpointsReturnIdempotentReplayStateHonestly(t *testing.T) {
 		status     evaluation.Status
 		wantStatus int
 	}{
+		{status: evaluation.StatusValidating, wantStatus: http.StatusOK},
 		{status: evaluation.StatusQueued, wantStatus: http.StatusAccepted},
 		{status: evaluation.StatusRunning, wantStatus: http.StatusOK},
 		{status: evaluation.StatusReady, wantStatus: http.StatusOK},
@@ -358,6 +359,32 @@ func TestWriteEndpointsReturnIdempotentReplayStateHonestly(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestReevaluateReturnsFreshValidatingIdentity(t *testing.T) {
+	accepted := queuedReevaluation()
+	accepted.EvaluationStatus = evaluation.StatusValidating
+	router := newTestRouter(t, applicationStub{
+		reevaluate: fixedReevaluation(accepted),
+	}, &testActor)
+	response := performRequest(
+		router,
+		http.MethodPost,
+		"/v1/evaluations/"+testEvaluationID+"/re-evaluate",
+		validReevaluateBody(),
+		"application/json",
+	)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	assertJSONEquals(t, response.Body.String(), map[string]any{
+		"evaluation_id":          testEvaluationID,
+		"evaluation_revision_id": testNextRevision,
+		"revision":               float64(2),
+		"supersedes_revision_id": testRevisionID,
+		"evaluation_status":      "VALIDATING",
+		"status_url":             "/v1/evaluations/" + testEvaluationID,
+	})
 }
 
 func TestGetPublishesEveryLifecycleStateHonestly(t *testing.T) {
@@ -687,6 +714,41 @@ func TestGetIELTSSpeakingReportPublishesPollableEnvelope(t *testing.T) {
 	})
 }
 
+func TestGetIELTSSpeakingReportPublishesValidatingAsQueued(t *testing.T) {
+	resource := ieltsSpeakingReportResourceForStatus(
+		evaluation.StatusValidating,
+	)
+	router := newTestRouter(t, applicationStub{
+		getIELTSSpeakingReport: func(
+			context.Context,
+			requestcontext.Actor,
+			string,
+		) (IELTSSpeakingReportResource, error) {
+			return resource, nil
+		},
+	}, &testActor)
+	response := performRequest(
+		router,
+		http.MethodGet,
+		"/v1/practice-sessions/session_ielts_001/ielts-speaking-report",
+		"",
+		"",
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body)
+	}
+	assertJSONEquals(t, response.Body.String(), map[string]any{
+		"practice_session_id":    "session_ielts_001",
+		"evaluation_id":          testEvaluationID,
+		"evaluation_revision_id": testRevisionID,
+		"revision":               float64(1),
+		"evaluation_status":      "QUEUED",
+		"is_final":               false,
+		"status_url": "/v1/practice-sessions/session_ielts_001/" +
+			"ielts-speaking-report",
+	})
+}
+
 func TestGetSessionReportPublishesCanonicalLifecycleEnvelope(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -709,6 +771,30 @@ func TestGetSessionReportPublishesCanonicalLifecycleEnvelope(t *testing.T) {
 				"detail_schema":      "ielts-speaking-practice-report/v1",
 				"evaluation_status":  "QUEUED",
 				"status_url":         "/v1/practice-sessions/session_ielts_001/report",
+			},
+		},
+		{
+			name: "validating full mock remains wire compatible",
+			resource: SessionReportResource{
+				PracticeSessionID: "session_ielts_001",
+				PracticeMode:      "FULL_MOCK", ReportScope: "FULL_MOCK",
+				AvailableSections:    []string{"PART_1", "PART_2", "PART_3"},
+				DetailSchema:         evaluationreport.IELTSSpeakingReportSchemaVersion,
+				EvaluationStatus:     evaluation.StatusValidating,
+				EvaluationID:         testEvaluationID,
+				EvaluationRevisionID: testRevisionID,
+				Revision:             1,
+			},
+			want: map[string]any{
+				"practice_session_id": "session_ielts_001",
+				"practice_mode":       "FULL_MOCK", "report_scope": "FULL_MOCK",
+				"available_sections":     []any{"PART_1", "PART_2", "PART_3"},
+				"detail_schema":          "ielts-speaking-report/v1",
+				"evaluation_status":      "QUEUED",
+				"evaluation_id":          testEvaluationID,
+				"evaluation_revision_id": testRevisionID,
+				"revision":               float64(1),
+				"status_url":             "/v1/practice-sessions/session_ielts_001/report",
 			},
 		},
 		{

--- a/server/internal/coaching/evaluation/evidence/postgres_integration_test.go
+++ b/server/internal/coaching/evaluation/evidence/postgres_integration_test.go
@@ -619,6 +619,15 @@ func TestPostgresEvidenceSnapshotFencesConcurrentQuestionInsert(
 
 func TestEvidenceSnapshotMigrationDownRemovesOwnedSchema(t *testing.T) {
 	pool := evidenceSnapshotDatabase(t)
+	acousticDown, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.down.sql",
+	)
+	if err != nil {
+		t.Fatalf("read IELTS acoustic snapshot down migration: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), string(acousticDown)); err != nil {
+		t.Fatalf("apply IELTS acoustic snapshot down migration: %v", err)
+	}
 	down, err := migrations.Files.ReadFile(
 		"000036_evaluation_evidence_snapshots.down.sql",
 	)

--- a/server/internal/coaching/evaluation/postgres/durable_job.go
+++ b/server/internal/coaching/evaluation/postgres/durable_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/modelid"
 )
 
@@ -84,6 +85,8 @@ type durableSceneJobClaim struct {
 	Provider             string
 	Model                string
 	Snapshot             evidence.EvidenceSnapshot
+	AcousticSnapshot     *scoring.IELTSAcousticSnapshot
+	InputBundleHash      [sha256.Size]byte
 }
 
 func (claim durableSceneJobClaim) valid(spec durableSceneJobSpec) bool {
@@ -106,7 +109,26 @@ func (claim durableSceneJobClaim) valid(spec durableSceneJobSpec) bool {
 		claim.Snapshot.Valid() &&
 		claim.Snapshot.OwnerUserID == claim.OwnerUserID &&
 		claim.Snapshot.Scope == evaluation.ScopeSession &&
-		claim.Snapshot.SceneType == spec.sceneType
+		claim.Snapshot.SceneType == spec.sceneType &&
+		claim.validAcousticBinding(spec)
+}
+
+func (claim durableSceneJobClaim) validAcousticBinding(
+	spec durableSceneJobSpec,
+) bool {
+	requiresAcoustics := spec.sceneType == evaluation.SceneIELTSSpeaking &&
+		spec.strategyRef == scoring.IELTSSpeakingShadowStrategyRef
+	if !requiresAcoustics {
+		return claim.AcousticSnapshot == nil &&
+			claim.InputBundleHash == ([sha256.Size]byte{})
+	}
+	return claim.AcousticSnapshot != nil &&
+		!claim.AcousticSnapshot.CreatedAt.IsZero() &&
+		claim.AcousticSnapshot.ValidFor(claim.Snapshot) &&
+		claim.InputBundleHash == scoring.IELTSAcousticInputBundleHash(
+			claim.Snapshot,
+			*claim.AcousticSnapshot,
+		)
 }
 
 type durableSceneJobFailure struct {

--- a/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
@@ -1,0 +1,347 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
+	"github.com/jackc/pgx/v5"
+)
+
+var _ scoring.IELTSAcousticSnapshotRepository = (*PostgresRepository)(nil)
+
+func (r *PostgresRepository) FindPendingIELTSAcousticSnapshot(
+	ctx context.Context,
+) (scoring.IELTSAcousticSnapshotClaim, bool, error) {
+	if r == nil || r.pool == nil || ctx == nil {
+		return scoring.IELTSAcousticSnapshotClaim{}, false,
+			evaluation.ErrInvalidRequest
+	}
+	var claim scoring.IELTSAcousticSnapshotClaim
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			ledger.id::text,
+			revision.id::text,
+			ledger.owner_user_id::text,
+			revision.created_at
+		FROM evaluation_ledgers AS ledger
+		JOIN evaluation_revisions AS revision
+		  ON revision.evaluation_id = ledger.id
+		 AND revision.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_revision_states AS state
+		  ON state.evaluation_id = ledger.id
+		 AND state.revision_id = revision.id
+		 AND state.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_outbox AS outbox
+		  ON outbox.evaluation_id = ledger.id
+		 AND outbox.evaluation_revision_id = revision.id
+		 AND outbox.owner_user_id = ledger.owner_user_id
+		 AND outbox.channel = 'SCENE'
+		JOIN identity_users AS owner
+		  ON owner.id = ledger.owner_user_id
+		WHERE ledger.scope = 'SESSION'
+		  AND ledger.scene_type = 'IELTS_SPEAKING'
+		  AND revision.channels = ARRAY['SCENE']::text[]
+		  AND revision.scene_strategy_ref = $1
+		  AND revision.pipeline_version = $2
+		  AND revision.schema_version = $3
+		  AND state.evaluation_status = 'VALIDATING'
+		  AND state.completed_at IS NULL
+		  AND outbox.delivery_status = 'PENDING'
+		  AND owner.account_status = 'active'
+		  AND NOT EXISTS (
+		      SELECT 1
+		      FROM evaluation_revisions AS later
+		      WHERE later.evaluation_id = revision.evaluation_id
+		        AND later.revision > revision.revision
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1
+		      FROM evaluation_deletion_fences AS fence
+		      WHERE fence.owner_user_id = ledger.owner_user_id
+		  )
+		ORDER BY revision.created_at, revision.id
+		LIMIT 1
+	`, scoring.IELTSSpeakingShadowStrategyRef,
+		scoring.IELTSSpeakingShadowPipelineVersion,
+		evaluation.SchemaVersion).Scan(
+		&claim.EvaluationID,
+		&claim.EvaluationRevisionID,
+		&claim.OwnerUserID,
+		&claim.RevisionCreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return scoring.IELTSAcousticSnapshotClaim{}, false, nil
+	}
+	if err != nil {
+		return scoring.IELTSAcousticSnapshotClaim{}, false, fmt.Errorf(
+			"find pending IELTS acoustic snapshot: %w",
+			err,
+		)
+	}
+	claim.Snapshot, err = scanEvidenceSnapshot(r.pool.QueryRow(
+		ctx,
+		evidenceSnapshotSelect+`
+			FROM evaluation_evidence_snapshots AS snapshot
+			JOIN evaluation_ledgers AS ledger
+			  ON ledger.input_snapshot_id = snapshot.id
+			 AND ledger.owner_user_id = snapshot.owner_user_id
+			JOIN evaluation_revisions AS revision
+			  ON revision.evaluation_id = ledger.id
+			 AND revision.owner_user_id = ledger.owner_user_id
+			WHERE ledger.id = $1
+			  AND revision.id = $2
+			  AND ledger.owner_user_id = $3
+			  AND ledger.practice_session_id = snapshot.practice_session_id
+			  AND ledger.input_revision = snapshot.input_revision
+			  AND ledger.scope = snapshot.scope
+			  AND ledger.scene_type = snapshot.scene_type
+		`,
+		claim.EvaluationID,
+		claim.EvaluationRevisionID,
+		claim.OwnerUserID,
+	))
+	if err != nil {
+		return scoring.IELTSAcousticSnapshotClaim{}, false, fmt.Errorf(
+			"read pending IELTS acoustic base snapshot: %w",
+			err,
+		)
+	}
+	claim.RevisionCreatedAt = claim.RevisionCreatedAt.UTC()
+	if !claim.Valid() {
+		return scoring.IELTSAcousticSnapshotClaim{}, false,
+			evaluation.ErrInvalidRequest
+	}
+	return claim, true, nil
+}
+
+func (r *PostgresRepository) EnsureIELTSAcousticSnapshot(
+	ctx context.Context,
+	claim scoring.IELTSAcousticSnapshotClaim,
+	draft scoring.IELTSAcousticSnapshot,
+) (scoring.IELTSAcousticSnapshot, bool, error) {
+	if r == nil || r.pool == nil || ctx == nil || !claim.Valid() ||
+		!draft.ValidFor(claim.Snapshot) ||
+		draft.EvaluationID != claim.EvaluationID ||
+		draft.OwnerUserID != claim.OwnerUserID {
+		return scoring.IELTSAcousticSnapshot{}, false,
+			evaluation.ErrInvalidRequest
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, fmt.Errorf(
+			"begin IELTS acoustic snapshot ensure: %w",
+			err,
+		)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveOwner(ctx, tx, claim.OwnerUserID); err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, err
+	}
+	var status evaluation.Status
+	err = tx.QueryRow(ctx, `
+		SELECT state.evaluation_status
+		FROM evaluation_ledgers AS ledger
+		JOIN evaluation_revisions AS revision
+		  ON revision.evaluation_id = ledger.id
+		 AND revision.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_revision_states AS state
+		  ON state.evaluation_id = ledger.id
+		 AND state.revision_id = revision.id
+		 AND state.owner_user_id = ledger.owner_user_id
+		WHERE ledger.id = $1
+		  AND revision.id = $2
+		  AND ledger.owner_user_id = $3
+		  AND ledger.input_snapshot_id = $4
+		  AND ledger.scope = 'SESSION'
+		  AND ledger.scene_type = 'IELTS_SPEAKING'
+		  AND revision.channels = ARRAY['SCENE']::text[]
+		  AND revision.scene_strategy_ref = $5
+		  AND revision.pipeline_version = $6
+		  AND NOT EXISTS (
+		      SELECT 1
+		      FROM evaluation_revisions AS later
+		      WHERE later.evaluation_id = revision.evaluation_id
+		        AND later.revision > revision.revision
+		  )
+		FOR UPDATE OF state
+	`, claim.EvaluationID, claim.EvaluationRevisionID,
+		claim.OwnerUserID, claim.Snapshot.ID,
+		scoring.IELTSSpeakingShadowStrategyRef,
+		scoring.IELTSSpeakingShadowPipelineVersion).Scan(&status)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return scoring.IELTSAcousticSnapshot{}, false,
+			scoring.ErrRuntimeLeaseLost
+	}
+	if err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, fmt.Errorf(
+			"lock IELTS acoustic snapshot revision: %w",
+			err,
+		)
+	}
+	if status != evaluation.StatusValidating && status != evaluation.StatusQueued {
+		return scoring.IELTSAcousticSnapshot{}, false,
+			scoring.ErrRuntimeLeaseLost
+	}
+	command, err := tx.Exec(ctx, `
+		INSERT INTO evaluation_ielts_speaking_acoustic_snapshots (
+			id,
+			evaluation_id,
+			owner_user_id,
+			input_snapshot_id,
+			input_snapshot_hash,
+			schema_version,
+			resolution,
+			snapshot_hash,
+			canonical_payload
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (evaluation_id) DO NOTHING
+	`, draft.ID, draft.EvaluationID, draft.OwnerUserID,
+		draft.InputSnapshotID, draft.InputSnapshotHash[:],
+		scoring.IELTSAcousticSnapshotSchemaVersion,
+		draft.Resolution, draft.SnapshotHash[:], string(draft.Payload))
+	if err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, fmt.Errorf(
+			"insert IELTS acoustic snapshot: %w",
+			err,
+		)
+	}
+	stored, err := getIELTSAcousticSnapshot(
+		ctx,
+		tx,
+		claim.OwnerUserID,
+		claim.EvaluationID,
+		claim.Snapshot,
+	)
+	if err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, err
+	}
+	if stored.ID != draft.ID || stored.SnapshotHash != draft.SnapshotHash ||
+		stored.Resolution != draft.Resolution ||
+		!bytes.Equal(stored.Payload, draft.Payload) {
+		return scoring.IELTSAcousticSnapshot{}, false,
+			scoring.ErrRuntimeConfigurationConflict
+	}
+	if status == evaluation.StatusValidating {
+		updated, updateErr := tx.Exec(ctx, `
+			UPDATE evaluation_revision_states
+			SET evaluation_status = 'QUEUED',
+			    updated_at = transaction_timestamp()
+			WHERE evaluation_id = $1
+			  AND revision_id = $2
+			  AND owner_user_id = $3
+			  AND evaluation_status = 'VALIDATING'
+			  AND completed_at IS NULL
+		`, claim.EvaluationID, claim.EvaluationRevisionID,
+			claim.OwnerUserID)
+		if updateErr != nil {
+			return scoring.IELTSAcousticSnapshot{}, false, fmt.Errorf(
+				"queue frozen IELTS acoustic snapshot: %w",
+				updateErr,
+			)
+		}
+		if updated.RowsAffected() != 1 {
+			return scoring.IELTSAcousticSnapshot{}, false,
+				scoring.ErrRuntimeLeaseLost
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return scoring.IELTSAcousticSnapshot{}, false, fmt.Errorf(
+			"commit IELTS acoustic snapshot ensure: %w",
+			err,
+		)
+	}
+	return stored, command.RowsAffected() == 0, nil
+}
+
+func getIELTSAcousticSnapshot(
+	ctx context.Context,
+	db queryable,
+	ownerUserID string,
+	evaluationID string,
+	base evidence.EvidenceSnapshot,
+) (scoring.IELTSAcousticSnapshot, error) {
+	var result scoring.IELTSAcousticSnapshot
+	var inputHash, snapshotHash []byte
+	var schemaVersion string
+	err := db.QueryRow(ctx, `
+		SELECT
+			id,
+			evaluation_id::text,
+			owner_user_id::text,
+			input_snapshot_id,
+			input_snapshot_hash,
+			schema_version,
+			resolution,
+			snapshot_hash,
+			canonical_payload,
+			created_at
+		FROM evaluation_ielts_speaking_acoustic_snapshots
+		WHERE evaluation_id = $1
+		  AND owner_user_id = $2
+	`, evaluationID, ownerUserID).Scan(
+		&result.ID,
+		&result.EvaluationID,
+		&result.OwnerUserID,
+		&result.InputSnapshotID,
+		&inputHash,
+		&schemaVersion,
+		&result.Resolution,
+		&snapshotHash,
+		&result.Payload,
+		&result.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return scoring.IELTSAcousticSnapshot{}, evaluation.ErrNotFound
+	}
+	if err != nil {
+		return scoring.IELTSAcousticSnapshot{}, fmt.Errorf(
+			"read IELTS acoustic snapshot: %w",
+			err,
+		)
+	}
+	if len(inputHash) != sha256.Size || len(snapshotHash) != sha256.Size ||
+		schemaVersion != scoring.IELTSAcousticSnapshotSchemaVersion {
+		return scoring.IELTSAcousticSnapshot{},
+			scoring.ErrRuntimeConfigurationConflict
+	}
+	copy(result.InputSnapshotHash[:], inputHash)
+	copy(result.SnapshotHash[:], snapshotHash)
+	result.CreatedAt = result.CreatedAt.UTC()
+	if !result.ValidFor(base) {
+		return scoring.IELTSAcousticSnapshot{},
+			scoring.ErrRuntimeConfigurationConflict
+	}
+	return result, nil
+}
+
+func nullableAcousticSnapshotID(
+	snapshot *scoring.IELTSAcousticSnapshot,
+) any {
+	if snapshot == nil {
+		return nil
+	}
+	return snapshot.ID
+}
+
+func nullableAcousticSnapshotHash(
+	snapshot *scoring.IELTSAcousticSnapshot,
+) any {
+	if snapshot == nil {
+		return nil
+	}
+	return snapshot.SnapshotHash[:]
+}
+
+func nullableDigest(value [sha256.Size]byte) any {
+	if value == ([sha256.Size]byte{}) {
+		return nil
+	}
+	return value[:]
+}

--- a/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
@@ -17,12 +17,20 @@ var _ scoring.IELTSAcousticSnapshotRepository = (*PostgresRepository)(nil)
 
 func (r *PostgresRepository) FindPendingIELTSAcousticSnapshot(
 	ctx context.Context,
+	after *scoring.IELTSAcousticSnapshotCursor,
 ) (scoring.IELTSAcousticSnapshotClaim, bool, error) {
-	if r == nil || r.pool == nil || ctx == nil {
+	if r == nil || r.pool == nil || ctx == nil ||
+		(after != nil && !after.Valid()) {
 		return scoring.IELTSAcousticSnapshotClaim{}, false,
 			evaluation.ErrInvalidRequest
 	}
 	var claim scoring.IELTSAcousticSnapshotClaim
+	var afterCreatedAt any
+	var afterRevisionID any
+	if after != nil {
+		afterCreatedAt = after.RevisionCreatedAt
+		afterRevisionID = after.EvaluationRevisionID
+	}
 	err := r.pool.QueryRow(ctx, `
 		SELECT
 			ledger.id::text,
@@ -65,11 +73,16 @@ func (r *PostgresRepository) FindPendingIELTSAcousticSnapshot(
 		      FROM evaluation_deletion_fences AS fence
 		      WHERE fence.owner_user_id = ledger.owner_user_id
 		  )
+		  AND (
+		      $4::timestamptz IS NULL
+		      OR (revision.created_at, revision.id) >
+		         ($4::timestamptz, $5::uuid)
+		  )
 		ORDER BY revision.created_at, revision.id
 		LIMIT 1
 	`, scoring.IELTSSpeakingShadowStrategyRef,
 		scoring.IELTSSpeakingShadowPipelineVersion,
-		evaluation.SchemaVersion).Scan(
+		evaluation.SchemaVersion, afterCreatedAt, afterRevisionID).Scan(
 		&claim.EvaluationID,
 		&claim.EvaluationRevisionID,
 		&claim.OwnerUserID,

--- a/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_acoustic_snapshot.go
@@ -143,6 +143,32 @@ func (r *PostgresRepository) EnsureIELTSAcousticSnapshot(
 	if err := lockActiveOwner(ctx, tx, claim.OwnerUserID); err != nil {
 		return scoring.IELTSAcousticSnapshot{}, false, err
 	}
+	if err := lockEvaluationLedgerAndRevisionRows(
+		ctx,
+		tx,
+		claim.OwnerUserID,
+		claim.EvaluationID,
+		claim.EvaluationRevisionID,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return scoring.IELTSAcousticSnapshot{}, false,
+				scoring.ErrRuntimeLeaseLost
+		}
+		return scoring.IELTSAcousticSnapshot{}, false, err
+	}
+	if err := lockEvaluationRevisionRuntimeRows(
+		ctx,
+		tx,
+		claim.OwnerUserID,
+		claim.EvaluationID,
+		claim.EvaluationRevisionID,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return scoring.IELTSAcousticSnapshot{}, false,
+				scoring.ErrRuntimeLeaseLost
+		}
+		return scoring.IELTSAcousticSnapshot{}, false, err
+	}
 	var status evaluation.Status
 	err = tx.QueryRow(ctx, `
 		SELECT state.evaluation_status
@@ -258,6 +284,202 @@ func (r *PostgresRepository) EnsureIELTSAcousticSnapshot(
 		)
 	}
 	return stored, command.RowsAffected() == 0, nil
+}
+
+func (r *PostgresRepository) FailIELTSAcousticSnapshot(
+	ctx context.Context,
+	claim scoring.IELTSAcousticSnapshotClaim,
+) error {
+	if r == nil || r.pool == nil || ctx == nil || !claim.Valid() {
+		return evaluation.ErrInvalidRequest
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin IELTS acoustic snapshot failure: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveOwner(ctx, tx, claim.OwnerUserID); err != nil {
+		return err
+	}
+	if err := lockEvaluationLedgerAndRevisionRows(
+		ctx,
+		tx,
+		claim.OwnerUserID,
+		claim.EvaluationID,
+		claim.EvaluationRevisionID,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return scoring.ErrRuntimeLeaseLost
+		}
+		return err
+	}
+	if err := lockEvaluationRevisionRuntimeRows(
+		ctx,
+		tx,
+		claim.OwnerUserID,
+		claim.EvaluationID,
+		claim.EvaluationRevisionID,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return scoring.ErrRuntimeLeaseLost
+		}
+		return err
+	}
+
+	var revisionStatus, deliveryStatus, outboxFailureCode string
+	var moduleStatus, moduleFailureCode string
+	err = tx.QueryRow(ctx, `
+		SELECT
+			state.evaluation_status,
+			outbox.delivery_status,
+			coalesce(outbox.last_failure_code, ''),
+			coalesce(run.run_status, ''),
+			coalesce(run.last_failure_code, '')
+		FROM evaluation_ledgers AS ledger
+		JOIN evaluation_revisions AS revision
+		  ON revision.evaluation_id = ledger.id
+		 AND revision.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_revision_states AS state
+		  ON state.evaluation_id = ledger.id
+		 AND state.revision_id = revision.id
+		 AND state.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_evidence_snapshots AS snapshot
+		  ON snapshot.id = ledger.input_snapshot_id
+		 AND snapshot.owner_user_id = ledger.owner_user_id
+		JOIN evaluation_outbox AS outbox
+		  ON outbox.evaluation_id = ledger.id
+		 AND outbox.evaluation_revision_id = revision.id
+		 AND outbox.owner_user_id = ledger.owner_user_id
+		 AND outbox.channel = 'SCENE'
+		LEFT JOIN evaluation_module_runs AS run
+		  ON run.outbox_id = outbox.id
+		 AND run.evaluation_id = ledger.id
+		 AND run.evaluation_revision_id = revision.id
+		 AND run.owner_user_id = ledger.owner_user_id
+		 AND run.channel = outbox.channel
+		WHERE ledger.id = $1
+		  AND revision.id = $2
+		  AND ledger.owner_user_id = $3
+		  AND revision.created_at = $4
+		  AND ledger.input_snapshot_id = $5
+		  AND snapshot.snapshot_hash = $6
+		  AND ledger.scope = 'SESSION'
+		  AND ledger.scene_type = 'IELTS_SPEAKING'
+		  AND revision.channels = ARRAY['SCENE']::text[]
+		  AND revision.scene_strategy_ref = $7
+		  AND revision.pipeline_version = $8
+		  AND revision.schema_version = $9
+		  AND NOT EXISTS (
+		      SELECT 1
+		      FROM evaluation_revisions AS later
+		      WHERE later.evaluation_id = revision.evaluation_id
+		        AND later.revision > revision.revision
+		  )
+	`, claim.EvaluationID, claim.EvaluationRevisionID,
+		claim.OwnerUserID, claim.RevisionCreatedAt,
+		claim.Snapshot.ID, claim.Snapshot.SnapshotHash[:],
+		scoring.IELTSSpeakingShadowStrategyRef,
+		scoring.IELTSSpeakingShadowPipelineVersion,
+		evaluation.SchemaVersion).Scan(
+		&revisionStatus,
+		&deliveryStatus,
+		&outboxFailureCode,
+		&moduleStatus,
+		&moduleFailureCode,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return scoring.ErrRuntimeLeaseLost
+	}
+	if err != nil {
+		return fmt.Errorf("read IELTS acoustic snapshot failure state: %w", err)
+	}
+	if revisionStatus == "FAILED" {
+		moduleFailed := moduleStatus == "" ||
+			(moduleStatus == "FAILED" &&
+				moduleFailureCode == scoring.IELTSAcousticEvidenceFailureCode)
+		if deliveryStatus == "FAILED" &&
+			outboxFailureCode == scoring.IELTSAcousticEvidenceFailureCode &&
+			moduleFailed {
+			return nil
+		}
+		return scoring.ErrRuntimeConfigurationConflict
+	}
+	if revisionStatus != "VALIDATING" {
+		return scoring.ErrRuntimeLeaseLost
+	}
+	if deliveryStatus != "PENDING" ||
+		(moduleStatus != "" && moduleStatus != "RUNNING") {
+		return scoring.ErrRuntimeConfigurationConflict
+	}
+
+	if moduleStatus == "RUNNING" {
+		updated, updateErr := tx.Exec(ctx, `
+			UPDATE evaluation_module_runs
+			SET run_status = 'FAILED',
+			    last_failure_code = $1,
+			    updated_at = transaction_timestamp(),
+			    completed_at = transaction_timestamp()
+			WHERE evaluation_id = $2
+			  AND evaluation_revision_id = $3
+			  AND owner_user_id = $4
+			  AND channel = 'SCENE'
+			  AND strategy_ref = $5
+			  AND run_status = 'RUNNING'
+		`, scoring.IELTSAcousticEvidenceFailureCode,
+			claim.EvaluationID, claim.EvaluationRevisionID,
+			claim.OwnerUserID,
+			scoring.IELTSSpeakingShadowStrategyRef)
+		if updateErr != nil {
+			return fmt.Errorf("fail IELTS acoustic module run: %w", updateErr)
+		}
+		if updated.RowsAffected() != 1 {
+			return scoring.ErrRuntimeLeaseLost
+		}
+	}
+	outboxUpdate, err := tx.Exec(ctx, `
+		UPDATE evaluation_outbox
+		SET delivery_status = 'FAILED',
+		    lease_expires_at = NULL,
+		    last_failure_code = $1,
+		    failed_at = transaction_timestamp(),
+		    updated_at = transaction_timestamp()
+		WHERE evaluation_id = $2
+		  AND evaluation_revision_id = $3
+		  AND owner_user_id = $4
+		  AND channel = 'SCENE'
+		  AND delivery_status = 'PENDING'
+	`, scoring.IELTSAcousticEvidenceFailureCode,
+		claim.EvaluationID, claim.EvaluationRevisionID,
+		claim.OwnerUserID)
+	if err != nil {
+		return fmt.Errorf("fail IELTS acoustic outbox: %w", err)
+	}
+	if outboxUpdate.RowsAffected() != 1 {
+		return scoring.ErrRuntimeLeaseLost
+	}
+	stateUpdate, err := tx.Exec(ctx, `
+		UPDATE evaluation_revision_states
+		SET evaluation_status = 'FAILED',
+		    is_final = false,
+		    updated_at = transaction_timestamp(),
+		    completed_at = transaction_timestamp()
+		WHERE evaluation_id = $1
+		  AND revision_id = $2
+		  AND owner_user_id = $3
+		  AND evaluation_status = 'VALIDATING'
+		  AND completed_at IS NULL
+	`, claim.EvaluationID, claim.EvaluationRevisionID,
+		claim.OwnerUserID)
+	if err != nil {
+		return fmt.Errorf("fail IELTS acoustic revision: %w", err)
+	}
+	if stateUpdate.RowsAffected() != 1 {
+		return scoring.ErrRuntimeLeaseLost
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit IELTS acoustic snapshot failure: %w", err)
+	}
+	return nil
 }
 
 func getIELTSAcousticSnapshot(

--- a/server/internal/coaching/evaluation/postgres/ielts_scoring.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_scoring.go
@@ -56,13 +56,15 @@ func durableClaimFromIELTS(
 		Provider:             source.Provider,
 		Model:                source.Model,
 		Snapshot:             source.Snapshot,
+		AcousticSnapshot:     &source.AcousticSnapshot,
+		InputBundleHash:      source.InputBundleHash,
 	}
 }
 
 func ieltsClaimFromDurable(
 	source durableSceneJobClaim,
 ) scoring.IELTSSpeakingShadowClaim {
-	return scoring.IELTSSpeakingShadowClaim{
+	result := scoring.IELTSSpeakingShadowClaim{
 		OutboxID:             source.OutboxID,
 		ModuleRunID:          source.ModuleRunID,
 		EvaluationID:         source.EvaluationID,
@@ -79,7 +81,12 @@ func ieltsClaimFromDurable(
 		Provider:             source.Provider,
 		Model:                source.Model,
 		Snapshot:             source.Snapshot,
+		InputBundleHash:      source.InputBundleHash,
 	}
+	if source.AcousticSnapshot != nil {
+		result.AcousticSnapshot = *source.AcousticSnapshot
+	}
+	return result
 }
 
 func (r *PostgresRepository) ClaimIELTSSpeakingShadow(

--- a/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
@@ -209,9 +209,21 @@ func TestPostgresIELTSSpeakingReportReadsValidatingBarrierAsPending(
 func TestIELTSAcousticSnapshotFailureWithoutRunIsReadable(t *testing.T) {
 	pool, repository, value, _ := prepareIELTSSpeakingValidatingRuntime(t)
 	ctx := context.Background()
-	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx)
+	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx, nil)
 	if err != nil || !found || claim.EvaluationID != value.ID {
 		t.Fatalf("pending acoustic claim=%#v found=%t err=%v", claim, found, err)
+	}
+	cursor := claim.Cursor()
+	if next, nextFound, nextErr := repository.FindPendingIELTSAcousticSnapshot(
+		ctx,
+		&cursor,
+	); nextErr != nil || nextFound || next.EvaluationID != "" {
+		t.Fatalf(
+			"pending acoustic cursor next=%#v found=%t err=%v",
+			next,
+			nextFound,
+			nextErr,
+		)
 	}
 	failures := make(chan error, 2)
 	var wait sync.WaitGroup
@@ -942,7 +954,7 @@ func TestIELTSAcousticSnapshotFailureTerminatesLegacyRunAtomically(
 	running := claimIELTSSpeakingShadow(t, repository, configuration)
 	reapplyIELTSAcousticSnapshotMigration(t, pool)
 
-	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx)
+	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx, nil)
 	if err != nil || !found || claim.EvaluationID != value.ID ||
 		claim.EvaluationRevisionID != value.Revision.ID {
 		t.Fatalf("pending acoustic claim=%#v found=%t err=%v", claim, found, err)

--- a/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
@@ -163,33 +163,7 @@ func TestPostgresIELTSSpeakingReportReadIsOwnerScoped(
 func TestPostgresIELTSSpeakingReportReadsValidatingBarrierAsPending(
 	t *testing.T,
 ) {
-	pool := evaluationDatabase(t)
-	insertEvaluationUsers(t, pool, testOwnerA)
-	repository := NewPostgresRepository(pool)
-	evidenceRepository := evidence.NewPostgresRepository(pool)
-	snapshot := ieltsSpeakingTestSnapshot(t, ieltsPostgresQuestionCount)
-	persistEvidenceSnapshotFixture(t, pool, snapshot)
-	service := evaluationcore.NewService(repository, evidenceRepository)
-	value, replayed, err := service.Create(
-		testActorContext(testOwnerA),
-		testActor(testOwnerA),
-		evaluationcore.CreateRequest{
-			PracticeSessionID: snapshot.PracticeSessionID,
-			InputSnapshotID:   snapshot.ID,
-			InputRevision:     snapshot.InputRevision,
-			Scope:             evaluationcore.ScopeSession,
-			SceneType:         evaluationcore.SceneIELTSSpeaking,
-			Channels: []evaluationcore.Channel{
-				evaluationcore.ChannelScene,
-			},
-			SceneStrategyRef: scoring.IELTSSpeakingShadowStrategyRef,
-			PipelineVersion:  scoring.IELTSSpeakingShadowPipelineVersion,
-		},
-	)
-	if err != nil || replayed ||
-		value.Revision.Status != evaluationcore.StatusValidating {
-		t.Fatalf("evaluation=%#v replayed=%t err=%v", value, replayed, err)
-	}
+	pool, repository, value, _ := prepareIELTSSpeakingValidatingRuntime(t)
 	state, err := repository.GetCurrentIELTSSpeakingReportState(
 		context.Background(),
 		testOwnerA,
@@ -229,6 +203,85 @@ func TestPostgresIELTSSpeakingReportReadsValidatingBarrierAsPending(
 		  AND channel = 'SCENE'
 	`, value.Revision.ID).Scan(&attemptCount); err != nil || attemptCount != 0 {
 		t.Fatalf("validating attempt_count=%d err=%v", attemptCount, err)
+	}
+}
+
+func TestIELTSAcousticSnapshotFailureWithoutRunIsReadable(t *testing.T) {
+	pool, repository, value, _ := prepareIELTSSpeakingValidatingRuntime(t)
+	ctx := context.Background()
+	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx)
+	if err != nil || !found || claim.EvaluationID != value.ID {
+		t.Fatalf("pending acoustic claim=%#v found=%t err=%v", claim, found, err)
+	}
+	failures := make(chan error, 2)
+	var wait sync.WaitGroup
+	wait.Add(2)
+	for range 2 {
+		go func() {
+			defer wait.Done()
+			failures <- repository.FailIELTSAcousticSnapshot(ctx, claim)
+		}()
+	}
+	wait.Wait()
+	close(failures)
+	for failure := range failures {
+		if failure != nil {
+			t.Fatalf("concurrent FailIELTSAcousticSnapshot: %v", failure)
+		}
+	}
+
+	var revisionStatus, deliveryStatus, failureCode string
+	var moduleRuns int
+	err = pool.QueryRow(ctx, `
+		SELECT
+			state.evaluation_status,
+			outbox.delivery_status,
+			coalesce(outbox.last_failure_code, ''),
+			(
+				SELECT count(*)
+				FROM evaluation_module_runs AS run
+				WHERE run.evaluation_revision_id = state.revision_id
+			)
+		FROM evaluation_revision_states AS state
+		JOIN evaluation_outbox AS outbox
+		  ON outbox.evaluation_id = state.evaluation_id
+		 AND outbox.evaluation_revision_id = state.revision_id
+		 AND outbox.owner_user_id = state.owner_user_id
+		 AND outbox.channel = 'SCENE'
+		WHERE state.evaluation_id = $1
+		  AND state.revision_id = $2
+		  AND state.owner_user_id = $3
+	`, value.ID, value.Revision.ID, testOwnerA).Scan(
+		&revisionStatus,
+		&deliveryStatus,
+		&failureCode,
+		&moduleRuns,
+	)
+	if err != nil || revisionStatus != "FAILED" ||
+		deliveryStatus != "FAILED" ||
+		failureCode != scoring.IELTSAcousticEvidenceFailureCode ||
+		moduleRuns != 0 {
+		t.Fatalf(
+			"failure revision=%q outbox=%q/%q modules=%d err=%v",
+			revisionStatus,
+			deliveryStatus,
+			failureCode,
+			moduleRuns,
+			err,
+		)
+	}
+	state, err := repository.GetCurrentIELTSSpeakingReportState(
+		ctx,
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil ||
+		state.Evaluation.Revision.Status != evaluationcore.StatusFailed ||
+		state.Runtime.ModuleStatus != scoring.IELTSSpeakingShadowRuntimeFailed ||
+		state.Runtime.Failure == nil ||
+		state.Runtime.Failure.Code != scoring.IELTSAcousticEvidenceFailureCode ||
+		state.Snapshot != nil {
+		t.Fatalf("failed IELTS report state=%#v err=%v", state, err)
 	}
 }
 
@@ -878,6 +931,193 @@ func TestIELTSAcousticSnapshotMigrationBindsLegacyRunningRetry(t *testing.T) {
 		) {
 		t.Fatalf("migrated retry claim=%#v first=%#v", second, first)
 	}
+}
+
+func TestIELTSAcousticSnapshotFailureTerminatesLegacyRunAtomically(
+	t *testing.T,
+) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	ctx := context.Background()
+	running := claimIELTSSpeakingShadow(t, repository, configuration)
+	reapplyIELTSAcousticSnapshotMigration(t, pool)
+
+	claim, found, err := repository.FindPendingIELTSAcousticSnapshot(ctx)
+	if err != nil || !found || claim.EvaluationID != value.ID ||
+		claim.EvaluationRevisionID != value.Revision.ID {
+		t.Fatalf("pending acoustic claim=%#v found=%t err=%v", claim, found, err)
+	}
+	if err := repository.FailIELTSAcousticSnapshot(ctx, claim); err != nil {
+		t.Fatalf("FailIELTSAcousticSnapshot: %v", err)
+	}
+	if err := repository.FailIELTSAcousticSnapshot(ctx, claim); err != nil {
+		t.Fatalf("idempotent FailIELTSAcousticSnapshot: %v", err)
+	}
+
+	var revisionStatus, deliveryStatus, outboxCode string
+	var runStatus, runCode string
+	err = pool.QueryRow(ctx, `
+		SELECT
+			state.evaluation_status,
+			outbox.delivery_status,
+			coalesce(outbox.last_failure_code, ''),
+			run.run_status,
+			coalesce(run.last_failure_code, '')
+		FROM evaluation_revision_states AS state
+		JOIN evaluation_outbox AS outbox
+		  ON outbox.evaluation_id = state.evaluation_id
+		 AND outbox.evaluation_revision_id = state.revision_id
+		 AND outbox.owner_user_id = state.owner_user_id
+		 AND outbox.channel = 'SCENE'
+		JOIN evaluation_module_runs AS run
+		  ON run.outbox_id = outbox.id
+		 AND run.evaluation_id = state.evaluation_id
+		 AND run.evaluation_revision_id = state.revision_id
+		 AND run.owner_user_id = state.owner_user_id
+		WHERE state.evaluation_id = $1
+		  AND state.revision_id = $2
+		  AND state.owner_user_id = $3
+	`, value.ID, value.Revision.ID, testOwnerA).Scan(
+		&revisionStatus,
+		&deliveryStatus,
+		&outboxCode,
+		&runStatus,
+		&runCode,
+	)
+	if err != nil || revisionStatus != "FAILED" ||
+		deliveryStatus != "FAILED" || runStatus != "FAILED" ||
+		outboxCode != scoring.IELTSAcousticEvidenceFailureCode ||
+		runCode != scoring.IELTSAcousticEvidenceFailureCode {
+		t.Fatalf(
+			"failure revision=%q outbox=%q/%q run=%q/%q err=%v",
+			revisionStatus,
+			deliveryStatus,
+			outboxCode,
+			runStatus,
+			runCode,
+			err,
+		)
+	}
+	state, err := repository.GetCurrentIELTSSpeakingReportState(
+		ctx,
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil ||
+		state.Runtime.ModuleStatus != scoring.IELTSSpeakingShadowRuntimeFailed ||
+		state.Runtime.Failure == nil ||
+		state.Runtime.Failure.Code != scoring.IELTSAcousticEvidenceFailureCode ||
+		state.Snapshot != nil || running.ModuleRunID == "" {
+		t.Fatalf("failed IELTS report state=%#v err=%v", state, err)
+	}
+}
+
+func TestIELTSAcousticSnapshotMigrationLeavesExhaustedRunForCleanup(
+	t *testing.T,
+) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	ctx := context.Background()
+	first := claimIELTSSpeakingShadow(t, repository, configuration)
+	expireInterviewShadowLease(t, pool, first.OutboxID)
+	second := claimIELTSSpeakingShadow(t, repository, configuration)
+	expireInterviewShadowLease(t, pool, second.OutboxID)
+	third := claimIELTSSpeakingShadow(t, repository, configuration)
+	if third.AttemptCount != configuration.MaxAttempts {
+		t.Fatalf("third attempt=%d", third.AttemptCount)
+	}
+	expireInterviewShadowLease(t, pool, third.OutboxID)
+	reapplyIELTSAcousticSnapshotMigration(t, pool)
+
+	migrated, err := repository.Get(ctx, testOwnerA, value.ID)
+	if err != nil || migrated.Revision.Status != evaluationcore.StatusRunning {
+		t.Fatalf("migrated exhausted evaluation=%#v err=%v", migrated, err)
+	}
+	claim, acquired, err := repository.ClaimIELTSSpeakingShadow(
+		ctx,
+		configuration,
+	)
+	if err != nil || acquired || claim.EvaluationID != "" {
+		t.Fatalf("exhausted cleanup claim=%#v acquired=%t err=%v", claim, acquired, err)
+	}
+	state, err := repository.GetCurrentIELTSSpeakingReportState(
+		ctx,
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil ||
+		state.Evaluation.Revision.Status != evaluationcore.StatusFailed ||
+		state.Runtime.ModuleStatus != scoring.IELTSSpeakingShadowRuntimeFailed ||
+		state.Runtime.Failure == nil ||
+		state.Runtime.Failure.Code != "attempts_exhausted" ||
+		state.Snapshot != nil {
+		t.Fatalf("exhausted report state=%#v err=%v", state, err)
+	}
+}
+
+func reapplyIELTSAcousticSnapshotMigration(
+	t *testing.T,
+	pool *pgxpool.Pool,
+) {
+	t.Helper()
+	ctx := context.Background()
+	down, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.down.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(down)); err != nil {
+		t.Fatalf("apply IELTS acoustic snapshot down migration: %v", err)
+	}
+	up, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.up.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(up)); err != nil {
+		t.Fatalf("reapply IELTS acoustic snapshot up migration: %v", err)
+	}
+}
+
+func prepareIELTSSpeakingValidatingRuntime(
+	t *testing.T,
+) (
+	*pgxpool.Pool,
+	*PostgresRepository,
+	evaluationcore.Evaluation,
+	evidence.EvidenceSnapshot,
+) {
+	t.Helper()
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA)
+	repository := NewPostgresRepository(pool)
+	snapshot := ieltsSpeakingTestSnapshot(t, ieltsPostgresQuestionCount)
+	persistEvidenceSnapshotFixture(t, pool, snapshot)
+	service := evaluationcore.NewService(
+		repository,
+		evidence.NewPostgresRepository(pool),
+	)
+	value, replayed, err := service.Create(
+		testActorContext(testOwnerA),
+		testActor(testOwnerA),
+		evaluationcore.CreateRequest{
+			PracticeSessionID: snapshot.PracticeSessionID,
+			InputSnapshotID:   snapshot.ID,
+			InputRevision:     snapshot.InputRevision,
+			Scope:             evaluationcore.ScopeSession,
+			SceneType:         evaluationcore.SceneIELTSSpeaking,
+			Channels:          []evaluationcore.Channel{evaluationcore.ChannelScene},
+			SceneStrategyRef:  scoring.IELTSSpeakingShadowStrategyRef,
+			PipelineVersion:   scoring.IELTSSpeakingShadowPipelineVersion,
+		},
+	)
+	if err != nil || replayed ||
+		value.Revision.Status != evaluationcore.StatusValidating {
+		t.Fatalf("evaluation=%#v replayed=%t err=%v", value, replayed, err)
+	}
+	return pool, repository, value, snapshot
 }
 
 func prepareIELTSSpeakingShadowRuntime(

--- a/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -156,6 +157,168 @@ func TestPostgresIELTSSpeakingReportReadIsOwnerScoped(
 		evaluation.PracticeSessionID,
 	); !errors.Is(err, evaluationcore.ErrNotFound) {
 		t.Fatalf("cross-owner report error = %v", err)
+	}
+}
+
+func TestPostgresIELTSSpeakingReportReadsValidatingBarrierAsPending(
+	t *testing.T,
+) {
+	pool := evaluationDatabase(t)
+	insertEvaluationUsers(t, pool, testOwnerA)
+	repository := NewPostgresRepository(pool)
+	evidenceRepository := evidence.NewPostgresRepository(pool)
+	snapshot := ieltsSpeakingTestSnapshot(t, ieltsPostgresQuestionCount)
+	persistEvidenceSnapshotFixture(t, pool, snapshot)
+	service := evaluationcore.NewService(repository, evidenceRepository)
+	value, replayed, err := service.Create(
+		testActorContext(testOwnerA),
+		testActor(testOwnerA),
+		evaluationcore.CreateRequest{
+			PracticeSessionID: snapshot.PracticeSessionID,
+			InputSnapshotID:   snapshot.ID,
+			InputRevision:     snapshot.InputRevision,
+			Scope:             evaluationcore.ScopeSession,
+			SceneType:         evaluationcore.SceneIELTSSpeaking,
+			Channels: []evaluationcore.Channel{
+				evaluationcore.ChannelScene,
+			},
+			SceneStrategyRef: scoring.IELTSSpeakingShadowStrategyRef,
+			PipelineVersion:  scoring.IELTSSpeakingShadowPipelineVersion,
+		},
+	)
+	if err != nil || replayed ||
+		value.Revision.Status != evaluationcore.StatusValidating {
+		t.Fatalf("evaluation=%#v replayed=%t err=%v", value, replayed, err)
+	}
+	state, err := repository.GetCurrentIELTSSpeakingReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil ||
+		state.Evaluation.Revision.Status != evaluationcore.StatusValidating ||
+		state.Runtime.ModuleStatus !=
+			scoring.IELTSSpeakingShadowRuntimePending ||
+		state.Runtime.Result != nil || state.Snapshot != nil {
+		t.Fatalf("state=%#v err=%v", state, err)
+	}
+	configuration := scoring.IELTSSpeakingShadowRuntimeConfiguration{
+		MaxAttempts:          3,
+		LeaseDuration:        5 * time.Second,
+		AcousticWaitDuration: 15 * time.Second,
+		StrategyRef:          scoring.IELTSSpeakingShadowStrategyRef,
+		PipelineVersion:      scoring.IELTSSpeakingShadowPipelineVersion,
+		FullConfigHash:       sha256.Sum256([]byte("validating-barrier")),
+		PromptVersion:        scoring.IELTSSpeakingShadowPromptVersion,
+		Provider:             "qianwen",
+		Model:                "qwen-plus",
+	}
+	claim, acquired, err := repository.ClaimIELTSSpeakingShadow(
+		context.Background(),
+		configuration,
+	)
+	if err != nil || acquired || claim.EvaluationID != "" ||
+		claim.AttemptCount != 0 {
+		t.Fatalf("validating claim=%#v acquired=%t err=%v", claim, acquired, err)
+	}
+	var attemptCount int
+	if err := pool.QueryRow(context.Background(), `
+		SELECT attempt_count
+		FROM evaluation_outbox
+		WHERE evaluation_revision_id = $1
+		  AND channel = 'SCENE'
+	`, value.Revision.ID).Scan(&attemptCount); err != nil || attemptCount != 0 {
+		t.Fatalf("validating attempt_count=%d err=%v", attemptCount, err)
+	}
+}
+
+func TestPostgresIELTSSpeakingReevaluationReusesFrozenAcousticBundle(
+	t *testing.T,
+) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	var frozenID string
+	var frozenHash []byte
+	if err := pool.QueryRow(context.Background(), `
+		SELECT id, snapshot_hash
+		FROM evaluation_ielts_speaking_acoustic_snapshots
+		WHERE evaluation_id = $1
+	`, value.ID).Scan(&frozenID, &frozenHash); err != nil {
+		t.Fatal(err)
+	}
+	service := evaluationcore.NewService(
+		repository,
+		evidence.NewPostgresRepository(pool),
+	)
+	next, replayed, err := service.Reevaluate(
+		context.Background(),
+		testActor(testOwnerA),
+		value.ID,
+		evaluationcore.ReevaluateRequest{
+			Channels: []evaluationcore.Channel{
+				evaluationcore.ChannelScene,
+			},
+			SceneStrategyRef: scoring.IELTSSpeakingShadowStrategyRef,
+			PipelineVersion:  scoring.IELTSSpeakingShadowPipelineVersion,
+			ClientRequestID:  "ielts-acoustic-reuse",
+		},
+	)
+	if err != nil || replayed || next.Revision.Number != 2 ||
+		next.Revision.Status != evaluationcore.StatusQueued {
+		t.Fatalf("reevaluation=%#v replayed=%t err=%v", next, replayed, err)
+	}
+	claim := claimIELTSSpeakingShadow(t, repository, configuration)
+	if claim.AcousticSnapshot.ID != frozenID ||
+		!bytes.Equal(claim.AcousticSnapshot.SnapshotHash[:], frozenHash) ||
+		claim.InputBundleHash != scoring.IELTSAcousticInputBundleHash(
+			claim.Snapshot,
+			claim.AcousticSnapshot,
+		) {
+		t.Fatalf("reevaluation acoustic claim = %#v", claim)
+	}
+}
+
+func TestPostgresIELTSAcousticSnapshotAndRunBindingAreImmutable(
+	t *testing.T,
+) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	var hashMatches bool
+	if err := pool.QueryRow(context.Background(), `
+		SELECT snapshot_hash = sha256(convert_to(canonical_payload, 'UTF8'))
+		FROM evaluation_ielts_speaking_acoustic_snapshots
+		WHERE evaluation_id = $1
+	`, value.ID).Scan(&hashMatches); err != nil || !hashMatches {
+		t.Fatalf("snapshot hash matches=%t err=%v", hashMatches, err)
+	}
+	_, err := pool.Exec(context.Background(), `
+		UPDATE evaluation_ielts_speaking_acoustic_snapshots
+		SET resolution = 'PARTIAL'
+		WHERE evaluation_id = $1
+	`, value.ID)
+	var databaseError *pgconn.PgError
+	if !errors.As(err, &databaseError) || databaseError.Code != "55000" {
+		t.Fatalf("snapshot mutation error=%v", err)
+	}
+	claim := claimIELTSSpeakingShadow(t, repository, configuration)
+	if err := pool.QueryRow(context.Background(), `
+		SELECT input_bundle_hash = sha256(
+			convert_to('ielts-speaking-input-bundle/v1', 'UTF8') ||
+			decode('00', 'hex') || snapshot_hash || acoustic_snapshot_hash
+		)
+		FROM evaluation_module_runs
+		WHERE id = $1
+	`, claim.ModuleRunID).Scan(&hashMatches); err != nil || !hashMatches {
+		t.Fatalf("bundle hash matches=%t err=%v", hashMatches, err)
+	}
+	_, err = pool.Exec(context.Background(), `
+		UPDATE evaluation_module_runs
+		SET input_bundle_hash = decode(repeat('00', 32), 'hex')
+		WHERE id = $1
+	`, claim.ModuleRunID)
+	databaseError = nil
+	if !errors.As(err, &databaseError) || databaseError.Code != "55000" {
+		t.Fatalf("module run binding mutation error=%v", err)
 	}
 }
 
@@ -554,6 +717,169 @@ func TestIELTSSpeakingShadowRuntimeMigrationRoundTrip(t *testing.T) {
 	}
 }
 
+func TestIELTSAcousticSnapshotMigrationRoundTrip(t *testing.T) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	ctx := context.Background()
+	claim := claimIELTSSpeakingShadow(t, repository, configuration)
+	result := evaluateIELTSSpeakingClaim(t, claim)
+	if err := repository.CompleteIELTSSpeakingShadow(
+		ctx,
+		claim,
+		result,
+	); err != nil {
+		t.Fatalf("complete pre-migration IELTS report: %v", err)
+	}
+	down, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.down.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(down)); err != nil {
+		t.Fatalf("apply IELTS acoustic snapshot down migration: %v", err)
+	}
+	var tableExists bool
+	var columnExists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			to_regclass(
+				'evaluation_ielts_speaking_acoustic_snapshots'
+			) IS NOT NULL,
+			EXISTS (
+				SELECT 1
+				FROM information_schema.columns
+				WHERE table_schema = current_schema()
+				  AND table_name = 'evaluation_module_runs'
+				  AND column_name = 'input_bundle_hash'
+			)
+	`).Scan(&tableExists, &columnExists); err != nil {
+		t.Fatal(err)
+	}
+	if tableExists || columnExists {
+		t.Fatalf("down table=%t column=%t", tableExists, columnExists)
+	}
+	up, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.up.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(up)); err != nil {
+		t.Fatalf("reapply IELTS acoustic snapshot up migration: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			to_regclass(
+				'evaluation_ielts_speaking_acoustic_snapshots'
+			) IS NOT NULL,
+			EXISTS (
+				SELECT 1
+				FROM information_schema.columns
+				WHERE table_schema = current_schema()
+				  AND table_name = 'evaluation_module_runs'
+				  AND column_name = 'input_bundle_hash'
+			)
+	`).Scan(&tableExists, &columnExists); err != nil {
+		t.Fatal(err)
+	}
+	if !tableExists || !columnExists {
+		t.Fatalf("up table=%t column=%t", tableExists, columnExists)
+	}
+	state, err := repository.GetCurrentIELTSSpeakingReportState(
+		ctx,
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil ||
+		state.Runtime.ModuleStatus != scoring.IELTSSpeakingShadowRuntimeReady ||
+		state.Runtime.Result == nil || state.Snapshot == nil {
+		t.Fatalf("historical IELTS report state=%#v err=%v", state, err)
+	}
+}
+
+func TestIELTSAcousticSnapshotMigrationBindsLegacyRunningRetry(t *testing.T) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	ctx := context.Background()
+	first := claimIELTSSpeakingShadow(t, repository, configuration)
+	status, err := repository.FailIELTSSpeakingShadow(
+		ctx,
+		first,
+		scoring.IELTSSpeakingShadowFailure{
+			Code:      "provider_timeout",
+			Retryable: true,
+		},
+		configuration,
+	)
+	if err != nil || status != scoring.IELTSSpeakingShadowRuntimePending {
+		t.Fatalf("queue pre-migration retry status=%q err=%v", status, err)
+	}
+	down, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.down.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(down)); err != nil {
+		t.Fatalf("apply IELTS acoustic snapshot down migration: %v", err)
+	}
+	up, err := migrations.Files.ReadFile(
+		"000088_evaluation_ielts_acoustic_snapshot.up.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(up)); err != nil {
+		t.Fatalf("reapply IELTS acoustic snapshot up migration: %v", err)
+	}
+	migrated, err := repository.Get(ctx, testOwnerA, value.ID)
+	if err != nil ||
+		migrated.Revision.Status != evaluationcore.StatusValidating {
+		t.Fatalf("migrated evaluation=%#v err=%v", migrated, err)
+	}
+	draft, err := scoring.BuildIELTSAcousticSnapshot(
+		value.ID,
+		first.Snapshot,
+		scoring.IELTSSpeakingAcousticRead{},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, replayed, err := repository.EnsureIELTSAcousticSnapshot(
+		ctx,
+		scoring.IELTSAcousticSnapshotClaim{
+			EvaluationID:         value.ID,
+			EvaluationRevisionID: value.Revision.ID,
+			OwnerUserID:          testOwnerA,
+			RevisionCreatedAt:    value.Revision.CreatedAt,
+			Snapshot:             first.Snapshot,
+		},
+		draft,
+	)
+	if err != nil || replayed || !stored.ValidFor(first.Snapshot) {
+		t.Fatalf("freeze migrated retry=%#v replayed=%t err=%v", stored, replayed, err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE evaluation_outbox
+		SET available_at = transaction_timestamp() - interval '1 second',
+		    updated_at = transaction_timestamp()
+		WHERE id = $1
+	`, first.OutboxID); err != nil {
+		t.Fatalf("make migrated retry available: %v", err)
+	}
+	second := claimIELTSSpeakingShadow(t, repository, configuration)
+	if second.ModuleRunID != first.ModuleRunID || second.AttemptCount != 2 ||
+		second.AcousticSnapshot.ID != stored.ID ||
+		second.InputBundleHash != scoring.IELTSAcousticInputBundleHash(
+			second.Snapshot,
+			second.AcousticSnapshot,
+		) {
+		t.Fatalf("migrated retry claim=%#v first=%#v", second, first)
+	}
+}
+
 func prepareIELTSSpeakingShadowRuntime(
 	t *testing.T,
 ) (
@@ -596,11 +922,77 @@ func prepareIELTSSpeakingShadowRuntime(
 			err,
 		)
 	}
+	if evaluation.Revision.Status != evaluationcore.StatusValidating {
+		t.Fatalf("initial IELTS status = %s", evaluation.Revision.Status)
+	}
+	freezeClaim := scoring.IELTSAcousticSnapshotClaim{
+		EvaluationID:         evaluation.ID,
+		EvaluationRevisionID: evaluation.Revision.ID,
+		OwnerUserID:          testOwnerA,
+		RevisionCreatedAt:    evaluation.Revision.CreatedAt,
+		Snapshot:             snapshot,
+	}
+	draft, err := scoring.BuildIELTSAcousticSnapshot(
+		evaluation.ID,
+		snapshot,
+		scoring.IELTSSpeakingAcousticRead{},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("build IELTS acoustic snapshot: %v", err)
+	}
+	type freezeResult struct {
+		stored   scoring.IELTSAcousticSnapshot
+		replayed bool
+		err      error
+	}
+	freezeResults := make(chan freezeResult, 2)
+	var freezeWait sync.WaitGroup
+	freezeWait.Add(2)
+	for range 2 {
+		go func() {
+			defer freezeWait.Done()
+			stored, wasReplay, ensureErr :=
+				repository.EnsureIELTSAcousticSnapshot(
+					context.Background(),
+					freezeClaim,
+					draft,
+				)
+			freezeResults <- freezeResult{stored, wasReplay, ensureErr}
+		}()
+	}
+	freezeWait.Wait()
+	close(freezeResults)
+	replays := 0
+	for result := range freezeResults {
+		if result.err != nil || !result.stored.ValidFor(snapshot) {
+			t.Fatalf(
+				"freeze IELTS acoustics valid=%t error=%v",
+				result.stored.ValidFor(snapshot),
+				result.err,
+			)
+		}
+		if result.replayed {
+			replays++
+		}
+	}
+	if replays != 1 {
+		t.Fatalf("concurrent IELTS acoustic snapshot replays = %d", replays)
+	}
+	evaluation, err = repository.Get(
+		context.Background(),
+		testOwnerA,
+		evaluation.ID,
+	)
+	if err != nil || evaluation.Revision.Status != evaluationcore.StatusQueued {
+		t.Fatalf("queued IELTS Evaluation=%#v error=%v", evaluation, err)
+	}
 	configuration := scoring.IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     3,
-		LeaseDuration:   5 * time.Second,
-		StrategyRef:     scoring.IELTSSpeakingShadowStrategyRef,
-		PipelineVersion: scoring.IELTSSpeakingShadowPipelineVersion,
+		MaxAttempts:          3,
+		LeaseDuration:        5 * time.Second,
+		AcousticWaitDuration: 15 * time.Second,
+		StrategyRef:          scoring.IELTSSpeakingShadowStrategyRef,
+		PipelineVersion:      scoring.IELTSSpeakingShadowPipelineVersion,
 		FullConfigHash: sha256.Sum256(
 			[]byte("ielts-shadow-integration-config/v1"),
 		),
@@ -640,7 +1032,11 @@ func evaluateIELTSSpeakingClaim(
 	t.Helper()
 	result, err := scoring.NewIELTSSpeakingShadowEngine(
 		&ieltsProviderStub{},
-	).Evaluate(context.Background(), claim.Snapshot)
+	).EvaluateWithAcousticSnapshot(
+		context.Background(),
+		claim.Snapshot,
+		claim.AcousticSnapshot,
+	)
 	if err != nil {
 		t.Fatalf("evaluate IELTS claim: %v", err)
 	}

--- a/server/internal/coaching/evaluation/postgres/interview_scoring.go
+++ b/server/internal/coaching/evaluation/postgres/interview_scoring.go
@@ -387,6 +387,27 @@ func (r *PostgresRepository) claimDurableSceneJob(
 			err,
 		)
 	}
+	if spec.sceneType == evaluation.SceneIELTSSpeaking &&
+		spec.strategyRef == scoring.IELTSSpeakingShadowStrategyRef {
+		acoustics, acousticErr := getIELTSAcousticSnapshot(
+			ctx,
+			tx,
+			claim.OwnerUserID,
+			claim.EvaluationID,
+			claim.Snapshot,
+		)
+		if acousticErr != nil {
+			return durableSceneJobClaim{}, false, fmt.Errorf(
+				"read claimed IELTS acoustic snapshot: %w",
+				acousticErr,
+			)
+		}
+		claim.AcousticSnapshot = &acoustics
+		claim.InputBundleHash = scoring.IELTSAcousticInputBundleHash(
+			claim.Snapshot,
+			acoustics,
+		)
+	}
 
 	claim.StrategyRef = spec.strategyRef
 	claim.PromptVersion = configuration.PromptVersion
@@ -408,6 +429,9 @@ func (r *PostgresRepository) claimDurableSceneJob(
 			scope,
 			scene_type,
 			snapshot_hash,
+			acoustic_snapshot_id,
+			acoustic_snapshot_hash,
+			input_bundle_hash,
 			full_config_hash,
 			prompt_version,
 			provider,
@@ -417,7 +441,7 @@ func (r *PostgresRepository) claimDurableSceneJob(
 		)
 		VALUES (
 			$1, $2, $3, $4, 'SCENE', $5, $6, $7, $8,
-			'SESSION', $16, $9, $10, $11, $12, $13,
+			'SESSION', $16, $9, $17, $18, $19, $10, $11, $12, $13,
 			$14, $15
 		)
 		ON CONFLICT (
@@ -427,6 +451,18 @@ func (r *PostgresRepository) claimDurableSceneJob(
 		) DO UPDATE
 		SET attempt_count = EXCLUDED.attempt_count,
 		    fencing_token = EXCLUDED.fencing_token,
+		    acoustic_snapshot_id = coalesce(
+		        evaluation_module_runs.acoustic_snapshot_id,
+		        EXCLUDED.acoustic_snapshot_id
+		    ),
+		    acoustic_snapshot_hash = coalesce(
+		        evaluation_module_runs.acoustic_snapshot_hash,
+		        EXCLUDED.acoustic_snapshot_hash
+		    ),
+		    input_bundle_hash = coalesce(
+		        evaluation_module_runs.input_bundle_hash,
+		        EXCLUDED.input_bundle_hash
+		    ),
 		    last_failure_code = NULL,
 		    updated_at = transaction_timestamp()
 		WHERE evaluation_module_runs.run_status = 'RUNNING'
@@ -443,6 +479,24 @@ func (r *PostgresRepository) claimDurableSceneJob(
 		      EXCLUDED.input_revision
 		  AND evaluation_module_runs.snapshot_hash =
 		      EXCLUDED.snapshot_hash
+		  AND (
+		      (
+		          evaluation_module_runs.acoustic_snapshot_id IS NULL
+		          AND evaluation_module_runs.acoustic_snapshot_hash IS NULL
+		          AND evaluation_module_runs.input_bundle_hash IS NULL
+		          AND EXCLUDED.acoustic_snapshot_id IS NOT NULL
+		          AND EXCLUDED.acoustic_snapshot_hash IS NOT NULL
+		          AND EXCLUDED.input_bundle_hash IS NOT NULL
+		      )
+		      OR (
+		          evaluation_module_runs.acoustic_snapshot_id
+		              IS NOT DISTINCT FROM EXCLUDED.acoustic_snapshot_id
+		          AND evaluation_module_runs.acoustic_snapshot_hash
+		              IS NOT DISTINCT FROM EXCLUDED.acoustic_snapshot_hash
+		          AND evaluation_module_runs.input_bundle_hash
+		              IS NOT DISTINCT FROM EXCLUDED.input_bundle_hash
+		      )
+		  )
 		  AND evaluation_module_runs.full_config_hash =
 		      EXCLUDED.full_config_hash
 		  AND evaluation_module_runs.prompt_version =
@@ -461,7 +515,10 @@ func (r *PostgresRepository) claimDurableSceneJob(
 		claim.Snapshot.SnapshotHash[:], claim.FullConfigHash[:],
 		claim.PromptVersion, claim.Provider, claim.Model,
 		claim.AttemptCount, claim.FencingToken,
-		spec.sceneType).Scan(
+		spec.sceneType,
+		nullableAcousticSnapshotID(claim.AcousticSnapshot),
+		nullableAcousticSnapshotHash(claim.AcousticSnapshot),
+		nullableDigest(claim.InputBundleHash)).Scan(
 		&claim.ModuleRunID,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -1218,7 +1275,8 @@ func getDurableSceneJobState(
 				FullConfigHash: persistedConfigHash,
 			}, nil, nil
 		}
-		if revisionStatus != "QUEUED" &&
+		if revisionStatus != "VALIDATING" &&
+			revisionStatus != "QUEUED" &&
 			revisionStatus != "RUNNING" {
 			return durableSceneJobReadState{}, nil,
 				scoring.ErrRuntimeConfigurationConflict

--- a/server/internal/coaching/evaluation/postgres/interview_scoring.go
+++ b/server/internal/coaching/evaluation/postgres/interview_scoring.go
@@ -1268,6 +1268,16 @@ func getDurableSceneJobState(
 	}
 	switch deliveryStatus {
 	case "PENDING":
+		if revisionStatus == "VALIDATING" {
+			if moduleStatus != "" && moduleStatus != "RUNNING" {
+				return durableSceneJobReadState{}, nil,
+					scoring.ErrRuntimeConfigurationConflict
+			}
+			return durableSceneJobReadState{
+				ModuleStatus:   durableSceneJobPending,
+				FullConfigHash: persistedConfigHash,
+			}, nil, nil
+		}
 		if moduleStatus == "RUNNING" &&
 			leaseActive {
 			return durableSceneJobReadState{
@@ -1286,7 +1296,12 @@ func getDurableSceneJobState(
 			FullConfigHash: persistedConfigHash,
 		}, nil, nil
 	case "FAILED":
-		if moduleStatus != "FAILED" ||
+		acousticFailureBeforeRun := moduleStatus == "" &&
+			spec.sceneType == evaluation.SceneIELTSSpeaking &&
+			spec.strategyRef == scoring.IELTSSpeakingShadowStrategyRef &&
+			spec.pipelineVersion == scoring.IELTSSpeakingShadowPipelineVersion &&
+			failureCode == scoring.IELTSAcousticEvidenceFailureCode
+		if (moduleStatus != "FAILED" && !acousticFailureBeforeRun) ||
 			revisionStatus != "FAILED" ||
 			!durableSceneJobFailureCodePattern.MatchString(failureCode) {
 			return durableSceneJobReadState{}, nil,

--- a/server/internal/coaching/evaluation/postgres/repository.go
+++ b/server/internal/coaching/evaluation/postgres/repository.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -357,6 +358,11 @@ func insertRevision(
 	for index, channel := range config.Channels {
 		channelStrings[index] = string(channel)
 	}
+	requiresIELTSAcousticSnapshot := len(config.Channels) == 1 &&
+		config.Channels[0] == evaluation.ChannelScene &&
+		config.SceneStrategyRef == scoring.IELTSSpeakingShadowStrategyRef &&
+		config.Core4DStrategyRef == "" &&
+		config.PipelineVersion == scoring.IELTSSpeakingShadowPipelineVersion
 	var revisionID string
 	err := tx.QueryRow(ctx, `
 		INSERT INTO evaluation_revisions (
@@ -388,10 +394,28 @@ func insertRevision(
 		INSERT INTO evaluation_revision_states (
 			revision_id,
 			evaluation_id,
-			owner_user_id
+			owner_user_id,
+			evaluation_status
 		)
-		VALUES ($1, $2, $3)
-	`, revisionID, evaluationID, ownerUserID)
+		SELECT $1, $2, $3,
+		       CASE
+		           WHEN $4::boolean
+		            AND ledger.scope = 'SESSION'
+		            AND ledger.scene_type = 'IELTS_SPEAKING'
+		            AND NOT EXISTS (
+		                SELECT 1
+		                FROM evaluation_ielts_speaking_acoustic_snapshots
+		                WHERE evaluation_id = $2
+		                  AND owner_user_id = $3
+		            )
+		           THEN 'VALIDATING'
+		           ELSE 'QUEUED'
+		       END
+		FROM evaluation_ledgers AS ledger
+		WHERE ledger.id = $2
+		  AND ledger.owner_user_id = $3
+	`, revisionID, evaluationID, ownerUserID,
+		requiresIELTSAcousticSnapshot)
 	if err != nil {
 		return evaluation.Evaluation{}, fmt.Errorf(
 			"insert Evaluation revision state: %w",

--- a/server/internal/coaching/evaluation/postgres/session_report.go
+++ b/server/internal/coaching/evaluation/postgres/session_report.go
@@ -190,7 +190,8 @@ func (r *PostgresRepository) GetCurrentSessionReportState(
 	state.Status = value.Revision.Status
 	switch runtime.ModuleStatus {
 	case durableSceneJobPending:
-		if state.Status != evaluation.StatusQueued &&
+		if state.Status != evaluation.StatusValidating &&
+			state.Status != evaluation.StatusQueued &&
 			state.Status != evaluation.StatusRunning {
 			return report.SessionReportReadState{},
 				report.ErrSessionReportConfigurationConflict

--- a/server/internal/coaching/evaluation/postgres/session_report_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/session_report_integration_test.go
@@ -84,6 +84,48 @@ func TestPostgresSessionReportReadsMigratedActiveLeaseAsValidating(
 		state.FormalReport != nil || state.Failure != nil {
 		t.Fatalf("migrated active Session report state=%#v err=%v", state, err)
 	}
+	var leaseCleared bool
+	if err := pool.QueryRow(context.Background(), `
+		SELECT lease_expires_at IS NULL
+		FROM evaluation_outbox
+		WHERE id = $1
+	`, claim.OutboxID).Scan(&leaseCleared); err != nil || !leaseCleared {
+		t.Fatalf("migrated active lease cleared=%t err=%v", leaseCleared, err)
+	}
+
+	draft, err := scoring.BuildIELTSAcousticSnapshot(
+		value.ID,
+		claim.Snapshot,
+		scoring.IELTSSpeakingAcousticRead{},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = repository.EnsureIELTSAcousticSnapshot(
+		context.Background(),
+		scoring.IELTSAcousticSnapshotClaim{
+			EvaluationID:         value.ID,
+			EvaluationRevisionID: value.Revision.ID,
+			OwnerUserID:          testOwnerA,
+			RevisionCreatedAt:    value.Revision.CreatedAt,
+			Snapshot:             claim.Snapshot,
+		},
+		draft,
+	)
+	if err != nil {
+		t.Fatalf("freeze migrated active lease: %v", err)
+	}
+	state, err = repository.GetCurrentSessionReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil || state.Status != evaluationcore.StatusQueued ||
+		state.Evaluation == nil || state.FormalReport != nil ||
+		state.Failure != nil {
+		t.Fatalf("frozen migrated Session report state=%#v err=%v", state, err)
+	}
 }
 
 func installIELTSSessionReportAuthorityFixture(

--- a/server/internal/coaching/evaluation/postgres/session_report_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/session_report_integration_test.go
@@ -61,6 +61,31 @@ func TestPostgresSessionReportReadsReadyFullMockAndIsOwnerScoped(
 	}
 }
 
+func TestPostgresSessionReportReadsMigratedActiveLeaseAsValidating(
+	t *testing.T,
+) {
+	pool, repository, configuration, value :=
+		prepareIELTSSpeakingShadowRuntime(t)
+	snapshot := ieltsSpeakingTestSnapshot(t, ieltsPostgresQuestionCount)
+	installIELTSSessionReportAuthorityFixture(t, pool, snapshot)
+	claim := claimIELTSSpeakingShadow(t, repository, configuration)
+	if claim.AttemptCount != 1 || !claim.LeaseExpiresAt.After(time.Now()) {
+		t.Fatalf("active claim=%#v", claim)
+	}
+	reapplyIELTSAcousticSnapshotMigration(t, pool)
+
+	state, err := repository.GetCurrentSessionReportState(
+		context.Background(),
+		testOwnerA,
+		value.PracticeSessionID,
+	)
+	if err != nil || state.Status != evaluationcore.StatusValidating ||
+		state.Evaluation == nil || state.Evaluation.ID != value.ID ||
+		state.FormalReport != nil || state.Failure != nil {
+		t.Fatalf("migrated active Session report state=%#v err=%v", state, err)
+	}
+}
+
 func installIELTSSessionReportAuthorityFixture(
 	t *testing.T,
 	pool *pgxpool.Pool,

--- a/server/internal/coaching/evaluation/scoring/durable_job.go
+++ b/server/internal/coaching/evaluation/scoring/durable_job.go
@@ -113,6 +113,8 @@ type durableSceneJobClaim struct {
 	Provider             string
 	Model                string
 	Snapshot             evidence.EvidenceSnapshot
+	AcousticSnapshot     *IELTSAcousticSnapshot
+	InputBundleHash      [sha256.Size]byte
 }
 
 func (claim durableSceneJobClaim) valid(
@@ -137,7 +139,26 @@ func (claim durableSceneJobClaim) valid(
 		claim.Snapshot.Valid() &&
 		claim.Snapshot.OwnerUserID == claim.OwnerUserID &&
 		claim.Snapshot.Scope == evaluation.ScopeSession &&
-		claim.Snapshot.SceneType == spec.sceneType
+		claim.Snapshot.SceneType == spec.sceneType &&
+		claim.validAcousticBinding(spec)
+}
+
+func (claim durableSceneJobClaim) validAcousticBinding(
+	spec durableSceneJobSpec,
+) bool {
+	requiresAcoustics := spec.sceneType == evaluation.SceneIELTSSpeaking &&
+		spec.strategyRef == IELTSSpeakingShadowStrategyRef
+	if !requiresAcoustics {
+		return claim.AcousticSnapshot == nil &&
+			claim.InputBundleHash == ([sha256.Size]byte{})
+	}
+	return claim.AcousticSnapshot != nil &&
+		!claim.AcousticSnapshot.CreatedAt.IsZero() &&
+		claim.AcousticSnapshot.ValidFor(claim.Snapshot) &&
+		claim.InputBundleHash == IELTSAcousticInputBundleHash(
+			claim.Snapshot,
+			*claim.AcousticSnapshot,
+		)
 }
 
 type durableSceneJobFailure struct {
@@ -345,13 +366,15 @@ func durableClaimFromIELTS(
 		Provider:             source.Provider,
 		Model:                source.Model,
 		Snapshot:             source.Snapshot,
+		AcousticSnapshot:     &source.AcousticSnapshot,
+		InputBundleHash:      source.InputBundleHash,
 	}
 }
 
 func ieltsClaimFromDurable(
 	source durableSceneJobClaim,
 ) IELTSSpeakingShadowClaim {
-	return IELTSSpeakingShadowClaim{
+	result := IELTSSpeakingShadowClaim{
 		OutboxID:             source.OutboxID,
 		ModuleRunID:          source.ModuleRunID,
 		EvaluationID:         source.EvaluationID,
@@ -368,5 +391,10 @@ func ieltsClaimFromDurable(
 		Provider:             source.Provider,
 		Model:                source.Model,
 		Snapshot:             source.Snapshot,
+		InputBundleHash:      source.InputBundleHash,
 	}
+	if source.AcousticSnapshot != nil {
+		result.AcousticSnapshot = *source.AcousticSnapshot
+	}
+	return result
 }

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot.go
@@ -1,0 +1,431 @@
+package scoring
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+)
+
+const IELTSAcousticSnapshotSchemaVersion = "ielts-speaking-acoustic-snapshot/v1"
+
+var ErrIELTSAcousticSnapshotPending = errors.New(
+	"evaluation: IELTS acoustic snapshot pending",
+)
+
+type IELTSAcousticSnapshotResolution string
+
+const (
+	IELTSAcousticSnapshotComplete IELTSAcousticSnapshotResolution = "COMPLETE"
+	IELTSAcousticSnapshotPartial  IELTSAcousticSnapshotResolution = "PARTIAL"
+	IELTSAcousticSnapshotTextOnly IELTSAcousticSnapshotResolution = "TEXT_ONLY"
+)
+
+type IELTSSpeakingAcousticRead struct {
+	Values         []IELTSSpeakingTurnAcoustics
+	PendingTurnIDs []string
+}
+
+type IELTSAcousticSnapshot struct {
+	ID                string
+	EvaluationID      string
+	OwnerUserID       string
+	InputSnapshotID   string
+	InputSnapshotHash [sha256.Size]byte
+	Resolution        IELTSAcousticSnapshotResolution
+	SnapshotHash      [sha256.Size]byte
+	Payload           json.RawMessage
+	CreatedAt         time.Time
+}
+
+type ieltsAcousticSnapshotPayload struct {
+	SchemaVersion     string                          `json:"schema_version"`
+	EvaluationID      string                          `json:"evaluation_id"`
+	OwnerUserID       string                          `json:"owner_user_id"`
+	InputSnapshotID   string                          `json:"input_snapshot_id"`
+	InputSnapshotHash string                          `json:"input_snapshot_hash"`
+	Resolution        IELTSAcousticSnapshotResolution `json:"resolution"`
+	Turns             []ieltsAcousticSnapshotTurn     `json:"turns"`
+}
+
+type ieltsAcousticSnapshotTurn struct {
+	TurnID               string   `json:"turn_id"`
+	EvidenceRefID        string   `json:"evidence_ref_id"`
+	EvidenceVersion      int64    `json:"evidence_version"`
+	AudioAssetID         string   `json:"audio_asset_id,omitempty"`
+	AudioAssetVersion    uint64   `json:"audio_asset_version,omitempty"`
+	AudioChecksumSHA256  string   `json:"audio_checksum_sha256,omitempty"`
+	RecordingDurationMS  int64    `json:"recording_duration_ms"`
+	Status               string   `json:"status"`
+	UnavailableReason    string   `json:"unavailable_reason,omitempty"`
+	PronunciationScore   *float64 `json:"pronunciation_score,omitempty"`
+	AcousticFluencyScore *float64 `json:"acoustic_fluency_score,omitempty"`
+	SpeakingSpeedWPM     *float64 `json:"speaking_speed_wpm,omitempty"`
+	Provider             string   `json:"provider,omitempty"`
+	ProviderRunHash      string   `json:"provider_run_hash,omitempty"`
+}
+
+func BuildIELTSAcousticSnapshot(
+	evaluationID string,
+	base evidence.EvidenceSnapshot,
+	read IELTSSpeakingAcousticRead,
+	deadlineReached bool,
+) (IELTSAcousticSnapshot, error) {
+	if !validUUID(evaluationID) || !base.Valid() ||
+		base.SceneType != evaluation.SceneIELTSSpeaking ||
+		base.Scope != evaluation.ScopeSession {
+		return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+	}
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil {
+		return IELTSAcousticSnapshot{}, err
+	}
+	requestsByTurn := make(
+		map[string]IELTSSpeakingAcousticRequest,
+		len(requests),
+	)
+	for _, request := range requests {
+		requestsByTurn[request.TurnID] = request
+	}
+	values := make(map[string]IELTSSpeakingTurnAcoustics, len(read.Values))
+	for _, value := range read.Values {
+		request, requested := requestsByTurn[value.TurnID]
+		if !requested || value.EvidenceRefID != request.EvidenceRefID ||
+			request.RecordingDurationMS <= 0 ||
+			!validIELTSSpeakingTurnAcoustics(value) ||
+			!validIELTSAcousticProviderRunHash(value.ProviderRun) {
+			return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+		}
+		if _, duplicate := values[value.TurnID]; duplicate {
+			return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+		}
+		values[value.TurnID] = value
+	}
+	pending := make(map[string]struct{}, len(read.PendingTurnIDs))
+	for _, turnID := range read.PendingTurnIDs {
+		request, requested := requestsByTurn[turnID]
+		if !requested || request.RecordingDurationMS <= 0 ||
+			!validIdentifier(turnID) {
+			return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+		}
+		if _, duplicate := pending[turnID]; duplicate {
+			return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+		}
+		if _, assessed := values[turnID]; assessed {
+			return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+		}
+		pending[turnID] = struct{}{}
+	}
+	if len(pending) > 0 && !deadlineReached {
+		return IELTSAcousticSnapshot{}, ErrIELTSAcousticSnapshotPending
+	}
+	payload := ieltsAcousticSnapshotPayload{
+		SchemaVersion:     IELTSAcousticSnapshotSchemaVersion,
+		EvaluationID:      evaluationID,
+		OwnerUserID:       base.OwnerUserID,
+		InputSnapshotID:   base.ID,
+		InputSnapshotHash: hex.EncodeToString(base.SnapshotHash[:]),
+		Turns:             make([]ieltsAcousticSnapshotTurn, 0, len(requests)),
+	}
+	assessed := 0
+	for _, request := range requests {
+		turn := ieltsAcousticSnapshotTurn{
+			TurnID:              request.TurnID,
+			EvidenceRefID:       request.EvidenceRefID,
+			EvidenceVersion:     request.EvidenceVersion,
+			AudioAssetID:        request.AudioAssetID,
+			AudioAssetVersion:   request.AudioAssetVersion,
+			AudioChecksumSHA256: request.AudioChecksumSHA256,
+			RecordingDurationMS: request.RecordingDurationMS,
+		}
+		value, ok := values[request.TurnID]
+		switch {
+		case ok:
+			turn.Status = "ASSESSED"
+			pronunciation := value.PronunciationScore
+			turn.PronunciationScore = &pronunciation
+			turn.AcousticFluencyScore = cloneFloat64(value.AcousticFluencyScore)
+			turn.SpeakingSpeedWPM = cloneFloat64(value.SpeakingSpeedWPM)
+			turn.Provider = value.Provider
+			turn.ProviderRunHash = value.ProviderRun
+			assessed++
+		case containsStringKey(pending, request.TurnID):
+			turn.Status = "UNAVAILABLE"
+			turn.UnavailableReason = "DEADLINE_EXCEEDED"
+		default:
+			turn.Status = "UNAVAILABLE"
+			if request.RecordingDurationMS == 0 {
+				turn.UnavailableReason = "NO_AUDIO"
+			} else {
+				turn.UnavailableReason = "NOT_ASSESSED"
+			}
+		}
+		payload.Turns = append(payload.Turns, turn)
+		delete(values, request.TurnID)
+		delete(pending, request.TurnID)
+	}
+	if len(values) != 0 || len(pending) != 0 {
+		return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+	}
+	switch {
+	case assessed == len(requests):
+		payload.Resolution = IELTSAcousticSnapshotComplete
+	case assessed > 0:
+		payload.Resolution = IELTSAcousticSnapshotPartial
+	default:
+		payload.Resolution = IELTSAcousticSnapshotTextOnly
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+	}
+	snapshotHash := sha256.Sum256(encoded)
+	result := IELTSAcousticSnapshot{
+		EvaluationID:      evaluationID,
+		OwnerUserID:       base.OwnerUserID,
+		InputSnapshotID:   base.ID,
+		InputSnapshotHash: base.SnapshotHash,
+		Resolution:        payload.Resolution,
+		SnapshotHash:      snapshotHash,
+		Payload:           encoded,
+	}
+	result.ID = deriveIELTSAcousticSnapshotID(evaluationID, snapshotHash)
+	if !result.ValidFor(base) {
+		return IELTSAcousticSnapshot{}, evaluation.ErrInvalidRequest
+	}
+	return result, nil
+}
+
+func (snapshot IELTSAcousticSnapshot) ValidFor(
+	base evidence.EvidenceSnapshot,
+) bool {
+	if !base.Valid() || !validIdentifier(snapshot.ID) ||
+		!validUUID(snapshot.EvaluationID) ||
+		snapshot.OwnerUserID != base.OwnerUserID ||
+		snapshot.InputSnapshotID != base.ID ||
+		snapshot.InputSnapshotHash != base.SnapshotHash ||
+		snapshot.ID != deriveIELTSAcousticSnapshotID(
+			snapshot.EvaluationID,
+			snapshot.SnapshotHash,
+		) || sha256.Sum256(snapshot.Payload) != snapshot.SnapshotHash {
+		return false
+	}
+	var payload ieltsAcousticSnapshotPayload
+	decoder := json.NewDecoder(bytes.NewReader(snapshot.Payload))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&payload) != nil || ensureJSONEOF(decoder) != nil {
+		return false
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil || !bytes.Equal(encoded, snapshot.Payload) ||
+		payload.SchemaVersion != IELTSAcousticSnapshotSchemaVersion ||
+		payload.EvaluationID != snapshot.EvaluationID ||
+		payload.OwnerUserID != snapshot.OwnerUserID ||
+		payload.InputSnapshotID != snapshot.InputSnapshotID ||
+		payload.InputSnapshotHash != hex.EncodeToString(base.SnapshotHash[:]) ||
+		payload.Resolution != snapshot.Resolution {
+		return false
+	}
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil || len(payload.Turns) != len(requests) {
+		return false
+	}
+	assessed := 0
+	for index, turn := range payload.Turns {
+		request := requests[index]
+		if turn.TurnID != request.TurnID ||
+			turn.EvidenceRefID != request.EvidenceRefID ||
+			turn.EvidenceVersion != request.EvidenceVersion ||
+			turn.AudioAssetID != request.AudioAssetID ||
+			turn.AudioAssetVersion != request.AudioAssetVersion ||
+			turn.AudioChecksumSHA256 != request.AudioChecksumSHA256 ||
+			turn.RecordingDurationMS != request.RecordingDurationMS {
+			return false
+		}
+		switch turn.Status {
+		case "ASSESSED":
+			if request.RecordingDurationMS <= 0 {
+				return false
+			}
+			value := IELTSSpeakingTurnAcoustics{
+				TurnID:               turn.TurnID,
+				EvidenceRefID:        turn.EvidenceRefID,
+				AcousticFluencyScore: turn.AcousticFluencyScore,
+				SpeakingSpeedWPM:     turn.SpeakingSpeedWPM,
+				Provider:             turn.Provider,
+				ProviderRun:          turn.ProviderRunHash,
+			}
+			if turn.PronunciationScore == nil {
+				return false
+			}
+			value.PronunciationScore = *turn.PronunciationScore
+			if turn.UnavailableReason != "" ||
+				!validIELTSSpeakingTurnAcoustics(value) ||
+				!validIELTSAcousticProviderRunHash(turn.ProviderRunHash) {
+				return false
+			}
+			assessed++
+		case "UNAVAILABLE":
+			if !slices.Contains(
+				[]string{"NO_AUDIO", "NOT_ASSESSED", "DEADLINE_EXCEEDED"},
+				turn.UnavailableReason,
+			) || (turn.UnavailableReason == "NO_AUDIO") !=
+				(request.RecordingDurationMS == 0) ||
+				turn.PronunciationScore != nil ||
+				turn.AcousticFluencyScore != nil ||
+				turn.SpeakingSpeedWPM != nil || turn.Provider != "" ||
+				turn.ProviderRunHash != "" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	expected := IELTSAcousticSnapshotTextOnly
+	if assessed == len(payload.Turns) {
+		expected = IELTSAcousticSnapshotComplete
+	} else if assessed > 0 {
+		expected = IELTSAcousticSnapshotPartial
+	}
+	return snapshot.Resolution == expected
+}
+
+func (snapshot IELTSAcousticSnapshot) assessedValues(
+	base evidence.EvidenceSnapshot,
+) ([]IELTSSpeakingTurnAcoustics, error) {
+	if !snapshot.ValidFor(base) {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	var payload ieltsAcousticSnapshotPayload
+	if json.Unmarshal(snapshot.Payload, &payload) != nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	values := make([]IELTSSpeakingTurnAcoustics, 0, len(payload.Turns))
+	for _, turn := range payload.Turns {
+		if turn.Status != "ASSESSED" {
+			continue
+		}
+		if turn.PronunciationScore == nil {
+			return nil, evaluation.ErrInvalidRequest
+		}
+		values = append(values, IELTSSpeakingTurnAcoustics{
+			TurnID:               turn.TurnID,
+			EvidenceRefID:        turn.EvidenceRefID,
+			PronunciationScore:   *turn.PronunciationScore,
+			AcousticFluencyScore: cloneFloat64(turn.AcousticFluencyScore),
+			SpeakingSpeedWPM:     cloneFloat64(turn.SpeakingSpeedWPM),
+			Provider:             turn.Provider,
+			ProviderRun:          turn.ProviderRunHash,
+		})
+	}
+	return values, nil
+}
+
+func IELTSAcousticInputBundleHash(
+	base evidence.EvidenceSnapshot,
+	acoustics IELTSAcousticSnapshot,
+) [sha256.Size]byte {
+	if !acoustics.ValidFor(base) {
+		return [sha256.Size]byte{}
+	}
+	hasher := sha256.New()
+	_, _ = hasher.Write([]byte("ielts-speaking-input-bundle/v1\x00"))
+	_, _ = hasher.Write(base.SnapshotHash[:])
+	_, _ = hasher.Write(acoustics.SnapshotHash[:])
+	var result [sha256.Size]byte
+	copy(result[:], hasher.Sum(nil))
+	return result
+}
+
+func ieltsSpeakingAcousticRequests(
+	base evidence.EvidenceSnapshot,
+) ([]IELTSSpeakingAcousticRequest, error) {
+	if !base.Valid() || base.SceneType != evaluation.SceneIELTSSpeaking ||
+		base.Scope != evaluation.ScopeSession {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	var payload evidence.SnapshotPayload
+	decoder := json.NewDecoder(bytes.NewReader(base.Payload))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&payload) != nil || ensureJSONEOF(decoder) != nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	refs := make(map[string]evidence.Ref, len(payload.EvidenceRefs))
+	for _, ref := range payload.EvidenceRefs {
+		refs[ref.TurnID] = ref
+	}
+	requests := make([]IELTSSpeakingAcousticRequest, 0, len(payload.ConfirmedTurns))
+	for _, turn := range payload.ConfirmedTurns {
+		ref, ok := refs[turn.TurnID]
+		if !ok {
+			return nil, evaluation.ErrInvalidRequest
+		}
+		request := IELTSSpeakingAcousticRequest{
+			TurnID:              turn.TurnID,
+			EvidenceRefID:       ref.EvidenceRefID,
+			EvidenceVersion:     turn.Transcript.EvidenceVersion,
+			AudioAssetID:        turn.Audio.AudioAssetID,
+			AudioAssetVersion:   turn.Audio.Version,
+			AudioChecksumSHA256: turn.Audio.ChecksumSHA256,
+			RecordingDurationMS: turn.Audio.DurationMS,
+		}
+		if !validIELTSAcousticRequest(request) {
+			return nil, evaluation.ErrInvalidRequest
+		}
+		requests = append(requests, request)
+	}
+	return requests, nil
+}
+
+func validIELTSAcousticRequest(request IELTSSpeakingAcousticRequest) bool {
+	if !validIdentifier(request.TurnID) ||
+		!validIdentifier(request.EvidenceRefID) || request.EvidenceVersion < 1 ||
+		request.RecordingDurationMS < 0 {
+		return false
+	}
+	if request.RecordingDurationMS == 0 {
+		return request.AudioAssetID == "" && request.AudioAssetVersion == 0 &&
+			request.AudioChecksumSHA256 == ""
+	}
+	decoded, err := hex.DecodeString(request.AudioChecksumSHA256)
+	return validIdentifier(request.AudioAssetID) &&
+		request.AudioAssetVersion > 0 && len(decoded) == sha256.Size && err == nil
+}
+
+func deriveIELTSAcousticSnapshotID(
+	evaluationID string,
+	snapshotHash [sha256.Size]byte,
+) string {
+	hasher := sha256.New()
+	_, _ = hasher.Write([]byte("ielts-speaking-acoustic-snapshot-id/v1\x00"))
+	_, _ = hasher.Write([]byte(evaluationID))
+	_, _ = hasher.Write(snapshotHash[:])
+	return "ielts_acoustic_" + hex.EncodeToString(hasher.Sum(nil)[:16])
+}
+
+func cloneFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
+}
+
+func containsStringKey(values map[string]struct{}, key string) bool {
+	_, ok := values[key]
+	return ok
+}
+
+func validIELTSAcousticProviderRunHash(value string) bool {
+	if len(value) != len("run_")+24 || value[:len("run_")] != "run_" {
+		return false
+	}
+	decoded, err := hex.DecodeString(value[len("run_"):])
+	return err == nil && len(decoded) == 12
+}

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"time"
 
@@ -15,8 +16,14 @@ import (
 
 const IELTSAcousticSnapshotSchemaVersion = "ielts-speaking-acoustic-snapshot/v1"
 
-var ErrIELTSAcousticSnapshotPending = errors.New(
-	"evaluation: IELTS acoustic snapshot pending",
+var (
+	ErrIELTSAcousticSnapshotPending = errors.New(
+		"evaluation: IELTS acoustic snapshot pending",
+	)
+	ErrIELTSAcousticEvidenceInvalid = fmt.Errorf(
+		"%w: IELTS acoustic evidence invalid",
+		evaluation.ErrInvalidRequest,
+	)
 )
 
 type IELTSAcousticSnapshotResolution string

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_test.go
@@ -1,0 +1,196 @@
+package scoring
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+)
+
+func TestBuildIELTSAcousticSnapshotFreezesStableInputBundle(t *testing.T) {
+	t.Parallel()
+	base := ieltsSpeakingAcousticTestSnapshot(t)
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fluency := 76.0
+	read := IELTSSpeakingAcousticRead{
+		Values: []IELTSSpeakingTurnAcoustics{{
+			TurnID:               requests[0].TurnID,
+			EvidenceRefID:        requests[0].EvidenceRefID,
+			PronunciationScore:   72,
+			AcousticFluencyScore: &fluency,
+			Provider:             "xfyun_ise",
+			ProviderRun:          "run_0123456789abcdef01234567",
+		}},
+	}
+	first, err := BuildIELTSAcousticSnapshot(
+		"71000000-0000-4000-8000-000000000007",
+		base,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := BuildIELTSAcousticSnapshot(
+		"71000000-0000-4000-8000-000000000007",
+		base,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != second.ID ||
+		first.SnapshotHash != second.SnapshotHash ||
+		!bytes.Equal(first.Payload, second.Payload) ||
+		first.Resolution != IELTSAcousticSnapshotPartial ||
+		!first.ValidFor(base) {
+		t.Fatalf("first=%#v second=%#v", first, second)
+	}
+	firstBundle := IELTSAcousticInputBundleHash(base, first)
+	secondBundle := IELTSAcousticInputBundleHash(base, second)
+	if firstBundle != secondBundle || firstBundle == ([32]byte{}) {
+		t.Fatalf("bundle hashes differ: %x %x", firstBundle, secondBundle)
+	}
+}
+
+func TestBuildIELTSAcousticSnapshotWaitsBeforeDeadline(t *testing.T) {
+	t.Parallel()
+	base := ieltsSpeakingAcousticTestSnapshot(t)
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = BuildIELTSAcousticSnapshot(
+		"71000000-0000-4000-8000-000000000007",
+		base,
+		IELTSSpeakingAcousticRead{
+			PendingTurnIDs: []string{requests[0].TurnID},
+		},
+		false,
+	)
+	if err != ErrIELTSAcousticSnapshotPending {
+		t.Fatalf("pending error = %v", err)
+	}
+}
+
+func TestBuildIELTSAcousticSnapshotHashChangesWithEvidence(t *testing.T) {
+	t.Parallel()
+	base := ieltsSpeakingAcousticTestSnapshot(t)
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fluency := 76.0
+	read := IELTSSpeakingAcousticRead{Values: []IELTSSpeakingTurnAcoustics{{
+		TurnID:               requests[0].TurnID,
+		EvidenceRefID:        requests[0].EvidenceRefID,
+		PronunciationScore:   72,
+		AcousticFluencyScore: &fluency,
+		Provider:             "xfyun_ise",
+		ProviderRun:          "run_0123456789abcdef01234567",
+	}}}
+	first, err := BuildIELTSAcousticSnapshot(
+		"71000000-0000-4000-8000-000000000007",
+		base,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read.Values[0].PronunciationScore = 73
+	second, err := BuildIELTSAcousticSnapshot(
+		"71000000-0000-4000-8000-000000000007",
+		base,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SnapshotHash == second.SnapshotHash || first.ID == second.ID {
+		t.Fatalf("evidence change kept hash: %#v %#v", first, second)
+	}
+}
+
+func ieltsSpeakingAcousticTestSnapshot(t *testing.T) evidence.EvidenceSnapshot {
+	t.Helper()
+	base := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	var payload evidence.SnapshotPayload
+	if err := json.Unmarshal(base.Payload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for index := range payload.ConfirmedTurns {
+		turn := &payload.ConfirmedTurns[index]
+		turn.Audio = evidence.Audio{
+			Availability: "AVAILABLE",
+			AudioAssetID: "audio-" + turn.TurnID,
+			ChecksumSHA256: strings.Repeat(
+				string("abcdef0123456789"[index%16]),
+				64,
+			),
+			DurationMS:  4_000,
+			ContentType: "audio/wav",
+			SizeBytes:   64_000,
+			Status:      "readable",
+			Version:     1,
+			Quality:     evidenceNotAssessed,
+			ISE:         evidenceNotAssessed,
+		}
+		payload.EvidenceRefs[index].AudioSpan = &evidence.AudioSpan{
+			AudioAssetID: turn.Audio.AudioAssetID,
+			StartMS:      0,
+			EndMS:        turn.Audio.DurationMS,
+		}
+		payload.EvidenceRefs[index].Lineage.AudioAssetVersion =
+			turn.Audio.Version
+		payload.VersionManifest.TurnEvidence[index].AudioVersion =
+			turn.Audio.Version
+	}
+	return rebuildIELTSSpeakingSnapshot(t, payload)
+}
+
+func ieltsAcousticSnapshotForTest(
+	t *testing.T,
+	base evidence.EvidenceSnapshot,
+	limit int,
+) IELTSAcousticSnapshot {
+	t.Helper()
+	requests, err := ieltsSpeakingAcousticRequests(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limit <= 0 || limit > len(requests) {
+		limit = len(requests)
+	}
+	read := IELTSSpeakingAcousticRead{
+		Values: make([]IELTSSpeakingTurnAcoustics, 0, limit),
+	}
+	for _, request := range requests[:limit] {
+		fluency := 76.0
+		read.Values = append(read.Values, IELTSSpeakingTurnAcoustics{
+			TurnID:               request.TurnID,
+			EvidenceRefID:        request.EvidenceRefID,
+			PronunciationScore:   72,
+			AcousticFluencyScore: &fluency,
+			Provider:             "xfyun_ise",
+			ProviderRun:          "run_0123456789abcdef01234567",
+		})
+	}
+	result, err := BuildIELTSAcousticSnapshot(
+		testEvalID,
+		base,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
@@ -1,0 +1,138 @@
+package scoring
+
+import (
+	"context"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+)
+
+type IELTSAcousticSnapshotClaim struct {
+	EvaluationID         string
+	EvaluationRevisionID string
+	OwnerUserID          string
+	RevisionCreatedAt    time.Time
+	Snapshot             evidence.EvidenceSnapshot
+}
+
+func (claim IELTSAcousticSnapshotClaim) Valid() bool {
+	return validUUID(claim.EvaluationID) &&
+		validUUID(claim.EvaluationRevisionID) &&
+		validUUID(claim.OwnerUserID) &&
+		!claim.RevisionCreatedAt.IsZero() &&
+		claim.Snapshot.Valid() &&
+		claim.Snapshot.OwnerUserID == claim.OwnerUserID &&
+		claim.Snapshot.Scope == evaluation.ScopeSession &&
+		claim.Snapshot.SceneType == evaluation.SceneIELTSSpeaking
+}
+
+type IELTSAcousticSnapshotRepository interface {
+	FindPendingIELTSAcousticSnapshot(
+		context.Context,
+	) (IELTSAcousticSnapshotClaim, bool, error)
+	EnsureIELTSAcousticSnapshot(
+		context.Context,
+		IELTSAcousticSnapshotClaim,
+		IELTSAcousticSnapshot,
+	) (IELTSAcousticSnapshot, bool, error)
+}
+
+type IELTSSpeakingAcousticSource interface {
+	ReadIELTSSpeakingAcoustics(
+		context.Context,
+		string,
+		[]IELTSSpeakingAcousticRequest,
+	) (IELTSSpeakingAcousticRead, error)
+}
+
+type IELTSAcousticSnapshotSweepResult struct {
+	Inspected int
+	Frozen    int
+}
+
+type IELTSAcousticSnapshotFreezer struct {
+	repository   IELTSAcousticSnapshotRepository
+	source       IELTSSpeakingAcousticSource
+	waitDuration time.Duration
+	now          func() time.Time
+}
+
+func NewIELTSAcousticSnapshotFreezer(
+	repository IELTSAcousticSnapshotRepository,
+	source IELTSSpeakingAcousticSource,
+	waitDuration time.Duration,
+) (*IELTSAcousticSnapshotFreezer, error) {
+	if repository == nil || source == nil || waitDuration < time.Second ||
+		waitDuration > 10*time.Minute {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	return &IELTSAcousticSnapshotFreezer{
+		repository:   repository,
+		source:       source,
+		waitDuration: waitDuration,
+		now:          time.Now,
+	}, nil
+}
+
+func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
+	ctx context.Context,
+	limit int,
+) (IELTSAcousticSnapshotSweepResult, error) {
+	if freezer == nil || freezer.repository == nil || freezer.source == nil ||
+		freezer.now == nil || ctx == nil || limit < 1 || limit > 20 {
+		return IELTSAcousticSnapshotSweepResult{}, evaluation.ErrInvalidRequest
+	}
+	var sweep IELTSAcousticSnapshotSweepResult
+	for sweep.Inspected < limit {
+		claim, found, err := freezer.repository.
+			FindPendingIELTSAcousticSnapshot(ctx)
+		if err != nil {
+			return sweep, err
+		}
+		if !found {
+			return sweep, nil
+		}
+		if !claim.Valid() {
+			return sweep, evaluation.ErrInvalidRequest
+		}
+		sweep.Inspected++
+		requests, err := ieltsSpeakingAcousticRequests(claim.Snapshot)
+		if err != nil {
+			return sweep, err
+		}
+		read, err := freezer.source.ReadIELTSSpeakingAcoustics(
+			ctx,
+			claim.OwnerUserID,
+			requests,
+		)
+		if err != nil {
+			return sweep, err
+		}
+		deadlineReached := !freezer.now().UTC().Before(
+			claim.RevisionCreatedAt.Add(freezer.waitDuration),
+		)
+		draft, err := BuildIELTSAcousticSnapshot(
+			claim.EvaluationID,
+			claim.Snapshot,
+			read,
+			deadlineReached,
+		)
+		if err == ErrIELTSAcousticSnapshotPending {
+			return sweep, nil
+		}
+		if err != nil {
+			return sweep, err
+		}
+		_, _, err = freezer.repository.EnsureIELTSAcousticSnapshot(
+			ctx,
+			claim,
+			draft,
+		)
+		if err != nil {
+			return sweep, err
+		}
+		sweep.Frozen++
+	}
+	return sweep, nil
+}

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
@@ -3,6 +3,7 @@ package scoring
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
@@ -22,6 +23,23 @@ type IELTSAcousticSnapshotClaim struct {
 	Snapshot             evidence.EvidenceSnapshot
 }
 
+type IELTSAcousticSnapshotCursor struct {
+	RevisionCreatedAt    time.Time
+	EvaluationRevisionID string
+}
+
+func (cursor IELTSAcousticSnapshotCursor) Valid() bool {
+	return !cursor.RevisionCreatedAt.IsZero() &&
+		validUUID(cursor.EvaluationRevisionID)
+}
+
+func (claim IELTSAcousticSnapshotClaim) Cursor() IELTSAcousticSnapshotCursor {
+	return IELTSAcousticSnapshotCursor{
+		RevisionCreatedAt:    claim.RevisionCreatedAt,
+		EvaluationRevisionID: claim.EvaluationRevisionID,
+	}
+}
+
 func (claim IELTSAcousticSnapshotClaim) Valid() bool {
 	return validUUID(claim.EvaluationID) &&
 		validUUID(claim.EvaluationRevisionID) &&
@@ -36,6 +54,7 @@ func (claim IELTSAcousticSnapshotClaim) Valid() bool {
 type IELTSAcousticSnapshotRepository interface {
 	FindPendingIELTSAcousticSnapshot(
 		context.Context,
+		*IELTSAcousticSnapshotCursor,
 	) (IELTSAcousticSnapshotClaim, bool, error)
 	EnsureIELTSAcousticSnapshot(
 		context.Context,
@@ -67,6 +86,8 @@ type IELTSAcousticSnapshotFreezer struct {
 	source       IELTSSpeakingAcousticSource
 	waitDuration time.Duration
 	now          func() time.Time
+	cursorMu     sync.Mutex
+	cursor       *IELTSAcousticSnapshotCursor
 }
 
 func NewIELTSAcousticSnapshotFreezer(
@@ -95,18 +116,36 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 		return IELTSAcousticSnapshotSweepResult{}, evaluation.ErrInvalidRequest
 	}
 	var sweep IELTSAcousticSnapshotSweepResult
+	freezer.cursorMu.Lock()
+	defer freezer.cursorMu.Unlock()
+	cursor := freezer.cursor
+	wrapped := false
+	seen := make(map[string]struct{}, limit)
+	var firstErr error
 	for sweep.Inspected < limit {
 		claim, found, err := freezer.repository.
-			FindPendingIELTSAcousticSnapshot(ctx)
+			FindPendingIELTSAcousticSnapshot(ctx, cursor)
 		if err != nil {
 			return sweep, err
 		}
 		if !found {
-			return sweep, nil
+			if cursor == nil || wrapped {
+				return sweep, firstErr
+			}
+			cursor = nil
+			wrapped = true
+			continue
 		}
 		if !claim.Valid() {
 			return sweep, evaluation.ErrInvalidRequest
 		}
+		if _, alreadySeen := seen[claim.EvaluationRevisionID]; alreadySeen {
+			return sweep, firstErr
+		}
+		seen[claim.EvaluationRevisionID] = struct{}{}
+		nextCursor := claim.Cursor()
+		cursor = &nextCursor
+		freezer.cursor = &nextCursor
 		sweep.Inspected++
 		requests, err := ieltsSpeakingAcousticRequests(claim.Snapshot)
 		if err != nil {
@@ -138,7 +177,14 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 				sweep.Failed++
 				continue
 			}
-			return sweep, err
+			if errors.Is(err, context.Canceled) ||
+				errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+				return sweep, err
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
 		deadlineReached := !freezer.now().UTC().Before(
 			claim.RevisionCreatedAt.Add(freezer.waitDuration),
@@ -150,7 +196,7 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 			deadlineReached,
 		)
 		if err == ErrIELTSAcousticSnapshotPending {
-			return sweep, nil
+			continue
 		}
 		if err != nil {
 			if errors.Is(err, evaluation.ErrInvalidRequest) {
@@ -175,5 +221,5 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 		}
 		sweep.Frozen++
 	}
-	return sweep, nil
+	return sweep, firstErr
 }

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
@@ -2,10 +2,16 @@ package scoring
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+)
+
+const (
+	IELTSAcousticSnapshotWaitDurationV1 = 120 * time.Second
+	IELTSAcousticEvidenceFailureCode    = "acoustic_evidence_invalid"
 )
 
 type IELTSAcousticSnapshotClaim struct {
@@ -36,6 +42,10 @@ type IELTSAcousticSnapshotRepository interface {
 		IELTSAcousticSnapshotClaim,
 		IELTSAcousticSnapshot,
 	) (IELTSAcousticSnapshot, bool, error)
+	FailIELTSAcousticSnapshot(
+		context.Context,
+		IELTSAcousticSnapshotClaim,
+	) error
 }
 
 type IELTSSpeakingAcousticSource interface {
@@ -49,6 +59,7 @@ type IELTSSpeakingAcousticSource interface {
 type IELTSAcousticSnapshotSweepResult struct {
 	Inspected int
 	Frozen    int
+	Failed    int
 }
 
 type IELTSAcousticSnapshotFreezer struct {
@@ -99,6 +110,16 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 		sweep.Inspected++
 		requests, err := ieltsSpeakingAcousticRequests(claim.Snapshot)
 		if err != nil {
+			if errors.Is(err, evaluation.ErrInvalidRequest) {
+				if err := freezer.repository.FailIELTSAcousticSnapshot(
+					ctx,
+					claim,
+				); err != nil {
+					return sweep, err
+				}
+				sweep.Failed++
+				continue
+			}
 			return sweep, err
 		}
 		read, err := freezer.source.ReadIELTSSpeakingAcoustics(
@@ -107,6 +128,16 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 			requests,
 		)
 		if err != nil {
+			if errors.Is(err, ErrIELTSAcousticEvidenceInvalid) {
+				if err := freezer.repository.FailIELTSAcousticSnapshot(
+					ctx,
+					claim,
+				); err != nil {
+					return sweep, err
+				}
+				sweep.Failed++
+				continue
+			}
 			return sweep, err
 		}
 		deadlineReached := !freezer.now().UTC().Before(
@@ -122,6 +153,16 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 			return sweep, nil
 		}
 		if err != nil {
+			if errors.Is(err, evaluation.ErrInvalidRequest) {
+				if err := freezer.repository.FailIELTSAcousticSnapshot(
+					ctx,
+					claim,
+				); err != nil {
+					return sweep, err
+				}
+				sweep.Failed++
+				continue
+			}
 			return sweep, err
 		}
 		_, _, err = freezer.repository.EnsureIELTSAcousticSnapshot(

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker.go
@@ -72,6 +72,7 @@ type IELTSSpeakingAcousticSource interface {
 		context.Context,
 		string,
 		[]IELTSSpeakingAcousticRequest,
+		time.Time,
 	) (IELTSSpeakingAcousticRead, error)
 }
 
@@ -161,10 +162,12 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 			}
 			return sweep, err
 		}
+		cutoff := claim.RevisionCreatedAt.Add(freezer.waitDuration).UTC()
 		read, err := freezer.source.ReadIELTSSpeakingAcoustics(
 			ctx,
 			claim.OwnerUserID,
 			requests,
+			cutoff,
 		)
 		if err != nil {
 			if errors.Is(err, ErrIELTSAcousticEvidenceInvalid) {
@@ -186,9 +189,7 @@ func (freezer *IELTSAcousticSnapshotFreezer) ProcessPending(
 			}
 			continue
 		}
-		deadlineReached := !freezer.now().UTC().Before(
-			claim.RevisionCreatedAt.Add(freezer.waitDuration),
-		)
+		deadlineReached := !freezer.now().UTC().Before(cutoff)
 		draft, err := BuildIELTSAcousticSnapshot(
 			claim.EvaluationID,
 			claim.Snapshot,

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
@@ -1,0 +1,149 @@
+package scoring
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+func TestIELTSAcousticSnapshotFreezerKeepsRevisionValidatingBeforeDeadline(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := ieltsAcousticSnapshotClaimForTest(t)
+	repository := &ieltsAcousticSnapshotRepositoryStub{claim: claim}
+	source := &ieltsAcousticSnapshotSourceStub{
+		read: IELTSSpeakingAcousticRead{
+			PendingTurnIDs: []string{"turn-1"},
+		},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		15*time.Second,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return claim.RevisionCreatedAt.Add(14 * time.Second)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sweep != (IELTSAcousticSnapshotSweepResult{Inspected: 1}) ||
+		repository.ensureCalls != 0 || source.calls != 1 {
+		t.Fatalf("sweep=%#v repository=%#v source=%#v", sweep, repository, source)
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerDeadlineIsImmutableAgainstLateResult(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := ieltsAcousticSnapshotClaimForTest(t)
+	repository := &ieltsAcousticSnapshotRepositoryStub{claim: claim}
+	source := &ieltsAcousticSnapshotSourceStub{
+		read: IELTSSpeakingAcousticRead{
+			PendingTurnIDs: []string{"turn-1"},
+		},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		15*time.Second,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return claim.RevisionCreatedAt.Add(15 * time.Second)
+	}
+	firstSweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstSweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 1,
+		Frozen:    1,
+	}) || repository.ensureCalls != 1 ||
+		repository.stored.Resolution != IELTSAcousticSnapshotTextOnly {
+		t.Fatalf("sweep=%#v repository=%#v", firstSweep, repository)
+	}
+	frozenPayload := bytes.Clone(repository.stored.Payload)
+	request, err := ieltsSpeakingAcousticRequests(claim.Snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fluency := 80.0
+	source.read = IELTSSpeakingAcousticRead{
+		Values: []IELTSSpeakingTurnAcoustics{{
+			TurnID:               request[0].TurnID,
+			EvidenceRefID:        request[0].EvidenceRefID,
+			PronunciationScore:   80,
+			AcousticFluencyScore: &fluency,
+			Provider:             "xfyun_ise",
+			ProviderRun:          "run_0123456789abcdef01234567",
+		}},
+	}
+	secondSweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondSweep != (IELTSAcousticSnapshotSweepResult{}) ||
+		repository.ensureCalls != 1 || source.calls != 1 ||
+		!bytes.Equal(repository.stored.Payload, frozenPayload) {
+		t.Fatalf("sweep=%#v repository=%#v source=%#v", secondSweep, repository, source)
+	}
+}
+
+func ieltsAcousticSnapshotClaimForTest(
+	t *testing.T,
+) IELTSAcousticSnapshotClaim {
+	t.Helper()
+	return IELTSAcousticSnapshotClaim{
+		EvaluationID:         testEvalID,
+		EvaluationRevisionID: testRevID,
+		OwnerUserID:          testOwnerA,
+		RevisionCreatedAt:    time.Now().UTC(),
+		Snapshot:             ieltsSpeakingAcousticTestSnapshot(t),
+	}
+}
+
+type ieltsAcousticSnapshotRepositoryStub struct {
+	claim       IELTSAcousticSnapshotClaim
+	stored      IELTSAcousticSnapshot
+	ensureCalls int
+}
+
+func (stub *ieltsAcousticSnapshotRepositoryStub) FindPendingIELTSAcousticSnapshot(
+	context.Context,
+) (IELTSAcousticSnapshotClaim, bool, error) {
+	return stub.claim, stub.stored.ID == "", nil
+}
+
+func (stub *ieltsAcousticSnapshotRepositoryStub) EnsureIELTSAcousticSnapshot(
+	_ context.Context,
+	_ IELTSAcousticSnapshotClaim,
+	draft IELTSAcousticSnapshot,
+) (IELTSAcousticSnapshot, bool, error) {
+	stub.ensureCalls++
+	stub.stored = draft
+	return draft, false, nil
+}
+
+type ieltsAcousticSnapshotSourceStub struct {
+	read  IELTSSpeakingAcousticRead
+	calls int
+}
+
+func (stub *ieltsAcousticSnapshotSourceStub) ReadIELTSSpeakingAcoustics(
+	context.Context,
+	string,
+	[]IELTSSpeakingAcousticRequest,
+) (IELTSSpeakingAcousticRead, error) {
+	stub.calls++
+	return stub.read, nil
+}

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
@@ -177,6 +177,125 @@ func TestIELTSAcousticSnapshotFreezerFailsCorruptHeadAndContinues(
 	}
 }
 
+func TestIELTSAcousticSnapshotFreezerSkipsPendingHeadWithinSweep(
+	t *testing.T,
+) {
+	t.Parallel()
+	first := ieltsAcousticSnapshotClaimForTest(t)
+	second := first
+	second.EvaluationID = "72000000-0000-4000-8000-000000000007"
+	second.EvaluationRevisionID = "62000000-0000-4000-8000-000000000006"
+	repository := &ieltsAcousticSnapshotQueueRepositoryStub{
+		claims: []IELTSAcousticSnapshotClaim{first, second},
+	}
+	source := &ieltsAcousticSnapshotQueueSourceStub{
+		reads: []IELTSSpeakingAcousticRead{{
+			PendingTurnIDs: []string{"turn-1"},
+		}, {}},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return first.RevisionCreatedAt.Add(time.Second)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 2)
+	if err != nil || sweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 2,
+		Frozen:    1,
+	}) || repository.frozen != 1 || len(repository.claims) != 1 {
+		t.Fatalf("sweep=%#v err=%v repository=%#v", sweep, err, repository)
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerCursorReachesPastSweepLimit(
+	t *testing.T,
+) {
+	t.Parallel()
+	first := ieltsAcousticSnapshotClaimForTest(t)
+	second := first
+	second.EvaluationID = "72000000-0000-4000-8000-000000000007"
+	second.EvaluationRevisionID = "62000000-0000-4000-8000-000000000006"
+	repository := &ieltsAcousticSnapshotQueueRepositoryStub{
+		claims: []IELTSAcousticSnapshotClaim{first, second},
+	}
+	source := &ieltsAcousticSnapshotQueueSourceStub{
+		reads: []IELTSSpeakingAcousticRead{{
+			PendingTurnIDs: []string{"turn-1"},
+		}, {}},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return first.RevisionCreatedAt.Add(time.Second)
+	}
+	firstSweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil || firstSweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 1,
+	}) {
+		t.Fatalf("first sweep=%#v err=%v", firstSweep, err)
+	}
+	secondSweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil || secondSweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 1,
+		Frozen:    1,
+	}) || repository.frozen != 1 || len(repository.claims) != 1 {
+		t.Fatalf(
+			"second sweep=%#v err=%v repository=%#v",
+			secondSweep,
+			err,
+			repository,
+		)
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerSkipsTransientHeadWithinSweep(
+	t *testing.T,
+) {
+	t.Parallel()
+	first := ieltsAcousticSnapshotClaimForTest(t)
+	second := first
+	second.EvaluationID = "72000000-0000-4000-8000-000000000007"
+	second.EvaluationRevisionID = "62000000-0000-4000-8000-000000000006"
+	repository := &ieltsAcousticSnapshotQueueRepositoryStub{
+		claims: []IELTSAcousticSnapshotClaim{first, second},
+	}
+	sourceErr := errors.New("source temporarily unavailable")
+	source := &ieltsAcousticSnapshotQueueSourceStub{
+		errors: []error{sourceErr, nil},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return first.RevisionCreatedAt.Add(time.Second)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 2)
+	if !errors.Is(err, sourceErr) ||
+		sweep != (IELTSAcousticSnapshotSweepResult{
+			Inspected: 2,
+			Frozen:    1,
+		}) || repository.frozen != 1 || len(repository.claims) != 1 {
+		t.Fatalf("sweep=%#v err=%v repository=%#v", sweep, err, repository)
+	}
+}
+
 func TestIELTSAcousticSnapshotFreezerPreservesTransientFailures(
 	t *testing.T,
 ) {
@@ -269,6 +388,7 @@ type ieltsAcousticSnapshotRepositoryStub struct {
 
 func (stub *ieltsAcousticSnapshotRepositoryStub) FindPendingIELTSAcousticSnapshot(
 	context.Context,
+	*IELTSAcousticSnapshotCursor,
 ) (IELTSAcousticSnapshotClaim, bool, error) {
 	if stub.findErr != nil {
 		return IELTSAcousticSnapshotClaim{}, false, stub.findErr
@@ -315,9 +435,17 @@ type ieltsAcousticSnapshotQueueRepositoryStub struct {
 }
 
 func (stub *ieltsAcousticSnapshotQueueRepositoryStub) FindPendingIELTSAcousticSnapshot(
-	context.Context,
+	_ context.Context,
+	after *IELTSAcousticSnapshotCursor,
 ) (IELTSAcousticSnapshotClaim, bool, error) {
-	if len(stub.claims) == 0 {
+	for _, claim := range stub.claims {
+		if after == nil || claim.RevisionCreatedAt.After(after.RevisionCreatedAt) ||
+			(claim.RevisionCreatedAt.Equal(after.RevisionCreatedAt) &&
+				claim.EvaluationRevisionID > after.EvaluationRevisionID) {
+			return claim, true, nil
+		}
+	}
+	if len(stub.claims) == 0 || after != nil {
 		return IELTSAcousticSnapshotClaim{}, false, nil
 	}
 	return stub.claims[0], true, nil
@@ -328,11 +456,11 @@ func (stub *ieltsAcousticSnapshotQueueRepositoryStub) EnsureIELTSAcousticSnapsho
 	claim IELTSAcousticSnapshotClaim,
 	draft IELTSAcousticSnapshot,
 ) (IELTSAcousticSnapshot, bool, error) {
-	if len(stub.claims) == 0 ||
-		claim.EvaluationID != stub.claims[0].EvaluationID {
+	index := stub.claimIndex(claim.EvaluationID)
+	if index < 0 {
 		return IELTSAcousticSnapshot{}, false, evaluation.ErrInvalidRequest
 	}
-	stub.claims = stub.claims[1:]
+	stub.claims = append(stub.claims[:index], stub.claims[index+1:]...)
 	stub.frozen++
 	return draft, false, nil
 }
@@ -341,17 +469,29 @@ func (stub *ieltsAcousticSnapshotQueueRepositoryStub) FailIELTSAcousticSnapshot(
 	_ context.Context,
 	claim IELTSAcousticSnapshotClaim,
 ) error {
-	if len(stub.claims) == 0 ||
-		claim.EvaluationID != stub.claims[0].EvaluationID {
+	index := stub.claimIndex(claim.EvaluationID)
+	if index < 0 {
 		return evaluation.ErrInvalidRequest
 	}
-	stub.claims = stub.claims[1:]
+	stub.claims = append(stub.claims[:index], stub.claims[index+1:]...)
 	stub.failed++
 	return nil
 }
 
+func (stub *ieltsAcousticSnapshotQueueRepositoryStub) claimIndex(
+	evaluationID string,
+) int {
+	for index := range stub.claims {
+		if stub.claims[index].EvaluationID == evaluationID {
+			return index
+		}
+	}
+	return -1
+}
+
 type ieltsAcousticSnapshotQueueSourceStub struct {
 	errors []error
+	reads  []IELTSSpeakingAcousticRead
 	calls  int
 }
 
@@ -360,10 +500,17 @@ func (stub *ieltsAcousticSnapshotQueueSourceStub) ReadIELTSSpeakingAcoustics(
 	string,
 	[]IELTSSpeakingAcousticRequest,
 ) (IELTSSpeakingAcousticRead, error) {
-	if stub.calls >= len(stub.errors) {
+	if stub.calls >= len(stub.errors) && stub.calls >= len(stub.reads) {
 		return IELTSSpeakingAcousticRead{}, evaluation.ErrInvalidRequest
 	}
-	err := stub.errors[stub.calls]
+	var read IELTSSpeakingAcousticRead
+	if stub.calls < len(stub.reads) {
+		read = stub.reads[stub.calls]
+	}
+	var err error
+	if stub.calls < len(stub.errors) {
+		err = stub.errors[stub.calls]
+	}
 	stub.calls++
-	return IELTSSpeakingAcousticRead{}, err
+	return read, err
 }

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
@@ -106,6 +106,45 @@ func TestIELTSAcousticSnapshotFreezerDeadlineIsImmutableAgainstLateResult(
 	}
 }
 
+func TestIELTSAcousticSnapshotFreezerUsesRevisionCutoffAfterLateFirstSweep(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := ieltsAcousticSnapshotClaimForTest(t)
+	repository := &ieltsAcousticSnapshotRepositoryStub{claim: claim}
+	source := &ieltsAcousticSnapshotSourceStub{}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCutoff := claim.RevisionCreatedAt.Add(
+		IELTSAcousticSnapshotWaitDurationV1,
+	).UTC()
+	freezer.now = func() time.Time {
+		return expectedCutoff.Add(5 * time.Second)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 1,
+		Frozen:    1,
+	}) || !source.completedBy.Equal(expectedCutoff) ||
+		repository.stored.Resolution != IELTSAcousticSnapshotTextOnly {
+		t.Fatalf(
+			"sweep=%#v completedBy=%v repository=%#v",
+			sweep,
+			source.completedBy,
+			repository,
+		)
+	}
+}
+
 func TestIELTSAcousticSnapshotFreezerFreezesTerminalBeforeDeadline(
 	t *testing.T,
 ) {
@@ -415,16 +454,19 @@ func (stub *ieltsAcousticSnapshotRepositoryStub) FailIELTSAcousticSnapshot(
 }
 
 type ieltsAcousticSnapshotSourceStub struct {
-	read  IELTSSpeakingAcousticRead
-	calls int
+	read        IELTSSpeakingAcousticRead
+	completedBy time.Time
+	calls       int
 }
 
 func (stub *ieltsAcousticSnapshotSourceStub) ReadIELTSSpeakingAcoustics(
-	context.Context,
-	string,
-	[]IELTSSpeakingAcousticRequest,
+	_ context.Context,
+	_ string,
+	_ []IELTSSpeakingAcousticRequest,
+	completedBy time.Time,
 ) (IELTSSpeakingAcousticRead, error) {
 	stub.calls++
+	stub.completedBy = completedBy
 	return stub.read, nil
 }
 
@@ -499,6 +541,7 @@ func (stub *ieltsAcousticSnapshotQueueSourceStub) ReadIELTSSpeakingAcoustics(
 	context.Context,
 	string,
 	[]IELTSSpeakingAcousticRequest,
+	time.Time,
 ) (IELTSSpeakingAcousticRead, error) {
 	if stub.calls >= len(stub.errors) && stub.calls >= len(stub.reads) {
 		return IELTSSpeakingAcousticRead{}, evaluation.ErrInvalidRequest

--- a/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_acoustic_snapshot_worker_test.go
@@ -3,8 +3,11 @@ package scoring
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 )
 
 func TestIELTSAcousticSnapshotFreezerKeepsRevisionValidatingBeforeDeadline(
@@ -21,13 +24,15 @@ func TestIELTSAcousticSnapshotFreezerKeepsRevisionValidatingBeforeDeadline(
 	freezer, err := NewIELTSAcousticSnapshotFreezer(
 		repository,
 		source,
-		15*time.Second,
+		IELTSAcousticSnapshotWaitDurationV1,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	freezer.now = func() time.Time {
-		return claim.RevisionCreatedAt.Add(14 * time.Second)
+		return claim.RevisionCreatedAt.Add(
+			IELTSAcousticSnapshotWaitDurationV1 - time.Millisecond,
+		)
 	}
 	sweep, err := freezer.ProcessPending(context.Background(), 1)
 	if err != nil {
@@ -53,13 +58,15 @@ func TestIELTSAcousticSnapshotFreezerDeadlineIsImmutableAgainstLateResult(
 	freezer, err := NewIELTSAcousticSnapshotFreezer(
 		repository,
 		source,
-		15*time.Second,
+		IELTSAcousticSnapshotWaitDurationV1,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	freezer.now = func() time.Time {
-		return claim.RevisionCreatedAt.Add(15 * time.Second)
+		return claim.RevisionCreatedAt.Add(
+			IELTSAcousticSnapshotWaitDurationV1,
+		)
 	}
 	firstSweep, err := freezer.ProcessPending(context.Background(), 1)
 	if err != nil {
@@ -99,6 +106,146 @@ func TestIELTSAcousticSnapshotFreezerDeadlineIsImmutableAgainstLateResult(
 	}
 }
 
+func TestIELTSAcousticSnapshotFreezerFreezesTerminalBeforeDeadline(
+	t *testing.T,
+) {
+	t.Parallel()
+	claim := ieltsAcousticSnapshotClaimForTest(t)
+	repository := &ieltsAcousticSnapshotRepositoryStub{claim: claim}
+	source := &ieltsAcousticSnapshotSourceStub{}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return claim.RevisionCreatedAt.Add(time.Second)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 1,
+		Frozen:    1,
+	}) || repository.ensureCalls != 1 {
+		t.Fatalf("sweep=%#v repository=%#v", sweep, repository)
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerFailsCorruptHeadAndContinues(
+	t *testing.T,
+) {
+	t.Parallel()
+	first := ieltsAcousticSnapshotClaimForTest(t)
+	second := first
+	second.EvaluationID = "72000000-0000-4000-8000-000000000007"
+	second.EvaluationRevisionID = "62000000-0000-4000-8000-000000000006"
+	repository := &ieltsAcousticSnapshotQueueRepositoryStub{
+		claims: []IELTSAcousticSnapshotClaim{first, second},
+	}
+	source := &ieltsAcousticSnapshotQueueSourceStub{
+		errors: []error{ErrIELTSAcousticEvidenceInvalid, nil},
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezer.now = func() time.Time {
+		return first.RevisionCreatedAt.Add(
+			IELTSAcousticSnapshotWaitDurationV1,
+		)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sweep != (IELTSAcousticSnapshotSweepResult{
+		Inspected: 2,
+		Frozen:    1,
+		Failed:    1,
+	}) || repository.failed != 1 || repository.frozen != 1 ||
+		len(repository.claims) != 0 || source.calls != 2 {
+		t.Fatalf("sweep=%#v repository=%#v source=%#v", sweep, repository, source)
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerPreservesTransientFailures(
+	t *testing.T,
+) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "context canceled", err: context.Canceled},
+		{name: "context deadline", err: context.DeadlineExceeded},
+		{name: "source transient", err: errors.New("source unavailable")},
+		{name: "generic invalid request", err: evaluation.ErrInvalidRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			claim := ieltsAcousticSnapshotClaimForTest(t)
+			repository := &ieltsAcousticSnapshotRepositoryStub{claim: claim}
+			source := &ieltsAcousticSnapshotQueueSourceStub{
+				errors: []error{test.err},
+			}
+			freezer, err := NewIELTSAcousticSnapshotFreezer(
+				repository,
+				source,
+				IELTSAcousticSnapshotWaitDurationV1,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sweep, err := freezer.ProcessPending(context.Background(), 1)
+			if !errors.Is(err, test.err) ||
+				sweep != (IELTSAcousticSnapshotSweepResult{Inspected: 1}) ||
+				repository.failCalls != 0 || repository.ensureCalls != 0 {
+				t.Fatalf(
+					"sweep=%#v err=%v repository=%#v",
+					sweep,
+					err,
+					repository,
+				)
+			}
+		})
+	}
+}
+
+func TestIELTSAcousticSnapshotFreezerPreservesRepositoryFailure(
+	t *testing.T,
+) {
+	t.Parallel()
+	repositoryErr := errors.New("database unavailable")
+	repository := &ieltsAcousticSnapshotRepositoryStub{
+		claim:   ieltsAcousticSnapshotClaimForTest(t),
+		findErr: repositoryErr,
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		&ieltsAcousticSnapshotSourceStub{},
+		IELTSAcousticSnapshotWaitDurationV1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sweep, err := freezer.ProcessPending(context.Background(), 1)
+	if !errors.Is(err, repositoryErr) ||
+		sweep != (IELTSAcousticSnapshotSweepResult{}) ||
+		repository.failCalls != 0 || repository.ensureCalls != 0 {
+		t.Fatalf("sweep=%#v err=%v repository=%#v", sweep, err, repository)
+	}
+}
+
 func ieltsAcousticSnapshotClaimForTest(
 	t *testing.T,
 ) IELTSAcousticSnapshotClaim {
@@ -116,11 +263,16 @@ type ieltsAcousticSnapshotRepositoryStub struct {
 	claim       IELTSAcousticSnapshotClaim
 	stored      IELTSAcousticSnapshot
 	ensureCalls int
+	failCalls   int
+	findErr     error
 }
 
 func (stub *ieltsAcousticSnapshotRepositoryStub) FindPendingIELTSAcousticSnapshot(
 	context.Context,
 ) (IELTSAcousticSnapshotClaim, bool, error) {
+	if stub.findErr != nil {
+		return IELTSAcousticSnapshotClaim{}, false, stub.findErr
+	}
 	return stub.claim, stub.stored.ID == "", nil
 }
 
@@ -132,6 +284,14 @@ func (stub *ieltsAcousticSnapshotRepositoryStub) EnsureIELTSAcousticSnapshot(
 	stub.ensureCalls++
 	stub.stored = draft
 	return draft, false, nil
+}
+
+func (stub *ieltsAcousticSnapshotRepositoryStub) FailIELTSAcousticSnapshot(
+	context.Context,
+	IELTSAcousticSnapshotClaim,
+) error {
+	stub.failCalls++
+	return nil
 }
 
 type ieltsAcousticSnapshotSourceStub struct {
@@ -146,4 +306,64 @@ func (stub *ieltsAcousticSnapshotSourceStub) ReadIELTSSpeakingAcoustics(
 ) (IELTSSpeakingAcousticRead, error) {
 	stub.calls++
 	return stub.read, nil
+}
+
+type ieltsAcousticSnapshotQueueRepositoryStub struct {
+	claims []IELTSAcousticSnapshotClaim
+	failed int
+	frozen int
+}
+
+func (stub *ieltsAcousticSnapshotQueueRepositoryStub) FindPendingIELTSAcousticSnapshot(
+	context.Context,
+) (IELTSAcousticSnapshotClaim, bool, error) {
+	if len(stub.claims) == 0 {
+		return IELTSAcousticSnapshotClaim{}, false, nil
+	}
+	return stub.claims[0], true, nil
+}
+
+func (stub *ieltsAcousticSnapshotQueueRepositoryStub) EnsureIELTSAcousticSnapshot(
+	_ context.Context,
+	claim IELTSAcousticSnapshotClaim,
+	draft IELTSAcousticSnapshot,
+) (IELTSAcousticSnapshot, bool, error) {
+	if len(stub.claims) == 0 ||
+		claim.EvaluationID != stub.claims[0].EvaluationID {
+		return IELTSAcousticSnapshot{}, false, evaluation.ErrInvalidRequest
+	}
+	stub.claims = stub.claims[1:]
+	stub.frozen++
+	return draft, false, nil
+}
+
+func (stub *ieltsAcousticSnapshotQueueRepositoryStub) FailIELTSAcousticSnapshot(
+	_ context.Context,
+	claim IELTSAcousticSnapshotClaim,
+) error {
+	if len(stub.claims) == 0 ||
+		claim.EvaluationID != stub.claims[0].EvaluationID {
+		return evaluation.ErrInvalidRequest
+	}
+	stub.claims = stub.claims[1:]
+	stub.failed++
+	return nil
+}
+
+type ieltsAcousticSnapshotQueueSourceStub struct {
+	errors []error
+	calls  int
+}
+
+func (stub *ieltsAcousticSnapshotQueueSourceStub) ReadIELTSSpeakingAcoustics(
+	context.Context,
+	string,
+	[]IELTSSpeakingAcousticRequest,
+) (IELTSSpeakingAcousticRead, error) {
+	if stub.calls >= len(stub.errors) {
+		return IELTSSpeakingAcousticRead{}, evaluation.ErrInvalidRequest
+	}
+	err := stub.errors[stub.calls]
+	stub.calls++
+	return IELTSSpeakingAcousticRead{}, err
 }

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -51,10 +51,6 @@ var errIELTSSpeakingProviderSchemaMismatch = fmt.Errorf(
 	ErrInvalidIELTSSpeakingShadow,
 )
 
-var ErrIELTSSpeakingAcousticsPending = errors.New(
-	"evaluation: IELTS Speaking acoustics pending",
-)
-
 type IELTSCriterion string
 
 const (
@@ -194,6 +190,10 @@ type IELTSSpeakingProviderResponse struct {
 type IELTSSpeakingAcousticRequest struct {
 	TurnID              string
 	EvidenceRefID       string
+	EvidenceVersion     int64
+	AudioAssetID        string
+	AudioAssetVersion   uint64
+	AudioChecksumSHA256 string
 	RecordingDurationMS int64
 }
 
@@ -205,14 +205,6 @@ type IELTSSpeakingTurnAcoustics struct {
 	SpeakingSpeedWPM     *float64
 	Provider             string
 	ProviderRun          string
-}
-
-type IELTSSpeakingAcousticSource interface {
-	GetIELTSSpeakingAcoustics(
-		context.Context,
-		string,
-		[]IELTSSpeakingAcousticRequest,
-	) ([]IELTSSpeakingTurnAcoustics, error)
 }
 
 type IELTSSpeakingShadowProviderLineage struct {
@@ -287,8 +279,7 @@ type IELTSSpeakingShadowEvidence struct {
 }
 
 type IELTSSpeakingShadowEngine struct {
-	provider  IELTSSpeakingShadowProvider
-	acoustics IELTSSpeakingAcousticSource
+	provider IELTSSpeakingShadowProvider
 }
 
 func NewIELTSSpeakingShadowEngine(
@@ -297,34 +288,28 @@ func NewIELTSSpeakingShadowEngine(
 	return &IELTSSpeakingShadowEngine{provider: provider}
 }
 
-func NewIELTSSpeakingShadowEngineWithAcoustics(
-	provider IELTSSpeakingShadowProvider,
-	acoustics IELTSSpeakingAcousticSource,
-) *IELTSSpeakingShadowEngine {
-	return &IELTSSpeakingShadowEngine{
-		provider:  provider,
-		acoustics: acoustics,
-	}
-}
-
 func (engine *IELTSSpeakingShadowEngine) Evaluate(
 	ctx context.Context,
 	snapshot evidence.EvidenceSnapshot,
 ) (IELTSSpeakingShadowResult, error) {
-	return engine.evaluate(ctx, snapshot, true)
+	return engine.evaluate(ctx, snapshot, nil)
 }
 
-func (engine *IELTSSpeakingShadowEngine) evaluateWithoutAcoustics(
+func (engine *IELTSSpeakingShadowEngine) EvaluateWithAcousticSnapshot(
 	ctx context.Context,
 	snapshot evidence.EvidenceSnapshot,
+	acoustics IELTSAcousticSnapshot,
 ) (IELTSSpeakingShadowResult, error) {
-	return engine.evaluate(ctx, snapshot, false)
+	if !acoustics.ValidFor(snapshot) {
+		return IELTSSpeakingShadowResult{}, evaluation.ErrInvalidRequest
+	}
+	return engine.evaluate(ctx, snapshot, &acoustics)
 }
 
 func (engine *IELTSSpeakingShadowEngine) evaluate(
 	ctx context.Context,
 	snapshot evidence.EvidenceSnapshot,
-	includeAcoustics bool,
+	acoustics *IELTSAcousticSnapshot,
 ) (IELTSSpeakingShadowResult, error) {
 	if engine == nil || engine.provider == nil || ctx == nil {
 		return IELTSSpeakingShadowResult{}, evaluation.ErrInvalidRequest
@@ -337,8 +322,12 @@ func (engine *IELTSSpeakingShadowEngine) evaluate(
 		IELTSSpeakingScoreabilityInsufficient {
 		return prepared.result, nil
 	}
-	if includeAcoustics && engine.acoustics != nil {
-		prepared, err = engine.withAcoustics(ctx, snapshot, prepared)
+	if acoustics != nil {
+		prepared, err = withFrozenIELTSAcoustics(
+			snapshot,
+			*acoustics,
+			prepared,
+		)
 		if err != nil {
 			return IELTSSpeakingShadowResult{}, err
 		}
@@ -366,31 +355,12 @@ func (engine *IELTSSpeakingShadowEngine) evaluate(
 	return result, nil
 }
 
-func (engine *IELTSSpeakingShadowEngine) withAcoustics(
-	ctx context.Context,
+func withFrozenIELTSAcoustics(
 	snapshot evidence.EvidenceSnapshot,
+	acoustics IELTSAcousticSnapshot,
 	prepared preparedIELTSSpeakingShadow,
 ) (preparedIELTSSpeakingShadow, error) {
-	requests := make(
-		[]IELTSSpeakingAcousticRequest,
-		0,
-		len(prepared.input.Questions),
-	)
-	for _, question := range prepared.input.Questions {
-		if question.Response == nil {
-			return preparedIELTSSpeakingShadow{}, evaluation.ErrInvalidRequest
-		}
-		requests = append(requests, IELTSSpeakingAcousticRequest{
-			TurnID:              question.Response.TurnID,
-			EvidenceRefID:       question.Response.EvidenceRefID,
-			RecordingDurationMS: question.Response.RecordingDurationMS,
-		})
-	}
-	values, err := engine.acoustics.GetIELTSSpeakingAcoustics(
-		ctx,
-		snapshot.OwnerUserID,
-		requests,
-	)
+	values, err := acoustics.assessedValues(snapshot)
 	if err != nil {
 		return preparedIELTSSpeakingShadow{}, err
 	}
@@ -398,15 +368,8 @@ func (engine *IELTSSpeakingShadowEngine) withAcoustics(
 		return prepared, nil
 	}
 	byTurn := make(map[string]IELTSSpeakingTurnAcoustics, len(values))
-	requestedTurns := make(map[string]struct{}, len(requests))
-	for _, request := range requests {
-		requestedTurns[request.TurnID] = struct{}{}
-	}
 	for _, value := range values {
 		if !validIELTSSpeakingTurnAcoustics(value) {
-			return preparedIELTSSpeakingShadow{}, evaluation.ErrInvalidRequest
-		}
-		if _, requested := requestedTurns[value.TurnID]; !requested {
 			return preparedIELTSSpeakingShadow{}, evaluation.ErrInvalidRequest
 		}
 		if _, duplicate := byTurn[value.TurnID]; duplicate {

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
@@ -58,18 +58,16 @@ func TestIELTSSpeakingShadowProducesHonestPartialResult(t *testing.T) {
 func TestIELTSSpeakingShadowProducesFourBandsAndOverallWithAcoustics(
 	t *testing.T,
 ) {
-	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	snapshot := ieltsSpeakingAcousticTestSnapshot(t)
 	provider := &ieltsProviderStub{}
-	acoustics := &ieltsAcousticSourceStub{}
-	result, err := NewIELTSSpeakingShadowEngineWithAcoustics(
-		provider,
-		acoustics,
-	).Evaluate(context.Background(), snapshot)
+	acoustics := ieltsAcousticSnapshotForTest(t, snapshot, ieltsTestQuestionCount)
+	result, err := NewIELTSSpeakingShadowEngine(provider).
+		EvaluateWithAcousticSnapshot(context.Background(), snapshot, acoustics)
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
-	if acoustics.calls != 1 || len(result.Criteria) != 4 {
-		t.Fatalf("acoustic calls = %d; result = %#v", acoustics.calls, result)
+	if len(result.Criteria) != 4 {
+		t.Fatalf("result = %#v", result)
 	}
 	for _, criterion := range result.Criteria {
 		if criterion.Scoreability != IELTSSpeakingScoreabilityProvisional ||
@@ -81,12 +79,11 @@ func TestIELTSSpeakingShadowProducesFourBandsAndOverallWithAcoustics(
 }
 
 func TestIELTSSpeakingShadowUsesVerifiedPartialAcousticCoverage(t *testing.T) {
-	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	snapshot := ieltsSpeakingAcousticTestSnapshot(t)
 	provider := &ieltsProviderStub{}
-	result, err := NewIELTSSpeakingShadowEngineWithAcoustics(
-		provider,
-		&ieltsAcousticSourceStub{limit: 4},
-	).Evaluate(context.Background(), snapshot)
+	acoustics := ieltsAcousticSnapshotForTest(t, snapshot, 4)
+	result, err := NewIELTSSpeakingShadowEngine(provider).
+		EvaluateWithAcousticSnapshot(context.Background(), snapshot, acoustics)
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -507,39 +504,6 @@ type ieltsProviderStub struct {
 	err     error
 	calls   int
 	input   IELTSSpeakingShadowProviderInput
-}
-
-type ieltsAcousticSourceStub struct {
-	calls int
-	limit int
-	err   error
-}
-
-func (source *ieltsAcousticSourceStub) GetIELTSSpeakingAcoustics(
-	_ context.Context,
-	_ string,
-	requests []IELTSSpeakingAcousticRequest,
-) ([]IELTSSpeakingTurnAcoustics, error) {
-	source.calls++
-	if source.err != nil {
-		return nil, source.err
-	}
-	result := make([]IELTSSpeakingTurnAcoustics, 0, len(requests))
-	for _, request := range requests {
-		if source.limit > 0 && len(result) == source.limit {
-			break
-		}
-		fluency := 76.0
-		result = append(result, IELTSSpeakingTurnAcoustics{
-			TurnID:               request.TurnID,
-			EvidenceRefID:        request.EvidenceRefID,
-			PronunciationScore:   72,
-			AcousticFluencyScore: &fluency,
-			Provider:             "xfyun_ise",
-			ProviderRun:          "run_fixture",
-		})
-	}
-	return result, nil
 }
 
 func (provider *ieltsProviderStub) AnalyzeIELTSSpeaking(

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -208,9 +208,12 @@ func (worker *IELTSSpeakingShadowWorker) ProcessPending(
 		worker.engine == nil || ctx == nil {
 		return IELTSSpeakingShadowSweepResult{}, evaluation.ErrInvalidRequest
 	}
+	var freezerErr error
 	if worker.freezer != nil {
-		if _, err := worker.freezer.ProcessPending(ctx, limit); err != nil {
-			return IELTSSpeakingShadowSweepResult{}, err
+		_, freezerErr = worker.freezer.ProcessPending(ctx, limit)
+		if errors.Is(freezerErr, context.Canceled) ||
+			errors.Is(freezerErr, context.DeadlineExceeded) || ctx.Err() != nil {
+			return IELTSSpeakingShadowSweepResult{}, freezerErr
 		}
 	}
 	sweep, err := processDurableSceneJobs(
@@ -239,12 +242,16 @@ func (worker *IELTSSpeakingShadowWorker) ProcessPending(
 			return durableSceneJobStatus(status), processErr
 		},
 	)
-	return IELTSSpeakingShadowSweepResult{
+	result := IELTSSpeakingShadowSweepResult{
 		Claimed:   sweep.Claimed,
 		Completed: sweep.Completed,
 		Retried:   sweep.Retried,
 		Failed:    sweep.Failed,
-	}, err
+	}
+	if err != nil {
+		return result, err
+	}
+	return result, freezerErr
 }
 
 func (worker *IELTSSpeakingShadowWorker) processClaim(

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -15,20 +15,23 @@ import (
 )
 
 type IELTSSpeakingShadowRuntimeConfiguration struct {
-	MaxAttempts     int
-	LeaseDuration   time.Duration
-	StrategyRef     string
-	PipelineVersion string
-	FullConfigHash  [sha256.Size]byte
-	PromptVersion   string
-	Provider        string
-	Model           string
+	MaxAttempts          int
+	LeaseDuration        time.Duration
+	AcousticWaitDuration time.Duration
+	StrategyRef          string
+	PipelineVersion      string
+	FullConfigHash       [sha256.Size]byte
+	PromptVersion        string
+	Provider             string
+	Model                string
 }
 
 func (configuration IELTSSpeakingShadowRuntimeConfiguration) Valid() bool {
-	return durableConfigurationFromIELTS(configuration).valid(
-		ieltsDurableSceneJobSpec,
-	)
+	return configuration.AcousticWaitDuration >= time.Second &&
+		configuration.AcousticWaitDuration <= 10*time.Minute &&
+		durableConfigurationFromIELTS(configuration).valid(
+			ieltsDurableSceneJobSpec,
+		)
 }
 
 type IELTSSpeakingShadowClaim struct {
@@ -48,12 +51,17 @@ type IELTSSpeakingShadowClaim struct {
 	Provider             string
 	Model                string
 	Snapshot             evidence.EvidenceSnapshot
+	AcousticSnapshot     IELTSAcousticSnapshot
+	InputBundleHash      [sha256.Size]byte
 }
 
 func (claim IELTSSpeakingShadowClaim) Valid() bool {
-	return durableClaimFromIELTS(claim).valid(
-		ieltsDurableSceneJobSpec,
-	)
+	return !claim.AcousticSnapshot.CreatedAt.IsZero() &&
+		claim.AcousticSnapshot.ValidFor(claim.Snapshot) &&
+		claim.InputBundleHash == IELTSAcousticInputBundleHash(
+			claim.Snapshot,
+			claim.AcousticSnapshot,
+		) && durableClaimFromIELTS(claim).valid(ieltsDurableSceneJobSpec)
 }
 
 type IELTSSpeakingShadowFailure struct {
@@ -145,9 +153,8 @@ type IELTSSpeakingShadowWorker struct {
 	repository    IELTSSpeakingShadowRuntimeRepository
 	engine        *IELTSSpeakingShadowEngine
 	configuration IELTSSpeakingShadowRuntimeConfiguration
+	freezer       *IELTSAcousticSnapshotFreezer
 }
-
-const ieltsProviderAttemptReserve = 3
 
 func NewIELTSSpeakingShadowWorker(
 	repository IELTSSpeakingShadowRuntimeRepository,
@@ -164,6 +171,35 @@ func NewIELTSSpeakingShadowWorker(
 	}, nil
 }
 
+func NewIELTSSpeakingShadowWorkerWithAcousticSnapshots(
+	repository interface {
+		IELTSSpeakingShadowRuntimeRepository
+		IELTSAcousticSnapshotRepository
+	},
+	engine *IELTSSpeakingShadowEngine,
+	configuration IELTSSpeakingShadowRuntimeConfiguration,
+	source IELTSSpeakingAcousticSource,
+) (*IELTSSpeakingShadowWorker, error) {
+	worker, err := NewIELTSSpeakingShadowWorker(
+		repository,
+		engine,
+		configuration,
+	)
+	if err != nil {
+		return nil, err
+	}
+	freezer, err := NewIELTSAcousticSnapshotFreezer(
+		repository,
+		source,
+		configuration.AcousticWaitDuration,
+	)
+	if err != nil {
+		return nil, err
+	}
+	worker.freezer = freezer
+	return worker, nil
+}
+
 func (worker *IELTSSpeakingShadowWorker) ProcessPending(
 	ctx context.Context,
 	limit int,
@@ -171,6 +207,11 @@ func (worker *IELTSSpeakingShadowWorker) ProcessPending(
 	if worker == nil || worker.repository == nil ||
 		worker.engine == nil || ctx == nil {
 		return IELTSSpeakingShadowSweepResult{}, evaluation.ErrInvalidRequest
+	}
+	if worker.freezer != nil {
+		if _, err := worker.freezer.ProcessPending(ctx, limit); err != nil {
+			return IELTSSpeakingShadowSweepResult{}, err
+		}
 	}
 	sweep, err := processDurableSceneJobs(
 		ctx,
@@ -217,18 +258,11 @@ func (worker *IELTSSpeakingShadowWorker) processClaim(
 		) {
 		return "", evaluation.ErrInvalidRequest
 	}
-	result, err := worker.engine.Evaluate(ctx, claim.Snapshot)
-	if err != nil {
-		if errors.Is(err, ErrIELTSSpeakingAcousticsPending) &&
-			claim.AttemptCount > ieltsAcousticWaitAttemptLimit(
-				worker.configuration.MaxAttempts,
-			) {
-			result, err = worker.engine.evaluateWithoutAcoustics(
-				ctx,
-				claim.Snapshot,
-			)
-		}
-	}
+	result, err := worker.engine.EvaluateWithAcousticSnapshot(
+		ctx,
+		claim.Snapshot,
+		claim.AcousticSnapshot,
+	)
 	if err != nil {
 		return worker.recordFailure(ctx, claim, err)
 	}
@@ -255,17 +289,6 @@ func (worker *IELTSSpeakingShadowWorker) processClaim(
 		return "", err
 	}
 	return IELTSSpeakingShadowRuntimeReady, nil
-}
-
-func ieltsAcousticWaitAttemptLimit(maxAttempts int) int {
-	if maxAttempts <= 1 {
-		return 0
-	}
-	providerAttempts := min(
-		ieltsProviderAttemptReserve,
-		maxAttempts-1,
-	)
-	return maxAttempts - providerAttempts
 }
 
 func (worker *IELTSSpeakingShadowWorker) recordFailure(
@@ -329,11 +352,6 @@ func classifyIELTSSpeakingShadowFailure(
 	cause error,
 ) IELTSSpeakingShadowFailure {
 	switch {
-	case errors.Is(cause, ErrIELTSSpeakingAcousticsPending):
-		return IELTSSpeakingShadowFailure{
-			Code:      "acoustics_pending",
-			Retryable: true,
-		}
 	case errors.Is(cause, errIELTSSpeakingProviderInvalidJSON):
 		return IELTSSpeakingShadowFailure{
 			Code:      "provider_invalid_json",

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -60,6 +60,21 @@ func TestIELTSSpeakingShadowWorkerCompletesInsufficientEvidenceResult(
 		t,
 		"Yes, yes. 666 这是中文。",
 	)
+	var err error
+	claim.AcousticSnapshot, err = BuildIELTSAcousticSnapshot(
+		claim.EvaluationID,
+		claim.Snapshot,
+		IELTSSpeakingAcousticRead{},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim.AcousticSnapshot.CreatedAt = time.Now().UTC()
+	claim.InputBundleHash = IELTSAcousticInputBundleHash(
+		claim.Snapshot,
+		claim.AcousticSnapshot,
+	)
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:    claim,
 		acquired: true,
@@ -136,7 +151,7 @@ func TestIELTSSpeakingShadowWorkerRetriesTechnicalFailure(
 	}
 }
 
-func TestIELTSSpeakingShadowWorkerRetriesPendingAcoustics(
+func TestIELTSSpeakingShadowWorkerRetryUsesIdenticalFrozenProviderInput(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -146,103 +161,29 @@ func TestIELTSSpeakingShadowWorkerRetriesPendingAcoustics(
 		acquired:   true,
 		failStatus: IELTSSpeakingShadowRuntimePending,
 	}
+	provider := &ieltsRetryProviderStub{failFirst: true}
 	worker, err := NewIELTSSpeakingShadowWorker(
 		repository,
-		NewIELTSSpeakingShadowEngineWithAcoustics(
-			&ieltsProviderStub{},
-			&ieltsAcousticSourceStub{
-				err: ErrIELTSSpeakingAcousticsPending,
-			},
-		),
+		NewIELTSSpeakingShadowEngine(provider),
 		validIELTSSpeakingShadowRuntimeConfiguration(),
 	)
 	if err != nil {
-		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
+		t.Fatal(err)
 	}
-	sweep, err := worker.ProcessPending(context.Background(), 1)
-	if err != nil {
-		t.Fatalf("ProcessPending: %v", err)
+	first, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil || first.Retried != 1 {
+		t.Fatalf("first=%#v err=%v", first, err)
 	}
-	if sweep.Retried != 1 || repository.failCalls != 1 ||
-		repository.failure.Code != "acoustics_pending" ||
-		!repository.failure.Retryable || repository.completeCalls != 0 {
-		t.Fatalf("sweep = %#v; repository = %#v", sweep, repository)
+	repository.claim.AttemptCount = 2
+	repository.claim.FencingToken = 2
+	repository.acquired = true
+	second, err := worker.ProcessPending(context.Background(), 1)
+	if err != nil || second.Completed != 1 {
+		t.Fatalf("second=%#v err=%v", second, err)
 	}
-}
-
-func TestIELTSSpeakingShadowWorkerFallsBackAfterAcousticWaitExhaustion(
-	t *testing.T,
-) {
-	t.Parallel()
-	claim := validIELTSSpeakingShadowClaim(t)
-	claim.AttemptCount = 3
-	repository := &ieltsShadowRuntimeRepositoryStub{
-		claim:    claim,
-		acquired: true,
-	}
-	worker, err := NewIELTSSpeakingShadowWorker(
-		repository,
-		NewIELTSSpeakingShadowEngineWithAcoustics(
-			&ieltsProviderStub{},
-			&ieltsAcousticSourceStub{
-				err: ErrIELTSSpeakingAcousticsPending,
-			},
-		),
-		validIELTSSpeakingShadowRuntimeConfiguration(),
-	)
-	if err != nil {
-		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
-	}
-	sweep, err := worker.ProcessPending(context.Background(), 1)
-	if err != nil {
-		t.Fatalf("ProcessPending: %v", err)
-	}
-	if sweep.Completed != 1 || repository.completeCalls != 1 ||
-		repository.failCalls != 0 ||
-		repository.result.Criteria[3].EstimatedBand != nil {
-		t.Fatalf("sweep = %#v; repository = %#v", sweep, repository)
-	}
-}
-
-func TestIELTSSpeakingShadowWorkerReservesProviderRetryAfterAcousticWait(
-	t *testing.T,
-) {
-	t.Parallel()
-	claim := validIELTSSpeakingShadowClaim(t)
-	claim.AttemptCount = 2
-	repository := &ieltsShadowRuntimeRepositoryStub{
-		claim:      claim,
-		acquired:   true,
-		failStatus: IELTSSpeakingShadowRuntimePending,
-	}
-	provider := &ieltsProviderStub{err: context.DeadlineExceeded}
-	worker, err := NewIELTSSpeakingShadowWorker(
-		repository,
-		NewIELTSSpeakingShadowEngineWithAcoustics(
-			provider,
-			&ieltsAcousticSourceStub{
-				err: ErrIELTSSpeakingAcousticsPending,
-			},
-		),
-		validIELTSSpeakingShadowRuntimeConfiguration(),
-	)
-	if err != nil {
-		t.Fatalf("NewIELTSSpeakingShadowWorker: %v", err)
-	}
-	sweep, err := worker.ProcessPending(context.Background(), 1)
-	if err != nil {
-		t.Fatalf("ProcessPending: %v", err)
-	}
-	if sweep.Retried != 1 || provider.calls != 1 ||
-		repository.failCalls != 1 ||
-		repository.failure.Code != "provider_timeout" ||
-		!repository.failure.Retryable {
-		t.Fatalf(
-			"sweep = %#v; provider calls = %d; failure = %#v",
-			sweep,
-			provider.calls,
-			repository.failure,
-		)
+	if len(provider.inputs) != 2 ||
+		!bytes.Equal(provider.inputs[0], provider.inputs[1]) {
+		t.Fatalf("provider inputs changed: %q %q", provider.inputs[0], provider.inputs[1])
 	}
 }
 
@@ -412,10 +353,11 @@ func (failure ieltsGenerationFailureStub) Retryable() bool {
 
 func validIELTSSpeakingShadowRuntimeConfiguration() IELTSSpeakingShadowRuntimeConfiguration {
 	return IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     3,
-		LeaseDuration:   time.Minute,
-		StrategyRef:     IELTSSpeakingShadowStrategyRef,
-		PipelineVersion: IELTSSpeakingShadowPipelineVersion,
+		MaxAttempts:          3,
+		LeaseDuration:        time.Minute,
+		AcousticWaitDuration: 15 * time.Second,
+		StrategyRef:          IELTSSpeakingShadowStrategyRef,
+		PipelineVersion:      IELTSSpeakingShadowPipelineVersion,
 		FullConfigHash: sha256.Sum256(
 			[]byte("ielts-shadow-config-v1"),
 		),
@@ -430,6 +372,17 @@ func validIELTSSpeakingShadowClaim(
 ) IELTSSpeakingShadowClaim {
 	t.Helper()
 	configuration := validIELTSSpeakingShadowRuntimeConfiguration()
+	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	acoustics, err := BuildIELTSAcousticSnapshot(
+		testEvalID,
+		snapshot,
+		IELTSSpeakingAcousticRead{},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acoustics.CreatedAt = time.Now().UTC()
 	return IELTSSpeakingShadowClaim{
 		OutboxID:             "61000000-0000-4000-8000-000000000006",
 		ModuleRunID:          "71000000-0000-4000-8000-000000000007",
@@ -446,9 +399,11 @@ func validIELTSSpeakingShadowClaim(
 		PromptVersion:        configuration.PromptVersion,
 		Provider:             configuration.Provider,
 		Model:                configuration.Model,
-		Snapshot: ieltsSpeakingTestSnapshot(
-			t,
-			ieltsTestQuestionCount,
+		Snapshot:             snapshot,
+		AcousticSnapshot:     acoustics,
+		InputBundleHash: IELTSAcousticInputBundleHash(
+			snapshot,
+			acoustics,
 		),
 	}
 }
@@ -464,6 +419,27 @@ type ieltsShadowRuntimeRepositoryStub struct {
 	failCalls     int
 	result        IELTSSpeakingShadowResult
 	failure       IELTSSpeakingShadowFailure
+}
+
+type ieltsRetryProviderStub struct {
+	failFirst bool
+	inputs    [][]byte
+}
+
+func (stub *ieltsRetryProviderStub) AnalyzeIELTSSpeaking(
+	ctx context.Context,
+	input IELTSSpeakingShadowProviderInput,
+) (IELTSSpeakingShadowProviderResult, error) {
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		return IELTSSpeakingShadowProviderResult{}, err
+	}
+	stub.inputs = append(stub.inputs, encoded)
+	if stub.failFirst {
+		stub.failFirst = false
+		return IELTSSpeakingShadowProviderResult{}, context.DeadlineExceeded
+	}
+	return (&ieltsProviderStub{}).AnalyzeIELTSSpeaking(ctx, input)
 }
 
 func (stub *ieltsShadowRuntimeRepositoryStub) ClaimIELTSSpeakingShadow(

--- a/server/internal/coaching/evaluation/scoring/runtime.go
+++ b/server/internal/coaching/evaluation/scoring/runtime.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	runtimeLeaseDuration = 60 * time.Second
-	runtimeRetryDelay    = 5 * time.Second
-	runtimeMaxAttempts   = 3
+	runtimeLeaseDuration             = 60 * time.Second
+	runtimeRetryDelay                = 5 * time.Second
+	runtimeMaxAttempts               = 3
+	runtimeIELTSAcousticWaitDuration = 15 * time.Second
 )
 
 type Configuration struct {
@@ -65,6 +66,7 @@ func (configuration Configuration) valid() bool {
 type RuntimeRepository interface {
 	InterviewShadowRuntimeRepository
 	IELTSSpeakingShadowRuntimeRepository
+	IELTSAcousticSnapshotRepository
 	GeneralSceneRuntimeRepository
 }
 
@@ -86,27 +88,6 @@ type Runtime struct {
 	ieltsConfiguration     IELTSSpeakingShadowRuntimeConfiguration
 }
 
-func NewRuntime(
-	repository RuntimeRepository,
-	completions practice.CompletionHandoffRepository,
-	evidenceService RuntimeEvidence,
-	evaluationService RuntimeEvaluations,
-	textGenerator TextGenerator,
-	policies *EvaluationPolicyRegistry,
-	configuration Configuration,
-) (*Runtime, error) {
-	return NewRuntimeWithIELTSAcoustics(
-		repository,
-		completions,
-		evidenceService,
-		evaluationService,
-		textGenerator,
-		policies,
-		configuration,
-		nil,
-	)
-}
-
 func NewRuntimeWithIELTSAcoustics(
 	repository RuntimeRepository,
 	completions practice.CompletionHandoffRepository,
@@ -119,6 +100,7 @@ func NewRuntimeWithIELTSAcoustics(
 ) (*Runtime, error) {
 	if repository == nil || completions == nil || evidenceService == nil ||
 		evaluationService == nil || textGenerator == nil || policies == nil ||
+		acoustics == nil ||
 		!configuration.valid() {
 		return nil, evaluation.ErrInvalidRequest
 	}
@@ -158,16 +140,11 @@ func NewRuntimeWithIELTSAcoustics(
 		return nil, err
 	}
 	ieltsEngine := NewIELTSSpeakingShadowEngine(ieltsProvider)
-	if acoustics != nil {
-		ieltsEngine = NewIELTSSpeakingShadowEngineWithAcoustics(
-			ieltsProvider,
-			acoustics,
-		)
-	}
-	ieltsWorker, err := NewIELTSSpeakingShadowWorker(
+	ieltsWorker, err := NewIELTSSpeakingShadowWorkerWithAcousticSnapshots(
 		repository,
 		ieltsEngine,
 		ieltsConfiguration,
+		acoustics,
 	)
 	if err != nil {
 		return nil, err
@@ -412,14 +389,15 @@ func ieltsRuntimeConfiguration(
 		return IELTSSpeakingShadowRuntimeConfiguration{}, err
 	}
 	result := IELTSSpeakingShadowRuntimeConfiguration{
-		MaxAttempts:     configuration.maxAttempts,
-		LeaseDuration:   configuration.leaseDuration,
-		StrategyRef:     IELTSSpeakingShadowStrategyRef,
-		PipelineVersion: IELTSSpeakingShadowPipelineVersion,
-		FullConfigHash:  sha256.Sum256(encoded),
-		PromptVersion:   IELTSSpeakingShadowPromptVersion,
-		Provider:        configuration.provider,
-		Model:           configuration.model,
+		MaxAttempts:          configuration.maxAttempts,
+		LeaseDuration:        configuration.leaseDuration,
+		AcousticWaitDuration: runtimeIELTSAcousticWaitDuration,
+		StrategyRef:          IELTSSpeakingShadowStrategyRef,
+		PipelineVersion:      IELTSSpeakingShadowPipelineVersion,
+		FullConfigHash:       sha256.Sum256(encoded),
+		PromptVersion:        IELTSSpeakingShadowPromptVersion,
+		Provider:             configuration.provider,
+		Model:                configuration.model,
 	}
 	if !result.Valid() {
 		return IELTSSpeakingShadowRuntimeConfiguration{}, evaluation.ErrInvalidRequest

--- a/server/internal/coaching/evaluation/scoring/runtime.go
+++ b/server/internal/coaching/evaluation/scoring/runtime.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	runtimeLeaseDuration             = 60 * time.Second
-	runtimeRetryDelay                = 5 * time.Second
-	runtimeMaxAttempts               = 3
-	runtimeIELTSAcousticWaitDuration = 15 * time.Second
+	runtimeLeaseDuration = 60 * time.Second
+	runtimeRetryDelay    = 5 * time.Second
+	runtimeMaxAttempts   = 3
 )
 
 type Configuration struct {
@@ -391,7 +390,7 @@ func ieltsRuntimeConfiguration(
 	result := IELTSSpeakingShadowRuntimeConfiguration{
 		MaxAttempts:          configuration.maxAttempts,
 		LeaseDuration:        configuration.leaseDuration,
-		AcousticWaitDuration: runtimeIELTSAcousticWaitDuration,
+		AcousticWaitDuration: IELTSAcousticSnapshotWaitDurationV1,
 		StrategyRef:          IELTSSpeakingShadowStrategyRef,
 		PipelineVersion:      IELTSSpeakingShadowPipelineVersion,
 		FullConfigHash:       sha256.Sum256(encoded),

--- a/server/internal/coaching/evaluation/scoring/runtime_test.go
+++ b/server/internal/coaching/evaluation/scoring/runtime_test.go
@@ -1,6 +1,9 @@
 package scoring
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	t.Parallel()
@@ -38,6 +41,14 @@ func TestRuntimeConfigurationsAreDeterministic(t *testing.T) {
 	}
 	if firstIELTS.MaxAttempts != runtimeMaxAttempts {
 		t.Fatalf("IELTS max attempts = %d", firstIELTS.MaxAttempts)
+	}
+	if firstIELTS.AcousticWaitDuration !=
+		IELTSAcousticSnapshotWaitDurationV1 ||
+		IELTSAcousticSnapshotWaitDurationV1 != 120*time.Second {
+		t.Fatalf(
+			"IELTS acoustic wait = %s",
+			firstIELTS.AcousticWaitDuration,
+		)
 	}
 
 	firstGeneral, err := generalRuntimeConfiguration(configuration)

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
@@ -19,6 +20,7 @@ type ieltsSpeakingAcousticProjection struct {
 	AudioAssetID      string
 	AudioAssetVersion int64
 	AudioChecksum     string
+	CompletedAt       time.Time
 	Assessment        SpeechFeedbackAcousticAssessment
 }
 
@@ -47,8 +49,10 @@ func (source *ieltsSpeakingAcousticSource) ReadIELTSSpeakingAcoustics(
 	ctx context.Context,
 	ownerUserID string,
 	requests []scoring.IELTSSpeakingAcousticRequest,
+	completedBy time.Time,
 ) (scoring.IELTSSpeakingAcousticRead, error) {
-	if source == nil || source.feedback == nil || ctx == nil {
+	if source == nil || source.feedback == nil || ctx == nil ||
+		completedBy.IsZero() {
 		return scoring.IELTSSpeakingAcousticRead{}, evaluation.ErrInvalidRequest
 	}
 	result := scoring.IELTSSpeakingAcousticRead{
@@ -96,6 +100,13 @@ func (source *ieltsSpeakingAcousticSource) ReadIELTSSpeakingAcoustics(
 				"evaluation speech feedback: unsupported feedback status",
 			)
 		}
+		if projection.CompletedAt.IsZero() {
+			return scoring.IELTSSpeakingAcousticRead{},
+				ErrInvalidSpeechFeedback
+		}
+		if projection.CompletedAt.After(completedBy) {
+			continue
+		}
 		assessment := projection.Assessment
 		if assessment.Pronunciation != SpeechFeedbackAssessed ||
 			assessment.AcousticFluency != SpeechFeedbackAssessed {
@@ -137,6 +148,7 @@ func (r *PostgresRepository) ReadIELTSSpeakingAcousticProjection(
 	}
 	var projection ieltsSpeakingAcousticProjection
 	var (
+		completedAt   sql.NullTime
 		accuracy      sql.NullFloat64
 		fluency       sql.NullFloat64
 		integrity     sql.NullFloat64
@@ -149,6 +161,7 @@ func (r *PostgresRepository) ReadIELTSSpeakingAcousticProjection(
 	err := r.pool.QueryRow(ctx, `
 		SELECT
 			feedback.feedback_status,
+			feedback.completed_at,
 			snapshot.input_revision,
 			snapshot.audio_asset_id,
 			snapshot.audio_asset_version,
@@ -173,6 +186,7 @@ func (r *PostgresRepository) ReadIELTSSpeakingAcousticProjection(
 		  AND snapshot.turn_id = $2
 	`, ownerUserID, turnID).Scan(
 		&projection.FeedbackStatus,
+		&completedAt,
 		&projection.EvidenceVersion,
 		&projection.AudioAssetID,
 		&projection.AudioAssetVersion,
@@ -194,6 +208,9 @@ func (r *PostgresRepository) ReadIELTSSpeakingAcousticProjection(
 			"read IELTS Speaking acoustic projection: %w",
 			err,
 		)
+	}
+	if completedAt.Valid {
+		projection.CompletedAt = completedAt.Time
 	}
 	if provider.Valid {
 		projection.Assessment = SpeechFeedbackAcousticAssessment{

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
@@ -79,7 +79,7 @@ func (source *ieltsSpeakingAcousticSource) ReadIELTSSpeakingAcoustics(
 			projection.AudioAssetVersion != int64(request.AudioAssetVersion) ||
 			projection.AudioChecksum != request.AudioChecksumSHA256 {
 			return scoring.IELTSSpeakingAcousticRead{},
-				evaluation.ErrInvalidRequest
+				scoring.ErrIELTSAcousticEvidenceInvalid
 		}
 		switch projection.FeedbackStatus {
 		case SpeechFeedbackQueued, SpeechFeedbackRunning:

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics.go
@@ -3,24 +3,31 @@ package speechfeedback
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
+	"github.com/jackc/pgx/v5"
 )
 
+type ieltsSpeakingAcousticProjection struct {
+	FeedbackStatus    SpeechFeedbackStatus
+	EvidenceVersion   int64
+	AudioAssetID      string
+	AudioAssetVersion int64
+	AudioChecksum     string
+	Assessment        SpeechFeedbackAcousticAssessment
+}
+
 type IELTSSpeakingFeedbackReader interface {
-	FindSpeechFeedbackByConversationTurn(
+	ReadIELTSSpeakingAcousticProjection(
 		context.Context,
 		string,
 		string,
-	) (SpeechFeedbackReference, bool, error)
-	GetSpeechFeedback(
-		context.Context,
-		string,
-		string,
-	) (SpeechFeedback, error)
+	) (ieltsSpeakingAcousticProjection, bool, error)
 }
 
 type ieltsSpeakingAcousticSource struct {
@@ -36,61 +43,60 @@ func NewIELTSSpeakingAcousticSource(
 	return &ieltsSpeakingAcousticSource{feedback: feedback}, nil
 }
 
-func (source *ieltsSpeakingAcousticSource) GetIELTSSpeakingAcoustics(
+func (source *ieltsSpeakingAcousticSource) ReadIELTSSpeakingAcoustics(
 	ctx context.Context,
 	ownerUserID string,
 	requests []scoring.IELTSSpeakingAcousticRequest,
-) ([]scoring.IELTSSpeakingTurnAcoustics, error) {
+) (scoring.IELTSSpeakingAcousticRead, error) {
 	if source == nil || source.feedback == nil || ctx == nil {
-		return nil, evaluation.ErrInvalidRequest
+		return scoring.IELTSSpeakingAcousticRead{}, evaluation.ErrInvalidRequest
 	}
-	result := make(
-		[]scoring.IELTSSpeakingTurnAcoustics,
-		0,
-		len(requests),
-	)
-	pending := false
-	var readyDurationMS int64
+	result := scoring.IELTSSpeakingAcousticRead{
+		Values: make([]scoring.IELTSSpeakingTurnAcoustics, 0, len(requests)),
+	}
 	for _, request := range requests {
-		reference, found, err :=
-			source.feedback.FindSpeechFeedbackByConversationTurn(
+		if request.RecordingDurationMS == 0 {
+			continue
+		}
+		projection, found, err := source.feedback.
+			ReadIELTSSpeakingAcousticProjection(
 				ctx,
 				ownerUserID,
 				request.TurnID,
 			)
 		if err != nil {
-			return nil, err
+			return scoring.IELTSSpeakingAcousticRead{}, err
 		}
 		if !found {
-			// A confirmed recording normally creates SpeechFeedback in the same
-			// turn flow. Treat a missing projection as a short-lived race; text-only
-			// turns remain valid evidence and do not wait for an impossible row.
-			if request.RecordingDurationMS > 0 {
-				pending = true
-			}
+			result.PendingTurnIDs = append(
+				result.PendingTurnIDs,
+				request.TurnID,
+			)
 			continue
 		}
-		feedback, err := source.feedback.GetSpeechFeedback(
-			ctx,
-			ownerUserID,
-			reference.SpeechFeedbackID,
-		)
-		if err != nil {
-			return nil, err
+		if projection.EvidenceVersion != request.EvidenceVersion ||
+			projection.AudioAssetID != request.AudioAssetID ||
+			projection.AudioAssetVersion != int64(request.AudioAssetVersion) ||
+			projection.AudioChecksum != request.AudioChecksumSHA256 {
+			return scoring.IELTSSpeakingAcousticRead{},
+				evaluation.ErrInvalidRequest
 		}
-		switch feedback.FeedbackStatus {
+		switch projection.FeedbackStatus {
 		case SpeechFeedbackQueued, SpeechFeedbackRunning:
-			pending = true
+			result.PendingTurnIDs = append(
+				result.PendingTurnIDs,
+				request.TurnID,
+			)
 			continue
 		case SpeechFeedbackFailed:
 			continue
 		case SpeechFeedbackReady:
 		default:
-			return nil, errors.New(
+			return scoring.IELTSSpeakingAcousticRead{}, errors.New(
 				"evaluation speech feedback: unsupported feedback status",
 			)
 		}
-		assessment := feedback.AcousticAssessment
+		assessment := projection.Assessment
 		if assessment.Pronunciation != SpeechFeedbackAssessed ||
 			assessment.AcousticFluency != SpeechFeedbackAssessed {
 			continue
@@ -104,29 +110,132 @@ func (source *ieltsSpeakingAcousticSource) GetIELTSSpeakingAcoustics(
 				assessment.SpeakingSpeedWPM == nil) {
 			continue
 		}
-		result = append(result, scoring.IELTSSpeakingTurnAcoustics{
+		result.Values = append(result.Values, scoring.IELTSSpeakingTurnAcoustics{
 			TurnID:               request.TurnID,
 			EvidenceRefID:        request.EvidenceRefID,
 			PronunciationScore:   *pronunciation,
 			AcousticFluencyScore: assessment.FluencyScore,
 			SpeakingSpeedWPM:     assessment.SpeakingSpeedWPM,
 			Provider:             assessment.Provider,
-			ProviderRun:          acousticProviderRun(assessment.ProviderSession),
+			ProviderRun: acousticProviderRunHash(
+				assessment.ProviderSession,
+			),
 		})
-		readyDurationMS += request.RecordingDurationMS
-	}
-	if pending && !scoring.HasSufficientIELTSSpeakingAcousticCoverage(
-		readyDurationMS,
-		len(result),
-	) {
-		return nil, scoring.ErrIELTSSpeakingAcousticsPending
 	}
 	return result, nil
 }
 
-func acousticProviderRun(providerSession string) string {
+func (r *PostgresRepository) ReadIELTSSpeakingAcousticProjection(
+	ctx context.Context,
+	ownerUserID string,
+	turnID string,
+) (ieltsSpeakingAcousticProjection, bool, error) {
+	if r == nil || r.pool == nil || ctx == nil || !validUUID(ownerUserID) ||
+		!validSpeechFeedbackIdentifier(turnID) {
+		return ieltsSpeakingAcousticProjection{}, false,
+			ErrInvalidSpeechFeedback
+	}
+	var projection ieltsSpeakingAcousticProjection
+	var (
+		accuracy      sql.NullFloat64
+		fluency       sql.NullFloat64
+		integrity     sql.NullFloat64
+		pronunciation sql.NullFloat64
+		speed         sql.NullFloat64
+		provider      sql.NullString
+		providerRun   sql.NullString
+		category      sql.NullString
+	)
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			feedback.feedback_status,
+			snapshot.input_revision,
+			snapshot.audio_asset_id,
+			snapshot.audio_asset_version,
+			snapshot.audio_checksum_sha256,
+			acoustic.accuracy_score,
+			acoustic.fluency_score,
+			acoustic.integrity_score,
+			acoustic.phone_score,
+			acoustic.speaking_speed_wpm,
+			acoustic.provider,
+			acoustic.provider_session_id,
+			acoustic.category
+		FROM evaluation_speech_feedback_turn_snapshots AS snapshot
+		JOIN evaluation_speech_feedbacks AS feedback
+		  ON feedback.owner_user_id = snapshot.owner_user_id
+		 AND feedback.evidence_snapshot_id = snapshot.id
+		 AND feedback.turn_id = snapshot.turn_id
+		LEFT JOIN evaluation_speech_feedback_acoustic_evidence AS acoustic
+		  ON acoustic.owner_user_id = feedback.owner_user_id
+		 AND acoustic.speech_feedback_id = feedback.id
+		WHERE snapshot.owner_user_id = $1
+		  AND snapshot.turn_id = $2
+	`, ownerUserID, turnID).Scan(
+		&projection.FeedbackStatus,
+		&projection.EvidenceVersion,
+		&projection.AudioAssetID,
+		&projection.AudioAssetVersion,
+		&projection.AudioChecksum,
+		&accuracy,
+		&fluency,
+		&integrity,
+		&pronunciation,
+		&speed,
+		&provider,
+		&providerRun,
+		&category,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ieltsSpeakingAcousticProjection{}, false, nil
+	}
+	if err != nil {
+		return ieltsSpeakingAcousticProjection{}, false, fmt.Errorf(
+			"read IELTS Speaking acoustic projection: %w",
+			err,
+		)
+	}
+	if provider.Valid {
+		projection.Assessment = SpeechFeedbackAcousticAssessment{
+			Pronunciation:      SpeechFeedbackAssessed,
+			AcousticFluency:    SpeechFeedbackAssessed,
+			FluencyScore:       nullableFloat64(fluency),
+			IntegrityScore:     nullableFloat64(integrity),
+			PronunciationScore: nullableFloat64(pronunciation),
+			SpeakingSpeedWPM:   nullableFloat64(speed),
+			Provider:           provider.String,
+			ProviderSession:    providerRun.String,
+			Category:           category.String,
+			Notice:             SpeechFeedbackAcousticNotice,
+		}
+		if category.String == "topic" {
+			projection.Assessment.SemanticScore = nullableFloat64(accuracy)
+		} else {
+			projection.Assessment.AccuracyScore = nullableFloat64(accuracy)
+			projection.Assessment.Integrity = SpeechFeedbackAssessed
+		}
+		if !projection.Assessment.valid() {
+			return ieltsSpeakingAcousticProjection{}, false,
+				ErrInvalidSpeechFeedback
+		}
+	} else {
+		projection.Assessment = unavailableSpeechFeedbackAcoustics()
+	}
+	return projection, true, nil
+}
+
+func nullableFloat64(value sql.NullFloat64) *float64 {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Float64
+	return &result
+}
+
+func acousticProviderRunHash(providerSession string) string {
 	digest := sha256.Sum256([]byte(providerSession))
 	return "run_" + hex.EncodeToString(digest[:12])
 }
 
 var _ scoring.IELTSSpeakingAcousticSource = (*ieltsSpeakingAcousticSource)(nil)
+var _ IELTSSpeakingFeedbackReader = (*PostgresRepository)(nil)

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
@@ -3,6 +3,7 @@ package speechfeedback
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
@@ -18,95 +19,61 @@ func TestNewIELTSSpeakingAcousticSourceRejectsNilReader(t *testing.T) {
 	}
 }
 
-func TestIELTSSpeakingAcousticSourceAcceptsSentenceAssessment(t *testing.T) {
+func TestIELTSSpeakingAcousticSourceReturnsVersionBoundAssessment(t *testing.T) {
+	request := ieltsAcousticRequestFixture()
 	accuracy := 74.0
 	fluency := 68.0
 	reader := &ieltsSpeakingFeedbackReaderStub{
-		feedback: SpeechFeedback{
-			FeedbackStatus: SpeechFeedbackReady,
-			AcousticAssessment: SpeechFeedbackAcousticAssessment{
-				Pronunciation:   SpeechFeedbackAssessed,
-				AcousticFluency: SpeechFeedbackAssessed,
-				AccuracyScore:   &accuracy,
-				FluencyScore:    &fluency,
-				Provider:        "xfyun_ise",
-				ProviderSession: "session-1",
-			},
-		},
-	}
-	source, err := NewIELTSSpeakingAcousticSource(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	values, err := source.GetIELTSSpeakingAcoustics(
-		context.Background(),
-		"10000000-0000-4000-8000-000000000001",
-		[]scoring.IELTSSpeakingAcousticRequest{{
-			TurnID:        "turn_1",
-			EvidenceRefID: "evidence_1",
-		}},
-	)
-	if err != nil {
-		t.Fatalf("GetIELTSSpeakingAcoustics: %v", err)
-	}
-	if len(values) != 1 || values[0].PronunciationScore != accuracy ||
-		values[0].AcousticFluencyScore == nil ||
-		*values[0].AcousticFluencyScore != fluency ||
-		values[0].SpeakingSpeedWPM != nil {
-		t.Fatalf("acoustics = %#v", values)
-	}
-}
-
-func TestIELTSSpeakingAcousticSourceKeepsValidPartialEvidence(t *testing.T) {
-	accuracy := 82.0
-	fluency := 79.0
-	reader := &ieltsSpeakingFeedbackReaderStub{
-		referenceByTurn: map[string]string{
-			"turn_ready":  "feedback_ready",
-			"turn_failed": "feedback_failed",
-		},
-		feedbackByID: map[string]SpeechFeedback{
-			"feedback_ready": {
-				FeedbackStatus: SpeechFeedbackReady,
-				AcousticAssessment: SpeechFeedbackAcousticAssessment{
+		projections: map[string]ieltsSpeakingAcousticProjection{
+			request.TurnID: {
+				FeedbackStatus:    SpeechFeedbackReady,
+				EvidenceVersion:   request.EvidenceVersion,
+				AudioAssetID:      request.AudioAssetID,
+				AudioAssetVersion: int64(request.AudioAssetVersion),
+				AudioChecksum:     request.AudioChecksumSHA256,
+				Assessment: SpeechFeedbackAcousticAssessment{
 					Pronunciation:   SpeechFeedbackAssessed,
 					AcousticFluency: SpeechFeedbackAssessed,
 					AccuracyScore:   &accuracy,
 					FluencyScore:    &fluency,
 					Provider:        "xfyun_ise",
-					ProviderSession: "session-ready",
+					ProviderSession: "secret-provider-session",
 				},
 			},
-			"feedback_failed": {FeedbackStatus: SpeechFeedbackFailed},
 		},
 	}
 	source, err := NewIELTSSpeakingAcousticSource(reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	values, err := source.GetIELTSSpeakingAcoustics(
+	read, err := source.ReadIELTSSpeakingAcoustics(
 		context.Background(),
 		"10000000-0000-4000-8000-000000000001",
-		[]scoring.IELTSSpeakingAcousticRequest{
-			{TurnID: "turn_ready", EvidenceRefID: "evidence_ready"},
-			{TurnID: "turn_failed", EvidenceRefID: "evidence_failed"},
-		},
+		[]scoring.IELTSSpeakingAcousticRequest{request},
 	)
-	if err != nil || len(values) != 1 || values[0].TurnID != "turn_ready" {
-		t.Fatalf("acoustics = %#v; err = %v", values, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(read.Values) != 1 || len(read.PendingTurnIDs) != 0 ||
+		read.Values[0].PronunciationScore != accuracy ||
+		read.Values[0].ProviderRun == "secret-provider-session" ||
+		!strings.HasPrefix(read.Values[0].ProviderRun, "run_") {
+		t.Fatalf("read = %#v", read)
 	}
 }
 
-func TestIELTSSpeakingAcousticSourceWaitsForPendingEvidence(
+func TestIELTSSpeakingAcousticSourceReportsPendingWithoutPartialShortcut(
 	t *testing.T,
 ) {
+	request := ieltsAcousticRequestFixture()
 	reader := &ieltsSpeakingFeedbackReaderStub{
-		referenceByTurn: map[string]string{
-			"turn_pending": "feedback_pending",
-		},
-		feedbackByID: map[string]SpeechFeedback{
-			"feedback_pending": {
-				FeedbackStatus: SpeechFeedbackRunning,
+		projections: map[string]ieltsSpeakingAcousticProjection{
+			request.TurnID: {
+				FeedbackStatus:    SpeechFeedbackRunning,
+				EvidenceVersion:   request.EvidenceVersion,
+				AudioAssetID:      request.AudioAssetID,
+				AudioAssetVersion: int64(request.AudioAssetVersion),
+				AudioChecksum:     request.AudioChecksumSHA256,
 			},
 		},
 	}
@@ -114,129 +81,88 @@ func TestIELTSSpeakingAcousticSourceWaitsForPendingEvidence(
 	if err != nil {
 		t.Fatal(err)
 	}
-	values, err := source.GetIELTSSpeakingAcoustics(
+	read, err := source.ReadIELTSSpeakingAcoustics(
 		context.Background(),
 		"10000000-0000-4000-8000-000000000001",
-		[]scoring.IELTSSpeakingAcousticRequest{
-			{TurnID: "turn_text", EvidenceRefID: "evidence_text"},
-			{
-				TurnID:              "turn_pending",
-				EvidenceRefID:       "evidence_pending",
-				RecordingDurationMS: 2000,
-			},
-		},
+		[]scoring.IELTSSpeakingAcousticRequest{request},
 	)
-	if !errors.Is(err, scoring.ErrIELTSSpeakingAcousticsPending) ||
-		len(values) != 0 {
-		t.Fatalf("acoustics = %#v; err = %v", values, err)
+	if err != nil || len(read.Values) != 0 ||
+		len(read.PendingTurnIDs) != 1 ||
+		read.PendingTurnIDs[0] != request.TurnID {
+		t.Fatalf("read = %#v, err = %v", read, err)
 	}
 }
 
-func TestIELTSSpeakingAcousticSourceUsesSufficientReadyEvidenceWhilePending(
-	t *testing.T,
-) {
-	accuracy := 82.0
-	fluency := 79.0
-	reader := &ieltsSpeakingFeedbackReaderStub{
-		referenceByTurn: map[string]string{
-			"turn_ready":   "feedback_ready",
-			"turn_pending": "feedback_pending",
+func TestIELTSSpeakingAcousticSourceRejectsStaleAudioProjection(t *testing.T) {
+	request := ieltsAcousticRequestFixture()
+	base := ieltsSpeakingAcousticProjection{
+		FeedbackStatus:    SpeechFeedbackReady,
+		EvidenceVersion:   request.EvidenceVersion,
+		AudioAssetID:      request.AudioAssetID,
+		AudioAssetVersion: int64(request.AudioAssetVersion),
+		AudioChecksum:     request.AudioChecksumSHA256,
+	}
+	tests := map[string]func(*ieltsSpeakingAcousticProjection){
+		"evidence version": func(value *ieltsSpeakingAcousticProjection) {
+			value.EvidenceVersion++
 		},
-		feedbackByID: map[string]SpeechFeedback{
-			"feedback_ready": {
-				FeedbackStatus: SpeechFeedbackReady,
-				AcousticAssessment: SpeechFeedbackAcousticAssessment{
-					Pronunciation:   SpeechFeedbackAssessed,
-					AcousticFluency: SpeechFeedbackAssessed,
-					AccuracyScore:   &accuracy,
-					FluencyScore:    &fluency,
-					Provider:        "xfyun_ise",
-					ProviderSession: "session-ready",
+		"audio asset": func(value *ieltsSpeakingAcousticProjection) {
+			value.AudioAssetID = "audio-stale"
+		},
+		"audio version": func(value *ieltsSpeakingAcousticProjection) {
+			value.AudioAssetVersion++
+		},
+		"audio checksum": func(value *ieltsSpeakingAcousticProjection) {
+			value.AudioChecksum = strings.Repeat("cd", 32)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			projection := base
+			mutate(&projection)
+			source, err := NewIELTSSpeakingAcousticSource(
+				&ieltsSpeakingFeedbackReaderStub{
+					projections: map[string]ieltsSpeakingAcousticProjection{
+						request.TurnID: projection,
+					},
 				},
-			},
-			"feedback_pending": {FeedbackStatus: SpeechFeedbackRunning},
-		},
-	}
-	source, err := NewIELTSSpeakingAcousticSource(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	values, err := source.GetIELTSSpeakingAcoustics(
-		context.Background(),
-		"10000000-0000-4000-8000-000000000001",
-		[]scoring.IELTSSpeakingAcousticRequest{
-			{
-				TurnID:              "turn_ready",
-				EvidenceRefID:       "evidence_ready",
-				RecordingDurationMS: 3000,
-			},
-			{
-				TurnID:              "turn_pending",
-				EvidenceRefID:       "evidence_pending",
-				RecordingDurationMS: 2000,
-			},
-		},
-	)
-	if err != nil || len(values) != 1 || values[0].TurnID != "turn_ready" {
-		t.Fatalf("acoustics = %#v; err = %v", values, err)
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = source.ReadIELTSSpeakingAcoustics(
+				context.Background(),
+				"10000000-0000-4000-8000-000000000001",
+				[]scoring.IELTSSpeakingAcousticRequest{request},
+			)
+			if !errors.Is(err, evaluation.ErrInvalidRequest) {
+				t.Fatalf("error = %v", err)
+			}
+		})
 	}
 }
 
-func TestIELTSSpeakingAcousticSourceWaitsForMissingRecordedTurn(
-	t *testing.T,
-) {
-	source, err := NewIELTSSpeakingAcousticSource(
-		&ieltsSpeakingFeedbackReaderStub{
-			referenceByTurn: map[string]string{},
-		},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	values, err := source.GetIELTSSpeakingAcoustics(
-		context.Background(),
-		"10000000-0000-4000-8000-000000000001",
-		[]scoring.IELTSSpeakingAcousticRequest{{
-			TurnID:              "turn_recorded",
-			EvidenceRefID:       "evidence_recorded",
-			RecordingDurationMS: 2000,
-		}},
-	)
-	if !errors.Is(err, scoring.ErrIELTSSpeakingAcousticsPending) ||
-		len(values) != 0 {
-		t.Fatalf("acoustics = %#v; err = %v", values, err)
+func ieltsAcousticRequestFixture() scoring.IELTSSpeakingAcousticRequest {
+	return scoring.IELTSSpeakingAcousticRequest{
+		TurnID:              "turn-1",
+		EvidenceRefID:       "evidence-1",
+		EvidenceVersion:     2,
+		AudioAssetID:        "audio-1",
+		AudioAssetVersion:   3,
+		AudioChecksumSHA256: strings.Repeat("ab", 32),
+		RecordingDurationMS: 4_000,
 	}
 }
 
 type ieltsSpeakingFeedbackReaderStub struct {
-	feedback        SpeechFeedback
-	referenceByTurn map[string]string
-	feedbackByID    map[string]SpeechFeedback
+	projections map[string]ieltsSpeakingAcousticProjection
 }
 
-func (stub *ieltsSpeakingFeedbackReaderStub) FindSpeechFeedbackByConversationTurn(
+func (stub *ieltsSpeakingFeedbackReaderStub) ReadIELTSSpeakingAcousticProjection(
 	_ context.Context,
 	_ string,
 	turnID string,
-) (SpeechFeedbackReference, bool, error) {
-	if id, ok := stub.referenceByTurn[turnID]; ok {
-		return SpeechFeedbackReference{SpeechFeedbackID: id}, true, nil
-	}
-	if stub.referenceByTurn != nil {
-		return SpeechFeedbackReference{}, false, nil
-	}
-	return SpeechFeedbackReference{
-		SpeechFeedbackID: "20000000-0000-4000-8000-000000000001",
-	}, true, nil
-}
-
-func (stub *ieltsSpeakingFeedbackReaderStub) GetSpeechFeedback(
-	_ context.Context,
-	_ string,
-	feedbackID string,
-) (SpeechFeedback, error) {
-	if feedback, ok := stub.feedbackByID[feedbackID]; ok {
-		return feedback, nil
-	}
-	return stub.feedback, nil
+) (ieltsSpeakingAcousticProjection, bool, error) {
+	projection, found := stub.projections[turnID]
+	return projection, found, nil
 }

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
@@ -21,12 +22,14 @@ func TestNewIELTSSpeakingAcousticSourceRejectsNilReader(t *testing.T) {
 
 func TestIELTSSpeakingAcousticSourceReturnsVersionBoundAssessment(t *testing.T) {
 	request := ieltsAcousticRequestFixture()
+	completedAt := time.Now().UTC()
 	accuracy := 74.0
 	fluency := 68.0
 	reader := &ieltsSpeakingFeedbackReaderStub{
 		projections: map[string]ieltsSpeakingAcousticProjection{
 			request.TurnID: {
 				FeedbackStatus:    SpeechFeedbackReady,
+				CompletedAt:       completedAt,
 				EvidenceVersion:   request.EvidenceVersion,
 				AudioAssetID:      request.AudioAssetID,
 				AudioAssetVersion: int64(request.AudioAssetVersion),
@@ -50,6 +53,7 @@ func TestIELTSSpeakingAcousticSourceReturnsVersionBoundAssessment(t *testing.T) 
 		context.Background(),
 		"10000000-0000-4000-8000-000000000001",
 		[]scoring.IELTSSpeakingAcousticRequest{request},
+		completedAt,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +89,7 @@ func TestIELTSSpeakingAcousticSourceReportsPendingWithoutPartialShortcut(
 		context.Background(),
 		"10000000-0000-4000-8000-000000000001",
 		[]scoring.IELTSSpeakingAcousticRequest{request},
+		time.Now().Add(time.Minute),
 	)
 	if err != nil || len(read.Values) != 0 ||
 		len(read.PendingTurnIDs) != 1 ||
@@ -93,10 +98,54 @@ func TestIELTSSpeakingAcousticSourceReportsPendingWithoutPartialShortcut(
 	}
 }
 
+func TestIELTSSpeakingAcousticSourceExcludesAssessmentCompletedAfterCutoff(
+	t *testing.T,
+) {
+	request := ieltsAcousticRequestFixture()
+	cutoff := time.Now().UTC()
+	accuracy := 74.0
+	fluency := 68.0
+	source, err := NewIELTSSpeakingAcousticSource(
+		&ieltsSpeakingFeedbackReaderStub{
+			projections: map[string]ieltsSpeakingAcousticProjection{
+				request.TurnID: {
+					FeedbackStatus:    SpeechFeedbackReady,
+					CompletedAt:       cutoff.Add(time.Millisecond),
+					EvidenceVersion:   request.EvidenceVersion,
+					AudioAssetID:      request.AudioAssetID,
+					AudioAssetVersion: int64(request.AudioAssetVersion),
+					AudioChecksum:     request.AudioChecksumSHA256,
+					Assessment: SpeechFeedbackAcousticAssessment{
+						Pronunciation:   SpeechFeedbackAssessed,
+						AcousticFluency: SpeechFeedbackAssessed,
+						AccuracyScore:   &accuracy,
+						FluencyScore:    &fluency,
+						Provider:        "xfyun_ise",
+						ProviderSession: "late-provider-session",
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read, err := source.ReadIELTSSpeakingAcoustics(
+		context.Background(),
+		"10000000-0000-4000-8000-000000000001",
+		[]scoring.IELTSSpeakingAcousticRequest{request},
+		cutoff,
+	)
+	if err != nil || len(read.Values) != 0 || len(read.PendingTurnIDs) != 0 {
+		t.Fatalf("read=%#v err=%v", read, err)
+	}
+}
+
 func TestIELTSSpeakingAcousticSourceRejectsStaleAudioProjection(t *testing.T) {
 	request := ieltsAcousticRequestFixture()
 	base := ieltsSpeakingAcousticProjection{
 		FeedbackStatus:    SpeechFeedbackReady,
+		CompletedAt:       time.Now().UTC(),
 		EvidenceVersion:   request.EvidenceVersion,
 		AudioAssetID:      request.AudioAssetID,
 		AudioAssetVersion: int64(request.AudioAssetVersion),
@@ -134,6 +183,7 @@ func TestIELTSSpeakingAcousticSourceRejectsStaleAudioProjection(t *testing.T) {
 				context.Background(),
 				"10000000-0000-4000-8000-000000000001",
 				[]scoring.IELTSSpeakingAcousticRequest{request},
+				time.Now().Add(time.Minute),
 			)
 			if !errors.Is(err, scoring.ErrIELTSAcousticEvidenceInvalid) ||
 				!errors.Is(err, evaluation.ErrInvalidRequest) {

--- a/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/ielts_acoustics_test.go
@@ -135,7 +135,8 @@ func TestIELTSSpeakingAcousticSourceRejectsStaleAudioProjection(t *testing.T) {
 				"10000000-0000-4000-8000-000000000001",
 				[]scoring.IELTSSpeakingAcousticRequest{request},
 			)
-			if !errors.Is(err, evaluation.ErrInvalidRequest) {
+			if !errors.Is(err, scoring.ErrIELTSAcousticEvidenceInvalid) ||
+				!errors.Is(err, evaluation.ErrInvalidRequest) {
 				t.Fatalf("error = %v", err)
 			}
 		})

--- a/server/internal/coaching/evaluation/speechfeedback/postgres_integration_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/postgres_integration_test.go
@@ -237,6 +237,7 @@ func TestPostgresSpeechFeedbackPersistsTopicAcousticEvidence(t *testing.T) {
 		context.Background(),
 		ownerID,
 		[]scoring.IELTSSpeakingAcousticRequest{acousticRequest},
+		time.Now().Add(time.Minute),
 	)
 	if err != nil || len(read.PendingTurnIDs) != 1 ||
 		read.PendingTurnIDs[0] != turnID {
@@ -247,6 +248,7 @@ func TestPostgresSpeechFeedbackPersistsTopicAcousticEvidence(t *testing.T) {
 		context.Background(),
 		ownerID,
 		[]scoring.IELTSSpeakingAcousticRequest{acousticRequest},
+		time.Now().Add(time.Minute),
 	); !errors.Is(err, evaluation.ErrInvalidRequest) {
 		t.Fatalf("stale acoustic projection error=%v", err)
 	}

--- a/server/internal/coaching/evaluation/speechfeedback/postgres_integration_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/postgres_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	evaluationpostgres "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/postgres"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 	"github.com/1024XEngineer/XE3-ESL/server/migrations"
 )
@@ -205,6 +207,48 @@ func TestPostgresSpeechFeedbackPersistsTopicAcousticEvidence(t *testing.T) {
 		assessment.SemanticScore == nil ||
 		*assessment.SemanticScore != semantic {
 		t.Fatalf("topic assessment = %#v", assessment)
+	}
+	var acousticRequest scoring.IELTSSpeakingAcousticRequest
+	acousticRequest.TurnID = turnID
+	acousticRequest.EvidenceRefID = "full-mock-evidence-ref"
+	acousticRequest.RecordingDurationMS = 1_000
+	if err := pool.QueryRow(context.Background(), `
+		SELECT
+			input_revision,
+			audio_asset_id,
+			audio_asset_version,
+			audio_checksum_sha256
+		FROM evaluation_speech_feedback_turn_snapshots
+		WHERE owner_user_id = $1
+		  AND turn_id = $2
+	`, ownerID, turnID).Scan(
+		&acousticRequest.EvidenceVersion,
+		&acousticRequest.AudioAssetID,
+		&acousticRequest.AudioAssetVersion,
+		&acousticRequest.AudioChecksumSHA256,
+	); err != nil {
+		t.Fatal(err)
+	}
+	source, err := speechfeedback.NewIELTSSpeakingAcousticSource(repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read, err := source.ReadIELTSSpeakingAcoustics(
+		context.Background(),
+		ownerID,
+		[]scoring.IELTSSpeakingAcousticRequest{acousticRequest},
+	)
+	if err != nil || len(read.PendingTurnIDs) != 1 ||
+		read.PendingTurnIDs[0] != turnID {
+		t.Fatalf("version-bound pending read=%#v err=%v", read, err)
+	}
+	acousticRequest.AudioChecksumSHA256 = strings.Repeat("f", 64)
+	if _, err := source.ReadIELTSSpeakingAcoustics(
+		context.Background(),
+		ownerID,
+		[]scoring.IELTSSpeakingAcousticRequest{acousticRequest},
+	); !errors.Is(err, evaluation.ErrInvalidRequest) {
+		t.Fatalf("stale acoustic projection error=%v", err)
 	}
 }
 

--- a/server/migrations/000088_evaluation_ielts_acoustic_snapshot.down.sql
+++ b/server/migrations/000088_evaluation_ielts_acoustic_snapshot.down.sql
@@ -1,0 +1,195 @@
+BEGIN;
+
+UPDATE evaluation_revision_states AS state
+SET evaluation_status = CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM evaluation_module_runs AS run
+            WHERE run.evaluation_id = state.evaluation_id
+              AND run.evaluation_revision_id = state.revision_id
+              AND run.owner_user_id = state.owner_user_id
+              AND run.channel = 'SCENE'
+              AND run.strategy_ref =
+                  'ielts-speaking-full-mock-shadow/v1'
+              AND run.run_status = 'RUNNING'
+        )
+        THEN 'RUNNING'
+        ELSE 'QUEUED'
+    END,
+    updated_at = transaction_timestamp()
+FROM evaluation_revisions AS revision
+JOIN evaluation_ledgers AS ledger
+  ON ledger.id = revision.evaluation_id
+ AND ledger.owner_user_id = revision.owner_user_id
+WHERE state.revision_id = revision.id
+  AND state.evaluation_id = ledger.id
+  AND state.owner_user_id = ledger.owner_user_id
+  AND state.evaluation_status = 'VALIDATING'
+  AND ledger.scope = 'SESSION'
+  AND ledger.scene_type = 'IELTS_SPEAKING'
+  AND revision.channels = ARRAY['SCENE']::text[]
+  AND revision.scene_strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+  AND revision.pipeline_version = 'evaluation-pipeline-shadow/v1';
+
+ALTER TABLE evaluation_module_runs
+    DROP CONSTRAINT evaluation_module_runs_acoustic_fkey,
+    DROP CONSTRAINT evaluation_module_runs_acoustic_shape_check,
+    DROP COLUMN input_bundle_hash,
+    DROP COLUMN acoustic_snapshot_hash,
+    DROP COLUMN acoustic_snapshot_id;
+
+DROP TRIGGER evaluation_ielts_acoustic_snapshots_immutable
+    ON evaluation_ielts_speaking_acoustic_snapshots;
+DROP FUNCTION reject_evaluation_ielts_acoustic_snapshot_mutation();
+DROP TABLE evaluation_ielts_speaking_acoustic_snapshots;
+
+CREATE OR REPLACE FUNCTION reject_evaluation_module_run_identity_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    owner_status text;
+    deletion_fenced boolean;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        SELECT account_status INTO owner_status
+        FROM identity_users WHERE id = OLD.owner_user_id;
+        IF owner_status IN ('deleting', 'deleted') THEN
+            RETURN OLD;
+        END IF;
+        SELECT EXISTS (
+            SELECT 1 FROM evaluation_deletion_fences
+            WHERE owner_user_id = OLD.owner_user_id
+        ) INTO deletion_fenced;
+        IF deletion_fenced THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION 'evaluation module runs cannot be deleted'
+            USING ERRCODE = '55000';
+    END IF;
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.outbox_id IS DISTINCT FROM OLD.outbox_id
+       OR NEW.evaluation_id IS DISTINCT FROM OLD.evaluation_id
+       OR NEW.evaluation_revision_id IS DISTINCT FROM OLD.evaluation_revision_id
+       OR NEW.owner_user_id IS DISTINCT FROM OLD.owner_user_id
+       OR NEW.channel IS DISTINCT FROM OLD.channel
+       OR NEW.strategy_ref IS DISTINCT FROM OLD.strategy_ref
+       OR NEW.practice_session_id IS DISTINCT FROM OLD.practice_session_id
+       OR NEW.input_snapshot_id IS DISTINCT FROM OLD.input_snapshot_id
+       OR NEW.input_revision IS DISTINCT FROM OLD.input_revision
+       OR NEW.scope IS DISTINCT FROM OLD.scope
+       OR NEW.scene_type IS DISTINCT FROM OLD.scene_type
+       OR NEW.snapshot_hash IS DISTINCT FROM OLD.snapshot_hash
+       OR NEW.full_config_hash IS DISTINCT FROM OLD.full_config_hash
+       OR NEW.prompt_version IS DISTINCT FROM OLD.prompt_version
+       OR NEW.provider IS DISTINCT FROM OLD.provider
+       OR NEW.model IS DISTINCT FROM OLD.model
+       OR NEW.deletion_generation IS DISTINCT FROM OLD.deletion_generation
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR NEW.attempt_count < OLD.attempt_count
+       OR NEW.fencing_token < OLD.fencing_token
+       OR (
+           OLD.run_status IN ('READY', 'FAILED')
+           AND NEW.run_status IS DISTINCT FROM OLD.run_status
+       )
+    THEN
+        RAISE EXCEPTION 'evaluation module run identity is immutable'
+            USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION evaluation_assert_scene_job_run_binding()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    bound_record record;
+BEGIN
+    SELECT
+        ledger.practice_session_id,
+        ledger.input_snapshot_id,
+        ledger.input_revision,
+        ledger.scope,
+        ledger.scene_type,
+        revision.scene_strategy_ref,
+        revision.pipeline_version,
+        snapshot.snapshot_hash,
+        outbox.channel,
+        outbox.attempt_count,
+        outbox.fencing_token
+      INTO bound_record
+      FROM evaluation_ledgers AS ledger
+      JOIN evaluation_revisions AS revision
+        ON revision.evaluation_id = ledger.id
+       AND revision.owner_user_id = ledger.owner_user_id
+       AND revision.id = NEW.evaluation_revision_id
+      JOIN evaluation_evidence_snapshots AS snapshot
+        ON snapshot.id = ledger.input_snapshot_id
+       AND snapshot.owner_user_id = ledger.owner_user_id
+      JOIN evaluation_outbox AS outbox
+        ON outbox.id = NEW.outbox_id
+       AND outbox.evaluation_id = ledger.id
+       AND outbox.evaluation_revision_id = revision.id
+       AND outbox.owner_user_id = ledger.owner_user_id
+      JOIN identity_users AS owner ON owner.id = ledger.owner_user_id
+      JOIN evaluation_revision_states AS state
+        ON state.evaluation_id = ledger.id
+       AND state.revision_id = revision.id
+       AND state.owner_user_id = ledger.owner_user_id
+     WHERE ledger.id = NEW.evaluation_id
+       AND ledger.owner_user_id = NEW.owner_user_id
+       AND owner.account_status = 'active'
+       AND revision.channels = ARRAY['SCENE']::text[]
+       AND (
+           (ledger.scene_type = 'INTERVIEW'
+            AND revision.scene_strategy_ref = 'interview-scene-shadow/v1'
+            AND revision.pipeline_version = 'evaluation-pipeline-shadow/v1')
+           OR
+           (ledger.scene_type = 'IELTS_SPEAKING'
+            AND revision.scene_strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+            AND revision.pipeline_version = 'evaluation-pipeline-shadow/v1')
+           OR
+           (ledger.scene_type IN (
+                'IELTS_SPEAKING',
+                'OVERSEAS_DAILY_LIFE',
+                'OVERSEAS_WORKPLACE'
+            )
+            AND revision.scene_strategy_ref = 'general-scene-evaluation/v1'
+            AND revision.pipeline_version = 'evaluation-pipeline/v1')
+       )
+       AND state.evaluation_status IN ('QUEUED', 'RUNNING')
+       AND outbox.delivery_status = 'PENDING'
+       AND outbox.lease_expires_at > clock_timestamp()
+       AND NOT EXISTS (
+           SELECT 1 FROM evaluation_revisions AS later
+           WHERE later.evaluation_id = revision.evaluation_id
+             AND later.revision > revision.revision
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM evaluation_deletion_fences AS fence
+           WHERE fence.owner_user_id = ledger.owner_user_id
+       )
+     FOR SHARE OF ledger, revision, snapshot, outbox, owner, state;
+    IF NOT FOUND
+       OR NEW.practice_session_id <> bound_record.practice_session_id
+       OR NEW.input_snapshot_id <> bound_record.input_snapshot_id
+       OR NEW.input_revision <> bound_record.input_revision
+       OR NEW.scope <> bound_record.scope
+       OR NEW.scene_type <> bound_record.scene_type
+       OR NEW.channel <> bound_record.channel
+       OR NEW.strategy_ref <> bound_record.scene_strategy_ref
+       OR NEW.snapshot_hash <> bound_record.snapshot_hash
+       OR NEW.attempt_count <> bound_record.attempt_count
+       OR NEW.fencing_token <> bound_record.fencing_token
+       OR NEW.deletion_generation <> 0
+    THEN
+        RAISE EXCEPTION 'invalid durable Scene job module run binding'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMIT;

--- a/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
+++ b/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
@@ -422,4 +422,32 @@ WHERE state.revision_id = revision.id
   )
 ;
 
+-- A worker leased before this migration cannot complete while the revision is
+-- VALIDATING. Release that lease so the frozen revision can be reclaimed with
+-- a new fencing token as soon as it returns to QUEUED.
+UPDATE evaluation_outbox AS outbox
+SET lease_expires_at = NULL,
+    updated_at = transaction_timestamp()
+FROM evaluation_revisions AS revision
+JOIN evaluation_ledgers AS ledger
+  ON ledger.id = revision.evaluation_id
+ AND ledger.owner_user_id = revision.owner_user_id
+JOIN evaluation_revision_states AS state
+  ON state.evaluation_id = ledger.id
+ AND state.revision_id = revision.id
+ AND state.owner_user_id = ledger.owner_user_id
+WHERE outbox.evaluation_id = ledger.id
+  AND outbox.evaluation_revision_id = revision.id
+  AND outbox.owner_user_id = ledger.owner_user_id
+  AND outbox.channel = 'SCENE'
+  AND outbox.delivery_status = 'PENDING'
+  AND outbox.lease_expires_at IS NOT NULL
+  AND state.evaluation_status = 'VALIDATING'
+  AND ledger.scope = 'SESSION'
+  AND ledger.scene_type = 'IELTS_SPEAKING'
+  AND revision.channels = ARRAY['SCENE']::text[]
+  AND revision.scene_strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+  AND revision.pipeline_version = 'evaluation-pipeline-shadow/v1'
+;
+
 COMMIT;

--- a/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
+++ b/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
@@ -392,7 +392,23 @@ JOIN evaluation_ledgers AS ledger
 WHERE state.revision_id = revision.id
   AND state.evaluation_id = ledger.id
   AND state.owner_user_id = ledger.owner_user_id
-  AND state.evaluation_status IN ('QUEUED', 'RUNNING')
+  AND (
+      state.evaluation_status = 'QUEUED'
+      OR (
+          state.evaluation_status = 'RUNNING'
+          AND EXISTS (
+              SELECT 1
+              FROM evaluation_outbox AS outbox
+              WHERE outbox.evaluation_id = state.evaluation_id
+                AND outbox.evaluation_revision_id = state.revision_id
+                AND outbox.owner_user_id = state.owner_user_id
+                AND outbox.channel = 'SCENE'
+                AND outbox.delivery_status = 'PENDING'
+                -- The migrated v1 runtime has a three-attempt budget.
+                AND outbox.attempt_count < 3
+          )
+      )
+  )
   AND ledger.scope = 'SESSION'
   AND ledger.scene_type = 'IELTS_SPEAKING'
   AND revision.channels = ARRAY['SCENE']::text[]

--- a/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
+++ b/server/migrations/000088_evaluation_ielts_acoustic_snapshot.up.sql
@@ -1,0 +1,409 @@
+BEGIN;
+
+CREATE TABLE evaluation_ielts_speaking_acoustic_snapshots (
+    id text COLLATE "C" PRIMARY KEY,
+    evaluation_id uuid NOT NULL UNIQUE,
+    owner_user_id uuid NOT NULL,
+    input_snapshot_id text COLLATE "C" NOT NULL,
+    input_snapshot_hash bytea NOT NULL,
+    schema_version text COLLATE "C" NOT NULL,
+    resolution text COLLATE "C" NOT NULL,
+    snapshot_hash bytea NOT NULL,
+    canonical_payload text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    CONSTRAINT evaluation_ielts_acoustic_ledger_fkey
+        FOREIGN KEY (evaluation_id, owner_user_id)
+        REFERENCES evaluation_ledgers (id, owner_user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT evaluation_ielts_acoustic_evidence_fkey
+        FOREIGN KEY (input_snapshot_id, owner_user_id)
+        REFERENCES evaluation_evidence_snapshots (id, owner_user_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT evaluation_ielts_acoustic_identity_unique
+        UNIQUE (id, evaluation_id, owner_user_id),
+    CONSTRAINT evaluation_ielts_acoustic_id_check
+        CHECK (id ~ '^ielts_acoustic_[0-9a-f]{32}$'),
+    CONSTRAINT evaluation_ielts_acoustic_schema_check
+        CHECK (schema_version = 'ielts-speaking-acoustic-snapshot/v1'),
+    CONSTRAINT evaluation_ielts_acoustic_resolution_check
+        CHECK (resolution IN ('COMPLETE', 'PARTIAL', 'TEXT_ONLY')),
+    CONSTRAINT evaluation_ielts_acoustic_base_hash_check
+        CHECK (octet_length(input_snapshot_hash) = 32),
+    CONSTRAINT evaluation_ielts_acoustic_hash_check
+        CHECK (
+            octet_length(snapshot_hash) = 32
+            AND snapshot_hash = sha256(
+                convert_to(canonical_payload, 'UTF8')
+            )
+        ),
+    CONSTRAINT evaluation_ielts_acoustic_payload_check
+        CHECK (
+            jsonb_typeof(canonical_payload::jsonb) = 'object'
+            AND canonical_payload::jsonb ->> 'schema_version'
+                = schema_version
+            AND canonical_payload::jsonb ->> 'evaluation_id'
+                = evaluation_id::text
+            AND canonical_payload::jsonb ->> 'owner_user_id'
+                = owner_user_id::text
+            AND canonical_payload::jsonb ->> 'input_snapshot_id'
+                = input_snapshot_id
+            AND canonical_payload::jsonb ->> 'input_snapshot_hash'
+                = encode(input_snapshot_hash, 'hex')
+            AND canonical_payload::jsonb ->> 'resolution'
+                = resolution
+            AND jsonb_typeof(canonical_payload::jsonb -> 'turns') = 'array'
+            AND NOT jsonb_path_exists(
+                canonical_payload::jsonb,
+                '$.** ? (@.type() == "object").keyvalue() ? (
+                    @.key like_regex
+                    "^(provider[-_]?session|session[-_]?id|raw[-_]?result|object[-_]?key|signed[-_]?url|audio[-_]?url|url)$"
+                    flag "i"
+                )'
+            )
+        )
+);
+
+CREATE INDEX evaluation_ielts_acoustic_owner_created_idx
+    ON evaluation_ielts_speaking_acoustic_snapshots (
+        owner_user_id,
+        created_at DESC,
+        id DESC
+    );
+
+CREATE FUNCTION reject_evaluation_ielts_acoustic_snapshot_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    owner_status text;
+    deletion_fenced boolean;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        SELECT account_status
+          INTO owner_status
+          FROM identity_users
+         WHERE id = OLD.owner_user_id;
+        IF owner_status IN ('deleting', 'deleted') THEN
+            RETURN OLD;
+        END IF;
+        SELECT EXISTS (
+            SELECT 1
+            FROM evaluation_deletion_fences
+            WHERE owner_user_id = OLD.owner_user_id
+        ) INTO deletion_fenced;
+        IF deletion_fenced THEN
+            RETURN OLD;
+        END IF;
+    END IF;
+    RAISE EXCEPTION 'IELTS acoustic snapshots are immutable'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER evaluation_ielts_acoustic_snapshots_immutable
+BEFORE UPDATE OR DELETE ON evaluation_ielts_speaking_acoustic_snapshots
+FOR EACH ROW
+EXECUTE FUNCTION reject_evaluation_ielts_acoustic_snapshot_mutation();
+
+ALTER TABLE evaluation_module_runs
+    ADD COLUMN acoustic_snapshot_id text COLLATE "C",
+    ADD COLUMN acoustic_snapshot_hash bytea,
+    ADD COLUMN input_bundle_hash bytea,
+    ADD CONSTRAINT evaluation_module_runs_acoustic_shape_check
+        CHECK (
+            (
+                acoustic_snapshot_id IS NULL
+                AND acoustic_snapshot_hash IS NULL
+                AND input_bundle_hash IS NULL
+            )
+            OR
+            (
+                acoustic_snapshot_id ~ '^ielts_acoustic_[0-9a-f]{32}$'
+                AND octet_length(acoustic_snapshot_hash) = 32
+                AND octet_length(input_bundle_hash) = 32
+            )
+        ),
+    ADD CONSTRAINT evaluation_module_runs_acoustic_fkey
+        FOREIGN KEY (
+            acoustic_snapshot_id,
+            evaluation_id,
+            owner_user_id
+        )
+        REFERENCES evaluation_ielts_speaking_acoustic_snapshots (
+            id,
+            evaluation_id,
+            owner_user_id
+        )
+        ON DELETE RESTRICT;
+
+CREATE OR REPLACE FUNCTION evaluation_assert_scene_job_run_binding()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    bound_record record;
+    expected_bundle_hash bytea;
+BEGIN
+    SELECT
+        ledger.practice_session_id,
+        ledger.input_snapshot_id,
+        ledger.input_revision,
+        ledger.scope,
+        ledger.scene_type,
+        revision.scene_strategy_ref,
+        revision.pipeline_version,
+        snapshot.snapshot_hash,
+        outbox.channel,
+        outbox.attempt_count,
+        outbox.fencing_token,
+        acoustic.id AS acoustic_snapshot_id,
+        acoustic.snapshot_hash AS acoustic_snapshot_hash
+      INTO bound_record
+      FROM evaluation_ledgers AS ledger
+      JOIN evaluation_revisions AS revision
+        ON revision.evaluation_id = ledger.id
+       AND revision.owner_user_id = ledger.owner_user_id
+       AND revision.id = NEW.evaluation_revision_id
+      JOIN evaluation_evidence_snapshots AS snapshot
+        ON snapshot.id = ledger.input_snapshot_id
+       AND snapshot.owner_user_id = ledger.owner_user_id
+      JOIN evaluation_outbox AS outbox
+        ON outbox.id = NEW.outbox_id
+       AND outbox.evaluation_id = ledger.id
+       AND outbox.evaluation_revision_id = revision.id
+       AND outbox.owner_user_id = ledger.owner_user_id
+      JOIN identity_users AS owner
+        ON owner.id = ledger.owner_user_id
+      JOIN evaluation_revision_states AS state
+        ON state.evaluation_id = ledger.id
+       AND state.revision_id = revision.id
+       AND state.owner_user_id = ledger.owner_user_id
+      LEFT JOIN evaluation_ielts_speaking_acoustic_snapshots AS acoustic
+        ON acoustic.evaluation_id = ledger.id
+       AND acoustic.owner_user_id = ledger.owner_user_id
+       AND acoustic.input_snapshot_id = ledger.input_snapshot_id
+       AND acoustic.input_snapshot_hash = snapshot.snapshot_hash
+     WHERE ledger.id = NEW.evaluation_id
+       AND ledger.owner_user_id = NEW.owner_user_id
+       AND owner.account_status = 'active'
+       AND revision.channels = ARRAY['SCENE']::text[]
+       AND (
+           (
+               ledger.scene_type = 'INTERVIEW'
+               AND revision.scene_strategy_ref =
+                   'interview-scene-shadow/v1'
+               AND revision.pipeline_version =
+                   'evaluation-pipeline-shadow/v1'
+           )
+           OR (
+               ledger.scene_type = 'IELTS_SPEAKING'
+               AND revision.scene_strategy_ref =
+                   'ielts-speaking-full-mock-shadow/v1'
+               AND revision.pipeline_version =
+                   'evaluation-pipeline-shadow/v1'
+           )
+           OR (
+               ledger.scene_type IN (
+                   'IELTS_SPEAKING',
+                   'OVERSEAS_DAILY_LIFE',
+                   'OVERSEAS_WORKPLACE'
+               )
+               AND revision.scene_strategy_ref =
+                   'general-scene-evaluation/v1'
+               AND revision.pipeline_version =
+                   'evaluation-pipeline/v1'
+           )
+       )
+       AND state.evaluation_status IN ('QUEUED', 'RUNNING')
+       AND outbox.delivery_status = 'PENDING'
+       AND outbox.lease_expires_at > clock_timestamp()
+       AND NOT EXISTS (
+           SELECT 1
+           FROM evaluation_revisions AS later
+           WHERE later.evaluation_id = revision.evaluation_id
+             AND later.revision > revision.revision
+       )
+       AND NOT EXISTS (
+           SELECT 1
+           FROM evaluation_deletion_fences AS fence
+           WHERE fence.owner_user_id = ledger.owner_user_id
+       )
+     FOR SHARE OF ledger, revision, snapshot, outbox, owner, state;
+
+    IF NOT FOUND
+       OR NEW.practice_session_id <> bound_record.practice_session_id
+       OR NEW.input_snapshot_id <> bound_record.input_snapshot_id
+       OR NEW.input_revision <> bound_record.input_revision
+       OR NEW.scope <> bound_record.scope
+       OR NEW.scene_type <> bound_record.scene_type
+       OR NEW.channel <> bound_record.channel
+       OR NEW.strategy_ref <> bound_record.scene_strategy_ref
+       OR NEW.snapshot_hash <> bound_record.snapshot_hash
+       OR NEW.attempt_count <> bound_record.attempt_count
+       OR NEW.fencing_token <> bound_record.fencing_token
+       OR NEW.deletion_generation <> 0
+    THEN
+        RAISE EXCEPTION 'invalid durable Scene job module run binding'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.scene_type = 'IELTS_SPEAKING'
+       AND NEW.strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+    THEN
+        expected_bundle_hash := sha256(
+            convert_to('ielts-speaking-input-bundle/v1', 'UTF8') ||
+                decode('00', 'hex') || bound_record.snapshot_hash ||
+                bound_record.acoustic_snapshot_hash
+        );
+        IF bound_record.acoustic_snapshot_id IS NULL
+           OR NEW.acoustic_snapshot_id
+                IS DISTINCT FROM bound_record.acoustic_snapshot_id
+           OR NEW.acoustic_snapshot_hash
+                IS DISTINCT FROM bound_record.acoustic_snapshot_hash
+           OR NEW.input_bundle_hash IS DISTINCT FROM expected_bundle_hash
+        THEN
+            RAISE EXCEPTION 'invalid frozen IELTS acoustic binding'
+                USING ERRCODE = '23514';
+        END IF;
+    ELSIF NEW.acoustic_snapshot_id IS NOT NULL
+       OR NEW.acoustic_snapshot_hash IS NOT NULL
+       OR NEW.input_bundle_hash IS NOT NULL
+    THEN
+        RAISE EXCEPTION 'unexpected IELTS acoustic binding'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION reject_evaluation_module_run_identity_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    owner_status text;
+    deletion_fenced boolean;
+    legacy_acoustic_binding boolean := false;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        SELECT account_status
+          INTO owner_status
+          FROM identity_users
+         WHERE id = OLD.owner_user_id;
+        IF owner_status IN ('deleting', 'deleted') THEN
+            RETURN OLD;
+        END IF;
+        SELECT EXISTS (
+            SELECT 1
+            FROM evaluation_deletion_fences
+            WHERE owner_user_id = OLD.owner_user_id
+        ) INTO deletion_fenced;
+        IF deletion_fenced THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION 'evaluation module runs cannot be deleted'
+            USING ERRCODE = '55000';
+    END IF;
+
+    IF OLD.acoustic_snapshot_id IS NULL
+       AND OLD.acoustic_snapshot_hash IS NULL
+       AND OLD.input_bundle_hash IS NULL
+       AND NEW.acoustic_snapshot_id IS NOT NULL
+       AND NEW.acoustic_snapshot_hash IS NOT NULL
+       AND NEW.input_bundle_hash IS NOT NULL
+       AND OLD.run_status = 'RUNNING'
+       AND NEW.run_status = 'RUNNING'
+       AND NEW.scene_type = 'IELTS_SPEAKING'
+       AND NEW.strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+    THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM evaluation_ielts_speaking_acoustic_snapshots AS acoustic
+            WHERE acoustic.id = NEW.acoustic_snapshot_id
+              AND acoustic.evaluation_id = NEW.evaluation_id
+              AND acoustic.owner_user_id = NEW.owner_user_id
+              AND acoustic.input_snapshot_id = NEW.input_snapshot_id
+              AND acoustic.input_snapshot_hash = NEW.snapshot_hash
+              AND acoustic.snapshot_hash = NEW.acoustic_snapshot_hash
+              AND NEW.input_bundle_hash = sha256(
+                  convert_to(
+                      'ielts-speaking-input-bundle/v1',
+                      'UTF8'
+                  ) || decode('00', 'hex') || NEW.snapshot_hash ||
+                      acoustic.snapshot_hash
+              )
+        ) INTO legacy_acoustic_binding;
+    END IF;
+
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.outbox_id IS DISTINCT FROM OLD.outbox_id
+       OR NEW.evaluation_id IS DISTINCT FROM OLD.evaluation_id
+       OR NEW.evaluation_revision_id
+            IS DISTINCT FROM OLD.evaluation_revision_id
+       OR NEW.owner_user_id IS DISTINCT FROM OLD.owner_user_id
+       OR NEW.channel IS DISTINCT FROM OLD.channel
+       OR NEW.strategy_ref IS DISTINCT FROM OLD.strategy_ref
+       OR NEW.practice_session_id
+            IS DISTINCT FROM OLD.practice_session_id
+       OR NEW.input_snapshot_id IS DISTINCT FROM OLD.input_snapshot_id
+       OR NEW.input_revision IS DISTINCT FROM OLD.input_revision
+       OR NEW.scope IS DISTINCT FROM OLD.scope
+       OR NEW.scene_type IS DISTINCT FROM OLD.scene_type
+       OR NEW.snapshot_hash IS DISTINCT FROM OLD.snapshot_hash
+       OR (
+           (
+               NEW.acoustic_snapshot_id
+                    IS DISTINCT FROM OLD.acoustic_snapshot_id
+               OR NEW.acoustic_snapshot_hash
+                    IS DISTINCT FROM OLD.acoustic_snapshot_hash
+               OR NEW.input_bundle_hash
+                    IS DISTINCT FROM OLD.input_bundle_hash
+           )
+           AND NOT legacy_acoustic_binding
+       )
+       OR NEW.full_config_hash IS DISTINCT FROM OLD.full_config_hash
+       OR NEW.prompt_version IS DISTINCT FROM OLD.prompt_version
+       OR NEW.provider IS DISTINCT FROM OLD.provider
+       OR NEW.model IS DISTINCT FROM OLD.model
+       OR NEW.deletion_generation
+            IS DISTINCT FROM OLD.deletion_generation
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR NEW.attempt_count < OLD.attempt_count
+       OR NEW.fencing_token < OLD.fencing_token
+       OR (
+           OLD.run_status IN ('READY', 'FAILED')
+           AND NEW.run_status IS DISTINCT FROM OLD.run_status
+       )
+    THEN
+        RAISE EXCEPTION 'evaluation module run identity is immutable'
+            USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+UPDATE evaluation_revision_states AS state
+SET evaluation_status = 'VALIDATING',
+    updated_at = transaction_timestamp()
+FROM evaluation_revisions AS revision
+JOIN evaluation_ledgers AS ledger
+  ON ledger.id = revision.evaluation_id
+ AND ledger.owner_user_id = revision.owner_user_id
+WHERE state.revision_id = revision.id
+  AND state.evaluation_id = ledger.id
+  AND state.owner_user_id = ledger.owner_user_id
+  AND state.evaluation_status IN ('QUEUED', 'RUNNING')
+  AND ledger.scope = 'SESSION'
+  AND ledger.scene_type = 'IELTS_SPEAKING'
+  AND revision.channels = ARRAY['SCENE']::text[]
+  AND revision.scene_strategy_ref = 'ielts-speaking-full-mock-shadow/v1'
+  AND revision.pipeline_version = 'evaluation-pipeline-shadow/v1'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM evaluation_revisions AS later
+      WHERE later.evaluation_id = revision.evaluation_id
+        AND later.revision > revision.revision
+  )
+;
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -73,4 +73,5 @@ import "embed"
 //go:embed 000085_evaluation_ielts_speaking_prompt_v5.*.sql
 //go:embed 000086_provider_qualified_model_ids.*.sql
 //go:embed 000087_ielts_part1_cue_card_types.*.sql
+//go:embed 000088_evaluation_ielts_acoustic_snapshot.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能

- 在完整模考报告调用模型前冻结不可变声学输入，避免同一报告重试时证据变化。
- 校验录音资产版本、校验和与证据引用；保存声学快照哈希和完整输入包哈希。
- VALIDATING 阶段对客户端继续表现为生成中，并扩大完成页轮询预算。
- 修复冻结队列的坏队头、瞬时错误、公平扫描、旧活跃租约和重新生成兼容问题。

## 实现

- 新增 IELTS 声学快照与 000088 数据库约束。
- Provider 只读取 claim 绑定的冻结快照，不再在每次尝试时实时拼接 SpeechFeedback。
- 最长等待 120 秒；终态证据可提前冻结，超时后确定性降级。
- 冻结扫描使用有界 keyset 游标，不让单个 pending 或瞬时失败阻塞其他用户。

## 测试

- Go：API、scoring、postgres、speechfeedback、migrations 定向测试通过。
- Go vet：受影响包通过。
- Flutter：practice_report_status_test.dart 27/27 通过。
- 真实 PostgreSQL：冻结并发、迁移 up/down/up、坏队头、旧租约、重评复用、不可变约束均通过。
- 组合联调：现有 15 题完整模考成功生成 PARTIAL 声学报告，输入包哈希已绑定。

Closes #623