### PR TITLE
fix(ielts): 修复完整模考报告多条 Part 反馈无法解码

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -2453,11 +2453,11 @@ components:
           items:
             $ref: '#/components/schemas/StableIdentifier'
         strength_finding_ids:
-          $ref: '#/components/schemas/IeltsSpeakingFindingIds'
+          $ref: '#/components/schemas/IeltsSpeakingPartFindingIds'
         improvement_finding_ids:
-          $ref: '#/components/schemas/IeltsSpeakingFindingIds'
+          $ref: '#/components/schemas/IeltsSpeakingPartFindingIds'
         upgrade_example_finding_ids:
-          $ref: '#/components/schemas/IeltsSpeakingFindingIds'
+          $ref: '#/components/schemas/IeltsSpeakingPartFindingIds'
     IeltsSpeakingQuestionReview:
       type: object
       additionalProperties: false
@@ -2646,6 +2646,12 @@ components:
     IeltsSpeakingFindingIds:
       type: array
       maxItems: 3
+      uniqueItems: true
+      items:
+        $ref: '#/components/schemas/StableIdentifier'
+    IeltsSpeakingPartFindingIds:
+      type: array
+      maxItems: 36
       uniqueItems: true
       items:
         $ref: '#/components/schemas/StableIdentifier'

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -1462,6 +1462,47 @@ for (const [name, value] of Object.entries(ieltsSpeakingReportFixture)) {
   );
   assertIeltsSpeakingReportSemantics(value);
 }
+const ieltsReportWithFourPartFindings = structuredClone(
+  ieltsSpeakingReportFixture.ready,
+);
+ieltsReportWithFourPartFindings.report.part_reviews[0]
+  .improvement_finding_ids = Array.from(
+  { length: 4 },
+  (_, index) => `ielts_part_finding_${index}`,
+);
+assertValid(
+  'IELTS Speaking Part with four aggregated findings',
+  'IeltsSpeakingReportEnvelope',
+  ieltsReportWithFourPartFindings,
+);
+
+const ieltsReportWithThirtySevenPartFindings = structuredClone(
+  ieltsSpeakingReportFixture.ready,
+);
+ieltsReportWithThirtySevenPartFindings.report.part_reviews[0]
+  .improvement_finding_ids = Array.from(
+  { length: 37 },
+  (_, index) => `ielts_part_finding_${index}`,
+);
+assertSchemaRejected(
+  'IELTS Speaking Part with 37 aggregated findings',
+  'IeltsSpeakingReportEnvelope',
+  ieltsReportWithThirtySevenPartFindings,
+);
+
+const ieltsReportWithFourQuestionCriterionFindings = structuredClone(
+  ieltsSpeakingReportFixture.ready,
+);
+ieltsReportWithFourQuestionCriterionFindings.report.questions[0]
+  .criterion_findings[0].strength_finding_ids = Array.from(
+  { length: 4 },
+  (_, index) => `ielts_question_finding_${index}`,
+);
+assertSchemaRejected(
+  'IELTS Speaking question criterion with four findings',
+  'IeltsSpeakingReportEnvelope',
+  ieltsReportWithFourQuestionCriterionFindings,
+);
 const digitLeadingIeltsReport = structuredClone(
   ieltsSpeakingReportFixture.ready,
 );

--- a/mobile/lib/features/coaching/review/ielts_speaking_report_decoder.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_decoder.dart
@@ -788,15 +788,15 @@ IeltsSpeakingPartReview _partReview(
     ),
     strengthFindingIds: _uniqueIdentifiers(
       root['strength_finding_ids'],
-      maximumItems: 3,
+      maximumItems: _maximumPartFindingRefs,
     ),
     improvementFindingIds: _uniqueIdentifiers(
       root['improvement_finding_ids'],
-      maximumItems: 3,
+      maximumItems: _maximumPartFindingRefs,
     ),
     upgradeExampleFindingIds: _uniqueIdentifiers(
       root['upgrade_example_finding_ids'],
-      maximumItems: 3,
+      maximumItems: _maximumPartFindingRefs,
     ),
   );
 }
