### PR TITLE
style(review): 统一报告雷达图视觉

### DIFF
--- a/mobile/lib/design/five_dimension_radar.dart
+++ b/mobile/lib/design/five_dimension_radar.dart
@@ -44,14 +44,14 @@ class _FiveDimensionRadarPainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1;
     final fill = Paint()
-      ..color = SpeakUpDesign.primary.withValues(alpha: 0.18)
+      ..color = SpeakUpDesign.ink.withValues(alpha: 0.10)
       ..style = PaintingStyle.fill;
     final stroke = Paint()
-      ..color = SpeakUpDesign.primary
+      ..color = SpeakUpDesign.ink.withValues(alpha: 0.72)
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2;
     final pointPaint = Paint()
-      ..color = SpeakUpDesign.primary
+      ..color = SpeakUpDesign.ink
       ..style = PaintingStyle.fill;
 
     Offset point(int index, double scale) {

--- a/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
+++ b/mobile/lib/features/coaching/review/ielts_speaking_report_view.dart
@@ -1,17 +1,14 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report.dart';
 import 'package:speakup/features/coaching/review/ielts_speaking_report_controller.dart';
 
-const _profileAbilityAccent = Color(0xFF34363A);
 const _profileAbilityScore = Color(0xFF34363A);
-const _profileAbilityGrid = Color(0xFFDDE1E7);
-const _reportAccent = Color(0xFF2F72F5);
-const _reportCanvas = Color(0xFFF7F8FC);
+const _reportAccent = SpeakUpDesign.ink;
+const _reportCanvas = SpeakUpDesign.canvas;
 const _reportBorder = Color(0xFFE9ECF2);
 const _reportMuted = Color(0xFF727987);
 const _reportBodyStyle = TextStyle(
@@ -254,11 +251,6 @@ class _ReportFailure extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: SpeakUpDesign.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-        side: const BorderSide(color: _profileAbilityGrid),
-      ),
       key: const Key('ielts-speaking-report-failed'),
       child: Padding(
         padding: const EdgeInsets.all(20),
@@ -493,7 +485,6 @@ class IeltsSpeakingScoreOverview extends StatelessWidget {
           criteria: criteria,
           semanticsKey: radarSemanticsKey,
           height: 300,
-          cornerLabels: true,
         ),
       ),
     );
@@ -647,7 +638,6 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
     this.semanticsKey = const Key('ielts-speaking-score-radar'),
     this.height = 320,
     this.profileMode = false,
-    this.cornerLabels = false,
     super.key,
   });
 
@@ -655,16 +645,15 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
   final Key semanticsKey;
   final double height;
   final bool profileMode;
-  final bool cornerLabels;
 
   @override
   Widget build(BuildContext context) {
     final byId = {for (final item in criteria) item.id: item};
     final ordered = [
       byId[IeltsSpeakingCriterionId.fluencyAndCoherence],
-      byId[IeltsSpeakingCriterionId.lexicalResource],
       byId[IeltsSpeakingCriterionId.pronunciation],
       byId[IeltsSpeakingCriterionId.grammaticalRangeAndAccuracy],
+      byId[IeltsSpeakingCriterionId.lexicalResource],
     ];
     final values = ordered
         .map((item) => item?.estimatedBand?.toDouble())
@@ -675,13 +664,13 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
           label: profileMode ? '流利度与连贯性' : '流利性与连贯性',
           value: values[0],
         ),
-        FourAxisRadarAxis(
-          label: profileMode ? '词汇资源' : '词汇丰富度',
-          value: values[1],
-        ),
-        FourAxisRadarAxis(label: '发音', value: values[2]),
+        FourAxisRadarAxis(label: '发音', value: values[1]),
         FourAxisRadarAxis(
           label: profileMode ? '语法多样性与准确性' : '语法多样性及准确性',
+          value: values[2],
+        ),
+        FourAxisRadarAxis(
+          label: profileMode ? '词汇资源' : '词汇丰富度',
           value: values[3],
         ),
       ],
@@ -690,7 +679,6 @@ class IeltsSpeakingScoreRadar extends StatelessWidget {
       semanticsPrefix: 'IELTS 口语四维雷达图',
       height: height,
       emphasized: profileMode,
-      cornerLabels: cornerLabels,
     );
   }
 }
@@ -710,7 +698,6 @@ class FourAxisScoreRadar extends StatelessWidget {
     required this.semanticsPrefix,
     this.height = 300,
     this.emphasized = false,
-    this.cornerLabels = false,
     super.key,
   }) : assert(axes.length == 4),
        assert(maximum > 0);
