### PR TITLE
feat(interview): 统一开放式训练的主动结束与复盘体验

### DIFF
--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -448,6 +448,19 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(
+      find.byKey(
+        Key(
+          'practice-assistant-translate-${practiceController.currentQuestion!.id}',
+        ),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('scenario-turn-progress')), findsNothing);
+    final completeButton = tester.widget<TextButton>(
+      find.byKey(const Key('scenario-complete-practice')),
+    );
+    expect(completeButton.onPressed, isNull);
     expect(find.byKey(const Key('practice-page')), findsNothing);
   });
 
@@ -572,7 +585,8 @@ Future<PracticeController> _interviewPracticeController() async {
     capabilities: testPracticeCapabilities,
     sessionVersion: 1,
     completedTurns: 0,
-    turnLimit: 3,
+    turnLimit: 0,
+    completionMode: PracticeCompletionMode.userControlled,
     sessionCompleted: false,
     currentQuestion: const PracticeQuestion(
       id: 'question-interview-avatar-1',
@@ -616,7 +630,8 @@ SceneDefinition _dailyTravelScene(String id) => testScene(
   ),
 );
 
-final class _SnapshotPracticeClient implements PracticeClient {
+final class _SnapshotPracticeClient
+    implements PracticeClient, PracticeQuestionTranslationClient {
   _SnapshotPracticeClient(this.snapshot);
 
   final PracticeSessionSnapshot snapshot;
@@ -671,6 +686,15 @@ final class _SnapshotPracticeClient implements PracticeClient {
   ) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<PracticeQuestionTranslation> translateQuestion({
+    required String questionId,
+  }) async => PracticeQuestionTranslation(
+    questionId: questionId,
+    targetLanguage: 'zh-CN',
+    content: '这是当前问题的中文翻译。',
+  );
 }
 
 final class _QuestionMediaClient implements PracticeMediaClient {

--- a/server/internal/bootstrap/practice_context_integration_test.go
+++ b/server/internal/bootstrap/practice_context_integration_test.go
@@ -16,6 +16,7 @@ import (
 	evaluationagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/agentcapability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/scoring"
 	goalagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/goal/agentcapability"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
 	preparationagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/agentcapability"
 	reviewagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/review/agentcapability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
@@ -251,7 +252,9 @@ func TestIdentityAgentPracticeCompositionPersistsAndResolvesContext(
 	if err != nil {
 		t.Fatalf("get stored Preview plan: %v", err)
 	}
-	if storedPreviewPlan.SessionPolicy.MaxEffectiveTurns != 4 ||
+	if storedPreviewPlan.SessionPolicy.CompletionMode !=
+		preparation.CompletionModeUserControlled ||
+		storedPreviewPlan.SessionPolicy.MaxEffectiveTurns != 0 ||
 		storedPreviewPlan.SceneSelection.PracticeOptionID !=
 			testFullSimulationOptionID {
 		t.Fatalf("stored Preview plan = %#v", storedPreviewPlan)

--- a/server/internal/coaching/practice/execution_policy.go
+++ b/server/internal/coaching/practice/execution_policy.go
@@ -13,18 +13,20 @@ const (
 	IELTSSpeakingPart3TurnPolicy          = "ielts.speaking_part3.turn.v1"
 	IELTSSpeakingFullMockTurnPolicy       = "ielts.speaking_full_mock.turn.v1"
 
-	GenericPracticeSessionPolicy             = "generic.practice.session.v1"
-	DailyPracticeSessionPolicy               = "daily.practice.session.v1"
-	WorkplacePracticeSessionPolicy           = "workplace.practice.session.v1"
-	InterviewPracticeSessionPolicy           = "interview.practice.session.v1"
-	ExamPracticeSessionPolicy                = "exam.practice.session.v1"
-	DailyHotelCheckinIssueSessionPolicy      = "daily.hotel_checkin_issue.session.v1"
-	WorkplaceProgressRiskUpdateSessionPolicy = "workplace.progress_risk_update.session.v1"
-	InterviewProjectDeepDiveSessionPolicy    = "interview.project_deep_dive.session.v1"
-	IELTSSpeakingPart1SessionPolicy          = "ielts.speaking_part1.session.v1"
-	IELTSSpeakingPart2SessionPolicy          = "ielts.speaking_part2.session.v1"
-	IELTSSpeakingPart3SessionPolicy          = "ielts.speaking_part3.session.v1"
-	IELTSSpeakingFullMockSessionPolicy       = "ielts.speaking_full_mock.session.v1"
+	GenericPracticeSessionPolicy                        = "generic.practice.session.v1"
+	DailyPracticeSessionPolicy                          = "daily.practice.session.v1"
+	WorkplacePracticeSessionPolicy                      = "workplace.practice.session.v1"
+	InterviewPracticeSessionPolicy                      = "interview.practice.session.v1"
+	InterviewUserControlledSessionPolicy                = "interview.user_controlled.session.v1"
+	ExamPracticeSessionPolicy                           = "exam.practice.session.v1"
+	DailyHotelCheckinIssueSessionPolicy                 = "daily.hotel_checkin_issue.session.v1"
+	WorkplaceProgressRiskUpdateSessionPolicy            = "workplace.progress_risk_update.session.v1"
+	InterviewProjectDeepDiveSessionPolicy               = "interview.project_deep_dive.session.v1"
+	InterviewProjectDeepDiveUserControlledSessionPolicy = "interview.project_deep_dive.user_controlled.session.v1"
+	IELTSSpeakingPart1SessionPolicy                     = "ielts.speaking_part1.session.v1"
+	IELTSSpeakingPart2SessionPolicy                     = "ielts.speaking_part2.session.v1"
+	IELTSSpeakingPart3SessionPolicy                     = "ielts.speaking_part3.session.v1"
+	IELTSSpeakingFullMockSessionPolicy                  = "ielts.speaking_full_mock.session.v1"
 )
 
 var ErrExecutionPolicyNotFound = errors.New(
@@ -189,6 +191,17 @@ func resolveSessionPolicyRegistration(
 		standard.avatarAllowed = true
 		standard.speechFeedbackAllowed = true
 		return standard, true
+	case InterviewUserControlledSessionPolicy:
+		standard.completionMode = CompletionModeUserControlled
+		standard.minEffectiveTurns = 1
+		standard.maxEffectiveTurns = 0
+		standard.coverageCheckpointTurn = 1
+		standard.maxFollowUpsPerQuestion = 3
+		standard.questionTranslationAllowed = true
+		standard.questionTipsAllowed = true
+		standard.avatarAllowed = true
+		standard.speechFeedbackAllowed = true
+		return standard, true
 	case DailyPracticeSessionPolicy,
 		DailyHotelCheckinIssueSessionPolicy,
 		WorkplacePracticeSessionPolicy,
@@ -204,6 +217,17 @@ func resolveSessionPolicyRegistration(
 		standard.speechFeedbackAllowed = true
 		return standard, true
 	case InterviewProjectDeepDiveSessionPolicy:
+		standard.maxFollowUpsPerQuestion = 3
+		standard.questionTranslationAllowed = true
+		standard.questionTipsAllowed = true
+		standard.avatarAllowed = true
+		standard.speechFeedbackAllowed = true
+		return standard, true
+	case InterviewProjectDeepDiveUserControlledSessionPolicy:
+		standard.completionMode = CompletionModeUserControlled
+		standard.minEffectiveTurns = 1
+		standard.maxEffectiveTurns = 0
+		standard.coverageCheckpointTurn = 1
 		standard.maxFollowUpsPerQuestion = 3
 		standard.questionTranslationAllowed = true
 		standard.questionTipsAllowed = true

--- a/server/internal/coaching/practice/execution_policy_test.go
+++ b/server/internal/coaching/practice/execution_policy_test.go
@@ -28,8 +28,10 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 		{"daily hotel", DailyHotelCheckinIssueSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
 		{"workplace", WorkplacePracticeSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
 		{"workplace risk", WorkplaceProgressRiskUpdateSessionPolicy, CompletionModeUserControlled, 0, true, true, 1, nil},
-		{"interview", InterviewPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
-		{"interview deep dive", InterviewProjectDeepDiveSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
+		{"legacy interview", InterviewPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
+		{"interview", InterviewUserControlledSessionPolicy, CompletionModeUserControlled, 0, false, true, 3, nil},
+		{"legacy interview deep dive", InterviewProjectDeepDiveSessionPolicy, CompletionModeTurnLimited, 6, false, true, 3, nil},
+		{"interview deep dive", InterviewProjectDeepDiveUserControlledSessionPolicy, CompletionModeUserControlled, 0, false, true, 3, nil},
 		{"exam", ExamPracticeSessionPolicy, CompletionModeTurnLimited, 6, false, false, 1, nil},
 		{"unknown", "unknown.practice.session.v1", "", 0, false, false, 0, ErrExecutionPolicyNotFound},
 	}

--- a/server/internal/coaching/practice/interview_completion_migration_test.go
+++ b/server/internal/coaching/practice/interview_completion_migration_test.go
@@ -1,0 +1,51 @@
+package practice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+)
+
+func TestInterviewUserControlledSessionMigrationVersionsPoliciesSafely(
+	t *testing.T,
+) {
+	t.Parallel()
+	upContent, err := migrations.Files.ReadFile(
+		"000093_interview_user_controlled_sessions.up.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	downContent, err := migrations.Files.ReadFile(
+		"000093_interview_user_controlled_sessions.down.sql",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upSQL := strings.ToLower(string(upContent))
+	for _, required := range []string{
+		"interview.user_controlled.session.v1",
+		"interview.project_deep_dive.user_controlled.session.v1",
+		"'completion_mode', 'user_controlled'",
+		"'max_effective_turns', 0",
+		"not exists",
+		"from practice_sessions",
+	} {
+		if !strings.Contains(upSQL, required) {
+			t.Errorf("up migration is missing %q", required)
+		}
+	}
+
+	downSQL := strings.ToLower(string(downContent))
+	for _, required := range []string{
+		"interview.practice.session.v1",
+		"interview.project_deep_dive.session.v1",
+		"'completion_mode', 'turn_limited'",
+	} {
+		if !strings.Contains(downSQL, required) {
+			t.Errorf("down migration is missing %q", required)
+		}
+	}
+}

--- a/server/internal/coaching/practice/voice/question.go
+++ b/server/internal/coaching/practice/voice/question.go
@@ -350,10 +350,15 @@ func interviewQuestionGenerationRequest(
 	followUpAllowed bool,
 ) (QuestionGenerationRequest, error) {
 	prompt := session.Prompt
+	turnLimited := session.CompletionMode == practice.CompletionModeTurnLimited
+	userControlled := session.CompletionMode == practice.CompletionModeUserControlled
 	maxQuestions := session.TurnLimit * (session.MaxFollowUpsPerQuestion + 1)
-	if sequence < 2 || sequence > maxQuestions ||
+	if sequence < 2 ||
+		(!turnLimited && !userControlled) ||
+		(turnLimited &&
+			(sequence > maxQuestions || session.EffectiveTurns >= session.TurnLimit)) ||
+		(userControlled && session.TurnLimit != 0) ||
 		session.EffectiveTurns < 1 ||
-		session.EffectiveTurns >= session.TurnLimit ||
 		session.MaxFollowUpsPerQuestion < 1 ||
 		strings.TrimSpace(session.PreviousQuestion) == "" ||
 		strings.TrimSpace(session.PreviousUserResponse) == "" ||
@@ -379,11 +384,22 @@ func interviewQuestionGenerationRequest(
 		prompt.PersonaSummary,
 		decisionRule,
 	)
+	progressContext := fmt.Sprintf(
+		"Completed primary interview questions: %d. Continue naturally until the learner chooses to finish.",
+		session.EffectiveTurns,
+	)
+	if turnLimited {
+		progressContext = fmt.Sprintf(
+			"Current displayed round: %d of %d.",
+			session.EffectiveTurns,
+			session.TurnLimit,
+		)
+	}
 	contextParts := []string{
 		fmt.Sprintf("Scene: %s", prompt.PublicSceneBrief),
 		fmt.Sprintf("Practice goal: %s", prompt.PracticeGoal),
 		fmt.Sprintf("Focus areas: %s", strings.Join(prompt.FocusAreas, "; ")),
-		fmt.Sprintf("Current displayed round: %d of %d.", session.EffectiveTurns, session.TurnLimit),
+		progressContext,
 		fmt.Sprintf("Previous interviewer question: %s", session.PreviousQuestion),
 		fmt.Sprintf("Latest learner answer: %s", session.PreviousUserResponse),
 		fmt.Sprintf("Next independent-question blueprint: %s", prompt.TurnBlueprints[nextBlueprintIndex]),

--- a/server/internal/coaching/practice/voice/question_test.go
+++ b/server/internal/coaching/practice/voice/question_test.go
@@ -97,6 +97,41 @@ func TestInterviewQuestionsUseBoundedUntrustedPreparationMaterial(t *testing.T) 
 	}
 }
 
+func TestInterviewQuestionsAllowUserControlledTurnsPastBlueprints(t *testing.T) {
+	t.Parallel()
+	session := Session{
+		PracticeExperience:      string(practice.PracticeExperienceInterview),
+		SceneCategory:           "INTERVIEW_PROFESSIONAL",
+		PracticeMode:            string(practice.PracticeModeFullSimulation),
+		TurnLimit:               0,
+		CompletionMode:          practice.CompletionModeUserControlled,
+		MaxFollowUpsPerQuestion: 3,
+		EffectiveTurns:          65,
+		PreviousQuestion:        "What trade-off did you make?",
+		PreviousUserResponse:    "I chose consistency over delivery speed.",
+		Prompt: practice.ScenePrompt{
+			PublicSceneBrief: "A backend engineering interview.",
+			PracticeGoal:     "Assess role readiness in English.",
+			UserRole:         "Candidate",
+			AIRole:           "Interviewer",
+			PersonaSummary:   "Evidence seeking.",
+			FocusAreas:       []string{"system design"},
+			TurnBlueprints:   []string{"Ask for an introduction.", "Probe impact."},
+		},
+	}
+
+	request, err := interviewQuestionGenerationRequest(session, 66, true)
+	if err != nil {
+		t.Fatalf("interviewQuestionGenerationRequest() error = %v", err)
+	}
+	if !strings.Contains(request.UserPrompt, "Completed primary interview questions: 65") ||
+		!strings.Contains(request.UserPrompt, "learner chooses to finish") ||
+		!strings.Contains(request.UserPrompt, "Probe impact.") ||
+		strings.Contains(request.UserPrompt, "of 0") {
+		t.Fatalf("user-controlled interview prompt = %q", request.UserPrompt)
+	}
+}
+
 func TestInterviewQuestionContextProjectsFrozenJobAndResume(t *testing.T) {
 	t.Parallel()
 	snapshot := practice.SessionSnapshot{

--- a/server/migrations/000093_interview_user_controlled_sessions.down.sql
+++ b/server/migrations/000093_interview_user_controlled_sessions.down.sql
@@ -1,0 +1,135 @@
+BEGIN;
+
+ALTER TABLE coaching_scene_versions
+    DISABLE TRIGGER coaching_scene_versions_are_immutable;
+
+UPDATE coaching_scene_versions AS version
+SET practice_options = (
+    SELECT jsonb_agg(
+        CASE option.value ->> 'session_policy_ref'
+            WHEN 'interview.user_controlled.session.v1' THEN jsonb_set(
+                option.value,
+                '{session_policy_ref}',
+                '"interview.practice.session.v1"'::jsonb
+            )
+            WHEN 'interview.project_deep_dive.user_controlled.session.v1' THEN jsonb_set(
+                option.value,
+                '{session_policy_ref}',
+                '"interview.project_deep_dive.session.v1"'::jsonb
+            )
+            ELSE option.value
+        END
+        ORDER BY
+            (option.value ->> 'display_order')::integer,
+            option.value ->> 'practice_option_id'
+    )
+    FROM jsonb_array_elements(version.practice_options) AS option(value)
+)
+WHERE version.practice_experience = 'INTERVIEW'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(version.practice_options) AS option(value)
+      WHERE option.value ->> 'session_policy_ref' IN (
+          'interview.user_controlled.session.v1',
+          'interview.project_deep_dive.user_controlled.session.v1'
+      )
+  );
+
+ALTER TABLE coaching_scene_versions
+    ENABLE TRIGGER coaching_scene_versions_are_immutable;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DISABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+UPDATE preparation_practice_plan_revisions AS revision
+SET scene_selection = jsonb_set(
+        revision.scene_selection,
+        '{scene,practice_options}',
+        (
+            SELECT jsonb_agg(
+                CASE option.value ->> 'session_policy_ref'
+                    WHEN 'interview.user_controlled.session.v1' THEN jsonb_set(
+                        option.value,
+                        '{session_policy_ref}',
+                        '"interview.practice.session.v1"'::jsonb
+                    )
+                    WHEN 'interview.project_deep_dive.user_controlled.session.v1' THEN jsonb_set(
+                        option.value,
+                        '{session_policy_ref}',
+                        '"interview.project_deep_dive.session.v1"'::jsonb
+                    )
+                    ELSE option.value
+                END
+                ORDER BY option.ordinal
+            )
+            FROM jsonb_array_elements(
+                revision.scene_selection #> '{scene,practice_options}'
+            ) WITH ORDINALITY AS option(value, ordinal)
+        )
+    ),
+    session_policy = revision.session_policy || jsonb_build_object(
+        'completion_mode', 'TURN_LIMITED',
+        'min_effective_turns', CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(
+                    revision.scene_selection #> '{scene,practice_options}'
+                ) AS option(value)
+                WHERE option.value ->> 'practice_option_id' =
+                        revision.scene_selection ->> 'practice_option_id'
+                  AND option.value ->> 'practice_mode' = 'FOCUS'
+            ) THEN 1
+            ELSE 4
+        END,
+        'max_effective_turns', CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(
+                    revision.scene_selection #> '{scene,practice_options}'
+                ) AS option(value)
+                WHERE option.value ->> 'practice_option_id' =
+                        revision.scene_selection ->> 'practice_option_id'
+                  AND option.value ->> 'practice_mode' = 'FOCUS'
+            ) THEN 3
+            ELSE 6
+        END,
+        'coverage_checkpoint_turn', CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(
+                    revision.scene_selection #> '{scene,practice_options}'
+                ) AS option(value)
+                WHERE option.value ->> 'practice_option_id' =
+                        revision.scene_selection ->> 'practice_option_id'
+                  AND option.value ->> 'practice_mode' = 'FOCUS'
+            ) THEN 1
+            ELSE 4
+        END
+    )
+FROM preparation_practice_plans AS plan
+WHERE plan.owner_user_id = revision.owner_user_id
+  AND plan.plan_id = revision.plan_id
+  AND plan.current_revision = revision.revision
+  AND plan.status = 'ready'
+  AND revision.scene_selection #>> '{scene,practice_experience}' = 'INTERVIEW'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM practice_sessions AS session
+      WHERE session.owner_user_id = plan.owner_user_id
+        AND session.plan_id = plan.plan_id
+  )
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(
+          revision.scene_selection #> '{scene,practice_options}'
+      ) AS option(value)
+      WHERE option.value ->> 'session_policy_ref' IN (
+          'interview.user_controlled.session.v1',
+          'interview.project_deep_dive.user_controlled.session.v1'
+      )
+  );
+
+ALTER TABLE preparation_practice_plan_revisions
+    ENABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+COMMIT;

--- a/server/migrations/000093_interview_user_controlled_sessions.up.sql
+++ b/server/migrations/000093_interview_user_controlled_sessions.up.sql
@@ -1,0 +1,102 @@
+BEGIN;
+
+ALTER TABLE coaching_scene_versions
+    DISABLE TRIGGER coaching_scene_versions_are_immutable;
+
+UPDATE coaching_scene_versions AS version
+SET practice_options = (
+    SELECT jsonb_agg(
+        CASE option.value ->> 'session_policy_ref'
+            WHEN 'interview.practice.session.v1' THEN jsonb_set(
+                option.value,
+                '{session_policy_ref}',
+                '"interview.user_controlled.session.v1"'::jsonb
+            )
+            WHEN 'interview.project_deep_dive.session.v1' THEN jsonb_set(
+                option.value,
+                '{session_policy_ref}',
+                '"interview.project_deep_dive.user_controlled.session.v1"'::jsonb
+            )
+            ELSE option.value
+        END
+        ORDER BY
+            (option.value ->> 'display_order')::integer,
+            option.value ->> 'practice_option_id'
+    )
+    FROM jsonb_array_elements(version.practice_options) AS option(value)
+)
+WHERE version.practice_experience = 'INTERVIEW'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(version.practice_options) AS option(value)
+      WHERE option.value ->> 'session_policy_ref' IN (
+          'interview.practice.session.v1',
+          'interview.project_deep_dive.session.v1'
+      )
+  );
+
+ALTER TABLE coaching_scene_versions
+    ENABLE TRIGGER coaching_scene_versions_are_immutable;
+
+ALTER TABLE preparation_practice_plan_revisions
+    DISABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+UPDATE preparation_practice_plan_revisions AS revision
+SET scene_selection = jsonb_set(
+        revision.scene_selection,
+        '{scene,practice_options}',
+        (
+            SELECT jsonb_agg(
+                CASE option.value ->> 'session_policy_ref'
+                    WHEN 'interview.practice.session.v1' THEN jsonb_set(
+                        option.value,
+                        '{session_policy_ref}',
+                        '"interview.user_controlled.session.v1"'::jsonb
+                    )
+                    WHEN 'interview.project_deep_dive.session.v1' THEN jsonb_set(
+                        option.value,
+                        '{session_policy_ref}',
+                        '"interview.project_deep_dive.user_controlled.session.v1"'::jsonb
+                    )
+                    ELSE option.value
+                END
+                ORDER BY option.ordinal
+            )
+            FROM jsonb_array_elements(
+                revision.scene_selection #> '{scene,practice_options}'
+            ) WITH ORDINALITY AS option(value, ordinal)
+        )
+    ),
+    session_policy = revision.session_policy || jsonb_build_object(
+        'completion_mode', 'USER_CONTROLLED',
+        'min_effective_turns', 1,
+        'max_effective_turns', 0,
+        'coverage_checkpoint_turn', 1
+    )
+FROM preparation_practice_plans AS plan
+WHERE plan.owner_user_id = revision.owner_user_id
+  AND plan.plan_id = revision.plan_id
+  AND plan.current_revision = revision.revision
+  AND plan.status = 'ready'
+  AND revision.scene_selection #>> '{scene,practice_experience}' = 'INTERVIEW'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM practice_sessions AS session
+      WHERE session.owner_user_id = plan.owner_user_id
+        AND session.plan_id = plan.plan_id
+  )
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(
+          revision.scene_selection #> '{scene,practice_options}'
+      ) AS option(value)
+      WHERE option.value ->> 'session_policy_ref' IN (
+          'interview.practice.session.v1',
+          'interview.project_deep_dive.session.v1'
+      )
+  );
+
+ALTER TABLE preparation_practice_plan_revisions
+    ENABLE TRIGGER preparation_practice_plan_revisions_are_immutable;
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -78,4 +78,5 @@ import "embed"
 //go:embed 000090_evaluation_ielts_speaking_prompt_v6.*.sql
 //go:embed 000091_evaluation_ielts_speaking_prompt_v7.*.sql
 //go:embed 000092_evaluation_ielts_practice_band_runtime.*.sql
+//go:embed 000093_interview_user_controlled_sessions.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述

- 将新建模拟面试计划切换为 USER_CONTROLLED，不再展示固定轮数或到轮数自动结束。
- 完成至少一轮后允许用户随时点击“结束练习并复盘”，继续复用现有 durable evaluation handoff。
- 面试继续走与日常、商务相同的 ScenarioPracticePage 和 ReviewReportDetailPage，保留面试专属评分维度。
- 保持 IELTS 固定结构不变。

## 实现思路

- 新增独立的面试 user-controlled Session Policy 引用，保留旧引用的 TURN_LIMITED 语义，避免破坏已经冻结的历史计划和会话。
- 迁移所有面试场景版本，以及尚未创建会话的当前 ready 面试计划；已经创建会话的计划不改写。
- 放开面试问题生成器对 USER_CONTROLLED 会话的固定轮数校验；超过 blueprint 数量后继续自然追问，并保留每题最多 3 次追问及 JD/简历上下文。
- 增加面试真实路由回归，覆盖共享头像页、Tips、翻译、隐藏轮数和首轮前禁用主动结束按钮。

## 测试

- `make check-go` ✅
- `make check-api` ✅
- `flutter test --no-pub test/coaching/practice/scenario_practice_session_test.dart test/coaching/practice/scenario_practice_test.dart test/review/review_history_test.dart` ✅（59 项）
- `flutter analyze --no-pub` ✅
- `make check-flutter`：898/899 通过；失败项为 `conversation_controller_test.dart` 的既有账户清理时序测试。该失败已在未包含本 PR 改动的干净 `upstream/dev`（5f994f9）上单独复现。

Closes #654