### PR TITLE
fix(mobile,server): 恢复模拟面试卡片长按删除

### DIFF
--- a/api/modules/preparation.yaml
+++ b/api/modules/preparation.yaml
@@ -168,6 +168,25 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+    delete:
+      tags: [Preparation]
+      summary: Archive a practice card
+      description: |
+        Removes an actor-owned ready practice card from current listings and
+        prevents new sessions from starting from it. Existing sessions and
+        their review history remain available.
+      operationId: archivePracticePlan
+      parameters:
+        - $ref: '#/components/parameters/PracticePlanId'
+      responses:
+        '204':
+          description: The practice card was archived.
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/practice-plans/{practice_plan_id}/confirm:
     post:
       tags: [Preparation]
@@ -699,7 +718,7 @@ components:
           minimum: 1
         practice_plan_status:
           type: string
-          enum: [draft, ready]
+          enum: [draft, ready, archived]
         created_at:
           type: string
           format: date-time

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -492,6 +492,9 @@ const me = requireOperation('GET /v1/me');
 const getProfile = requireOperation('GET /v1/me/profile');
 const updateProfile = requireOperation('PATCH /v1/me/profile');
 const createPracticePlan = requireOperation('POST /v1/practice-plans');
+const archivePracticePlan = requireOperation(
+  'DELETE /v1/practice-plans/{practice_plan_id}',
+);
 
 assert.equal(register.operationId, 'registerUser');
 assert.equal(login.operationId, 'loginUser');
@@ -500,6 +503,7 @@ assert.equal(me.operationId, 'getCurrentUser');
 assert.equal(getProfile.operationId, 'getCurrentUserProfile');
 assert.equal(updateProfile.operationId, 'updateCurrentUserProfile');
 assert.equal(createPracticePlan.operationId, 'createPracticePlan');
+assert.equal(archivePracticePlan.operationId, 'archivePracticePlan');
 assert.ok(register.requestBody?.required);
 assert.ok(login.requestBody?.required);
 assert.ok(createPracticePlan.requestBody?.required);
@@ -520,6 +524,13 @@ assert.deepEqual(
   bearerSecurity,
   'Preparation Plan creation must resolve its Actor from BearerSession.',
 );
+assert.deepEqual(
+  archivePracticePlan.security ?? openApi.security,
+  bearerSecurity,
+  'Preparation Plan archival must resolve its Actor from BearerSession.',
+);
+assert.ok(archivePracticePlan.responses?.['204']);
+assert.ok(archivePracticePlan.responses?.['404']);
 assert.ok(register.responses?.['201']);
 assert.ok(register.responses?.['409']);
 assert.ok(register.responses?.['429']);
@@ -667,7 +678,7 @@ assert.equal(
 );
 assert.deepEqual(
   practicePlanSchema?.properties?.practice_plan_status?.enum,
-  ['draft', 'ready'],
+  ['draft', 'ready', 'archived'],
 );
 assert.equal(
   practicePlanSchema?.properties?.ielts_assignment?.$ref,

--- a/mobile/lib/features/coaching/interview/interview_catalog.dart
+++ b/mobile/lib/features/coaching/interview/interview_catalog.dart
@@ -8,6 +8,7 @@ class InterviewCatalog extends StatelessWidget {
     required this.loading,
     required this.onCreatePressed,
     required this.onPlanPressed,
+    required this.onPlanDeleted,
     required this.onRetry,
     this.errorMessage,
     super.key,
@@ -18,6 +19,7 @@ class InterviewCatalog extends StatelessWidget {
   final String? errorMessage;
   final VoidCallback? onCreatePressed;
   final ValueChanged<PracticePlanSummary> onPlanPressed;
+  final ValueChanged<PracticePlanSummary> onPlanDeleted;
   final VoidCallback onRetry;
 
   @override
@@ -36,6 +38,7 @@ class InterviewCatalog extends StatelessWidget {
             _PlanCard(
               plan: plans[index],
               onPressed: () => onPlanPressed(plans[index]),
+              onDelete: () => _confirmDelete(context, plans[index]),
             ),
             if (index != plans.length - 1) const SizedBox(height: 12),
           ],
@@ -46,6 +49,33 @@ class InterviewCatalog extends StatelessWidget {
         ],
       ],
     );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    PracticePlanSummary plan,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('删除模拟面试？'),
+        content: const Text('该面试将从列表移除，已产生的练习和复盘会保留。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            key: const Key('confirm-delete-interview-plan'),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && context.mounted) {
+      onPlanDeleted(plan);
+    }
   }
 }
 
