### PR TITLE
fix(evaluation): 统一练习复盘生成为简体中文

### DIFF
--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -33,7 +33,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.InterviewStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "interview-report/v1",
+			PromptVersion:   "interview-report/v2",
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -42,7 +42,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "ielts-report/v1",
+			PromptVersion:   "ielts-report/v2",
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -51,7 +51,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.GeneralStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "general-report/v1",
+			PromptVersion:   "general-report/v2",
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -635,7 +635,7 @@ func insufficientReport(
 		SceneType:     sceneType, PracticeExperience: snapshot.PracticeExperience,
 		SceneCategory: snapshot.SceneCategory, PracticeMode: snapshot.PracticeMode,
 		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
-		Summary:            "There is not enough confirmed practice evidence to produce a reliable evaluation.",
+		Summary:            "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
 		Questions:          reportQuestions(snapshot),
 		Dimensions:         dimensions, PriorityActions: []report.ReportPriorityAction{},
 	}
@@ -649,11 +649,11 @@ func encodeReport(value report.FormalReport) (json.RawMessage, error) {
 	return encoded, err
 }
 
-const interviewSystemPrompt = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
+const interviewSystemPrompt = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
-const ieltsSystemPrompt = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
+const ieltsSystemPrompt = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
 
-const generalSystemPrompt = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
+const generalSystemPrompt = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
 func (failure providerResponseFailure) Error() string          { return failure.message }
 func (failure providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -24,6 +24,15 @@ const pipelineVersion = "session-evaluation/v1"
 
 const minimumPronunciationCoverage = 0.6
 
+const (
+	interviewPromptVersionV1 = "interview-report/v1"
+	interviewPromptVersionV2 = "interview-report/v2"
+	ieltsPromptVersionV1     = "ielts-report/v1"
+	ieltsPromptVersionV2     = "ielts-report/v2"
+	generalPromptVersionV1   = "general-report/v1"
+	generalPromptVersionV2   = "general-report/v2"
+)
+
 func Lineages(
 	provider string,
 	model string,
@@ -33,7 +42,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.InterviewStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "interview-report/v2",
+			PromptVersion:   interviewPromptVersionV2,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -42,7 +51,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "ielts-report/v2",
+			PromptVersion:   ieltsPromptVersionV2,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -51,7 +60,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.GeneralStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   "general-report/v2",
+			PromptVersion:   generalPromptVersionV2,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -129,8 +138,18 @@ func (evaluator *InterviewEvaluator) Evaluate(
 	snapshot evaluation.SessionInputSnapshot,
 	lineage evaluation.ConfigLineage,
 ) (json.RawMessage, error) {
+	prompt, err := selectReportPrompt(
+		lineage.PromptVersion,
+		interviewPromptVersionV1,
+		interviewSystemPromptV1,
+		interviewPromptVersionV2,
+		interviewSystemPromptV2,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
-		interviewSystemPrompt, evaluation.SceneInterview,
+		prompt.system, prompt.insufficientSummary, evaluation.SceneInterview,
 		[]string{
 			"INTERVIEW_RELEVANCE",
 			"INTERVIEW_STRUCTURE",
@@ -146,6 +165,16 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	snapshot evaluation.SessionInputSnapshot,
 	lineage evaluation.ConfigLineage,
 ) (json.RawMessage, error) {
+	prompt, err := selectReportPrompt(
+		lineage.PromptVersion,
+		ieltsPromptVersionV1,
+		ieltsSystemPromptV1,
+		ieltsPromptVersionV2,
+		ieltsSystemPromptV2,
+	)
+	if err != nil {
+		return nil, err
+	}
 	pronunciationAssessed, _, _ := pronunciationAvailability(snapshot)
 	dimensions := []string{
 		"FLUENCY_COHERENCE",
@@ -156,7 +185,7 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		dimensions = append(dimensions, "PRONUNCIATION")
 	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
-		ieltsSystemPrompt, evaluation.SceneIELTSSpeaking,
+		prompt.system, prompt.insufficientSummary, evaluation.SceneIELTSSpeaking,
 		dimensions, report.ReportScaleIELTSBand, true)
 }
 
@@ -166,6 +195,16 @@ func (evaluator *GeneralEvaluator) Evaluate(
 	snapshot evaluation.SessionInputSnapshot,
 	lineage evaluation.ConfigLineage,
 ) (json.RawMessage, error) {
+	prompt, err := selectReportPrompt(
+		lineage.PromptVersion,
+		generalPromptVersionV1,
+		generalSystemPromptV1,
+		generalPromptVersionV2,
+		generalSystemPromptV2,
+	)
+	if err != nil {
+		return nil, err
+	}
 	var sceneType evaluation.SceneType
 	switch snapshot.EvaluationPolicyRef {
 	case evaluation.WorkplaceEvaluationPolicyRef:
@@ -183,7 +222,7 @@ func (evaluator *GeneralEvaluator) Evaluate(
 		return nil, evaluation.ErrInvalidRequest
 	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
-		generalSystemPrompt, sceneType,
+		prompt.system, prompt.insufficientSummary, sceneType,
 		[]string{
 			"TASK_ACHIEVEMENT",
 			"CLARITY_COHERENCE",
@@ -198,12 +237,14 @@ func evaluate(
 	snapshot evaluation.SessionInputSnapshot,
 	lineage evaluation.ConfigLineage,
 	systemPrompt string,
+	insufficientSummary string,
 	sceneType evaluation.SceneType,
 	dimensionKeys []string,
 	scale report.ReportScoreScale,
 	allowRepair bool,
 ) (json.RawMessage, error) {
 	if generator == nil || ctx == nil || strings.TrimSpace(systemPrompt) == "" ||
+		strings.TrimSpace(insufficientSummary) == "" ||
 		!snapshot.Valid() || !lineage.Valid() || len(dimensionKeys) == 0 {
 		return nil, evaluation.ErrInvalidRequest
 	}
@@ -214,7 +255,9 @@ func evaluate(
 		}
 	}
 	if len(effectiveTurns) == 0 {
-		return encodeReport(insufficientReport(snapshot, sceneType, dimensionKeys, scale))
+		return encodeReport(insufficientReport(
+			snapshot, sceneType, dimensionKeys, scale, insufficientSummary,
+		))
 	}
 	payload, err := json.Marshal(providerInput{
 		SceneType:     sceneType,
@@ -610,6 +653,7 @@ func insufficientReport(
 	sceneType evaluation.SceneType,
 	dimensionKeys []string,
 	scale report.ReportScoreScale,
+	summary string,
 ) report.FormalReport {
 	dimensions := make([]report.ReportDimension, 0, len(dimensionKeys)+1)
 	for _, key := range dimensionKeys {
@@ -635,7 +679,7 @@ func insufficientReport(
 		SceneType:     sceneType, PracticeExperience: snapshot.PracticeExperience,
 		SceneCategory: snapshot.SceneCategory, PracticeMode: snapshot.PracticeMode,
 		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
-		Summary:            "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		Summary:            summary,
 		Questions:          reportQuestions(snapshot),
 		Dimensions:         dimensions, PriorityActions: []report.ReportPriorityAction{},
 	}
@@ -649,11 +693,45 @@ func encodeReport(value report.FormalReport) (json.RawMessage, error) {
 	return encoded, err
 }
 
-const interviewSystemPrompt = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
+type reportPrompt struct {
+	system              string
+	insufficientSummary string
+}
 
-const ieltsSystemPrompt = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
+func selectReportPrompt(
+	recordedVersion string,
+	v1Version string,
+	v1System string,
+	v2Version string,
+	v2System string,
+) (reportPrompt, error) {
+	switch recordedVersion {
+	case v1Version:
+		return reportPrompt{
+			system:              v1System,
+			insufficientSummary: "There is not enough confirmed practice evidence to produce a reliable evaluation.",
+		}, nil
+	case v2Version:
+		return reportPrompt{
+			system:              v2System,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}, nil
+	default:
+		return reportPrompt{}, evaluation.ErrInvalidRequest
+	}
+}
 
-const generalSystemPrompt = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
+const interviewSystemPromptV1 = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
+
+const interviewSystemPromptV2 = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
+
+const ieltsSystemPromptV1 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
+
+const ieltsSystemPromptV2 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
+
+const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
+
+const generalSystemPromptV2 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
 func (failure providerResponseFailure) Error() string          { return failure.message }
 func (failure providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -242,6 +242,64 @@ func TestGeneralEvaluatorRejectsPolicyCategoryMismatch(t *testing.T) {
 	}
 }
 
+func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *testing.T) {
+	tests := []struct {
+		name    string
+		prompt  string
+		version string
+	}{
+		{name: "interview", prompt: interviewSystemPrompt, version: "interview-report/v2"},
+		{name: "IELTS", prompt: ieltsSystemPrompt, version: "ielts-report/v2"},
+		{name: "general", prompt: generalSystemPrompt, version: "general-report/v2"},
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions := map[string]string{
+		"interview": lineages.Interview.PromptVersion,
+		"IELTS":     lineages.IELTS.PromptVersion,
+		"general":   lineages.General.PromptVersion,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, requirement := range []string{
+				"summary and every finding message in Simplified Chinese",
+				"suggestions for strengths and improvements in Simplified Chinese",
+				"directly reusable English expression in suggestion",
+				"question, answer, and evidence quote in its original language",
+			} {
+				if !strings.Contains(test.prompt, requirement) {
+					t.Fatalf("prompt omitted language requirement %q: %s", requirement, test.prompt)
+				}
+			}
+			if versions[test.name] != test.version {
+				t.Fatalf("PromptVersion = %q, want %q", versions[test.name], test.version)
+			}
+		})
+	}
+}
+
+func TestInsufficientReportUsesChineseSummaryAndPreservesOriginalText(t *testing.T) {
+	snapshot := sessionSnapshotFixture()
+	snapshot.Turns[0].Effective = false
+	report := insufficientReport(
+		snapshot,
+		evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE"},
+		report.ReportScaleIELTSBand,
+	)
+	if report.Summary != "本次练习的有效证据不足，暂时无法形成可靠的评估结论。" {
+		t.Fatalf("Summary = %q", report.Summary)
+	}
+	if len(report.Questions) != 1 || report.Questions[0].Text != snapshot.Questions[0].Text {
+		t.Fatalf("question projection = %#v", report.Questions)
+	}
+	if report.Questions[0].Answer != nil {
+		t.Fatalf("ineffective answer must not be projected: %#v", report.Questions[0].Answer)
+	}
+}
+
 type reportGeneratorFake struct {
 	last textgeneration.Request
 }

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -248,9 +248,9 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 		prompt  string
 		version string
 	}{
-		{name: "interview", prompt: interviewSystemPrompt, version: "interview-report/v2"},
-		{name: "IELTS", prompt: ieltsSystemPrompt, version: "ielts-report/v2"},
-		{name: "general", prompt: generalSystemPrompt, version: "general-report/v2"},
+		{name: "interview", prompt: interviewSystemPromptV2, version: interviewPromptVersionV2},
+		{name: "IELTS", prompt: ieltsSystemPromptV2, version: ieltsPromptVersionV2},
+		{name: "general", prompt: generalSystemPromptV2, version: generalPromptVersionV2},
 	}
 	lineages, err := Lineages("qianwen", "qwen-plus")
 	if err != nil {
@@ -280,23 +280,133 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 	}
 }
 
-func TestInsufficientReportUsesChineseSummaryAndPreservesOriginalText(t *testing.T) {
+func TestSessionEvaluationPromptsFollowRecordedVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		v1Version string
+		v1Prompt  string
+		v2Version string
+		v2Prompt  string
+	}{
+		{
+			name: "interview", v1Version: interviewPromptVersionV1,
+			v1Prompt: interviewSystemPromptV1, v2Version: interviewPromptVersionV2,
+			v2Prompt: interviewSystemPromptV2,
+		},
+		{
+			name: "IELTS", v1Version: ieltsPromptVersionV1,
+			v1Prompt: ieltsSystemPromptV1, v2Version: ieltsPromptVersionV2,
+			v2Prompt: ieltsSystemPromptV2,
+		},
+		{
+			name: "general", v1Version: generalPromptVersionV1,
+			v1Prompt: generalSystemPromptV1, v2Version: generalPromptVersionV2,
+			v2Prompt: generalSystemPromptV2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v1, err := selectReportPrompt(
+				test.v1Version, test.v1Version, test.v1Prompt,
+				test.v2Version, test.v2Prompt,
+			)
+			if err != nil || v1.system != test.v1Prompt ||
+				v1.insufficientSummary != "There is not enough confirmed practice evidence to produce a reliable evaluation." {
+				t.Fatalf("v1 prompt = %#v, error = %v", v1, err)
+			}
+			v2, err := selectReportPrompt(
+				test.v2Version, test.v1Version, test.v1Prompt,
+				test.v2Version, test.v2Prompt,
+			)
+			if err != nil || v2.system != test.v2Prompt ||
+				v2.insufficientSummary != "本次练习的有效证据不足，暂时无法形成可靠的评估结论。" {
+				t.Fatalf("v2 prompt = %#v, error = %v", v2, err)
+			}
+			if _, err := selectReportPrompt(
+				"unknown/v1", test.v1Version, test.v1Prompt,
+				test.v2Version, test.v2Prompt,
+			); err != evaluation.ErrInvalidRequest {
+				t.Fatalf("unknown version error = %v", err)
+			}
+		})
+	}
+}
+
+func TestInterviewEvaluatorUsesRecordedV1Prompt(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages.Interview.PromptVersion = interviewPromptVersionV1
+	snapshot := sessionSnapshotFixture()
+	snapshot.EvaluationPolicyRef = evaluation.InterviewEvaluationPolicyRef
+	snapshot.PracticeExperience = "INTERVIEW"
+	snapshot.SceneCategory = "INTERVIEW_RECRUITER"
+	snapshot.PracticeMode = "FULL_SIMULATION"
+	if _, err := evaluators.EvaluateInterview(
+		context.Background(), evaluation.Record{}, snapshot, lineages.Interview,
+	); err != nil {
+		t.Fatalf("EvaluateInterview() error = %v", err)
+	}
+	if generator.last.SystemPrompt != interviewSystemPromptV1 {
+		t.Fatal("v1 lineage did not use the v1 interview prompt")
+	}
+}
+
+func TestInsufficientReportFollowsRecordedVersionAndPreservesOriginalText(t *testing.T) {
 	snapshot := sessionSnapshotFixture()
 	snapshot.Turns[0].Effective = false
-	report := insufficientReport(
-		snapshot,
-		evaluation.SceneIELTSSpeaking,
-		[]string{"FLUENCY_COHERENCE"},
-		report.ReportScaleIELTSBand,
-	)
-	if report.Summary != "本次练习的有效证据不足，暂时无法形成可靠的评估结论。" {
-		t.Fatalf("Summary = %q", report.Summary)
+	evaluators, err := New(&reportGeneratorFake{})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if len(report.Questions) != 1 || report.Questions[0].Text != snapshot.Questions[0].Text {
-		t.Fatalf("question projection = %#v", report.Questions)
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if report.Questions[0].Answer != nil {
-		t.Fatalf("ineffective answer must not be projected: %#v", report.Questions[0].Answer)
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name: "v1", version: ieltsPromptVersionV1,
+			want: "There is not enough confirmed practice evidence to produce a reliable evaluation.",
+		},
+		{
+			name: "v2", version: ieltsPromptVersionV2,
+			want: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lineage := lineages.IELTS
+			lineage.PromptVersion = test.version
+			encoded, err := evaluators.EvaluateIELTS(
+				context.Background(), evaluation.Record{}, snapshot, lineage,
+			)
+			if err != nil {
+				t.Fatalf("EvaluateIELTS() error = %v", err)
+			}
+			var formal report.FormalReport
+			if err := evaluation.DecodeStrict(encoded, &formal); err != nil {
+				t.Fatal(err)
+			}
+			if formal.Summary != test.want {
+				t.Fatalf("Summary = %q", formal.Summary)
+			}
+			if len(formal.Questions) != 1 || formal.Questions[0].Text != snapshot.Questions[0].Text {
+				t.Fatalf("question projection = %#v", formal.Questions)
+			}
+			if formal.Questions[0].Answer != nil {
+				t.Fatalf("ineffective answer must not be projected: %#v", formal.Questions[0].Answer)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 功能描述

统一面试、IELTS、日常与职场正式练习复盘的生成语言：题目、用户作答和证据引用保持原文；AI 生成的总结、优点、问题、建议和解释使用简体中文；供用户直接复用的英文表达保持英文。

Closes #768

## 实现思路

- 为 interview、IELTS、general 三个 Evaluation system prompt 增加一致的语言边界。
- 将三个 PromptVersion 从 v1 提升至 v2，保留生成配置的可追溯性。
- 将无有效回答时的固定证据不足总结改为简体中文。
- 保持 Evaluation Report v2 JSON 契约、评分维度、证据逐字校验、声学评估和移动端数据模型不变。
- 不迁移或回填已经持久化的历史报告。

## 可复现测试

```sh
cd server
go test ./internal/coaching/evaluation/sessionevaluation ./internal/coaching/evaluation/...
go test ./...
```

以上命令均已在本地通过。

## 验收检查

- [x] 面试、IELTS、日常和职场 Prompt 使用相同语言边界
- [x] 题目、作答和 evidence quote 保持原文
- [x] 总结及解释性反馈要求使用简体中文
- [x] 可直接复用的英文表达保持英文
- [x] 证据不足固定总结使用简体中文
- [x] 服务端全量测试通过