### PR TITLE
fix(evaluation): retry transient invalid IELTS report responses

### DIFF
--- a/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/ielts_scoring_integration_test.go
@@ -504,7 +504,7 @@ func TestPostgresIELTSSpeakingResultConstraintRejectsFCBand(
 	}
 }
 
-func TestPostgresIELTSSpeakingPromptV8LineageConstraintAndRoundTrip(
+func TestPostgresIELTSSpeakingPromptV9LineageConstraintAndRoundTrip(
 	t *testing.T,
 ) {
 	pool, repository, configuration, evaluation :=
@@ -631,8 +631,8 @@ func TestPostgresIELTSSpeakingPromptV8LineageConstraintAndRoundTrip(
 			var databaseError *pgconn.PgError
 			if !errors.As(err, &databaseError) ||
 				databaseError.ConstraintName !=
-					"evaluation_ielts_scene_results_v8_lineage_check" {
-				t.Fatalf("invalid v8 lineage error = %v", err)
+					"evaluation_ielts_scene_results_v9_lineage_check" {
+				t.Fatalf("invalid v9 lineage error = %v", err)
 			}
 		})
 	}
@@ -642,7 +642,7 @@ func TestPostgresIELTSSpeakingPromptV8LineageConstraintAndRoundTrip(
 		claim,
 		result,
 	); err != nil {
-		t.Fatalf("complete valid v8 lineage: %v", err)
+		t.Fatalf("complete valid v9 lineage: %v", err)
 	}
 	state, err := repository.GetIELTSSpeakingShadowState(
 		context.Background(),
@@ -651,10 +651,10 @@ func TestPostgresIELTSSpeakingPromptV8LineageConstraintAndRoundTrip(
 		evaluation.Revision.ID,
 	)
 	if err != nil {
-		t.Fatalf("read v8 lineage: %v", err)
+		t.Fatalf("read v9 lineage: %v", err)
 	}
 	if state.Result == nil {
-		t.Fatal("round-trip v8 result is missing")
+		t.Fatal("round-trip v9 result is missing")
 	}
 	want, err := json.Marshal(result.Provider)
 	if err != nil {
@@ -669,7 +669,7 @@ func TestPostgresIELTSSpeakingPromptV8LineageConstraintAndRoundTrip(
 	}
 }
 
-func TestPostgresIELTSSpeakingPromptV8AllowsNoProviderLineageWhenInsufficient(
+func TestPostgresIELTSSpeakingPromptV9AllowsNoProviderLineageWhenInsufficient(
 	t *testing.T,
 ) {
 	snapshot := ieltsSpeakingTestSnapshot(t, ieltsPostgresQuestionCount-1)

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow.go
@@ -23,7 +23,7 @@ import (
 const (
 	IELTSSpeakingShadowSchemaVersion          = "ielts-speaking-full-mock-shadow/v1"
 	IELTSSpeakingShadowProviderSchemaVersion  = "ielts-speaking-full-mock-shadow-provider/v3"
-	IELTSSpeakingShadowPromptVersion          = "ielts-speaking-full-mock-shadow-prompt/v8"
+	IELTSSpeakingShadowPromptVersion          = "ielts-speaking-full-mock-shadow-prompt/v9"
 	IELTSSpeakingShadowRubricVersion          = "ielts-speaking-public-band-rubric/v2"
 	IELTSSpeakingCriterionRepairPolicyVersion = "ielts-speaking-criterion-repair/v1"
 

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker.go
@@ -365,6 +365,7 @@ func ieltsClaimMatchesRuntime(
 func classifyIELTSSpeakingShadowFailure(
 	cause error,
 ) IELTSSpeakingShadowFailure {
+	var providerRejection *ieltsCriterionProviderRejection
 	switch {
 	case errors.Is(cause, errIELTSSpeakingProviderInvalidJSON):
 		return IELTSSpeakingShadowFailure{
@@ -375,6 +376,11 @@ func classifyIELTSSpeakingShadowFailure(
 		return IELTSSpeakingShadowFailure{
 			Code:      "provider_schema_mismatch",
 			Retryable: false,
+		}
+	case errors.As(cause, &providerRejection):
+		return IELTSSpeakingShadowFailure{
+			Code:      "provider_invalid_response",
+			Retryable: true,
 		}
 	case errors.Is(cause, ErrInvalidIELTSSpeakingShadow),
 		errors.Is(cause, evaluation.ErrInvalidRequest):

--- a/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
+++ b/server/internal/coaching/evaluation/scoring/ielts_speaking_shadow_worker_test.go
@@ -291,7 +291,7 @@ func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
 	repository := &ieltsShadowRuntimeRepositoryStub{
 		claim:      claim,
 		acquired:   true,
-		failStatus: IELTSSpeakingShadowRuntimeFailed,
+		failStatus: IELTSSpeakingShadowRuntimePending,
 	}
 	worker, err := NewIELTSSpeakingShadowWorker(
 		repository,
@@ -321,7 +321,8 @@ func TestIELTSSpeakingShadowWorkerLogsSafeSemanticRejectionStage(
 		t.Fatalf("ProcessPending: %v", err)
 	}
 	logged := output.String()
-	if sweep.Failed != 1 ||
+	if sweep.Retried != 1 ||
+		!repository.failure.Retryable ||
 		!strings.Contains(logged, `"failure_code":"provider_invalid_response"`) ||
 		!strings.Contains(logged, `"rejection_stage":"semantic_validation"`) ||
 		!strings.Contains(logged, `"criterion_id":"IELTS_FC"`) ||
@@ -353,7 +354,17 @@ func TestClassifyIELTSSpeakingShadowFailureUsesStableProviderCodes(
 			code:  "provider_schema_mismatch",
 		},
 		{
-			name:  "semantic response rejection",
+			name: "semantic response rejection",
+			cause: newIELTSCriterionProviderRejection(
+				"semantic_validation",
+				"no_primary_findings",
+				errIELTSProviderNoPrimaryFindings,
+			),
+			code:      "provider_invalid_response",
+			retryable: true,
+		},
+		{
+			name:  "internal result validation",
 			cause: ErrInvalidIELTSSpeakingShadow,
 			code:  "provider_invalid_response",
 		},

--- a/server/internal/coaching/evaluation/scoring/prompts.go
+++ b/server/internal/coaching/evaluation/scoring/prompts.go
@@ -21,7 +21,7 @@ Return exactly one JSON object. For an FC request, the shape is illustrated by:
 {"schema_version":"ielts-speaking-full-mock-shadow-provider/v3","criteria":[{"criterion_id":"IELTS_FC","rubric_descriptor":"FC_PRACTICE_BAND_6","strengths":[{"template_id":"ielts.fc.strength.v1","evidence":[{"evidence_ref_id":"...","quote":"exact substring","occurrence":1}]}],"improvements":[],"upgrade_examples":[]}]}
 The criteria array must contain exactly one item whose criterion_id equals input.assessable_criteria[0]. Include no other criterion.
 For every criterion that has a supplied rubric_descriptors set, select exactly one descriptor from that set. Omit rubric_descriptor only when that criterion has no supplied descriptor set; never invent or numerically average a Band.
-Strengths, improvements, and upgrade_examples must be arrays with at most three items each, and strengths plus improvements must contain at least one item.
+Strengths, improvements, and upgrade_examples must be arrays with at most three items each. Strengths must contain at least one evidence-bound item; improvements and upgrade_examples may be empty.
 Use only the exact template_id matching the criterion and collection: ielts.fc.*, ielts.lr.*, ielts.gra.*, or ielts.pr.*.
 Each evidence quote must be an exact, non-empty substring of the transcript paired with its evidence_ref_id. occurrence is one-based when the quote repeats.
 For at least one strength or improvement, copy a short quote character-for-character from input.questions[].response.transcript. Never paraphrase, correct grammar, change case or punctuation, or use an acoustic score as the quote. This requirement still applies to pronunciation.

--- a/server/internal/coaching/evaluation/scoring/provider.go
+++ b/server/internal/coaching/evaluation/scoring/provider.go
@@ -105,10 +105,11 @@ func (provider *ieltsSpeakingShadowTextProvider) AnalyzeIELTSCriterion(
 	generated, err := provider.generator.Generate(
 		generationContext,
 		TextGenerationRequest{
-			SystemPrompt:    IELTSSpeakingShadowSystemContract,
-			UserPrompt:      string(evidenceJSON),
-			OutputContract:  TextGenerationOutputIELTSSpeakingCriterionV3,
-			OutputCriterion: request.Input.AssessableCriteria[0],
+			SystemPrompt:         IELTSSpeakingShadowSystemContract,
+			UserPrompt:           string(evidenceJSON),
+			OutputContract:       TextGenerationOutputIELTSSpeakingCriterionV3,
+			OutputCriterion:      request.Input.AssessableCriteria[0],
+			OutputRubricRequired: len(request.Input.RubricDescriptors) == 1,
 		},
 	)
 	if err != nil {

--- a/server/internal/coaching/evaluation/scoring/provider_test.go
+++ b/server/internal/coaching/evaluation/scoring/provider_test.go
@@ -182,7 +182,8 @@ func TestIELTSSpeakingShadowTextProviderUsesStrictJSONRequest(t *testing.T) {
 		request.UserPrompt == request.SystemPrompt ||
 		request.OutputContract !=
 			TextGenerationOutputIELTSSpeakingCriterionV3 ||
-		request.OutputCriterion != IELTSCriterionLR {
+		request.OutputCriterion != IELTSCriterionLR ||
+		!request.OutputRubricRequired {
 		t.Fatalf("request = %#v", request)
 	}
 	for _, required := range []string{

--- a/server/internal/coaching/evaluation/scoring/text_generation.go
+++ b/server/internal/coaching/evaluation/scoring/text_generation.go
@@ -10,10 +10,11 @@ const (
 )
 
 type TextGenerationRequest struct {
-	SystemPrompt    string
-	UserPrompt      string
-	OutputContract  TextGenerationOutputContract
-	OutputCriterion IELTSCriterion
+	SystemPrompt         string
+	UserPrompt           string
+	OutputContract       TextGenerationOutputContract
+	OutputCriterion      IELTSCriterion
+	OutputRubricRequired bool
 }
 
 type TextGenerationResult struct {

--- a/server/internal/providers/qianwen/business_generation_test.go
+++ b/server/internal/providers/qianwen/business_generation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -180,10 +181,11 @@ func TestQianwenIELTSCriterionUsesStrictJSONSchema(t *testing.T) {
 	result, err := (&EvaluationScoringGenerator{generator: client}).Generate(
 		context.Background(),
 		scoring.TextGenerationRequest{
-			SystemPrompt:    scoring.IELTSSpeakingShadowSystemContract,
-			UserPrompt:      `{"input":{"assessable_criteria":["IELTS_LR"]}}`,
-			OutputContract:  scoring.TextGenerationOutputIELTSSpeakingCriterionV3,
-			OutputCriterion: scoring.IELTSCriterionLR,
+			SystemPrompt:         scoring.IELTSSpeakingShadowSystemContract,
+			UserPrompt:           `{"input":{"assessable_criteria":["IELTS_LR"]}}`,
+			OutputContract:       scoring.TextGenerationOutputIELTSSpeakingCriterionV3,
+			OutputCriterion:      scoring.IELTSCriterionLR,
+			OutputRubricRequired: true,
 		},
 	)
 	if err != nil || result.Content != content {
@@ -203,6 +205,15 @@ func TestQianwenIELTSCriterionUsesStrictJSONSchema(t *testing.T) {
 	if criteria["minItems"] != float64(1) ||
 		criteria["maxItems"] != float64(1) {
 		t.Fatalf("criteria schema=%#v", criteria)
+	}
+	criterion := criteria["items"].(map[string]any)
+	required := criterion["required"].([]any)
+	if !slices.Contains(required, any("rubric_descriptor")) {
+		t.Fatalf("criterion required=%#v", required)
+	}
+	strengths := criterion["properties"].(map[string]any)["strengths"].(map[string]any)
+	if strengths["minItems"] != float64(1) {
+		t.Fatalf("strengths schema=%#v", strengths)
 	}
 }
 

--- a/server/internal/providers/qianwen/evaluation_scoring.go
+++ b/server/internal/providers/qianwen/evaluation_scoring.go
@@ -16,7 +16,17 @@ const ieltsSpeakingCriterionToolName = "ielts.speaking.criterion.v3"
 // or dynamic evidence identity; the local validator owns those rules.
 func ieltsSpeakingCriterionToolSchema(
 	criterion scoring.IELTSCriterion,
+	rubricRequired bool,
 ) map[string]any {
+	required := []string{
+		"criterion_id",
+		"strengths",
+		"improvements",
+		"upgrade_examples",
+	}
+	if rubricRequired {
+		required = append(required, "rubric_descriptor")
+	}
 	return map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -35,12 +45,7 @@ func ieltsSpeakingCriterionToolSchema(
 				"items": map[string]any{
 					"type":                 "object",
 					"additionalProperties": false,
-					"required": []string{
-						"criterion_id",
-						"strengths",
-						"improvements",
-						"upgrade_examples",
-					},
+					"required":             required,
 					"properties": map[string]any{
 						"criterion_id": map[string]any{
 							"type": "string",
@@ -56,16 +61,19 @@ func ieltsSpeakingCriterionToolSchema(
 							criterion,
 							"strength",
 							false,
+							true,
 						),
 						"improvements": ieltsSpeakingFindingArraySchema(
 							criterion,
 							"improvement",
 							true,
+							false,
 						),
 						"upgrade_examples": ieltsSpeakingFindingArraySchema(
 							criterion,
 							"upgrade",
 							true,
+							false,
 						),
 					},
 				},
@@ -78,6 +86,7 @@ func ieltsSpeakingFindingArraySchema(
 	criterion scoring.IELTSCriterion,
 	kind string,
 	allowSuggestion bool,
+	requireFinding bool,
 ) map[string]any {
 	properties := map[string]any{
 		"template_id": map[string]any{
@@ -118,7 +127,7 @@ func ieltsSpeakingFindingArraySchema(
 			"type": "string", "minLength": 1, "maxLength": 512,
 		}
 	}
-	return map[string]any{
+	result := map[string]any{
 		"type":     "array",
 		"maxItems": 3,
 		"items": map[string]any{
@@ -128,6 +137,10 @@ func ieltsSpeakingFindingArraySchema(
 			"properties":           properties,
 		},
 	}
+	if requireFinding {
+		result["minItems"] = 1
+	}
+	return result
 }
 
 func ieltsSpeakingRubricDescriptorIDs(
@@ -217,6 +230,7 @@ func (generator *EvaluationScoringGenerator) Generate(
 				"criterion.",
 			InputSchema: ieltsSpeakingCriterionToolSchema(
 				request.OutputCriterion,
+				request.OutputRubricRequired,
 			),
 		}}
 		providerRequest.ToolChoice = protocol.ToolChoice{
@@ -230,6 +244,7 @@ func (generator *EvaluationScoringGenerator) Generate(
 			Strict: true,
 			Schema: ieltsSpeakingCriterionToolSchema(
 				request.OutputCriterion,
+				request.OutputRubricRequired,
 			),
 		}
 	}

--- a/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
+++ b/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
@@ -139,10 +139,11 @@ func TestQiniuIELTSCriterionUsesForcedSingleCriterionTool(t *testing.T) {
 	result, err := (&EvaluationScoringGenerator{generator: client}).Generate(
 		context.Background(),
 		scoring.TextGenerationRequest{
-			SystemPrompt:    scoring.IELTSSpeakingShadowSystemContract,
-			UserPrompt:      `{"input":{"assessable_criteria":["IELTS_LR"]}}`,
-			OutputContract:  scoring.TextGenerationOutputIELTSSpeakingCriterionV3,
-			OutputCriterion: scoring.IELTSCriterionLR,
+			SystemPrompt:         scoring.IELTSSpeakingShadowSystemContract,
+			UserPrompt:           `{"input":{"assessable_criteria":["IELTS_LR"]}}`,
+			OutputContract:       scoring.TextGenerationOutputIELTSSpeakingCriterionV3,
+			OutputCriterion:      scoring.IELTSCriterionLR,
+			OutputRubricRequired: true,
 		},
 	)
 	if err != nil {
@@ -189,7 +190,10 @@ func TestQiniuIELTSCriterionUsesForcedSingleCriterionTool(t *testing.T) {
 		"upgrade_examples": "upgrade",
 	} {
 		value := criterionProperties[collection].(map[string]any)
-		if _, hasMinimum := value["minItems"]; hasMinimum ||
+		minimum, hasMinimum := value["minItems"]
+		if (collection == "strengths" &&
+			(!hasMinimum || minimum != float64(1))) ||
+			(collection != "strengths" && hasMinimum) ||
 			value["maxItems"] != float64(3) {
 			t.Fatalf("%s schema = %#v", collection, value)
 		}

--- a/server/migrations/000095_evaluation_ielts_speaking_prompt_v9.down.sql
+++ b/server/migrations/000095_evaluation_ielts_speaking_prompt_v9.down.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    DROP CONSTRAINT evaluation_ielts_scene_results_v9_lineage_check;
+
+DROP FUNCTION evaluation_ielts_v9_lineage_is_valid(jsonb);
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    DROP CONSTRAINT evaluation_ielts_scene_results_prompt_check;
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    ADD CONSTRAINT evaluation_ielts_scene_results_prompt_check
+        CHECK (
+            prompt_version IN (
+                'ielts-speaking-full-mock-shadow-prompt/v1',
+                'ielts-speaking-full-mock-shadow-prompt/v2',
+                'ielts-speaking-full-mock-shadow-prompt/v3',
+                'ielts-speaking-full-mock-shadow-prompt/v4',
+                'ielts-speaking-full-mock-shadow-prompt/v5',
+                'ielts-speaking-full-mock-shadow-prompt/v6',
+                'ielts-speaking-full-mock-shadow-prompt/v7',
+                'ielts-speaking-full-mock-shadow-prompt/v8'
+            )
+        );
+
+COMMIT;

--- a/server/migrations/000095_evaluation_ielts_speaking_prompt_v9.up.sql
+++ b/server/migrations/000095_evaluation_ielts_speaking_prompt_v9.up.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    DROP CONSTRAINT evaluation_ielts_scene_results_prompt_check;
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    ADD CONSTRAINT evaluation_ielts_scene_results_prompt_check
+        CHECK (
+            prompt_version IN (
+                'ielts-speaking-full-mock-shadow-prompt/v1',
+                'ielts-speaking-full-mock-shadow-prompt/v2',
+                'ielts-speaking-full-mock-shadow-prompt/v3',
+                'ielts-speaking-full-mock-shadow-prompt/v4',
+                'ielts-speaking-full-mock-shadow-prompt/v5',
+                'ielts-speaking-full-mock-shadow-prompt/v6',
+                'ielts-speaking-full-mock-shadow-prompt/v7',
+                'ielts-speaking-full-mock-shadow-prompt/v8',
+                'ielts-speaking-full-mock-shadow-prompt/v9'
+            )
+        );
+
+CREATE OR REPLACE FUNCTION evaluation_ielts_v9_lineage_is_valid(payload jsonb)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $$
+    SELECT
+        payload #>> '{provider_lineage,prompt_version}' =
+            'ielts-speaking-full-mock-shadow-prompt/v9'
+        AND evaluation_ielts_v8_lineage_is_valid(
+            jsonb_set(
+                payload,
+                '{provider_lineage,prompt_version}',
+                '"ielts-speaking-full-mock-shadow-prompt/v8"'::jsonb
+            )
+        );
+$$;
+
+ALTER TABLE evaluation_ielts_speaking_scene_results
+    ADD CONSTRAINT evaluation_ielts_scene_results_v9_lineage_check
+        CHECK (
+            prompt_version <>
+                'ielts-speaking-full-mock-shadow-prompt/v9'
+            OR (
+                provider_request_id IS NULL
+                AND (
+                    (
+                        result_payload ->> 'scoreability_status' =
+                            'INSUFFICIENT'
+                        AND NOT result_payload ? 'provider_lineage'
+                    )
+                    OR (
+                        result_payload ->> 'scoreability_status' =
+                            'PROVISIONAL'
+                        AND (
+                            result_payload #>>
+                                '{provider_lineage,provider}'
+                        ) IS NOT DISTINCT FROM provider
+                        AND (
+                            result_payload #>>
+                                '{provider_lineage,model}'
+                        ) IS NOT DISTINCT FROM model
+                        AND evaluation_ielts_v9_lineage_is_valid(
+                            result_payload
+                        )
+                    )
+                )
+            )
+        );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -80,4 +80,5 @@ import "embed"
 //go:embed 000092_evaluation_ielts_practice_band_runtime.*.sql
 //go:embed 000093_interview_user_controlled_sessions.*.sql
 //go:embed 000094_ielts_sports_team_category.*.sql
+//go:embed 000095_evaluation_ielts_speaking_prompt_v9.*.sql
 var Files embed.FS


### PR DESCRIPTION
## 功能描述
避免 IELTS 报告因评分供应商偶发语义无效响应而永久失败。

## 实现思路
- 将 provider criterion 语义拒绝分类为可持久化重试的 `provider_invalid_response`
- 保留代码侧非法请求的不可重试语义和既有 MaxAttempts 上限
- v9 Prompt/Schema 要求 strengths 至少一项，并在存在官方 rubric 时强制返回 descriptor
- 添加迁移记录新的 prompt 版本

## 可复现测试
- `cd server && go test ./internal/coaching/evaluation/scoring ./internal/providers/qianwen`
- 验证 provider 语义拒绝进入 retried 状态；达到上限后仍明确失败，不生成伪报告

Closes #712