### PR TITLE
fix(mobile): 修复面试列表并补齐复盘分类

### DIFF
--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -1071,8 +1071,10 @@ components:
           type: integer
           minimum: 1
         max_effective_turns:
+          description: Zero denotes a USER_CONTROLLED plan with no fixed turn limit.
           type: integer
-          minimum: 1
+          minimum: 0
+          maximum: 64
         created_at:
           type: string
           format: date-time

--- a/mobile/lib/features/coaching/interview/interview_catalog.dart
+++ b/mobile/lib/features/coaching/interview/interview_catalog.dart
@@ -178,8 +178,9 @@ class _PlanCard extends StatelessWidget {
                     ),
                     _PlanMeta(
                       icon: Icons.repeat_rounded,
-                      label:
-                          '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
+                      label: plan.maxEffectiveTurns == 0
+                          ? '开放轮次'
+                          : '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
                     ),
                   ],
                 ),

--- a/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
+++ b/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
@@ -959,9 +959,9 @@ List<PracticePlanSummary> _decodePracticePlanList(String body) {
           utf8.encode(jobTitleValue).length > 512) {
         throw _invalidResponse();
       }
-      int positiveInt(String key) {
+      int integerAtLeast(String key, int minimum) {
         final value = object[key];
-        if (value is! int || value < 1) {
+        if (value is! int || value < minimum) {
           throw _invalidResponse();
         }
         return value;
@@ -984,9 +984,12 @@ List<PracticePlanSummary> _decodePracticePlanList(String body) {
           objectiveValues.map((item) => _text(item, maxBytes: 2048)),
         ),
         resumeUsed: object['resume_used']! as bool,
-        suggestedDurationSeconds: positiveInt('suggested_duration_seconds'),
-        minEffectiveTurns: positiveInt('min_effective_turns'),
-        maxEffectiveTurns: positiveInt('max_effective_turns'),
+        suggestedDurationSeconds: integerAtLeast(
+          'suggested_duration_seconds',
+          1,
+        ),
+        minEffectiveTurns: integerAtLeast('min_effective_turns', 1),
+        maxEffectiveTurns: integerAtLeast('max_effective_turns', 0),
         createdAt: _dateTime(object['created_at']),
         updatedAt: _dateTime(object['updated_at']),
       );

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -429,6 +429,8 @@ class _ReviewFilters extends StatelessWidget {
       ('全部', null),
       ('面试', EvaluationReportSceneType.interview),
       ('雅思', EvaluationReportSceneType.ieltsSpeaking),
+      ('日常英语', EvaluationReportSceneType.overseasDailyLife),
+      ('职场英语', EvaluationReportSceneType.overseasWorkplace),
     ];
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,

--- a/mobile/test/coaching/interview/interview_catalog_test.dart
+++ b/mobile/test/coaching/interview/interview_catalog_test.dart
@@ -64,6 +64,16 @@ void main() {
     expect(find.byType(Card), findsNWidgets(2));
   });
 
+  testWidgets('labels a user-controlled plan as open-ended', (tester) async {
+    await _pumpCatalog(
+      tester,
+      plans: [_plan('plan-open', maxEffectiveTurns: 0)],
+    );
+
+    expect(find.text('开放轮次'), findsOneWidget);
+    expect(find.text('1–0 轮'), findsNothing);
+  });
+
   testWidgets('keeps plan metadata usable at 320px and 3x text', (
     tester,
   ) async {
@@ -120,7 +130,7 @@ Future<void> _pumpCatalog(
   );
 }
 
-PracticePlanSummary _plan(String id) {
+PracticePlanSummary _plan(String id, {int maxEffectiveTurns = 3}) {
   return PracticePlanSummary(
     id: id,
     revision: 1,
@@ -133,7 +143,7 @@ PracticePlanSummary _plan(String id) {
     resumeUsed: true,
     suggestedDurationSeconds: 900,
     minEffectiveTurns: 1,
-    maxEffectiveTurns: 3,
+    maxEffectiveTurns: maxEffectiveTurns,
     createdAt: DateTime.utc(2026, 8, 7),
     updatedAt: DateTime.utc(2026, 8, 7),
   );

--- a/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/interview/job_preparation_models.dart'
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/interview/wire_job_preparation_client.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 
@@ -198,6 +199,36 @@ void main() {
       });
     },
   );
+
+  test('lists a user-controlled plan with an open turn limit', () async {
+    final summary = <String, Object?>{
+      'practice_plan_id': _planId,
+      'plan_revision': 1,
+      'practice_plan_status': 'ready',
+      'practice_experience': 'INTERVIEW',
+      'scene_name': 'Technical interview',
+      'practice_scope': 'System design focus',
+      'job_title': '',
+      'practice_objectives': <Object?>['Explain one design trade-off.'],
+      'resume_used': false,
+      'suggested_duration_seconds': 900,
+      'min_effective_turns': 1,
+      'max_effective_turns': 0,
+      'created_at': '2026-08-07T00:00:00Z',
+      'updated_at': '2026-08-07T00:00:00Z',
+    };
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.ok, <String, Object?>{
+        'practice_plans': <Object?>[summary],
+      }),
+    ]);
+
+    final plans = await _client(
+      transport,
+    ).listPlans(experience: PracticeExperience.interview);
+
+    expect(plans.single.maxEffectiveTurns, 0);
+  });
 
   group('strict JobTarget decoder', () {
     final cases = <String, void Function(Map<String, Object?>)>{


### PR DESCRIPTION
## 功能描述

- 修复开放轮次 Interview 计划被移动端误判为无效响应的问题。
- 开放轮次计划显示“开放轮次”，不再显示错误的 `1–0 轮`。
- Review 页面补齐日常英语、职场英语筛选，与四类报告模型保持一致。

## 实现思路

- 依据后端用户主动结束策略，允许计划摘要的 `max_effective_turns` 为 `0`。
- 仅在固定轮次计划中显示最小–最大轮次。
- 直接复用现有 `EvaluationReportSceneType` 完成 Review 分类，不增加新状态或依赖。

## 测试

- `flutter test test/coaching/preparation/wire_job_preparation_client_test.dart`
- `flutter test test/coaching/interview/interview_catalog_test.dart`
- `flutter test test/review/review_history_test.dart`
- `flutter analyze lib/features/coaching/interview/wire_job_preparation_client.dart lib/features/coaching/interview/interview_catalog.dart lib/features/coaching/review/review.dart`

Closes #673