### PR TITLE
[MS3] 统一练习模型优先 TTS 与系统降级

### DIFF
--- a/api/modules/practice-runtime.yaml
+++ b/api/modules/practice-runtime.yaml
@@ -418,6 +418,54 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-speech/realtime:
+    get:
+      tags:
+        - Practice
+      summary: Stream authenticated Coaching prompt text as synthesized PCM
+      description: |
+        Authenticates the Actor before upgrading. After `stream.ready`, the
+        client sends exactly one bounded `speak` event. The server streams mono
+        24 kHz signed 16-bit little-endian PCM chunks and then exactly one
+        `stream.completed` or `stream.failed` event. The prompt is ephemeral and
+        must not be persisted or logged.
+      operationId: streamPracticePromptSpeech
+      parameters:
+        - name: Sec-WebSocket-Protocol
+          in: header
+          required: true
+          schema:
+            type: string
+            const: speakup.practice-question-speech.v1
+      responses:
+        '101':
+          description: WebSocket protocol upgrade accepted.
+          headers:
+            Sec-WebSocket-Protocol:
+              schema:
+                type: string
+                const: speakup.practice-question-speech.v1
+        '400':
+          $ref: ../common/errors.yaml#/components/responses/BadRequest
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
+      x-websocket-client-event-schema:
+        $ref: ../websocket/practice-question-speech.schema.json#/$defs/ClientEvent
+      x-websocket-event-schema:
+        $ref: ../websocket/practice-question-speech.schema.json#/$defs/ServerEvent
+      x-websocket-security:
+        credential_location: authorization_header
+        header: Authorization
+        scheme: Bearer
+        other_credential_locations_allowed: false
+        production_transport: wss
+        local_loopback_transport: ws
+        subprotocol:
+          allowed:
+            - speakup.practice-question-speech.v1
+          carries_credentials: false
   /v1/audio-assets/{audio_asset_id}:
     delete:
       tags:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -151,6 +151,8 @@ paths:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1practice-questions~1{question_id}~1speech
   /v1/practice-questions/{question_id}/speech/realtime:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1practice-questions~1{question_id}~1speech~1realtime
+  /v1/practice-speech/realtime:
+    $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1practice-speech~1realtime
   /v1/practice-questions/{question_id}/translation:
     $ref: ./modules/practice-runtime.yaml#/paths/~1v1~1practice-questions~1{question_id}~1translation
   /v1/evaluation-reports:

--- a/api/scripts/validate-practice-question-speech.mjs
+++ b/api/scripts/validate-practice-question-speech.mjs
@@ -17,6 +17,9 @@ ajv.addSchema(schema);
 const validate = ajv.compile({
   $ref: `${schema.$id}#/$defs/ServerEvent`,
 });
