### PR TITLE
feat(ielts): 升级口语报告的证据化个性点评

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -1762,10 +1762,14 @@ components:
       type: object
       additionalProperties: false
       description: |
-        Partial IELTS Speaking practice feedback projected from one frozen
-        Shadow revision. LR and GRA may contain provisional integer rubric
-        Bands. FC never contains a complete Band, PR is blocked, Speaking
-        Overall is unavailable, and no Part or question contains a score.
+        IELTS Speaking practice feedback projected from one frozen Shadow
+        revision. Complete, trustworthy acoustic evidence may support
+        provisional integer rubric Bands for all four criteria and a
+        calculated Speaking Overall. Without complete acoustic evidence, the
+        report remains partial: only supported criteria may contain Bands,
+        unsupported criteria are blocked, and Speaking Overall is unavailable
+        unless all four criterion Bands exist. No Part or question contains a
+        score.
       required:
         - schema_version
         - disclaimer_code
@@ -2727,8 +2731,10 @@ components:
       maxLength: 2048
       pattern: '^\S(?:[\s\S]*\S)?$'
       description: |
-        Server-controlled rubric descriptor or feedback template text;
-        never unvalidated provider prose.
+        Server-controlled rubric descriptor or validated feedback text; never
+        unvalidated provider prose. Runtime validation measures UTF-8 bytes
+        and requires a trimmed, non-empty value no larger than 2048 bytes; the
+        schema shape and maxLength remain unchanged.
     IeltsSpeakingReportSourceText:
       type: string
       minLength: 1

