### PR TITLE
ci(coverage): 在 PR 中报告并守护 Go 覆盖率

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Resolve PR and coverage baseline
         id: context
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const run = context.payload.workflow_run;
@@ -154,7 +154,7 @@ jobs:
 
       - name: Create or update PR coverage comment
         if: steps.context.outputs.available == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BASE_BRANCH: ${{ steps.context.outputs.base_branch }}
           PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pull_request_number }}

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Download current Go coverage
         if: steps.context.outputs.available == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
           path: coverage/current
@@ -145,7 +145,7 @@ jobs:
 
       - name: Download baseline Go coverage
         if: steps.context.outputs.available == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
           path: coverage/baseline

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,330 @@
+name: Coverage Comment
+
+on:
+  workflow_run:
+    workflows:
+      - Quality
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Update PR coverage comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Resolve PR and coverage baseline
+        id: context
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const currentArtifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              },
+            );
+            if (!currentArtifacts.some(
+              (artifact) => artifact.name === "go-coverage-server",
+            )) {
+              core.warning("PR run has no Go coverage artifact; comment skipped");
+              core.setOutput("available", "false");
+              core.setOutput("reason", "current Go coverage artifact is unavailable");
+              return;
+            }
+
+            let pullRequest = null;
+            const linkedPullRequest = run.pull_requests?.[0];
+            if (linkedPullRequest?.number) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: linkedPullRequest.number,
+              });
+              pullRequest = response.data;
+            }
+
+            if (!pullRequest) {
+              const headOwner = run.head_repository?.owner?.login;
+              if (headOwner && run.head_branch) {
+                const candidates = await github.paginate(
+                  github.rest.pulls.list,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: "open",
+                    head: `${headOwner}:${run.head_branch}`,
+                    per_page: 100,
+                  },
+                );
+                pullRequest = candidates.find(
+                  (candidate) => candidate.head.sha === run.head_sha,
+                ) ?? null;
+              }
+            }
+
+            if (!pullRequest?.base?.ref) {
+              core.warning("Unable to resolve the pull request; comment skipped");
+              core.setOutput("available", "false");
+              core.setOutput("reason", "pull request context is unavailable");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: run.workflow_id,
+                branch: pullRequest.base.ref,
+                event: "push",
+                status: "completed",
+                per_page: 100,
+              },
+            );
+
+            let baseline = null;
+            for (const candidate of runs.filter(
+              (item) => item.conclusion === "success",
+            )) {
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: candidate.id,
+                  per_page: 100,
+                },
+              );
+              if (artifacts.some(
+                (artifact) => artifact.name === "go-coverage-server",
+              )) {
+                baseline = candidate;
+                break;
+              }
+            }
+
+            if (!baseline) {
+              core.warning(
+                "Base branch has no successful Go coverage artifact; comment skipped",
+              );
+              core.setOutput("available", "false");
+              core.setOutput("reason", "base branch coverage baseline is unavailable");
+              return;
+            }
+
+            core.setOutput("available", "true");
+            core.setOutput("baseline_run_id", String(baseline.id));
+            core.setOutput("base_branch", pullRequest.base.ref);
+            core.setOutput("pull_request_number", String(pullRequest.number));
+
+      - name: Explain why coverage comment is unavailable
+        if: steps.context.outputs.available != 'true'
+        env:
+          SKIP_REASON: ${{ steps.context.outputs.reason }}
+        run: echo "Coverage comment skipped because ${SKIP_REASON}."
+
+      - name: Download current Go coverage
+        if: steps.context.outputs.available == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: go-coverage-server
+          path: coverage/current
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download baseline Go coverage
+        if: steps.context.outputs.available == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: go-coverage-server
+          path: coverage/baseline
+          run-id: ${{ steps.context.outputs.baseline_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Create or update PR coverage comment
+        if: steps.context.outputs.available == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          BASE_BRANCH: ${{ steps.context.outputs.base_branch }}
+          PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pull_request_number }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const marker = "<!-- go-native-coverage -->";
+            const modulePrefix =
+              "github.com/1024XEngineer/XE3-ESL/server/";
+            const maxFiles = 5;
+
+            function displayPath(source) {
+              if (source.startsWith(modulePrefix)) {
+                return `server/${source.slice(modulePrefix.length)}`;
+              }
+              return `server/${source}`;
+            }
+
+            function readCoverage(profilePath) {
+              const files = new Map();
+              let totalStatements = 0;
+              let coveredStatements = 0;
+              const content = fs.readFileSync(profilePath, "utf8");
+
+              for (const line of content.split(/\r?\n/)) {
+                if (!line || line.startsWith("mode:")) continue;
+
+                const match = line.match(
+                  /^(.*):\d+\.\d+,\d+\.\d+\s+(\d+)\s+(\d+)$/,
+                );
+                if (!match) continue;
+
+                const file = displayPath(match[1]);
+                const statements = Number(match[2]);
+                const hits = Number(match[3]);
+                const covered = hits > 0 ? statements : 0;
+                totalStatements += statements;
+                coveredStatements += covered;
+
+                const current = files.get(file) ?? {
+                  totalStatements: 0,
+                  coveredStatements: 0,
+                };
+                current.totalStatements += statements;
+                current.coveredStatements += covered;
+                files.set(file, current);
+              }
+
+              return { files, totalStatements, coveredStatements };
+            }
+
+            function percent(stats) {
+              return stats.totalStatements === 0
+                ? 0
+                : (stats.coveredStatements / stats.totalStatements) * 100;
+            }
+
+            function formatPercent(value) {
+              return `${value.toFixed(1)}%`;
+            }
+
+            function formatDelta(value) {
+              const rounded = Number(value.toFixed(1));
+              return `${rounded >= 0 ? "+" : ""}${rounded.toFixed(1)}%`;
+            }
+
+            const current = readCoverage(
+              path.join("coverage", "current", "coverage.out"),
+            );
+            const baseline = readCoverage(
+              path.join("coverage", "baseline", "coverage.out"),
+            );
+            const currentTotal = percent(current);
+            const baselineTotal = percent(baseline);
+            const totalDelta = currentTotal - baselineTotal;
+
+            const bodyLines = [
+              marker,
+              "## Go coverage",
+              "",
+              "| Scope | Current | Baseline | Delta |",
+              "| --- | ---: | ---: | ---: |",
+              `| server | ${formatPercent(currentTotal)} | ` +
+                `${formatPercent(baselineTotal)} | ${formatDelta(totalDelta)} |`,
+              `| **Total** | **${formatPercent(currentTotal)}** | ` +
+                `**${formatPercent(baselineTotal)}** | ` +
+                `**${formatDelta(totalDelta)}** |`,
+            ];
+
+            const lowFiles = [];
+            for (const [file, currentFile] of current.files) {
+              const baselineFile = baseline.files.get(file);
+              if (!baselineFile) continue;
+
+              const currentFilePercent = percent(currentFile);
+              const baselineFilePercent = percent(baselineFile);
+              const delta = currentFilePercent - baselineFilePercent;
+              if (Number(delta.toFixed(1)) < 0) {
+                lowFiles.push({
+                  file,
+                  current: currentFilePercent,
+                  baseline: baselineFilePercent,
+                  delta,
+                });
+              }
+            }
+            lowFiles.sort(
+              (left, right) =>
+                left.delta - right.delta || left.file.localeCompare(right.file),
+            );
+
+            if (lowFiles.length > 0) {
+              bodyLines.push(
+                "",
+                "### Files below baseline",
+                "",
+                `Showing up to ${maxFiles} largest file-level regressions.`,
+                "",
+                "| File | Current | Baseline | Delta |",
+                "| --- | ---: | ---: | ---: |",
+              );
+              for (const file of lowFiles.slice(0, maxFiles)) {
+                bodyLines.push(
+                  `| ${file.file} | ${formatPercent(file.current)} | ` +
+                    `${formatPercent(file.baseline)} | ` +
+                    `${formatDelta(file.delta)} |`,
+                );
+              }
+            }
+
+            const run = context.payload.workflow_run;
+            bodyLines.push(
+              "",
+              `Base branch: ${process.env.BASE_BRANCH} · ` +
+                `Commit: ${run.head_sha.slice(0, 7)} · ` +
+                `[Quality workflow run](${run.html_url})`,
+            );
+            const body = bodyLines.join("\n");
+            const pullRequestNumber = Number(
+              process.env.PULL_REQUEST_NUMBER,
+            );
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                body,
+              });
+            }

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -70,7 +71,7 @@ jobs:
             while IFS= read -r -d '' file; do
               printf 'Changed file: %q\n' "$file"
               case "$file" in
