### PR TITLE
feat(practice): enrich scene confirmation cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ server/bin/
 
 #docs
 server/internal/agent/docs
+server/internal/coaching/preparation/docs
+server/internal/resume/docs
+docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,6 @@
 - 涉及移动端交互或视觉验证时，启动前将当前任务分支更新到最新 `upstream/dev` 并保留当前修改，然后从同一 worktree 运行 `make dev-ios-simulator`；使用真实后端，模拟器禁用数字人。
 - iOS 模拟器因代理无法访问 OSS 时，仅在当前 worktree 的本地 `.env` 中设置 `OSS_ENABLED=0` 和 `RESUME_OCR_ENABLED=0`，不得提交该配置或改用 mock。
 - 只修改当前 Issue 范围，优先复用现有组件及官方或主流实现，不提交密钥、`.env`、缓存、构建产物或无关文件。
-- Commit 使用 `<type>(<scope>): <subject>`；PR 必须包含功能描述、实现思路、可复现测试和关联 Issue，默认邀请 `gangcaiyoule`、`jyqin0203`、`zhiwilliam1-cell`；合入前，相关分析、测试、构建和契约校验通过，Reviewer 可复现，Review 意见已解决且范围一致，AI 修改经人工检查且提交者能够解释。
+- Commit 使用 `<type>(<scope>): <subject>`；PR 必须包含功能描述、实现思路、可复现测试和关联 Issue，默认邀请 `gangcaiyoule`、`jyqin0203`、`zhiwilliam1-cell`、`Scorbunny2`、`Lq0412`；合入前，相关分析、测试、构建和契约校验通过，Reviewer 可复现，Review 意见已解决且范围一致，AI 修改经人工检查且提交者能够解释。
 - 提 PR 后必须检查 CI 和 Review；CI 未全部通过或 Review 尚有未解决意见时，只能报告实际状态，不得宣称完成。
 - 视觉改动除非已明确要求直接提交，否则先启动并截图确认；PR 合并后关闭对应 Issue、同步个人 Fork，并仅删除当前任务创建且确认干净、已同步的分支和 worktree。

