### PR TITLE
test(review): 锁定复盘历史四分类筛选

### DIFF
--- a/mobile/test/review/review_history_test.dart
+++ b/mobile/test/review/review_history_test.dart
@@ -1086,6 +1086,67 @@ void main() {
     }
   });
 
+  testWidgets('history filters keep all four scene families available', (
+    tester,
+  ) async {
+    const cases = [
+      (
+        id: 'filter-interview',
+        sceneType: EvaluationReportSceneType.interview,
+        label: '面试',
+      ),
+      (
+        id: 'filter-ielts',
+        sceneType: EvaluationReportSceneType.ieltsSpeaking,
+        label: '雅思',
+      ),
+      (
+        id: 'filter-daily-life',
+        sceneType: EvaluationReportSceneType.overseasDailyLife,
+        label: '日常英语',
+      ),
+      (
+        id: 'filter-workplace',
+        sceneType: EvaluationReportSceneType.overseasWorkplace,
+        label: '职场英语',
+      ),
+    ];
+    final items = [
+      for (final testCase in cases)
+        _sceneItem(
+          id: testCase.id,
+          sceneType: testCase.sceneType,
+          scoreability: EvaluationReportScoreability.provisional,
+          dimensions: const <EvaluationReportDimension>[],
+        ),
+    ];
+    final controller = ReviewHistoryController(
+      client: _FixedItemsClient(items),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ReviewPage(historyController: controller)),
+    );
+    await tester.pumpAndSettle();
+
+    for (final testCase in cases) {
+      expect(find.text(testCase.label), findsOneWidget);
+    }
+
+    for (final selectedCase in cases) {
+      await tester.tap(find.text(selectedCase.label));
+      await tester.pumpAndSettle();
+
+      for (final testCase in cases) {
+        expect(
+          find.byKey(Key('review-history-${testCase.id}')),
+          testCase == selectedCase ? findsOneWidget : findsNothing,
+        );
+      }
+    }
+  });
+
   testWidgets('insufficient evidence never renders a zero score', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

为复盘历史的四类筛选补充回归保障，锁定面试、雅思、日常英语和职场英语四个入口及对应过滤行为。

## 实现思路

- 使用四类真实 `EvaluationReportSceneType` 构造复盘历史。
- 验证四个分类入口均展示。
- 逐个点击分类，验证列表只保留对应场景的报告。
- 生产实现已在 `dev` 恢复，本 PR 不做重复或无意义改写。

## 可复现测试

```bash
cd mobile
dart format test/review/review_history_test.dart
flutter test test/review/review_history_test.dart
flutter analyze lib/features/coaching/review/review.dart test/review/review_history_test.dart
```

结果：31 项测试通过；静态分析无问题。

Closes #707