### PR TITLE
[MS3][全栈] Tips 参考回答追加简体中文翻译

### DIFF
--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -906,6 +906,7 @@ components:
         - practice_session_id
         - question_id
         - content
+        - translation
         - created_at
       properties:
         tip_id:
@@ -918,6 +919,11 @@ components:
           type: string
           minLength: 1
           maxLength: 800
+        translation:
+          type: string
+          minLength: 1
+          maxLength: 2000
+          description: Simplified Chinese translation of the English Tip content.
         created_at:
           type: string
           format: date-time

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -139,6 +139,7 @@ class _ExamConversation extends StatelessWidget {
                 padding: const EdgeInsets.only(bottom: 12),
                 child: QuestionTipCard(
                   content: tip.content,
+                  translation: tip.translation,
                   onClose: onHideTip,
                   onSpeak: onSpeakTip,
                 ),

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -149,6 +149,7 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
       useSafeArea: true,
       builder: (context) => QuestionTipSheet(
         content: tip.content,
+        translation: tip.translation,
         onSpeak: () async {
           final speaker =
               widget.practicePromptSpeaker ??

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -116,6 +116,7 @@ final class PracticeQuestionTip {
     required this.sessionId,
     required this.questionId,
     required this.content,
+    required this.translation,
     required this.createdAt,
   });
 
@@ -123,6 +124,7 @@ final class PracticeQuestionTip {
   final String sessionId;
   final String questionId;
   final String content;
+  final String translation;
   final DateTime createdAt;
 }
 

--- a/mobile/lib/features/coaching/practice/question_tip_sheet.dart
+++ b/mobile/lib/features/coaching/practice/question_tip_sheet.dart
@@ -4,12 +4,14 @@ import 'package:speakup/design/speak_up_design.dart';
 class QuestionTipCard extends StatefulWidget {
   const QuestionTipCard({
     required this.content,
+    required this.translation,
     required this.onClose,
     required this.onSpeak,
     super.key,
   });
 
   final String content;
+  final String translation;
   final VoidCallback onClose;
   final Future<void> Function() onSpeak;
 
@@ -81,9 +83,29 @@ class _QuestionTipCardState extends State<QuestionTipCard> {
             ],
           ),
           ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 112),
+            constraints: const BoxConstraints(maxHeight: 220),
             child: SingleChildScrollView(
-              child: Text(widget.content, style: SpeakUpDesign.body),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    widget.content,
+                    key: const Key('practice-question-tip-content'),
+                    style: SpeakUpDesign.body,
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    widget.translation,
+                    key: const Key('practice-question-tip-translation'),
+                    style: const TextStyle(
+                      color: SpeakUpDesign.secondary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w400,
+                      height: 1.5,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 6),
@@ -125,11 +147,13 @@ class _QuestionTipCardState extends State<QuestionTipCard> {
 class QuestionTipSheet extends StatefulWidget {
   const QuestionTipSheet({
     required this.content,
+    required this.translation,
     required this.onSpeak,
     super.key,
   });
 
   final String content;
+  final String translation;
   final Future<void> Function() onSpeak;
 
   @override
@@ -188,7 +212,30 @@ class _QuestionTipSheetState extends State<QuestionTipSheet> {
             ],
           ),
           const SizedBox(height: 12),
-          Text(widget.content, style: SpeakUpDesign.body),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.sizeOf(context).height * 0.5,
+            ),
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(widget.content, style: SpeakUpDesign.body),
+                  const SizedBox(height: 10),
+                  Text(
+                    widget.translation,
+                    key: const Key('practice-question-tip-sheet-translation'),
+                    style: const TextStyle(
+                      color: SpeakUpDesign.secondary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w400,
+                      height: 1.5,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
           const SizedBox(height: 18),
           OutlinedButton.icon(
             key: const Key('practice-question-tip-speak'),

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -1212,6 +1212,7 @@ PracticeQuestionTip _decodeQuestionTip(
       'practice_session_id',
       'question_id',
       'content',
+      'translation',
       'created_at',
     },
   );
@@ -1220,6 +1221,12 @@ PracticeQuestionTip _decodeQuestionTip(
     sessionId: _string(root, 'practice_session_id'),
     questionId: _string(root, 'question_id'),
     content: _utf8String(root, 'content', maxLength: 800, maxBytes: 2400),
+    translation: _utf8String(
+      root,
+      'translation',
+      maxLength: 2000,
+      maxBytes: 6000,
+    ),
     createdAt: _dateTime(root, 'created_at'),
   );
   if (tip.sessionId != expectedSessionId ||

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -774,6 +774,7 @@ class _ConversationPanel extends StatelessWidget {
                                 padding: const EdgeInsets.only(top: 4),
                                 child: QuestionTipCard(
                                   content: tip.content,
+                                  translation: tip.translation,
                                   onClose: onHideTip,
                                   onSpeak: onSpeakTip,
                                 ),

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -2209,6 +2209,7 @@ final class _IeltsPracticeClient
     sessionId: sessionId,
     questionId: questionId,
     content: 'Give a direct answer and one short reason.',
+    translation: '直接回答，并给出一个简短的理由。',
     createdAt: DateTime.utc(2026, 8, 10),
   );
 }

--- a/mobile/test/coaching/practice/question_tip_card_test.dart
+++ b/mobile/test/coaching/practice/question_tip_card_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
+
+void main() {
+  testWidgets('places a smaller Chinese translation after the English Tip', (
+    tester,
+  ) async {
+    var speakCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: QuestionTipCard(
+            content: 'I would start with the goal and explain my approach.',
+            translation: '我会先说明目标，再解释我的方法。',
+            onClose: () {},
+            onSpeak: () async => speakCalls++,
+          ),
+        ),
+      ),
+    );
+
+    final english = tester.widget<Text>(
+      find.byKey(const Key('practice-question-tip-content')),
+    );
+    final chinese = tester.widget<Text>(
+      find.byKey(const Key('practice-question-tip-translation')),
+    );
+    expect(chinese.data, '我会先说明目标，再解释我的方法。');
+    expect(chinese.style!.fontSize, lessThan(english.style!.fontSize!));
+    expect(
+      tester.getTopLeft(find.byWidget(chinese)).dy,
+      greaterThan(tester.getTopLeft(find.byWidget(english)).dy),
+    );
+
+    await tester.tap(
+      find.byKey(const Key('practice-question-tip-speak-inline')),
+    );
+    await tester.pump();
+    expect(speakCalls, 1);
+  });
+
+  testWidgets('bilingual Tip remains scrollable at 320pt and large text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(3)),
+          child: Scaffold(
+            body: QuestionTipCard(
+              content: List.filled(
+                4,
+                'I would explain the context, action, and result clearly.',
+              ).join(' '),
+              translation: List.filled(4, '我会清晰说明背景、行动和结果。').join(''),
+              onClose: () {},
+              onSpeak: () async {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('bilingual Tip sheet remains usable at 320pt and large text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(3)),
+          child: Scaffold(
+            body: QuestionTipSheet(
+              content: List.filled(
+                4,
+                'I would explain the context, action, and result clearly.',
+              ).join(' '),
+              translation: List.filled(4, '我会清晰说明背景、行动和结果。').join(''),
+              onSpeak: () async {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -194,6 +194,7 @@ void main() {
       find.text('I would describe the situation and my specific role.'),
       findsOneWidget,
     );
+    expect(find.text('我会描述当时的情况以及我的具体职责。'), findsOneWidget);
     expect(
       find.byKey(const Key('scenario-record')).hitTestable(),
       findsOneWidget,
@@ -777,6 +778,7 @@ final class _TranslationPracticeClient
     sessionId: sessionId,
     questionId: questionId,
     content: 'I would describe the situation and my specific role.',
+    translation: '我会描述当时的情况以及我的具体职责。',
     createdAt: DateTime.utc(2026, 8, 12),
   );
 }

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -262,6 +262,7 @@ void main() {
           'question_id': _questionId,
           'content':
               'I would clarify the goal first. Then I would explain my approach clearly.',
+          'translation': '我会先确认目标，然后清晰地说明我的方法。',
           'created_at': _timestamp,
         }),
       ),
@@ -276,6 +277,7 @@ void main() {
     expect(tip.id, 'question-tip-1');
     expect(tip.questionId, _questionId);
     expect(tip.content, contains('clarify the goal'));
+    expect(tip.translation, '我会先确认目标，然后清晰地说明我的方法。');
     transport.expectDone();
   });
 

--- a/server/internal/coaching/practice/interaction/http/handler.go
+++ b/server/internal/coaching/practice/interaction/http/handler.go
@@ -506,6 +506,7 @@ func QuestionTipResponse(tip practiceinteraction.QuestionTipResult) gin.H {
 		"practice_session_id": tip.SessionID,
 		"question_id":         tip.QuestionID,
 		"content":             tip.Content,
+		"translation":         tip.Translation,
 		"created_at":          tip.CreatedAt.UTC().Format(time.RFC3339Nano),
 	}
 }

--- a/server/internal/coaching/practice/interaction/persistence.go
+++ b/server/internal/coaching/practice/interaction/persistence.go
@@ -182,6 +182,7 @@ type QuestionTip struct {
 	LeaseAcquired      bool
 	LeaseExpiresAt     time.Time
 	Content            string
+	Translation        string
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
 	CompletedAt        *time.Time
@@ -199,6 +200,7 @@ type CompleteQuestionTipCommand struct {
 	FencingToken       int64
 	DeletionGeneration int64
 	Content            string
+	Translation        string
 	Provider           string
 	Model              string
 	ProviderRequestID  string

--- a/server/internal/coaching/practice/interaction/postgres/question_tip.go
+++ b/server/internal/coaching/practice/interaction/postgres/question_tip.go
@@ -16,7 +16,8 @@ import (
 const questionTipColumns = `
 	SELECT q.tip_id, q.session_id, q.question_id, q.tip_client_request_id,
 	       q.tip_status, q.tip_fencing_token, q.tip_lease_expires_at,
-	       COALESCE(q.tip_content, ''), q.tip_created_at, q.updated_at,
+	       COALESCE(q.tip_content, ''), COALESCE(q.tip_translation, ''),
+	       q.tip_created_at, q.updated_at,
 	       q.tip_completed_at
 	FROM practice_questions q
 	JOIN practice_sessions s ON s.session_id=q.session_id
@@ -114,7 +115,8 @@ func (r *Repository) ClaimQuestionTip(
 			UPDATE practice_questions q
 			SET tip_client_request_id = $4, tip_status = 'processing',
 			    tip_fencing_token = $5, tip_lease_expires_at = $6,
-			    tip_content = NULL, tip_provider = NULL, tip_model = NULL,
+			    tip_content = NULL, tip_translation = NULL,
+			    tip_provider = NULL, tip_model = NULL,
 			    tip_provider_request_id = NULL, tip_completed_at = NULL,
 			    updated_at = $7
 			FROM practice_sessions s
@@ -164,6 +166,7 @@ func (r *Repository) CompleteQuestionTip(
 	if r == nil || r.pool == nil || ctx == nil || !validInputActor(actor) ||
 		strings.TrimSpace(command.TipID) == "" || command.FencingToken <= 0 ||
 		command.DeletionGeneration != 0 || strings.TrimSpace(command.Content) == "" ||
+		strings.TrimSpace(command.Translation) == "" ||
 		strings.TrimSpace(command.Provider) == "" || !modelid.Valid(command.Model) ||
 		strings.TrimSpace(command.ProviderRequestID) == "" {
 		return practiceinteraction.QuestionTip{}, practiceinteraction.ErrPersistenceInvalid
@@ -183,8 +186,9 @@ func (r *Repository) CompleteQuestionTip(
 		return practiceinteraction.QuestionTip{}, err
 	}
 	content := strings.TrimSpace(command.Content)
+	translation := strings.TrimSpace(command.Translation)
 	if tip.Status == practiceinteraction.QuestionTipCompleted {
-		if tip.Content != content {
+		if tip.Content != content || tip.Translation != translation {
 			return practiceinteraction.QuestionTip{}, practiceinteraction.ErrPersistenceConflict
 		}
 		if err := tx.Commit(ctx); err != nil {
@@ -200,18 +204,19 @@ func (r *Repository) CompleteQuestionTip(
 	}
 	_, err = tx.Exec(ctx, `
 		UPDATE practice_questions q
-		SET tip_status = 'completed', tip_content = $3, tip_provider = $4,
-		    tip_model = $5, tip_provider_request_id = $6,
-		    tip_lease_expires_at = NULL, tip_completed_at = $7, updated_at = $7
+		SET tip_status = 'completed', tip_content = $3, tip_translation = $4,
+		    tip_provider = $5, tip_model = $6, tip_provider_request_id = $7,
+		    tip_lease_expires_at = NULL, tip_completed_at = $8, updated_at = $8
 		FROM practice_sessions s
 		WHERE s.session_id=q.session_id AND s.user_id = $1 AND q.tip_id = $2
-	`, actor.UserID, command.TipID, content, command.Provider, command.Model,
+	`, actor.UserID, command.TipID, content, translation, command.Provider, command.Model,
 		command.ProviderRequestID, now)
 	if err != nil {
 		return practiceinteraction.QuestionTip{}, safeDatabaseError(err)
 	}
 	tip.Status = practiceinteraction.QuestionTipCompleted
 	tip.Content = content
+	tip.Translation = translation
 	tip.UpdatedAt = now
 	tip.CompletedAt = &now
 	if err := tx.Commit(ctx); err != nil {
@@ -267,7 +272,7 @@ func scanQuestionTip(row rowScanner) (practiceinteraction.QuestionTip, error) {
 	var leaseExpiresAt sql.NullTime
 	err := row.Scan(
 		&tip.ID, &tip.SessionID, &tip.QuestionID, &tip.IdempotencyKey,
-		&tip.Status, &tip.FencingToken, &leaseExpiresAt, &tip.Content,
+		&tip.Status, &tip.FencingToken, &leaseExpiresAt, &tip.Content, &tip.Translation,
 		&tip.CreatedAt, &tip.UpdatedAt, &tip.CompletedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/coaching/practice/interaction/question_tip.go
+++ b/server/internal/coaching/practice/interaction/question_tip.go
@@ -10,6 +10,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/modelid"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 )
 
 const (
@@ -20,11 +21,12 @@ const (
 )
 
 type QuestionTipResult struct {
-	ID         string
-	SessionID  string
-	QuestionID string
-	Content    string
-	CreatedAt  time.Time
+	ID          string
+	SessionID   string
+	QuestionID  string
+	Content     string
+	Translation string
+	CreatedAt   time.Time
 }
 
 type QuestionTipPort interface {
@@ -39,18 +41,20 @@ type QuestionTipPort interface {
 }
 
 type QuestionTipService struct {
-	store     QuestionTipStore
-	generator AnswerTipGenerator
+	store      QuestionTipStore
+	generator  AnswerTipGenerator
+	translator sharedtranslation.Translator
 }
 
 func NewQuestionTipService(
 	store QuestionTipStore,
 	generator AnswerTipGenerator,
+	translator sharedtranslation.Translator,
 ) (*QuestionTipService, error) {
-	if store == nil || generator == nil {
+	if store == nil || generator == nil || translator == nil {
 		return nil, ErrInvalidRequest
 	}
-	return &QuestionTipService{store: store, generator: generator}, nil
+	return &QuestionTipService{store: store, generator: generator, translator: translator}, nil
 }
 
 func (service *QuestionTipService) EnsureQuestionTip(
@@ -61,7 +65,7 @@ func (service *QuestionTipService) EnsureQuestionTip(
 	history []TurnExchange,
 	idempotencyKey string,
 ) (QuestionTipResult, error) {
-	if service == nil || service.store == nil || service.generator == nil ||
+	if service == nil || service.store == nil || service.generator == nil || service.translator == nil ||
 		!actor.Valid() || session.ID == "" || !session.QuestionTipsAllowed ||
 		question.ID == "" || question.SessionID != session.ID ||
 		strings.TrimSpace(question.Content) == "" ||
@@ -129,23 +133,7 @@ func (service *QuestionTipService) generateQuestionTip(
 		question.Sequence,
 		question.Content,
 	); ok {
-		completed, err := service.store.CompleteQuestionTip(
-			ctx,
-			actor,
-			CompleteQuestionTipCommand{
-				TipID:              tip.ID,
-				FencingToken:       tip.FencingToken,
-				DeletionGeneration: tip.DeletionGeneration,
-				Content:            answer,
-				Provider:           "practice-plan",
-				Model:              "prepared-answer-v1",
-				ProviderRequestID:  tip.ID,
-			},
-		)
-		if err != nil {
-			return QuestionTipResult{}, mapPersistenceError(err)
-		}
-		return mapQuestionTip(completed)
+		return service.translateAndComplete(ctx, actor, tip, answer, "practice-plan", "prepared-answer-v1", tip.ID)
 	}
 	result, err := service.generator.GenerateAnswerTip(
 		ctx,
@@ -176,6 +164,24 @@ func (service *QuestionTipService) generateQuestionTip(
 		}
 		return QuestionTipResult{}, ErrInvalidContext
 	}
+	return service.translateAndComplete(ctx, actor, tip, content, result.Provider, result.Model, result.RequestID)
+}
+
+func (service *QuestionTipService) translateAndComplete(
+	ctx context.Context,
+	actor Actor,
+	tip QuestionTip,
+	content, provider, model, providerRequestID string,
+) (QuestionTipResult, error) {
+	translation, err := service.translator.Translate(ctx, sharedtranslation.Request{Text: content})
+	translation = strings.TrimSpace(translation)
+	if err != nil || translation == "" || utf8.RuneCountInString(translation) > questionTipMaxRunes {
+		service.failQuestionTip(ctx, actor, tip)
+		if err != nil {
+			return QuestionTipResult{}, err
+		}
+		return QuestionTipResult{}, ErrInvalidContext
+	}
 	completed, err := service.store.CompleteQuestionTip(
 		ctx,
 		actor,
@@ -184,15 +190,25 @@ func (service *QuestionTipService) generateQuestionTip(
 			FencingToken:       tip.FencingToken,
 			DeletionGeneration: tip.DeletionGeneration,
 			Content:            content,
-			Provider:           result.Provider,
-			Model:              result.Model,
-			ProviderRequestID:  result.RequestID,
+			Translation:        translation,
+			Provider:           provider,
+			Model:              model,
+			ProviderRequestID:  providerRequestID,
 		},
 	)
 	if err != nil {
 		return QuestionTipResult{}, mapPersistenceError(err)
 	}
 	return mapQuestionTip(completed)
+}
+
+func (service *QuestionTipService) failQuestionTip(ctx context.Context, actor Actor, tip QuestionTip) {
+	failureCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	_ = service.store.FailQuestionTip(failureCtx, actor, FailQuestionTipCommand{
+		TipID: tip.ID, FencingToken: tip.FencingToken,
+		DeletionGeneration: tip.DeletionGeneration,
+	})
 }
 
 func preparedIELTSAnswer(
@@ -260,15 +276,16 @@ func questionTipRequest(
 func mapQuestionTip(tip QuestionTip) (QuestionTipResult, error) {
 	if tip.Status != QuestionTipCompleted || tip.ID == "" ||
 		tip.SessionID == "" || tip.QuestionID == "" ||
-		strings.TrimSpace(tip.Content) == "" || tip.CreatedAt.IsZero() {
+		strings.TrimSpace(tip.Content) == "" || strings.TrimSpace(tip.Translation) == "" || tip.CreatedAt.IsZero() {
 		return QuestionTipResult{}, ErrInvalidContext
 	}
 	return QuestionTipResult{
-		ID:         tip.ID,
-		SessionID:  tip.SessionID,
-		QuestionID: tip.QuestionID,
-		Content:    tip.Content,
-		CreatedAt:  tip.CreatedAt,
+		ID:          tip.ID,
+		SessionID:   tip.SessionID,
+		QuestionID:  tip.QuestionID,
+		Content:     tip.Content,
+		Translation: tip.Translation,
+		CreatedAt:   tip.CreatedAt,
 	}, nil
 }
 

--- a/server/internal/coaching/practice/interaction/question_tip_test.go
+++ b/server/internal/coaching/practice/interaction/question_tip_test.go
@@ -1,9 +1,14 @@
 package interaction
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 )
 
 func TestPreparedIELTSAnswerUsesFrozenQuestionPosition(t *testing.T) {
@@ -22,4 +27,138 @@ func TestPreparedIELTSAnswerUsesFrozenQuestionPosition(t *testing.T) {
 	if _, ok := preparedIELTSAnswer(assignment, 2, "follow-up"); ok {
 		t.Fatal("a follow-up at the same sequence reused another question's answer")
 	}
+}
+
+func TestQuestionTipPersistsEnglishAndSimplifiedChineseTogether(t *testing.T) {
+	store := &questionTipStoreStub{}
+	generator := &answerTipGeneratorStub{result: AnswerTipGenerationResult{
+		RequestID: "tip-request-1",
+		Provider:  "qianwen",
+		Model:     "qwen-plus",
+		Content:   "  I would explain the goal and my approach.  ",
+	}}
+	translator := &questionTipTranslatorStub{content: "  我会说明目标和我的方法。  "}
+	service, err := NewQuestionTipService(store, generator, translator)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := service.EnsureQuestionTip(
+		context.Background(),
+		requestcontext.Actor{UserID: "user-1", SessionID: "auth-session-1"},
+		Session{ID: "session-1", QuestionTipsAllowed: true},
+		practice.Question{ID: "question-1", SessionID: "session-1", Content: "Tell me about your approach."},
+		nil,
+		"tip-operation-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if translator.request.Text != "I would explain the goal and my approach." {
+		t.Fatalf("translation source=%q", translator.request.Text)
+	}
+	if store.completed.Content != translator.request.Text ||
+		store.completed.Translation != "我会说明目标和我的方法。" {
+		t.Fatalf("complete command=%#v", store.completed)
+	}
+	if result.Content != store.completed.Content || result.Translation != store.completed.Translation {
+		t.Fatalf("result=%#v", result)
+	}
+	if store.failCalls != 0 || generator.calls != 1 || translator.calls != 1 {
+		t.Fatalf("calls generator=%d translator=%d fail=%d", generator.calls, translator.calls, store.failCalls)
+	}
+}
+
+func TestQuestionTipTranslationFailureDoesNotPersistPartialTip(t *testing.T) {
+	store := &questionTipStoreStub{}
+	generator := &answerTipGeneratorStub{result: AnswerTipGenerationResult{
+		RequestID: "tip-request-1", Provider: "qianwen", Model: "qwen-plus",
+		Content: "I would give a concise answer.",
+	}}
+	translationErr := sharedtranslation.NewProviderError(
+		sharedtranslation.ProviderErrorUnavailable,
+		"translation-request-1",
+		errors.New("unavailable"),
+	)
+	translator := &questionTipTranslatorStub{err: translationErr}
+	service, err := NewQuestionTipService(store, generator, translator)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = service.EnsureQuestionTip(
+		context.Background(),
+		requestcontext.Actor{UserID: "user-1", SessionID: "auth-session-1"},
+		Session{ID: "session-1", QuestionTipsAllowed: true},
+		practice.Question{ID: "question-1", SessionID: "session-1", Content: "Answer briefly."},
+		nil,
+		"tip-operation-1",
+	)
+	if !errors.Is(err, translationErr) {
+		t.Fatalf("error=%v", err)
+	}
+	if store.failCalls != 1 || store.completeCalls != 0 {
+		t.Fatalf("fail calls=%d complete calls=%d", store.failCalls, store.completeCalls)
+	}
+}
+
+type questionTipStoreStub struct {
+	completed     CompleteQuestionTipCommand
+	completeCalls int
+	failCalls     int
+}
+
+func (*questionTipStoreStub) ClaimQuestionTip(_ context.Context, _ Actor, command ClaimQuestionTipCommand) (QuestionTip, error) {
+	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	return QuestionTip{
+		ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", SessionID: command.SessionID,
+		QuestionID: command.QuestionID, IdempotencyKey: command.IdempotencyKey,
+		Status: QuestionTipProcessing, FencingToken: 1, LeaseAcquired: true,
+		LeaseExpiresAt: now.Add(time.Minute), CreatedAt: now, UpdatedAt: now,
+	}, nil
+}
+
+func (*questionTipStoreStub) GetQuestionTip(context.Context, Actor, string, string) (QuestionTip, error) {
+	return QuestionTip{}, ErrPersistenceNotFound
+}
+
+func (store *questionTipStoreStub) CompleteQuestionTip(_ context.Context, _ Actor, command CompleteQuestionTipCommand) (QuestionTip, error) {
+	store.completeCalls++
+	store.completed = command
+	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	return QuestionTip{
+		ID: command.TipID, SessionID: "session-1", QuestionID: "question-1",
+		Status: QuestionTipCompleted, FencingToken: command.FencingToken,
+		Content: command.Content, Translation: command.Translation,
+		CreatedAt: now, UpdatedAt: now, CompletedAt: &now,
+	}, nil
+}
+
+func (store *questionTipStoreStub) FailQuestionTip(context.Context, Actor, FailQuestionTipCommand) error {
+	store.failCalls++
+	return nil
+}
+
+type answerTipGeneratorStub struct {
+	result AnswerTipGenerationResult
+	err    error
+	calls  int
+}
+
+func (generator *answerTipGeneratorStub) GenerateAnswerTip(context.Context, AnswerTipGenerationRequest) (AnswerTipGenerationResult, error) {
+	generator.calls++
+	return generator.result, generator.err
+}
+
+type questionTipTranslatorStub struct {
+	content string
+	err     error
+	request sharedtranslation.Request
+	calls   int
+}
+
+func (translator *questionTipTranslatorStub) Translate(_ context.Context, request sharedtranslation.Request) (string, error) {
+	translator.calls++
+	translator.request = request
+	return translator.content, translator.err
 }

--- a/server/internal/coaching/practice/interaction/runtime.go
+++ b/server/internal/coaching/practice/interaction/runtime.go
@@ -120,10 +120,11 @@ func NewRuntimeApplications(
 		)
 	}
 	var tipPort QuestionTipPort
-	if configuration.AnswerTipGenerator != nil {
+	if configuration.AnswerTipGenerator != nil && configuration.QuestionTranslator != nil {
 		tipService, tipErr := NewQuestionTipService(
 			configuration.Repository,
 			configuration.AnswerTipGenerator,
+			configuration.QuestionTranslator,
 		)
 		if tipErr != nil {
 			return nil, nil, tipErr

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -54,6 +54,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to Practice Plan archive = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to Agent domain completion = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))

--- a/server/migrations/000004_question_tip_translation.down.sql
+++ b/server/migrations/000004_question_tip_translation.down.sql
@@ -1,0 +1,61 @@
+BEGIN;
+
+ALTER TABLE practice_questions
+    DROP CONSTRAINT practice_questions_tip_check;
+ALTER TABLE practice_questions
+    DROP COLUMN tip_translation;
+
+ALTER TABLE practice_questions
+    ADD CONSTRAINT practice_questions_tip_check CHECK (
+        (
+            tip_status IS NULL
+            AND tip_id IS NULL
+            AND tip_client_request_id IS NULL
+            AND tip_fencing_token = 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NULL
+            AND tip_completed_at IS NULL
+        ) OR (
+            tip_status = 'processing'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at > updated_at
+            AND tip_content IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NULL
+        ) OR (
+            tip_status = 'completed'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NOT NULL
+            AND tip_provider IS NOT NULL
+            AND tip_model IS NOT NULL
+            AND tip_provider_request_id IS NOT NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NOT NULL
+        ) OR (
+            tip_status = 'failed'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NULL
+        )
+    );
+
+COMMIT;

--- a/server/migrations/000004_question_tip_translation.up.sql
+++ b/server/migrations/000004_question_tip_translation.up.sql
@@ -1,0 +1,79 @@
+BEGIN;
+
+ALTER TABLE practice_questions
+    DROP CONSTRAINT practice_questions_tip_check;
+ALTER TABLE practice_questions
+    ADD COLUMN tip_translation text;
+
+UPDATE practice_questions
+SET tip_status = 'failed',
+    tip_content = NULL,
+    tip_provider = NULL,
+    tip_model = NULL,
+    tip_provider_request_id = NULL,
+    tip_completed_at = NULL,
+    updated_at = transaction_timestamp()
+WHERE tip_status = 'completed';
+
+ALTER TABLE practice_questions
+    ADD CONSTRAINT practice_questions_tip_check CHECK (
+        (
+            tip_status IS NULL
+            AND tip_id IS NULL
+            AND tip_client_request_id IS NULL
+            AND tip_fencing_token = 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NULL
+            AND tip_translation IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NULL
+            AND tip_completed_at IS NULL
+        ) OR (
+            tip_status = 'processing'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at > updated_at
+            AND tip_content IS NULL
+            AND tip_translation IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NULL
+        ) OR (
+            tip_status = 'completed'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NOT NULL
+            AND tip_content = btrim(tip_content)
+            AND tip_content <> ''
+            AND tip_translation IS NOT NULL
+            AND tip_translation = btrim(tip_translation)
+            AND tip_translation <> ''
+            AND tip_provider IS NOT NULL
+            AND tip_model IS NOT NULL
+            AND tip_provider_request_id IS NOT NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NOT NULL
+        ) OR (
+            tip_status = 'failed'
+            AND tip_id IS NOT NULL
+            AND tip_client_request_id IS NOT NULL
+            AND tip_fencing_token > 0
+            AND tip_lease_expires_at IS NULL
+            AND tip_content IS NULL
+            AND tip_translation IS NULL
+            AND tip_provider IS NULL
+            AND tip_model IS NULL
+            AND tip_provider_request_id IS NULL
+            AND tip_created_at IS NOT NULL
+            AND tip_completed_at IS NULL
+        )
+    );
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -40,6 +40,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000002_agent_run_domain_completion.up.sql",
 		"000003_archive_practice_plans.down.sql",
 		"000003_archive_practice_plans.up.sql",
+		"000004_question_tip_translation.down.sql",
+		"000004_question_tip_translation.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -55,6 +57,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000002_agent_run_domain_completion.down.sql",
 		"000003_archive_practice_plans.up.sql",
 		"000003_archive_practice_plans.down.sql",
+		"000004_question_tip_translation.up.sql",
+		"000004_question_tip_translation.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {
@@ -128,6 +132,20 @@ func TestPracticePlanArchiveMigrationExtendsStatusConstraint(t *testing.T) {
 	if !strings.Contains(down, "SET status = 'ready'") ||
 		!strings.Contains(down, "status IN ('draft', 'ready')") {
 		t.Fatal("practice plan archive rollback must preserve archived plans as ready")
+	}
+}
+
+func TestQuestionTipTranslationMigrationRequiresCompleteBilingualContent(t *testing.T) {
+	up := readMigration(t, "000004_question_tip_translation.up.sql")
+	for _, required := range []string{
+		"ADD COLUMN tip_translation text",
+		"tip_content = btrim(tip_content)",
+		"tip_translation = btrim(tip_translation)",
+		"WHERE tip_status = 'completed'",
+	} {
+		if !strings.Contains(up, required) {
+			t.Errorf("Question Tip translation migration is missing %q", required)
+		}
 	}
 }
 


### PR DESCRIPTION
## 功能描述

- Tips 参考回答在英文正文下方追加简体中文翻译，并使用更小、更弱的文字层级
- Daily / Interview / IELTS 三类练习统一使用双语 Tip
- 保持朗读只播放英文参考回答
- 小屏和大字号下中英文区域可滚动

## 实现思路

- 复用现有服务端 `Translator`，英文 Tip 生成后翻译为 `zh-CN`
- 英文和中文通过同一次完成写入原子持久化；翻译失败时不暴露半成品
- 新增 append-only migration `000004` 与 OpenAPI `translation` 必填字段
- Flutter Wire 层严格解析翻译字段，卡片与弹层按英文在上、中文在下展示

## 可复现测试

- `make check-go`
- `cd api && npm run check`
- `cd mobile && dart format --output=none --set-exit-if-changed lib test`
- `cd mobile && flutter analyze --no-pub`（在纯英文临时路径运行，规避 Flutter 3.44 对中文工作区路径的 analysis server 问题）
- `cd mobile && flutter test --no-pub`（664 tests）
- `TEST_DATABASE_URL=... go test ./internal/platform/migration -run TestMigrationHistoryFreshUpDownUp -count=1 -v`

Closes #760