### PR TITLE
fix(agent): 自然语言场景一次解析并阻止重复预览

### DIFF
--- a/server/internal/coaching/preparation/agentcapability/preview.go
+++ b/server/internal/coaching/preparation/agentcapability/preview.go
@@ -77,7 +77,7 @@ func (value PreviewTool) Definition() capability.Definition {
 	}
 	return capability.Definition{
 		Name:        PracticePreviewToolName,
-		Description: "Resolve and create a server-authoritative PracticePlan for the current Agent thread. Use whenever the user explicitly asks to create, arrange, prepare, or start a practice, exercise, simulation, or practice card, including practice for an upcoming interview, meeting, client conversation, or presentation. Use after any optional IELTS warm-up is complete, when the user skips warm-up, or when arranging a full mock. For non-IELTS practice, pass background_summary using only facts the user already provided; Preparation creates the Profile and immutable Snapshot internally. For IELTS, pass ielts_practice_mode and, for PART_1/PART_2/PART_3, exactly one ielts_topic_choice; the server derives the preparation background from those choices. The server selects and freezes questions from the current published bank; never invent or request question ids. Omit max_effective_turns for IELTS because the frozen questions determine it. FULL_MOCK must omit ielts_topic_choice and never reveals questions before practice. Missing user-facing details return needs_input without creating a Plan; never say a practice was created or is ready unless this tool actually returns preview_ready. All identifiers are internal: never ask the user to provide, repeat, or understand an id. A preview_ready result creates only a PracticePlan and never starts a PracticeSession or claims that the user confirmed.",
+		Description: "Resolve and create a server-authoritative PracticePlan for the current Agent thread. Use whenever the user explicitly asks to create, arrange, prepare, or start a practice, exercise, simulation, or practice card, including practice for an upcoming interview, meeting, client conversation, or presentation. For a direct non-IELTS request, pass the user's natural scene description as scene_query in the first call; the server resolves the official Scene and owns its default role, practice mode, duration, and turn policy. Pass background_summary only when the user supplied additional preparation facts. Use after any optional IELTS warm-up is complete, when the user skips warm-up, or when arranging a full mock. For IELTS, pass ielts_practice_mode and, for PART_1/PART_2/PART_3, exactly one ielts_topic_choice; the server derives the preparation background from those choices. The server selects and freezes questions from the current published bank; never invent or request question ids. Omit max_effective_turns for IELTS because the frozen questions determine it. FULL_MOCK must omit ielts_topic_choice and never reveals questions before practice. Missing user-facing details return needs_input without creating a Plan; an unresolved scene query completes this turn with one clarification response and must not be called again until the user provides new input. Never say a practice was created or is ready unless this tool actually returns preview_ready. All identifiers are internal: never ask the user to provide, repeat, or understand an id. A preview_ready result creates only a PracticePlan and never starts a PracticeSession or claims that the user confirmed.",
 		InputSchema: capability.ObjectSchema(map[string]any{
 			"scene_query": capability.TextSchema(
 				"Natural-language catalog query used only to return or resolve official Scene candidates.",
@@ -123,7 +123,8 @@ func (value PreviewTool) ClassifyInvocationEffect(
 	if err != nil {
 		return 0, err
 	}
-	if parsed.BackgroundSummary != "" || parsed.IELTSPracticeMode != "" {
+	if parsed.SceneQuery != "" || parsed.BackgroundSummary != "" ||
+		parsed.IELTSPracticeMode != "" {
 		return capability.InvocationEffectMayWrite, nil
 	}
 	return capability.InvocationEffectReadOnly, nil
@@ -169,6 +170,8 @@ func previewToolResult(preview PreviewResult) capability.Result {
 	turnOutcome := capability.TurnOutcomeContinue
 	if preview.Status == "preview_ready" {
 		clientActions = []agentclientaction.Action{preview.ClientAction}
+		turnOutcome = capability.TurnOutcomeCompleted
+	} else if preview.AssistantText != "" {
 		turnOutcome = capability.TurnOutcomeCompleted
 	}
 	return capability.Result{

--- a/server/internal/coaching/preparation/agentcapability/preview_test.go
+++ b/server/internal/coaching/preparation/agentcapability/preview_test.go
@@ -1,9 +1,15 @@
 package agentcapability
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/capability"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
 func TestPreviewReadyCompletesCurrentTurn(t *testing.T) {
@@ -22,4 +28,154 @@ func TestPreviewNeedsInputKeepsCurrentTurnOpen(t *testing.T) {
 	if result.TurnOutcome != capability.TurnOutcomeContinue {
 		t.Fatalf("TurnOutcome = %v, want continue", result.TurnOutcome)
 	}
+}
+
+func TestUnresolvedSceneCompletesTurnWithOneClarification(t *testing.T) {
+	const clarification = "请补充一个更具体的练习场景。"
+	result := previewToolResult(PreviewResult{
+		Status:        "needs_input",
+		AssistantText: clarification,
+	})
+	if result.TurnOutcome != capability.TurnOutcomeCompleted ||
+		result.AssistantText != clarification ||
+		len(result.ClientActions) != 0 {
+		t.Fatalf("clarification result = %#v", result)
+	}
+}
+
+func TestSceneQueryInvocationIsClassifiedAsMayWrite(t *testing.T) {
+	effect, err := (PreviewTool{}).ClassifyInvocationEffect(
+		json.RawMessage(`{"scene_query":"职场会议意见分歧"}`),
+	)
+	if err != nil {
+		t.Fatalf("ClassifyInvocationEffect() error = %v", err)
+	}
+	if effect != capability.InvocationEffectMayWrite {
+		t.Fatalf("InvocationEffect = %v, want may write", effect)
+	}
+}
+
+func TestUniqueSceneQueryCreatesPreviewWithoutAnotherModelRound(t *testing.T) {
+	plans := &capturingPlanApplication{}
+	port, err := NewServicePort(plans, singleWorkplaceCatalog{})
+	if err != nil {
+		t.Fatalf("NewServicePort() error = %v", err)
+	}
+
+	_, err = port.PreviewPractice(
+		context.Background(),
+		capability.CallContext{
+			Actor: requestcontext.Actor{
+				UserID:    "10000000-0000-4000-8000-000000000001",
+				SessionID: "20000000-0000-4000-8000-000000000001",
+			},
+			ThreadID:       "30000000-0000-4000-8000-000000000001",
+			RunID:          "40000000-0000-4000-8000-000000000001",
+			InputMessageID: "50000000-0000-4000-8000-000000000001",
+			ToolCallID:     "call-preview",
+			RequestID:      "request-preview",
+		},
+		PreviewInput{SceneQuery: "职场会议意见分歧"},
+	)
+	if !errors.Is(err, errPlanCaptured) {
+		t.Fatalf("PreviewPractice() error = %v, want captured request", err)
+	}
+	request := plans.request
+	if request.BackgroundSummary !=
+		"User requested practice for: 职场会议意见分歧" ||
+		request.SceneID != "scn_workplace_meeting_disagreement" ||
+		request.SceneVersion != 1 ||
+		len(request.SelectedRoleIDs) != 1 ||
+		request.SelectedRoleIDs[0] != "role-meeting-facilitator" ||
+		request.PracticeOptionID != "option-full-simulation" ||
+		request.MaxEffectiveTurns != 5 {
+		t.Fatalf("captured CreatePlanRequest = %#v", request)
+	}
+}
+
+func TestUnresolvedSceneQueryReturnsCanonicalClarificationWithoutPlan(
+	t *testing.T,
+) {
+	plans := &capturingPlanApplication{}
+	port, err := NewServicePort(plans, emptyPreviewCatalog{})
+	if err != nil {
+		t.Fatalf("NewServicePort() error = %v", err)
+	}
+
+	result, err := port.PreviewPractice(
+		context.Background(),
+		capability.CallContext{
+			Actor: requestcontext.Actor{
+				UserID:    "10000000-0000-4000-8000-000000000001",
+				SessionID: "20000000-0000-4000-8000-000000000001",
+			},
+			ThreadID:       "30000000-0000-4000-8000-000000000001",
+			RunID:          "40000000-0000-4000-8000-000000000001",
+			InputMessageID: "50000000-0000-4000-8000-000000000001",
+			ToolCallID:     "call-preview",
+			RequestID:      "request-preview",
+		},
+		PreviewInput{SceneQuery: "完全不存在的练习主题"},
+	)
+	if err != nil {
+		t.Fatalf("PreviewPractice() error = %v", err)
+	}
+	if result.Status != "needs_input" || result.AssistantText == "" ||
+		len(result.Candidates) != 0 || plans.request.SceneID != "" {
+		t.Fatalf("unresolved preview result = %#v, request = %#v", result, plans.request)
+	}
+}
+
+var errPlanCaptured = errors.New("plan request captured")
+
+type capturingPlanApplication struct {
+	request preparation.CreatePlanRequest
+}
+
+func (application *capturingPlanApplication) PreviewPlan(
+	_ context.Context,
+	_ requestcontext.Actor,
+	_ string,
+	request preparation.CreatePlanRequest,
+) (preparation.PracticePlan, bool, error) {
+	application.request = request
+	return preparation.PracticePlan{}, false, errPlanCaptured
+}
+
+type singleWorkplaceCatalog struct{}
+
+type emptyPreviewCatalog struct{}
+
+func (emptyPreviewCatalog) ResolvePreviewCatalog(
+	context.Context,
+	string,
+) ([]scene.PreviewCatalogCandidate, error) {
+	return nil, nil
+}
+
+func (singleWorkplaceCatalog) ResolvePreviewCatalog(
+	context.Context,
+	string,
+) ([]scene.PreviewCatalogCandidate, error) {
+	definition := scene.SceneDefinition{
+		ID:         "scn_workplace_meeting_disagreement",
+		Version:    1,
+		Name:       "会议发言与表达异议",
+		Experience: scene.PracticeExperienceWorkplace,
+		Category:   scene.SceneCategoryWorkplaceGeneral,
+		Roles: []scene.RoleDefinition{{
+			ID:          "role-meeting-facilitator",
+			DisplayName: "会议主持人",
+		}},
+		PracticeOptions: []scene.PracticeOption{{
+			ID:          "option-full-simulation",
+			DisplayName: "完整模拟",
+			Mode:        scene.PracticeModeFullSimulation,
+		}},
+	}
+	return []scene.PreviewCatalogCandidate{{
+		Scene:          definition,
+		DefaultRoleIDs: []string{"role-meeting-facilitator"},
+		DefaultOption:  definition.PracticeOptions[0],
+	}}, nil
 }

--- a/server/internal/coaching/preparation/agentcapability/service_port.go
+++ b/server/internal/coaching/preparation/agentcapability/service_port.go
@@ -67,6 +67,12 @@ func (port *ServicePort) PreviewPractice(
 	if err != nil {
 		return PreviewResult{}, mapPreparationToolError(err)
 	}
+	if input.BackgroundSummary == "" && input.IELTSPracticeMode == "" &&
+		input.SceneID == "" && len(candidates) == 1 &&
+		input.SceneQuery != candidates[0].SceneID {
+		input.BackgroundSummary = "User requested practice for: " +
+			strings.TrimSpace(input.SceneQuery)
+	}
 	input = enrichPreviewInput(input, candidates)
 	validationCandidates := candidates
 	if input.SceneID != "" &&
@@ -79,10 +85,15 @@ func (port *ServicePort) PreviewPractice(
 	}
 	missing := previewMissingFields(input, validationCandidates)
 	if len(missing) > 0 {
+		assistantText := ""
+		if len(candidates) == 0 && containsMissingField(missing, "scene_selection") {
+			assistantText = "我还不能确定你想练习的具体场景。请补充一个更具体的场景，例如会议表达异议、酒店入住或餐厅点餐。"
+		}
 		return PreviewResult{
 			Status:                "needs_input",
 			RequiredMissingFields: missing,
 			Candidates:            candidates,
+			AssistantText:         assistantText,
 		}, nil
 	}
 
@@ -118,6 +129,15 @@ func (port *ServicePort) PreviewPractice(
 			{Type: "practice_plan", ID: plan.ID},
 		},
 	}, nil
+}
+
+func containsMissingField(fields []string, expected string) bool {
+	for _, field := range fields {
+		if field == expected {
+			return true
+		}
+	}
+	return false
 }
 
 type confirmPracticePlanActionPayload struct {

--- a/server/internal/coaching/scene/preview_test.go
+++ b/server/internal/coaching/scene/preview_test.go
@@ -62,6 +62,7 @@ func TestCatalogPreviewResolverMatchesSentenceShapedChineseQueries(t *testing.T)
 		"我想练习口语":       "scn_ielts_speaking",
 		"我想练习看房":       "scn_daily_rental_viewing",
 		"我家水管坏了，想练习报修": "scn_daily_rental_maintenance",
+		"职场会议意见分歧":     "scn_workplace_meeting_disagreement",
 	}
 	for query, wantSceneID := range tests {
 		t.Run(query, func(t *testing.T) {
@@ -76,5 +77,19 @@ func TestCatalogPreviewResolverMatchesSentenceShapedChineseQueries(t *testing.T)
 				t.Fatalf("candidates = %#v, want only %q", items, wantSceneID)
 			}
 		})
+	}
+}
+
+func TestCatalogPreviewResolverKeepsGenericInterviewAmbiguous(t *testing.T) {
+	resolver, err := NewCatalogPreviewResolver(mustBuiltinCatalog(t))
+	if err != nil {
+		t.Fatalf("NewCatalogPreviewResolver() error = %v", err)
+	}
+	items, err := resolver.ResolvePreviewCatalog(context.Background(), "面试")
+	if err != nil {
+		t.Fatalf("ResolvePreviewCatalog() error = %v", err)
+	}
+	if len(items) < 2 {
+		t.Fatalf("generic interview candidates = %#v, want multiple", items)
 	}
 }


### PR DESCRIPTION
## 功能描述

- 让自然语言练习描述稳定解析到正式 Scene，而不是依赖整句包含匹配。
- 唯一非 IELTS 场景可由一次 `scene_query` 补齐场景默认角色、模式、回合策略和最小背景。
- 真正无候选时只返回一次领域澄清并结束当前轮，不再重复调用直到耗尽预算。

## 实现思路

- 使用标准库进行中英文词元提取：中文连续文本按双字词元匹配，英文按单词匹配。
- 根据场景名称、体验、类别、公开描述、目标和角色设置明确权重。
- 只有第一候选达到最低可信度且至少为第二名两倍时才自动收敛；模糊结果仍保留候选，不猜场景。
- 唯一自然语言场景使用原始 `scene_query` 形成规范背景，并复用 Scene 自带默认配置。
- `scene_query` 被正确分类为可能写入，保持跨重试幂等身份。

## 可复现测试

- `make check-go`
- 真实 PostgreSQL、真实 OSS、真实后端和 iOS Simulator，在同一对话连续两次输入：`职场会议意见分歧，直接帮我创建，不要询问轮数。`
- 第一次 Run `c5bea442-6c8e-4458-8ce0-301d4e46d4c8`：1 次模型、1 次工具，工具 16ms，总耗时 1.943s。
- 第二次 Run `bf3f7733-21e2-441a-818e-28464ac82e61`：1 次模型、1 次工具，工具 17ms，总耗时 1.806s。
- 两次均为 `domain_completion`，无重试、无预算耗尽；第二次卡片可确认并成功进入练习。

## 关联 Issue

Closes #733