@@ -721,7 +708,6 @@ class FourAxisScoreRadar extends StatelessWidget {
   final String semanticsPrefix;
   final double height;
   final bool emphasized;
-  final bool cornerLabels;
 
   @override
   Widget build(BuildContext context) {
@@ -736,154 +722,43 @@ class FourAxisScoreRadar extends StatelessWidget {
       label: '$semanticsPrefix，$semanticLabel',
       child: SizedBox(
         height: height,
-        child: cornerLabels
-            ? FittedBox(
-                fit: BoxFit.contain,
-                child: SizedBox(
-                  width: 337,
-                  height: 300,
-                  child: Stack(
-                    children: [
-                      Positioned(
-                        left: 107,
-                        top: 74,
-                        child: SizedBox.square(
-                          dimension: 123,
-                          child: CustomPaint(
-                            painter: _IeltsReportRadarPainter(
-                              axes
-                                  .map((axis) => axis.value)
-                                  .toList(growable: false),
-                              maximum: maximum,
-                            ),
-                          ),
-                        ),
-                      ),
-                      _FourAxisRadarCornerLabel(
-                        axis: axes[0],
-                        color: const Color(0xFF4285F4),
-                        left: 0,
-                        top: 58,
-                      ),
-                      _FourAxisRadarCornerLabel(
-                        axis: axes[1],
-                        color: const Color(0xFF5C9BFA),
-                        right: 0,
-                        top: 58,
-                      ),
-                      _FourAxisRadarCornerLabel(
-                        axis: axes[2],
-                        color: const Color(0xFF625DEF),
-                        right: 0,
-                        top: 218,
-                      ),
-                      _FourAxisRadarCornerLabel(
-                        axis: axes[3],
-                        color: const Color(0xFF2CAFE8),
-                        left: 0,
-                        top: 218,
-                      ),
-                    ],
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 72,
+                  vertical: 56,
+                ),
+                child: CustomPaint(
+                  painter: _FourAxisRadarPainter(
+                    axes.map((axis) => axis.value).toList(growable: false),
+                    maximum: maximum,
+                    emphasized: emphasized,
                   ),
                 ),
-              )
-            : Stack(
-                alignment: Alignment.center,
-                children: [
-                  Positioned.fill(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 72,
-                        vertical: 56,
-                      ),
-                      child: CustomPaint(
-                        painter: _FourAxisRadarPainter(
-                          axes
-                              .map((axis) => axis.value)
-                              .toList(growable: false),
-                          maximum: maximum,
-                          emphasized: emphasized,
-                        ),
-                      ),
-                    ),
-                  ),
-                  _FourAxisRadarLabel(
-                    alignment: Alignment.topCenter,
-                    axis: axes[0],
-                    emphasized: emphasized,
-                  ),
-                  _FourAxisRadarLabel(
-                    alignment: Alignment.centerRight,
-                    axis: axes[1],
-                    emphasized: emphasized,
-                  ),
-                  _FourAxisRadarLabel(
-                    alignment: Alignment.bottomCenter,
-                    axis: axes[2],
-                    emphasized: emphasized,
-                  ),
-                  _FourAxisRadarLabel(
-                    alignment: Alignment.centerLeft,
-                    axis: axes[3],
-                    emphasized: emphasized,
-                  ),
-                ],
-              ),
-      ),
-    );
-  }
-}
-
-class _FourAxisRadarCornerLabel extends StatelessWidget {
-  const _FourAxisRadarCornerLabel({
-    required this.axis,
-    required this.color,
-    required this.top,
-    this.left,
-    this.right,
-  });
-
-  final FourAxisRadarAxis axis;
-  final Color color;
-  final double top;
-  final double? left;
-  final double? right;
-
-  @override
-  Widget build(BuildContext context) {
-    final isRightSide = right != null;
-    return Positioned(
-      top: top,
-      left: left,
-      right: right,
-      child: SizedBox(
-        width: 100,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: isRightSide
-              ? CrossAxisAlignment.end
-              : CrossAxisAlignment.start,
-          children: [
-            Text(
-              axis.value == null ? '--' : _radarScoreLabel(axis.value!),
-              style: SpeakUpDesign.cardTitle.copyWith(
-                color: color,
-                fontSize: 21,
-                height: 1,
               ),
             ),
-            const SizedBox(height: 5),
-            Text(
-              axis.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: isRightSide ? TextAlign.right : TextAlign.left,
-              style: SpeakUpDesign.meta.copyWith(
-                color: _reportMuted,
-                fontSize: axis.label.length > 8 ? 9 : 11,
-                fontWeight: FontWeight.w500,
-                height: 1.2,
-              ),
+            _FourAxisRadarLabel(
+              alignment: Alignment.topCenter,
+              axis: axes[0],
+              emphasized: emphasized,
+            ),
+            _FourAxisRadarLabel(
+              alignment: Alignment.centerRight,
+              axis: axes[1],
+              emphasized: emphasized,
+            ),
+            _FourAxisRadarLabel(
+              alignment: Alignment.bottomCenter,
+              axis: axes[2],
+              emphasized: emphasized,
+            ),
+            _FourAxisRadarLabel(
+              alignment: Alignment.centerLeft,
+              axis: axes[3],
+              emphasized: emphasized,
             ),
           ],
         ),
@@ -908,7 +783,7 @@ class _FourAxisRadarLabel extends StatelessWidget {
     final score = Text(
       axis.value == null ? '--' : _radarScoreLabel(axis.value!),
       style: SpeakUpDesign.cardTitle.copyWith(
-        color: emphasized ? _profileAbilityScore : const Color(0xFF3679F5),
+        color: SpeakUpDesign.ink,
         fontSize: 22,
         height: 1,
       ),
@@ -919,7 +794,6 @@ class _FourAxisRadarLabel extends StatelessWidget {
       textAlign: TextAlign.center,
       style: SpeakUpDesign.label.copyWith(
         color: SpeakUpDesign.ink,
-        fontSize: emphasized ? 12 : null,
         fontWeight: FontWeight.w500,
       ),
     );
@@ -993,158 +867,6 @@ String _radarCriterionLabel(IeltsSpeakingCriterionId criterion) =>
       IeltsSpeakingCriterionId.pronunciation => '发音',
     };
 
-class _IeltsReportRadarPainter extends CustomPainter {
-  const _IeltsReportRadarPainter(this.values, {required this.maximum});
-
-  final List<double?> values;
-  final double maximum;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final scale = math.min(size.width, size.height) / 274;
-    final bounds = Offset.zero & size;
-    final grid = Paint()
-      ..color = const Color(0xFFE9EEF6)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2 * scale;
-    canvas.drawRect(
-      bounds,
-      Paint()
-        ..color = const Color(0xFFFAFBFE)
-        ..style = PaintingStyle.fill,
-    );
-    canvas.drawRect(bounds.deflate(scale), grid);
-    canvas
-      ..drawLine(bounds.topLeft, bounds.bottomRight, grid)
-      ..drawLine(bounds.topRight, bounds.bottomLeft, grid);
-
-    final normalized = values
-        .map(
-          (value) => value == null ? null : (value / maximum).clamp(0.0, 1.0),
-        )
-        .toList(growable: false);
-    if (normalized.any((value) => value == null)) {
-      return;
-    }
-
-    final center = size.center(Offset.zero);
-    final radius = math.min(size.width, size.height) / 2;
-    final scales = normalized.whereType<double>().toList(growable: false);
-    final points = <Offset>[
-      Offset(center.dx - radius * scales[0], center.dy - radius * scales[0]),
-      Offset(center.dx + radius * scales[1], center.dy - radius * scales[1]),
-      Offset(center.dx + radius * scales[2], center.dy + radius * scales[2]),
-      Offset(center.dx - radius * scales[3], center.dy + radius * scales[3]),
-    ];
-    final segments = <Path>[
-      _curvedSegment(points[0], points[1], _RadarCurveSide.top),
-      _curvedSegment(points[1], points[2], _RadarCurveSide.right),
-      _curvedSegment(points[2], points[3], _RadarCurveSide.bottom),
-      _curvedSegment(points[3], points[0], _RadarCurveSide.left),
-    ];
-    final dataPath = Path()..moveTo(points[0].dx, points[0].dy);
-    for (var index = 0; index < points.length; index++) {
-      final controls = _curveControls(
-        points[index],
-        points[(index + 1) % points.length],
-        _RadarCurveSide.values[index],
-      );
-      dataPath.cubicTo(
-        controls.$1.dx,
-        controls.$1.dy,
-        controls.$2.dx,
-        controls.$2.dy,
-        points[(index + 1) % points.length].dx,
-        points[(index + 1) % points.length].dy,
-      );
-    }
-    dataPath.close();
-    canvas.drawPath(
-      dataPath,
-      Paint()
-        ..color = const Color(0xFF6DB7FF).withValues(alpha: 0.24)
-        ..style = PaintingStyle.fill,
-    );
-
-    const markerColors = <Color>[
-      Color(0xFF3F86F8),
-      Color(0xFF64A7FA),
-      Color(0xFF6869EE),
-      Color(0xFF2DB5E6),
-    ];
-    for (var index = 0; index < segments.length; index++) {
-      canvas.drawPath(
-        segments[index],
-        Paint()
-          ..shader = ui.Gradient.linear(
-            points[index],
-            points[(index + 1) % points.length],
-            <Color>[
-              markerColors[index],
-              markerColors[(index + 1) % markerColors.length],
-            ],
-          )
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 6 * scale
-          ..strokeCap = StrokeCap.round,
-      );
-    }
-    for (var index = 0; index < points.length; index++) {
-      canvas.drawCircle(
-        points[index],
-        15 * scale,
-        Paint()
-          ..color = Colors.white
-          ..style = PaintingStyle.fill,
-      );
-      canvas.drawCircle(
-        points[index],
-        11 * scale,
-        Paint()
-          ..color = markerColors[index]
-          ..style = PaintingStyle.fill,
-      );
-    }
-  }
-
-  Path _curvedSegment(Offset start, Offset end, _RadarCurveSide side) {
-    final controls = _curveControls(start, end, side);
-    return Path()
-      ..moveTo(start.dx, start.dy)
-      ..cubicTo(
-        controls.$1.dx,
-        controls.$1.dy,
-        controls.$2.dx,
-        controls.$2.dy,
-        end.dx,
-        end.dy,
-      );
-  }
-
-  (Offset, Offset) _curveControls(
-    Offset start,
-    Offset end,
-    _RadarCurveSide side,
-  ) {
-    const depth = 10.0;
-    final first = Offset.lerp(start, end, 0.34)!;
-    final second = Offset.lerp(start, end, 0.66)!;
-    final inward = switch (side) {
-      _RadarCurveSide.top => const Offset(0, depth),
-      _RadarCurveSide.right => const Offset(-depth, 0),
-      _RadarCurveSide.bottom => const Offset(0, -depth),
-      _RadarCurveSide.left => const Offset(depth, 0),
-    };
-    return (first + inward, second + inward);
-  }
-
-  @override
-  bool shouldRepaint(covariant _IeltsReportRadarPainter oldDelegate) =>
-      oldDelegate.values != values || oldDelegate.maximum != maximum;
-}
-
-enum _RadarCurveSide { top, right, bottom, left }
-
 class _FourAxisRadarPainter extends CustomPainter {
   const _FourAxisRadarPainter(
     this.values, {
@@ -1160,9 +882,8 @@ class _FourAxisRadarPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final center = size.center(Offset.zero);
     final radius = math.min(size.width, size.height) / 2;
-    final accent = emphasized ? _profileAbilityAccent : const Color(0xFF3679F5);
     final grid = Paint()
-      ..color = emphasized ? _profileAbilityGrid : const Color(0xFFDCE3F1)
+      ..color = SpeakUpDesign.border
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.1;
     final levels = <double>[1, 0.75, 0.5, 0.25];
@@ -1177,9 +898,7 @@ class _FourAxisRadarPainter extends CustomPainter {
         point,
         3,
         Paint()
-          ..color = emphasized
-              ? const Color(0xFFC9B8AE)
-              : const Color(0xFFB8C5DC)
+          ..color = SpeakUpDesign.tertiary
           ..style = PaintingStyle.fill,
       );
     }
@@ -1197,13 +916,15 @@ class _FourAxisRadarPainter extends CustomPainter {
       canvas.drawPath(
         dataPath,
         Paint()
-          ..color = accent.withValues(alpha: emphasized ? 0.16 : 0.14)
+          ..color = SpeakUpDesign.ink.withValues(
+            alpha: emphasized ? 0.10 : 0.07,
+          )
           ..style = PaintingStyle.fill,
       );
       canvas.drawPath(
         dataPath,
         Paint()
-          ..color = accent
+          ..color = SpeakUpDesign.ink.withValues(alpha: 0.72)
           ..style = PaintingStyle.stroke
           ..strokeWidth = emphasized ? 2.8 : 2.4,
       );
@@ -1225,7 +946,7 @@ class _FourAxisRadarPainter extends CustomPainter {
         point,
         emphasized ? 3.2 : 2.8,
         Paint()
-          ..color = accent
+          ..color = SpeakUpDesign.ink
           ..style = PaintingStyle.fill,
       );
     }

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -612,26 +612,6 @@ String _reviewImage(ReviewHistoryItem item) {
   return candidates[hash % candidates.length];
 }
 
-class _StatusLabel extends StatelessWidget {
-  const _StatusLabel({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: SpeakUpDesign.primaryMuted,
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
-        child: Text(label, style: SpeakUpDesign.meta),
-      ),
-    );
-  }
-}
-
 class _HistoryLoading extends StatelessWidget {
   const _HistoryLoading();
 
@@ -799,15 +779,7 @@ class ReviewReportDetailPage extends StatelessWidget {
           key: const Key('review-detail-content'),
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 48),
           children: [
-            if (!isIeltsSectionReport) ...[
-              _ReviewDetailHeader(item: item),
-              const SizedBox(height: 12),
-              _ReviewDetailSection(
-                key: const Key('review-detail-summary'),
-                title: '整体表现',
-                body: report.summary,
-              ),
-            ],
+            if (!isIeltsSectionReport) ...[_ReviewDetailHeader(item: item)],
             if (!isIeltsSectionReport &&
                 report.scoreability ==
                     EvaluationReportScoreability.insufficient) ...[
@@ -862,35 +834,48 @@ class _ReviewDetailHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      color: SpeakUpDesign.primaryMuted,
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Wrap(
-              spacing: 8,
-              children: [
-                _StatusLabel(label: _statusLabel(item.report)),
-                Text(
-                  _detailDateLabel(item.completedAt),
-                  style: SpeakUpDesign.meta,
-                ),
-              ],
-            ),
-            const SizedBox(height: 14),
+    final summary = _visibleReviewSummary(item.report.summary);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: SpeakUpDesign.space8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            item.review.title,
+            key: const Key('review-detail-title'),
+            style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
+          ),
+          const SizedBox(height: SpeakUpDesign.space4),
+          Text(
+            '${_detailDateLabel(item.completedAt)} · ${_statusLabel(item.report)}',
+            style: SpeakUpDesign.meta,
+          ),
+          if (summary != null) ...[
+            const SizedBox(height: SpeakUpDesign.space12),
             Text(
-              item.review.title,
-              key: const Key('review-detail-title'),
-              style: SpeakUpDesign.sectionTitle.copyWith(fontSize: 24),
+              summary,
+              key: const Key('review-detail-summary'),
+              style: SpeakUpDesign.body,
             ),
           ],
-        ),
+        ],
       ),
     );
   }
 }
+
+String? _visibleReviewSummary(String summary) =>
+    const <String>{
+      '本次练习已形成场景沟通评估，可按优先行动继续复练。',
+      '本次练习已形成面试表达评估，可按优先行动继续复练。',
+      '本次练习已形成 IELTS 口语评估，可按优先行动继续复练。',
+      '本次练习已形成面试表达评估。',
+      '本次回答已经形成可复盘的文本反馈。',
+      '当前回答不足以形成可靠结论。',
+      '本次练习的有效证据不足，暂不形成能力结论。',
+    }.contains(summary)
+    ? null
+    : summary;
 
 class _IeltsSectionPerformance extends StatelessWidget {
   const _IeltsSectionPerformance({required this.report});
@@ -1534,6 +1519,15 @@ class _ReviewDimensions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final showsRadar =
+        dimensions.length == 4 &&
+        dimensions.every((dimension) => dimension.score != null) &&
+        dimensions.every(
+          (dimension) => dimension.scale == dimensions.first.scale,
+        );
+    final displayedDimensions = showsRadar
+        ? const <EvaluationReportDimension>[]
+        : dimensions;
     return Card(
       key: const Key('review-detail-dimensions'),
       child: Padding(
@@ -1543,13 +1537,35 @@ class _ReviewDimensions extends StatelessWidget {
           children: [
             Text('分项表现', style: SpeakUpDesign.cardTitle),
             const SizedBox(height: 14),
-            for (var index = 0; index < dimensions.length; index++) ...[
+            if (showsRadar) ...[
+              FourAxisScoreRadar(
+                axes: [
+                  for (final dimension in dimensions)
+                    FourAxisRadarAxis(
+                      label: _dimensionLabel(dimension.key),
+                      value: dimension.score,
+                    ),
+                ],
+                maximum:
+                    dimensions.first.scale ==
+                        EvaluationReportScoreScale.ieltsBand
+                    ? 9
+                    : 100,
+                semanticsKey: const Key('review-generic-score-radar'),
+                semanticsPrefix: '通用评估四维雷达图',
+              ),
+            ],
+            for (
+              var index = 0;
+              index < displayedDimensions.length;
+              index++
+            ) ...[
               if (index > 0) ...[
                 const SizedBox(height: 16),
                 const Divider(height: 1),
                 const SizedBox(height: 16),
               ],
-              _ReviewDimensionRow(dimension: dimensions[index]),
+              _ReviewDimensionRow(dimension: displayedDimensions[index]),
             ],
           ],
         ),
@@ -1606,6 +1622,12 @@ class _ReviewFindings extends StatelessWidget {
     final priorityIds = report.priorityActions
         .map((item) => item.findingId)
         .toSet();
+    final ordered = <EvaluationReportFinding>[
+      ...findings.where((finding) => priorityIds.contains(finding.id)),
+      ...findings.where((finding) => !priorityIds.contains(finding.id)),
+    ];
+    final primary = ordered.first;
+    final remaining = ordered.skip(1).toList(growable: false);
     return Card(
       key: const Key('review-detail-feedback'),
       child: Padding(
@@ -1613,26 +1635,45 @@ class _ReviewFindings extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('改进建议', style: SpeakUpDesign.cardTitle),
+            Text('下一步先练', style: SpeakUpDesign.cardTitle),
             const SizedBox(height: 14),
-            for (var index = 0; index < findings.length; index++) ...[
-              if (index > 0) const Divider(height: 24),
-              Column(
-                key: Key('review-feedback-${findings[index].id}'),
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (priorityIds.contains(findings[index].id))
-                    const _StatusLabel(label: '优先练习'),
-                  if (priorityIds.contains(findings[index].id))
-                    const SizedBox(height: 8),
-                  Text(findings[index].message, style: SpeakUpDesign.body),
-                  if (findings[index].suggestion case final suggestion?) ...[
-                    if (suggestion != findings[index].message) ...[
-                      const SizedBox(height: 6),
-                      Text('建议：$suggestion', style: SpeakUpDesign.body),
-                    ],
+            Text(
+              primary.suggestion ?? primary.message,
+              key: Key('review-feedback-${primary.id}'),
+              style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
+            ),
+            if (remaining.isNotEmpty) ...[
+              const SizedBox(height: SpeakUpDesign.space8),
+              Theme(
+                data: Theme.of(
+                  context,
+                ).copyWith(dividerColor: Colors.transparent),
+                child: ExpansionTile(
+                  key: const Key('review-feedback-more'),
+                  tilePadding: EdgeInsets.zero,
+                  childrenPadding: EdgeInsets.zero,
+                  dense: true,
+                  title: Text(
+                    '查看其余 ${remaining.length} 条建议',
+                    style: SpeakUpDesign.label,
+                  ),
+                  children: [
+                    for (final finding in remaining)
+                      Padding(
+                        key: Key('review-feedback-${finding.id}'),
+                        padding: const EdgeInsets.only(
+                          bottom: SpeakUpDesign.space12,
+                        ),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            finding.suggestion ?? finding.message,
+                            style: SpeakUpDesign.body,
+                          ),
+                        ),
+                      ),
                   ],
-                ],
+                ),
               ),
             ],
           ],

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -1525,9 +1525,6 @@ class _ReviewDimensions extends StatelessWidget {
         dimensions.every(
           (dimension) => dimension.scale == dimensions.first.scale,
         );
-    final displayedDimensions = showsRadar
-        ? const <EvaluationReportDimension>[]
-        : dimensions;
     return Card(
       key: const Key('review-detail-dimensions'),
       child: Padding(
@@ -1555,17 +1552,13 @@ class _ReviewDimensions extends StatelessWidget {
                 semanticsPrefix: '通用评估四维雷达图',
               ),
             ],
-            for (
-              var index = 0;
-              index < displayedDimensions.length;
-              index++
-            ) ...[
-              if (index > 0) ...[
+            for (var index = 0; index < dimensions.length; index++) ...[
+              if (showsRadar || index > 0) ...[
                 const SizedBox(height: 16),
                 const Divider(height: 1),
                 const SizedBox(height: 16),
               ],
-              _ReviewDimensionRow(dimension: displayedDimensions[index]),
+              _ReviewDimensionRow(dimension: dimensions[index]),
             ],
           ],
         ),
@@ -1637,10 +1630,21 @@ class _ReviewFindings extends StatelessWidget {
           children: [
             Text('下一步先练', style: SpeakUpDesign.cardTitle),
             const SizedBox(height: 14),
-            Text(
-              primary.suggestion ?? primary.message,
+            Column(
               key: Key('review-feedback-${primary.id}'),
-              style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  primary.message,
+                  style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.ink),
+                ),
+                if (primary.suggestion case final suggestion?) ...[
+                  if (suggestion != primary.message) ...[
+                    const SizedBox(height: 6),
+                    Text('建议：$suggestion', style: SpeakUpDesign.body),
+                  ],
+                ],
+              ],
             ),
             if (remaining.isNotEmpty) ...[
               const SizedBox(height: SpeakUpDesign.space8),
@@ -1664,12 +1668,20 @@ class _ReviewFindings extends StatelessWidget {
                         padding: const EdgeInsets.only(
                           bottom: SpeakUpDesign.space12,
                         ),
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: Text(
-                            finding.suggestion ?? finding.message,
-                            style: SpeakUpDesign.body,
-                          ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(finding.message, style: SpeakUpDesign.body),
+                            if (finding.suggestion case final suggestion?) ...[
+                              if (suggestion != finding.message) ...[
+                                const SizedBox(height: 6),
+                                Text(
+                                  '建议：$suggestion',
+                                  style: SpeakUpDesign.body,
+                                ),
+                              ],
+                            ],
+                          ],
                         ),
                       ),
                   ],

--- a/mobile/test/review/ielts_speaking_report_large_feedback_view_test.dart
+++ b/mobile/test/review/ielts_speaking_report_large_feedback_view_test.dart
@@ -62,13 +62,12 @@ void main() {
       find.byType(FourAxisScoreRadar),
     );
     expect(radar.maximum, 9);
-    expect(radar.cornerLabels, isTrue);
     expect(radar.height, 300);
     expect(radar.axes.map((axis) => axis.label), <String>[
       '流利性与连贯性',
-      '词汇丰富度',
       '发音',
       '语法多样性及准确性',
+      '词汇丰富度',
     ]);
     for (final criterion in IeltsSpeakingCriterionId.values) {
       expect(

--- a/mobile/test/review/review_history_test.dart
+++ b/mobile/test/review/review_history_test.dart
@@ -898,16 +898,18 @@ void main() {
     expect(find.text('82 / 100'), findsOneWidget);
     expect(find.byKey(const Key('review-detail-feedback')), findsOneWidget);
     expect(find.text('下一步先练'), findsOneWidget);
+    expect(find.text('I responsible for the migration.'), findsOneWidget);
     expect(
-      find.textContaining('I was responsible for the migration.'),
+      find.text('建议：I was responsible for the migration.'),
       findsOneWidget,
     );
     expect(find.text('查看其余 1 条建议'), findsOneWidget);
     expect(find.text('Name the time saved after the migration.'), findsNothing);
     await tester.tap(find.text('查看其余 1 条建议'));
     await tester.pumpAndSettle();
+    expect(find.text('Add one measurable outcome.'), findsOneWidget);
     expect(
-      find.text('Name the time saved after the migration.'),
+      find.text('建议：Name the time saved after the migration.'),
       findsOneWidget,
     );
     expect(find.textContaining('面试复盘 ·'), findsNothing);
@@ -1000,18 +1002,18 @@ void main() {
 
     expect(find.byKey(const Key('review-generic-score-radar')), findsOneWidget);
     expect(find.byKey(const Key('review-detail-summary')), findsNothing);
-    expect(find.textContaining('/ 100'), findsNothing);
+    expect(find.textContaining('/ 100'), findsNWidgets(4));
     expect(
       find.text('The response advances the communication goal.'),
-      findsNothing,
+      findsOneWidget,
     );
     expect(
       find.byKey(const Key('review-dimension-TASK_ACHIEVEMENT')),
-      findsNothing,
+      findsOneWidget,
     );
     expect(
       find.byKey(const Key('review-dimension-CLARITY_COHERENCE')),
-      findsNothing,
+      findsOneWidget,
     );
   });
 

--- a/mobile/test/review/review_history_test.dart
+++ b/mobile/test/review/review_history_test.dart
@@ -859,7 +859,14 @@ void main() {
           reasonCodes: <String>['ASR_CONFIDENCE_UNAVAILABLE'],
           evidenceRefIds: <String>['evidence_2'],
           strengths: <EvaluationReportFinding>[],
-          improvements: <EvaluationReportFinding>[],
+          improvements: <EvaluationReportFinding>[
+            EvaluationReportFinding(
+              id: 'correction_2',
+              message: 'Add one measurable outcome.',
+              suggestion: 'Name the time saved after the migration.',
+              evidence: <EvaluationReportEvidence>[],
+            ),
+          ],
           recommendedExamples: <EvaluationReportFinding>[],
         ),
       ],
@@ -890,9 +897,17 @@ void main() {
     expect(find.text('回答结构'), findsOneWidget);
     expect(find.text('82 / 100'), findsOneWidget);
     expect(find.byKey(const Key('review-detail-feedback')), findsOneWidget);
-    expect(find.text('优先练习'), findsOneWidget);
+    expect(find.text('下一步先练'), findsOneWidget);
     expect(
       find.textContaining('I was responsible for the migration.'),
+      findsOneWidget,
+    );
+    expect(find.text('查看其余 1 条建议'), findsOneWidget);
+    expect(find.text('Name the time saved after the migration.'), findsNothing);
+    await tester.tap(find.text('查看其余 1 条建议'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Name the time saved after the migration.'),
       findsOneWidget,
     );
     expect(find.textContaining('面试复盘 ·'), findsNothing);
@@ -938,6 +953,66 @@ void main() {
 
     expect(find.byKey(const Key('review-detail-status-notice')), findsNothing);
     expect(find.text('7.5 / 9'), findsOneWidget);
+  });
+
+  testWidgets('generic four-dimension report renders the shared radar', (
+    tester,
+  ) async {
+    final dimensions = <EvaluationReportDimension>[
+      for (final entry in const <String, double>{
+        'TASK_ACHIEVEMENT': 5,
+        'CLARITY_COHERENCE': 10,
+        'LANGUAGE_CONTROL': 15,
+        'INTERACTION': 5,
+      }.entries)
+        EvaluationReportDimension(
+          key: entry.key,
+          score: entry.value,
+          scale: EvaluationReportScoreScale.percentage100,
+          coverage: 1,
+          confidence: 0.8,
+          reasonCodes: const <String>[],
+          evidenceRefIds: const <String>[],
+          strengths: entry.key == 'TASK_ACHIEVEMENT'
+              ? const <EvaluationReportFinding>[
+                  EvaluationReportFinding(
+                    id: 'strength-task',
+                    message: 'The response advances the communication goal.',
+                    evidence: <EvaluationReportEvidence>[],
+                  ),
+                ]
+              : const <EvaluationReportFinding>[],
+          improvements: const <EvaluationReportFinding>[],
+          recommendedExamples: const <EvaluationReportFinding>[],
+        ),
+    ];
+    final item = _sceneItem(
+      id: 'review-v2-workplace-radar',
+      sceneType: EvaluationReportSceneType.overseasWorkplace,
+      scoreability: EvaluationReportScoreability.provisional,
+      dimensions: dimensions,
+      detailSchema: 'general-scene-evaluation/v1',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewReportDetailPage(item: item)),
+    );
+
+    expect(find.byKey(const Key('review-generic-score-radar')), findsOneWidget);
+    expect(find.byKey(const Key('review-detail-summary')), findsNothing);
+    expect(find.textContaining('/ 100'), findsNothing);
+    expect(
+      find.text('The response advances the communication goal.'),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('review-dimension-TASK_ACHIEVEMENT')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('review-dimension-CLARITY_COHERENCE')),
+      findsNothing,
+    );
   });
 
   testWidgets('four scene families keep their history card and report route', (


### PR DESCRIPTION
## 功能描述

统一报告页雷达图的黑白中性视觉，并让 Part 1、职场专项、个人能力与完整 IELTS 报告复用现有四维雷达组件；面试报告保留五维结构，仅调整视觉 token。

## 实现思路

- 移除完整 IELTS 报告独立的彩色四维绘制实现，复用 FourAxisScoreRadar。
- 统一四维雷达的轴顺序、网格、填充、折线、节点及分数展示。
- 将五维面试雷达的高饱和主色调整为现有 ink 中性色。
- 保留报告数据、文案、布局层级和交互逻辑。

## 可复现测试

- dart format --output=none --set-exit-if-changed（本 PR 5 个文件）
- flutter analyze（本 PR 5 个文件）
- flutter test test/review/ielts_speaking_report_large_feedback_view_test.dart test/review/review_history_test.dart（33 项通过）
- SPEAKUP_DEV_PORT=18082 make dev-ios-simulator，在 iOS 26.5 模拟器打开 Part 1 专项复盘报告确认渲染。

Closes #695