### PR TITLE
feat(practice): 为普通场景消息增加学习辅助操作

### DIFF
--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -30,6 +30,7 @@ class ScenarioPracticePage extends StatefulWidget {
     this.onBeforeStartRecording,
     this.onBeforeSubmitText,
     this.onReplayQuestion,
+    this.questionSpeaker,
     this.onPracticeCompleted,
     this.speechFeedbackController,
     this.replayLoading = false,
@@ -45,6 +46,7 @@ class ScenarioPracticePage extends StatefulWidget {
   final ScenarioAsyncAction? onBeforeStartRecording;
   final ScenarioAsyncAction? onBeforeSubmitText;
   final ScenarioAsyncAction? onReplayQuestion;
+  final PracticePromptSpeaker? questionSpeaker;
   final Future<bool> Function()? onPracticeCompleted;
   final SpeechFeedbackController? speechFeedbackController;
   final bool replayLoading;
@@ -71,8 +73,12 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
   final Map<String, String> _questionTranslations = <String, String>{};
   bool _feedbackRebuildScheduled = false;
   bool _completionInFlight = false;
+  PracticePromptSpeaker? _ownedQuestionSpeaker;
   PracticePromptSpeaker? _ownedTipSpeaker;
   String? _visibleTipQuestionId;
+  String? _playingQuestionId;
+  String? _questionNarrationErrorId;
+  int _questionNarrationGeneration = 0;
 
   @override
   void initState() {
@@ -109,6 +115,16 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       oldWidget.practiceController.removeListener(_handleControllerState);
       _observedMessageCount = widget.practiceController.practiceMessages.length;
       _visibleTipQuestionId = null;
+      _questionTranslations.clear();
+      _questionNarrationGeneration++;
+      _playingQuestionId = null;
+      _questionNarrationErrorId = null;
+      unawaited(oldWidget.practiceController.stopPracticeAudio(notify: false));
+      final previousSpeaker =
+          oldWidget.questionSpeaker ?? _ownedQuestionSpeaker;
+      if (previousSpeaker != null) {
+        unawaited(_stopSpeakerSafely(previousSpeaker));
+      }
       widget.practiceController.addListener(_handleControllerState);
       _syncRecordingTimer();
     }
@@ -125,6 +141,11 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     _textController.dispose();
     _textFocusNode.dispose();
     unawaited(widget.practiceController.stopPracticeAudio(notify: false));
+    if (widget.questionSpeaker case final speaker?) {
+      unawaited(_stopSpeakerSafely(speaker));
+    } else if (_ownedQuestionSpeaker case final speaker?) {
+      unawaited(speaker.dispose());
+    }
     if (_ownedTipSpeaker case final speaker?) {
       unawaited(speaker.dispose());
     }
@@ -147,6 +168,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     if (tip == null || _visibleTipQuestionId != tip.questionId) {
       return;
     }
+    await _stopQuestionNarration();
     final speaker = _ownedTipSpeaker ??= SystemPracticePromptSpeaker();
     await speaker.speak(tip.content);
   }
@@ -169,8 +191,106 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
 
   Future<void> _beforeStartRecording() async {
     await _stopQuestionTipSpeech();
+    await _stopQuestionNarration();
     await _runBoundedUserTurnAction(widget.onBeforeStartRecording);
   }
+
+  Future<void> _playQuestion(PracticeMessage message) async {
+    final controller = widget.practiceController;
+    final currentQuestion = controller.currentQuestion;
+    final current = currentQuestion?.id == message.id;
+
+    if (_playingQuestionId == message.id) {
+      await _stopQuestionNarration();
+      return;
+    }
+
+    await _stopQuestionTipSpeech();
+
+    if (current && widget.onReplayQuestion != null) {
+      _questionNarrationGeneration++;
+      await _stopQuestionSpeakerSafely();
+      if (!mounted) {
+        return;
+      }
+      setState(() => _questionNarrationErrorId = null);
+      try {
+        await widget.onReplayQuestion!();
+      } on Object {
+        if (mounted) {
+          setState(() => _questionNarrationErrorId = message.id);
+        }
+      }
+      return;
+    }
+
+    if (current && controller.canPlayQuestionAudio) {
+      _questionNarrationGeneration++;
+      await _stopQuestionSpeakerSafely();
+      if (mounted) {
+        setState(() => _questionNarrationErrorId = null);
+      }
+      await controller.toggleQuestionAudio();
+      return;
+    }
+
+    await _stopQuestionNarration();
+    final generation = ++_questionNarrationGeneration;
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _playingQuestionId = message.id;
+      _questionNarrationErrorId = null;
+    });
+    try {
+      await _questionSpeaker.speak(message.text);
+    } on Object {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _questionNarrationErrorId = message.id);
+      }
+    } finally {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _playingQuestionId = null);
+      }
+    }
+  }
+
+  Future<void> _stopQuestionNarration() async {
+    _questionNarrationGeneration++;
+    if (widget.replayPlaying && widget.onReplayQuestion != null) {
+      try {
+        await widget.onReplayQuestion!();
+      } on Object {
+        // Avatar playback is best-effort and must not block user input.
+      }
+    }
+    await widget.practiceController.stopPracticeAudio();
+    await _stopQuestionSpeakerSafely();
+    if (mounted && _playingQuestionId != null) {
+      setState(() => _playingQuestionId = null);
+    }
+  }
+
+  Future<void> _stopQuestionSpeakerSafely() async {
+    final speaker = widget.questionSpeaker ?? _ownedQuestionSpeaker;
+    if (speaker == null) {
+      return;
+    }
+    await _stopSpeakerSafely(speaker);
+  }
+
+  Future<void> _stopSpeakerSafely(PracticePromptSpeaker speaker) async {
+    try {
+      await speaker.stop();
+    } on Object {
+      // Recording and navigation remain usable when platform TTS degrades.
+    }
+  }
+
+  PracticePromptSpeaker get _questionSpeaker =>
+      widget.questionSpeaker ??
+      (_ownedQuestionSpeaker ??= SystemPracticePromptSpeaker());
 
   void _handleControllerState() {
     if (!mounted) {
@@ -295,6 +415,11 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     if (!mounted || _completionInFlight) {
       return;
     }
+    await _stopQuestionTipSpeech();
+    await _stopQuestionNarration();
+    if (!mounted) {
+      return;
+    }
     final callback = widget.onPracticeCompleted;
     if (callback == null) {
       await Navigator.of(context).maybePop();
@@ -360,6 +485,8 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
   }
 
   Future<void> _submitText() async {
+    await _stopQuestionTipSpeech();
+    await _stopQuestionNarration();
     await _runBoundedUserTurnAction(widget.onBeforeSubmitText);
     if (!mounted) {
       return;
@@ -408,6 +535,11 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
 
   Future<void> _requestExit() async {
     if (!mounted || _exitInFlight || _exitApproved) {
+      return;
+    }
+    await _stopQuestionTipSpeech();
+    await _stopQuestionNarration();
+    if (!mounted) {
       return;
     }
     final route = ModalRoute.of(context);
@@ -488,10 +620,12 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                     recordingSeconds: _recordingSeconds,
                     previewMode: widget.previewMode,
                     onBeforeStartRecording: _beforeStartRecording,
-                    onReplayQuestion: widget.onReplayQuestion,
                     speechFeedbackController: widget.speechFeedbackController,
                     replayLoading: widget.replayLoading,
                     replayPlaying: widget.replayPlaying,
+                    playingQuestionId: _playingQuestionId,
+                    narrationErrorQuestionId: _questionNarrationErrorId,
+                    onPlayQuestion: _playQuestion,
                     onToggleTextMode: _toggleTextMode,
                     onSubmitText: _submitText,
                     onTranslateQuestion:
@@ -524,10 +658,12 @@ class _ConversationPanel extends StatelessWidget {
     required this.recordingSeconds,
     required this.previewMode,
     required this.onBeforeStartRecording,
-    required this.onReplayQuestion,
     required this.speechFeedbackController,
     required this.replayLoading,
     required this.replayPlaying,
+    required this.playingQuestionId,
+    required this.narrationErrorQuestionId,
+    required this.onPlayQuestion,
     required this.onToggleTextMode,
     required this.onSubmitText,
     required this.onTranslateQuestion,
@@ -547,10 +683,12 @@ class _ConversationPanel extends StatelessWidget {
   final int recordingSeconds;
   final bool previewMode;
   final ScenarioAsyncAction? onBeforeStartRecording;
-  final ScenarioAsyncAction? onReplayQuestion;
   final SpeechFeedbackController? speechFeedbackController;
   final bool replayLoading;
   final bool replayPlaying;
+  final String? playingQuestionId;
+  final String? narrationErrorQuestionId;
+  final Future<void> Function(PracticeMessage message) onPlayQuestion;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
   final Future<String> Function(PracticeMessage message)? onTranslateQuestion;
@@ -570,10 +708,6 @@ class _ConversationPanel extends StatelessWidget {
         children: [
           _ConversationHeader(
             controller: controller,
-            onShowTip: onShowTip,
-            onReplayQuestion: onReplayQuestion,
-            replayLoading: replayLoading,
-            replayPlaying: replayPlaying,
             onCompleteRequested: onCompleteRequested,
           ),
           Expanded(
@@ -592,6 +726,34 @@ class _ConversationPanel extends StatelessWidget {
                     itemBuilder: (context, index) {
                       if (index < messages.length) {
                         final message = messages[index];
+                        final assistant =
+                            message.role == PracticeMessageRole.assistant;
+                        final currentQuestion =
+                            assistant && message.id == controller.questionId;
+                        final playing =
+                            playingQuestionId == message.id ||
+                            (currentQuestion &&
+                                (replayPlaying ||
+                                    controller.isQuestionAudioPlaying));
+                        final playbackLoading =
+                            currentQuestion &&
+                            (replayLoading ||
+                                controller.isQuestionAudioLoading);
+                        final tipsAvailable =
+                            currentQuestion &&
+                            (controller
+                                    .practiceCapabilities
+                                    ?.questionTipsAllowed ??
+                                false);
+                        final tip = controller.questionTip;
+                        final showTip =
+                            assistant &&
+                            tip != null &&
+                            tip.questionId == message.id &&
+                            tip.questionId == visibleTipQuestionId;
+                        final tipError = currentQuestion
+                            ? controller.questionTipErrorMessage
+                            : null;
                         final projection = _feedbackProjection(message);
                         return Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -600,11 +762,59 @@ class _ConversationPanel extends StatelessWidget {
                               message: message,
                               feedbackProjection: projection,
                               messageTextVisible: true,
-                              onTranslate:
-                                  message.role == PracticeMessageRole.assistant
+                              onTranslate: assistant
                                   ? onTranslateQuestion
                                   : null,
+                              actions: assistant
+                                  ? _ScenarioQuestionActions(
+                                      messageId: message.id,
+                                      playing: playing,
+                                      playbackLoading: playbackLoading,
+                                      playbackFailed:
+                                          narrationErrorQuestionId ==
+                                          message.id,
+                                      playbackEnabled:
+                                          !playbackLoading &&
+                                          _canTriggerScenarioReplay(controller),
+                                      tipsAvailable: tipsAvailable,
+                                      tipLoading:
+                                          currentQuestion &&
+                                          controller.isQuestionTipLoading,
+                                      tipEnabled:
+                                          currentQuestion &&
+                                          controller.canRequestQuestionTip,
+                                      onPlay: () =>
+                                          unawaited(onPlayQuestion(message)),
+                                      onShowTip: onShowTip,
+                                    )
+                                  : null,
                             ),
+                            if (showTip)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 4),
+                                child: QuestionTipCard(
+                                  content: tip.content,
+                                  onClose: onHideTip,
+                                  onSpeak: onSpeakTip,
+                                ),
+                              ),
+                            if (assistant && tipError != null)
+                              Padding(
+                                padding: const EdgeInsets.fromLTRB(
+                                  12,
+                                  4,
+                                  12,
+                                  0,
+                                ),
+                                child: Text(
+                                  tipError,
+                                  key: const Key('scenario-question-tip-error'),
+                                  style: const TextStyle(
+                                    color: SpeakUpDesign.error,
+                                    fontSize: 12,
+                                  ),
+                                ),
+                              ),
                           ],
                         );
                       }
@@ -629,26 +839,6 @@ class _ConversationPanel extends StatelessWidget {
                     },
                   ),
           ),
-          if (controller.questionTip case final tip?
-              when tip.questionId == visibleTipQuestionId)
-            QuestionTipCard(
-              content: tip.content,
-              onClose: onHideTip,
-              onSpeak: onSpeakTip,
-            ),
-          if (controller.questionTipErrorMessage case final message?)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Text(
-                message,
-                key: const Key('scenario-question-tip-error'),
-                textAlign: TextAlign.right,
-                style: const TextStyle(
-                  color: SpeakUpDesign.error,
-                  fontSize: 12,
-                ),
-              ),
-            ),
           _ScenarioComposer(
             controller: controller,
             textController: textController,
@@ -684,18 +874,10 @@ class _ConversationPanel extends StatelessWidget {
 class _ConversationHeader extends StatelessWidget {
   const _ConversationHeader({
     required this.controller,
-    required this.onShowTip,
-    required this.onReplayQuestion,
-    required this.replayLoading,
-    required this.replayPlaying,
     required this.onCompleteRequested,
   });
 
   final PracticeController controller;
-  final VoidCallback onShowTip;
-  final ScenarioAsyncAction? onReplayQuestion;
-  final bool replayLoading;
-  final bool replayPlaying;
   final VoidCallback onCompleteRequested;
 
   @override
@@ -733,66 +915,98 @@ class _ConversationHeader extends StatelessWidget {
                 style: SpeakUpDesign.meta,
               ),
             ),
-          if (controller.practiceCapabilities?.questionTipsAllowed ??
-              false) ...[
-            const SizedBox(width: 8),
-            TextButton.icon(
-              key: const Key('scenario-question-tip'),
-              onPressed: controller.canRequestQuestionTip ? onShowTip : null,
-              style: TextButton.styleFrom(
-                foregroundColor: SpeakUpDesign.primary,
-                backgroundColor: SpeakUpDesign.primaryMuted,
-                minimumSize: const Size(0, 34),
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                visualDensity: VisualDensity.compact,
-              ),
-              icon: controller.isQuestionTipLoading
-                  ? const SizedBox.square(
-                      dimension: 15,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.lightbulb_outline_rounded, size: 18),
-              label: Text(controller.isQuestionTipLoading ? '生成中' : 'Tips'),
-            ),
-          ],
-          if (onReplayQuestion != null || controller.canPlayQuestionAudio) ...[
-            const SizedBox(width: 6),
-            IconButton(
-              key: const Key('scenario-replay-question'),
-              tooltip:
-                  (onReplayQuestion != null
-                      ? replayPlaying
-                      : controller.isQuestionAudioPlaying)
-                  ? '停止播放'
-                  : '重听对方',
-              onPressed: onReplayQuestion != null
-                  ? replayLoading || !_canTriggerScenarioReplay(controller)
-                        ? null
-                        : () => unawaited(onReplayQuestion!())
-                  : controller.canUsePracticeAudio
-                  ? controller.toggleQuestionAudio
-                  : null,
-              visualDensity: VisualDensity.compact,
-              icon:
-                  (onReplayQuestion != null
-                      ? replayLoading
-                      : controller.isQuestionAudioLoading)
-                  ? const SizedBox.square(
-                      dimension: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : Icon(
-                      (onReplayQuestion != null
-                              ? replayPlaying
-                              : controller.isQuestionAudioPlaying)
-                          ? Icons.stop_circle_outlined
-                          : Icons.volume_up_outlined,
-                    ),
-            ),
-          ],
         ],
       ),
+    );
+  }
+}
+
+class _ScenarioQuestionActions extends StatelessWidget {
+  const _ScenarioQuestionActions({
+    required this.messageId,
+    required this.playing,
+    required this.playbackLoading,
+    required this.playbackFailed,
+    required this.playbackEnabled,
+    required this.tipsAvailable,
+    required this.tipLoading,
+    required this.tipEnabled,
+    required this.onPlay,
+    required this.onShowTip,
+  });
+
+  final String messageId;
+  final bool playing;
+  final bool playbackLoading;
+  final bool playbackFailed;
+  final bool playbackEnabled;
+  final bool tipsAvailable;
+  final bool tipLoading;
+  final bool tipEnabled;
+  final VoidCallback onPlay;
+  final VoidCallback onShowTip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 0,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        TextButton.icon(
+          key: ValueKey('scenario-question-voice-$messageId'),
+          onPressed: playbackEnabled ? onPlay : null,
+          style: TextButton.styleFrom(
+            foregroundColor: SpeakUpDesign.primary,
+            backgroundColor: SpeakUpDesign.surfaceMuted,
+            minimumSize: const Size(0, 32),
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            visualDensity: VisualDensity.compact,
+            textStyle: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          icon: playbackLoading
+              ? const SizedBox.square(
+                  dimension: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Icon(
+                  playing ? Icons.stop_rounded : Icons.volume_up_outlined,
+                  size: 17,
+                ),
+          label: Text(
+            playing
+                ? '停止朗读'
+                : playbackFailed
+                ? '重试朗读'
+                : '朗读',
+          ),
+        ),
+        if (tipsAvailable)
+          TextButton.icon(
+            key: ValueKey('scenario-question-tip-$messageId'),
+            onPressed: tipEnabled ? onShowTip : null,
+            style: TextButton.styleFrom(
+              foregroundColor: SpeakUpDesign.primary,
+              minimumSize: const Size(0, 32),
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              visualDensity: VisualDensity.compact,
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            icon: tipLoading
+                ? const SizedBox.square(
+                    dimension: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.lightbulb_outline_rounded, size: 17),
+            label: Text(tipLoading ? '生成中' : 'Tips'),
+          ),
+      ],
     );
   }
 }

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -442,7 +442,12 @@ void main() {
     expect(factoryCalls, 1);
     expect(find.byKey(const Key('scenario-practice-page')), findsOneWidget);
     expect(find.byKey(const Key('scenario-avatar-surface')), findsOneWidget);
-    expect(find.byKey(const Key('scenario-question-tip')), findsOneWidget);
+    expect(
+      find.byKey(
+        Key('scenario-question-tip-${practiceController.currentQuestion!.id}'),
+      ),
+      findsOneWidget,
+    );
     expect(find.byKey(const Key('practice-page')), findsNothing);
   });
 

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -13,6 +13,7 @@ import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_client.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -57,6 +58,8 @@ void main() {
       closeTo(844 * 0.34, 0.1),
     );
     expect(find.byKey(const Key('scenario-conversation-history')), findsOne);
+    expect(find.byKey(const Key('scenario-replay-question')), findsNothing);
+    expect(find.byKey(const Key('scenario-question-tip')), findsNothing);
     expect(find.textContaining('评分'), findsNothing);
     expect(find.text('翻译'), findsNothing);
     expect(tester.takeException(), isNull);
@@ -226,7 +229,7 @@ void main() {
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
     final controller = await _scenarioController(
-      practiceClient: _QuestionTipPracticeClient(),
+      practiceClient: _TranslationPracticeClient(),
     );
     addTearDown(controller.dispose);
 
@@ -235,8 +238,10 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.byKey(const Key('scenario-question-tip')), findsOneWidget);
-    await tester.tap(find.byKey(const Key('scenario-question-tip')));
+    final questionId = controller.currentQuestion!.id;
+    final tipButton = find.byKey(Key('scenario-question-tip-$questionId'));
+    expect(tipButton, findsOneWidget);
+    await tester.tap(tipButton);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
@@ -625,7 +630,8 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('scenario-replay-question')));
+    final questionId = controller.currentQuestion!.id;
+    await tester.tap(find.byKey(Key('scenario-question-voice-$questionId')));
     await tester.pump();
 
     expect(replayCalls, 1);
