### PR TITLE
[MS3][后端] Question Tip 生成与翻译期间续租

### DIFF
--- a/server/internal/coaching/practice/interaction/persistence.go
+++ b/server/internal/coaching/practice/interaction/persistence.go
@@ -195,6 +195,13 @@ type ClaimQuestionTipCommand struct {
 	LeaseDuration  time.Duration
 }
 
+type RenewQuestionTipLeaseCommand struct {
+	TipID              string
+	FencingToken       int64
+	DeletionGeneration int64
+	LeaseDuration      time.Duration
+}
+
 type CompleteQuestionTipCommand struct {
 	TipID              string
 	FencingToken       int64
@@ -218,6 +225,11 @@ type QuestionTipStore interface {
 		Actor,
 		ClaimQuestionTipCommand,
 	) (QuestionTip, error)
+	RenewQuestionTipLease(
+		context.Context,
+		Actor,
+		RenewQuestionTipLeaseCommand,
+	) error
 	GetQuestionTip(
 		context.Context,
 		Actor,

--- a/server/internal/coaching/practice/interaction/postgres/question_tip.go
+++ b/server/internal/coaching/practice/interaction/postgres/question_tip.go
@@ -158,6 +158,46 @@ func (r *Repository) GetQuestionTip(
 	return tip, nil
 }
 
+func (r *Repository) RenewQuestionTipLease(
+	ctx context.Context,
+	actor practiceinteraction.Actor,
+	command practiceinteraction.RenewQuestionTipLeaseCommand,
+) error {
+	if r == nil || r.pool == nil || ctx == nil || !validInputActor(actor) ||
+		strings.TrimSpace(command.TipID) == "" || command.FencingToken <= 0 ||
+		command.DeletionGeneration != 0 || command.LeaseDuration <= 0 {
+		return practiceinteraction.ErrPersistenceInvalid
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return safeDatabaseError(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := ensureActorWritable(ctx, tx, actor.UserID); err != nil {
+		return err
+	}
+	now := databaseTime(r.now)
+	tag, err := tx.Exec(ctx, `
+		UPDATE practice_questions q
+		SET tip_lease_expires_at = $4, updated_at = $5
+		FROM practice_sessions s
+		WHERE s.session_id=q.session_id AND s.user_id = $1 AND q.tip_id = $2
+		  AND q.tip_status = 'processing' AND q.tip_fencing_token = $3
+		  AND q.tip_lease_expires_at > $5
+	`, actor.UserID, command.TipID, command.FencingToken,
+		now.Add(command.LeaseDuration), now)
+	if err != nil {
+		return safeDatabaseError(err)
+	}
+	if tag.RowsAffected() != 1 {
+		return practiceinteraction.ErrPersistenceConflict
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return safeDatabaseError(err)
+	}
+	return nil
+}
+
 func (r *Repository) CompleteQuestionTip(
 	ctx context.Context,
 	actor practiceinteraction.Actor,

--- a/server/internal/coaching/practice/interaction/postgres/question_tip_integration_test.go
+++ b/server/internal/coaching/practice/interaction/postgres/question_tip_integration_test.go
@@ -1,0 +1,179 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	practiceinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/interaction"
+	"github.com/1024XEngineer/XE3-ESL/server/migrations"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestRenewQuestionTipLeaseRequiresCurrentUnexpiredFencingToken(t *testing.T) {
+	pool := questionTipTestDatabase(t)
+	ctx := context.Background()
+	actor := practiceinteraction.Actor{
+		UserID:    "11111111-1111-4111-8111-111111111111",
+		SessionID: "auth-session-1",
+	}
+	planID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	sessionID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	questionID := "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+	tipID := "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+	baseNow := time.Date(2026, 8, 18, 2, 0, 0, 0, time.UTC)
+	currentNow := baseNow.Add(5 * time.Second)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id, canonical_email) VALUES ($1, 'tip-lease@example.com')
+	`, actor.UserID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO practice_plans (
+			user_id, plan_id, preparation_snapshot, scene_selection, session_policy,
+			practice_objectives, practice_experience, status, initial_client_request_id,
+			initial_request_fingerprint
+		) VALUES ($1,$2,'{}','{}','{}','[{}]','INTERVIEW','ready','plan-create-1',$3)
+	`, actor.UserID, planID, make([]byte, 32)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO practice_sessions (
+			session_id, user_id, plan_id, plan_version, practice_experience,
+			scene_category, practice_mode, evaluation_policy_ref, plan_snapshot,
+			participants, initial_client_request_id, initial_request_fingerprint,
+			created_at, updated_at
+		) VALUES ($1,$2,$3,1,'INTERVIEW','INTERVIEW_PROFESSIONAL','FULL_SIMULATION',
+			'test-policy','{}','[{}]','session-create-1',$4,$5,$5)
+	`, sessionID, actor.UserID, planID, make([]byte, 32), baseNow); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO practice_questions (
+			question_id, session_id, objective_id, question_type, content,
+			speaker_participant_id, addressee_participant_ids, sequence,
+			tip_id, tip_client_request_id, tip_status, tip_fencing_token,
+			tip_lease_expires_at, tip_created_at, created_at, updated_at
+		) VALUES ($1,$2,'objective-1','INTERVIEW','Tell me about a result.',
+			'coach',ARRAY['candidate'],1,$3,'tip-operation-1','processing',7,
+			$5,$4,$4,$4)
+	`, questionID, sessionID, tipID, baseNow, baseNow.Add(30*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := &Repository{pool: pool, now: func() time.Time { return currentNow }}
+	command := practiceinteraction.RenewQuestionTipLeaseCommand{
+		TipID: tipID, FencingToken: 7, LeaseDuration: time.Minute,
+	}
+	if err := repository.RenewQuestionTipLease(ctx, actor, command); err != nil {
+		t.Fatalf("renew current lease: %v", err)
+	}
+	var leaseExpiresAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT tip_lease_expires_at FROM practice_questions WHERE question_id=$1
+	`, questionID).Scan(&leaseExpiresAt); err != nil {
+		t.Fatal(err)
+	}
+	if !leaseExpiresAt.Equal(currentNow.Add(time.Minute)) {
+		t.Fatalf("lease expiry=%s", leaseExpiresAt)
+	}
+
+	stale := command
+	stale.FencingToken = 6
+	if err := repository.RenewQuestionTipLease(ctx, actor, stale); !errors.Is(err, practiceinteraction.ErrPersistenceConflict) {
+		t.Fatalf("stale fencing error=%v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE practice_questions
+		SET tip_lease_expires_at=$2, updated_at=$3
+		WHERE question_id=$1
+	`, questionID, baseNow.Add(4*time.Second), baseNow.Add(3*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.RenewQuestionTipLease(ctx, actor, command); !errors.Is(err, practiceinteraction.ErrPersistenceConflict) {
+		t.Fatalf("expired lease error=%v", err)
+	}
+
+	currentNow = baseNow.Add(10 * time.Second)
+	if _, err := pool.Exec(ctx, `
+		UPDATE practice_questions
+		SET tip_lease_expires_at=$2, updated_at=$3
+		WHERE question_id=$1
+	`, questionID, baseNow.Add(40*time.Second), baseNow.Add(9*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.CompleteQuestionTip(
+		ctx,
+		actor,
+		practiceinteraction.CompleteQuestionTipCommand{
+			TipID: tipID, FencingToken: 7,
+			Content: "I delivered the result.", Translation: "我交付了结果。",
+			Provider: "qianwen", Model: "qwen-plus", ProviderRequestID: "request-1",
+		},
+	); err != nil {
+		t.Fatalf("complete tip: %v", err)
+	}
+	if err := repository.RenewQuestionTipLease(ctx, actor, command); !errors.Is(err, practiceinteraction.ErrPersistenceConflict) {
+		t.Fatalf("completed lease error=%v", err)
+	}
+}
+
+func questionTipTestDatabase(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if raw == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, raw)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		t.Fatal(err)
+	}
+	schemaName := "question_tip_lease_" + hex.EncodeToString(suffix[:])
+	identifier := pgx.Identifier{schemaName}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+identifier); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	config, err := pgxpool.ParseConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = identifier
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		_, _ = admin.Exec(context.Background(), "DROP SCHEMA "+identifier+" CASCADE")
+		admin.Close()
+	})
+	for _, name := range []string{
+		"000001_clean_baseline.up.sql",
+		"000002_agent_run_domain_completion.up.sql",
+		"000003_archive_practice_plans.up.sql",
+		"000004_question_tip_translation.up.sql",
+	} {
+		migration, err := migrations.Files.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(ctx, string(migration)); err != nil {
+			t.Fatalf("apply %s: %v", name, err)
+		}
+	}
+	return pool
+}

--- a/server/internal/coaching/practice/interaction/question_tip.go
+++ b/server/internal/coaching/practice/interaction/question_tip.go
@@ -2,6 +2,7 @@ package interaction
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -15,6 +16,8 @@ import (
 
 const (
 	questionTipLease      = 45 * time.Second
+	questionTipRenewEvery = questionTipLease / 3
+	questionTipRenewWait  = 2 * time.Second
 	questionTipPoll       = 75 * time.Millisecond
 	questionTipMaxRunes   = 2000
 	questionTipMaxHistory = 6
@@ -41,9 +44,12 @@ type QuestionTipPort interface {
 }
 
 type QuestionTipService struct {
-	store      QuestionTipStore
-	generator  AnswerTipGenerator
-	translator sharedtranslation.Translator
+	store              QuestionTipStore
+	generator          AnswerTipGenerator
+	translator         sharedtranslation.Translator
+	leaseDuration      time.Duration
+	leaseRenewInterval time.Duration
+	leaseRenewTimeout  time.Duration
 }
 
 func NewQuestionTipService(
@@ -54,7 +60,11 @@ func NewQuestionTipService(
 	if store == nil || generator == nil || translator == nil {
 		return nil, ErrInvalidRequest
 	}
-	return &QuestionTipService{store: store, generator: generator, translator: translator}, nil
+	return &QuestionTipService{
+		store: store, generator: generator, translator: translator,
+		leaseDuration: questionTipLease, leaseRenewInterval: questionTipRenewEvery,
+		leaseRenewTimeout: questionTipRenewWait,
+	}, nil
 }
 
 func (service *QuestionTipService) EnsureQuestionTip(
@@ -66,6 +76,8 @@ func (service *QuestionTipService) EnsureQuestionTip(
 	idempotencyKey string,
 ) (QuestionTipResult, error) {
 	if service == nil || service.store == nil || service.generator == nil || service.translator == nil ||
+		service.leaseDuration <= 0 || service.leaseRenewInterval <= 0 ||
+		service.leaseRenewInterval >= service.leaseDuration || service.leaseRenewTimeout <= 0 ||
 		!actor.Valid() || session.ID == "" || !session.QuestionTipsAllowed ||
 		question.ID == "" || question.SessionID != session.ID ||
 		strings.TrimSpace(question.Content) == "" ||
@@ -81,7 +93,7 @@ func (service *QuestionTipService) EnsureQuestionTip(
 				SessionID:      session.ID,
 				QuestionID:     question.ID,
 				IdempotencyKey: idempotencyKey,
-				LeaseDuration:  questionTipLease,
+				LeaseDuration:  service.leaseDuration,
 			},
 		)
 		if err != nil {
@@ -128,12 +140,62 @@ func (service *QuestionTipService) generateQuestionTip(
 	question practice.Question,
 	history []TurnExchange,
 ) (QuestionTipResult, error) {
+	prepared, err := service.prepareQuestionTipWithLease(
+		ctx,
+		actor,
+		tip,
+		func(workCtx context.Context) (preparedQuestionTip, error) {
+			return service.prepareQuestionTip(workCtx, tip, session, question, history)
+		},
+	)
+	if err != nil {
+		var renewalError *questionTipLeaseRenewalError
+		if !errors.As(err, &renewalError) {
+			service.failQuestionTip(ctx, actor, tip)
+		}
+		return QuestionTipResult{}, err
+	}
+	completed, err := service.store.CompleteQuestionTip(
+		ctx,
+		actor,
+		CompleteQuestionTipCommand{
+			TipID:              tip.ID,
+			FencingToken:       tip.FencingToken,
+			DeletionGeneration: tip.DeletionGeneration,
+			Content:            prepared.content,
+			Translation:        prepared.translation,
+			Provider:           prepared.provider,
+			Model:              prepared.model,
+			ProviderRequestID:  prepared.providerRequestID,
+		},
+	)
+	if err != nil {
+		return QuestionTipResult{}, mapPersistenceError(err)
+	}
+	return mapQuestionTip(completed)
+}
+
+type preparedQuestionTip struct {
+	content           string
+	translation       string
+	provider          string
+	model             string
+	providerRequestID string
+}
+
+func (service *QuestionTipService) prepareQuestionTip(
+	ctx context.Context,
+	tip QuestionTip,
+	session Session,
+	question practice.Question,
+	history []TurnExchange,
+) (preparedQuestionTip, error) {
 	if answer, ok := preparedIELTSAnswer(
 		session.IELTSAssignment,
 		question.Sequence,
 		question.Content,
 	); ok {
-		return service.translateAndComplete(ctx, actor, tip, answer, "practice-plan", "prepared-answer-v1", tip.ID)
+		return service.translateQuestionTip(ctx, answer, "practice-plan", "prepared-answer-v1", tip.ID)
 	}
 	result, err := service.generator.GenerateAnswerTip(
 		ctx,
@@ -145,61 +207,115 @@ func (service *QuestionTipService) generateQuestionTip(
 		!validVoiceIdentifier(result.Provider) ||
 		!modelid.Valid(result.Model) ||
 		!validVoiceIdentifier(result.RequestID) {
-		failureCtx, cancel := context.WithTimeout(
-			context.WithoutCancel(ctx),
-			2*time.Second,
-		)
-		defer cancel()
-		_ = service.store.FailQuestionTip(
-			failureCtx,
-			actor,
-			FailQuestionTipCommand{
-				TipID:              tip.ID,
-				FencingToken:       tip.FencingToken,
-				DeletionGeneration: tip.DeletionGeneration,
-			},
-		)
 		if err != nil {
-			return QuestionTipResult{}, err
+			return preparedQuestionTip{}, err
 		}
-		return QuestionTipResult{}, ErrInvalidContext
+		return preparedQuestionTip{}, ErrInvalidContext
 	}
-	return service.translateAndComplete(ctx, actor, tip, content, result.Provider, result.Model, result.RequestID)
+	return service.translateQuestionTip(ctx, content, result.Provider, result.Model, result.RequestID)
 }
 
-func (service *QuestionTipService) translateAndComplete(
+func (service *QuestionTipService) translateQuestionTip(
 	ctx context.Context,
-	actor Actor,
-	tip QuestionTip,
 	content, provider, model, providerRequestID string,
-) (QuestionTipResult, error) {
+) (preparedQuestionTip, error) {
 	translation, err := service.translator.Translate(ctx, sharedtranslation.Request{Text: content})
 	translation = strings.TrimSpace(translation)
 	if err != nil || translation == "" || utf8.RuneCountInString(translation) > questionTipMaxRunes {
-		service.failQuestionTip(ctx, actor, tip)
 		if err != nil {
-			return QuestionTipResult{}, err
+			return preparedQuestionTip{}, err
 		}
-		return QuestionTipResult{}, ErrInvalidContext
+		return preparedQuestionTip{}, ErrInvalidContext
 	}
-	completed, err := service.store.CompleteQuestionTip(
-		ctx,
+	return preparedQuestionTip{
+		content: content, translation: translation, provider: provider,
+		model: model, providerRequestID: providerRequestID,
+	}, nil
+}
+
+type questionTipLeaseRenewalError struct {
+	cause error
+}
+
+func (err *questionTipLeaseRenewalError) Error() string {
+	if err == nil || err.cause == nil {
+		return "question tip lease renewal failed"
+	}
+	return err.cause.Error()
+}
+
+func (err *questionTipLeaseRenewalError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.cause
+}
+
+func (service *QuestionTipService) prepareQuestionTipWithLease(
+	ctx context.Context,
+	actor Actor,
+	tip QuestionTip,
+	prepare func(context.Context) (preparedQuestionTip, error),
+) (preparedQuestionTip, error) {
+	workCtx, cancelWork := context.WithCancel(ctx)
+	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
+	heartbeatDone := make(chan error, 1)
+	go service.maintainQuestionTipLease(
+		heartbeatCtx,
+		cancelWork,
+		heartbeatDone,
 		actor,
-		CompleteQuestionTipCommand{
-			TipID:              tip.ID,
-			FencingToken:       tip.FencingToken,
-			DeletionGeneration: tip.DeletionGeneration,
-			Content:            content,
-			Translation:        translation,
-			Provider:           provider,
-			Model:              model,
-			ProviderRequestID:  providerRequestID,
-		},
+		tip,
 	)
-	if err != nil {
-		return QuestionTipResult{}, mapPersistenceError(err)
+
+	prepared, prepareErr := prepare(workCtx)
+	cancelHeartbeat()
+	heartbeatErr := <-heartbeatDone
+	cancelWork()
+	if heartbeatErr != nil {
+		return preparedQuestionTip{}, heartbeatErr
 	}
-	return mapQuestionTip(completed)
+	return prepared, prepareErr
+}
+
+func (service *QuestionTipService) maintainQuestionTipLease(
+	ctx context.Context,
+	cancelWork context.CancelFunc,
+	done chan<- error,
+	actor Actor,
+	tip QuestionTip,
+) {
+	ticker := time.NewTicker(service.leaseRenewInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			done <- nil
+			return
+		case <-ticker.C:
+			renewCtx, cancel := context.WithTimeout(ctx, service.leaseRenewTimeout)
+			err := service.store.RenewQuestionTipLease(
+				renewCtx,
+				actor,
+				RenewQuestionTipLeaseCommand{
+					TipID: tip.ID, FencingToken: tip.FencingToken,
+					DeletionGeneration: tip.DeletionGeneration,
+					LeaseDuration:      service.leaseDuration,
+				},
+			)
+			cancel()
+			if err == nil {
+				continue
+			}
+			if ctx.Err() != nil {
+				done <- nil
+				return
+			}
+			cancelWork()
+			done <- &questionTipLeaseRenewalError{cause: mapPersistenceError(err)}
+			return
+		}
+	}
 }
 
 func (service *QuestionTipService) failQuestionTip(ctx context.Context, actor Actor, tip QuestionTip) {

--- a/server/internal/coaching/practice/interaction/question_tip_test.go
+++ b/server/internal/coaching/practice/interaction/question_tip_test.go
@@ -3,6 +3,7 @@ package interaction
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -102,19 +103,104 @@ func TestQuestionTipTranslationFailureDoesNotPersistPartialTip(t *testing.T) {
 	}
 }
 
+func TestQuestionTipRenewsLeaseAcrossGenerationAndTranslation(t *testing.T) {
+	store := &questionTipStoreStub{}
+	generator := &answerTipGeneratorStub{
+		delay: 35 * time.Millisecond,
+		result: AnswerTipGenerationResult{
+			RequestID: "tip-request-1", Provider: "qianwen", Model: "qwen-plus",
+			Content: "I would explain the result clearly.",
+		},
+	}
+	translator := &questionTipTranslatorStub{
+		delay:   35 * time.Millisecond,
+		content: "我会清楚地说明结果。",
+	}
+	service, err := NewQuestionTipService(store, generator, translator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.leaseDuration = 30 * time.Millisecond
+	service.leaseRenewInterval = 5 * time.Millisecond
+	service.leaseRenewTimeout = 20 * time.Millisecond
+
+	result, err := service.EnsureQuestionTip(
+		context.Background(),
+		requestcontext.Actor{UserID: "user-1", SessionID: "auth-session-1"},
+		Session{ID: "session-1", QuestionTipsAllowed: true},
+		practice.Question{ID: "question-1", SessionID: "session-1", Content: "What happened?"},
+		nil,
+		"tip-operation-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Translation != translator.content || store.renewCalls.Load() < 2 {
+		t.Fatalf("result=%#v renewals=%d", result, store.renewCalls.Load())
+	}
+	if store.completeCalls != 1 || store.failCalls != 0 {
+		t.Fatalf("complete=%d fail=%d", store.completeCalls, store.failCalls)
+	}
+}
+
+func TestQuestionTipLeaseRenewalFailureCancelsProviderAndRejectsResult(t *testing.T) {
+	store := &questionTipStoreStub{renewErr: ErrPersistenceConflict}
+	generator := &answerTipGeneratorStub{
+		delay: time.Second,
+		result: AnswerTipGenerationResult{
+			RequestID: "tip-request-1", Provider: "qianwen", Model: "qwen-plus",
+			Content: "This result must not be persisted.",
+		},
+	}
+	translator := &questionTipTranslatorStub{content: "不得保存此结果。"}
+	service, err := NewQuestionTipService(store, generator, translator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.leaseDuration = 30 * time.Millisecond
+	service.leaseRenewInterval = 5 * time.Millisecond
+	service.leaseRenewTimeout = 20 * time.Millisecond
+
+	_, err = service.EnsureQuestionTip(
+		context.Background(),
+		requestcontext.Actor{UserID: "user-1", SessionID: "auth-session-1"},
+		Session{ID: "session-1", QuestionTipsAllowed: true},
+		practice.Question{ID: "question-1", SessionID: "session-1", Content: "What happened?"},
+		nil,
+		"tip-operation-1",
+	)
+	if !errors.Is(err, ErrVoiceRoundConflict) {
+		t.Fatalf("error=%v", err)
+	}
+	if store.renewCalls.Load() != 1 || store.completeCalls != 0 || store.failCalls != 0 {
+		t.Fatalf(
+			"renew=%d complete=%d fail=%d",
+			store.renewCalls.Load(), store.completeCalls, store.failCalls,
+		)
+	}
+	if translator.calls != 0 {
+		t.Fatalf("translation calls=%d", translator.calls)
+	}
+}
+
 type questionTipStoreStub struct {
 	completed     CompleteQuestionTipCommand
 	completeCalls int
 	failCalls     int
+	renewCalls    atomic.Int32
+	leaseExpiry   atomic.Int64
+	renewErr      error
 }
 
-func (*questionTipStoreStub) ClaimQuestionTip(_ context.Context, _ Actor, command ClaimQuestionTipCommand) (QuestionTip, error) {
-	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+func (store *questionTipStoreStub) ClaimQuestionTip(_ context.Context, _ Actor, command ClaimQuestionTipCommand) (QuestionTip, error) {
+	now := time.Now().UTC()
+	leaseExpiresAt := now.Add(command.LeaseDuration)
+	store.leaseExpiry.Store(leaseExpiresAt.UnixNano())
 	return QuestionTip{
 		ID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", SessionID: command.SessionID,
 		QuestionID: command.QuestionID, IdempotencyKey: command.IdempotencyKey,
 		Status: QuestionTipProcessing, FencingToken: 1, LeaseAcquired: true,
-		LeaseExpiresAt: now.Add(time.Minute), CreatedAt: now, UpdatedAt: now,
+		LeaseExpiresAt: leaseExpiresAt, CreatedAt: now, UpdatedAt: now,
 	}, nil
 }
 
@@ -122,7 +208,22 @@ func (*questionTipStoreStub) GetQuestionTip(context.Context, Actor, string, stri
 	return QuestionTip{}, ErrPersistenceNotFound
 }
 
+func (store *questionTipStoreStub) RenewQuestionTipLease(
+	_ context.Context,
+	_ Actor,
+	command RenewQuestionTipLeaseCommand,
+) error {
+	store.renewCalls.Add(1)
+	if store.renewErr == nil {
+		store.leaseExpiry.Store(time.Now().Add(command.LeaseDuration).UnixNano())
+	}
+	return store.renewErr
+}
+
 func (store *questionTipStoreStub) CompleteQuestionTip(_ context.Context, _ Actor, command CompleteQuestionTipCommand) (QuestionTip, error) {
+	if expiry := store.leaseExpiry.Load(); expiry > 0 && time.Now().UnixNano() >= expiry {
+		return QuestionTip{}, ErrPersistenceConflict
+	}
 	store.completeCalls++
 	store.completed = command
 	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
@@ -143,10 +244,18 @@ type answerTipGeneratorStub struct {
 	result AnswerTipGenerationResult
 	err    error
 	calls  int
+	delay  time.Duration
 }
 
-func (generator *answerTipGeneratorStub) GenerateAnswerTip(context.Context, AnswerTipGenerationRequest) (AnswerTipGenerationResult, error) {
+func (generator *answerTipGeneratorStub) GenerateAnswerTip(ctx context.Context, _ AnswerTipGenerationRequest) (AnswerTipGenerationResult, error) {
 	generator.calls++
+	if generator.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return AnswerTipGenerationResult{}, ctx.Err()
+		case <-time.After(generator.delay):
+		}
+	}
 	return generator.result, generator.err
 }
 
@@ -155,10 +264,18 @@ type questionTipTranslatorStub struct {
 	err     error
 	request sharedtranslation.Request
 	calls   int
+	delay   time.Duration
 }
 
-func (translator *questionTipTranslatorStub) Translate(_ context.Context, request sharedtranslation.Request) (string, error) {
+func (translator *questionTipTranslatorStub) Translate(ctx context.Context, request sharedtranslation.Request) (string, error) {
 	translator.calls++
 	translator.request = request
+	if translator.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(translator.delay):
+		}
+	}
 	return translator.content, translator.err
 }


### PR DESCRIPTION
## 功能描述

- 修复双语 Tip 的英文生成与中文翻译总耗时超过初始 45 秒租约时，成功结果可能因 fencing 冲突被丢弃的问题
- 处理中每 15 秒续租一次，保持合法 worker 的租约
- 续租失败时取消进行中的 provider 调用，旧 worker 不得持久化结果

## 实现思路

- 在 `QuestionTipStore` 增加受 `tip_id`、`processing` 状态、未过期租约和当前 fencing token 共同约束的续租操作
- provider 工作由独立可取消 context 承载，心跳续租失败会取消工作 context
- 英文和中文先在内存中准备完成；停止并确认心跳无错误后才执行原子的 `CompleteQuestionTip`
- 保留过期 worker、旧 fencing token 与已完成 Tip 不可续租/不可覆盖的语义

## 可复现测试

- `make check-go`
- `go test -race ./internal/coaching/practice/interaction -run 'TestQuestionTip(RenewsLeaseAcrossGenerationAndTranslation|LeaseRenewalFailureCancelsProviderAndRejectsResult)' -count=1`\n- `go test ./internal/coaching/practice/interaction -run 'TestQuestionTip' -count=30`\n- `TEST_DATABASE_URL=... go test ./internal/coaching/practice/interaction/postgres -run TestRenewQuestionTipLeaseRequiresCurrentUnexpiredFencingToken -count=1 -v`\n\nCloses #764