@@ -71,127 +101,141 @@ class InterviewCatalogCreateButton extends StatelessWidget {
 }
 
 class _PlanCard extends StatelessWidget {
-  const _PlanCard({required this.plan, required this.onPressed});
+  const _PlanCard({
+    required this.plan,
+    required this.onPressed,
+    required this.onDelete,
+  });
 
   final PracticePlanSummary plan;
   final VoidCallback onPressed;
+  final VoidCallback onDelete;
 
   @override
   Widget build(BuildContext context) {
     final minutes = (plan.suggestedDurationSeconds / 60).ceil();
     final title = plan.jobTitle.isEmpty ? plan.sceneName : plan.jobTitle;
-    return Card(
-      key: Key('interview-plan-${plan.id}'),
-      margin: EdgeInsets.zero,
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onPressed,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: Image.asset(
-                'assets/images/scenes/interview-plan-card-v2.webp',
-                key: Key('interview-plan-cover-${plan.id}'),
-                fit: BoxFit.cover,
-                excludeFromSemantics: true,
+    return Semantics(
+      button: true,
+      label: '模拟面试：$title',
+      hint: '长按删除模拟面试',
+      onTap: onPressed,
+      onLongPress: onDelete,
+      excludeSemantics: true,
+      child: Card(
+        key: Key('interview-plan-${plan.id}'),
+        margin: EdgeInsets.zero,
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onPressed,
+          onLongPress: onDelete,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: Image.asset(
+                  'assets/images/scenes/interview-plan-card-v2.webp',
+                  key: Key('interview-plan-cover-${plan.id}'),
+                  fit: BoxFit.cover,
+                  excludeFromSemantics: true,
+                ),
               ),
-            ),
-            const Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      Color(0x18000000),
-                      Color(0x66000000),
-                      Color(0xD6000000),
-                    ],
-                    stops: [0, 0.46, 1],
+              const Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        Color(0x18000000),
+                        Color(0x66000000),
+                        Color(0xD6000000),
+                      ],
+                      stops: [0, 0.46, 1],
+                    ),
                   ),
                 ),
               ),
