### PR TITLE
fix(mobile): 结束练习后不再向主聊天自动发送复盘请求

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -362,8 +362,8 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
           title: completion.title,
           speechFeedbackController: widget.speechFeedbackController,
           speechFeedbackSourceKeys: completion.speechFeedbackSourceKeys,
-          onContinueWithAgent:
-              widget.preparationLaunchController?.completeAndContinueWithAgent,
+          onReturnToConversation:
+              widget.preparationLaunchController?.parkCurrentPractice,
         ),
       ),
     );
@@ -500,7 +500,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
         return ScenarioPracticeSession(
           practiceController: _practiceController,
           avatarControllerFactory: factory,
-          onPracticeCompleted: launchController?.completeAndContinueWithAgent,
+          onPracticeCompleted: launchController?.parkCurrentPractice,
           speechFeedbackController: widget.speechFeedbackController,
           onExitRequested: launchController?.parkCurrentPractice,
         );
@@ -508,7 +508,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       return ScenarioPracticePage(
         previewMode: widget.allowFakePreview,
         practiceController: _practiceController,
-        onPracticeCompleted: launchController?.completeAndContinueWithAgent,
+        onPracticeCompleted: launchController?.parkCurrentPractice,
         speechFeedbackController: widget.speechFeedbackController,
         onExitRequested: launchController?.parkCurrentPractice,
       );
@@ -524,7 +524,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
           : _openInterviewReport,
       speechFeedbackController: widget.speechFeedbackController,
       onExitRequested: launchController?.parkCurrentPractice,
-      onContinueWithAgent: launchController?.completeAndContinueWithAgent,
+      onReturnToConversation: launchController?.parkCurrentPractice,
     );
   }
 

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -322,7 +322,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
           ),
         );
       } else if (mounted &&
-          result == CompletedPracticeRouteResult.continueWithAgent) {
+          result == CompletedPracticeRouteResult.returnToConversation) {
         setState(() => _selectedIndex = 0);
       }
     } finally {

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -39,7 +39,7 @@ class InterviewPracticePage extends StatefulWidget {
     this.previewMode = false,
     this.practiceController,
     this.onExitRequested,
-    this.onContinueWithAgent,
+    this.onReturnToConversation,
     this.onOpenInterviewReport,
     this.speechFeedbackController,
     this.practicePromptSpeaker,
@@ -49,7 +49,7 @@ class InterviewPracticePage extends StatefulWidget {
   final bool previewMode;
   final PracticeController? practiceController;
   final Future<bool> Function()? onExitRequested;
-  final Future<bool> Function()? onContinueWithAgent;
+  final Future<bool> Function()? onReturnToConversation;
   final OpenInterviewPracticeReport? onOpenInterviewReport;
   final SpeechFeedbackController? speechFeedbackController;
   final PracticePromptSpeaker? practicePromptSpeaker;
@@ -226,7 +226,8 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
           ),
         ),
       );
