### PR TITLE
fix(deps): 修复 PDF 解析依赖拒绝服务漏洞

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -66,3 +66,6 @@ require (
 	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 )
+
+// GO-2026-6115: use upstream PR #78 until ledongthuc/pdf publishes a fixed version.
+replace github.com/ledongthuc/pdf => github.com/gage-marshall/pdf v0.0.0-20260724223906-84256728aa1a

--- a/server/go.sum
+++ b/server/go.sum
@@ -58,6 +58,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/gage-marshall/pdf v0.0.0-20260724223906-84256728aa1a h1:MCLWvzwc3l3IUzhrSPmO7FHubbvLFMT4XcNBdjD2udY=
+github.com/gage-marshall/pdf v0.0.0-20260724223906-84256728aa1a/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.11.0 h1:OW/6PLjyusp2PPXtyxKHU0RbX6I/l28FTdDlae5ueWk=


### PR DESCRIPTION
## 功能描述

修复 Go 官方漏洞 `GO-2026-6115` / `CVE-2026-56867` 对简历 PDF 文本解析链路的可达影响，并恢复 `govulncheck` CI。

Closes #781

## 已验证事实

- Go 官方漏洞库于 2026-08-18 16:48 UTC 发布该漏洞；所有 `github.com/ledongthuc/pdf` 已发布版本均受影响，`Fixed in: N/A`。
- 当前服务端直接调用受影响的 `NewReader`、`Reader.Page` 和 `Page.GetPlainText`。
- 现有 `recover` 和输入大小限制无法防御库内部不可恢复的 OOM、栈溢出和无限循环。
- 官方漏洞报告引用 `ledongthuc/pdf` PR #78 作为参考补丁；该补丁包含针对恶意 PDF 的系统性加固和回归测试，但尚未合并发布。

## 实现思路

使用 Go module `replace` 将现有 import path 精确固定到上游 PR #78 的补丁 Fork HEAD：

```go
replace github.com/ledongthuc/pdf => github.com/gage-marshall/pdf v0.0.0-20260724223906-84256728aa1a
```

- 精确 pseudo-version，不跟随浮动分支；
- 不修改 PDF Parser 业务代码或 OCR 协议；
- 不通过 CI skip、漏洞忽略或静默降级绕过扫描；
- 上游发布正式 fixed version 后，应另建 Issue 移除临时 replace。

参考：

- `https://pkg.go.dev/vuln/GO-2026-6115`
- `https://github.com/golang/vulndb/issues/6115`
- `https://github.com/ledongthuc/pdf/pull/78`

## 可复现测试

```bash
cd server
GOCACHE=/tmp/xe3-esl-issue-781-go-cache go test -count=1 ./internal/coaching/preparation/interviewresume/document ./internal/coaching/preparation/interviewresume/...
GOCACHE=/tmp/xe3-esl-issue-781-go-cache go test -count=1 ./...
GOCACHE=/tmp/xe3-esl-issue-781-go-cache go vet ./...
go mod verify
GOTOOLCHAIN=local go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
```

本地结果：

- PDF/简历解析测试：通过
- 完整 Go 测试：通过
- `go vet ./...`：通过
- `go mod verify`：`all modules verified`
- `govulncheck v1.6.0`：`No vulnerabilities found`

## 范围说明

- 仅修改 `server/go.mod` 和 `server/go.sum`。
- 不改变简历上传、PDF 文本提取、OCR 回退或公开 API 行为。