-            ),
-            ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 164),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 14, 10, 14),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Expanded(flex: 4, child: SizedBox.shrink()),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      flex: 6,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 9,
-                                vertical: 4,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.16),
-                                borderRadius: BorderRadius.circular(999),
-                              ),
-                              child: Text(
-                                '模拟面试',
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: PreparationDesign.meta.copyWith(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w700,
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 164),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 14, 10, 14),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Expanded(flex: 4, child: SizedBox.shrink()),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        flex: 6,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 9,
+                                  vertical: 4,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.white.withValues(alpha: 0.16),
+                                  borderRadius: BorderRadius.circular(999),
+                                ),
+                                child: Text(
+                                  '模拟面试',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: PreparationDesign.meta.copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w700,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                          const SizedBox(height: 6),
-                          Text(
-                            title,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.titleMedium
-                                ?.copyWith(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w800,
-                                  height: 1.1,
-                                ),
-                          ),
-                          const SizedBox(height: 6),
-                          Text(
-                            plan.practiceScope,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: PreparationDesign.body.copyWith(
-                              color: Colors.white70,
+                            const SizedBox(height: 6),
+                            Text(
+                              title,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w800,
+                                    height: 1.1,
+                                  ),
                             ),
-                          ),
-                          const SizedBox(height: 10),
-                          Wrap(
-                            spacing: 14,
-                            runSpacing: 8,
-                            children: [
-                              _PlanMeta(
-                                icon: Icons.schedule_rounded,
-                                label: '约 $minutes 分钟',
+                            const SizedBox(height: 6),
+                            Text(
+                              plan.practiceScope,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: PreparationDesign.body.copyWith(
+                                color: Colors.white70,
                               ),
-                              _PlanMeta(
-                                icon: Icons.repeat_rounded,
-                                label: plan.maxEffectiveTurns == 0
-                                    ? '开放轮次'
-                                    : '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
-                              ),
-                            ],
-                          ),
-                        ],
+                            ),
+                            const SizedBox(height: 10),
+                            Wrap(
+                              spacing: 14,
+                              runSpacing: 8,
+                              children: [
+                                _PlanMeta(
+                                  icon: Icons.schedule_rounded,
+                                  label: '约 $minutes 分钟',
+                                ),
+                                _PlanMeta(
+                                  icon: Icons.repeat_rounded,
+                                  label: plan.maxEffectiveTurns == 0
+                                      ? '开放轮次'
+                                      : '${plan.minEffectiveTurns}–${plan.maxEffectiveTurns} 轮',
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/coaching/interview/job_preparation_client.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_client.dart
@@ -40,6 +40,8 @@ abstract interface class JobPreparationClient implements PreparationClient {
     required PracticeExperience experience,
   });
 
+  Future<void> deletePlan(String planId);
+
   Future<PreparationPracticeBootstrap> createSession({
     required PracticePlan plan,
     required CreatePreparationSessionInput input,

--- a/mobile/lib/features/coaching/interview/job_preparation_controller.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_controller.dart
@@ -111,6 +111,32 @@ final class JobPreparationController extends ChangeNotifier {
     }
   }
 
+  Future<bool> deleteInterviewPlan(String planId) async {
+    if (_disposed || _plansLoading || !_validUUID(planId)) return false;
+    _plansLoading = true;
+    _plansErrorMessage = null;
+    final requestEpoch = ++_planListEpoch;
+    notifyListeners();
+    try {
+      await client.deletePlan(planId);
+      if (_disposed || requestEpoch != _planListEpoch) return false;
+      _interviewPlans = _interviewPlans
+          .where((plan) => plan.id != planId)
+          .toList(growable: false);
+      return true;
+    } on Object {
+      if (!_disposed && requestEpoch == _planListEpoch) {
+        _plansErrorMessage = '暂时无法删除这场模拟面试，请稍后重试。';
+      }
+      return false;
+    } finally {
+      if (!_disposed && requestEpoch == _planListEpoch) {
+        _plansLoading = false;
+        notifyListeners();
+      }
+    }
+  }
+
   void beginNewPreparation() {
     if (_disposed || isBusy) return;
     _epoch++;

--- a/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
+++ b/mobile/lib/features/coaching/interview/wire_job_preparation_client.dart
@@ -315,6 +315,17 @@ final class WireJobPreparationClient implements JobPreparationClient {
   }
 
   @override
+  Future<void> deletePlan(String planId) async {
+    _requireAggregateId(planId);
+    await _request(
+      method: 'DELETE',
+      path: '/v1/practice-plans/${Uri.encodeComponent(planId)}',
+      stage: JobPreparationOperationStage.plan,
+      expectedStatus: HttpStatus.noContent,
+    );
+  }
+
+  @override
   Future<PracticePlan> confirmPlan({
     required String planId,
     required int expectedVersion,

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -712,6 +712,9 @@ class _PreparationPageState extends State<PreparationPage> {
             errorMessage: widget.jobPreparationController?.plansErrorMessage,
             onCreatePressed: widget.onOpenJobPreparation,
             onPlanPressed: (plan) => widget.onOpenInterviewPlan?.call(plan.id),
+            onPlanDeleted: (plan) => unawaited(
+              widget.jobPreparationController?.deleteInterviewPlan(plan.id),
+            ),
             onRetry: () => unawaited(
               widget.jobPreparationController?.loadInterviewPlans(force: true),
             ),

--- a/mobile/test/coaching/interview/interview_catalog_test.dart
+++ b/mobile/test/coaching/interview/interview_catalog_test.dart
@@ -6,7 +6,7 @@ import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
 void main() {
-  testWidgets('separates plan content and opens the selected plan', (
+  testWidgets('separates plan content and opens the selected plan on tap', (
     tester,
   ) async {
     PracticePlanSummary? opened;
@@ -32,8 +32,50 @@ void main() {
     await tester.tap(find.byKey(const Key('interview-plan-plan-1')));
     await tester.pump();
     expect(opened, same(plan));
+  });
 
-    expect(find.byKey(const Key('delete-interview-plan-plan-1')), findsNothing);
+  testWidgets('long press confirms deletion without opening the plan', (
+    tester,
+  ) async {
+    PracticePlanSummary? opened;
+    PracticePlanSummary? deleted;
+    final plan = _plan('plan-1');
+
+    await _pumpCatalog(
+      tester,
+      plans: [plan],
+      onPlanPressed: (value) => opened = value,
+      onPlanDeleted: (value) => deleted = value,
+    );
+
+    final card = find.byKey(const Key('interview-plan-plan-1'));
+    expect(
+      tester.getSemantics(card),
+      matchesSemantics(
+        label: '模拟面试：Java Developer',
+        hint: '长按删除模拟面试',
+        isButton: true,
+        hasTapAction: true,
+        hasLongPressAction: true,
+      ),
+    );
+
+    await tester.longPress(card);
+    await tester.pumpAndSettle();
+    expect(find.text('删除模拟面试？'), findsOneWidget);
+    expect(opened, isNull);
+    expect(deleted, isNull);
+
+    await tester.tap(find.text('取消'));
+    await tester.pumpAndSettle();
+    expect(deleted, isNull);
+
+    await tester.longPress(card);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('confirm-delete-interview-plan')));
+    await tester.pumpAndSettle();
+    expect(deleted, same(plan));
+    expect(opened, isNull);
   });
 
   testWidgets('renders loading, error, empty, and multiple plan states', (
@@ -88,7 +130,6 @@ void main() {
       await tester.pumpAndSettle();
       expect(content, findsOneWidget);
     }
-    expect(find.byKey(const Key('delete-interview-plan-plan-1')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 }
@@ -99,6 +140,7 @@ Future<void> _pumpCatalog(
   bool loading = false,
   String? errorMessage,
   ValueChanged<PracticePlanSummary>? onPlanPressed,
+  ValueChanged<PracticePlanSummary>? onPlanDeleted,
   VoidCallback? onRetry,
 }) {
   return tester.pumpWidget(
@@ -113,6 +155,7 @@ Future<void> _pumpCatalog(
             errorMessage: errorMessage,
             onCreatePressed: () {},
             onPlanPressed: onPlanPressed ?? (_) {},
+            onPlanDeleted: onPlanDeleted ?? (_) {},
             onRetry: onRetry ?? () {},
           ),
         ),

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -99,7 +99,64 @@ void main() {
       expect(harness.practice.practicePlanId, contractPlanId);
     },
   );
+
+  test(
+    'deleting a saved interview removes it from the local catalog',
+    () async {
+      final harness = await _Harness.create();
+      addTearDown(harness.dispose);
+      harness.client.plans = <PracticePlanSummary>[_planSummary()];
+
+      await harness.controller.loadInterviewPlans();
+      expect(harness.controller.interviewPlans, hasLength(1));
+
+      expect(
+        await harness.controller.deleteInterviewPlan(contractPlanId),
+        isTrue,
+      );
+      expect(harness.client.deletedPlanIds, <String>[contractPlanId]);
+      expect(harness.controller.interviewPlans, isEmpty);
+      expect(harness.controller.plansErrorMessage, isNull);
+    },
+  );
+
+  test(
+    'failed interview deletion keeps the plan and exposes an error',
+    () async {
+      final harness = await _Harness.create();
+      addTearDown(harness.dispose);
+      harness.client
+        ..plans = <PracticePlanSummary>[_planSummary()]
+        ..deleteFailure = StateError('network unavailable');
+
+      await harness.controller.loadInterviewPlans();
+
+      expect(
+        await harness.controller.deleteInterviewPlan(contractPlanId),
+        isFalse,
+      );
+      expect(harness.controller.interviewPlans, hasLength(1));
+      expect(harness.controller.plansErrorMessage, '暂时无法删除这场模拟面试，请稍后重试。');
+    },
+  );
 }
+
+PracticePlanSummary _planSummary() => PracticePlanSummary(
+  id: contractPlanId,
+  version: 1,
+  status: PracticePlanStatus.ready,
+  experience: PracticeExperience.interview,
+  sceneName: 'Project deep dive',
+  practiceScope: '技术深挖',
+  jobTitle: 'Backend Engineer',
+  practiceObjectives: const <String>['清楚说明技术取舍'],
+  resumeUsed: true,
+  suggestedDurationSeconds: 900,
+  minEffectiveTurns: 1,
+  maxEffectiveTurns: 3,
+  createdAt: DateTime.utc(2026, 8, 15),
+  updatedAt: DateTime.utc(2026, 8, 15),
+);
 
 final class _Harness {
   _Harness._({
@@ -187,6 +244,9 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   final List<CreatePracticePlanInput> planInputs = <CreatePracticePlanInput>[];
   final List<CreatePreparationSessionInput> sessionInputs =
       <CreatePreparationSessionInput>[];
+  List<PracticePlanSummary> plans = <PracticePlanSummary>[];
+  final List<String> deletedPlanIds = <String>[];
+  Object? deleteFailure;
 
   @override
   Future<InterviewPreparation> createInterviewPreparation({
@@ -239,7 +299,13 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   @override
   Future<List<PracticePlanSummary>> listPlans({
     required PracticeExperience experience,
-  }) async => <PracticePlanSummary>[];
+  }) async => plans;
+
+  @override
+  Future<void> deletePlan(String planId) async {
+    deletedPlanIds.add(planId);
+    if (deleteFailure case final failure?) throw failure;
+  }
 
   @override
   Future<InterviewPreparation> getInterviewPreparation(String id) async =>

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -132,6 +132,9 @@ final class _WizardClient implements JobPreparationClient {
   }) async => const <PracticePlanSummary>[];
 
   @override
+  Future<void> deletePlan(String planId) async {}
+
+  @override
   Future<InterviewPreparation> getInterviewPreparation(String id) async =>
       contractInterviewPreparation();
 

--- a/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
@@ -154,6 +154,21 @@ void main() {
     );
     expect(transport.calls, isEmpty);
   });
+
+  test('archives a practice plan with DELETE', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.noContent, const <String, Object?>{}),
+    ]);
+    final client = _client(transport);
+
+    await client.deletePlan(contractPlanId);
+
+    expect(transport.calls.single.method, 'DELETE');
+    expect(
+      transport.calls.single.uri.path,
+      '/v1/practice-plans/$contractPlanId',
+    );
+  });
 }
 
 WireJobPreparationClient _client(IdentityHttpTransport transport) {

--- a/server/internal/coaching/preparation/plan.go
+++ b/server/internal/coaching/preparation/plan.go
@@ -26,8 +26,9 @@ var (
 type PlanStatus string
 
 const (
-	PlanStatusDraft PlanStatus = "draft"
-	PlanStatusReady PlanStatus = "ready"
+	PlanStatusDraft    PlanStatus = "draft"
+	PlanStatusReady    PlanStatus = "ready"
+	PlanStatusArchived PlanStatus = "archived"
 )
 
 type EarlyCompletionRule string
@@ -178,6 +179,7 @@ type PlanRepository interface {
 	CreatePlan(context.Context, requestcontext.Actor, CreatePlanCommand) (PracticePlan, bool, error)
 	ReadCurrentPlan(context.Context, requestcontext.Actor, string) (PracticePlan, error)
 	ListCurrentPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]PracticePlan, error)
+	ArchivePlan(context.Context, requestcontext.Actor, string) error
 	ConfirmPlan(context.Context, requestcontext.Actor, ConfirmPlanCommand) (PracticePlan, bool, error)
 	ReadExecutablePlan(context.Context, requestcontext.Actor, string, int) (PracticePlan, error)
 }

--- a/server/internal/coaching/preparation/repository/postgres/plan.go
+++ b/server/internal/coaching/preparation/repository/postgres/plan.go
@@ -118,7 +118,7 @@ func (r *PostgresPlanRepository) ListCurrentPlans(ctx context.Context, actor req
 	if r == nil || r.pool == nil || ctx == nil || !actor.Valid() {
 		return nil, preparation.ErrPlanInvalid
 	}
-	rows, err := r.pool.Query(ctx, `SELECT `+planColumns+` FROM practice_plans WHERE user_id=$1 AND practice_experience=$2 ORDER BY created_at DESC, plan_id DESC`, actor.UserID, string(experience))
+	rows, err := r.pool.Query(ctx, `SELECT `+planColumns+` FROM practice_plans WHERE user_id=$1 AND practice_experience=$2 AND status<>'archived' ORDER BY created_at DESC, plan_id DESC`, actor.UserID, string(experience))
 	if err != nil {
 		return nil, planDB(err)
 	}
@@ -135,6 +135,20 @@ func (r *PostgresPlanRepository) ListCurrentPlans(ctx context.Context, actor req
 		return nil, planDB(err)
 	}
 	return plans, nil
+}
+
+func (r *PostgresPlanRepository) ArchivePlan(ctx context.Context, actor requestcontext.Actor, planID string) error {
+	if r == nil || r.pool == nil || ctx == nil || !actor.Valid() || !validAggregateID(planID) {
+		return preparation.ErrPlanNotFound
+	}
+	tag, err := r.pool.Exec(ctx, `UPDATE practice_plans SET status='archived', updated_at=transaction_timestamp() WHERE user_id=$1 AND plan_id=$2 AND status='ready'`, actor.UserID, planID)
+	if err != nil {
+		return classifyPlanError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return preparation.ErrPlanNotFound
+	}
+	return nil
 }
 
 func (r *PostgresPlanRepository) ConfirmPlan(ctx context.Context, actor requestcontext.Actor, command preparation.ConfirmPlanCommand) (preparation.PracticePlan, bool, error) {

--- a/server/internal/coaching/preparation/repository/postgres/plan_archive_integration_test.go
+++ b/server/internal/coaching/preparation/repository/postgres/plan_archive_integration_test.go
@@ -1,0 +1,119 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestArchivePlanIsOwnerScopedAndPreservesExistingSessions(t *testing.T) {
+	pool := planArchiveTestDatabase(t)
+	ctx := context.Background()
+	owner := requestcontext.Actor{UserID: "11111111-1111-4111-8111-111111111111", SessionID: "owner-session"}
+	other := requestcontext.Actor{UserID: "22222222-2222-4222-8222-222222222222", SessionID: "other-session"}
+	planID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	sessionID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, canonical_email) VALUES ($1,$2),($3,$4)`, owner.UserID, "plan-owner@example.com", other.UserID, "plan-other@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO practice_plans (
+user_id, plan_id, preparation_snapshot, scene_selection, session_policy,
+practice_objectives, practice_experience, status, initial_client_request_id,
+initial_request_fingerprint)
+VALUES ($1,$2,'{}','{}','{}','[{}]','INTERVIEW','ready','plan-create-1',$3)`, owner.UserID, planID, make([]byte, 32)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO practice_sessions (
+session_id, user_id, plan_id, plan_version, practice_experience,
+scene_category, practice_mode, evaluation_policy_ref, plan_snapshot,
+participants, initial_client_request_id, initial_request_fingerprint)
+VALUES ($1,$2,$3,1,'INTERVIEW','INTERVIEW_PROFESSIONAL','FULL_SIMULATION',
+'test-policy','{}','[{}]','session-create-1',$4)`, sessionID, owner.UserID, planID, make([]byte, 32)); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := NewPostgresPlanRepository(pool)
+	if err := repository.ArchivePlan(ctx, other, planID); !errors.Is(err, preparation.ErrPlanNotFound) {
+		t.Fatalf("foreign archive error=%v", err)
+	}
+	if err := repository.ArchivePlan(ctx, owner, planID); err != nil {
+		t.Fatalf("owner archive: %v", err)
+	}
+	if err := repository.ArchivePlan(ctx, owner, planID); !errors.Is(err, preparation.ErrPlanNotFound) {
+		t.Fatalf("repeat archive error=%v", err)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM practice_plans WHERE plan_id=$1`, planID).Scan(&status); err != nil || status != "archived" {
+		t.Fatalf("status=%q error=%v", status, err)
+	}
+	plans, err := repository.ListCurrentPlans(ctx, owner, scene.PracticeExperience("INTERVIEW"))
+	if err != nil || len(plans) != 0 {
+		t.Fatalf("listed plans=%d error=%v", len(plans), err)
+	}
+	if _, err := repository.ReadExecutablePlan(ctx, owner, planID, 1); !errors.Is(err, preparation.ErrPlanNotFound) {
+		t.Fatalf("executable archived plan error=%v", err)
+	}
+	var sessions int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM practice_sessions WHERE session_id=$1 AND plan_id=$2`, sessionID, planID).Scan(&sessions); err != nil || sessions != 1 {
+		t.Fatalf("preserved sessions=%d error=%v", sessions, err)
+	}
+}
+
+func planArchiveTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if raw == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, raw)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		t.Fatal(err)
+	}
+	schemaName := "preparation_archive_" + hex.EncodeToString(suffix[:])
+	identifier := pgx.Identifier{schemaName}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+identifier); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	config, err := pgxpool.ParseConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = identifier
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE")
+		admin.Close()
+	})
+	baseline, err := migrations.Files.ReadFile("000001_clean_baseline.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(baseline)); err != nil {
+		t.Fatalf("apply clean baseline: %v", err)
+	}
+	return pool
+}

--- a/server/internal/coaching/preparation/repository/postgres/plan_archive_integration_test.go
+++ b/server/internal/coaching/preparation/repository/postgres/plan_archive_integration_test.go
@@ -115,5 +115,19 @@ func planArchiveTestDatabase(t *testing.T) *pgxpool.Pool {
 	if _, err := pool.Exec(ctx, string(baseline)); err != nil {
 		t.Fatalf("apply clean baseline: %v", err)
 	}
+	domainCompletionMigration, err := migrations.Files.ReadFile("000002_agent_run_domain_completion.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(domainCompletionMigration)); err != nil {
+		t.Fatalf("apply Agent domain completion migration: %v", err)
+	}
+	archiveMigration, err := migrations.Files.ReadFile("000003_archive_practice_plans.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(archiveMigration)); err != nil {
+		t.Fatalf("apply practice plan archive migration: %v", err)
+	}
 	return pool
 }

--- a/server/internal/coaching/preparation/service/plan.go
+++ b/server/internal/coaching/preparation/service/plan.go
@@ -148,6 +148,13 @@ func (s *PlanService) ListPlans(ctx context.Context, actor requestcontext.Actor,
 	return result, nil
 }
 
+func (s *PlanService) ArchivePlan(ctx context.Context, actor requestcontext.Actor, id string) error {
+	if ctx == nil || !actor.Valid() || !validPlanAggregateID(id) {
+		return preparation.ErrPlanNotFound
+	}
+	return s.repository.ArchivePlan(ctx, actor, id)
+}
+
 func (s *PlanService) ConfirmPlan(ctx context.Context, actor requestcontext.Actor, id, clientRequestID string, request preparation.ConfirmPlanRequest) (preparation.PracticePlan, bool, error) {
 	if ctx == nil || !actor.Valid() || !validPlanAggregateID(id) || !validIdempotencyKey(clientRequestID) || request.ExpectedVersion < 1 {
 		return preparation.PracticePlan{}, false, preparation.ErrPlanInvalid
@@ -784,7 +791,7 @@ func validReturnedPlan(
 		return false
 	}
 	if plan.Version < 1 ||
-		(plan.Status != preparation.PlanStatusReady && plan.Status != preparation.PlanStatusDraft) ||
+		(plan.Status != preparation.PlanStatusReady && plan.Status != preparation.PlanStatusDraft && plan.Status != preparation.PlanStatusArchived) ||
 		(plan.SourceThreadID != "" &&
 			!validPlanAggregateID(plan.SourceThreadID)) ||
 		plan.CreatedAt.IsZero() || plan.UpdatedAt.Before(plan.CreatedAt) ||

--- a/server/internal/coaching/preparation/service/plan_archive_test.go
+++ b/server/internal/coaching/preparation/service/plan_archive_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type archivePlanRepository struct {
+	actor requestcontext.Actor
+	id    string
+	err   error
+}
+
+func (*archivePlanRepository) CreatePlan(context.Context, requestcontext.Actor, preparation.CreatePlanCommand) (preparation.PracticePlan, bool, error) {
+	return preparation.PracticePlan{}, false, nil
+}
+
+func (*archivePlanRepository) ReadCurrentPlan(context.Context, requestcontext.Actor, string) (preparation.PracticePlan, error) {
+	return preparation.PracticePlan{}, nil
+}
+
+func (*archivePlanRepository) ListCurrentPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]preparation.PracticePlan, error) {
+	return nil, nil
+}
+
+func (repository *archivePlanRepository) ArchivePlan(_ context.Context, actor requestcontext.Actor, id string) error {
+	repository.actor = actor
+	repository.id = id
+	return repository.err
+}
+
+func (*archivePlanRepository) ConfirmPlan(context.Context, requestcontext.Actor, preparation.ConfirmPlanCommand) (preparation.PracticePlan, bool, error) {
+	return preparation.PracticePlan{}, false, nil
+}
+
+func (*archivePlanRepository) ReadExecutablePlan(context.Context, requestcontext.Actor, string, int) (preparation.PracticePlan, error) {
+	return preparation.PracticePlan{}, nil
+}
+
+func TestArchivePlanDelegatesOwnedAggregate(t *testing.T) {
+	repository := &archivePlanRepository{}
+	service := &PlanService{repository: repository}
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	id := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+	if err := service.ArchivePlan(context.Background(), actor, id); err != nil {
+		t.Fatal(err)
+	}
+	if repository.actor != actor || repository.id != id {
+		t.Fatalf("archive actor=%#v id=%q", repository.actor, repository.id)
+	}
+}
+
+func TestArchivePlanRejectsInvalidIdentityOrIDAsNotFound(t *testing.T) {
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		actor requestcontext.Actor
+		id    string
+	}{
+		{"nil context", nil, requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},
+		{"invalid actor", context.Background(), requestcontext.Actor{}, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},
+		{"invalid id", context.Background(), requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}, "not-an-id"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repository := &archivePlanRepository{}
+			service := &PlanService{repository: repository}
+			if err := service.ArchivePlan(test.ctx, test.actor, test.id); !errors.Is(err, preparation.ErrPlanNotFound) {
+				t.Fatalf("error=%v", err)
+			}
+			if repository.id != "" {
+				t.Fatalf("repository unexpectedly called with %q", repository.id)
+			}
+		})
+	}
+}
+
+func TestArchivePlanPreservesRepositoryNotFound(t *testing.T) {
+	repository := &archivePlanRepository{err: preparation.ErrPlanNotFound}
+	service := &PlanService{repository: repository}
+	actor := requestcontext.Actor{UserID: "user-1", SessionID: "session-1"}
+	if err := service.ArchivePlan(context.Background(), actor, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"); !errors.Is(err, preparation.ErrPlanNotFound) {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/server/internal/coaching/preparation/transport/http/plan_archive_handler_test.go
+++ b/server/internal/coaching/preparation/transport/http/plan_archive_handler_test.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+const archivePlanID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+type archivePlanApplication struct {
+	archiveActor requestcontext.Actor
+	archiveID    string
+	archiveErr   error
+}
+
+func (*archivePlanApplication) ListPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]PracticePlanSummary, error) {
+	return nil, nil
+}
+
+func (*archivePlanApplication) CreatePlan(context.Context, requestcontext.Actor, string, CreatePlanRequest) (PracticePlan, bool, error) {
+	return PracticePlan{}, false, nil
+}
+
+func (*archivePlanApplication) ReadPlan(context.Context, requestcontext.Actor, string) (PracticePlan, error) {
+	return PracticePlan{}, nil
+}
+
+func (application *archivePlanApplication) ArchivePlan(_ context.Context, actor requestcontext.Actor, id string) error {
+	application.archiveActor = actor
+	application.archiveID = id
+	return application.archiveErr
+}
+
+func (*archivePlanApplication) ConfirmPlan(context.Context, requestcontext.Actor, string, string, ConfirmPlanRequest) (PracticePlan, bool, error) {
+	return PracticePlan{}, false, nil
+}
+
+func TestArchivePlanRouteReturnsNoContent(t *testing.T) {
+	application := &archivePlanApplication{}
+	response := performArchivePlanRequest(t, application, archivePlanID)
+
+	if response.Code != http.StatusNoContent || response.Body.Len() != 0 {
+		t.Fatalf("response status=%d body=%q", response.Code, response.Body.String())
+	}
+	if application.archiveActor.UserID != "11111111-1111-4111-8111-111111111111" || application.archiveID != archivePlanID {
+		t.Fatalf("archive actor=%#v id=%q", application.archiveActor, application.archiveID)
+	}
+	if response.Header().Get("Cache-Control") != "no-store" || response.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("cache headers=%v", response.Header())
+	}
+}
+
+func TestArchivePlanRouteHidesMissingOrForeignPlans(t *testing.T) {
+	application := &archivePlanApplication{archiveErr: ErrPlanNotFound}
+	response := performArchivePlanRequest(t, application, archivePlanID)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+}
+
+func TestArchivePlanRouteRejectsMalformedIDWithoutCallingApplication(t *testing.T) {
+	application := &archivePlanApplication{}
+	response := performArchivePlanRequest(t, application, strings.Repeat("a", 129))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+	if application.archiveID != "" {
+		t.Fatalf("application unexpectedly called with %q", application.archiveID)
+	}
+}
+
+func performArchivePlanRequest(t *testing.T, application *archivePlanApplication, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler, err := NewPlanHTTPHandler(application)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		actor := requestcontext.Actor{UserID: "11111111-1111-4111-8111-111111111111", SessionID: "test-session"}
+		c.Request = c.Request.WithContext(requestcontext.WithActor(c.Request.Context(), actor))
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodDelete, "/v1/practice-plans/"+id, nil))
+	return response
+}

--- a/server/internal/coaching/preparation/transport/http/plan_handler.go
+++ b/server/internal/coaching/preparation/transport/http/plan_handler.go
@@ -14,6 +14,7 @@ type PlanHTTPApplication interface {
 	ListPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]PracticePlanSummary, error)
 	CreatePlan(context.Context, requestcontext.Actor, string, CreatePlanRequest) (PracticePlan, bool, error)
 	ReadPlan(context.Context, requestcontext.Actor, string) (PracticePlan, error)
+	ArchivePlan(context.Context, requestcontext.Actor, string) error
 	ConfirmPlan(context.Context, requestcontext.Actor, string, string, ConfirmPlanRequest) (PracticePlan, bool, error)
 }
 
@@ -30,6 +31,7 @@ func (h *PlanHTTPHandler) RegisterRoutes(routes gin.IRoutes) {
 	routes.GET("/v1/practice-plans", h.list)
 	routes.POST("/v1/practice-plans", h.create)
 	routes.GET("/v1/practice-plans/:practice_plan_id", h.read)
+	routes.DELETE("/v1/practice-plans/:practice_plan_id", h.archive)
 	routes.POST("/v1/practice-plans/:practice_plan_id/confirm", h.confirm)
 }
 
@@ -93,6 +95,24 @@ func (h *PlanHTTPHandler) read(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, plan)
+}
+
+func (h *PlanHTTPHandler) archive(c *gin.Context) {
+	setPrivateHeaders(c)
+	actor, ok := actorFromContext(c)
+	if !ok {
+		return
+	}
+	id := c.Param("practice_plan_id")
+	if !validPlanResourceID(id) {
+		writePlanError(c, http.StatusNotFound, "practice_plan_not_found")
+		return
+	}
+	if err := h.application.ArchivePlan(c.Request.Context(), actor, id); err != nil {
+		writePlanServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 func (h *PlanHTTPHandler) confirm(c *gin.Context) {

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -54,6 +54,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to Agent domain completion = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to baseline = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))

--- a/server/migrations/000001_clean_baseline.up.sql
+++ b/server/migrations/000001_clean_baseline.up.sql
@@ -640,7 +640,7 @@ CREATE TABLE practice_plans (
         FOREIGN KEY (source_thread_id, user_id)
         REFERENCES agent_threads (id, user_id)
         ON DELETE SET NULL (source_thread_id),
-    CONSTRAINT practice_plans_status_check CHECK (status IN ('draft', 'ready')),
+    CONSTRAINT practice_plans_status_check CHECK (status IN ('draft', 'ready', 'archived')),
     CONSTRAINT practice_plans_version_check CHECK (version > 0),
     CONSTRAINT practice_plans_json_check CHECK (
         jsonb_typeof(preparation_snapshot) = 'object'

--- a/server/migrations/000001_clean_baseline.up.sql
+++ b/server/migrations/000001_clean_baseline.up.sql
@@ -640,7 +640,7 @@ CREATE TABLE practice_plans (
         FOREIGN KEY (source_thread_id, user_id)
         REFERENCES agent_threads (id, user_id)
         ON DELETE SET NULL (source_thread_id),
-    CONSTRAINT practice_plans_status_check CHECK (status IN ('draft', 'ready', 'archived')),
+    CONSTRAINT practice_plans_status_check CHECK (status IN ('draft', 'ready')),
     CONSTRAINT practice_plans_version_check CHECK (version > 0),
     CONSTRAINT practice_plans_json_check CHECK (
         jsonb_typeof(preparation_snapshot) = 'object'

--- a/server/migrations/000003_archive_practice_plans.down.sql
+++ b/server/migrations/000003_archive_practice_plans.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+UPDATE practice_plans
+SET status = 'ready', updated_at = transaction_timestamp()
+WHERE status = 'archived';
+
+ALTER TABLE practice_plans
+    DROP CONSTRAINT practice_plans_status_check;
+ALTER TABLE practice_plans
+    ADD CONSTRAINT practice_plans_status_check
+    CHECK (status IN ('draft', 'ready'));
+
+COMMIT;

--- a/server/migrations/000003_archive_practice_plans.up.sql
+++ b/server/migrations/000003_archive_practice_plans.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE practice_plans
+    DROP CONSTRAINT practice_plans_status_check;
+ALTER TABLE practice_plans
+    ADD CONSTRAINT practice_plans_status_check
+    CHECK (status IN ('draft', 'ready', 'archived'));
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -38,6 +38,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000001_clean_baseline.up.sql",
 		"000002_agent_run_domain_completion.down.sql",
 		"000002_agent_run_domain_completion.up.sql",
+		"000003_archive_practice_plans.down.sql",
+		"000003_archive_practice_plans.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -51,6 +53,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000001_clean_baseline.down.sql",
 		"000002_agent_run_domain_completion.up.sql",
 		"000002_agent_run_domain_completion.down.sql",
+		"000003_archive_practice_plans.up.sql",
+		"000003_archive_practice_plans.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {
@@ -106,13 +110,24 @@ func TestCleanBaselineKeepsCriticalOwnershipAndConcurrencyConstraints(
 		"agent_runs_one_nonterminal_per_thread_idx",
 		"agent_voice_drafts_thread_idx",
 		"created_at DESC, plan_id DESC",
-		"status IN ('draft', 'ready', 'archived')",
 		"practice_questions_tip_check",
 		"practice_sessions_state_check",
 	} {
 		if !strings.Contains(sql, required) {
 			t.Errorf("baseline is missing %q", required)
 		}
+	}
+}
+
+func TestPracticePlanArchiveMigrationExtendsStatusConstraint(t *testing.T) {
+	up := readMigration(t, "000003_archive_practice_plans.up.sql")
+	if !strings.Contains(up, "status IN ('draft', 'ready', 'archived')") {
+		t.Fatal("practice plan archive migration must allow archived status")
+	}
+	down := readMigration(t, "000003_archive_practice_plans.down.sql")
+	if !strings.Contains(down, "SET status = 'ready'") ||
+		!strings.Contains(down, "status IN ('draft', 'ready')") {
+		t.Fatal("practice plan archive rollback must preserve archived plans as ready")
 	}
 }
 

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -106,6 +106,7 @@ func TestCleanBaselineKeepsCriticalOwnershipAndConcurrencyConstraints(
 		"agent_runs_one_nonterminal_per_thread_idx",
 		"agent_voice_drafts_thread_idx",
 		"created_at DESC, plan_id DESC",
+		"status IN ('draft', 'ready', 'archived')",
 		"practice_questions_tip_check",
 		"practice_sessions_state_check",
 	} {


### PR DESCRIPTION
## 功能描述

- 恢复模拟面试计划的长按删除能力。
- 面试卡片复用主界面对话列表交互：点击打开，长按后显示删除确认。
- 恢复服务端 `DELETE /v1/practice-plans/{practice_plan_id}` 归档契约，并同步 OpenAPI。
- 归档后卡片从列表消失且不能再创建新练习；已有练习和复盘记录保留。
- 删除失败时保留卡片并显示可重试错误。

## 实现思路

- 为面试卡片的 `InkWell` 与语义节点增加长按删除动作，不添加显式垃圾桶按钮。
- `JobPreparationClient` 发送 DELETE，Controller 使用请求 epoch 防止账号切换或并发刷新后写回过期状态。
- 服务端按当前 Actor 归档 ready 计划，列表过滤 archived 计划，执行读取仍只接受 ready 计划。
- 数据库使用状态归档而非物理删除，保留 `practice_sessions` 及下游复盘数据。
- 增加 HTTP、Service、PostgreSQL 集成与 OpenAPI 安全契约回归测试。

## 可复现测试

```shell
make check
```

本地结果：Flutter 格式、静态分析与 662 项测试通过；Go vet 与全量测试通过；PostgreSQL 归档集成测试通过；OpenAPI、安全、WebSocket、Evaluation 契约校验通过。

Closes #747
