### PR TITLE
perf(mobile): 日常商务面试题目改用系统语音朗读

### DIFF
--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -77,6 +77,10 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
   int _recordingSeconds = 0;
   bool _speechFeedbackRebuildScheduled = false;
   bool _interviewReportRouteActive = false;
+  String? _playingQuestionId;
+  String? _questionNarrationErrorId;
+  int _questionNarrationGeneration = 0;
+  PracticePromptSpeaker? _ownedQuestionSpeaker;
   PracticePromptSpeaker? _ownedTipSpeaker;
 
   @override
@@ -126,6 +130,9 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
     _textAnswerController.dispose();
     _textAnswerFocusNode.dispose();
     unawaited(widget.practiceController?.stopPracticeAudio(notify: false));
+    if (_ownedQuestionSpeaker case final speaker?) {
+      unawaited(speaker.dispose());
+    }
     if (_ownedTipSpeaker case final speaker?) {
       unawaited(speaker.dispose());
     }
@@ -374,6 +381,7 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
     if (controller == null) {
       return;
     }
+    await _stopQuestionNarration();
     final submitted = await controller.submitPracticeText(
       _textAnswerController.text,
     );
@@ -436,6 +444,10 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
 
   Future<void> _requestExit() async {
     if (!mounted || _exitInFlight || _exitApproved) {
+      return;
+    }
+    await _stopQuestionNarration();
+    if (!mounted) {
       return;
     }
     final callback = widget.onExitRequested;
@@ -516,6 +528,9 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
                         speechFeedbackController:
                             widget.speechFeedbackController,
                         onRepractice: _startSpeechFeedbackRetry,
+                        playingQuestionId: _playingQuestionId,
+                        narrationErrorQuestionId: _questionNarrationErrorId,
+                        onPlayQuestion: _playQuestion,
                       ),
                     ),
                     _RecordingPanel(
@@ -528,12 +543,65 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
                       recordingSeconds: _recordingSeconds,
                       onOpenReport: _openInterviewReport,
                       onShowTip: _showQuestionTip,
+                      onBeforeStartRecording: _stopQuestionNarration,
                     ),
                   ],
                 ),
         ),
       ),
     );
+  }
+
+  PracticePromptSpeaker get _questionSpeaker =>
+      widget.practicePromptSpeaker ??
+      (_ownedQuestionSpeaker ??= SystemPracticePromptSpeaker());
+
+  Future<void> _playQuestion(PracticeMessage message) async {
+    if (_playingQuestionId == message.id) {
+      await _stopQuestionNarration();
+      return;
+    }
+    final generation = ++_questionNarrationGeneration;
+    await _stopQuestionSpeakerSafely();
+    if (!mounted || generation != _questionNarrationGeneration) {
+      return;
+    }
+    setState(() {
+      _playingQuestionId = message.id;
+      _questionNarrationErrorId = null;
+    });
+    try {
+      await _questionSpeaker.speak(message.text);
+    } on Object {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _questionNarrationErrorId = message.id);
+      }
+    } finally {
+      if (mounted && generation == _questionNarrationGeneration) {
+        setState(() => _playingQuestionId = null);
+      }
+    }
+  }
+
+  Future<void> _stopQuestionNarration() async {
+    _questionNarrationGeneration++;
+    await widget.practiceController?.stopPracticeAudio();
+    await _stopQuestionSpeakerSafely();
+    if (mounted && _playingQuestionId != null) {
+      setState(() => _playingQuestionId = null);
+    }
+  }
+
+  Future<void> _stopQuestionSpeakerSafely() async {
+    final speaker = widget.practicePromptSpeaker ?? _ownedQuestionSpeaker;
+    if (speaker == null) {
+      return;
+    }
+    try {
+      await speaker.stop();
+    } on Object {
+      // Recording and navigation remain usable when platform TTS degrades.
+    }
   }
 }
 
@@ -604,6 +672,9 @@ class _SceneConversationMessageList extends StatelessWidget {
     required this.scrollController,
     required this.previewMode,
     required this.onRepractice,
+    required this.playingQuestionId,
+    required this.narrationErrorQuestionId,
+    required this.onPlayQuestion,
     this.speechFeedbackController,
   });
 
