### PR TITLE
fix(ielts): remove report criterion icons

### DIFF
--- a/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
@@ -907,21 +907,6 @@ class _CriterionFeedback extends StatelessWidget {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  width: 42,
-                  height: 42,
-                  decoration: BoxDecoration(
-                    color: _criterionColor(
-                      criterion.id,
-                    ).withValues(alpha: 0.12),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Icon(
-                    _criterionIcon(criterion.id),
-                    color: _criterionColor(criterion.id),
-                  ),
-                ),
-                const SizedBox(width: SpeakUpDesign.space12),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -1075,16 +1060,6 @@ String _criterionEnglishLabel(IeltsSpeakingCriterionId criterion) =>
     };
 
 Color _criterionColor(IeltsSpeakingCriterionId _) => SpeakUpDesign.ink;
-
-IconData _criterionIcon(IeltsSpeakingCriterionId criterion) =>
-    switch (criterion) {
-      IeltsSpeakingCriterionId.fluencyAndCoherence =>
-        Icons.auto_stories_rounded,
-      IeltsSpeakingCriterionId.lexicalResource => Icons.translate_rounded,
-      IeltsSpeakingCriterionId.grammaticalRangeAndAccuracy =>
-        Icons.task_alt_rounded,
-      IeltsSpeakingCriterionId.pronunciation => Icons.record_voice_over_rounded,
-    };
 
 String _durationLabel(int durationMs) {
   final totalSeconds = durationMs ~/ 1000;

--- a/mobile/test/review/ielts_speaking_report_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_view_test.dart
@@ -84,6 +84,20 @@ void main() {
     expect(find.text('分 Part 复盘'), findsNothing);
     expect(find.text('同题复练'), findsNothing);
     expect(find.textContaining('Band 0'), findsNothing);
+    for (final criterion in <String>[
+      'fluencyAndCoherence',
+      'lexicalResource',
+      'grammaticalRangeAndAccuracy',
+      'pronunciation',
+    ]) {
+      expect(
+        find.descendant(
+          of: find.byKey(Key('ielts-speaking-criterion-$criterion')),
+          matching: find.byType(Icon),
+        ),
+        findsNothing,
+      );
+    }
   });
 
   testWidgets('renders all four Bands and rounded Overall', (tester) async {


### PR DESCRIPTION
## 功能描述

- 移除 IELTS 完整模考四个评分维度卡片标题前的装饰性图标及占位。
- 保留维度名称、英文名称、Band、反馈、证据和建议。
- 不修改专项报告、雷达图、报告数据契约或评分逻辑。

## 实现思路

- 删除评分维度到装饰图标的映射和标题行图标节点。
- 继续复用现有标题与 Band 布局，不新增组件或样式分支。
- 增加 Widget 断言，确保完整报告不再渲染这些图标。

## 可复现测试

- `flutter analyze lib/features/coaching/review/ielts_speaking_report_view.dart test/review/ielts_speaking_report_view_test.dart`：通过。
- `flutter test test/review/ielts_speaking_report_view_test.dart`：7/7 通过。
- 按用户明确要求直接提交 PR；合入前仍需 Reviewer 复现并确认视觉。

Closes #620