--- a/mobile/lib/features/agent/client_action/practice_plan_client_action_card.dart
+++ b/mobile/lib/features/agent/client_action/practice_plan_client_action_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/preparation/practice_plan_client_action.dart';
+import 'package:speakup/features/coaching/scenario/scenario_assets.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
 
 final class PracticePlanClientActionCard extends StatelessWidget {
   const PracticePlanClientActionCard({
@@ -24,6 +26,7 @@ final class PracticePlanClientActionCard extends StatelessWidget {
     final role = action.userRole == null
         ? aiRole
         : '你：${action.userRole} · AI：$aiRole';
+    final heroStyle = _practiceHeroStyle(action);
 
     return Align(
       alignment: Alignment.center,
@@ -40,8 +43,7 @@ final class PracticePlanClientActionCard extends StatelessWidget {
               title: title,
               goal: action.practiceGoal,
               role: role,
-              isIELTS: isIELTS,
-              isInterview: isInterview,
+              style: heroStyle,
             ),
             Transform.translate(
               offset: const Offset(0, -7),
@@ -147,15 +149,13 @@ final class _PracticeHero extends StatelessWidget {
     required this.title,
     required this.goal,
     required this.role,
-    required this.isIELTS,
-    required this.isInterview,
+    required this.style,
   });
 
   final String title;
   final String goal;
   final String role;
-  final bool isIELTS;
-  final bool isInterview;
+  final _PracticeHeroStyle style;
 
   @override
   Widget build(BuildContext context) {
@@ -172,13 +172,11 @@ final class _PracticeHero extends StatelessWidget {
                 gradient: LinearGradient(
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,
-                  colors: isInterview
-                      ? const [Color(0xFFF3F0EA), Color(0xFFE6DDD2)]
-                      : const [Color(0xFFF4F1FF), Color(0xFFE9E3FF)],
+                  colors: [style.backgroundStart, style.backgroundEnd],
                 ),
               ),
             ),
-            if (isIELTS || isInterview)
+            if (style.imageAsset case final imageAsset?)
               Positioned(
                 top: 0,
                 right: -4,
@@ -186,7 +184,7 @@ final class _PracticeHero extends StatelessWidget {
                 width: 160,
                 child: Semantics(
                   image: true,
-                  label: isIELTS ? 'IELTS 考官头像' : '面试官场景图',
+                  label: style.imageLabel,
                   child: ShaderMask(
                     blendMode: BlendMode.dstIn,
                     shaderCallback: (bounds) => const LinearGradient(
@@ -194,33 +192,23 @@ final class _PracticeHero extends StatelessWidget {
                       stops: [0, 0.3],
                     ).createShader(bounds),
                     child: Image.asset(
-                      isIELTS
-                          ? 'assets/images/scenes/ielts-examiner.jpg'
-                          : 'assets/images/scenes/interview-plan-card-v2.webp',
+                      imageAsset,
                       fit: BoxFit.cover,
-                      alignment: isIELTS
-                          ? const Alignment(0, -0.3)
-                          : const Alignment(-1, -0.2),
+                      alignment: style.imageAlignment,
                     ),
                   ),
                 ),
               ),
-            if (isIELTS || isInterview)
+            if (style.imageAsset != null)
               Positioned.fill(
                 child: DecoratedBox(
                   decoration: BoxDecoration(
                     gradient: LinearGradient(
-                      colors: isInterview
-                          ? const [
-                              Color(0xFFF3F0EA),
-                              Color(0xE6F3F0EA),
-                              Color(0x00F3F0EA),
-                            ]
-                          : const [
-                              Color(0xFFF4F1FF),
-                              Color(0xE6F4F1FF),
-                              Color(0x00F4F1FF),
-                            ],
+                      colors: [
+                        style.backgroundStart,
+                        style.backgroundStart.withAlpha(230),
+                        style.backgroundStart.withAlpha(0),
+                      ],
                       stops: [0, 0.42, 0.78],
                     ),
                   ),
@@ -233,7 +221,7 @@ final class _PracticeHero extends StatelessWidget {
                   padding: EdgeInsets.fromLTRB(
                     14,
                     14,
-                    isIELTS || isInterview ? 74 : 14,
+                    style.imageAsset != null ? 74 : 14,
                     14,
                   ),
                   child: Column(
@@ -321,6 +309,78 @@ final class _PracticeHero extends StatelessWidget {
       ),
     );
   }
+}
+
+final class _PracticeHeroStyle {
+  const _PracticeHeroStyle({
+    required this.backgroundStart,
+    required this.backgroundEnd,
+    required this.imageAsset,
+    required this.imageAlignment,
+    required this.imageLabel,
+  });
+
+  final Color backgroundStart;
+  final Color backgroundEnd;
+  final String? imageAsset;
+  final Alignment imageAlignment;
+  final String? imageLabel;
+}
+
+_PracticeHeroStyle _practiceHeroStyle(ConfirmPracticePlanClientAction action) {
+  if (action.practiceExperience == 'IELTS_SPEAKING') {
+    return const _PracticeHeroStyle(
+      backgroundStart: Color(0xFFF4F1FF),
+      backgroundEnd: Color(0xFFE9E3FF),
+      imageAsset: 'assets/images/scenes/ielts-examiner.jpg',
+      imageAlignment: Alignment(0, -0.3),
+      imageLabel: 'IELTS 考官头像',
+    );
+  }
+  if (action.practiceExperience == 'INTERVIEW') {
+    return const _PracticeHeroStyle(
+      backgroundStart: Color(0xFFF3F0EA),
+      backgroundEnd: Color(0xFFE6DDD2),
+      imageAsset: 'assets/images/scenes/interview-plan-card-v2.webp',
+      imageAlignment: Alignment(-1, -0.2),
+      imageLabel: '面试官场景图',
+    );
+  }
+
+  final category = SceneCategory.fromWireValue(action.sceneCategory);
+  final imageAsset = category == null
+      ? null
+      : scenarioAssetPathFor(sceneId: action.sceneId ?? '', category: category);
+  return switch (category) {
+    SceneCategory.workplaceGeneral => _PracticeHeroStyle(
+      backgroundStart: const Color(0xFFE8EBED),
+      backgroundEnd: const Color(0xFFD8E0E4),
+      imageAsset: imageAsset,
+      imageAlignment: Alignment.topCenter,
+      imageLabel: '职场场景图',
+    ),
+    SceneCategory.lifeTravel => _PracticeHeroStyle(
+      backgroundStart: const Color(0xFFDDEBF0),
+      backgroundEnd: const Color(0xFFC9DFE7),
+      imageAsset: imageAsset,
+      imageAlignment: Alignment.center,
+      imageLabel: '旅行场景图',
+    ),
+    SceneCategory.lifeDaily => _PracticeHeroStyle(
+      backgroundStart: const Color(0xFFF2E8DE),
+      backgroundEnd: const Color(0xFFE6D5C5),
+      imageAsset: imageAsset,
+      imageAlignment: const Alignment(0, -0.4),
+      imageLabel: '生活场景图',
+    ),
+    _ => _PracticeHeroStyle(
+      backgroundStart: const Color(0xFFF4F1FF),
+      backgroundEnd: const Color(0xFFE9E3FF),
+      imageAsset: imageAsset,
+      imageAlignment: Alignment.center,
+      imageLabel: imageAsset == null ? null : '练习场景图',
+    ),
+  };
 }
 
 final class _PracticeFact extends StatelessWidget {

--- a/mobile/lib/features/coaching/preparation/practice_plan_client_action.dart
+++ b/mobile/lib/features/coaching/preparation/practice_plan_client_action.dart
@@ -27,6 +27,7 @@ final class ConfirmPracticePlanClientAction {
     required this.label,
     required this.practicePlanId,
     required this.planVersion,
+    required this.sceneId,
     required this.sceneName,
     required this.practiceGoal,
     required this.aiRoles,
@@ -46,6 +47,7 @@ final class ConfirmPracticePlanClientAction {
   final String label;
   final String practicePlanId;
   final int planVersion;
+  final String? sceneId;
   final String sceneName;
   final String? userRole;
   final List<String> aiRoles;
@@ -81,6 +83,7 @@ const _confirmPracticePlanV2Fields = <String>{
   'label',
   'practice_plan_id',
   'plan_version',
+  'scene_id',
   'scene_name',
   'user_role',
   'ai_roles',
@@ -140,6 +143,7 @@ AgentClientAction encodeConfirmPracticePlanClientAction(
       'label': action.label,
       'practice_plan_id': action.practicePlanId,
       'plan_version': action.planVersion,
+      'scene_id': action.sceneId,
       'scene_name': action.sceneName,
       'user_role': action.userRole,
       'ai_roles': action.aiRoles,
@@ -199,6 +203,9 @@ ConfirmPracticePlanClientAction decodeConfirmPracticePlanClientAction(
     label: _string(object['label'], 1, 100),
     practicePlanId: _uuid(object['practice_plan_id']),
     planVersion: _integer(object['plan_version'], 1),
+    sceneId: protocol == ConfirmPracticePlanProtocol.v2
+        ? _string(object['scene_id'], 1, 200)
+        : null,
     sceneName: _string(object['scene_name'], 1, 200),
     userRole: protocol == ConfirmPracticePlanProtocol.v2
         ? _string(object['user_role'], 1, 200)

--- a/mobile/lib/features/coaching/scenario/scenario_assets.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_assets.dart
@@ -1,6 +1,13 @@
 import 'package:speakup/features/coaching/scene/scene.dart';
 
 String? scenarioAssetPath(SceneDefinition scene) {
+  return scenarioAssetPathFor(sceneId: scene.id, category: scene.category);
+}
+
+String? scenarioAssetPathFor({
+  required String sceneId,
+  required SceneCategory category,
+}) {
   const sceneAssets = <String, String>{
     'scn_daily_small_talk': 'assets/images/scenes/small-talk.jpg',
     'scn_daily_restaurant_ordering': 'assets/images/scenes/daily-tutor.jpg',
@@ -35,10 +42,10 @@ String? scenarioAssetPath(SceneDefinition scene) {
     'scn_workplace_negotiation':
         'assets/images/scenes/workplace-negotiation.jpg',
   };
-  if (sceneAssets[scene.id] case final assetPath?) {
+  if (sceneAssets[sceneId] case final assetPath?) {
     return assetPath;
   }
-  return switch (scene.category) {
+  return switch (category) {
     SceneCategory.workplaceGeneral =>
       'assets/images/scenes/workplace-scene.jpg',
     SceneCategory.lifeTravel => 'assets/images/scenes/travel-scene.jpg',

--- a/mobile/test/agent/agent_message_bubble_test.dart
+++ b/mobile/test/agent/agent_message_bubble_test.dart
@@ -310,6 +310,7 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000001',
       planVersion: 2,
+      sceneId: 'scn_interview_project_deep_dive',
       sceneName: '项目经历深挖',
       userRole: '候选人',
       practiceGoal: 'Java Interview Practice',
@@ -377,6 +378,7 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000006',
       planVersion: 1,
+      sceneId: 'scn_interview_self_introduction',
       sceneName: '英文自我介绍',
       userRole: '候选人',
       practiceGoal: '说清背景、优势和岗位匹配，并自然回应一到两个追问。',
@@ -445,6 +447,7 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000003',
       planVersion: 1,
+      sceneId: 'ielts-speaking',
       sceneName: 'IELTS 口语',
       userRole: '考生',
       practiceGoal: '按所选 IELTS 口语模式完成真实节奏的连续表达。',
@@ -524,6 +527,7 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000004',
       planVersion: 1,
+      sceneId: 'ielts-speaking',
       sceneName: 'IELTS 口语',
       userRole: '考生',
       practiceGoal: '按所选 IELTS 口语模式完成真实节奏的连续表达。',
@@ -600,13 +604,14 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000002',
       planVersion: 1,
-      sceneName: '酒店入住',
-      userRole: '住客',
-      practiceGoal: 'Travel English Practice',
+      sceneId: 'scn_daily_rental_viewing',
+      sceneName: '看房与租赁咨询',
+      userRole: '租客',
+      practiceGoal: '了解房屋条件、租金费用、租期和入住要求',
       practiceExperience: 'LIFE_AND_TRAVEL',
-      sceneCategory: 'LIFE_TRAVEL',
+      sceneCategory: 'LIFE_DAILY',
       practiceMode: 'FULL_SIMULATION',
-      aiRoles: <String>['前台'],
+      aiRoles: <String>['房产中介'],
       practiceScope: '开放对话',
       suggestedDuration: Duration(minutes: 10),
       minEffectiveTurns: 1,
@@ -632,6 +637,13 @@ void main() {
     );
 
     expect(find.text('约 10 分钟'), findsOneWidget);
+    expect(find.text('看房与租赁咨询'), findsOneWidget);
+    expect(find.bySemanticsLabel('生活场景图'), findsOneWidget);
+    final image = tester.widget<Image>(find.byType(Image));
+    expect(
+      (image.image as AssetImage).assetName,
+      'assets/images/scenes/daily-rental-viewing.jpg',
+    );
     expect(find.textContaining('轮'), findsNothing);
   });
 
@@ -690,6 +702,7 @@ void main() {
       label: '确认并开始练习',
       practicePlanId: '10000000-0000-4000-8000-000000000007',
       planVersion: 1,
+      sceneId: 'scn_daily_restaurant_ordering',
       sceneName: '餐厅点餐',
       userRole: '顾客',
       aiRoles: <String>['服务员'],
@@ -741,6 +754,7 @@ void main() {
           label: '确认并开始练习',
           practicePlanId: '10000000-0000-4000-8000-000000000008',
           planVersion: 1,
+          sceneId: 'custom_scene_long',
           sceneName: List<String>.filled(100, '场景').join(),
           userRole: List<String>.filled(100, '用户').join(),
           aiRoles: List<String>.generate(

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -60,6 +60,7 @@ void main() {
                       'label': '确认并开始练习',
                       'practice_plan_id': _practicePlanId,
                       'plan_version': 2,
+                      'scene_id': 'scn_interview_project_deep_dive',
                       'scene_name': '项目经历深挖',
                       'user_role': '候选人',
                       'ai_roles': ['面试官'],

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -941,6 +941,7 @@ void main() {
               'label': '确认并开始练习',
               'practice_plan_id': _practicePlanId,
               'plan_version': 2,
+              'scene_id': 'scn_interview_project_deep_dive',
               'scene_name': '项目经历深挖',
               'user_role': '候选人',
               'ai_roles': <Object?>['面试官'],

--- a/mobile/test/coaching/preparation/practice_plan_client_action_controller_test.dart
+++ b/mobile/test/coaching/preparation/practice_plan_client_action_controller_test.dart
@@ -467,6 +467,7 @@ ConfirmPracticePlanClientAction _action(PracticePlan plan) =>
       label: 'Confirm and start',
       practicePlanId: plan.id,
       planVersion: plan.version,
+      sceneId: plan.sceneSelection.scene.id,
       sceneName: plan.sceneSelection.scene.name,
       userRole: plan.sceneSelection.scene.prompt.userRole,
       practiceGoal: plan.sceneSelection.scene.prompt.practiceGoal,

--- a/mobile/test/coaching/preparation/practice_plan_client_action_test.dart
+++ b/mobile/test/coaching/preparation/practice_plan_client_action_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(action.protocol, ConfirmPracticePlanProtocol.v1);
     expect(action.practicePlanId, _planId);
     expect(action.planVersion, 2);
+    expect(action.sceneId, isNull);
     expect(action.userRole, isNull);
     expect(action.aiRoles, <String>['面试官']);
     expect(action.practiceGoal, '准备 Java 后端面试');
@@ -20,6 +21,10 @@ void main() {
 
     expect(envelope.type, practicePlanConfirmClientActionType);
     expect(envelope.payload, containsPair('user_role', '候选人'));
+    expect(
+      envelope.payload,
+      containsPair('scene_id', 'scn_interview_project_deep_dive'),
+    );
     expect(envelope.payload['ai_roles'], <String>['面试官']);
     expect(envelope.payload, containsPair('practice_goal', '准备 Java 后端面试'));
     expect(envelope.payload, isNot(contains('target')));
@@ -106,6 +111,7 @@ void main() {
           label: '确认并开始练习',
           practicePlanId: _planId,
           planVersion: 2,
+          sceneId: null,
           sceneName: '项目经历深挖',
           practiceGoal: '准备 Java 后端面试',
           aiRoles: const <String>['面试官'],
@@ -129,6 +135,7 @@ ConfirmPracticePlanClientAction _validV2Action() =>
       label: '确认并开始练习',
       practicePlanId: _planId,
       planVersion: 2,
+      sceneId: 'scn_interview_project_deep_dive',
       sceneName: '项目经历深挖',
       userRole: '候选人',
       aiRoles: <String>['面试官'],

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1350,6 +1350,7 @@ const _ieltsPart1ScrollAction = ConfirmPracticePlanClientAction(
   label: '确认并开始练习',
   practicePlanId: '10000000-0000-4000-8000-000000000005',
   planVersion: 1,
+  sceneId: 'ielts-speaking',
   sceneName: 'IELTS 口语',
   userRole: '考生',
   practiceGoal: '按所选 IELTS 口语模式完成真实节奏的连续表达。',

--- a/server/internal/coaching/preparation/agentcapability/preview_test.go
+++ b/server/internal/coaching/preparation/agentcapability/preview_test.go
@@ -625,7 +625,8 @@ func TestPracticePlanClientActionEmitsExactV2BusinessPayload(t *testing.T) {
 	if _, found := payload["roles"]; found {
 		t.Fatalf("v2 payload contains legacy roles: %#v", payload)
 	}
-	if payload["scene_name"] != "在展会上介绍机器人" ||
+	if payload["scene_id"] == "" ||
+		payload["scene_name"] != "在展会上介绍机器人" ||
 		payload["user_role"] != "销售代表" ||
 		payload["practice_goal"] != "说明产品价值并回应疑虑" {
 		t.Fatalf("payload values = %#v", payload)

--- a/server/internal/coaching/preparation/agentcapability/service_port.go
+++ b/server/internal/coaching/preparation/agentcapability/service_port.go
@@ -404,6 +404,7 @@ type confirmPracticePlanActionPayload struct {
 	Label                    string   `json:"label"`
 	PracticePlanID           string   `json:"practice_plan_id"`
 	PlanVersion              int      `json:"plan_version"`
+	SceneID                  string   `json:"scene_id"`
 	SceneName                string   `json:"scene_name"`
 	UserRole                 string   `json:"user_role"`
 	AIRoles                  []string `json:"ai_roles"`
@@ -420,7 +421,7 @@ type confirmPracticePlanActionPayload struct {
 
 var confirmPracticePlanActionFields = map[string]struct{}{
 	"label": {}, "practice_plan_id": {}, "plan_version": {},
-	"scene_name": {}, "user_role": {}, "ai_roles": {},
+	"scene_id": {}, "scene_name": {}, "user_role": {}, "ai_roles": {},
 	"practice_goal": {}, "practice_experience": {},
 	"scene_category": {}, "practice_mode": {}, "practice_scope": {},
 	"suggested_duration_seconds": {}, "min_effective_turns": {},
@@ -446,11 +447,16 @@ func practicePlanClientAction(
 	for index, role := range roles {
 		roleNames[index] = role.DisplayName
 	}
+	sceneID := strings.TrimSpace(plan.SceneSelection.Source.SceneID)
+	if sceneID == "" {
+		sceneID = strings.TrimSpace(plan.SceneSelection.Scene.Key)
+	}
 	prompt := plan.SceneSelection.Scene.Prompt
 	payload := confirmPracticePlanActionPayload{
 		Label:                    "确认并开始练习",
 		PracticePlanID:           plan.ID,
 		PlanVersion:              plan.Version,
+		SceneID:                  sceneID,
 		SceneName:                plan.SceneSelection.Scene.Name,
 		UserRole:                 strings.TrimSpace(prompt.UserRole),
 		AIRoles:                  roleNames,
@@ -484,6 +490,7 @@ func validConfirmPracticePlanActionPayload(
 	if !validActionText(payload.Label, 100) ||
 		!practicePlanUUIDPattern.MatchString(payload.PracticePlanID) ||
 		payload.PlanVersion < 1 ||
+		!validActionText(payload.SceneID, 200) ||
 		!validActionText(payload.SceneName, 200) ||
 		!validActionText(payload.UserRole, 200) ||
 		!validActionText(payload.PracticeGoal, 500) ||

--- a/server/test/agent/benchmark/server.go
+++ b/server/test/agent/benchmark/server.go
@@ -212,6 +212,7 @@ func (port *benchmarkPreviewPort) PreviewPractice(
   "label": "确认并开始练习",
   "practice_plan_id": "00000000-0000-4000-8000-000000000001",
   "plan_version": 1,
+  "scene_id": "benchmark_scene",
   "scene_name": "Agent Routing Benchmark",
   "user_role": "练习者",
   "ai_roles": ["对话角色"],

--- a/server/test/agent/routing/tool_registry.go
+++ b/server/test/agent/routing/tool_registry.go
@@ -93,6 +93,7 @@ func (ports *routingPorts) PreviewPractice(
   "label": "确认并开始练习",
   "practice_plan_id": "00000000-0000-4000-8000-000000000001",
   "plan_version": 1,
+  "scene_id": "scn_workplace_meeting_disagreement",
   "scene_name": "会议发言与表达异议",
   "user_role": "参会者",
   "ai_roles": ["会议主持人"],


### PR DESCRIPTION
## 功能描述

- 普通职场、生活与旅行练习卡片复用面试/雅思卡片的高级 Hero 视觉
- 卡片标题统一显示简洁的场景名称，而不是较长的练习目标
- Catalog 场景按 scene_id 显示对应图片，例如看房咨询固定使用看房图片
- 自定义场景与历史 V1 卡片继续按场景分类使用兜底图片

## 实现思路

- 在 practice.plan.confirm.v2 的严格载荷中增加必填 scene_id
- 服务端 Catalog 场景传递稳定 SceneID，自定义场景传递计划内 SceneKey
- 前端复用场景资源解析器，通过 scene_id 精确选择图片，并保留分类兜底
- 保留 V1 解码兼容，V1 不要求新增字段

## 可复现测试

- `dart analyze`
- `flutter test --no-pub test/agent/agent_wire_codec_test.dart test/agent/wire_agent_client_test.dart test/agent/wire_agent_voice_client_test.dart test/agent/agent_voice_fence_test.dart test/agent/agent_message_bubble_test.dart test/coaching/preparation/practice_plan_client_action_test.dart test/coaching/preparation/practice_plan_client_action_controller_test.dart test/speak_up_app_test.dart`
- `go test ./internal/coaching/preparation/...`
- `git diff --check`
- iPhone 17 Pro 模拟器连接真实本地后端人工验收：看房与租赁咨询标题和看房图片显示正确，语音创建链路正常

Closes #766