@@ -611,6 +682,9 @@ class _SceneConversationMessageList extends StatelessWidget {
   final ScrollController scrollController;
   final bool previewMode;
   final ValueChanged<SpeechFeedbackItem> onRepractice;
+  final String? playingQuestionId;
+  final String? narrationErrorQuestionId;
+  final ValueChanged<PracticeMessage> onPlayQuestion;
   final SpeechFeedbackController? speechFeedbackController;
 
   @override
@@ -639,11 +713,13 @@ class _SceneConversationMessageList extends StatelessWidget {
               onFeedbackRepractice: controller.canStartSpeechFeedbackRetry
                   ? onRepractice
                   : null,
-              actions:
-                  message.role == PracticeMessageRole.assistant &&
-                      message.id == controller.questionId &&
-                      controller.canPlayQuestionAudio
-                  ? _QuestionAudioAction(controller: controller)
+              actions: message.role == PracticeMessageRole.assistant
+                  ? _QuestionAudioAction(
+                      messageId: message.id,
+                      playing: playingQuestionId == message.id,
+                      playbackFailed: narrationErrorQuestionId == message.id,
+                      onPressed: () => onPlayQuestion(message),
+                    )
                   : null,
             ),
             const SizedBox(height: 14),
@@ -718,29 +794,34 @@ class _SceneAIThinkingBubble extends StatelessWidget {
 }
 
 class _QuestionAudioAction extends StatelessWidget {
-  const _QuestionAudioAction({required this.controller});
+  const _QuestionAudioAction({
+    required this.messageId,
+    required this.playing,
+    required this.playbackFailed,
+    required this.onPressed,
+  });
 
-  final PracticeController controller;
+  final String messageId;
+  final bool playing;
+  final bool playbackFailed;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     return TextButton.icon(
-      key: const Key('practice-question-audio'),
-      onPressed: controller.canUsePracticeAudio
-          ? controller.toggleQuestionAudio
-          : null,
-      icon: controller.isQuestionAudioLoading
-          ? const SizedBox.square(
-              dimension: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : Icon(
-              controller.isQuestionAudioPlaying
-                  ? Icons.stop_circle_outlined
-                  : Icons.volume_up_outlined,
-              size: 19,
-            ),
-      label: Text(controller.isQuestionAudioPlaying ? '停止播放' : '重听问题'),
+      key: ValueKey('practice-question-audio-$messageId'),
+      onPressed: onPressed,
+      icon: Icon(
+        playing ? Icons.stop_rounded : Icons.volume_up_outlined,
+        size: 19,
+      ),
+      label: Text(
+        playing
+            ? '停止朗读'
+            : playbackFailed
+            ? '重试朗读'
+            : '朗读',
+      ),
     );
   }
 }
@@ -756,6 +837,7 @@ class _RecordingPanel extends StatefulWidget {
     required this.recordingSeconds,
     required this.onOpenReport,
     required this.onShowTip,
+    required this.onBeforeStartRecording,
   });
 
   final PracticeController controller;
