### PR TITLE
fix(agent): 以领域终态编排写工具调用

### DIFF
--- a/server/internal/agent/capability/executor.go
+++ b/server/internal/agent/capability/executor.go
@@ -75,6 +75,10 @@ func (executor *Executor) Execute(
 	if result.Content == nil {
 		result.Content = map[string]any{}
 	}
+	if !result.TurnOutcome.Valid() {
+		executor.logFailure(call, definition, time.Since(startedAt), ErrExecutionRejected)
+		return Result{}, ErrExecutionRejected
+	}
 	if err := agentclientaction.ValidateItems(result.ClientActions); err != nil {
 		executor.logFailure(call, definition, time.Since(startedAt), err)
 		return Result{}, ErrExecutionRejected

--- a/server/internal/agent/capability/registry_test.go
+++ b/server/internal/agent/capability/registry_test.go
@@ -305,6 +305,31 @@ func TestExecutorValidatesAndRunsTool(t *testing.T) {
 	}
 }
 
+func TestExecutorRejectsInvalidTurnOutcome(t *testing.T) {
+	tool := &stubTool{
+		definition: readToolDefinition("review.search.v1"),
+		result: Result{
+			Content:     map[string]any{"ok": true},
+			TurnOutcome: TurnOutcome(255),
+		},
+	}
+	registry, err := NewRegistry(tool)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	_, err = NewExecutor(registry).Execute(
+		context.Background(),
+		validCallContext(),
+		Invocation{
+			Name:  "review.search.v1",
+			Input: json.RawMessage(`{"query":"last interview"}`),
+		},
+	)
+	if !errors.Is(err, ErrExecutionRejected) {
+		t.Fatalf("Execute() error = %v, want %v", err, ErrExecutionRejected)
+	}
+}
+
 func TestExecutorFiltersUnknownInputFields(t *testing.T) {
 	tool := &stubTool{
 		definition: readToolDefinition("review.search.v1"),

--- a/server/internal/agent/capability/schema.go
+++ b/server/internal/agent/capability/schema.go
@@ -81,10 +81,25 @@ type InvocationEffectClassifier interface {
 	) (InvocationEffect, error)
 }
 
+// TurnOutcome tells the Agent loop whether a successful capability result has
+// completed the current user turn's domain work. It is orchestration metadata
+// and is never exposed to the model or persisted as tool result content.
+type TurnOutcome uint8
+
+const (
+	TurnOutcomeContinue TurnOutcome = iota
+	TurnOutcomeCompleted
+)
+
+func (outcome TurnOutcome) Valid() bool {
+	return outcome == TurnOutcomeContinue || outcome == TurnOutcomeCompleted
+}
+
 type Result struct {
 	Content       map[string]any             `json:"content"`
 	SourceRefs    []SourceRef                `json:"source_refs,omitempty"`
 	ClientActions []agentclientaction.Action `json:"client_actions,omitempty"`
+	TurnOutcome   TurnOutcome                `json:"-"`
 }
 
 type Tool interface {

--- a/server/internal/agent/run/logging.go
+++ b/server/internal/agent/run/logging.go
@@ -56,8 +56,8 @@ func reasonSummary(reasonCode string, decision string) string {
 		return "本轮已达到 Agent Loop 工具迭代预算。"
 	case FailureToolCallBudgetExhausted:
 		return "本轮已达到 Agent Loop 工具调用预算。"
-	case FailureWriteToolCallBudgetExhausted:
-		return "本轮已达到 Agent Loop 写工具调用预算。"
+	case reasonDomainTurnCompleted:
+		return "领域工具已完成本轮目标，进入最终回复。"
 	case FailureDuplicateToolCall:
 		return "模型重复提交了同一 ToolCall ID，本轮已停止执行。"
 	default:

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -575,11 +575,18 @@ func TestRunLoopFeedsInvalidArgumentsBackToModel(t *testing.T) {
 }
 
 func TestRunLoopFailsWhenToolBudgetExhausted(t *testing.T) {
+	store := capabilityfixture.NewStore()
+	conditional := &loopConditionalTool{}
 	generator := newScriptedGenerator(
 		toolLoopResult("call-1", reviewcapability.ReviewSearchToolName, `{"query":"one"}`),
-		toolLoopResult("call-2", reviewcapability.ReviewSearchToolName, `{"query":"two"}`),
+		toolLoopResult(
+			"call-2",
+			loopConditionalToolName,
+			`{"write_value":"must-not-run"}`,
+		),
 	)
-	service := newLoopTestService(t, generator)
+	service := newLoopTestServiceWithStore(t, generator, store)
+	setLoopTools(t, service, store, conditional)
 	service.loopLimits.MaxToolCalls = 1
 
 	result, err := service.generate(
@@ -592,6 +599,9 @@ func TestRunLoopFailsWhenToolBudgetExhausted(t *testing.T) {
 	assertLoopFailure(t, result, err, FailureToolCallBudgetExhausted)
 	if got, want := generator.CallCount(), 2; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+	if len(conditional.inputs) != 0 {
+		t.Fatalf("write executed after total budget was exhausted: %#v", conditional.inputs)
 	}
 }
 
@@ -755,28 +765,31 @@ func TestToolCallRequestIDUsesTrustedWriteAndReadIdentities(t *testing.T) {
 	}
 }
 
-func TestRunLoopFailsBeforeExecutingBatchOverWriteBudget(t *testing.T) {
+func TestRunLoopExecutesMultipleLegalWritesWithinTotalBudget(t *testing.T) {
 	store := capabilityfixture.NewStore()
 	conditional := &loopConditionalTool{}
-	generator := newScriptedGenerator(TextResult{
-		ID:           "fake-completion-tools",
-		Provider:     "fake",
-		Model:        "configured-model",
-		FinishReason: "tool_calls",
-		ToolCalls: []ModelToolCall{
-			{
-				ID:        "call-create-1",
-				Name:      loopConditionalToolName,
-				Arguments: json.RawMessage(`{"write_value":"first"}`),
+	generator := newScriptedGenerator(
+		TextResult{
+			ID:           "fake-completion-tools",
+			Provider:     "fake",
+			Model:        "configured-model",
+			FinishReason: "tool_calls",
+			ToolCalls: []ModelToolCall{
+				{
+					ID:        "call-create-1",
+					Name:      loopConditionalToolName,
+					Arguments: json.RawMessage(`{"write_value":"first"}`),
+				},
+				{
+					ID:        "call-create-2",
+					Name:      loopConditionalToolName,
+					Arguments: json.RawMessage(`{"write_value":"second"}`),
+				},
 			},
-			{
-				ID:        "call-create-2",
-				Name:      loopConditionalToolName,
-				Arguments: json.RawMessage(`{"write_value":"second"}`),
-			},
+			Usage: TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		},
-		Usage: TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
-	})
+		finalLoopResult("Both writes completed."),
+	)
 	service := newLoopTestServiceWithStore(t, generator, store)
 	setLoopTools(t, service, store, conditional)
 
@@ -785,17 +798,25 @@ func TestRunLoopFailsBeforeExecutingBatchOverWriteBudget(t *testing.T) {
 		loopActor(),
 		loopRun(),
 		agentcontext.Manifest{},
-		loopRequest("帮我创建一个英文 PM 面试练习场景"),
+		loopRequest("执行两个合法的领域写入"),
 	)
-	assertLoopFailure(t, result, err, FailureWriteToolCallBudgetExhausted)
-	if len(conditional.inputs) != 0 {
-		t.Fatalf("over-budget batch reached tool: %#v", conditional.inputs)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if got, want := result.Content, "Both writes completed."; got != want {
+		t.Fatalf("Content = %q, want %q", got, want)
+	}
+	if got, want := conditional.inputs, []loopConditionalInput{
+		{WriteValue: "first"},
+		{WriteValue: "second"},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("conditional inputs = %#v, want %#v", got, want)
 	}
 }
 
 func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
 	store := capabilityfixture.NewStore()
-	conditional := &loopConditionalTool{}
+	conditional := &loopConditionalTool{completeAfterWrite: true}
 	generator := newScriptedGenerator(
 		toolLoopResult(
 			"call-conditional-query",
@@ -832,12 +853,70 @@ func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
 		conditional.inputs[1].WriteValue == "" {
 		t.Fatalf("conditional inputs = %#v", conditional.inputs)
 	}
-	if got, want := generator.CallCount(), 4; got != want {
+	if got, want := generator.CallCount(), 3; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+	if requests := generator.Requests(); requests[2].ToolChoice.Mode != ToolChoiceNone {
+		t.Fatalf("final request tool choice = %q, want %q", requests[2].ToolChoice.Mode, ToolChoiceNone)
 	}
 }
 
-func TestRunLoopReservesWriteBudgetForRejectedInvocations(t *testing.T) {
+func TestRunLoopFinalizesAfterRepeatedCompletedWriteCommand(t *testing.T) {
+	writeTool := &loopRequestIDTool{
+		name:        "resource.create.v1",
+		turnOutcome: capability.TurnOutcomeCompleted,
+	}
+	generator := newScriptedGenerator(
+		TextResult{
+			ID:           "fake-completion-tools",
+			Provider:     "fake",
+			Model:        "configured-model",
+			FinishReason: "tool_calls",
+			ToolCalls: []ModelToolCall{
+				{ID: "call-create-1", Name: writeTool.name, Arguments: json.RawMessage(`{}`)},
+				{ID: "call-create-2", Name: writeTool.name, Arguments: json.RawMessage(`{}`)},
+			},
+			Usage: TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		},
+		finalLoopResult("The resource is ready."),
+	)
+	service := newLoopTestService(t, generator)
+	setLoopTools(t, service, capabilityfixture.NewStore(), writeTool)
+
+	result, err := service.generate(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		agentcontext.Manifest{},
+		loopRequest("create the resource"),
+	)
+	if err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if got, want := result.Content, "The resource is ready."; got != want {
+		t.Fatalf("Content = %q, want %q", got, want)
+	}
+	if got, want := len(writeTool.requestIDs), 2; got != want {
+		t.Fatalf("write calls = %d, want %d", got, want)
+	}
+	if writeTool.requestIDs[0] != writeTool.requestIDs[1] {
+		t.Fatalf("repeated command request ids = %#v, want stable identity", writeTool.requestIDs)
+	}
+	if got, want := generator.CallCount(), 2; got != want {
+		t.Fatalf("Generate calls = %d, want %d", got, want)
+	}
+	requests := generator.Requests()
+	if requests[1].ToolChoice.Mode != ToolChoiceNone {
+		t.Fatalf("final request tool choice = %q, want %q", requests[1].ToolChoice.Mode, ToolChoiceNone)
+	}
+	toolResults := requests[1].Messages
+	if !strings.Contains(toolResults[len(toolResults)-2].Content, `"replayed":false`) ||
+		!strings.Contains(toolResults[len(toolResults)-1].Content, `"replayed":true`) {
+		t.Fatalf("repeated command results = %#v, want recognizable replay", toolResults)
+	}
+}
+
+func TestRunLoopRejectedInvocationDoesNotPreventLaterWrite(t *testing.T) {
 	tests := []struct {
 		name string
 		call TextResult
@@ -870,6 +949,7 @@ func TestRunLoopReservesWriteBudgetForRejectedInvocations(t *testing.T) {
 					loopConditionalToolName,
 					`{"write_value":"after-rejected"}`,
 				),
+				finalLoopResult("The later write completed."),
 			)
 			service := newLoopTestServiceWithStore(t, generator, store)
 			setLoopTools(t, service, store, conditional)
@@ -881,12 +961,19 @@ func TestRunLoopReservesWriteBudgetForRejectedInvocations(t *testing.T) {
 				agentcontext.Manifest{},
 				loopRequest("attempt a guarded write"),
 			)
-			assertLoopFailure(t, result, err, FailureWriteToolCallBudgetExhausted)
-			if got, want := generator.CallCount(), 2; got != want {
+			if err != nil {
+				t.Fatalf("generate() error = %v", err)
+			}
+			if got, want := result.Content, "The later write completed."; got != want {
+				t.Fatalf("Content = %q, want %q", got, want)
+			}
+			if got, want := generator.CallCount(), 4; got != want {
 				t.Fatalf("Generate calls = %d, want %d", got, want)
 			}
-			if len(conditional.inputs) != 0 {
-				t.Fatalf("rejected invocation reached tool: %#v", conditional.inputs)
+			if got, want := conditional.inputs, []loopConditionalInput{
+				{WriteValue: "after-rejected"},
+			}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("conditional inputs = %#v, want %#v", got, want)
 			}
 		})
 	}
@@ -1047,8 +1134,10 @@ const loopConditionalToolName = "conditional.write.v1"
 const loopSensitiveSourceToolName = "sensitive.source.read.v1"
 
 type loopRequestIDTool struct {
-	name       string
-	requestIDs []string
+	name         string
+	requestIDs   []string
+	seenRequests map[string]struct{}
+	turnOutcome  capability.TurnOutcome
 }
 
 func (tool *loopRequestIDTool) Definition() capability.Definition {
@@ -1067,7 +1156,18 @@ func (tool *loopRequestIDTool) Execute(
 	_ json.RawMessage,
 ) (capability.Result, error) {
 	tool.requestIDs = append(tool.requestIDs, call.RequestID)
-	return capability.Result{Content: map[string]any{"ok": true}}, nil
+	if tool.seenRequests == nil {
+		tool.seenRequests = make(map[string]struct{})
+	}
+	_, replayed := tool.seenRequests[call.RequestID]
+	tool.seenRequests[call.RequestID] = struct{}{}
+	return capability.Result{
+		Content: map[string]any{
+			"ok":       true,
+			"replayed": replayed,
+		},
+		TurnOutcome: tool.turnOutcome,
+	}, nil
 }
 
 type loopSensitiveSourceTool struct{}
@@ -1114,7 +1214,8 @@ type loopConditionalInput struct {
 }
 
 type loopConditionalTool struct {
-	inputs []loopConditionalInput
+	inputs             []loopConditionalInput
+	completeAfterWrite bool
 }
 
 func (conditional *loopConditionalTool) Definition() capability.Definition {
@@ -1152,7 +1253,14 @@ func (conditional *loopConditionalTool) Execute(
 		return capability.Result{}, err
 	}
 	conditional.inputs = append(conditional.inputs, parsed)
-	return capability.Result{Content: map[string]any{"ok": true}}, nil
+	outcome := capability.TurnOutcomeContinue
+	if conditional.completeAfterWrite && parsed.WriteValue != "" {
+		outcome = capability.TurnOutcomeCompleted
+	}
+	return capability.Result{
+		Content:     map[string]any{"ok": true},
+		TurnOutcome: outcome,
+	}, nil
 }
 
 func parseLoopConditionalInput(

--- a/server/internal/agent/run/model.go
+++ b/server/internal/agent/run/model.go
@@ -30,7 +30,6 @@ const (
 	FailureInvalidContext               = "invalid_context"
 	FailureToolIterationBudgetExhausted = "tool_iteration_budget_exhausted"
 	FailureToolCallBudgetExhausted      = "tool_call_budget_exhausted"
-	FailureWriteToolCallBudgetExhausted = "write_tool_call_budget_exhausted"
 	FailureDuplicateToolCall            = "duplicate_tool_call"
 	FailureInternal                     = "internal_error"
 )

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -22,7 +22,6 @@ const (
 	maxPersistedTokenCount   = 1<<31 - 1
 	defaultMaxIterations     = 3
 	MaxToolCallsPerRun       = 4
-	maxWriteCallsPerRun      = 1
 	defaultToolTimeout       = 5 * time.Second
 	defaultLoopTimeout       = 25 * time.Second
 	defaultMaxToolResult     = 16 * 1024
@@ -739,7 +738,6 @@ func (service *Service) generateObserved(
 	exposed := exposedToolNames(request.Tools)
 	seenToolCallIDs := make(map[string]struct{})
 	toolCalls := 0
-	writeCalls := 0
 	toolIterations := 0
 	modelIterations := 0
 	finalDecision := "direct_response"
@@ -842,16 +840,6 @@ func (service *Service) generateObserved(
 			)
 		}
 
-		pendingWriteCalls := service.writeToolCallCount(result.ToolCalls)
-		if writeCalls+pendingWriteCalls > maxWriteCallsPerRun {
-			return TextResult{}, nil, service.stopLoop(
-				run,
-				FailureWriteToolCallBudgetExhausted,
-				selected,
-				modelIterations,
-			)
-		}
-		writeCalls += pendingWriteCalls
 		request.Messages = append(request.Messages, TextMessage{
 			Content:   result.Content,
 			Role:      TextRoleAssistant,
@@ -860,6 +848,7 @@ func (service *Service) generateObserved(
 		toolIterations++
 		toolCalls += len(result.ToolCalls)
 
+		turnCompleted := false
 		for _, call := range result.ToolCalls {
 			seenToolCallIDs[call.ID] = struct{}{}
 			if err := service.saveToolCallProposed(loopCtx, run, call); err != nil {
@@ -891,7 +880,7 @@ func (service *Service) generateObserved(
 				)
 				continue
 			}
-			toolMessage, status, err := service.executeToolCall(
+			toolMessage, status, outcome, err := service.executeToolCall(
 				loopCtx,
 				actor,
 				run,
@@ -915,8 +904,40 @@ func (service *Service) generateObserved(
 				}
 			}
 			request.Messages = append(request.Messages, toolMessage)
+			if status == ToolCallSucceeded && outcome == capability.TurnOutcomeCompleted {
+				turnCompleted = true
+			}
 		}
 		finalDecision = "tool_call_then_response"
+		if turnCompleted {
+			service.logRoutingDecision(
+				run,
+				finalDecision,
+				selected,
+				reasonDomainTurnCompleted,
+				reasonSummary(reasonDomainTurnCompleted, finalDecision),
+				modelIterations,
+			)
+			finalResult, finalDeltas, finalErr := service.generateFinalOutput(
+				loopCtx,
+				request,
+				observer,
+				output,
+			)
+			if finalErr != nil {
+				return TextResult{}, nil, finalErr
+			}
+			modelIterations++
+			service.logRunCompleted(
+				run,
+				finalDecision,
+				modelIterations,
+				toolCalls,
+				startedAt,
+				finalResult.Content,
+			)
+			return finalResult, finalDeltas, nil
+		}
 	}
 }
 
@@ -1091,7 +1112,7 @@ func (service *Service) executeToolCall(
 	actor requestcontext.Actor,
 	run Run,
 	call ModelToolCall,
-) (TextMessage, ToolCallStatus, error) {
+) (TextMessage, ToolCallStatus, capability.TurnOutcome, error) {
 	toolCtx, cancel := context.WithTimeout(ctx, service.loopLimits.ToolTimeout)
 	defer cancel()
 	effect := service.registry.InvocationEffect(capability.Invocation{
@@ -1106,7 +1127,7 @@ func (service *Service) executeToolCall(
 		call.ID,
 		requestID,
 	); err != nil {
-		return TextMessage{}, ToolCallFailed, err
+		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, err
 	}
 	result, err := service.executor.Execute(
 		toolCtx,
@@ -1132,10 +1153,10 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			capability.ErrorCategory(err),
 		); persistErr != nil {
-			return TextMessage{}, ToolCallFailed, persistErr
+			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, persistErr
 		}
 		// 工具自身失败属于模型可处理结果，回填稳定分类后让模型决定重试、换工具或解释。
-		return toolFailureMessage(call.ID, err), ToolCallFailed, nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, nil
 	}
 	content, err := marshalToolResult(result, service.loopLimits.MaxToolResultBytes)
 	if err != nil {
@@ -1150,9 +1171,9 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			"internal",
 		); persistErr != nil {
-			return TextMessage{}, ToolCallFailed, persistErr
+			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, persistErr
 		}
-		return toolFailureMessage(call.ID, err), ToolCallFailed, nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, nil
 	}
 	persistCtx, persistCancel := runPersistenceContext(ctx)
 	defer persistCancel()
@@ -1166,13 +1187,13 @@ func (service *Service) executeToolCall(
 		toolSourceRefs(result.SourceRefs),
 		result.ClientActions,
 	); err != nil {
-		return TextMessage{}, ToolCallFailed, err
+		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, err
 	}
 	return TextMessage{
 		Role:       TextRoleTool,
 		Content:    content,
 		ToolCallID: call.ID,
-	}, ToolCallSucceeded, nil
+	}, ToolCallSucceeded, result.TurnOutcome, nil
 }
 
 func (service *Service) saveToolCallProposed(
@@ -1582,22 +1603,6 @@ func toolCallRequestID(run Run, call ModelToolCall, mayWrite bool) string {
 	}
 	sum := sha256.Sum256([]byte(seed))
 	return fmt.Sprintf("%s%x", prefix, sum[:])
-}
-
-func (service *Service) writeToolCallCount(
-	calls []ModelToolCall,
-) int {
-	count := 0
-	for _, call := range calls {
-		effect := service.registry.InvocationEffect(capability.Invocation{
-			Name:  call.Name,
-			Input: call.Arguments,
-		})
-		if effect.MayWrite() {
-			count++
-		}
-	}
-	return count
 }
 
 func (service *Service) stopLoop(

--- a/server/internal/agent/run/tool_routing.go
+++ b/server/internal/agent/run/tool_routing.go
@@ -10,6 +10,7 @@ import (
 const (
 	modelToolRoutingVersionV3 = "model-tool-routing-v3"
 	reasonModelToolSelection  = "model_tool_selection"
+	reasonDomainTurnCompleted = "domain_turn_completed"
 )
 
 type modelToolRouting struct {

--- a/server/internal/coaching/preparation/agentcapability/preview.go
+++ b/server/internal/coaching/preparation/agentcapability/preview.go
@@ -165,12 +165,15 @@ func previewToolResult(preview PreviewResult) capability.Result {
 		content["catalog_candidates"] = preview.Candidates
 	}
 	clientActions := []agentclientaction.Action(nil)
+	turnOutcome := capability.TurnOutcomeContinue
 	if preview.Status == "preview_ready" {
 		clientActions = []agentclientaction.Action{preview.ClientAction}
+		turnOutcome = capability.TurnOutcomeCompleted
 	}
 	return capability.Result{
 		Content:       content,
 		SourceRefs:    preview.SourceRefs,
 		ClientActions: clientActions,
+		TurnOutcome:   turnOutcome,
 	}
 }

--- a/server/internal/coaching/preparation/agentcapability/preview_test.go
+++ b/server/internal/coaching/preparation/agentcapability/preview_test.go
@@ -1,0 +1,25 @@
+package agentcapability
+
+import (
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/capability"
+)
+
+func TestPreviewReadyCompletesCurrentTurn(t *testing.T) {
+	result := previewToolResult(PreviewResult{
+		Status: "preview_ready",
+	})
+	if result.TurnOutcome != capability.TurnOutcomeCompleted {
+		t.Fatalf("TurnOutcome = %v, want completed", result.TurnOutcome)
+	}
+}
+
+func TestPreviewNeedsInputKeepsCurrentTurnOpen(t *testing.T) {
+	result := previewToolResult(PreviewResult{
+		Status: "needs_input",
+	})
+	if result.TurnOutcome != capability.TurnOutcomeContinue {
+		t.Fatalf("TurnOutcome = %v, want continue", result.TurnOutcome)
+	}
+}


### PR DESCRIPTION
## 功能描述

- 移除每个 Run 最多一次 MayWrite 调用的全局业务限制。
- 由 capability 返回内部 TurnOutcome，明确本轮领域目标是否完成。
- practice.preview.v1 仅在 preview_ready 时标记领域完成，needs_input 继续 Agent Loop。
- 领域完成后直接进入工具禁用的最终回复阶段，避免模型再次规划并重复创建。
- 保留总工具调用、迭代、超时、风险与确认等安全约束。

## 实现思路

- TurnOutcome 属于 provider-neutral capability 结果元数据，不进入模型可见内容，也不持久化为工具结果。
- Agent Loop 只消费领域结果，不解析 practice.preview.v1 的业务状态字符串。
- 写命令继续使用可信 InputMessage 与工具名生成稳定请求 ID；重复语义命令由现有仓储幂等约束识别并重放。
- 不增加数据库字段，不包含数据库迁移。

## 可复现测试

- GOCACHE=/tmp/xe3-esl-issue-730-go-cache make check-go
- iOS Simulator 使用真实后端、禁用数字人，连续发送：餐厅点餐，直接帮我创建，不要询问轮数。
- 第一次 Run：1 次 practice.preview.v1，随后 domain_turn_completed，HTTP 200，约 2.8 秒。
- 第二次 Run：同一 Run 内 2 次 practice.preview.v1；第一次未创建资源，第二次创建成功后 domain_turn_completed，HTTP 200，约 4.7 秒。
- 两次均未出现 write_tool_call_budget_exhausted 或 agent.run.failed；练习卡确认、Session 创建与激活成功。

Closes #730