### PR TITLE
fix(interview): 修复立即开始后的方案历史回显

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -233,6 +233,12 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     _navigatorKey.currentState?.pushNamed(AppRoutes.jobPreparation);
   }
 
+  void _closeJobPreparation() {
+    _navigatorKey.currentState?.popUntil(
+      (route) => route.settings.name != AppRoutes.jobPreparation,
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -427,6 +433,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
               controller: widget.jobPreparationController!,
               catalogController: widget.preparationController,
               resumeController: widget.resumeController,
+              onExit: _closeJobPreparation,
               onPracticeStarted: () async {
                 await _navigatorKey.currentState?.pushReplacementNamed(
                   AppRoutes.practice,

--- a/mobile/lib/features/coaching/interview/job_preparation_controller.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_controller.dart
@@ -134,6 +134,9 @@ final class JobPreparationController extends ChangeNotifier {
     _plansLoading = true;
     _plansErrorMessage = null;
     final requestEpoch = ++_planListEpoch;
+    final plansAtRequestStart = <String, PracticePlanSummary>{
+      for (final plan in _interviewPlans) plan.id: plan,
+    };
     notifyListeners();
     try {
       final plans = await client.listPlans(
@@ -142,7 +145,16 @@ final class JobPreparationController extends ChangeNotifier {
       if (_disposed || requestEpoch != _planListEpoch) {
         return;
       }
-      _interviewPlans = plans;
+      final localUpserts = <PracticePlanSummary>[
+        for (final plan in _interviewPlans)
+          if (!identical(plansAtRequestStart[plan.id], plan)) plan,
+      ];
+      final localUpsertIds = localUpserts.map((plan) => plan.id).toSet();
+      _interviewPlans = <PracticePlanSummary>[
+        ...localUpserts,
+        for (final plan in plans)
+          if (!localUpsertIds.contains(plan.id)) plan,
+      ];
       _plansLoaded = true;
     } on Object {
       if (!_disposed && requestEpoch == _planListEpoch) {
@@ -923,9 +935,9 @@ final class JobPreparationController extends ChangeNotifier {
       for (final existing in _interviewPlans)
         if (existing.id != summary.id) existing,
     ];
-    _planListEpoch++;
-    _plansLoading = false;
-    _plansLoaded = true;
+    if (!_plansLoading) {
+      _plansLoaded = true;
+    }
     _plansErrorMessage = null;
   }
 

--- a/mobile/lib/features/coaching/interview/job_preparation_controller.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_controller.dart
@@ -854,6 +854,7 @@ final class JobPreparationController extends ChangeNotifier {
         );
       }
       _plan = plan;
+      _upsertInterviewPlan(plan);
       _bootstrap = null;
       _sessionKey = null;
       _voiceKey = null;
@@ -897,6 +898,37 @@ final class JobPreparationController extends ChangeNotifier {
     return startPractice();
   }
 
+  void _upsertInterviewPlan(PracticePlan plan) {
+    final candidate = plan.preparationSnapshot.jobTargetCandidate;
+    final summary = PracticePlanSummary(
+      id: plan.id,
+      revision: plan.revision,
+      status: plan.status,
+      experience: plan.sceneSelection.scene.experience,
+      sceneName: plan.sceneSelection.scene.name,
+      practiceScope: plan.practiceOption.displayName,
+      jobTitle: candidate?.jobTitle ?? '',
+      practiceObjectives: List<String>.unmodifiable(
+        plan.practiceObjectives.map((objective) => objective.description),
+      ),
+      resumeUsed: plan.preparationSnapshot.resumeSnapshot != null,
+      suggestedDurationSeconds: plan.sessionPolicy.suggestedDurationSeconds,
+      minEffectiveTurns: plan.sessionPolicy.minEffectiveTurns,
+      maxEffectiveTurns: plan.sessionPolicy.maxEffectiveTurns,
+      createdAt: plan.createdAt,
+      updatedAt: plan.updatedAt,
+    );
+    _interviewPlans = <PracticePlanSummary>[
+      summary,
+      for (final existing in _interviewPlans)
+        if (existing.id != summary.id) existing,
+    ];
+    _planListEpoch++;
+    _plansLoading = false;
+    _plansLoaded = true;
+    _plansErrorMessage = null;
+  }
+
   Future<bool> revisePreview({
     required String roleDefinitionId,
     required String practiceOptionId,
@@ -928,6 +960,7 @@ final class JobPreparationController extends ChangeNotifier {
         );
       }
       _plan = revised;
+      _upsertInterviewPlan(revised);
       _planRevisionKey = null;
       _bootstrap = null;
       _sessionKey = null;

--- a/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
@@ -30,13 +30,15 @@ class JobPreparationWizard extends StatefulWidget {
     this.catalogController,
     this.resumeController,
     this.onPracticeStarted,
+    this.onExit,
     super.key,
   });
 
   final JobPreparationController controller;
   final PreparationController? catalogController;
   final ResumeController? resumeController;
-  final VoidCallback? onPracticeStarted;
+  final FutureOr<void> Function()? onPracticeStarted;
+  final VoidCallback? onExit;
 
   @override
   State<JobPreparationWizard> createState() => _JobPreparationWizardState();
@@ -331,7 +333,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     if (started && mounted) {
       _practiceStarted = true;
       widget.catalogController?.showSceneList();
-      widget.onPracticeStarted?.call();
+      await widget.onPracticeStarted?.call();
     }
   }
 
@@ -353,7 +355,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     if (started && mounted) {
       _practiceStarted = true;
       widget.catalogController?.showSceneList();
-      widget.onPracticeStarted?.call();
+      await widget.onPracticeStarted?.call();
     }
   }
 
@@ -381,7 +383,12 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     setState(() {});
     await WidgetsBinding.instance.endOfFrame;
     if (mounted) {
-      await Navigator.of(context).maybePop();
+      final onExit = widget.onExit;
+      if (onExit != null) {
+        onExit();
+      } else {
+        await Navigator.of(context).maybePop();
+      }
     }
   }
 

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -101,6 +101,37 @@ void main() {
     expect(voiceKeys, hasLength(1));
   });
 
+  test('creation during plan load merges the eventual server list', () async {
+    final listPlans = Completer<List<PracticePlanSummary>>();
+    final client = _FakeJobPreparationClient(listPlansCompleter: listPlans);
+    final controller = _controller(client);
+    addTearDown(controller.dispose);
+    controller.updateInput(_input);
+
+    final loading = controller.loadInterviewPlans();
+    await _flush();
+    expect(controller.plansLoading, isTrue);
+
+    await controller.analyze();
+    await controller.confirm();
+    expect(await controller.createPreview(), isTrue);
+    final createdPlanId = controller.plan!.id;
+    expect(controller.interviewPlans.map((plan) => plan.id), <String>[
+      createdPlanId,
+    ]);
+    expect(controller.plansLoading, isTrue);
+
+    listPlans.complete(<PracticePlanSummary>[_planSummary('existing-plan')]);
+    await loading;
+
+    expect(controller.plansLoading, isFalse);
+    expect(controller.plansLoaded, isTrue);
+    expect(controller.interviewPlans.map((plan) => plan.id), <String>[
+      createdPlanId,
+      'existing-plan',
+    ]);
+  });
+
   test('double start creates exactly one Session', () async {
     final session = Completer<PreparationPracticeBootstrap>();
     final client = _FakeJobPreparationClient(sessionCompleter: session);
@@ -889,6 +920,7 @@ Future<void> _flush() async {
 final class _FakeJobPreparationClient implements JobPreparationClient {
   _FakeJobPreparationClient({
     this.analysisCompleter,
+    this.listPlansCompleter,
     this.sessionCompleter,
     this.sessionResult,
     this.failFirstCreate = false,
@@ -900,6 +932,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
            restoredTarget ?? _target(JobTargetStage.awaitingConfirmation);
 
   final Completer<JobTarget>? analysisCompleter;
+  final Completer<List<PracticePlanSummary>>? listPlansCompleter;
   final Completer<PreparationPracticeBootstrap>? sessionCompleter;
   final PreparationPracticeBootstrap? sessionResult;
   final bool failFirstCreate;
@@ -1053,7 +1086,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   @override
   Future<List<PracticePlanSummary>> listPlans({
     required PracticeExperience experience,
-  }) async => const <PracticePlanSummary>[];
+  }) async => listPlansCompleter?.future ?? const <PracticePlanSummary>[];
 
   @override
   Future<void> deletePlan(String planId) async {}
@@ -1144,6 +1177,25 @@ JobTarget _target(
         : null,
     createdAt: now,
     updatedAt: now,
+  );
+}
+
+PracticePlanSummary _planSummary(String id) {
+  return PracticePlanSummary(
+    id: id,
+    revision: 1,
+    status: PracticePlanStatus.ready,
+    experience: PracticeExperience.interview,
+    sceneName: 'Existing interview',
+    practiceScope: 'Technical depth',
+    jobTitle: 'Existing role',
+    practiceObjectives: const <String>['Explain trade-offs'],
+    resumeUsed: false,
+    suggestedDurationSeconds: 900,
+    minEffectiveTurns: 1,
+    maxEffectiveTurns: 3,
+    createdAt: _now,
+    updatedAt: _now,
   );
 }
 

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -95,6 +95,9 @@ void main() {
     ]);
     expect(controller.plan, isNotNull);
     expect(controller.bootstrap, isNotNull);
+    expect(controller.interviewPlans, hasLength(1));
+    expect(controller.interviewPlans.single.id, controller.plan!.id);
+    expect(controller.interviewPlans.single.jobTitle, 'Backend engineer');
     expect(voiceKeys, hasLength(1));
   });
 

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -162,7 +162,7 @@ void main() {
       MaterialApp(
         home: JobPreparationWizard(
           controller: controller,
-          onPracticeStarted: () => created++,
+          onPracticeStarted: () async => created++,
         ),
       ),
     );
@@ -224,6 +224,26 @@ void main() {
     expect(find.text('不使用简历'), findsNothing);
     expect(find.byType(DropdownButtonFormField<String?>), findsNothing);
     expect(controller.resumeSelection, isNull);
+  });
+
+  testWidgets('close delegates to the catalog route boundary', (tester) async {
+    final controller = _controller(_WizardClient());
+    var exits = 0;
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: JobPreparationWizard(
+          controller: controller,
+          onExit: () => exits++,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('job-wizard-close')));
+    await tester.pumpAndSettle();
+
+    expect(exits, 1);
+    expect(find.byKey(const Key('job-preparation-wizard')), findsOneWidget);
   });
 
   testWidgets('temporary parse failure keeps job context and can be skipped', (


### PR DESCRIPTION
## 功能描述

- 在创建或修订模拟面试方案后，立即将服务端返回的 PracticePlan 回填到本地方案列表
- 关闭岗位准备向导时返回方案库路由边界，确保新方案立即可见
- 等待练习路由切换完成，避免异步导航与向导状态竞争

## 实现思路

- 通过 `_upsertInterviewPlan` 将完整方案投影为 `PracticePlanSummary`，按方案 ID 幂等更新列表并刷新列表 epoch
- 为向导增加显式 `onExit` 回调，由应用导航层统一退出岗位准备路由
- 补充 Controller 与 Widget 回归测试，覆盖方案列表回填和退出委托

## 验证

- `dart format --output=none --set-exit-if-changed ...`：通过
- `flutter analyze ...`：通过，无问题
- 相关 Flutter 测试已启动但按提交要求未等待完整执行，未作为本次提交前置条件

Closes #486