### PR TITLE
feat(practice): 实时自动播放日常商务面试问题语音

### DIFF
--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -319,6 +319,77 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/voice-questions/{question_id}/speech/realtime:
+    get:
+      tags:
+        - Practice
+      summary: Stream the persisted Question as synthesized PCM
+      description: |
+        Authenticates the Actor and resolves the Actor-owned persisted Question
+        before upgrading. The server emits `stream.ready`, then binary mono
+        24 kHz signed 16-bit little-endian PCM chunks as synthesis progresses,
+        followed by exactly one `stream.completed` or `stream.failed` event.
+        The client supplies only the Question identity and cannot provide or
+        replace the text sent to the speech provider.
+      operationId: streamVoiceQuestionSpeech
+      parameters:
+        - $ref: '#/components/parameters/QuestionId'
+        - name: Sec-WebSocket-Protocol
+          in: header
+          required: true
+          description: Required realtime Practice Question speech subprotocol.
+          schema:
+            type: string
+            const: speakup.practice-question-speech.v1
+      responses:
+        '101':
+          description: WebSocket protocol upgrade accepted.
+          headers:
+            Sec-WebSocket-Protocol:
+              description: Negotiated Practice Question speech protocol.
+              schema:
+                type: string
+                const: speakup.practice-question-speech.v1
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+      x-websocket-event-schema:
+        $ref: ../websocket/practice-question-speech.schema.json#/$defs/ServerEvent
+      x-websocket-security:
+        credential_location: authorization_header
+        header: Authorization
+        scheme: Bearer
+        other_credential_locations_allowed: false
+        production_transport: wss
+        local_loopback_transport: ws
+        pre_upgrade:
+          validation_order:
+            - session
+            - actor
+            - resource_ownership
+            - subprotocol
+            - upgrade
+          authentication_failure:
+            http_status: 401
+            error_code: authentication_required
+          resource_not_visible:
+            http_status: 404
+            error_code: resource_not_found
+        connection_binding:
+          actor_fields:
+            - user_id
+            - session_id
+          target_field: question_id
+          target_switch_allowed: false
+        subprotocol:
+          allowed:
+            - speakup.practice-question-speech.v1
+          carries_credentials: false
   /v1/voice-questions/{question_id}/translation:
     get:
       tags:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -181,6 +181,8 @@ paths:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1transcription-candidates~1{candidate_id}~1confirmations
   /v1/voice-questions/{question_id}/speech:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-questions~1{question_id}~1speech
+  /v1/voice-questions/{question_id}/speech/realtime:
+    $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-questions~1{question_id}~1speech~1realtime
   /v1/voice-questions/{question_id}/translation:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1voice-questions~1{question_id}~1translation
   /v1/evaluation-reports:

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "check": "npm run lint:openapi && npm run validate:security && npm run validate:websocket && npm run validate:fixture && npm run validate:evaluation && npm run validate:speech-feedback",
     "lint:openapi": "redocly lint openapi.yaml --config redocly.yaml",
     "validate:security": "node scripts/validate-security.mjs",
-    "validate:websocket": "node scripts/validate-events.mjs && node scripts/validate-agent-voice-transcription.mjs",
+    "validate:websocket": "node scripts/validate-events.mjs && node scripts/validate-agent-voice-transcription.mjs && node scripts/validate-practice-question-speech.mjs",
     "validate:fixture": "node scripts/validate-main-flow.mjs",
     "validate:evaluation": "node scripts/validate-evaluation.mjs",
     "validate:speech-feedback": "node scripts/validate-speech-feedback.mjs"

--- a/api/scripts/validate-practice-question-speech.mjs
+++ b/api/scripts/validate-practice-question-speech.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const apiDirectory = fileURLToPath(new URL('..', import.meta.url));
+const schema = JSON.parse(
+  await readFile(
+    resolve(apiDirectory, 'websocket/practice-question-speech.schema.json'),
+    { encoding: 'utf8' },
+  ),
+);
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+ajv.addSchema(schema);
+const validate = ajv.compile({
+  $ref: `${schema.$id}#/$defs/ServerEvent`,
+});
+
+const validEvents = [
+  {
+    type: 'stream.ready',
+    data: {
+      content_type: 'audio/pcm',
+      sample_rate: 24000,
+      channel_count: 1,
+      bits_per_sample: 16,
+    },
+  },
+  { type: 'stream.completed', data: {} },
+  {
+    type: 'stream.failed',
+    data: { kind: 'synthesis_failed', retryable: true },
+  },
+];
+const invalidEvents = [
+  { type: 'stream.ready', data: { content_type: 'audio/wav' } },
+  { type: 'stream.completed', data: { audio_url: 'forbidden' } },
+  {
+    type: 'stream.failed',
+    data: {
+      kind: 'synthesis_failed',
+      retryable: true,
+      provider_payload: 'forbidden',
+    },
+  },
+];
+for (const event of validEvents) {
+  assert.equal(validate(event), true, ajv.errorsText(validate.errors));
+}
+for (const event of invalidEvents) {
+  assert.equal(validate(event), false, `accepted ${event.type}`);
+}
+
+console.log(
+  `Validated ${validEvents.length} Practice Question speech events and ` +
+    `${invalidEvents.length} rejections.`,
+);

