### PR TITLE
[MS3][全栈] 提升 IELTS 专项报告可信度与可读性

### DIFF
--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -980,10 +980,11 @@ _IeltsPriorityFeedback? _ieltsPriorityFeedback(
 ) {
   final needsTrustedEvidence =
       report.detailSchema == _ieltsSpeakingPracticeReportSchema;
-  final questionByTurnId = <String, IeltsPracticeReportQuestion>{
-    for (final question in sectionDetail?.questions ?? const [])
-      if (question.responseTurnId case final turnId?) turnId: question,
-  };
+  final questionByTurnId = <String, IeltsPracticeReportQuestion>{};
+  for (final question in sectionDetail?.questions ?? const []) {
+    final turnId = question.responseTurnId;
+    if (turnId != null) questionByTurnId[turnId] = question;
+  }
   for (final action in report.priorityActions) {
     for (final dimension in report.dimensions) {
       if (dimension.key != action.dimensionKey) continue;

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -1325,13 +1325,13 @@ class _IeltsSectionCard extends StatelessWidget {
             const Divider(height: 1),
             _IeltsQuestionFeedbackTile(
               question: question,
-              strength: _questionFinding(
+              strengths: _questionFindings(
                 question,
                 section.strengthFindingIds,
                 strengths,
                 excludedFindingId: excludedFindingId,
               ),
-              improvement: _questionFinding(
+              improvements: _questionFindings(
                 question,
                 section.improvementFindingIds,
                 improvements,
@@ -1356,7 +1356,7 @@ typedef _IeltsQuestionFinding = ({
   EvaluationReportEvidence evidence,
 });
 
-_IeltsQuestionFinding? _questionFinding(
+List<_IeltsQuestionFinding> _questionFindings(
   IeltsPracticeReportQuestion question,
   List<String> findingIds,
   Map<String, _IeltsFindingFeedback> findings, {
@@ -1367,8 +1367,9 @@ _IeltsQuestionFinding? _questionFinding(
   if (transcript == null ||
       turnId == null ||
       _englishWordCount(transcript) < 3) {
-    return null;
+    return const [];
   }
+  final matches = <_IeltsQuestionFinding>[];
   for (final id in findingIds) {
     if (id == excludedFindingId) continue;
     final feedback = findings[id];
@@ -1379,26 +1380,26 @@ _IeltsQuestionFinding? _questionFinding(
           _englishWordCount(item.originalExcerpt) >= 1;
     }).firstOrNull;
     if (evidence != null) {
-      return (
+      matches.add((
         dimensionKey: feedback.dimensionKey,
         finding: feedback.finding,
         evidence: evidence,
-      );
+      ));
     }
   }
-  return null;
+  return matches;
 }
 
 class _IeltsQuestionFeedbackTile extends StatelessWidget {
   const _IeltsQuestionFeedbackTile({
     required this.question,
-    required this.strength,
-    required this.improvement,
+    required this.strengths,
+    required this.improvements,
   });
 
   final IeltsPracticeReportQuestion question;
-  final _IeltsQuestionFinding? strength;
-  final _IeltsQuestionFinding? improvement;
+  final List<_IeltsQuestionFinding> strengths;
+  final List<_IeltsQuestionFinding> improvements;
 
   @override
   Widget build(BuildContext context) {
@@ -1425,22 +1426,26 @@ class _IeltsQuestionFeedbackTile extends StatelessWidget {
               style: SpeakUpDesign.meta,
             ),
       children: [
-        if (strength != null)
+        for (var index = 0; index < strengths.length; index++) ...[
+          if (index > 0) const SizedBox(height: SpeakUpDesign.space16),
           _IeltsQuestionFindingBlock(
             title: '做得好',
-            feedback: strength!,
+            feedback: strengths[index],
             transcript: transcript,
           ),
-        if (strength != null && improvement != null)
+        ],
+        if (strengths.isNotEmpty && improvements.isNotEmpty)
           const SizedBox(height: SpeakUpDesign.space16),
-        if (improvement != null)
+        for (var index = 0; index < improvements.length; index++) ...[
+          if (index > 0) const SizedBox(height: SpeakUpDesign.space16),
           _IeltsQuestionFindingBlock(
             title: '待改进',
-            feedback: improvement!,
+            feedback: improvements[index],
             transcript: transcript,
             showSuggestion: true,
           ),
-        if (strength == null && improvement == null)
+        ],
+        if (strengths.isEmpty && improvements.isEmpty)
           Align(
             alignment: Alignment.centerLeft,
             child: Text('这道题暂无单独反馈。', style: SpeakUpDesign.meta),

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -778,7 +778,10 @@ class ReviewReportDetailPage extends StatelessWidget {
     final findings = report.dimensions
         .expand((dimension) => dimension.improvements)
         .toList(growable: false);
-    final priorityFeedback = _ieltsPriorityFeedback(report);
+    final priorityFeedback =
+        report.scoreability == EvaluationReportScoreability.insufficient
+        ? null
+        : _ieltsPriorityFeedback(report, sectionDetail);
     return Scaffold(
       key: const Key('review-detail-page'),
       appBar: AppBar(
@@ -808,14 +811,15 @@ class ReviewReportDetailPage extends StatelessWidget {
                 body: report.summary,
               ),
             ],
-            if (report.scoreability ==
-                EvaluationReportScoreability.insufficient) ...[
+            if (!isIeltsSectionReport &&
+                report.scoreability ==
+                    EvaluationReportScoreability.insufficient) ...[
               const SizedBox(height: 12),
               const _ReviewStatusNotice(),
             ],
-            if (isIeltsSectionReport && report.dimensions.isNotEmpty) ...[
+            if (isIeltsSectionReport) ...[
               const SizedBox(height: 12),
-              _IeltsSectionPerformance(dimensions: report.dimensions),
+              _IeltsSectionPerformance(report: report),
             ],
             if (isIeltsSectionReport && priorityFeedback != null) ...[
               const SizedBox(height: 12),
@@ -823,25 +827,27 @@ class ReviewReportDetailPage extends StatelessWidget {
             ],
             if (sectionDetail != null) ...[
               const SizedBox(height: 12),
-              _IeltsSectionReport(report: report, detail: sectionDetail),
+              _IeltsSectionReport(
+                report: report,
+                detail: sectionDetail,
+                excludedFindingId: priorityFeedback?.finding.id,
+              ),
             ] else if (expectsSectionDetail) ...[
               const SizedBox(height: 12),
               const _ReviewDetailSection(
                 key: Key('ielts-section-detail-invalid'),
                 title: '分段复盘暂不可用',
-                body: '专项报告的分段数据无法识别，下方仍保留本次练习的通用反馈。',
+                body: '专项报告的逐题数据无法识别，请稍后重试。',
               ),
+            ] else if (isIeltsSectionReport && findings.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _IeltsDetailedFeedback(findings: findings),
             ],
             if (!isIeltsSectionReport && report.dimensions.isNotEmpty) ...[
               const SizedBox(height: 12),
               _ReviewDimensions(dimensions: report.dimensions),
             ],
-            if (isIeltsSectionReport &&
-                sectionDetail == null &&
-                findings.isNotEmpty) ...[
-              const SizedBox(height: 12),
-              _IeltsDetailedFeedback(findings: findings),
-            ] else if (!isIeltsSectionReport && findings.isNotEmpty) ...[
+            if (!isIeltsSectionReport && findings.isNotEmpty) ...[
               const SizedBox(height: 12),
               _ReviewFindings(report: report, findings: findings),
             ],
@@ -890,15 +896,22 @@ class _ReviewDetailHeader extends StatelessWidget {
 }
 
 class _IeltsSectionPerformance extends StatelessWidget {
-  const _IeltsSectionPerformance({required this.dimensions});
+  const _IeltsSectionPerformance({required this.report});
 
-  final List<EvaluationReportDimension> dimensions;
+  final EvaluationReport report;
 
   @override
   Widget build(BuildContext context) {
-    final usesIeltsBandScale = dimensions.every(
-      (dimension) => dimension.scale == EvaluationReportScoreScale.ieltsBand,
-    );
+    final dimensions = report.dimensions;
+    final usesIeltsBandScale =
+        dimensions.isNotEmpty &&
+        dimensions.every(
+          (dimension) =>
+              dimension.scale == EvaluationReportScoreScale.ieltsBand,
+        );
+    final showsRadar =
+        dimensions.isNotEmpty &&
+        report.scoreability != EvaluationReportScoreability.insufficient;
     final byKey = {
       for (final dimension in dimensions) dimension.key: dimension,
     };
@@ -918,6 +931,12 @@ class _IeltsSectionPerformance extends StatelessWidget {
     final labels = usesIeltsBandScale
         ? const ['流利与连贯', '发音', '语法', '词汇']
         : const ['任务达成', '清晰与连贯', '语言运用', '互动表现'];
+    final status =
+        report.scoreability == EvaluationReportScoreability.insufficient
+        ? '本次录音不足以判断，暂不形成 Band 结论。'
+        : usesIeltsBandScale
+        ? '本次回答已达到可评分条件；以上 Band 仅为本次表现估分。'
+        : '本次回答已达到可评分条件；本报告仅反映本次表现。';
     return Card(
       key: const Key('review-detail-dimensions'),
       child: Padding(
@@ -925,19 +944,23 @@ class _IeltsSectionPerformance extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('口语能力', style: SpeakUpDesign.sectionTitle),
-            const SizedBox(height: SpeakUpDesign.space20),
-            FourAxisScoreRadar(
-              axes: <FourAxisRadarAxis>[
-                FourAxisRadarAxis(label: labels[0], value: ordered[0]?.score),
-                FourAxisRadarAxis(label: labels[1], value: ordered[1]?.score),
-                FourAxisRadarAxis(label: labels[2], value: ordered[2]?.score),
-                FourAxisRadarAxis(label: labels[3], value: ordered[3]?.score),
-              ],
-              maximum: usesIeltsBandScale ? 9 : 100,
-              semanticsKey: const Key('review-section-score-radar'),
-              semanticsPrefix: '专项练习四维雷达图',
-            ),
+            Text('本次表现', style: SpeakUpDesign.sectionTitle),
+            if (showsRadar) ...[
+              const SizedBox(height: SpeakUpDesign.space16),
+              FourAxisScoreRadar(
+                axes: <FourAxisRadarAxis>[
+                  FourAxisRadarAxis(label: labels[0], value: ordered[0]?.score),
+                  FourAxisRadarAxis(label: labels[1], value: ordered[1]?.score),
+                  FourAxisRadarAxis(label: labels[2], value: ordered[2]?.score),
+                  FourAxisRadarAxis(label: labels[3], value: ordered[3]?.score),
+                ],
+                maximum: usesIeltsBandScale ? 9 : 100,
+                semanticsKey: const Key('review-section-score-radar'),
+                semanticsPrefix: '专项练习四维雷达图',
+              ),
+            ],
+            const SizedBox(height: SpeakUpDesign.space16),
+            Text(status, style: SpeakUpDesign.body),
           ],
         ),
       ),
@@ -948,9 +971,19 @@ class _IeltsSectionPerformance extends StatelessWidget {
 typedef _IeltsPriorityFeedback = ({
   String dimensionKey,
   EvaluationReportFinding finding,
+  EvaluationReportEvidence evidence,
 });
 
-_IeltsPriorityFeedback? _ieltsPriorityFeedback(EvaluationReport report) {
+_IeltsPriorityFeedback? _ieltsPriorityFeedback(
+  EvaluationReport report,
+  IeltsPracticeReportDetail? sectionDetail,
+) {
+  final needsTrustedEvidence =
+      report.detailSchema == _ieltsSpeakingPracticeReportSchema;
+  final questionByTurnId = <String, IeltsPracticeReportQuestion>{
+    for (final question in sectionDetail?.questions ?? const [])
+      if (question.responseTurnId case final turnId?) turnId: question,
+  };
   for (final action in report.priorityActions) {
     for (final dimension in report.dimensions) {
       if (dimension.key != action.dimensionKey) continue;
@@ -959,7 +992,21 @@ _IeltsPriorityFeedback? _ieltsPriorityFeedback(EvaluationReport report) {
         ...dimension.recommendedExamples,
       ]) {
         if (finding.id == action.findingId) {
-          return (dimensionKey: dimension.key, finding: finding);
+          final evidence = finding.evidence.where((item) {
+            if (!needsTrustedEvidence) return true;
+            final question = questionByTurnId[item.turnId];
+            final transcript = question?.confirmedTranscript;
+            return _englishWordCount(item.originalExcerpt) >= 1 &&
+                transcript != null &&
+                _englishWordCount(transcript) >= 3 &&
+                question!.evidenceRefIds.contains(item.evidenceRefId);
+          }).firstOrNull;
+          if (evidence == null) continue;
+          return (
+            dimensionKey: dimension.key,
+            finding: finding,
+            evidence: evidence,
+          );
         }
       }
     }
@@ -975,8 +1022,8 @@ class _IeltsPriorityFocus extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final finding = feedback.finding;
-    final suggestion = finding.suggestion;
-    final evidence = finding.evidence.firstOrNull?.originalExcerpt;
+    final suggestion = _userFacingIeltsSuggestion(finding.suggestion);
+    final evidence = feedback.evidence.originalExcerpt;
     return Container(
       key: const Key('review-detail-priority-focus'),
       padding: const EdgeInsets.all(SpeakUpDesign.space20),
@@ -987,28 +1034,28 @@ class _IeltsPriorityFocus extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('下一步先练这个', style: SpeakUpDesign.cardTitle),
+          Text('最该先改的一点', style: SpeakUpDesign.cardTitle),
           const SizedBox(height: SpeakUpDesign.space16),
           Text(
             _dimensionLabel(feedback.dimensionKey),
             style: SpeakUpDesign.label.copyWith(color: SpeakUpDesign.secondary),
           ),
+          const SizedBox(height: SpeakUpDesign.space16),
+          Text('报告依据的原句', style: SpeakUpDesign.label),
+          const SizedBox(height: SpeakUpDesign.space4),
+          Text('“$evidence”', style: SpeakUpDesign.body),
+          const SizedBox(height: SpeakUpDesign.space16),
+          Text('为什么要先改', style: SpeakUpDesign.label),
           const SizedBox(height: SpeakUpDesign.space4),
           Text(
             finding.message,
             style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
           ),
           if (suggestion != null && suggestion != finding.message) ...[
+            const Divider(height: SpeakUpDesign.space32),
+            Text('下一步练习', style: SpeakUpDesign.cardTitle),
             const SizedBox(height: SpeakUpDesign.space16),
-            Text('下次这样说', style: SpeakUpDesign.label),
-            const SizedBox(height: SpeakUpDesign.space4),
             Text(suggestion, style: SpeakUpDesign.body),
-          ],
-          if (evidence != null) ...[
-            const SizedBox(height: SpeakUpDesign.space16),
-            Text('本次回答', style: SpeakUpDesign.label),
-            const SizedBox(height: SpeakUpDesign.space4),
-            Text('“$evidence”', style: SpeakUpDesign.body),
           ],
         ],
       ),
@@ -1114,26 +1161,31 @@ bool _matchesParts(
 }
 
 class _IeltsSectionReport extends StatelessWidget {
-  const _IeltsSectionReport({required this.report, required this.detail});
+  const _IeltsSectionReport({
+    required this.report,
+    required this.detail,
+    required this.excludedFindingId,
+  });
 
   final EvaluationReport report;
   final IeltsPracticeReportDetail detail;
+  final String? excludedFindingId;
 
   @override
   Widget build(BuildContext context) {
-    final strengths = <String, EvaluationReportFinding>{
+    final strengths = <String, _IeltsFindingFeedback>{
       for (final dimension in report.dimensions)
-        for (final finding in dimension.strengths) finding.id: finding,
+        for (final finding in dimension.strengths)
+          finding.id: (dimensionKey: dimension.key, finding: finding),
     };
-    final improvements = <String, EvaluationReportFinding>{
+    final improvements = <String, _IeltsFindingFeedback>{
       for (final dimension in report.dimensions)
-        for (final finding in dimension.improvements) finding.id: finding,
+        for (final finding in dimension.improvements)
+          finding.id: (dimensionKey: dimension.key, finding: finding),
     };
-    final examples = <String, EvaluationReportFinding>{
-      for (final dimension in report.dimensions)
-        for (final finding in dimension.recommendedExamples)
-          finding.id: finding,
-    };
+    final answered = detail.questions
+        .where((question) => question.confirmedTranscript != null)
+        .length;
     return Card(
       key: const Key('ielts-section-report'),
       clipBehavior: Clip.antiAlias,
@@ -1148,8 +1200,11 @@ class _IeltsSectionReport extends StatelessWidget {
           SpeakUpDesign.space20,
           SpeakUpDesign.space20,
         ),
-        title: Text('详细反馈', style: SpeakUpDesign.cardTitle),
-        subtitle: Text('评分依据与本次回答', style: SpeakUpDesign.meta),
+        title: Text('逐题反馈', style: SpeakUpDesign.cardTitle),
+        subtitle: Text(
+          '$answered/${detail.questions.length} 题已回答 · 点开查看原句与建议',
+          style: SpeakUpDesign.meta,
+        ),
         children: [
           for (
             var index = 0;
@@ -1167,7 +1222,7 @@ class _IeltsSectionReport extends StatelessWidget {
                   .toList(growable: false),
               strengths: strengths,
               improvements: improvements,
-              examples: examples,
+              excludedFindingId: excludedFindingId,
             ),
           ],
         ],
@@ -1197,9 +1252,9 @@ class _IeltsDetailedFeedback extends StatelessWidget {
           SpeakUpDesign.space20,
           SpeakUpDesign.space20,
         ),
-        title: Text('详细反馈', style: SpeakUpDesign.cardTitle),
+        title: Text('查看全部评分依据', style: SpeakUpDesign.cardTitle),
         subtitle: Text(
-          '查看全部 ${findings.length} 条建议',
+          '查看其余 ${findings.length} 条分项反馈',
           style: SpeakUpDesign.meta,
         ),
         children: [
@@ -1210,10 +1265,11 @@ class _IeltsDetailedFeedback extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(findings[index].message, style: SpeakUpDesign.body),
-                if (findings[index].suggestion case final suggestion?) ...[
+                if (_userFacingIeltsSuggestion(findings[index].suggestion)
+                    case final suggestion?) ...[
                   if (suggestion != findings[index].message) ...[
                     const SizedBox(height: SpeakUpDesign.space8),
-                    Text('建议：$suggestion', style: SpeakUpDesign.body),
+                    Text('练习方法：$suggestion', style: SpeakUpDesign.body),
                   ],
                 ],
               ],
@@ -1231,14 +1287,14 @@ class _IeltsSectionCard extends StatelessWidget {
     required this.questions,
     required this.strengths,
     required this.improvements,
-    required this.examples,
+    required this.excludedFindingId,
   });
 
   final IeltsPracticeSectionReview section;
   final List<IeltsPracticeReportQuestion> questions;
-  final Map<String, EvaluationReportFinding> strengths;
-  final Map<String, EvaluationReportFinding> improvements;
-  final Map<String, EvaluationReportFinding> examples;
+  final Map<String, _IeltsFindingFeedback> strengths;
+  final Map<String, _IeltsFindingFeedback> improvements;
+  final String? excludedFindingId;
 
   @override
   Widget build(BuildContext context) {
@@ -1264,49 +1320,23 @@ class _IeltsSectionCard extends StatelessWidget {
               ),
             ],
           ),
-          if (section.strengthFindingIds.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionFindingGroup(
-              title: '做得好',
-              ids: section.strengthFindingIds,
-              findings: strengths,
-            ),
-          ],
-          if (section.improvementFindingIds.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionFindingGroup(
-              title: '可改进',
-              ids: section.improvementFindingIds,
-              findings: improvements,
-            ),
-          ],
-          if (section.upgradeExampleFindingIds.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionFindingGroup(
-              title: '提升表达',
-              ids: section.upgradeExampleFindingIds,
-              findings: examples,
-            ),
-          ],
-          const SizedBox(height: 16),
-          const Divider(height: 1),
-          const SizedBox(height: 14),
-          Text('本段题目', style: SpeakUpDesign.label),
           for (final question in questions) ...[
-            const SizedBox(height: 10),
-            Text(
-              '${question.index}. ${question.questionText}',
-              style: SpeakUpDesign.body,
-            ),
-            if (question.confirmedTranscript case final transcript?) ...[
-              const SizedBox(height: 3),
-              Text(
-                transcript,
-                maxLines: 3,
-                overflow: TextOverflow.ellipsis,
-                style: SpeakUpDesign.meta,
+            const Divider(height: 1),
+            _IeltsQuestionFeedbackTile(
+              question: question,
+              strength: _questionFinding(
+                question,
+                section.strengthFindingIds,
+                strengths,
+                excludedFindingId: excludedFindingId,
               ),
-            ],
+              improvement: _questionFinding(
+                question,
+                section.improvementFindingIds,
+                improvements,
+                excludedFindingId: excludedFindingId,
+              ),
+            ),
           ],
         ],
       ),
@@ -1314,33 +1344,154 @@ class _IeltsSectionCard extends StatelessWidget {
   }
 }
 
-class _SectionFindingGroup extends StatelessWidget {
-  const _SectionFindingGroup({
-    required this.title,
-    required this.ids,
-    required this.findings,
+typedef _IeltsFindingFeedback = ({
+  String dimensionKey,
+  EvaluationReportFinding finding,
+});
+
+typedef _IeltsQuestionFinding = ({
+  String dimensionKey,
+  EvaluationReportFinding finding,
+  EvaluationReportEvidence evidence,
+});
+
+_IeltsQuestionFinding? _questionFinding(
+  IeltsPracticeReportQuestion question,
+  List<String> findingIds,
+  Map<String, _IeltsFindingFeedback> findings, {
+  String? excludedFindingId,
+}) {
+  final transcript = question.confirmedTranscript;
+  final turnId = question.responseTurnId;
+  if (transcript == null ||
+      turnId == null ||
+      _englishWordCount(transcript) < 3) {
+    return null;
+  }
+  for (final id in findingIds) {
+    if (id == excludedFindingId) continue;
+    final feedback = findings[id];
+    if (feedback == null) continue;
+    final evidence = feedback.finding.evidence.where((item) {
+      return item.turnId == turnId &&
+          question.evidenceRefIds.contains(item.evidenceRefId) &&
+          _englishWordCount(item.originalExcerpt) >= 1;
+    }).firstOrNull;
+    if (evidence != null) {
+      return (
+        dimensionKey: feedback.dimensionKey,
+        finding: feedback.finding,
+        evidence: evidence,
+      );
+    }
+  }
+  return null;
+}
+
+class _IeltsQuestionFeedbackTile extends StatelessWidget {
+  const _IeltsQuestionFeedbackTile({
+    required this.question,
+    required this.strength,
+    required this.improvement,
   });
 
-  final String title;
-  final List<String> ids;
-  final Map<String, EvaluationReportFinding> findings;
+  final IeltsPracticeReportQuestion question;
+  final _IeltsQuestionFinding? strength;
+  final _IeltsQuestionFinding? improvement;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(title, style: SpeakUpDesign.label),
-        for (final id in ids) ...[
-          const SizedBox(height: 5),
-          Text('• ${findings[id]!.message}', style: SpeakUpDesign.body),
-          if (findings[id]!.suggestion case final suggestion?)
-            Padding(
-              padding: const EdgeInsets.only(left: 13, top: 3),
-              child: Text('建议：$suggestion', style: SpeakUpDesign.meta),
+    final transcript = question.confirmedTranscript;
+    return ExpansionTile(
+      key: Key('ielts-question-feedback-${question.questionId}'),
+      tilePadding: EdgeInsets.zero,
+      childrenPadding: const EdgeInsets.only(bottom: SpeakUpDesign.space16),
+      title: Text(
+        'Q${question.index}. ${question.questionText}',
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: SpeakUpDesign.body.copyWith(
+          color: SpeakUpDesign.ink,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: transcript == null
+          ? Text('未回答', style: SpeakUpDesign.meta)
+          : Text(
+              '我的回答：$transcript',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: SpeakUpDesign.meta,
             ),
-        ],
+      children: [
+        if (strength != null)
+          _IeltsQuestionFindingBlock(
+            title: '做得好',
+            feedback: strength!,
+            transcript: transcript,
+          ),
+        if (strength != null && improvement != null)
+          const SizedBox(height: SpeakUpDesign.space16),
+        if (improvement != null)
+          _IeltsQuestionFindingBlock(
+            title: '待改进',
+            feedback: improvement!,
+            transcript: transcript,
+            showSuggestion: true,
+          ),
+        if (strength == null && improvement == null)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text('这道题暂无单独反馈。', style: SpeakUpDesign.meta),
+          ),
       ],
+    );
+  }
+}
+
+class _IeltsQuestionFindingBlock extends StatelessWidget {
+  const _IeltsQuestionFindingBlock({
+    required this.title,
+    required this.feedback,
+    required this.transcript,
+    this.showSuggestion = false,
+  });
+
+  final String title;
+  final _IeltsQuestionFinding feedback;
+  final String? transcript;
+  final bool showSuggestion;
+
+  @override
+  Widget build(BuildContext context) {
+    final suggestion = showSuggestion
+        ? _userFacingIeltsSuggestion(feedback.finding.suggestion)
+        : null;
+    final excerpt = feedback.evidence.originalExcerpt;
+    final showExcerpt =
+        showSuggestion &&
+        _normalizedText(excerpt) != _normalizedText(transcript);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$title · ${_dimensionLabel(feedback.dimensionKey)}',
+            style: SpeakUpDesign.label.copyWith(color: SpeakUpDesign.secondary),
+          ),
+          if (showExcerpt) ...[
+            const SizedBox(height: SpeakUpDesign.space4),
+            Text('“$excerpt”', style: SpeakUpDesign.body),
+          ],
+          const SizedBox(height: SpeakUpDesign.space4),
+          Text(feedback.finding.message, style: SpeakUpDesign.body),
+          if (suggestion != null && suggestion != feedback.finding.message) ...[
+            const SizedBox(height: SpeakUpDesign.space8),
+            Text('怎么练：$suggestion', style: SpeakUpDesign.meta),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -1519,8 +1670,27 @@ String _dimensionLabel(String key) {
         'CLARITY_COHERENCE': '清晰度与连贯性',
         'LANGUAGE_CONTROL': '语言运用',
         'INTERACTION': '互动表现',
+        'IELTS_FC': '流利与连贯',
+        'IELTS_LR': '词汇资源',
+        'IELTS_GRA': '语法范围与准确性',
+        'IELTS_PR': '发音',
       }[key] ??
-      key.toLowerCase().replaceAll('_', ' ');
+      '未识别评分维度';
+}
+
+int _englishWordCount(String value) =>
+    RegExp(r"[A-Za-z]+(?:['’-][A-Za-z]+)*").allMatches(value).length;
+
+String _normalizedText(String? value) =>
+    (value ?? '').trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
+String? _userFacingIeltsSuggestion(String? value) {
+  if (value == null) return null;
+  const providerDetailMarker = '结合本次原句，还可以这样调整：';
+  final markerIndex = value.indexOf(providerDetailMarker);
+  final visible = (markerIndex < 0 ? value : value.substring(0, markerIndex))
+      .trim();
+  return visible.isEmpty ? null : visible;
 }
 
 String _compactDateLabel(DateTime value) {

--- a/mobile/test/review/ielts_report_routing_test.dart
+++ b/mobile/test/review/ielts_report_routing_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
     expect(find.byKey(const Key('review-detail-title')), findsOneWidget);
-    await tester.tap(find.text('详细反馈'));
+    await tester.tap(find.text('逐题反馈'));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('ielts-section-part2')), findsOneWidget);
     expect(find.byKey(const Key('ielts-section-part3')), findsOneWidget);
@@ -128,8 +128,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('已完成'), findsNothing);
-      expect(find.text('本次表现'), findsNothing);
-      expect(find.text(item.report.summary), findsNothing);
+      expect(find.text('本次表现'), findsOneWidget);
       expect(find.byKey(const Key('review-detail-dimensions')), findsOneWidget);
       expect(
         find.byKey(const Key('review-section-score-radar')),
@@ -139,6 +138,7 @@ void main() {
       expect(find.byType(LinearProgressIndicator), findsNothing);
       expect(find.text('任务达成'), findsWidgets);
       expect(find.text('5'), findsOneWidget);
+      expect(find.textContaining('本报告仅反映本次表现'), findsOneWidget);
       expect(find.textContaining('非 IELTS'), findsNothing);
       await tester.drag(
         find.byKey(const Key('review-detail-content')),
@@ -149,7 +149,10 @@ void main() {
         find.byKey(const Key('review-detail-priority-focus')),
         findsOneWidget,
       );
-      expect(find.text('下一步先练这个'), findsOneWidget);
+      expect(find.text('最该先改的一点'), findsOneWidget);
+      expect(find.text('报告依据的原句'), findsOneWidget);
+      expect(find.text('为什么要先改'), findsOneWidget);
+      expect(find.text('下一步练习'), findsOneWidget);
       expect(find.text('State the intended outcome first.'), findsOneWidget);
       expect(find.text('“I think maybe...”'), findsOneWidget);
       await tester.drag(
@@ -232,6 +235,12 @@ void main() {
     expect(find.text('7'), findsOneWidget);
     expect(find.text('8'), findsOneWidget);
     expect(find.text('9'), findsOneWidget);
+    expect(find.byType(FourAxisScoreRadar), findsOneWidget);
+    expect(find.text('IELTS_FC'), findsNothing);
+    expect(find.text('IELTS_LR'), findsNothing);
+    expect(find.text('IELTS_GRA'), findsNothing);
+    expect(find.text('IELTS_PR'), findsNothing);
+    expect(find.textContaining('以上 Band 仅为本次表现估分'), findsOneWidget);
     expect(find.text('任务达成'), findsNothing);
   });
 
@@ -262,12 +271,23 @@ void main() {
       id: 'general-finding:part1.improvement-v1',
       message: 'Connect the answer to one clear reason.',
       suggestion: 'Add a short reason after the direct answer.',
-      evidence: <EvaluationReportEvidence>[],
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 0,
+          endUtf8Byte: 11,
+          originalExcerpt: 'answer one',
+        ),
+      ],
     );
     final item = _item(
       practiceMode: 'PART_1',
       detailSchema: 'ielts-speaking-practice-report/v1',
-      detail: _part1SectionDetail(finding.id),
+      detail: _part1SectionDetail(
+        finding.id,
+        confirmedTranscript: 'This is answer one.',
+      ),
       dimensions: const <EvaluationReportDimension>[
         EvaluationReportDimension(
           key: 'TASK_ACHIEVEMENT',
@@ -291,11 +311,98 @@ void main() {
 
     expect(find.byKey(const Key('ielts-section-detail-invalid')), findsNothing);
     expect(find.byKey(const Key('ielts-section-report')), findsOneWidget);
-    await tester.ensureVisible(find.text('详细反馈'));
-    await tester.tap(find.text('详细反馈'));
+    await tester.ensureVisible(find.text('逐题反馈'));
+    await tester.tap(find.text('逐题反馈'));
+    await tester.pumpAndSettle();
+    final questionTile = find.byKey(
+      const Key('ielts-question-feedback-question_1'),
+    );
+    await tester.drag(
+      find.byKey(const Key('review-detail-content')),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(questionTile);
     await tester.pumpAndSettle();
     expect(find.textContaining(finding.message), findsOneWidget);
-    expect(find.text('Answer 1.'), findsOneWidget);
+    expect(find.textContaining('This is answer one.'), findsOneWidget);
+  });
+
+  testWidgets('Part 1 skips untrusted old priority evidence', (tester) async {
+    const untrusted = EvaluationReportFinding(
+      id: 'finding_untrusted',
+      message: '这条结论不应展示。',
+      suggestion: '先直接回答。',
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 0,
+          endUtf8Byte: 6,
+          originalExcerpt: '问题啊得很',
+        ),
+      ],
+    );
+    const trusted = EvaluationReportFinding(
+      id: 'finding_trusted',
+      message: '补充一个具体信息，让回答更容易理解。',
+      suggestion: '先说结论，再补一个细节。结合本次原句，还可以这样调整：Use a stronger phrase.',
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 6,
+          endUtf8Byte: 38,
+          originalExcerpt: 'looking for specific information',
+        ),
+      ],
+    );
+    final item = _item(
+      practiceMode: 'PART_1',
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      detail: _part1SectionDetail(
+        trusted.id,
+        confirmedTranscript: 'I was looking for specific information.',
+      ),
+      dimensions: const <EvaluationReportDimension>[
+        EvaluationReportDimension(
+          key: 'IELTS_LR',
+          score: 5,
+          scale: EvaluationReportScoreScale.ieltsBand,
+          coverage: 1,
+          confidence: 0.8,
+          reasonCodes: <String>[],
+          evidenceRefIds: <String>['evidence_1'],
+          strengths: <EvaluationReportFinding>[],
+          improvements: <EvaluationReportFinding>[untrusted, trusted],
+          recommendedExamples: <EvaluationReportFinding>[],
+        ),
+      ],
+      priorityActions: const <EvaluationReportPriorityAction>[
+        EvaluationReportPriorityAction(
+          dimensionKey: 'IELTS_LR',
+          findingId: 'finding_untrusted',
+        ),
+        EvaluationReportPriorityAction(
+          dimensionKey: 'IELTS_LR',
+          findingId: 'finding_trusted',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('review-detail-priority-focus')),
+    );
+
+    expect(find.text('这条结论不应展示。'), findsNothing);
+    expect(find.text('“问题啊得很”'), findsNothing);
+    expect(find.text('“looking for specific information”'), findsOneWidget);
+    expect(find.text('先说结论，再补一个细节。'), findsOneWidget);
+    expect(find.textContaining('Use a stronger phrase.'), findsNothing);
   });
 
   testWidgets(
@@ -435,29 +542,38 @@ Map<String, Object?> _sectionDetail() => <String, Object?>{
   ],
 };
 
-Map<String, Object?> _part1SectionDetail(String improvementFindingId) =>
+Map<String, Object?> _part1SectionDetail(
+  String improvementFindingId, {
+  String? confirmedTranscript,
+}) => <String, Object?>{
+  'schema_version': 'ielts-speaking-practice-report/v1',
+  'report_scope': 'PART_1',
+  'available_sections': <Object?>['PART_1'],
+  'questions': <Object?>[
+    _sectionQuestion(
+      part: 'PART_1',
+      index: 1,
+      confirmedTranscript: confirmedTranscript,
+    ),
+  ],
+  'section_reviews': <Object?>[
     <String, Object?>{
-      'schema_version': 'ielts-speaking-practice-report/v1',
-      'report_scope': 'PART_1',
-      'available_sections': <Object?>['PART_1'],
-      'questions': <Object?>[_sectionQuestion(part: 'PART_1', index: 1)],
-      'section_reviews': <Object?>[
-        <String, Object?>{
-          ..._sectionReview(part: 'PART_1', index: 1),
-          'improvement_finding_ids': <Object?>[improvementFindingId],
-        },
-      ],
-    };
+      ..._sectionReview(part: 'PART_1', index: 1),
+      'improvement_finding_ids': <Object?>[improvementFindingId],
+    },
+  ],
+};
 
 Map<String, Object?> _sectionQuestion({
   required String part,
   required int index,
+  String? confirmedTranscript,
 }) => <String, Object?>{
   'question_id': 'question_$index',
   'part_id': part,
   'index': index,
   'question_text': 'Question $index?',
-  'confirmed_transcript': 'Answer $index.',
+  'confirmed_transcript': confirmedTranscript ?? 'Answer $index.',
   'response_turn_id': 'turn_$index',
   'evidence_ref_ids': <Object?>['evidence_$index'],
 };

--- a/mobile/test/review/ielts_report_routing_test.dart
+++ b/mobile/test/review/ielts_report_routing_test.dart
@@ -284,10 +284,9 @@ void main() {
     final item = _item(
       practiceMode: 'PART_1',
       detailSchema: 'ielts-speaking-practice-report/v1',
-      detail: _part1SectionDetail(
+      detail: _part1SectionDetail(<String>[
         finding.id,
-        confirmedTranscript: 'This is answer one.',
-      ),
+      ], confirmedTranscript: 'This is answer one.'),
       dimensions: const <EvaluationReportDimension>[
         EvaluationReportDimension(
           key: 'TASK_ACHIEVEMENT',
@@ -328,6 +327,108 @@ void main() {
     expect(find.textContaining('This is answer one.'), findsOneWidget);
   });
 
+  testWidgets('Part 1 keeps all trusted non-priority question findings', (
+    tester,
+  ) async {
+    const priority = EvaluationReportFinding(
+      id: 'finding_priority',
+      message: 'Priority feedback.',
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 0,
+          endUtf8Byte: 6,
+          originalExcerpt: 'answer one',
+        ),
+      ],
+    );
+    const lexical = EvaluationReportFinding(
+      id: 'finding_lexical',
+      message: 'Use more precise vocabulary.',
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 0,
+          endUtf8Byte: 6,
+          originalExcerpt: 'answer one',
+        ),
+      ],
+    );
+    const grammar = EvaluationReportFinding(
+      id: 'finding_grammar',
+      message: 'Use a wider range of sentence structures.',
+      evidence: <EvaluationReportEvidence>[
+        EvaluationReportEvidence(
+          evidenceRefId: 'evidence_1',
+          turnId: 'turn_1',
+          startUtf8Byte: 0,
+          endUtf8Byte: 6,
+          originalExcerpt: 'answer one',
+        ),
+      ],
+    );
+    final item = _item(
+      practiceMode: 'PART_1',
+      detailSchema: 'ielts-speaking-practice-report/v1',
+      detail: _part1SectionDetail(const <String>[
+        'finding_priority',
+        'finding_lexical',
+        'finding_grammar',
+      ], confirmedTranscript: 'This is answer one.'),
+      dimensions: const <EvaluationReportDimension>[
+        EvaluationReportDimension(
+          key: 'IELTS_LR',
+          score: 5,
+          scale: EvaluationReportScoreScale.ieltsBand,
+          coverage: 1,
+          confidence: 0.8,
+          reasonCodes: <String>[],
+          evidenceRefIds: <String>['evidence_1'],
+          strengths: <EvaluationReportFinding>[],
+          improvements: <EvaluationReportFinding>[priority, lexical, grammar],
+          recommendedExamples: <EvaluationReportFinding>[],
+        ),
+      ],
+      priorityActions: const <EvaluationReportPriorityAction>[
+        EvaluationReportPriorityAction(
+          dimensionKey: 'IELTS_LR',
+          findingId: 'finding_priority',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('逐题反馈'),
+      300,
+      scrollable: find.descendant(
+        of: find.byKey(const Key('review-detail-content')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    await tester.tap(find.text('逐题反馈'));
+    await tester.pumpAndSettle();
+    final questionTile = find.byKey(
+      const Key('ielts-question-feedback-question_1'),
+    );
+    await tester.drag(
+      find.byKey(const Key('review-detail-content')),
+      const Offset(0, -150),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(questionTile);
+    await tester.pumpAndSettle();
+
+    expect(find.text(priority.message), findsOneWidget);
+    expect(find.text(lexical.message), findsOneWidget);
+    expect(find.text(grammar.message), findsOneWidget);
+  });
+
   testWidgets('Part 1 skips untrusted old priority evidence', (tester) async {
     const untrusted = EvaluationReportFinding(
       id: 'finding_untrusted',
@@ -360,10 +461,9 @@ void main() {
     final item = _item(
       practiceMode: 'PART_1',
       detailSchema: 'ielts-speaking-practice-report/v1',
-      detail: _part1SectionDetail(
-        trusted.id,
-        confirmedTranscript: 'I was looking for specific information.',
-      ),
+      detail: _part1SectionDetail(const <String>[
+        'finding_trusted',
+      ], confirmedTranscript: 'I was looking for specific information.'),
       dimensions: const <EvaluationReportDimension>[
         EvaluationReportDimension(
           key: 'IELTS_LR',
@@ -543,7 +643,7 @@ Map<String, Object?> _sectionDetail() => <String, Object?>{
 };
 
 Map<String, Object?> _part1SectionDetail(
-  String improvementFindingId, {
+  List<String> improvementFindingIds, {
   String? confirmedTranscript,
 }) => <String, Object?>{
   'schema_version': 'ielts-speaking-practice-report/v1',
@@ -559,7 +659,7 @@ Map<String, Object?> _part1SectionDetail(
   'section_reviews': <Object?>[
     <String, Object?>{
       ..._sectionReview(part: 'PART_1', index: 1),
-      'improvement_finding_ids': <Object?>[improvementFindingId],
+      'improvement_finding_ids': improvementFindingIds,
     },
   ],
 };

--- a/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
+++ b/server/internal/coaching/evaluation/report/ielts_speaking_content_test.go
@@ -306,7 +306,7 @@ func TestProjectIELTSSpeakingReportPublishesEvidenceBoundContentAndActions(
 	wantOrder := []scoring.IELTSCriterion{
 		scoring.IELTSCriterionPR,
 		scoring.IELTSCriterionLR,
-		scoring.IELTSCriterionFC,
+		scoring.IELTSCriterionGRA,
 	}
 	if len(report.PriorityActions) != len(wantOrder) {
 		t.Fatalf(

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -1289,25 +1289,6 @@ func lookupIELTSFeedbackTemplate(
 	}
 }
 
-func normalizeIELTSImprovementSuggestion(
-	criterion IELTSCriterion,
-	template ieltsFeedbackTemplate,
-	providerSuggestion string,
-) string {
-	fallback := template.ImprovementSuggestion
-	if criterion == IELTSCriterionPR ||
-		!validInterviewText(providerSuggestion, ieltsMaximumFindingText) ||
-		providerSuggestion == fallback {
-		return fallback
-	}
-	combined := fallback + " 结合本次原句，还可以这样调整：" +
-		providerSuggestion
-	if !validInterviewText(combined, ieltsMaximumFindingText) {
-		return fallback
-	}
-	return combined
-}
-
 func normalizeIELTSSpeakingCriterionProviderResult(
 	prepared preparedIELTSSpeakingShadow,
 	target IELTSCriterion,
@@ -1571,6 +1552,19 @@ items:
 			if err != nil {
 				continue items
 			}
+			if kind == ieltsFindingImprovement {
+				turn := prepared.turnsByID[resolved.TurnID]
+				turnEnglishWords, _ := ieltsLanguageEvidence(
+					turn.Transcript.Text,
+				)
+				anchorEnglishWords, _ := ieltsLanguageEvidence(
+					resolved.OriginalExcerpt,
+				)
+				if turnEnglishWords < ieltsMinimumEnglishWordsPerTurn ||
+					anchorEnglishWords == 0 {
+					continue items
+				}
+			}
 			if criterion == IELTSCriterionPR &&
 				len(prepared.acousticRefs) > 0 {
 				if _, acousticallyAssessed := prepared.acousticRefs[resolved.EvidenceRefID]; !acousticallyAssessed {
@@ -1588,11 +1582,7 @@ items:
 		}
 		suggestion := item.Suggestion
 		if kind == ieltsFindingImprovement {
-			suggestion = normalizeIELTSImprovementSuggestion(
-				criterion,
-				template,
-				item.Suggestion,
-			)
+			suggestion = template.ImprovementSuggestion
 		}
 		finding := IELTSSpeakingShadowFinding{
 			Message:    template.Message,

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_test.go
@@ -410,7 +410,7 @@ func TestIELTSSpeakingShadowRejectsAmbiguousMispairedAnchor(t *testing.T) {
 	}
 }
 
-func TestIELTSSpeakingShadowKeepsValidFindingWhenPeerIsInvalid(
+func TestIELTSSpeakingShadowKeepsWordAnchorFromValidTurnWhenPeerIsInvalid(
 	t *testing.T,
 ) {
 	snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
@@ -445,7 +445,7 @@ func TestIELTSSpeakingShadowKeepsValidFindingWhenPeerIsInvalid(
 			Suggestion: "Use a more precise example.",
 			Evidence: []ieltsProviderAnchor{{
 				EvidenceRefID: response.EvidenceRefID,
-				Quote:         response.Transcript,
+				Quote:         "concrete",
 				Occurrence:    1,
 			}},
 		},
@@ -460,11 +460,91 @@ func TestIELTSSpeakingShadowKeepsValidFindingWhenPeerIsInvalid(
 		t.Fatalf("normalize valid sibling: %v", err)
 	}
 	if len(criterion.Strengths) != 0 || len(criterion.Improvements) != 1 ||
-		!strings.Contains(
-			criterion.Improvements[0].Suggestion,
-			"Use a more precise example.",
-		) {
+		criterion.Improvements[0].Suggestion !=
+			template.ImprovementSuggestion {
 		t.Fatalf("criterion findings = %#v", criterion)
+	}
+}
+
+func TestIELTSSpeakingShadowDropsImprovementWithoutEnglishAnchorOrTurn(
+	t *testing.T,
+) {
+	tests := []struct {
+		name       string
+		transcript string
+		quote      string
+	}{
+		{name: "short turn", transcript: "I agree", quote: "I agree"},
+		{name: "Chinese turn", transcript: "这个我不知道", quote: "这个我不知道"},
+		{
+			name:       "Chinese anchor in mixed valid turn",
+			transcript: "I have enough English words 问题啊得很",
+			quote:      "问题啊得很",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := ieltsSpeakingTestSnapshot(t, ieltsTestQuestionCount)
+			var snapshotPayload evidence.SnapshotPayload
+			if err := json.Unmarshal(snapshot.Payload, &snapshotPayload); err != nil {
+				t.Fatal(err)
+			}
+			snapshotPayload.ConfirmedTurns[0].Transcript.Text = test.transcript
+			snapshotPayload.EvidenceRefs[0].TranscriptSpan.EndUTF8Byte =
+				len(test.transcript)
+			snapshot = rebuildIELTSSpeakingSnapshot(t, snapshotPayload)
+
+			prepared, err := prepareIELTSSpeakingShadow(snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload := singleIELTSProviderPayload(
+				t,
+				prepared.input,
+				IELTSCriterionLR,
+			)
+			targetResponse := prepared.input.Questions[0].Response
+			validResponse := prepared.input.Questions[1].Response
+			if targetResponse == nil || validResponse == nil {
+				t.Fatal("missing response fixture")
+			}
+			strength, _ := lookupIELTSFeedbackTemplate(
+				IELTSCriterionLR,
+				ieltsFindingStrength,
+			)
+			improvement, _ := lookupIELTSFeedbackTemplate(
+				IELTSCriterionLR,
+				ieltsFindingImprovement,
+			)
+			payload.Criteria[0].Strengths = []ieltsProviderFinding{{
+				TemplateID: strength.ID,
+				Evidence: []ieltsProviderAnchor{{
+					EvidenceRefID: validResponse.EvidenceRefID,
+					Quote:         validResponse.Transcript,
+					Occurrence:    1,
+				}},
+			}}
+			payload.Criteria[0].Improvements = []ieltsProviderFinding{{
+				TemplateID: improvement.ID,
+				Evidence: []ieltsProviderAnchor{{
+					EvidenceRefID: targetResponse.EvidenceRefID,
+					Quote:         test.quote,
+					Occurrence:    1,
+				}},
+			}}
+
+			criterion, err := normalizeIELTSSpeakingCriterionProviderResult(
+				prepared,
+				IELTSCriterionLR,
+				ieltsProviderResult(t, payload),
+			)
+			if err != nil {
+				t.Fatalf("normalize criterion: %v", err)
+			}
+			if len(criterion.Strengths) != 1 || len(criterion.Improvements) != 0 {
+				t.Fatalf("criterion findings = %#v", criterion)
+			}
+		})
 	}
 }
 
@@ -502,7 +582,7 @@ func TestIELTSSpeakingFeedbackTemplatesUseChineseCriterionCopy(t *testing.T) {
 	}
 }
 
-func TestIELTSSpeakingImprovementSuggestionIncludesValidProviderAdvice(
+func TestIELTSSpeakingImprovementSuggestionDoesNotExposeProviderAdvice(
 	t *testing.T,
 ) {
 	providerSuggestion := "Use a more precise collocation in the quoted sentence."
@@ -516,8 +596,8 @@ func TestIELTSSpeakingImprovementSuggestionIncludesValidProviderAdvice(
 		ieltsFindingImprovement,
 	)
 	if finding.Message != template.Message ||
-		!strings.HasPrefix(finding.Suggestion, template.ImprovementSuggestion) ||
-		!strings.Contains(finding.Suggestion, providerSuggestion) {
+		finding.Suggestion != template.ImprovementSuggestion ||
+		strings.Contains(finding.Suggestion, providerSuggestion) {
 		t.Fatalf("finding = %#v", finding)
 	}
 }


### PR DESCRIPTION
## 功能描述
- 保留 IELTS 专项报告四维雷达图，并按官方 Band 维度显示中文名称
- 首屏聚焦本次表现、一个可信优先问题和下一步练习
- 将详细反馈改为逐题展开，绑定真实回答证据并去除重复内容
- 过滤短回答、非英文证据与 provider 原始建议，避免不可信结论

## 实现思路
- 评分归一化同时校验完整 turn 与 evidence anchor 的英文证据
- 移动端通过 turn ID + evidence ref 将 finding 绑定到具体题目
- 旧报告在展示层过滤不可信证据并清理历史 provider 文案
- 不修改完整模考报告结构，不改变 IELTS 评分规则

## 可复现测试
- `cd server && go test ./internal/coaching/evaluation/scoring ./internal/coaching/evaluation/report`
- `cd mobile && flutter test test/review/ielts_report_routing_test.dart`
- iOS 26.5 模拟器真实后端检查 Part 1 专项报告首屏与逐题展开

Closes #660