### PR TITLE
feat(mobile): 重构 Agent 推荐练习卡片视觉

### DIFF
--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -122,32 +122,39 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
       ),
       AgentMessageModality.text => _buildTextMessage(),
     };
-    return ConversationBubbleSurface(
+    final bubble = ConversationBubbleSurface(
       bubbleKey: Key('agent-message-${message.id}'),
       isUser: isUser,
-      margin: const EdgeInsets.only(bottom: 7),
+      margin: message.handoffs.isEmpty
+          ? const EdgeInsets.only(bottom: 7)
+          : EdgeInsets.zero,
       padding: isUser && message.modality == AgentMessageModality.voice
           ? EdgeInsets.fromLTRB(14, 11, 12, voiceNeedsBottomInset ? 11 : 0)
           : null,
-      child: message.handoffs.isEmpty
-          ? primaryContent
-          : Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                primaryContent,
-                const SizedBox(height: 10),
-                for (final handoff in message.handoffs)
-                  switch (handoff) {
-                    ConfirmPracticePlanHandoff() => PracticePlanHandoffCard(
-                      handoff: handoff,
-                      onConfirm: widget.onHandoff == null
-                          ? null
-                          : () => widget.onHandoff!(handoff),
-                    ),
-                  },
-              ],
-            ),
+      child: primaryContent,
+    );
+    if (message.handoffs.isEmpty) {
+      return bubble;
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 7),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          bubble,
+          const SizedBox(height: 10),
+          for (final handoff in message.handoffs)
+            switch (handoff) {
+              ConfirmPracticePlanHandoff() => PracticePlanHandoffCard(
+                handoff: handoff,
+                onConfirm: widget.onHandoff == null
+                    ? null
+                    : () => widget.onHandoff!(handoff),
+              ),
+            },
+        ],
+      ),
     );
   }
 

--- a/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
+++ b/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
@@ -16,80 +16,298 @@ final class PracticePlanHandoffCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final minutes = (handoff.suggestedDuration.inSeconds / 60).ceil();
     final isIELTS = handoff.practiceExperience == 'IELTS_SPEAKING';