--- a/api/websocket/practice-question-speech.schema.json
+++ b/api/websocket/practice-question-speech.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speak-up.top/api/schemas/websocket/practice-question-speech.schema.json",
+  "title": "Practice Question realtime speech",
+  "description": "Server text events surrounding binary PCM chunks for one authenticated, Actor-owned Practice Question.",
+  "$defs": {
+    "ServerEvent": {
+      "oneOf": [
+        { "$ref": "#/$defs/StreamReady" },
+        { "$ref": "#/$defs/StreamCompleted" },
+        { "$ref": "#/$defs/StreamFailed" }
+      ]
+    },
+    "StreamReady": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": { "const": "stream.ready" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "content_type",
+            "sample_rate",
+            "channel_count",
+            "bits_per_sample"
+          ],
+          "properties": {
+            "content_type": { "const": "audio/pcm" },
+            "sample_rate": { "const": 24000 },
+            "channel_count": { "const": 1 },
+            "bits_per_sample": { "const": 16 }
+          }
+        }
+      }
+    },
+    "StreamCompleted": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": { "const": "stream.completed" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    },
+    "StreamFailed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "data"],
+      "properties": {
+        "type": { "const": "stream.failed" },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "retryable"],
+          "properties": {
+            "kind": { "const": "synthesis_failed" },
+            "retryable": { "type": "boolean" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mobile/lib/features/coaching/practice/practice_audio_player.dart
+++ b/mobile/lib/features/coaching/practice/practice_audio_player.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -18,6 +18,82 @@ abstract interface class PracticeAudioPlayer {
   Future<void> clearAccountState();
 
   Future<void> dispose();
+}
+
+abstract interface class PracticePCMStreamPlayer {
+  Future<void> startPCMStream();
+
+  Future<void> appendPCM(Uint8List bytes);
+
+  Future<void> finishPCMStream();
+
+  Future<void> stopPCMStream();
+
+  Future<void> disposePCMStream();
+}
+
+final class MethodChannelPracticePCMStreamPlayer
+    implements PracticePCMStreamPlayer {
+  static const _channel = MethodChannel('speakup/agent_pcm_player');
+  bool _started = false;
+  bool _disposed = false;
+
+  @override
+  Future<void> startPCMStream() async {
+    if (_disposed) {
+      throw const PracticeAudioPlaybackException();
+    }
+    await stopPCMStream();
+    await _channel.invokeMethod<void>('start', const <String, Object>{
+      'sampleRate': 24000,
+      'channelCount': 1,
+      'bitsPerSample': 16,
+      'speed': 1.0,
+    });
+    if (_disposed) {
+      await _channel.invokeMethod<void>('stop');
+      throw const PracticeAudioPlaybackException();
+    }
+    _started = true;
+  }
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) async {
+    if (_disposed || !_started || bytes.isEmpty || bytes.length.isOdd) {
+      throw const PracticeAudioPlaybackException();
+    }
+    await _channel.invokeMethod<void>('append', bytes);
+  }
+
+  @override
+  Future<void> finishPCMStream() async {
+    if (!_started) {
+      return;
+    }
+    await _channel.invokeMethod<void>('finish');
+    _started = false;
+  }
+
+  @override
+  Future<void> stopPCMStream() async {
+    if (!_started) {
+      return;
+    }
+    _started = false;
+    await _channel.invokeMethod<void>('stop');
+  }
+
+  @override
+  Future<void> disposePCMStream() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    if (_started) {
+      _started = false;
+      await _channel.invokeMethod<void>('stop');
+    }
+  }
 }
 
 abstract interface class NativePracticeAudioPlayer {

--- a/mobile/lib/features/coaching/practice/practice_audio_player.dart
+++ b/mobile/lib/features/coaching/practice/practice_audio_player.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:audioplayers/audioplayers.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter/widgets.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -26,6 +26,7 @@ final class PracticeController extends ChangeNotifier
     PracticeRecorder? recorder,
     this.mediaClient,
     this.audioPlayer,
+    this.questionSpeechPlayer,
     PracticeClientIdFactory? clientIdFactory,
     Duration recordingLimit = const Duration(seconds: 58),
   }) : recorder = recorder ?? FakePracticeRecorder(),
@@ -34,6 +35,12 @@ final class PracticeController extends ChangeNotifier
     if ((mediaClient == null) != (audioPlayer == null)) {
       throw ArgumentError(
         'Practice media client and audio player must be injected together.',
+      );
+    }
+    if (questionSpeechPlayer != null &&
+        mediaClient is! PracticeQuestionSpeechClient) {
+      throw ArgumentError(
+        'The realtime question speech player requires a streaming media client.',
       );
     }
     if (recordingLimit <= Duration.zero ||
@@ -47,7 +54,7 @@ final class PracticeController extends ChangeNotifier
     _mediaCompletionSubscription = audioPlayer?.onComplete.listen((_) {
       _handleMediaCompletion();
     });
-    if (mediaClient != null) {
+    if (mediaClient != null || questionSpeechPlayer != null) {
       WidgetsBinding.instance.addObserver(this);
     }
   }
@@ -56,6 +63,7 @@ final class PracticeController extends ChangeNotifier
   final PracticeRecorder recorder;
   final PracticeMediaClient? mediaClient;
   final PracticeAudioPlayer? audioPlayer;
+  final PracticePCMStreamPlayer? questionSpeechPlayer;
   final PracticeClientIdFactory _clientIdFactory;
   final Duration _recordingLimit;
   String? _practiceSessionId;
@@ -108,6 +116,9 @@ final class PracticeController extends ChangeNotifier
   String? _mediaErrorMessage;
   int _mediaGeneration = 0;
   Future<void>? _mediaOperation;
+  Future<void>? _questionSpeechOperation;
+  StreamIterator<Uint8List>? _questionSpeechIterator;
+  String? _autoPlayedQuestionId;
   String? get practiceSessionId => _practiceSessionId;
   PracticeExperience? get practiceExperience => _practiceExperience;
   SceneCategory? get practiceSceneCategory => _practiceSceneCategory;
@@ -265,6 +276,9 @@ final class PracticeController extends ChangeNotifier
         PracticeRecordingState.submitting => false,
       };
   bool get supportsPracticeMedia => mediaClient != null && audioPlayer != null;
+  bool get supportsRealtimeQuestionSpeech =>
+      mediaClient is PracticeQuestionSpeechClient &&
+      questionSpeechPlayer != null;
   List<PracticeRecordingReference> get recordings =>
       List<PracticeRecordingReference>.unmodifiable(_recordings);
   String? get mediaErrorMessage => _mediaErrorMessage;
@@ -275,9 +289,10 @@ final class PracticeController extends ChangeNotifier
       _currentQuestion != null &&
       _playingMediaKey == _questionMediaKey(_currentQuestion!.id);
   bool get canPlayQuestionAudio =>
-      supportsPracticeMedia && _currentQuestion?.speechPath != null;
+      (supportsRealtimeQuestionSpeech || supportsPracticeMedia) &&
+      _currentQuestion != null;
   bool get canUsePracticeAudio =>
