### PR TITLE
fix(ielts): decode section report finding references

### DIFF
--- a/mobile/lib/features/coaching/review/ielts_practice_report_decoder.dart
+++ b/mobile/lib/features/coaching/review/ielts_practice_report_decoder.dart
@@ -147,9 +147,11 @@ IeltsPracticeSectionReview _sectionReview(Object? value) {
     partId: _part(root['part_id']),
     questionIndexes: _positiveInts(root['question_indexes']),
     evidenceRefIds: _identifiers(root['evidence_ref_ids']),
-    strengthFindingIds: _identifiers(root['strength_finding_ids']),
-    improvementFindingIds: _identifiers(root['improvement_finding_ids']),
-    upgradeExampleFindingIds: _identifiers(root['upgrade_example_finding_ids']),
+    strengthFindingIds: _findingReferences(root['strength_finding_ids']),
+    improvementFindingIds: _findingReferences(root['improvement_finding_ids']),
+    upgradeExampleFindingIds: _findingReferences(
+      root['upgrade_example_finding_ids'],
+    ),
   );
 }
 
@@ -247,6 +249,26 @@ List<String> _identifiers(Object? value, {int maximum = 64}) {
     throw const IeltsPracticeReportDecodeException();
   }
   return result;
+}
+
+List<String> _findingReferences(Object? value) {
+  if (value is! List<Object?> || value.length > 64) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  final result = value.map(_findingReference).toList(growable: false);
+  if (result.toSet().length != result.length) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return result;
+}
+
+String _findingReference(Object? value) {
+  if (value is! String ||
+      value.length > 160 ||
+      !RegExp(r'^[A-Za-z][A-Za-z0-9._:/-]*$').hasMatch(value)) {
+    throw const IeltsPracticeReportDecodeException();
+  }
+  return value;
 }
 
 bool _sameValues<T>(List<T> left, List<T> right) {

--- a/mobile/test/review/ielts_report_routing_test.dart
+++ b/mobile/test/review/ielts_report_routing_test.dart
@@ -183,6 +183,49 @@ void main() {
     );
   });
 