-    final practiceSummary = <String>[
-      handoff.sceneName,
-      if (!isIELTS) handoff.roles.join('、'),
-      handoff.practiceScope,
-    ].join(' · ');
-    final title = isIELTS ? practiceSummary : handoff.target;
-    return Material(
-      key: Key(
-        'agent-handoff-practice-plan-'
-        '${handoff.practicePlanId}-${handoff.planRevision}',
-      ),
-      color: SpeakUpDesign.surface,
-      shape: RoundedRectangleBorder(
-        side: const BorderSide(color: SpeakUpDesign.border),
-        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        key: Key(
-          'confirm-practice-plan-'
-          '${handoff.practicePlanId}-${handoff.planRevision}',
-        ),
-        onTap: onConfirm,
-        child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
+    final title = isIELTS
+        ? 'IELTS Speaking · ${handoff.practiceScope}'
+        : handoff.target;
+    final role = handoff.roles.join('、');
+
+    return Align(
+      alignment: Alignment.center,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 353),
+        child: SizedBox(
+          key: Key(
+            'agent-handoff-practice-plan-'
+            '${handoff.practicePlanId}-${handoff.planRevision}',
+          ),
+          width: double.infinity,
+          height: 282,
+          child: Stack(
             children: [
-              Expanded(
-                child: isIELTS
-                    ? Text.rich(
-                        TextSpan(
-                          children: [
-                            TextSpan(
-                              text: title,
-                              style: SpeakUpDesign.cardTitle,
-                            ),
-                            TextSpan(
-                              text: '   约 $minutes 分钟',
-                              style: SpeakUpDesign.meta,
-                            ),
-                          ],
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      )
-                    : Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(title, style: SpeakUpDesign.cardTitle),
-                          const SizedBox(height: 6),
-                          Text(
-                            practiceSummary,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: SpeakUpDesign.body,
-                          ),
-                          const SizedBox(height: 6),
-                          Text('约 $minutes 分钟', style: SpeakUpDesign.meta),
-                        ],
-                      ),
-              ),
-              if (onConfirm != null) ...[
-                const SizedBox(width: 12),
-                const Icon(
-                  Icons.chevron_right_rounded,
-                  size: 22,
-                  color: SpeakUpDesign.secondary,
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 160,
+                child: _PracticeHero(
+                  title: title,
+                  role: role,
+                  isIELTS: isIELTS,
                 ),
-              ],
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: 129,
+                child: Material(
+                  color: SpeakUpDesign.surface,
+                  elevation: 4,
+                  shadowColor: const Color(0x1A000000),
+                  borderRadius: BorderRadius.circular(
+                    SpeakUpDesign.radiusMedia,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(14, 13, 14, 13),
+                    child: Column(
+                      children: [
+                        Expanded(
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: _PracticeFact(
+                                  icon: Icons.schedule_rounded,
+                                  label: '约 $minutes 分钟',
+                                ),
+                              ),
+                              const SizedBox(
+                                height: 24,
+                                child: VerticalDivider(width: 1),
+                              ),
+                              Expanded(
+                                child: _PracticeFact(
+                                  icon: Icons.chat_bubble_outline_rounded,
+                                  label: _questionCountLabel(handoff),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 9),
+                        Material(
+                          color: onConfirm == null
+                              ? SpeakUpDesign.primaryMuted
+                              : SpeakUpDesign.primary,
+                          borderRadius: BorderRadius.circular(999),
+                          clipBehavior: Clip.antiAlias,
+                          child: InkWell(
+                            key: Key(
+                              'confirm-practice-plan-'
+                              '${handoff.practicePlanId}-'
+                              '${handoff.planRevision}',
+                            ),
+                            onTap: onConfirm,
+                            child: SizedBox(
+                              height: 46,
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.play_arrow_rounded,
+                                    size: 23,
+                                    color: onConfirm == null
+                                        ? SpeakUpDesign.tertiary
+                                        : SpeakUpDesign.surface,
+                                  ),
+                                  const SizedBox(width: 7),
+                                  Text(
+                                    '开始练习',
+                                    style: SpeakUpDesign.cardTitle.copyWith(
+                                      color: onConfirm == null
+                                          ? SpeakUpDesign.tertiary
+                                          : SpeakUpDesign.surface,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             ],
           ),
         ),
       ),
     );
   }
+}
+
+final class _PracticeHero extends StatelessWidget {
+  const _PracticeHero({
+    required this.title,
+    required this.role,
+    required this.isIELTS,
+  });
+
+  final String title;
+  final String role;
+  final bool isIELTS;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(SpeakUpDesign.radiusMedia),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [Color(0xFFF4F1FF), Color(0xFFE9E3FF)],
+              ),
+            ),
+          ),
+          if (isIELTS)
+            Positioned(
+              top: 0,
+              right: -4,
+              bottom: 0,
+              width: 160,
+              child: Semantics(
+                image: true,
+                label: 'IELTS 考官头像',
+                child: ShaderMask(
+                  blendMode: BlendMode.dstIn,
+                  shaderCallback: (bounds) => const LinearGradient(
+                    colors: [Colors.transparent, Colors.black],
+                    stops: [0, 0.3],
+                  ).createShader(bounds),
+                  child: Image.asset(
+                    'assets/images/scenes/ielts-examiner.jpg',
+                    fit: BoxFit.cover,
+                    alignment: const Alignment(0, -0.3),
+                  ),
+                ),
+              ),
+            ),
+          if (isIELTS)
+            const Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      Color(0xFFF4F1FF),
+                      Color(0xE6F4F1FF),
+                      Color(0x00F4F1FF),
+                    ],
+                    stops: [0, 0.42, 0.78],
+                  ),
+                ),
+              ),
+            ),
+          Positioned(
+            top: 14,
+            left: 14,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: const Color(0x99FFFFFF),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Text(
+                  '已为你准备好',
+                  style: TextStyle(
+                    color: SpeakUpDesign.ink,
+                    fontSize: 11.5,
+                    fontWeight: FontWeight.w500,
+                    height: 1.1,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 48,
+            left: 14,
+            right: isIELTS ? 74 : 14,
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: SpeakUpDesign.cardTitle.copyWith(
+                fontSize: 18,
+                height: 1.2,
+                letterSpacing: -0.25,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 88,
+            left: 14,
+            right: isIELTS ? 90 : 14,
+            child: Row(
+              children: [
+                const Icon(
+                  Icons.account_circle_outlined,
+                  size: 18,
+                  color: SpeakUpDesign.secondary,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Text(
+                    isIELTS ? '$role · IELTS Examiner' : role,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: SpeakUpDesign.ink,
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w500,
+                      height: 1.25,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _PracticeFact extends StatelessWidget {
+  const _PracticeFact({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(icon, size: 19, color: SpeakUpDesign.secondary),
+        const SizedBox(width: 7),
+        Flexible(
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: SpeakUpDesign.body.copyWith(
+              color: SpeakUpDesign.ink,
+              fontSize: 13,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _questionCountLabel(ConfirmPracticePlanHandoff handoff) {
+  final maximum = handoff.maxEffectiveTurns;
+  if (maximum == 0) {
+    return '${handoff.minEffectiveTurns}+ 个问题';
+  }
+  if (maximum == handoff.minEffectiveTurns) {
+    return '$maximum 个问题';
+  }
+  return '${handoff.minEffectiveTurns}–$maximum 个问题';
 }

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -316,9 +316,12 @@ void main() {
     );
 
     expect(find.text('Java Interview Practice'), findsOneWidget);
-    expect(find.text('项目经历深挖 · 面试官、候选人 · 围绕项目难点完成三轮追问'), findsOneWidget);
+    expect(find.text('已为你准备好'), findsOneWidget);
+    expect(find.text('围绕项目难点完成三轮追问'), findsNothing);
+    expect(find.text('面试官、候选人'), findsOneWidget);
     expect(find.text('约 12 分钟'), findsOneWidget);
-    expect(find.text('开始练习'), findsNothing);
+    expect(find.text('3–5 个问题'), findsOneWidget);
+    expect(find.text('开始练习'), findsOneWidget);
     expect(find.text('确认并开始练习'), findsNothing);
     expect(find.text('场景：项目经历深挖'), findsNothing);
     expect(find.text('角色：面试官、候选人'), findsNothing);
@@ -406,14 +409,28 @@ void main() {
     expect(markdown, isNot(contains('卡片')));
     expect(markdown, isNot(contains('Part 1')));
     expect(markdown, isNot(contains('练前跟练')));
-    expect(find.text('IELTS 口语 · Part 1   约 5 分钟'), findsOneWidget);
+    expect(find.text('IELTS Speaking · Part 1'), findsOneWidget);
     expect(find.text(handoff.target), findsNothing);
+    expect(find.text('IELTS 口语考官 · IELTS Examiner'), findsOneWidget);
+    expect(find.text('约 5 分钟'), findsOneWidget);
+    expect(find.text('3 个问题'), findsOneWidget);
+    expect(find.bySemanticsLabel('IELTS 考官头像'), findsOneWidget);
+    final card = find.byKey(
+      const Key(
+        'agent-handoff-practice-plan-'
+        '10000000-0000-4000-8000-000000000003-1',
+      ),
+    );
+    expect(
+      tester.getCenter(card).dx,
+      tester.view.physicalSize.width / tester.view.devicePixelRatio / 2,
+    );
     expect(find.text('场景：IELTS 口语'), findsNothing);
     expect(find.text('角色：IELTS 口语考官'), findsNothing);
     expect(find.text('范围：Part 1'), findsNothing);
     expect(find.textContaining('3–3 轮'), findsNothing);
     expect(find.text(handoff.confirmationPrompt), findsNothing);
-    expect(find.text('开始练习'), findsNothing);
+    expect(find.text('开始练习'), findsOneWidget);
 
     await tester.tap(
       find.byKey(
@@ -461,7 +478,9 @@ void main() {
       'assistant-ielts-full-mock',
     ).map(_selectablePlainText).join(' ');
     expect(markdown, '好。');
-    expect(find.text('IELTS 口语 · 完整模考   约 14 分钟'), findsOneWidget);
+    expect(find.text('IELTS Speaking · 完整模考'), findsOneWidget);
+    expect(find.text('约 14 分钟'), findsOneWidget);
+    expect(find.text('14 个问题'), findsOneWidget);
     final card = find.byKey(
       const Key(
         'agent-handoff-practice-plan-'


### PR DESCRIPTION
## 功能描述

重构 Agent 推荐练习卡片，使创建状态、练习标题、角色、时长、题数和主操作更清晰，并让卡片与消息气泡分离展示。

## 实现思路

- 将练习卡片改为顶部场景信息与底部练习信息/CTA 的双层布局。
- IELTS 卡片复用现有考官图片资产并补充无障碍语义。
- 根据练习计划已有轮次数据展示问题数，不修改协议或后端。
- 保留确认开始练习的原有回调和路由行为。
- 更新消息气泡布局和 widget 测试以覆盖新版卡片。

## 可复现测试

```bash
cd mobile
dart format lib/features/agent/conversation/agent_message_bubble.dart lib/features/agent/handoff/practice_plan_handoff_card.dart test/agent/agent_message_bubble_test.dart
flutter test test/agent/agent_message_bubble_test.dart
flutter analyze lib/features/agent/conversation/agent_message_bubble.dart lib/features/agent/handoff/practice_plan_handoff_card.dart test/agent/agent_message_bubble_test.dart
```

结果：14 项 widget 测试通过；静态分析无问题。

Closes #705