@@ -767,6 +849,7 @@ class _RecordingPanel extends StatefulWidget {
   final int recordingSeconds;
   final VoidCallback onOpenReport;
   final VoidCallback onShowTip;
+  final Future<void> Function() onBeforeStartRecording;
 
   @override
   State<_RecordingPanel> createState() => _RecordingPanelState();
@@ -827,7 +910,10 @@ class _RecordingPanelState extends State<_RecordingPanel> {
     return VoiceCaptureControl(
       phase: capturePhase,
       enabled: captureEnabled,
-      onStart: widget.controller.startRecording,
+      onStart: () async {
+        await widget.onBeforeStartRecording();
+        await widget.controller.startRecording();
+      },
       onSendVoice: _sendVoice,
       onConvertToText: _convertToText,
       onCancel: _cancel,

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -224,16 +224,6 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       return;
     }
 
-    if (current && controller.canPlayQuestionAudio) {
-      _questionNarrationGeneration++;
-      await _stopQuestionSpeakerSafely();
-      if (mounted) {
-        setState(() => _questionNarrationErrorId = null);
-      }
-      await controller.toggleQuestionAudio();
-      return;
-    }
-
     await _stopQuestionNarration();
     final generation = ++_questionNarrationGeneration;
     if (!mounted) {

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -1,4 +1,6 @@
 import '../support/scene_fixtures.dart';
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
@@ -17,6 +19,7 @@ import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/scene/scene_client.dart';
 import 'package:speakup/features/coaching/preparation/preparation_controller.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -267,6 +270,40 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('interview questions use immediate system narration controls', (
+    tester,
+  ) async {
+    final harness = await _startedHarness();
+    final speaker = _ControlledPracticePromptSpeaker();
+    addTearDown(harness.dispose);
+    final question = harness.practice.currentQuestion!;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: InterviewPracticePage(
+          practiceController: harness.practice,
+          practicePromptSpeaker: speaker,
+        ),
+      ),
+    );
+
+    final button = find.byKey(
+      ValueKey('practice-question-audio-${question.id}'),
+    );
+    await tester.tap(button);
+    await tester.pump();
+
+    expect(speaker.spokenTexts, <String>[question.text]);
+    expect(find.text('停止朗读'), findsOneWidget);
+    expect(harness.practice.isQuestionAudioLoading, isFalse);
+
+    await tester.tap(button);
+    await tester.pump();
+
+    expect(speaker.stopCalls, greaterThanOrEqualTo(2));
+    expect(find.text('朗读'), findsOneWidget);
+  });
+
   testWidgets('completion does not replace a newer route', (tester) async {
     final harness = await _startedHarness();
     addTearDown(harness.dispose);
@@ -378,6 +415,32 @@ final class _AgentHarness {
     conversation.dispose();
     practice.dispose();
   }
+}
+
+final class _ControlledPracticePromptSpeaker implements PracticePromptSpeaker {
+  final List<String> spokenTexts = <String>[];
+  Completer<void>? _activeSpeech;
+  int stopCalls = 0;
+
+  @override
+  Future<void> speak(String text) {
+    spokenTexts.add(text);
+    _activeSpeech = Completer<void>();
+    return _activeSpeech!.future;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    final speech = _activeSpeech;
+    if (speech != null && !speech.isCompleted) {
+      speech.complete();
+    }
+    _activeSpeech = null;
+  }
+
+  @override
+  Future<void> dispose() => stop();
 }
 
 final class _AuthenticatedIdentityClient implements IdentityClient {

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -3,16 +3,19 @@ import '../../support/scene_fixtures.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_media.dart';
 import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_client.dart';
@@ -696,7 +699,12 @@ void main() {
   });
 
   testWidgets('reads and stops an assistant message inline', (tester) async {
-    final controller = await _scenarioController();
+    final mediaClient = _TrackingPracticeMediaClient();
+    final audioPlayer = _TrackingPracticeAudioPlayer();
+    final controller = await _scenarioController(
+      mediaClient: mediaClient,
+      audioPlayer: audioPlayer,
+    );
     addTearDown(controller.dispose);
     final speaker = _ControlledPromptSpeaker();
     final question = controller.currentQuestion!;
@@ -715,6 +723,8 @@ void main() {
     await tester.pump();
 
     expect(speaker.spokenTexts, <String>[question.text]);
+    expect(mediaClient.questionSpeechLoads, 0);
+    expect(audioPlayer.playCalls, 0);
     expect(find.text('停止朗读'), findsOneWidget);
 
     await tester.tap(button);
@@ -813,6 +823,8 @@ void main() {
 Future<PracticeController> _scenarioController({
   PracticeClient? practiceClient,
   SceneDefinition? selectedScene,
+  PracticeMediaClient? mediaClient,
+  PracticeAudioPlayer? audioPlayer,
 }) async {
   final scene =
       selectedScene ??
@@ -837,7 +849,11 @@ Future<PracticeController> _scenarioController({
         practiceExperience: scene.experience,
         sceneCategory: scene.category,
       );
-  final controller = PracticeController(client: resolvedPracticeClient);
+  final controller = PracticeController(
+    client: resolvedPracticeClient,
+    mediaClient: mediaClient,
+    audioPlayer: audioPlayer,
+  );
   await controller.activateCreatedPractice(
     scene: scene,
     sessionId: _scenarioSessionId,
@@ -1308,6 +1324,51 @@ final class _ControlledPromptSpeaker implements PracticePromptSpeaker {
 
   @override
   Future<void> dispose() => stop();
+}
+
+final class _TrackingPracticeMediaClient implements PracticeMediaClient {
+  int questionSpeechLoads = 0;
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) async {
+    questionSpeechLoads++;
+    return Uint8List(44);
+  }
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) async => Uint8List(44);
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+final class _TrackingPracticeAudioPlayer implements PracticeAudioPlayer {
+  final StreamController<void> _completions =
+      StreamController<void>.broadcast();
+  int playCalls = 0;
+
+  @override
+  Stream<void> get onComplete => _completions.stream;
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {
+    playCalls++;
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() => _completions.close();
 }
 
 final class _FailingPromptSpeaker implements PracticePromptSpeaker {


### PR DESCRIPTION
## 功能描述

将日常、商务和面试练习的题目朗读统一为 IELTS 已使用的系统英语语音路径，避免点击后等待服务端实时合成并下载完整 WAV。

## 实现思路

- 日常/商务场景：普通题目朗读直接使用 `SystemPracticePromptSpeaker`；显式数字人回放回调仍保持优先。
- 面试场景：当前及历史面试官问题均使用同一系统语音，并统一为“朗读 / 停止朗读 / 重试朗读”状态。
- 开始录音、提交文字或退出页面前停止朗读，避免语音与用户输入重叠。
- 不修改服务端 TTS、ASR、Tips、翻译、口语评测或报告契约。
- 回归测试明确注入可用的网络媒体客户端，验证日常/商务朗读不会发起 `loadQuestionSpeech` 或 WAV 播放。

## 测试方式

```bash
cd mobile
flutter analyze
flutter test test/coaching/practice/scenario_practice_test.dart \
  test/agent/agent_flow_test.dart \
  test/review/turn_feedback_page_integration_test.dart \
  test/coaching/practice/ielts_mock_practice_test.dart
```

本地共 76 项相关测试通过，并已在 iPhone 17 Pro 模拟器热重启验证系统语音插件无初始化错误。

Closes #669