### PR TITLE
fix(mobile): parse frozen IELTS prepared answers

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_assignment.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_assignment.dart
@@ -27,6 +27,7 @@ final class IeltsPracticePartAssignment {
     required this.turnBlueprints,
     this.topicTitle,
     this.cueCard,
+    this.preparedAnswers = const <IeltsPreparedAnswer>[],
   });
 
   final IeltsSpeakingPart part;
@@ -34,6 +35,7 @@ final class IeltsPracticePartAssignment {
   final String? topicTitle;
   final String? cueCard;
   final List<String> turnBlueprints;
+  final List<IeltsPreparedAnswer> preparedAnswers;
 
   Map<String, Object> toJson() => <String, Object>{
     'part': part.wireValue,
@@ -41,6 +43,16 @@ final class IeltsPracticePartAssignment {
     'topic_title': ?topicTitle,
     'cue_card': ?cueCard,
     'turn_blueprints': turnBlueprints,
+    if (preparedAnswers.isNotEmpty)
+      'prepared_answers': preparedAnswers
+          .map(
+            (answer) => <String, Object>{
+              'question_position': answer.questionPosition,
+              'answer': answer.answer,
+              'personalized': answer.personalized,
+            },
+          )
+          .toList(growable: false),
   };
 
   @override
@@ -50,7 +62,8 @@ final class IeltsPracticePartAssignment {
       other.sourceId == sourceId &&
       other.topicTitle == topicTitle &&
       other.cueCard == cueCard &&
-      _sameStrings(other.turnBlueprints, turnBlueprints);
+      _sameStrings(other.turnBlueprints, turnBlueprints) &&
+      _samePreparedAnswers(other.preparedAnswers, preparedAnswers);
 
   @override
   int get hashCode => Object.hash(
@@ -59,6 +72,7 @@ final class IeltsPracticePartAssignment {
     topicTitle,
     cueCard,
     Object.hashAll(turnBlueprints),
+    Object.hashAll(preparedAnswers.map(_preparedAnswerHash)),
   );
 }
 
@@ -128,3 +142,28 @@ bool _sameStrings(List<String> left, List<String> right) =>
       left.length,
       (index) => left[index] == right[index],
     ).every((same) => same);
+
+bool _samePreparedAnswers(
+  List<IeltsPreparedAnswer> left,
+  List<IeltsPreparedAnswer> right,
+) =>
+    left.length == right.length &&
+    List<bool>.generate(left.length, (index) {
+      final leftAnswer = left[index];
+      final rightAnswer = right[index];
+      return leftAnswer.bankId == rightAnswer.bankId &&
+          leftAnswer.part == rightAnswer.part &&
+          leftAnswer.sourceId == rightAnswer.sourceId &&
+          leftAnswer.questionPosition == rightAnswer.questionPosition &&
+          leftAnswer.answer == rightAnswer.answer &&
+          leftAnswer.personalized == rightAnswer.personalized;
+    }).every((same) => same);
+
+int _preparedAnswerHash(IeltsPreparedAnswer answer) => Object.hash(
+  answer.bankId,
+  answer.part,
+  answer.sourceId,
+  answer.questionPosition,
+  answer.answer,
+  answer.personalized,
+);

--- a/mobile/lib/features/coaching/ielts/ielts_assignment_codec.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_assignment_codec.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:speakup/features/coaching/ielts/ielts_assignment.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
@@ -13,6 +14,7 @@ IeltsPracticeAssignment decodeIeltsAssignment(Object? value) {
     value,
     required: const <String>{'bank_id', 'season', 'mode', 'parts'},
   );
+  final bankId = _resourceId(object['bank_id']);
   final mode = PracticeMode.fromWireValue(_text(object['mode'], maxBytes: 16));
   final rawParts = object['parts'];
   if (mode == null ||
@@ -21,7 +23,9 @@ IeltsPracticeAssignment decodeIeltsAssignment(Object? value) {
       rawParts.length > 3) {
     throw const IeltsAssignmentWireFormatException();
   }
-  final parts = rawParts.map(_part).toList(growable: false);
+  final parts = rawParts
+      .map((value) => _part(value, bankId))
+      .toList(growable: false);
   final expectedParts = switch (mode) {
     PracticeMode.fullMock => const <IeltsSpeakingPart>[
       IeltsSpeakingPart.part1,
@@ -53,18 +57,18 @@ IeltsPracticeAssignment decodeIeltsAssignment(Object? value) {
     throw const IeltsAssignmentWireFormatException();
   }
   return IeltsPracticeAssignment(
-    bankId: _resourceId(object['bank_id']),
+    bankId: bankId,
     season: _text(object['season']),
     mode: mode,
     parts: List<IeltsPracticePartAssignment>.unmodifiable(parts),
   );
 }
 
-IeltsPracticePartAssignment _part(Object? value) {
+IeltsPracticePartAssignment _part(Object? value, String bankId) {
   final object = _object(
     value,
     required: const <String>{'part', 'source_id', 'turn_blueprints'},
-    optional: const <String>{'topic_title', 'cue_card'},
+    optional: const <String>{'topic_title', 'cue_card', 'prepared_answers'},
   );
   final part = IeltsSpeakingPart.fromWireValue(
     _text(object['part'], maxBytes: 16),
@@ -86,6 +90,16 @@ IeltsPracticePartAssignment _part(Object? value) {
   final cueCard = object.containsKey('cue_card')
       ? _text(object['cue_card'])
       : null;
+  final sourceId = _resourceId(object['source_id']);
+  final preparedAnswers = object.containsKey('prepared_answers')
+      ? _preparedAnswers(
+          object['prepared_answers'],
+          bankId: bankId,
+          part: part,
+          sourceId: sourceId,
+          turnCount: turnBlueprints.length,
+        )
+      : const <IeltsPreparedAnswer>[];
   final validMetadata = switch (part) {
     IeltsSpeakingPart.part1 => topicTitle == null && cueCard == null,
     IeltsSpeakingPart.part2 =>
@@ -97,11 +111,56 @@ IeltsPracticePartAssignment _part(Object? value) {
   }
   return IeltsPracticePartAssignment(
     part: part,
-    sourceId: _resourceId(object['source_id']),
+    sourceId: sourceId,
     topicTitle: topicTitle,
     cueCard: cueCard,
     turnBlueprints: List<String>.unmodifiable(turnBlueprints),
+    preparedAnswers: preparedAnswers,
   );
+}
+
+List<IeltsPreparedAnswer> _preparedAnswers(
+  Object? value, {
+  required String bankId,
+  required IeltsSpeakingPart part,
+  required String sourceId,
+  required int turnCount,
+}) {
+  if (value is! List<Object?> || value.length > practiceTurnSafetyLimit) {
+    throw const IeltsAssignmentWireFormatException();
+  }
+  final positions = <int>{};
+  final answers = <IeltsPreparedAnswer>[];
+  for (final rawAnswer in value) {
+    final object = _object(
+      rawAnswer,
+      required: const <String>{'question_position', 'answer', 'personalized'},
+    );
+    final position = object['question_position'];
+    final personalized = object['personalized'];
+    if (position is! int ||
+        position < 1 ||
+        position > turnCount ||
+        !positions.add(position) ||
+        personalized is! bool) {
+      throw const IeltsAssignmentWireFormatException();
+    }
+    final answer = _text(object['answer'], maxBytes: 8000);
+    if (answer.runes.length > 2000) {
+      throw const IeltsAssignmentWireFormatException();
+    }
+    answers.add(
+      IeltsPreparedAnswer(
+        bankId: bankId,
+        part: part.wireValue,
+        sourceId: sourceId,
+        questionPosition: position,
+        answer: answer,
+        personalized: personalized,
+      ),
+    );
+  }
+  return List<IeltsPreparedAnswer>.unmodifiable(answers);
 }
 
 Map<String, Object?> _object(

--- a/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
@@ -3,9 +3,13 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/ielts/ielts_assignment.dart';
+import 'package:speakup/features/coaching/ielts/ielts_question_bank.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/preparation/wire_preparation_launch_client.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+import 'package:speakup/features/coaching/scene/scene_wire_codec.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 
@@ -87,6 +91,61 @@ void main() {
       });
     },
   );
+
+  test('accepts a Part 2 Plan with a frozen prepared answer', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.created, _ieltsPlanJson()),
+    ]);
+    final client = _client(transport);
+
+    final plan = await client.createPlan(
+      input: _ieltsPlanInput,
+      idempotencyKey: 'ielts-part-2-plan-key',
+    );
+
+    final preparedAnswer = plan.ieltsAssignment!
+        .part(IeltsSpeakingPart.part2)!
+        .preparedAnswers
+        .single;
+    expect(preparedAnswer.bankId, 'ielts-bank');
+    expect(preparedAnswer.part, 'PART_2');
+    expect(preparedAnswer.sourceId, 'famous-person');
+    expect(preparedAnswer.questionPosition, 1);
+    expect(
+      preparedAnswer.answer,
+      'I would like to meet a songwriter I admire.',
+    );
+    expect(preparedAnswer.personalized, isTrue);
+  });
+
+  test('rejects unknown fields in a frozen prepared answer', () async {
+    final response = _ieltsPlanJson();
+    final assignment = response['ielts_assignment']! as Map<String, Object?>;
+    final parts = assignment['parts']! as List<Object?>;
+    final part2 = parts.first! as Map<String, Object?>;
+    final answers = part2['prepared_answers']! as List<Object?>;
+    final answer = answers.single! as Map<String, Object?>;
+    answer['unexpected'] = true;
+    final client = _client(
+      _QueueTransport(<IdentityHttpResponse>[
+        _response(HttpStatus.created, response),
+      ]),
+    );
+
+    await expectLater(
+      client.createPlan(
+        input: _ieltsPlanInput,
+        idempotencyKey: 'strict-ielts-plan-key',
+      ),
+      throwsA(
+        isA<PreparationLaunchException>().having(
+          (error) => error.kind,
+          'kind',
+          PreparationLaunchFailureKind.invalidResponse,
+        ),
+      ),
+    );
+  });
 
   test('rejects the removed plan_revision response field', () async {
     final response = contractPlanJson();
@@ -211,3 +270,121 @@ final class _CompleterTransport implements IdentityHttpTransport {
     List<int>? bodyBytes,
   }) => _response.future;
 }
+
+const _ieltsScene = SceneDefinition(
+  id: 'ielts-speaking',
+  experience: PracticeExperience.ieltsSpeaking,
+  category: SceneCategory.ieltsSpeaking,
+  name: 'IELTS Speaking',
+  version: 1,
+  status: SceneStatus.active,
+  prompt: ScenePrompt(
+    publicSceneBrief: 'Practice IELTS Speaking Part 2 and Part 3.',
+    practiceGoal: 'Answer one cue card and six follow-up questions.',
+    userRole: 'Candidate',
+    aiRole: 'Examiner',
+    personaSummary: 'A neutral IELTS examiner.',
+    focusAreas: <String>['fluency'],
+    turnBlueprints: <String>['Ask the frozen IELTS questions.'],
+  ),
+  roles: <RoleDefinition>[
+    RoleDefinition(
+      id: 'ielts-examiner',
+      sceneId: 'ielts-speaking',
+      type: 'EXAMINER',
+      displayName: 'IELTS examiner',
+      responsibilities: 'Ask the frozen questions in order.',
+      style: 'Neutral',
+      practiceObjectives: <RolePracticeObjective>[
+        RolePracticeObjective(
+          objectiveId: 'fluency',
+          description: 'Speak fluently and coherently.',
+        ),
+      ],
+    ),
+  ],
+  practiceOptions: <PracticeOption>[
+    PracticeOption(
+      id: 'ielts-part-2',
+      sceneId: 'ielts-speaking',
+      mode: PracticeMode.part2,
+      displayName: 'Part 2',
+      suggestedDurationSeconds: 600,
+      turnPolicyRef: 'ielts-part-2-turn-policy',
+      sessionPolicyRef: 'ielts-part-2-session-policy',
+      evaluationPolicyRef: 'ielts-part-2-evaluation-policy',
+    ),
+  ],
+);
+
+const _ieltsPlanInput = CreatePracticePlanInput(
+  backgroundSummary: contractBackground,
+  sceneId: 'ielts-speaking',
+  sceneVersion: 1,
+  selectedRoleIds: <String>['ielts-examiner'],
+  practiceOptionId: 'ielts-part-2',
+  maxEffectiveTurns: 7,
+  ieltsSelection: IeltsPracticeSelection(topicGroupId: 'famous-person'),
+  ieltsPreparedAnswers: <IeltsPreparedAnswer>[
+    IeltsPreparedAnswer(
+      bankId: 'ielts-bank',
+      part: 'PART_2',
+      sourceId: 'famous-person',
+      questionPosition: 1,
+      answer: 'I would like to meet a songwriter I admire.',
+      personalized: true,
+    ),
+  ],
+);
+
+Map<String, Object?> _ieltsPlanJson() {
+  final response = contractPlanJson();
+  response['scene_selection'] = <String, Object?>{
+    'scene': encodeSceneDefinition(_ieltsScene),
+    'selected_role_ids': <String>['ielts-examiner'],
+    'practice_option_id': 'ielts-part-2',
+  };
+  response['session_policy'] = <String, Object?>{
+    ...contractSessionPolicyJson(),
+    'max_effective_turns': 7,
+  };
+  response['ielts_assignment'] = _ieltsPart2AssignmentJson();
+  return response;
+}
+
+Map<String, Object?> _ieltsPart2AssignmentJson() => <String, Object?>{
+  'bank_id': 'ielts-bank',
+  'season': '2026-08',
+  'mode': 'PART_2',
+  'parts': <Object?>[
+    <String, Object?>{
+      'part': 'PART_2',
+      'source_id': 'famous-person',
+      'topic_title': 'Famous people',
+      'cue_card': 'Describe a famous person you would like to meet.',
+      'turn_blueprints': <String>[
+        'Describe a famous person you would like to meet.',
+      ],
+      'prepared_answers': <Object?>[
+        <String, Object?>{
+          'question_position': 1,
+          'answer': 'I would like to meet a songwriter I admire.',
+          'personalized': true,
+        },
+      ],
+    },
+    <String, Object?>{
+      'part': 'PART_3',
+      'source_id': 'famous-person',
+      'topic_title': 'Famous people',
+      'turn_blueprints': <String>[
+        'Why do people become famous?',
+        'Is talent necessary for fame?',
+        'How does fame affect children?',
+        'What responsibilities do famous people have?',
+        'Is it easier to become famous today?',
+        'Would you like to be famous?',
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## 功能描述

修复 IELTS Part 2/3 在携带个性化参考答案创建 PracticePlan 后，移动端因无法解析 `ielts_assignment.parts[].prepared_answers` 而阻止进入练习的问题。

## 实现思路

- 扩展移动端 IELTS assignment 模型，保留冻结的参考答案。
- 严格解析 `question_position`、`answer` 和 `personalized`，并从 assignment 上下文恢复 bank、part 与 source 标识。
- 校验题号范围、重复位置、答案长度和未知字段，不放宽现有严格响应契约。
- 序列化 assignment 时保留冻结参考答案，支持 PracticePlan 到 PracticeSession 的快照传递。

## 可复现测试

1. 在 IELTS Part 2/3 题单生成个性化参考答案。
2. 点击开始练习。
3. `POST /v1/practice-plans` 返回包含 `prepared_answers` 的 `201` 响应。
4. 移动端成功解析计划并进入后续 Session 创建流程，不再显示“练习服务返回了无法识别的数据”。

自动化验证：

- `make check-flutter`
- 结果：格式检查、Flutter analyze、658 项测试全部通过。
- 新增回归覆盖：带冻结参考答案的 Part 2 Plan 可解析；参考答案内未知字段仍被拒绝。

Closes #734