@@ -646,10 +652,121 @@ void main() {
       ),
     );
 
-    final button = tester.widget<IconButton>(
-      find.byKey(const Key('scenario-replay-question')),
+    final questionId = controller.currentQuestion!.id;
+    final button = tester.widget<TextButton>(
+      find.byKey(Key('scenario-question-voice-$questionId')),
     );
     expect(button.onPressed, isNull);
+    await controller.cancelRecording();
+  });
+
+  testWidgets('keeps Tips on the current assistant message only', (
+    tester,
+  ) async {
+    final controller = await _scenarioController(
+      practiceClient: _TranslationPracticeClient(),
+    );
+    addTearDown(controller.dispose);
+    final firstQuestionId = controller.currentQuestion!.id;
+    await controller.submitPracticeText('I have a reservation under Chen.');
+    final currentQuestionId = controller.currentQuestion!.id;
+
+    await tester.pumpWidget(
+      MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(Key('scenario-question-voice-$firstQuestionId')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(Key('scenario-question-tip-$firstQuestionId')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(Key('scenario-question-tip-$currentQuestionId')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(Key('practice-assistant-translate-$firstQuestionId')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('reads and stops an assistant message inline', (tester) async {
+    final controller = await _scenarioController();
+    addTearDown(controller.dispose);
+    final speaker = _ControlledPromptSpeaker();
+    final question = controller.currentQuestion!;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          questionSpeaker: speaker,
+        ),
+      ),
+    );
+
+    final button = find.byKey(Key('scenario-question-voice-${question.id}'));
+    await tester.tap(button);
+    await tester.pump();
+
+    expect(speaker.spokenTexts, <String>[question.text]);
+    expect(find.text('停止朗读'), findsOneWidget);
+
+    await tester.tap(button);
+    await tester.pump();
+
+    expect(speaker.stopCalls, greaterThanOrEqualTo(2));
+    expect(find.text('朗读'), findsOneWidget);
+  });
+
+  testWidgets('shows retry after inline narration fails', (tester) async {
+    final controller = await _scenarioController();
+    addTearDown(controller.dispose);
+    final questionId = controller.currentQuestion!.id;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          questionSpeaker: _FailingPromptSpeaker(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(Key('scenario-question-voice-$questionId')));
+    await tester.pump();
+
+    expect(find.text('重试朗读'), findsOneWidget);
+  });
+
+  testWidgets('stops inline narration before recording starts', (tester) async {
+    final controller = await _scenarioController();
+    addTearDown(controller.dispose);
+    final speaker = _ControlledPromptSpeaker();
+    final questionId = controller.currentQuestion!.id;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          questionSpeaker: speaker,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(Key('scenario-question-voice-$questionId')));
+    await tester.pump();
+    final stopsBeforeRecording = speaker.stopCalls;
+
+    await tester.tap(find.byKey(const Key('scenario-record')));
+    await tester.pump();
+
+    expect(speaker.stopCalls, greaterThan(stopsBeforeRecording));
+    expect(controller.recordingState, PracticeRecordingState.recording);
     await controller.cancelRecording();
   });
 
@@ -807,7 +924,10 @@ final class _ScenePracticeClient implements PracticeClient {
 }
 
 final class _TranslationPracticeClient
-    implements PracticeClient, PracticeQuestionTranslationClient {
+    implements
+        PracticeClient,
+        PracticeQuestionTranslationClient,
+        PracticeQuestionTipClient {
   final _delegate = _AsyncReviewPracticeClient(
     practiceExperience: PracticeExperience.lifeAndTravel,
     sceneCategory: SceneCategory.lifeTravel,
@@ -878,6 +998,19 @@ final class _TranslationPracticeClient
       content: translation,
     );
   }
+
+  @override
+  Future<PracticeQuestionTip> ensureQuestionTip({
+    required String sessionId,
+    required String questionId,
+    required String idempotencyKey,
+  }) async => PracticeQuestionTip(
+    id: 'tip-translation-client',
+    sessionId: sessionId,
+    questionId: questionId,
+    content: 'I would describe the situation and my specific role.',
+    createdAt: DateTime.utc(2026, 8, 12),
+  );
 }
 
 final class _FailOncePracticeClient implements PracticeClient {
@@ -955,75 +1088,6 @@ final class _FailOncePracticeClient implements PracticeClient {
     ),
     PracticeExperience.lifeAndTravel,
     SceneCategory.lifeTravel,
-  );
-}
-
-final class _QuestionTipPracticeClient
-    implements PracticeClient, PracticeQuestionTipClient {
-  final _delegate = FakePracticeClient(
-    practiceExperience: PracticeExperience.lifeAndTravel,
-    sceneCategory: SceneCategory.lifeTravel,
-  );
-
-  @override
-  Future<void> clearAccountState() => _delegate.clearAccountState();
-
-  @override
-  Future<PracticeSessionSnapshot> restorePractice({
-    required String sessionId,
-  }) => _delegate.restorePractice(sessionId: sessionId);
-
-  @override
-  Future<PracticeSessionSnapshot> activatePractice({
-    required String sessionId,
-    required String clientOperationId,
-  }) => _delegate.activatePractice(
-    sessionId: sessionId,
-    clientOperationId: clientOperationId,
-  );
-
-  @override
-  Future<TranscriptionCandidate> transcribe(
-    PracticeTranscriptionRequest request,
-  ) => _delegate.transcribe(request);
-
-  @override
-  Future<PracticeTurnConfirmation> confirm({
-    required String sessionId,
-    required String questionId,
-    required String candidateId,
-    required String idempotencyKey,
-  }) => _delegate.confirm(
-    sessionId: sessionId,
-    questionId: questionId,
-    candidateId: candidateId,
-    idempotencyKey: idempotencyKey,
-  );
-
-  @override
-  Future<PracticeTurnConfirmation> submitText({
-    required String sessionId,
-    required String questionId,
-    required String answerText,
-    required String idempotencyKey,
-  }) => _delegate.submitText(
-    sessionId: sessionId,
-    questionId: questionId,
-    answerText: answerText,
-    idempotencyKey: idempotencyKey,
-  );
-
-  @override
-  Future<PracticeQuestionTip> ensureQuestionTip({
-    required String sessionId,
-    required String questionId,
-    required String idempotencyKey,
-  }) async => PracticeQuestionTip(
-    id: 'tip-1',
-    sessionId: sessionId,
-    questionId: questionId,
-    content: 'I would describe the situation and my specific role.',
-    createdAt: DateTime.utc(2026, 8, 3),
   );
 }
 
@@ -1217,4 +1281,43 @@ final class _PendingSpeechFeedbackClient implements SpeechFeedbackClient {
 
   @override
   Future<void> clearAccountState() async {}
+}
+
+final class _ControlledPromptSpeaker implements PracticePromptSpeaker {
+  final List<String> spokenTexts = <String>[];
+  Completer<void>? _activeSpeech;
+  int stopCalls = 0;
+
+  @override
+  Future<void> speak(String text) {
+    spokenTexts.add(text);
+    _activeSpeech = Completer<void>();
+    return _activeSpeech!.future;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    final activeSpeech = _activeSpeech;
+    if (activeSpeech != null && !activeSpeech.isCompleted) {
+      activeSpeech.complete();
+    }
+    _activeSpeech = null;
+  }
+
+  @override
+  Future<void> dispose() => stop();
+}
+
+final class _FailingPromptSpeaker implements PracticePromptSpeaker {
+  @override
+  Future<void> speak(String text) async {
+    throw StateError('narration failed');
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {}
 }

--- a/server/internal/coaching/practice/execution_policy.go
+++ b/server/internal/coaching/practice/execution_policy.go
@@ -198,6 +198,8 @@ func resolveSessionPolicyRegistration(
 		standard.maxEffectiveTurns = 0
 		standard.coverageCheckpointTurn = 1
 		standard.retryAllowed = true
+		standard.questionTranslationAllowed = true
+		standard.questionTipsAllowed = true
 		standard.avatarAllowed = true
 		standard.speechFeedbackAllowed = true
 		return standard, true

--- a/server/internal/coaching/practice/execution_policy_test.go
+++ b/server/internal/coaching/practice/execution_policy_test.go
@@ -15,17 +15,19 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 		SuggestedDurationSeconds: 600,
 	}
 	tests := []struct {
-		name        string
-		reference   string
-		completion  CompletionMode
-		maxTurns    int
-		retry       bool
-		translation bool
-		followUps   int
-		wantErr     error
+		name       string
+		reference  string
+		completion CompletionMode
+		maxTurns   int
+		retry      bool
+		readAids   bool
+		followUps  int
+		wantErr    error
 	}{
-		{"daily", DailyPracticeSessionPolicy, CompletionModeUserControlled, 0, true, false, 1, nil},
-		{"workplace", WorkplacePracticeSessionPolicy, CompletionModeUserControlled, 0, true, false, 1, nil},
+		{"daily", DailyPracticeSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
+		{"daily hotel", DailyHotelCheckinIssueSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
+		{"workplace", WorkplacePracticeSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
+		{"workplace risk", WorkplaceProgressRiskUpdateSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
 		{"interview", InterviewPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
 		{"interview deep dive", InterviewProjectDeepDiveSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
 		{"exam", ExamPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, false, 1, nil},
@@ -43,7 +45,8 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 			if err != nil || policy.CompletionMode != test.completion ||
 				policy.MaxEffectiveTurns != test.maxTurns ||
 				policy.RetryAllowed != test.retry ||
-				policy.QuestionTranslationAllowed != test.translation ||
+				policy.QuestionTranslationAllowed != test.readAids ||
+				policy.QuestionTipsAllowed != test.readAids ||
 				policy.MaxFollowUpsPerQuestion != test.followUps ||
 				!ValidSessionPolicy(
 					test.reference,

--- a/server/internal/coaching/practice/preparationsource/reader_test.go
+++ b/server/internal/coaching/practice/preparationsource/reader_test.go
@@ -182,9 +182,11 @@ func confirmedPlanFixture() preparation.PracticePlan {
 			MaxFollowUpsPerQuestion:  1,
 			EarlyCompletionRule: preparation.
 				EarlyCompletionCoverageSatisfiedAfterCheckpoint,
-			RetryAllowed:          true,
-			AvatarAllowed:         true,
-			SpeechFeedbackAllowed: true,
+			RetryAllowed:               true,
+			QuestionTranslationAllowed: true,
+			QuestionTipsAllowed:        true,
+			AvatarAllowed:              true,
+			SpeechFeedbackAllowed:      true,
 		},
 		PracticeObjectives: []preparation.PracticeObjective{{
 			ID: "clarity", Description: "Speak clearly.",


### PR DESCRIPTION
## 功能描述

- 在职场英语、生活与旅行场景的每条 AI 消息下方增加朗读和翻译操作
- 仅为当前正在回答的问题显示 Tips，历史 AI 消息不显示 Tips
- 将 Tips 卡片放在对应 AI 消息下方，并移除顶部重复入口
- 支持停止朗读、朗读失败重试，以及开始录音、提交和退出前自动停止

## 实现思路

- 在普通场景页面内复制 IELTS 操作栏的布局和状态处理，不抽取公共组件
- 继续复用现有 MessageTranslationDisclosure 完成翻译展示
- 历史问题使用系统 TTS，当前问题优先复用数字人或题目音频
- 为普通场景会话策略开放问题翻译和 Tips 能力

## 可复现测试

- `flutter analyze --no-pub`（ASCII 临时运行副本，规避中文路径 Analysis Server 通信问题）
- `flutter test test/coaching/practice`（203 tests passed）
- `go test ./internal/coaching/practice/...`
- `dart format --output=none --set-exit-if-changed lib/features/coaching/scenario/scenario_practice.dart test/coaching/practice/scenario_practice_session_test.dart test/coaching/practice/scenario_practice_test.dart`
- iPhone 17 Pro 模拟器连接真实后端手动验证通过；数据库迁移版本 92，后端 health/readyz 正常

Closes #644