### PR TITLE
fix(evaluation): enforce trustworthy speech feedback categories

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -151,6 +151,9 @@ components:
     EvaluationStatus:
       type: string
       enum: [QUEUED, RUNNING, READY, FAILED]
+    FeedbackItemCategory:
+      type: string
+      enum: [CORRECTION, STRENGTH, RECOMMENDED_EXPRESSION]
     EvaluationResource:
       type: object
       additionalProperties: false
@@ -175,6 +178,13 @@ components:
           type: array
           maxItems: 32
           items: {$ref: '#/components/schemas/FeedbackItem'}
+          allOf:
+            - if:
+                contains:
+                  type: object
+                  required: [category]
+                  properties: {category: {const: STRENGTH}}
+              then: {maxItems: 1}
         result:
           oneOf:
             - $ref: '#/components/schemas/FormalReport'
@@ -229,7 +239,7 @@ components:
         feedback_item_id: {$ref: '#/components/schemas/UUID'}
         evaluation_id: {$ref: '#/components/schemas/UUID'}
         position: {type: integer, minimum: 1}
-        category: {$ref: '#/components/schemas/Identifier'}
+        category: {$ref: '#/components/schemas/FeedbackItemCategory'}
         severity: {$ref: '#/components/schemas/Identifier'}
         evidence: {$ref: '#/components/schemas/FeedbackEvidence'}
         recommendation:
@@ -243,6 +253,18 @@ components:
           type: string
           enum: [NONE, SAME_QUESTION]
         created_at: {type: string, format: date-time}
+      allOf:
+        - if:
+            properties: {category: {const: STRENGTH}}
+            required: [category]
+          then:
+            properties: {repractice_mode: {const: NONE}}
+            not: {required: [correction]}
+        - if:
+            properties:
+              category: {enum: [CORRECTION, RECOMMENDED_EXPRESSION]}
+            required: [category]
+          then: {required: [correction]}
     FeedbackEvidence:
       type: object
       additionalProperties: false

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -41,6 +41,10 @@ try {
       `${schema}: ${ajv.errorsText(validator.errors, {separator: '\n'})}`,
     );
   };
+  const reject = (schema, value) => {
+    const validator = ajv.compile({$ref: `contract#/components/schemas/${schema}`});
+    assert.equal(validator(value), false, `${schema} unexpectedly accepted value`);
+  };
 
   const evaluationId = '10000000-0000-4000-8000-000000000001';
   const sessionId = '20000000-0000-4000-8000-000000000001';
@@ -158,6 +162,66 @@ try {
     },
   });
 
