### PR TITLE
fix(mobile): 短语音消息气泡随内容收缩

### DIFF
--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -89,20 +89,26 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
           onPressed: _toggle,
         ),
     ];
+    final actionWrap = Wrap(
+      spacing: SpeakUpDesign.space4,
+      runSpacing: SpeakUpDesign.space4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: actions,
+    );
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
+          mainAxisSize: widget.trailing == null
+              ? MainAxisSize.min
+              : MainAxisSize.max,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Expanded(
-              child: Wrap(
-                spacing: SpeakUpDesign.space4,
-                runSpacing: SpeakUpDesign.space4,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: actions,
-              ),
-            ),
+            if (widget.trailing == null)
+              actionWrap
+            else
+              Expanded(child: actionWrap),
             if (widget.trailing != null) widget.trailing!,
           ],
         ),

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -283,6 +283,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         ? audioController?.errorMessage
         : null;
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -230,7 +230,7 @@ void main() {
     const message = AgentMessage(
       id: 'user-voice-spacing',
       role: AgentMessageRole.user,
-      text: 'Can you help me study knowledge about AI?',
+      text: '嗯。',
       modality: AgentMessageModality.voice,
       audio: AgentMessageAudio(
         id: 'audio-spacing',
@@ -277,6 +277,7 @@ void main() {
     );
     expect(tester.getSize(playback), const Size.square(44));
     expect(tester.getSize(optimize), const Size.square(40));
+    expect(tester.getSize(bubble).width, lessThan(340));
   });
 
   testWidgets('renders and dispatches a practice plan handoff', (tester) async {


### PR DESCRIPTION
## 功能描述
修复 Agent 对话中短语音转写仍占满最大气泡宽度的问题。

## 实现思路
- 无尾部操作时让内联反馈操作区按内容收缩。
- 用户语音内容列使用最小主轴尺寸，长内容继续受现有 340pt 最大宽度限制。

## 可复现测试
```bash
cd mobile
flutter test test/agent/agent_message_bubble_test.dart
```
验证短转写气泡宽度小于最大宽度，播放/优化点击区域保持原尺寸，展开反馈用例通过。

Closes #686