### PR TITLE
fix(agent): stage final assistant output for speech

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -534,9 +534,16 @@ paths:
       description: |
         Commits the same Draft, Message, attachment, and Run as the non-streaming
         confirmation endpoint, then returns Server-Sent Events ordered as
-        `input.committed`, `assistant.started`, zero or more `assistant.delta`,
-        and exactly one terminal `run.completed` or `run.failed`. The
-        `input.committed` payload contains the confirmed Draft under `draft`.
+        `input.committed`, zero or more typed `tool.started` plus
+        `tool.completed` or `tool.failed` steps, one final output sequence
+        (`assistant.output.started`, one or more `assistant.output.delta`, and
+        `assistant.output.completed`), and exactly one terminal `run.completed`
+        or `run.failed`. The `input.committed` payload contains the confirmed
+        Draft under `draft`. Tool events expose only stable step identity and
+        name; tool inputs and results remain private. Final output events share
+        an `output_id` equal to the persisted assistant Message ID. Ordered
+        deltas carry a one-based `sequence`, and their concatenation equals the
+        completed output `text` and canonical Message content.
       operationId: streamAgentVoiceDraftConfirmation
       requestBody:
         required: true
@@ -791,12 +798,16 @@ paths:
       description: |
         Commits the same durable user Message and AgentRun as the non-streaming
         endpoint, then returns a bounded UTF-8 Server-Sent Events stream.
-        Events are ordered as `input.committed`, `assistant.started`, zero or
-        more `assistant.delta`, and exactly one terminal `run.completed` or
-        `run.failed`. Deltas contain visible assistant text only; reasoning and
-        fragmented tool-call arguments are never exposed. Only the validated
-        canonical assistant Message is persisted. Replaying
-        `client_message_id` never creates a duplicate user Message.
+        Events are ordered as `input.committed`, zero or more typed
+        `tool.started` plus `tool.completed` or `tool.failed` steps, one final
+        output sequence (`assistant.output.started`, one or more
+        `assistant.output.delta`, and `assistant.output.completed`), and exactly
+        one terminal `run.completed` or `run.failed`. Tool inputs, results,
+        reasoning, and non-final model text are never exposed. Final output
+        events share an `output_id` equal to the persisted assistant Message
+        ID. Ordered deltas carry a one-based `sequence`, and their concatenation
+        equals the completed output `text` and canonical Message content.
+        Replaying `client_message_id` never creates a duplicate user Message.
       operationId: streamAgentTextRun
       requestBody:
         required: true