+const validateClient = ajv.compile({
+  $ref: `${schema.$id}#/$defs/ClientEvent`,
+});
 
 const validEvents = [
   {
@@ -52,6 +55,12 @@ for (const event of validEvents) {
 for (const event of invalidEvents) {
   assert.equal(validate(event), false, `accepted ${event.type}`);
 }
+assert.equal(validateClient({ type: 'speak', text: 'Try this answer.' }), true);
+assert.equal(validateClient({ type: 'speak', text: '' }), false);
+assert.equal(
+  validateClient({ type: 'speak', text: 'valid', provider: 'forbidden' }),
+  false,
+);
 
 console.log(
   `Validated ${validEvents.length} Practice Question speech events and ` +

--- a/api/websocket/practice-question-speech.schema.json
+++ b/api/websocket/practice-question-speech.schema.json
@@ -4,6 +4,18 @@
   "title": "Practice Question realtime speech",
   "description": "Server text events surrounding binary PCM chunks for one authenticated, Actor-owned Practice Question.",
   "$defs": {
+    "ClientEvent": {
+      "$ref": "#/$defs/Speak"
+    },
+    "Speak": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "text"],
+      "properties": {
+        "type": { "const": "speak" },
+        "text": { "type": "string", "minLength": 1, "maxLength": 4096 }
+      }
+    },
     "ServerEvent": {
       "oneOf": [
         { "$ref": "#/$defs/StreamReady" },

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -490,6 +490,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       return ScenarioPracticePage(
         previewMode: widget.allowFakePreview,
         practiceController: _practiceController,
+        questionSpeaker: _practiceController.promptSpeaker,
         onPracticeCompleted: launchController?.parkCurrentPractice,
         speechFeedbackController: widget.speechFeedbackController,
         onExitRequested: launchController?.parkCurrentPractice,
@@ -501,6 +502,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
     return InterviewPracticePage(
       previewMode: widget.allowFakePreview,
       practiceController: _practiceController,
+      practicePromptSpeaker: _practiceController.promptSpeaker,
       onOpenInterviewReport: widget.sessionEvaluationController == null
           ? null
           : _openInterviewReport,
@@ -516,6 +518,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
   }) {
     return IeltsSpeakingMockPage(
       controller: _practiceController,
+      examinerSpeaker: _practiceController.promptSpeaker,
       onExitRequested: launchController?.parkCurrentPractice,
       ieltsController: widget.ieltsPreparationController,
       reportStatusController: widget.sessionEvaluationController,

--- a/mobile/lib/features/coaching/ielts/ielts_catalog.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_catalog.dart
@@ -7,6 +7,7 @@ import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dar
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
 import 'package:speakup/features/coaching/ielts/ielts_speech_client.dart';
 import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/preparation/preparation_catalog_components.dart';
 import 'package:speakup/features/coaching/preparation/preparation_design.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
@@ -19,6 +20,7 @@ class IeltsCatalog extends StatefulWidget {
     required this.onRetry,
     this.speechClient,
     this.audioPlayer,
+    this.answerSpeaker,
     super.key,
   }) : assert((speechClient == null) == (audioPlayer == null));
 
@@ -34,6 +36,7 @@ class IeltsCatalog extends StatefulWidget {
   final Future<void> Function() onRetry;
   final IeltsSpeechClient? speechClient;
   final PracticeAudioPlayer? audioPlayer;
+  final PracticePromptSpeaker? answerSpeaker;
   IeltsAnswerGenerator? get answerGenerator => controller.answerGenerator;
 
   @override
@@ -274,6 +277,7 @@ class _IeltsCatalogState extends State<IeltsCatalog> {
           speechClient: widget.speechClient,
           audioPlayer: widget.audioPlayer,
           answerGenerator: widget.answerGenerator,
+          answerSpeaker: widget.answerSpeaker,
           cueCardQuestionReference: item.mode == PracticeMode.part2
               ? IeltsQuestionReference(
                   bankId: bank.bankId,

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -137,13 +137,13 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   String? _part2QuestionId;
   int _part2TranscriptionRetryAttempts = 0;
   bool _exitApproved = false;
+  bool _exitPromptOpen = false;
   bool _exitInFlight = false;
   bool _narrationBusy = false;
   bool _introNarrated = false;
   String? _narrationError;
   String? _answerLanguageError;
   final Map<String, String> _questionTranslations = <String, String>{};
-  PracticePromptSpeaker? _ownedTipSpeaker;
   String? _visibleTipQuestionId;
   String? _autoNarratedQuestionId;
   String? _autoNarratedQuestionText;
@@ -315,9 +315,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     unawaited(_stopExaminerSpeakerSafely());
     if (_ownsExaminerSpeaker) {
       unawaited(_examinerSpeaker.dispose());
-    }
-    if (_ownedTipSpeaker case final speaker?) {
-      unawaited(speaker.dispose());
     }
     final reportSessionId = widget.reportStatusController?.practiceSessionId;
     if (reportSessionId != null) {
@@ -725,7 +722,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _questionNarrationErrorId = null;
     });
     try {
-      await _examinerSpeaker.speak(text);
+      final speaker = _examinerSpeaker;
+      if (speaker is CoachingSpeechPlayer) {
+        await speaker.speakQuestion(questionId: questionId, fallbackText: text);
+      } else {
+        await speaker.speak(text);
+      }
     } catch (_) {
       if (mounted && generation == _questionNarrationGeneration) {
         setState(() => _questionNarrationErrorId = questionId);
@@ -789,8 +791,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (tip == null || _visibleTipQuestionId != tip.questionId) {
       return;
     }
-    final speaker = _ownedTipSpeaker ??= SystemPracticePromptSpeaker();
-    await speaker.speak(tip.content);
+    await _examinerSpeaker.speak(tip.content);
   }
 
   void _hideQuestionTip() {
@@ -803,7 +804,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   Future<void> _stopQuestionTipSpeech() async {
     try {
-      await _ownedTipSpeaker?.stop();
+      await _examinerSpeaker.stop();
     } on Object {
       // Recording must remain usable if platform TTS cannot stop cleanly.
     }
@@ -1221,6 +1222,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
 
   void _schedulePart2TranscriptionRetry() {
     if (!mounted ||
+        _exitPromptOpen ||
+        _exitInFlight ||
         _part2TranscriptionRetryTimer != null ||
         _part2TranscriptionRetryAttempts >= 3 ||
         widget.controller.recordingState != PracticeRecordingState.idle ||
@@ -1440,9 +1443,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     IeltsPracticeRouteResult? result,
     bool fromCompletion = false,
   }) async {
-    if (_exitApproved || _exitInFlight || !mounted) {
+    if (_exitApproved || _exitPromptOpen || _exitInFlight || !mounted) {
       return;
     }
+    _exitPromptOpen = true;
+    _part2TranscriptionRetryTimer?.cancel();
+    _part2TranscriptionRetryTimer = null;
     final shouldExit =
         fromCompletion ||
         _progress?.phase == IeltsMockPhase.complete ||
@@ -1457,10 +1463,16 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
               ),
             ) ==
             true;
+    _exitPromptOpen = false;
     if (!shouldExit || !mounted) {
+      _schedulePart2TranscriptionRetry();
       return;
     }
     setState(() => _exitInFlight = true);
+    await widget.controller.abandonPendingTranscriptionForExit();
+    if (!mounted) {
+      return;
+    }
     final callback = widget.onExitRequested;
     var parked = callback == null;
     try {

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -11,6 +11,7 @@ import 'package:speakup/features/coaching/practice/practice_client_error.dart';
 import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_media.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 
@@ -54,6 +55,11 @@ final class PracticeController extends ChangeNotifier
     if (mediaClient != null || questionSpeechPlayer != null) {
       WidgetsBinding.instance.addObserver(this);
     }
+    promptSpeaker = ModelFirstPracticePromptSpeaker(
+      speakTextWithModel: _speakPromptTextWithModel,
+      speakQuestionWithModel: _speakPromptQuestionWithModel,
+      stopModelSpeech: () => stopPracticeAudio(notify: false),
+    );
   }
 
   final PracticeClient client;
@@ -61,6 +67,7 @@ final class PracticeController extends ChangeNotifier
   final PracticeMediaClient? mediaClient;
   final PracticeAudioPlayer? audioPlayer;
   final PracticePCMStreamPlayer? questionSpeechPlayer;
+  late final CoachingSpeechPlayer promptSpeaker;
   final PracticeClientIdFactory _clientIdFactory;
   final Duration _recordingLimit;
   String? _practiceSessionId;
@@ -598,6 +605,82 @@ final class PracticeController extends ChangeNotifier
       if (identical(_questionSpeechOperation, operation)) {
         _questionSpeechOperation = null;
       }
+    }
+  }
+
+  Future<void> _speakPromptTextWithModel(String text) {
+    final speechClient = mediaClient;
+    if (speechClient is! PracticeTextSpeechClient) {
+      throw const ModelSpeechPlaybackException(audioStarted: false);
+    }
+    return _playStandaloneModelSpeech(
+      (speechClient as PracticeTextSpeechClient).streamTextSpeech(text),
+    );
+  }
+
+  Future<void> _speakPromptQuestionWithModel(
+    String questionId,
+    String fallbackText,
+  ) {
+    final speechClient = mediaClient;
+    if (speechClient is! PracticeQuestionSpeechClient || questionId.isEmpty) {
+      throw const ModelSpeechPlaybackException(audioStarted: false);
+    }
+    return _playStandaloneModelSpeech(
+      (speechClient as PracticeQuestionSpeechClient).streamQuestionSpeech(
+        questionId,
+      ),
+    );
+  }
+
+  Future<void> _playStandaloneModelSpeech(Stream<Uint8List> stream) async {
+    final player = questionSpeechPlayer;
+    if (player == null || _disposed || !canUsePracticeAudio) {
+      throw const ModelSpeechPlaybackException(audioStarted: false);
+    }
+    await stopPracticeAudio();
+    final generation = ++_mediaGeneration;
+    var started = false;
+    final iterator = StreamIterator<Uint8List>(stream);
+    _questionSpeechIterator = iterator;
+    try {
+      while (await iterator.moveNext()) {
+        final bytes = iterator.current;
+        if (!_isCurrentMedia(generation)) {
+          throw ModelSpeechPlaybackException(audioStarted: started);
+        }
+        if (!started) {
+          await player.startPCMStream();
+          if (!_isCurrentMedia(generation)) {
+            await player.stopPCMStream();
+            throw const ModelSpeechPlaybackException(audioStarted: false);
+          }
+          started = true;
+        }
+        try {
+          await player.appendPCM(bytes);
+        } finally {
+          bytes.fillRange(0, bytes.length, 0);
+        }
+      }
+      if (!started) {
+        throw const ModelSpeechPlaybackException(audioStarted: false);
+      }
+      if (!_isCurrentMedia(generation)) {
+        throw const ModelSpeechPlaybackException(audioStarted: true);
+      }
+      await player.finishPCMStream();
+    } on ModelSpeechPlaybackException {
+      await player.stopPCMStream();
+      rethrow;
+    } catch (_) {
+      await player.stopPCMStream();
+      throw ModelSpeechPlaybackException(audioStarted: started);
+    } finally {
+      if (identical(_questionSpeechIterator, iterator)) {
+        _questionSpeechIterator = null;
+      }
+      await iterator.cancel();
     }
   }
 
@@ -1587,6 +1670,30 @@ final class PracticeController extends ChangeNotifier
     });
   }
 
+  /// Abandons an unsubmitted local recording so an explicit user exit never
+  /// waits for a slow or unavailable transcription provider.
+  Future<void> abandonPendingTranscriptionForExit() async {
+    final pending = _pendingPracticeAudio;
+    if (pending == null || _disposed) {
+      return;
+    }
+    _practiceGeneration++;
+    _pendingPracticeAudio = null;
+    _stopRecordingFuture = null;
+    _candidate = null;
+    _activeConfirmationId = null;
+    _activeTextAnswer = null;
+    _recordingState = PracticeRecordingState.idle;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      await recorder.discard(pending.audio);
+    } catch (_) {
+      // The stale transcription also owns best-effort cleanup. Exiting must
+      // remain available if the temporary file was already removed.
+    }
+  }
+
   Future<void> discardPendingPracticeAudio() {
     final pending = _pendingPracticeAudio;
     final inFlight = _stopRecordingFuture;
@@ -2131,6 +2238,7 @@ final class PracticeController extends ChangeNotifier
     _mediaGeneration++;
     _speechFeedbackRetry = null;
     _speechFeedbackRetryCandidate = null;
+    unawaited(promptSpeaker.dispose());
     unawaited(
       Future<void>.sync(() async {
         await _recorderStartFuture;

--- a/mobile/lib/features/coaching/practice/practice_media.dart
+++ b/mobile/lib/features/coaching/practice/practice_media.dart
@@ -30,6 +30,10 @@ abstract interface class PracticeQuestionSpeechClient {
   Stream<Uint8List> streamQuestionSpeech(String questionId);
 }
 
+abstract interface class PracticeTextSpeechClient {
+  Stream<Uint8List> streamTextSpeech(String text);
+}
+
 final class PracticeMediaWireRequest {
   const PracticeMediaWireRequest({
     required this.method,
@@ -68,7 +72,10 @@ abstract interface class PracticeMediaWireTransport {
 /// signed URL is consumed by a separate request with no App Session header,
 /// then only the resulting WAV bytes cross the player boundary.
 final class WirePracticeMediaClient
-    implements PracticeMediaClient, PracticeQuestionSpeechClient {
+    implements
+        PracticeMediaClient,
+        PracticeQuestionSpeechClient,
+        PracticeTextSpeechClient {
   factory WirePracticeMediaClient({
     required Uri baseUri,
     required AuthSessionCredentialProvider credentialProvider,
@@ -171,10 +178,34 @@ final class WirePracticeMediaClient
   @override
   Stream<Uint8List> streamQuestionSpeech(String questionId) async* {
     final id = _requireResourceId(questionId);
-    final generation = _accountGeneration;
     final uri = _practiceWebSocketBaseUri(_baseUri).resolve(
       '/v1/practice-questions/${Uri.encodeComponent(id)}/speech/realtime',
     );
+    yield* _streamSpeech(uri);
+  }
+
+  @override
+  Stream<Uint8List> streamTextSpeech(String text) async* {
+    final value = text.trim();
+    if (value.isEmpty || value.runes.length > 4096) {
+      throw const PracticeClientException(
+        kind: PracticeClientFailureKind.invalidRequest,
+      );
+    }
+    final uri = _practiceWebSocketBaseUri(
+      _baseUri,
+    ).resolve('/v1/practice-speech/realtime');
+    yield* _streamSpeech(
+      uri,
+      initialMessage: jsonEncode(<String, String>{
+        'type': 'speak',
+        'text': value,
+      }),
+    );
+  }
+
+  Stream<Uint8List> _streamSpeech(Uri uri, {String? initialMessage}) async* {
+    final generation = _accountGeneration;
     SessionAuthenticatedWebSocketConnection? connection;
     StreamIterator<dynamic>? messages;
     var receivedBytes = 0;
@@ -184,6 +215,9 @@ final class WirePracticeMediaClient
       messages = StreamIterator<dynamic>(connection.socket);
       final ready = await _nextPracticeSpeechMessage(messages);
       _requirePracticeSpeechEvent(ready, 'stream.ready');
+      if (initialMessage != null) {
+        connection.socket.add(initialMessage);
+      }
       while (true) {
         final message = await _nextPracticeSpeechMessage(messages);
         if (message is String) {

--- a/mobile/lib/features/coaching/practice/practice_prompt_speaker.dart
+++ b/mobile/lib/features/coaching/practice/practice_prompt_speaker.dart
@@ -8,6 +8,106 @@ abstract interface class PracticePromptSpeaker {
   Future<void> dispose();
 }
 
+abstract interface class CoachingSpeechPlayer implements PracticePromptSpeaker {
+  Future<void> speakQuestion({
+    required String questionId,
+    required String fallbackText,
+  });
+}
+
+final class ModelSpeechPlaybackException implements Exception {
+  const ModelSpeechPlaybackException({required this.audioStarted});
+
+  final bool audioStarted;
+}
+
+typedef ModelTextSpeech = Future<void> Function(String text);
+typedef ModelQuestionSpeech =
+    Future<void> Function(String questionId, String fallbackText);
+typedef ModelSpeechStop = Future<void> Function();
+
+final class ModelFirstPracticePromptSpeaker implements CoachingSpeechPlayer {
+  ModelFirstPracticePromptSpeaker({
+    required this._speakTextWithModel,
+    required this._speakQuestionWithModel,
+    required this._stopModelSpeech,
+  });
+
+  final ModelTextSpeech _speakTextWithModel;
+  final ModelQuestionSpeech _speakQuestionWithModel;
+  final ModelSpeechStop _stopModelSpeech;
+  PracticePromptSpeaker? _fallback;
+  int _generation = 0;
+  bool _disposed = false;
+
+  @override
+  Future<void> speak(String text) =>
+      _play(text, () => _speakTextWithModel(text));
+
+  @override
+  Future<void> speakQuestion({
+    required String questionId,
+    required String fallbackText,
+  }) => _play(
+    fallbackText,
+    () => _speakQuestionWithModel(questionId, fallbackText),
+  );
+
+  Future<void> _play(String fallbackText, Future<void> Function() model) async {
+    if (_disposed) {
+      throw StateError('Coaching speech player is disposed.');
+    }
+    final generation = ++_generation;
+    final existingFallback = _fallback;
+    if (existingFallback != null) {
+      await _bestEffort(existingFallback.stop);
+    }
+    try {
+      await model();
+    } on ModelSpeechPlaybackException catch (error) {
+      if (error.audioStarted || _disposed || generation != _generation) {
+        rethrow;
+      }
+      final fallback = _fallback ??= SystemPracticePromptSpeaker();
+      await fallback.speak(fallbackText);
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    _generation++;
+    final existingFallback = _fallback;
+    await Future.wait<void>([
+      _bestEffort(_stopModelSpeech),
+      if (existingFallback != null) _bestEffort(existingFallback.stop),
+    ]);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _generation++;
+    final existingFallback = _fallback;
+    _fallback = null;
+    await Future.wait<void>([
+      _bestEffort(_stopModelSpeech),
+      if (existingFallback != null) _bestEffort(existingFallback.dispose),
+    ]);
+  }
+
+  Future<void> _bestEffort(Future<void> Function() operation) async {
+    try {
+      await operation();
+    } catch (_) {
+      // Stopping either playback implementation must never block navigation
+      // or disposal of the owning screen.
+    }
+  }
+}
+
 final class SystemPracticePromptSpeaker implements PracticePromptSpeaker {
   SystemPracticePromptSpeaker({FlutterTts? flutterTts})
     : _flutterTts = flutterTts ?? FlutterTts();

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -723,6 +723,7 @@ class _PreparationPageState extends State<PreparationPage> {
           IeltsCatalog(
             controller: ielts!,
             scenes: scenes,
+            answerSpeaker: widget.practiceController?.promptSpeaker,
             speechClient: widget.practiceController?.mediaClient == null
                 ? null
                 : WireIeltsSpeechClient(

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -165,7 +165,9 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       return;
     }
     await _stopQuestionNarration();
-    final speaker = _ownedTipSpeaker ??= SystemPracticePromptSpeaker();
+    final speaker =
+        widget.questionSpeaker ??
+        (_ownedTipSpeaker ??= SystemPracticePromptSpeaker());
     await speaker.speak(tip.content);
   }
 
@@ -179,7 +181,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
 
   Future<void> _stopQuestionTipSpeech() async {
     try {
-      await _ownedTipSpeaker?.stop();
+      await (widget.questionSpeaker ?? _ownedTipSpeaker)?.stop();
     } on Object {
       // Recording and dismissal must not be blocked by a platform TTS error.
     }
@@ -240,7 +242,15 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       _questionNarrationErrorId = null;
     });
     try {
-      await _questionSpeaker.speak(message.text);
+      final speaker = _questionSpeaker;
+      if (speaker is CoachingSpeechPlayer) {
+        await speaker.speakQuestion(
+          questionId: message.id,
+          fallbackText: message.text,
+        );
+      } else {
+        await speaker.speak(message.text);
+      }
     } on Object {
       if (mounted && generation == _questionNarrationGeneration) {
         setState(() => _questionNarrationErrorId = message.id);

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -79,6 +79,7 @@ class ScenarioPracticeSession extends StatelessWidget {
       surfaceKey: const Key('scenario-avatar-surface'),
       builder: (context, avatar) => ScenarioPracticePage(
         practiceController: practiceController,
+        questionSpeaker: practiceController.promptSpeaker,
         avatarSurfaceBuilder: avatar.surfaceBuilder,
         avatarStatusLabel: avatar.statusLabel,
         onBeforeStartRecording: avatar.interruptForUserTurn,

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -637,6 +637,113 @@ void main() {
     expect(find.byKey(const Key('ielts-mock-record')), findsOneWidget);
   });
 
+  testWidgets('Part 2 can exit while transcription is still in flight', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final transcriptionGate = Completer<void>();
+    final practice = _IeltsPracticeClient(initialCompleted: 8)
+      ..transcriptionGate = transcriptionGate;
+    final recorder = _Recorder();
+    final controller = PracticeController(client: practice, recorder: recorder);
+    addTearDown(controller.dispose);
+    await _activatePractice(controller, practice, _ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              key: const Key('open-part2'),
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => IeltsSpeakingMockPage(
+                    controller: controller,
+                    progressStore: _MemoryProgressStore(),
+                    examinerSpeaker: _ImmediateExaminerSpeaker(),
+                    onExitRequested: controller.parkPractice,
+                  ),
+                ),
+              ),
+              child: const Text('Open Part 2'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-part2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('进入 Part 2'));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-start-speaking')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-finish-speaking')));
+    await tester.pump();
+
+    expect(controller.recordingState, PracticeRecordingState.transcribing);
+    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
+    await tester.pump(const Duration(milliseconds: 500));
+    tester
+        .widget<FilledButton>(find.byKey(const Key('ielts-mock-save-and-exit')))
+        .onPressed!();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.byKey(const Key('open-part2')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-page')), findsNothing);
+    expect(controller.practiceSessionId, isNull);
+    expect(recorder.discardedAudioPaths, contains('ielts-1.wav'));
+
+    transcriptionGate.complete();
+    await tester.pump();
+    expect(controller.practiceSessionId, isNull);
+  });
+
+  testWidgets('opening Part 2 exit confirmation pauses failed ASR retries', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 8)
+      ..transcribeFailure = StateError('provider unavailable');
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(controller, practice, _ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text('进入 Part 2'));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ielts-mock-start-speaking')));
+    await tester.pump();
+    await controller.finishRecordingGesture();
+    await tester.pump();
+
+    expect(practice.transcriptionRequests, hasLength(1));
+    expect(controller.recordingState, PracticeRecordingState.idle);
+    await tester.tap(find.byKey(const Key('ielts-mock-exit')));
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 4));
+
+    expect(find.byKey(const Key('ielts-mock-exit-sheet')), findsOneWidget);
+    expect(practice.transcriptionRequests, hasLength(1));
+  });
+
   testWidgets('Part 2 records locally while Part 3 keeps realtime ASR', (
     tester,
   ) async {

--- a/server/internal/coaching/practice/interaction/http/handler.go
+++ b/server/internal/coaching/practice/interaction/http/handler.go
@@ -164,6 +164,7 @@ func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 			"/v1/practice-questions/:question_id/speech/realtime",
 			handler.questionSpeechRealtime,
 		)
+		routes.GET("/v1/practice-speech/realtime", handler.promptSpeechRealtime)
 	}
 	routes.GET(
 		"/v1/practice-questions/:question_id/translation",

--- a/server/internal/coaching/practice/interaction/http/realtime_speech.go
+++ b/server/internal/coaching/practice/interaction/http/realtime_speech.go
@@ -1,9 +1,14 @@
 package voicehttp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
+	"strings"
 	"sync"
+	"unicode/utf8"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
@@ -12,6 +17,13 @@ import (
 )
 
 const practiceQuestionSpeechWebSocketProtocol = "speakup.practice-question-speech.v1"
+
+const maxPracticePromptSpeechRunes = 4096
+
+type practicePromptSpeechFrame struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
 
 func (handler *Handler) questionSpeechRealtime(c *gin.Context) {
 	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
@@ -38,14 +50,62 @@ func (handler *Handler) questionSpeechRealtime(c *gin.Context) {
 		handler.write(c, invalidRequest(nil))
 		return
 	}
-	connection, err := (&websocket.Upgrader{
-		Subprotocols: []string{practiceQuestionSpeechWebSocketProtocol},
-	}).Upgrade(c.Writer, c.Request, nil)
+	connection, err := upgradePracticeSpeech(c)
 	if err != nil {
 		return
 	}
 	defer connection.Close()
-	if err := connection.WriteJSON(gin.H{
+	if writePracticeSpeechReady(connection) != nil {
+		return
+	}
+	handler.streamPracticeSpeech(c.Request.Context(), connection, text)
+}
+
+func (handler *Handler) promptSpeechRealtime(c *gin.Context) {
+	if _, ok := requestcontext.ActorFromContext(c.Request.Context()); !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	if !containsWebSocketProtocol(
+		websocket.Subprotocols(c.Request),
+		practiceQuestionSpeechWebSocketProtocol,
+	) {
+		handler.write(c, invalidRequest(nil))
+		return
+	}
+	connection, err := upgradePracticeSpeech(c)
+	if err != nil {
+		return
+	}
+	defer connection.Close()
+	connection.SetReadLimit(16 * 1024)
+	if writePracticeSpeechReady(connection) != nil {
+		return
+	}
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil {
+		return
+	}
+	if messageType != websocket.TextMessage {
+		writePracticeSpeechFailure(connection, false)
+		return
+	}
+	text, err := decodePracticePromptSpeech(payload)
+	if err != nil {
+		writePracticeSpeechFailure(connection, false)
+		return
+	}
+	handler.streamPracticeSpeech(c.Request.Context(), connection, text)
+}
+
+func upgradePracticeSpeech(c *gin.Context) (*websocket.Conn, error) {
+	return (&websocket.Upgrader{
+		Subprotocols: []string{practiceQuestionSpeechWebSocketProtocol},
+	}).Upgrade(c.Writer, c.Request, nil)
+}
+
+func writePracticeSpeechReady(connection *websocket.Conn) error {
+	return connection.WriteJSON(gin.H{
 		"type": "stream.ready",
 		"data": gin.H{
 			"content_type":    agentconversation.AssistantSpeechContentTypePCM,
@@ -53,11 +113,35 @@ func (handler *Handler) questionSpeechRealtime(c *gin.Context) {
 			"channel_count":   agentconversation.AssistantSpeechChannelCount,
 			"bits_per_sample": agentconversation.AssistantSpeechBitsPerSample,
 		},
-	}); err != nil {
-		return
-	}
+	})
+}
 
-	streamContext, cancel := context.WithCancel(c.Request.Context())
+func decodePracticePromptSpeech(payload []byte) (string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var frame practicePromptSpeechFrame
+	if err := decoder.Decode(&frame); err != nil {
+		return "", err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return "", context.Canceled
+	}
+	text := strings.TrimSpace(frame.Text)
+	if frame.Type != "speak" || text == "" || !utf8.ValidString(text) ||
+		utf8.RuneCountInString(text) > maxPracticePromptSpeechRunes {
+		return "", context.Canceled
+	}
+	return text, nil
+}
+
+func (handler *Handler) streamPracticeSpeech(
+	requestContext context.Context,
+	connection *websocket.Conn,
+	text string,
+) {
+
+	streamContext, cancel := context.WithCancel(requestContext)
 	defer cancel()
 	var firstAudio sync.Once
 	chunks, bytes := 0, 0

--- a/server/internal/coaching/practice/interaction/http/realtime_test.go
+++ b/server/internal/coaching/practice/interaction/http/realtime_test.go
@@ -249,6 +249,54 @@ func TestPracticeQuestionSpeechStreamsTrustedQuestionPCM(t *testing.T) {
 	}
 }
 
+func TestPracticePromptSpeechStreamsBoundedClientText(t *testing.T) {
+	application := &practiceRealtimeHTTPApplication{}
+	synthesizer := &practiceQuestionSpeechSynthesizer{}
+	server := httptest.NewServer(
+		newPracticeRealtimeHTTPRouterWithOptions(
+			t,
+			application,
+			Options{RealtimeSpeech: synthesizer},
+		),
+	)
+	defer server.Close()
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/v1/practice-speech/realtime"
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{practiceQuestionSpeechWebSocketProtocol},
+	}).Dial(
+		endpoint,
+		http.Header{"Authorization": []string{"Bearer voice-token-a"}},
+	)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial realtime prompt speech: %v", err)
+	}
+	defer connection.Close()
+	if _, _, err := connection.ReadMessage(); err != nil {
+		t.Fatalf("read ready: %v", err)
+	}
+	if err := connection.WriteJSON(gin.H{
+		"type": "speak", "text": "  Try this answer.  ",
+	}); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+	messageType, audio, err := connection.ReadMessage()
+	if err != nil || messageType != websocket.BinaryMessage ||
+		string(audio) != "\x01\x02\x03\x04" {
+		t.Fatalf("audio = (%d, %v), err = %v", messageType, audio, err)
+	}
+	if _, completed, err := connection.ReadMessage(); err != nil ||
+		!strings.Contains(string(completed), `"type":"stream.completed"`) {
+		t.Fatalf("completed = %q, err = %v", completed, err)
+	}
+	if synthesizer.text != "Try this answer." {
+		t.Fatalf("speech text = %q", synthesizer.text)
+	}
+}
+
 func TestPracticeRealtimeFailureUsesStableSafeCategory(t *testing.T) {
 	providerFailure := practiceinteraction.NewProviderError(
 		practiceinteraction.ProviderOperationTranscription,


### PR DESCRIPTION
## 功能描述

- 抽取公共的模型优先练习朗读器，模型 TTS 不可用且尚未开始播放时静默降级到系统语音
- 统一 IELTS Part 2/Part 3 考官、Tips、定制答案，以及场景/面试练习的朗读入口
- 新增通用文本 TTS WebSocket，复用现有 AssistantSpeechSynthesizer 与 PCM 播放链路
- 修复 Part 2 转写处理中或失败重试时无法保存退出的问题；退出时终止本地等待并隔离迟到响应

## 实现思路

- 服务端在现有 practice speech handler 中增加 `/v1/practice-speech/realtime`，复用既有鉴权、WebSocket 子协议、TTS provider 和 PCM 事件
- 移动端由 `PracticeController` 持有唯一的 `ModelFirstPracticePromptSpeaker`，页面通过依赖注入复用，不另建一套 TTS 实现
- 系统 TTS 仅在模型音频尚未开始且模型失败时懒加载；降级过程不显示提示文案
- Part 2 打开退出确认时暂停 ASR 自动重试，确认退出后使在途转写失效并清理未提交录音

## 可复现测试

1. `make check`
   - Flutter analyze 与 707 项测试通过
   - Go vet 与全包测试通过
   - OpenAPI、安全、WebSocket、Evaluation 契约校验通过
2. `cd server && go build ./cmd/server`
3. `make dev-ios-simulator`
   - iPhone 17 Pro 模拟器构建并启动成功，真实后端，数字人禁用
4. IELTS Part 2 开始作答后让转写保持处理中或返回 503，点击保存并退出，页面应立即退出且不再自动重试
5. IELTS Part 2/Part 3、Tips 和定制答案朗读应优先走模型 TTS；模型在首个音频块前失败时静默使用系统朗读

## 环境说明

直接执行 `flutter build ios --simulator --no-codesign` 会被仓库当前真实 `avatar_kit` framework 的 Unsupported Swift architecture 限制阻断；按仓库规定的 `make dev-ios-simulator` 使用 avatar stub 后构建成功。

Closes #774