### PR TITLE
fix(ielts): unify preview speech playback

### DIFF
--- a/api/modules/ielts.yaml
+++ b/api/modules/ielts.yaml
@@ -17,6 +17,27 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/BadRequest
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/ielts-speaking/question-banks/{bank_id}/{part}/{source_id}/questions/{question_position}/speech:
+    get:
+      tags: [IELTS Speaking]
+      summary: Synthesize a published IELTS question on demand
+      description: Resolves the prompt from its stable question-bank reference and returns ephemeral WAV bytes. Arbitrary text is never accepted.
+      operationId: getIeltsQuestionSpeech
+      parameters:
+        - {name: bank_id, in: path, required: true, schema: {$ref: '#/components/schemas/ResourceId'}}
+        - {name: part, in: path, required: true, schema: {type: string, enum: [PART_1, PART_2, PART_3]}}
+        - {name: source_id, in: path, required: true, schema: {$ref: '#/components/schemas/ResourceId'}}
+        - {name: question_position, in: path, required: true, schema: {type: integer, minimum: 1}}
+      responses:
+        '200':
+          description: Synthesized question audio.
+          content:
+            audio/wav:
+              schema: {type: string, format: binary}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
   /v1/ielts-speaking/answer-preparations:
     post:
       tags: [IELTS Speaking]
@@ -101,6 +122,24 @@ paths:
         '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
         '409': {$ref: ../common/errors.yaml#/components/responses/Conflict}
         '502': {description: Generation failed; response is the persisted failed resource and a fresh idempotency key may retry., content: {application/json: {schema: {$ref: '#/components/schemas/IeltsAnswerPreparation'}}}}
+        default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}/speech:
+    parameters:
+      - {$ref: '#/components/parameters/AnswerPreparationId'}
+    get:
+      tags: [IELTS Speaking]
+      summary: Synthesize an actor-owned IELTS answer on demand
+      description: Returns ephemeral WAV bytes for the ready preparation's speech text. The authenticated actor must own the resource.
+      operationId: getIeltsAnswerPreparationSpeech
+      responses:
+        '200':
+          description: Synthesized answer audio.
+          content:
+            audio/wav:
+              schema: {type: string, format: binary}
+        '400': {$ref: ../common/errors.yaml#/components/responses/BadRequest}
+        '401': {$ref: ../common/errors.yaml#/components/responses/Unauthorized}
+        '404': {$ref: ../common/errors.yaml#/components/responses/NotFound}
         default: {$ref: ../common/errors.yaml#/components/responses/DefaultError}
 components:
   parameters:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -103,12 +103,16 @@ paths:
     $ref: ./modules/scene.yaml#/paths/~1v1~1scenes
   /v1/ielts-speaking/question-bank:
     $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1question-bank
+  /v1/ielts-speaking/question-banks/{bank_id}/{part}/{source_id}/questions/{question_position}/speech:
+    $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1question-banks~1{bank_id}~1{part}~1{source_id}~1questions~1{question_position}~1speech
   /v1/ielts-speaking/answer-preparations:
     $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations
   /v1/ielts-speaking/answer-preparations/{answer_preparation_id}:
     $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations~1{answer_preparation_id}
   /v1/ielts-speaking/answer-preparations/{answer_preparation_id}/generations:
     $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations~1{answer_preparation_id}~1generations
+  /v1/ielts-speaking/answer-preparations/{answer_preparation_id}/speech:
+    $ref: ./modules/ielts.yaml#/paths/~1v1~1ielts-speaking~1answer-preparations~1{answer_preparation_id}~1speech
   /v1/goals:
     $ref: ./modules/goal.yaml#/paths/~1v1~1goals
   /v1/goals/{goal_id}:

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -295,6 +295,10 @@ private final class AgentPCMStreamPlayer {
       finishResult = nil
       result(nil)
     }
+    try? AVAudioSession.sharedInstance().setActive(
+      false,
+      options: .notifyOthersOnDeactivation
+    )
   }
 
   private enum PlayerError: Error {

--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -5,6 +5,8 @@ import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
+import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/preparation/preparation_catalog_components.dart';
 import 'package:speakup/features/coaching/preparation/preparation_design.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -15,8 +17,10 @@ class IeltsCatalog extends StatefulWidget {
     required this.scenes,
     required this.onSelectionPressed,
     required this.onRetry,
+    this.speechClient,
+    this.audioPlayer,
     super.key,
-  });
+  }) : assert((speechClient == null) == (audioPlayer == null));
 
   final IeltsPreparationController controller;
   final List<SceneDefinition> scenes;