--- a/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_client.dart
@@ -283,10 +283,20 @@ final class FakeAgentVoiceClient
     );
     yield AgentVoiceInputCommitted(confirmation);
     if (confirmation.assistantMessage case final assistant?) {
-      yield AgentVoiceAssistantStarted(runId: confirmation.run.id);
-      yield AgentVoiceAssistantDelta(
+      yield AgentVoiceAssistantOutputStarted(
         runId: confirmation.run.id,
+        outputId: assistant.id,
+      );
+      yield AgentVoiceAssistantOutputDelta(
+        runId: confirmation.run.id,
+        outputId: assistant.id,
+        sequence: 1,
         delta: assistant.text,
+      );
+      yield AgentVoiceAssistantOutputCompleted(
+        runId: confirmation.run.id,
+        outputId: assistant.id,
+        text: assistant.text,
       );
     }
     yield AgentVoiceRunCompleted(confirmation.run);

--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -802,8 +802,10 @@ final class AgentVoiceController extends ChangeNotifier
             _confirmationCommand = null;
             _state = AgentVoiceComposerState.awaitingAssistant;
             notifyListeners();
-          case AgentVoiceAssistantStarted(:final runId):
-            transientAssistantId = 'stream-$runId';
+          case AgentVoiceToolStepEvent():
+            break;
+          case AgentVoiceAssistantOutputStarted(:final outputId):
+            transientAssistantId = outputId;
             _changeStreamMessage(
               null,
               AgentMessage(
@@ -817,7 +819,7 @@ final class AgentVoiceController extends ChangeNotifier
             if (streamStarted != null) {
               await streamStarted(transientAssistantId);
             }
-          case AgentVoiceAssistantDelta(:final delta):
+          case AgentVoiceAssistantOutputDelta(:final delta):
             final messageId = transientAssistantId;
             if (messageId == null) {
               throw StateError('Voice assistant delta started out of order.');
@@ -833,6 +835,19 @@ final class AgentVoiceController extends ChangeNotifier
               ),
             );
             onAssistantStreamDelta?.call(messageId, delta);
+          case AgentVoiceAssistantOutputCompleted(:final outputId, :final text):
+            if (transientAssistantId != outputId || assistantText != text) {
+              throw StateError(
+                'Voice assistant output completed inconsistently.',
+              );
+            }
+            final completed = AgentMessage(
+              id: outputId,
+              role: AgentMessageRole.assistant,
+              text: text,
+            );
+            onAssistantStreamCompleted?.call(outputId, completed);
+            _changeStreamMessage(outputId, completed);
           case AgentVoiceRunCompleted(:final run):
             _pendingRun = run;
             final messageId = run.assistantMessageId;
@@ -847,14 +862,15 @@ final class AgentVoiceController extends ChangeNotifier
               return;
             }
             if (assistant == null ||
-                assistant.role != AgentMessageRole.assistant) {
+                assistant.role != AgentMessageRole.assistant ||
+                assistant.id != transientAssistantId ||
+                assistant.text != assistantText) {
               throw StateError('Voice assistant Message is unavailable.');
             }
             final transientId = transientAssistantId;
             if (transientId == null) {
               onMessagesCommitted(<AgentMessage>[assistant]);
             } else {
-              onAssistantStreamCompleted?.call(transientId, assistant);
               _changeStreamMessage(transientId, assistant);
             }
             _resetWorkflowPresentation();

--- a/mobile/lib/features/agent/composer/voice/agent_voice_models.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_models.dart
@@ -170,18 +170,59 @@ final class AgentVoiceInputCommitted extends AgentVoiceConfirmationStreamEvent {
   final AgentVoiceConfirmation confirmation;
 }
 
-final class AgentVoiceAssistantStarted
-    extends AgentVoiceConfirmationStreamEvent {
-  const AgentVoiceAssistantStarted({required this.runId});
+enum AgentVoiceToolStepStatus { started, completed, failed }
+
+final class AgentVoiceToolStepEvent extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceToolStepEvent({
+    required this.runId,
+    required this.stepId,
+    required this.name,
+    required this.status,
+  });
 
   final String runId;
+  final String stepId;
+  final String name;
+  final AgentVoiceToolStepStatus status;
 }
 
-final class AgentVoiceAssistantDelta extends AgentVoiceConfirmationStreamEvent {
-  const AgentVoiceAssistantDelta({required this.runId, required this.delta});
+final class AgentVoiceAssistantOutputStarted
+    extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceAssistantOutputStarted({
+    required this.runId,
+    required this.outputId,
+  });
 
   final String runId;
+  final String outputId;
+}
+
+final class AgentVoiceAssistantOutputDelta
+    extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceAssistantOutputDelta({
+    required this.runId,
+    required this.outputId,
+    required this.sequence,
+    required this.delta,
+  });
+
+  final String runId;
+  final String outputId;
+  final int sequence;
   final String delta;
+}
+
+final class AgentVoiceAssistantOutputCompleted
+    extends AgentVoiceConfirmationStreamEvent {
+  const AgentVoiceAssistantOutputCompleted({
+    required this.runId,
+    required this.outputId,
+    required this.text,
+  });
+
+  final String runId;
+  final String outputId;
+  final String text;
 }
 
 final class AgentVoiceRunCompleted extends AgentVoiceConfirmationStreamEvent {

--- a/mobile/lib/features/agent/conversation/agent_client.dart
+++ b/mobile/lib/features/agent/conversation/agent_client.dart
@@ -68,14 +68,52 @@ final class AgentInputCommitted extends AgentTextStreamEvent {
   final AgentMessage userMessage;
 }
 
-final class AgentAssistantStarted extends AgentTextStreamEvent {
-  const AgentAssistantStarted({required super.runId});
+enum AgentToolStepStatus { started, completed, failed }
+
+final class AgentToolStepEvent extends AgentTextStreamEvent {
+  const AgentToolStepEvent({
+    required super.runId,
+    required this.stepId,
+    required this.name,
+    required this.status,
+  });
+
+  final String stepId;
+  final String name;
+  final AgentToolStepStatus status;
 }
 
-final class AgentAssistantDelta extends AgentTextStreamEvent {
-  const AgentAssistantDelta({required super.runId, required this.delta});
+final class AgentAssistantOutputStarted extends AgentTextStreamEvent {
+  const AgentAssistantOutputStarted({
+    required super.runId,
+    required this.outputId,
+  });
 
+  final String outputId;
+}
+
+final class AgentAssistantOutputDelta extends AgentTextStreamEvent {
+  const AgentAssistantOutputDelta({
+    required super.runId,
+    required this.outputId,
+    required this.sequence,
+    required this.delta,
+  });
+
+  final String outputId;
+  final int sequence;
   final String delta;
+}
+
+final class AgentAssistantOutputCompleted extends AgentTextStreamEvent {
+  const AgentAssistantOutputCompleted({
+    required super.runId,
+    required this.outputId,
+    required this.text,
+  });
+
+  final String outputId;
+  final String text;
 }
 
 final class AgentRunCompleted extends AgentTextStreamEvent {

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -800,46 +800,59 @@ final class ConversationController extends ChangeNotifier {
             if (pendingUser != null) {
               replaceMessage(localUserID, userMessage);
             }
-          case AgentAssistantStarted(:final runId):
+          case AgentToolStepEvent():
+            break;
+          case AgentAssistantOutputStarted(:final outputId):
             final current = _messages
                 .where((message) => message.id == assistantID)
                 .firstOrNull;
-            if (current != null && assistantID != 'stream-$runId') {
-              final canonicalTransientID = 'stream-$runId';
+            if (current != null && assistantID != outputId) {
               replaceMessage(
                 assistantID,
                 current.copyWith(
-                  id: canonicalTransientID,
+                  id: outputId,
                   text: '',
                   isStreaming: true,
                   hasFailed: false,
                 ),
               );
-              assistantID = canonicalTransientID;
+              assistantID = outputId;
               assistantText = '';
             }
             await _startAssistantStream(assistantID);
-          case AgentAssistantDelta(:final delta):
+          case AgentAssistantOutputDelta(:final delta):
             pending.write(delta);
             _appendAssistantStream(assistantID, delta);
             frameTimer ??= Timer(const Duration(milliseconds: 16), flushDelta);
-          case AgentRunCompleted(:final assistantMessageId):
-            completedAssistantMessageID = assistantMessageId;
+          case AgentAssistantOutputCompleted(:final outputId, :final text):
             frameTimer?.cancel();
             flushDelta();
+            if (assistantID != outputId || assistantText != text) {
+              throw const AgentClientException(
+                kind: AgentClientFailureKind.invalidResponse,
+                retryable: true,
+              );
+            }
             final current = _messages
                 .where((message) => message.id == assistantID)
                 .firstOrNull;
             if (current != null) {
               final completed = current.copyWith(
-                id: assistantMessageId,
-                text: assistantText,
+                id: outputId,
+                text: text,
                 isStreaming: false,
                 hasFailed: false,
               );
               replaceMessage(assistantID, completed);
               _completeAssistantStream(assistantID, completed);
-              assistantID = assistantMessageId;
+            }
+            completedAssistantMessageID = outputId;
+          case AgentRunCompleted(:final assistantMessageId):
+            if (assistantMessageId != completedAssistantMessageID) {
+              throw const AgentClientException(
+                kind: AgentClientFailureKind.invalidResponse,
+                retryable: true,
+              );
             }
           case AgentRunFailed(:final kind, :final retryable):
             throw AgentClientException(

--- a/mobile/lib/providers/agent/wire_agent_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_client.dart
@@ -640,6 +640,10 @@ final class WireAgentClient
         );
       }
       String? eventName;
+      String? outputId;
+      final activeToolSteps = <String, String>{};
+      final outputText = StringBuffer();
+      var nextOutputSequence = 1;
       var eventCount = 0;
       var streamPhase = 0;
       await for (final line
@@ -684,17 +688,62 @@ final class WireAgentClient
           decoded,
           expectedThreadId: threadId,
         );
-        streamPhase = switch (event) {
-          AgentInputCommitted() when streamPhase == 0 => 1,
-          AgentAssistantStarted() when streamPhase == 1 => 2,
-          AgentAssistantDelta() when streamPhase == 2 => 2,
-          AgentRunCompleted() when streamPhase == 1 || streamPhase == 2 => 3,
-          AgentRunFailed() when streamPhase == 1 || streamPhase == 2 => 3,
-          _ => throw const AgentClientException(
-            kind: AgentClientFailureKind.invalidResponse,
-            retryable: true,
-          ),
-        };
+        switch (event) {
+          case AgentInputCommitted() when streamPhase == 0:
+            streamPhase = 1;
+          case AgentToolStepEvent(:final stepId, :final name, :final status)
+              when streamPhase == 1:
+            switch (status) {
+              case AgentToolStepStatus.started:
+                if (activeToolSteps.containsKey(stepId)) {
+                  throw const AgentClientException(
+                    kind: AgentClientFailureKind.invalidResponse,
+                    retryable: true,
+                  );
+                }
+                activeToolSteps[stepId] = name;
+              case AgentToolStepStatus.completed:
+              case AgentToolStepStatus.failed:
+                if (activeToolSteps.remove(stepId) != name) {
+                  throw const AgentClientException(
+                    kind: AgentClientFailureKind.invalidResponse,
+                    retryable: true,
+                  );
+                }
+            }
+          case AgentAssistantOutputStarted(outputId: final startedOutputId)
+              when streamPhase == 1 && activeToolSteps.isEmpty:
+            outputId = startedOutputId;
+            streamPhase = 2;
+          case AgentAssistantOutputDelta(
+                outputId: final deltaOutputId,
+                :final sequence,
+                :final delta,
+              )
+              when streamPhase == 2 &&
+                  deltaOutputId == outputId &&
+                  sequence == nextOutputSequence:
+            outputText.write(delta);
+            nextOutputSequence++;
+          case AgentAssistantOutputCompleted(
+                outputId: final completedOutputId,
+                :final text,
+              )
+              when streamPhase == 2 &&
+                  completedOutputId == outputId &&
+                  text == outputText.toString():
+            streamPhase = 3;
+          case AgentRunCompleted(:final assistantMessageId)
+              when streamPhase == 3 && assistantMessageId == outputId:
+            streamPhase = 4;
+          case AgentRunFailed() when streamPhase >= 1 && streamPhase <= 3:
+            streamPhase = 4;
+          default:
+            throw const AgentClientException(
+              kind: AgentClientFailureKind.invalidResponse,
+              retryable: true,
+            );
+        }
         if (event case AgentRunFailed(:final runId, :final retryable)) {
           if (retryable) {
             _failedRuns[operationKey] = _FailedRun(
@@ -718,7 +767,7 @@ final class WireAgentClient
           retryable: true,
         );
       }
-      if (streamPhase != 3) {
+      if (streamPhase != 4) {
         throw const AgentClientException(
           kind: AgentClientFailureKind.network,
           retryable: true,
@@ -780,17 +829,77 @@ final class WireAgentClient
             expectedThreadId: expectedThreadId,
           ).presentation,
         );
-      case 'assistant.started':
-        return AgentAssistantStarted(runId: runId);
-      case 'assistant.delta':
-        final delta = data['delta'];
-        if (delta is! String || delta.isEmpty) {
+      case 'tool.started':
+      case 'tool.completed':
+      case 'tool.failed':
+        final stepId = data['step_id'];
+        final name = data['name'];
+        if (stepId is! String ||
+            stepId.isEmpty ||
+            name is! String ||
+            name.isEmpty) {
           throw const AgentClientException(
             kind: AgentClientFailureKind.invalidResponse,
             retryable: true,
           );
         }
-        return AgentAssistantDelta(runId: runId, delta: delta);
+        return AgentToolStepEvent(
+          runId: runId,
+          stepId: stepId,
+          name: name,
+          status: switch (eventName) {
+            'tool.started' => AgentToolStepStatus.started,
+            'tool.completed' => AgentToolStepStatus.completed,
+            _ => AgentToolStepStatus.failed,
+          },
+        );
+      case 'assistant.output.started':
+        final outputId = data['output_id'];
+        if (outputId is! String || outputId.isEmpty) {
+          throw const AgentClientException(
+            kind: AgentClientFailureKind.invalidResponse,
+            retryable: true,
+          );
+        }
+        return AgentAssistantOutputStarted(runId: runId, outputId: outputId);
+      case 'assistant.output.delta':
+        final outputId = data['output_id'];
+        final sequence = data['sequence'];
+        final delta = data['delta'];
+        if (outputId is! String ||
+            outputId.isEmpty ||
+            sequence is! int ||
+            sequence < 1 ||
+            delta is! String ||
+            delta.isEmpty) {
+          throw const AgentClientException(
+            kind: AgentClientFailureKind.invalidResponse,
+            retryable: true,
+          );
+        }
+        return AgentAssistantOutputDelta(
+          runId: runId,
+          outputId: outputId,
+          sequence: sequence,
+          delta: delta,
+        );
+      case 'assistant.output.completed':
+        final outputId = data['output_id'];
+        final text = data['text'];
+        if (outputId is! String ||
+            outputId.isEmpty ||
+            text is! String ||
+            text.trim().isEmpty) {
+          throw const AgentClientException(
+            kind: AgentClientFailureKind.invalidResponse,
+            retryable: true,
+          );
+        }
+        return AgentAssistantOutputCompleted(
+          runId: runId,
+          outputId: outputId,
+          text: text,
+        );
       case 'run.completed':
         if (run is! Map<String, dynamic>) {
           throw const AgentClientException(

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -1142,6 +1142,10 @@ final class WireAgentVoiceClient
     var eventData = '';
     var phase = 0;
     String? runId;
+    String? outputId;
+    final activeToolSteps = <String, String>{};
+    final outputText = StringBuffer();
+    var nextOutputSequence = 1;
     try {
       final lines = response.body
           .map((chunk) {
@@ -1171,14 +1175,53 @@ final class WireAgentVoiceClient
             case AgentVoiceInputCommitted(:final confirmation) when phase == 0:
               phase = 1;
               runId = confirmation.run.id;
-            case AgentVoiceAssistantStarted() when phase == 1:
+            case AgentVoiceToolStepEvent(
+                  :final stepId,
+                  :final name,
+                  :final status,
+                )
+                when phase == 1:
+              switch (status) {
+                case AgentVoiceToolStepStatus.started:
+                  if (activeToolSteps.containsKey(stepId)) {
+                    throw const _InvalidVoiceResponse();
+                  }
+                  activeToolSteps[stepId] = name;
+                case AgentVoiceToolStepStatus.completed:
+                case AgentVoiceToolStepStatus.failed:
+                  if (activeToolSteps.remove(stepId) != name) {
+                    throw const _InvalidVoiceResponse();
+                  }
+              }
+            case AgentVoiceAssistantOutputStarted(
+                  outputId: final startedOutputId,
+                )
+                when phase == 1 && activeToolSteps.isEmpty:
+              outputId = startedOutputId;
               phase = 2;
-            case AgentVoiceAssistantDelta() when phase == 2:
-              phase = 2;
-            case AgentVoiceRunCompleted() when phase == 1 || phase == 2:
+            case AgentVoiceAssistantOutputDelta(
+                  outputId: final deltaOutputId,
+                  :final sequence,
+                  :final delta,
+                )
+                when phase == 2 &&
+                    deltaOutputId == outputId &&
+                    sequence == nextOutputSequence:
+              outputText.write(delta);
+              nextOutputSequence++;
+            case AgentVoiceAssistantOutputCompleted(
+                  outputId: final completedOutputId,
+                  :final text,
+                )
+                when phase == 2 &&
+                    completedOutputId == outputId &&
+                    text == outputText.toString():
               phase = 3;
-            case AgentVoiceRunFailed() when phase == 1 || phase == 2:
-              phase = 3;
+            case AgentVoiceRunCompleted(:final run)
+                when phase == 3 && run.assistantMessageId == outputId:
+              phase = 4;
+            case AgentVoiceRunFailed() when phase >= 1 && phase <= 3:
+              phase = 4;
             default:
               throw const _InvalidVoiceResponse();
           }
@@ -1203,7 +1246,7 @@ final class WireAgentVoiceClient
     } on _InvalidVoiceResponse {
       throw _invalidResponse();
     }
-    if (phase != 3 || eventName.isNotEmpty || eventData.isNotEmpty) {
+    if (phase != 4 || eventName.isNotEmpty || eventData.isNotEmpty) {
       throw _invalidResponse();
     }
   }
@@ -1236,19 +1279,61 @@ final class WireAgentVoiceClient
           throw const _InvalidVoiceResponse();
         }
         return AgentVoiceInputCommitted(confirmation);
-      case 'assistant.started':
+      case 'tool.started':
+      case 'tool.completed':
+      case 'tool.failed':
         final runId = _strictString(object['run_id'], min: 1, max: 128);
-        if (object.length != 1 || runId != expectedRunId) {
+        final stepId = _strictString(object['step_id'], min: 1, max: 128);
+        final name = _strictString(object['name'], min: 1, max: 128);
+        if (object.length != 3 || runId != expectedRunId) {
           throw const _InvalidVoiceResponse();
         }
-        return AgentVoiceAssistantStarted(runId: runId);
-      case 'assistant.delta':
+        return AgentVoiceToolStepEvent(
+          runId: runId,
+          stepId: stepId,
+          name: name,
+          status: switch (event) {
+            'tool.started' => AgentVoiceToolStepStatus.started,
+            'tool.completed' => AgentVoiceToolStepStatus.completed,
+            _ => AgentVoiceToolStepStatus.failed,
+          },
+        );
+      case 'assistant.output.started':
         final runId = _strictString(object['run_id'], min: 1, max: 128);
-        final delta = _strictContent(object['delta']);
+        final outputId = _strictUuid(object['output_id']);
         if (object.length != 2 || runId != expectedRunId) {
           throw const _InvalidVoiceResponse();
         }
-        return AgentVoiceAssistantDelta(runId: runId, delta: delta);
+        return AgentVoiceAssistantOutputStarted(
+          runId: runId,
+          outputId: outputId,
+        );
+      case 'assistant.output.delta':
+        final runId = _strictString(object['run_id'], min: 1, max: 128);
+        final outputId = _strictUuid(object['output_id']);
+        final sequence = _strictInt(object['sequence'], min: 1, max: 10000);
+        final delta = _strictContent(object['delta']);
+        if (object.length != 4 || runId != expectedRunId) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceAssistantOutputDelta(
+          runId: runId,
+          outputId: outputId,
+          sequence: sequence,
+          delta: delta,
+        );
+      case 'assistant.output.completed':
+        final runId = _strictString(object['run_id'], min: 1, max: 128);
+        final outputId = _strictUuid(object['output_id']);
+        final text = _strictContent(object['text']);
+        if (object.length != 3 || runId != expectedRunId) {
+          throw const _InvalidVoiceResponse();
+        }
+        return AgentVoiceAssistantOutputCompleted(
+          runId: runId,
+          outputId: outputId,
+          text: text,
+        );
       case 'run.completed':
         final run = _decodeRunObject(object['run']);
         if (object.length != 1 ||

--- a/mobile/test/agent/agent_streaming_test.dart
+++ b/mobile/test/agent/agent_streaming_test.dart
@@ -51,20 +51,47 @@ void main() {
             ),
           ),
         )
-        ..add(const AgentAssistantStarted(runId: 'run-1'))
-        ..add(const AgentAssistantDelta(runId: 'run-1', delta: '你'))
-        ..add(const AgentAssistantDelta(runId: 'run-1', delta: '好，**小花**。'));
+        ..add(
+          const AgentAssistantOutputStarted(
+            runId: 'run-1',
+            outputId: 'assistant-1',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputDelta(
+            runId: 'run-1',
+            outputId: 'assistant-1',
+            sequence: 1,
+            delta: '你',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputDelta(
+            runId: 'run-1',
+            outputId: 'assistant-1',
+            sequence: 2,
+            delta: '好，**小花**。',
+          ),
+        );
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       expect(controller.messages.last.text, '你好，**小花**。');
       expect(controller.messages.last.isStreaming, isTrue);
 
-      client.events.add(
-        const AgentRunCompleted(
-          runId: 'run-1',
-          assistantMessageId: 'assistant-1',
-        ),
-      );
+      client.events
+        ..add(
+          const AgentAssistantOutputCompleted(
+            runId: 'run-1',
+            outputId: 'assistant-1',
+            text: '你好，**小花**。',
+          ),
+        )
+        ..add(
+          const AgentRunCompleted(
+            runId: 'run-1',
+            assistantMessageId: 'assistant-1',
+          ),
+        );
       await client.events.close();
       await Future<void>.delayed(Duration.zero);
 
@@ -75,10 +102,10 @@ void main() {
       ]);
       expect(controller.messages.last.isStreaming, isFalse);
       expect(speechEvents, <String>[
-        'start:stream-run-1',
-        'delta:stream-run-1:你',
-        'delta:stream-run-1:好，**小花**。',
-        'complete:stream-run-1:assistant-1:你好，**小花**。',
+        'start:assistant-1',
+        'delta:assistant-1:你',
+        'delta:assistant-1:好，**小花**。',
+        'complete:assistant-1:assistant-1:你好，**小花**。',
       ]);
     },
   );
@@ -104,8 +131,20 @@ void main() {
 
     expect(await controller.sendText('Please help me.'), isTrue);
     client.events
-      ..add(const AgentAssistantStarted(runId: 'run-failed'))
-      ..add(const AgentAssistantDelta(runId: 'run-failed', delta: 'I can help'))
+      ..add(
+        const AgentAssistantOutputStarted(
+          runId: 'run-failed',
+          outputId: 'assistant-failed',
+        ),
+      )
+      ..add(
+        const AgentAssistantOutputDelta(
+          runId: 'run-failed',
+          outputId: 'assistant-failed',
+          sequence: 1,
+          delta: 'I can help',
+        ),
+      )
       ..add(
         const AgentRunFailed(
           runId: 'run-failed',
@@ -117,9 +156,9 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(speechEvents, <String>[
-      'start:stream-run-failed',
-      'delta:stream-run-failed:I can help',
-      'fail:stream-run-failed',
+      'start:assistant-failed',
+      'delta:assistant-failed:I can help',
+      'fail:assistant-failed',
     ]);
     expect(controller.messages.last.hasFailed, isTrue);
   });
@@ -188,9 +227,26 @@ void main() {
           ),
         ),
       )
-      ..add(const AgentAssistantStarted(runId: 'run-retry-2'))
       ..add(
-        const AgentAssistantDelta(runId: 'run-retry-2', delta: 'Recovered.'),
+        const AgentAssistantOutputStarted(
+          runId: 'run-retry-2',
+          outputId: 'assistant-retry-2',
+        ),
+      )
+      ..add(
+        const AgentAssistantOutputDelta(
+          runId: 'run-retry-2',
+          outputId: 'assistant-retry-2',
+          sequence: 1,
+          delta: 'Recovered.',
+        ),
+      )
+      ..add(
+        const AgentAssistantOutputCompleted(
+          runId: 'run-retry-2',
+          outputId: 'assistant-retry-2',
+          text: 'Recovered.',
+        ),
       )
       ..add(
         const AgentRunCompleted(
@@ -237,11 +293,25 @@ void main() {
 
       expect(await controller.sendText('Please continue.'), isTrue);
       client.events
-        ..add(const AgentAssistantStarted(runId: 'run-completed-failure'))
         ..add(
-          const AgentAssistantDelta(
+          const AgentAssistantOutputStarted(
             runId: 'run-completed-failure',
+            outputId: 'assistant-completed-failure',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputDelta(
+            runId: 'run-completed-failure',
+            outputId: 'assistant-completed-failure',
+            sequence: 1,
             delta: 'The response is complete.',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputCompleted(
+            runId: 'run-completed-failure',
+            outputId: 'assistant-completed-failure',
+            text: 'The response is complete.',
           ),
         )
         ..add(
@@ -255,9 +325,9 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(speechEvents, <String>[
-        'start:stream-run-completed-failure',
-        'delta:stream-run-completed-failure:The response is complete.',
-        'complete:stream-run-completed-failure:assistant-completed-failure',
+        'start:assistant-completed-failure',
+        'delta:assistant-completed-failure:The response is complete.',
+        'complete:assistant-completed-failure:assistant-completed-failure',
         'fail:assistant-completed-failure',
       ]);
       expect(controller.messages.last.id, 'assistant-completed-failure');
@@ -279,11 +349,25 @@ void main() {
 
     expect(await controller.sendText('Please continue.'), isTrue);
     client.events
-      ..add(const AgentAssistantStarted(runId: 'run-text-success'))
       ..add(
-        const AgentAssistantDelta(
+        const AgentAssistantOutputStarted(
           runId: 'run-text-success',
+          outputId: 'assistant-text-success',
+        ),
+      )
+      ..add(
+        const AgentAssistantOutputDelta(
+          runId: 'run-text-success',
+          outputId: 'assistant-text-success',
+          sequence: 1,
           delta: 'The text still succeeds.',
+        ),
+      )
+      ..add(
+        const AgentAssistantOutputCompleted(
+          runId: 'run-text-success',
+          outputId: 'assistant-text-success',
+          text: 'The text still succeeds.',
         ),
       )
       ..add(
@@ -340,11 +424,25 @@ void main() {
             ),
           ),
         )
-        ..add(const AgentAssistantStarted(runId: 'run-client-action-1'))
         ..add(
-          const AgentAssistantDelta(
+          const AgentAssistantOutputStarted(
             runId: 'run-client-action-1',
+            outputId: 'assistant-client-action-1',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputDelta(
+            runId: 'run-client-action-1',
+            outputId: 'assistant-client-action-1',
+            sequence: 1,
             delta: '练习方案已准备好。',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputCompleted(
+            runId: 'run-client-action-1',
+            outputId: 'assistant-client-action-1',
+            text: '练习方案已准备好。',
           ),
         )
         ..add(
@@ -404,11 +502,25 @@ void main() {
             ),
           ),
         )
-        ..add(const AgentAssistantStarted(runId: 'run-client-action-retry-1'))
         ..add(
-          const AgentAssistantDelta(
+          const AgentAssistantOutputStarted(
             runId: 'run-client-action-retry-1',
+            outputId: 'assistant-client-action-retry-1',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputDelta(
+            runId: 'run-client-action-retry-1',
+            outputId: 'assistant-client-action-retry-1',
+            sequence: 1,
             delta: '练习方案已准备好。',
+          ),
+        )
+        ..add(
+          const AgentAssistantOutputCompleted(
+            runId: 'run-client-action-retry-1',
+            outputId: 'assistant-client-action-retry-1',
+            text: '练习方案已准备好。',
           ),
         )
         ..add(
@@ -477,8 +589,31 @@ void main() {
             'retryable': true,
           })
         else ...[
-          _sse('assistant.started', {'run_id': retryRunId}),
-          _sse('assistant.delta', {'run_id': retryRunId, 'delta': '你好，小花。'}),
+          _sse('tool.started', {
+            'run_id': retryRunId,
+            'step_id': 'tool-step-1',
+            'name': 'practice.preview.v1',
+          }),
+          _sse('tool.completed', {
+            'run_id': retryRunId,
+            'step_id': 'tool-step-1',
+            'name': 'practice.preview.v1',
+          }),
+          _sse('assistant.output.started', {
+            'run_id': retryRunId,
+            'output_id': assistantMessageId,
+          }),
+          _sse('assistant.output.delta', {
+            'run_id': retryRunId,
+            'output_id': assistantMessageId,
+            'sequence': 1,
+            'delta': '你好，小花。',
+          }),
+          _sse('assistant.output.completed', {
+            'run_id': retryRunId,
+            'output_id': assistantMessageId,
+            'text': '你好，小花。',
+          }),
           _sse('run.completed', {
             'run': <String, Object?>{
               'run_id': retryRunId,

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -511,14 +511,38 @@ void main() {
                 'run': _runJson(status: 'pending'),
               },
             ),
-            ('assistant.started', <String, Object?>{'run_id': _runId}),
             (
-              'assistant.delta',
-              <String, Object?>{'run_id': _runId, 'delta': 'Hello'},
+              'assistant.output.started',
+              <String, Object?>{
+                'run_id': _runId,
+                'output_id': _assistantMessageId,
+              },
             ),
             (
-              'assistant.delta',
-              <String, Object?>{'run_id': _runId, 'delta': ', how can I help?'},
+              'assistant.output.delta',
+              <String, Object?>{
+                'run_id': _runId,
+                'output_id': _assistantMessageId,
+                'sequence': 1,
+                'delta': 'Hello',
+              },
+            ),
+            (
+              'assistant.output.delta',
+              <String, Object?>{
+                'run_id': _runId,
+                'output_id': _assistantMessageId,
+                'sequence': 2,
+                'delta': ', how can I help?',
+              },
+            ),
+            (
+              'assistant.output.completed',
+              <String, Object?>{
+                'run_id': _runId,
+                'output_id': _assistantMessageId,
+                'text': 'Hello, how can I help?',
+              },
             ),
             ('run.completed', <String, Object?>{'run': completedRun}),
           ]),
@@ -536,9 +560,9 @@ void main() {
           )
           .toList();
 
-      expect(events, hasLength(5));
+      expect(events, hasLength(6));
       expect(
-        events.whereType<AgentVoiceAssistantDelta>().map(
+        events.whereType<AgentVoiceAssistantOutputDelta>().map(
           (event) => event.delta,
         ),
         <String>['Hello', ', how can I help?'],
@@ -547,6 +571,64 @@ void main() {
       transport.expectDone();
     },
   );
+
+  test('rejects a non-contiguous assistant output sequence', () async {
+    final transport = _ScriptedVoiceTransport([
+      _Step(
+        method: 'POST',
+        path: '/v1/agent-voice-drafts/$_draftId/confirmations/stream',
+        response: _sseResponse(<(String, Object?)>[
+          (
+            'input.committed',
+            <String, Object?>{
+              'draft': _draftJson(status: 'confirmed', confirmed: true),
+              'message': _voiceMessageJson(
+                content: 'Edited confirmed transcript',
+              ),
+              'run': _runJson(status: 'pending'),
+            },
+          ),
+          (
+            'assistant.output.started',
+            <String, Object?>{
+              'run_id': _runId,
+              'output_id': _assistantMessageId,
+            },
+          ),
+          (
+            'assistant.output.delta',
+            <String, Object?>{
+              'run_id': _runId,
+              'output_id': _assistantMessageId,
+              'sequence': 2,
+              'delta': 'Skipped sequence one.',
+            },
+          ),
+        ]),
+      ),
+    ]);
+    final client = _client(transport);
+    addTearDown(client.dispose);
+
+    await expectLater(
+      client
+          .confirmDraftStream(
+            draftId: _draftId,
+            draftVersion: 1,
+            clientMessageId: 'voice_message_001',
+            confirmedText: 'Edited confirmed transcript',
+          )
+          .toList(),
+      throwsA(
+        isA<AgentClientException>().having(
+          (error) => error.kind,
+          'kind',
+          AgentClientFailureKind.invalidResponse,
+        ),
+      ),
+    );
+    transport.expectDone();
+  });
 
   test('decodes exactly four durable draft states', () async {
     final transport = _ScriptedVoiceTransport([

--- a/server/internal/agent/input/voice/http/handler.go
+++ b/server/internal/agent/input/voice/http/handler.go
@@ -295,21 +295,49 @@ func (writer *confirmationSSEWriter) OnConfirmationCommitted(
 	return writer.write("input.committed", confirmationResponse(confirmation))
 }
 
-func (writer *confirmationSSEWriter) OnAssistantStarted(
-	_ context.Context,
-	pending agentrun.Run,
-) error {
-	writer.runID = pending.ID
-	return writer.write("assistant.started", gin.H{"run_id": pending.ID})
+func (writer *confirmationSSEWriter) OnToolStarted(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.started", step)
 }
 
-func (writer *confirmationSSEWriter) OnAssistantDelta(
+func (writer *confirmationSSEWriter) OnToolCompleted(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.completed", step)
+}
+
+func (writer *confirmationSSEWriter) OnToolFailed(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.failed", step)
+}
+
+func (writer *confirmationSSEWriter) writeTool(event string, step agentrun.ToolStep) error {
+	return writer.write(event, gin.H{
+		"run_id": step.RunID, "step_id": step.ID, "name": step.Name,
+	})
+}
+
+func (writer *confirmationSSEWriter) OnAssistantOutputStarted(
 	_ context.Context,
-	delta string,
+	output agentrun.AssistantOutput,
 ) error {
-	return writer.write("assistant.delta", gin.H{
-		"run_id": writer.runID,
-		"delta":  delta,
+	return writer.write("assistant.output.started", gin.H{
+		"run_id": output.RunID, "output_id": output.ID,
+	})
+}
+
+func (writer *confirmationSSEWriter) OnAssistantOutputDelta(
+	_ context.Context,
+	delta agentrun.AssistantOutputDelta,
+) error {
+	return writer.write("assistant.output.delta", gin.H{
+		"run_id": delta.RunID, "output_id": delta.OutputID,
+		"sequence": delta.Sequence, "delta": delta.Delta,
+	})
+}
+
+func (writer *confirmationSSEWriter) OnAssistantOutputCompleted(
+	_ context.Context,
+	output agentrun.AssistantOutput,
+) error {
+	return writer.write("assistant.output.completed", gin.H{
+		"run_id": output.RunID, "output_id": output.ID, "text": output.Content,
 	})
 }
 

--- a/server/internal/agent/input/voice/model.go
+++ b/server/internal/agent/input/voice/model.go
@@ -157,8 +157,12 @@ type PendingRunProcessor interface {
 
 type ConfirmationStreamObserver interface {
 	OnConfirmationCommitted(context.Context, Confirmation) error
-	OnAssistantStarted(context.Context, run.Run) error
-	OnAssistantDelta(context.Context, string) error
+	OnToolStarted(context.Context, run.ToolStep) error
+	OnToolCompleted(context.Context, run.ToolStep) error
+	OnToolFailed(context.Context, run.ToolStep) error
+	OnAssistantOutputStarted(context.Context, run.AssistantOutput) error
+	OnAssistantOutputDelta(context.Context, run.AssistantOutputDelta) error
+	OnAssistantOutputCompleted(context.Context, run.AssistantOutput) error
 }
 
 type FeedbackReference struct {

--- a/server/internal/agent/input/voice/service.go
+++ b/server/internal/agent/input/voice/service.go
@@ -323,18 +323,46 @@ func (confirmationRunObserver) OnInputCommitted(context.Context, run.Submission)
 	return nil
 }
 
-func (observer confirmationRunObserver) OnAssistantStarted(
+func (observer confirmationRunObserver) OnToolStarted(
 	ctx context.Context,
-	pending run.Run,
+	step run.ToolStep,
 ) error {
-	return observer.delegate.OnAssistantStarted(ctx, pending)
+	return observer.delegate.OnToolStarted(ctx, step)
 }
 
-func (observer confirmationRunObserver) OnAssistantDelta(
+func (observer confirmationRunObserver) OnToolCompleted(
 	ctx context.Context,
-	delta string,
+	step run.ToolStep,
 ) error {
-	return observer.delegate.OnAssistantDelta(ctx, delta)
+	return observer.delegate.OnToolCompleted(ctx, step)
+}
+
+func (observer confirmationRunObserver) OnToolFailed(
+	ctx context.Context,
+	step run.ToolStep,
+) error {
+	return observer.delegate.OnToolFailed(ctx, step)
+}
+
+func (observer confirmationRunObserver) OnAssistantOutputStarted(
+	ctx context.Context,
+	output run.AssistantOutput,
+) error {
+	return observer.delegate.OnAssistantOutputStarted(ctx, output)
+}
+
+func (observer confirmationRunObserver) OnAssistantOutputDelta(
+	ctx context.Context,
+	delta run.AssistantOutputDelta,
+) error {
+	return observer.delegate.OnAssistantOutputDelta(ctx, delta)
+}
+
+func (observer confirmationRunObserver) OnAssistantOutputCompleted(
+	ctx context.Context,
+	output run.AssistantOutput,
+) error {
+	return observer.delegate.OnAssistantOutputCompleted(ctx, output)
 }
 
 func (service *Service) Playback(

--- a/server/internal/agent/run/http/handler.go
+++ b/server/internal/agent/run/http/handler.go
@@ -246,20 +246,49 @@ func (writer *sseWriter) OnInputCommitted(
 	})
 }
 
-func (writer *sseWriter) OnAssistantStarted(
-	_ context.Context,
-	run agentrun.Run,
-) error {
-	writer.runID = run.ID
-	return writer.write("assistant.started", gin.H{"run_id": run.ID})
+func (writer *sseWriter) OnToolStarted(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.started", step)
 }
 
-func (writer *sseWriter) OnAssistantDelta(
+func (writer *sseWriter) OnToolCompleted(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.completed", step)
+}
+
+func (writer *sseWriter) OnToolFailed(_ context.Context, step agentrun.ToolStep) error {
+	return writer.writeTool("tool.failed", step)
+}
+
+func (writer *sseWriter) writeTool(event string, step agentrun.ToolStep) error {
+	return writer.write(event, gin.H{
+		"run_id": step.RunID, "step_id": step.ID, "name": step.Name,
+	})
+}
+
+func (writer *sseWriter) OnAssistantOutputStarted(
 	_ context.Context,
-	delta string,
+	output agentrun.AssistantOutput,
 ) error {
-	return writer.write("assistant.delta", gin.H{
-		"run_id": writer.runID, "delta": delta,
+	return writer.write("assistant.output.started", gin.H{
+		"run_id": output.RunID, "output_id": output.ID,
+	})
+}
+
+func (writer *sseWriter) OnAssistantOutputDelta(
+	_ context.Context,
+	delta agentrun.AssistantOutputDelta,
+) error {
+	return writer.write("assistant.output.delta", gin.H{
+		"run_id": delta.RunID, "output_id": delta.OutputID,
+		"sequence": delta.Sequence, "delta": delta.Delta,
+	})
+}
+
+func (writer *sseWriter) OnAssistantOutputCompleted(
+	_ context.Context,
+	output agentrun.AssistantOutput,
+) error {
+	return writer.write("assistant.output.completed", gin.H{
+		"run_id": output.RunID, "output_id": output.ID, "text": output.Content,
 	})
 }
 

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -98,6 +98,49 @@ func TestRunLoopExecutesToolCallAndFeedsResultBackToModel(t *testing.T) {
 	}
 }
 
+func TestRunLoopPublishesOnlyTheFinalAssistantOutput(t *testing.T) {
+	toolResult := toolLoopResult(
+		"call-review-stream-1",
+		reviewcapability.ReviewSearchToolName,
+		`{"query":"metrics","limit":1}`,
+	)
+	toolResult.Content = "I will search your reviews first."
+	generator := newScriptedGenerator(
+		toolResult,
+		finalLoopResult("I found the review and summarized it."),
+	)
+	service := newLoopTestService(t, generator)
+	observer := &recordingLoopStreamObserver{}
+
+	result, deltas, err := service.generateObserved(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		agentcontext.Manifest{},
+		loopRequest("请结合我的信息处理一下"),
+		observer,
+	)
+	if err != nil {
+		t.Fatalf("generateObserved() error = %v", err)
+	}
+	if result.Content != "I found the review and summarized it." {
+		t.Fatalf("Content = %q", result.Content)
+	}
+	if got := joinedTextDeltas(deltas); got != result.Content {
+		t.Fatalf("final deltas = %q, want %q", got, result.Content)
+	}
+	if strings.Contains(joinedTextDeltas(deltas), "search your reviews") {
+		t.Fatalf("tool-stage text leaked into final deltas: %#v", deltas)
+	}
+	wantSteps := []string{
+		"started:call-review-stream-1",
+		"completed:call-review-stream-1",
+	}
+	if !reflect.DeepEqual(observer.steps, wantSteps) {
+		t.Fatalf("tool steps = %#v, want %#v", observer.steps, wantSteps)
+	}
+}
+
 func TestRunLoopKeepsSourceRefsOutOfProviderMessagesAndInAudit(t *testing.T) {
 	generator := newScriptedGenerator(
 		toolLoopResult(
@@ -1114,11 +1157,73 @@ func (generator *scriptedGenerator) Generate(
 }
 
 func (generator *scriptedGenerator) GenerateStream(
-	context.Context,
-	TextRequest,
-	TextDeltaObserver,
+	ctx context.Context,
+	request TextRequest,
+	observer TextDeltaObserver,
 ) (TextResult, error) {
-	panic("non-streaming run unexpectedly selected GenerateStream")
+	result, err := generator.Generate(ctx, request)
+	if err != nil {
+		return TextResult{}, err
+	}
+	if result.Content != "" {
+		if err := observer.OnTextDelta(ctx, result.Content); err != nil {
+			return TextResult{}, err
+		}
+	}
+	return result, nil
+}
+
+type recordingLoopStreamObserver struct {
+	steps []string
+}
+
+func (*recordingLoopStreamObserver) OnInputCommitted(context.Context, Submission) error {
+	return nil
+}
+
+func (observer *recordingLoopStreamObserver) OnToolStarted(
+	_ context.Context,
+	step ToolStep,
+) error {
+	observer.steps = append(observer.steps, "started:"+step.ID)
+	return nil
+}
+
+func (observer *recordingLoopStreamObserver) OnToolCompleted(
+	_ context.Context,
+	step ToolStep,
+) error {
+	observer.steps = append(observer.steps, "completed:"+step.ID)
+	return nil
+}
+
+func (observer *recordingLoopStreamObserver) OnToolFailed(
+	_ context.Context,
+	step ToolStep,
+) error {
+	observer.steps = append(observer.steps, "failed:"+step.ID)
+	return nil
+}
+
+func (*recordingLoopStreamObserver) OnAssistantOutputStarted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
+}
+
+func (*recordingLoopStreamObserver) OnAssistantOutputDelta(
+	context.Context,
+	AssistantOutputDelta,
+) error {
+	return nil
+}
+
+func (*recordingLoopStreamObserver) OnAssistantOutputCompleted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
 }
 
 func (generator *scriptedGenerator) Requests() []TextRequest {
@@ -1285,12 +1390,16 @@ func (loopRepository) ListClientActions(
 	panic("unexpected ListClientActions")
 }
 
+func (loopRepository) NewAssistantMessageID() (string, error) {
+	return "70000000-0000-4000-8000-000000000001", nil
+}
+
 func (loopRepository) Complete(
 	context.Context,
 	string,
 	string,
 	string,
-	string,
+	AssistantOutput,
 	TextResult,
 ) (Run, error) {
 	panic("unexpected Complete")

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -44,12 +45,46 @@ func TestRunLoopExposesAllToolsAndAllowsDirectResponse(t *testing.T) {
 		capabilityfixture.MistakeSearchToolName,
 		reviewcapability.ReviewGetToolName,
 		reviewcapability.ReviewSearchToolName,
+		finalResponseToolName,
 	}
 	if !reflect.DeepEqual(gotTools, wantTools) {
 		t.Fatalf("Tools = %#v, want %#v", gotTools, wantTools)
 	}
-	if requests[0].ToolChoice.Mode != ToolChoiceAuto {
-		t.Fatalf("ToolChoice = %#v, want auto", requests[0].ToolChoice)
+	if requests[0].ToolChoice.Mode != ToolChoiceRequired {
+		t.Fatalf("ToolChoice = %#v, want required", requests[0].ToolChoice)
+	}
+	if got, want := len(requests), 2; got != want ||
+		requests[1].ToolChoice.Mode != ToolChoiceNone ||
+		len(requests[1].Tools) != 0 {
+		t.Fatalf("final output request = %#v", requests[1])
+	}
+}
+
+func TestFinalResponseControlRequiresExplicitDecision(t *testing.T) {
+	definition := finalResponseToolDefinition()
+	validArguments := json.RawMessage(`{"decision":"respond"}`)
+	if err := capability.ValidateInput(definition.InputSchema, validArguments); err != nil {
+		t.Fatalf("ValidateInput(valid) error = %v", err)
+	}
+	if !validFinalResponseRequest([]ModelToolCall{{
+		ID: "call-final-response", Name: definition.Name, Arguments: validArguments,
+	}}) {
+		t.Fatal("valid final response decision was rejected")
+	}
+	for name, arguments := range map[string]json.RawMessage{
+		"empty object":   json.RawMessage(`{}`),
+		"wrong decision": json.RawMessage(`{"decision":"continue"}`),
+		"extra field": json.RawMessage(
+			`{"decision":"respond","content":"do not buffer this"}`,
+		),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if validFinalResponseRequest([]ModelToolCall{{
+				ID: "call-final-response", Name: definition.Name, Arguments: arguments,
+			}}) {
+				t.Fatalf("arguments %s were accepted", arguments)
+			}
+		})
 	}
 }
 
@@ -74,18 +109,18 @@ func TestRunLoopExecutesToolCallAndFeedsResultBackToModel(t *testing.T) {
 		t.Fatalf("Content = %q", result.Content)
 	}
 	requests := generator.Requests()
-	if got, want := len(requests), 2; got != want {
+	if got, want := len(requests), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	if got := len(requests[0].Tools); got == 0 {
 		t.Fatal("first request exposed no tools")
 	}
-	if requests[0].ToolChoice.Mode != ToolChoiceAuto {
-		t.Fatalf("first ToolChoice = %#v, want auto", requests[0].ToolChoice)
+	if requests[0].ToolChoice.Mode != ToolChoiceRequired {
+		t.Fatalf("first ToolChoice = %#v, want required", requests[0].ToolChoice)
 	}
 	second := requests[1]
-	if second.ToolChoice.Mode != ToolChoiceAuto {
-		t.Fatalf("second ToolChoice = %#v, want auto", second.ToolChoice)
+	if second.ToolChoice.Mode != ToolChoiceRequired {
+		t.Fatalf("second ToolChoice = %#v, want required", second.ToolChoice)
 	}
 	if got, want := len(second.Messages), 4; got != want {
 		t.Fatalf("second request messages = %d, want %d", got, want)
@@ -119,6 +154,9 @@ func TestRunLoopPublishesOnlyTheFinalAssistantOutput(t *testing.T) {
 		agentcontext.Manifest{},
 		loopRequest("请结合我的信息处理一下"),
 		observer,
+		AssistantOutput{
+			ID: "b86cf498-a89d-4a40-bab6-ad33e8e0efdb", RunID: "run-1",
+		},
 	)
 	if err != nil {
 		t.Fatalf("generateObserved() error = %v", err)
@@ -138,6 +176,61 @@ func TestRunLoopPublishesOnlyTheFinalAssistantOutput(t *testing.T) {
 	}
 	if !reflect.DeepEqual(observer.steps, wantSteps) {
 		t.Fatalf("tool steps = %#v, want %#v", observer.steps, wantSteps)
+	}
+}
+
+func TestRunLoopForwardsFinalDeltaBeforeProviderCompletes(t *testing.T) {
+	release := make(chan struct{})
+	generator := &blockingFinalGenerator{release: release}
+	service := newLoopTestService(t, generator)
+	observer := &realtimeLoopStreamObserver{events: make(chan string, 4)}
+	type generationResult struct {
+		result TextResult
+		deltas []string
+		err    error
+	}
+	completed := make(chan generationResult, 1)
+	go func() {
+		result, deltas, err := service.generateObserved(
+			context.Background(),
+			loopActor(),
+			loopRun(),
+			agentcontext.Manifest{},
+			loopRequest("请直接回答"),
+			observer,
+			AssistantOutput{
+				ID: "5d1dd070-0805-4be4-9b4a-aa689b78bf6e", RunID: "run-1",
+			},
+		)
+		completed <- generationResult{result: result, deltas: deltas, err: err}
+	}()
+
+	wantEvents := []string{
+		"started:5d1dd070-0805-4be4-9b4a-aa689b78bf6e",
+		"delta:1:first",
+	}
+	for _, want := range wantEvents {
+		select {
+		case got := <-observer.events:
+			if got != want {
+				close(release)
+				t.Fatalf("stream event = %q, want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatalf("timed out waiting for %q before provider completion", want)
+		}
+	}
+	close(release)
+	outcome := <-completed
+	if outcome.err != nil {
+		t.Fatalf("generateObserved() error = %v", outcome.err)
+	}
+	if got, want := outcome.result.Content, "first second"; got != want {
+		t.Fatalf("Content = %q, want %q", got, want)
+	}
+	if got := joinedTextDeltas(outcome.deltas); got != outcome.result.Content {
+		t.Fatalf("deltas = %q, want %q", got, outcome.result.Content)
 	}
 }
 
@@ -171,7 +264,7 @@ func TestRunLoopKeepsSourceRefsOutOfProviderMessagesAndInAudit(t *testing.T) {
 	}
 
 	requests := generator.Requests()
-	if got, want := len(requests), 2; got != want {
+	if got, want := len(requests), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	toolMessage := requests[1].Messages[len(requests[1].Messages)-1]
@@ -255,7 +348,7 @@ func TestRunLoopExecutesMultipleToolCallsAndFeedsAllResultsBack(t *testing.T) {
 	}
 
 	requests := generator.Requests()
-	if got, want := len(requests), 2; got != want {
+	if got, want := len(requests), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	messages := requests[1].Messages
@@ -307,7 +400,7 @@ func TestRunLoopSupportsConsecutiveToolRoundsBeforeFinalResponse(t *testing.T) {
 		t.Fatalf("Content = %q", result.Content)
 	}
 	requests := generator.Requests()
-	if got, want := len(requests), 3; got != want {
+	if got, want := len(requests), 4; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	lastMessages := requests[2].Messages
@@ -365,11 +458,11 @@ func TestRunLoopTreatsSlashPrefixedTextAsNaturalLanguage(t *testing.T) {
 		t.Fatalf("Content = %q", result.Content)
 	}
 	requests := generator.Requests()
-	if got, want := len(requests), 2; got != want {
+	if got, want := len(requests), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	initial := requests[0]
-	if initial.ToolChoice.Mode != ToolChoiceAuto || len(initial.Tools) != 4 {
+	if initial.ToolChoice.Mode != ToolChoiceRequired || len(initial.Tools) != 5 {
 		t.Fatalf(
 			"initial routing = choice %#v, tools %d",
 			initial.ToolChoice,
@@ -410,7 +503,7 @@ func TestRunLoopFeedsExplicitCapabilityFailureBackToModel(t *testing.T) {
 	if result.Content != "I could not read the material, so I will continue without it." {
 		t.Fatalf("Content = %q", result.Content)
 	}
-	if got, want := generator.CallCount(), 2; got != want {
+	if got, want := generator.CallCount(), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 	toolResult := generator.Requests()[1].Messages[3]
@@ -739,7 +832,7 @@ func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
 		conditional.inputs[1].WriteValue == "" {
 		t.Fatalf("conditional inputs = %#v", conditional.inputs)
 	}
-	if got, want := generator.CallCount(), 3; got != want {
+	if got, want := generator.CallCount(), 4; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
 }
@@ -1120,6 +1213,51 @@ type scriptedGenerator struct {
 	requests []TextRequest
 }
 
+type blockingFinalGenerator struct {
+	release <-chan struct{}
+}
+
+func (*blockingFinalGenerator) Generate(
+	ctx context.Context,
+	request TextRequest,
+) (TextResult, error) {
+	if err := ValidateTextRequest(request); err != nil {
+		return TextResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return TextResult{}, err
+	}
+	if request.ToolChoice.Mode != ToolChoiceRequired {
+		return TextResult{}, errors.New("planning request did not require a control decision")
+	}
+	return finalResponseLoopResult(), nil
+}
+
+func (generator *blockingFinalGenerator) GenerateStream(
+	ctx context.Context,
+	request TextRequest,
+	observer TextDeltaObserver,
+) (TextResult, error) {
+	if err := ValidateTextRequest(request); err != nil {
+		return TextResult{}, err
+	}
+	if request.ToolChoice.Mode != ToolChoiceNone || len(request.Tools) != 0 {
+		return TextResult{}, errors.New("final output request still exposes tools")
+	}
+	if err := observer.OnTextDelta(ctx, "first"); err != nil {
+		return TextResult{}, err
+	}
+	select {
+	case <-ctx.Done():
+		return TextResult{}, ctx.Err()
+	case <-generator.release:
+	}
+	if err := observer.OnTextDelta(ctx, " second"); err != nil {
+		return TextResult{}, err
+	}
+	return finalLoopResult("first second"), nil
+}
+
 type failingTextGenerator struct {
 	err error
 }
@@ -1149,7 +1287,14 @@ func (generator *scriptedGenerator) Generate(
 	defer generator.mu.Unlock()
 	generator.requests = append(generator.requests, request)
 	if len(generator.results) == 0 {
+		if request.ToolChoice.Mode == ToolChoiceRequired {
+			return finalResponseLoopResult(), nil
+		}
 		return finalLoopResult("default"), nil
+	}
+	if request.ToolChoice.Mode == ToolChoiceRequired &&
+		len(generator.results[0].ToolCalls) == 0 {
+		return finalResponseLoopResult(), nil
 	}
 	result := generator.results[0]
 	generator.results = generator.results[1:]
@@ -1175,6 +1320,49 @@ func (generator *scriptedGenerator) GenerateStream(
 
 type recordingLoopStreamObserver struct {
 	steps []string
+}
+
+type realtimeLoopStreamObserver struct {
+	events chan string
+}
+
+func (*realtimeLoopStreamObserver) OnInputCommitted(context.Context, Submission) error {
+	return nil
+}
+
+func (*realtimeLoopStreamObserver) OnToolStarted(context.Context, ToolStep) error {
+	return errors.New("unexpected tool start")
+}
+
+func (*realtimeLoopStreamObserver) OnToolCompleted(context.Context, ToolStep) error {
+	return errors.New("unexpected tool completion")
+}
+
+func (*realtimeLoopStreamObserver) OnToolFailed(context.Context, ToolStep) error {
+	return errors.New("unexpected tool failure")
+}
+
+func (observer *realtimeLoopStreamObserver) OnAssistantOutputStarted(
+	_ context.Context,
+	output AssistantOutput,
+) error {
+	observer.events <- "started:" + output.ID
+	return nil
+}
+
+func (observer *realtimeLoopStreamObserver) OnAssistantOutputDelta(
+	_ context.Context,
+	delta AssistantOutputDelta,
+) error {
+	observer.events <- fmt.Sprintf("delta:%d:%s", delta.Sequence, delta.Delta)
+	return nil
+}
+
+func (*realtimeLoopStreamObserver) OnAssistantOutputCompleted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
 }
 
 func (*recordingLoopStreamObserver) OnInputCommitted(context.Context, Submission) error {
@@ -1444,6 +1632,14 @@ func finalLoopResult(content string) TextResult {
 		FinishReason: "stop",
 		Usage:        TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 	}
+}
+
+func finalResponseLoopResult() TextResult {
+	return toolLoopResult(
+		"call-final-response",
+		finalResponseToolName,
+		`{"decision":"respond"}`,
+	)
 }
 
 func toolLoopResult(id string, name string, arguments string) TextResult {

--- a/server/internal/agent/run/postgres/repository_impl.go
+++ b/server/internal/agent/run/postgres/repository_impl.go
@@ -588,9 +588,13 @@ func (r *Repository) Complete(
 	ownerID string,
 	runID string,
 	leaseToken string,
-	content string,
+	output agentrun.AssistantOutput,
 	result agentrun.TextResult,
 ) (agentrun.Run, error) {
+	if !agentrun.ValidUUID(output.ID) || output.RunID != runID ||
+		!conversation.ValidMessageContent(output.Content) {
+		return agentrun.Run{}, agentrun.ErrInvalidRequest
+	}
 	tx, err := r.database.Begin(ctx)
 	if err != nil {
 		return agentrun.Run{}, agentrun.ErrRepository
@@ -613,15 +617,11 @@ func (r *Repository) Complete(
 	if err != nil {
 		return agentrun.Run{}, err
 	}
-	messageID, err := r.ids.NewID()
-	if err != nil {
-		return agentrun.Run{}, agentrun.ErrRepository
-	}
 	if _, err := tx.Exec(ctx, `
 INSERT INTO agent_messages (
     id, thread_id, sequence_no, role, produced_by_run_id, modality, content
 ) VALUES ($1, $2, $3, 'assistant', $4, 'text', $5)`,
-		messageID, run.ThreadID, nextSequence, run.ID, content,
+		output.ID, run.ThreadID, nextSequence, run.ID, output.Content,
 	); err != nil {
 		return agentrun.Run{}, mapRunPostgresError(err)
 	}
@@ -684,6 +684,10 @@ WHERE id = $1 AND user_id = $2`, run.ThreadID, ownerID, nextSequence); err != ni
 		return agentrun.Run{}, agentrun.ErrRepository
 	}
 	return completed, nil
+}
+
+func (r *Repository) NewAssistantMessageID() (string, error) {
+	return r.ids.NewID()
 }
 
 func (r *Repository) Fail(

--- a/server/internal/agent/run/repository.go
+++ b/server/internal/agent/run/repository.go
@@ -54,12 +54,13 @@ type Repository interface {
 		string,
 		string,
 	) ([]agentclientaction.Action, error)
+	NewAssistantMessageID() (string, error)
 	Complete(
 		stdcontext.Context,
 		string,
 		string,
 		string,
-		string,
+		AssistantOutput,
 		TextResult,
 	) (Run, error)
 	Fail(stdcontext.Context, string, string, string, string, bool) (Run, error)

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -226,13 +226,7 @@ func (service *Service) SubmitTextStream(
 	if err := observer.OnInputCommitted(ctx, submission); err != nil {
 		return Submission{}, err
 	}
-	if submission.Run.Status == StatusPending {
-		if err := observer.OnAssistantStarted(ctx, submission.Run); err != nil {
-			return Submission{}, err
-		}
-	}
-	deltas := &countingDeltaObserver{delegate: observer}
-	submission.Run, err = service.process(ctx, actor, submission.Run, deltas)
+	submission.Run, err = service.process(ctx, actor, submission.Run, observer)
 	if err == nil {
 		submission.Run, err = service.waitForTerminalRun(
 			ctx,
@@ -364,13 +358,7 @@ func (service *Service) RetryTextStream(
 	}); err != nil {
 		return Retry{}, err
 	}
-	if retry.Run.Status == StatusPending {
-		if err := observer.OnAssistantStarted(ctx, retry.Run); err != nil {
-			return Retry{}, err
-		}
-	}
-	deltas := &countingDeltaObserver{delegate: observer}
-	retry.Run, err = service.process(ctx, actor, retry.Run, deltas)
+	retry.Run, err = service.process(ctx, actor, retry.Run, observer)
 	if err == nil {
 		retry.Run, err = service.waitForTerminalRun(
 			ctx,
@@ -466,7 +454,8 @@ func (service *Service) ProcessPending(
 }
 
 // ProcessPendingStream resumes a Run created by another Agent input workflow
-// while forwarding model output to that workflow's live response.
+// while forwarding typed tool steps and the committed Assistant Output to that
+// workflow's live response.
 func (service *Service) ProcessPendingStream(
 	ctx context.Context,
 	actor requestcontext.Actor,
@@ -480,13 +469,7 @@ func (service *Service) ProcessPendingStream(
 		!ValidUUID(run.InputMessageID) {
 		return Run{}, ErrInvalidRequest
 	}
-	if run.Status == StatusPending {
-		if err := observer.OnAssistantStarted(ctx, run); err != nil {
-			return Run{}, err
-		}
-	}
-	deltas := &countingDeltaObserver{delegate: observer}
-	processed, err := service.process(ctx, actor, run, deltas)
+	processed, err := service.process(ctx, actor, run, observer)
 	if err == nil {
 		processed, err = service.waitForTerminalRun(
 			ctx,
@@ -501,7 +484,7 @@ func (service *Service) process(
 	ctx context.Context,
 	actor requestcontext.Actor,
 	run Run,
-	observer *countingDeltaObserver,
+	observer StreamObserver,
 ) (Run, error) {
 	if run.Status != StatusPending {
 		return run, nil
@@ -597,6 +580,7 @@ func (service *Service) process(
 		return failed, failErr
 	}
 	var result TextResult
+	var finalDeltas []string
 	if observer == nil {
 		result, err = service.generate(
 			ctx,
@@ -606,7 +590,7 @@ func (service *Service) process(
 			request,
 		)
 	} else {
-		result, err = service.generateObserved(
+		result, finalDeltas, err = service.generateObserved(
 			ctx,
 			actor,
 			claimed,
@@ -648,8 +632,39 @@ func (service *Service) process(
 		)
 		return failed, failErr
 	}
-	if observer != nil && observer.count == 0 {
-		if err := observer.OnTextDelta(ctx, result.Content); err != nil {
+	outputID, err := service.repository.NewAssistantMessageID()
+	if err != nil || !ValidUUID(outputID) {
+		failed, failErr := service.persistFailure(
+			ctx,
+			actor.UserID,
+			claimed.ID,
+			claimed.WorkerLeaseToken,
+			FailureInternal,
+			true,
+		)
+		return failed, failErr
+	}
+	output := AssistantOutput{
+		ID: outputID, RunID: claimed.ID, Content: result.Content,
+	}
+	if observer != nil {
+		if len(finalDeltas) == 0 {
+			finalDeltas = []string{result.Content}
+		}
+		if joinedTextDeltas(finalDeltas) != result.Content {
+			failed, failErr := service.persistFailure(
+				ctx,
+				actor.UserID,
+				claimed.ID,
+				claimed.WorkerLeaseToken,
+				string(ErrorInvalidResponse),
+				ErrorInvalidResponse.Retryable(),
+			)
+			return failed, failErr
+		}
+		if err := observer.OnAssistantOutputStarted(ctx, AssistantOutput{
+			ID: output.ID, RunID: output.RunID,
+		}); err != nil {
 			failed, failErr := service.persistFailure(
 				ctx,
 				actor.UserID,
@@ -660,6 +675,30 @@ func (service *Service) process(
 			)
 			return failed, failErr
 		}
+		for index, delta := range finalDeltas {
+			if delta == "" {
+				continue
+			}
+			if err := observer.OnAssistantOutputDelta(
+				ctx,
+				AssistantOutputDelta{
+					OutputID: output.ID,
+					RunID:    output.RunID,
+					Sequence: index + 1,
+					Delta:    delta,
+				},
+			); err != nil {
+				failed, failErr := service.persistFailure(
+					ctx,
+					actor.UserID,
+					claimed.ID,
+					claimed.WorkerLeaseToken,
+					string(ErrorCancelled),
+					true,
+				)
+				return failed, failErr
+			}
+		}
 	}
 	persistContext, cancel := runPersistenceContext(ctx)
 	defer cancel()
@@ -668,10 +707,16 @@ func (service *Service) process(
 		actor.UserID,
 		claimed.ID,
 		claimed.WorkerLeaseToken,
-		result.Content,
+		output,
 		result,
 	)
-	return completed, err
+	if err != nil || observer == nil {
+		return completed, err
+	}
+	if err := observer.OnAssistantOutputCompleted(ctx, output); err != nil {
+		return completed, err
+	}
+	return completed, nil
 }
 
 func (service *Service) generate(
@@ -681,7 +726,10 @@ func (service *Service) generate(
 	manifest agentcontext.Manifest,
 	request TextRequest,
 ) (TextResult, error) {
-	return service.generateObserved(ctx, actor, run, manifest, request, nil)
+	result, _, err := service.generateObserved(
+		ctx, actor, run, manifest, request, nil,
+	)
+	return result, err
 }
 
 func (service *Service) generateObserved(
@@ -690,19 +738,17 @@ func (service *Service) generateObserved(
 	run Run,
 	manifest agentcontext.Manifest,
 	request TextRequest,
-	observer *countingDeltaObserver,
-) (TextResult, error) {
-	var deltaObserver TextDeltaObserver
-	if observer != nil {
-		deltaObserver = observer
-	}
+	observer StreamObserver,
+) (TextResult, []string, error) {
 	if service.registry == nil || service.executor == nil {
 		if err := service.repository.SaveContextSnapshot(
 			ctx, run.OwnerID, run.ID, run.WorkerLeaseToken, manifest,
 		); err != nil {
-			return TextResult{}, err
+			return TextResult{}, nil, err
 		}
-		return service.generateModel(ctx, request, deltaObserver)
+		buffer := &textDeltaBuffer{}
+		result, err := service.generateModel(ctx, request, buffer.observer(observer))
+		return result, buffer.deltas, err
 	}
 
 	loopCtx, cancel := context.WithTimeout(ctx, service.loopLimits.LoopTimeout)
@@ -722,7 +768,7 @@ func (service *Service) generateObserved(
 	if err := service.repository.SaveContextSnapshot(
 		loopCtx, run.OwnerID, run.ID, run.WorkerLeaseToken, manifest,
 	); err != nil {
-		return TextResult{}, err
+		return TextResult{}, nil, err
 	}
 
 	exposed := exposedToolNames(request.Tools)
@@ -735,13 +781,12 @@ func (service *Service) generateObserved(
 
 	for {
 		service.logLoopIteration(run, modelIterations, toolCalls)
-		modelObserver := deltaObserver
-		if toolCalls > 0 {
-			modelObserver = nil
-		}
-		result, err := service.generateModel(loopCtx, request, modelObserver)
+		buffer := &textDeltaBuffer{}
+		result, err := service.generateModel(
+			loopCtx, request, buffer.observer(observer),
+		)
 		if err != nil {
-			return TextResult{}, err
+			return TextResult{}, nil, err
 		}
 		modelIterations++
 		if !validLoopTextResult(result) ||
@@ -749,7 +794,7 @@ func (service *Service) generateObserved(
 			result.Model != service.configuration.Model ||
 			result.Usage.OutputTokens > service.configuration.MaxOutputTokens {
 			service.logInvalidModelResult(run, result)
-			return result, nil
+			return result, nil, nil
 		}
 		if len(result.ToolCalls) == 0 {
 			service.logRoutingDecision(
@@ -768,7 +813,7 @@ func (service *Service) generateObserved(
 				startedAt,
 				result.Content,
 			)
-			return result, nil
+			return result, buffer.deltas, nil
 		}
 
 		selected := toolCallNames(result.ToolCalls)
@@ -781,7 +826,7 @@ func (service *Service) generateObserved(
 			modelIterations,
 		)
 		if toolIterations >= service.loopLimits.MaxIterations {
-			return TextResult{}, service.stopLoop(
+			return TextResult{}, nil, service.stopLoop(
 				run,
 				FailureToolIterationBudgetExhausted,
 				selected,
@@ -789,7 +834,7 @@ func (service *Service) generateObserved(
 			)
 		}
 		if toolCalls+len(result.ToolCalls) > service.loopLimits.MaxToolCalls {
-			return TextResult{}, service.stopLoop(
+			return TextResult{}, nil, service.stopLoop(
 				run,
 				FailureToolCallBudgetExhausted,
 				selected,
@@ -797,7 +842,7 @@ func (service *Service) generateObserved(
 			)
 		}
 		if hasRepeatedToolCallID(result.ToolCalls, seenToolCallIDs) {
-			return TextResult{}, service.stopLoop(
+			return TextResult{}, nil, service.stopLoop(
 				run,
 				FailureDuplicateToolCall,
 				selected,
@@ -807,7 +852,7 @@ func (service *Service) generateObserved(
 
 		pendingWriteCalls := service.writeToolCallCount(result.ToolCalls)
 		if writeCalls+pendingWriteCalls > maxWriteCallsPerRun {
-			return TextResult{}, service.stopLoop(
+			return TextResult{}, nil, service.stopLoop(
 				run,
 				FailureWriteToolCallBudgetExhausted,
 				selected,
@@ -826,7 +871,13 @@ func (service *Service) generateObserved(
 		for _, call := range result.ToolCalls {
 			seenToolCallIDs[call.ID] = struct{}{}
 			if err := service.saveToolCallProposed(loopCtx, run, call); err != nil {
-				return TextResult{}, err
+				return TextResult{}, nil, err
+			}
+			step := ToolStep{ID: call.ID, RunID: run.ID, Name: call.Name}
+			if observer != nil {
+				if err := observer.OnToolStarted(loopCtx, step); err != nil {
+					return TextResult{}, nil, err
+				}
 			}
 			if !toolExposed(exposed, call.Name) {
 				if err := service.markToolCallRejected(
@@ -835,7 +886,12 @@ func (service *Service) generateObserved(
 					call.ID,
 					"unknown_tool",
 				); err != nil {
-					return TextResult{}, err
+					return TextResult{}, nil, err
+				}
+				if observer != nil {
+					if err := observer.OnToolFailed(loopCtx, step); err != nil {
+						return TextResult{}, nil, err
+					}
 				}
 				request.Messages = append(
 					request.Messages,
@@ -843,14 +899,28 @@ func (service *Service) generateObserved(
 				)
 				continue
 			}
-			toolMessage, err := service.executeToolCall(
+			toolMessage, status, err := service.executeToolCall(
 				loopCtx,
 				actor,
 				run,
 				call,
 			)
 			if err != nil {
-				return TextResult{}, err
+				if observer != nil {
+					_ = observer.OnToolFailed(loopCtx, step)
+				}
+				return TextResult{}, nil, err
+			}
+			if observer != nil {
+				var eventErr error
+				if status == ToolCallSucceeded {
+					eventErr = observer.OnToolCompleted(loopCtx, step)
+				} else {
+					eventErr = observer.OnToolFailed(loopCtx, step)
+				}
+				if eventErr != nil {
+					return TextResult{}, nil, eventErr
+				}
 			}
 			request.Messages = append(request.Messages, toolMessage)
 		}
@@ -887,23 +957,31 @@ func (service *Service) generateModel(
 	return streaming.GenerateStream(ctx, request, observer)
 }
 
-type countingDeltaObserver struct {
-	delegate StreamObserver
-	count    int
+type textDeltaBuffer struct {
+	deltas []string
 }
 
-func (observer *countingDeltaObserver) OnTextDelta(
-	ctx context.Context,
-	delta string,
-) error {
+func (buffer *textDeltaBuffer) observer(observer StreamObserver) TextDeltaObserver {
+	if observer == nil {
+		return nil
+	}
+	return buffer
+}
+
+func (buffer *textDeltaBuffer) OnTextDelta(_ context.Context, delta string) error {
 	if delta == "" {
 		return nil
 	}
-	if err := observer.delegate.OnAssistantDelta(ctx, delta); err != nil {
-		return err
-	}
-	observer.count += len(delta)
+	buffer.deltas = append(buffer.deltas, delta)
 	return nil
+}
+
+func joinedTextDeltas(deltas []string) string {
+	var joined []byte
+	for _, delta := range deltas {
+		joined = append(joined, delta...)
+	}
+	return string(joined)
 }
 
 func (service *Service) executeToolCall(
@@ -911,7 +989,7 @@ func (service *Service) executeToolCall(
 	actor requestcontext.Actor,
 	run Run,
 	call ModelToolCall,
-) (TextMessage, error) {
+) (TextMessage, ToolCallStatus, error) {
 	toolCtx, cancel := context.WithTimeout(ctx, service.loopLimits.ToolTimeout)
 	defer cancel()
 	effect := service.registry.InvocationEffect(capability.Invocation{
@@ -926,7 +1004,7 @@ func (service *Service) executeToolCall(
 		call.ID,
 		requestID,
 	); err != nil {
-		return TextMessage{}, err
+		return TextMessage{}, ToolCallFailed, err
 	}
 	result, err := service.executor.Execute(
 		toolCtx,
@@ -952,10 +1030,10 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			capability.ErrorCategory(err),
 		); persistErr != nil {
-			return TextMessage{}, persistErr
+			return TextMessage{}, ToolCallFailed, persistErr
 		}
 		// 工具自身失败属于模型可处理结果，回填稳定分类后让模型决定重试、换工具或解释。
-		return toolFailureMessage(call.ID, err), nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, nil
 	}
 	content, err := marshalToolResult(result, service.loopLimits.MaxToolResultBytes)
 	if err != nil {
@@ -970,9 +1048,9 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			"internal",
 		); persistErr != nil {
-			return TextMessage{}, persistErr
+			return TextMessage{}, ToolCallFailed, persistErr
 		}
-		return toolFailureMessage(call.ID, err), nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, nil
 	}
 	persistCtx, persistCancel := runPersistenceContext(ctx)
 	defer persistCancel()
@@ -986,13 +1064,13 @@ func (service *Service) executeToolCall(
 		toolSourceRefs(result.SourceRefs),
 		result.ClientActions,
 	); err != nil {
-		return TextMessage{}, err
+		return TextMessage{}, ToolCallFailed, err
 	}
 	return TextMessage{
 		Role:       TextRoleTool,
 		Content:    content,
 		ToolCallID: call.ID,
-	}, nil
+	}, ToolCallSucceeded, nil
 }
 
 func (service *Service) saveToolCallProposed(

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -29,6 +29,7 @@ const (
 	streamReplayPollInterval = 100 * time.Millisecond
 	toolSchemaVersionV1      = "tool-schema-v1"
 	maxImagesPerMessage      = 4
+	finalResponseToolName    = "agent.final_response.v1"
 )
 
 type Service struct {
@@ -579,6 +580,19 @@ func (service *Service) process(
 		)
 		return failed, failErr
 	}
+	outputID, err := service.repository.NewAssistantMessageID()
+	if err != nil || !ValidUUID(outputID) {
+		failed, failErr := service.persistFailure(
+			ctx,
+			actor.UserID,
+			claimed.ID,
+			claimed.WorkerLeaseToken,
+			FailureInternal,
+			true,
+		)
+		return failed, failErr
+	}
+	output := AssistantOutput{ID: outputID, RunID: claimed.ID}
 	var result TextResult
 	var finalDeltas []string
 	if observer == nil {
@@ -597,6 +611,7 @@ func (service *Service) process(
 			manifest,
 			request,
 			observer,
+			output,
 		)
 	}
 	if err != nil {
@@ -610,6 +625,7 @@ func (service *Service) process(
 			retryable,
 		)
 		service.logRunFailed(claimed, kind, retryable, claimed.StartedAt)
+		service.logGenerationFailureDetail(claimed, err)
 		return failed, failErr
 	}
 	if !validFinalTextResult(result) ||
@@ -632,26 +648,9 @@ func (service *Service) process(
 		)
 		return failed, failErr
 	}
-	outputID, err := service.repository.NewAssistantMessageID()
-	if err != nil || !ValidUUID(outputID) {
-		failed, failErr := service.persistFailure(
-			ctx,
-			actor.UserID,
-			claimed.ID,
-			claimed.WorkerLeaseToken,
-			FailureInternal,
-			true,
-		)
-		return failed, failErr
-	}
-	output := AssistantOutput{
-		ID: outputID, RunID: claimed.ID, Content: result.Content,
-	}
+	output.Content = result.Content
 	if observer != nil {
-		if len(finalDeltas) == 0 {
-			finalDeltas = []string{result.Content}
-		}
-		if joinedTextDeltas(finalDeltas) != result.Content {
+		if len(finalDeltas) == 0 || joinedTextDeltas(finalDeltas) != result.Content {
 			failed, failErr := service.persistFailure(
 				ctx,
 				actor.UserID,
@@ -661,43 +660,6 @@ func (service *Service) process(
 				ErrorInvalidResponse.Retryable(),
 			)
 			return failed, failErr
-		}
-		if err := observer.OnAssistantOutputStarted(ctx, AssistantOutput{
-			ID: output.ID, RunID: output.RunID,
-		}); err != nil {
-			failed, failErr := service.persistFailure(
-				ctx,
-				actor.UserID,
-				claimed.ID,
-				claimed.WorkerLeaseToken,
-				string(ErrorCancelled),
-				true,
-			)
-			return failed, failErr
-		}
-		for index, delta := range finalDeltas {
-			if delta == "" {
-				continue
-			}
-			if err := observer.OnAssistantOutputDelta(
-				ctx,
-				AssistantOutputDelta{
-					OutputID: output.ID,
-					RunID:    output.RunID,
-					Sequence: index + 1,
-					Delta:    delta,
-				},
-			); err != nil {
-				failed, failErr := service.persistFailure(
-					ctx,
-					actor.UserID,
-					claimed.ID,
-					claimed.WorkerLeaseToken,
-					string(ErrorCancelled),
-					true,
-				)
-				return failed, failErr
-			}
 		}
 	}
 	persistContext, cancel := runPersistenceContext(ctx)
@@ -727,7 +689,7 @@ func (service *Service) generate(
 	request TextRequest,
 ) (TextResult, error) {
 	result, _, err := service.generateObserved(
-		ctx, actor, run, manifest, request, nil,
+		ctx, actor, run, manifest, request, nil, AssistantOutput{},
 	)
 	return result, err
 }
@@ -739,6 +701,7 @@ func (service *Service) generateObserved(
 	manifest agentcontext.Manifest,
 	request TextRequest,
 	observer StreamObserver,
+	output AssistantOutput,
 ) (TextResult, []string, error) {
 	if service.registry == nil || service.executor == nil {
 		if err := service.repository.SaveContextSnapshot(
@@ -746,9 +709,7 @@ func (service *Service) generateObserved(
 		); err != nil {
 			return TextResult{}, nil, err
 		}
-		buffer := &textDeltaBuffer{}
-		result, err := service.generateModel(ctx, request, buffer.observer(observer))
-		return result, buffer.deltas, err
+		return service.generateFinalOutput(ctx, request, observer, output)
 	}
 
 	loopCtx, cancel := context.WithTimeout(ctx, service.loopLimits.LoopTimeout)
@@ -760,7 +721,11 @@ func (service *Service) generateObserved(
 		service.registry,
 		service.logger,
 		run.ID,
-		ToolChoice{Mode: ToolChoiceAuto},
+		ToolChoice{Mode: ToolChoiceRequired},
+	)
+	routing.Definitions = append(
+		routing.Definitions,
+		finalResponseToolDefinition(),
 	)
 	request.Tools = routing.Definitions
 	request.ToolChoice = routing.ToolChoice
@@ -781,10 +746,7 @@ func (service *Service) generateObserved(
 
 	for {
 		service.logLoopIteration(run, modelIterations, toolCalls)
-		buffer := &textDeltaBuffer{}
-		result, err := service.generateModel(
-			loopCtx, request, buffer.observer(observer),
-		)
+		result, err := service.generateModel(loopCtx, request, nil)
 		if err != nil {
 			return TextResult{}, nil, err
 		}
@@ -797,6 +759,26 @@ func (service *Service) generateObserved(
 			return result, nil, nil
 		}
 		if len(result.ToolCalls) == 0 {
+			service.logInvalidModelResult(run, result)
+			return TextResult{}, nil, NewGenerationError(
+				ErrorInvalidResponse,
+				0,
+				"",
+				"",
+				errors.New("agent: planning response did not choose a tool or final output"),
+			)
+		}
+		if finalResponseRequested(result.ToolCalls) {
+			if !validFinalResponseRequest(result.ToolCalls) {
+				service.logInvalidModelResult(run, result)
+				return TextResult{}, nil, NewGenerationError(
+					ErrorInvalidResponse,
+					0,
+					"",
+					"",
+					errors.New("agent: final response control call is invalid"),
+				)
+			}
 			service.logRoutingDecision(
 				run,
 				finalDecision,
@@ -805,15 +787,25 @@ func (service *Service) generateObserved(
 				reasonSummary(reasonModelToolSelection, finalDecision),
 				modelIterations,
 			)
+			finalResult, finalDeltas, finalErr := service.generateFinalOutput(
+				loopCtx,
+				request,
+				observer,
+				output,
+			)
+			if finalErr != nil {
+				return TextResult{}, nil, finalErr
+			}
+			modelIterations++
 			service.logRunCompleted(
 				run,
 				finalDecision,
 				modelIterations,
 				toolCalls,
 				startedAt,
-				result.Content,
+				finalResult.Content,
 			)
-			return result, buffer.deltas, nil
+			return finalResult, finalDeltas, nil
 		}
 
 		selected := toolCallNames(result.ToolCalls)
@@ -927,6 +919,95 @@ func (service *Service) generateObserved(
 		finalDecision = "tool_call_then_response"
 	}
 }
+
+func finalResponseToolDefinition() ToolDefinition {
+	return ToolDefinition{
+		Name: finalResponseToolName,
+		Description: "Choose this control tool only when no further domain tool is " +
+			"needed and the assistant is ready to produce its final user-visible response. " +
+			"Set decision to respond and do not include the response text in this call; " +
+			"the server starts a separate tool-disabled final output phase.",
+		InputSchema: capability.ObjectSchema(map[string]any{
+			"decision": capability.StringEnumSchema(
+				"Enter the final user-visible response phase.",
+				"respond",
+			),
+		}, []string{"decision"}),
+	}
+}
+
+func finalResponseRequested(calls []ModelToolCall) bool {
+	for _, call := range calls {
+		if call.Name == finalResponseToolName {
+			return true
+		}
+	}
+	return false
+}
+
+func validFinalResponseRequest(calls []ModelToolCall) bool {
+	if len(calls) != 1 || calls[0].Name != finalResponseToolName {
+		return false
+	}
+	var input map[string]any
+	if json.Unmarshal(calls[0].Arguments, &input) != nil || len(input) != 1 {
+		return false
+	}
+	decision, ok := input["decision"].(string)
+	return ok && decision == "respond"
+}
+
+func (service *Service) generateFinalOutput(
+	ctx context.Context,
+	request TextRequest,
+	observer StreamObserver,
+	output AssistantOutput,
+) (TextResult, []string, error) {
+	request.Tools = nil
+	request.ToolChoice = ToolChoice{Mode: ToolChoiceNone}
+	if observer == nil {
+		result, err := service.generateModel(ctx, request, nil)
+		return result, nil, err
+	}
+	if !ValidUUID(output.ID) || output.RunID == "" {
+		return TextResult{}, nil, NewGenerationError(
+			ErrorInvalidRequest,
+			0,
+			"",
+			"",
+			errors.New("agent: final output identity is invalid"),
+		)
+	}
+	if err := ValidateTextRequest(request); err != nil {
+		return TextResult{}, nil, NewGenerationError(
+			ErrorInvalidRequest,
+			0,
+			"",
+			"",
+			err,
+		)
+	}
+	streaming, ok := service.generator.(StreamingTextGenerator)
+	if !ok {
+		return TextResult{}, nil, NewGenerationError(
+			ErrorConfiguration,
+			0,
+			"",
+			"",
+			errors.New("agent: configured text generator does not support streaming"),
+		)
+	}
+	stream := &assistantOutputDeltaStream{observer: observer, output: output}
+	if err := stream.start(ctx); err != nil {
+		return TextResult{}, nil, streamObserverGenerationError(err)
+	}
+	result, err := streaming.GenerateStream(ctx, request, stream)
+	if err != nil {
+		return TextResult{}, nil, err
+	}
+	return result, stream.deltas, nil
+}
+
 func (service *Service) generateModel(
 	ctx context.Context,
 	request TextRequest,
@@ -957,23 +1038,44 @@ func (service *Service) generateModel(
 	return streaming.GenerateStream(ctx, request, observer)
 }
 
-type textDeltaBuffer struct {
-	deltas []string
+type assistantOutputDeltaStream struct {
+	observer StreamObserver
+	output   AssistantOutput
+	sequence int
+	deltas   []string
 }
 
-func (buffer *textDeltaBuffer) observer(observer StreamObserver) TextDeltaObserver {
-	if observer == nil {
-		return nil
-	}
-	return buffer
+func (stream *assistantOutputDeltaStream) start(ctx context.Context) error {
+	return stream.observer.OnAssistantOutputStarted(ctx, AssistantOutput{
+		ID: stream.output.ID, RunID: stream.output.RunID,
+	})
 }
 
-func (buffer *textDeltaBuffer) OnTextDelta(_ context.Context, delta string) error {
+func (stream *assistantOutputDeltaStream) OnTextDelta(
+	ctx context.Context,
+	delta string,
+) error {
 	if delta == "" {
 		return nil
 	}
-	buffer.deltas = append(buffer.deltas, delta)
+	stream.sequence++
+	if err := stream.observer.OnAssistantOutputDelta(
+		ctx,
+		AssistantOutputDelta{
+			OutputID: stream.output.ID,
+			RunID:    stream.output.RunID,
+			Sequence: stream.sequence,
+			Delta:    delta,
+		},
+	); err != nil {
+		return streamObserverGenerationError(err)
+	}
+	stream.deltas = append(stream.deltas, delta)
 	return nil
+}
+
+func streamObserverGenerationError(err error) *GenerationError {
+	return NewGenerationError(ErrorCancelled, 0, "", "", err)
 }
 
 func joinedTextDeltas(deltas []string) string {

--- a/server/internal/agent/run/service_test.go
+++ b/server/internal/agent/run/service_test.go
@@ -205,10 +205,35 @@ func (observer *recordingStreamObserver) OnInputCommitted(
 	return nil
 }
 
-func (*recordingStreamObserver) OnAssistantStarted(context.Context, Run) error {
+func (*recordingStreamObserver) OnToolStarted(context.Context, ToolStep) error {
 	return nil
 }
 
-func (*recordingStreamObserver) OnAssistantDelta(context.Context, string) error {
+func (*recordingStreamObserver) OnToolCompleted(context.Context, ToolStep) error {
+	return nil
+}
+
+func (*recordingStreamObserver) OnToolFailed(context.Context, ToolStep) error {
+	return nil
+}
+
+func (*recordingStreamObserver) OnAssistantOutputStarted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
+}
+
+func (*recordingStreamObserver) OnAssistantOutputDelta(
+	context.Context,
+	AssistantOutputDelta,
+) error {
+	return nil
+}
+
+func (*recordingStreamObserver) OnAssistantOutputCompleted(
+	context.Context,
+	AssistantOutput,
+) error {
 	return nil
 }

--- a/server/internal/agent/run/stream.go
+++ b/server/internal/agent/run/stream.go
@@ -2,8 +2,31 @@ package run
 
 import "context"
 
+type ToolStep struct {
+	ID    string
+	RunID string
+	Name  string
+}
+
+type AssistantOutput struct {
+	ID      string
+	RunID   string
+	Content string
+}
+
+type AssistantOutputDelta struct {
+	OutputID string
+	RunID    string
+	Sequence int
+	Delta    string
+}
+
 type StreamObserver interface {
 	OnInputCommitted(context.Context, Submission) error
-	OnAssistantStarted(context.Context, Run) error
-	OnAssistantDelta(context.Context, string) error
+	OnToolStarted(context.Context, ToolStep) error
+	OnToolCompleted(context.Context, ToolStep) error
+	OnToolFailed(context.Context, ToolStep) error
+	OnAssistantOutputStarted(context.Context, AssistantOutput) error
+	OnAssistantOutputDelta(context.Context, AssistantOutputDelta) error
+	OnAssistantOutputCompleted(context.Context, AssistantOutput) error
 }

--- a/server/internal/app/run_completion_wakeup.go
+++ b/server/internal/app/run_completion_wakeup.go
@@ -16,7 +16,7 @@ func (repository *runCompletionNotifyingRepository) Complete(
 	ownerID string,
 	runID string,
 	workerLeaseToken string,
-	content string,
+	output agentrun.AssistantOutput,
 	result agentrun.TextResult,
 ) (agentrun.Run, error) {
 	run, err := repository.Repository.Complete(
@@ -24,7 +24,7 @@ func (repository *runCompletionNotifyingRepository) Complete(
 		ownerID,
 		runID,
 		workerLeaseToken,
-		content,
+		output,
 		result,
 	)
 	if err == nil && run.Status == agentrun.StatusCompleted {

--- a/server/test/agent/postgres/run_core_integration_test.go
+++ b/server/test/agent/postgres/run_core_integration_test.go
@@ -164,12 +164,19 @@ func TestDeletingUserCascadesAgentCoreGraph(t *testing.T) {
 	if err != nil || !acquired {
 		t.Fatalf("claim Run: acquired=%t err=%v", acquired, err)
 	}
+	assistantMessageID, err := repositories.run.NewAssistantMessageID()
+	if err != nil {
+		t.Fatalf("allocate Assistant Message ID: %v", err)
+	}
 	if _, err := repositories.run.Complete(
 		ctx,
 		actor.UserID,
 		claimed.ID,
 		claimed.WorkerLeaseToken,
-		"The complete graph may be removed with its owner.",
+		agentrun.AssistantOutput{
+			ID: assistantMessageID, RunID: claimed.ID,
+			Content: "The complete graph may be removed with its owner.",
+		},
 		successfulTextResult(),
 	); err != nil {
 		t.Fatalf("complete Run: %v", err)
@@ -315,19 +322,30 @@ func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
 				); err != nil {
 					t.Fatalf("complete Tool Call: %v", err)
 				}
+				assistantMessageID, err := repositories.run.NewAssistantMessageID()
+				if err != nil {
+					t.Fatalf("allocate Assistant Message ID: %v", err)
+				}
 				completed, err := repositories.run.Complete(
 					ctx,
 					actor.UserID,
 					claimed.ID,
 					claimed.WorkerLeaseToken,
-					"Terminal projection completed.",
+					agentrun.AssistantOutput{
+						ID: assistantMessageID, RunID: claimed.ID,
+						Content: "Terminal projection completed.",
+					},
 					successfulTextResult(),
 				)
 				if err != nil {
 					t.Fatalf("complete Run: %v", err)
 				}
-				if completed.AssistantMessageID == "" {
-					t.Fatal("completed Run did not project its Assistant Message")
+				if completed.AssistantMessageID != assistantMessageID {
+					t.Fatalf(
+						"Assistant Message ID = %q, want %q",
+						completed.AssistantMessageID,
+						assistantMessageID,
+					)
 				}
 				expectedActions = 1
 			case "fail":


### PR DESCRIPTION
## 功能描述

修复 Agent 经工具调用后，实时朗读可能播放到一半中断的问题，并消除等待完整模型响应后才回放分片造成的首字与首音频延迟。建立正式的分阶段输出协议，使界面、TTS 与最终落库消息只消费同一份最终 assistant output。

Closes #728

## 实现思路

- 将流式响应明确划分为 `input.committed`、工具生命周期、`assistant.output.started/delta/completed` 和 Run 终态。
- 决策阶段强制模型选择领域工具或内部 `agent.final_response.v1` 控制工具；控制工具使用显式 `{"decision":"respond"}`，兼容七牛 Gemini 的工具参数返回。
- 进入正式输出阶段后移除全部工具并设置 `tool_choice=none`，直接把提供方 delta 实时转发给界面和 TTS，同时累积并校验最终全文。
- 工具阶段的模型临时文本保持内部可见，不进入界面、朗读或最终消息。
- 最终输出预分配 `output_id`，并复用为持久化 assistant Message ID；严格校验分片序号、拼接全文与落库内容一致。
- 移动端仅在正式 output 开始后展示和朗读，并在 output 完成时关闭 TTS 输入；`run.completed` 不再提前停止仍在播放的音频。
- 复用现有 `agent_messages.id` 与 `produced_by_run_id`，不新增数据库字段或迁移。

## 可复现测试

- `make check-go`
- `make check-api`
- `make check-flutter`：静态分析通过，656 个测试通过
- iOS 模拟器使用真实后端、七牛 Gemini、数字人禁用，连续 3 个新对话发送“请用三段话详细介绍餐厅点餐英语练习的重点，每段至少两句话。”；均成功完成正式输出与朗读。
- 三次测试中，首次音频分别早于全文完成约 2.5 秒、1.7 秒和 2.1 秒；最长一次完整朗读 395 字，无 `invalid_response` 或实时朗读中断。
- 启动日志确认数据库 `migrations=unchanged`。

## 协议验收

- 工具阶段的模型临时文本不会进入 display/TTS。
- 所有正式 delta 的 `output_id` 一致且 `sequence` 严格递增。
- 首个正式 delta 在提供方完成之前转发，不等待完整响应。
- delta 拼接结果等于 `assistant.output.completed.text`、最终 Message 内容和 TTS 输入。
- `run.completed.assistant_message_id` 等于 `output_id`。

## 范围说明

Agent 写入编排与全局单次写入上限由 #730 单独处理，本 PR 不修改该领域规则。