-      if (mounted && result == CompletedPracticeRouteResult.continueWithAgent) {
+      if (mounted &&
+          result == CompletedPracticeRouteResult.returnToConversation) {
         Navigator.of(context).pop(result);
       }
     } finally {

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -399,7 +399,7 @@ enum PracticeSessionLifecycleStatus {
   endedEarly,
 }
 
-enum CompletedPracticeRouteResult { continueWithAgent }
+enum CompletedPracticeRouteResult { returnToConversation }
 
 final class PracticeSessionLifecycle {
   const PracticeSessionLifecycle({

--- a/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
+++ b/mobile/lib/features/coaching/preparation/practice_workspace_controller.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
-import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/preparation/practice_launch_record_store.dart';
 
 final class PracticeWorkspaceLease {
@@ -473,35 +472,6 @@ final class PracticeWorkspaceController extends ChangeNotifier {
         operationGeneration: operationGeneration,
       );
     }
-  }
-
-  Future<bool> completeAndContinueWithAgent() async {
-    final current = _current;
-    if (current == null ||
-        !current.isCommitted ||
-        current.returnThreadId == null ||
-        conversationController.threadId != current.practiceThreadId ||
-        practiceController.practiceSessionId != current.sessionId ||
-        practiceController.recordingState != PracticeRecordingState.completed) {
-      _setError('练习尚未完整结束，暂时无法回到 Agent 复盘。');
-      return false;
-    }
-    final title = current.scene!.name;
-    final completedTurns = practiceController.completedTurns;
-    if (!await parkCurrentPractice()) {
-      return false;
-    }
-    final sent = await conversationController.sendText(
-      '我刚完成了“$title”的 $completedTurns 轮练习。'
-      '请直接读取这次练习的真实评分与报告，先概括我的主要表现，'
-      '再问我想重点复盘哪一项。',
-    );
-    if (!sent) {
-      _setError('已回到原会话，但暂时无法把练习结果发送给 Agent。');
-      return false;
-    }
-    _errorMessage = null;
-    return true;
   }
 
   Future<PracticeWorkspaceLease?> replaceCurrentPractice(

--- a/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
+++ b/mobile/lib/features/coaching/preparation/preparation_launch_controller.dart
@@ -123,11 +123,6 @@ final class PreparationLaunchController extends ChangeNotifier {
     return workspace!.parkCurrentPractice();
   }
 
-  Future<bool> completeAndContinueWithAgent() async {
-    final workspace = workspaceController;
-    return workspace != null && await workspace.completeAndContinueWithAgent();
-  }
-
   Future<void> activateAccount(String accountId) async {
     await workspaceController?.activateAccount(accountId);
   }

--- a/mobile/lib/features/coaching/review/interview_report_view.dart
+++ b/mobile/lib/features/coaching/review/interview_report_view.dart
@@ -16,7 +16,7 @@ class InterviewReportPage extends StatefulWidget {
     this.title = '面试复盘报告',
     this.speechFeedbackController,
     this.speechFeedbackSourceKeys = const <String>[],
-    this.onContinueWithAgent,
+    this.onReturnToConversation,
     super.key,
   });
 
@@ -25,7 +25,7 @@ class InterviewReportPage extends StatefulWidget {
   final String title;
   final SpeechFeedbackController? speechFeedbackController;
   final List<String> speechFeedbackSourceKeys;
-  final Future<bool> Function()? onContinueWithAgent;
+  final Future<bool> Function()? onReturnToConversation;
 
   @override
   State<InterviewReportPage> createState() => _InterviewReportPageState();
@@ -76,7 +76,7 @@ class _InterviewReportPageState extends State<InterviewReportPage> {
               ],
               InterviewReportPanel(
                 controller: widget.controller,
-                onContinueWithAgent: widget.onContinueWithAgent,
+                onReturnToConversation: widget.onReturnToConversation,
               ),
             ],
           ),
@@ -89,12 +89,12 @@ class _InterviewReportPageState extends State<InterviewReportPage> {
 class InterviewReportPanel extends StatefulWidget {
   const InterviewReportPanel({
     required this.controller,
-    this.onContinueWithAgent,
+    this.onReturnToConversation,
     super.key,
   });
 
   final InterviewReportController controller;
-  final Future<bool> Function()? onContinueWithAgent;
+  final Future<bool> Function()? onReturnToConversation;
 
   @override
   State<InterviewReportPanel> createState() => _InterviewReportPanelState();
@@ -151,7 +151,7 @@ class _InterviewReportPanelState extends State<InterviewReportPanel> {
       ),
       InterviewReportEvaluationStatus.ready => _ReadyInterviewReport(
         report: envelope.report!,
-        onContinueWithAgent: widget.onContinueWithAgent,
+        onReturnToConversation: widget.onReturnToConversation,
       ),
       InterviewReportEvaluationStatus.failed => _ReportFailure(
         message: '报告生成遇到技术问题，这不代表你的面试表现较差。',
@@ -248,17 +248,18 @@ class _LanguagePerformancePanelState extends State<_LanguagePerformancePanel> {
   }
 }
 
-class _ContinueWithAgentButton extends StatefulWidget {
-  const _ContinueWithAgentButton({required this.onPressed});
+class _ReturnToConversationButton extends StatefulWidget {
+  const _ReturnToConversationButton({required this.onPressed});
 
   final Future<bool> Function() onPressed;
 
   @override
-  State<_ContinueWithAgentButton> createState() =>
-      _ContinueWithAgentButtonState();
+  State<_ReturnToConversationButton> createState() =>
+      _ReturnToConversationButtonState();
 }
 
-class _ContinueWithAgentButtonState extends State<_ContinueWithAgentButton> {
+class _ReturnToConversationButtonState
+    extends State<_ReturnToConversationButton> {
   bool _busy = false;
   String? _error;
 
@@ -275,7 +276,9 @@ class _ContinueWithAgentButtonState extends State<_ContinueWithAgentButton> {
       return;
     }
     if (completed) {
-      Navigator.of(context).pop(CompletedPracticeRouteResult.continueWithAgent);
+      Navigator.of(
+        context,
+      ).pop(CompletedPracticeRouteResult.returnToConversation);
       return;
     }
     setState(() {
@@ -290,7 +293,7 @@ class _ContinueWithAgentButtonState extends State<_ContinueWithAgentButton> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         FilledButton.icon(
-          key: const Key('interview-report-continue-agent'),
+          key: const Key('interview-report-return-conversation'),
           onPressed: _busy ? null : _continue,
           icon: _busy
               ? const SizedBox.square(
@@ -298,7 +301,7 @@ class _ContinueWithAgentButtonState extends State<_ContinueWithAgentButton> {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.chat_bubble_outline_rounded),
-          label: Text(_busy ? '正在回到原会话…' : '和 Agent 继续复盘'),
+          label: Text(_busy ? '正在回到原会话…' : '返回主聊天'),
         ),
         if (_error != null) ...[
           const SizedBox(height: 8),
@@ -409,10 +412,13 @@ class _ReportFailure extends StatelessWidget {
 }
 
 class _ReadyInterviewReport extends StatelessWidget {
-  const _ReadyInterviewReport({required this.report, this.onContinueWithAgent});
+  const _ReadyInterviewReport({
+    required this.report,
+    this.onReturnToConversation,
+  });
 
   final InterviewReport report;
-  final Future<bool> Function()? onContinueWithAgent;
+  final Future<bool> Function()? onReturnToConversation;
 
   @override
   Widget build(BuildContext context) {
@@ -433,9 +439,9 @@ class _ReadyInterviewReport extends StatelessWidget {
           const SizedBox(height: 12),
           _PriorityActions(report: report),
         ],
-        if (onContinueWithAgent != null) ...[
+        if (onReturnToConversation != null) ...[
           const SizedBox(height: 16),
-          _ContinueWithAgentButton(onPressed: onContinueWithAgent!),
+          _ReturnToConversationButton(onPressed: onReturnToConversation!),
         ],
       ],
     );

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -437,7 +437,9 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     }
     setState(() => _completionInFlight = false);
     if (completed) {
-      Navigator.of(context).pop(CompletedPracticeRouteResult.continueWithAgent);
+      Navigator.of(
+        context,
+      ).pop(CompletedPracticeRouteResult.returnToConversation);
       return;
     }
     ScaffoldMessenger.of(context)
@@ -453,8 +455,8 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('结束练习并复盘？'),
-        content: const Text('结束后将保存本次对话，并进入评分与复盘。'),
+        title: const Text('结束练习？'),
+        content: const Text('结束后将保存本次对话并生成练习报告，稍后可在“复盘”中查看。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -463,7 +465,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
           FilledButton(
             key: const Key('scenario-confirm-completion'),
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('结束并复盘'),
+            child: const Text('结束练习'),
           ),
         ],
       ),
@@ -902,7 +904,7 @@ class _ConversationHeader extends StatelessWidget {
                   ? onCompleteRequested
                   : null,
               icon: const Icon(Icons.stop_circle_outlined, size: 18),
-              label: const Text('结束练习并复盘'),
+              label: const Text('结束练习'),
             )
           else
             Flexible(
@@ -1170,8 +1172,8 @@ class _ScenarioComposerState extends State<_ScenarioComposer> {
                 : '回答已发送，Agent 正在回复…',
           ),
           PracticeRecordingState.completed => PracticeComposerAction(
-            label: '练习已完成，可以返回继续对话。',
-            actionLabel: '完成并返回',
+            label: '练习已结束，报告生成后可在“复盘”中查看。',
+            actionLabel: '返回主聊天',
             onPressed: widget.onPracticeCompleted,
           ),
         },

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -149,7 +149,8 @@ void main() {
 
     await tester.tap(find.byKey(const Key('scenario-complete-practice')));
     await tester.pumpAndSettle();
-    expect(find.text('结束练习并复盘？'), findsOneWidget);
+    expect(find.text('结束练习？'), findsOneWidget);
+    expect(find.text('结束后将保存本次对话并生成练习报告，稍后可在“复盘”中查看。'), findsOneWidget);
     await tester.tap(find.byKey(const Key('scenario-confirm-completion')));
     await tester.pumpAndSettle();
 
@@ -578,7 +579,7 @@ void main() {
       );
       expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
       expect(find.text('正在生成评分与纠错…'), findsNothing);
-      expect(find.text('完成并返回'), findsOneWidget);
+      expect(find.text('返回主聊天'), findsOneWidget);
     },
   );
 
@@ -606,7 +607,7 @@ void main() {
         ),
       ),
     );
-    await tester.tap(find.text('完成并返回'));
+    await tester.tap(find.text('返回主聊天'));
     await tester.pump();
 
     expect(completionCalls, 1);

--- a/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_workspace_controller_test.dart
@@ -908,66 +908,66 @@ void main() {
     expect(await store.read('account-1'), isNull);
   });
 
-  test(
-    'completed interview returns to its source Agent thread for review',
-    () async {
-      final store = _InspectableRecordStore();
-      final harness = await _createHarness();
-      final workspace = PracticeWorkspaceController(
-        conversationController: harness.conversation,
-        practiceController: harness.practiceController,
-        recordStore: store,
-      );
-      addTearDown(() {
-        workspace.dispose();
-        harness.dispose();
-      });
-      await workspace.activateAccount('account-1');
-      final homeThreadId = harness.conversation.threadId;
-      final launched = await _launchPractice(
-        harness: harness,
-        workspace: workspace,
-        operationId: 'agent-created-interview',
-        sceneId: 'interview-screening',
-        sceneTitle: '招聘初筛',
-        sessionId: 'practice-session-1',
-        practiceExperience: PracticeExperience.interview,
-      );
-      expect(await workspace.parkCurrentPractice(), isTrue);
-      harness.practiceClient.complete(launched.lease.practiceThreadId);
-      expect(
-        await harness.conversation.selectThread(
-          launched.lease.practiceThreadId,
-        ),
-        isTrue,
-      );
-      await harness.practiceController.restoreCreatedPractice(
-        sessionId: 'practice-session-1',
-        scene: launched.scene,
-      );
-      expect(
-        harness.practiceController.recordingState,
-        PracticeRecordingState.completed,
-      );
+  test('completed practice returns without sending a review request', () async {
+    final store = _InspectableRecordStore();
+    final harness = await _createHarness();
+    final workspace = PracticeWorkspaceController(
+      conversationController: harness.conversation,
+      practiceController: harness.practiceController,
+      recordStore: store,
+    );
+    addTearDown(() {
+      workspace.dispose();
+      harness.dispose();
+    });
+    await workspace.activateAccount('account-1');
+    final homeThreadId = harness.conversation.threadId;
+    final homeMessages = harness.conversation.messages
+        .map((message) => (message.role, message.text))
+        .toList(growable: false);
+    final launched = await _launchPractice(
+      harness: harness,
+      workspace: workspace,
+      operationId: 'agent-created-interview',
+      sceneId: 'interview-screening',
+      sceneTitle: '招聘初筛',
+      sessionId: 'practice-session-1',
+      practiceExperience: PracticeExperience.interview,
+    );
+    expect(await workspace.parkCurrentPractice(), isTrue);
+    harness.practiceClient.complete(launched.lease.practiceThreadId);
+    expect(
+      await harness.conversation.selectThread(launched.lease.practiceThreadId),
+      isTrue,
+    );
+    await harness.practiceController.restoreCreatedPractice(
+      sessionId: 'practice-session-1',
+      scene: launched.scene,
+    );
+    expect(
+      harness.practiceController.recordingState,
+      PracticeRecordingState.completed,
+    );
 
-      expect(await workspace.completeAndContinueWithAgent(), isTrue);
+    expect(await workspace.parkCurrentPractice(), isTrue);
 
-      expect(harness.conversation.threadId, homeThreadId);
-      expect(workspace.hasResumable, isFalse);
-      expect(
-        harness.conversation.messages.any(
-          (message) =>
-              message.role == AgentMessageRole.user &&
-              message.text.contains('招聘初筛') &&
-              !message.text.contains('practice-session-1') &&
-              !message.text.contains('练习记录 ID') &&
-              !message.text.contains('profile ID') &&
-              message.text.contains('直接读取这次练习的真实评分与报告'),
-        ),
-        isTrue,
-      );
-    },
-  );
+    expect(harness.conversation.threadId, homeThreadId);
+    expect(workspace.hasResumable, isFalse);
+    expect(
+      harness.conversation.messages
+          .map((message) => (message.role, message.text))
+          .toList(growable: false),
+      homeMessages,
+    );
+    expect(
+      harness.conversation.messages.any(
+        (message) =>
+            message.role == AgentMessageRole.user &&
+            message.text.contains('直接读取这次练习的真实评分与报告'),
+      ),
+      isFalse,
+    );
+  });
 
   test(
     'records stay isolated by account and private cleanup deletes one account',

--- a/mobile/test/review/interview_report_view_test.dart
+++ b/mobile/test/review/interview_report_view_test.dart
@@ -203,7 +203,7 @@ void main() {
     expect(find.byKey(const Key('interview-report-dimensions')), findsNothing);
   });
 
-  testWidgets('Agent continuation triggers a server-side report lookup', (
+  testWidgets('return to conversation invokes the completion callback', (
     tester,
   ) async {
     final ready = decodeInterviewReport(
@@ -222,7 +222,7 @@ void main() {
           body: SingleChildScrollView(
             child: InterviewReportPanel(
               controller: controller,
-              onContinueWithAgent: () async {
+              onReturnToConversation: () async {
                 continued = true;
                 return false;
               },
@@ -234,9 +234,11 @@ void main() {
     await controller.load(ready.practiceSessionId);
     await tester.pump();
     await tester.ensureVisible(
-      find.byKey(const Key('interview-report-continue-agent')),
+      find.byKey(const Key('interview-report-return-conversation')),
     );
-    await tester.tap(find.byKey(const Key('interview-report-continue-agent')));
+    await tester.tap(
+      find.byKey(const Key('interview-report-return-conversation')),
+    );
     await tester.pump();
 
     expect(continued, isTrue);


### PR DESCRIPTION
## 功能描述

- 职场英语、生活与旅行、面试练习完成后仍生成正式报告并返回主聊天
- 删除返回主聊天时自动发送的“请读取报告并复盘”用户消息
- 将相关操作文案统一为“结束练习”或“返回主聊天”
- IELTS 原有完成与报告流程保持不变

## 实现思路

- 完成回调统一复用 `parkCurrentPractice()`，只恢复原会话并清理本地练习恢复记录
- 删除不再使用的 `completeAndContinueWithAgent()` 及上层包装方法
- 将完成路由结果重命名为 `returnToConversation`，同步面试报告页语义
- 保留练习页调用 `/complete` 的既有链路，因此评分和正式报告照常生成

## 可复现测试

1. `cd mobile && flutter test test/coaching/practice/scenario_practice_test.dart test/coaching/preparation/practice_workspace_controller_test.dart test/review/interview_report_view_test.dart`
2. `cd mobile && dart analyze --fatal-infos`
3. `make dev-ios-simulator`，使用真实后端启动 iOS 模拟器，数字人关闭；界面流程由产品负责人手动验收

Closes #653