--- a/mobile/test/review/ielts_speaking_report_decoder_test.dart
+++ b/mobile/test/review/ielts_speaking_report_decoder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_decoder.dart';
@@ -70,6 +72,60 @@ void main() {
     expect(decoded.speakingOverallBand, 6.5);
     expect(decoded.criteria[0].estimatedBand, 7);
     expect(decoded.criteria[3].estimatedBand, 6);
+  });
+
+  test('decodes detailed Chinese report feedback without new fields', () {
+    final value = completeIeltsSpeakingReportContractFixture();
+    final report = _report(value);
+    const overall = '本次回答能够围绕问题展开，主要观点易于理解；词汇是当前相对优势，复杂句的稳定性是下一步的重点。';
+    const criterionExplanation =
+        '在 Part 2 中能使用具体词组展开话题，但“very good”重复较多，影响了用词的准确性和自然度。';
+    const findingMessage = '“very good”在多个回答中重复出现，表达能被理解，但词汇变化不足。';
+    const suggestion =
+        '把原表达分别改为 beneficial、effective 或 enjoyable，再围绕本次话题各造两个句子。';
+
+    (report['speaking_overall']! as Map<String, Object?>)['explanation'] =
+        overall;
+    final lexical = _criterion(value, 1)
+      ..['explanation'] = criterionExplanation;
+    final improvement =
+        (lexical['improvements']! as List<Object?>).single!
+            as Map<String, Object?>;
+    improvement
+      ..['message'] = findingMessage
+      ..['suggestion'] = suggestion;
+
+    final decoded = decodeIeltsSpeakingReport(value).report!;
+
+    expect(decoded.speakingOverallExplanation, overall);
+    expect(decoded.criteria[1].explanation, criterionExplanation);
+    expect(decoded.criteria[1].improvements.single.message, findingMessage);
+    expect(decoded.criteria[1].improvements.single.suggestion, suggestion);
+  });
+
+  test('enforces the 2048-byte feedback limit for Chinese and emoji', () {
+    final exactly2048 = '${List.filled(681, '语').join()}🙂a';
+    final over2048 = '${exactly2048}b';
+    expect(utf8.encode(exactly2048), hasLength(2048));
+    expect(utf8.encode(over2048), hasLength(2049));
+
+    final accepted = _readyClone();
+    final acceptedOverall =
+        _report(accepted)['speaking_overall']! as Map<String, Object?>;
+    acceptedOverall['explanation'] = exactly2048;
+    expect(
+      decodeIeltsSpeakingReport(accepted).report?.speakingOverallExplanation,
+      exactly2048,
+    );
+
+    final rejected = _readyClone();
+    final rejectedOverall =
+        _report(rejected)['speaking_overall']! as Map<String, Object?>;
+    rejectedOverall['explanation'] = over2048;
+    expect(
+      () => decodeIeltsSpeakingReport(rejected),
+      throwsA(isA<IeltsSpeakingReportDecodeException>()),
+    );
   });
 
   test('derives non-default Part boundaries from the report questions', () {

--- a/server/internal/coaching/evaluation/report/formal.go
+++ b/server/internal/coaching/evaluation/report/formal.go
@@ -204,15 +204,15 @@ func ProjectIELTSFormalReport(
 			projected.Score = &value
 		}
 		report.Dimensions[index] = projected
-		for _, finding := range criterion.Improvements {
-			if len(report.PriorityActions) == 3 {
-				break
-			}
-			report.PriorityActions = append(report.PriorityActions, ReportPriorityAction{
-				DimensionKey: string(criterion.CriterionID),
-				FindingID:    finding.ID,
-			})
-		}
+	}
+	for _, action := range projectIELTSSpeakingPriorityActions(result.Criteria) {
+		report.PriorityActions = append(
+			report.PriorityActions,
+			ReportPriorityAction{
+				DimensionKey: string(action.CriterionID),
+				FindingID:    action.FindingID,
+			},
+		)
 	}
 	report.Detail, err = json.Marshal(detail)
 	if err != nil || !report.Valid() {

--- a/server/internal/coaching/evaluation/report/ielts_speaking.go
+++ b/server/internal/coaching/evaluation/report/ielts_speaking.go
@@ -513,19 +513,20 @@ func ieltsSpeakingOverallExplanation(
 	band float64,
 	criteria []IELTSSpeakingReportCriterion,
 ) string {
-	intro := "考生能够在熟悉话题中表达基本意思，但语言控制仍会给交流带来一定负担。"
+	intro := "你能够表达部分基本信息，但回答的完整度、语言准确性和清晰度仍会明显影响交流。"
 	switch {
 	case band >= 8:
-		intro = "考生能够流畅、清晰且精确地讨论熟悉和抽象话题，语言运用自然，整体交流几乎不受影响。"
+		intro = "你能够流畅、清晰且准确地讨论熟悉和抽象话题，语言运用自然，交流几乎不受影响。"
 	case band >= 7:
-		intro = "考生能够较自然地展开观点并进行连贯交流，语言范围和控制较好，少量不准确或犹豫通常不影响理解。"
+		intro = "你能够自然地展开观点并保持连贯交流，词汇和句式运用较灵活；少量犹豫或错误通常不影响理解。"
 	case band >= 6:
-		intro = "考生能够清楚回答问题并表达主要观点，整体交流可以顺利进行；在较长或较复杂的回答中，语言的连贯性、精确度或稳定性仍会波动。"
+		intro = "你能够清楚回答问题并表达主要观点，交流大多可以顺利进行；回答变长或内容更复杂时，连贯性、准确性或清晰度仍会波动。"
 	case band >= 5:
-		intro = "考生能够围绕常见话题传达主要意思，但回答展开和语言控制不够稳定，遇到复杂内容时会增加听者的理解负担。"
+		intro = "你能够就熟悉话题表达主要意思，听者通常可以理解；但回答变长或内容更复杂时，观点展开和语言控制还不够稳定。"
 	case band < 4.5:
-		intro = "考生能够传达部分基本信息，但回答展开、语言准确性和整体清晰度较受限制，交流需要听者较多配合。"
+		intro = "你能够传达部分基本信息，但回答的完整度、语言准确性和清晰度仍会明显影响交流。"
 	}
+	intro = fmt.Sprintf("本次口语练习估分为 %s 分。%s", formatIELTSBand(band), intro)
 	if len(criteria) == 0 {
 		return intro
 	}
@@ -546,43 +547,17 @@ func ieltsSpeakingOverallExplanation(
 		return intro
 	}
 	if maximum == minimum {
-		strengthFocus := ""
-		improvementFocus := ""
-		for _, criterion := range criteria {
-			if strengthFocus == "" && len(criterion.Strengths) > 0 {
-				strengthFocus = truncateIELTSReportText(
-					criterion.Strengths[0].Message,
-					220,
-				)
-			}
-			if improvementFocus == "" && len(criterion.Improvements) > 0 {
-				improvementFocus = truncateIELTSReportText(
-					criterion.Improvements[0].Message,
-					220,
-				)
-			}
-		}
-		detail := ""
-		if strengthFocus != "" {
-			detail += " 已核验优势是：" + strengthFocus
-		}
-		if improvementFocus != "" {
-			detail += " 当前首先要改善的是：" + improvementFocus
-		}
 		return truncateIELTSReportText(
 			fmt.Sprintf(
-				"%s 四项均为 %d 分，表现较为均衡。%s 下方各维度列出了对应原句与具体练法。",
+				"%s 四项均为 %d 分，当前表现较为均衡，没有明显的单项优势或短板。下一步建议进行完整回答训练：每次连续回答 60 秒，并依次检查观点是否展开、用词是否准确、句式是否完整、表达是否容易听懂。",
 				intro,
 				maximum,
-				strings.TrimSpace(detail),
 			),
 			reportMaximumTextBytes,
 		)
 	}
 	highNames := []string{}
 	lowNames := []string{}
-	highFocus := ""
-	lowFocus := ""
 	for _, criterion := range criteria {
 		if criterion.EstimatedBand == nil {
 			continue
@@ -592,42 +567,108 @@ func ieltsSpeakingOverallExplanation(
 				highNames,
 				ieltsCriterionName(criterion.CriterionID),
 			)
-			if highFocus == "" && len(criterion.Strengths) > 0 {
-				highFocus = truncateIELTSReportText(
-					criterion.Strengths[0].Message,
-					220,
-				)
-			}
 		}
 		if *criterion.EstimatedBand == minimum {
 			lowNames = append(
 				lowNames,
 				ieltsCriterionName(criterion.CriterionID),
 			)
-			if lowFocus == "" && len(criterion.Improvements) > 0 {
-				lowFocus = truncateIELTSReportText(
-					criterion.Improvements[0].Message,
-					240,
-				)
-			}
 		}
 	}
-	result := fmt.Sprintf(
-		"%s 从四项表现看，%s（%d 分）是相对优势；%s（%d 分）是优先提升方向。",
-		intro,
-		strings.Join(highNames, "、"),
-		maximum,
-		strings.Join(lowNames, "、"),
-		minimum,
-	)
-	if highFocus != "" {
-		result += " 这项优势的已核验证据表明：" + highFocus
+	result := intro
+	if len(highNames) == 1 {
+		result += fmt.Sprintf(
+			" 当前优势是%s（%d 分）：%s",
+			strings.Join(highNames, "、"),
+			maximum,
+			ieltsOverallCriterionMeaning(criteria, maximum),
+		)
+	} else {
+		result += fmt.Sprintf(
+			" 当前相对优势是%s（%d 分），这些维度共同支撑了你的整体表现。",
+			strings.Join(highNames, "、"),
+			maximum,
+		)
 	}
-	if lowFocus != "" {
-		result += " 短板对应的已核验回答显示：" + lowFocus
+	if len(lowNames) == 1 {
+		result += fmt.Sprintf(
+			" 首要提升的是%s（%d 分）：%s",
+			strings.Join(lowNames, "、"),
+			minimum,
+			ieltsOverallCriterionMeaning(criteria, minimum),
+		)
+	} else {
+		result += fmt.Sprintf(
+			" 优先提升的是%s（%d 分），需要结合下方反馈逐项练习。",
+			strings.Join(lowNames, "、"),
+			minimum,
+		)
 	}
-	result += " 下方各维度列出了对应原句与具体练法。"
+	result += " 下一步先做：" + ieltsOverallNextStep(criteria, minimum)
 	return truncateIELTSReportText(result, reportMaximumTextBytes)
+}
+
+func formatIELTSBand(band float64) string {
+	if band == float64(int(band)) {
+		return fmt.Sprintf("%d", int(band))
+	}
+	return fmt.Sprintf("%.1f", band)
+}
+
+func ieltsOverallCriterionMeaning(
+	criteria []IELTSSpeakingReportCriterion,
+	band int,
+) string {
+	for _, criterion := range criteria {
+		if criterion.EstimatedBand == nil || *criterion.EstimatedBand != band {
+			continue
+		}
+		switch criterion.CriterionID {
+		case scoring.IELTSCriterionFC:
+			if band >= 6 {
+				return "主要观点通常容易跟随，较长回答中的衔接和展开仍可更稳定。"
+			}
+			return "你能给出基本回答，但停顿、重复或重新起句会打断观点推进。"
+		case scoring.IELTSCriterionLR:
+			if band >= 6 {
+				return "现有词汇能支撑话题表达，复杂内容中的选词和改述仍可更准确。"
+			}
+			return "常用词汇可以传达基本意思，但重复、模糊选词或搭配不自然会降低表达的准确度。"
+		case scoring.IELTSCriterionGRA:
+			if band >= 6 {
+				return "你能使用简单句和部分复杂句表达主要意思，较复杂结构的稳定性仍可提升。"
+			}
+			return "你能够使用基础句式，但语法错误或句子不完整有时会让意思变得不够清楚。"
+		case scoring.IELTSCriterionPR:
+			if band >= 6 {
+				return "整体发音较清楚，主要意思容易听懂，较长表达中的清晰度仍可更稳定。"
+			}
+			return "多数基本内容可以听懂，但整句清晰度和语流稳定性仍需要加强。"
+		}
+	}
+	return ""
+}
+
+func ieltsOverallNextStep(
+	criteria []IELTSSpeakingReportCriterion,
+	minimum int,
+) string {
+	for _, criterion := range criteria {
+		if criterion.EstimatedBand == nil || *criterion.EstimatedBand != minimum {
+			continue
+		}
+		switch criterion.CriterionID {
+		case scoring.IELTSCriterionFC:
+			return "用“观点—原因—例子”结构完成 60 秒连续作答；录音复听时标出停顿、重复和重新起句的位置，再完整重答一次。"
+		case scoring.IELTSCriterionLR:
+			return "围绕一个高频话题准备 5 组常用搭配和 2 种改述方式，并在 60 秒回答中实际使用，避免只背单词。"
+		case scoring.IELTSCriterionGRA:
+			return "选取本次回答中的 3 个基础句，分别加入原因、条件或对比信息，改写后朗读并检查句子是否完整准确。"
+		case scoring.IELTSCriterionPR:
+			return "选取一段完整回答做两轮跟读和录音对比，复听时只检查整句是否容易听清、节奏是否稳定。"
+		}
+	}
+	return "结合下方各维度的原句和练法，先完成一轮针对性练习。"
 }
 
 func ieltsCriterionName(criterion scoring.IELTSCriterion) string {

--- a/server/internal/coaching/evaluation/report/ielts_speaking.go
+++ b/server/internal/coaching/evaluation/report/ielts_speaking.go
@@ -3,8 +3,11 @@ package report
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"slices"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
@@ -127,6 +130,7 @@ func ProjectIELTSSpeakingReport(
 	for _, turn := range payload.ConfirmedTurns {
 		turnsByID[turn.TurnID] = turn
 	}
+	evidenceLocations := ieltsEvidenceLocations(result.QuestionResults)
 
 	report := IELTSSpeakingReport{
 		SchemaVersion:      IELTSSpeakingReportSchemaVersion,
@@ -161,20 +165,13 @@ func ProjectIELTSSpeakingReport(
 	}
 	for index, criterion := range result.Criteria {
 		report.Criteria[index] =
-			projectIELTSSpeakingReportCriterion(criterion)
-		for _, finding := range criterion.Improvements {
-			if len(report.PriorityActions) == 3 {
-				break
-			}
-			report.PriorityActions = append(
-				report.PriorityActions,
-				IELTSSpeakingReportPriorityRef{
-					CriterionID: criterion.CriterionID,
-					FindingID:   finding.ID,
-				},
+			projectIELTSSpeakingReportCriterion(
+				criterion,
+				evidenceLocations,
 			)
-		}
 	}
+	report.PriorityActions =
+		projectIELTSSpeakingPriorityActions(result.Criteria)
 	if overall, available := projectIELTSSpeakingOverall(report.Criteria); available {
 		report.SpeakingOverall = overall
 	}
@@ -239,12 +236,16 @@ func projectIELTSSpeakingOverall(
 	return IELTSSpeakingReportOverall{
 		Status:        IELTSSpeakingOverallAvailable,
 		EstimatedBand: &band,
-		Explanation:   "口语总分按四项练习估分等权平均，并四舍五入到最近的 0.5 分。",
+		Explanation: ieltsSpeakingOverallExplanation(
+			band,
+			criteria,
+		),
 	}, true
 }
 
 func projectIELTSSpeakingReportCriterion(
 	source scoring.IELTSSpeakingShadowCriterionResult,
+	locations map[string]ieltsEvidenceLocation,
 ) IELTSSpeakingReportCriterion {
 	var estimatedBand *int
 	if source.EstimatedBand != nil {
@@ -252,12 +253,15 @@ func projectIELTSSpeakingReportCriterion(
 		estimatedBand = &value
 	}
 	return IELTSSpeakingReportCriterion{
-		CriterionID:     source.CriterionID,
-		Scoreability:    source.Scoreability,
-		Gate:            source.Gate,
-		EstimatedBand:   estimatedBand,
-		BandDescriptor:  source.BandDescriptor,
-		Explanation:     ieltsCriterionExplanation(source),
+		CriterionID:    source.CriterionID,
+		Scoreability:   source.Scoreability,
+		Gate:           source.Gate,
+		EstimatedBand:  estimatedBand,
+		BandDescriptor: source.BandDescriptor,
+		Explanation: ieltsCriterionExplanation(
+			source,
+			locations,
+		),
 		Coverage:        source.Coverage,
 		Confidence:      source.Confidence,
 		ReasonCodes:     slices.Clone(source.ReasonCodes),
@@ -301,6 +305,7 @@ func projectIELTSSpeakingTestSummary(
 
 func ieltsCriterionExplanation(
 	criterion scoring.IELTSSpeakingShadowCriterionResult,
+	locations map[string]ieltsEvidenceLocation,
 ) string {
 	if criterion.Scoreability == scoring.IELTSSpeakingScoreabilityInsufficient {
 		if criterion.CriterionID == scoring.IELTSCriterionPR {
@@ -308,10 +313,189 @@ func ieltsCriterionExplanation(
 		}
 		return "本次可确认的回答证据不足，因此不展示该维度分数。"
 	}
-	if criterion.BandDescriptor != "" {
-		return criterion.BandDescriptor
+	parts := []string{ieltsCriterionBandSummary(criterion)}
+	if len(criterion.Strengths) > 0 {
+		parts = append(parts, ieltsCriterionFindingSentence(
+			criterion.CriterionID,
+			criterion.Strengths[0],
+			locations,
+			true,
+		))
 	}
-	switch criterion.CriterionID {
+	if len(criterion.Improvements) > 0 {
+		parts = append(parts, ieltsCriterionFindingSentence(
+			criterion.CriterionID,
+			criterion.Improvements[0],
+			locations,
+			false,
+		))
+	}
+	if criterion.EstimatedBand == nil {
+		parts = append(parts, "由于缺少完整的时序声学证据，本次只能对观点展开与衔接作定性反馈，暂不展示该维度分数。")
+	} else {
+		parts = append(parts, fmt.Sprintf(
+			"综合这些已核验表现，本维度练习估分为 %d 分。",
+			*criterion.EstimatedBand,
+		))
+	}
+	return truncateIELTSReportText(
+		strings.Join(nonEmptyIELTSReportParts(parts), " "),
+		reportMaximumTextBytes,
+	)
+}
+
+type ieltsEvidenceLocation struct {
+	part    scoring.IELTSPart
+	ordinal int
+}
+
+func ieltsEvidenceLocations(
+	questions []scoring.IELTSSpeakingShadowQuestionResult,
+) map[string]ieltsEvidenceLocation {
+	result := make(map[string]ieltsEvidenceLocation)
+	partOrdinals := make(map[scoring.IELTSPart]int, len(ieltsPartOrder))
+	for _, question := range questions {
+		partOrdinals[question.PartID]++
+		location := ieltsEvidenceLocation{
+			part:    question.PartID,
+			ordinal: partOrdinals[question.PartID],
+		}
+		for _, refID := range question.EvidenceRefIDs {
+			result[refID] = location
+		}
+	}
+	return result
+}
+
+func ieltsEvidenceLocationLabel(location ieltsEvidenceLocation) string {
+	switch location.part {
+	case scoring.IELTSPart1:
+		return fmt.Sprintf("Part 1 第 %d 题", location.ordinal)
+	case scoring.IELTSPart2:
+		if location.ordinal == 1 {
+			return "Part 2"
+		}
+		return fmt.Sprintf("Part 2 第 %d 题", location.ordinal)
+	case scoring.IELTSPart3:
+		return fmt.Sprintf("Part 3 第 %d 题", location.ordinal)
+	default:
+		return "本次回答"
+	}
+}
+
+func ieltsCriterionFindingSentence(
+	criterion scoring.IELTSCriterion,
+	finding scoring.IELTSSpeakingShadowFinding,
+	locations map[string]ieltsEvidenceLocation,
+	strength bool,
+) string {
+	if len(finding.Evidence) == 0 {
+		return ""
+	}
+	evidence := finding.Evidence[0]
+	where := "本次回答中"
+	if location, exists := locations[evidence.EvidenceRefID]; exists {
+		where = "在" + ieltsEvidenceLocationLabel(location)
+	}
+	quote := truncateIELTSReportText(evidence.OriginalExcerpt, 240)
+	message := truncateIELTSReportText(finding.Message, 300)
+	if criterion == scoring.IELTSCriterionPR {
+		if strength {
+			return fmt.Sprintf(
+				"%s，对应原句“%s”的整轮录音为整体可理解度提供了正向声学证据。",
+				where,
+				quote,
+			)
+		}
+		result := fmt.Sprintf(
+			"%s，对应原句“%s”的整轮录音显示整体清晰度或稳定性仍可提升。",
+			where,
+			quote,
+		)
+		result += "建议：选取完整句子进行两轮跟读和录音对比，复听时只检查整句是否容易听清、整体表达是否稳定。"
+		return result
+	}
+	if strength {
+		return fmt.Sprintf(
+			"%s，原句“%s”是本维度的一项优势证据：%s",
+			where,
+			quote,
+			message,
+		)
+	}
+	result := fmt.Sprintf(
+		"%s，原句“%s”需要优先关注：%s",
+		where,
+		quote,
+		message,
+	)
+	if finding.Suggestion != "" {
+		result += " 建议：" +
+			truncateIELTSReportText(finding.Suggestion, 420)
+	}
+	return result
+}
+
+func ieltsCriterionBandSummary(
+	criterion scoring.IELTSSpeakingShadowCriterionResult,
+) string {
+	if criterion.EstimatedBand == nil {
+		if criterion.CriterionID == scoring.IELTSCriterionFC {
+			return "从已确认的回答看，考生能够表达主要观点；本次重点观察回答是否围绕问题展开，以及观点之间是否容易跟随。"
+		}
+		return ieltsCriterionDefaultSummary(criterion.CriterionID)
+	}
+	band := *criterion.EstimatedBand
+	summaries := map[scoring.IELTSCriterion][]string{
+		scoring.IELTSCriterionFC: {
+			"能够表达部分基本意思，但观点展开与衔接还不稳定，听者需要较多推断。",
+			"能够围绕熟悉话题给出基本回答，但展开常较短，连接或自我修正会影响连贯性。",
+			"能够较清楚地回答并展开主要观点，整体容易跟随；较长回答中的衔接、重复或停顿控制仍不稳定。",
+			"能够较自然地延展观点并保持逻辑联系，偶尔的重复或犹豫通常不妨碍交流。",
+			"能够流畅、连贯且有层次地发展观点，衔接自然，听者几乎无需额外推断。",
+		},
+		scoring.IELTSCriterionLR: {
+			"能够使用基础词汇表达部分意思，但范围和准确性会限制信息传达。",
+			"具备熟悉话题所需的常用词汇，但重复、模糊选词或不自然搭配会影响精确度。",
+			"词汇范围足以讨论常见话题并表达主要意思，较复杂内容中的选词、搭配和改述仍有不稳定之处。",
+			"能够较灵活、准确地选择词汇并进行改述，少量不恰当用词通常不妨碍理解。",
+			"能够广泛、自然且精确地使用词汇和搭配，并根据话题灵活调整表达。",
+		},
+		scoring.IELTSCriterionGRA: {
+			"能够构成部分基础句，但语法错误和句子控制会明显限制意思表达。",
+			"能够使用简单句并尝试复杂结构，但准确性不稳定，错误有时会增加理解负担。",
+			"能够混合使用简单句和部分复杂句，主要意思清楚；复杂结构、时态或句子完整性仍会出现偏差。",
+			"能够使用多样句式并较好控制复杂结构，多数句子准确，少量错误通常不影响交流。",
+			"能够灵活运用丰富句式并持续保持较高准确性，复杂表达自然且清楚。",
+		},
+		scoring.IELTSCriterionPR: {
+			"部分内容可以听懂，但整体清晰度与语流稳定性会给理解带来明显负担。",
+			"多数基本内容可以听懂，但整句清晰度不够稳定，需要听者适应。",
+			"整体发音清楚、主要意思容易听懂；较长表达中的清晰度与语流稳定性仍可提升。",
+			"整体容易听懂，语流较自然，偶尔的清晰度波动通常不影响交流。",
+			"发音持续清晰自然，整体语流控制成熟，听者几乎不需要额外适应。",
+		},
+	}
+	values, exists := summaries[criterion.CriterionID]
+	if !exists {
+		return ""
+	}
+	index := 0
+	switch {
+	case band >= 8:
+		index = 4
+	case band >= 7:
+		index = 3
+	case band >= 6:
+		index = 2
+	case band >= 5:
+		index = 1
+	}
+	return values[index]
+}
+
+func ieltsCriterionDefaultSummary(criterion scoring.IELTSCriterion) string {
+	switch criterion {
 	case scoring.IELTSCriterionFC:
 		return "根据已确认回答评估观点衔接与话题展开；缺少完整时序证据时只提供定性反馈。"
 	case scoring.IELTSCriterionLR:
@@ -319,10 +503,245 @@ func ieltsCriterionExplanation(
 	case scoring.IELTSCriterionGRA:
 		return "根据已确认回答评估句式范围、复杂结构控制和语法准确性。"
 	case scoring.IELTSCriterionPR:
-		return "根据录音声学证据评估可理解度、音段、重音、节奏与语调。"
+		return "根据整轮录音的声学证据评估整体可理解度、清晰度与语流稳定性。"
 	default:
 		return ""
 	}
+}
+
+func ieltsSpeakingOverallExplanation(
+	band float64,
+	criteria []IELTSSpeakingReportCriterion,
+) string {
+	intro := "考生能够在熟悉话题中表达基本意思，但语言控制仍会给交流带来一定负担。"
+	switch {
+	case band >= 8:
+		intro = "考生能够流畅、清晰且精确地讨论熟悉和抽象话题，语言运用自然，整体交流几乎不受影响。"
+	case band >= 7:
+		intro = "考生能够较自然地展开观点并进行连贯交流，语言范围和控制较好，少量不准确或犹豫通常不影响理解。"
+	case band >= 6:
+		intro = "考生能够清楚回答问题并表达主要观点，整体交流可以顺利进行；在较长或较复杂的回答中，语言的连贯性、精确度或稳定性仍会波动。"
+	case band >= 5:
+		intro = "考生能够围绕常见话题传达主要意思，但回答展开和语言控制不够稳定，遇到复杂内容时会增加听者的理解负担。"
+	case band < 4.5:
+		intro = "考生能够传达部分基本信息，但回答展开、语言准确性和整体清晰度较受限制，交流需要听者较多配合。"
+	}
+	if len(criteria) == 0 {
+		return intro
+	}
+	minimum := 10
+	maximum := 0
+	for _, criterion := range criteria {
+		if criterion.EstimatedBand == nil {
+			continue
+		}
+		if *criterion.EstimatedBand < minimum {
+			minimum = *criterion.EstimatedBand
+		}
+		if *criterion.EstimatedBand > maximum {
+			maximum = *criterion.EstimatedBand
+		}
+	}
+	if maximum == 0 || minimum == 10 {
+		return intro
+	}
+	if maximum == minimum {
+		strengthFocus := ""
+		improvementFocus := ""
+		for _, criterion := range criteria {
+			if strengthFocus == "" && len(criterion.Strengths) > 0 {
+				strengthFocus = truncateIELTSReportText(
+					criterion.Strengths[0].Message,
+					220,
+				)
+			}
+			if improvementFocus == "" && len(criterion.Improvements) > 0 {
+				improvementFocus = truncateIELTSReportText(
+					criterion.Improvements[0].Message,
+					220,
+				)
+			}
+		}
+		detail := ""
+		if strengthFocus != "" {
+			detail += " 已核验优势是：" + strengthFocus
+		}
+		if improvementFocus != "" {
+			detail += " 当前首先要改善的是：" + improvementFocus
+		}
+		return truncateIELTSReportText(
+			fmt.Sprintf(
+				"%s 四项均为 %d 分，表现较为均衡。%s 下方各维度列出了对应原句与具体练法。",
+				intro,
+				maximum,
+				strings.TrimSpace(detail),
+			),
+			reportMaximumTextBytes,
+		)
+	}
+	highNames := []string{}
+	lowNames := []string{}
+	highFocus := ""
+	lowFocus := ""
+	for _, criterion := range criteria {
+		if criterion.EstimatedBand == nil {
+			continue
+		}
+		if *criterion.EstimatedBand == maximum {
+			highNames = append(
+				highNames,
+				ieltsCriterionName(criterion.CriterionID),
+			)
+			if highFocus == "" && len(criterion.Strengths) > 0 {
+				highFocus = truncateIELTSReportText(
+					criterion.Strengths[0].Message,
+					220,
+				)
+			}
+		}
+		if *criterion.EstimatedBand == minimum {
+			lowNames = append(
+				lowNames,
+				ieltsCriterionName(criterion.CriterionID),
+			)
+			if lowFocus == "" && len(criterion.Improvements) > 0 {
+				lowFocus = truncateIELTSReportText(
+					criterion.Improvements[0].Message,
+					240,
+				)
+			}
+		}
+	}
+	result := fmt.Sprintf(
+		"%s 从四项表现看，%s（%d 分）是相对优势；%s（%d 分）是优先提升方向。",
+		intro,
+		strings.Join(highNames, "、"),
+		maximum,
+		strings.Join(lowNames, "、"),
+		minimum,
+	)
+	if highFocus != "" {
+		result += " 这项优势的已核验证据表明：" + highFocus
+	}
+	if lowFocus != "" {
+		result += " 短板对应的已核验回答显示：" + lowFocus
+	}
+	result += " 下方各维度列出了对应原句与具体练法。"
+	return truncateIELTSReportText(result, reportMaximumTextBytes)
+}
+
+func ieltsCriterionName(criterion scoring.IELTSCriterion) string {
+	switch criterion {
+	case scoring.IELTSCriterionFC:
+		return "流利性与连贯性"
+	case scoring.IELTSCriterionLR:
+		return "词汇丰富度"
+	case scoring.IELTSCriterionGRA:
+		return "语法多样性及准确性"
+	case scoring.IELTSCriterionPR:
+		return "发音"
+	default:
+		return string(criterion)
+	}
+}
+
+func projectIELTSSpeakingPriorityActions(
+	criteria []scoring.IELTSSpeakingShadowCriterionResult,
+) []IELTSSpeakingReportPriorityRef {
+	ordered := slices.Clone(criteria)
+	slices.SortStableFunc(
+		ordered,
+		func(left, right scoring.IELTSSpeakingShadowCriterionResult) int {
+			leftBand := 10
+			rightBand := 10
+			if left.EstimatedBand != nil {
+				leftBand = *left.EstimatedBand
+			}
+			if right.EstimatedBand != nil {
+				rightBand = *right.EstimatedBand
+			}
+			return leftBand - rightBand
+		},
+	)
+	result := make([]IELTSSpeakingReportPriorityRef, 0, 3)
+	seen := make(map[string]struct{})
+	appendFinding := func(
+		criterion scoring.IELTSSpeakingShadowCriterionResult,
+		finding scoring.IELTSSpeakingShadowFinding,
+	) {
+		if len(result) == 3 {
+			return
+		}
+		content := finding.Suggestion
+		if content == "" {
+			content = finding.Message
+		}
+		key := ieltsPriorityActionKey(content)
+		if _, duplicate := seen[key]; duplicate {
+			return
+		}
+		seen[key] = struct{}{}
+		result = append(result, IELTSSpeakingReportPriorityRef{
+			CriterionID: criterion.CriterionID,
+			FindingID:   finding.ID,
+		})
+	}
+	for _, criterion := range ordered {
+		if len(criterion.Improvements) > 0 {
+			appendFinding(criterion, criterion.Improvements[0])
+		}
+	}
+	for _, criterion := range ordered {
+		for index := 1; index < len(criterion.Improvements); index++ {
+			finding := criterion.Improvements[index]
+			appendFinding(criterion, finding)
+		}
+	}
+	return result
+}
+
+func ieltsPriorityActionKey(content string) string {
+	const providerAdjustmentMarker = "结合本次原句，还可以这样调整："
+	if index := strings.LastIndex(
+		content,
+		providerAdjustmentMarker,
+	); index >= 0 {
+		content = content[index+len(providerAdjustmentMarker):]
+	}
+	return strings.ToLower(strings.Join(strings.Fields(content), " "))
+}
+
+func nonEmptyIELTSReportParts(parts []string) []string {
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			result = append(result, strings.TrimSpace(part))
+		}
+	}
+	return result
+}
+
+func truncateIELTSReportText(value string, maximumBytes int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= maximumBytes {
+		return value
+	}
+	if maximumBytes < len("…") {
+		return ""
+	}
+	if maximumBytes == len("…") {
+		return "…"
+	}
+	limit := maximumBytes - len("…")
+	cut := 0
+	for index, current := range value {
+		end := index + utf8.RuneLen(current)
+		if end > limit {
+			break
+		}
+		cut = end
+	}
+	return strings.TrimSpace(value[:cut]) + "…"
 }
 
 func cloneIELTSFindings(
@@ -438,7 +857,6 @@ func (report IELTSSpeakingReport) Valid() bool {
 		!validIELTSSpeakingTestSummary(report.TestSummary) ||
 		len(report.Criteria) != len(ieltsCriterionOrder) ||
 		!validIELTSSpeakingOverall(report.SpeakingOverall, report.Criteria) ||
-		report.SpeakingOverall.Explanation == "" ||
 		len(report.PartReviews) != len(ieltsPartOrder) ||
 		len(report.Questions) != report.TestSummary.QuestionCount ||
 		!validIELTSReportQuestionSequence(report.Questions) ||
@@ -570,7 +988,10 @@ func validIELTSSpeakingOverall(
 	overall IELTSSpeakingReportOverall,
 	criteria []IELTSSpeakingReportCriterion,
 ) bool {
-	if overall.Explanation == "" {
+	if !validReportText(
+		overall.Explanation,
+		reportMaximumTextBytes,
+	) {
 		return false
 	}
 	expected, available := projectIELTSSpeakingOverall(criteria)
@@ -614,7 +1035,10 @@ func validIELTSReportCriterion(
 		criterion.Scoreability,
 		criterion.Gate,
 	) ||
-		criterion.Explanation == "" ||
+		!validReportText(
+			criterion.Explanation,
+			reportMaximumTextBytes,
+		) ||
 		criterion.Coverage < 0 || criterion.Coverage > 1 ||
 		criterion.Confidence != 0 ||
 		criterion.ReasonCodes == nil ||

--- a/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
+++ b/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
@@ -1,0 +1,549 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
+)
+
+func TestIELTSSpeakingReportValidatesGeneratedExplanationText(t *testing.T) {
+	t.Parallel()
+	snapshot := ieltsReportTestSnapshot(t, ieltsReportQuestionCount)
+	result := ieltsReportTestResult(t, snapshot)
+	base, err := ProjectIELTSSpeakingReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectIELTSSpeakingReport: %v", err)
+	}
+	if !base.Valid() {
+		t.Fatal("projected IELTS report is invalid")
+	}
+
+	exactlyMaximumUTF8Bytes := strings.Repeat("界", 682) + "ab"
+	overMaximumUTF8Bytes := exactlyMaximumUTF8Bytes + "c"
+	if len(exactlyMaximumUTF8Bytes) != reportMaximumTextBytes ||
+		len(overMaximumUTF8Bytes) != reportMaximumTextBytes+1 {
+		t.Fatal("test data does not exercise the intended UTF-8 byte boundary")
+	}
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "blank", value: " \t\n", valid: false},
+		{name: "NUL", value: "有效说明\x00不可见内容", valid: false},
+		{name: "invalid UTF-8", value: string([]byte{'a', 0xff}), valid: false},
+		{name: "exactly 2048 UTF-8 bytes", value: exactlyMaximumUTF8Bytes, valid: true},
+		{name: "2049 UTF-8 bytes", value: overMaximumUTF8Bytes, valid: false},
+	}
+	targets := []struct {
+		name   string
+		mutate func(*IELTSSpeakingReport, string)
+	}{
+		{
+			name: "overall explanation",
+			mutate: func(report *IELTSSpeakingReport, value string) {
+				report.SpeakingOverall.Explanation = value
+			},
+		},
+		{
+			name: "criterion explanation",
+			mutate: func(report *IELTSSpeakingReport, value string) {
+				report.Criteria[0].Explanation = value
+			},
+		},
+	}
+	for _, target := range targets {
+		t.Run(target.name, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					report := base
+					report.Criteria = slices.Clone(base.Criteria)
+					target.mutate(&report, test.value)
+					if got := report.Valid(); got != test.valid {
+						t.Fatalf("Valid() = %t, want %t", got, test.valid)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestIELTSSpeakingNarrativesUseManualEvidenceContexts(t *testing.T) {
+	t.Parallel()
+	band := func(value int) *int { return &value }
+	criteria := []IELTSSpeakingReportCriterion{
+		{CriterionID: scoring.IELTSCriterionFC, EstimatedBand: band(7)},
+		{CriterionID: scoring.IELTSCriterionLR, EstimatedBand: band(5)},
+		{CriterionID: scoring.IELTSCriterionGRA, EstimatedBand: band(6)},
+		{CriterionID: scoring.IELTSCriterionPR, EstimatedBand: band(4)},
+	}
+	overall := ieltsSpeakingOverallExplanation(5.5, criteria)
+	for _, expected := range []string{
+		"流利性与连贯性（7 分）",
+		"发音（4 分）",
+	} {
+		if !strings.Contains(overall, expected) {
+			t.Errorf("overall explanation %q does not contain %q", overall, expected)
+		}
+	}
+
+	locations := map[string]ieltsEvidenceLocation{
+		"ref-fc":  {part: scoring.IELTSPart1, ordinal: 2},
+		"ref-lr":  {part: scoring.IELTSPart2, ordinal: 1},
+		"ref-gra": {part: scoring.IELTSPart3, ordinal: 1},
+		"ref-pr":  {part: scoring.IELTSPart3, ordinal: 2},
+	}
+	tests := []struct {
+		criterion scoring.IELTSCriterion
+		band      int
+		refID     string
+		part      string
+		excerpt   string
+	}{
+		{
+			criterion: scoring.IELTSCriterionFC,
+			band:      7,
+			refID:     "ref-fc",
+			part:      "Part 1 第 2 题",
+			excerpt:   "I linked the reason to a concrete example.",
+		},
+		{
+			criterion: scoring.IELTSCriterionLR,
+			band:      5,
+			refID:     "ref-lr",
+			part:      "Part 2",
+			excerpt:   "I learned pottery from a patient local artist.",
+		},
+		{
+			criterion: scoring.IELTSCriterionGRA,
+			band:      6,
+			refID:     "ref-gra",
+			part:      "Part 3 第 1 题",
+			excerpt:   "Although it takes time, the skill remains valuable.",
+		},
+		{
+			criterion: scoring.IELTSCriterionPR,
+			band:      4,
+			refID:     "ref-pr",
+			part:      "Part 3 第 2 题",
+			excerpt:   "People can practise the whole sentence together.",
+		},
+	}
+	for _, test := range tests {
+		t.Run(string(test.criterion), func(t *testing.T) {
+			t.Parallel()
+			score := test.band
+			source := scoring.IELTSSpeakingShadowCriterionResult{
+				CriterionID:   test.criterion,
+				Scoreability:  scoring.IELTSSpeakingScoreabilityProvisional,
+				EstimatedBand: &score,
+				Strengths: []scoring.IELTSSpeakingShadowFinding{{
+					Message: "这是由已核验证据支持的表现。",
+					Evidence: []scoring.IELTSSpeakingShadowEvidence{{
+						EvidenceRefID:   test.refID,
+						OriginalExcerpt: test.excerpt,
+					}},
+				}},
+			}
+			explanation := ieltsCriterionExplanation(source, locations)
+			for _, expected := range []string{test.part, test.excerpt} {
+				if !strings.Contains(explanation, expected) {
+					t.Errorf(
+						"explanation %q does not contain %q",
+						explanation,
+						expected,
+					)
+				}
+			}
+			if test.criterion == scoring.IELTSCriterionPR {
+				assertIELTSExplanationHasNoInventedPhoneme(t, explanation)
+			}
+		})
+	}
+}
+
+func TestProjectIELTSSpeakingPriorityActionsOrdersDeduplicatesAndCaps(
+	t *testing.T,
+) {
+	t.Parallel()
+	band := func(value int) *int { return &value }
+	finding := func(id, suggestion string) scoring.IELTSSpeakingShadowFinding {
+		return scoring.IELTSSpeakingShadowFinding{
+			ID: id, Message: "改进说明", Suggestion: suggestion,
+		}
+	}
+	criteria := []scoring.IELTSSpeakingShadowCriterionResult{
+		{
+			CriterionID:   scoring.IELTSCriterionFC,
+			EstimatedBand: band(7),
+			Improvements: []scoring.IELTSSpeakingShadowFinding{
+				finding("fc-primary", "Link the idea with one reason and example."),
+				finding("fc-secondary", "Record a second connected answer."),
+			},
+		},
+		{
+			CriterionID:   scoring.IELTSCriterionLR,
+			EstimatedBand: band(5),
+			Improvements: []scoring.IELTSSpeakingShadowFinding{
+				finding("lr-primary", "Replace general words with one precise topic noun."),
+			},
+		},
+		{
+			CriterionID:   scoring.IELTSCriterionGRA,
+			EstimatedBand: band(6),
+			Improvements: []scoring.IELTSSpeakingShadowFinding{
+				finding("gra-duplicate", "  replace GENERAL words with one precise topic noun.  "),
+			},
+		},
+		{
+			CriterionID:   scoring.IELTSCriterionPR,
+			EstimatedBand: band(4),
+			Improvements: []scoring.IELTSSpeakingShadowFinding{
+				finding("pr-primary", "Record the whole sentence and compare overall clarity."),
+				finding("pr-secondary", "Repeat the sentence at a steady pace."),
+			},
+		},
+	}
+
+	actions := projectIELTSSpeakingPriorityActions(criteria)
+	want := []IELTSSpeakingReportPriorityRef{
+		{CriterionID: scoring.IELTSCriterionPR, FindingID: "pr-primary"},
+		{CriterionID: scoring.IELTSCriterionLR, FindingID: "lr-primary"},
+		{CriterionID: scoring.IELTSCriterionFC, FindingID: "fc-primary"},
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("priority actions = %#v, want %#v", actions, want)
+	}
+}
+
+func TestProjectIELTSSpeakingReportPublishesEvidenceBoundContentAndActions(
+	t *testing.T,
+) {
+	t.Parallel()
+	snapshot, acoustics := ieltsContentReportAcousticFixture(t)
+	result, err := scoring.NewIELTSSpeakingShadowEngine(
+		&ieltsContentReportProvider{},
+	).EvaluateWithAcousticSnapshot(
+		context.Background(),
+		snapshot,
+		acoustics,
+	)
+	if err != nil {
+		t.Fatalf("EvaluateWithAcousticSnapshot: %v", err)
+	}
+	report, err := ProjectIELTSSpeakingReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectIELTSSpeakingReport: %v", err)
+	}
+	if !report.Valid() {
+		t.Fatal("projected IELTS report is invalid")
+	}
+
+	for _, expected := range []string{
+		"流利性与连贯性（7 分）",
+		"发音（4 分）",
+	} {
+		if !strings.Contains(report.SpeakingOverall.Explanation, expected) {
+			t.Errorf(
+				"overall explanation %q does not contain %q",
+				report.SpeakingOverall.Explanation,
+				expected,
+			)
+		}
+	}
+
+	expectedEvidence := map[scoring.IELTSCriterion]struct {
+		part    string
+		excerpt string
+	}{
+		scoring.IELTSCriterionFC: {
+			part: "Part 1", excerpt: "I explain answer 1 clearly with a concrete example.",
+		},
+		scoring.IELTSCriterionLR: {
+			part: "Part 2", excerpt: "I explain answer 4 clearly with a concrete example.",
+		},
+		scoring.IELTSCriterionGRA: {
+			part: "Part 3", excerpt: "I explain answer 5 clearly with a concrete example.",
+		},
+		scoring.IELTSCriterionPR: {
+			part: "Part 3", excerpt: "I explain answer 7 clearly with a concrete example.",
+		},
+	}
+	for _, criterion := range report.Criteria {
+		expected := expectedEvidence[criterion.CriterionID]
+		for _, fragment := range []string{expected.part, expected.excerpt} {
+			if !strings.Contains(criterion.Explanation, fragment) {
+				t.Errorf(
+					"%s explanation %q does not contain %q",
+					criterion.CriterionID,
+					criterion.Explanation,
+					fragment,
+				)
+			}
+		}
+		if criterion.CriterionID == scoring.IELTSCriterionPR {
+			assertIELTSExplanationHasNoInventedPhoneme(
+				t,
+				criterion.Explanation,
+			)
+		}
+	}
+
+	wantOrder := []scoring.IELTSCriterion{
+		scoring.IELTSCriterionPR,
+		scoring.IELTSCriterionLR,
+		scoring.IELTSCriterionFC,
+	}
+	if len(report.PriorityActions) != len(wantOrder) {
+		t.Fatalf(
+			"priority action count = %d, want %d: %#v",
+			len(report.PriorityActions),
+			len(wantOrder),
+			report.PriorityActions,
+		)
+	}
+	seenSuggestions := make(map[string]struct{}, len(report.PriorityActions))
+	for index, action := range report.PriorityActions {
+		if action.CriterionID != wantOrder[index] {
+			t.Errorf(
+				"priority action %d criterion = %s, want %s",
+				index,
+				action.CriterionID,
+				wantOrder[index],
+			)
+		}
+		finding := ieltsContentReportFinding(report, action)
+		normalized := strings.ToLower(strings.Join(
+			strings.Fields(finding.Suggestion),
+			" ",
+		))
+		if _, duplicate := seenSuggestions[normalized]; duplicate {
+			t.Errorf("duplicate priority suggestion %q", finding.Suggestion)
+		}
+		seenSuggestions[normalized] = struct{}{}
+	}
+
+	formal, err := ProjectIELTSFormalReport(snapshot, result)
+	if err != nil {
+		t.Fatalf("ProjectIELTSFormalReport: %v", err)
+	}
+	var detail IELTSSpeakingReport
+	if err := json.Unmarshal(formal.Detail, &detail); err != nil {
+		t.Fatalf("decode IELTS formal detail: %v", err)
+	}
+	if !reflect.DeepEqual(detail, report) {
+		t.Errorf("formal detail differs from standalone report")
+	}
+	if len(formal.PriorityActions) != len(detail.PriorityActions) {
+		t.Fatalf(
+			"formal priority action count = %d, detail = %d",
+			len(formal.PriorityActions),
+			len(detail.PriorityActions),
+		)
+	}
+	for index, action := range detail.PriorityActions {
+		formalAction := formal.PriorityActions[index]
+		if formalAction.DimensionKey != string(action.CriterionID) ||
+			formalAction.FindingID != action.FindingID {
+			t.Errorf(
+				"formal priority action %d = %#v, detail = %#v",
+				index,
+				formalAction,
+				action,
+			)
+		}
+	}
+}
+
+func assertIELTSExplanationHasNoInventedPhoneme(
+	t *testing.T,
+	explanation string,
+) {
+	t.Helper()
+	for _, unsupported := range []string{
+		"/θ/", "/ð/", "th 音", "元音发成", "辅音发成", "重音落在",
+	} {
+		if strings.Contains(explanation, unsupported) {
+			t.Errorf(
+				"pronunciation explanation invents unsupported phoneme evidence: %q",
+				explanation,
+			)
+		}
+	}
+}
+
+type ieltsContentReportProvider struct{}
+
+func (*ieltsContentReportProvider) AnalyzeIELTSCriterion(
+	_ context.Context,
+	request scoring.IELTSSpeakingCriterionProviderRequest,
+) (scoring.IELTSSpeakingShadowProviderResult, error) {
+	input := request.Input
+	criterion := input.AssessableCriteria[0]
+	responseIndex := map[scoring.IELTSCriterion]int{
+		scoring.IELTSCriterionFC:  0,
+		scoring.IELTSCriterionLR:  3,
+		scoring.IELTSCriterionGRA: 4,
+		scoring.IELTSCriterionPR:  6,
+	}[criterion]
+	response := input.Questions[responseIndex].Response
+	if response == nil {
+		panic("IELTS content report fixture requires every response")
+	}
+	band := map[scoring.IELTSCriterion]int{
+		scoring.IELTSCriterionFC:  7,
+		scoring.IELTSCriterionLR:  5,
+		scoring.IELTSCriterionGRA: 6,
+		scoring.IELTSCriterionPR:  4,
+	}[criterion]
+	suggestion := map[scoring.IELTSCriterion]string{
+		scoring.IELTSCriterionFC:  "Link the idea with one clear reason and example.",
+		scoring.IELTSCriterionLR:  "Replace general words with one precise topic noun.",
+		scoring.IELTSCriterionGRA: "replace GENERAL words with one precise topic noun.",
+		scoring.IELTSCriterionPR:  "Record the whole sentence again and compare its overall clarity.",
+	}[criterion]
+	token := strings.ToLower(strings.TrimPrefix(string(criterion), "IELTS_"))
+	anchor := ieltsReportProviderAnchor{
+		EvidenceRefID: response.EvidenceRefID,
+		Quote:         response.Transcript,
+		Occurrence:    1,
+	}
+	payload := ieltsReportProviderPayload{
+		SchemaVersion: scoring.IELTSSpeakingShadowProviderSchemaVersion,
+		Criteria: []ieltsReportProviderCriterion{{
+			CriterionID: criterion,
+			RubricDescriptor: ieltsContentReportDescriptor(
+				input,
+				criterion,
+				band,
+			),
+			Strengths: []ieltsReportProviderFinding{{
+				TemplateID: "ielts." + token + ".strength.v1",
+				Evidence:   []ieltsReportProviderAnchor{anchor},
+			}},
+			Improvements: []ieltsReportProviderFinding{{
+				TemplateID: "ielts." + token + ".improvement.v1",
+				Suggestion: suggestion,
+				Evidence:   []ieltsReportProviderAnchor{anchor},
+			}},
+			UpgradeExamples: []ieltsReportProviderFinding{},
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return scoring.IELTSSpeakingShadowProviderResult{}, err
+	}
+	return scoring.IELTSSpeakingShadowProviderResult{
+		Payload:   raw,
+		Provider:  "provider",
+		Model:     "model",
+		RequestID: "content-request-" + token,
+	}, nil
+}
+
+func ieltsContentReportDescriptor(
+	input scoring.IELTSSpeakingShadowProviderInput,
+	criterion scoring.IELTSCriterion,
+	band int,
+) string {
+	for _, set := range input.RubricDescriptors {
+		if set.CriterionID == criterion {
+			return set.Descriptors[band-1].ID
+		}
+	}
+	panic("IELTS content report fixture has no descriptor")
+}
+
+func ieltsContentReportAcousticFixture(
+	t *testing.T,
+) (evidence.EvidenceSnapshot, scoring.IELTSAcousticSnapshot) {
+	t.Helper()
+	base := ieltsReportTestSnapshot(t, ieltsReportQuestionCount)
+	var payload evidence.SnapshotPayload
+	if err := json.Unmarshal(base.Payload, &payload); err != nil {
+		t.Fatalf("decode IELTS content fixture: %v", err)
+	}
+	for index := range payload.ConfirmedTurns {
+		turn := &payload.ConfirmedTurns[index]
+		turn.Audio = evidence.Audio{
+			Availability: "AVAILABLE",
+			AudioAssetID: "audio-" + turn.TurnID,
+			ChecksumSHA256: strings.Repeat(
+				string("abcdef0123456789"[index%16]),
+				64,
+			),
+			DurationMS:  4_000,
+			ContentType: "audio/wav",
+			SizeBytes:   64_000,
+			Status:      "readable",
+			Version:     1,
+			Quality:     reportEvidenceNotAssessed,
+			ISE:         reportEvidenceNotAssessed,
+		}
+		payload.EvidenceRefs[index].AudioSpan = &evidence.AudioSpan{
+			AudioAssetID: turn.Audio.AudioAssetID,
+			StartMS:      0,
+			EndMS:        turn.Audio.DurationMS,
+		}
+		payload.EvidenceRefs[index].Lineage.AudioAssetVersion =
+			turn.Audio.Version
+		payload.VersionManifest.TurnEvidence[index].AudioVersion =
+			turn.Audio.Version
+	}
+	snapshot := rebuildReportTestSnapshot(t, payload, base.SceneType)
+	if err := json.Unmarshal(snapshot.Payload, &payload); err != nil {
+		t.Fatalf("decode rebuilt IELTS content fixture: %v", err)
+	}
+	read := scoring.IELTSSpeakingAcousticRead{
+		Values: make(
+			[]scoring.IELTSSpeakingTurnAcoustics,
+			0,
+			len(payload.ConfirmedTurns),
+		),
+	}
+	for index, turn := range payload.ConfirmedTurns {
+		fluency := 76.0
+		read.Values = append(read.Values, scoring.IELTSSpeakingTurnAcoustics{
+			TurnID:               turn.TurnID,
+			EvidenceRefID:        payload.EvidenceRefs[index].EvidenceRefID,
+			PronunciationScore:   72,
+			AcousticFluencyScore: &fluency,
+			Provider:             "xfyun_ise",
+			ProviderRun:          "run_0123456789abcdef01234567",
+		})
+	}
+	acoustics, err := scoring.BuildIELTSAcousticSnapshot(
+		"20000000-0000-4000-8000-000000000002",
+		snapshot,
+		read,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BuildIELTSAcousticSnapshot: %v", err)
+	}
+	return snapshot, acoustics
+}
+
+func ieltsContentReportFinding(
+	report IELTSSpeakingReport,
+	action IELTSSpeakingReportPriorityRef,
+) scoring.IELTSSpeakingShadowFinding {
+	for _, criterion := range report.Criteria {
+		if criterion.CriterionID != action.CriterionID {
+			continue
+		}
+		for _, finding := range criterion.Improvements {
+			if finding.ID == action.FindingID {
+				return finding
+			}
+		}
+	}
+	panic("priority action does not reference an improvement")
+}

--- a/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
+++ b/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
@@ -86,11 +86,18 @@ func TestIELTSSpeakingNarrativesUseManualEvidenceContexts(t *testing.T) {
 	}
 	overall := ieltsSpeakingOverallExplanation(5.5, criteria)
 	for _, expected := range []string{
+		"本次口语练习估分为 5.5 分",
 		"流利性与连贯性（7 分）",
 		"发音（4 分）",
+		"下一步先做",
 	} {
 		if !strings.Contains(overall, expected) {
 			t.Errorf("overall explanation %q does not contain %q", overall, expected)
+		}
+	}
+	for _, unexpected := range []string{"考生", "已核验", "综合声学证据"} {
+		if strings.Contains(overall, unexpected) {
+			t.Errorf("overall explanation %q contains system-facing wording %q", overall, unexpected)
 		}
 	}
 

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -1194,51 +1194,118 @@ const (
 )
 
 type ieltsFeedbackTemplate struct {
-	ID      string
-	Message string
+	ID                    string
+	Message               string
+	ImprovementSuggestion string
+}
+
+type ieltsCriterionFeedbackCopy struct {
+	StrengthMessage       string
+	ImprovementMessage    string
+	UpgradeMessage        string
+	ImprovementSuggestion string
+}
+
+func ieltsFeedbackCopyForCriterion(
+	criterion IELTSCriterion,
+) (ieltsCriterionFeedbackCopy, bool) {
+	switch criterion {
+	case IELTSCriterionFC:
+		return ieltsCriterionFeedbackCopy{
+			StrengthMessage: "这段回答在观点衔接或话题展开方面表现较好。",
+			ImprovementMessage: "这段回答在观点衔接、表达推进或内容展开上" +
+				"仍有提升空间。",
+			UpgradeMessage: "可以在保留原意的基础上，让这段表达衔接更清楚、" +
+				"展开更完整。",
+			ImprovementSuggestion: "先按“观点—原因—例子”整理这段回答，" +
+				"再连续复述并录音；复听时只检查衔接是否清楚，以及是否存在" +
+				"不必要的重复或回退。",
+		}, true
+	case IELTSCriterionLR:
+		return ieltsCriterionFeedbackCopy{
+			StrengthMessage: "这段回答在选词或话题表达上较为恰当，" +
+				"能够传达具体意思。",
+			ImprovementMessage: "这段回答的选词、搭配或表达精确度" +
+				"仍有提升空间。",
+			UpgradeMessage: "可以在保留原意的基础上，换用更准确、自然的" +
+				"词语或搭配。",
+			ImprovementSuggestion: "从原句中挑出一个不够准确或重复的词语，" +
+				"查证常见搭配后改写整句，并用新表达再造两个与本题相关的句子。",
+		}, true
+	case IELTSCriterionGRA:
+		return ieltsCriterionFeedbackCopy{
+			StrengthMessage: "这段回答使用了能够清楚传达意思的句式或语法结构。",
+			ImprovementMessage: "这段回答的句式组织或语法准确性" +
+				"仍有提升空间。",
+			UpgradeMessage: "可以在保留原意的基础上，把句子组织得更完整、准确。",
+			ImprovementSuggestion: "先把原句拆成主干和修饰部分，检查主谓、" +
+				"时态和句子连接，再改写为一个语法完整的版本并朗读两遍。",
+		}, true
+	case IELTSCriterionPR:
+		return ieltsCriterionFeedbackCopy{
+			StrengthMessage: "该回答轮次的综合声学证据显示，" +
+				"整体发音具有一定可理解度。",
+			ImprovementMessage: "该回答轮次的综合声学表现显示，" +
+				"整体清晰度与稳定性仍有提升空间。",
+			UpgradeMessage: "可以通过整句复练提升这段回答的整体清晰度与稳定性。",
+			ImprovementSuggestion: "选取这段回答中的完整句子进行两轮跟读和" +
+				"录音对比；每轮只检查听者能否轻松听清整句，以及整体表达是否稳定。",
+		}, true
+	default:
+		return ieltsCriterionFeedbackCopy{}, false
+	}
 }
 
 func lookupIELTSFeedbackTemplate(
 	criterion IELTSCriterion,
 	kind ieltsFindingKind,
 ) (ieltsFeedbackTemplate, bool) {
-	criterionName := map[IELTSCriterion]string{
-		IELTSCriterionFC:  "coherence",
-		IELTSCriterionLR:  "lexical resource",
-		IELTSCriterionGRA: "grammar",
-		IELTSCriterionPR:  "pronunciation",
-	}[criterion]
-	if criterionName == "" {
+	copy, ok := ieltsFeedbackCopyForCriterion(criterion)
+	if !ok {
 		return ieltsFeedbackTemplate{}, false
 	}
+	token := strings.ToLower(
+		strings.TrimPrefix(string(criterion), "IELTS_"),
+	)
 	switch kind {
 	case ieltsFindingStrength:
 		return ieltsFeedbackTemplate{
-			ID: "ielts." + strings.ToLower(
-				strings.TrimPrefix(string(criterion), "IELTS_"),
-			) + ".strength.v1",
-			Message: "This excerpt provides supported " +
-				criterionName + " evidence.",
+			ID:      "ielts." + token + ".strength.v1",
+			Message: copy.StrengthMessage,
 		}, true
 	case ieltsFindingImprovement:
 		return ieltsFeedbackTemplate{
-			ID: "ielts." + strings.ToLower(
-				strings.TrimPrefix(string(criterion), "IELTS_"),
-			) + ".improvement.v1",
-			Message: "This excerpt shows a supported " +
-				criterionName + " improvement opportunity.",
+			ID:                    "ielts." + token + ".improvement.v1",
+			Message:               copy.ImprovementMessage,
+			ImprovementSuggestion: copy.ImprovementSuggestion,
 		}, true
 	case ieltsFindingUpgrade:
 		return ieltsFeedbackTemplate{
-			ID: "ielts." + strings.ToLower(
-				strings.TrimPrefix(string(criterion), "IELTS_"),
-			) + ".upgrade.v1",
-			Message: "A clearer practice expression can be tried " +
-				"for this excerpt.",
+			ID:      "ielts." + token + ".upgrade.v1",
+			Message: copy.UpgradeMessage,
 		}, true
 	default:
 		return ieltsFeedbackTemplate{}, false
 	}
+}
+
+func normalizeIELTSImprovementSuggestion(
+	criterion IELTSCriterion,
+	template ieltsFeedbackTemplate,
+	providerSuggestion string,
+) string {
+	fallback := template.ImprovementSuggestion
+	if criterion == IELTSCriterionPR ||
+		!validInterviewText(providerSuggestion, ieltsMaximumFindingText) ||
+		providerSuggestion == fallback {
+		return fallback
+	}
+	combined := fallback + " 结合本次原句，还可以这样调整：" +
+		providerSuggestion
+	if !validInterviewText(combined, ieltsMaximumFindingText) {
+		return fallback
+	}
+	return combined
 }
 
 func normalizeIELTSSpeakingCriterionProviderResult(
@@ -1483,7 +1550,7 @@ items:
 			len(item.Evidence) == 0 ||
 			len(item.Evidence) > ieltsMaximumAnchors ||
 			(kind == ieltsFindingStrength && item.Suggestion != "") ||
-			(item.Suggestion != "" &&
+			(kind == ieltsFindingUpgrade && item.Suggestion != "" &&
 				!validInterviewText(
 					item.Suggestion,
 					ieltsMaximumFindingText,
@@ -1519,9 +1586,17 @@ items:
 			seenAnchors[key] = struct{}{}
 			evidence = append(evidence, resolved)
 		}
+		suggestion := item.Suggestion
+		if kind == ieltsFindingImprovement {
+			suggestion = normalizeIELTSImprovementSuggestion(
+				criterion,
+				template,
+				item.Suggestion,
+			)
+		}
 		finding := IELTSSpeakingShadowFinding{
 			Message:    template.Message,
-			Suggestion: item.Suggestion,
+			Suggestion: suggestion,
 			Evidence:   evidence,
 		}
 		finding.ID = stableIELTSFindingID(

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/evidence"
@@ -458,9 +460,209 @@ func TestIELTSSpeakingShadowKeepsValidFindingWhenPeerIsInvalid(
 		t.Fatalf("normalize valid sibling: %v", err)
 	}
 	if len(criterion.Strengths) != 0 || len(criterion.Improvements) != 1 ||
-		criterion.Improvements[0].Suggestion != "Use a more precise example." {
+		!strings.Contains(
+			criterion.Improvements[0].Suggestion,
+			"Use a more precise example.",
+		) {
 		t.Fatalf("criterion findings = %#v", criterion)
 	}
+}
+
+func TestIELTSSpeakingFeedbackTemplatesUseChineseCriterionCopy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		criterion IELTSCriterion
+		kind      ieltsFindingKind
+		contains  string
+	}{
+		{IELTSCriterionFC, ieltsFindingStrength, "观点衔接"},
+		{IELTSCriterionFC, ieltsFindingImprovement, "内容展开"},
+		{IELTSCriterionFC, ieltsFindingUpgrade, "衔接更清楚"},
+		{IELTSCriterionLR, ieltsFindingStrength, "选词"},
+		{IELTSCriterionLR, ieltsFindingImprovement, "表达精确度"},
+		{IELTSCriterionLR, ieltsFindingUpgrade, "词语或搭配"},
+		{IELTSCriterionGRA, ieltsFindingStrength, "语法结构"},
+		{IELTSCriterionGRA, ieltsFindingImprovement, "语法准确性"},
+		{IELTSCriterionGRA, ieltsFindingUpgrade, "完整、准确"},
+		{IELTSCriterionPR, ieltsFindingStrength, "综合声学证据"},
+		{IELTSCriterionPR, ieltsFindingImprovement, "整体清晰度"},
+		{IELTSCriterionPR, ieltsFindingUpgrade, "整句复练"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.criterion)+"/"+string(test.kind), func(t *testing.T) {
+			template, ok := lookupIELTSFeedbackTemplate(
+				test.criterion,
+				test.kind,
+			)
+			if !ok || !utf8.ValidString(template.Message) ||
+				!strings.Contains(template.Message, test.contains) {
+				t.Fatalf("template = %#v", template)
+			}
+		})
+	}
+}
+
+func TestIELTSSpeakingImprovementSuggestionIncludesValidProviderAdvice(
+	t *testing.T,
+) {
+	providerSuggestion := "Use a more precise collocation in the quoted sentence."
+	finding := normalizedIELTSImprovementForTest(
+		t,
+		IELTSCriterionLR,
+		providerSuggestion,
+	)
+	template, _ := lookupIELTSFeedbackTemplate(
+		IELTSCriterionLR,
+		ieltsFindingImprovement,
+	)
+	if finding.Message != template.Message ||
+		!strings.HasPrefix(finding.Suggestion, template.ImprovementSuggestion) ||
+		!strings.Contains(finding.Suggestion, providerSuggestion) {
+		t.Fatalf("finding = %#v", finding)
+	}
+}
+
+func TestIELTSSpeakingImprovementSuggestionFallsBackWhenEmpty(t *testing.T) {
+	finding := normalizedIELTSImprovementForTest(
+		t,
+		IELTSCriterionGRA,
+		"",
+	)
+	template, _ := lookupIELTSFeedbackTemplate(
+		IELTSCriterionGRA,
+		ieltsFindingImprovement,
+	)
+	if finding.Suggestion == "" ||
+		finding.Suggestion != template.ImprovementSuggestion {
+		t.Fatalf("finding = %#v", finding)
+	}
+}
+
+func TestIELTSSpeakingImprovementSuggestionFallsBackBeforeUTF8Overflow(
+	t *testing.T,
+) {
+	providerSuggestion := strings.Repeat(
+		"练",
+		ieltsMaximumFindingText/len("练"),
+	)
+	if !validInterviewText(providerSuggestion, ieltsMaximumFindingText) {
+		t.Fatal("test Provider suggestion must be independently valid")
+	}
+	finding := normalizedIELTSImprovementForTest(
+		t,
+		IELTSCriterionFC,
+		providerSuggestion,
+	)
+	template, _ := lookupIELTSFeedbackTemplate(
+		IELTSCriterionFC,
+		ieltsFindingImprovement,
+	)
+	if finding.Suggestion != template.ImprovementSuggestion ||
+		!utf8.ValidString(finding.Suggestion) ||
+		len(finding.Suggestion) > ieltsMaximumFindingText {
+		t.Fatalf("suggestion = %q", finding.Suggestion)
+	}
+}
+
+func TestIELTSSpeakingPronunciationImprovementStaysAtTurnLevel(t *testing.T) {
+	providerSuggestion := "Correct the stress in university and the /th/ phoneme."
+	finding := normalizedIELTSImprovementForTest(
+		t,
+		IELTSCriterionPR,
+		providerSuggestion,
+	)
+	template, _ := lookupIELTSFeedbackTemplate(
+		IELTSCriterionPR,
+		ieltsFindingImprovement,
+	)
+	if finding.Message != template.Message ||
+		finding.Suggestion != template.ImprovementSuggestion {
+		t.Fatalf("finding = %#v", finding)
+	}
+	for _, unsupported := range []string{
+		"university",
+		"phoneme",
+		"音素",
+		"重音",
+	} {
+		if strings.Contains(finding.Message, unsupported) ||
+			strings.Contains(finding.Suggestion, unsupported) {
+			t.Fatalf("PR finding contains unsupported detail %q: %#v", unsupported, finding)
+		}
+	}
+}
+
+func normalizedIELTSImprovementForTest(
+	t *testing.T,
+	criterion IELTSCriterion,
+	providerSuggestion string,
+) IELTSSpeakingShadowFinding {
+	t.Helper()
+	var snapshot evidence.EvidenceSnapshot
+	if criterion == IELTSCriterionPR {
+		snapshot = ieltsSpeakingAcousticTestSnapshot(t)
+	} else {
+		snapshot = ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+	}
+	prepared, err := prepareIELTSSpeakingShadow(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if criterion == IELTSCriterionPR {
+		prepared, err = withFrozenIELTSAcoustics(
+			snapshot,
+			ieltsAcousticSnapshotForTest(t, snapshot, ieltsTestQuestionCount),
+			prepared,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	payload := singleIELTSProviderPayload(t, prepared.input, criterion)
+	response := prepared.input.Questions[0].Response
+	if response == nil {
+		t.Fatal("missing response fixture")
+	}
+	template, ok := lookupIELTSFeedbackTemplate(
+		criterion,
+		ieltsFindingImprovement,
+	)
+	if !ok {
+		t.Fatal("missing improvement template")
+	}
+	payload.Criteria[0].Strengths = []ieltsProviderFinding{}
+	payload.Criteria[0].Improvements = []ieltsProviderFinding{{
+		TemplateID: template.ID,
+		Suggestion: providerSuggestion,
+		Evidence: []ieltsProviderAnchor{{
+			EvidenceRefID: response.EvidenceRefID,
+			Quote:         response.Transcript,
+			Occurrence:    1,
+		}},
+	}}
+
+	result, err := normalizeIELTSSpeakingCriterionProviderResult(
+		prepared,
+		criterion,
+		ieltsProviderResult(t, payload),
+	)
+	if err != nil {
+		t.Fatalf("normalize improvement: %v", err)
+	}
+	if len(result.Improvements) != 1 {
+		t.Fatalf("improvements = %#v", result.Improvements)
+	}
+	finding := result.Improvements[0]
+	expectedID := stableIELTSFindingID(
+		prepared.result.SnapshotID,
+		criterion,
+		ieltsFindingImprovement,
+		finding,
+	)
+	if finding.ID != expectedID {
+		t.Fatalf("finding ID = %q, want %q", finding.ID, expectedID)
+	}
+	return finding
 }
 
 func TestIELTSSpeakingShadowRejectsCriterionWhenAllPrimaryFindingsAreDropped(


### PR DESCRIPTION
## 功能描述

- 将 IELTS 口语总评改为“练习估分—实际交流表现—当前优势—首要短板—下一步练法”的通俗结构
- 为四个评分维度生成结合 Band 水平、真实回答原句与练习方式的具体说明
- 将改进建议按低分维度优先、跨维去重并限制为最多 3 条
- 保持 `ielts-speaking-report/v1` JSON 形状不变，兼容现有移动端与历史报告

## 实现思路

- 在服务端投影阶段使用受控中文模板组织总评和四维描述，不在读取报告时新增 LLM 调用
- 仅使用已校验的 transcript excerpt 与声学证据；发音反馈不虚构具体单词、音素或重音错误
- 对总评和维度说明统一执行 UTF-8、空白、NUL 与 2048-byte 边界校验
- 按维度分数与固定顺序生成稳定、去重的优先行动

## 可复现测试

- `cd server && go test ./internal/coaching/evaluation/report ./internal/coaching/evaluation/scoring -count=1`
- `cd mobile && flutter test test/review/ielts_speaking_report_decoder_test.dart`
- `cd mobile && flutter analyze`
- `cd api && npm run validate:evaluation`
- `cd api && npm run lint:openapi`
- 使用真实本地后端和 iPhone 16 Pro 模拟器检查完整旧报告重新投影后的总评、四维卡片与长文滚动，无溢出

Closes #650