+  testWidgets('Part 1 report resolves versioned finding references', (
+    tester,
+  ) async {
+    const finding = EvaluationReportFinding(
+      id: 'general-finding:part1.improvement-v1',
+      message: 'Connect the answer to one clear reason.',
+      suggestion: 'Add a short reason after the direct answer.',
+      evidence: <EvaluationReportEvidence>[],
+    );
+    final item = _item(
+      practiceMode: 'PART_1',
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      detail: _part1SectionDetail(finding.id),
+      dimensions: const <EvaluationReportDimension>[
+        EvaluationReportDimension(
+          key: 'TASK_ACHIEVEMENT',
+          score: 75,
+          scale: EvaluationReportScoreScale.percentage100,
+          coverage: 1,
+          confidence: 0.8,
+          reasonCodes: <String>[],
+          evidenceRefIds: <String>['evidence_1'],
+          strengths: <EvaluationReportFinding>[],
+          improvements: <EvaluationReportFinding>[finding],
+          recommendedExamples: <EvaluationReportFinding>[],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-section-detail-invalid')), findsNothing);
+    expect(find.byKey(const Key('ielts-section-report')), findsOneWidget);
+    await tester.ensureVisible(find.text('详细反馈'));
+    await tester.tap(find.text('详细反馈'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining(finding.message), findsOneWidget);
+    expect(find.text('Answer 1.'), findsOneWidget);
+  });
+
   testWidgets(
     'full mock history opens its embedded report without refetching',
     (tester) async {
@@ -242,6 +285,7 @@ ReviewHistoryItem _item({
       const <EvaluationReportDimension>[],
   List<EvaluationReportPriorityAction> priorityActions =
       const <EvaluationReportPriorityAction>[],
+  Map<String, Object?>? detail,
 }) {
   final createdAt = DateTime.utc(2026, 8, 11, 4);
   final report = EvaluationReport(
@@ -259,13 +303,15 @@ ReviewHistoryItem _item({
     dimensions: dimensions,
     priorityActions: priorityActions,
     detailSchema: detailSchema,
-    detail: switch (detailSchema) {
-      'ielts-speaking-practice-report/v1' => _sectionDetail(),
-      'ielts-speaking-report/v1' =>
-        completeIeltsSpeakingReportContractFixture()['report']!
-            as Map<String, Object?>,
-      _ => <String, Object?>{'schema_version': detailSchema},
-    },
+    detail:
+        detail ??
+        switch (detailSchema) {
+          'ielts-speaking-practice-report/v1' => _sectionDetail(),
+          'ielts-speaking-report/v1' =>
+            completeIeltsSpeakingReportContractFixture()['report']!
+                as Map<String, Object?>,
+          _ => <String, Object?>{'schema_version': detailSchema},
+        },
     createdAt: createdAt,
   );
   return ReviewHistoryItem(
@@ -290,6 +336,20 @@ Map<String, Object?> _sectionDetail() => <String, Object?>{
     _sectionReview(part: 'PART_3', index: 2),
   ],
 };
+
+Map<String, Object?> _part1SectionDetail(String improvementFindingId) =>
+    <String, Object?>{
+      'schema_version': 'ielts-speaking-practice-report/v1',
+      'report_scope': 'PART_1',
+      'available_sections': <Object?>['PART_1'],
+      'questions': <Object?>[_sectionQuestion(part: 'PART_1', index: 1)],
+      'section_reviews': <Object?>[
+        <String, Object?>{
+          ..._sectionReview(part: 'PART_1', index: 1),
+          'improvement_finding_ids': <Object?>[improvementFindingId],
+        },
+      ],
+    };
 
 Map<String, Object?> _sectionQuestion({
   required String part,

--- a/mobile/test/review/practice_report_status_test.dart
+++ b/mobile/test/review/practice_report_status_test.dart
@@ -318,6 +318,31 @@ void main() {
     expect(detail.sectionReviews.last.partId, IeltsSpeakingPartId.part3);
   });
 
+  test('accepts versioned finding references from formal reports', () {
+    final detail = _sectionDetail();
+    final reviews = detail['section_reviews']! as List<Object?>;
+    (reviews.first as Map<String, Object?>)['improvement_finding_ids'] =
+        <Object?>['general-finding:part2.improvement-v1'];
+
+    final decoded = decodeIeltsPracticeReportDetail(detail);
+
+    expect(decoded.sectionReviews.first.improvementFindingIds, <String>[
+      'general-finding:part2.improvement-v1',
+    ]);
+  });
+
+  test('rejects malformed versioned finding references', () {
+    final detail = _sectionDetail();
+    final reviews = detail['section_reviews']! as List<Object?>;
+    (reviews.first as Map<String, Object?>)['improvement_finding_ids'] =
+        <Object?>['general finding with spaces'];
+
+    expect(
+      () => decodeIeltsPracticeReportDetail(detail),
+      throwsA(isA<IeltsPracticeReportDecodeException>()),
+    );
+  });
+
   test('rejects practice report sections outside server order', () {
     final detail = _sectionDetail()
       ..['available_sections'] = <Object?>['PART_3', 'PART_2']


### PR DESCRIPTION
## 功能描述

- 恢复 IELTS 单 Part 正式报告的结构化详细反馈。
- 合法的 `general-finding:...` 引用可关联真实评分 finding。
- 非法引用、未知引用、错 Part 与错误证据绑定仍严格拒绝。

## 实现思路

- finding 引用采用与 Evaluation `finding_id` 一致的版本化标识规则。
- 普通 question、turn、evidence identifier 保持原有严格校验。
- 路由继续使用既有单 Part 报告详情，不放宽未知字段合同。

## 可复现测试

- `flutter analyze lib/features/coaching/review/ielts_practice_report_decoder.dart test/review/ielts_report_routing_test.dart test/review/practice_report_status_test.dart`：通过。
- `flutter test test/review/ielts_report_routing_test.dart test/review/practice_report_status_test.dart`：35/35 通过。

Closes #622