### PR TITLE
feat(mobile): add interview-specific Agent practice handoff card

### DIFF
--- a/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
+++ b/mobile/lib/features/agent/handoff/practice_plan_handoff_card.dart
@@ -16,8 +16,11 @@ final class PracticePlanHandoffCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final minutes = (handoff.suggestedDuration.inSeconds / 60).ceil();
     final isIELTS = handoff.practiceExperience == 'IELTS_SPEAKING';
+    final isInterview = handoff.practiceExperience == 'INTERVIEW';
     final title = isIELTS
         ? 'IELTS Speaking · ${handoff.practiceScope}'
+        : isInterview
+        ? handoff.sceneName
         : handoff.target;
     final role = handoff.roles.join('、');
 
@@ -43,6 +46,7 @@ final class PracticePlanHandoffCard extends StatelessWidget {
                   title: title,
                   role: role,
                   isIELTS: isIELTS,
+                  isInterview: isInterview,
                 ),
               ),
               Positioned(
@@ -77,7 +81,9 @@ final class PracticePlanHandoffCard extends StatelessWidget {
                               Expanded(
                                 child: _PracticeFact(
                                   icon: Icons.chat_bubble_outline_rounded,
-                                  label: _questionCountLabel(handoff),
+                                  label: isInterview
+                                      ? handoff.practiceScope
+                                      : _questionCountLabel(handoff),
                                 ),
                               ),
                             ],
@@ -141,11 +147,13 @@ final class _PracticeHero extends StatelessWidget {
     required this.title,
     required this.role,
     required this.isIELTS,
+    required this.isInterview,
   });
 
   final String title;
   final String role;
   final bool isIELTS;
+  final bool isInterview;
 
   @override
   Widget build(BuildContext context) {
@@ -154,16 +162,18 @@ final class _PracticeHero extends StatelessWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          const DecoratedBox(
+          DecoratedBox(
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
-                colors: [Color(0xFFF4F1FF), Color(0xFFE9E3FF)],
+                colors: isInterview
+                    ? const [Color(0xFFF3F0EA), Color(0xFFE6DDD2)]
+                    : const [Color(0xFFF4F1FF), Color(0xFFE9E3FF)],
               ),
             ),
           ),
