### PR TITLE
feat(profile): 支持用户修改头像

### DIFF
--- a/api/modules/identity.yaml
+++ b/api/modules/identity.yaml
@@ -258,20 +258,33 @@ paths:
     get:
       tags:
         - Identity
-      summary: Issue a short-lived read capability for the current avatar
+      summary: Read the current private avatar through the authenticated API
       operationId: getCurrentUserAvatarContent
       responses:
         '200':
-          description: Ephemeral private avatar content capability.
+          description: Validated private avatar bytes.
           headers:
             Cache-Control:
               schema:
                 type: string
                 const: no-store
-          content:
-            application/json:
+            X-Content-Type-Options:
               schema:
-                $ref: '#/components/schemas/UserAvatarContent'
+                type: string
+                const: nosniff
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
         '401':
           $ref: ../common/errors.yaml#/components/responses/Unauthorized
         '404':
@@ -462,21 +475,6 @@ components:
           maximum: 16384
           readOnly: true
         updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-    UserAvatarContent:
-      type: object
-      additionalProperties: false
-      required:
-        - content_url
-        - expires_at
-      properties:
-        content_url:
-          type: string
-          format: uri
-          readOnly: true
-        expires_at:
           type: string
           format: date-time
           readOnly: true

--- a/api/modules/identity.yaml
+++ b/api/modules/identity.yaml
@@ -188,7 +188,114 @@ paths:
           $ref: '#/components/responses/ProfileConflict'
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/me/avatar:
+    post:
+      tags:
+        - Identity
+      summary: Replace the current user's private profile avatar
+      operationId: replaceCurrentUserAvatar
+      parameters:
+        - $ref: '#/components/parameters/ProfileVersionMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          image/jpeg:
+            schema:
+              type: string
+              format: binary
+              maxLength: 10485760
+          image/png:
+            schema:
+              type: string
+              format: binary
+              maxLength: 10485760
+          image/webp:
+            schema:
+              type: string
+              format: binary
+              maxLength: 10485760
+      responses:
+        '200':
+          description: The updated profile after the avatar is committed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        '413':
+          $ref: ../common/errors.yaml#/components/responses/PayloadTooLarge
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+    delete:
+      tags:
+        - Identity
+      summary: Restore the current user's default profile avatar
+      operationId: useDefaultCurrentUserAvatar
+      parameters:
+        - $ref: '#/components/parameters/ProfileVersionMatch'
+      responses:
+        '200':
+          description: The profile after restoring the default avatar.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/me/avatar/content:
+    get:
+      tags:
+        - Identity
+      summary: Issue a short-lived read capability for the current avatar
+      operationId: getCurrentUserAvatarContent
+      responses:
+        '200':
+          description: Ephemeral private avatar content capability.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                const: no-store
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAvatarContent'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
 components:
+  parameters:
+    ProfileVersionMatch:
+      name: If-Match
+      in: header
+      required: true
+      schema:
+        type: string
+        pattern: '^"[1-9][0-9]*"$'
+      description: Quoted current UserProfile version.
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      schema:
+        type: string
+        minLength: 8
+        maxLength: 128
   responses:
     InvalidCredentials:
       description: |
@@ -326,11 +433,50 @@ components:
           format: int64
           minimum: 1
           readOnly: true
+        avatar:
+          $ref: '#/components/schemas/UserProfileAvatar'
         created_at:
           type: string
           format: date-time
           readOnly: true
         updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    UserProfileAvatar:
+      type: object
+      additionalProperties: false
+      required:
+        - width
+        - height
+        - updated_at
+      properties:
+        width:
+          type: integer
+          minimum: 1
+          maximum: 16384
+          readOnly: true
+        height:
+          type: integer
+          minimum: 1
+          maximum: 16384
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+    UserAvatarContent:
+      type: object
+      additionalProperties: false
+      required:
+        - content_url
+        - expires_at
+      properties:
+        content_url:
+          type: string
+          format: uri
+          readOnly: true
+        expires_at:
           type: string
           format: date-time
           readOnly: true

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -242,8 +242,6 @@ components:
       $ref: ./modules/identity.yaml#/components/schemas/UserProfile
     UserProfileAvatar:
       $ref: ./modules/identity.yaml#/components/schemas/UserProfileAvatar
-    UserAvatarContent:
-      $ref: ./modules/identity.yaml#/components/schemas/UserAvatarContent
     UpdateUserProfileRequest:
       $ref: ./modules/identity.yaml#/components/schemas/UpdateUserProfileRequest
     CoachingProfile:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -79,6 +79,10 @@ paths:
     $ref: ./modules/identity.yaml#/paths/~1v1~1me
   /v1/me/profile:
     $ref: ./modules/identity.yaml#/paths/~1v1~1me~1profile
+  /v1/me/avatar:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1me~1avatar
+  /v1/me/avatar/content:
+    $ref: ./modules/identity.yaml#/paths/~1v1~1me~1avatar~1content
   /v1/me/coaching-profile:
     $ref: ./modules/coaching-profile.yaml#/paths/~1v1~1me~1coaching-profile
   /v1/scenes:
@@ -236,6 +240,10 @@ components:
       $ref: ./modules/identity.yaml#/components/schemas/User
     UserProfile:
       $ref: ./modules/identity.yaml#/components/schemas/UserProfile
+    UserProfileAvatar:
+      $ref: ./modules/identity.yaml#/components/schemas/UserProfileAvatar
+    UserAvatarContent:
+      $ref: ./modules/identity.yaml#/components/schemas/UserAvatarContent
     UpdateUserProfileRequest:
       $ref: ./modules/identity.yaml#/components/schemas/UpdateUserProfileRequest
     CoachingProfile:

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -491,6 +491,9 @@ const logout = requireOperation('POST /v1/auth/logout');
 const me = requireOperation('GET /v1/me');
 const getProfile = requireOperation('GET /v1/me/profile');
 const updateProfile = requireOperation('PATCH /v1/me/profile');