-      supportsPracticeMedia &&
+      (supportsPracticeMedia || supportsRealtimeQuestionSpeech) &&
       !_disposed &&
       !_busy &&
       switch (_recordingState) {
@@ -406,8 +421,20 @@ final class PracticeController extends ChangeNotifier
 
   Future<void> toggleQuestionAudio() async {
     final question = _currentQuestion;
-    final speechPath = question?.speechPath;
-    if (question == null || speechPath == null) {
+    if (question == null) {
+      return;
+    }
+    if (supportsRealtimeQuestionSpeech) {
+      final key = _questionMediaKey(question.id)!;
+      if (_playingMediaKey == key || _loadingMediaKey == key) {
+        await stopPracticeAudio();
+        return;
+      }
+      await _playRealtimeQuestionSpeech(question);
+      return;
+    }
+    final speechPath = question.speechPath;
+    if (speechPath == null) {
       return;
     }
     await _togglePracticeMedia(
@@ -520,10 +547,144 @@ final class PracticeController extends ChangeNotifier
       notifyListeners();
     }
     try {
+      final iterator = _questionSpeechIterator;
+      _questionSpeechIterator = null;
+      await iterator?.cancel();
+      await questionSpeechPlayer?.stopPCMStream();
       await audioPlayer?.stop();
     } catch (_) {
       // The private UI is already cleared; native cleanup remains best effort.
     }
+  }
+
+  Future<void> _playRealtimeQuestionSpeech(PracticeQuestion question) async {
+    final speechClient = mediaClient;
+    final player = questionSpeechPlayer;
+    if (speechClient is! PracticeQuestionSpeechClient ||
+        player == null ||
+        _disposed ||
+        !canUsePracticeAudio ||
+        _mediaOperation != null) {
+      return;
+    }
+    final realtimeClient = speechClient as PracticeQuestionSpeechClient;
+    final previousOperation = _questionSpeechOperation;
+    await stopPracticeAudio();
+    await previousOperation;
+    if (_disposed ||
+        !canUsePracticeAudio ||
+        _currentQuestion?.id != question.id) {
+      return;
+    }
+    final generation = ++_mediaGeneration;
+    final key = _questionMediaKey(question.id)!;
+    _loadingMediaKey = key;
+    _mediaErrorMessage = null;
+    notifyListeners();
+    late final Future<void> operation;
+    operation = _streamAndPlayQuestionSpeech(
+      generation: generation,
+      key: key,
+      question: question,
+      client: realtimeClient,
+      player: player,
+    );
+    _questionSpeechOperation = operation;
+    try {
+      await operation;
+    } finally {
+      if (identical(_questionSpeechOperation, operation)) {
+        _questionSpeechOperation = null;
+      }
+    }
+  }
+
+  Future<void> _streamAndPlayQuestionSpeech({
+    required int generation,
+    required String key,
+    required PracticeQuestion question,
+    required PracticeQuestionSpeechClient client,
+    required PracticePCMStreamPlayer player,
+  }) async {
+    var started = false;
+    final iterator = StreamIterator<Uint8List>(
+      client.streamQuestionSpeech(question.id),
+    );
+    _questionSpeechIterator = iterator;
+    try {
+      while (await iterator.moveNext()) {
+        final bytes = iterator.current;
+        if (!_isCurrentMedia(generation) ||
+            _currentQuestion?.id != question.id) {
+          return;
+        }
+        if (!started) {
+          await player.startPCMStream();
+          if (!_isCurrentMedia(generation) ||
+              _currentQuestion?.id != question.id) {
+            await player.stopPCMStream();
+            return;
+          }
+          started = true;
+          _loadingMediaKey = null;
+          _playingMediaKey = key;
+          notifyListeners();
+        }
+        try {
+          await player.appendPCM(bytes);
+        } finally {
+          bytes.fillRange(0, bytes.length, 0);
+        }
+      }
+      if (started && _isCurrentMedia(generation)) {
+        await player.finishPCMStream();
+      }
+      if (_isCurrentMedia(generation)) {
+        _loadingMediaKey = null;
+        _playingMediaKey = null;
+        _mediaErrorMessage = null;
+      }
+    } on PracticeClientOperationCancelled {
+      // A newer question or account cleanup owns the presentation now.
+    } catch (error) {
+      if (_isCurrentMedia(generation)) {
+        _loadingMediaKey = null;
+        _playingMediaKey = null;
+        _mediaErrorMessage = _mediaFailureMessage(error, action: '播放音频');
+        await player.stopPCMStream();
+      }
+    } finally {
+      if (identical(_questionSpeechIterator, iterator)) {
+        _questionSpeechIterator = null;
+      }
+      await iterator.cancel();
+      if (_isCurrentMedia(generation)) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _scheduleAutomaticQuestionSpeech() {
+    final question = _currentQuestion;
+    final experience = _practiceExperience;
+    if (!supportsRealtimeQuestionSpeech ||
+        question == null ||
+        _sessionCompleted ||
+        _autoPlayedQuestionId == question.id ||
+        experience == null ||
+        experience == PracticeExperience.ieltsSpeaking) {
+      return;
+    }
+    _autoPlayedQuestionId = question.id;
+    scheduleMicrotask(() async {
+      if (_disposed ||
+          _currentQuestion?.id != question.id ||
+          _sessionCompleted ||
+          !canUsePracticeAudio) {
+        return;
+      }
+      await _playRealtimeQuestionSpeech(question);
+    });
   }
 
   /// Safely detaches the locally presented Session before the App leaves its
@@ -1807,6 +1968,7 @@ final class PracticeController extends ChangeNotifier
     } else {
       _recordingState = PracticeRecordingState.idle;
     }
+    _scheduleAutomaticQuestionSpeech();
   }
 
   Future<PracticeQuestionTip?> requestQuestionTip() async {
@@ -1962,6 +2124,7 @@ final class PracticeController extends ChangeNotifier
     _deletingAudioAssetId = null;
     _mediaErrorMessage = null;
     _mediaGeneration++;
+    _autoPlayedQuestionId = null;
     _busy = false;
     if (!_disposed) {
       notifyListeners();
@@ -1978,6 +2141,13 @@ final class PracticeController extends ChangeNotifier
         Future<void>.sync(media.clearAccountState),
       if (audioPlayer case final player?)
         Future<void>.sync(player.clearAccountState),
+      if (questionSpeechPlayer case final player?)
+        Future<void>.sync(() async {
+          final iterator = _questionSpeechIterator;
+          _questionSpeechIterator = null;
+          await iterator?.cancel();
+          await player.stopPCMStream();
+        }),
     ]);
     _accountCleanupFuture = cleanup;
     try {
@@ -1999,7 +2169,7 @@ final class PracticeController extends ChangeNotifier
     final practiceAudioOperation = _stopRecordingFuture;
     _pendingPracticeAudio = null;
     _disposed = true;
-    if (mediaClient != null) {
+    if (mediaClient != null || questionSpeechPlayer != null) {
       WidgetsBinding.instance.removeObserver(this);
     }
     _cancelRecordingLimit();
@@ -2025,6 +2195,12 @@ final class PracticeController extends ChangeNotifier
     unawaited(_mediaCompletionSubscription?.cancel());
     unawaited(mediaClient?.dispose());
     unawaited(audioPlayer?.dispose());
+    unawaited(
+      Future<void>.sync(() async {
+        await _questionSpeechIterator?.cancel();
+        await questionSpeechPlayer?.disposePCMStream();
+      }),
+    );
     super.dispose();
   }
 
@@ -2065,7 +2241,9 @@ final class PracticeController extends ChangeNotifier
     _deletingAudioAssetId = null;
     _mediaErrorMessage = null;
     _mediaGeneration++;
+    _autoPlayedQuestionId = null;
     unawaited(audioPlayer?.stop());
+    unawaited(questionSpeechPlayer?.stopPCMStream());
     if (snapshot == null) {
       _practiceSessionId = null;
       _practiceExperience = null;
@@ -2145,6 +2323,7 @@ final class PracticeController extends ChangeNotifier
     _recordingState = snapshot.sessionCompleted
         ? PracticeRecordingState.completed
         : PracticeRecordingState.idle;
+    _scheduleAutomaticQuestionSpeech();
   }
 
   void _appendPracticeMessages(Iterable<PracticeMessage> values) {

--- a/mobile/lib/features/coaching/practice/practice_media.dart
+++ b/mobile/lib/features/coaching/practice/practice_media.dart
@@ -798,19 +798,51 @@ void _requirePracticeSpeechEvent(dynamic message, String expected) {
     );
   }
   final decoded = jsonDecode(message);
-  if (decoded is! Map<String, dynamic> || decoded['type'] != expected) {
+  if (decoded is! Map<String, dynamic> ||
+      decoded.keys.toSet().difference(const <String>{
+        'type',
+        'data',
+      }).isNotEmpty ||
+      !decoded.containsKey('type') ||
+      !decoded.containsKey('data')) {
     throw const PracticeClientException(
       kind: PracticeClientFailureKind.invalidResponse,
     );
   }
+  final type = decoded['type'];
   final data = decoded['data'];
   if (data is! Map<String, dynamic>) {
     throw const PracticeClientException(
       kind: PracticeClientFailureKind.invalidResponse,
     );
   }
+  if (type == 'stream.failed') {
+    final kind = data['kind'];
+    final retryable = data['retryable'];
+    if (data.length != 2 ||
+        kind is! String ||
+        kind.isEmpty ||
+        kind.length > 64 ||
+        kind.trim() != kind ||
+        retryable is! bool) {
+      throw const PracticeClientException(
+        kind: PracticeClientFailureKind.invalidResponse,
+      );
+    }
+    throw PracticeClientException(
+      kind: PracticeClientFailureKind.network,
+      errorCode: kind,
+      retryable: retryable,
+    );
+  }
+  if (type != expected || (type == 'stream.completed' && data.isNotEmpty)) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.invalidResponse,
+    );
+  }
   if (expected == 'stream.ready' &&
       (data['content_type'] != 'audio/pcm' ||
+          data.length != 4 ||
           data['sample_rate'] != 24000 ||
           data['channel_count'] != 1 ||
           data['bits_per_sample'] != 16)) {

--- a/mobile/lib/features/coaching/practice/practice_media.dart
+++ b/mobile/lib/features/coaching/practice/practice_media.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/practice/practice_client_error.dart';
 
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/bearer_authentication.dart';
+import 'package:speakup/identity/network/authenticated_web_socket.dart';
 import 'package:speakup/identity/network/transport_security.dart';
 
 typedef PracticeMediaClock = DateTime Function();
@@ -23,6 +24,10 @@ abstract interface class PracticeMediaClient {
   Future<void> clearAccountState();
 
   Future<void> dispose();
+}
+
+abstract interface class PracticeQuestionSpeechClient {
+  Stream<Uint8List> streamQuestionSpeech(String questionId);
 }
 
 final class PracticeMediaWireRequest {
@@ -62,7 +67,8 @@ abstract interface class PracticeMediaWireTransport {
 /// API requests use the authenticated, same-origin transport. A recording's
 /// signed URL is consumed by a separate request with no App Session header,
 /// then only the resulting WAV bytes cross the player boundary.
-final class WirePracticeMediaClient implements PracticeMediaClient {
+final class WirePracticeMediaClient
+    implements PracticeMediaClient, PracticeQuestionSpeechClient {
   factory WirePracticeMediaClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -70,6 +76,7 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
     PracticeMediaWireTransport? apiTransport,
     PracticeMediaWireTransport? signedAudioTransport,
     PracticeMediaWireTransportFactory? transportFactory,
+    AuthenticatedWebSocketConnector? questionSpeechConnector,
     PracticeMediaClock? clock,
     Duration timeout = const Duration(seconds: 30),
   }) {
@@ -88,6 +95,16 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
       apiTransport == null,
       signedAudioTransport == null,
       createTransport,
+      SessionAuthenticatedWebSocketConnector(
+        connector:
+            questionSpeechConnector ??
+            IoAuthenticatedWebSocketConnector(
+              protocols: const <String>[_questionSpeechProtocol],
+            ),
+        credentialProvider: credentialProvider,
+        invalidateSession: invalidateSession,
+        trustedBaseUri: _practiceWebSocketBaseUri(baseUri),
+      ),
       clock ?? _utcNow,
       timeout,
     );
@@ -103,6 +120,7 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
     this._ownsApiTransport,
     this._ownsSignedAudioTransport,
     this._transportFactory,
+    this._questionSpeechConnector,
     this._clock,
     this._timeout,
   );
@@ -111,6 +129,7 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
   static const _maximumJsonBytes = 64 * 1024;
   static const _maximumPlaybackLifetime = Duration(minutes: 2);
   static const _maximumLocalClockSkew = Duration(seconds: 30);
+  static const _questionSpeechProtocol = 'speakup.practice-question-speech.v1';
 
   final Uri _baseUri;
   final TrustedIdentityHttpOrigin _trustedOrigin;
@@ -121,6 +140,7 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
   final bool _ownsApiTransport;
   final bool _ownsSignedAudioTransport;
   final PracticeMediaWireTransportFactory _transportFactory;
+  final SessionAuthenticatedWebSocketConnector _questionSpeechConnector;
   final PracticeMediaClock _clock;
   final Duration _timeout;
 
@@ -146,6 +166,63 @@ final class WirePracticeMediaClient implements PracticeMediaClient {
         _zero(response.body);
       }
     });
+  }
+
+  @override
+  Stream<Uint8List> streamQuestionSpeech(String questionId) async* {
+    final id = _requireResourceId(questionId);
+    final generation = _accountGeneration;
+    final uri = _practiceWebSocketBaseUri(
+      _baseUri,
+    ).resolve('/v1/voice-questions/${Uri.encodeComponent(id)}/speech/realtime');
+    SessionAuthenticatedWebSocketConnection? connection;
+    StreamIterator<dynamic>? messages;
+    var receivedBytes = 0;
+    try {
+      connection = await _questionSpeechConnector.connect(uri: uri);
+      _requireGeneration(generation);
+      messages = StreamIterator<dynamic>(connection.socket);
+      final ready = await _nextPracticeSpeechMessage(messages);
+      _requirePracticeSpeechEvent(ready, 'stream.ready');
+      while (true) {
+        final message = await _nextPracticeSpeechMessage(messages);
+        if (message is String) {
+          _requirePracticeSpeechEvent(message, 'stream.completed');
+          if (receivedBytes == 0) {
+            throw const PracticeClientException(
+              kind: PracticeClientFailureKind.invalidResponse,
+            );
+          }
+          break;
+        }
+        if (message is! List<int> || message.isEmpty || message.length.isOdd) {
+          throw const PracticeClientException(
+            kind: PracticeClientFailureKind.invalidResponse,
+          );
+        }
+        receivedBytes += message.length;
+        if (receivedBytes > _maximumAudioBytes) {
+          throw const PracticeClientException(
+            kind: PracticeClientFailureKind.invalidResponse,
+          );
+        }
+        yield Uint8List.fromList(message);
+      }
+    } on AuthenticatedWebSocketException catch (error) {
+      throw PracticeClientException(
+        kind: error.invalidatesAuthentication
+            ? PracticeClientFailureKind.authenticationRequired
+            : PracticeClientFailureKind.network,
+        retryable: !error.invalidatesAuthentication,
+      );
+    } on FormatException {
+      throw const PracticeClientException(
+        kind: PracticeClientFailureKind.invalidResponse,
+      );
+    } finally {
+      await messages?.cancel();
+      await connection?.socket.close();
+    }
   }
 
   @override
@@ -700,6 +777,56 @@ PracticeClientException _invalidResponse() {
     kind: PracticeClientFailureKind.invalidResponse,
     retryable: true,
   );
+}
+
+Future<dynamic> _nextPracticeSpeechMessage(
+  StreamIterator<dynamic> messages,
+) async {
+  if (!await messages.moveNext()) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.network,
+      retryable: true,
+    );
+  }
+  return messages.current;
+}
+
+void _requirePracticeSpeechEvent(dynamic message, String expected) {
+  if (message is! String) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.invalidResponse,
+    );
+  }
+  final decoded = jsonDecode(message);
+  if (decoded is! Map<String, dynamic> || decoded['type'] != expected) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.invalidResponse,
+    );
+  }
+  final data = decoded['data'];
+  if (data is! Map<String, dynamic>) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.invalidResponse,
+    );
+  }
+  if (expected == 'stream.ready' &&
+      (data['content_type'] != 'audio/pcm' ||
+          data['sample_rate'] != 24000 ||
+          data['channel_count'] != 1 ||
+          data['bits_per_sample'] != 16)) {
+    throw const PracticeClientException(
+      kind: PracticeClientFailureKind.invalidResponse,
+    );
+  }
+}
+
+Uri _practiceWebSocketBaseUri(Uri httpBaseUri) {
+  final scheme = switch (httpBaseUri.scheme) {
+    'https' => 'wss',
+    'http' => 'ws',
+    _ => throw ArgumentError('Practice media base URI must use HTTP or HTTPS.'),
+  };
+  return httpBaseUri.replace(scheme: scheme);
 }
 
 DateTime _utcNow() => DateTime.now().toUtc();

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -342,6 +342,12 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return;
     }
     _autoHandledQuestionId = question.id;