-                Makefile|.github/workflows/quality.yml)
+                Makefile|.github/workflows/quality.yml|.github/workflows/coverage-comment.yml)
                   set_all_checks
                   ;;
                 mobile/*)
@@ -140,8 +141,18 @@ jobs:
           cache: true
           cache-dependency-path: server/go.sum
 
-      - name: Check Go
-        run: make check-go
+      - name: Check Go and collect coverage
+        run: make check-go-coverage
+
+      - name: Upload Go coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: go-coverage-server
+          path: |
+            server/coverage.out
+            server/coverage.txt
+          if-no-files-found: error
+          retention-days: 14
 
   api:
     name: API contracts
@@ -165,6 +176,158 @@ jobs:
       - name: Check API contracts
         run: make check-api
 
+  coverage-gate:
+    name: Coverage gate
+    needs:
+      - changes
+      - go
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.go == 'true' &&
+      needs.go.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Download current Go coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: go-coverage-server
+          path: coverage/current
+
+      - name: Resolve baseline run
+        id: baseline
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const baseBranch = context.payload.pull_request.base.ref;
+            const workflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const qualityWorkflow = workflows.find(
+              (workflow) => workflow.name === "Quality",
+            );
+            if (!qualityWorkflow) {
+              core.warning("Unable to find the Quality workflow; coverage gate skipped");
+              core.setOutput("available", "false");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: qualityWorkflow.id,
+                branch: baseBranch,
+                event: "push",
+                status: "completed",
+                per_page: 100,
+              },
+            );
+
+            let baseline = null;
+            for (const run of runs.filter(
+              (candidate) => candidate.conclusion === "success",
+            )) {
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100,
+                },
+              );
+              if (artifacts.some(
+                (artifact) => artifact.name === "go-coverage-server",
+              )) {
+                baseline = run;
+                break;
+              }
+            }
+
+            if (!baseline) {
+              core.warning(
+                "No successful Quality run has a Go coverage artifact; coverage gate skipped",
+              );
+              core.setOutput("available", "false");
+              return;
+            }
+
+            core.setOutput("run_id", String(baseline.id));
+            core.setOutput("available", "true");
+
+      - name: Explain missing coverage baseline
+        if: steps.baseline.outputs.available != 'true'
+        run: >-
+          echo "Coverage gate skipped because the base branch has no Go
+          coverage artifact baseline yet."
+
+      - name: Download baseline Go coverage
+        if: steps.baseline.outputs.available == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: go-coverage-server
+          path: coverage/baseline
+          run-id: ${{ steps.baseline.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Reject total Go coverage regression
+        if: steps.baseline.outputs.available == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            function readCoverage(profilePath) {
+              let totalStatements = 0;
+              let coveredStatements = 0;
+              const content = fs.readFileSync(profilePath, "utf8");
+
+              for (const line of content.split(/\r?\n/)) {
+                if (!line || line.startsWith("mode:")) continue;
+
+                const match = line.match(
+                  /^(.*):\d+\.\d+,\d+\.\d+\s+(\d+)\s+(\d+)$/,
+                );
+                if (!match) continue;
+
+                const statements = Number(match[2]);
+                const hits = Number(match[3]);
+                totalStatements += statements;
+                coveredStatements += hits > 0 ? statements : 0;
+              }
+
+              return totalStatements === 0
+                ? 0
+                : (coveredStatements / totalStatements) * 100;
+            }
+
+            const current = readCoverage(
+              path.join("coverage", "current", "coverage.out"),
+            );
+            const baseline = readCoverage(
+              path.join("coverage", "baseline", "coverage.out"),
+            );
+            const currentRounded = Number(current.toFixed(1));
+            const baselineRounded = Number(baseline.toFixed(1));
+
+            core.info(
+              `Current: ${current.toFixed(1)}%; baseline: ${baseline.toFixed(1)}%`,
+            );
+            if (currentRounded < baselineRounded) {
+              core.setFailed(
+                `Total Go coverage ${current.toFixed(1)}% is below baseline ` +
+                  `${baseline.toFixed(1)}%`,
+              );
+            }
+
   quality-gate:
     name: Quality gate
     needs:
@@ -172,6 +335,7 @@ jobs:
       - flutter
       - go
       - api
+      - coverage-gate
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -183,6 +347,7 @@ jobs:
       GO_RESULT: ${{ needs.go.result }}
       API_REQUIRED: ${{ needs.changes.outputs.api }}
       API_RESULT: ${{ needs.api.result }}
+      COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
     steps:
       - name: Require every selected check to pass
         shell: bash
@@ -226,3 +391,12 @@ jobs:
           require_result "Flutter" "$FLUTTER_REQUIRED" "$FLUTTER_RESULT"
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
+
+          case "$COVERAGE_RESULT" in
+            success|skipped)
+              ;;
+            *)
+              echo "Coverage gate finished with unexpected result: $COVERAGE_RESULT"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -145,7 +145,7 @@ jobs:
         run: make check-go-coverage
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: go-coverage-server
           path: |
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download current Go coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
           path: coverage/current
@@ -270,7 +270,7 @@ jobs:
 
       - name: Download baseline Go coverage
         if: steps.baseline.outputs.available == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
           path: coverage/baseline

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Resolve baseline run
         id: baseline
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const baseBranch = context.payload.pull_request.base.ref;
@@ -279,7 +279,7 @@ jobs:
 
       - name: Reject total Go coverage regression
         if: steps.baseline.outputs.available == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require("fs");

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # Go
 server/bin/
+server/coverage.txt
 *.test
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SHELL := /bin/bash
 	check-flutter-analyze \
 	check-flutter-test \
 	check-go \
+	check-go-coverage \
 	check-go-format \
 	check-go-vet \
 	check-go-test \
@@ -30,6 +31,7 @@ help:
 		'  make check          Run Flutter, Go, and API checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
 		'  make check-go       Run Go format, vet, and test checks' \
+		'  make check-go-coverage  Run Go checks and write server/coverage.out' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
 		'  make check-kodo-live Run the real Kodo lifecycle test with exported QINIU_* variables' \
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
@@ -70,6 +72,10 @@ check-go-vet: check-go-format
 
 check-go-test: check-go-vet
 	cd server && go test -count=1 ./...
+
+check-go-coverage: check-go-vet
+	cd server && go test -count=1 -covermode=atomic -coverprofile=coverage.out ./...
+	cd server && go tool cover -func=coverage.out > coverage.txt && tail -n 1 coverage.txt
 
 check-oss-live:
 	@set -euo pipefail; \


### PR DESCRIPTION
## 功能描述

- 让现有 Quality/Go job 生成并上传 `coverage.out` 与函数摘要。
- 以 PR 目标分支最近一次成功的 Quality push 产物作为 baseline。
- 总覆盖率按 0.1 个百分点精度下降时令 Coverage gate 失败。
- 通过独立、最小写权限的 `workflow_run` 工作流创建或更新唯一一条 PR 覆盖率评论，并列出最多 5 个文件级回退。
- 无 Go 变更、无当前产物或无 baseline 时安全跳过并输出原因。

## 实现思路

- 复用现有 Go 测试，只把 CI 入口改为 `make check-go-coverage`，不重复运行测试。
- 当前与 baseline 报告均通过 GitHub Actions Artifact 传递，保留 14 天，不引入第三方服务或密钥。
- PR 测试工作流保持只读；写评论工作流不 checkout、不执行 PR 代码，只解析固定名称的原生覆盖率文本。
- 使用 `<!-- go-native-coverage -->` 标记定位并更新同一条 bot 评论，避免刷屏。
- Actions 全部固定到 commit SHA。

> 首次上线说明：GitHub 只会从默认分支 `main` 触发 `workflow_run`。本 PR 合入 `dev` 后会先由 dev push 生成 baseline；该工作流随发布进入 `main` 后，自动评论开始生效。

## 可复现测试

- `make check-go-coverage`：通过，总覆盖率 43.9%。
- `make check-api`：通过。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/quality.yml .github/workflows/coverage-comment.yml`：通过。
- 使用生成的真实 `server/coverage.out` 离线执行 Coverage gate 比较器：通过。
- 使用同一报告离线执行评论渲染器：成功生成 server 43.9% / baseline 43.9% / delta +0.0% 表格。
- `make check-flutter`：本机 Flutter 3.44.8 因锁文件由仓库固定的 3.44.6 生成，在 `flutter pub get --enforce-lockfile` 处拒绝解析；未改写锁文件，等待 CI 以固定版本验证。

Closes #791