### PR TITLE
fix(preparation): preserve empty interview job titles

### DIFF
--- a/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_job_preparation_client_test.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/interview/job_preparation_models.dart'
 import 'package:speakup/features/coaching/interview/wire_job_preparation_client.dart';
 import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
 import 'package:speakup/features/coaching/preparation/preparation_models.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 
@@ -168,6 +169,58 @@ void main() {
       transport.calls.single.uri.path,
       '/v1/practice-plans/$contractPlanId',
     );
+  });
+
+  test(
+    'lists no practice plans without treating the empty state as an error',
+    () async {
+      final transport = _QueueTransport(<IdentityHttpResponse>[
+        _response(HttpStatus.ok, <String, Object?>{
+          'practice_plans': <Object?>[],
+        }),
+      ]);
+      final client = _client(transport);
+
+      final plans = await client.listPlans(
+        experience: PracticeExperience.interview,
+      );
+
+      expect(plans, isEmpty);
+    },
+  );
+
+  test('lists an interview plan whose required job title is empty', () async {
+    final transport = _QueueTransport(<IdentityHttpResponse>[
+      _response(HttpStatus.ok, <String, Object?>{
+        'practice_plans': <Object?>[
+          <String, Object?>{
+            'practice_plan_id': contractPlanId,
+            'version': 1,
+            'practice_plan_status': 'ready',
+            'practice_experience': 'INTERVIEW',
+            'scene_name': 'Project deep dive',
+            'practice_scope': 'Full simulation',
+            'job_title': '',
+            'practice_objectives': <String>['Communicate clearly.'],
+            'resume_used': false,
+            'suggested_duration_seconds': 600,
+            'min_effective_turns': 3,
+            'max_effective_turns': 6,
+            'created_at': contractCreatedAt,
+            'updated_at': contractCreatedAt,
+          },
+        ],
+      }),
+    ]);
+    final client = _client(transport);
+
+    final plans = await client.listPlans(
+      experience: PracticeExperience.interview,
+    );
+
+    expect(plans, hasLength(1));
+    expect(plans.single.jobTitle, isEmpty);
+    expect(plans.single.sceneName, 'Project deep dive');
   });
 }
 

--- a/server/internal/coaching/preparation/plan.go
+++ b/server/internal/coaching/preparation/plan.go
@@ -127,7 +127,7 @@ type PracticePlanSummary struct {
 	PracticeExperience       scene.PracticeExperience `json:"practice_experience"`
 	SceneName                string                   `json:"scene_name"`
 	PracticeScope            string                   `json:"practice_scope"`
-	JobTitle                 string                   `json:"job_title,omitempty"`
+	JobTitle                 string                   `json:"job_title"`
 	PracticeObjectives       []string                 `json:"practice_objectives"`
 	ResumeUsed               bool                     `json:"resume_used"`
 	SuggestedDurationSeconds int                      `json:"suggested_duration_seconds"`

--- a/server/internal/coaching/preparation/transport/http/plan_archive_handler_test.go
+++ b/server/internal/coaching/preparation/transport/http/plan_archive_handler_test.go
@@ -2,11 +2,14 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 	"github.com/gin-gonic/gin"
@@ -18,10 +21,11 @@ type archivePlanApplication struct {
 	archiveActor requestcontext.Actor
 	archiveID    string
 	archiveErr   error
+	plans        []PracticePlanSummary
 }
 
-func (*archivePlanApplication) ListPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]PracticePlanSummary, error) {
-	return nil, nil
+func (application *archivePlanApplication) ListPlans(context.Context, requestcontext.Actor, scene.PracticeExperience) ([]PracticePlanSummary, error) {
+	return application.plans, nil
 }
 
 func (*archivePlanApplication) CreatePlan(context.Context, requestcontext.Actor, string, CreatePlanRequest) (PracticePlan, bool, error) {
@@ -76,6 +80,44 @@ func TestArchivePlanRouteRejectsMalformedIDWithoutCallingApplication(t *testing.
 	}
 }
 
+func TestListPlansRoutePreservesEmptyJobTitle(t *testing.T) {
+	now := time.Date(2026, time.August, 18, 6, 0, 0, 0, time.UTC)
+	application := &archivePlanApplication{plans: []PracticePlanSummary{{
+		ID:                       archivePlanID,
+		Version:                  1,
+		Status:                   preparation.PlanStatusReady,
+		PracticeExperience:       scene.PracticeExperienceInterview,
+		SceneName:                "Project deep dive",
+		PracticeScope:            "Full simulation",
+		JobTitle:                 "",
+		PracticeObjectives:       []string{"Communicate clearly."},
+		ResumeUsed:               false,
+		SuggestedDurationSeconds: 600,
+		MinEffectiveTurns:        3,
+		MaxEffectiveTurns:        6,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}}}
+
+	response := performListPlansRequest(t, application)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", response.Code, response.Body.String())
+	}
+	var body struct {
+		Plans []map[string]any `json:"practice_plans"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Plans) != 1 {
+		t.Fatalf("plans=%#v", body.Plans)
+	}
+	jobTitle, ok := body.Plans[0]["job_title"]
+	if !ok || jobTitle != "" {
+		t.Fatalf("job_title present=%t value=%#v", ok, jobTitle)
+	}
+}
+
 func performArchivePlanRequest(t *testing.T, application *archivePlanApplication, id string) *httptest.ResponseRecorder {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -92,5 +134,24 @@ func performArchivePlanRequest(t *testing.T, application *archivePlanApplication
 	handler.RegisterRoutes(router)
 	response := httptest.NewRecorder()
 	router.ServeHTTP(response, httptest.NewRequest(http.MethodDelete, "/v1/practice-plans/"+id, nil))
+	return response
+}
+
+func performListPlansRequest(t *testing.T, application *archivePlanApplication) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler, err := NewPlanHTTPHandler(application)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		actor := requestcontext.Actor{UserID: "11111111-1111-4111-8111-111111111111", SessionID: "test-session"}
+		c.Request = c.Request.WithContext(requestcontext.WithActor(c.Request.Context(), actor))
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/v1/practice-plans?practice_experience=INTERVIEW", nil))
 	return response
 }


### PR DESCRIPTION
## 功能描述

修复无岗位标题的面试计划导致整个模拟面试列表解析失败、页面显示“暂时无法加载”的问题。真正没有面试计划时继续显示既有空状态。

Closes #770

## 实现思路

- `PracticePlanSummary.job_title` 始终序列化；无岗位标题时返回空字符串，与 OpenAPI 必填字段契约一致。
- 增加后端响应回归测试，确保空岗位标题字段存在。
- 增加 Flutter 线协议测试，覆盖真正空列表和空岗位标题计划。

## 测试方式

```bash
cd server
go test ./internal/coaching/preparation/transport/http ./internal/coaching/preparation/service

cd ../mobile
flutter test test/coaching/preparation/wire_job_preparation_client_test.dart test/coaching/interview/interview_catalog_test.dart
flutter analyze

cd ..
git diff --check
```

以上命令均通过。