### PR TITLE
feat(navigation): 增加侧栏个人主页头像入口

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -121,6 +121,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   AgentConversationFeedbackPresenter? _feedbackPresenter;
   bool _practiceRouteInFlight = false;
   bool _agentHandoffInFlight = false;
+  bool _conversationDrawerOpen = false;
   int _navigationGeneration = 0;
 
   @override
@@ -552,6 +553,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
           : Colors.transparent,
       drawer: _ConversationDrawer(
         controller: widget.conversationController,
+        onOpenProfile: () => _selectDestination(3),
         hiddenThreadIds: {
           ?widget
               .preparationLaunchController
@@ -559,13 +561,20 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
               ?.currentPracticeThreadId,
         },
       ),
+      onDrawerChanged: (open) {
+        if (_conversationDrawerOpen != open) {
+          setState(() => _conversationDrawerOpen = open);
+        }
+      },
       drawerScrimColor: const Color(0x52000000),
       body: IndexedStack(index: _selectedIndex, children: pages),
-      bottomNavigationBar: PlatformNavigationBar(
-        destinations: _destinations,
-        selectedIndex: _selectedIndex,
-        onDestinationSelected: _selectDestinationFromNavigation,
-      ),
+      bottomNavigationBar: _conversationDrawerOpen
+          ? null
+          : PlatformNavigationBar(
+              destinations: _destinations,
+              selectedIndex: _selectedIndex,
+              onDestinationSelected: _selectDestinationFromNavigation,
+            ),
     );
   }
 
@@ -580,10 +589,12 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
 class _ConversationDrawer extends StatelessWidget {
   const _ConversationDrawer({
     required this.controller,
+    required this.onOpenProfile,
     this.hiddenThreadIds = const <String>{},
   });
 
   final ConversationController controller;
+  final VoidCallback onOpenProfile;
   final Set<String> hiddenThreadIds;
 
   @override
@@ -706,28 +717,55 @@ class _ConversationDrawer extends StatelessWidget {
                   ),
                   Positioned(
                     left: 16,
+                    right: 16,
                     bottom: 16,
-                    child: FilledButton.icon(
-                      key: const Key('new-conversation-button'),
-                      onPressed: busy
-                          ? null
-                          : () async {
-                              final created = await controller.createThread();
-                              if (!context.mounted || !created) {
-                                return;
-                              }
-                              Navigator.of(context).pop();
-                            },
-                      icon: const Icon(Icons.edit_outlined, size: 22),
-                      label: const Text('聊天'),
-                      style: FilledButton.styleFrom(
-                        minimumSize: const Size(0, 48),
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        backgroundColor: SpeakUpDesign.primary,
-                        foregroundColor: SpeakUpDesign.canvas,
-                        shape: const StadiumBorder(),
-                        textStyle: SpeakUpDesign.cardTitle,
-                      ),
+                    child: Row(
+                      children: [
+                        FilledButton.icon(
+                          key: const Key('new-conversation-button'),
+                          onPressed: busy
+                              ? null
+                              : () async {
+                                  final created = await controller
+                                      .createThread();
+                                  if (!context.mounted || !created) {
+                                    return;
+                                  }
+                                  Navigator.of(context).pop();
+                                },
+                          icon: const Icon(Icons.edit_outlined, size: 22),
+                          label: const Text('聊天'),
+                          style: FilledButton.styleFrom(
+                            minimumSize: const Size(0, 48),
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
+                            backgroundColor: SpeakUpDesign.primary,
+                            foregroundColor: SpeakUpDesign.canvas,
+                            shape: const StadiumBorder(),
+                            textStyle: SpeakUpDesign.cardTitle,
+                          ),
+                        ),
+                        const Spacer(),
+                        IconButton(
+                          key: const Key('drawer-profile-button'),
+                          tooltip: '打开我的页面',
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            onOpenProfile();
+                          },
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints.tightFor(
+                            width: 48,
+                            height: 48,
+                          ),
+                          icon: const CircleAvatar(
+                            radius: 24,
+                            backgroundColor: SpeakUpDesign.surfaceMuted,
+                            backgroundImage: AssetImage(
+                              'assets/images/scenes/profile-avatar-alex.png',
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ],

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -964,6 +964,36 @@ void main() {
     );
   });
 
+  testWidgets('conversation drawer avatar opens the Profile page', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp.preview());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('conversation-menu-button')));
+    await tester.pumpAndSettle();
+
+    final profileButton = find.byKey(const Key('drawer-profile-button'));
+    final chatButton = find.byKey(const Key('new-conversation-button'));
+    expect(profileButton, findsOneWidget);
+    expect(find.byTooltip('打开我的页面'), findsOneWidget);
+    expect(find.byKey(const Key('primary-navigation')), findsNothing);
+    expect(
+      tester.getRect(profileButton).right,
+      tester.getRect(find.byType(Drawer)).right - 16,
+    );
+    expect(
+      tester.getRect(profileButton).center.dy,
+      tester.getRect(chatButton).center.dy,
+    );
+
+    await tester.tap(profileButton);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Drawer), findsNothing);
+    expect(find.byKey(const Key('profile-page')), findsOneWidget);
+  });
+
   testWidgets('conversation drawer excludes practice-owned Threads', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

在对话侧栏底部聊天按钮右侧增加圆形头像入口，点击后关闭侧栏并进入“我的”页面。

## 实现思路

- 复用个人主页现有头像资产与主导航索引，不新增路由或状态层。
- 聊天按钮贴左、头像贴右，两者中心线平齐。
- 侧栏打开时隐藏原生 iOS 底栏，避免 UIKit 玻璃层在悬浮按钮上方形成分割线。

## 可复现测试

- flutter analyze lib/app/speak_up_shell.dart test/speak_up_app_test.dart
- flutter test test/speak_up_app_test.dart --plain-name "conversation drawer"（4 项通过）
- SPEAKUP_DEV_PORT=18082 make dev-ios-simulator，在 iOS 26.5 模拟器验证头像位置、无分割线及跳转。

Closes #700