### PR TITLE
fix(agent): 保持三项快捷操作底部对齐

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -139,9 +139,8 @@ class ConversationPage extends StatefulWidget {
     final horizontalPadding = width >= 390 ? 20.0 : 16.0;
     final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final titleSize = width < 350 ? 27.0 : 30.0;
-    final emptyHomeActionGap =
-        (MediaQuery.sizeOf(context).height * 0.325).clamp(180.0, 274.0) +
-        (onContinuePractice == null ? 52.0 : 0.0);
+    final emptyHomeActionGap = (MediaQuery.sizeOf(context).height * 0.325)
+        .clamp(180.0, 274.0);
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
     final canCompose = hasFocusedThread || onCreateConversation != null;
@@ -872,13 +871,6 @@ class _QuickActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final actions = <_QuickActionButton>[
-      if (onContinuePractice != null)
-        _QuickActionButton(
-          actionKey: const Key('quick-action-continue-practice'),
-          icon: Icons.play_circle_outline_rounded,
-          label: '继续上次练习',
-          onPressed: onContinuePractice,
-        ),
       _QuickActionButton(
         actionKey: const Key('quick-action-create-plan'),
         icon: Icons.work_outline_rounded,
@@ -901,6 +893,20 @@ class _QuickActions extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        Visibility(
+          visible: onContinuePractice != null,
+          maintainState: true,
+          maintainAnimation: true,
+          maintainSize: true,
+          child: _QuickActionButton(
+            actionKey: onContinuePractice == null
+                ? null
+                : const Key('quick-action-continue-practice'),
+            icon: Icons.play_circle_outline_rounded,
+            label: '继续上次练习',
+            onPressed: onContinuePractice,
+          ),
+        ),
         for (var index = 0; index < actions.length; index++) ...[
           actions[index],
           if (index != actions.length - 1) const SizedBox.shrink(),

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -139,8 +139,9 @@ class ConversationPage extends StatefulWidget {
     final horizontalPadding = width >= 390 ? 20.0 : 16.0;
     final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final titleSize = width < 350 ? 27.0 : 30.0;
-    final emptyHomeActionGap = (MediaQuery.sizeOf(context).height * 0.325)
-        .clamp(180.0, 274.0);
+    final emptyHomeActionGap =
+        (MediaQuery.sizeOf(context).height * 0.325).clamp(180.0, 274.0) +
+        (onContinuePractice == null ? 52.0 : 0.0);
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
     final canCompose = hasFocusedThread || onCreateConversation != null;

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -920,6 +920,31 @@ void main() {
     expect(composerRect.top - lastActionRect.bottom, greaterThanOrEqualTo(16));
   });
 
+  testWidgets('keeps three and four Agent actions on the same bottom edge', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(402, 874);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(const MaterialApp(home: ConversationPage()));
+    await tester.pumpAndSettle();
+    final threeActionBottom = tester
+        .getRect(find.byKey(const Key('quick-action-recent-review')))
+        .bottom;
+
+    await tester.pumpWidget(
+      MaterialApp(home: ConversationPage(onContinuePractice: () {})),
+    );
+    await tester.pumpAndSettle();
+    final fourActionBottom = tester
+        .getRect(find.byKey(const Key('quick-action-recent-review')))
+        .bottom;
+
+    expect(threeActionBottom, closeTo(fourActionBottom, 0.01));
+  });
+
   testWidgets('conversation drawer exposes bounded Thread actions only', (
     tester,
   ) async {

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -925,8 +925,10 @@ void main() {
   ) async {
     tester.view.physicalSize = const Size(402, 874);
     tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
 
     await tester.pumpWidget(const MaterialApp(home: ConversationPage()));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 功能描述

首页没有可继续的上一场练习时，剩余三项快捷操作仍与四项状态保持相同底边，贴近输入框上方排列。

## 实现思路

- 保留现有响应式标题间距和四项顺序。
- 隐藏“继续上次练习”时，将其 52px 最小高度补入标题与操作区之间。
- 不修改按钮文案、图标或导航行为。

## 可复现测试

- flutter analyze lib/features/agent/conversation/conversation.dart test/speak_up_app_test.dart
- flutter test test/speak_up_app_test.dart --plain-name "Agent actions"（4 项通过）
- 新增三项/四项底边坐标一致断言。
- SPEAKUP_DEV_PORT=18082 make dev-ios-simulator，在 iOS 26.5 模拟器验证四项状态无回归。

Closes #702