### PR TITLE
fix(mobile): 优化 Agent 输入栏外侧边界阴影

### DIFF
--- a/mobile/lib/design/voice_composer_dock.dart
+++ b/mobile/lib/design/voice_composer_dock.dart
@@ -196,11 +196,15 @@ class ConversationComposerCapsule extends StatelessWidget {
       constraints: BoxConstraints(minHeight: minHeight),
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
       decoration: BoxDecoration(
-        color: SpeakUpDesign.primaryMuted.withValues(alpha: 0.9),
+        color: SpeakUpDesign.surface,
         borderRadius: BorderRadius.circular(999),
-        border: Border.all(
-          color: SpeakUpDesign.surface.withValues(alpha: 0.72),
-        ),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x14000000),
+            blurRadius: 18,
+            offset: Offset(0, 4),
+          ),
+        ],
       ),
       child: child,
     );

--- a/mobile/test/design/voice_composer_dock_test.dart
+++ b/mobile/test/design/voice_composer_dock_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/voice_composer_dock.dart';
+
+void main() {
+  testWidgets('composer capsule uses a white surface with an outer shadow', (
+    tester,
+  ) async {
+    const capsuleKey = Key('composer-capsule');
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ConversationComposerCapsule(
+            key: capsuleKey,
+            child: SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+
+    final capsule = tester.widget<AnimatedContainer>(
+      find.descendant(
+        of: find.byKey(capsuleKey),
+        matching: find.byType(AnimatedContainer),
+      ),
+    );
+    final decoration = capsule.decoration! as BoxDecoration;
+
+    expect(decoration.color, SpeakUpDesign.surface);
+    expect(decoration.border, isNull);
+    expect(decoration.boxShadow, hasLength(1));
+    expect(decoration.boxShadow!.single.color, const Color(0x14000000));
+    expect(decoration.boxShadow!.single.blurRadius, 18);
+    expect(decoration.boxShadow!.single.offset, const Offset(0, 4));
+  });
+}


### PR DESCRIPTION
## 功能描述

- 将 Agent 底部输入胶囊从半透明灰色内填充改为纯白表面
- 使用胶囊外侧的轻量灰色阴影建立边界
- 保持现有圆角、布局、文案、图标和输入交互不变

## 实现思路

- 复用现有 `ConversationComposerCapsule` 与 `SpeakUpDesign.surface`
- 移除原有内部灰色填充与白色边框
- 添加单层低对比度 `BoxShadow`
- 新增组件测试，锁定白底、无边框和外阴影属性

## 可复现测试

```bash
cd mobile
flutter test test/design/voice_composer_dock_test.dart \
  test/coaching/preparation/wire_job_preparation_client_test.dart \
  test/coaching/interview/interview_catalog_test.dart
flutter test test/speak_up_app_test.dart
flutter analyze lib/design/voice_composer_dock.dart \
  test/design/voice_composer_dock_test.dart
```

结果：

- 组件与相关契约测试：37 项通过
- 应用级测试：33 项通过
- 静态分析：通过

## 视觉验证

- 设备：`XE3 iPhone 16 Pro 26.5 QA`（iOS 26.5）
- 后端：真实本地后端，端口 `18082`
- 数字人：禁用
- 已确认语音态与键盘输入态均为纯白表面，边界由外侧柔和阴影呈现，输入框内部无灰色填充
- 视觉效果已由需求提出者确认可接受

Closes #677
