### PR TITLE
fix(review): refresh cached profile ability

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -176,9 +176,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
 
   Future<void> _selectDestinationAfterParking(int index) async {
     if (_selectedIndex == index) {
-      if (index == 2 ||
-          (index == 3 &&
-              (widget.reviewHistoryController?.items.isEmpty ?? false))) {
+      if (index == 2 || index == 3) {
         _refreshReviewIndexes();
       }
       return;
@@ -221,9 +219,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       return;
     }
     unawaited(widget.practiceController.stopPracticeAudio());
-    if (index == 2 ||
-        (index == 3 &&
-            (widget.reviewHistoryController?.items.isEmpty ?? false))) {
+    if (index == 2 || index == 3) {
       _refreshReviewIndexes();
     }
     setState(() => _selectedIndex = index);

--- a/mobile/test/review/review_history_test.dart
+++ b/mobile/test/review/review_history_test.dart
@@ -351,6 +351,41 @@ void main() {
     expect(client.requests, hasLength(1));
   });
 
+  testWidgets('Shell refreshes cached history when the Profile tab is opened', (
+    tester,
+  ) async {
+    final client = _SequencedControlledClient();
+    final historyController = ReviewHistoryController(client: client);
+    final harness = await _completedShellHarness(_newerId);
+    addTearDown(historyController.dispose);
+    addTearDown(harness.dispose);
+
+    final initialRefresh = historyController.refresh();
+    client.complete(0, ReviewHistoryPage(items: [_item(_olderId, score: 78)]));
+    await initialRefresh;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SpeakUpShell(
+          conversationController: harness.conversation,
+          composerController: harness.composer,
+          practiceController: harness.practice,
+          reviewHistoryController: historyController,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(historyController.items, hasLength(1));
+    expect(client.requests, hasLength(1));
+
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pump();
+
+    expect(client.requests, hasLength(2));
+    expect(client.requests.last.cursor, isNull);
+  });
+
   testWidgets('Practice restore does not trigger Review history loading', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 修复复盘历史已有缓存时，进入“我的”页面不会刷新雅思能力数据的问题。
- 每次进入复盘或“我的”页面时刷新复盘索引，确保能力概览使用最新完整模考。

## 实现思路

- 移除“我的”页面仅在空缓存时刷新的限制。
- 继续复用 `ReviewHistoryController` 现有的请求合并与串行调度。
- 增加缓存非空时进入“我的”仍发起刷新请求的回归测试。

## 可复现测试

- `flutter test --no-pub -j 1 test/review/review_history_test.dart`：29 项全部通过。
- `flutter analyze`：通过。
- 其余检查交由 CI 执行。

Closes #658