@@ -1058,6 +1058,8 @@ const _criterionOrder = <IeltsSpeakingCriterionId>[
   IeltsSpeakingCriterionId.grammaticalRangeAndAccuracy,
   IeltsSpeakingCriterionId.pronunciation,
 ];
+
+const _maximumPartFindingRefs = 36;
 
 const _partOrder = <IeltsSpeakingPartId>[
   IeltsSpeakingPartId.part1,

--- a/mobile/test/review/ielts_speaking_report_decoder_test.dart
+++ b/mobile/test/review/ielts_speaking_report_decoder_test.dart
@@ -117,6 +117,76 @@ void main() {
     expect(decoded.partReviews[2].questionIndexes, <int>[4, 5]);
   });
 
+  test('decodes a Part that aggregates more than three finding refs', () {
+    final value = _readyClone();
+    final lexical = _criterion(value, 1);
+    final improvements = lexical['improvements']! as List<Object?>;
+    final source = improvements.single! as Map<String, Object?>;
+    for (final id in <String>['ielts_finding_lr_002', 'ielts_finding_lr_003']) {
+      improvements.add(
+        cloneIeltsSpeakingReportFixture(source)..['finding_id'] = id,
+      );
+    }
+    final questionFindings =
+        _question(value, 0)['criterion_findings']! as List<Object?>;
+    (questionFindings[1]!
+        as Map<String, Object?>)['improvement_finding_ids'] = <Object?>[
+      'ielts_finding_lr_001',
+      'ielts_finding_lr_002',
+      'ielts_finding_lr_003',
+    ];
+    _part(value, 0)['improvement_finding_ids'] = <Object?>[
+      'ielts_finding_lr_001',
+      'ielts_finding_lr_002',
+      'ielts_finding_lr_003',
+      'ielts_finding_gra_001',
+    ];
+
+    final decoded = decodeIeltsSpeakingReport(value).report!;
+
+    expect(decoded.partReviews.first.improvementFindingIds, hasLength(4));
+  });
+
+  test('rejects a Part with more than 36 finding refs', () {
+    final value = _readyClone();
+    _part(value, 0)['improvement_finding_ids'] = <Object?>[
+      for (var index = 0; index < 37; index++) 'ielts_finding_$index',
+    ];
+
+    expect(
+      () => decodeIeltsSpeakingReport(value),
+      throwsA(isA<IeltsSpeakingReportDecodeException>()),
+    );
+  });
+
+  test('rejects duplicate finding refs within a Part', () {
+    final value = _readyClone();
+    _part(value, 0)['improvement_finding_ids'] = <Object?>[
+      'ielts_finding_lr_001',
+      'ielts_finding_lr_001',
+    ];
+
+    expect(
+      () => decodeIeltsSpeakingReport(value),
+      throwsA(isA<IeltsSpeakingReportDecodeException>()),
+    );
+  });
+
+  test('rejects a question criterion with more than three finding refs', () {
+    final value = _readyClone();
+    final questionFindings =
+        _question(value, 0)['criterion_findings']! as List<Object?>;
+    (questionFindings.first!
+        as Map<String, Object?>)['strength_finding_ids'] = <Object?>[
+      for (var index = 0; index < 4; index++) 'ielts_finding_$index',
+    ];
+
+    expect(
+      () => decodeIeltsSpeakingReport(value),
+      throwsA(isA<IeltsSpeakingReportDecodeException>()),
+    );
+  });
+
   test('accepts only false for an explicitly non-retryable failure', () {
     final value = cloneIeltsSpeakingReportFixture(
       ieltsSpeakingReportContractFixture()['failed'],

--- a/mobile/test/review/ielts_speaking_report_large_feedback_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_large_feedback_view_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
+import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+
+import 'ielts_speaking_report_fixture.dart';
+
+void main() {
+  testWidgets('renders a complete report with more than three Part findings', (
+    tester,
+  ) async {
+    final value = completeIeltsSpeakingReportContractFixture();
+    final report = value['report']! as Map<String, Object?>;
+    final criteria = report['criteria']! as List<Object?>;
+    final lexical = criteria[1]! as Map<String, Object?>;
+    final improvements = lexical['improvements']! as List<Object?>;
+    final source = improvements.single! as Map<String, Object?>;
+    for (final id in <String>['ielts_finding_lr_002', 'ielts_finding_lr_003']) {
+      improvements.add(
+        cloneIeltsSpeakingReportFixture(source)..['finding_id'] = id,
+      );
+    }
+
+    final questions = report['questions']! as List<Object?>;
+    final firstQuestion = questions.first! as Map<String, Object?>;
+    final questionFindings =
+        firstQuestion['criterion_findings']! as List<Object?>;
+    (questionFindings[1]!
+        as Map<String, Object?>)['improvement_finding_ids'] = <Object?>[
+      'ielts_finding_lr_001',
+      'ielts_finding_lr_002',
+      'ielts_finding_lr_003',
+    ];
+
+    final parts = report['part_reviews']! as List<Object?>;
+    (parts.first!
+        as Map<String, Object?>)['improvement_finding_ids'] = <Object?>[
+      'ielts_finding_lr_001',
+      'ielts_finding_lr_002',
+      'ielts_finding_lr_003',
+      'ielts_finding_gra_001',
+    ];
+
+    final decoded = decodeIeltsSpeakingReport(value).report!;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: IeltsSpeakingReadyReportView(report: decoded),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('ielts-speaking-overall-available')),
+      findsOneWidget,
+    );
+    expect(find.text('6.5'), findsOneWidget);
+    final radar = tester.widget<FourAxisScoreRadar>(
+      find.byType(FourAxisScoreRadar),
+    );
+    expect(radar.maximum, 9);
+    for (final criterion in IeltsSpeakingCriterionId.values) {
+      expect(
+        find.byKey(Key('ielts-speaking-criterion-${criterion.name}')),
+        findsOneWidget,
+      );
+    }
+    expect(find.text('评分描述'), findsOneWidget);
+    expect(find.text('改进建议'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-speaking-target-not-configured')),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Replace the general word with one exact noun.'),
+      findsWidgets,
+    );
+  });
+}


### PR DESCRIPTION
## 功能描述

修复 IELTS 完整模考报告在 Part 聚合反馈超过 3 条时无法打开的问题，恢复专用报告中的总分、9 分制雷达图、四项评分描述与改进建议。

Closes #632

## 实现思路

- 移动端仅将 Part 级 strength/improvement/upgrade finding 引用上限对齐后端契约的 36；题目单维引用仍保持最多 3 条。
- OpenAPI 新增 Part 专用 finding IDs schema（maxItems: 36），消除契约与服务端响应不一致。
- 保留唯一性校验以及 37 条越界拒绝，避免放宽后掩盖异常响应。
- 新增 UI 回归，确认大于 3 条 Part 反馈时仍渲染总分、maximum=9 雷达、四项卡片、评分描述和改进建议。

## 可复现测试

- `cd api && npm run check`
- `cd mobile && flutter analyze --no-pub`
- `cd mobile && flutter test --no-pub test/review/ielts_speaking_report_decoder_test.dart test/review/ielts_speaking_report_view_test.dart test/review/ielts_speaking_report_large_feedback_view_test.dart test/review/ielts_report_routing_test.dart`
- `make dev-ios-simulator`

移动端相关测试 29 项通过；使用真实后端、阿里 OSS、数字人关闭，在本次 15/15 完整模考真实报告上复验：报告可打开，显示口语总分 5/9、四项均 5 的 0–9 雷达图，并可查看四项评分描述和改进建议。