+const uploadAvatar = requireOperation('POST /v1/me/avatar');
+const useDefaultAvatar = requireOperation('DELETE /v1/me/avatar');
+const getAvatarContent = requireOperation('GET /v1/me/avatar/content');
 const createPracticePlan = requireOperation('POST /v1/practice-plans');
 const archivePracticePlan = requireOperation(
   'DELETE /v1/practice-plans/{practice_plan_id}',
@@ -502,6 +505,9 @@ assert.equal(logout.operationId, 'logoutCurrentSession');
 assert.equal(me.operationId, 'getCurrentUser');
 assert.equal(getProfile.operationId, 'getCurrentUserProfile');
 assert.equal(updateProfile.operationId, 'updateCurrentUserProfile');
+assert.equal(uploadAvatar.operationId, 'replaceCurrentUserAvatar');
+assert.equal(useDefaultAvatar.operationId, 'useDefaultCurrentUserAvatar');
+assert.equal(getAvatarContent.operationId, 'getCurrentUserAvatarContent');
 assert.equal(createPracticePlan.operationId, 'createPracticePlan');
 assert.equal(archivePracticePlan.operationId, 'archivePracticePlan');
 assert.ok(register.requestBody?.required);
@@ -544,6 +550,14 @@ assert.ok(getProfile.responses?.['404']);
 assert.ok(updateProfile.responses?.['200']);
 assert.ok(updateProfile.responses?.['409']);
 assert.ok(updateProfile.requestBody?.required);
+assert.ok(uploadAvatar.requestBody?.required);
+assert.ok(uploadAvatar.responses?.['200']);
+assert.ok(uploadAvatar.responses?.['409']);
+assert.ok(uploadAvatar.responses?.['413']);
+assert.ok(useDefaultAvatar.responses?.['200']);
+assert.ok(useDefaultAvatar.responses?.['409']);
+assert.ok(getAvatarContent.responses?.['200']);
+assert.ok(getAvatarContent.responses?.['404']);
 assert.equal(
   getJsonSchema(updateProfile.requestBody)?.$ref,
   '#/components/schemas/UpdateUserProfileRequest',
@@ -735,6 +749,17 @@ assert.deepEqual(sorted(userProfileSchema?.required ?? []), [
   'user_id',
 ]);
 assert.equal(userProfileSchema?.additionalProperties, false);
+assert.equal(
+  userProfileSchema?.properties?.avatar?.$ref,
+  '#/components/schemas/UserProfileAvatar',
+);
+const userProfileAvatarSchema = schemas.UserProfileAvatar;
+assert.deepEqual(sorted(userProfileAvatarSchema?.required ?? []), [
+  'height',
+  'updated_at',
+  'width',
+]);
+assert.equal(userProfileAvatarSchema?.additionalProperties, false);
 assert.equal(userProfileSchema?.properties?.user_id?.readOnly, true);
 assert.equal(
   userProfileSchema?.properties?.profile_version?.readOnly,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -33,6 +33,7 @@ import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.da
 import 'package:speakup/features/coaching/evaluation/agent_conversation_feedback_presenter.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 import 'package:speakup/features/profile/profile_page.dart';
+import 'package:speakup/features/profile/profile_avatar_view.dart';
 
 class SpeakUpShell extends StatefulWidget {
   const SpeakUpShell({
@@ -576,6 +577,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         profileErrorMessage: widget.authController?.profileErrorMessage,
         profileSaving: widget.authController?.profileSaving ?? false,
         onSaveDisplayName: widget.authController?.updateDisplayName,
+        avatarUrl: widget.authController?.avatarUrl,
+        avatarSaving: widget.authController?.avatarSaving ?? false,
+        onUploadAvatar: widget.authController?.updateAvatar,
+        onUseDefaultAvatar: widget.authController?.useDefaultAvatar,
         onLogout: widget.authController?.logout,
         reviewHistoryController: widget.reviewHistoryController,
         coachingProfileController: widget.coachingProfileController,
@@ -593,6 +598,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
               : Colors.transparent,
           drawer: _ConversationDrawer(
             controller: widget.conversationController,
+            avatarUrl: widget.authController?.avatarUrl,
             onOpenProfile: () => _selectDestination(3),
           ),
           onDrawerChanged: (open) {
@@ -778,10 +784,12 @@ class _ConversationDrawer extends StatelessWidget {
   const _ConversationDrawer({
     required this.controller,
     required this.onOpenProfile,
+    this.avatarUrl,
   });
 
   final ConversationController controller;
   final VoidCallback onOpenProfile;
+  final Uri? avatarUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -940,12 +948,9 @@ class _ConversationDrawer extends StatelessWidget {
                             width: 48,
                             height: 48,
                           ),
-                          icon: const CircleAvatar(
-                            radius: 24,
-                            backgroundColor: SpeakUpDesign.surfaceMuted,
-                            backgroundImage: AssetImage(
-                              'assets/images/scenes/profile-avatar-alex.png',
-                            ),
+                          icon: ProfileAvatarView(
+                            size: 48,
+                            avatarUrl: avatarUrl,
                           ),
                         ),
                       ],

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -127,6 +127,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   @override
   void initState() {
     super.initState();
+    widget.authController?.addListener(_handleAuthState);
     widget.conversationController.addListener(_handleAgentInteractionState);
     widget.composerController.addListener(_handleAgentInteractionState);
     widget.practiceController.addListener(_handlePracticeState);
@@ -136,6 +137,10 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   @override
   void didUpdateWidget(covariant SpeakUpShell oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.authController != widget.authController) {
+      oldWidget.authController?.removeListener(_handleAuthState);
+      widget.authController?.addListener(_handleAuthState);
+    }
     final conversationControllerChanged =
         oldWidget.conversationController != widget.conversationController;
     if (conversationControllerChanged) {
@@ -160,11 +165,18 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
 
   @override
   void dispose() {
+    widget.authController?.removeListener(_handleAuthState);
     widget.conversationController.removeListener(_handleAgentInteractionState);
     widget.composerController.removeListener(_handleAgentInteractionState);
     widget.practiceController.removeListener(_handlePracticeState);
     _feedbackPresenter?.dispose();
     super.dispose();
+  }
+
+  void _handleAuthState() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   void _selectDestination(int index) {

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
@@ -577,7 +578,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         profileErrorMessage: widget.authController?.profileErrorMessage,
         profileSaving: widget.authController?.profileSaving ?? false,
         onSaveDisplayName: widget.authController?.updateDisplayName,
-        avatarUrl: widget.authController?.avatarUrl,
+        avatarBytes: widget.authController?.avatarBytes,
         avatarSaving: widget.authController?.avatarSaving ?? false,
         onUploadAvatar: widget.authController?.updateAvatar,
         onUseDefaultAvatar: widget.authController?.useDefaultAvatar,
@@ -598,7 +599,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
               : Colors.transparent,
           drawer: _ConversationDrawer(
             controller: widget.conversationController,
-            avatarUrl: widget.authController?.avatarUrl,
+            avatarBytes: widget.authController?.avatarBytes,
             onOpenProfile: () => _selectDestination(3),
           ),
           onDrawerChanged: (open) {
@@ -784,12 +785,12 @@ class _ConversationDrawer extends StatelessWidget {
   const _ConversationDrawer({
     required this.controller,
     required this.onOpenProfile,
-    this.avatarUrl,
+    this.avatarBytes,
   });
 
   final ConversationController controller;
   final VoidCallback onOpenProfile;
-  final Uri? avatarUrl;
+  final Uint8List? avatarBytes;
 
   @override
   Widget build(BuildContext context) {
@@ -950,7 +951,7 @@ class _ConversationDrawer extends StatelessWidget {
                           ),
                           icon: ProfileAvatarView(
                             size: 48,
-                            avatarUrl: avatarUrl,
+                            avatarBytes: avatarBytes,
                           ),
                         ),
                       ],

--- a/mobile/lib/features/profile/profile_avatar_picker.dart
+++ b/mobile/lib/features/profile/profile_avatar_picker.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:speakup/identity/client/identity_client.dart';
+
+abstract interface class ProfileAvatarPicker {
+  Future<UserAvatarImage?> pickFromGallery();
+
+  Future<UserAvatarImage?> takePhoto();
+}
+
+final class SystemProfileAvatarPicker implements ProfileAvatarPicker {
+  SystemProfileAvatarPicker({ImagePicker? picker})
+    : _picker = picker ?? ImagePicker();
+
+  final ImagePicker _picker;
+
+  @override
+  Future<UserAvatarImage?> pickFromGallery() => _pick(ImageSource.gallery);
+
+  @override
+  Future<UserAvatarImage?> takePhoto() => _pick(ImageSource.camera);
+
+  Future<UserAvatarImage?> _pick(ImageSource source) async {
+    final file = await _picker.pickImage(
+      source: source,
+      maxWidth: 2048,
+      maxHeight: 2048,
+      imageQuality: 92,
+      requestFullMetadata: false,
+    );
+    if (file == null) {
+      return null;
+    }
+    final bytes = Uint8List.fromList(await file.readAsBytes());
+    return UserAvatarImage(contentType: _contentType(file), bytes: bytes);
+  }
+}
+
+String _contentType(XFile file) {
+  final declared = file.mimeType?.toLowerCase();
+  if (declared == 'image/jpeg' ||
+      declared == 'image/png' ||
+      declared == 'image/webp') {
+    return declared!;
+  }
+  final name = file.name.toLowerCase();
+  if (name.endsWith('.jpg') || name.endsWith('.jpeg')) return 'image/jpeg';
+  if (name.endsWith('.png')) return 'image/png';
+  if (name.endsWith('.webp')) return 'image/webp';
+  return 'application/octet-stream';
+}

--- a/mobile/lib/features/profile/profile_avatar_view.dart
+++ b/mobile/lib/features/profile/profile_avatar_view.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+class ProfileAvatarView extends StatelessWidget {
+  const ProfileAvatarView({
+    required this.size,
+    this.avatarUrl,
+    this.editable = false,
+    this.saving = false,
+    this.onTap,
+    this.avatarKey,
+    super.key,
+  });
+
+  final double size;
+  final Uri? avatarUrl;
+  final bool editable;
+  final bool saving;
+  final VoidCallback? onTap;
+  final Key? avatarKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatar = Container(
+      key: avatarKey,
+      width: size,
+      height: size,
+      padding: EdgeInsets.all(size >= 100 ? 3 : 0),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.surface,
+        shape: BoxShape.circle,
+        boxShadow: size >= 100
+            ? const [
+                BoxShadow(
+                  color: Color(0x14000000),
+                  blurRadius: 20,
+                  offset: Offset(0, 8),
+                ),
+              ]
+            : null,
+      ),
+      child: ClipOval(
+        child: avatarUrl == null
+            ? Image.asset(
+                'assets/images/scenes/profile-avatar-alex.png',
+                fit: BoxFit.cover,
+              )
+            : Image.network(
+                avatarUrl.toString(),
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => Image.asset(
+                  'assets/images/scenes/profile-avatar-alex.png',
+                  fit: BoxFit.cover,
+                ),
+              ),
+      ),
+    );
+    if (!editable) {
+      return avatar;
+    }
+    return Semantics(
+      button: true,
+      label: '修改头像',
+      child: InkWell(
+        key: const Key('profile-avatar-edit-button'),
+        customBorder: const CircleBorder(),
+        onTap: saving ? null : onTap,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            avatar,
+            Positioned(
+              right: 2,
+              bottom: 2,
+              child: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: SpeakUpDesign.primary,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: SpeakUpDesign.surface, width: 3),
+                ),
+                child: saving
+                    ? const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: SpeakUpDesign.canvas,
+                        ),
+                      )
+                    : const Icon(
+                        Icons.photo_camera_rounded,
+                        color: SpeakUpDesign.canvas,
+                        size: 18,
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/profile/profile_avatar_view.dart
+++ b/mobile/lib/features/profile/profile_avatar_view.dart
@@ -1,10 +1,12 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 
 class ProfileAvatarView extends StatelessWidget {
   const ProfileAvatarView({
     required this.size,
-    this.avatarUrl,
+    this.avatarBytes,
     this.editable = false,
     this.saving = false,
     this.onTap,
@@ -13,7 +15,7 @@ class ProfileAvatarView extends StatelessWidget {
   });
 
   final double size;
-  final Uri? avatarUrl;
+  final Uint8List? avatarBytes;
   final bool editable;
   final bool saving;
   final VoidCallback? onTap;
@@ -40,13 +42,13 @@ class ProfileAvatarView extends StatelessWidget {
             : null,
       ),
       child: ClipOval(
-        child: avatarUrl == null
+        child: avatarBytes == null
             ? Image.asset(
                 'assets/images/scenes/profile-avatar-alex.png',
                 fit: BoxFit.cover,
               )
-            : Image.network(
-                avatarUrl.toString(),
+            : Image.memory(
+                avatarBytes!,
                 fit: BoxFit.cover,
                 errorBuilder: (_, _, _) => Image.asset(
                   'assets/images/scenes/profile-avatar-alex.png',

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
@@ -16,7 +18,7 @@ class ProfilePage extends StatelessWidget {
     required this.profileErrorMessage,
     required this.profileSaving,
     required this.onSaveDisplayName,
-    required this.avatarUrl,
+    required this.avatarBytes,
     required this.avatarSaving,
     required this.onUploadAvatar,
     required this.onUseDefaultAvatar,
@@ -33,7 +35,7 @@ class ProfilePage extends StatelessWidget {
   final String? profileErrorMessage;
   final bool profileSaving;
   final Future<String?> Function(String)? onSaveDisplayName;
-  final Uri? avatarUrl;
+  final Uint8List? avatarBytes;
   final bool avatarSaving;
   final Future<String?> Function(UserAvatarImage)? onUploadAvatar;
   final Future<String?> Function()? onUseDefaultAvatar;
@@ -74,7 +76,7 @@ class ProfilePage extends StatelessWidget {
                       ProfileAvatarView(
                         avatarKey: const Key('profile-avatar'),
                         size: 132,
-                        avatarUrl: avatarUrl,
+                        avatarBytes: avatarBytes,
                         editable: user != null && onUploadAvatar != null,
                         saving: avatarSaving,
                         onTap: () => _editAvatar(context),

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -3,6 +3,9 @@ import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 import 'package:speakup/features/coaching/review/review.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
+import 'package:speakup/features/profile/profile_avatar_picker.dart';
+import 'package:speakup/features/profile/profile_avatar_view.dart';
+import 'package:speakup/identity/client/identity_client.dart';
 import 'package:speakup/identity/model/identity_models.dart';
 
 class ProfilePage extends StatelessWidget {
@@ -13,9 +16,14 @@ class ProfilePage extends StatelessWidget {
     required this.profileErrorMessage,
     required this.profileSaving,
     required this.onSaveDisplayName,
+    required this.avatarUrl,
+    required this.avatarSaving,
+    required this.onUploadAvatar,
+    required this.onUseDefaultAvatar,
     required this.onLogout,
     required this.reviewHistoryController,
     required this.coachingProfileController,
+    this.avatarPicker,
     super.key,
   });
 
@@ -25,9 +33,14 @@ class ProfilePage extends StatelessWidget {
   final String? profileErrorMessage;
   final bool profileSaving;
   final Future<String?> Function(String)? onSaveDisplayName;
+  final Uri? avatarUrl;
+  final bool avatarSaving;
+  final Future<String?> Function(UserAvatarImage)? onUploadAvatar;
+  final Future<String?> Function()? onUseDefaultAvatar;
   final VoidCallback? onLogout;
   final ReviewHistoryController? reviewHistoryController;
   final CoachingProfileController? coachingProfileController;
+  final ProfileAvatarPicker? avatarPicker;
 
   @override
   Widget build(BuildContext context) {
@@ -58,28 +71,13 @@ class ProfilePage extends StatelessWidget {
                 Center(
                   child: Column(
                     children: [
-                      Container(
-                        key: const Key('profile-avatar'),
-                        width: 132,
-                        height: 132,
-                        padding: const EdgeInsets.all(3),
-                        decoration: const BoxDecoration(
-                          color: SpeakUpDesign.surface,
-                          shape: BoxShape.circle,
-                          boxShadow: [
-                            BoxShadow(
-                              color: Color(0x14000000),
-                              blurRadius: 20,
-                              offset: Offset(0, 8),
-                            ),
-                          ],
-                        ),
-                        child: const CircleAvatar(
-                          backgroundColor: SpeakUpDesign.surfaceMuted,
-                          backgroundImage: AssetImage(
-                            'assets/images/scenes/profile-avatar-alex.png',
-                          ),
-                        ),
+                      ProfileAvatarView(
+                        avatarKey: const Key('profile-avatar'),
+                        size: 132,
+                        avatarUrl: avatarUrl,
+                        editable: user != null && onUploadAvatar != null,
+                        saving: avatarSaving,
+                        onTap: () => _editAvatar(context),
                       ),
                       const SizedBox(height: SpeakUpDesign.space20),
                       Row(
@@ -183,7 +181,79 @@ class ProfilePage extends StatelessWidget {
       ).showSnackBar(const SnackBar(content: Text('昵称已更新')));
     }
   }
+
+  Future<void> _editAvatar(BuildContext context) async {
+    final action = await showModalBottomSheet<_AvatarAction>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                key: const Key('profile-avatar-gallery'),
+                leading: const Icon(Icons.photo_library_outlined),
+                title: const Text('从相册选择'),
+                onTap: () => Navigator.pop(sheetContext, _AvatarAction.gallery),
+              ),
+              ListTile(
+                key: const Key('profile-avatar-camera'),
+                leading: const Icon(Icons.photo_camera_outlined),
+                title: const Text('拍照'),
+                onTap: () => Navigator.pop(sheetContext, _AvatarAction.camera),
+              ),
+              ListTile(
+                key: const Key('profile-avatar-default'),
+                enabled: profile?.avatar != null,
+                leading: const Icon(Icons.account_circle_outlined),
+                title: const Text('使用默认头像'),
+                trailing: profile?.avatar == null
+                    ? const Icon(Icons.check_rounded)
+                    : null,
+                onTap: profile?.avatar == null
+                    ? null
+                    : () =>
+                          Navigator.pop(sheetContext, _AvatarAction.useDefault),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    if (action == null || !context.mounted) return;
+    if (action == _AvatarAction.useDefault) {
+      final error = await onUseDefaultAvatar?.call();
+      if (context.mounted) {
+        _showAvatarMessage(context, error ?? '已使用默认头像');
+      }
+      return;
+    }
+    String? error;
+    try {
+      final picker = avatarPicker ?? SystemProfileAvatarPicker();
+      final image = action == _AvatarAction.gallery
+          ? await picker.pickFromGallery()
+          : await picker.takePhoto();
+      if (image == null || !context.mounted) return;
+      error = await onUploadAvatar?.call(image);
+    } catch (_) {
+      error = '无法读取图片，请检查照片权限后重试。';
+    }
+    if (context.mounted) {
+      _showAvatarMessage(context, error ?? '头像已更新');
+    }
+  }
+
+  void _showAvatarMessage(BuildContext context, String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
 }
+
+enum _AvatarAction { gallery, camera, useDefault }
 
 class _DisplayNameDialog extends StatefulWidget {
   const _DisplayNameDialog({required this.initialName, required this.onSave});

--- a/mobile/lib/identity/auth_controller.dart
+++ b/mobile/lib/identity/auth_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:speakup/identity/auth_state.dart';
@@ -34,7 +35,7 @@ final class AuthController extends ChangeNotifier {
   bool _profileSaving = false;
   bool _profilePromptDismissed = false;
   String? _profileErrorMessage;
-  Uri? _avatarUrl;
+  Uint8List? _avatarBytes;
   bool _avatarSaving = false;
   int _avatarRequestSequence = 0;
 
@@ -42,7 +43,7 @@ final class AuthController extends ChangeNotifier {
   UserProfile? get profile => _profile;
   bool get profileSaving => _profileSaving;
   String? get profileErrorMessage => _profileErrorMessage;
-  Uri? get avatarUrl => _avatarUrl;
+  Uint8List? get avatarBytes => _avatarBytes;
   bool get avatarSaving => _avatarSaving;
   bool get shouldPromptForProfile =>
       profileClient != null &&
@@ -376,7 +377,7 @@ final class AuthController extends ChangeNotifier {
         return null;
       }
       _profile = updated;
-      _avatarUrl = null;
+      _avatarBytes = null;
       await _loadAvatarContent(
         client: client,
         token: expectedToken,
@@ -446,7 +447,7 @@ final class AuthController extends ChangeNotifier {
         return null;
       }
       _profile = updated;
-      _avatarUrl = null;
+      _avatarBytes = null;
       return null;
     } on IdentityClientException catch (error) {
       if (!_matchesCredential(expectedGeneration, expectedToken)) {
@@ -625,7 +626,7 @@ final class AuthController extends ChangeNotifier {
       }
       _profile = loaded;
       _profileLoaded = true;
-      _avatarUrl = null;
+      _avatarBytes = null;
       if (loaded.avatar != null && avatarClient != null) {
         await _loadAvatarContent(
           client: avatarClient!,
@@ -657,7 +658,7 @@ final class AuthController extends ChangeNotifier {
     _profileSaving = false;
     _profilePromptDismissed = false;
     _profileErrorMessage = null;
-    _avatarUrl = null;
+    _avatarBytes = null;
     _avatarSaving = false;
   }
 
@@ -669,11 +670,11 @@ final class AuthController extends ChangeNotifier {
     try {
       final content = await client.currentAvatarContent(sessionToken: token);
       if (_matchesCredential(generation, token)) {
-        _avatarUrl = content.url;
+        _avatarBytes = Uint8List.fromList(content.bytes);
       }
     } catch (_) {
       if (_matchesCredential(generation, token)) {
-        _avatarUrl = null;
+        _avatarBytes = null;
       }
     }
   }

--- a/mobile/lib/identity/auth_controller.dart
+++ b/mobile/lib/identity/auth_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:speakup/identity/auth_state.dart';
@@ -377,11 +376,13 @@ final class AuthController extends ChangeNotifier {
         return null;
       }
       _profile = updated;
-      _avatarBytes = null;
+      _avatarBytes = Uint8List.fromList(image.bytes);
+      notifyListeners();
       await _loadAvatarContent(
         client: client,
         token: expectedToken,
         generation: expectedGeneration,
+        preserveCurrentOnFailure: true,
       );
       return null;
     } on IdentityClientException catch (error) {
@@ -448,6 +449,7 @@ final class AuthController extends ChangeNotifier {
       }
       _profile = updated;
       _avatarBytes = null;
+      notifyListeners();
       return null;
     } on IdentityClientException catch (error) {
       if (!_matchesCredential(expectedGeneration, expectedToken)) {
@@ -666,6 +668,7 @@ final class AuthController extends ChangeNotifier {
     required UserAvatarClient client,
     required String token,
     required int generation,
+    bool preserveCurrentOnFailure = false,
   }) async {
     try {
       final content = await client.currentAvatarContent(sessionToken: token);
@@ -673,7 +676,7 @@ final class AuthController extends ChangeNotifier {
         _avatarBytes = Uint8List.fromList(content.bytes);
       }
     } catch (_) {
-      if (_matchesCredential(generation, token)) {
+      if (_matchesCredential(generation, token) && !preserveCurrentOnFailure) {
         _avatarBytes = null;
       }
     }

--- a/mobile/lib/identity/auth_controller.dart
+++ b/mobile/lib/identity/auth_controller.dart
@@ -13,12 +13,14 @@ final class AuthController extends ChangeNotifier {
     required this.identityClient,
     required this.sessionStore,
     this.profileClient,
+    this.avatarClient,
     PrivateStateCleanup? clearPrivateState,
   }) : _clearPrivateState = clearPrivateState ?? _noCleanup;
 
   final IdentityClient identityClient;
   final SessionStore sessionStore;
   final UserProfileClient? profileClient;
+  final UserAvatarClient? avatarClient;
   final PrivateStateCleanup _clearPrivateState;
 
   AuthState _state = const AuthLoading();
@@ -32,11 +34,16 @@ final class AuthController extends ChangeNotifier {
   bool _profileSaving = false;
   bool _profilePromptDismissed = false;
   String? _profileErrorMessage;
+  Uri? _avatarUrl;
+  bool _avatarSaving = false;
+  int _avatarRequestSequence = 0;
 
   AuthState get state => _state;
   UserProfile? get profile => _profile;
   bool get profileSaving => _profileSaving;
   String? get profileErrorMessage => _profileErrorMessage;
+  Uri? get avatarUrl => _avatarUrl;
+  bool get avatarSaving => _avatarSaving;
   bool get shouldPromptForProfile =>
       profileClient != null &&
       _profileLoaded &&
@@ -340,6 +347,137 @@ final class AuthController extends ChangeNotifier {
     }
   }
 
+  Future<String?> updateAvatar(UserAvatarImage image) async {
+    final client = avatarClient;
+    final credential = currentCredential;
+    final currentState = _state;
+    final currentProfile = _profile;
+    if (client == null ||
+        credential == null ||
+        currentState is! AuthAuthenticated ||
+        currentProfile == null ||
+        _avatarSaving) {
+      return '当前账号暂时不能修改头像。';
+    }
+    final expectedGeneration = credential.generation;
+    final expectedToken = credential.sessionToken;
+    _avatarSaving = true;
+    notifyListeners();
+    try {
+      final updated = await client.uploadAvatar(
+        sessionToken: expectedToken,
+        image: image,
+        expectedProfileVersion: currentProfile.profileVersion,
+        idempotencyKey:
+            'avatar-${DateTime.now().microsecondsSinceEpoch}-${++_avatarRequestSequence}',
+      );
+      if (!_matchesCredential(expectedGeneration, expectedToken) ||
+          updated.userId != currentState.user.id) {
+        return null;
+      }
+      _profile = updated;
+      _avatarUrl = null;
+      await _loadAvatarContent(
+        client: client,
+        token: expectedToken,
+        generation: expectedGeneration,
+      );
+      return null;
+    } on IdentityClientException catch (error) {
+      if (!_matchesCredential(expectedGeneration, expectedToken)) {
+        return null;
+      }
+      if (error.isAuthenticationFailure) {
+        await invalidateSession(
+          expectedSessionToken: expectedToken,
+          expectedGeneration: expectedGeneration,
+        );
+        return '登录状态已失效，请重新登录。';
+      }
+      if (error.kind == IdentityFailureKind.profileVersionConflict) {
+        await _loadProfile(
+          epoch: _authEpoch,
+          token: expectedToken,
+          userId: currentState.user.id,
+        );
+        return '头像已在其他设备修改，已为你刷新。';
+      }
+      return switch (error.kind) {
+        IdentityFailureKind.imageTooLarge => '图片过大，请选择 10 MB 以内的图片。',
+        IdentityFailureKind.invalidImage => '暂不支持这张图片，请选择 JPG、PNG 或 WebP。',
+        _ => '头像上传失败，请稍后重试。',
+      };
+    } catch (_) {
+      return '头像上传失败，请稍后重试。';
+    } finally {
+      if (_matchesCredential(expectedGeneration, expectedToken)) {
+        _avatarSaving = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<String?> useDefaultAvatar() async {
+    final client = avatarClient;
+    final credential = currentCredential;
+    final currentState = _state;
+    final currentProfile = _profile;
+    if (client == null ||
+        credential == null ||
+        currentState is! AuthAuthenticated ||
+        currentProfile == null ||
+        _avatarSaving) {
+      return '当前账号暂时不能修改头像。';
+    }
+    if (currentProfile.avatar == null) {
+      return null;
+    }
+    final expectedGeneration = credential.generation;
+    final expectedToken = credential.sessionToken;
+    _avatarSaving = true;
+    notifyListeners();
+    try {
+      final updated = await client.useDefaultAvatar(
+        sessionToken: expectedToken,
+        expectedProfileVersion: currentProfile.profileVersion,
+      );
+      if (!_matchesCredential(expectedGeneration, expectedToken) ||
+          updated.userId != currentState.user.id) {
+        return null;
+      }
+      _profile = updated;
+      _avatarUrl = null;
+      return null;
+    } on IdentityClientException catch (error) {
+      if (!_matchesCredential(expectedGeneration, expectedToken)) {
+        return null;
+      }
+      if (error.isAuthenticationFailure) {
+        await invalidateSession(
+          expectedSessionToken: expectedToken,
+          expectedGeneration: expectedGeneration,
+        );
+        return '登录状态已失效，请重新登录。';
+      }
+      if (error.kind == IdentityFailureKind.profileVersionConflict) {
+        await _loadProfile(
+          epoch: _authEpoch,
+          token: expectedToken,
+          userId: currentState.user.id,
+        );
+        return '头像已在其他设备修改，已为你刷新。';
+      }
+      return '暂时无法使用默认头像，请稍后重试。';
+    } catch (_) {
+      return '暂时无法使用默认头像，请稍后重试。';
+    } finally {
+      if (_matchesCredential(expectedGeneration, expectedToken)) {
+        _avatarSaving = false;
+        notifyListeners();
+      }
+    }
+  }
+
   Future<void> retry() async {
     final current = _state;
     if (current is! AuthRetryableError) {
@@ -487,6 +625,14 @@ final class AuthController extends ChangeNotifier {
       }
       _profile = loaded;
       _profileLoaded = true;
+      _avatarUrl = null;
+      if (loaded.avatar != null && avatarClient != null) {
+        await _loadAvatarContent(
+          client: avatarClient!,
+          token: token,
+          generation: _sessionGeneration,
+        );
+      }
     } on IdentityClientException catch (error) {
       if (!_isCurrentSession(epoch, token)) {
         return;
@@ -511,6 +657,25 @@ final class AuthController extends ChangeNotifier {
     _profileSaving = false;
     _profilePromptDismissed = false;
     _profileErrorMessage = null;
+    _avatarUrl = null;
+    _avatarSaving = false;
+  }
+
+  Future<void> _loadAvatarContent({
+    required UserAvatarClient client,
+    required String token,
+    required int generation,
+  }) async {
+    try {
+      final content = await client.currentAvatarContent(sessionToken: token);
+      if (_matchesCredential(generation, token)) {
+        _avatarUrl = content.url;
+      }
+    } catch (_) {
+      if (_matchesCredential(generation, token)) {
+        _avatarUrl = null;
+      }
+    }
   }
 
   Future<T> _withSessionStoreLock<T>(Future<T> Function() action) {

--- a/mobile/lib/identity/client/identity_client.dart
+++ b/mobile/lib/identity/client/identity_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import '../model/identity_models.dart';
 import '../network/bearer_authentication.dart';
@@ -19,6 +20,11 @@ enum IdentityFailureKind {
   network,
   invalidResponse,
   unexpected,
+  imageTooLarge,
+  invalidImage,
+  idempotencyConflict,
+  resourceNotFound,
+  resourceProcessing,
 }
 
 enum _IdentityOperation {
@@ -28,6 +34,9 @@ enum _IdentityOperation {
   currentProfile,
   updateProfile,
   logout,
+  uploadAvatar,
+  useDefaultAvatar,
+  avatarContent,
 }
 
 final class IdentityClientException implements Exception {
@@ -84,8 +93,45 @@ abstract interface class UserProfileClient {
   });
 }
 
+final class UserAvatarImage {
+  UserAvatarImage({required this.contentType, required Uint8List bytes})
+    : bytes = Uint8List.fromList(bytes);
+
+  final String contentType;
+  final Uint8List bytes;
+}
+
+final class UserAvatarContent {
+  const UserAvatarContent({required this.url, required this.expiresAt});
+
+  final Uri url;
+  final DateTime expiresAt;
+}
+
+abstract interface class UserAvatarClient {
+  Future<UserProfile> uploadAvatar({
+    required String sessionToken,
+    required UserAvatarImage image,
+    required int expectedProfileVersion,
+    required String idempotencyKey,
+  });
+
+  Future<UserProfile> useDefaultAvatar({
+    required String sessionToken,
+    required int expectedProfileVersion,
+  });
+
+  Future<UserAvatarContent> currentAvatarContent({
+    required String sessionToken,
+  });
+}
+
 final class WireIdentityClient
-    implements IdentityClient, ProfileRegistrationClient, UserProfileClient {
+    implements
+        IdentityClient,
+        ProfileRegistrationClient,
+        UserProfileClient,
+        UserAvatarClient {
   factory WireIdentityClient({
     required Uri baseUri,
     IdentityHttpTransport? transport,
@@ -203,10 +249,82 @@ final class WireIdentityClient
     _requireStatus(response, 204, _IdentityOperation.logout);
   }
 
+  @override
+  Future<UserProfile> uploadAvatar({
+    required String sessionToken,
+    required UserAvatarImage image,
+    required int expectedProfileVersion,
+    required String idempotencyKey,
+  }) async {
+    final response = await _send(
+      method: 'POST',
+      path: '/v1/me/avatar',
+      sessionToken: sessionToken,
+      bodyBytes: image.bytes,
+      headers: <String, String>{
+        HttpHeaders.contentTypeHeader: image.contentType,
+        HttpHeaders.ifMatchHeader: '"$expectedProfileVersion"',
+        'Idempotency-Key': idempotencyKey,
+      },
+    );
+    _requireStatus(response, 200, _IdentityOperation.uploadAvatar);
+    return _decode(response, UserProfile.fromJson);
+  }
+
+  @override
+  Future<UserProfile> useDefaultAvatar({
+    required String sessionToken,
+    required int expectedProfileVersion,
+  }) async {
+    final response = await _send(
+      method: 'DELETE',
+      path: '/v1/me/avatar',
+      sessionToken: sessionToken,
+      headers: <String, String>{
+        HttpHeaders.ifMatchHeader: '"$expectedProfileVersion"',
+      },
+    );
+    _requireStatus(response, 200, _IdentityOperation.useDefaultAvatar);
+    return _decode(response, UserProfile.fromJson);
+  }
+
+  @override
+  Future<UserAvatarContent> currentAvatarContent({
+    required String sessionToken,
+  }) async {
+    final response = await _send(
+      method: 'GET',
+      path: '/v1/me/avatar/content',
+      sessionToken: sessionToken,
+    );
+    _requireStatus(response, 200, _IdentityOperation.avatarContent);
+    return _decode(response, (json) {
+      if (!_hasExactJsonKeys(json, const {'content_url', 'expires_at'})) {
+        throw const FormatException('Invalid avatar content response.');
+      }
+      final rawUrl = json['content_url'];
+      final rawExpiry = json['expires_at'];
+      if (rawUrl is! String || rawExpiry is! String) {
+        throw const FormatException('Invalid avatar content response.');
+      }
+      final url = Uri.tryParse(rawUrl);
+      final expiresAt = DateTime.tryParse(rawExpiry)?.toUtc();
+      if (url == null ||
+          !url.hasAuthority ||
+          (url.scheme != 'https' && url.scheme != 'http') ||
+          expiresAt == null ||
+          !expiresAt.isAfter(DateTime.now().toUtc())) {
+        throw const FormatException('Invalid avatar content response.');
+      }
+      return UserAvatarContent(url: url, expiresAt: expiresAt);
+    });
+  }
+
   Future<IdentityHttpResponse> _send({
     required String method,
     required String path,
     Map<String, Object?>? body,
+    Uint8List? bodyBytes,
     String? sessionToken,
     Map<String, String> headers = const {},
   }) async {
@@ -228,6 +346,7 @@ final class WireIdentityClient
         uri: uri,
         headers: requestHeaders,
         body: body == null ? null : jsonEncode(body),
+        bodyBytes: bodyBytes,
       );
     } on IdentityClientException {
       rethrow;
@@ -307,6 +426,12 @@ final class WireIdentityClient
       'profile_version_conflict' => IdentityFailureKind.profileVersionConflict,
       'rate_limited' => IdentityFailureKind.rateLimited,
       'internal_error' => IdentityFailureKind.server,
+      'image_too_large' => IdentityFailureKind.imageTooLarge,
+      'invalid_image' ||
+      'unsupported_image_format' => IdentityFailureKind.invalidImage,
+      'idempotency_key_conflict' => IdentityFailureKind.idempotencyConflict,
+      'resource_not_found' => IdentityFailureKind.resourceNotFound,
+      'resource_processing' => IdentityFailureKind.resourceProcessing,
       _ => IdentityFailureKind.unexpected,
     };
 
@@ -339,6 +464,9 @@ final class WireIdentityClient
         _IdentityOperation.currentUser ||
             _IdentityOperation.currentProfile ||
             _IdentityOperation.updateProfile ||
+            _IdentityOperation.uploadAvatar ||
+            _IdentityOperation.useDefaultAvatar ||
+            _IdentityOperation.avatarContent ||
             _IdentityOperation.logout,
         401,
         'authentication_required',
@@ -352,6 +480,26 @@ final class WireIdentityClient
         'profile_version_conflict',
       (_IdentityOperation.updateProfile, 400, 'invalid_request') =>
         'invalid_request',
+      (_IdentityOperation.uploadAvatar, 400, 'invalid_request') =>
+        'invalid_request',
+      (_IdentityOperation.uploadAvatar, 400, 'invalid_image') =>
+        'invalid_image',
+      (_IdentityOperation.uploadAvatar, 400, 'unsupported_image_format') =>
+        'unsupported_image_format',
+      (_IdentityOperation.uploadAvatar, 413, 'image_too_large') =>
+        'image_too_large',
+      (_IdentityOperation.uploadAvatar, 409, 'idempotency_key_conflict') =>
+        'idempotency_key_conflict',
+      (_IdentityOperation.uploadAvatar, 409, 'resource_processing') =>
+        'resource_processing',
+      (
+        _IdentityOperation.uploadAvatar || _IdentityOperation.useDefaultAvatar,
+        409,
+        'profile_version_conflict',
+      ) =>
+        'profile_version_conflict',
+      (_IdentityOperation.avatarContent, 404, 'resource_not_found') =>
+        'resource_not_found',
       (
         _IdentityOperation.register || _IdentityOperation.login,
         429,
@@ -373,6 +521,9 @@ final class WireIdentityClient
         _IdentityOperation.currentUser ||
             _IdentityOperation.currentProfile ||
             _IdentityOperation.updateProfile ||
+            _IdentityOperation.uploadAvatar ||
+            _IdentityOperation.useDefaultAvatar ||
+            _IdentityOperation.avatarContent ||
             _IdentityOperation.logout,
         401,
       ) =>
@@ -381,6 +532,14 @@ final class WireIdentityClient
       (_IdentityOperation.currentProfile, 404) => 'profile_not_found',
       (_IdentityOperation.updateProfile, 400) => 'invalid_request',
       (_IdentityOperation.updateProfile, 409) => 'profile_version_conflict',
+      (_IdentityOperation.uploadAvatar, 400) => 'invalid_image',
+      (_IdentityOperation.uploadAvatar, 413) => 'image_too_large',
+      (
+        _IdentityOperation.uploadAvatar || _IdentityOperation.useDefaultAvatar,
+        409,
+      ) =>
+        'profile_version_conflict',
+      (_IdentityOperation.avatarContent, 404) => 'resource_not_found',
       (_IdentityOperation.register || _IdentityOperation.login, 429) =>
         'rate_limited',
       (_, >= 500) => 'internal_error',
@@ -410,4 +569,8 @@ final class WireIdentityClient
       );
     }
   }
+}
+
+bool _hasExactJsonKeys(Map<String, Object?> json, Set<String> expected) {
+  return json.length == expected.length && expected.every(json.containsKey);
 }

--- a/mobile/lib/identity/client/identity_client.dart
+++ b/mobile/lib/identity/client/identity_client.dart
@@ -102,10 +102,11 @@ final class UserAvatarImage {
 }
 
 final class UserAvatarContent {
-  const UserAvatarContent({required this.url, required this.expiresAt});
+  UserAvatarContent({required this.contentType, required Uint8List bytes})
+    : bytes = Uint8List.fromList(bytes);
 
-  final Uri url;
-  final DateTime expiresAt;
+  final String contentType;
+  final Uint8List bytes;
 }
 
 abstract interface class UserAvatarClient {
@@ -298,26 +299,25 @@ final class WireIdentityClient
       sessionToken: sessionToken,
     );
     _requireStatus(response, 200, _IdentityOperation.avatarContent);
-    return _decode(response, (json) {
-      if (!_hasExactJsonKeys(json, const {'content_url', 'expires_at'})) {
-        throw const FormatException('Invalid avatar content response.');
-      }
-      final rawUrl = json['content_url'];
-      final rawExpiry = json['expires_at'];
-      if (rawUrl is! String || rawExpiry is! String) {
-        throw const FormatException('Invalid avatar content response.');
-      }
-      final url = Uri.tryParse(rawUrl);
-      final expiresAt = DateTime.tryParse(rawExpiry)?.toUtc();
-      if (url == null ||
-          !url.hasAuthority ||
-          (url.scheme != 'https' && url.scheme != 'http') ||
-          expiresAt == null ||
-          !expiresAt.isAfter(DateTime.now().toUtc())) {
-        throw const FormatException('Invalid avatar content response.');
-      }
-      return UserAvatarContent(url: url, expiresAt: expiresAt);
-    });
+    final contentType = response.headers[HttpHeaders.contentTypeHeader]
+        ?.split(';')
+        .first
+        .trim()
+        .toLowerCase();
+    if ((contentType != 'image/jpeg' &&
+            contentType != 'image/png' &&
+            contentType != 'image/webp') ||
+        response.bodyBytes.isEmpty ||
+        response.bodyBytes.length > 10 * 1024 * 1024) {
+      throw IdentityClientException(
+        kind: IdentityFailureKind.invalidResponse,
+        statusCode: response.statusCode,
+      );
+    }
+    return UserAvatarContent(
+      contentType: contentType!,
+      bytes: Uint8List.fromList(response.bodyBytes),
+    );
   }
 
   Future<IdentityHttpResponse> _send({
@@ -569,8 +569,4 @@ final class WireIdentityClient
       );
     }
   }
-}
-
-bool _hasExactJsonKeys(Map<String, Object?> json, Set<String> expected) {
-  return json.length == expected.length && expected.every(json.containsKey);
 }

--- a/mobile/lib/identity/model/identity_models.dart
+++ b/mobile/lib/identity/model/identity_models.dart
@@ -49,17 +49,22 @@ final class UserProfile {
     required this.userId,
     required this.displayName,
     required this.profileVersion,
+    this.avatar,
     required this.createdAt,
     required this.updatedAt,
   });
 
   factory UserProfile.fromJson(Map<String, Object?> json) {
-    if (!_hasExactKeys(json, const {
+    const requiredKeys = {
       'user_id',
       'display_name',
       'profile_version',
       'created_at',
       'updated_at',
+    };
+    if (!_hasRequiredAndAllowedKeys(json, requiredKeys, const {
+      ...requiredKeys,
+      'avatar',
     })) {
       throw const FormatException('Invalid user profile response.');
     }
@@ -68,6 +73,7 @@ final class UserProfile {
     final profileVersion = json['profile_version'];
     final createdAt = json['created_at'];
     final updatedAt = json['updated_at'];
+    final avatarJson = json['avatar'];
     if (userId.length > 128 ||
         !_userIdPattern.hasMatch(userId) ||
         displayName.trim() != displayName ||
@@ -89,6 +95,11 @@ final class UserProfile {
       userId: userId,
       displayName: displayName,
       profileVersion: profileVersion,
+      avatar: avatarJson == null
+          ? null
+          : avatarJson is Map<String, Object?>
+          ? UserProfileAvatar.fromJson(avatarJson)
+          : throw const FormatException('Invalid user profile response.'),
       createdAt: parsedCreatedAt,
       updatedAt: parsedUpdatedAt,
     );
@@ -97,7 +108,47 @@ final class UserProfile {
   final String userId;
   final String displayName;
   final int profileVersion;
+  final UserProfileAvatar? avatar;
   final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+final class UserProfileAvatar {
+  const UserProfileAvatar({
+    required this.width,
+    required this.height,
+    required this.updatedAt,
+  });
+
+  factory UserProfileAvatar.fromJson(Map<String, Object?> json) {
+    if (!_hasExactKeys(json, const {'width', 'height', 'updated_at'})) {
+      throw const FormatException('Invalid user profile avatar response.');
+    }
+    final width = json['width'];
+    final height = json['height'];
+    final updatedAt = json['updated_at'];
+    if (width is! int ||
+        width < 1 ||
+        width > 16384 ||
+        height is! int ||
+        height < 1 ||
+        height > 16384 ||
+        updatedAt is! String) {
+      throw const FormatException('Invalid user profile avatar response.');
+    }
+    final parsedUpdatedAt = _tryParseStrictRfc3339(updatedAt);
+    if (parsedUpdatedAt == null) {
+      throw const FormatException('Invalid user profile avatar response.');
+    }
+    return UserProfileAvatar(
+      width: width,
+      height: height,
+      updatedAt: parsedUpdatedAt,
+    );
+  }
+
+  final int width;
+  final int height;
   final DateTime updatedAt;
 }
 
@@ -149,6 +200,14 @@ final class LoginResult {
 
 bool _hasExactKeys(Map<String, Object?> json, Set<String> expected) {
   return json.length == expected.length && expected.every(json.containsKey);
+}
+
+bool _hasRequiredAndAllowedKeys(
+  Map<String, Object?> json,
+  Set<String> required,
+  Set<String> allowed,
+) {
+  return required.every(json.containsKey) && json.keys.every(allowed.contains);
 }
 
 DateTime? _tryParseStrictRfc3339(String value) {

--- a/mobile/lib/identity/network/identity_http_transport.dart
+++ b/mobile/lib/identity/network/identity_http_transport.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:speakup/identity/auth_state.dart';
 
@@ -10,11 +11,13 @@ final class IdentityHttpResponse {
   const IdentityHttpResponse({
     required this.statusCode,
     required this.body,
+    this.bodyBytes = const <int>[],
     this.headers = const <String, String>{},
   });
 
   final int statusCode;
   final String body;
+  final List<int> bodyBytes;
   final Map<String, String> headers;
 }
 
@@ -125,7 +128,13 @@ final class IoIdentityHttpTransport implements IdentityHttpTransport {
     }
 
     final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final responseBytes = Uint8List.fromList(
+      await response.fold<List<int>>(<int>[], (buffer, chunk) {
+        buffer.addAll(chunk);
+        return buffer;
+      }),
+    );
+    final responseBody = utf8.decode(responseBytes, allowMalformed: true);
     final responseHeaders = <String, String>{};
     response.headers.forEach((name, values) {
       responseHeaders[name] = values.join(',');
@@ -133,6 +142,7 @@ final class IoIdentityHttpTransport implements IdentityHttpTransport {
     return IdentityHttpResponse(
       statusCode: response.statusCode,
       body: responseBody,
+      bodyBytes: responseBytes,
       headers: responseHeaders,
     );
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -451,6 +451,7 @@ ProductionAppDependencies createProductionAppDependencies({
   authController = AuthController(
     identityClient: identityClient,
     profileClient: identityClient,
+    avatarClient: identityClient,
     sessionStore: sessionStore ?? const IosKeychainSessionStore(),
     clearPrivateState: () => _runAllPrivateStateCleanups([
       sessionEvaluationController.clearAccountState,

--- a/mobile/test/identity/identity_client_test.dart
+++ b/mobile/test/identity/identity_client_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/identity/client/identity_client.dart';
@@ -89,6 +90,61 @@ void main() {
           'display_name': '林同学',
           'expected_profile_version': 1,
         });
+      },
+    );
+
+    test(
+      'avatar operations preserve version, bytes, and private URL',
+      () async {
+        transport.response = const IdentityHttpResponse(
+          statusCode: 200,
+          body:
+              '{"user_id":"user_1","display_name":"小林",'
+              '"profile_version":2,"avatar":{"width":512,"height":512,'
+              '"updated_at":"2026-08-18T08:00:00Z"},'
+              '"created_at":"2026-08-18T07:00:00Z",'
+              '"updated_at":"2026-08-18T08:00:00Z"}',
+        );
+        final profile = await client.uploadAvatar(
+          sessionToken: 'sess_opaque-secret',
+          image: UserAvatarImage(
+            contentType: 'image/png',
+            bytes: Uint8List.fromList([1, 2, 3]),
+          ),
+          expectedProfileVersion: 1,
+          idempotencyKey: 'avatar-request-1',
+        );
+        expect(profile.avatar?.width, 512);
+        expect(transport.uri?.path, '/v1/me/avatar');
+        expect(transport.headers?[HttpHeaders.ifMatchHeader], '"1"');
+        expect(transport.headers?['Idempotency-Key'], 'avatar-request-1');
+        expect(transport.bodyBytes, [1, 2, 3]);
+
+        transport.response = const IdentityHttpResponse(
+          statusCode: 200,
+          body:
+              '{"user_id":"user_1","display_name":"小林",'
+              '"profile_version":3,"created_at":"2026-08-18T07:00:00Z",'
+              '"updated_at":"2026-08-18T09:00:00Z"}',
+        );
+        final defaultProfile = await client.useDefaultAvatar(
+          sessionToken: 'sess_opaque-secret',
+          expectedProfileVersion: 2,
+        );
+        expect(defaultProfile.avatar, isNull);
+        expect(transport.method, 'DELETE');
+
+        transport.response = const IdentityHttpResponse(
+          statusCode: 200,
+          body:
+              '{"content_url":"https://objects.example/avatar.png?sig=1",'
+              '"expires_at":"2099-08-18T10:00:00Z"}',
+        );
+        final content = await client.currentAvatarContent(
+          sessionToken: 'sess_opaque-secret',
+        );
+        expect(content.url.host, 'objects.example');
+        expect(transport.uri?.path, '/v1/me/avatar/content');
       },
     );
 
@@ -596,6 +652,7 @@ final class _FakeTransport implements IdentityHttpTransport {
   Uri? uri;
   Map<String, String>? headers;
   String? body;
+  List<int>? bodyBytes;
 
   @override
   Future<IdentityHttpResponse> send({
@@ -609,6 +666,7 @@ final class _FakeTransport implements IdentityHttpTransport {
     this.uri = uri;
     this.headers = Map<String, String>.of(headers);
     this.body = body;
+    this.bodyBytes = bodyBytes == null ? null : List<int>.of(bodyBytes);
     final failure = this.failure;
     if (failure != null) {
       throw failure;

--- a/mobile/test/identity/identity_client_test.dart
+++ b/mobile/test/identity/identity_client_test.dart
@@ -136,14 +136,15 @@ void main() {
 
         transport.response = const IdentityHttpResponse(
           statusCode: 200,
-          body:
-              '{"content_url":"https://objects.example/avatar.png?sig=1",'
-              '"expires_at":"2099-08-18T10:00:00Z"}',
+          body: '',
+          bodyBytes: [1, 2, 3],
+          headers: {'content-type': 'image/png'},
         );
         final content = await client.currentAvatarContent(
           sessionToken: 'sess_opaque-secret',
         );
-        expect(content.url.host, 'objects.example');
+        expect(content.contentType, 'image/png');
+        expect(content.bytes, [1, 2, 3]);
         expect(transport.uri?.path, '/v1/me/avatar/content');
       },
     );

--- a/mobile/test/profile/profile_avatar_refresh_test.dart
+++ b/mobile/test/profile/profile_avatar_refresh_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/speak_up_shell.dart';
+import 'package:speakup/features/agent/composer/composer_controller.dart';
+import 'package:speakup/features/agent/conversation/agent_client.dart';
+import 'package:speakup/features/agent/conversation/conversation_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/identity/auth_controller.dart';
+import 'package:speakup/identity/client/identity_client.dart';
+import 'package:speakup/identity/model/identity_models.dart';
+import 'package:speakup/identity/session_store.dart';
+
+void main() {
+  testWidgets('profile avatar refreshes without rebuilding the shell route', (
+    tester,
+  ) async {
+    final accountClient = _AccountClient();
+    final authController = AuthController(
+      identityClient: accountClient,
+      profileClient: accountClient,
+      avatarClient: accountClient,
+      sessionStore: _SessionStore(),
+    );
+    await authController.initialize();
+
+    final conversationController = ConversationController(
+      client: FakeAgentClient(),
+    );
+    final composerController = ComposerController(
+      conversationController: conversationController,
+    );
+    final practiceController = PracticeController(client: FakePracticeClient());
+    addTearDown(authController.dispose);
+    addTearDown(composerController.dispose);
+    addTearDown(conversationController.dispose);
+    addTearDown(practiceController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SpeakUpShell(
+          user: _AccountClient.user,
+          authController: authController,
+          conversationController: conversationController,
+          composerController: composerController,
+          practiceController: practiceController,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pumpAndSettle();
+
+    expect(_avatarProvider(tester), isA<MemoryImage>());
+
+    expect(await authController.useDefaultAvatar(), isNull);
+    await tester.pump();
+    expect(_avatarProvider(tester), isA<AssetImage>());
+
+    expect(
+      await authController.updateAvatar(
+        UserAvatarImage(contentType: 'image/png', bytes: _newAvatarBytes),
+      ),
+      isNull,
+    );
+    await tester.pump();
+    final refreshed = _avatarProvider(tester) as MemoryImage;
+    expect(refreshed.bytes, orderedEquals(_newAvatarBytes));
+  });
+}
+
+ImageProvider<Object> _avatarProvider(WidgetTester tester) {
+  final image = tester.widget<Image>(
+    find
+        .descendant(
+          of: find.byKey(const Key('profile-avatar')),
+          matching: find.byType(Image),
+        )
+        .first,
+  );
+  return image.image;
+}
+
+final Uint8List _initialAvatarBytes = Uint8List.fromList(
+  base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  ),
+);
+
+final Uint8List _newAvatarBytes = Uint8List.fromList(
+  base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAC0lEQVR42mP8/x8AAusB9Y9Z4pAAAAAASUVORK5CYII=',
+  ),
+);
+
+final class _SessionStore implements SessionStore {
+  String? _token = 'sess_avatar-refresh';
+
+  @override
+  Future<void> deleteToken() async => _token = null;
+
+  @override
+  Future<String?> readToken() async => _token;
+
+  @override
+  Future<void> writeToken(String value) async => _token = value;
+}
+
+final class _AccountClient
+    implements IdentityClient, UserProfileClient, UserAvatarClient {
+  static const user = User(id: 'user-1', email: 'learner@example.com');
+  static final _createdAt = DateTime.utc(2026, 8, 18, 8);
+
+  UserProfile _profile = _customProfile(1);
+  Uint8List _content = Uint8List.fromList(_initialAvatarBytes);
+
+  @override
+  Future<User> currentUser({required String sessionToken}) async => user;
+
+  @override
+  Future<UserProfile> currentProfile({required String sessionToken}) async =>
+      _profile;
+
+  @override
+  Future<UserAvatarContent> currentAvatarContent({
+    required String sessionToken,
+  }) async => UserAvatarContent(contentType: 'image/png', bytes: _content);
+
+  @override
+  Future<UserProfile> uploadAvatar({
+    required String sessionToken,
+    required UserAvatarImage image,
+    required int expectedProfileVersion,
+    required String idempotencyKey,
+  }) async {
+    _content = Uint8List.fromList(image.bytes);
+    _profile = _customProfile(expectedProfileVersion + 1);
+    return _profile;
+  }
+
+  @override
+  Future<UserProfile> useDefaultAvatar({
+    required String sessionToken,
+    required int expectedProfileVersion,
+  }) async {
+    _profile = UserProfile(
+      userId: user.id,
+      displayName: 'Dada',
+      profileVersion: expectedProfileVersion + 1,
+      createdAt: _createdAt,
+      updatedAt: _createdAt.add(const Duration(minutes: 1)),
+    );
+    return _profile;
+  }
+
+  @override
+  Future<UserProfile> updateProfile({
+    required String sessionToken,
+    required String displayName,
+    required int? expectedProfileVersion,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<LoginResult> login({
+    required String email,
+    required String password,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<void> logout({required String sessionToken}) async {}
+
+  @override
+  Future<User> register({
+    required String email,
+    required String password,
+  }) async => throw UnimplementedError();
+
+  static UserProfile _customProfile(int version) => UserProfile(
+    userId: user.id,
+    displayName: 'Dada',
+    profileVersion: version,
+    avatar: UserProfileAvatar(width: 1, height: 1, updatedAt: _createdAt),
+    createdAt: _createdAt,
+    updatedAt: _createdAt,
+  );
+}

--- a/mobile/test/profile/profile_avatar_test.dart
+++ b/mobile/test/profile/profile_avatar_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/profile/profile_avatar_picker.dart';
+import 'package:speakup/features/profile/profile_page.dart';
+import 'package:speakup/identity/client/identity_client.dart';
+import 'package:speakup/identity/model/identity_models.dart';
+
+void main() {
+  testWidgets('avatar sheet exposes gallery, camera, and default actions', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(profile: _profile()));
+
+    await tester.tap(find.byKey(const Key('profile-avatar-edit-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('从相册选择'), findsOneWidget);
+    expect(find.text('拍照'), findsOneWidget);
+    expect(find.text('使用默认头像'), findsOneWidget);
+    expect(
+      tester
+          .widget<ListTile>(find.byKey(const Key('profile-avatar-default')))
+          .enabled,
+      isFalse,
+    );
+  });
+
+  testWidgets('gallery uploads and custom avatar can restore the default', (
+    tester,
+  ) async {
+    var uploads = 0;
+    var defaults = 0;
+    final picker = _Picker();
+    await tester.pumpWidget(
+      _app(
+        profile: _profile(customAvatar: true),
+        picker: picker,
+        onUpload: (_) async {
+          uploads++;
+          return null;
+        },
+        onDefault: () async {
+          defaults++;
+          return null;
+        },
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('profile-avatar-edit-button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('profile-avatar-gallery')));
+    await tester.pumpAndSettle();
+    expect(uploads, 1);
+    expect(find.text('头像已更新'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('profile-avatar-edit-button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('profile-avatar-default')));
+    await tester.pumpAndSettle();
+    expect(defaults, 1);
+  });
+}
+
+Widget _app({
+  required UserProfile profile,
+  ProfileAvatarPicker? picker,
+  Future<String?> Function(UserAvatarImage)? onUpload,
+  Future<String?> Function()? onDefault,
+}) {
+  return MaterialApp(
+    home: ProfilePage(
+      showBackButton: false,
+      user: const User(id: 'user-1', email: 'learner@example.com'),
+      profile: profile,
+      profileErrorMessage: null,
+      profileSaving: false,
+      onSaveDisplayName: (_) async => null,
+      avatarUrl: null,
+      avatarSaving: false,
+      onUploadAvatar: onUpload ?? (_) async => null,
+      onUseDefaultAvatar: onDefault ?? () async => null,
+      onLogout: null,
+      reviewHistoryController: null,
+      coachingProfileController: null,
+      avatarPicker: picker,
+    ),
+  );
+}
+
+UserProfile _profile({bool customAvatar = false}) {
+  final createdAt = DateTime.utc(2026, 8, 18, 8);
+  return UserProfile(
+    userId: 'user-1',
+    displayName: '小林',
+    profileVersion: customAvatar ? 2 : 1,
+    avatar: customAvatar
+        ? UserProfileAvatar(width: 512, height: 512, updatedAt: createdAt)
+        : null,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  );
+}
+
+final class _Picker implements ProfileAvatarPicker {
+  @override
+  Future<UserAvatarImage?> pickFromGallery() async => UserAvatarImage(
+    contentType: 'image/png',
+    bytes: Uint8List.fromList([1, 2, 3]),
+  );
+
+  @override
+  Future<UserAvatarImage?> takePhoto() async => null;
+}

--- a/mobile/test/profile/profile_avatar_test.dart
+++ b/mobile/test/profile/profile_avatar_test.dart
@@ -77,7 +77,7 @@ Widget _app({
       profileErrorMessage: null,
       profileSaving: false,
       onSaveDisplayName: (_) async => null,
-      avatarUrl: null,
+      avatarBytes: null,
       avatarSaving: false,
       onUploadAvatar: onUpload ?? (_) async => null,
       onUseDefaultAvatar: onDefault ?? () async => null,

--- a/server/internal/agent/input/image/normalize.go
+++ b/server/internal/agent/input/image/normalize.go
@@ -21,6 +21,20 @@ type normalizedImage struct {
 	height      int
 }
 
+// NormalizePayload validates an untrusted image, strips metadata, applies JPEG
+// orientation, and returns a canonical payload shared by image-owning domains.
+func NormalizePayload(
+	declaredContentType string,
+	payload []byte,
+) ([]byte, string, int, int, error) {
+	normalized, err := normalizeImage(declaredContentType, payload)
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	return normalized.payload, normalized.contentType,
+		normalized.width, normalized.height, nil
+}
+
 func normalizeImage(
 	declaredContentType string,
 	payload []byte,

--- a/server/internal/app/agent_data.go
+++ b/server/internal/app/agent_data.go
@@ -38,6 +38,7 @@ import (
 	profilehttp "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/profile/transport/http"
 	reviewagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/review/agentcapability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	identityavatar "github.com/1024XEngineer/XE3-ESL/server/internal/identity/avatar"
 	sharedmedia "github.com/1024XEngineer/XE3-ESL/server/internal/media"
 	mediapostgres "github.com/1024XEngineer/XE3-ESL/server/internal/media/postgres"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
@@ -408,6 +409,25 @@ func buildIdentityAgentComposition(
 		conversationHTTP,
 		translationHTTP,
 		runHTTP,
+	}
+	if imageConfiguration != nil {
+		avatarRepository, avatarErr := identityavatar.NewPostgresRepository(database)
+		if avatarErr != nil {
+			return nil, avatarErr
+		}
+		avatarService, avatarErr := identityavatar.NewService(
+			avatarRepository,
+			agentMedia,
+			identityavatar.Config{StagedTTL: imageConfiguration.StagedTTL},
+		)
+		if avatarErr != nil {
+			return nil, avatarErr
+		}
+		avatarHTTP, avatarErr := identityavatar.NewHandler(avatarService, errorRenderer)
+		if avatarErr != nil {
+			return nil, avatarErr
+		}
+		registrars = append(registrars, avatarHTTP)
 	}
 	if realtimeRecognizer != nil {
 		ephemeralHTTP, ephemeralHTTPErr :=

--- a/server/internal/identity/avatar/http.go
+++ b/server/internal/identity/avatar/http.go
@@ -87,10 +87,8 @@ func (handler *Handler) content(c *gin.Context) {
 		return
 	}
 	c.Header("Cache-Control", "no-store")
-	c.JSON(http.StatusOK, gin.H{
-		"content_url": content.URL,
-		"expires_at":  content.ExpiresAt.UTC().Format(time.RFC3339Nano),
-	})
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Data(http.StatusOK, content.ContentType, content.Payload)
 }
 
 func (handler *Handler) useDefault(c *gin.Context) {

--- a/server/internal/identity/avatar/http.go
+++ b/server/internal/identity/avatar/http.go
@@ -1,0 +1,192 @@
+package avatar
+
+import (
+	"errors"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	agentimage "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/image"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpinput"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpresponse"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+const defaultReadTimeout = 30 * time.Second
+
+type Handler struct {
+	application Application
+	errors      *httpresponse.Renderer
+	readTimeout time.Duration
+}
+
+func NewHandler(application Application, renderer *httpresponse.Renderer) (*Handler, error) {
+	if application == nil {
+		return nil, ErrInvalidRequest
+	}
+	if renderer == nil {
+		renderer = httpresponse.NewRenderer(nil)
+	}
+	return &Handler{application: application, errors: renderer, readTimeout: defaultReadTimeout}, nil
+}
+
+func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
+	routes.POST("/v1/me/avatar", handler.upload)
+	routes.GET("/v1/me/avatar/content", handler.content)
+	routes.DELETE("/v1/me/avatar", handler.useDefault)
+}
+
+func (handler *Handler) upload(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	key, keyOK := httpinput.IdempotencyKey(c.Request)
+	version, versionOK := expectedVersion(c.Request)
+	contentType, typeOK := imageContentType(c.Request.Header.Get("Content-Type"))
+	if !ok || !keyOK || !versionOK || !typeOK || c.Request.Body == nil {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	if c.Request.ContentLength > MaxBytes {
+		handler.write(c, imageTooLarge(nil))
+		return
+	}
+	controller := http.NewResponseController(c.Writer)
+	if err := controller.SetReadDeadline(time.Now().Add(handler.readTimeout)); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		handler.write(c, internalError(err))
+		return
+	}
+	defer func() { _ = controller.SetReadDeadline(time.Time{}) }()
+	profile, err := handler.application.Upload(
+		c.Request.Context(), actor,
+		UploadRequest{
+			IdempotencyKey: key, ContentType: contentType,
+			Body:                   http.MaxBytesReader(c.Writer, c.Request.Body, MaxBytes),
+			ExpectedProfileVersion: version,
+		},
+	)
+	if err != nil {
+		handler.write(c, mapHTTPError(err))
+		return
+	}
+	c.JSON(http.StatusOK, profileResponse(profile))
+}
+
+func (handler *Handler) content(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	content, err := handler.application.Content(c.Request.Context(), actor)
+	if err != nil {
+		handler.write(c, mapHTTPError(err))
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	c.JSON(http.StatusOK, gin.H{
+		"content_url": content.URL,
+		"expires_at":  content.ExpiresAt.UTC().Format(time.RFC3339Nano),
+	})
+}
+
+func (handler *Handler) useDefault(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	version, versionOK := expectedVersion(c.Request)
+	if !ok || !versionOK || c.Request.ContentLength > 0 {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	profile, err := handler.application.UseDefault(c.Request.Context(), actor, version)
+	if err != nil {
+		handler.write(c, mapHTTPError(err))
+		return
+	}
+	c.JSON(http.StatusOK, profileResponse(profile))
+}
+
+func expectedVersion(request *http.Request) (int64, bool) {
+	raw := strings.TrimSpace(request.Header.Get("If-Match"))
+	if len(raw) < 3 || raw[0] != '"' || raw[len(raw)-1] != '"' {
+		return 0, false
+	}
+	version, err := strconv.ParseInt(raw[1:len(raw)-1], 10, 64)
+	return version, err == nil && version >= 1
+}
+
+func imageContentType(raw string) (string, bool) {
+	contentType, parameters, err := mime.ParseMediaType(strings.TrimSpace(raw))
+	if err != nil || len(parameters) != 0 {
+		return "", false
+	}
+	switch strings.ToLower(contentType) {
+	case "image/jpeg", "image/png", "image/webp":
+		return strings.ToLower(contentType), true
+	default:
+		return "", false
+	}
+}
+
+func profileResponse(profile identity.UserProfile) gin.H {
+	response := gin.H{
+		"user_id": profile.UserID, "display_name": profile.DisplayName,
+		"profile_version": profile.ProfileVersion,
+		"created_at":      profile.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"updated_at":      profile.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if profile.Avatar != nil {
+		response["avatar"] = gin.H{
+			"width": profile.Avatar.Width, "height": profile.Avatar.Height,
+			"updated_at": profile.Avatar.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		}
+	}
+	return response
+}
+
+func mapHTTPError(err error) error {
+	switch {
+	case errors.Is(err, agentimage.ErrTooLarge):
+		return imageTooLarge(err)
+	case errors.Is(err, agentimage.ErrUnsupported):
+		return apperror.New(apperror.InvalidArgument, "unsupported_image_format", "The image format is unsupported.", apperror.WithCause(err))
+	case errors.Is(err, agentimage.ErrInvalid):
+		return apperror.New(apperror.InvalidArgument, "invalid_image", "The image payload is invalid.", apperror.WithCause(err))
+	case errors.Is(err, ErrIdempotencyConflict):
+		return apperror.New(apperror.Conflict, "idempotency_key_conflict", "Idempotency key conflicts with the original request.", apperror.WithCause(err))
+	case errors.Is(err, ErrConflict):
+		return apperror.New(apperror.Conflict, "profile_version_conflict", "User profile changed before this update.", apperror.WithCause(err))
+	case errors.Is(err, ErrUploadInProgress):
+		return apperror.New(apperror.Conflict, "resource_processing", "Avatar upload is still in progress.", apperror.WithRetryable(true), apperror.WithCause(err))
+	case errors.Is(err, ErrNotFound):
+		return apperror.New(apperror.NotFound, "resource_not_found", "User avatar was not found.", apperror.WithCause(err))
+	case errors.Is(err, ErrInvalidRequest):
+		return invalidRequest(err)
+	default:
+		return internalError(err)
+	}
+}
+
+func imageTooLarge(err error) error {
+	return apperror.New(apperror.PayloadTooLarge, "image_too_large", "The image exceeds the allowed limits.", apperror.WithCause(err))
+}
+
+func invalidRequest(err error) error {
+	return apperror.New(apperror.InvalidArgument, "invalid_request", "The request is invalid.", apperror.WithCause(err))
+}
+
+func authenticationRequired() error {
+	return apperror.New(apperror.Unauthenticated, "authentication_required", "Authentication is required.")
+}
+
+func internalError(err error) error {
+	return apperror.New(apperror.Internal, "internal_error", "The request could not be completed.", apperror.WithCause(err))
+}
+
+func (handler *Handler) write(c *gin.Context, err error) {
+	handler.errors.Write(c, err)
+}
+
+var _ interface{ RegisterRoutes(gin.IRoutes) } = (*Handler)(nil)

--- a/server/internal/identity/avatar/http_test.go
+++ b/server/internal/identity/avatar/http_test.go
@@ -1,0 +1,131 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+	"github.com/gin-gonic/gin"
+)
+
+func TestAvatarHTTPUploadContentAndDefault(t *testing.T) {
+	now := time.Date(2026, 8, 18, 8, 0, 0, 0, time.UTC)
+	application := &avatarApplicationStub{profile: identity.UserProfile{
+		UserID: "user-1", DisplayName: "小林", ProfileVersion: 2,
+		Avatar:    &identity.ProfileAvatar{Width: 512, Height: 512, UpdatedAt: now},
+		CreatedAt: now.Add(-time.Hour), UpdatedAt: now,
+	}, content: objectstore.SignedGetResult{
+		URL:       "https://objects.invalid/avatar.png?signature=safe",
+		ExpiresAt: now.Add(time.Minute),
+	}}
+	router := avatarRouter(t, application)
+
+	upload := httptest.NewRequest(
+		http.MethodPost, "/v1/me/avatar", bytes.NewReader([]byte{1, 2, 3}),
+	)
+	upload.Header.Set("Content-Type", "image/png")
+	upload.Header.Set("Idempotency-Key", "avatar-request-1")
+	upload.Header.Set("If-Match", `"1"`)
+	uploadResponse := httptest.NewRecorder()
+	router.ServeHTTP(uploadResponse, upload)
+	if uploadResponse.Code != http.StatusOK ||
+		application.upload.ExpectedProfileVersion != 1 ||
+		application.upload.IdempotencyKey != "avatar-request-1" ||
+		!bytes.Equal(application.uploadBody, []byte{1, 2, 3}) {
+		t.Fatalf("upload response/request = %d / %#v", uploadResponse.Code, application.upload)
+	}
+
+	content := httptest.NewRequest(http.MethodGet, "/v1/me/avatar/content", nil)
+	contentResponse := httptest.NewRecorder()
+	router.ServeHTTP(contentResponse, content)
+	if contentResponse.Code != http.StatusOK ||
+		contentResponse.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("content response = %d / %#v", contentResponse.Code, contentResponse.Header())
+	}
+
+	useDefault := httptest.NewRequest(http.MethodDelete, "/v1/me/avatar", nil)
+	useDefault.Header.Set("If-Match", `"2"`)
+	defaultResponse := httptest.NewRecorder()
+	router.ServeHTTP(defaultResponse, useDefault)
+	if defaultResponse.Code != http.StatusOK || application.defaultVersion != 2 {
+		t.Fatalf("default response/version = %d / %d", defaultResponse.Code, application.defaultVersion)
+	}
+}
+
+func TestAvatarHTTPRejectsMissingConcurrencyAndIdempotencyHeaders(t *testing.T) {
+	application := &avatarApplicationStub{}
+	router := avatarRouter(t, application)
+	request := httptest.NewRequest(
+		http.MethodPost, "/v1/me/avatar", bytes.NewReader([]byte{1}),
+	)
+	request.Header.Set("Content-Type", "image/png")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest || application.uploadCalls != 0 {
+		t.Fatalf("response/calls = %d / %d", response.Code, application.uploadCalls)
+	}
+}
+
+func avatarRouter(t *testing.T, application Application) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler, err := NewHandler(application, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(requestcontext.WithActor(
+			c.Request.Context(),
+			requestcontext.Actor{UserID: "user-1", SessionID: "session-1"},
+		))
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	return router
+}
+
+type avatarApplicationStub struct {
+	profile        identity.UserProfile
+	content        objectstore.SignedGetResult
+	upload         UploadRequest
+	uploadBody     []byte
+	uploadCalls    int
+	defaultVersion int64
+}
+
+func (stub *avatarApplicationStub) Upload(
+	_ context.Context,
+	_ requestcontext.Actor,
+	request UploadRequest,
+) (identity.UserProfile, error) {
+	stub.uploadCalls++
+	stub.upload = request
+	stub.uploadBody, _ = io.ReadAll(request.Body)
+	return stub.profile, nil
+}
+
+func (stub *avatarApplicationStub) UseDefault(
+	_ context.Context,
+	_ requestcontext.Actor,
+	version int64,
+) (identity.UserProfile, error) {
+	stub.defaultVersion = version
+	stub.profile.Avatar = nil
+	stub.profile.ProfileVersion = version + 1
+	return stub.profile, nil
+}
+
+func (stub *avatarApplicationStub) Content(
+	context.Context,
+	requestcontext.Actor,
+) (objectstore.SignedGetResult, error) {
+	return stub.content, nil
+}

--- a/server/internal/identity/avatar/http_test.go
+++ b/server/internal/identity/avatar/http_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
-	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 	"github.com/gin-gonic/gin"
 )
@@ -21,9 +20,8 @@ func TestAvatarHTTPUploadContentAndDefault(t *testing.T) {
 		UserID: "user-1", DisplayName: "小林", ProfileVersion: 2,
 		Avatar:    &identity.ProfileAvatar{Width: 512, Height: 512, UpdatedAt: now},
 		CreatedAt: now.Add(-time.Hour), UpdatedAt: now,
-	}, content: objectstore.SignedGetResult{
-		URL:       "https://objects.invalid/avatar.png?signature=safe",
-		ExpiresAt: now.Add(time.Minute),
+	}, content: Content{
+		Payload: []byte{1, 2, 3}, ContentType: "image/png",
 	}}
 	router := avatarRouter(t, application)
 
@@ -46,7 +44,9 @@ func TestAvatarHTTPUploadContentAndDefault(t *testing.T) {
 	contentResponse := httptest.NewRecorder()
 	router.ServeHTTP(contentResponse, content)
 	if contentResponse.Code != http.StatusOK ||
-		contentResponse.Header().Get("Cache-Control") != "no-store" {
+		contentResponse.Header().Get("Cache-Control") != "no-store" ||
+		contentResponse.Header().Get("Content-Type") != "image/png" ||
+		!bytes.Equal(contentResponse.Body.Bytes(), []byte{1, 2, 3}) {
 		t.Fatalf("content response = %d / %#v", contentResponse.Code, contentResponse.Header())
 	}
 
@@ -94,7 +94,7 @@ func avatarRouter(t *testing.T, application Application) *gin.Engine {
 
 type avatarApplicationStub struct {
 	profile        identity.UserProfile
-	content        objectstore.SignedGetResult
+	content        Content
 	upload         UploadRequest
 	uploadBody     []byte
 	uploadCalls    int
@@ -126,6 +126,6 @@ func (stub *avatarApplicationStub) UseDefault(
 func (stub *avatarApplicationStub) Content(
 	context.Context,
 	requestcontext.Actor,
-) (objectstore.SignedGetResult, error) {
+) (Content, error) {
 	return stub.content, nil
 }

--- a/server/internal/identity/avatar/model.go
+++ b/server/internal/identity/avatar/model.go
@@ -1,0 +1,47 @@
+// Package avatar owns the authenticated user's profile-avatar lifecycle.
+package avatar
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+const MaxBytes = 10 * 1024 * 1024
+
+var (
+	ErrInvalidRequest      = errors.New("profile avatar: invalid request")
+	ErrNotFound            = errors.New("profile avatar: not found")
+	ErrConflict            = errors.New("profile avatar: profile version conflict")
+	ErrUploadInProgress    = errors.New("profile avatar: upload in progress")
+	ErrIdempotencyConflict = errors.New("profile avatar: idempotency conflict")
+	ErrRepository          = errors.New("profile avatar: repository failed")
+)
+
+type UploadRequest struct {
+	IdempotencyKey         string
+	ContentType            string
+	Body                   io.Reader
+	ExpectedProfileVersion int64
+}
+
+type Repository interface {
+	Attach(context.Context, string, string, int64) (identity.UserProfile, error)
+	UseDefault(context.Context, string, int64) (identity.UserProfile, error)
+	CurrentAssetID(context.Context, string) (string, error)
+}
+
+type Application interface {
+	Upload(context.Context, requestcontext.Actor, UploadRequest) (identity.UserProfile, error)
+	UseDefault(context.Context, requestcontext.Actor, int64) (identity.UserProfile, error)
+	Content(context.Context, requestcontext.Actor) (objectstore.SignedGetResult, error)
+}
+
+type Config struct {
+	StagedTTL time.Duration
+}

--- a/server/internal/identity/avatar/model.go
+++ b/server/internal/identity/avatar/model.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
-	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
@@ -30,6 +29,11 @@ type UploadRequest struct {
 	ExpectedProfileVersion int64
 }
 
+type Content struct {
+	Payload     []byte
+	ContentType string
+}
+
 type Repository interface {
 	Attach(context.Context, string, string, int64) (identity.UserProfile, error)
 	UseDefault(context.Context, string, int64) (identity.UserProfile, error)
@@ -39,7 +43,7 @@ type Repository interface {
 type Application interface {
 	Upload(context.Context, requestcontext.Actor, UploadRequest) (identity.UserProfile, error)
 	UseDefault(context.Context, requestcontext.Actor, int64) (identity.UserProfile, error)
-	Content(context.Context, requestcontext.Actor) (objectstore.SignedGetResult, error)
+	Content(context.Context, requestcontext.Actor) (Content, error)
 }
 
 type Config struct {

--- a/server/internal/identity/avatar/postgres.go
+++ b/server/internal/identity/avatar/postgres.go
@@ -1,0 +1,238 @@
+package avatar
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	sharedmedia "github.com/1024XEngineer/XE3-ESL/server/internal/media"
+	mediapostgres "github.com/1024XEngineer/XE3-ESL/server/internal/media/postgres"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PostgresRepository struct {
+	database *pgxpool.Pool
+}
+
+func NewPostgresRepository(database *pgxpool.Pool) (*PostgresRepository, error) {
+	if database == nil {
+		return nil, ErrRepository
+	}
+	return &PostgresRepository{database: database}, nil
+}
+
+type lockedProfile struct {
+	userID, displayName, avatarAssetID string
+	version                            int64
+	createdAt, updatedAt               time.Time
+}
+
+func (repository *PostgresRepository) Attach(
+	ctx context.Context,
+	userID string,
+	uploadRequestID string,
+	expectedVersion int64,
+) (_ identity.UserProfile, resultErr error) {
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	profile, err := lockProfile(ctx, tx, userID)
+	if err != nil {
+		return identity.UserProfile{}, err
+	}
+	if profile.avatarAssetID != "" {
+		var current sharedmedia.Asset
+		if err := tx.QueryRow(ctx, `
+SELECT id::text, upload_request_id, width, height, updated_at
+FROM media_assets
+WHERE id = $1 AND user_id = $2 AND kind = 'image' AND status = 'ready'
+FOR UPDATE`, profile.avatarAssetID, userID).Scan(
+			&current.ID,
+			&current.UploadRequestID,
+			&current.Width,
+			&current.Height,
+			&current.UpdatedAt,
+		); err != nil {
+			return identity.UserProfile{}, mapTransactionMediaError(err)
+		}
+		if current.UploadRequestID == uploadRequestID {
+			if err := tx.Commit(ctx); err != nil {
+				return identity.UserProfile{}, ErrRepository
+			}
+			return projectProfile(profile, &current), nil
+		}
+	}
+	asset, err := mediapostgres.LockReadyByUploadRequestInTransaction(
+		ctx, tx, userID, sharedmedia.KindImage, uploadRequestID,
+	)
+	if err != nil {
+		return identity.UserProfile{}, mapTransactionMediaError(err)
+	}
+	if profile.version != expectedVersion {
+		return identity.UserProfile{}, ErrConflict
+	}
+	oldAssetID := profile.avatarAssetID
+	var updatedAt time.Time
+	if err := tx.QueryRow(ctx, `
+UPDATE users
+SET
+    avatar_asset_id = $2,
+    profile_version = profile_version + 1,
+    updated_at = GREATEST(CURRENT_TIMESTAMP, updated_at + INTERVAL '1 microsecond')
+WHERE id = $1 AND status = 'active'
+RETURNING updated_at`, userID, asset.ID).Scan(&updatedAt); err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	if err := mediapostgres.RetainInTransaction(
+		ctx, tx, userID, sharedmedia.KindImage, []string{asset.ID},
+	); err != nil {
+		return identity.UserProfile{}, mapTransactionMediaError(err)
+	}
+	if oldAssetID != "" {
+		if err := mediapostgres.ScheduleDeletionInTransaction(
+			ctx, tx, userID, []string{oldAssetID},
+		); err != nil {
+			return identity.UserProfile{}, mapTransactionMediaError(err)
+		}
+	}
+	profile.avatarAssetID = asset.ID
+	profile.version++
+	profile.updatedAt = updatedAt
+	if err := tx.Commit(ctx); err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	return projectProfile(profile, &asset), nil
+}
+
+func (repository *PostgresRepository) UseDefault(
+	ctx context.Context,
+	userID string,
+	expectedVersion int64,
+) (_ identity.UserProfile, resultErr error) {
+	tx, err := repository.database.Begin(ctx)
+	if err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	profile, err := lockProfile(ctx, tx, userID)
+	if err != nil {
+		return identity.UserProfile{}, err
+	}
+	if profile.avatarAssetID == "" {
+		if err := tx.Commit(ctx); err != nil {
+			return identity.UserProfile{}, ErrRepository
+		}
+		return projectProfile(profile, nil), nil
+	}
+	if profile.version != expectedVersion {
+		return identity.UserProfile{}, ErrConflict
+	}
+	oldAssetID := profile.avatarAssetID
+	var updatedAt time.Time
+	if err := tx.QueryRow(ctx, `
+UPDATE users
+SET
+    avatar_asset_id = NULL,
+    profile_version = profile_version + 1,
+    updated_at = GREATEST(CURRENT_TIMESTAMP, updated_at + INTERVAL '1 microsecond')
+WHERE id = $1 AND status = 'active'
+RETURNING updated_at`, userID).Scan(&updatedAt); err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	if err := mediapostgres.ScheduleDeletionInTransaction(
+		ctx, tx, userID, []string{oldAssetID},
+	); err != nil {
+		return identity.UserProfile{}, mapTransactionMediaError(err)
+	}
+	profile.avatarAssetID = ""
+	profile.version++
+	profile.updatedAt = updatedAt
+	if err := tx.Commit(ctx); err != nil {
+		return identity.UserProfile{}, ErrRepository
+	}
+	return projectProfile(profile, nil), nil
+}
+
+func (repository *PostgresRepository) CurrentAssetID(
+	ctx context.Context,
+	userID string,
+) (string, error) {
+	var assetID string
+	err := repository.database.QueryRow(ctx, `
+SELECT asset.id::text
+FROM users AS owner
+JOIN media_assets AS asset
+  ON asset.id = owner.avatar_asset_id AND asset.user_id = owner.id
+WHERE owner.id = $1 AND owner.status = 'active'
+  AND owner.display_name IS NOT NULL
+  AND asset.kind = 'image' AND asset.status = 'ready' AND asset.etag <> ''`,
+		userID,
+	).Scan(&assetID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", ErrRepository
+	}
+	return assetID, nil
+}
+
+func lockProfile(ctx context.Context, tx pgx.Tx, userID string) (lockedProfile, error) {
+	var profile lockedProfile
+	err := tx.QueryRow(ctx, `
+SELECT
+    id::text,
+    display_name,
+    profile_version,
+    COALESCE(avatar_asset_id::text, ''),
+    created_at,
+    updated_at
+FROM users
+WHERE id = $1 AND status = 'active' AND display_name IS NOT NULL
+FOR UPDATE`, userID).Scan(
+		&profile.userID,
+		&profile.displayName,
+		&profile.version,
+		&profile.avatarAssetID,
+		&profile.createdAt,
+		&profile.updatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return lockedProfile{}, ErrNotFound
+	}
+	if err != nil {
+		return lockedProfile{}, ErrRepository
+	}
+	return profile, nil
+}
+
+func projectProfile(profile lockedProfile, asset *sharedmedia.Asset) identity.UserProfile {
+	result := identity.UserProfile{
+		UserID: profile.userID, DisplayName: profile.displayName,
+		ProfileVersion: profile.version, CreatedAt: profile.createdAt,
+		UpdatedAt: profile.updatedAt,
+	}
+	if asset != nil {
+		result.Avatar = &identity.ProfileAvatar{
+			Width: asset.Width, Height: asset.Height, UpdatedAt: profile.updatedAt,
+		}
+	}
+	return result
+}
+
+func mapTransactionMediaError(err error) error {
+	switch {
+	case errors.Is(err, sharedmedia.ErrNotFound):
+		return ErrNotFound
+	case errors.Is(err, sharedmedia.ErrConflict):
+		return ErrConflict
+	case errors.Is(err, sharedmedia.ErrInvalidRequest):
+		return ErrInvalidRequest
+	default:
+		return ErrRepository
+	}
+}

--- a/server/internal/identity/avatar/service.go
+++ b/server/internal/identity/avatar/service.go
@@ -1,0 +1,118 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"time"
+
+	agentimage "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/image"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
+	sharedmedia "github.com/1024XEngineer/XE3-ESL/server/internal/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
+)
+
+type Service struct {
+	repository Repository
+	media      *sharedmedia.Service
+	config     Config
+}
+
+func NewService(repository Repository, media *sharedmedia.Service, config Config) (*Service, error) {
+	if repository == nil || media == nil || config.StagedTTL <= 0 {
+		return nil, ErrInvalidRequest
+	}
+	return &Service{repository: repository, media: media, config: config}, nil
+}
+
+func (service *Service) Upload(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	request UploadRequest,
+) (identity.UserProfile, error) {
+	if ctx == nil || !actor.Valid() || request.Body == nil ||
+		!sharedmedia.ValidIdempotencyKey(request.IdempotencyKey) ||
+		request.ExpectedProfileVersion < 1 {
+		return identity.UserProfile{}, ErrInvalidRequest
+	}
+	payload, err := io.ReadAll(io.LimitReader(request.Body, MaxBytes+1))
+	if err != nil || len(payload) == 0 {
+		return identity.UserProfile{}, ErrInvalidRequest
+	}
+	if len(payload) > MaxBytes {
+		return identity.UserProfile{}, agentimage.ErrTooLarge
+	}
+	normalized, contentType, width, height, err := agentimage.NormalizePayload(
+		request.ContentType,
+		payload,
+	)
+	if err != nil {
+		return identity.UserProfile{}, err
+	}
+	checksum := sha256.Sum256(normalized)
+	asset, err := service.media.Upload(ctx, sharedmedia.Upload{
+		UserID: actor.UserID, Kind: sharedmedia.KindImage,
+		IdempotencyKey: request.IdempotencyKey,
+		ContentType:    contentType, Body: bytes.NewReader(normalized),
+		Size: int64(len(normalized)), ChecksumSHA256: hex.EncodeToString(checksum[:]),
+		Width: width, Height: height,
+		ExpiresAt: time.Now().UTC().Add(service.config.StagedTTL),
+	})
+	if err != nil {
+		return identity.UserProfile{}, mapMediaError(err)
+	}
+	if asset.Status != sharedmedia.StatusReady {
+		return identity.UserProfile{}, ErrUploadInProgress
+	}
+	return service.repository.Attach(
+		ctx, actor.UserID, request.IdempotencyKey, request.ExpectedProfileVersion,
+	)
+}
+
+func (service *Service) UseDefault(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	expectedVersion int64,
+) (identity.UserProfile, error) {
+	if ctx == nil || !actor.Valid() || expectedVersion < 1 {
+		return identity.UserProfile{}, ErrInvalidRequest
+	}
+	return service.repository.UseDefault(ctx, actor.UserID, expectedVersion)
+}
+
+func (service *Service) Content(
+	ctx context.Context,
+	actor requestcontext.Actor,
+) (objectstore.SignedGetResult, error) {
+	if ctx == nil || !actor.Valid() {
+		return objectstore.SignedGetResult{}, ErrNotFound
+	}
+	assetID, err := service.repository.CurrentAssetID(ctx, actor.UserID)
+	if err != nil {
+		return objectstore.SignedGetResult{}, err
+	}
+	content, err := service.media.SignedGet(ctx, actor.UserID, assetID)
+	if err != nil {
+		return objectstore.SignedGetResult{}, mapMediaError(err)
+	}
+	return content, nil
+}
+
+func mapMediaError(err error) error {
+	switch {
+	case errors.Is(err, sharedmedia.ErrIdempotencyConflict):
+		return ErrIdempotencyConflict
+	case errors.Is(err, sharedmedia.ErrConflict):
+		return ErrUploadInProgress
+	case errors.Is(err, sharedmedia.ErrNotFound):
+		return ErrNotFound
+	case errors.Is(err, sharedmedia.ErrInvalidRequest):
+		return ErrInvalidRequest
+	default:
+		return ErrRepository
+	}
+}

--- a/server/internal/identity/avatar/service.go
+++ b/server/internal/identity/avatar/service.go
@@ -7,12 +7,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	agentimage "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/image"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
 	sharedmedia "github.com/1024XEngineer/XE3-ESL/server/internal/media"
-	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 )
 
@@ -20,13 +22,24 @@ type Service struct {
 	repository Repository
 	media      *sharedmedia.Service
 	config     Config
+	httpClient *http.Client
 }
 
 func NewService(repository Repository, media *sharedmedia.Service, config Config) (*Service, error) {
 	if repository == nil || media == nil || config.StagedTTL <= 0 {
 		return nil, ErrInvalidRequest
 	}
-	return &Service{repository: repository, media: media, config: config}, nil
+	return &Service{
+		repository: repository,
+		media:      media,
+		config:     config,
+		httpClient: &http.Client{
+			Timeout: defaultReadTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
 }
 
 func (service *Service) Upload(
@@ -87,19 +100,49 @@ func (service *Service) UseDefault(
 func (service *Service) Content(
 	ctx context.Context,
 	actor requestcontext.Actor,
-) (objectstore.SignedGetResult, error) {
+) (Content, error) {
 	if ctx == nil || !actor.Valid() {
-		return objectstore.SignedGetResult{}, ErrNotFound
+		return Content{}, ErrNotFound
 	}
 	assetID, err := service.repository.CurrentAssetID(ctx, actor.UserID)
 	if err != nil {
-		return objectstore.SignedGetResult{}, err
+		return Content{}, err
 	}
-	content, err := service.media.SignedGet(ctx, actor.UserID, assetID)
+	asset, err := service.media.FindOwned(ctx, actor.UserID, assetID)
+	if err != nil || asset.Kind != sharedmedia.KindImage ||
+		asset.Status != sharedmedia.StatusReady || asset.Size < 1 || asset.Size > MaxBytes {
+		return Content{}, ErrNotFound
+	}
+	signed, err := service.media.SignedGet(ctx, actor.UserID, assetID)
 	if err != nil {
-		return objectstore.SignedGetResult{}, mapMediaError(err)
+		return Content{}, mapMediaError(err)
 	}
-	return content, nil
+	signedURL, err := url.Parse(signed.URL)
+	if err != nil || signedURL.Scheme != "https" || signedURL.Host == "" {
+		return Content{}, ErrRepository
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, signedURL.String(), nil)
+	if err != nil {
+		return Content{}, ErrRepository
+	}
+	response, err := service.httpClient.Do(request)
+	if err != nil {
+		return Content{}, ErrRepository
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK ||
+		!strings.EqualFold(strings.TrimSpace(response.Header.Get("Content-Type")), asset.ContentType) {
+		return Content{}, ErrRepository
+	}
+	payload, err := io.ReadAll(io.LimitReader(response.Body, MaxBytes+1))
+	if err != nil || int64(len(payload)) != asset.Size || len(payload) > MaxBytes {
+		return Content{}, ErrRepository
+	}
+	checksum := sha256.Sum256(payload)
+	if hex.EncodeToString(checksum[:]) != asset.ChecksumSHA256 {
+		return Content{}, ErrRepository
+	}
+	return Content{Payload: payload, ContentType: asset.ContentType}, nil
 }
 
 func mapMediaError(err error) error {

--- a/server/internal/identity/http.go
+++ b/server/internal/identity/http.go
@@ -614,13 +614,21 @@ func userResponse(user User) gin.H {
 }
 
 func profileResponse(profile UserProfile) gin.H {
-	return gin.H{
+	response := gin.H{
 		"user_id":         profile.UserID,
 		"display_name":    profile.DisplayName,
 		"profile_version": profile.ProfileVersion,
 		"created_at":      profile.CreatedAt.UTC().Format(time.RFC3339Nano),
 		"updated_at":      profile.UpdatedAt.UTC().Format(time.RFC3339Nano),
 	}
+	if profile.Avatar != nil {
+		response["avatar"] = gin.H{
+			"width":      profile.Avatar.Width,
+			"height":     profile.Avatar.Height,
+			"updated_at": profile.Avatar.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		}
+	}
+	return response
 }
 
 func newCorrelationID() string {

--- a/server/internal/identity/model.go
+++ b/server/internal/identity/model.go
@@ -26,8 +26,15 @@ type UserProfile struct {
 	UserID         string
 	DisplayName    string
 	ProfileVersion int64
+	Avatar         *ProfileAvatar
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
+}
+
+type ProfileAvatar struct {
+	Width     int
+	Height    int
+	UpdatedAt time.Time
 }
 
 type UpdateProfileCommand struct {

--- a/server/internal/identity/postgres.go
+++ b/server/internal/identity/postgres.go
@@ -104,25 +104,43 @@ func (r *PostgresRepository) FindProfileByUserID(
 	userID string,
 ) (UserProfile, error) {
 	var profile UserProfile
+	var avatarID string
+	var avatarWidth, avatarHeight int
+	var avatarUpdatedAt time.Time
 	err := r.database.QueryRow(ctx, `
 SELECT
-    id::text,
-    display_name,
-    profile_version,
-    created_at,
-    updated_at
-FROM users
-WHERE id = $1 AND status = 'active' AND display_name IS NOT NULL`,
+    owner.id::text,
+    owner.display_name,
+    owner.profile_version,
+    COALESCE(asset.id::text, ''),
+    COALESCE(asset.width, 0),
+    COALESCE(asset.height, 0),
+    COALESCE(asset.updated_at, TIMESTAMPTZ 'epoch'),
+    owner.created_at,
+    owner.updated_at
+FROM users AS owner
+LEFT JOIN media_assets AS asset ON asset.id = owner.avatar_asset_id
+WHERE owner.id = $1 AND owner.status = 'active'
+  AND owner.display_name IS NOT NULL`,
 		userID,
 	).Scan(
 		&profile.UserID,
 		&profile.DisplayName,
 		&profile.ProfileVersion,
+		&avatarID,
+		&avatarWidth,
+		&avatarHeight,
+		&avatarUpdatedAt,
 		&profile.CreatedAt,
 		&profile.UpdatedAt,
 	)
 	if err != nil {
 		return UserProfile{}, mapPostgresError(err)
+	}
+	if avatarID != "" {
+		profile.Avatar = &ProfileAvatar{
+			Width: avatarWidth, Height: avatarHeight, UpdatedAt: avatarUpdatedAt,
+		}
 	}
 	return profile, nil
 }
@@ -132,13 +150,16 @@ func (r *PostgresRepository) PersistProfile(
 	command PersistProfileCommand,
 ) (UserProfile, error) {
 	var profile UserProfile
+	var avatarID string
+	var avatarWidth, avatarHeight int
+	var avatarUpdatedAt time.Time
 	err := r.database.QueryRow(ctx, `
 WITH locked_user AS (
     SELECT id, display_name, profile_version
     FROM users
     WHERE id = $1 AND status = 'active'
     FOR UPDATE
-)
+), updated AS (
 UPDATE users AS owner
 SET
     display_name = $2,
@@ -161,8 +182,22 @@ RETURNING
     owner.id::text,
     owner.display_name,
     owner.profile_version,
+    owner.avatar_asset_id,
     owner.created_at,
-    owner.updated_at`,
+    owner.updated_at
+)
+SELECT
+    updated.id,
+    updated.display_name,
+    updated.profile_version,
+    COALESCE(asset.id::text, ''),
+    COALESCE(asset.width, 0),
+    COALESCE(asset.height, 0),
+    COALESCE(asset.updated_at, TIMESTAMPTZ 'epoch'),
+    updated.created_at,
+    updated.updated_at
+FROM updated
+LEFT JOIN media_assets AS asset ON asset.id = updated.avatar_asset_id`,
 		command.UserID,
 		command.DisplayName,
 		command.ExpectedProfileVersion,
@@ -170,6 +205,10 @@ RETURNING
 		&profile.UserID,
 		&profile.DisplayName,
 		&profile.ProfileVersion,
+		&avatarID,
+		&avatarWidth,
+		&avatarHeight,
+		&avatarUpdatedAt,
 		&profile.CreatedAt,
 		&profile.UpdatedAt,
 	)
@@ -178,6 +217,11 @@ RETURNING
 	}
 	if err != nil {
 		return UserProfile{}, mapPostgresError(err)
+	}
+	if avatarID != "" {
+		profile.Avatar = &ProfileAvatar{
+			Width: avatarWidth, Height: avatarHeight, UpdatedAt: avatarUpdatedAt,
+		}
 	}
 	return profile, nil
 }

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -73,6 +73,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to Scene selection source = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to Question Tip translation = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -127,6 +127,9 @@ func TestSceneSelectionSourceMigrationTransformsPlansAndPreservesSessions(
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v5 Scene selection source = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v4 legacy Scene selection = %t, %v", changed, downErr)
 	}
 
@@ -254,6 +257,9 @@ FROM practice_sessions WHERE session_id = $1
 	}
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("roll back v6 = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("roll back v5 = %t, %v", changed, downErr)
 	}
 	var restoredID, restoredRoleID, restoredOptionID, restoredStatus string
@@ -285,6 +291,9 @@ func TestMigratedLegacyCatalogPlanCompletesThroughFormalReport(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v5 Scene selection source = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v4 legacy Scene selection = %t, %v", changed, downErr)
@@ -535,6 +544,9 @@ func TestSceneSelectionSourceMigrationRejectsDownWithCustomPlan(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v5 Scene selection source = %t, %v", changed, downErr)
 	}
 
 	database, err := pgx.ConnectConfig(context.Background(), config)

--- a/server/migrations/000006_user_profile_avatar.down.sql
+++ b/server/migrations/000006_user_profile_avatar.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP INDEX users_avatar_asset_unique_idx;
+
+ALTER TABLE users
+    DROP CONSTRAINT users_avatar_asset_fkey,
+    DROP COLUMN avatar_asset_id;
+
+COMMIT;

--- a/server/migrations/000006_user_profile_avatar.up.sql
+++ b/server/migrations/000006_user_profile_avatar.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE users
+    ADD COLUMN avatar_asset_id uuid;
+
+ALTER TABLE users
+    ADD CONSTRAINT users_avatar_asset_fkey
+        FOREIGN KEY (avatar_asset_id)
+        REFERENCES media_assets (id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX users_avatar_asset_unique_idx
+    ON users (avatar_asset_id)
+    WHERE avatar_asset_id IS NOT NULL;
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -44,6 +44,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000004_question_tip_translation.up.sql",
 		"000005_scene_selection_source.down.sql",
 		"000005_scene_selection_source.up.sql",
+		"000006_user_profile_avatar.down.sql",
+		"000006_user_profile_avatar.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -63,6 +65,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000004_question_tip_translation.down.sql",
 		"000005_scene_selection_source.up.sql",
 		"000005_scene_selection_source.down.sql",
+		"000006_user_profile_avatar.up.sql",
+		"000006_user_profile_avatar.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {


### PR DESCRIPTION
## 功能描述

- 在现有 `users` 表增加可空 `avatar_asset_id`，不新增用户头像业务表
- 个人页提供“从相册选择”“拍照”“使用默认头像”
- 个人页与会话抽屉复用统一头像组件，保持现有视觉风格
- 私有头像由已鉴权后端回源校验后返回，App 不直接访问对象存储

## 实现思路

- 复用 `media_assets` 和现有对象存储上传链路，对 JPG/PNG/WebP 做解码校验、方向纠正和元数据清理
- 上传成功后，在同一数据库事务内锁定用户资料、校验 `profile_version`、切换头像引用、保留新资源并将旧资源加入延迟清理
- 恢复默认头像同样在事务内清空引用、递增版本并调度旧资源清理
- 使用 `Idempotency-Key` 防止同一上传请求被重复提交，使用 `If-Match` 防止多端覆盖
- 头像展示通过 Bearer 鉴权接口由服务端读取短时签名资源，并校验 MIME、长度和 SHA-256 后返回图片字节，避免设备直连 OSS 失败后静默回退默认图

## 可复现测试

```bash
cd server && go test ./...
cd api && npm run check
cd mobile && flutter analyze --no-pub
cd mobile && flutter test --no-pub
```

初版实现已通过 Go 全仓测试、API 契约/安全校验、Flutter 静态分析和 708 项 Flutter 测试。针对真机验收发现的 OSS 展示链路问题已提交修复，按提交者要求由其继续进行交互验收。

## 手工验收

1. 登录后进入“我的”，点击头像。
2. 分别验证从相册选择和拍照；上传后个人页及会话抽屉显示一致。
3. 点击“使用默认头像”，确认恢复默认图且重新登录后状态保持。
4. 两端以相同资料版本并发修改，确认后提交的一端收到版本冲突并刷新。
5. 重复提交相同 `Idempotency-Key`，确认不产生重复头像切换。

Closes #776