### PR TITLE
fix(ielts): Part 1 完成后直达专项复盘

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -995,7 +995,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     _readyReportNavigationScheduled = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    scheduleMicrotask(() {
       _readyReportNavigationScheduled = false;
       if (mounted && !_disposing) {
         unawaited(_openReadyReport());

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -24,6 +24,7 @@ import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.da
 import 'package:speakup/features/coaching/review/evaluation_report_presentation.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
+import 'package:speakup/features/coaching/review/practice_report_status.dart';
 import 'package:speakup/features/coaching/review/practice_report_status_controller.dart';
 import 'package:speakup/features/coaching/review/practice_report_status_view.dart';
 import 'package:speakup/features/coaching/review/review.dart';
@@ -155,6 +156,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   int _observedCompletedTurns = 0;
   bool _preserveCompletedConversation = false;
   bool _showCompletionSheet = false;
+  bool _readyReportNavigationScheduled = false;
+  bool _openingReadyReport = false;
+  bool _part1ReadyReviewOpened = false;
 
   IeltsPracticeSelection? get _selection {
     final sessionId = widget.controller.practiceSessionId;
@@ -240,6 +244,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _observedMessageCount = widget.controller.practiceMessages.length;
     _observedCompletedTurns = widget.controller.completedTurns;
     widget.controller.addListener(_handleControllerState);
+    widget.reportStatusController?.addListener(_handleReportStatusState);
     widget.speechFeedbackController?.addListener(_handleSpeechFeedbackState);
     _notesController.addListener(_saveNotes);
     _syncSpeechFeedbackSources();
@@ -261,6 +266,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _observedCompletedTurns = widget.controller.completedTurns;
       _preserveCompletedConversation = false;
       _showCompletionSheet = false;
+      _readyReportNavigationScheduled = false;
+      _openingReadyReport = false;
+      _part1ReadyReviewOpened = false;
       _questionNarrationGeneration++;
       _autoNarratedQuestionId = null;
       _autoNarratedQuestionText = null;
@@ -284,11 +292,19 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _syncSpeechFeedbackSources();
     }
     if (oldWidget.reportStatusController != widget.reportStatusController) {
+      oldWidget.reportStatusController?.removeListener(
+        _handleReportStatusState,
+      );
       final sessionId = oldWidget.reportStatusController?.practiceSessionId;
       if (sessionId != null) {
         oldWidget.reportStatusController?.cancel(sessionId);
       }
+      widget.reportStatusController?.addListener(_handleReportStatusState);
+      _readyReportNavigationScheduled = false;
+      _openingReadyReport = false;
+      _part1ReadyReviewOpened = false;
       _syncCompletionReport();
+      _handleReportStatusState();
     }
   }
 
@@ -296,6 +312,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   void dispose() {
     _disposing = true;
     widget.controller.removeListener(_handleControllerState);
+    widget.reportStatusController?.removeListener(_handleReportStatusState);
     widget.speechFeedbackController?.removeListener(_handleSpeechFeedbackState);
     _removeSpeechFeedbackSources(widget.speechFeedbackController);
     unawaited(widget.controller.cancelRecording());
@@ -962,6 +979,28 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     unawaited(reportController.load(sessionId));
+  }
+
+  void _handleReportStatusState() {
+    final reportController = widget.reportStatusController;
+    if (!mounted ||
+        _disposing ||
+        widget.controller.practiceMode != PracticeMode.part1 ||
+        _progress?.phase != IeltsMockPhase.complete ||
+        reportController?.status?.evaluationStatus !=
+            PracticeReportEvaluationStatus.ready ||
+        _readyReportNavigationScheduled ||
+        _openingReadyReport ||
+        _part1ReadyReviewOpened) {
+      return;
+    }
+    _readyReportNavigationScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _readyReportNavigationScheduled = false;
+      if (mounted && !_disposing) {
+        unawaited(_openReadyReport());
+      }
+    });
   }
 
   void _syncTicker() {
@@ -1731,43 +1770,58 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   Future<void> _openReadyReport() async {
+    if (_openingReadyReport) return;
     final statusController = widget.reportStatusController;
     final sessionId = widget.controller.practiceSessionId;
-    if (statusController == null || sessionId == null) return;
-    final report = await statusController.loadReadyReport();
-    if (!mounted || report == null) return;
-    if (_mode == PracticeMode.fullMock) {
-      try {
-        final detail = decodeIeltsSpeakingReportDetail(report.detail);
-        await Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (_) => _CompletedReportPage(
-              title: evaluationReportTitle(report),
-              child: IeltsSpeakingReadyReportView(report: detail),
+    final mode = widget.controller.practiceMode;
+    if (statusController == null || sessionId == null || mode == null) return;
+    _openingReadyReport = true;
+    try {
+      final report = await statusController.loadReadyReport();
+      if (!mounted || report == null) return;
+      if (mode == PracticeMode.fullMock) {
+        try {
+          final detail = decodeIeltsSpeakingReportDetail(report.detail);
+          await Navigator.of(context).push<void>(
+            MaterialPageRoute<void>(
+              builder: (_) => _CompletedReportPage(
+                title: evaluationReportTitle(report),
+                child: IeltsSpeakingReadyReportView(report: detail),
+              ),
             ),
-          ),
-        );
-      } on IeltsSpeakingReportDecodeException {
-        if (mounted) {
-          ScaffoldMessenger.of(context)
-            ..hideCurrentSnackBar()
-            ..showSnackBar(const SnackBar(content: Text('报告内容暂时无法识别，请稍后重试。')));
+          );
+        } on IeltsSpeakingReportDecodeException {
+          if (mounted) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                const SnackBar(content: Text('报告内容暂时无法识别，请稍后重试。')),
+              );
+          }
         }
+        return;
       }
-      return;
+      final item = ReviewHistoryItem(
+        review: presentEvaluationReport(report),
+        report: report,
+        practiceSessionId: report.practiceSessionId,
+        createdAt: report.createdAt,
+        completedAt: report.createdAt,
+      );
+      if (mode == PracticeMode.part1) {
+        _part1ReadyReviewOpened = true;
+      }
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute<void>(
+          builder: (_) => ReviewReportDetailPage(item: item),
+        ),
+      );
+      if (mounted && widget.controller.practiceMode == PracticeMode.part1) {
+        await _finishSection(IeltsPracticeCompletionAction.list);
+      }
+    } finally {
+      _openingReadyReport = false;
     }
-    final item = ReviewHistoryItem(
-      review: presentEvaluationReport(report),
-      report: report,
-      practiceSessionId: report.practiceSessionId,
-      createdAt: report.createdAt,
-      completedAt: report.createdAt,
-    );
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (_) => ReviewReportDetailPage(item: item),
-      ),
-    );
   }
 
   void _leaveCompletedPractice() {

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1588,9 +1588,14 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       );
     }
     final complete = progress.phase == IeltsMockPhase.complete;
