### PR TITLE
feat(agent): 优化练习计划卡片开始入口

### DIFF
--- a/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
+++ b/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
@@ -78,14 +78,14 @@ final class PracticePlanHandoffCard extends StatelessWidget {
                         ],
                       ),
               ),
-              const SizedBox(width: 12),
-              Icon(
-                Icons.chevron_right_rounded,
-                size: 22,
-                color: onConfirm == null
-                    ? SpeakUpDesign.tertiary
-                    : SpeakUpDesign.secondary,
-              ),
+              if (onConfirm != null) ...[
+                const SizedBox(width: 12),
+                const Icon(
+                  Icons.chevron_right_rounded,
+                  size: 22,
+                  color: SpeakUpDesign.secondary,
+                ),
+              ],
             ],
           ),
         ),

--- a/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
+++ b/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
@@ -21,48 +21,74 @@ final class PracticePlanHandoffCard extends StatelessWidget {
       if (!isIELTS) handoff.roles.join('、'),
       handoff.practiceScope,
     ].join(' · ');
-    return Container(
+    final title = isIELTS ? practiceSummary : handoff.target;
+    return Material(
       key: Key(
         'agent-handoff-practice-plan-'
         '${handoff.practicePlanId}-${handoff.planRevision}',
       ),
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: SpeakUpDesign.surface,
-        border: Border.all(color: SpeakUpDesign.border),
+      color: SpeakUpDesign.surface,
+      shape: RoundedRectangleBorder(
+        side: const BorderSide(color: SpeakUpDesign.border),
         borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            isIELTS ? practiceSummary : handoff.target,
-            style: SpeakUpDesign.cardTitle,
-          ),
-          if (!isIELTS) ...[
-            const SizedBox(height: 6),
-            Text(
-              practiceSummary,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: SpeakUpDesign.body,
-            ),
-          ],
-          const SizedBox(height: 6),
-          Text('约 $minutes 分钟', style: SpeakUpDesign.meta),
-          const SizedBox(height: 10),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              key: Key(
-                'confirm-practice-plan-'
-                '${handoff.practicePlanId}-${handoff.planRevision}',
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        key: Key(
+          'confirm-practice-plan-'
+          '${handoff.practicePlanId}-${handoff.planRevision}',
+        ),
+        onTap: onConfirm,
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: isIELTS
+                    ? Text.rich(
+                        TextSpan(
+                          children: [
+                            TextSpan(
+                              text: title,
+                              style: SpeakUpDesign.cardTitle,
+                            ),
+                            TextSpan(
+                              text: '   约 $minutes 分钟',
+                              style: SpeakUpDesign.meta,
+                            ),
+                          ],
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(title, style: SpeakUpDesign.cardTitle),
+                          const SizedBox(height: 6),
+                          Text(
+                            practiceSummary,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: SpeakUpDesign.body,
+                          ),
+                          const SizedBox(height: 6),
+                          Text('约 $minutes 分钟', style: SpeakUpDesign.meta),
+                        ],
+                      ),
               ),
-              onPressed: onConfirm,
-              child: const Text('开始练习'),
-            ),
+              const SizedBox(width: 12),
+              Icon(
+                Icons.chevron_right_rounded,
+                size: 22,
+                color: onConfirm == null
+                    ? SpeakUpDesign.tertiary
+                    : SpeakUpDesign.secondary,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -318,7 +318,7 @@ void main() {
     expect(find.text('Java Interview Practice'), findsOneWidget);
     expect(find.text('项目经历深挖 · 面试官、候选人 · 围绕项目难点完成三轮追问'), findsOneWidget);
     expect(find.text('约 12 分钟'), findsOneWidget);
-    expect(find.text('开始练习'), findsOneWidget);
+    expect(find.text('开始练习'), findsNothing);
     expect(find.text('确认并开始练习'), findsNothing);
     expect(find.text('场景：项目经历深挖'), findsNothing);
     expect(find.text('角色：面试官、候选人'), findsNothing);
@@ -406,15 +406,14 @@ void main() {
     expect(markdown, isNot(contains('卡片')));
     expect(markdown, isNot(contains('Part 1')));
     expect(markdown, isNot(contains('练前跟练')));
-    expect(find.text('IELTS 口语 · Part 1'), findsOneWidget);
-    expect(find.text('约 5 分钟'), findsOneWidget);
+    expect(find.text('IELTS 口语 · Part 1   约 5 分钟'), findsOneWidget);
     expect(find.text(handoff.target), findsNothing);
     expect(find.text('场景：IELTS 口语'), findsNothing);
     expect(find.text('角色：IELTS 口语考官'), findsNothing);
     expect(find.text('范围：Part 1'), findsNothing);
     expect(find.textContaining('3–3 轮'), findsNothing);
     expect(find.text(handoff.confirmationPrompt), findsNothing);
-    expect(find.text('开始练习'), findsOneWidget);
+    expect(find.text('开始练习'), findsNothing);
 
     await tester.tap(
       find.byKey(
@@ -462,8 +461,7 @@ void main() {
       'assistant-ielts-full-mock',
     ).map(_selectablePlainText).join(' ');
     expect(markdown, '好。');
-    expect(find.text('IELTS 口语 · 完整模考'), findsOneWidget);
-    expect(find.text('约 14 分钟'), findsOneWidget);
+    expect(find.text('IELTS 口语 · 完整模考   约 14 分钟'), findsOneWidget);
     final card = find.byKey(
       const Key(
         'agent-handoff-practice-plan-'

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -468,6 +468,22 @@ void main() {
         '10000000-0000-4000-8000-000000000004-1',
       ),
     );
+    final entry = tester.widget<InkWell>(
+      find.byKey(
+        const Key(
+          'confirm-practice-plan-'
+          '10000000-0000-4000-8000-000000000004-1',
+        ),
+      ),
+    );
+    expect(entry.onTap, isNull);
+    expect(
+      find.descendant(
+        of: card,
+        matching: find.byIcon(Icons.chevron_right_rounded),
+      ),
+      findsNothing,
+    );
     for (final hidden in const <String>[
       '练前跟练',
       '不计分',

--- a/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
@@ -167,11 +167,11 @@ void main() {
     final threadCount = harness.conversation.threads.length;
 
     await _pumpConflictShell(tester, harness, controller);
-    final confirmButton = tester.widget<FilledButton>(
+    final confirmButton = tester.widget<InkWell>(
       find.byKey(const Key('confirm-practice-plan-practice-plan-session-1-2')),
     );
-    confirmButton.onPressed!();
-    confirmButton.onPressed!();
+    confirmButton.onTap!();
+    confirmButton.onTap!();
     await tester.pumpAndSettle();
     expect(find.text('开始新的练习？'), findsOneWidget);
     await tester.tap(find.byKey(const Key('cancel-existing-practice-action')));


### PR DESCRIPTION
## 功能描述

- 将 Agent 练习计划卡片从整行黑色按钮改为整卡可点击的轻量入口。
- IELTS 卡片保持单行：练习模式使用标题层级，时长使用弱化辅助层级，尾部使用系统 chevron。
- 非 IELTS 卡片保留原有目标、场景摘要和时长信息，同时统一使用整卡点击入口。
- 保留原确认回调、组件 Key、禁用态及点击反馈。

## 实现思路

- 复用 Material + InkWell 提供裁切、按压反馈和整卡点击区域，不新增组件或依赖。
- 使用尾部 chevron 表达进入练习流程；文本单行溢出时省略，避免挤压箭头。
- 依据 Apple Lists and Tables 的 disclosure indicator 模式与 44pt 触控区域原则调整视觉层级。

## 可复现测试

```bash
cd mobile
flutter test test/agent/agent_message_bubble_test.dart
flutter analyze lib/features/agent/handoff/practice_plan_handoff_card.dart
```

14 条 Agent 消息与 handoff 测试通过，静态分析无问题。已使用真实后端、18082 端口、禁用数字人的 iOS 模拟器完成视觉验证。

Closes #693