@@ -27,6 +31,8 @@ class IeltsCatalog extends StatefulWidget {
   )
   onSelectionPressed;
   final Future<void> Function() onRetry;
+  final IeltsSpeechClient? speechClient;
+  final PracticeAudioPlayer? audioPlayer;
 
   @override
   State<IeltsCatalog> createState() => _IeltsCatalogState();
@@ -263,6 +269,8 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
               ? const <String>[]
               : item.questions,
           cueCard: item.cueCard,
+          speechClient: widget.speechClient,
+          audioPlayer: widget.audioPlayer,
           answerPreparationClient: widget.controller.answerPreparationClient,
           cueCardQuestionReference: item.mode == PracticeMode.part2
               ? IeltsAnswerQuestionReference(

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
-import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
+import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/preparation/preparation_design.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
@@ -15,12 +17,13 @@ class IeltsSetDetailPage extends StatefulWidget {
     required this.questions,
     required this.onStart,
     this.cueCard,
-    this.promptSpeaker,
+    this.speechClient,
+    this.audioPlayer,
     this.answerPreparationClient,
     this.cueCardQuestionReference,
     this.questionReferences = const <IeltsAnswerQuestionReference>[],
     super.key,
-  });
+  }) : assert((speechClient == null) == (audioPlayer == null));
 
   final PracticeMode mode;
   final String title;
