### PR TITLE
fix(mobile): 关闭面试详情时恢复 Interview 目录状态

### DIFF
--- a/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_wizard.dart
@@ -139,6 +139,8 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
     final candidate = widget.controller.candidate;
     if (!mounted ||
         _practiceStarted ||
+        _exitInFlight ||
+        _exitApproved ||
         catalog == null ||
         candidate == null ||
         _catalogSyncing) {
@@ -149,6 +151,8 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       await catalog.loadIfNeeded();
       if (!mounted ||
           _practiceStarted ||
+          _exitInFlight ||
+          _exitApproved ||
           widget.controller.candidate != candidate) {
         return;
       }
@@ -164,6 +168,8 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       }
       if (!mounted ||
           _practiceStarted ||
+          _exitInFlight ||
+          _exitApproved ||
           widget.controller.candidate != candidate) {
         if (_practiceStarted && catalog.selectedScene != null) {
           catalog.showSceneList();
@@ -380,6 +386,7 @@ class _JobPreparationWizardState extends State<JobPreparationWizard> {
       return;
     }
     _exitApproved = true;
+    widget.catalogController?.showSceneList();
     setState(() {});
     await WidgetsBinding.instance.endOfFrame;
     if (mounted) {

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -7,9 +7,11 @@ import 'package:speakup/features/coaching/interview/job_preparation_controller.d
 import 'package:speakup/features/coaching/interview/job_preparation_draft_store.dart';
 import 'package:speakup/features/coaching/interview/job_preparation_models.dart';
 import 'package:speakup/features/coaching/interview/job_preparation_wizard.dart';
+import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/features/coaching/scene/scene_client.dart';
 import 'package:speakup/resume/resume.dart';
 
 void main() {
@@ -244,6 +246,37 @@ void main() {
 
     expect(exits, 1);
     expect(find.byKey(const Key('job-preparation-wizard')), findsOneWidget);
+  });
+
+  testWidgets('closing a saved plan restores the interview catalog state', (
+    tester,
+  ) async {
+    final controller = _controller(_WizardClient());
+    final catalogController = PreparationController(
+      client: _WizardCatalogClient(),
+    );
+    var exits = 0;
+    addTearDown(controller.dispose);
+    addTearDown(catalogController.dispose);
+    expect(await controller.openSavedPlan(_plan.id), isTrue);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: JobPreparationWizard(
+          controller: controller,
+          catalogController: catalogController,
+          onExit: () => exits++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(catalogController.selectedScene?.id, _sceneId);
+    await tester.tap(find.byKey(const Key('job-wizard-close')));
+    await tester.pumpAndSettle();
+
+    expect(exits, 1);
+    expect(catalogController.selectedScene, isNull);
   });
 
   testWidgets('temporary parse failure keeps job context and can be skipped', (
@@ -683,6 +716,17 @@ final class _WizardClient implements JobPreparationClient {
     _target = _targetFor(JobTargetStage.draft, input: input);
     return _target!;
   }
+}
+
+final class _WizardCatalogClient implements SceneClient {
+  @override
+  Future<SceneDefinition> getScene(String sceneId) async => _scene;
+
+  @override
+  Future<List<SceneDefinition>> listScenes() async => [_scene];
+
+  @override
+  Future<List<RoleDefinition>> listRoles(String sceneId) async => [_role];
 }
 
 ResumeItem _wizardResume(


### PR DESCRIPTION
## 功能描述

修复从 Interview 列表打开已保存的模拟面试方案后，点击详情页左上角 X 会误显示“正在准备练习…”的问题。

关闭详情后现在会恢复 Interview 目录状态；未点击“开始模拟面试”时不会残留场景启动状态。

## 实现思路

- 面试详情退出成功后清理预览期间写入共享 `PreparationController` 的临时场景选择。
- 在退出请求进行中或已批准退出后，阻止异步目录同步重新写入 `selectedScene`。
- 保留已有练习停放检查，不修改 Session 创建、语音启动或服务端契约。
- 增加回归测试，验证打开已保存方案后关闭会清除临时场景并执行退出边界。

## 测试方式

```bash
cd mobile
flutter analyze
flutter test test/coaching/preparation/job_preparation_wizard_test.dart test/coaching/preparation/preparation_page_test.dart
flutter test test/main_wiring_test.dart
```

以上命令本地均通过。

Closes #665