### PR TITLE
perf(preparation): parse interview inputs concurrently

### DIFF
--- a/server/internal/coaching/preparation/job_target.go
+++ b/server/internal/coaching/preparation/job_target.go
@@ -334,21 +334,44 @@ func (s *InterviewPreparationService) Create(ctx context.Context, actor requestc
 		return existing, found, err
 	}
 	var resume *ResumeMaterial
-	if request.Resume != nil {
+	var candidate JobTargetCandidate
+	var parseErr error
+	if request.Resume == nil {
+		candidate, parseErr = s.parser.ParseJobTarget(ctx, request.Input)
+	} else {
 		if s.resumes == nil {
 			return InterviewPreparation{}, false, ErrInterviewPreparationGeneration
 		}
-		material, extractErr := s.resumes.Extract(
-			ctx, actor.UserID, clientRequestID, *request.Resume,
-		)
-		if extractErr != nil {
-			return InterviewPreparation{}, false, extractErr
+		type resumeParseResult struct {
+			material ResumeMaterial
+			err      error
 		}
-		resume = &material
+		type candidateParseResult struct {
+			candidate JobTargetCandidate
+			err       error
+		}
+		resumeResults := make(chan resumeParseResult, 1)
+		candidateResults := make(chan candidateParseResult, 1)
+		go func() {
+			material, err := s.resumes.Extract(
+				ctx, actor.UserID, clientRequestID, *request.Resume,
+			)
+			resumeResults <- resumeParseResult{material: material, err: err}
+		}()
+		go func() {
+			parsed, err := s.parser.ParseJobTarget(ctx, request.Input)
+			candidateResults <- candidateParseResult{candidate: parsed, err: err}
+		}()
+		resumeResult := <-resumeResults
+		candidateResult := <-candidateResults
+		if resumeResult.err != nil {
+			return InterviewPreparation{}, false, resumeResult.err
+		}
+		resume = &resumeResult.material
+		candidate, parseErr = candidateResult.candidate, candidateResult.err
 	}
-	candidate, err := s.parser.ParseJobTarget(ctx, request.Input)
-	if err != nil {
-		return InterviewPreparation{}, false, errors.Join(ErrInterviewPreparationGeneration, err)
+	if parseErr != nil {
+		return InterviewPreparation{}, false, errors.Join(ErrInterviewPreparationGeneration, parseErr)
 	}
 	if err := validateJobTargetCandidate(ctx, candidate, request.Input.Source, s.catalog); err != nil {
 		return InterviewPreparation{}, false, err

--- a/server/internal/coaching/preparation/job_target_service_test.go
+++ b/server/internal/coaching/preparation/job_target_service_test.go
@@ -1,0 +1,236 @@
+package preparation
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const interviewServiceTestID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+func TestInterviewPreparationCreateParsesResumeAndJobTargetConcurrently(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	repository := &interviewServiceRepositoryFake{}
+	service := newInterviewServiceForTest(t, repository,
+		&interviewServiceParserFake{parse: func(context.Context, JobTargetInput) (JobTargetCandidate, error) {
+			started <- "job target"
+			<-release
+			return interviewServiceCandidate(), nil
+		}},
+		&interviewServiceResumeFake{extract: func(context.Context, string, string, InterviewResumeUpload) (ResumeMaterial, error) {
+			started <- "resume"
+			<-release
+			return interviewServiceResume(), nil
+		}},
+	)
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := service.Create(context.Background(), interviewServiceActor(), "interview-create-key", interviewServiceRequest(true))
+		result <- err
+	}()
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case task := <-started:
+			seen[task] = true
+		case <-time.After(time.Second):
+			t.Fatal("resume and job-target parsing did not start concurrently")
+		}
+	}
+	if !seen["resume"] || !seen["job target"] {
+		t.Fatalf("started tasks=%v", seen)
+	}
+	close(release)
+	released = true
+	if err := <-result; err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if repository.createCalls != 1 || repository.command.ResumeContent == nil {
+		t.Fatalf("create calls=%d command=%#v", repository.createCalls, repository.command)
+	}
+}
+
+func TestInterviewPreparationCreateWithoutResumeOnlyParsesJobTarget(t *testing.T) {
+	repository := &interviewServiceRepositoryFake{}
+	parserCalls := 0
+	service := newInterviewServiceForTest(t, repository,
+		&interviewServiceParserFake{parse: func(context.Context, JobTargetInput) (JobTargetCandidate, error) {
+			parserCalls++
+			return interviewServiceCandidate(), nil
+		}},
+		nil,
+	)
+
+	_, _, err := service.Create(context.Background(), interviewServiceActor(), "interview-create-key", interviewServiceRequest(false))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if parserCalls != 1 || repository.createCalls != 1 || repository.command.ResumeContent != nil {
+		t.Fatalf("parser calls=%d repository=%#v", parserCalls, repository)
+	}
+}
+
+func TestInterviewPreparationCreateDoesNotPersistParallelParseFailures(t *testing.T) {
+	resumeFailure := errors.New("resume failed")
+	parserFailure := errors.New("job target failed")
+	tests := []struct {
+		name       string
+		resumeErr  error
+		parserErr  error
+		wantError  error
+		wantJoined bool
+	}{
+		{name: "resume", resumeErr: resumeFailure, wantError: resumeFailure},
+		{name: "job target", parserErr: parserFailure, wantError: parserFailure, wantJoined: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repository := &interviewServiceRepositoryFake{}
+			service := newInterviewServiceForTest(t, repository,
+				&interviewServiceParserFake{parse: func(context.Context, JobTargetInput) (JobTargetCandidate, error) {
+					return interviewServiceCandidate(), test.parserErr
+				}},
+				&interviewServiceResumeFake{extract: func(context.Context, string, string, InterviewResumeUpload) (ResumeMaterial, error) {
+					return interviewServiceResume(), test.resumeErr
+				}},
+			)
+
+			_, _, err := service.Create(context.Background(), interviewServiceActor(), "interview-create-key", interviewServiceRequest(true))
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("error=%v, want %v", err, test.wantError)
+			}
+			if errors.Is(err, ErrInterviewPreparationGeneration) != test.wantJoined {
+				t.Fatalf("generation error=%t, want %t: %v", errors.Is(err, ErrInterviewPreparationGeneration), test.wantJoined, err)
+			}
+			if repository.createCalls != 0 {
+				t.Fatalf("repository Create called %d times", repository.createCalls)
+			}
+		})
+	}
+}
+
+func newInterviewServiceForTest(t *testing.T, repository InterviewPreparationRepository, parser JobTargetParser, resumes InterviewResumeExtractor) *InterviewPreparationService {
+	t.Helper()
+	service, err := NewInterviewPreparationService(repository, interviewServiceIDGenerator{}, parser, interviewServiceCatalog{}, resumes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return service
+}
+
+func interviewServiceRequest(withResume bool) CreateInterviewPreparationRequest {
+	request := CreateInterviewPreparationRequest{Input: JobTargetInput{Source: JobTargetSourceQuickStart, JobTitle: "Backend Engineer"}}
+	if withResume {
+		request.Resume = &InterviewResumeUpload{
+			Body: strings.NewReader("%PDF-1.7"), Size: 8,
+			ChecksumSHA256: strings.Repeat("a", 64),
+		}
+	}
+	return request
+}
+
+func interviewServiceActor() requestcontext.Actor {
+	return requestcontext.Actor{UserID: "11111111-1111-4111-8111-111111111111", SessionID: "test-session"}
+}
+
+func interviewServiceCandidate() JobTargetCandidate {
+	return JobTargetCandidate{
+		Source: JobTargetSourceQuickStart, GeneralAdviceOnly: true,
+		JobTitle: "Backend Engineer", Seniority: "Mid-level",
+		Responsibilities: []string{"Build services"}, CoreSkills: []string{"Go"},
+		CommunicationFocus: []string{"Explain trade-offs"}, PracticeGoals: []string{"Answer clearly"},
+		ScopeNotice: "General advice only.",
+		CatalogRecommendation: JobTargetCatalogRecommendation{
+			SceneID: "project-deep-dive", SceneVersion: 1,
+			SelectedRoleIDs: []string{"technical-interviewer"}, PracticeOptionID: "full-simulation",
+		},
+	}
+}
+
+func interviewServiceResume() ResumeMaterial {
+	return ResumeMaterial{
+		WorkExperiences: []ResumeWorkExperience{}, ProjectExperiences: []ResumeProjectExperience{},
+		EducationExperiences: []ResumeEducationExperience{}, Skills: []string{}, Awards: []string{},
+	}
+}
+
+type interviewServiceParserFake struct {
+	parse func(context.Context, JobTargetInput) (JobTargetCandidate, error)
+}
+
+func (fake *interviewServiceParserFake) ParseJobTarget(ctx context.Context, input JobTargetInput) (JobTargetCandidate, error) {
+	return fake.parse(ctx, input)
+}
+
+type interviewServiceResumeFake struct {
+	extract func(context.Context, string, string, InterviewResumeUpload) (ResumeMaterial, error)
+}
+
+func (fake *interviewServiceResumeFake) Extract(ctx context.Context, userID, requestID string, upload InterviewResumeUpload) (ResumeMaterial, error) {
+	return fake.extract(ctx, userID, requestID, upload)
+}
+
+type interviewServiceIDGenerator struct{}
+
+func (interviewServiceIDGenerator) NewID() (string, error) { return interviewServiceTestID, nil }
+
+type interviewServiceRepositoryFake struct {
+	createCalls int
+	command     CreateInterviewPreparationCommand
+}
+
+func (*interviewServiceRepositoryFake) ReplayCreate(context.Context, requestcontext.Actor, string, [sha256.Size]byte) (InterviewPreparation, bool, error) {
+	return InterviewPreparation{}, false, nil
+}
+
+func (fake *interviewServiceRepositoryFake) Create(_ context.Context, actor requestcontext.Actor, command CreateInterviewPreparationCommand) (InterviewPreparation, bool, error) {
+	fake.createCalls++
+	fake.command = command
+	return InterviewPreparation{
+		ID: command.ID, UserID: actor.UserID, Input: command.Input, Candidate: command.Candidate,
+		ResumeContent: command.ResumeContent, Status: InterviewPreparationDraft, Version: 1,
+	}, false, nil
+}
+
+func (*interviewServiceRepositoryFake) Get(context.Context, requestcontext.Actor, string) (InterviewPreparation, error) {
+	return InterviewPreparation{}, ErrInterviewPreparationNotFound
+}
+
+func (*interviewServiceRepositoryFake) Patch(context.Context, requestcontext.Actor, PatchInterviewPreparationCommand) (InterviewPreparation, bool, error) {
+	return InterviewPreparation{}, false, ErrInterviewPreparationNotFound
+}
+
+type interviewServiceCatalog struct{}
+
+func (interviewServiceCatalog) ListActiveScenes(context.Context) ([]scene.SceneDefinition, error) {
+	return nil, nil
+}
+
+func (interviewServiceCatalog) GetScene(context.Context, string) (scene.SceneDefinition, error) {
+	return scene.SceneDefinition{}, scene.ErrSceneNotFound
+}
+
+func (interviewServiceCatalog) ListRoles(context.Context, string) ([]scene.RoleDefinition, error) {
+	return nil, nil
+}
+
+func (interviewServiceCatalog) ResolveSelection(_ context.Context, _ string, _ int, selectedRoleIDs []string, _ string) (scene.SelectionSnapshot, error) {
+	return scene.SelectionSnapshot{
+		Scene:           scene.ExecutableSceneSnapshot{Experience: scene.PracticeExperienceInterview},
+		SelectedRoleIDs: append([]string(nil), selectedRoleIDs...),
+	}, nil
+}


### PR DESCRIPTION
## 功能描述

创建包含简历的面试准备时，并行执行简历解析与岗位信息解析，使解析阶段总等待时间从两项耗时之和降低为较慢一项的耗时。

Closes #775

## 实现思路

- 仅在请求包含简历时同时启动 `InterviewResumeExtractor.Extract` 和 `JobTargetParser.ParseJobTarget`。
- 等待两项结果后沿用现有校验与持久化流程。
- 保持原有错误优先级；任一解析失败均不写入 InterviewPreparation。
- 不含简历时保持原有单独岗位解析路径。
- 未增加耗时日志，未修改模型、Prompt、API、数据库或移动端。

## 测试方式

```bash
cd server
go test ./internal/coaching/preparation/...
go test -race ./internal/coaching/preparation
cd ..
git diff --check
```

新增测试通过阻塞两个解析器并确认二者均已启动后才放行，能够识别串行实现；同时覆盖无简历路径和两类失败不落库。以上命令均通过。