+    if (widget.practiceController.supportsRealtimeQuestionSpeech) {
+      // The shared Practice controller starts cloud PCM as soon as the new
+      // question is presented. Do not replace it with the avatar's slower
+      // complete-WAV path or the two players would race each other.
+      return;
+    }
     await _speakQuestion(question);
   }
 
@@ -563,6 +569,10 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       await _interruptForUserTurn();
       return;
     }
+    if (widget.practiceController.supportsRealtimeQuestionSpeech) {
+      await widget.practiceController.toggleQuestionAudio();
+      return;
+    }
     final question = widget.practiceController.currentQuestion;
     if (question != null) {
       await _speakQuestion(question, replay: true);
@@ -619,12 +629,14 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
             : SizedBox.expand(key: widget.surfaceKey),
         statusLabel: _avatarStatusLabel,
         interruptForUserTurn: _interruptForUserTurn,
-        onReplayQuestion:
-            widget.practiceController.currentQuestion?.speechPath == null
+        onReplayQuestion: !widget.practiceController.canPlayQuestionAudio
             ? null
             : _replayQuestion,
-        replayLoading: _replayLoading,
-        replayPlaying: _isAvatarSpeaking,
+        replayLoading:
+            _replayLoading || widget.practiceController.isQuestionAudioLoading,
+        replayPlaying:
+            _isAvatarSpeaking ||
+            widget.practiceController.isQuestionAudioPlaying,
       ),
     );
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -326,6 +326,10 @@ ProductionAppDependencies createProductionAppDependencies({
     recorder: practiceRecorder ?? IosPracticeRecorder(),
     mediaClient: resolvedPracticeMediaClient,
     audioPlayer: resolvedPracticeAudioPlayer,
+    questionSpeechPlayer:
+        resolvedPracticeMediaClient is PracticeQuestionSpeechClient
+        ? MethodChannelPracticePCMStreamPlayer()
+        : null,
   );
   final reviewHistoryController = ReviewHistoryController(
     client: WireReviewHistoryClient(

--- a/mobile/test/coaching/practice/formal_practice_activation_test.dart
+++ b/mobile/test/coaching/practice/formal_practice_activation_test.dart
@@ -1,16 +1,79 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_media.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 
 import '../../support/practice_fixtures.dart';
 import '../../support/scene_fixtures.dart';
 
 void main() {
+  testWidgets(
+    'automatically streams each daily business and interview question',
+    (tester) async {
+      for (final scenario in <(PracticeExperience, SceneCategory)>[
+        (PracticeExperience.lifeAndTravel, SceneCategory.lifeDaily),
+        (PracticeExperience.workplace, SceneCategory.workplaceGeneral),
+        (PracticeExperience.interview, SceneCategory.interviewProfessional),
+      ]) {
+        final scene = testScene(
+          id: 'auto-${scenario.$1.name}',
+          experience: scenario.$1,
+          category: scenario.$2,
+        );
+        final snapshot = PracticeSessionSnapshot(
+          sessionId: 'session-${scenario.$1.name}',
+          planId: 'plan-${scenario.$1.name}',
+          practiceExperience: scenario.$1,
+          sceneCategory: scenario.$2,
+          practiceMode: PracticeMode.fullSimulation,
+          capabilities: testPracticeCapabilities,
+          sessionVersion: 1,
+          completedTurns: 0,
+          turnLimit: scenario.$1 == PracticeExperience.interview ? 0 : 3,
+          completionMode: scenario.$1 == PracticeExperience.interview
+              ? PracticeCompletionMode.userControlled
+              : PracticeCompletionMode.turnLimited,
+          sessionCompleted: false,
+          currentQuestion: PracticeQuestion(
+            id: 'question-${scenario.$1.name}',
+            sessionId: 'session-${scenario.$1.name}',
+            text: 'Please answer this question.',
+          ),
+        );
+        final media = _RealtimeQuestionMediaClient();
+        final streamPlayer = _PCMStreamPlayer();
+        final controller = PracticeController(
+          client: _ActivationPracticeClient(snapshot: snapshot),
+          mediaClient: media,
+          audioPlayer: _SilentPracticeAudioPlayer(),
+          questionSpeechPlayer: streamPlayer,
+        );
+
+        await controller.activateCreatedPractice(
+          scene: scene,
+          sessionId: snapshot.sessionId,
+          planId: snapshot.planId,
+          practiceMode: snapshot.practiceMode,
+          turnLimit: snapshot.turnLimit,
+          clientOperationId: 'activate-${scenario.$1.name}',
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(media.questionIds, <String>['question-${scenario.$1.name}']);
+        expect(streamPlayer.events, <String>['start', 'append:4', 'finish']);
+        controller.dispose();
+      }
+    },
+  );
+
   test(
     'activates only the exact formal Session with the frozen turn limit',
     () async {
@@ -399,3 +462,73 @@ final _scene = testScene(
     turnBlueprints: <String>['Ask one technical interview question.'],
   ),
 );
+
+final class _RealtimeQuestionMediaClient
+    implements PracticeMediaClient, PracticeQuestionSpeechClient {
+  final List<String> questionIds = <String>[];
+
+  @override
+  Stream<Uint8List> streamQuestionSpeech(String questionId) async* {
+    questionIds.add(questionId);
+    yield Uint8List.fromList(<int>[1, 2, 3, 4]);
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) =>
+      throw UnimplementedError();
+}
+
+final class _PCMStreamPlayer implements PracticePCMStreamPlayer {
+  final List<String> events = <String>[];
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) async {
+    events.add('append:${bytes.length}');
+  }
+
+  @override
+  Future<void> disposePCMStream() async {}
+
+  @override
+  Future<void> finishPCMStream() async {
+    events.add('finish');
+  }
+
+  @override
+  Future<void> startPCMStream() async {
+    events.add('start');
+  }
+
+  @override
+  Future<void> stopPCMStream() async {}
+}
+
+final class _SilentPracticeAudioPlayer implements PracticeAudioPlayer {
+  @override
+  Stream<void> get onComplete => const Stream<void>.empty();
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {}
+
+  @override
+  Future<void> stop() async {}
+}

--- a/mobile/test/coaching/practice/practice_media_test.dart
+++ b/mobile/test/coaching/practice/practice_media_test.dart
@@ -39,6 +39,83 @@ void main() {
   });
 
   test(
+    'question realtime TTS yields the first PCM chunk before completion',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final releaseCompletion = Completer<void>();
+      final handled = Completer<void>();
+      server.listen((request) async {
+        expect(
+          request.uri.path,
+          '/v1/voice-questions/question-1/speech/realtime',
+        );
+        expect(
+          request.headers.value(HttpHeaders.authorizationHeader),
+          'Bearer sess_practice-media',
+        );
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (protocols) {
+            expect(protocols, contains('speakup.practice-question-speech.v1'));
+            return 'speakup.practice-question-speech.v1';
+          },
+        );
+        socket.add(
+          jsonEncode(const <String, Object>{
+            'type': 'stream.ready',
+            'data': <String, Object>{
+              'content_type': 'audio/pcm',
+              'sample_rate': 24000,
+              'channel_count': 1,
+              'bits_per_sample': 16,
+            },
+          }),
+        );
+        socket.add(Uint8List.fromList(<int>[1, 2, 3, 4]));
+        await releaseCompletion.future;
+        socket.add(
+          jsonEncode(const <String, Object>{
+            'type': 'stream.completed',
+            'data': <String, Object>{},
+          }),
+        );
+        await socket.close();
+        handled.complete();
+      });
+      final client = WirePracticeMediaClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => const AuthSessionCredential(
+          sessionToken: 'sess_practice-media',
+          generation: 1,
+        ),
+        invalidateSession:
+            ({
+              required expectedSessionToken,
+              required expectedGeneration,
+            }) async {},
+        apiTransport: _Transport(const <_Response>[]),
+        signedAudioTransport: _Transport(const <_Response>[]),
+      );
+      addTearDown(client.dispose);
+      final stream = StreamIterator<Uint8List>(
+        client.streamQuestionSpeech('question-1'),
+      );
+      addTearDown(stream.cancel);
+
+      expect(
+        await stream.moveNext().timeout(const Duration(seconds: 2)),
+        isTrue,
+      );
+      expect(stream.current, <int>[1, 2, 3, 4]);
+      expect(releaseCompletion.isCompleted, isFalse);
+      releaseCompletion.complete();
+      expect(await stream.moveNext(), isFalse);
+      await handled.future;
+    },
+  );
+
+  test(
     'recording metadata is protected but signed WAV fetch has no Bearer',
     () async {
       final signedUri = Uri.parse(

--- a/mobile/test/coaching/practice/practice_media_test.dart
+++ b/mobile/test/coaching/practice/practice_media_test.dart
@@ -115,6 +115,70 @@ void main() {
     },
   );
 
+  test('question realtime TTS preserves retryable synthesis failure', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    final handled = Completer<void>();
+    server.listen((request) async {
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (_) => 'speakup.practice-question-speech.v1',
+      );
+      socket.add(
+        jsonEncode(const <String, Object>{
+          'type': 'stream.ready',
+          'data': <String, Object>{
+            'content_type': 'audio/pcm',
+            'sample_rate': 24000,
+            'channel_count': 1,
+            'bits_per_sample': 16,
+          },
+        }),
+      );
+      socket.add(
+        jsonEncode(const <String, Object>{
+          'type': 'stream.failed',
+          'data': <String, Object>{
+            'kind': 'synthesis_failed',
+            'retryable': true,
+          },
+        }),
+      );
+      await socket.close();
+      handled.complete();
+    });
+    final client = WirePracticeMediaClient(
+      baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+      credentialProvider: () => const AuthSessionCredential(
+        sessionToken: 'sess_practice-media',
+        generation: 1,
+      ),
+      invalidateSession:
+          ({
+            required expectedSessionToken,
+            required expectedGeneration,
+          }) async {},
+      apiTransport: _Transport(const <_Response>[]),
+      signedAudioTransport: _Transport(const <_Response>[]),
+    );
+    addTearDown(client.dispose);
+
+    await expectLater(
+      client.streamQuestionSpeech('question-1'),
+      emitsError(
+        isA<PracticeClientException>()
+            .having(
+              (error) => error.kind,
+              'kind',
+              PracticeClientFailureKind.network,
+            )
+            .having((error) => error.errorCode, 'errorCode', 'synthesis_failed')
+            .having((error) => error.retryable, 'retryable', isTrue),
+      ),
+    );
+    await handled.future;
+  });
+
   test(
     'recording metadata is protected but signed WAV fetch has no Bearer',
     () async {

--- a/server/internal/bootstrap/agent_data.go
+++ b/server/internal/bootstrap/agent_data.go
@@ -535,6 +535,7 @@ func buildIdentityAgentComposition(
 				RecordedReadTimeout: voiceConfigurations[0].RecordedAudioReadTimeout,
 				SameQuestionRetry:   sameQuestionRetry,
 				AudioAssets:         audioAssets,
+				RealtimeSpeech:      voiceConfigurations[0].AssistantSpeech,
 			},
 			errorRenderer,
 		)

--- a/server/internal/coaching/practice/voice/http/handler.go
+++ b/server/internal/coaching/practice/voice/http/handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
@@ -76,17 +77,23 @@ type Application interface {
 	) (practicevoice.QuestionTipResult, error)
 }
 
+type questionTextApplication interface {
+	QuestionText(context.Context, requestcontext.Actor, string) (string, error)
+}
+
 type Options struct {
 	RealtimeReadTimeout time.Duration
 	RecordedReadTimeout time.Duration
 	SameQuestionRetry   *practicevoice.SameQuestionRetryApplication
 	AudioAssets         AudioAssetHTTPService
+	RealtimeSpeech      agentconversation.AssistantSpeechSynthesizer
 }
 
 type Handler struct {
 	application         Application
 	retry               *practicevoice.SameQuestionRetryApplication
 	audioAssets         AudioAssetHTTPService
+	realtimeSpeech      agentconversation.AssistantSpeechSynthesizer
 	realtimeReadTimeout time.Duration
 	recordedReadTimeout time.Duration
 	errors              *httpresponse.Renderer
@@ -114,6 +121,7 @@ func NewHandler(
 		application:         application,
 		retry:               options.SameQuestionRetry,
 		audioAssets:         options.AudioAssets,
+		realtimeSpeech:      options.RealtimeSpeech,
 		realtimeReadTimeout: options.RealtimeReadTimeout,
 		recordedReadTimeout: options.RecordedReadTimeout,
 		errors:              errorRenderer,
@@ -150,6 +158,12 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 		handler.confirmCandidate,
 	)
 	routes.GET("/v1/voice-questions/:question_id/speech", handler.questionSpeech)
+	if handler.realtimeSpeech != nil {
+		routes.GET(
+			"/v1/voice-questions/:question_id/speech/realtime",
+			handler.questionSpeechRealtime,
+		)
+	}
 	routes.GET(
 		"/v1/voice-questions/:question_id/translation",
 		handler.questionTranslation,

--- a/server/internal/coaching/practice/voice/http/realtime_speech.go
+++ b/server/internal/coaching/practice/voice/http/realtime_speech.go
@@ -1,0 +1,111 @@
+package voicehttp
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+const practiceQuestionSpeechWebSocketProtocol = "speakup.practice-question-speech.v1"
+
+func (handler *Handler) questionSpeechRealtime(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	textApplication, ok := handler.application.(questionTextApplication)
+	if !ok {
+		handler.write(c, providerUnavailable(nil))
+		return
+	}
+	text, err := textApplication.QuestionText(
+		c.Request.Context(), actor, c.Param("question_id"),
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	if !containsWebSocketProtocol(
+		websocket.Subprotocols(c.Request),
+		practiceQuestionSpeechWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := (&websocket.Upgrader{
+		Subprotocols: []string{practiceQuestionSpeechWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	if err := connection.WriteJSON(gin.H{
+		"type": "stream.ready",
+		"data": gin.H{
+			"content_type":    agentconversation.AssistantSpeechContentTypePCM,
+			"sample_rate":     agentconversation.AssistantSpeechSampleRate,
+			"channel_count":   agentconversation.AssistantSpeechChannelCount,
+			"bits_per_sample": agentconversation.AssistantSpeechBitsPerSample,
+		},
+	}); err != nil {
+		return
+	}
+
+	streamContext, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+	var firstAudio sync.Once
+	chunks, bytes := 0, 0
+	speech, err := handler.realtimeSpeech.OpenAssistantSpeech(
+		streamContext,
+		func(audio []byte) error {
+			firstAudio.Do(func() {
+				slog.InfoContext(streamContext, "practice.question_speech.first_audio")
+			})
+			chunks++
+			bytes += len(audio)
+			return connection.WriteMessage(websocket.BinaryMessage, audio)
+		},
+	)
+	if err != nil {
+		writePracticeSpeechFailure(connection, true)
+		return
+	}
+	defer speech.Close()
+	if err := speech.AppendText(text); err != nil {
+		writePracticeSpeechFailure(connection, true)
+		return
+	}
+	if err := speech.Finish(); err != nil || chunks == 0 {
+		writePracticeSpeechFailure(connection, true)
+		return
+	}
+	slog.InfoContext(
+		streamContext,
+		"practice.question_speech.completed",
+		slog.Int("audio_chunks", chunks),
+		slog.Int("audio_bytes", bytes),
+	)
+	_ = connection.WriteJSON(gin.H{"type": "stream.completed", "data": gin.H{}})
+}
+
+func writePracticeSpeechFailure(connection *websocket.Conn, retryable bool) {
+	_ = connection.WriteJSON(gin.H{
+		"type": "stream.failed",
+		"data": gin.H{"kind": "synthesis_failed", "retryable": retryable},
+	})
+}
+
+func containsWebSocketProtocol(protocols []string, required string) bool {
+	for _, protocol := range protocols {
+		if protocol == required {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/coaching/practice/voice/http/realtime_test.go
+++ b/server/internal/coaching/practice/voice/http/realtime_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	practicevoice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/voice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
@@ -200,6 +201,54 @@ func TestPracticeRealtimeVoiceInputRejectsUnauthorizedOrNonCurrentQuestion(
 	}
 }
 
+func TestPracticeQuestionSpeechStreamsTrustedQuestionPCM(t *testing.T) {
+	application := &practiceRealtimeHTTPApplication{
+		questionText: "Could you introduce yourself?",
+	}
+	synthesizer := &practiceQuestionSpeechSynthesizer{}
+	server := httptest.NewServer(
+		newPracticeRealtimeHTTPRouterWithOptions(
+			t,
+			application,
+			Options{RealtimeSpeech: synthesizer},
+		),
+	)
+	defer server.Close()
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/voice-questions/question-1/speech/realtime"
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{practiceQuestionSpeechWebSocketProtocol},
+	}).Dial(
+		endpoint,
+		http.Header{"Authorization": []string{"Bearer voice-token-a"}},
+	)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial realtime question speech: %v", err)
+	}
+	defer connection.Close()
+	_, ready, err := connection.ReadMessage()
+	if err != nil || !strings.Contains(string(ready), `"type":"stream.ready"`) {
+		t.Fatalf("ready = %q, err = %v", ready, err)
+	}
+	messageType, audio, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.BinaryMessage ||
+		string(audio) != "\x01\x02\x03\x04" {
+		t.Fatalf("audio = (%d, %v), err = %v", messageType, audio, err)
+	}
+	_, completed, err := connection.ReadMessage()
+	if err != nil || !strings.Contains(string(completed), `"type":"stream.completed"`) {
+		t.Fatalf("completed = %q, err = %v", completed, err)
+	}
+	if application.questionID != "question-1" ||
+		application.questionActor != "user-a" ||
+		synthesizer.text != application.questionText {
+		t.Fatalf("application = %#v, speech text = %q", application, synthesizer.text)
+	}
+}
+
 func TestPracticeRealtimeFailureUsesStableSafeCategory(t *testing.T) {
 	providerFailure := practicevoice.NewProviderError(
 		practicevoice.ProviderOperationTranscription,
@@ -243,10 +292,18 @@ func newPracticeRealtimeHTTPRouter(
 	t *testing.T,
 	application Application,
 ) http.Handler {
+	return newPracticeRealtimeHTTPRouterWithOptions(t, application, Options{})
+}
+
+func newPracticeRealtimeHTTPRouterWithOptions(
+	t *testing.T,
+	application Application,
+	options Options,
+) http.Handler {
 	t.Helper()
 	handler, err := NewHandler(
 		application,
-		Options{},
+		options,
 		httpresponse.NewRenderer(
 			func() string { return "corr_practice_voice_realtime" },
 		),
@@ -279,6 +336,22 @@ type practiceRealtimeHTTPApplication struct {
 	streamKey        string
 	streamBytes      int
 	streamSampleRate int
+	questionText     string
+	questionID       string
+	questionActor    string
+}
+
+func (application *practiceRealtimeHTTPApplication) QuestionText(
+	_ context.Context,
+	actor requestcontext.Actor,
+	questionID string,
+) (string, error) {
+	if actor.UserID != "user-a" || questionID != "question-1" {
+		return "", practicevoice.ErrNotFound
+	}
+	application.questionID = questionID
+	application.questionActor = actor.UserID
+	return application.questionText, nil
 }
 
 func (application *practiceRealtimeHTTPApplication) Start(
@@ -389,3 +462,31 @@ func (application *practiceRealtimeHTTPApplication) EnsureQuestionTip(
 }
 
 var _ Application = (*practiceRealtimeHTTPApplication)(nil)
+
+type practiceQuestionSpeechSynthesizer struct {
+	text string
+}
+
+func (synthesizer *practiceQuestionSpeechSynthesizer) OpenAssistantSpeech(
+	_ context.Context,
+	onAudio func([]byte) error,
+) (agentconversation.AssistantSpeechSession, error) {
+	return &practiceQuestionSpeechSession{
+		synthesizer: synthesizer,
+		onAudio:     onAudio,
+	}, nil
+}
+
+type practiceQuestionSpeechSession struct {
+	synthesizer *practiceQuestionSpeechSynthesizer
+	onAudio     func([]byte) error
+}
+
+func (session *practiceQuestionSpeechSession) AppendText(text string) error {
+	session.synthesizer.text = text
+	return session.onAudio([]byte{1, 2, 3, 4})
+}
+
+func (*practiceQuestionSpeechSession) Finish() error { return nil }
+
+func (*practiceQuestionSpeechSession) Close() error { return nil }

--- a/server/internal/coaching/practice/voice/session_application.go
+++ b/server/internal/coaching/practice/voice/session_application.go
@@ -364,6 +364,25 @@ func (application *SessionApplication) QuestionSpeech(
 	return application.orchestrator.SynthesizeQuestion(ctx, question.Content)
 }
 
+func (application *SessionApplication) QuestionText(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	questionID string,
+) (string, error) {
+	if err := validateVoiceActor(ctx, actor); err != nil ||
+		strings.TrimSpace(questionID) == "" {
+		return "", ErrInvalidRequest
+	}
+	question, err := application.questions.GetQuestion(ctx, actor, questionID)
+	if err != nil {
+		return "", err
+	}
+	if question.ID != questionID || strings.TrimSpace(question.Content) == "" {
+		return "", ErrInvalidContext
+	}
+	return strings.TrimSpace(question.Content), nil
+}
+
 func (application *SessionApplication) state(
 	ctx context.Context,
 	actor requestcontext.Actor,


### PR DESCRIPTION
## 功能描述

- 日常、商务、面试新问题出现后自动播放千问实时 TTS
- 通过认证 WebSocket 下发 24kHz 单声道 PCM，首个音频块到达即开始播放
- 朗读按钮、录音开始、切题、退出和账号切换共享同一播放中断状态
- 数字人场景不再用完整 WAV 慢链路抢占实时播放
- 新增正式 OpenAPI/WebSocket 事件契约

## 实现思路

服务端先按 Actor 校验并读取持久化 Question，再把可信文本交给现有千问实时 TTS。Flutter 端使用认证 WebSocket 接收 PCM，并复用原生流式播放器；自动播放统一放在 PracticeController，明确排除 IELTS，避免改变雅思现有行为。

## 验证

- `cd server && go test ./...`
- `cd server && go vet ./...`
- `cd mobile && dart format --output=none --set-exit-if-changed lib test`
- `cd mobile && flutter analyze --no-pub`
- `cd mobile && flutter test`
- `cd api && npm run check`
- iOS Simulator 构建与本地后端联调

Closes #674