### PR TITLE
fix(agent): 恢复首页语音消息原声与逐条反馈

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_message_image_client.dart';
@@ -245,9 +244,6 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     final previewVoiceClient = widget.allowFakePreview
         ? FakeAgentVoiceClient()
         : null;
-    final previewVoiceInputClient = widget.allowFakePreview
-        ? FakeAgentVoiceInputClient()
-        : null;
     final injectedController = widget.conversationController;
     if (injectedController == null && !widget.allowFakePreview) {
       throw StateError(
@@ -287,7 +283,8 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
         injectedComposerController ??
         ComposerController(
           conversationController: _conversationController,
-          voiceInputClient: previewVoiceInputClient,
+          voiceClient: previewVoiceClient,
+          onAssistantCommitted: _messageAudioController?.playCommittedAssistant,
         );
     final injectedPracticeController = widget.practiceController;
     if (injectedPracticeController == null && !widget.allowFakePreview) {

--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -377,6 +377,7 @@ class _AgentComposerState extends State<AgentComposer> {
         starting ||
         recording ||
         (widget.onStartVoice != null &&
+            widget.pendingImages.isEmpty &&
             widget.voiceEnabled &&
             widget.enabled &&
             !widget.isBusy);

--- a/mobile/lib/features/agent/composer/agent_composer.dart
+++ b/mobile/lib/features/agent/composer/agent_composer.dart
@@ -9,7 +9,8 @@ import 'package:speakup/design/voice_composer_dock.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
 import 'package:speakup/features/agent/composer/pending_image_strip.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_composer.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 
 typedef AgentComposerAction = FutureOr<void> Function();
 
@@ -42,7 +43,7 @@ class AgentComposer extends StatefulWidget {
   final String? acceptedUserMessageId;
   final String? acceptedUserMessageText;
   final AgentComposerAction? onStartVoice;
-  final AgentVoiceInputController? voiceController;
+  final AgentVoiceController? voiceController;
   final bool voiceEnabled;
   final Future<bool> Function(String)? onSubmitText;
   final bool enabled;
@@ -122,6 +123,10 @@ class _AgentComposerState extends State<AgentComposer> {
 
   void _handleTextChanged() {
     if (!_suppressControllerNotifications) {
+      final voice = widget.voiceController;
+      if (voice?.state == AgentVoiceComposerState.awaitingConfirmation) {
+        voice?.updateTranscript(_controller.text);
+      }
       setState(() {});
     }
   }
@@ -129,6 +134,26 @@ class _AgentComposerState extends State<AgentComposer> {
   void _handleVoiceChanged() {
     if (!mounted) {
       return;
+    }
+    final voice = widget.voiceController;
+    if (voice?.state == AgentVoiceComposerState.awaitingConfirmation &&
+        _controller.text != voice?.editedTranscript) {
+      _suppressControllerNotifications = true;
+      _controller.value = TextEditingValue(
+        text: voice!.editedTranscript,
+        selection: TextSelection.collapsed(
+          offset: voice.editedTranscript.length,
+        ),
+      );
+      _suppressControllerNotifications = false;
+    }
+    if (voice?.state == AgentVoiceComposerState.awaitingConfirmation) {
+      _textMode = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _focusNode.requestFocus();
+        }
+      });
     }
     setState(() {});
   }
@@ -154,7 +179,15 @@ class _AgentComposerState extends State<AgentComposer> {
     if (voice == null) {
       return;
     }
-    await voice.stopRecording();
+    await voice.stopRecordingAndUpload();
+    if (!mounted || !voice.canConfirm) {
+      return;
+    }
+    await voice.confirm();
+    if (!mounted || voice.editedTranscript.isNotEmpty) {
+      return;
+    }
+    _replaceComposerText(_draftBeforeVoice);
   }
 
   Future<void> _convertVoiceToText() async {
@@ -162,12 +195,14 @@ class _AgentComposerState extends State<AgentComposer> {
     if (voice == null) {
       return;
     }
-    await voice.stopRecording();
+    await voice.stopRecordingAndUpload();
   }
 
   Future<void> _cancelVoice() async {
     final voice = widget.voiceController;
-    if (voice == null) {
+    if (voice == null ||
+        voice.state == AgentVoiceComposerState.confirming ||
+        voice.state == AgentVoiceComposerState.awaitingAssistant) {
       return;
     }
     await voice.cancel();
@@ -206,6 +241,31 @@ class _AgentComposerState extends State<AgentComposer> {
   void _showVoiceComposer() {
     _focusNode.unfocus();
     setState(() => _textMode = false);
+  }
+
+  Future<void> _submitConvertedText() async {
+    final voice = widget.voiceController;
+    final text = _controller.text.trim();
+    if (voice == null ||
+        !voice.canConfirm ||
+        text.isEmpty ||
+        _textSubmissionInFlight ||
+        widget.onSubmitText == null) {
+      return;
+    }
+    setState(() => _textSubmissionInFlight = true);
+    try {
+      await voice.cancel();
+      final sent = await widget.onSubmitText!(text);
+      if (mounted && sent) {
+        _controller.clear();
+        setState(() => _textMode = false);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _textSubmissionInFlight = false);
+      }
+    }
   }
 
   Future<void> _submit() async {
@@ -293,17 +353,24 @@ class _AgentComposerState extends State<AgentComposer> {
   @override
   Widget build(BuildContext context) {
     final voice = widget.voiceController;
-    final voiceState = voice?.state ?? AgentVoiceInputState.idle;
-    final starting = voiceState == AgentVoiceInputState.starting;
-    final recording = voiceState == AgentVoiceInputState.recording;
+    final voiceState = voice?.state ?? AgentVoiceComposerState.idle;
+    final starting = voiceState == AgentVoiceComposerState.starting;
+    final recording = voiceState == AgentVoiceComposerState.recording;
+    final confirmingText =
+        voiceState == AgentVoiceComposerState.awaitingConfirmation;
     final voiceProgress =
-        voiceState == AgentVoiceInputState.completing ||
-        voiceState == AgentVoiceInputState.submitting;
-    final voiceFailure = voiceState == AgentVoiceInputState.failed;
+        voiceState == AgentVoiceComposerState.uploading ||
+        voiceState == AgentVoiceComposerState.transcribing ||
+        voiceState == AgentVoiceComposerState.confirming ||
+        voiceState == AgentVoiceComposerState.awaitingAssistant;
+    final voiceSubmissionInFlight =
+        voiceState == AgentVoiceComposerState.confirming ||
+        voiceState == AgentVoiceComposerState.awaitingAssistant;
+    final voiceFailure = voiceState == AgentVoiceComposerState.failed;
     final capturePhase = switch (voiceState) {
-      AgentVoiceInputState.idle => VoiceCapturePhase.idle,
-      AgentVoiceInputState.starting => VoiceCapturePhase.starting,
-      AgentVoiceInputState.recording => VoiceCapturePhase.recording,
+      AgentVoiceComposerState.idle => VoiceCapturePhase.idle,
+      AgentVoiceComposerState.starting => VoiceCapturePhase.starting,
+      AgentVoiceComposerState.recording => VoiceCapturePhase.recording,
       _ => VoiceCapturePhase.busy,
     };
     final voiceCaptureEnabled =
@@ -314,7 +381,12 @@ class _AgentComposerState extends State<AgentComposer> {
             widget.enabled &&
             !widget.isBusy);
     final showTextComposer =
-        _textMode && !starting && !recording && !voiceProgress && !voiceFailure;
+        confirmingText ||
+        (_textMode &&
+            !starting &&
+            !recording &&
+            !voiceProgress &&
+            !voiceFailure);
     final imageUploadPending = widget.pendingImages.any(
       (image) => image.state == AgentPendingImageState.uploading,
     );
@@ -362,10 +434,11 @@ class _AgentComposerState extends State<AgentComposer> {
                     state: voiceState,
                     message: voiceFailure
                         ? voice?.errorMessage ?? '语音识别失败'
-                        : voice?.liveTranscript.trim().isNotEmpty == true
+                        : voiceState == AgentVoiceComposerState.transcribing &&
+                              voice?.liveTranscript.trim().isNotEmpty == true
                         ? voice!.liveTranscript
                         : agentComposerVoiceStateLabel(voiceState),
-                    canCancel: voiceState != AgentVoiceInputState.submitting,
+                    canCancel: !voiceSubmissionInFlight,
                     canRetry: voiceFailure && voice?.canRetry == true,
                     onCancel: _cancelVoice,
                     onRetry: voice?.retry,
@@ -375,16 +448,20 @@ class _AgentComposerState extends State<AgentComposer> {
                     controller: _controller,
                     focusNode: _focusNode,
                     keyboardVisible: widget.keyboardVisible,
-                    enabled: widget.enabled,
+                    enabled: confirmingText || widget.enabled,
+                    confirmingConvertedText: confirmingText,
                     submitting: _textSubmissionInFlight,
+                    canSubmitConvertedText: voice?.canConfirm == true,
                     canSubmitText:
                         widget.onSubmitText != null &&
                         widget.enabled &&
                         !widget.isBusy &&
                         !imageUploadPending &&
                         !imageUploadFailed,
-                    onReturnToVoice: _showVoiceComposer,
-                    onSubmit: _submit,
+                    onReturnToVoice: confirmingText
+                        ? _cancelVoice
+                        : _showVoiceComposer,
+                    onSubmit: confirmingText ? _submitConvertedText : _submit,
                   )
                 : AgentComposerVoiceDock(
                     capture: capture,
@@ -412,7 +489,9 @@ class _AgentTextDock extends StatelessWidget {
     required this.focusNode,
     required this.keyboardVisible,
     required this.enabled,
+    required this.confirmingConvertedText,
     required this.submitting,
+    required this.canSubmitConvertedText,
     required this.canSubmitText,
     required this.onReturnToVoice,
     required this.onSubmit,
@@ -422,7 +501,9 @@ class _AgentTextDock extends StatelessWidget {
   final FocusNode focusNode;
   final bool keyboardVisible;
   final bool enabled;
+  final bool confirmingConvertedText;
   final bool submitting;
+  final bool canSubmitConvertedText;
   final bool canSubmitText;
   final FutureOr<void> Function() onReturnToVoice;
   final FutureOr<void> Function() onSubmit;
@@ -433,16 +514,30 @@ class _AgentTextDock extends StatelessWidget {
       controller: controller,
       focusNode: focusNode,
       enabled: enabled,
-      canSubmit: canSubmitText,
+      canSubmit: confirmingConvertedText
+          ? canSubmitConvertedText
+          : canSubmitText,
       submitting: submitting,
       onReturn: onReturnToVoice,
       onSubmit: onSubmit,
-      returnKey: const Key('agent-show-voice-composer'),
+      returnKey: Key(
+        confirmingConvertedText
+            ? 'agent-voice-cancel'
+            : 'agent-show-voice-composer',
+      ),
       fieldKey: const Key('agent-composer-field'),
-      submitKey: const Key('agent-send-button'),
-      returnTooltip: '切换到语音输入',
-      returnIcon: Icons.mic_none_rounded,
-      hintText: enabled ? '问问 SpeakUp' : '暂时无法开始对话',
+      submitKey: Key(
+        confirmingConvertedText ? 'agent-voice-confirm' : 'agent-send-button',
+      ),
+      returnTooltip: confirmingConvertedText ? '取消转文字' : '切换到语音输入',
+      returnIcon: confirmingConvertedText
+          ? Icons.close_rounded
+          : Icons.mic_none_rounded,
+      hintText: enabled
+          ? confirmingConvertedText
+                ? '编辑识别文字后发送'
+                : '问问 SpeakUp'
+          : '暂时无法开始对话',
       maxLines: keyboardVisible ? 3 : 2,
       inputFormatters: <TextInputFormatter>[_agentContentFormatter],
     );

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -2,9 +2,11 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_recording.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
@@ -21,16 +23,35 @@ final class ComposerController extends ChangeNotifier {
     required this.conversationController,
     this.imageClient,
     this.imagePicker,
-    AgentVoiceInputClient? voiceInputClient,
+    AgentVoiceClient? voiceClient,
     AgentVoiceRecorder? voiceRecorder,
+    AgentAudioPlayer? draftAudioPlayer,
+    this.onAssistantCommitted,
+    this.onAssistantStreamStarted,
+    this.onAssistantStreamDelta,
+    this.onAssistantStreamCompleted,
+    this.onAssistantStreamFailed,
     ComposerClientIdFactory? clientIdFactory,
   }) : _clientIdFactory = clientIdFactory ?? _createSecureComposerId {
-    if (voiceInputClient != null) {
-      _voiceController = AgentVoiceInputController(
-        client: voiceInputClient,
-        recorder: voiceRecorder ?? FakeAgentVoiceStreamingRecorder(),
+    if (voiceClient != null) {
+      if ((voiceRecorder == null) != (draftAudioPlayer == null)) {
+        throw ArgumentError(
+          'Agent voice recorder and audio player must be injected together.',
+        );
+      }
+      _voiceController = AgentVoiceController(
+        client: voiceClient,
+        recorder: voiceRecorder ?? FakeAgentVoiceRecorder(),
+        audioPlayer: draftAudioPlayer ?? FakeAgentAudioPlayer(),
+        onMessagesCommitted: conversationController.commitComposerMessages,
+        onStreamMessageChanged:
+            conversationController.changeComposerStreamMessage,
+        onAssistantCommitted: onAssistantCommitted,
+        onAssistantStreamStarted: onAssistantStreamStarted,
+        onAssistantStreamDelta: onAssistantStreamDelta,
+        onAssistantStreamCompleted: onAssistantStreamCompleted,
+        onAssistantStreamFailed: onAssistantStreamFailed,
         idFactory: _newId,
-        submitTranscript: sendText,
       )..addListener(_relayVoiceState);
     }
     conversationController.addListener(_syncConversationState);
@@ -40,9 +61,14 @@ final class ComposerController extends ChangeNotifier {
   final ConversationController conversationController;
   final AgentImageClient? imageClient;
   final AgentImagePicker? imagePicker;
+  final AgentVoiceAssistantCommitted? onAssistantCommitted;
+  final AgentVoiceAssistantStreamStarted? onAssistantStreamStarted;
+  final AgentVoiceAssistantStreamDelta? onAssistantStreamDelta;
+  final AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted;
+  final AgentVoiceAssistantStreamFailed? onAssistantStreamFailed;
   final ComposerClientIdFactory _clientIdFactory;
 
-  AgentVoiceInputController? _voiceController;
+  AgentVoiceController? _voiceController;
   List<AgentPendingImage> _pendingImages = const <AgentPendingImage>[];
   String? _imageErrorMessage;
   bool _imageSelectionInFlight = false;
@@ -53,7 +79,7 @@ final class ComposerController extends ChangeNotifier {
   bool _departureInFlight = false;
   String? _boundThreadId;
 
-  AgentVoiceInputController? get voiceController => _voiceController;
+  AgentVoiceController? get voiceController => _voiceController;
   bool get supportsAgentVoice => _voiceController != null;
   bool get supportsAgentImages => imageClient != null && imagePicker != null;
   List<AgentPendingImage> get pendingImages =>
@@ -119,7 +145,7 @@ final class ComposerController extends ChangeNotifier {
   }
 
   Future<void> _startAgentVoiceRecording(
-    AgentVoiceInputController voice,
+    AgentVoiceController voice,
     int generation,
   ) async {
     await conversationController.initialize();
@@ -410,8 +436,14 @@ final class ComposerController extends ChangeNotifier {
       if (voice == null) {
         return true;
       }
-      if (voice.state != AgentVoiceInputState.idle) {
-        await voice.cancel();
+      switch (voice.state) {
+        case AgentVoiceComposerState.confirming ||
+            AgentVoiceComposerState.awaitingAssistant:
+          return false;
+        case AgentVoiceComposerState.idle:
+          break;
+        default:
+          await voice.cancel();
       }
       return !_disposed && !voice.hasActiveWorkflow;
     } finally {
@@ -433,7 +465,7 @@ final class ComposerController extends ChangeNotifier {
       notifyListeners();
     }
     await Future.wait([
-      if (_voiceController case final AgentVoiceInputController voice)
+      if (_voiceController case final AgentVoiceController voice)
         voice.clearPrivateState(),
       for (final asset in stagedAssets)
         imageClient?.deleteImage(imageAssetId: asset.id).catchError((_) {}) ??
@@ -454,7 +486,7 @@ final class ComposerController extends ChangeNotifier {
 
   bool _isCurrent(int generation) => !_disposed && generation == _generation;
 
-  bool _isVoiceStartCurrent(AgentVoiceInputController voice, int generation) =>
+  bool _isVoiceStartCurrent(AgentVoiceController voice, int generation) =>
       !_disposed &&
       !_departureInFlight &&
       generation == _voiceStartGeneration &&

--- a/mobile/lib/features/agent/composer/composer_controller.dart
+++ b/mobile/lib/features/agent/composer/composer_controller.dart
@@ -128,6 +128,7 @@ final class ComposerController extends ChangeNotifier {
     final voice = _voiceController;
     if (voice == null ||
         _disposed ||
+        _pendingImages.isNotEmpty ||
         voice.hasActiveWorkflow ||
         _departureInFlight ||
         _voiceStartFuture != null) {

--- a/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_composer.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 import 'package:speakup/design/voice_composer_dock.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 
 class AgentComposerVoiceDock extends StatelessWidget {
   const AgentComposerVoiceDock({
@@ -46,9 +46,6 @@ class AgentComposerVoiceDock extends StatelessWidget {
       onShowText: onShowText,
       liveTranscript: liveTranscript,
       liveTranscriptKey: const Key('agent-voice-live-transcript'),
-      tapRecordingLabel: '点击转文字 · 上滑取消',
-      holdRecordingLabel: '上滑取消 · 松开转文字',
-      capturingSemanticsLabel: '停止录音并转文字',
       leading: IconButton(
         key: const Key('agent-image-picker-button'),
         tooltip: '添加图片',
@@ -73,7 +70,7 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
     super.key,
   });
 
-  final AgentVoiceInputState state;
+  final AgentVoiceComposerState state;
   final String message;
   final bool canCancel;
   final bool canRetry;
@@ -82,7 +79,7 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final failed = state == AgentVoiceInputState.failed;
+    final failed = state == AgentVoiceComposerState.failed;
     if (!failed) {
       return SizedBox(
         height: 48,
@@ -171,11 +168,13 @@ class AgentComposerVoiceStatusDock extends StatelessWidget {
   }
 }
 
-String agentComposerVoiceStateLabel(AgentVoiceInputState state) {
+String agentComposerVoiceStateLabel(AgentVoiceComposerState state) {
   return switch (state) {
-    AgentVoiceInputState.starting => '正在打开麦克风…',
-    AgentVoiceInputState.completing => '正在整理识别文字…',
-    AgentVoiceInputState.submitting => '正在发送…',
+    AgentVoiceComposerState.starting => '正在打开麦克风…',
+    AgentVoiceComposerState.uploading => '正在处理语音…',
+    AgentVoiceComposerState.transcribing => '正在转写…',
+    AgentVoiceComposerState.confirming => '已识别，SpeakUp 正在回复…',
+    AgentVoiceComposerState.awaitingAssistant => 'SpeakUp 正在回复…',
     _ => '正在处理…',
   };
 }

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -10,7 +10,8 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/agent/composer/agent_composer.dart';
 import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
 import 'package:speakup/features/agent/composer/pending_image_strip.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
@@ -106,7 +107,7 @@ class ConversationPage extends StatefulWidget {
   final Future<bool> Function(String)? onSubmitText;
   final VoidCallback? onRetryOperation;
   final VoidCallback? onLoadEarlierMessages;
-  final AgentVoiceInputController? voiceController;
+  final AgentVoiceController? voiceController;
   final AgentMessageAudioController? messageAudioController;
   final ConversationMessageTranslator? onTranslateMessage;
   final List<AgentPendingImage> pendingImages;
@@ -141,7 +142,12 @@ class ConversationPage extends StatefulWidget {
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
     final canCompose = hasFocusedThread || onCreateConversation != null;
-    final replyPending = isBusy;
+    final voiceShowsReplyProgress = switch (voiceController?.state) {
+      AgentVoiceComposerState.confirming ||
+      AgentVoiceComposerState.awaitingAssistant => true,
+      _ => false,
+    };
+    final replyPending = isBusy || voiceShowsReplyProgress;
     const topContentInset = 65.0;
     const topOverlayExtent = 76.0;
     final bottomOverlayExtent = composerBottom + composerHeight + 16;
@@ -279,7 +285,7 @@ class ConversationPage extends StatefulWidget {
                                   : null,
                             ),
                           ],
-                          if (isBusy) ...[
+                          if (isBusy && !voiceShowsReplyProgress) ...[
                             const SizedBox(height: 14),
                             Center(
                               child: Semantics(
@@ -587,7 +593,14 @@ class _ConversationPageState extends State<ConversationPage> {
       if (!mounted) {
         return;
       }
+      final keepLatestVisible = _isNearLatest();
+      final voiceState = widget.voiceController?.state;
       setState(() {});
+      if (voiceState == AgentVoiceComposerState.awaitingAssistant ||
+          (keepLatestVisible &&
+              voiceState == AgentVoiceComposerState.confirming)) {
+        _scheduleScrollToLatest();
+      }
     });
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -159,6 +159,7 @@ ProductionAppDependencies createProductionAppDependencies({
   PracticeMediaWireTransport? signedAudioTransport,
   PracticeRecorder? practiceRecorder,
   AgentVoiceRecorder? agentVoiceRecorder,
+  AgentAudioPlayer? agentComposerAudioPlayer,
   AgentAudioPlayer? agentMessageAudioPlayer,
   PracticeMediaClient? practiceMediaClient,
   PracticeAudioPlayer? practiceAudioPlayer,
@@ -318,8 +319,24 @@ ProductionAppDependencies createProductionAppDependencies({
     conversationController: conversationController,
     imageClient: agentImageClient,
     imagePicker: ImagePickerAgentImagePicker(),
-    voiceInputClient: agentVoiceClient,
+    voiceClient: agentVoiceClient,
     voiceRecorder: agentVoiceRecorder ?? IosAgentVoiceRecorder(),
+    draftAudioPlayer:
+        agentComposerAudioPlayer ?? AudioplayersAgentAudioPlayer(),
+    onAssistantStreamStarted: (transientMessageId) => messageAudioController
+        .startLiveAssistantSpeech(transientMessageId: transientMessageId),
+    onAssistantStreamDelta: (transientMessageId, delta) =>
+        messageAudioController.appendLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          delta: delta,
+        ),
+    onAssistantStreamCompleted: (transientMessageId, message) =>
+        messageAudioController.completeLiveAssistantSpeech(
+          transientMessageId: transientMessageId,
+          message: message,
+        ),
+    onAssistantStreamFailed: (transientMessageId) => messageAudioController
+        .failLiveAssistantSpeech(transientMessageId: transientMessageId),
   );
   final practiceController = PracticeController(
     client: practiceClient,

--- a/mobile/test/agent/agent_flow_test.dart
+++ b/mobile/test/agent/agent_flow_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
-import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
@@ -350,7 +349,7 @@ _AgentHarness _agentHarness({PracticeClient? practiceClient}) {
     conversation: conversation,
     composer: ComposerController(
       conversationController: conversation,
-      voiceInputClient: FakeAgentVoiceInputClient(),
+      voiceClient: voiceClient,
     ),
     messageAudio: messageAudio,
     practice: PracticeController(

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
+import 'package:speakup/features/agent/composer/image/agent_image_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
@@ -87,6 +89,43 @@ void main() {
       composerController.voiceController?.state,
       AgentVoiceComposerState.idle,
     );
+  });
+
+  testWidgets('staged images disable voice capture and remain staged', (
+    tester,
+  ) async {
+    final conversationController = ConversationController(
+      client: FakeAgentClient(),
+    );
+    final composerController = ComposerController(
+      conversationController: conversationController,
+      imageClient: FakeAgentImageClient(),
+      imagePicker: _SingleImagePicker(),
+      voiceClient: FakeAgentVoiceClient(),
+    );
+    addTearDown(() {
+      composerController.dispose();
+      conversationController.dispose();
+    });
+    await tester.pumpWidget(
+      SpeakUpApp.preview(
+        conversationController: conversationController,
+        composerController: composerController,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await composerController.pickAgentImages();
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await tester.pump();
+
+    expect(composerController.pendingImages, hasLength(1));
+    expect(
+      composerController.voiceController?.state,
+      AgentVoiceComposerState.idle,
+    );
+    expect(conversationController.messages, isEmpty);
   });
 
   test(
@@ -553,6 +592,28 @@ final class _TrackingStreamingRecorder
     clearAccountStateCalls++;
     await discardCurrent();
   }
+}
+
+final class _SingleImagePicker implements AgentImagePicker {
+  @override
+  Future<List<AgentLocalImage>> pickFromGallery({required int limit}) async =>
+      <AgentLocalImage>[
+        AgentLocalImage(
+          name: 'fixture.png',
+          contentType: 'image/png',
+          bytes: base64Decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+            '+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+          ),
+        ),
+      ];
+
+  @override
+  Future<List<AgentLocalImage>> recoverLostImages() async =>
+      const <AgentLocalImage>[];
+
+  @override
+  Future<AgentLocalImage?> takePhoto() async => null;
 }
 
 final class _ControlledVoiceInputClient implements AgentVoiceInputClient {

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -4,7 +4,9 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
+import 'package:speakup/features/agent/composer/voice/agent_voice_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_input_client.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_input_controller.dart';
 import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
@@ -15,87 +17,77 @@ import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 
 void main() {
-  testWidgets(
-    'home voice input shows partial text then auto-sends an ordinary Message',
-    (tester) async {
-      final recorder = _TrackingStreamingRecorder();
-      final conversationController = ConversationController(
-        client: FakeAgentClient(),
-      );
-      final composerController = ComposerController(
+  testWidgets('home microphone commits a playable voice Message', (
+    tester,
+  ) async {
+    final recorder = _TrackingStreamingRecorder();
+    final conversationController = ConversationController(
+      client: FakeAgentClient(),
+    );
+    final composerController = ComposerController(
+      conversationController: conversationController,
+      voiceClient: FakeAgentVoiceClient(),
+      voiceRecorder: recorder,
+      draftAudioPlayer: FakeAgentAudioPlayer(),
+      clientIdFactory: _sequentialIdFactory(),
+    );
+    addTearDown(() {
+      composerController.dispose();
+      conversationController.dispose();
+    });
+
+    await tester.pumpWidget(
+      SpeakUpApp.preview(
         conversationController: conversationController,
-        voiceInputClient: FakeAgentVoiceInputClient(),
-        voiceRecorder: recorder,
-        clientIdFactory: _sequentialIdFactory(),
-      );
-      addTearDown(() {
-        composerController.dispose();
-        conversationController.dispose();
-      });
+        composerController: composerController,
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(
-        SpeakUpApp.preview(
-          conversationController: conversationController,
-          composerController: composerController,
-        ),
-      );
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await tester.pump();
+    await tester.pump();
 
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await tester.pump();
-      await tester.pump();
+    expect(
+      composerController.voiceController?.state,
+      AgentVoiceComposerState.recording,
+    );
+    expect(conversationController.messages, isEmpty);
 
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceInputState.recording,
-      );
-      expect(
-        find.byKey(const Key('agent-voice-live-transcript')),
-        findsOneWidget,
-      );
-      expect(find.text('点击转文字 · 上滑取消'), findsOneWidget);
-      expect(conversationController.messages, isEmpty);
+    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+    await _pumpUntil(
+      tester,
+      () => conversationController.messages.any(
+        (message) => message.role == AgentMessageRole.user,
+      ),
+    );
 
-      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-      await _pumpUntil(
-        tester,
-        () => conversationController.messages.any(
-          (message) => message.role == AgentMessageRole.user,
-        ),
-      );
-
-      expect(find.byKey(const Key('agent-composer-field')), findsNothing);
-
-      final userMessages = conversationController.messages
-          .where((message) => message.role == AgentMessageRole.user)
-          .toList();
-      expect(userMessages, hasLength(1));
-      expect(
-        userMessages.single.text,
-        'I explained the problem, the trade-off, and the result clearly.',
-      );
-      expect(userMessages.single.modality, AgentMessageModality.text);
-      expect(userMessages.single.audio, isNull);
-      expect(recorder.stopAudioStreamAndDiscardCalls, 1);
-      expect(recorder.discardedRecordings, 0);
-      expect(
-        conversationController.messages.where(
-          (message) => message.modality == AgentMessageModality.voice,
-        ),
-        isEmpty,
-      );
-      expect(
-        conversationController.messages.where(
-          (message) => message.role == AgentMessageRole.assistant,
-        ),
-        hasLength(1),
-      );
-      expect(
-        composerController.voiceController?.state,
-        AgentVoiceInputState.idle,
-      );
-    },
-  );
+    final userMessages = conversationController.messages
+        .where((message) => message.role == AgentMessageRole.user)
+        .toList();
+    expect(userMessages, hasLength(1));
+    expect(
+      userMessages.single.text,
+      'I explained the problem, the trade-off, and the result clearly.',
+    );
+    expect(userMessages.single.modality, AgentMessageModality.voice);
+    expect(userMessages.single.audio?.isReadable, isTrue);
+    expect(recorder.discardedRecordings, 1);
+    expect(
+      find.byKey(Key('agent-user-voice-play-${userMessages.single.id}')),
+      findsOneWidget,
+    );
+    expect(
+      conversationController.messages.where(
+        (message) => message.role == AgentMessageRole.assistant,
+      ),
+      hasLength(1),
+    );
+    expect(
+      composerController.voiceController?.state,
+      AgentVoiceComposerState.idle,
+    );
+  });
 
   test(
     'completed transcription discards PCM without creating a local WAV',
@@ -191,14 +183,14 @@ void main() {
     expect(controller.state, AgentVoiceInputState.idle);
   });
 
-  testWidgets('submitting status does not expose a cancel action', (
+  testWidgets('confirming status does not expose a cancel action', (
     tester,
   ) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: AgentComposerVoiceStatusDock(
-            state: AgentVoiceInputState.submitting,
+            state: AgentVoiceComposerState.confirming,
             message: '正在发送…',
             canCancel: false,
             canRetry: false,
@@ -244,52 +236,6 @@ void main() {
       expect(controller.state, AgentVoiceInputState.recording);
     },
   );
-
-  testWidgets('automatic text send failure retains text without local audio', (
-    tester,
-  ) async {
-    final recorder = _TrackingStreamingRecorder();
-    final conversationController = ConversationController(
-      client: _FailingTextAgentClient(),
-    );
-    final composerController = ComposerController(
-      conversationController: conversationController,
-      voiceInputClient: FakeAgentVoiceInputClient(),
-      voiceRecorder: recorder,
-      clientIdFactory: _sequentialIdFactory(),
-    );
-    addTearDown(() {
-      composerController.dispose();
-      conversationController.dispose();
-    });
-    await tester.pumpWidget(
-      SpeakUpApp.preview(
-        conversationController: conversationController,
-        composerController: composerController,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
-    await _pumpUntil(
-      tester,
-      () =>
-          composerController.voiceController?.state ==
-          AgentVoiceInputState.failed,
-    );
-
-    expect(conversationController.messages, isEmpty);
-    expect(recorder.stopAudioStreamAndDiscardCalls, 1);
-    expect(recorder.discardedRecordings, 0);
-    expect(recorder.hasCurrentRecording, isFalse);
-    expect(find.text('消息未发送，请重试。'), findsOneWidget);
-    expect(
-      composerController.voiceController?.liveTranscript,
-      'I explained the problem, the trade-off, and the result clearly.',
-    );
-  });
 
   test(
     'Thread switch cleans capture and fences late transcription events',
@@ -444,8 +390,9 @@ void main() {
     );
     final composerController = ComposerController(
       conversationController: conversationController,
-      voiceInputClient: FakeAgentVoiceInputClient(),
+      voiceClient: FakeAgentVoiceClient(),
       voiceRecorder: recorder,
+      draftAudioPlayer: FakeAgentAudioPlayer(),
       clientIdFactory: _sequentialIdFactory(),
     );
     addTearDown(() {
@@ -634,59 +581,6 @@ final class _ControlledVoiceInputClient implements AgentVoiceInputClient {
     disposeCalls++;
     await _audioSubscription?.cancel();
     await events.close();
-  }
-}
-
-final class _FailingTextAgentClient implements AgentClient {
-  final _delegate = FakeAgentClient();
-
-  @override
-  Future<void> clearAccountState() => _delegate.clearAccountState();
-
-  @override
-  Future<AgentThreadSummary> createThread() => _delegate.createThread();
-
-  @override
-  Future<void> clearFocusedThread() => _delegate.clearFocusedThread();
-
-  @override
-  Future<void> deleteThread({required String threadId}) =>
-      _delegate.deleteThread(threadId: threadId);
-
-  @override
-  Future<AgentThreadSnapshot?> getFocusedThread() =>
-      _delegate.getFocusedThread();
-
-  @override
-  Future<AgentThreadPage> listThreads({int pageSize = 20, String? cursor}) =>
-      _delegate.listThreads(pageSize: pageSize, cursor: cursor);
-
-  @override
-  Future<AgentMessagePage> listMessages({
-    required String threadId,
-    int pageSize = 50,
-    String? cursor,
-  }) => _delegate.listMessages(
-    threadId: threadId,
-    pageSize: pageSize,
-    cursor: cursor,
-  );
-
-  @override
-  Future<AgentThreadSnapshot> setFocusedThread({required String threadId}) =>
-      _delegate.setFocusedThread(threadId: threadId);
-
-  @override
-  Future<AgentExchange> sendText({
-    required String threadId,
-    required String text,
-    required String clientMessageId,
-    List<String> imageAssetIds = const <String>[],
-  }) {
-    throw const AgentClientException(
-      kind: AgentClientFailureKind.network,
-      retryable: true,
-    );
   }
 }
 

--- a/mobile/test/main_wiring_test.dart
+++ b/mobile/test/main_wiring_test.dart
@@ -170,6 +170,7 @@ void main() {
       final practiceMediaClient = _TrackingPracticeMediaClient();
       final practiceAudioPlayer = _TrackingPracticeAudioPlayer();
       final agentVoiceRecorder = _TrackingAgentVoiceRecorder();
+      final agentComposerAudioPlayer = _TrackingAgentAudioPlayer();
       final agentMessageAudioPlayer = _TrackingAgentAudioPlayer();
       final dependencies = production.createProductionAppDependencies(
         baseUri: Uri.parse('https://api.speak-up.test'),
@@ -181,6 +182,7 @@ void main() {
         practiceTransport: _PracticeTransport(),
         practiceRecorder: practiceRecorder,
         agentVoiceRecorder: agentVoiceRecorder,
+        agentComposerAudioPlayer: agentComposerAudioPlayer,
         agentMessageAudioPlayer: agentMessageAudioPlayer,
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
@@ -371,7 +373,8 @@ void main() {
       expect(practiceRecorder.clearCount, 1);
       expect(practiceMediaClient.clearCount, 1);
       expect(practiceAudioPlayer.clearCount, 2);
-      expect(agentVoiceRecorder.clearCount, 1);
+      expect(agentVoiceRecorder.clearCount, 2);
+      expect(agentComposerAudioPlayer.clearCount, 2);
       expect(agentMessageAudioPlayer.clearCount, 2);
 
       reviewHistoryTransport.completeWithReview();
@@ -462,6 +465,7 @@ void main() {
       final practiceMediaClient = _TrackingPracticeMediaClient();
       final practiceAudioPlayer = _TrackingPracticeAudioPlayer();
       final agentVoiceRecorder = _TrackingAgentVoiceRecorder();
+      final agentComposerAudioPlayer = _TrackingAgentAudioPlayer();
       final agentMessageAudioPlayer = _TrackingAgentAudioPlayer();
       final launchRecordStore = _FailingPracticeLaunchRecordStore();
       final dependencies = production.createProductionAppDependencies(
@@ -471,6 +475,7 @@ void main() {
         practiceTransport: _PracticeTransport(),
         practiceRecorder: practiceRecorder,
         agentVoiceRecorder: agentVoiceRecorder,
+        agentComposerAudioPlayer: agentComposerAudioPlayer,
         agentMessageAudioPlayer: agentMessageAudioPlayer,
         practiceMediaClient: practiceMediaClient,
         practiceAudioPlayer: practiceAudioPlayer,
@@ -502,6 +507,7 @@ void main() {
       expect(dependencies.conversationController.threadId, isNull);
       expect(dependencies.conversationController.messages, isEmpty);
       expect(agentVoiceRecorder.clearCount, greaterThan(0));
+      expect(agentComposerAudioPlayer.clearCount, greaterThan(0));
       expect(agentMessageAudioPlayer.clearCount, greaterThan(0));
       expect(practiceRecorder.clearCount, greaterThan(0));
       expect(practiceMediaClient.clearCount, greaterThan(0));


### PR DESCRIPTION
## 功能描述

恢复 SpeakUp 首页麦克风的语音消息语义：录音发送后保留原始音频，用户消息展示播放入口，并继续加载逐条语音反馈；键盘输入仍发送普通文本消息。

Closes #683

## 实现思路

- 将首页 Composer 重新接回已有的 `AgentVoiceController` 与持久化 voice candidate/confirmation 流程。
- 复用现有用户语音气泡、消息音频播放和 speech feedback 状态加载，不新增协议或后端接口。
- 恢复确认/等待回复阶段的交互保护、滚动跟随与 AI 流式朗读衔接。
- 将录音提示从“转文字”恢复为“发送”，避免与实际行为冲突。

## 可复现测试

1. `cd mobile && flutter analyze`
2. `cd mobile && flutter test test/agent/agent_voice_flow_test.dart test/agent/agent_voice_fence_test.dart test/agent/agent_flow_test.dart test/review/turn_feedback_page_integration_test.dart`
3. `cd server && go test ./internal/agent/input/voice/...`
4. iOS 26.5：`SPEAKUP_DEV_PORT=18082 IOS_SIMULATOR_ID=4EDDF964-F37E-45FB-8E39-B0808068EFFC make dev-ios-simulator`
5. 首页点击麦克风录音并再次点击发送；确认生成带波形播放入口的用户语音消息，服务端 realtime candidate、confirmation stream 与 speech feedback 请求均返回 200。

## 验证结果

- Flutter analyze：通过。
- Flutter 定向测试：37 项通过。
- Agent voice Go 测试：3 个 package 通过。
- iPhone 16 Pro / iOS 26.5 / 真实后端 18082 / 数字人禁用：通过。