### PR TITLE
fix(feedback): 原表达自然时提示无需润色

### DIFF
--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -25,6 +25,7 @@ class InlineLanguageFeedback extends StatefulWidget {
     this.trailing,
     this.correction,
     this.polish,
+    this.feedbackNotice,
     this.correctionFooter,
     this.polishFooter,
     this.onSpeakSuggestion,
@@ -41,6 +42,7 @@ class InlineLanguageFeedback extends StatefulWidget {
   final Widget? trailing;
   final InlineLanguageSuggestion? correction;
   final InlineLanguageSuggestion? polish;
+  final String? feedbackNotice;
   final Widget? correctionFooter;
   final Widget? polishFooter;
   final ValueChanged<String>? onSpeakSuggestion;
@@ -61,7 +63,9 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
   @override
   void didUpdateWidget(covariant InlineLanguageFeedback oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.correction == null && widget.polish == null) {
+    if (widget.correction == null &&
+        widget.polish == null &&
+        widget.feedbackNotice == null) {
       _expanded = false;
     }
   }
@@ -74,7 +78,10 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
 
   @override
   Widget build(BuildContext context) {
-    final hasFeedback = widget.correction != null || widget.polish != null;
+    final hasFeedback =
+        widget.correction != null ||
+        widget.polish != null ||
+        widget.feedbackNotice != null;
     final spokenSuggestion = widget.polish ?? widget.correction;
     final actions = <Widget>[
       if (widget.leading != null) widget.leading!,
@@ -114,6 +121,12 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
         ),
         if (_expanded && hasFeedback) ...[
           const SizedBox(height: SpeakUpDesign.space8),
+          if (widget.feedbackNotice case final notice?)
+            Text(
+              notice,
+              key: const Key('inline-language-feedback-notice'),
+              style: SpeakUpDesign.body.copyWith(color: widget.textColor),
+            ),
           if (widget.correction case final correction?) ...[
             _InlineFeedbackHeading(label: '纠错', color: widget.foregroundColor),
             const SizedBox(height: SpeakUpDesign.space4),

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -20,6 +20,7 @@ final class AgentMessageBubble extends StatefulWidget {
     this.onRefreshImage,
     this.correction,
     this.polish,
+    this.feedbackNotice,
     super.key,
   });
 
@@ -31,6 +32,7 @@ final class AgentMessageBubble extends StatefulWidget {
   onRefreshImage;
   final InlineLanguageSuggestion? correction;
   final InlineLanguageSuggestion? polish;
+  final String? feedbackNotice;
 
   @override
   State<AgentMessageBubble> createState() => _AgentMessageBubbleState();
@@ -51,7 +53,9 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
   void didUpdateWidget(covariant AgentMessageBubble oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.message.id != widget.message.id ||
-        (widget.correction == null && widget.polish == null)) {
+        (widget.correction == null &&
+            widget.polish == null &&
+            widget.feedbackNotice == null)) {
       _languageFeedbackExpanded = false;
     }
     if (oldWidget.messageAudioController != widget.messageAudioController) {
@@ -303,6 +307,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           ),
           correction: widget.correction,
           polish: widget.polish,
+          feedbackNotice: widget.feedbackNotice,
           optimizeIconOnly: true,
           onExpandedChanged: (expanded) {
             if (_languageFeedbackExpanded == expanded) {

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -37,6 +37,8 @@ abstract interface class ConversationMessageFeedbackPresenter
   InlineLanguageSuggestion? correctionFor(AgentMessage message);
 
   InlineLanguageSuggestion? polishFor(AgentMessage message);
+
+  String? feedbackNoticeFor(AgentMessage message);
 }
 
 class ConversationPage extends StatefulWidget {
@@ -1006,6 +1008,7 @@ class _MessageList extends StatelessWidget {
               onRefreshImage: onRefreshImage,
               correction: feedbackPresenter?.correctionFor(message),
               polish: feedbackPresenter?.polishFor(message),
+              feedbackNotice: feedbackPresenter?.feedbackNoticeFor(message),
             ),
       ],
     );

--- a/mobile/lib/features/coaching/evaluation/agent_conversation_feedback_presenter.dart
+++ b/mobile/lib/features/coaching/evaluation/agent_conversation_feedback_presenter.dart
@@ -86,6 +86,12 @@ final class AgentConversationFeedbackPresenter extends ChangeNotifier
     );
   }
 
+  @override
+  String? feedbackNoticeFor(AgentMessage message) {
+    final strength = _projection(message)?.feedback?.items.strength;
+    return strength == null ? null : '表达已经很自然，无需润色';
+  }
+
   SpeechFeedbackProjection? _projection(AgentMessage message) {
     if (message.speechFeedbackStatusUrl == null) {
       return null;

--- a/mobile/lib/features/coaching/evaluation/inline_speech_feedback.dart
+++ b/mobile/lib/features/coaching/evaluation/inline_speech_feedback.dart
@@ -32,6 +32,7 @@ class InlineSpeechFeedback extends StatelessWidget {
             SpeechFeedbackScoreabilityStatus.insufficient;
     final correction = visible ? feedback!.items.correction : null;
     final polish = visible ? feedback!.items.polish : null;
+    final strength = visible ? feedback!.items.strength : null;
     return InlineLanguageFeedback(
       leading: leading,
       trailing: trailing,
@@ -48,6 +49,7 @@ class InlineSpeechFeedback extends StatelessWidget {
               text: polish!.suggestedText!,
               explanation: polish.explanation,
             ),
+      feedbackNotice: strength == null ? null : '表达已经很自然，无需润色',
       correctionFooter: correction == null || onRepractice == null
           ? null
           : TextButton.icon(

--- a/mobile/lib/features/coaching/evaluation/turn_feedback.dart
+++ b/mobile/lib/features/coaching/evaluation/turn_feedback.dart
@@ -118,6 +118,15 @@ final class SpeechFeedbackItem {
 }
 
 extension SpeechFeedbackItemsPresentation on Iterable<SpeechFeedbackItem> {
+  SpeechFeedbackItem? get strength {
+    for (final item in this) {
+      if (item.kind == SpeechFeedbackItemKind.strength) {
+        return item;
+      }
+    }
+    return null;
+  }
+
   SpeechFeedbackItem? get correction {
     for (final item in this) {
       if (item.kind == SpeechFeedbackItemKind.correction &&

--- a/mobile/test/design/practice_conversation_components_test.dart
+++ b/mobile/test/design/practice_conversation_components_test.dart
@@ -4,6 +4,23 @@ import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/voice_capture_control.dart';
 
 void main() {
+  testWidgets('inline feedback reports when no polish is needed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InlineLanguageFeedback(feedbackNotice: '表达已经很自然，无需润色'),
+        ),
+      ),
+    );
+
+    expect(find.text('表达已经很自然，无需润色'), findsNothing);
+    await tester.tap(find.byKey(const Key('inline-language-optimize')));
+    await tester.pump();
+    expect(find.text('表达已经很自然，无需润色'), findsOneWidget);
+  });
+
   testWidgets('shared recording composer shows the live transcript', (
     tester,
   ) async {

--- a/server/internal/coaching/evaluation/speechfeedback/model.go
+++ b/server/internal/coaching/evaluation/speechfeedback/model.go
@@ -14,7 +14,7 @@ const (
 	SpeechFeedbackSchemaVersion   = "speech-feedback/v1"
 	SpeechFeedbackStrategyRef     = "qianwen-speech-feedback/v1"
 	SpeechFeedbackPipelineVersion = "speech-feedback-pipeline/v1"
-	SpeechFeedbackPromptVersion   = "speech-feedback-prompt/v6"
+	SpeechFeedbackPromptVersion   = "speech-feedback-prompt/v7"
 
 	SpeechFeedbackAcousticReasonUnavailable = "ACOUSTIC_EVIDENCE_UNAVAILABLE"
 	SpeechFeedbackAcousticNotice            = "根据本次录音自动评估，仅供练习参考。"

--- a/server/internal/coaching/evaluation/speechfeedback/provider.go
+++ b/server/internal/coaching/evaluation/speechfeedback/provider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 const (
@@ -114,14 +115,14 @@ func (provider *TextSpeechFeedbackProvider) GenerateSpeechFeedback(
 
 const speechFeedbackSystemPrompt = `You return cautious English-learning feedback for one confirmed transcript.
 Return one JSON object only with this exact shape: {"items":[...]}.
-Every item must contain exactly three non-empty string fields: kind, explanation, suggested_text.
-The only allowed kinds are CORRECTION and RECOMMENDED_EXPRESSION.
+The only allowed kinds are CORRECTION, RECOMMENDED_EXPRESSION, and STRENGTH.
 The user payload contains english_text that was deterministically extracted from the confirmed transcript. Use only english_text. Never reconstruct, translate, or infer omitted non-English text.
-Always return exactly one RECOMMENDED_EXPRESSION. Its suggested_text must contain the complete polished English expression, preserve the meaning, and add no new facts.
-If and only if english_text contains a clear grammar or word-choice error, also return exactly one CORRECTION before RECOMMENDED_EXPRESSION. CORRECTION fixes the error and explains it briefly. Never label a merely less-natural expression as CORRECTION.
+Return CORRECTION if and only if english_text contains a clear grammar or word-choice error. It must contain exactly kind, explanation, and suggested_text. CORRECTION fixes the error and explains it briefly. Never label a merely less-natural expression as CORRECTION.
+Return RECOMMENDED_EXPRESSION only when its complete suggested_text meaningfully improves naturalness or completeness, preserves the meaning, adds no new facts, and differs from english_text. It must contain exactly kind, explanation, and suggested_text. Do not rewrite merely to make the output different.
+When neither correction nor meaningful improvement is needed, return exactly one STRENGTH with kind and explanation only, using this shape: {"items":[{"kind":"STRENGTH","explanation":"The expression is already natural."}]}.
+Never combine STRENGTH with another item.
 Do not score, grade, infer pronunciation, fluency, confidence, audio quality, intent, or facts not present in english_text.
-When no correction is needed, follow this example shape exactly: {"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"More natural wording.","suggested_text":"Complete polished English expression."}]}.
-Return at most 2 items and no unknown fields. Never omit suggested_text.`
+Return at most 2 items and no unknown fields. Never omit suggested_text from CORRECTION or RECOMMENDED_EXPRESSION.`
 
 type SpeechFeedbackDraftItem struct {
 	Kind           SpeechFeedbackItemKind
@@ -210,7 +211,22 @@ func normalizeSpeechFeedbackProviderResult(
 		return nil, err
 	}
 	seen := make(map[string]struct{}, len(envelope.Items))
+	englishText := speechFeedbackEnglishReferenceText(input.ConfirmedText)
 	for _, generated := range envelope.Items {
+		switch generated.Kind {
+		case SpeechFeedbackItemCorrection,
+			SpeechFeedbackItemRecommendedExpression:
+			if generated.SuggestedText != nil &&
+				equalSpeechFeedbackText(*generated.SuggestedText, englishText) {
+				return nil, ErrInvalidSpeechFeedback
+			}
+		case SpeechFeedbackItemStrength:
+			if len(envelope.Items) != 1 {
+				return nil, ErrInvalidSpeechFeedback
+			}
+		default:
+			return nil, ErrInvalidSpeechFeedback
+		}
 		repractice := SpeechFeedbackRepracticeNone
 		if generated.Kind != SpeechFeedbackItemStrength {
 			switch input.Source.SourceKind {
@@ -255,6 +271,14 @@ func normalizeSpeechFeedbackProviderResult(
 		normalized = append(normalized, item)
 	}
 	return normalized, nil
+}
+
+func equalSpeechFeedbackText(left, right string) bool {
+	const edgeCharacters = " \t\r\n,;:!?-."
+	return strings.EqualFold(
+		strings.Join(strings.Fields(strings.Trim(left, edgeCharacters)), " "),
+		strings.Join(strings.Fields(strings.Trim(right, edgeCharacters)), " "),
+	)
 }
 
 func speechFeedbackAnchorForInput(

--- a/server/internal/coaching/evaluation/speechfeedback/provider_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/provider_test.go
@@ -230,6 +230,42 @@ func TestNormalizeSpeechFeedbackProviderResultBuildsConversationAnchor(
 	}
 }
 
+func TestNormalizeSpeechFeedbackProviderResultRejectsUnchangedSuggestion(
+	t *testing.T,
+) {
+	t.Parallel()
+	input := SpeechFeedbackProviderInput{
+		SchemaVersion: SpeechFeedbackSchemaVersion,
+		PromptVersion: SpeechFeedbackPromptVersion,
+		Source: SpeechFeedbackSource{
+			SourceKind:         SpeechFeedbackSourceConversationTurn,
+			PracticeSessionID:  "practice-1",
+			TurnID:             "turn-1",
+			InputRevision:      1,
+			EvidenceSnapshotID: "evaluation_snapshot_1",
+		},
+		EvidenceRefID: "evaluation_evidence_1",
+		ConfirmedText: "This expression is already natural.",
+	}
+	if _, err := normalizeSpeechFeedbackProviderResult(
+		input,
+		SpeechFeedbackProviderResult{
+			Payload: json.RawMessage(`{
+				"items": [{
+					"kind": "RECOMMENDED_EXPRESSION",
+					"explanation": "This is already natural.",
+					"suggested_text": " this expression is already natural. "
+				}]
+			}`),
+			Provider:  "qianwen",
+			Model:     "qwen-plus",
+			RequestID: "request-1",
+		},
+	); err == nil {
+		t.Fatal("unchanged recommendation was accepted")
+	}
+}
+
 func TestNormalizeSpeechFeedbackProviderResultCapsItemsAtEight(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## 功能描述
当英文原表达已经自然时，不再强制生成“更自然的表达”，而是在优化入口中提示“表达已经很自然，无需润色”。

## 实现思路
- 提示词升级到 v7：只有确有改进时才返回纠错或推荐表达，无需修改时复用现有 `STRENGTH` 契约。
- 服务端拒绝与英文原文仅大小写、空白或句末标点不同的伪建议，并禁止 `STRENGTH` 与其他反馈混用。
- 移动端将 `STRENGTH` 映射为固定中文提示，Agent 与共享逐句反馈组件统一展示。

## 可复现测试
```bash
cd server
go test ./internal/coaching/evaluation/speechfeedback

cd ../mobile
flutter test test/design/practice_conversation_components_test.dart test/review/turn_feedback_page_integration_test.dart
```
覆盖无需润色提示、原样建议拒绝，并复用现有 STRENGTH 接受及原有反馈集成用例。

Closes #687