### PR TITLE
docs(video): 固化首版产品宣传片方案与动效映射

### DIFF
--- a/docs/视频方案.md
+++ b/docs/视频方案.md
@@ -1,0 +1,170 @@
+# SpeakUp 首版产品宣传视频方案
+
+> 状态：共同创作中的已确认方案基线，尚未构成最终分镜或制作放行
+>
+> 关联 Issue：[1024XEngineer/XE3-ESL#691](https://github.com/1024XEngineer/XE3-ESL/issues/691)
+>
+> Shotcraft 动态样片：[Video Shotcraft Gallery](https://vincentwei1021.github.io/video-shotcraft/library.html)
+
+## 1. 当前已确认的制作边界
+
+- 首版时长约 60 秒，采用 16:9 横屏、1920×1080、30 fps；锁片后可升级 4K 或裁切 9:16。
+- 不出现真人、AI 人物、书桌、酒店、办公室等现实人物场景。
+- 从用户痛点文字直接进入产品功能，由真实 App 页面回答痛点。
+- 所有可读 App 界面、训练计划、题目、倒计时、反馈和报告均使用当前项目的真实截图或真实录屏，不使用生成式 AI 伪造 UI。
+- 策划采用共同创作：用户参与定位、文案、结构、视觉方向、镜头取舍和最终分镜确认；AI 负责素材采集、动效、声音、剪辑、渲染与技术 QA。
+- 第一版不使用旁白，依靠屏幕文字、BGM、界面拟音和转场 SFX 完成叙事；后续可以在不改变主时间线的前提下增加旁白。
+- 录制数据全部使用虚构演示账号和脱敏内容，不展示真实姓名、简历、对话、成绩、Token、密钥或内部数据。
+
+## 2. 核心表达
+
+暂定核心主张：
+
+> 你的每一个英语难题，都能变成一次针对性的练习。
+
+叙事因果链：
+
+```text
+用户痛点
+→ SpeakUp 出现
+→ 用户告诉 Agent 目标
+→ Agent 组织训练
+→ 用户进入对应场景练习
+→ 获得即时反馈
+→ 在复盘中看见问题与下一步
+```
+
+本片不是功能目录。每个功能镜头必须回答前文提出的一个具体问题，并使用当前版本可稳定复现的真实页面作为证据。
+
+## 3. 痛点与产品回答
+
+| 用户痛点 | SpeakUp 的回答 | 必须使用的真实产品证据 |
+|---|---|---|
+| 想练口语，却不知道从哪里开始 | 直接把现实目标告诉 Agent | Agent 主会话、文字或语音输入状态 |
+| 一到真实场景，就不知道怎么说 | Agent 将目标组织成明确训练，并提供不同场景入口 | 训练计划卡、面试、IELTS、职场、生活与旅行入口 |
+| 说完了，却不知道哪里需要改 | 根据用户原话提供反馈和更自然的表达建议 | 真实逐句反馈、原表达、建议表达和解释 |
+| 练了很多次，却不知道下一步是什么 | 保存练习结果并展示复盘重点 | 真实报告、能力维度、历史记录和下一步建议 |
+
+宣传表达必须服从当前产品事实。若某个页面或链路在正式采集时无法使用真实后端稳定复现，应缩小宣传表述或调整镜头，不用假 UI 补齐。
+
+## 4. 约 60 秒视频结构
+
+下表是方案级时间线，不是最终逐帧分镜。Gallery 卡名和 `style-key` 已通过 Video Shotcraft 的 `gallery/api/library.json` 校验；点击卡名可在在线画廊中查看或直接在画廊搜索完整名称。
+
+| 时间 | 内容与主要表达 | 屏幕文字草案 | 产品画面 | Shotcraft 动效与实现边界 |
+|---|---|---|---|---|
+| 0–4 秒 | 痛点一：不知道从哪里开始 | 想练口语，却不知道从哪里开始？ | 无产品画面，使用 SpeakUp 黑白排版与克制纸感底 | 使用 [`paper-title-card`](https://vincentwei1021.github.io/video-shotcraft/library.html#paper-title-card)，`style-key: paper-title-card`；保留逐词压印和单一重点词，换用 SpeakUp 字体与黑白配色 |
+| 4–8 秒 | 痛点二：真实场景卡住 | 一到真实场景，就不知道怎么说。 | 无产品画面 | 继续使用 `paper-title-card` 的同类字卡语法，作为统一的问题陈述词汇，不增加第二套标题动效 |
+| 8–12 秒 | 痛点三：不知道哪里需要改 | 说完了，却不知道哪里需要改。 | 可短暂出现一组抽象的原句与问号，但不伪造产品 UI | 继续使用 `paper-title-card`；突出词由“真实场景”改为“哪里需要改” |
+| 12–16 秒 | 痛点四并引出解决方案 | 练了很多次，下一步是什么？ | 四个痛点关键词向中央收拢 | 参考 [`radial-wave`](https://vincentwei1021.github.io/video-shotcraft/library.html#radial-wave)，`style-key: radial-wave`；只借用由中心扩散、外圈回收的波动语法，改成浅底黑灰声波。该段需要 SpeakUp 定制实现，不直接复刻暗场蓝色点阵 |
+| 16–20 秒 | SpeakUp 品牌正式登场 | SpeakUp | 使用仓库中的真实 SpeakUp 字标 | 使用 [`brand-ink-open`](https://vincentwei1021.github.io/video-shotcraft/library.html#brand-ink-open)，`style-key: brand-ink-open`；字标落定后保持至少 1 秒，禁止重新绘制或生成 Logo |
+| 20–25 秒 | 产品全景：“这就是 SpeakUp” | 把问题直接告诉 SpeakUp | 中央手机展示真实 Agent 主页面，两侧标签为“说出目标”“开始练习” | 使用 [`radial-ripple-phone-chips`](https://vincentwei1021.github.io/video-shotcraft/library.html#radial-ripple-phone-chips)，`style-key: radial-ripple-phone-chips`；真实截图替换骨架 feed，保留错相呼吸圆和两侧 chip 的错峰弹入 |
+| 25–31 秒 | 用户通过语音告诉 Agent 自己的目标 | 不用先找课程。先说出你正在面对什么。 | 真实主会话、麦克风状态和提交动作 | 使用 [`voice-waveform-live`](https://vincentwei1021.github.io/video-shotcraft/library.html#voice-waveform-live)，`style-key: voice-waveform-live`；使用确定性声纹，呈现“说话→停顿→继续→提交”，声纹嵌入真实页面而不是另造输入 UI |
+| 31–37 秒 | Agent 回复并形成可执行训练 | 一句话，变成一次可以完成的训练。 | 真实 Agent 回复和训练计划卡；镜头聚焦目标、场景、角色与轮次 | 使用 [`spotlight-hero-card`](https://vincentwei1021.github.io/video-shotcraft/library.html#spotlight-hero-card)，`style-key: spotlight-hero-card`；仅在全片使用一次完整的“聚光→推近→悬浮→归位”动作弧，主角必须是真实计划卡 |
+| 37–42 秒 | 四类训练场景证明产品广度 | 面试 · IELTS · 职场 · 生活与旅行 | 使用训练首页或四类真实场景入口截图 | 使用 [`picker-carousel-feature-cycle`](https://vincentwei1021.github.io/video-shotcraft/library.html#picker-carousel-feature-cycle)，`style-key: picker-carousel-feature-cycle`；固定焦点药丸，四类场景穿过焦点并逐次吸附，每次落定必须有可读静止时间 |
+| 42–46 秒 | 从场景入口进入真实练习页面 | 进入你的训练场景 | 前页为场景选择，后页为真实练习页 | 使用 [`page-turn-transitions · cube-rotate`](https://vincentwei1021.github.io/video-shotcraft/library.html#page-turn-transitions)，卡名 `page-turn-transitions`、`style-key: cube-rotate`；只使用一次，表达两个并列产品模块间的章节翻篇；转场前后页面均需先静止建立 |
+| 46–51 秒 | 真实口语练习正在进行 | 开口练。继续说。直到表达完整。 | 真实题目、对话气泡、录音状态、练习阶段 | 不重复使用完整 `voice-waveform-live`。以真实页面录屏和自定义 PageCam 缓推为主，只保留轻量、与真实录音状态同步的页面内声纹；本镜头不依赖新的 Gallery 卡 |
+| 51–56 秒 | 反馈证明“具体改在哪里” | 不只是指出错误，还告诉你怎样说得更自然。 | 同一条真实用户表达的原句、建议表达与解释，前后布局必须对齐 | 使用 [`before-after-slider-scrub`](https://vincentwei1021.github.io/video-shotcraft/library.html#before-after-slider-scrub)，`style-key: before-after-slider-scrub`；快甩宣告变化、慢扫留出阅读时间。两侧必须来自同一真实反馈状态，不制作故意难看的假 Before |
+| 56–61 秒 | 复盘回答“下一步是什么” | 看见问题，也看见下一步。 | 真实报告、能力维度、练习重点或历史记录；只展示 2–3 个可读结论 | 使用 [`card-flip-reveal`](https://vincentwei1021.github.io/video-shotcraft/library.html#card-flip-reveal)，`style-key: card-flip-reveal`；正面为真实维度卡，背面为与其语义成对的简短结论，最多三卡，落定后静止至少 0.5 秒 |
+| 61–66 秒 | 产品 UI 收束为品牌 | SpeakUp / 每一个真实挑战，都可以先练一次。 | 输入区域或产品页面收回，真实 SpeakUp 字标落定 | 参考 [`ui-to-brand-morph · input-morph-assemble`](https://vincentwei1021.github.io/video-shotcraft/library.html#ui-to-brand-morph)，卡名 `ui-to-brand-morph`、`style-key: input-morph-assemble`；只借用“输入框收缩→元素集结→字标落定”的因果语法。SpeakUp 目前是手写 wordmark，不能照搬 demo 的几何花瓣，需定制为声波收束后交棒真实字标 |
+
+总时长允许在 60–66 秒内根据真实页面可读性调整。需要阅读的 UI 镜头优先延长停留，不能为了卡满 60 秒压缩文字。
+
+## 5. Shotcraft 动效索引与生产追踪
+
+下表记录已选卡片、具体样式、用途和准确参考实现。正式制作时必须从准确 demo 复制已调参数，再替换为 SpeakUp 的真实素材和视觉 token；不得仅凭卡名重新写近似动画。
+
+| 卡名 | `style-key` | 本片用途 | 准确参考实现 | 适配重点 |
+|---|---|---|---|---|
+| `paper-title-card` | `paper-title-card` | 四组痛点字卡 | `template/src/aifl/PaperTitleCard.tsx` | 保留逐词压印、单重点词和呼吸位；改用 SpeakUp 排版与黑白色板 |
+| `radial-wave` | `radial-wave` | 痛点收拢至品牌的声波桥接 | `demos/ui-entrance/radial-wave/RadialWave.tsx` | 从暗场蓝点阵改为浅底黑灰声波；调整末帧保证干净静止 |
+| `brand-ink-open` | `brand-ink-open` | 品牌登场 | `template/src/aifl/live/SceneOpen.tsx` 的品牌开场段 | 使用真实字标；完整 lockup 保持至少 1 秒 |
+| `radial-ripple-phone-chips` | `radial-ripple-phone-chips` | 中央手机产品全景 | `demos/effects/radial-ripple-phone-chips/RadialRipplePhoneChips.tsx` | 真实 App 截图替换骨架 feed；根据手机宽度同步修改 chip 定位 |
+| `voice-waveform-live` | `voice-waveform-live` | Agent 语音输入 | `demos/interaction/voice-waveform-live/VoiceWaveformLive.tsx` | 替换 emoji 麦克风为项目图标；浅色界面用实底胶囊；无人声版采用确定性合成包络 |
+| `spotlight-hero-card` | `spotlight-hero-card` | 训练计划卡英雄镜头 | `template/src/aifl/live/SceneOpen.tsx` 的单卡宏观段 | 真实截图需额外高分辨率元素切片，防止推进后文字模糊；落地后相机必须真静止 |
+| `picker-carousel-feature-cycle` | `picker-carousel-feature-cycle` | 四类训练场景轮换 | `demos/interaction/picker-carousel-feature-cycle/PickerCarouselFeatureCycle.tsx` | 保留固定焦点、outQuint 吸附和 HOLD；项目场景名过长时缩字号，不换行 |
+| `page-turn-transitions` | `cube-rotate` | 场景入口到练习页的章节转场 | `demos/transition/page-turn-transitions/CubeRotate.tsx` | 使用 CSS 立方体自实现；两张真实截图需同规格且转场前后留静止帧 |
+| `before-after-slider-scrub` | `before-after-slider-scrub` | 原表达与建议表达对比 | `demos/data/before-after-slider-scrub/BeforeAfterSliderScrub.tsx` | 两侧同布局、同机位；分割杆与裁切边界逐帧一致；定格时保留建议表达 |
+| `card-flip-reveal` | `card-flip-reveal` | 复盘维度揭示结论 | `demos/transition/card-flip-reveal/CardFlipReveal.tsx` | 正反面必须语义成对；不超过三卡；真实截图需控制背面渲染开销 |
+| `ui-to-brand-morph` | `input-morph-assemble` | 输入 UI 到品牌收尾 | `demos/outro/ui-to-brand-morph/InputMorphsIntoLogo.tsx` | 只继承输入框收缩与错峰集结节奏；不使用 demo 的几何花瓣，改为声波交棒真实 SpeakUp 字标 |
+
+## 6. Gallery 动效与定制实现的边界
+
+### 6.1 可直接继承运动语法的镜头
+
+- `paper-title-card`
+- `brand-ink-open`
+- `radial-ripple-phone-chips`
+- `voice-waveform-live`
+- `spotlight-hero-card`
+- `picker-carousel-feature-cycle`
+- `page-turn-transitions · cube-rotate`
+- `before-after-slider-scrub`
+- `card-flip-reveal`
+
+“直接继承”只指运动结构、缓动、时值配比和已验证的参数。字体、颜色、材质、截图、文案和构图仍要按 SpeakUp 重新蒙皮。
+
+### 6.2 只作为参考、必须定制的镜头
+
+- `radial-wave`：原样片是暗场蓝色点阵，本片只取扩散与回收的节奏，重新设计为 SpeakUp 浅色声音波纹。
+- `ui-to-brand-morph · input-morph-assemble`：原样片把输入框变成几何品牌图形；SpeakUp 没有同构几何 mark，因此改成输入框收缩、声音波纹回收、真实 wordmark 落定。
+- 练习页面缓推：采用 Video Shotcraft 的 `PageCam` 能力和真实页面截图，但不对应某一张 Gallery 卡。
+
+## 7. 视觉和节奏原则
+
+- 延续项目现有黑、白、浅灰色板、圆角卡片、克制留白与 Allura 手写字标。
+- 暖色场景插画只作为真实 App 页面中的内容出现，不另造宣传片背景世界。
+- 每个镜头只讲一个主要动效；`spotlight-hero-card` 的完整动作弧全片只出现一次。
+- 品牌字标落定保持至少 1 秒，批量动效收尾保持至少 0.5 秒静止。
+- 真实 UI 的可读性优先于速度。推近后的文字必须使用高分辨率元素切片，不能依赖低分辨率整页截图放大。
+- 不使用霓虹、粒子爆炸、科幻传送门、卡片群舞或游戏式 UI 音色。
+- 伪随机声纹和其他程序动画使用固定种子，不使用 `Math.random()` 或 `Date.now()`，保证逐帧渲染可复现。
+
+## 8. 声音方案
+
+第一版无旁白，声音承担动作因果而不是持续铺满：
+
+- 痛点字卡：轻纸张压印或短促文字 swoosh，四张保持同一声音词汇。
+- 声波桥接：一次短 riser，引出品牌落定的柔和 impact。
+- 语音输入：轻环境底噪、声纹活性、提交 pop 和短下滑音。
+- 训练计划卡：弹起 whoosh、轮廓扫描 sparkle、归位 snap，各只出现一次。
+- 场景吸附：每次落定使用克制的轻 tick。
+- Cube 转场：一次低频 whoosh，页面落定后留白。
+- 前后对比：快甩 whoosh、回弹 tick，慢扫阶段基本无声。
+- 复盘翻卡：每张落定一声轻“啪”，最多三次。
+- 结尾：输入提交声、声波收束音、字标落定的柔和 impact；字标 hold 阶段保持安静。
+
+若后续选择强节奏 BGM，必须先完成 BPM、相位和瞬态分析，再把转场与主要动作钉到真实拍点；最终固定交付带 BGM 版和无 BGM、保留 SFX 版。
+
+## 9. 真实素材清单
+
+进入最终分镜后再进行完整采集。本方案预计需要：
+
+1. SpeakUp 主会话空闲态。
+2. 文字输入或语音输入状态。
+3. Agent 对目标的真实回复。
+4. 训练计划卡及其目标、场景、角色、轮次信息。
+5. 面试、IELTS、职场、生活与旅行四类真实入口。
+6. 至少一个可稳定运行的真实练习页面和录音状态。
+7. 一条包含原表达、建议表达与解释的真实逐句反馈。
+8. 一组可稳定展示的真实报告、能力维度、下一步建议或历史记录。
+9. SpeakUp 真实字标文件。
+
+素材采集必须从当前任务 worktree 运行真实后端与 iOS 模拟器；模拟器禁用数字人。若 OSS 代理阻塞，仅允许在当前 worktree 的本地 `.env` 中设置 `OSS_ENABLED=0` 和 `RESUME_OCR_ENABLED=0`，不得提交该配置或改用 mock。
+
+## 10. 后续共同创作节点
+
+本文件确认的是总体方案和功能到动效的映射，不是制作放行。后续顺序为：
+
+1. 核对当前真实后端下各目标页面的录制可用性和宣传边界。
+2. 确认最终屏幕文案、CTA 和需要重点展示的训练场景。
+3. 使用少量安全截图制作 2–3 张 1920×1080 styleframe，确认静态视觉语言。
+4. 输出最终逐镜头分镜，至少记录时间/帧、功能信息、镜头卡、主动作、页面状态、素材来源、字幕、转场和 SFX。
+5. 用户确认 styleframe、最终分镜和数据口径后，才进行完整素材采集与 Remotion 制作。
+6. 首次整片渲染后进行逐镜头静帧、整片抽帧、音频卡点和数据安全检查；交付前由独立审查上下文进行终检。
+
+当前仍需在最终分镜前共同确认：
+
+- 四组痛点与结尾主张的最终措辞。
+- 四类训练场景在 60 秒主片中的相对权重，以及核心演示采用 IELTS、职场还是其他场景。
+- 片尾是否增加下载、试用、官网或 GitHub 等明确 CTA。


### PR DESCRIPTION
## 功能描述

新增 `docs/视频方案.md`，固化当前共同创作已确认的首版 SpeakUp 产品宣传片方案：约 60 秒、纯真实产品界面、不使用真人或 AI 人物、第一版无旁白。

文档逐段标注 Video Shotcraft Gallery 中采用的卡名与 `style-key`，并区分直接继承运动语法、仅作参考的定制实现和不依赖 Gallery 的 PageCam 镜头。

## 实现思路

- 用四组痛点字卡建立问题。
- 用真实 Agent、训练计划、四类场景、练习、反馈和复盘页面逐一回答痛点。
- 对 11 张已选 Shotcraft 卡记录用途、具体变体、准确参考实现和 SpeakUp 适配边界。
- 明确真实 UI、数据安全、声音、节奏与后续共同确认节点。

## 可复现测试

1. 打开 `docs/视频方案.md`，确认约 60 秒时间线逐段标注卡名和 style-key。
2. 在 https://vincentwei1021.github.io/video-shotcraft/library.html 搜索文档中的卡名，确认均可匹配。
3. 运行 `git diff --check upstream/dev...HEAD`，确认无空白错误。

已执行：

```text
git diff --cached --check
```

结果：通过。此 PR 仅新增文档，未运行 Flutter/Go 构建。

Closes #691