-    final showCompletionPage = complete && !_preserveCompletedConversation;
+    final keepPart1CompletionConversation = _keepsPart1CompletionInConversation(
+      progress,
+    );
+    final keepCompletedConversation =
+        _preserveCompletedConversation || keepPart1CompletionConversation;
+    final showCompletionPage = complete && !keepCompletedConversation;
     final completionSheet = _completionSheet(progress);
-    final stagePhase = complete && _preserveCompletedConversation
+    final stagePhase = complete && keepCompletedConversation
         ? (_mode == PracticeMode.part1
               ? IeltsMockPhase.part1
               : IeltsMockPhase.part3)
@@ -1691,18 +1696,23 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       duration: const Duration(milliseconds: 220),
       child:
           progress.phase == IeltsMockPhase.complete &&
-              _preserveCompletedConversation
+              (_preserveCompletedConversation ||
+                  _keepsPart1CompletionInConversation(progress))
           ? _completedConversationPhase()
           : _buildPhase(progress),
     );
   }
 
   Widget? _completionSheet(IeltsMockProgress progress) {
-    if (_showCompletionSheet) {
+    if (_showCompletionSheet || _keepsPart1CompletionInConversation(progress)) {
       return _SectionCompletionSheet(
         title: _completionTitle,
         message: '${widget.controller.completedTurns} 道回答已保存',
-        primaryLabel: _mode == PracticeMode.fullMock ? '查看报告状态' : '查看专项复盘',
+        primaryLabel: switch (_mode) {
+          PracticeMode.fullMock => '查看报告状态',
+          PracticeMode.part1 => _part1CompletionPrimaryLabel,
+          _ => '查看专项复盘',
+        },
         secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
         onPrimary: _openCompletedReview,
         onSecondary: _leaveCompletedPractice,
@@ -1734,6 +1744,20 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     return null;
   }
 
+  bool _keepsPart1CompletionInConversation(IeltsMockProgress progress) {
+    final reportController = widget.reportStatusController;
+    if (_mode != PracticeMode.part1 ||
+        progress.phase != IeltsMockPhase.complete ||
+        reportController == null) {
+      return false;
+    }
+    final reportStatus = reportController.status?.evaluationStatus;
+    return reportStatus == PracticeReportEvaluationStatus.queued ||
+        reportStatus == PracticeReportEvaluationStatus.running ||
+        reportStatus == PracticeReportEvaluationStatus.ready ||
+        reportStatus == null && reportController.errorMessage == null;
+  }
+
   String get _completionTitle => switch (_mode) {
     PracticeMode.part1 => 'Part 1 已完成',
     PracticeMode.part2 => 'Part 2 + Part 3 已完成',
@@ -1763,10 +1787,40 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _openCompletedReview() {
+    if (_mode == PracticeMode.part1) {
+      final reportController = widget.reportStatusController;
+      final reportStatus = reportController?.status?.evaluationStatus;
+      if (reportStatus == PracticeReportEvaluationStatus.ready) {
+        unawaited(_openReadyReport());
+        return;
+      }
+      if (reportController != null &&
+          (reportStatus == null ||
+              reportStatus == PracticeReportEvaluationStatus.queued ||
+              reportStatus == PracticeReportEvaluationStatus.running)) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(const SnackBar(content: Text('复盘生成中，完成后将自动打开。')));
+        return;
+      }
+    }
     setState(() {
       _showCompletionSheet = false;
       _preserveCompletedConversation = false;
     });
+  }
+
+  String get _part1CompletionPrimaryLabel {
+    final reportController = widget.reportStatusController;
+    final reportStatus = reportController?.status?.evaluationStatus;
+    if (reportStatus == PracticeReportEvaluationStatus.ready) {
+      return '查看专项复盘';
+    }
+    if (reportStatus == PracticeReportEvaluationStatus.failed ||
+        reportController?.errorMessage != null && reportStatus == null) {
+      return '查看生成状态';
+    }
+    return '复盘生成中…';
   }
 
   Future<void> _openReadyReport() async {

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -21,6 +21,7 @@ import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
 import 'package:speakup/features/coaching/review/evaluation_report_presentation.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_view.dart';
@@ -156,9 +157,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   int _observedCompletedTurns = 0;
   bool _preserveCompletedConversation = false;
   bool _showCompletionSheet = false;
-  bool _readyReportNavigationScheduled = false;
   bool _openingReadyReport = false;
-  bool _part1ReadyReviewOpened = false;
 
   IeltsPracticeSelection? get _selection {
     final sessionId = widget.controller.practiceSessionId;
@@ -244,7 +243,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _observedMessageCount = widget.controller.practiceMessages.length;
     _observedCompletedTurns = widget.controller.completedTurns;
     widget.controller.addListener(_handleControllerState);
-    widget.reportStatusController?.addListener(_handleReportStatusState);
     widget.speechFeedbackController?.addListener(_handleSpeechFeedbackState);
     _notesController.addListener(_saveNotes);
     _syncSpeechFeedbackSources();
@@ -266,9 +264,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _observedCompletedTurns = widget.controller.completedTurns;
       _preserveCompletedConversation = false;
       _showCompletionSheet = false;
-      _readyReportNavigationScheduled = false;
       _openingReadyReport = false;
-      _part1ReadyReviewOpened = false;
       _questionNarrationGeneration++;
       _autoNarratedQuestionId = null;
       _autoNarratedQuestionText = null;
@@ -292,19 +288,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _syncSpeechFeedbackSources();
     }
     if (oldWidget.reportStatusController != widget.reportStatusController) {
-      oldWidget.reportStatusController?.removeListener(
-        _handleReportStatusState,
-      );
       final sessionId = oldWidget.reportStatusController?.practiceSessionId;
       if (sessionId != null) {
         oldWidget.reportStatusController?.cancel(sessionId);
       }
-      widget.reportStatusController?.addListener(_handleReportStatusState);
-      _readyReportNavigationScheduled = false;
       _openingReadyReport = false;
-      _part1ReadyReviewOpened = false;
       _syncCompletionReport();
-      _handleReportStatusState();
     }
   }
 
@@ -312,7 +301,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   void dispose() {
     _disposing = true;
     widget.controller.removeListener(_handleControllerState);
-    widget.reportStatusController?.removeListener(_handleReportStatusState);
     widget.speechFeedbackController?.removeListener(_handleSpeechFeedbackState);
     _removeSpeechFeedbackSources(widget.speechFeedbackController);
     unawaited(widget.controller.cancelRecording());
@@ -979,28 +967,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     unawaited(reportController.load(sessionId));
-  }
-
-  void _handleReportStatusState() {
-    final reportController = widget.reportStatusController;
-    if (!mounted ||
-        _disposing ||
-        widget.controller.practiceMode != PracticeMode.part1 ||
-        _progress?.phase != IeltsMockPhase.complete ||
-        reportController?.status?.evaluationStatus !=
-            PracticeReportEvaluationStatus.ready ||
-        _readyReportNavigationScheduled ||
-        _openingReadyReport ||
-        _part1ReadyReviewOpened) {
-      return;
-    }
-    _readyReportNavigationScheduled = true;
-    scheduleMicrotask(() {
-      _readyReportNavigationScheduled = false;
-      if (mounted && !_disposing) {
-        unawaited(_openReadyReport());
-      }
-    });
   }
 
   void _syncTicker() {
@@ -1710,7 +1676,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         message: '${widget.controller.completedTurns} 道回答已保存',
         primaryLabel: switch (_mode) {
           PracticeMode.fullMock => '查看报告状态',
-          PracticeMode.part1 => _part1CompletionPrimaryLabel,
+          PracticeMode.part1 => '查看复盘报告',
           _ => '查看专项复盘',
         },
         secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
@@ -1779,25 +1745,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   void _openCompletedReview() {
     if (_mode == PracticeMode.part1) {
-      final reportController = widget.reportStatusController;
-      final reportStatus = reportController?.status?.evaluationStatus;
-      if (reportStatus == PracticeReportEvaluationStatus.ready) {
-        unawaited(_openReadyReport());
-        return;
-      }
-      if (reportStatus == PracticeReportEvaluationStatus.queued ||
-          reportStatus == PracticeReportEvaluationStatus.running ||
-          reportStatus == null && reportController?.errorMessage == null) {
-        _showPart1ReportMessage('复盘生成中，完成后将自动打开。');
-      } else if (reportController?.canRetry == true) {
-        unawaited(reportController!.retry());
-        _showPart1ReportMessage('正在重新获取复盘状态…');
-      } else if (reportStatus == PracticeReportEvaluationStatus.failed ||
-          reportController?.errorMessage != null) {
-        _showPart1ReportMessage('复盘暂时无法生成，请稍后到复盘页查看。');
-      } else {
-        _showPart1ReportMessage('复盘生成中，完成后将自动打开。');
-      }
+      unawaited(_openPart1Review());
       return;
     }
     setState(() {
@@ -1806,23 +1754,24 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
   }
 
-  String get _part1CompletionPrimaryLabel {
-    final reportController = widget.reportStatusController;
-    final reportStatus = reportController?.status?.evaluationStatus;
-    if (reportStatus == PracticeReportEvaluationStatus.ready) {
-      return '查看专项复盘';
+  Future<void> _openPart1Review() async {
+    if (_openingReadyReport) return;
+    _openingReadyReport = true;
+    try {
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute<void>(
+          builder: (_) => _Part1ReviewPage(
+            controller: widget.reportStatusController,
+            answerCount: widget.controller.completedTurns,
+          ),
+        ),
+      );
+      if (mounted && widget.controller.practiceMode == PracticeMode.part1) {
+        await _finishSection(IeltsPracticeCompletionAction.list);
+      }
+    } finally {
+      _openingReadyReport = false;
     }
-    if (reportStatus == PracticeReportEvaluationStatus.failed ||
-        reportController?.errorMessage != null && reportStatus == null) {
-      return reportController?.canRetry == true ? '重试复盘状态' : '复盘暂不可用';
-    }
-    return '复盘生成中…';
-  }
-
-  void _showPart1ReportMessage(String message) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _openReadyReport() async {
@@ -1864,9 +1813,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         createdAt: report.createdAt,
         completedAt: report.createdAt,
       );
-      if (mode == PracticeMode.part1) {
-        _part1ReadyReviewOpened = true;
-      }
       await Navigator.of(context).push<void>(
         MaterialPageRoute<void>(
           builder: (_) => ReviewReportDetailPage(item: item),
@@ -3732,6 +3678,321 @@ class _CompactCompletionHeader extends StatelessWidget {
             ],
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _Part1ReviewPage extends StatefulWidget {
+  const _Part1ReviewPage({required this.controller, required this.answerCount});
+
+  final PracticeReportStatusController? controller;
+  final int answerCount;
+
+  @override
+  State<_Part1ReviewPage> createState() => _Part1ReviewPageState();
+}
+
+class _Part1ReviewPageState extends State<_Part1ReviewPage> {
+  EvaluationReport? _report;
+  bool _loadingReport = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?.addListener(_handleStatusChanged);
+    scheduleMicrotask(_syncReadyReport);
+  }
+
+  @override
+  void didUpdateWidget(covariant _Part1ReviewPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+    oldWidget.controller?.removeListener(_handleStatusChanged);
+    widget.controller?.addListener(_handleStatusChanged);
+    _report = null;
+    _loadingReport = false;
+    scheduleMicrotask(_syncReadyReport);
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_handleStatusChanged);
+    super.dispose();
+  }
+
+  void _handleStatusChanged() {
+    if (!mounted) return;
+    setState(() {});
+    unawaited(_syncReadyReport());
+  }
+
+  Future<void> _syncReadyReport() async {
+    final controller = widget.controller;
+    if (!mounted ||
+        controller == null ||
+        _loadingReport ||
+        _report != null ||
+        controller.status?.evaluationStatus !=
+            PracticeReportEvaluationStatus.ready) {
+      return;
+    }
+    _loadingReport = true;
+    final report = await controller.loadReadyReport();
+    if (!mounted) return;
+    setState(() {
+      _report = report;
+      _loadingReport = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final report = _report;
+    if (report != null) {
+      return ReviewReportDetailPage(
+        item: ReviewHistoryItem(
+          review: presentEvaluationReport(report),
+          report: report,
+          practiceSessionId: report.practiceSessionId,
+          createdAt: report.createdAt,
+          completedAt: report.createdAt,
+        ),
+      );
+    }
+    final controller = widget.controller;
+    final status = controller?.status?.evaluationStatus;
+    final failed =
+        status == PracticeReportEvaluationStatus.failed ||
+        controller?.errorMessage != null &&
+            status != PracticeReportEvaluationStatus.queued &&
+            status != PracticeReportEvaluationStatus.running;
+    return Scaffold(
+      key: const Key('part1-review-loading-page'),
+      appBar: AppBar(title: const Text('Part 1 专项复盘')),
+      body: SafeArea(
+        top: false,
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(28, 32, 28, 48),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 460),
+              child: failed
+                  ? _Part1ReviewFailure(
+                      message: controller?.errorMessage ?? '本次复盘暂时无法生成。',
+                      canRetry: controller?.canRetry == true,
+                      onRetry: controller == null
+                          ? null
+                          : () => unawaited(controller.retry()),
+                    )
+                  : _Part1ReviewLoading(answerCount: widget.answerCount),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Part1ReviewLoading extends StatefulWidget {
+  const _Part1ReviewLoading({required this.answerCount});
+
+  final int answerCount;
+
+  @override
+  State<_Part1ReviewLoading> createState() => _Part1ReviewLoadingState();
+}
+
+class _Part1ReviewLoadingState extends State<_Part1ReviewLoading>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animation = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1800),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _animation.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedBuilder(
+          animation: _animation,
+          builder: (context, _) {
+            final pulse = (math.sin(_animation.value * math.pi * 2) + 1) / 2;
+            return SizedBox(
+              key: const Key('part1-review-loading-animation'),
+              width: 184,
+              height: 184,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    width: 148 + pulse * 20,
+                    height: 148 + pulse * 20,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: SpeakUpDesign.primaryMuted.withValues(
+                        alpha: 0.45 - pulse * 0.2,
+                      ),
+                    ),
+                  ),
+                  Transform.rotate(
+                    angle: _animation.value * math.pi * 2,
+                    child: Container(
+                      width: 128,
+                      height: 128,
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        gradient: SweepGradient(
+                          colors: [
+                            Colors.transparent,
+                            SpeakUpDesign.tertiary,
+                            SpeakUpDesign.ink,
+                            Colors.transparent,
+                          ],
+                        ),
+                      ),
+                      padding: const EdgeInsets.all(3),
+                      child: const DecoratedBox(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: SpeakUpDesign.canvas,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    width: 92,
+                    height: 92,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: SpeakUpDesign.ink,
+                      boxShadow: [
+                        BoxShadow(
+                          color: SpeakUpDesign.ink.withValues(alpha: 0.16),
+                          blurRadius: 24,
+                          offset: const Offset(0, 10),
+                        ),
+                      ],
+                    ),
+                    child: const Icon(
+                      Icons.auto_graph_rounded,
+                      color: Colors.white,
+                      size: 42,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 28),
+        Text(
+          '正在生成你的专项复盘',
+          textAlign: TextAlign.center,
+          style: SpeakUpDesign.pageTitle.copyWith(fontSize: 25),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          '正在整理 ${widget.answerCount} 道回答，分析表达表现并生成下一步建议',
+          textAlign: TextAlign.center,
+          style: SpeakUpDesign.body.copyWith(height: 1.55),
+        ),
+        const SizedBox(height: 28),
+        const _ReviewLoadingSteps(),
+      ],
+    );
+  }
+}
+
+class _ReviewLoadingSteps extends StatelessWidget {
+  const _ReviewLoadingSteps();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+      ),
+      child: const Row(
+        children: [
+          _LoadingStep(icon: Icons.notes_rounded, label: '整理回答'),
+          _LoadingConnector(),
+          _LoadingStep(icon: Icons.radar_rounded, label: '分析表现'),
+          _LoadingConnector(),
+          _LoadingStep(icon: Icons.lightbulb_outline_rounded, label: '生成建议'),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadingStep extends StatelessWidget {
+  const _LoadingStep({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          Icon(icon, size: 22, color: SpeakUpDesign.ink),
+          const SizedBox(height: 6),
+          Text(label, maxLines: 1, style: SpeakUpDesign.meta),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadingConnector extends StatelessWidget {
+  const _LoadingConnector();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(width: 16, height: 1, color: SpeakUpDesign.border);
+  }
+}
+
+class _Part1ReviewFailure extends StatelessWidget {
+  const _Part1ReviewFailure({
+    required this.message,
+    required this.canRetry,
+    required this.onRetry,
+  });
+
+  final String message;
+  final bool canRetry;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(
+          Icons.error_outline_rounded,
+          size: 64,
+          color: SpeakUpDesign.error,
+        ),
+        const SizedBox(height: 20),
+        Text('复盘暂时没有生成', style: SpeakUpDesign.sectionTitle),
+        const SizedBox(height: 10),
+        Text(message, textAlign: TextAlign.center, style: SpeakUpDesign.body),
+        if (canRetry) ...[
+          const SizedBox(height: 24),
+          FilledButton(onPressed: onRetry, child: const Text('重新加载')),
+        ],
       ],
     );
   }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1745,17 +1745,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   bool _keepsPart1CompletionInConversation(IeltsMockProgress progress) {
-    final reportController = widget.reportStatusController;
-    if (_mode != PracticeMode.part1 ||
-        progress.phase != IeltsMockPhase.complete ||
-        reportController == null) {
-      return false;
-    }
-    final reportStatus = reportController.status?.evaluationStatus;
-    return reportStatus == PracticeReportEvaluationStatus.queued ||
-        reportStatus == PracticeReportEvaluationStatus.running ||
-        reportStatus == PracticeReportEvaluationStatus.ready ||
-        reportStatus == null && reportController.errorMessage == null;
+    return _mode == PracticeMode.part1 &&
+        progress.phase == IeltsMockPhase.complete;
   }
 
   String get _completionTitle => switch (_mode) {
@@ -1794,15 +1785,20 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         unawaited(_openReadyReport());
         return;
       }
-      if (reportController != null &&
-          (reportStatus == null ||
-              reportStatus == PracticeReportEvaluationStatus.queued ||
-              reportStatus == PracticeReportEvaluationStatus.running)) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(const SnackBar(content: Text('复盘生成中，完成后将自动打开。')));
-        return;
+      if (reportStatus == PracticeReportEvaluationStatus.queued ||
+          reportStatus == PracticeReportEvaluationStatus.running ||
+          reportStatus == null && reportController?.errorMessage == null) {
+        _showPart1ReportMessage('复盘生成中，完成后将自动打开。');
+      } else if (reportController?.canRetry == true) {
+        unawaited(reportController!.retry());
+        _showPart1ReportMessage('正在重新获取复盘状态…');
+      } else if (reportStatus == PracticeReportEvaluationStatus.failed ||
+          reportController?.errorMessage != null) {
+        _showPart1ReportMessage('复盘暂时无法生成，请稍后到复盘页查看。');
+      } else {
+        _showPart1ReportMessage('复盘生成中，完成后将自动打开。');
       }
+      return;
     }
     setState(() {
       _showCompletionSheet = false;
@@ -1818,9 +1814,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     if (reportStatus == PracticeReportEvaluationStatus.failed ||
         reportController?.errorMessage != null && reportStatus == null) {
-      return '查看生成状态';
+      return reportController?.canRetry == true ? '重试复盘状态' : '复盘暂不可用';
     }
     return '复盘生成中…';
+  }
+
+  void _showPart1ReportMessage(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _openReadyReport() async {

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1477,16 +1477,13 @@ void main() {
 
       expect(
         find.byKey(const Key('ielts-section-completion-sheet')),
-        findsNothing,
+        findsOneWidget,
       );
       expect(
         find.byKey(const Key('ielts-section-practice-complete-part1')),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(
-        find.byKey(const Key('ielts-completion-report-unavailable')),
-        findsOneWidget,
-      );
+      expect(find.text('复盘生成中，完成后将自动打开。'), findsOneWidget);
       expect(reportClient.started.isCompleted, isFalse);
       expect(reportController.practiceSessionId, isNull);
     },
@@ -1542,15 +1539,7 @@ void main() {
     await tester.pumpAndSettle();
     await _answerCurrentShortQuestion(tester, controller);
 
-    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
-    await tester.pump();
-
-    expect(find.text('练习完成'), findsOneWidget);
-    expect(find.text('4 道回答已保存'), findsOneWidget);
-    expect(find.text('练习下一套'), findsOneWidget);
-    expect(find.byKey(const Key('ielts-section-list-action')), findsNothing);
-
-    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
+    await tester.tap(find.byKey(const Key('ielts-section-list-action')));
     await tester.pumpAndSettle();
 
     final request = preparation.takeNavigationRequest();
@@ -1666,6 +1655,54 @@ void main() {
       );
     },
   );
+
+  testWidgets('Part 1 report failure never falls back to the completion page', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 1, turnLimit: 1);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    final reportController = PracticeReportStatusController(
+      client: _Part1ReportStatusClient(
+        evaluationStatus: PracticeReportEvaluationStatus.failed,
+      ),
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    addTearDown(reportController.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          reportStatusController: reportController,
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('复盘暂不可用'), findsOneWidget);
+    expect(
+      find.byKey(const Key('ielts-section-practice-complete-part1')),
+      findsNothing,
+    );
+  });
 
   testWidgets(
     'Part 1 ready report opens directly and returns to the section list',

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1559,6 +1559,86 @@ void main() {
     expect(find.byKey(const Key('open-section-completion')), findsOneWidget);
   });
 
+  testWidgets(
+    'Part 1 ready report opens directly and returns to the section list',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      final preparation = IeltsPreparationController(
+        client: _UnusedQuestionBankClient(),
+      );
+      final reportClient = _ReadyPart1ReportStatusClient();
+      final reportController = PracticeReportStatusController(
+        client: reportClient,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 1,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(preparation.dispose);
+      addTearDown(reportController.dispose);
+      await _activatePractice(
+        controller,
+        practice,
+        _ieltsScene,
+        mode: PracticeMode.part1,
+      );
+      await preparation.beginSession(
+        _sessionId,
+        PracticeMode.part1,
+        const IeltsPracticeSelection(part1SetId: 'p1-set-02'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                key: const Key('open-part1-practice'),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<IeltsPracticeRouteResult>(
+                    builder: (_) => IeltsSpeakingMockPage(
+                      controller: controller,
+                      progressStore: _MemoryProgressStore(),
+                      ieltsController: preparation,
+                      reportStatusController: reportController,
+                      examinerSpeaker: _ImmediateExaminerSpeaker(),
+                      onExitRequested: () async => true,
+                    ),
+                  ),
+                ),
+                child: const Text('Open Part 1 practice'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('open-part1-practice')));
+      await tester.pumpAndSettle();
+
+      await _answerCurrentShortQuestion(tester, controller);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
+      expect(find.text('Part 1 专项复盘'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part1')),
+        findsNothing,
+      );
+      expect(reportClient.readyReportCalls, 1);
+
+      await tester.tap(find.byKey(const Key('review-detail-back')));
+      await tester.pumpAndSettle();
+
+      final request = preparation.takeNavigationRequest();
+      expect(request?.mode, PracticeMode.part1);
+      expect(request?.selection, isNull);
+      expect(find.byKey(const Key('open-part1-practice')), findsOneWidget);
+    },
+  );
+
   testWidgets('the full-mock PracticeOption opens the three-part flow', (
     tester,
   ) async {
@@ -2186,6 +2266,70 @@ final class _UnusedQuestionBankClient implements IeltsQuestionBankClient {
   Future<IeltsQuestionBank> getQuestionBank() {
     throw UnimplementedError();
   }
+}
+
+final class _ReadyPart1ReportStatusClient
+    implements PracticeReportStatusClient {
+  static const _evaluationId = '7b000001-0000-4000-8000-000000000001';
+  static const _evaluationRevisionId = 'a1000001-0000-4000-8000-000000000001';
+  static const _reportId = '20000000-0000-4000-8000-000000000002';
+
+  int readyReportCalls = 0;
+
+  @override
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async =>
+      PracticeReportStatus(
+        practiceSessionId: practiceSessionId,
+        practiceMode: PracticeMode.part1,
+        reportScope: PracticeReportScope.part1,
+        availableSections: const <IeltsSpeakingPartId>[
+          IeltsSpeakingPartId.part1,
+        ],
+        detailSchema: 'ielts-speaking-practice-report/v1',
+        evaluationStatus: PracticeReportEvaluationStatus.ready,
+        statusUrl: '/v1/practice-sessions/$practiceSessionId/report',
+        evaluationId: _evaluationId,
+        evaluationRevisionId: _evaluationRevisionId,
+        revision: 1,
+        reportRef: const PracticeReportRef(
+          reportId: _reportId,
+          href: '/v1/evaluation-reports/$_reportId',
+        ),
+        scoreability: EvaluationReportScoreability.provisional,
+        summary: 'Part 1 专项复盘已生成。',
+      );
+
+  @override
+  Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) async {
+    readyReportCalls++;
+    return EvaluationReport(
+      id: _reportId,
+      evaluationId: _evaluationId,
+      evaluationRevisionId: _evaluationRevisionId,
+      practiceSessionId: _sessionId,
+      revision: 1,
+      sceneType: EvaluationReportSceneType.ieltsSpeaking,
+      practiceExperience: 'IELTS_SPEAKING',
+      sceneCategory: 'IELTS_SPEAKING',
+      practiceMode: 'PART_1',
+      scoreability: EvaluationReportScoreability.provisional,
+      summary: 'Part 1 专项复盘已生成。',
+      dimensions: const <EvaluationReportDimension>[],
+      priorityActions: const <EvaluationReportPriorityAction>[],
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      detail: const <String, Object?>{
+        'schema_version': 'ielts-speaking-practice-report/v1',
+        'report_scope': 'PART_1',
+        'available_sections': <Object?>['PART_1'],
+        'questions': <Object?>[],
+        'section_reviews': <Object?>[],
+      },
+      createdAt: DateTime.utc(2026, 8, 12),
+    );
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
 }
 
 final class _PracticeReportStatusClient implements PracticeReportStatusClient {

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1560,6 +1560,114 @@ void main() {
   });
 
   testWidgets(
+    'Part 1 running report stays with the final answer instead of opening the completion page',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      final reportController = PracticeReportStatusController(
+        client: _Part1ReportStatusClient(
+          evaluationStatus: PracticeReportEvaluationStatus.running,
+        ),
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 1,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(reportController.dispose);
+      await _activatePractice(
+        controller,
+        practice,
+        _ieltsScene,
+        mode: PracticeMode.part1,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+            reportStatusController: reportController,
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await _answerCurrentShortQuestion(tester, controller);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('复盘生成中…'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part1')),
+        findsNothing,
+      );
+      expect(find.text('复盘生成中，完成后将自动打开。'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'restored completed Part 1 keeps the pending report with the final answer',
+    (tester) async {
+      final practice = _IeltsPracticeClient(initialCompleted: 1, turnLimit: 1);
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      final reportController = PracticeReportStatusController(
+        client: _Part1ReportStatusClient(
+          evaluationStatus: PracticeReportEvaluationStatus.running,
+        ),
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 1,
+      );
+      addTearDown(controller.dispose);
+      addTearDown(reportController.dispose);
+      await _activatePractice(
+        controller,
+        practice,
+        _ieltsScene,
+        mode: PracticeMode.part1,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+            reportStatusController: reportController,
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('复盘生成中…'), findsOneWidget);
+      expect(
+        find.byKey(const Key('ielts-section-practice-complete-part1')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
     'Part 1 ready report opens directly and returns to the section list',
     (tester) async {
       final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
@@ -1570,7 +1678,9 @@ void main() {
       final preparation = IeltsPreparationController(
         client: _UnusedQuestionBankClient(),
       );
-      final reportClient = _ReadyPart1ReportStatusClient();
+      final reportClient = _Part1ReportStatusClient(
+        evaluationStatus: PracticeReportEvaluationStatus.ready,
+      );
       final reportController = PracticeReportStatusController(
         client: reportClient,
         pollInterval: Duration.zero,
@@ -2268,12 +2378,14 @@ final class _UnusedQuestionBankClient implements IeltsQuestionBankClient {
   }
 }
 
-final class _ReadyPart1ReportStatusClient
-    implements PracticeReportStatusClient {
+final class _Part1ReportStatusClient implements PracticeReportStatusClient {
+  _Part1ReportStatusClient({required this.evaluationStatus});
+
   static const _evaluationId = '7b000001-0000-4000-8000-000000000001';
   static const _evaluationRevisionId = 'a1000001-0000-4000-8000-000000000001';
   static const _reportId = '20000000-0000-4000-8000-000000000002';
 
+  final PracticeReportEvaluationStatus evaluationStatus;
   int readyReportCalls = 0;
 
   @override
@@ -2286,17 +2398,23 @@ final class _ReadyPart1ReportStatusClient
           IeltsSpeakingPartId.part1,
         ],
         detailSchema: 'ielts-speaking-practice-report/v1',
-        evaluationStatus: PracticeReportEvaluationStatus.ready,
+        evaluationStatus: evaluationStatus,
         statusUrl: '/v1/practice-sessions/$practiceSessionId/report',
         evaluationId: _evaluationId,
         evaluationRevisionId: _evaluationRevisionId,
         revision: 1,
-        reportRef: const PracticeReportRef(
-          reportId: _reportId,
-          href: '/v1/evaluation-reports/$_reportId',
-        ),
-        scoreability: EvaluationReportScoreability.provisional,
-        summary: 'Part 1 专项复盘已生成。',
+        reportRef: evaluationStatus == PracticeReportEvaluationStatus.ready
+            ? const PracticeReportRef(
+                reportId: _reportId,
+                href: '/v1/evaluation-reports/$_reportId',
+              )
+            : null,
+        scoreability: evaluationStatus == PracticeReportEvaluationStatus.ready
+            ? EvaluationReportScoreability.provisional
+            : null,
+        summary: evaluationStatus == PracticeReportEvaluationStatus.ready
+            ? 'Part 1 专项复盘已生成。'
+            : null,
       );
 
   @override

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1474,18 +1474,17 @@ void main() {
 
       await tester.tap(find.byKey(const Key('ielts-section-review-action')));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
 
       expect(
-        find.byKey(const Key('ielts-section-completion-sheet')),
+        find.byKey(const Key('part1-review-loading-page')),
         findsOneWidget,
       );
-      expect(
-        find.byKey(const Key('ielts-section-practice-complete-part1')),
-        findsNothing,
-      );
-      expect(find.text('复盘生成中，完成后将自动打开。'), findsOneWidget);
+      expect(find.text('Part 1 专项复盘'), findsOneWidget);
+      expect(find.text('正在生成你的专项复盘'), findsOneWidget);
       expect(reportClient.started.isCompleted, isFalse);
       expect(reportController.practiceSessionId, isNull);
+      await tester.pumpWidget(const SizedBox());
     },
   );
 
@@ -1591,19 +1590,21 @@ void main() {
         find.byKey(const Key('ielts-section-completion-sheet')),
         findsOneWidget,
       );
-      expect(find.text('复盘生成中…'), findsOneWidget);
+      expect(find.text('查看复盘报告'), findsOneWidget);
       await tester.tap(find.byKey(const Key('ielts-section-review-action')));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
 
       expect(
-        find.byKey(const Key('ielts-section-completion-sheet')),
+        find.byKey(const Key('part1-review-loading-page')),
         findsOneWidget,
       );
       expect(
-        find.byKey(const Key('ielts-section-practice-complete-part1')),
-        findsNothing,
+        find.byKey(const Key('part1-review-loading-animation')),
+        findsOneWidget,
       );
-      expect(find.text('复盘生成中，完成后将自动打开。'), findsOneWidget);
+      expect(find.text('正在生成你的专项复盘'), findsOneWidget);
+      await tester.pumpWidget(const SizedBox());
     },
   );
 
@@ -1648,7 +1649,7 @@ void main() {
         find.byKey(const Key('ielts-section-completion-sheet')),
         findsOneWidget,
       );
-      expect(find.text('复盘生成中…'), findsOneWidget);
+      expect(find.text('查看复盘报告'), findsOneWidget);
       expect(
         find.byKey(const Key('ielts-section-practice-complete-part1')),
         findsNothing,
@@ -1697,15 +1698,22 @@ void main() {
       find.byKey(const Key('ielts-section-completion-sheet')),
       findsOneWidget,
     );
-    expect(find.text('复盘暂不可用'), findsOneWidget);
+    expect(find.text('查看复盘报告'), findsOneWidget);
     expect(
       find.byKey(const Key('ielts-section-practice-complete-part1')),
       findsNothing,
     );
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.byKey(const Key('part1-review-loading-page')), findsOneWidget);
+    expect(find.text('复盘暂时没有生成'), findsOneWidget);
+    await tester.pumpWidget(const SizedBox());
   });
 
   testWidgets(
-    'Part 1 ready report opens directly and returns to the section list',
+    'Part 1 ready report opens after tapping and returns to the section list',
     (tester) async {
       final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
       final controller = PracticeController(
@@ -1766,6 +1774,16 @@ void main() {
       await tester.pumpAndSettle();
 
       await _answerCurrentShortQuestion(tester, controller);
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('ielts-section-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('查看复盘报告'), findsOneWidget);
+      expect(reportClient.readyReportCalls, 0);
+
+      await tester.tap(find.byKey(const Key('ielts-section-review-action')));
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
@@ -1786,7 +1804,7 @@ void main() {
     },
   );
 
-  testWidgets('Part 1 ready transition opens without another screen frame', (
+  testWidgets('Part 1 review replaces loading with the ready report in place', (
     tester,
   ) async {
     final statusGate = Completer<void>();
@@ -1826,10 +1844,18 @@ void main() {
     await tester.pumpAndSettle();
     expect(reportClient.readyReportCalls, 0);
 
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byKey(const Key('part1-review-loading-page')), findsOneWidget);
+    expect(find.text('正在生成你的专项复盘'), findsOneWidget);
+
     statusGate.complete();
-    await tester.idle();
+    await tester.pumpAndSettle();
 
     expect(reportClient.readyReportCalls, 1);
+    expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
+    await tester.pumpWidget(const SizedBox());
   });
 
   testWidgets('the full-mock PracticeOption opens the three-part flow', (

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1786,6 +1786,52 @@ void main() {
     },
   );
 
+  testWidgets('Part 1 ready transition opens without another screen frame', (
+    tester,
+  ) async {
+    final statusGate = Completer<void>();
+    final practice = _IeltsPracticeClient(initialCompleted: 1, turnLimit: 1);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    final reportClient = _Part1ReportStatusClient(
+      evaluationStatus: PracticeReportEvaluationStatus.ready,
+      statusGate: statusGate.future,
+    );
+    final reportController = PracticeReportStatusController(
+      client: reportClient,
+      pollInterval: Duration.zero,
+      maximumPollAttempts: 1,
+    );
+    addTearDown(controller.dispose);
+    addTearDown(reportController.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          reportStatusController: reportController,
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(reportClient.readyReportCalls, 0);
+
+    statusGate.complete();
+    await tester.idle();
+
+    expect(reportClient.readyReportCalls, 1);
+  });
+
   testWidgets('the full-mock PracticeOption opens the three-part flow', (
     tester,
   ) async {
@@ -2416,43 +2462,44 @@ final class _UnusedQuestionBankClient implements IeltsQuestionBankClient {
 }
 
 final class _Part1ReportStatusClient implements PracticeReportStatusClient {
-  _Part1ReportStatusClient({required this.evaluationStatus});
+  _Part1ReportStatusClient({required this.evaluationStatus, this.statusGate});
 
   static const _evaluationId = '7b000001-0000-4000-8000-000000000001';
   static const _evaluationRevisionId = 'a1000001-0000-4000-8000-000000000001';
   static const _reportId = '20000000-0000-4000-8000-000000000002';
 
   final PracticeReportEvaluationStatus evaluationStatus;
+  final Future<void>? statusGate;
   int readyReportCalls = 0;
 
   @override
-  Future<PracticeReportStatus> getStatus(String practiceSessionId) async =>
-      PracticeReportStatus(
-        practiceSessionId: practiceSessionId,
-        practiceMode: PracticeMode.part1,
-        reportScope: PracticeReportScope.part1,
-        availableSections: const <IeltsSpeakingPartId>[
-          IeltsSpeakingPartId.part1,
-        ],
-        detailSchema: 'ielts-speaking-practice-report/v1',
-        evaluationStatus: evaluationStatus,
-        statusUrl: '/v1/practice-sessions/$practiceSessionId/report',
-        evaluationId: _evaluationId,
-        evaluationRevisionId: _evaluationRevisionId,
-        revision: 1,
-        reportRef: evaluationStatus == PracticeReportEvaluationStatus.ready
-            ? const PracticeReportRef(
-                reportId: _reportId,
-                href: '/v1/evaluation-reports/$_reportId',
-              )
-            : null,
-        scoreability: evaluationStatus == PracticeReportEvaluationStatus.ready
-            ? EvaluationReportScoreability.provisional
-            : null,
-        summary: evaluationStatus == PracticeReportEvaluationStatus.ready
-            ? 'Part 1 专项复盘已生成。'
-            : null,
-      );
+  Future<PracticeReportStatus> getStatus(String practiceSessionId) async {
+    await statusGate;
+    return PracticeReportStatus(
+      practiceSessionId: practiceSessionId,
+      practiceMode: PracticeMode.part1,
+      reportScope: PracticeReportScope.part1,
+      availableSections: const <IeltsSpeakingPartId>[IeltsSpeakingPartId.part1],
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      evaluationStatus: evaluationStatus,
+      statusUrl: '/v1/practice-sessions/$practiceSessionId/report',
+      evaluationId: _evaluationId,
+      evaluationRevisionId: _evaluationRevisionId,
+      revision: 1,
+      reportRef: evaluationStatus == PracticeReportEvaluationStatus.ready
+          ? const PracticeReportRef(
+              reportId: _reportId,
+              href: '/v1/evaluation-reports/$_reportId',
+            )
+          : null,
+      scoreability: evaluationStatus == PracticeReportEvaluationStatus.ready
+          ? EvaluationReportScoreability.provisional
+          : null,
+      summary: evaluationStatus == PracticeReportEvaluationStatus.ready
+          ? 'Part 1 专项复盘已生成。'
+          : null,
+    );
+  }
 
   @override
   Future<EvaluationReport> getReadyReport(PracticeReportRef reportRef) async {

--- a/server/cmd/server/evaluation_shadow.go
+++ b/server/cmd/server/evaluation_shadow.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	evaluationShadowInterval     = 5 * time.Second
+	evaluationShadowInterval     = 1 * time.Second
 	evaluationShadowSweepTimeout = 60 * time.Second
 	evaluationShadowClaimLimit   = 2
 )


### PR DESCRIPTION
## 功能描述

- Part 1 专项练习的报告状态变为 READY 后自动打开本次专项复盘。
- 报告关闭后结束已完成练习并返回 Part 1 题单，不再回到冗余完成页。
- queued、running、failed 状态继续使用现有真实状态页面；完整模考和其他专项模式保持不变。

## 实现思路

- 监听现有 `PracticeReportStatusController` 的 READY 终态，仅对 `PracticeMode.part1` 触发自动导航。
- 使用调度、打开中和已打开三层保护，避免轮询通知重复 push。
- 统一 Part 1 手动/自动打开报告后的返回语义。
- 新增 Widget 主链路测试，覆盖最后一题提交、READY 直达、无完成中间页及返回题单。

## 测试

- `flutter test --no-pub test/coaching/practice/ielts_mock_practice_test.dart`：39 项通过。
- `flutter test --no-pub test/review/practice_report_status_test.dart`：29 项通过。
- `flutter analyze --no-pub`：通过。
- iOS 26.5 iPhone 17 Pro 模拟器：真实后端迁移、readiness、Xcode 构建与 Flutter 调试连接通过。
- `make check-flutter`：格式与 analyze 通过；全量测试在与本次改动无关的既有 `conversation_controller_test.dart` 用例 `Fake client cancels old account work and reuses stable write IDs` 失败，单独重跑可复现。

Closes #633