+  const feedbackEvidence = {
+    evidence_ref_id: turnId,
+    start_utf8_byte: 0,
+    end_utf8_byte: 3,
+    original_excerpt: 'and',
+  };
+  reject('FeedbackItem', {
+    feedback_item_id: '40000000-0000-4000-8000-000000000001',
+    evaluation_id: evaluationId,
+    position: 1,
+    category: 'STYLE_CORRECTION',
+    evidence: feedbackEvidence,
+    recommendation: 'Optional wording.',
+    correction: 'so',
+    repractice_mode: 'SAME_QUESTION',
+    created_at: createdAt,
+  });
+  reject('EvaluationResource', {
+    evaluation_id: '10000000-0000-4000-8000-000000000003',
+    kind: 'PRACTICE_TURN_FEEDBACK',
+    source_id: turnId,
+    context_id: sessionId,
+    status: 'READY',
+    created_at: createdAt,
+    updated_at: createdAt,
+    feedback_items: [
+      {
+        feedback_item_id: '40000000-0000-4000-8000-000000000001',
+        evaluation_id: '10000000-0000-4000-8000-000000000003',
+        position: 1,
+        category: 'STRENGTH',
+        evidence: feedbackEvidence,
+        recommendation: 'No change is needed.',
+        repractice_mode: 'NONE',
+        created_at: createdAt,
+      },
+      {
+        feedback_item_id: '40000000-0000-4000-8000-000000000002',
+        evaluation_id: '10000000-0000-4000-8000-000000000003',
+        position: 2,
+        category: 'RECOMMENDED_EXPRESSION',
+        evidence: feedbackEvidence,
+        recommendation: 'Optional wording.',
+        correction: 'so',
+        repractice_mode: 'SAME_QUESTION',
+        created_at: createdAt,
+      },
+    ],
+    result: {
+      schema_version: 'speech-feedback/v1',
+      scoreability_status: 'PROVISIONAL',
+      summary: 'Feedback is ready.',
+      reason_codes: [],
+      acoustic: {
+        status: 'NOT_ASSESSED',
+        reason: 'ACOUSTIC_ASSESSMENT_NOT_CONFIGURED',
+      },
+    },
+  });
+
   const operations = new Set();
   for (const [path, item] of Object.entries(contract.paths)) {
     for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
@@ -198,6 +262,11 @@ try {
     contract.components.schemas.FeedbackItem.properties.repractice_mode.enum,
     ['NONE', 'SAME_QUESTION'],
   );
+  assert.deepEqual(contract.components.schemas.FeedbackItemCategory.enum, [
+    'CORRECTION',
+    'STRENGTH',
+    'RECOMMENDED_EXPRESSION',
+  ]);
   assert.deepEqual(
     contract.components.schemas.RetryTurnResource.properties.status.enum,
     ['answering', 'transcribing', 'transcribed', 'confirmed', 'failed'],

--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -78,10 +78,13 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
 
   @override
   Widget build(BuildContext context) {
+    final feedbackNotice = widget.correction == null && widget.polish == null
+        ? widget.feedbackNotice
+        : null;
     final hasFeedback =
         widget.correction != null ||
         widget.polish != null ||
-        widget.feedbackNotice != null;
+        feedbackNotice != null;
     final spokenSuggestion = widget.polish ?? widget.correction;
     final actions = <Widget>[
       if (widget.leading != null) widget.leading!,
@@ -121,7 +124,7 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
         ),
         if (_expanded && hasFeedback) ...[
           const SizedBox(height: SpeakUpDesign.space8),
-          if (widget.feedbackNotice case final notice?)
+          if (feedbackNotice case final notice?)
             Text(
               notice,
               key: const Key('inline-language-feedback-notice'),

--- a/mobile/lib/features/coaching/evaluation/turn_feedback.dart
+++ b/mobile/lib/features/coaching/evaluation/turn_feedback.dart
@@ -94,18 +94,21 @@ final class SpeechFeedbackItem {
 
 extension SpeechFeedbackItemsPresentation on Iterable<SpeechFeedbackItem> {
   SpeechFeedbackItem? get strength {
-    for (final item in this) {
-      if (item.kind == SpeechFeedbackItemKind.strength) {
-        return item;
-      }
+    final values = toList(growable: false);
+    if (values.length == 1 &&
+        values.single.kind == SpeechFeedbackItemKind.strength) {
+      return values.single;
     }
     return null;
   }
 
   SpeechFeedbackItem? get correction {
+    if (strength != null) {
+      return null;
+    }
     for (final item in this) {
       if (item.kind == SpeechFeedbackItemKind.correction &&
-          item.suggestedText != null) {
+          item.hasLocatableLanguageCorrection) {
         return item;
       }
     }
@@ -113,6 +116,9 @@ extension SpeechFeedbackItemsPresentation on Iterable<SpeechFeedbackItem> {
   }
 
   SpeechFeedbackItem? get polish {
+    if (strength != null) {
+      return null;
+    }
     for (final item in this) {
       if (item.kind == SpeechFeedbackItemKind.recommendedExpression &&
           item.suggestedText != null) {
@@ -121,6 +127,61 @@ extension SpeechFeedbackItemsPresentation on Iterable<SpeechFeedbackItem> {
     }
     return null;
   }
+
+  List<SpeechFeedbackItem> get presentationItems {
+    final noChange = strength;
+    if (noChange != null) {
+      return List<SpeechFeedbackItem>.unmodifiable([noChange]);
+    }
+    return List<SpeechFeedbackItem>.unmodifiable(
+      where(
+        (item) =>
+            item.kind != SpeechFeedbackItemKind.strength &&
+            (item.kind != SpeechFeedbackItemKind.correction ||
+                item.hasLocatableLanguageCorrection),
+      ),
+    );
+  }
+}
+
+extension SpeechFeedbackItemContract on SpeechFeedbackItem {
+  bool get hasLocatableLanguageCorrection {
+    final suggested = suggestedText;
+    if (kind != SpeechFeedbackItemKind.correction || suggested == null) {
+      return false;
+    }
+    final before = _speechFeedbackWords(anchor.originalExcerpt);
+    final after = _speechFeedbackWords(suggested);
+    if (before.isEmpty || _sameSpeechFeedbackWords(before, after)) {
+      return false;
+    }
+    if (before.length == 1 && after.length == 1) {
+      final source = before.single;
+      final replacement = after.single;
+      if (source != replacement &&
+          (source == 'and' || source == 'so') &&
+          (replacement == 'and' || replacement == 'so')) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+List<String> _speechFeedbackWords(String value) => RegExp(
+  r"[A-Za-z]+(?:['’][A-Za-z]+)*",
+).allMatches(value).map((match) => match.group(0)!.toLowerCase()).toList();
+
+bool _sameSpeechFeedbackWords(List<String> left, List<String> right) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 final class SpeechFeedbackAcousticAssessment {

--- a/mobile/lib/features/coaching/evaluation/turn_feedback_decoder.dart
+++ b/mobile/lib/features/coaching/evaluation/turn_feedback_decoder.dart
@@ -171,22 +171,30 @@ List<SpeechFeedbackItem> _feedbackItems(
     if (anchor.evidenceRefId != sourceId) {
       throw const SpeechFeedbackDecodeException();
     }
-    items.add(
-      SpeechFeedbackItem(
-        feedbackItemId: itemId,
-        evaluationId: evaluationId,
-        position: index + 1,
-        kind: kind,
-        severity: root.containsKey('severity')
-            ? _identifier(root['severity'])
-            : null,
-        anchor: anchor,
-        explanation: _text(root['recommendation'], maximumBytes: 4096),
-        suggestedText: correction,
-        repracticeMode: mode,
-        createdAt: _dateTime(root['created_at']),
-      ),
+    final item = SpeechFeedbackItem(
+      feedbackItemId: itemId,
+      evaluationId: evaluationId,
+      position: index + 1,
+      kind: kind,
+      severity: root.containsKey('severity')
+          ? _identifier(root['severity'])
+          : null,
+      anchor: anchor,
+      explanation: _text(root['recommendation'], maximumBytes: 4096),
+      suggestedText: correction,
+      repracticeMode: mode,
+      createdAt: _dateTime(root['created_at']),
     );
+    if (kind == SpeechFeedbackItemKind.correction &&
+        !item.hasLocatableLanguageCorrection) {
+      throw const SpeechFeedbackDecodeException();
+    }
+    items.add(item);
+  }
+  if (items.any((item) => item.kind == SpeechFeedbackItemKind.strength) &&
+      (items.length != 1 ||
+          items.single.kind != SpeechFeedbackItemKind.strength)) {
+    throw const SpeechFeedbackDecodeException();
   }
   return List<SpeechFeedbackItem>.unmodifiable(items);
 }

--- a/mobile/lib/features/coaching/evaluation/turn_feedback_disclosure.dart
+++ b/mobile/lib/features/coaching/evaluation/turn_feedback_disclosure.dart
@@ -158,6 +158,7 @@ class _SpeechFeedbackDisclosureState extends State<SpeechFeedbackDisclosure> {
             SpeechFeedbackScoreabilityStatus.insufficient) {
           return _InsufficientDetails(feedback: feedback);
         }
+        final presentationItems = feedback.items.presentationItems;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -170,10 +171,10 @@ class _SpeechFeedbackDisclosureState extends State<SpeechFeedbackDisclosure> {
               ).textTheme.bodySmall?.copyWith(color: SpeakUpDesign.secondary),
             ),
             const SizedBox(height: SpeakUpDesign.space12),
-            for (var index = 0; index < feedback.items.length; index++) ...[
+            for (var index = 0; index < presentationItems.length; index++) ...[
               if (index > 0) const SizedBox(height: SpeakUpDesign.space12),
               _FeedbackItemDetails(
-                item: feedback.items[index],
+                item: presentationItems[index],
                 onRepractice: widget.onRepractice,
               ),
             ],

--- a/mobile/test/design/practice_conversation_components_test.dart
+++ b/mobile/test/design/practice_conversation_components_test.dart
@@ -21,6 +21,26 @@ void main() {
     expect(find.text('表达已经很自然，无需润色'), findsOneWidget);
   });
 
+  testWidgets('inline feedback never mixes no-change with a recommendation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InlineLanguageFeedback(
+            feedbackNotice: '表达已经很自然，无需润色',
+            polish: InlineLanguageSuggestion(text: 'I already have a plan.'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('inline-language-optimize')));
+    await tester.pump();
+    expect(find.text('表达已经很自然，无需润色'), findsNothing);
+    expect(find.text('I already have a plan.'), findsOneWidget);
+  });
+
   testWidgets('shared recording composer shows the live transcript', (
     tester,
   ) async {

--- a/mobile/test/review/turn_feedback_decoder_test.dart
+++ b/mobile/test/review/turn_feedback_decoder_test.dart
@@ -112,6 +112,7 @@ void main() {
 
   test('validates exact UTF-8 evidence byte ranges', () {
     final valid = readyPracticeFeedbackFixture();
+    _item(valid)['category'] = 'RECOMMENDED_EXPRESSION';
     final evidence = _item(valid)['evidence']! as Map<String, Object?>;
     evidence
       ..['start_utf8_byte'] = 4
@@ -129,6 +130,48 @@ void main() {
     (_item(invalid)['evidence']! as Map<String, Object?>)['end_utf8_byte'] = 9;
     expect(
       () => decodeSpeechFeedback(invalid, statusUrl: practiceStatusUrl),
+      throwsA(isA<SpeechFeedbackDecodeException>()),
+    );
+  });
+
+  test('rejects corrections without a lexical language change', () {
+    final punctuationAndCase = readyPracticeFeedbackFixture();
+    _item(punctuationAndCase)['correction'] = 'i manage!';
+
+    final optionalConnector = readyPracticeFeedbackFixture();
+    final evidence =
+        _item(optionalConnector)['evidence']! as Map<String, Object?>;
+    evidence
+      ..['start_utf8_byte'] = 0
+      ..['end_utf8_byte'] = 3
+      ..['original_excerpt'] = 'and';
+    _item(optionalConnector)['correction'] = 'so';
+
+    for (final value in [punctuationAndCase, optionalConnector]) {
+      expect(
+        () => decodeSpeechFeedback(value, statusUrl: practiceStatusUrl),
+        throwsA(isA<SpeechFeedbackDecodeException>()),
+      );
+    }
+  });
+
+  test('rejects no-change feedback mixed with a recommendation', () {
+    final conflict = readyPracticeFeedbackFixture();
+    final recommendation = cloneFeedbackFixture(_item(conflict));
+    final strength = _item(conflict)
+      ..['category'] = 'STRENGTH'
+      ..remove('severity')
+      ..remove('correction')
+      ..['repractice_mode'] = 'NONE';
+    recommendation
+      ..['feedback_item_id'] = '40000000-0000-4000-8000-000000000002'
+      ..['position'] = 2
+      ..['category'] = 'RECOMMENDED_EXPRESSION'
+      ..['correction'] = 'I handled the project.';
+    conflict['feedback_items'] = <Object?>[strength, recommendation];
+
+    expect(
+      () => decodeSpeechFeedback(conflict, statusUrl: practiceStatusUrl),
       throwsA(isA<SpeechFeedbackDecodeException>()),
     );
   });

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
@@ -199,6 +199,7 @@ func compactFeedbackItems(
 
 	items := make([]evaluation.FeedbackItemDraft, 0, len(envelope.Items))
 	seen := make(map[string]struct{}, len(envelope.Items))
+	projection := projectSpeechFeedbackEnglishText(snapshot.Transcript)
 	for _, generatedItem := range envelope.Items {
 		sourceTextValue, sourcePresent := compactProviderNullableText(
 			generatedItem.SourceText,
@@ -223,12 +224,11 @@ func compactFeedbackItems(
 			!speechFeedbackEnglishWordPattern.MatchString(suggestedText) {
 			return nil, compactProviderError("provider suggestion has no language evidence")
 		}
-		start := speechFeedbackExcerptStart(
-			snapshot.Transcript,
+		start, end, located := projection.excerptRange(
 			sourceText,
 			*sourceOccurrence,
 		)
-		if start < 0 {
+		if !located {
 			return nil, compactProviderError("provider source text is not evidence")
 		}
 		if sameSpeechFeedbackLexicalContent(sourceText, suggestedText) {
@@ -239,8 +239,8 @@ func compactFeedbackItems(
 			Evidence: evaluation.FeedbackEvidence{
 				EvidenceRefID:   snapshot.EvidenceRefID,
 				StartUTF8Byte:   start,
-				EndUTF8Byte:     start + len(sourceText),
-				OriginalExcerpt: sourceText,
+				EndUTF8Byte:     end,
+				OriginalExcerpt: snapshot.Transcript[start:end],
 			},
 			Recommendation: safeSpeechFeedbackExplanation(
 				generatedItem.Kind,
@@ -259,7 +259,7 @@ func compactFeedbackItems(
 				item.Evidence.EndUTF8Byte = len(snapshot.Transcript)
 				item.Evidence.OriginalExcerpt = snapshot.Transcript
 				item.Correction = snapshot.Transcript[:start] + suggestedText +
-					snapshot.Transcript[start+len(sourceText):]
+					snapshot.Transcript[end:]
 			} else {
 				item.Severity = "MEDIUM"
 			}

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
@@ -20,7 +20,7 @@ func Lineage(provider string, model string) (evaluation.ConfigLineage, error) {
 		SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 		StrategyRef:     "speech-feedback/v1",
 		PipelineVersion: "speech-evaluation/v1",
-		PromptVersion:   "speech-feedback/v1",
+		PromptVersion:   "speech-feedback/v2",
 		ResultSchema:    SpeechFeedbackSchemaVersion,
 		Provider:        provider,
 		Model:           model,
@@ -122,9 +122,11 @@ func (evaluator *CompactEvaluator) evaluate(
 }
 
 type compactProviderItem struct {
-	Kind          SpeechFeedbackItemKind `json:"kind"`
-	Explanation   string                 `json:"explanation"`
-	SuggestedText *string                `json:"suggested_text,omitempty"`
+	Kind             SpeechFeedbackItemKind `json:"kind"`
+	Explanation      string                 `json:"explanation"`
+	SourceText       json.RawMessage        `json:"source_text"`
+	SourceOccurrence json.RawMessage        `json:"source_occurrence"`
+	SuggestedText    json.RawMessage        `json:"suggested_text"`
 }
 
 type compactProviderEnvelope struct {
@@ -157,44 +159,114 @@ func compactFeedbackItems(
 	if len(envelope.Items) == 0 || len(envelope.Items) > maxSpeechFeedbackProviderItems {
 		return nil, compactProviderError("provider item count is invalid")
 	}
-	items := make([]evaluation.FeedbackItemDraft, len(envelope.Items))
+	for _, generatedItem := range envelope.Items {
+		if generatedItem.Kind == SpeechFeedbackItemStrength {
+			sourceText, sourcePresent := compactProviderNullableText(
+				generatedItem.SourceText,
+			)
+			sourceOccurrence, occurrencePresent := compactProviderNullableInteger(
+				generatedItem.SourceOccurrence,
+			)
+			suggestedText, suggestedPresent := compactProviderNullableText(
+				generatedItem.SuggestedText,
+			)
+			if len(envelope.Items) != 1 || !sourcePresent || sourceText != nil ||
+				!occurrencePresent || sourceOccurrence != nil ||
+				!suggestedPresent || suggestedText != nil {
+				return nil, compactProviderError("STRENGTH must be the only item")
+			}
+			item := evaluation.FeedbackItemDraft{
+				Category: string(SpeechFeedbackItemStrength),
+				Evidence: evaluation.FeedbackEvidence{
+					EvidenceRefID:   snapshot.EvidenceRefID,
+					StartUTF8Byte:   0,
+					EndUTF8Byte:     len(snapshot.Transcript),
+					OriginalExcerpt: snapshot.Transcript,
+				},
+				Recommendation: safeSpeechFeedbackExplanation(
+					generatedItem.Kind,
+					generatedItem.Explanation,
+					englishText,
+				),
+				RepracticeMode: "NONE",
+			}
+			if !item.Valid() {
+				return nil, compactProviderError("normalized feedback item is invalid")
+			}
+			return []evaluation.FeedbackItemDraft{item}, nil
+		}
+	}
+
+	items := make([]evaluation.FeedbackItemDraft, 0, len(envelope.Items))
 	seen := make(map[string]struct{}, len(envelope.Items))
-	for index, generatedItem := range envelope.Items {
-		if !validSpeechFeedbackAdviceText(generatedItem.Explanation) {
-			return nil, compactProviderError("provider explanation is invalid")
+	for _, generatedItem := range envelope.Items {
+		sourceTextValue, sourcePresent := compactProviderNullableText(
+			generatedItem.SourceText,
+		)
+		sourceOccurrence, occurrencePresent := compactProviderNullableInteger(
+			generatedItem.SourceOccurrence,
+		)
+		suggestedTextValue, suggestedPresent := compactProviderNullableText(
+			generatedItem.SuggestedText,
+		)
+		if !sourcePresent || sourceTextValue == nil ||
+			!validSpeechFeedbackAdviceText(*sourceTextValue) ||
+			!occurrencePresent || sourceOccurrence == nil ||
+			*sourceOccurrence < 1 ||
+			!suggestedPresent || suggestedTextValue == nil ||
+			!validSpeechFeedbackAdviceText(*suggestedTextValue) {
+			return nil, compactProviderError("provider suggestion is invalid")
+		}
+		sourceText := strings.TrimSpace(*sourceTextValue)
+		suggestedText := strings.TrimSpace(*suggestedTextValue)
+		if !speechFeedbackEnglishWordPattern.MatchString(sourceText) ||
+			!speechFeedbackEnglishWordPattern.MatchString(suggestedText) {
+			return nil, compactProviderError("provider suggestion has no language evidence")
+		}
+		start := speechFeedbackExcerptStart(
+			snapshot.Transcript,
+			sourceText,
+			*sourceOccurrence,
+		)
+		if start < 0 {
+			return nil, compactProviderError("provider source text is not evidence")
+		}
+		if sameSpeechFeedbackLexicalContent(sourceText, suggestedText) {
+			continue
 		}
 		item := evaluation.FeedbackItemDraft{
 			Category: string(generatedItem.Kind),
 			Evidence: evaluation.FeedbackEvidence{
 				EvidenceRefID:   snapshot.EvidenceRefID,
-				StartUTF8Byte:   0,
-				EndUTF8Byte:     len(snapshot.Transcript),
-				OriginalExcerpt: snapshot.Transcript,
+				StartUTF8Byte:   start,
+				EndUTF8Byte:     start + len(sourceText),
+				OriginalExcerpt: sourceText,
 			},
-			Recommendation: generatedItem.Explanation,
+			Recommendation: safeSpeechFeedbackExplanation(
+				generatedItem.Kind,
+				generatedItem.Explanation,
+				englishText,
+			),
+			Correction:     suggestedText,
+			RepracticeMode: repracticeMode,
 		}
 		switch generatedItem.Kind {
 		case SpeechFeedbackItemCorrection:
-			item.Severity = "MEDIUM"
-			item.RepracticeMode = repracticeMode
+			if optionalSpeechFeedbackConnectorSwap(sourceText, suggestedText) {
+				item.Category = string(SpeechFeedbackItemRecommendedExpression)
+				item.Severity = "LOW"
+				item.Evidence.StartUTF8Byte = 0
+				item.Evidence.EndUTF8Byte = len(snapshot.Transcript)
+				item.Evidence.OriginalExcerpt = snapshot.Transcript
+				item.Correction = snapshot.Transcript[:start] + suggestedText +
+					snapshot.Transcript[start+len(sourceText):]
+			} else {
+				item.Severity = "MEDIUM"
+			}
 		case SpeechFeedbackItemRecommendedExpression:
 			item.Severity = "LOW"
-			item.RepracticeMode = repracticeMode
-		case SpeechFeedbackItemStrength:
-			if len(envelope.Items) != 1 || generatedItem.SuggestedText != nil {
-				return nil, compactProviderError("STRENGTH must be the only item")
-			}
-			item.RepracticeMode = "NONE"
 		default:
 			return nil, compactProviderError("provider item kind is invalid")
-		}
-		if generatedItem.Kind != SpeechFeedbackItemStrength {
-			if generatedItem.SuggestedText == nil ||
-				!validSpeechFeedbackAdviceText(*generatedItem.SuggestedText) ||
-				equalSpeechFeedbackText(*generatedItem.SuggestedText, englishText) {
-				return nil, compactProviderError("provider correction is invalid")
-			}
-			item.Correction = strings.TrimSpace(*generatedItem.SuggestedText)
 		}
 		if !item.Valid() {
 			return nil, compactProviderError("normalized feedback item is invalid")
@@ -204,9 +276,74 @@ func compactFeedbackItems(
 			return nil, compactProviderError("provider returned duplicate items")
 		}
 		seen[key] = struct{}{}
-		items[index] = item
+		items = append(items, item)
+	}
+	if len(items) == 0 {
+		item := evaluation.FeedbackItemDraft{
+			Category: string(SpeechFeedbackItemStrength),
+			Evidence: evaluation.FeedbackEvidence{
+				EvidenceRefID:   snapshot.EvidenceRefID,
+				StartUTF8Byte:   0,
+				EndUTF8Byte:     len(snapshot.Transcript),
+				OriginalExcerpt: snapshot.Transcript,
+			},
+			Recommendation: "原表达没有可定位的语言错误，无需修改。",
+			RepracticeMode: "NONE",
+		}
+		if !item.Valid() {
+			return nil, compactProviderError("normalized feedback item is invalid")
+		}
+		items = append(items, item)
 	}
 	return items, nil
+}
+
+func compactProviderNullableText(value json.RawMessage) (*string, bool) {
+	if len(value) == 0 {
+		return nil, false
+	}
+	if bytes.Equal(value, []byte("null")) {
+		return nil, true
+	}
+	var decoded string
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return nil, false
+	}
+	return &decoded, true
+}
+
+func compactProviderNullableInteger(value json.RawMessage) (*int, bool) {
+	if len(value) == 0 {
+		return nil, false
+	}
+	if bytes.Equal(value, []byte("null")) {
+		return nil, true
+	}
+	var decoded int
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return nil, false
+	}
+	return &decoded, true
+}
+
+func speechFeedbackExcerptStart(
+	transcript string,
+	excerpt string,
+	occurrence int,
+) int {
+	searchStart := 0
+	for current := 1; current <= occurrence; current++ {
+		relative := strings.Index(transcript[searchStart:], excerpt)
+		if relative < 0 {
+			return -1
+		}
+		absolute := searchStart + relative
+		if current == occurrence {
+			return absolute
+		}
+		searchStart = absolute + len(excerpt)
+	}
+	return -1
 }
 
 func encodeCompactSpeechResult(

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
@@ -218,6 +218,44 @@ func TestCompactFeedbackItemsEnforcesClassificationContract(t *testing.T) {
 		}
 	})
 
+	t.Run("projected source maps back to mixed transcript bytes", func(t *testing.T) {
+		current := snapshot
+		current.Transcript = "中文 I  has a plan."
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"主语后动词形式不正确。","source_text":"has","source_occurrence":1,"suggested_text":"have"}]}`),
+			current,
+			speechFeedbackEnglishReferenceText(current.Transcript),
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Evidence.StartUTF8Byte != 10 ||
+			items[0].Evidence.EndUTF8Byte != 13 ||
+			items[0].Evidence.OriginalExcerpt != "has" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("projected source spans collapsed original whitespace", func(t *testing.T) {
+		current := snapshot
+		current.Transcript = "I  has a plan."
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"主语后动词形式不正确。","source_text":"I has","source_occurrence":1,"suggested_text":"I have"}]}`),
+			current,
+			speechFeedbackEnglishReferenceText(current.Transcript),
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Evidence.StartUTF8Byte != 0 ||
+			items[0].Evidence.EndUTF8Byte != 6 ||
+			items[0].Evidence.OriginalExcerpt != "I  has" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
 	t.Run("missing required structured field is rejected", func(t *testing.T) {
 		_, err := compactFeedbackItems(
 			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"have","suggested_text":"had"}]}`),

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
@@ -93,9 +93,196 @@ func (compactGeneratorFake) Generate(
 		RequestID: "request-1",
 		Provider:  "qianwen",
 		Model:     "qwen-plus",
-		Content: `{"items":[{"kind":"CORRECTION","explanation":"Use the correct verb form.",` +
-			`"suggested_text":"I have a plan."}]}`,
+		Content: `{"items":[{"kind":"CORRECTION","explanation":"主语后应使用正确的动词形式。",` +
+			`"source_text":"has","source_occurrence":1,"suggested_text":"have"}]}`,
 	}, nil
 }
 
 var _ TextGenerator = compactGeneratorFake{}
+
+func TestCompactFeedbackItemsEnforcesClassificationContract(t *testing.T) {
+	t.Parallel()
+
+	snapshot := evaluation.SpeechInputSnapshot{
+		Transcript:    "I have a plan, and I can start today.",
+		EvidenceRefID: "30000000-0000-4000-8000-000000000001",
+	}
+
+	t.Run("correct answer remains no change", func(t *testing.T) {
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"STRENGTH","explanation":"表达自然，无需修改。","source_text":null,"source_occurrence":null,"suggested_text":null}]}`),
+			snapshot,
+			snapshot.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Category != "STRENGTH" ||
+			items[0].Correction != "" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("punctuation and case only correction safely becomes no change", func(t *testing.T) {
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"只有大小写或标点差异，不属于语言错误。","source_text":"I have a plan,","source_occurrence":1,"suggested_text":"i have a plan."}]}`),
+			snapshot,
+			snapshot.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Category != "STRENGTH" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	for _, connector := range []struct {
+		name       string
+		transcript string
+		source     string
+		suggested  string
+		want       string
+	}{
+		{
+			name:       "and to so",
+			transcript: "It is leaking, and I need help.",
+			source:     "and", suggested: "so",
+			want: "It is leaking, so I need help.",
+		},
+		{
+			name:       "so to and",
+			transcript: "It is leaking, so I need help.",
+			source:     "so", suggested: "and",
+			want: "It is leaking, and I need help.",
+		},
+	} {
+		connector := connector
+		t.Run(connector.name+" is optional", func(t *testing.T) {
+			current := snapshot
+			current.Transcript = connector.transcript
+			items, err := compactFeedbackItems(
+				compactResult(`{"items":[{"kind":"CORRECTION","explanation":"连接方式属于可选表达。","source_text":"`+
+					connector.source+`","source_occurrence":1,"suggested_text":"`+connector.suggested+`"}]}`),
+				current,
+				current.Transcript,
+				"SAME_QUESTION",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(items) != 1 ||
+				items[0].Category != "RECOMMENDED_EXPRESSION" ||
+				items[0].Correction != connector.want {
+				t.Fatalf("items = %#v", items)
+			}
+		})
+	}
+
+	t.Run("real grammar error stays a localized correction", func(t *testing.T) {
+		current := snapshot
+		current.Transcript = "I has a plan."
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"主语后应使用正确的动词形式。","source_text":"has","source_occurrence":1,"suggested_text":"have"}]}`),
+			current,
+			current.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Category != "CORRECTION" ||
+			items[0].Evidence.OriginalExcerpt != "has" ||
+			items[0].Evidence.StartUTF8Byte != 2 ||
+			items[0].Correction != "have" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("repeated evidence uses the declared occurrence", func(t *testing.T) {
+		current := snapshot
+		current.Transcript = "He has a plan, but I has none."
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"第二处动词形式与主语不一致。","source_text":"has","source_occurrence":2,"suggested_text":"have"}]}`),
+			current,
+			current.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Evidence.StartUTF8Byte != 21 {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("missing required structured field is rejected", func(t *testing.T) {
+		_, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"have","suggested_text":"had"}]}`),
+			snapshot,
+			snapshot.Transcript,
+			"SAME_QUESTION",
+		)
+		if err == nil {
+			t.Fatal("provider item without source_occurrence was accepted")
+		}
+	})
+
+	t.Run("explanation mentioning absent English words is repaired", func(t *testing.T) {
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"原输入中的 fix 和 service 可以更自然。","source_text":"I have a plan","source_occurrence":1,"suggested_text":"I already have a plan"}]}`),
+			snapshot,
+			snapshot.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 ||
+			items[0].Category != "RECOMMENDED_EXPRESSION" ||
+			items[0].Recommendation != "这是保留原意的可选表达。" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("correction explanation cannot introduce the replacement word", func(t *testing.T) {
+		current := snapshot
+		current.Transcript = "I has a plan."
+		items, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"CORRECTION","explanation":"将 has 改为 have。","source_text":"has","source_occurrence":1,"suggested_text":"have"}]}`),
+			current,
+			current.Transcript,
+			"SAME_QUESTION",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || items[0].Category != "CORRECTION" ||
+			items[0].Recommendation != "此处存在可定位的语言错误，建议使用右侧表达。" {
+			t.Fatalf("items = %#v", items)
+		}
+	})
+
+	t.Run("no change conflicts with recommendations", func(t *testing.T) {
+		_, err := compactFeedbackItems(
+			compactResult(`{"items":[{"kind":"STRENGTH","explanation":"无需修改。","source_text":null,"source_occurrence":null,"suggested_text":null},{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是可选表达。","source_text":"I have a plan","source_occurrence":1,"suggested_text":"I already have a plan"}]}`),
+			snapshot,
+			snapshot.Transcript,
+			"SAME_QUESTION",
+		)
+		if err == nil {
+			t.Fatal("conflicting provider output was accepted")
+		}
+	})
+}
+
+func compactResult(content string) TextGenerationResult {
+	return TextGenerationResult{
+		RequestID: "request-1",
+		Provider:  "qianwen",
+		Model:     "qwen-plus",
+		Content:   content,
+	}
+}

--- a/server/internal/coaching/evaluation/speechfeedback/language.go
+++ b/server/internal/coaching/evaluation/speechfeedback/language.go
@@ -3,6 +3,7 @@ package speechfeedback
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 type speechFeedbackLanguage string
@@ -53,26 +54,78 @@ func speechFeedbackHasAssessableEnglish(text string) bool {
 // of a confirmed mixed-language transcript. The original transcript remains
 // the immutable text evidence; this projection is used only as the ISE paper.
 func speechFeedbackEnglishReferenceText(text string) string {
+	return projectSpeechFeedbackEnglishText(text).text
+}
+
+type speechFeedbackEnglishProjection struct {
+	text           string
+	originalStarts []int
+	originalEnds   []int
+}
+
+func projectSpeechFeedbackEnglishText(text string) speechFeedbackEnglishProjection {
 	var output strings.Builder
+	originalStarts := make([]int, 0, len(text))
+	originalEnds := make([]int, 0, len(text))
 	needsSpace := false
-	for _, character := range strings.TrimSpace(text) {
+	spaceStart := 0
+	appendRune := func(character rune, originalStart int, originalEnd int) {
+		output.WriteRune(character)
+		for range utf8.RuneLen(character) {
+			originalStarts = append(originalStarts, originalStart)
+			originalEnds = append(originalEnds, originalEnd)
+		}
+	}
+	for originalStart, character := range text {
+		originalEnd := originalStart + utf8.RuneLen(character)
 		allowed := unicode.Is(unicode.Latin, character) &&
 			unicode.IsLetter(character)
 		allowed = allowed || unicode.IsNumber(character) ||
 			(character <= unicode.MaxASCII &&
 				(unicode.IsPunct(character) || unicode.IsSpace(character)))
-		if !allowed {
+		if !allowed || unicode.IsSpace(character) {
+			if output.Len() > 0 && !needsSpace {
+				spaceStart = originalStart
+			}
 			needsSpace = output.Len() > 0
 			continue
 		}
-		if needsSpace && !unicode.IsSpace(character) {
-			output.WriteByte(' ')
+		if needsSpace {
+			appendRune(' ', spaceStart, originalStart)
 		}
-		output.WriteRune(character)
+		appendRune(character, originalStart, originalEnd)
 		needsSpace = false
 	}
-	projected := strings.Join(strings.Fields(output.String()), " ")
-	return strings.Trim(projected, " \t\r\n,;:!?-.")
+	projected := output.String()
+	trimmed := strings.Trim(projected, " \t\r\n,;:!?-.")
+	if trimmed == "" {
+		return speechFeedbackEnglishProjection{}
+	}
+	start := strings.Index(projected, trimmed)
+	end := start + len(trimmed)
+	return speechFeedbackEnglishProjection{
+		text:           trimmed,
+		originalStarts: originalStarts[start:end],
+		originalEnds:   originalEnds[start:end],
+	}
+}
+
+func (projection speechFeedbackEnglishProjection) excerptRange(
+	excerpt string,
+	occurrence int,
+) (int, int, bool) {
+	projectedStart := speechFeedbackExcerptStart(
+		projection.text,
+		excerpt,
+		occurrence,
+	)
+	projectedEnd := projectedStart + len(excerpt)
+	if projectedStart < 0 || projectedEnd > len(projection.originalStarts) ||
+		projectedStart >= projectedEnd {
+		return 0, 0, false
+	}
+	return projection.originalStarts[projectedStart],
+		projection.originalEnds[projectedEnd-1], true
 }
 
 func speechFeedbackAcousticCategory(

--- a/server/internal/coaching/evaluation/speechfeedback/support.go
+++ b/server/internal/coaching/evaluation/speechfeedback/support.go
@@ -27,6 +27,10 @@ var speechFeedbackIdentifierPattern = regexp.MustCompile(
 	`^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$`,
 )
 
+var speechFeedbackEnglishWordPattern = regexp.MustCompile(
+	`[A-Za-z]+(?:['’][A-Za-z]+)*`,
+)
+
 func validSpeechFeedbackIdentifier(value string) bool {
 	return value == strings.TrimSpace(value) &&
 		speechFeedbackIdentifierPattern.MatchString(value)
@@ -41,11 +45,65 @@ func validSpeechFeedbackAdviceText(value string) bool {
 		value != "" && len(value) <= 4096 && !strings.ContainsRune(value, '\x00')
 }
 
-func equalSpeechFeedbackText(left string, right string) bool {
-	normalize := func(value string) string {
-		return strings.ToLower(strings.Join(strings.Fields(value), " "))
+func sameSpeechFeedbackLexicalContent(left string, right string) bool {
+	leftWords := speechFeedbackEnglishWordPattern.FindAllString(left, -1)
+	rightWords := speechFeedbackEnglishWordPattern.FindAllString(right, -1)
+	if len(leftWords) == 0 || len(leftWords) != len(rightWords) {
+		return false
 	}
-	return normalize(left) == normalize(right)
+	for index := range leftWords {
+		if !strings.EqualFold(leftWords[index], rightWords[index]) {
+			return false
+		}
+	}
+	return true
 }
 
-const speechFeedbackSystemPrompt = `Return one JSON object with an items array for a confirmed English transcript. Each item must have kind, explanation, and suggested_text. Allowed kinds are STRENGTH, CORRECTION, and RECOMMENDED_EXPRESSION. If the answer is already strong, return exactly one STRENGTH with suggested_text set to null. Otherwise return one to three non-duplicate CORRECTION or RECOMMENDED_EXPRESSION items and include a genuinely improved suggested_text for each. Do not claim to assess pronunciation or audio. Return JSON only.`
+func validSpeechFeedbackExplanation(value string, englishText string) bool {
+	if !validSpeechFeedbackAdviceText(value) {
+		return false
+	}
+	inputWords := make(map[string]struct{})
+	for _, word := range speechFeedbackEnglishWordPattern.FindAllString(
+		englishText,
+		-1,
+	) {
+		inputWords[strings.ToLower(word)] = struct{}{}
+	}
+	for _, word := range speechFeedbackEnglishWordPattern.FindAllString(value, -1) {
+		if _, exists := inputWords[strings.ToLower(word)]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func safeSpeechFeedbackExplanation(
+	kind SpeechFeedbackItemKind,
+	value string,
+	englishText string,
+) string {
+	if validSpeechFeedbackExplanation(value, englishText) {
+		return strings.TrimSpace(value)
+	}
+	switch kind {
+	case SpeechFeedbackItemCorrection:
+		return "此处存在可定位的语言错误，建议使用右侧表达。"
+	case SpeechFeedbackItemRecommendedExpression:
+		return "这是保留原意的可选表达。"
+	case SpeechFeedbackItemStrength:
+		return "原表达没有可定位的语言错误，无需修改。"
+	default:
+		return "反馈内容已通过安全校验。"
+	}
+}
+
+func optionalSpeechFeedbackConnectorSwap(left string, right string) bool {
+	left = strings.ToLower(strings.TrimSpace(left))
+	right = strings.ToLower(strings.TrimSpace(right))
+	return left != right &&
+		(left == "and" || left == "so") &&
+		(right == "and" || right == "so")
+}
+
+const speechFeedbackSystemPrompt = `Return one JSON object with an items array for a confirmed English transcript. Every item must have kind, explanation, source_text, source_occurrence, and suggested_text. Allowed kinds are STRENGTH, CORRECTION, and RECOMMENDED_EXPRESSION. Use CORRECTION only for a necessary, locatable language error: source_text must be one exact contiguous excerpt copied from english_text, source_occurrence must be its 1-based occurrence, and suggested_text must contain only the replacement for that excerpt. Never use CORRECTION for capitalization, punctuation, personal preference, optional wording, or a valid choice between and and so. Use RECOMMENDED_EXPRESSION only for an optional meaning-preserving alternative; source_text and source_occurrence must still identify exact input evidence. If no change is useful, return exactly one STRENGTH with source_text, source_occurrence, and suggested_text set to null. STRENGTH cannot appear with any other item. Write explanation only in Simplified Chinese without English words; never invent or discuss a word the user did not say. Do not claim to assess pronunciation or audio. Return JSON only.`

--- a/server/internal/providers/qianwen/evaluation_speechfeedback.go
+++ b/server/internal/providers/qianwen/evaluation_speechfeedback.go
@@ -58,7 +58,9 @@ func (generator *EvaluationSpeechFeedbackGenerator) Generate(
 
 func speechFeedbackSchema() map[string]any {
 	item := strictObjectSchema(
-		[]any{"kind", "explanation", "suggested_text"},
+		[]any{
+			"kind", "explanation", "source_text", "source_occurrence", "suggested_text",
+		},
 		map[string]any{
 			"kind": map[string]any{
 				"type": "string",
@@ -67,6 +69,15 @@ func speechFeedbackSchema() map[string]any {
 				},
 			},
 			"explanation": stringSchema(),
+			"source_text": map[string]any{
+				"anyOf": []any{stringSchema(), map[string]any{"type": "null"}},
+			},
+			"source_occurrence": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "integer", "minimum": 1},
+					map[string]any{"type": "null"},
+				},
+			},
 			"suggested_text": map[string]any{
 				"anyOf": []any{stringSchema(), map[string]any{"type": "null"}},
 			},

--- a/server/internal/providers/qianwen/structured_business_generation_test.go
+++ b/server/internal/providers/qianwen/structured_business_generation_test.go
@@ -21,7 +21,7 @@ func TestEvaluationSpeechFeedbackUsesStrictSchema(t *testing.T) {
 		return jsonResponse(http.StatusOK, `{
 			"id":"chatcmpl-feedback-1",
 			"model":"qwen3.5-flash",
-			"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"items\":[{\"kind\":\"STRENGTH\",\"explanation\":\"Clear answer.\",\"suggested_text\":null}]}"}}],
+			"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"items\":[{\"kind\":\"STRENGTH\",\"explanation\":\"表达清晰。\",\"source_text\":null,\"source_occurrence\":null,\"suggested_text\":null}]}"}}],
 			"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}
 		}`), nil
 	}))
@@ -44,6 +44,14 @@ func TestEvaluationSpeechFeedbackUsesStrictSchema(t *testing.T) {
 	items := properties["items"].(map[string]any)
 	item := items["items"].(map[string]any)
 	itemProperties := item["properties"].(map[string]any)
+	source := itemProperties["source_text"].(map[string]any)
+	if _, ok := source["anyOf"].([]any); !ok {
+		t.Fatalf("source_text schema = %#v", source)
+	}
+	occurrence := itemProperties["source_occurrence"].(map[string]any)
+	if _, ok := occurrence["anyOf"].([]any); !ok {
+		t.Fatalf("source_occurrence schema = %#v", occurrence)
+	}
 	suggested := itemProperties["suggested_text"].(map[string]any)
 	if _, ok := suggested["anyOf"].([]any); !ok {
 		t.Fatalf("suggested_text schema = %#v", suggested)


### PR DESCRIPTION
## 功能描述

- 严格区分 `CORRECTION`、`RECOMMENDED_EXPRESSION` 与唯一 `STRENGTH`（无需修改）。
- 只有可定位、存在词汇变化的语言错误允许触发删除线。
- 大小写/标点差异安全降级为无需修改；`and`/`so` 互换只能作为可选表达。
- 解释中的输入外英文词会被确定性替换为分类安全中文说明。
- 前端解码与渲染再次校验分类，拒绝矛盾数据，避免删除线误伤。

## 实现思路

- Qwen 严格结构化输出新增精确 `source_text`、1-based `source_occurrence` 与 nullable suggestion。
- 后端按 UTF-8 证据位置、词汇变化、类别互斥和解释引用做确定性归一。
- OpenAPI 与 Flutter presentation 层同步收紧三类契约。
- 结构化输出仍在业务侧验证/修复，参考阿里云 Qwen Structured Output 官方建议：https://help.aliyun.com/en/model-studio/qwen-structured-output

## 可复现测试

- `make check-go`
- `cd mobile && flutter test --no-pub test/review/turn_feedback_decoder_test.dart test/design/practice_conversation_components_test.dart`
- `cd api && npm run validate:evaluation && npm run lint:openapi`
- `make check-flutter`（714 tests passed）
- `make check-api`

## 真人模拟器验收

真实后端 `127.0.0.1:18082`，数字人禁用：

- 正确 `and` 句：唯一 `STRENGTH`，无 correction。
- 正确 `so` 句：唯一 `STRENGTH`，无 correction。
- `I has a repair appointment tomorrow.`：`READY / CORRECTION / MEDIUM`，证据仅锚定 `has`（UTF-8 bytes 2–5），纠正为 `have`，安全中文解释不引用输入外英文词。

Closes #788