@@ -28,7 +31,8 @@ class IeltsSetDetailPage extends StatefulWidget {
   final List<String> questions;
   final IeltsCueCard? cueCard;
   final VoidCallback? onStart;
-  final PracticePromptSpeaker? promptSpeaker;
+  final IeltsSpeechClient? speechClient;
+  final PracticeAudioPlayer? audioPlayer;
   final IeltsAnswerPreparationClient? answerPreparationClient;
   final IeltsAnswerQuestionReference? cueCardQuestionReference;
   final List<IeltsAnswerQuestionReference> questionReferences;
@@ -38,8 +42,7 @@ class IeltsSetDetailPage extends StatefulWidget {
 }
 
 class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
-  late final PracticePromptSpeaker _promptSpeaker;
-  late final bool _ownsPromptSpeaker;
+  StreamSubscription<void>? _speechCompletion;
   int? _speakingQuestionIndex;
   int? _speakingAnswerIndex;
   int? _expandedQuestionIndex;
@@ -66,8 +69,15 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   @override
   void initState() {
     super.initState();
-    _ownsPromptSpeaker = widget.promptSpeaker == null;
-    _promptSpeaker = widget.promptSpeaker ?? SystemPracticePromptSpeaker();
+    _speechCompletion = widget.audioPlayer?.onComplete.listen((_) {
+      if (mounted &&
+          (_speakingQuestionIndex != null || _speakingAnswerIndex != null)) {
+        setState(() {
+          _speakingQuestionIndex = null;
+          _speakingAnswerIndex = null;
+        });
+      }
+    });
     if (_canPrepareQuestionAnswers) {
       _expandedQuestionIndex = 0;
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -120,79 +130,75 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   @override
   void dispose() {
     _speechRequest++;
-    if (_ownsPromptSpeaker) {
-      unawaited(_promptSpeaker.dispose());
-    } else {
-      unawaited(_promptSpeaker.stop());
-    }
+    unawaited(_speechCompletion?.cancel());
+    unawaited(widget.audioPlayer?.stop());
     super.dispose();
   }
 
   Future<void> _toggleQuestionSpeech(int index) async {
-    final request = ++_speechRequest;
-    final wasSpeaking = _speakingQuestionIndex == index;
-
-    try {
-      await _promptSpeaker.stop();
-      if (!mounted || request != _speechRequest) {
-        return;
-      }
-      if (wasSpeaking) {
-        setState(() {
-          _speakingQuestionIndex = null;
-          _speechError = null;
-        });
-        return;
-      }
-
-      setState(() {
-        _speakingQuestionIndex = index;
-        _speakingAnswerIndex = null;
-        _speechError = null;
-      });
-      await _promptSpeaker.speak(widget.questions[index]);
-      if (mounted && request == _speechRequest) {
-        setState(() => _speakingQuestionIndex = null);
-      }
-    } catch (_) {
-      if (mounted && request == _speechRequest) {
-        setState(() {
-          _speakingQuestionIndex = null;
-          _speechError = '题目朗读失败，请稍后重试。';
-        });
-      }
-    }
+    final reference = widget.questionReferences[index];
+    await _toggleSpeech(
+      questionIndex: index,
+      load: () => widget.speechClient!.loadQuestion(reference),
+      failureMessage: '题目朗读失败，请稍后重试。',
+    );
   }
 
-  Future<void> _toggleAnswerSpeech(int index, String text) async {
+  Future<void> _toggleAnswerSpeech(
+    int index,
+    IeltsAnswerPreparation preparation,
+  ) async {
+    await _toggleSpeech(
+      answerIndex: index,
+      load: () => widget.speechClient!.loadAnswer(preparation.id),
+      failureMessage: '答案朗读失败，请稍后重试。',
+    );
+  }
+
+  Future<void> _toggleSpeech({
+    int? questionIndex,
+    int? answerIndex,
+    required Future<Uint8List> Function() load,
+    required String failureMessage,
+  }) async {
     final request = ++_speechRequest;
-    final wasSpeaking = _speakingAnswerIndex == index;
+    final wasSpeaking = questionIndex != null
+        ? _speakingQuestionIndex == questionIndex
+        : _speakingAnswerIndex == answerIndex;
+
     try {
-      await _promptSpeaker.stop();
+      await widget.audioPlayer!.stop();
       if (!mounted || request != _speechRequest) {
         return;
       }
       if (wasSpeaking) {
         setState(() {
-          _speakingAnswerIndex = null;
+          _speakingQuestionIndex = null;
           _speechError = null;
         });
         return;
       }
+
       setState(() {
-        _speakingQuestionIndex = null;
-        _speakingAnswerIndex = index;
+        _speakingQuestionIndex = questionIndex;
+        _speakingAnswerIndex = answerIndex;
         _speechError = null;
       });
-      await _promptSpeaker.speak(text);
-      if (mounted && request == _speechRequest) {
-        setState(() => _speakingAnswerIndex = null);
+      final bytes = await load();
+      try {
+        if (!mounted || request != _speechRequest) {
+          return;
+        }
+        await widget.audioPlayer!.playWav(bytes);
+      } finally {
+        bytes.fillRange(0, bytes.length, 0);
       }
     } catch (_) {
       if (mounted && request == _speechRequest) {
         setState(() {
+          _speakingQuestionIndex = null;
           _speakingAnswerIndex = null;
-          _speechError = '答案朗读失败，请稍后重试。';
+          _speechError = failureMessage;
         });
       }
     }
@@ -408,12 +414,12 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                               0,
                               widget.cueCardQuestionReference!,
                             ),
-                            onSpeak: _preparations[0]?.speechText == null
+                            onSpeak:
+                                widget.speechClient == null ||
+                                    _preparations[0]?.speechText == null
                                 ? null
-                                : () => _toggleAnswerSpeech(
-                                    0,
-                                    _preparations[0]!.speechText!,
-                                  ),
+                                : () =>
+                                      _toggleAnswerSpeech(0, _preparations[0]!),
                           ),
                       ],
                       if (widget.questions.isNotEmpty)
@@ -436,7 +442,11 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                           index: index + 1,
                           question: widget.questions[index],
                           speaking: _speakingQuestionIndex == index,
-                          onSpeak: () => _toggleQuestionSpeech(index),
+                          onSpeak:
+                              widget.speechClient == null ||
+                                  index >= widget.questionReferences.length
+                              ? null
+                              : () => _toggleQuestionSpeech(index),
                           expanded: _expandedQuestionIndex == index,
                           onToggle: _canPrepareQuestionAnswers
                               ? () {
@@ -478,11 +488,13 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
                               index,
                               widget.questionReferences[index],
                             ),
-                            onSpeak: _preparations[index]?.speechText == null
+                            onSpeak:
+                                widget.speechClient == null ||
+                                    _preparations[index]?.speechText == null
                                 ? null
                                 : () => _toggleAnswerSpeech(
                                     index,
-                                    _preparations[index]!.speechText!,
+                                    _preparations[index]!,
                                   ),
                           ),
                       ],
@@ -685,7 +697,7 @@ class _QuestionRow extends StatelessWidget {
   final int index;
   final String question;
   final bool speaking;
-  final VoidCallback onSpeak;
+  final VoidCallback? onSpeak;
   final bool expanded;
   final VoidCallback? onToggle;
 

--- a/mobile/lib/features/coaching/ielts/ielts_speech_client.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_speech_client.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
+import 'package:speakup/features/coaching/practice/practice_media.dart';
+
+abstract interface class IeltsSpeechClient {
+  Future<Uint8List> loadQuestion(IeltsAnswerQuestionReference question);
+
+  Future<Uint8List> loadAnswer(String answerPreparationId);
+}
+
+final class WireIeltsSpeechClient implements IeltsSpeechClient {
+  const WireIeltsSpeechClient(this._mediaClient);
+
+  final PracticeMediaClient _mediaClient;
+
+  @override
+  Future<Uint8List> loadQuestion(IeltsAnswerQuestionReference question) {
+    final bankId = Uri.encodeComponent(question.bankId);
+    final part = Uri.encodeComponent(question.part);
+    final sourceId = Uri.encodeComponent(question.sourceId);
+    return _mediaClient.loadQuestionSpeech(
+      '/v1/ielts-speaking/question-banks/$bankId/$part/$sourceId/questions/${question.questionPosition}/speech',
+    );
+  }
+
+  @override
+  Future<Uint8List> loadAnswer(
+    String answerPreparationId,
+  ) => _mediaClient.loadQuestionSpeech(
+    '/v1/ielts-speaking/answer-preparations/${Uri.encodeComponent(answerPreparationId)}/speech',
+  );
+}

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
+import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/interview/interview_catalog.dart';
 import 'package:speakup/features/coaching/interview/job_preparation_controller.dart';
@@ -702,6 +703,12 @@ class _PreparationPageState extends State<PreparationPage> {
           IeltsCatalog(
             controller: ielts!,
             scenes: scenes,
+            speechClient: widget.practiceController?.mediaClient == null
+                ? null
+                : WireIeltsSpeechClient(
+                    widget.practiceController!.mediaClient!,
+                  ),
+            audioPlayer: widget.practiceController?.audioPlayer,
             onRetry: ielts.retryLoad,
             onSelectionPressed: (scene, mode, selection) => unawaited(
               _startSceneDirectly(

--- a/mobile/test/coaching/ielts/ielts_speech_client_test.dart
+++ b/mobile/test/coaching/ielts/ielts_speech_client_test.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/ielts/ielts_answer_preparation.dart';
+import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
+import 'package:speakup/features/coaching/practice/practice_media.dart';
+
+void main() {
+  test('loads IELTS speech only through stable resource paths', () async {
+    final media = _MediaClient();
+    final client = WireIeltsSpeechClient(media);
+
+    await client.loadQuestion(
+      const IeltsAnswerQuestionReference(
+        bankId: 'bank-2026',
+        part: 'PART_1',
+        sourceId: 'teachers',
+        questionPosition: 2,
+      ),
+    );
+    await client.loadAnswer('ielts_answer_0123456789abcdef0123456789abcdef');
+
+    expect(media.paths, [
+      '/v1/ielts-speaking/question-banks/bank-2026/PART_1/teachers/questions/2/speech',
+      '/v1/ielts-speaking/answer-preparations/ielts_answer_0123456789abcdef0123456789abcdef/speech',
+    ]);
+  });
+}
+
+final class _MediaClient implements PracticeMediaClient {
+  final List<String> paths = [];
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) async {
+    paths.add(speechPath);
+    return Uint8List.fromList([1]);
+  }
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import '../../support/scene_fixtures.dart';
 import 'package:flutter/material.dart';
@@ -14,7 +15,8 @@ import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart'
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
-import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
+import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 
 void main() {
   testWidgets('shows exactly the four product-level practice entries', (
@@ -329,10 +331,11 @@ void main() {
     expect(selectedSet, const IeltsPracticeSelection(topicGroupId: 'p23-001'));
   });
 
-  testWidgets('reads an IELTS question with the configured system speaker', (
+  testWidgets('plays an IELTS question with the server speech client', (
     tester,
   ) async {
-    final speaker = _DetailPromptSpeaker();
+    final speech = _DetailSpeechClient();
+    final player = _DetailAudioPlayer();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -341,8 +344,23 @@ void main() {
           title: '音乐',
           subtitle: 'Music',
           questions: const ['Do you enjoy music?', 'Do you sing?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 2,
+            ),
+          ],
           onStart: () {},
-          promptSpeaker: speaker,
+          speechClient: speech,
+          audioPlayer: player,
         ),
       ),
     );
@@ -352,12 +370,51 @@ void main() {
     );
     await tester.pump();
 
-    expect(speaker.spoken, ['Do you enjoy music?']);
-    expect(speaker.stopCalls, 1);
+    expect(speech.questions.single.questionPosition, 1);
+    expect(player.played.single, orderedEquals(speech.audio));
+    expect(player.stopCalls, 1);
     expect(
       find.byKey(const Key('ielts-set-detail-speech-error')),
       findsNothing,
     );
+  });
+
+  testWidgets('plays a ready IELTS answer by its owned resource id', (
+    tester,
+  ) async {
+    final speech = _DetailSpeechClient();
+    final player = _DetailAudioPlayer();
+    final answers = _AnswerPreparationClient(existingAnswer: 'Saved answer.');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSetDetailPage(
+          mode: PracticeMode.part1,
+          title: '音乐',
+          subtitle: 'Music',
+          questions: const ['Do you enjoy music?'],
+          questionReferences: const [
+            IeltsAnswerQuestionReference(
+              bankId: 'bank-1',
+              part: 'PART_1',
+              sourceId: 'music',
+              questionPosition: 1,
+            ),
+          ],
+          answerPreparationClient: answers,
+          speechClient: speech,
+          audioPlayer: player,
+          onStart: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('ielts-speak-answer-1')));
+    await tester.pump();
+
+    expect(speech.answers, ['ielts_answer_00000000000000000000000000000000']);
+    expect(player.played.single, orderedEquals(speech.audio));
   });
 
   testWidgets('shows an example and polishes it from the experience drawer', (
@@ -984,14 +1041,35 @@ Future<void> _showModule(WidgetTester tester, Key key) async {
   expect(entry, findsOneWidget);
 }
 
-final class _DetailPromptSpeaker implements PracticePromptSpeaker {
-  final List<String> spoken = <String>[];
+final class _DetailSpeechClient implements IeltsSpeechClient {
+  final audio = Uint8List.fromList([1, 2, 3]);
+  final List<IeltsAnswerQuestionReference> questions = [];
+  final List<String> answers = [];
+
+  @override
+  Future<Uint8List> loadQuestion(IeltsAnswerQuestionReference question) async {
+    questions.add(question);
+    return Uint8List.fromList(audio);
+  }
+
+  @override
+  Future<Uint8List> loadAnswer(String answerPreparationId) async {
+    answers.add(answerPreparationId);
+    return Uint8List.fromList(audio);
+  }
+}
+
+final class _DetailAudioPlayer implements PracticeAudioPlayer {
+  final _completions = StreamController<void>.broadcast();
+  final List<Uint8List> played = [];
   int stopCalls = 0;
 
   @override
-  Future<void> speak(String text) async {
-    spoken.add(text);
-  }
+  Stream<void> get onComplete => _completions.stream;
+
+  @override
+  Future<void> playWav(Uint8List bytes) async =>
+      played.add(Uint8List.fromList(bytes));
 
   @override
   Future<void> stop() async {
@@ -999,7 +1077,10 @@ final class _DetailPromptSpeaker implements PracticePromptSpeaker {
   }
 
   @override
-  Future<void> dispose() async {}
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() => _completions.close();
 }
 
 final class _AnswerPreparationClient implements IeltsAnswerPreparationClient {

--- a/server/cmd/server/ielts_speech.go
+++ b/server/cmd/server/ielts_speech.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+)
+
+type ieltsSpeechSynthesizer struct {
+	practice practicevoice.SpeechSynthesizer
+}
+
+func (synthesizer ieltsSpeechSynthesizer) Synthesize(ctx context.Context, text string) (platformmedia.ManagedAudioSource, error) {
+	if synthesizer.practice == nil {
+		return nil, errors.New("IELTS speech synthesizer is required")
+	}
+	result, err := synthesizer.practice.Synthesize(ctx, practicevoice.SynthesisRequest{Text: text})
+	if err != nil {
+		return nil, err
+	}
+	if result.Audio == nil {
+		return nil, errors.New("IELTS speech synthesis returned no audio")
+	}
+	return result.Audio, nil
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -242,6 +242,20 @@ func run() int {
 		logger.Error("IELTS answer preparation HTTP startup failed")
 		return 1
 	}
+	ieltsSpeechService, err := ielts.NewSpeechService(
+		ieltsQuestionBank,
+		ieltsAnswerService,
+		ieltsSpeechSynthesizer{practice: practiceSynthesizer},
+	)
+	if err != nil {
+		logger.Error("IELTS speech startup failed")
+		return 1
+	}
+	ieltsSpeechHTTP, err := ielts.NewSpeechHTTPHandler(ieltsSpeechService)
+	if err != nil {
+		logger.Error("IELTS speech HTTP startup failed")
+		return 1
+	}
 
 	resumeComposition, err := buildResumeComposition(
 		ctx,
@@ -503,6 +517,7 @@ func run() int {
 	protectedRegistrars := []bootstrap.ProtectedRouteRegistrar{
 		avatarHTTP,
 		ieltsAnswerHTTP,
+		ieltsSpeechHTTP,
 		evaluationComposition.HTTPHandler(),
 		speechFeedbackComposition.HTTPHandler(),
 		speechFeedbackComposition.RetryHTTPHandler(),

--- a/server/internal/coaching/scene/ielts/speech.go
+++ b/server/internal/coaching/scene/ielts/speech.go
@@ -1,0 +1,75 @@
+package ielts
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+var (
+	ErrSpeechInvalid     = errors.New("ielts: invalid speech request")
+	ErrSpeechNotFound    = errors.New("ielts: speech resource not found")
+	ErrSpeechUnavailable = errors.New("ielts: speech synthesis unavailable")
+)
+
+type SpeechSynthesizer interface {
+	Synthesize(context.Context, string) (platformmedia.ManagedAudioSource, error)
+}
+
+type SpeechService struct {
+	questions AnswerQuestionResolver
+	answers   *AnswerPreparationService
+	speech    SpeechSynthesizer
+}
+
+func NewSpeechService(questions AnswerQuestionResolver, answers *AnswerPreparationService, speech SpeechSynthesizer) (*SpeechService, error) {
+	if questions == nil || answers == nil || speech == nil {
+		return nil, ErrSpeechInvalid
+	}
+	return &SpeechService{questions: questions, answers: answers, speech: speech}, nil
+}
+
+func (service *SpeechService) Question(ctx context.Context, actor requestcontext.Actor, reference QuestionReference) (platformmedia.ManagedAudioSource, error) {
+	if ctx == nil || !actor.Valid() || !validQuestionReference(reference) {
+		return nil, ErrSpeechInvalid
+	}
+	question, err := service.questions.ResolveAnswerQuestion(ctx, reference)
+	if err != nil {
+		if errors.Is(err, ErrQuestionSetNotFound) {
+			return nil, ErrSpeechNotFound
+		}
+		return nil, err
+	}
+	return service.synthesize(ctx, question.Prompt)
+}
+
+func (service *SpeechService) Answer(ctx context.Context, actor requestcontext.Actor, answerPreparationID string) (platformmedia.ManagedAudioSource, error) {
+	if ctx == nil || !actor.Valid() || !validAnswerPreparationID(answerPreparationID) {
+		return nil, ErrSpeechInvalid
+	}
+	preparation, err := service.answers.Get(ctx, actor, answerPreparationID)
+	if err != nil {
+		if errors.Is(err, ErrAnswerPreparationNotFound) {
+			return nil, ErrSpeechNotFound
+		}
+		return nil, err
+	}
+	if preparation.Status != AnswerPreparationReady || strings.TrimSpace(preparation.SpeechText) == "" {
+		return nil, ErrSpeechNotFound
+	}
+	return service.synthesize(ctx, preparation.SpeechText)
+}
+
+func (service *SpeechService) synthesize(ctx context.Context, text string) (platformmedia.ManagedAudioSource, error) {
+	audio, err := service.speech.Synthesize(ctx, strings.TrimSpace(text))
+	if err != nil || audio == nil || platformmedia.ValidateAudioSource(audio) != nil {
+		if audio != nil {
+			_ = audio.Close()
+		}
+		return nil, ErrSpeechUnavailable
+	}
+	return audio, nil
+}

--- a/server/internal/coaching/scene/ielts/speech_http.go
+++ b/server/internal/coaching/scene/ielts/speech_http.go
@@ -1,0 +1,81 @@
+package ielts
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type SpeechHTTPHandler struct{ service *SpeechService }
+
+func NewSpeechHTTPHandler(service *SpeechService) (*SpeechHTTPHandler, error) {
+	if service == nil {
+		return nil, ErrSpeechInvalid
+	}
+	return &SpeechHTTPHandler{service: service}, nil
+}
+
+func (handler *SpeechHTTPHandler) RegisterRoutes(routes gin.IRoutes) {
+	routes.GET("/v1/ielts-speaking/question-banks/:bank_id/:part/:source_id/questions/:question_position/speech", handler.question)
+	routes.GET("/v1/ielts-speaking/answer-preparations/:answer_preparation_id/speech", handler.answer)
+}
+
+func (handler *SpeechHTTPHandler) question(c *gin.Context) {
+	position, err := strconv.Atoi(c.Param("question_position"))
+	if err != nil {
+		writeSpeechError(c, ErrSpeechInvalid)
+		return
+	}
+	handler.write(c, func(actor requestcontext.Actor) (platformmedia.ManagedAudioSource, error) {
+		return handler.service.Question(c.Request.Context(), actor, QuestionReference{
+			BankID: c.Param("bank_id"), Part: PracticeMode(c.Param("part")),
+			SourceID: c.Param("source_id"), QuestionPosition: position,
+		})
+	})
+}
+
+func (handler *SpeechHTTPHandler) answer(c *gin.Context) {
+	handler.write(c, func(actor requestcontext.Actor) (platformmedia.ManagedAudioSource, error) {
+		return handler.service.Answer(c.Request.Context(), actor, c.Param("answer_preparation_id"))
+	})
+}
+
+func (handler *SpeechHTTPHandler) write(c *gin.Context, load func(requestcontext.Actor) (platformmedia.ManagedAudioSource, error)) {
+	setAnswerPrivateHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		writeAnswerAuthentication(c)
+		return
+	}
+	audio, err := load(actor)
+	if err != nil {
+		writeSpeechError(c, err)
+		return
+	}
+	defer func() { _ = audio.Close() }()
+	reader, err := audio.Open()
+	if err != nil {
+		writeSpeechError(c, ErrSpeechUnavailable)
+		return
+	}
+	defer reader.Close()
+	c.DataFromReader(http.StatusOK, audio.Size(), audio.MediaType(), reader, nil)
+}
+
+func writeSpeechError(c *gin.Context, err error) {
+	status, code, retryable := http.StatusInternalServerError, "internal_error", false
+	switch {
+	case errors.Is(err, ErrSpeechInvalid):
+		status, code = http.StatusBadRequest, "invalid_request"
+	case errors.Is(err, ErrSpeechNotFound), errors.Is(err, ErrAnswerPreparationNotFound):
+		status, code = http.StatusNotFound, "speech_resource_not_found"
+	case errors.Is(err, ErrSpeechUnavailable):
+		status, code, retryable = http.StatusBadGateway, "speech_synthesis_unavailable", true
+	}
+	c.JSON(status, gin.H{"error": gin.H{"code": code, "message": "IELTS speech is unavailable.", "retryable": retryable, "correlation_id": newCorrelationID()}})
+}

--- a/server/internal/coaching/scene/ielts/speech_test.go
+++ b/server/internal/coaching/scene/ielts/speech_test.go
@@ -1,0 +1,159 @@
+package ielts
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type ieltsSpeechSynthesizerStub struct {
+	text  string
+	err   error
+	audio *ieltsSpeechAudio
+}
+
+func (stub *ieltsSpeechSynthesizerStub) Synthesize(_ context.Context, text string) (platformmedia.ManagedAudioSource, error) {
+	stub.text = text
+	if stub.err != nil {
+		return nil, stub.err
+	}
+	stub.audio = &ieltsSpeechAudio{data: []byte("RIFF-test-wave")}
+	return stub.audio, nil
+}
+
+type ieltsSpeechAudio struct {
+	data   []byte
+	closed bool
+}
+
+func (audio *ieltsSpeechAudio) Open() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(audio.data)), nil
+}
+func (audio *ieltsSpeechAudio) MediaType() string       { return platformmedia.ContentTypeWAV }
+func (audio *ieltsSpeechAudio) Size() int64             { return int64(len(audio.data)) }
+func (audio *ieltsSpeechAudio) Duration() time.Duration { return time.Second }
+func (audio *ieltsSpeechAudio) SampleRate() int         { return 24_000 }
+func (audio *ieltsSpeechAudio) Close() error {
+	audio.closed = true
+	return nil
+}
+
+func TestSpeechServiceUsesResolvedQuestionAndOwnedAnswerText(t *testing.T) {
+	repository := &answerRepositoryStub{value: AnswerPreparation{
+		ID:         "ielts_answer_0123456789abcdef0123456789abcdef",
+		Status:     AnswerPreparationReady,
+		SpeechText: "My prepared answer.",
+	}}
+	answers, err := NewAnswerPreparationService(repository, answerQuestionStub{}, &answerGeneratorStub{}, answerIDStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	synthesizer := &ieltsSpeechSynthesizerStub{}
+	service, err := NewSpeechService(answerQuestionStub{}, answers, synthesizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	reference := QuestionReference{BankID: "bank-1", Part: PracticeModePart1, SourceID: "teachers", QuestionPosition: 1}
+
+	questionAudio, err := service.Question(context.Background(), actor, reference)
+	if err != nil {
+		t.Fatalf("Question: %v", err)
+	}
+	if synthesizer.text != "Do you enjoy music?" {
+		t.Fatalf("question synthesis text = %q", synthesizer.text)
+	}
+	_ = questionAudio.Close()
+
+	answerAudio, err := service.Answer(context.Background(), actor, repository.value.ID)
+	if err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	if synthesizer.text != "My prepared answer." {
+		t.Fatalf("answer synthesis text = %q", synthesizer.text)
+	}
+	_ = answerAudio.Close()
+}
+
+func TestSpeechServiceRejectsNonReadyAnswerAndProviderFailure(t *testing.T) {
+	repository := &answerRepositoryStub{value: AnswerPreparation{
+		ID:     "ielts_answer_0123456789abcdef0123456789abcdef",
+		Status: AnswerPreparationDraft,
+	}}
+	answers, err := NewAnswerPreparationService(repository, answerQuestionStub{}, &answerGeneratorStub{}, answerIDStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	synthesizer := &ieltsSpeechSynthesizerStub{err: errors.New("provider failed")}
+	service, err := NewSpeechService(answerQuestionStub{}, answers, synthesizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+
+	if _, err := service.Answer(context.Background(), actor, repository.value.ID); !errors.Is(err, ErrSpeechNotFound) {
+		t.Fatalf("non-ready answer error = %v", err)
+	}
+	if _, err := service.Question(context.Background(), actor, QuestionReference{BankID: "bank-1", Part: PracticeModePart1, SourceID: "teachers", QuestionPosition: 1}); !errors.Is(err, ErrSpeechUnavailable) {
+		t.Fatalf("provider error = %v", err)
+	}
+}
+
+func TestSpeechHTTPRequiresAuthenticationAndServesWAV(t *testing.T) {
+	router, synthesizer := speechTestRouter(t, false)
+	path := "/v1/ielts-speaking/question-banks/bank-1/PART_1/teachers/questions/1/speech"
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status = %d", response.Code)
+	}
+
+	router, synthesizer = speechTestRouter(t, true)
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+	if response.Code != http.StatusOK || response.Header().Get("Content-Type") != platformmedia.ContentTypeWAV {
+		t.Fatalf("speech response = %d %q", response.Code, response.Header().Get("Content-Type"))
+	}
+	if response.Body.String() != "RIFF-test-wave" || synthesizer.audio == nil || !synthesizer.audio.closed {
+		t.Fatalf("speech body or cleanup invalid: body=%q audio=%#v", response.Body.String(), synthesizer.audio)
+	}
+}
+
+func speechTestRouter(t *testing.T, authenticated bool) (*gin.Engine, *ieltsSpeechSynthesizerStub) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	if authenticated {
+		router.Use(func(c *gin.Context) {
+			actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+			c.Request = c.Request.WithContext(requestcontext.WithActor(c.Request.Context(), actor))
+			c.Next()
+		})
+	}
+	repository := &answerRepositoryStub{}
+	answers, err := NewAnswerPreparationService(repository, answerQuestionStub{}, &answerGeneratorStub{}, answerIDStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	synthesizer := &ieltsSpeechSynthesizerStub{}
+	service, err := NewSpeechService(answerQuestionStub{}, answers, synthesizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewSpeechHTTPHandler(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.RegisterRoutes(router)
+	return router, synthesizer
+}


### PR DESCRIPTION
## 功能描述

统一 IELTS 套题详情页与整组练习的语音播放链路，详情页不再调用 iOS 系统 TTS。题目与示例答案均由后端使用现有 Practice TTS 合成 WAV，并由移动端复用 PracticeAudioPlayer 播放。

## 实现思路

- 增加题目和已生成示例答案的受保护语音接口
- 后端复用整组练习已配置的 SpeechSynthesizer，并校验、释放临时音频
- 移动端复用 PracticeMediaClient 与 PracticeAudioPlayer
- 保留播放竞态、页面销毁停止和音频会话释放处理
- 补充服务、HTTP、客户端和页面交互测试

## 测试方式

1. 执行 make check
2. 进入 IELTS 套题详情，分别播放题目与生成后的示例答案
3. 进入整组练习，对比两处音色与播放行为

## 验证结果

- Flutter analyze 通过
- Flutter 全量 887 项测试通过
- Go vet 与 Go 全仓测试通过
- OpenAPI、安全、WebSocket、fixture、evaluation、speech-feedback 校验通过
- deterministic main flow smoke test 通过

Closes #634