-          if (isIELTS)
+          if (isIELTS || isInterview)
             Positioned(
               top: 0,
               right: -4,
@@ -171,7 +181,7 @@ final class _PracticeHero extends StatelessWidget {
               width: 160,
               child: Semantics(
                 image: true,
-                label: 'IELTS 考官头像',
+                label: isIELTS ? 'IELTS 考官头像' : '面试官场景图',
                 child: ShaderMask(
                   blendMode: BlendMode.dstIn,
                   shaderCallback: (bounds) => const LinearGradient(
@@ -179,23 +189,33 @@ final class _PracticeHero extends StatelessWidget {
                     stops: [0, 0.3],
                   ).createShader(bounds),
                   child: Image.asset(
-                    'assets/images/scenes/ielts-examiner.jpg',
+                    isIELTS
+                        ? 'assets/images/scenes/ielts-examiner.jpg'
+                        : 'assets/images/scenes/interview-plan-card-v2.webp',
                     fit: BoxFit.cover,
-                    alignment: const Alignment(0, -0.3),
+                    alignment: isIELTS
+                        ? const Alignment(0, -0.3)
+                        : const Alignment(-1, -0.2),
                   ),
                 ),
               ),
             ),
-          if (isIELTS)
-            const Positioned.fill(
+          if (isIELTS || isInterview)
+            Positioned.fill(
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
-                    colors: [
-                      Color(0xFFF4F1FF),
-                      Color(0xE6F4F1FF),
-                      Color(0x00F4F1FF),
-                    ],
+                    colors: isInterview
+                        ? const [
+                            Color(0xFFF3F0EA),
+                            Color(0xE6F3F0EA),
+                            Color(0x00F3F0EA),
+                          ]
+                        : const [
+                            Color(0xFFF4F1FF),
+                            Color(0xE6F4F1FF),
+                            Color(0x00F4F1FF),
+                          ],
                     stops: [0, 0.42, 0.78],
                   ),
                 ),
@@ -226,7 +246,7 @@ final class _PracticeHero extends StatelessWidget {
           Positioned(
             top: 48,
             left: 14,
-            right: isIELTS ? 74 : 14,
+            right: isIELTS || isInterview ? 74 : 14,
             child: Text(
               title,
               maxLines: 1,
@@ -241,7 +261,7 @@ final class _PracticeHero extends StatelessWidget {
           Positioned(
             top: 88,
             left: 14,
-            right: isIELTS ? 90 : 14,
+            right: isIELTS || isInterview ? 90 : 14,
             child: Row(
               children: [
                 const Icon(
@@ -252,7 +272,11 @@ final class _PracticeHero extends StatelessWidget {
                 const SizedBox(width: 7),
                 Expanded(
                   child: Text(
-                    isIELTS ? '$role · IELTS Examiner' : role,
+                    isIELTS
+                        ? '$role · IELTS Examiner'
+                        : isInterview
+                        ? '$role · Interviewer'
+                        : role,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -315,12 +315,13 @@ void main() {
       ),
     );
 
-    expect(find.text('Java Interview Practice'), findsOneWidget);
+    expect(find.text('项目经历深挖'), findsOneWidget);
+    expect(find.text('Java Interview Practice'), findsNothing);
     expect(find.text('已为你准备好'), findsOneWidget);
-    expect(find.text('围绕项目难点完成三轮追问'), findsNothing);
-    expect(find.text('面试官、候选人'), findsOneWidget);
+    expect(find.text('面试官、候选人 · Interviewer'), findsOneWidget);
     expect(find.text('约 12 分钟'), findsOneWidget);
-    expect(find.text('3–5 个问题'), findsOneWidget);
+    expect(find.text('围绕项目难点完成三轮追问'), findsOneWidget);
+    expect(find.bySemanticsLabel('面试官场景图'), findsOneWidget);
     expect(find.text('开始练习'), findsOneWidget);
     expect(find.text('确认并开始练习'), findsNothing);
     expect(find.text('场景：项目经历深挖'), findsNothing);
@@ -337,6 +338,44 @@ void main() {
       ),
     );
     expect(selected, same(handoff));
+  });
+
+  testWidgets('renders the interview self-introduction recording sample', (
+    tester,
+  ) async {
+    const handoff = ConfirmPracticePlanHandoff(
+      label: '确认并开始练习',
+      practicePlanId: '10000000-0000-4000-8000-000000000006',
+      planRevision: 1,
+      target: '说清背景、优势和岗位匹配，并自然回应一到两个追问。',
+      sceneName: '英文自我介绍',
+      practiceExperience: 'INTERVIEW',
+      sceneCategory: 'INTERVIEW_RECRUITER',
+      practiceMode: 'FOCUS',
+      roles: <String>['招聘方'],
+      practiceScope: '重点练习',
+      suggestedDuration: Duration(minutes: 8),
+      minEffectiveTurns: 3,
+      maxEffectiveTurns: 8,
+      executableStatus: 'ready',
+      confirmationPrompt: '确认后将创建练习会话；确认前不会开始练习。',
+    );
+    await _pumpMessage(
+      tester,
+      const AgentMessage(
+        id: 'assistant-interview-self-introduction',
+        role: AgentMessageRole.assistant,
+        text: '我们从自我介绍开始。',
+        handoffs: <AgentHandoff>[handoff],
+      ),
+    );
+
+    expect(find.text('英文自我介绍'), findsOneWidget);
+    expect(find.text('招聘方 · Interviewer'), findsOneWidget);
+    expect(find.text('约 8 分钟'), findsOneWidget);
+    expect(find.text('重点练习'), findsOneWidget);
+    expect(find.bySemanticsLabel('面试官场景图'), findsOneWidget);
+    expect(find.text('开始练习'), findsOneWidget);
   });
 
   testWidgets('renders an unscored IELTS warm-up without a handoff', (


### PR DESCRIPTION
## 功能描述
为 Agent 创建的英文面试练习增加专属交接卡，清楚展示场景、面试官、时长和练习模式。

## 实现思路
- 复用现有 PracticePlan handoff 契约和 `interview-plan-card-v2.webp` 素材
- `INTERVIEW` 卡片使用暖色面试视觉、场景名和 Interviewer 角色标识
- 右侧信息展示练习模式；IELTS 与通用卡片行为保持不变

## 可复现测试
- `cd mobile && flutter test test/agent/agent_message_bubble_test.dart`
- iOS Simulator：通过真实 Agent 创建“英文自我介绍重点练习”，确认面试卡片出现并可进入练习

Closes #713