### PR TITLE
fix(mobile): prevent Home flash while opening Agent practice

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -267,7 +267,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         widget.conversationController.isBusy) {
       return;
     }
-    _agentHandoffInFlight = true;
+    setState(() => _agentHandoffInFlight = true);
     try {
       var replaceCurrentPractice = false;
       if (controller.workspaceController.hasResumable) {
@@ -326,7 +326,9 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       }
       await _openPracticeRoute();
     } finally {
-      _agentHandoffInFlight = false;
+      if (mounted) {
+        setState(() => _agentHandoffInFlight = false);
+      }
     }
   }
 
@@ -544,37 +546,43 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       ),
     ];
 
-    return Scaffold(
-      key: _scaffoldKey,
-      extendBody: !practiceSelected,
-      resizeToAvoidBottomInset: false,
-      backgroundColor: practiceSelected
-          ? SpeakUpDesign.canvas
-          : Colors.transparent,
-      drawer: _ConversationDrawer(
-        controller: widget.conversationController,
-        onOpenProfile: () => _selectDestination(3),
-        hiddenThreadIds: {
-          ?widget
-              .preparationLaunchController
-              ?.workspaceController
-              ?.currentPracticeThreadId,
-        },
-      ),
-      onDrawerChanged: (open) {
-        if (_conversationDrawerOpen != open) {
-          setState(() => _conversationDrawerOpen = open);
-        }
-      },
-      drawerScrimColor: const Color(0x52000000),
-      body: IndexedStack(index: _selectedIndex, children: pages),
-      bottomNavigationBar: _conversationDrawerOpen
-          ? null
-          : PlatformNavigationBar(
-              destinations: _destinations,
-              selectedIndex: _selectedIndex,
-              onDestinationSelected: _selectDestinationFromNavigation,
-            ),
+    return Stack(
+      children: [
+        Scaffold(
+          key: _scaffoldKey,
+          extendBody: !practiceSelected,
+          resizeToAvoidBottomInset: false,
+          backgroundColor: practiceSelected
+              ? SpeakUpDesign.canvas
+              : Colors.transparent,
+          drawer: _ConversationDrawer(
+            controller: widget.conversationController,
+            onOpenProfile: () => _selectDestination(3),
+            hiddenThreadIds: {
+              ?widget
+                  .preparationLaunchController
+                  ?.workspaceController
+                  ?.currentPracticeThreadId,
+            },
+          ),
+          onDrawerChanged: (open) {
+            if (_conversationDrawerOpen != open) {
+              setState(() => _conversationDrawerOpen = open);
+            }
+          },
+          drawerScrimColor: const Color(0x52000000),
+          body: IndexedStack(index: _selectedIndex, children: pages),
+          bottomNavigationBar: _conversationDrawerOpen
+              ? null
+              : PlatformNavigationBar(
+                  destinations: _destinations,
+                  selectedIndex: _selectedIndex,
+                  onDestinationSelected: _selectDestinationFromNavigation,
+                ),
+        ),
+        if (_agentHandoffInFlight)
+          const Positioned.fill(child: _PracticeTransitionOverlay()),
+      ],
     );
   }
 
@@ -583,6 +591,34 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     return controller == null
         ? null
         : AgentConversationFeedbackPresenter(controller: controller);
+  }
+}
+
+class _PracticeTransitionOverlay extends StatelessWidget {
+  const _PracticeTransitionOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      key: const Key('agent-practice-transition-overlay'),
+      color: SpeakUpDesign.canvas,
+      child: SafeArea(
+        child: Center(
+          child: Semantics(
+            label: '正在进入练习',
+            liveRegion: true,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.play_circle_outline_rounded, size: 34),
+                SizedBox(height: 16),
+                Text('正在进入练习…', style: SpeakUpDesign.body),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_plan_handoff_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/features/agent/conversation/agent_client.dart';
@@ -39,15 +41,15 @@ void main() {
     );
     addTearDown(harness.dispose);
     final plan = _plan(sourceThreadId: harness.conversation.threadId!);
+    final confirmation = Completer<PreparationPracticeBootstrap>();
     final controller = PracticePlanHandoffController(
       conversationController: harness.conversation,
       practiceController: harness.practice,
       ieltsPreparationController: harness.ieltsPreparation,
       workspaceController: harness.workspace,
       readPlan: (_) async => plan,
-      confirmPlan:
-          ({required plan, required input, required idempotencyKey}) async =>
-              _bootstrap(plan),
+      confirmPlan: ({required plan, required input, required idempotencyKey}) =>
+          confirmation.future,
       idFactory: _fixedId,
     );
     addTearDown(controller.dispose);
@@ -81,8 +83,22 @@ void main() {
     await tester.tap(
       find.byKey(const Key('confirm-practice-plan-practice-plan-session-1-2')),
     );
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('agent-practice-transition-overlay')),
+      findsOneWidget,
+    );
+    expect(find.text('正在进入练习…'), findsOneWidget);
+    expect(find.byKey(const Key('no-focused-conversation')), findsNothing);
+
+    confirmation.complete(_bootstrap(plan));
     await tester.pumpAndSettle();
 
+    expect(
+      find.byKey(const Key('agent-practice-transition-overlay')),
+      findsNothing,
+    );
     expect(find.byKey(const Key('confirmed-practice-route')), findsOneWidget);
     expect(harness.practice.practiceSessionId, _sessionId);
     expect(harness.workspace.currentSessionId, _sessionId);


### PR DESCRIPTION
## 功能描述
修复从 Agent 练习卡点击开始后，在正式练习路由打开前短暂闪回空白首页的问题。

## 实现思路
- handoff 执行期间由 Shell 显示全屏“正在进入练习”过渡层
- 保留现有 Session 创建、冲突处理和正式练习路由
- 使用 `setState` 同步过渡状态，并在完成或失败后清理

## 可复现测试
- `cd mobile && flutter test test/coaching/preparation/practice_plan_handoff_controller_test.dart`
- iOS Simulator：从 Agent 卡片点击“开始练习”，确认准备期间不出现首页，随后进入正式练习

Closes #711