### PR TITLE
fix(agent): 对齐 IELTS 选择流程与实时语音

### DIFF
--- a/server/internal/agent/run/ielts_tool_routing.go
+++ b/server/internal/agent/run/ielts_tool_routing.go
@@ -397,7 +397,7 @@ func isIELTSPracticeCreation(input string) bool {
 	if containsIELTSPracticeCancellation(normalized) || containsAny(normalized,
 		"怎么回答", "如何回答", "怎么答", "如何答", "评分规则", "评分标准",
 		"怎么练", "如何练", "怎么安排", "如何安排", "是什么", "有什么区别", "分析一下", "讲解一下",
-		"怎么样", "示例", "范例", "例子", "技巧", "建议", "方法",
+		"怎么备战", "如何备战", "怎么样", "示例", "范例", "例子", "技巧", "建议", "方法",
 	) {
 		return false
 	}
@@ -412,7 +412,7 @@ func isIELTSPracticeCreation(input string) bool {
 		}
 	}
 	if containsAny(normalized,
-		"想练", "想要练", "创建", "建立", "安排", "专项",
+		"想练", "想要练", "创建", "建立", "安排", "专项", "备战",
 		"来一场", "给我一场", "做一场", "准备一场",
 		"want to practice", "want to practise", "create", "set up",
 	) {
@@ -526,7 +526,8 @@ func containsNaturalRandomSelection(input string) bool {
 	}
 	return containsAny(normalized,
 		"随便帮我挑一个", "随便给我挑一个", "给我随便挑一个",
-		"帮我随便挑一个", "随便挑一个", "你来选", "你帮我选",
+		"帮我随便挑一个", "随便帮我选一个", "随便给我选一个",
+		"给我随便选一个", "帮我随便选一个", "随便挑一个", "你来选", "你帮我选",
 		"帮我选一个", "帮我挑一个",
 	)
 }

--- a/server/internal/agent/run/ielts_tool_routing_test.go
+++ b/server/internal/agent/run/ielts_tool_routing_test.go
@@ -617,6 +617,20 @@ func TestRunLoopReturnsDeterministicIELTSClarification(t *testing.T) {
 			want:     "没问题，你想先练 Part 1、Part 2、Part 3，还是直接来一场完整模考？",
 		},
 		{
+			name:     "IELTS preparation statement asks scope only",
+			messages: routingMessages("记记一下，我现在准备。嗯。备战雅思。"),
+			want:     "没问题，你想先练 Part 1、Part 2、Part 3，还是直接来一场完整模考？",
+		},
+		{
+			name: "random topic without Part still asks scope",
+			messages: routingConversation(
+				"记记一下，我现在准备。嗯。备战雅思。",
+				"请选择 Part 和话题类型。",
+				"呃，你随便给我选一个吧。",
+			),
+			want: "没问题，你想先练 Part 1、Part 2、Part 3，还是直接来一场完整模考？",
+		},
+		{
 			name:     "missing category",
 			messages: routingMessages("帮我创建一场 IELTS Part 1"),
 			want:     "好，那就先练 Part 1：你想聊人物、地点、事物还是经历，还是让我随机选一个？",
@@ -652,6 +666,37 @@ func TestRunLoopReturnsDeterministicIELTSClarification(t *testing.T) {
 				t.Fatalf("result = %#v, model calls = %d", result, generator.CallCount())
 			}
 		})
+	}
+}
+
+func TestIELTSModelDecisionDoesNotStreamBeforeFinalAuthority(t *testing.T) {
+	generator := newScriptedGenerator(finalLoopResult("好的，已取消。"))
+	service := newLoopTestService(t, generator)
+	observer := &countingDeltaObserver{delegate: &recordingStreamObserver{}}
+
+	result, err := service.generateObserved(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		agentcontext.Manifest{},
+		TextRequest{Messages: routingConversation(
+			"我想练一场雅思口语",
+			"想练哪个部分？",
+			"算了，先不练了",
+		)},
+		observer,
+	)
+	if err != nil {
+		t.Fatalf("generateObserved() error = %v", err)
+	}
+	if result.Content != "好的，已取消。" || observer.count != 0 ||
+		generator.CallCount() != 1 {
+		t.Fatalf(
+			"result = %#v, streamed bytes = %d, model calls = %d",
+			result,
+			observer.count,
+			generator.CallCount(),
+		)
 	}
 }
 
@@ -807,6 +852,7 @@ func TestIELTSNaturalRandomSelection(t *testing.T) {
 	for _, input := range []string{
 		"呃你给我随便挑一个。",
 		"呃随便帮我挑一个。",
+		"呃，你随便给我选一个吧。",
 		"你来选吧",
 	} {
 		topic, found := parseIELTSTopicChoice(input)

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -922,7 +922,8 @@ func (service *Service) generateObserved(
 	for {
 		service.logLoopIteration(run, modelIterations, toolCalls)
 		modelObserver := deltaObserver
-		if guardWarmUpAnswer {
+		if guardWarmUpAnswer ||
+			ieltsRouting.active && request.ToolChoice.Mode != ToolChoiceNone {
 			modelObserver = nil
 		}
 		result, err := service.generateModel(loopCtx, request, modelObserver)


### PR DESCRIPTION
## 功能描述

- 将“备战雅思”识别为 IELTS 练习配置入口，缺少范围时只询问 Part。
- 用户只说“随便选一个”但尚未选择 Part 时，不再由模型猜测 Part 或调用暖身工具。
- IELTS 工具决策阶段不再向 SSE/TTS 推送可能被权威工具结果替换的模型中间文本。

## 实现思路

- 复用现有确定性 IELTS 路由，补齐备战表达与自然随机选择表达。
- IELTS 路由仍可能调用工具时暂缓模型 delta；最终权威结果由既有 Run 完成路径统一输出。
- 不增加新抽象或依赖。

## 测试

- `go test -count=1 ./internal/agent/run`
- `go vet ./internal/agent/run`
- 定向覆盖：备战雅思只问 Part、缺 Part 的随机选择、最终权威文本前不流式输出。

Closes #670