### PR TITLE
fix(agent): 领域任务完成后直接持久化并交付卡片

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -1643,6 +1643,16 @@ components:
           type: string
           format: uuid
           readOnly: true
+        completion_source:
+          type: string
+          enum:
+            - model
+            - domain
+          description: >-
+            Present only for completed Runs. Model completions include provider
+            metadata and usage; domain completions include the completing tool
+            identity instead.
+          readOnly: true
         provider_completion_id:
           type: string
           minLength: 1
@@ -1663,6 +1673,18 @@ components:
           readOnly: true
         usage:
           $ref: '#/components/schemas/TokenUsage'
+        domain_tool_call_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+          readOnly: true
+        domain_tool_name:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+          readOnly: true
         failure:
           $ref: '#/components/schemas/AgentRunFailure'
         created_at:

--- a/mobile/lib/providers/agent/wire_agent_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_client.dart
@@ -1919,10 +1919,13 @@ _WireRun _decodeRun(String body) {
         'requested_model',
         'max_output_tokens',
         'assistant_message_id',
+        'completion_source',
         'provider_completion_id',
         'provider_model',
         'finish_reason',
         'usage',
+        'domain_tool_call_id',
+        'domain_tool_name',
         'failure',
         'created_at',
         'started_at',
@@ -2023,32 +2026,55 @@ _WireRun _decodeRun(String body) {
             completedAt == null) {
           throw const _InvalidAgentResponse();
         }
-        _strictClientIdentity(object['provider_completion_id']);
-        _strictClientIdentity(object['provider_model']);
-        final finishReason = _strictString(
-          object['finish_reason'],
+        final completionSource = _strictString(
+          object['completion_source'],
           minLength: 1,
           maxLength: 16,
         );
-        if (finishReason != 'stop' && finishReason != 'length') {
-          throw const _InvalidAgentResponse();
+        switch (completionSource) {
+          case 'model':
+            if (object['domain_tool_call_id'] != null ||
+                object['domain_tool_name'] != null) {
+              throw const _InvalidAgentResponse();
+            }
+            _strictClientIdentity(object['provider_completion_id']);
+            _strictClientIdentity(object['provider_model']);
+            final finishReason = _strictString(
+              object['finish_reason'],
+              minLength: 1,
+              maxLength: 16,
+            );
+            if (finishReason != 'stop' && finishReason != 'length') {
+              throw const _InvalidAgentResponse();
+            }
+            final usage = _strictObject(
+              object['usage'],
+              allowed: const <String>{
+                'input_tokens',
+                'output_tokens',
+                'total_tokens',
+              },
+              required: const <String>{
+                'input_tokens',
+                'output_tokens',
+                'total_tokens',
+              },
+            );
+            _strictInt(usage['input_tokens'], minimum: 0);
+            _strictInt(usage['output_tokens'], minimum: 0);
+            _strictInt(usage['total_tokens'], minimum: 0);
+          case 'domain':
+            if (object['provider_completion_id'] != null ||
+                object['provider_model'] != null ||
+                object['finish_reason'] != null ||
+                object['usage'] != null) {
+              throw const _InvalidAgentResponse();
+            }
+            _strictClientIdentity(object['domain_tool_call_id']);
+            _strictClientIdentity(object['domain_tool_name']);
+          default:
+            throw const _InvalidAgentResponse();
         }
-        final usage = _strictObject(
-          object['usage'],
-          allowed: const <String>{
-            'input_tokens',
-            'output_tokens',
-            'total_tokens',
-          },
-          required: const <String>{
-            'input_tokens',
-            'output_tokens',
-            'total_tokens',
-          },
-        );
-        _strictInt(usage['input_tokens'], minimum: 0);
-        _strictInt(usage['output_tokens'], minimum: 0);
-        _strictInt(usage['total_tokens'], minimum: 0);
       case _WireRunStatus.failed:
         if (failureObject == null ||
             assistantMessageId != null ||

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -734,7 +734,7 @@ void main() {
             path: '/v1/agent-threads/$_threadId/runs',
             response: _jsonResponse(
               HttpStatus.created,
-              _runJson(status: 'completed'),
+              _runJson(status: 'completed', completionSource: 'domain'),
             ),
           ),
           _messagesStep(userContent: text, clientMessageId: 'message_unicode'),
@@ -1820,6 +1820,7 @@ Map<String, Object?> _runJson({
   bool failureRetryable = false,
   String? retryOfRunId,
   String? clientRetryId,
+  String completionSource = 'model',
 }) {
   return {
     'run_id': id,
@@ -1838,10 +1839,16 @@ Map<String, Object?> _runJson({
       'completed_at': _completedAt,
     if (status == 'completed') ...{
       'assistant_message_id': _assistantMessageId,
-      'provider_completion_id': 'completion_1',
-      'provider_model': 'qwen-flash',
-      'finish_reason': 'stop',
-      'usage': {'input_tokens': 8, 'output_tokens': 5, 'total_tokens': 13},
+      'completion_source': completionSource,
+      if (completionSource == 'model') ...{
+        'provider_completion_id': 'completion_1',
+        'provider_model': 'qwen-flash',
+        'finish_reason': 'stop',
+        'usage': {'input_tokens': 8, 'output_tokens': 5, 'total_tokens': 13},
+      } else ...{
+        'domain_tool_call_id': 'call-practice-preview-1',
+        'domain_tool_name': 'practice.preview.v1',
+      },
     },
     if (status == 'failed')
       'failure': {

--- a/server/internal/agent/capability/executor.go
+++ b/server/internal/agent/capability/executor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	agentclientaction "github.com/1024XEngineer/XE3-ESL/server/internal/agent/clientaction"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 )
 
 type Executor struct {
@@ -76,6 +77,15 @@ func (executor *Executor) Execute(
 		result.Content = map[string]any{}
 	}
 	if !result.TurnOutcome.Valid() {
+		executor.logFailure(call, definition, time.Since(startedAt), ErrExecutionRejected)
+		return Result{}, ErrExecutionRejected
+	}
+	if result.TurnOutcome == TurnOutcomeCompleted {
+		if !conversation.ValidMessageContent(result.AssistantText) {
+			executor.logFailure(call, definition, time.Since(startedAt), ErrExecutionRejected)
+			return Result{}, ErrExecutionRejected
+		}
+	} else if result.AssistantText != "" {
 		executor.logFailure(call, definition, time.Since(startedAt), ErrExecutionRejected)
 		return Result{}, ErrExecutionRejected
 	}

--- a/server/internal/agent/capability/schema.go
+++ b/server/internal/agent/capability/schema.go
@@ -100,6 +100,7 @@ type Result struct {
 	SourceRefs    []SourceRef                `json:"source_refs,omitempty"`
 	ClientActions []agentclientaction.Action `json:"client_actions,omitempty"`
 	TurnOutcome   TurnOutcome                `json:"-"`
+	AssistantText string                     `json:"-"`
 }
 
 type Tool interface {

--- a/server/internal/agent/run/http/handler.go
+++ b/server/internal/agent/run/http/handler.go
@@ -342,14 +342,24 @@ func RunResponse(run agentrun.Run) gin.H {
 		result["completed_at"] = run.CompletedAt.UTC().Format(time.RFC3339Nano)
 	}
 	if run.Status == agentrun.StatusCompleted {
+		completionSource := run.CompletionSource
+		if completionSource == "" {
+			completionSource = agentrun.CompletionSourceModel
+		}
 		result["assistant_message_id"] = run.AssistantMessageID
-		result["provider_completion_id"] = run.ProviderCompletionID
-		result["provider_model"] = run.ProviderModel
-		result["finish_reason"] = run.FinishReason
-		result["usage"] = gin.H{
-			"input_tokens":  run.Usage.InputTokens,
-			"output_tokens": run.Usage.OutputTokens,
-			"total_tokens":  run.Usage.TotalTokens,
+		result["completion_source"] = completionSource
+		if completionSource == agentrun.CompletionSourceDomain {
+			result["domain_tool_call_id"] = run.DomainToolCallID
+			result["domain_tool_name"] = run.DomainToolName
+		} else {
+			result["provider_completion_id"] = run.ProviderCompletionID
+			result["provider_model"] = run.ProviderModel
+			result["finish_reason"] = run.FinishReason
+			result["usage"] = gin.H{
+				"input_tokens":  run.Usage.InputTokens,
+				"output_tokens": run.Usage.OutputTokens,
+				"total_tokens":  run.Usage.TotalTokens,
+			}
 		}
 	}
 	if run.Status == agentrun.StatusFailed {

--- a/server/internal/agent/run/logging.go
+++ b/server/internal/agent/run/logging.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"log/slog"
 	"strings"
 	"time"
 	"unicode"
@@ -57,7 +58,7 @@ func reasonSummary(reasonCode string, decision string) string {
 	case FailureToolCallBudgetExhausted:
 		return "本轮已达到 Agent Loop 工具调用预算。"
 	case reasonDomainTurnCompleted:
-		return "领域工具已完成本轮目标，进入最终回复。"
+		return "领域工具已完成本轮目标，直接提交规范回复与客户端动作。"
 	case FailureDuplicateToolCall:
 		return "模型重复提交了同一 ToolCall ID，本轮已停止执行。"
 	default:
@@ -70,4 +71,22 @@ func durationSince(startedAt time.Time) time.Duration {
 		return 0
 	}
 	return time.Since(startedAt)
+}
+
+func (service *Service) logAdvisoryStreamFailure(
+	run Run,
+	step ToolStep,
+	event string,
+) {
+	if service == nil || service.logger == nil {
+		return
+	}
+	service.logger.Warn(
+		"agent.stream.advisory_delivery_failed",
+		slog.String("run_id", run.ID),
+		slog.String("thread_id", run.ThreadID),
+		slog.String("tool_call_id", step.ID),
+		slog.String("tool_name", step.Name),
+		slog.String("event", event),
+	)
 }

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -828,7 +828,6 @@ func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
 			loopConditionalToolName,
 			`{"write_value":"persisted-value"}`,
 		),
-		finalLoopResult("The conditional write completed."),
 	)
 	service := newLoopTestServiceWithStore(t, generator, store)
 	setLoopTools(t, service, store, conditional)
@@ -853,11 +852,11 @@ func TestRunLoopQueriesThenExecutesOneConditionalWrite(t *testing.T) {
 		conditional.inputs[1].WriteValue == "" {
 		t.Fatalf("conditional inputs = %#v", conditional.inputs)
 	}
-	if got, want := generator.CallCount(), 3; got != want {
+	if got, want := generator.CallCount(), 2; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
-	if requests := generator.Requests(); requests[2].ToolChoice.Mode != ToolChoiceNone {
-		t.Fatalf("final request tool choice = %q, want %q", requests[2].ToolChoice.Mode, ToolChoiceNone)
+	if result.CompletionSource != CompletionSourceDomain {
+		t.Fatalf("CompletionSource = %q, want domain", result.CompletionSource)
 	}
 }
 
@@ -878,7 +877,6 @@ func TestRunLoopFinalizesAfterRepeatedCompletedWriteCommand(t *testing.T) {
 			},
 			Usage: TokenUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		},
-		finalLoopResult("The resource is ready."),
 	)
 	service := newLoopTestService(t, generator)
 	setLoopTools(t, service, capabilityfixture.NewStore(), writeTool)
@@ -896,23 +894,49 @@ func TestRunLoopFinalizesAfterRepeatedCompletedWriteCommand(t *testing.T) {
 	if got, want := result.Content, "The resource is ready."; got != want {
 		t.Fatalf("Content = %q, want %q", got, want)
 	}
-	if got, want := len(writeTool.requestIDs), 2; got != want {
+	if got, want := len(writeTool.requestIDs), 1; got != want {
 		t.Fatalf("write calls = %d, want %d", got, want)
 	}
-	if writeTool.requestIDs[0] != writeTool.requestIDs[1] {
-		t.Fatalf("repeated command request ids = %#v, want stable identity", writeTool.requestIDs)
-	}
-	if got, want := generator.CallCount(), 2; got != want {
+	if got, want := generator.CallCount(), 1; got != want {
 		t.Fatalf("Generate calls = %d, want %d", got, want)
 	}
-	requests := generator.Requests()
-	if requests[1].ToolChoice.Mode != ToolChoiceNone {
-		t.Fatalf("final request tool choice = %q, want %q", requests[1].ToolChoice.Mode, ToolChoiceNone)
+	if result.CompletionSource != CompletionSourceDomain {
+		t.Fatalf("CompletionSource = %q, want domain", result.CompletionSource)
 	}
-	toolResults := requests[1].Messages
-	if !strings.Contains(toolResults[len(toolResults)-2].Content, `"replayed":false`) ||
-		!strings.Contains(toolResults[len(toolResults)-1].Content, `"replayed":true`) {
-		t.Fatalf("repeated command results = %#v, want recognizable replay", toolResults)
+}
+
+func TestRunLoopKeepsCompletedDomainResultWhenToolNotificationDisconnects(
+	t *testing.T,
+) {
+	writeTool := &loopRequestIDTool{
+		name:        "resource.create.v1",
+		turnOutcome: capability.TurnOutcomeCompleted,
+	}
+	generator := newScriptedGenerator(
+		toolLoopResult("call-create", writeTool.name, `{}`),
+	)
+	service := newLoopTestService(t, generator)
+	setLoopTools(t, service, capabilityfixture.NewStore(), writeTool)
+
+	result, _, err := service.generateObserved(
+		context.Background(),
+		loopActor(),
+		loopRun(),
+		agentcontext.Manifest{},
+		loopRequest("create the resource"),
+		toolCompletionDisconnectObserver{},
+		AssistantOutput{
+			ID:    "5d1dd070-0805-4be4-9b4a-aa689b78bf6e",
+			RunID: "run-1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("generateObserved() error = %v", err)
+	}
+	if result.CompletionSource != CompletionSourceDomain ||
+		result.Content != "The resource is ready." ||
+		len(writeTool.requestIDs) != 1 {
+		t.Fatalf("domain result = %#v, requests = %#v", result, writeTool.requestIDs)
 	}
 }
 
@@ -1167,6 +1191,12 @@ func (tool *loopRequestIDTool) Execute(
 			"replayed": replayed,
 		},
 		TurnOutcome: tool.turnOutcome,
+		AssistantText: func() string {
+			if tool.turnOutcome == capability.TurnOutcomeCompleted {
+				return "The resource is ready."
+			}
+			return ""
+		}(),
 	}, nil
 }
 
@@ -1260,6 +1290,12 @@ func (conditional *loopConditionalTool) Execute(
 	return capability.Result{
 		Content:     map[string]any{"ok": true},
 		TurnOutcome: outcome,
+		AssistantText: func() string {
+			if outcome == capability.TurnOutcomeCompleted {
+				return "The conditional write completed."
+			}
+			return ""
+		}(),
 	}, nil
 }
 
@@ -1428,6 +1464,57 @@ func (generator *scriptedGenerator) GenerateStream(
 
 type recordingLoopStreamObserver struct {
 	steps []string
+}
+
+type toolCompletionDisconnectObserver struct{}
+
+func (toolCompletionDisconnectObserver) OnInputCommitted(
+	context.Context,
+	Submission,
+) error {
+	return nil
+}
+
+func (toolCompletionDisconnectObserver) OnToolStarted(
+	context.Context,
+	ToolStep,
+) error {
+	return nil
+}
+
+func (toolCompletionDisconnectObserver) OnToolCompleted(
+	context.Context,
+	ToolStep,
+) error {
+	return errors.New("stream disconnected")
+}
+
+func (toolCompletionDisconnectObserver) OnToolFailed(
+	context.Context,
+	ToolStep,
+) error {
+	return nil
+}
+
+func (toolCompletionDisconnectObserver) OnAssistantOutputStarted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
+}
+
+func (toolCompletionDisconnectObserver) OnAssistantOutputDelta(
+	context.Context,
+	AssistantOutputDelta,
+) error {
+	return nil
+}
+
+func (toolCompletionDisconnectObserver) OnAssistantOutputCompleted(
+	context.Context,
+	AssistantOutput,
+) error {
+	return nil
 }
 
 type realtimeLoopStreamObserver struct {

--- a/server/internal/agent/run/model.go
+++ b/server/internal/agent/run/model.go
@@ -54,6 +54,9 @@ type Run struct {
 	ProviderCompletionID string
 	ProviderModel        string
 	FinishReason         string
+	CompletionSource     CompletionSource
+	DomainToolCallID     string
+	DomainToolName       string
 	Usage                TokenUsage
 	FailureKind          string
 	FailureRetryable     bool

--- a/server/internal/agent/run/model_provider.go
+++ b/server/internal/agent/run/model_provider.go
@@ -120,15 +120,26 @@ type TokenUsage struct {
 	TotalTokens  int
 }
 
-// TextResult contains only completion metadata needed for Run auditing.
+type CompletionSource string
+
+const (
+	CompletionSourceModel  CompletionSource = "model"
+	CompletionSourceDomain CompletionSource = "domain"
+)
+
+// TextResult represents either a provider-generated completion or a
+// domain-owned completion with canonical assistant text.
 type TextResult struct {
-	ID           string
-	Provider     string
-	Model        string
-	Content      string
-	ToolCalls    []ModelToolCall
-	FinishReason string
-	Usage        TokenUsage
+	CompletionSource CompletionSource
+	ID               string
+	Provider         string
+	Model            string
+	Content          string
+	ToolCalls        []ModelToolCall
+	FinishReason     string
+	Usage            TokenUsage
+	DomainToolCallID string
+	DomainToolName   string
 }
 
 func ValidateTextRequest(request TextRequest) error {

--- a/server/internal/agent/run/postgres/repository_impl.go
+++ b/server/internal/agent/run/postgres/repository_impl.go
@@ -36,6 +36,11 @@ type storedModelResult struct {
 	FinishReason string `json:"finish_reason"`
 }
 
+type storedDomainResult struct {
+	ToolCallID string `json:"tool_call_id"`
+	ToolName   string `json:"tool_name"`
+}
+
 type storedUsage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
@@ -48,6 +53,13 @@ type storedFailure struct {
 }
 
 const maxToolTraceBytes = 512 << 10
+
+func nullableJSON(value []byte) any {
+	if len(value) == 0 {
+		return nil
+	}
+	return value
+}
 
 type storedToolCall struct {
 	ID            string                     `json:"id"`
@@ -625,31 +637,42 @@ INSERT INTO agent_messages (
 	); err != nil {
 		return agentrun.Run{}, mapRunPostgresError(err)
 	}
-	modelResult, err := json.Marshal(storedModelResult{
-		CompletionID: result.ID, Provider: result.Provider,
-		Model: result.Model, FinishReason: result.FinishReason,
-	})
-	if err != nil {
-		return agentrun.Run{}, agentrun.ErrInvalidRequest
+	var modelResult []byte
+	var usage []byte
+	var domainResult []byte
+	if result.CompletionSource == agentrun.CompletionSourceDomain {
+		domainResult, err = json.Marshal(storedDomainResult{
+			ToolCallID: result.DomainToolCallID,
+			ToolName:   result.DomainToolName,
+		})
+	} else {
+		modelResult, err = json.Marshal(storedModelResult{
+			CompletionID: result.ID, Provider: result.Provider,
+			Model: result.Model, FinishReason: result.FinishReason,
+		})
+		if err == nil {
+			usage, err = json.Marshal(storedUsage{
+				InputTokens:  result.Usage.InputTokens,
+				OutputTokens: result.Usage.OutputTokens,
+				TotalTokens:  result.Usage.TotalTokens,
+			})
+		}
 	}
-	usage, err := json.Marshal(storedUsage{
-		InputTokens:  result.Usage.InputTokens,
-		OutputTokens: result.Usage.OutputTokens,
-		TotalTokens:  result.Usage.TotalTokens,
-	})
 	if err != nil {
 		return agentrun.Run{}, agentrun.ErrInvalidRequest
 	}
 	tag, err := tx.Exec(ctx, `
 UPDATE agent_runs AS runs
 SET status = 'completed', phase = 'completed',
-    model_result = $3::jsonb, usage = $4::jsonb, error = NULL,
+    model_result = $3::jsonb, usage = $4::jsonb,
+    domain_result = $5::jsonb, error = NULL,
     tool_trace = `+terminalToolTraceProjectionSQL+`,
     lease_token = NULL, lease_expires_at = NULL,
     completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND status = 'running' AND lease_token = $2
   AND lease_expires_at > CURRENT_TIMESTAMP`,
-		runID, leaseToken, modelResult, usage,
+		runID, leaseToken, nullableJSON(modelResult), nullableJSON(usage),
+		nullableJSON(domainResult),
 	)
 	if err != nil {
 		return agentrun.Run{}, mapRunPostgresError(err)
@@ -989,6 +1012,7 @@ const runSelectColumns = `
     ), ''),
     runs.model_result,
     runs.usage,
+    runs.domain_result,
     runs.error,
     runs.context_snapshot,
     runs.tool_trace,
@@ -1003,6 +1027,7 @@ func scanRun(row rowScanner) (agentrun.Run, error) {
 	var modelConfigurationJSON []byte
 	var modelResultJSON []byte
 	var usageJSON []byte
+	var domainResultJSON []byte
 	var failureJSON []byte
 	var contextSnapshotJSON []byte
 	var toolTraceJSON []byte
@@ -1014,7 +1039,7 @@ func scanRun(row rowScanner) (agentrun.Run, error) {
 		&result.Attempt, &result.RetryOfRunID, &result.RetryClientID,
 		&status, &result.Phase, &modelConfigurationJSON,
 		&result.WorkerLeaseToken, &leaseExpiresAt, &result.AssistantMessageID,
-		&modelResultJSON, &usageJSON, &failureJSON, &contextSnapshotJSON,
+		&modelResultJSON, &usageJSON, &domainResultJSON, &failureJSON, &contextSnapshotJSON,
 		&toolTraceJSON, &result.CreatedAt, &startedAt, &completedAt,
 		&result.UpdatedAt,
 	); err != nil {
@@ -1062,6 +1087,18 @@ func scanRun(row rowScanner) (agentrun.Run, error) {
 		result.ProviderCompletionID = stored.CompletionID
 		result.ProviderModel = stored.Model
 		result.FinishReason = stored.FinishReason
+		result.CompletionSource = agentrun.CompletionSourceModel
+	}
+	if len(domainResultJSON) > 0 {
+		var stored storedDomainResult
+		if strictJSON(domainResultJSON, &stored) != nil ||
+			!agentrun.ValidOpaqueID(stored.ToolCallID) ||
+			!agentrun.ValidOpaqueID(stored.ToolName) {
+			return agentrun.Run{}, agentrun.ErrRepository
+		}
+		result.CompletionSource = agentrun.CompletionSourceDomain
+		result.DomainToolCallID = stored.ToolCallID
+		result.DomainToolName = stored.ToolName
 	}
 	if len(usageJSON) > 0 {
 		var stored storedUsage
@@ -1091,7 +1128,13 @@ func scanRun(row rowScanner) (agentrun.Run, error) {
 	if completedAt.Valid {
 		result.CompletedAt = completedAt.Time.UTC()
 	}
-	if !validStoredRun(result, modelResultJSON, usageJSON, failureJSON) {
+	if !validStoredRun(
+		result,
+		modelResultJSON,
+		usageJSON,
+		domainResultJSON,
+		failureJSON,
+	) {
 		return agentrun.Run{}, agentrun.ErrRepository
 	}
 	return result, nil
@@ -1101,6 +1144,7 @@ func validStoredRun(
 	run agentrun.Run,
 	modelResult []byte,
 	usage []byte,
+	domainResult []byte,
 	failure []byte,
 ) bool {
 	if !run.Status.Valid() || run.Attempt < 1 {
@@ -1110,22 +1154,25 @@ func validStoredRun(
 	case agentrun.StatusPending:
 		return run.Phase == "queued" && run.StartedAt.IsZero() &&
 			run.CompletedAt.IsZero() && run.WorkerLeaseToken == "" &&
-			len(modelResult) == 0 && len(usage) == 0 && len(failure) == 0
+			len(modelResult) == 0 && len(usage) == 0 &&
+			len(domainResult) == 0 && len(failure) == 0
 	case agentrun.StatusRunning:
 		return (run.Phase == "context" || run.Phase == "model" || run.Phase == "tool") &&
 			!run.StartedAt.IsZero() && run.CompletedAt.IsZero() &&
 			run.WorkerLeaseToken != "" && !run.WorkerLeaseExpiresAt.IsZero() &&
-			len(modelResult) == 0 && len(usage) == 0 && len(failure) == 0
+			len(modelResult) == 0 && len(usage) == 0 &&
+			len(domainResult) == 0 && len(failure) == 0
 	case agentrun.StatusCompleted:
 		return run.Phase == "completed" && !run.StartedAt.IsZero() &&
 			!run.CompletedAt.IsZero() && run.AssistantMessageID != "" &&
-			run.WorkerLeaseToken == "" && len(modelResult) > 0 &&
-			len(usage) > 0 && len(failure) == 0
+			run.WorkerLeaseToken == "" && len(failure) == 0 &&
+			((len(modelResult) > 0 && len(usage) > 0 && len(domainResult) == 0) ||
+				(len(modelResult) == 0 && len(usage) == 0 && len(domainResult) > 0))
 	case agentrun.StatusFailed:
 		return run.Phase == "failed" && !run.StartedAt.IsZero() &&
 			!run.CompletedAt.IsZero() && run.AssistantMessageID == "" &&
 			run.WorkerLeaseToken == "" && len(modelResult) == 0 &&
-			len(usage) == 0 && len(failure) > 0
+			len(usage) == 0 && len(domainResult) == 0 && len(failure) > 0
 	default:
 		return false
 	}

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -628,9 +628,10 @@ func (service *Service) process(
 		return failed, failErr
 	}
 	if !validFinalTextResult(result) ||
-		result.Provider != service.configuration.Provider ||
-		result.Model != service.configuration.Model ||
-		result.Usage.OutputTokens > service.configuration.MaxOutputTokens {
+		(result.CompletionSource != CompletionSourceDomain &&
+			(result.Provider != service.configuration.Provider ||
+				result.Model != service.configuration.Model ||
+				result.Usage.OutputTokens > service.configuration.MaxOutputTokens)) {
 		failed, failErr := service.persistFailure(
 			ctx,
 			actor.UserID,
@@ -648,7 +649,7 @@ func (service *Service) process(
 		return failed, failErr
 	}
 	output.Content = result.Content
-	if observer != nil {
+	if observer != nil && result.CompletionSource != CompletionSourceDomain {
 		if len(finalDeltas) == 0 || joinedTextDeltas(finalDeltas) != result.Content {
 			failed, failErr := service.persistFailure(
 				ctx,
@@ -673,6 +674,15 @@ func (service *Service) process(
 	)
 	if err != nil || observer == nil {
 		return completed, err
+	}
+	if result.CompletionSource == CompletionSourceDomain {
+		stream := &assistantOutputDeltaStream{observer: observer, output: output}
+		if err := stream.start(ctx); err != nil {
+			return completed, err
+		}
+		if err := stream.OnTextDelta(ctx, output.Content); err != nil {
+			return completed, err
+		}
 	}
 	if err := observer.OnAssistantOutputCompleted(ctx, output); err != nil {
 		return completed, err
@@ -849,6 +859,7 @@ func (service *Service) generateObserved(
 		toolCalls += len(result.ToolCalls)
 
 		turnCompleted := false
+		var domainCompletion TextResult
 		for _, call := range result.ToolCalls {
 			seenToolCallIDs[call.ID] = struct{}{}
 			if err := service.saveToolCallProposed(loopCtx, run, call); err != nil {
@@ -880,7 +891,7 @@ func (service *Service) generateObserved(
 				)
 				continue
 			}
-			toolMessage, status, outcome, err := service.executeToolCall(
+			toolMessage, status, outcome, assistantText, err := service.executeToolCall(
 				loopCtx,
 				actor,
 				run,
@@ -900,16 +911,32 @@ func (service *Service) generateObserved(
 					eventErr = observer.OnToolFailed(loopCtx, step)
 				}
 				if eventErr != nil {
-					return TextResult{}, nil, eventErr
+					if status != ToolCallSucceeded ||
+						outcome != capability.TurnOutcomeCompleted {
+						return TextResult{}, nil, eventErr
+					}
+					service.logAdvisoryStreamFailure(
+						run,
+						step,
+						"tool_completed",
+					)
 				}
 			}
 			request.Messages = append(request.Messages, toolMessage)
 			if status == ToolCallSucceeded && outcome == capability.TurnOutcomeCompleted {
 				turnCompleted = true
+				domainCompletion = TextResult{
+					CompletionSource: CompletionSourceDomain,
+					Content:          assistantText,
+					DomainToolCallID: call.ID,
+					DomainToolName:   call.Name,
+				}
+				break
 			}
 		}
 		finalDecision = "tool_call_then_response"
 		if turnCompleted {
+			finalDecision = "domain_completion"
 			service.logRoutingDecision(
 				run,
 				finalDecision,
@@ -918,25 +945,15 @@ func (service *Service) generateObserved(
 				reasonSummary(reasonDomainTurnCompleted, finalDecision),
 				modelIterations,
 			)
-			finalResult, finalDeltas, finalErr := service.generateFinalOutput(
-				loopCtx,
-				request,
-				observer,
-				output,
-			)
-			if finalErr != nil {
-				return TextResult{}, nil, finalErr
-			}
-			modelIterations++
 			service.logRunCompleted(
 				run,
 				finalDecision,
 				modelIterations,
 				toolCalls,
 				startedAt,
-				finalResult.Content,
+				domainCompletion.Content,
 			)
-			return finalResult, finalDeltas, nil
+			return domainCompletion, nil, nil
 		}
 	}
 }
@@ -1112,7 +1129,7 @@ func (service *Service) executeToolCall(
 	actor requestcontext.Actor,
 	run Run,
 	call ModelToolCall,
-) (TextMessage, ToolCallStatus, capability.TurnOutcome, error) {
+) (TextMessage, ToolCallStatus, capability.TurnOutcome, string, error) {
 	toolCtx, cancel := context.WithTimeout(ctx, service.loopLimits.ToolTimeout)
 	defer cancel()
 	effect := service.registry.InvocationEffect(capability.Invocation{
@@ -1127,7 +1144,7 @@ func (service *Service) executeToolCall(
 		call.ID,
 		requestID,
 	); err != nil {
-		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, err
+		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, "", err
 	}
 	result, err := service.executor.Execute(
 		toolCtx,
@@ -1153,10 +1170,10 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			capability.ErrorCategory(err),
 		); persistErr != nil {
-			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, persistErr
+			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, "", persistErr
 		}
 		// 工具自身失败属于模型可处理结果，回填稳定分类后让模型决定重试、换工具或解释。
-		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, "", nil
 	}
 	content, err := marshalToolResult(result, service.loopLimits.MaxToolResultBytes)
 	if err != nil {
@@ -1171,9 +1188,9 @@ func (service *Service) executeToolCall(
 			ToolCallFailed,
 			"internal",
 		); persistErr != nil {
-			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, persistErr
+			return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, "", persistErr
 		}
-		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, nil
+		return toolFailureMessage(call.ID, err), ToolCallFailed, capability.TurnOutcomeContinue, "", nil
 	}
 	persistCtx, persistCancel := runPersistenceContext(ctx)
 	defer persistCancel()
@@ -1187,13 +1204,13 @@ func (service *Service) executeToolCall(
 		toolSourceRefs(result.SourceRefs),
 		result.ClientActions,
 	); err != nil {
-		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, err
+		return TextMessage{}, ToolCallFailed, capability.TurnOutcomeContinue, "", err
 	}
 	return TextMessage{
 		Role:       TextRoleTool,
 		Content:    content,
 		ToolCallID: call.ID,
-	}, ToolCallSucceeded, result.TurnOutcome, nil
+	}, ToolCallSucceeded, result.TurnOutcome, result.AssistantText, nil
 }
 
 func (service *Service) saveToolCallProposed(
@@ -1507,6 +1524,18 @@ func classifyRunFailure(err error) (string, bool) {
 }
 
 func validFinalTextResult(result TextResult) bool {
+	if result.CompletionSource == CompletionSourceDomain {
+		return conversation.ValidMessageContent(result.Content) &&
+			ValidOpaqueID(result.DomainToolCallID) &&
+			ValidOpaqueID(result.DomainToolName) &&
+			result.ID == "" && result.Provider == "" && result.Model == "" &&
+			result.FinishReason == "" && result.Usage == (TokenUsage{}) &&
+			len(result.ToolCalls) == 0
+	}
+	if result.CompletionSource != "" &&
+		result.CompletionSource != CompletionSourceModel {
+		return false
+	}
 	return ValidOpaqueID(result.ID) &&
 		ValidProviderID(result.Provider) &&
 		ValidModelID(result.Model) &&

--- a/server/internal/coaching/preparation/agentcapability/preview.go
+++ b/server/internal/coaching/preparation/agentcapability/preview.go
@@ -48,6 +48,7 @@ type PreviewResult struct {
 	Replayed              bool
 	ClientAction          agentclientaction.Action
 	SourceRefs            []capability.SourceRef
+	AssistantText         string
 }
 
 type PreviewPort interface {
@@ -175,5 +176,6 @@ func previewToolResult(preview PreviewResult) capability.Result {
 		SourceRefs:    preview.SourceRefs,
 		ClientActions: clientActions,
 		TurnOutcome:   turnOutcome,
+		AssistantText: preview.AssistantText,
 	}
 }

--- a/server/internal/coaching/preparation/agentcapability/service_port.go
+++ b/server/internal/coaching/preparation/agentcapability/service_port.go
@@ -112,6 +112,8 @@ func (port *ServicePort) PreviewPractice(
 		Status:       "preview_ready",
 		Replayed:     replayed,
 		ClientAction: clientAction,
+		AssistantText: "已为您准备好“" + plan.SceneSelection.Scene.Name +
+			"”练习，请确认开始。",
 		SourceRefs: []capability.SourceRef{
 			{Type: "practice_plan", ID: plan.ID},
 		},

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -34,7 +34,7 @@ var cleanBaselineTables = []string{
 	"users",
 }
 
-func TestCleanBaselineFreshUpDownUp(t *testing.T) {
+func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 	config, admin, schema := isolatedMigrationConfig(t)
 	runner, err := openConfig(config)
 	if err != nil {
@@ -54,7 +54,13 @@ func TestCleanBaselineFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
-		t.Fatalf("DownOne = %t, %v", changed, err)
+		t.Fatalf("DownOne to baseline = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
+		t.Fatalf("DownOne to empty = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, 0)
 

--- a/server/migrations/000002_agent_run_domain_completion.down.sql
+++ b/server/migrations/000002_agent_run_domain_completion.down.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+ALTER TABLE agent_runs
+    DROP CONSTRAINT agent_runs_state_check,
+    DROP CONSTRAINT agent_runs_domain_result_check,
+    DROP COLUMN domain_result,
+    ADD CONSTRAINT agent_runs_state_check CHECK (
+        (
+            status = 'pending' AND phase = 'queued'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NULL AND completed_at IS NULL
+            AND model_result IS NULL AND usage IS NULL AND error IS NULL
+        ) OR (
+            status = 'running' AND phase IN ('context', 'model', 'tool')
+            AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL
+            AND started_at IS NOT NULL AND completed_at IS NULL
+            AND model_result IS NULL AND usage IS NULL AND error IS NULL
+        ) OR (
+            status = 'completed' AND phase = 'completed'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NOT NULL AND completed_at IS NOT NULL
+            AND model_result IS NOT NULL AND usage IS NOT NULL AND error IS NULL
+        ) OR (
+            status = 'failed' AND phase = 'failed'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NOT NULL AND completed_at IS NOT NULL
+            AND model_result IS NULL AND usage IS NULL AND error IS NOT NULL
+        )
+    );
+
+COMMIT;

--- a/server/migrations/000002_agent_run_domain_completion.up.sql
+++ b/server/migrations/000002_agent_run_domain_completion.up.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+ALTER TABLE agent_runs
+    DROP CONSTRAINT agent_runs_state_check,
+    ADD COLUMN domain_result jsonb,
+    ADD CONSTRAINT agent_runs_domain_result_check CHECK (
+        domain_result IS NULL OR (
+            jsonb_typeof(domain_result) = 'object'
+            AND domain_result ?& ARRAY['tool_call_id', 'tool_name']
+            AND domain_result - ARRAY['tool_call_id', 'tool_name'] = '{}'::jsonb
+            AND domain_result->>'tool_call_id' ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+            AND domain_result->>'tool_name' ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+        )
+    ),
+    ADD CONSTRAINT agent_runs_state_check CHECK (
+        (
+            status = 'pending' AND phase = 'queued'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NULL AND completed_at IS NULL
+            AND model_result IS NULL AND usage IS NULL
+            AND domain_result IS NULL AND error IS NULL
+        ) OR (
+            status = 'running' AND phase IN ('context', 'model', 'tool')
+            AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL
+            AND started_at IS NOT NULL AND completed_at IS NULL
+            AND model_result IS NULL AND usage IS NULL
+            AND domain_result IS NULL AND error IS NULL
+        ) OR (
+            status = 'completed' AND phase = 'completed'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NOT NULL AND completed_at IS NOT NULL
+            AND (
+                (model_result IS NOT NULL AND usage IS NOT NULL AND domain_result IS NULL)
+                OR
+                (model_result IS NULL AND usage IS NULL AND domain_result IS NOT NULL)
+            )
+            AND error IS NULL
+        ) OR (
+            status = 'failed' AND phase = 'failed'
+            AND lease_token IS NULL AND lease_expires_at IS NULL
+            AND started_at IS NOT NULL AND completed_at IS NOT NULL
+            AND model_result IS NULL AND usage IS NULL
+            AND domain_result IS NULL AND error IS NOT NULL
+        )
+    );
+
+COMMIT;

--- a/server/migrations/embed.go
+++ b/server/migrations/embed.go
@@ -1,10 +1,10 @@
-// Package migrations exposes the clean database baseline as an embedded
+// Package migrations exposes the append-only database history as an embedded
 // filesystem.
 package migrations
 
 import "embed"
 
-// Files contains the only executable migration pair.
+// Files contains every reviewed migration pair.
 //
-//go:embed 000001_clean_baseline.*.sql
+//go:embed *.sql
 var Files embed.FS

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -28,7 +28,7 @@ var applicationTables = []string{
 	"users",
 }
 
-func TestCleanBaselineIsTheOnlyEmbeddedMigrationPair(t *testing.T) {
+func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 	files, err := fs.Glob(Files, "*.sql")
 	if err != nil {
 		t.Fatal(err)
@@ -36,6 +36,8 @@ func TestCleanBaselineIsTheOnlyEmbeddedMigrationPair(t *testing.T) {
 	want := []string{
 		"000001_clean_baseline.down.sql",
 		"000001_clean_baseline.up.sql",
+		"000002_agent_run_domain_completion.down.sql",
+		"000002_agent_run_domain_completion.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -43,10 +45,12 @@ func TestCleanBaselineIsTheOnlyEmbeddedMigrationPair(t *testing.T) {
 	}
 }
 
-func TestCleanBaselineIsTransactional(t *testing.T) {
+func TestMigrationsAreTransactional(t *testing.T) {
 	for _, name := range []string{
 		"000001_clean_baseline.up.sql",
 		"000001_clean_baseline.down.sql",
+		"000002_agent_run_domain_completion.up.sql",
+		"000002_agent_run_domain_completion.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {

--- a/server/test/agent/benchmark/server.go
+++ b/server/test/agent/benchmark/server.go
@@ -151,8 +151,9 @@ func (benchmarkPreviewPort) PreviewPractice(
 		return preparationcapability.PreviewResult{}, err
 	}
 	return preparationcapability.PreviewResult{
-		Status:       "preview_ready",
-		ClientAction: action,
+		Status:        "preview_ready",
+		ClientAction:  action,
+		AssistantText: "练习已准备好，请确认开始。",
 	}, nil
 }
 

--- a/server/test/agent/postgres/run_core_integration_test.go
+++ b/server/test/agent/postgres/run_core_integration_test.go
@@ -246,7 +246,7 @@ VALUES ($1, $2, 0)`, submission.UserMessage.ID, imageID); err != nil {
 }
 
 func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
-	for _, terminal := range []string{"complete", "fail", "recover"} {
+	for _, terminal := range []string{"complete", "domain-complete", "fail", "recover"} {
 		t.Run(terminal, func(t *testing.T) {
 			database := newAgentTestDatabase(t)
 			service, _, repositories := newAgentRunServices(
@@ -296,7 +296,7 @@ func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
 
 			expectedActions := 0
 			switch terminal {
-			case "complete":
+			case "complete", "domain-complete":
 				if _, err := repositories.run.StartToolCall(
 					ctx, actor.UserID, claimed.ID, claimed.WorkerLeaseToken,
 					toolCallID, "provider-request-secret",
@@ -326,6 +326,15 @@ func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
 				if err != nil {
 					t.Fatalf("allocate Assistant Message ID: %v", err)
 				}
+				completion := successfulTextResult()
+				if terminal == "domain-complete" {
+					completion = agentrun.TextResult{
+						CompletionSource: agentrun.CompletionSourceDomain,
+						Content:          "Terminal projection completed.",
+						DomainToolCallID: toolCallID,
+						DomainToolName:   "review.search.v2",
+					}
+				}
 				completed, err := repositories.run.Complete(
 					ctx,
 					actor.UserID,
@@ -335,7 +344,7 @@ func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
 						ID: assistantMessageID, RunID: claimed.ID,
 						Content: "Terminal projection completed.",
 					},
-					successfulTextResult(),
+					completion,
 				)
 				if err != nil {
 					t.Fatalf("complete Run: %v", err)
@@ -346,6 +355,12 @@ func TestTerminalRunTransitionsCompactExecutionScratchData(t *testing.T) {
 						completed.AssistantMessageID,
 						assistantMessageID,
 					)
+				}
+				if terminal == "domain-complete" &&
+					(completed.CompletionSource != agentrun.CompletionSourceDomain ||
+						completed.DomainToolCallID != toolCallID ||
+						completed.DomainToolName != "review.search.v2") {
+					t.Fatalf("domain completion = %#v", completed)
 				}
 				expectedActions = 1
 			case "fail":

--- a/server/test/agent/routing/tool_registry.go
+++ b/server/test/agent/routing/tool_registry.go
@@ -36,7 +36,8 @@ func (routingPorts) PreviewPractice(
 		return preparationcapability.PreviewResult{}, err
 	}
 	return preparationcapability.PreviewResult{
-		Status:       "preview_ready",
-		ClientAction: action,
+		Status:        "preview_ready",
+		ClientAction:  action,
+		AssistantText: "练习已准备好，请确认开始。",
 	}, nil
 }


### PR DESCRIPTION
## 功能描述

- 将领域工具完成升级为正式的 Run 完成来源。
- `practice.preview.v1` 创建方案后直接提交规范助手文本和练习卡，不再等待第二次模型回复。
- HTTP 与移动端协议显式区分 `model` 和 `domain` 两种完成类型。
- 新增 PostgreSQL 迁移，互斥约束模型完成元数据与领域完成元数据。

## 实现思路

- 完成型 Capability 必须提供经过校验的规范助手文本。
- Agent Loop 遇到首个完成型结果后停止执行同批次后续工具，并返回领域完成结果。
- Run 在数据库提交成功后再向流式客户端交付规范文本，客户端断开不会使已完成领域结果回滚。
- 普通对话继续使用原有模型完成路径，两种结果在持久化和 wire contract 中严格区分。

## 可复现测试

- `make check-go`
- `make check-flutter`
- `make check-api`
- 使用真实 PostgreSQL、真实 OSS、真实后端和 iOS Simulator 输入：`职场会议意见分歧，直接帮我创建，不要询问轮数。`
- 真实 Run `afe591d0-4ff0-40fc-a962-603a1a2e0451` 成功完成：`domain_turn_completed` 后直接 `agent.run.completed`，没有第二次最终模型请求、`unknown tool` 或自动重试。

## 关联 Issue

Closes #736

> 空候选与重复预览导致的延迟和预算耗尽由 #733 独立处理。
