### PR TITLE
fix(agent): shorten IELTS warm-up transition response

### DIFF
--- a/server/internal/agent/run/ielts_tool_routing_test.go
+++ b/server/internal/agent/run/ielts_tool_routing_test.go
@@ -895,6 +895,61 @@ func TestIELTSWarmUpAnswerRequiresMeaningfulEnglish(t *testing.T) {
 	}
 }
 
+func TestRunLoopUsesOneFocusedModelCallAfterIELTSWarmUpAnswer(t *testing.T) {
+	matchingInput := json.RawMessage(
+		`{"ielts_practice_mode":"PART_1","ielts_topic_choice":"person"}`,
+	)
+	repository := &ieltsRoutingRepository{calls: []ToolCall{{
+		Name: ieltsWarmUpToolName, Input: matchingInput,
+		Status: ToolCallSucceeded,
+	}}}
+	preview := &ieltsLoopTool{
+		name: practicePreviewToolName,
+		result: capability.Result{
+			Content:  map[string]any{"status": "preview_ready"},
+			Handoffs: []agenthandoff.Item{loopPracticeHandoff()},
+		},
+	}
+	want := "听到了，你用 patient 和 encouraged 说明了这位老师为什么让你印象深刻。"
+	generator := newScriptedGenerator(finalLoopResult(want))
+	service := newLoopTestService(t, generator)
+	setLoopTools(t, service, capabilityfixture.NewStore(), preview)
+	service.repository = repository
+	service.messages = &recordingMessageReader{message: conversation.Message{
+		Role:            conversation.MessageRoleAssistant,
+		ProducedByRunID: "previous-run",
+	}}
+
+	result, err := service.generate(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		agentcontext.Manifest{SelectedMessages: adjacentIELTSMessageSources()},
+		TextRequest{Messages: routingConversation(
+			"创建雅思 Part 1 人物类专项练习",
+			"最近有没有谁让你印象挺深？用一两句英语说说。",
+			"My teacher was patient and always encouraged me.",
+		)},
+	)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	requests := generator.Requests()
+	if result.Content != want || preview.calls != 1 || len(requests) != 1 {
+		t.Fatalf(
+			"result = %#v, preview calls = %d, requests = %#v",
+			result,
+			preview.calls,
+			requests,
+		)
+	}
+	if len(requests[0].Messages) != 2 ||
+		!strings.Contains(requests[0].Messages[0].Content, "具体原因") ||
+		requests[0].ToolChoice.Mode != ToolChoiceNone {
+		t.Fatalf("focused request = %#v", requests[0])
+	}
+}
+
 func TestRunLoopRestoredWarmUpStateTransitions(t *testing.T) {
 	matchingInput := json.RawMessage(
 		`{"ielts_practice_mode":"PART_1","ielts_topic_choice":"random"}`,

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -828,7 +828,6 @@ func (service *Service) generateObserved(
 	toolIterations := 0
 	modelIterations := 0
 	previewSucceeded := previousIELTSTool == priorIELTSToolPreview
-	practicePreviewCalledThisTurn := false
 	ieltsPreviewCreatedThisTurn := false
 	seenToolCallIDs := make(map[string]struct{})
 	finalDecision := "direct_response"
@@ -884,7 +883,6 @@ func (service *Service) generateObserved(
 			return TextResult{}, err
 		}
 		request.Messages = append(request.Messages, toolMessage)
-		practicePreviewCalledThisTurn = call.Name == practicePreviewToolName
 		toolCalls = 1
 		toolIterations = 1
 		writeCalls = service.writeToolCallCount([]ModelToolCall{call})
@@ -893,6 +891,30 @@ func (service *Service) generateObserved(
 			isIELTSPracticePreviewCall(call)
 		seenToolCallIDs[call.ID] = struct{}{}
 		finalDecision = "tool_call_then_response"
+		if ieltsPreviewCreatedThisTurn && ieltsRouting.currentWarmUpAnswer {
+			result := service.repairIELTSWarmUpAcknowledgement(
+				loopCtx,
+				run,
+				input,
+			)
+			service.logRoutingDecision(
+				run,
+				finalDecision,
+				nil,
+				routingReason,
+				reasonSummary(routingReason, finalDecision),
+				1,
+			)
+			service.logRunCompleted(
+				run,
+				finalDecision,
+				1,
+				toolCalls,
+				startedAt,
+				result.Content,
+			)
+			return result, nil
+		}
 		if succeeded && call.Name == ieltsWarmUpToolName {
 			if prompt, ok := ieltsWarmUpPrompt(toolMessage); ok {
 				return service.completeDirectIELTSResponse(
@@ -920,12 +942,10 @@ func (service *Service) generateObserved(
 		}
 		request.ToolChoice = ToolChoice{Mode: ToolChoiceNone}
 	}
-	guardWarmUpAnswer := ieltsRouting.currentWarmUpAnswer &&
-		ieltsPreviewCreatedThisTurn
 	for {
 		service.logLoopIteration(run, modelIterations, toolCalls)
 		modelObserver := deltaObserver
-		if practicePreviewCalledThisTurn || guardWarmUpAnswer ||
+		if toolCalls > 0 ||
 			ieltsRouting.active && request.ToolChoice.Mode != ToolChoiceNone {
 			modelObserver = nil
 		}
@@ -979,19 +999,10 @@ func (service *Service) generateObserved(
 			return result, nil
 		}
 		if len(result.ToolCalls) == 0 {
-			if practicePreviewCalledThisTurn {
+			if toolCalls > 0 {
 				result.Content = sanitizeUserVisiblePracticeIdentifiers(
 					result.Content,
 				)
-			}
-			if guardWarmUpAnswer &&
-				!validIELTSWarmUpAcknowledgement(result.Content, input) {
-				result = service.repairIELTSWarmUpAcknowledgement(
-					loopCtx,
-					run,
-					input,
-				)
-				modelIterations++
 			}
 			if ieltsRouting.active && !previewSucceeded &&
 				claimsIELTSPracticeReady(result.Content) {
@@ -1134,8 +1145,6 @@ func (service *Service) generateObserved(
 				return TextResult{}, err
 			}
 			request.Messages = append(request.Messages, toolMessage)
-			practicePreviewCalledThisTurn = practicePreviewCalledThisTurn ||
-				call.Name == practicePreviewToolName
 			if succeeded && call.Name == ieltsWarmUpToolName {
 				warmUpSucceeded = true
 				warmUpPrompt, _ = ieltsWarmUpPrompt(toolMessage)
@@ -1146,9 +1155,6 @@ func (service *Service) generateObserved(
 		}
 		ieltsPreviewCreatedThisTurn = ieltsPreviewCreatedThisTurn ||
 			ieltsPreviewCreated
-		guardWarmUpAnswer = guardWarmUpAnswer ||
-			isEnglishWarmUpAnswerAttempt(input) &&
-				ieltsPreviewCreatedThisTurn
 		if warmUpPrompt != "" {
 			return service.completeDirectIELTSResponse(
 				run,
@@ -1160,7 +1166,7 @@ func (service *Service) generateObserved(
 				startedAt,
 			), nil
 		}
-		if ieltsPreviewCreated && !guardWarmUpAnswer {
+		if ieltsPreviewCreated {
 			return service.completeDirectIELTSResponse(
 				run,
 				"好。",
@@ -1224,8 +1230,8 @@ func (service *Service) repairIELTSWarmUpAcknowledgement(
 		Messages: []TextMessage{
 			{
 				Role: TextRoleSystem,
-				Content: "只回复一句简短、自然的中文反馈，表明你听到了学员刚才说的具体内容。" +
-					"必须原样包含学员输入里的至少一个有意义英文内容词；" +
+				Content: "只回复一句简短、自然的中文反馈，表明你理解了学员刚才说的具体内容。" +
+					"概括学员提到的对象或经历，以及令其印象深刻的具体原因，优先原样包含两个具体英文内容词；" +
 					"不要评分、纠错、追问，也不要提练习、计划、准备、卡片、创建或开始。只输出这句话。",
 			},
 			{Role: TextRoleUser, Content: input},


### PR DESCRIPTION
## 功能描述
- 缩短 IELTS 热身回答后的承接等待：practice.preview.v1 成功后只发起一次专用承接生成。
- 承接回复概括学员回答中的具体原因，并保持不评分、不纠错、不抢占练习卡操作。
- 增加针对该单次聚焦调用的后端回归测试。

## 实现思路
- 在本轮创建 IELTS Preview 且识别为当前热身回答时，直接走聚焦承接生成并返回。
- 复用现有承接生成入口，收紧提示词，使回复包含对象/经历与具体原因。
- 移除原来先完整生成、校验失败后再修复的串行路径。

## 可复现测试
- `go test ./internal/agent/run -run TestRunLoopUsesOneFocusedModelCallAfterIELTSWarmUpAnswer -count=1`
- `go test ./internal/agent/run -count=1`
- `make check-go`
- `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`（真实本地后端，数字人禁用；Simulator 与 App 启动成功）

Closes #710