### PR TITLE
fix(evaluation): 让报告失败可诊断并真正可重试

### DIFF
--- a/api/modules/evaluation.yaml
+++ b/api/modules/evaluation.yaml
@@ -19,6 +19,35 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/NotFound
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/practice-sessions/{practice_session_id}/evaluation/retry:
+    post:
+      tags: [Evaluation]
+      summary: Retry a failed practice-session evaluation
+      description: Atomically requeues an actor-owned, retryable FAILED SESSION_REPORT. Repeated calls replay the current evaluation resource.
+      operationId: retryPracticeSessionEvaluation
+      parameters:
+        - $ref: '#/components/parameters/PracticeSessionId'
+      responses:
+        '200':
+          description: The evaluation was already queued, running, or ready.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationResource'
+        '202':
+          description: The failed evaluation was accepted for retry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationResource'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        '409':
+          $ref: ../common/errors.yaml#/components/responses/Conflict
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/practice-turns/{turn_id}/evaluation:
     get:
       tags: [Evaluation]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -165,6 +165,8 @@ paths:
     $ref: ./modules/evaluation.yaml#/paths/~1v1~1evaluation-reports~1{report_id}
   /v1/practice-sessions/{practice_session_id}/evaluation:
     $ref: ./modules/evaluation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1evaluation
+  /v1/practice-sessions/{practice_session_id}/evaluation/retry:
+    $ref: ./modules/evaluation.yaml#/paths/~1v1~1practice-sessions~1{practice_session_id}~1evaluation~1retry
   /v1/practice-turns/{turn_id}/evaluation:
     $ref: ./modules/evaluation.yaml#/paths/~1v1~1practice-turns~1{turn_id}~1evaluation
   /v1/agent-messages/{message_id}/evaluation:

--- a/api/scripts/validate-evaluation.mjs
+++ b/api/scripts/validate-evaluation.mjs
@@ -230,6 +230,7 @@ try {
   }
   for (const expected of [
     'GET /v1/practice-sessions/{practice_session_id}/evaluation',
+    'POST /v1/practice-sessions/{practice_session_id}/evaluation/retry',
     'GET /v1/practice-turns/{turn_id}/evaluation',
     'GET /v1/agent-messages/{message_id}/evaluation',
     'GET /v1/evaluation-reports',
@@ -237,6 +238,16 @@ try {
     'POST /v1/evaluation-feedback-items/{feedback_item_id}/retry-turns',
   ]) {
     assert.ok(operations.has(expected), `missing ${expected}`);
+  }
+  const retrySessionEvaluation = contract.paths[
+    '/v1/practice-sessions/{practice_session_id}/evaluation/retry'
+  ].post;
+  assert.equal(retrySessionEvaluation.requestBody, undefined);
+  for (const status of ['200', '202']) {
+    assert.equal(
+      retrySessionEvaluation.responses[status].content['application/json'].schema.$ref,
+      '#/components/schemas/EvaluationResource',
+    );
   }
   for (const retired of [
     'POST /v1/evaluations',

--- a/api/scripts/validate-security.mjs
+++ b/api/scripts/validate-security.mjs
@@ -1099,6 +1099,26 @@ for (const [operationKey, operationId] of [
   );
 }
 
+const retrySessionEvaluation = requireOperation(
+  'POST /v1/practice-sessions/{practice_session_id}/evaluation/retry',
+);
+assert.equal(
+  retrySessionEvaluation.operationId,
+  'retryPracticeSessionEvaluation',
+);
+assert.deepEqual(
+  retrySessionEvaluation.security ?? openApi.security,
+  bearerSecurity,
+  'Session Evaluation retry must derive the Actor from BearerSession.',
+);
+assert.equal(retrySessionEvaluation.requestBody, undefined);
+for (const status of ['200', '202', '401', '404', '409', 'default']) {
+  assert.ok(
+    retrySessionEvaluation.responses?.[status],
+    `Session Evaluation retry must declare ${status}.`,
+  );
+}
+
 const evaluationReportHistory = requireOperation('GET /v1/evaluation-reports');
 const evaluationReportHistoryParameters = Object.fromEntries(
   (evaluationReportHistory.parameters ?? []).map((parameterValue) => {

--- a/mobile/lib/features/coaching/evaluation/session_evaluation_client.dart
+++ b/mobile/lib/features/coaching/evaluation/session_evaluation_client.dart
@@ -32,6 +32,8 @@ final class SessionEvaluationException implements Exception {
 abstract interface class SessionEvaluationClient {
   Future<SessionEvaluation> get(String practiceSessionId);
 
+  Future<SessionEvaluation> retry(String practiceSessionId);
+
   Future<void> clearAccountState();
 }
 
@@ -72,7 +74,17 @@ final class WireSessionEvaluationClient implements SessionEvaluationClient {
   int _accountGeneration = 0;
 
   @override
-  Future<SessionEvaluation> get(String practiceSessionId) async {
+  Future<SessionEvaluation> get(String practiceSessionId) =>
+      _request(practiceSessionId, retry: false);
+
+  @override
+  Future<SessionEvaluation> retry(String practiceSessionId) =>
+      _request(practiceSessionId, retry: true);
+
+  Future<SessionEvaluation> _request(
+    String practiceSessionId, {
+    required bool retry,
+  }) async {
     if (!_uuidPattern.hasMatch(practiceSessionId)) {
       throw const SessionEvaluationException(
         kind: SessionEvaluationFailureKind.invalidRequest,
@@ -80,7 +92,7 @@ final class WireSessionEvaluationClient implements SessionEvaluationClient {
     }
     final generation = _accountGeneration;
     final uri = _baseUri.resolve(
-      '/v1/practice-sessions/${Uri.encodeComponent(practiceSessionId)}/evaluation',
+      '/v1/practice-sessions/${Uri.encodeComponent(practiceSessionId)}/evaluation${retry ? '/retry' : ''}',
     );
     _trustedOrigin.validateResourceUri(uri);
     validateNoSessionCredentialInUri(uri);
@@ -88,7 +100,7 @@ final class WireSessionEvaluationClient implements SessionEvaluationClient {
     try {
       response = await _transport
           .send(
-            method: 'GET',
+            method: retry ? 'POST' : 'GET',
             uri: uri,
             headers: const {HttpHeaders.acceptHeader: 'application/json'},
           )
@@ -123,19 +135,21 @@ final class WireSessionEvaluationClient implements SessionEvaluationClient {
         kind: SessionEvaluationFailureKind.superseded,
       );
     }
+    if (response.statusCode == HttpStatus.ok ||
+        (retry && response.statusCode == HttpStatus.accepted)) {
+      try {
+        return decodeSessionEvaluation(jsonDecode(response.body));
+      } on FormatException catch (_) {
+        throw const SessionEvaluationException(
+          kind: SessionEvaluationFailureKind.invalidResponse,
+        );
+      } on SessionEvaluationDecodeException catch (_) {
+        throw const SessionEvaluationException(
+          kind: SessionEvaluationFailureKind.invalidResponse,
+        );
+      }
+    }
     switch (response.statusCode) {
-      case HttpStatus.ok:
-        try {
-          return decodeSessionEvaluation(jsonDecode(response.body));
-        } on FormatException catch (_) {
-          throw const SessionEvaluationException(
-            kind: SessionEvaluationFailureKind.invalidResponse,
-          );
-        } on SessionEvaluationDecodeException catch (_) {
-          throw const SessionEvaluationException(
-            kind: SessionEvaluationFailureKind.invalidResponse,
-          );
-        }
       case HttpStatus.unauthorized:
         throw const SessionEvaluationException(
           kind: SessionEvaluationFailureKind.authenticationRequired,

--- a/mobile/lib/features/coaching/evaluation/session_evaluation_controller.dart
+++ b/mobile/lib/features/coaching/evaluation/session_evaluation_controller.dart
@@ -32,7 +32,11 @@ final class SessionEvaluationController extends ChangeNotifier {
   String? get practiceSessionId => _practiceSessionId;
   String? get errorMessage => _errorMessage;
   bool get isLoading => _isLoading;
-  bool get canRetry => _practiceSessionId != null && !_isLoading;
+  bool get canRetry =>
+      _practiceSessionId != null &&
+      !_isLoading &&
+      _evaluation?.status == SessionEvaluationStatus.failed &&
+      (_evaluation?.failure?.retryable ?? false);
 
   Future<void> load(String practiceSessionId) async {
     final generation = ++_generation;
@@ -76,7 +80,32 @@ final class SessionEvaluationController extends ChangeNotifier {
 
   Future<void> retry() async {
     final sessionId = _practiceSessionId;
-    if (sessionId != null) await load(sessionId);
+    if (sessionId == null || !canRetry) return;
+    final generation = ++_generation;
+    _errorMessage = null;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final value = await client.retry(sessionId);
+      if (generation != _generation) return;
+      _evaluation = value;
+      if (value.status == SessionEvaluationStatus.ready) {
+        _isLoading = false;
+        notifyListeners();
+        return;
+      }
+    } on SessionEvaluationException catch (error) {
+      if (generation != _generation ||
+          error.kind == SessionEvaluationFailureKind.superseded) {
+        return;
+      }
+      _isLoading = false;
+      _errorMessage = _messageFor(error.kind);
+      notifyListeners();
+      return;
+    }
+    if (generation != _generation) return;
+    await load(sessionId);
   }
 
   void cancel(String practiceSessionId) {

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_review.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_review.dart
@@ -297,7 +297,7 @@ class _Part1ReviewFailure extends StatelessWidget {
         Text(message, textAlign: TextAlign.center, style: SpeakUpDesign.body),
         if (canRetry) ...[
           const SizedBox(height: 24),
-          FilledButton(onPressed: onRetry, child: const Text('重新加载')),
+          FilledButton(onPressed: onRetry, child: const Text('重新生成报告')),
         ],
       ],
     );

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -1552,7 +1552,7 @@ class _SessionEvaluationStatusCard extends StatelessWidget {
                   const SizedBox(height: 12),
                   OutlinedButton(
                     onPressed: () => unawaited(current.retry()),
-                    child: const Text('重新加载'),
+                    child: const Text('重新生成报告'),
                   ),
                 ] else ...[
                   const SizedBox(height: 12),

--- a/mobile/lib/features/coaching/review/session_evaluation_page.dart
+++ b/mobile/lib/features/coaching/review/session_evaluation_page.dart
@@ -89,7 +89,7 @@ class _SessionEvaluationPageState extends State<SessionEvaluationPage> {
                             FilledButton(
                               onPressed: () =>
                                   unawaited(widget.controller.retry()),
-                              child: const Text('重新加载'),
+                              child: const Text('重新生成报告'),
                             ),
                           ],
                         ],

--- a/mobile/test/review/session_evaluation_client_test.dart
+++ b/mobile/test/review/session_evaluation_client_test.dart
@@ -24,7 +24,26 @@ void main() {
 
     expect(result.status, SessionEvaluationStatus.ready);
     expect(transport.uri.path, '/v1/practice-sessions/$_sessionId/evaluation');
+    expect(transport.method, 'GET');
     expect(transport.authorization, 'Bearer sess_session_evaluation_token');
+  });
+
+  test('retries through the actor-owned session evaluation command', () async {
+    final transport = _Transport(
+      IdentityHttpResponse(
+        statusCode: HttpStatus.accepted,
+        body: jsonEncode(_queuedResource()),
+      ),
+    );
+
+    final result = await _client(transport).retry(_sessionId);
+
+    expect(result.status, SessionEvaluationStatus.queued);
+    expect(
+      transport.uri.path,
+      '/v1/practice-sessions/$_sessionId/evaluation/retry',
+    );
+    expect(transport.method, 'POST');
   });
 
   test('rejects invalid session ids before transport', () async {
@@ -87,6 +106,13 @@ Map<String, Object?> _readyResource() {
   };
 }
 
+Map<String, Object?> _queuedResource() {
+  final ready = _readyResource();
+  ready['status'] = 'QUEUED';
+  ready.remove('result');
+  return ready;
+}
+
 WireSessionEvaluationClient _client(IdentityHttpTransport transport) =>
     WireSessionEvaluationClient(
       baseUri: Uri.parse('https://api.speak-up.test'),
@@ -107,6 +133,7 @@ final class _Transport implements IdentityHttpTransport {
 
   final IdentityHttpResponse response;
   late Uri uri;
+  late String method;
   String? authorization;
   int calls = 0;
 
@@ -119,6 +146,7 @@ final class _Transport implements IdentityHttpTransport {
     List<int>? bodyBytes,
   }) async {
     calls++;
+    this.method = method;
     this.uri = uri;
     authorization = headers[HttpHeaders.authorizationHeader];
     return response;

--- a/mobile/test/review/session_evaluation_controller_test.dart
+++ b/mobile/test/review/session_evaluation_controller_test.dart
@@ -81,7 +81,7 @@ void main() {
     final client = _EvaluationClient(<SessionEvaluation>[
       _failedEvaluation(),
       _readyEvaluation(EvaluationReportSceneType.interview),
-    ]);
+    ], retryResponse: _evaluation(SessionEvaluationStatus.queued));
     final controller = SessionEvaluationController(
       client: client,
       pollInterval: const Duration(milliseconds: 1),
@@ -100,21 +100,50 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('评分服务暂不可用。'), findsOneWidget);
-    expect(find.text('重新加载'), findsOneWidget);
+    expect(find.text('重新生成报告'), findsOneWidget);
 
-    await tester.tap(find.text('重新加载'));
+    await tester.tap(find.text('重新生成报告'));
     await tester.pumpAndSettle();
 
     expect(client.calls, 2);
+    expect(client.retryCalls, 1);
     expect(find.byKey(const Key('review-detail-page')), findsOneWidget);
+  });
+
+  testWidgets('does not offer retry for a terminal non-retryable failure', (
+    tester,
+  ) async {
+    final controller = SessionEvaluationController(
+      client: _EvaluationClient(<SessionEvaluation>[
+        _failedEvaluation(retryable: false),
+      ]),
+      pollInterval: const Duration(milliseconds: 1),
+      maximumPolls: 1,
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SessionEvaluationPage(
+          practiceSessionId: _sessionId,
+          controller: controller,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('评分服务暂不可用。'), findsOneWidget);
+    expect(find.text('重新生成报告'), findsNothing);
   });
 }
 
 final class _EvaluationClient implements SessionEvaluationClient {
-  _EvaluationClient(this._responses);
+  _EvaluationClient(this._responses, {this.retryResponse});
 
   final List<SessionEvaluation> _responses;
+  final SessionEvaluation? retryResponse;
   int calls = 0;
+  int retryCalls = 0;
 
   @override
   Future<SessionEvaluation> get(String practiceSessionId) async {
@@ -122,6 +151,13 @@ final class _EvaluationClient implements SessionEvaluationClient {
     final index = calls < _responses.length ? calls : _responses.length - 1;
     calls++;
     return _responses[index];
+  }
+
+  @override
+  Future<SessionEvaluation> retry(String practiceSessionId) async {
+    expect(practiceSessionId, _sessionId);
+    retryCalls++;
+    return retryResponse ?? _responses.last;
   }
 
   @override
@@ -156,17 +192,18 @@ SessionEvaluation _readyEvaluation(EvaluationReportSceneType sceneType) =>
       ),
     );
 
-SessionEvaluation _failedEvaluation() => SessionEvaluation(
-  evaluationId: _evaluationId,
-  practiceSessionId: _sessionId,
-  status: SessionEvaluationStatus.failed,
-  updatedAt: _completedAt,
-  failure: const SessionEvaluationFailure(
-    code: 'PROVIDER_UNAVAILABLE',
-    retryable: true,
-    message: '评分服务暂不可用。',
-  ),
-);
+SessionEvaluation _failedEvaluation({bool retryable = true}) =>
+    SessionEvaluation(
+      evaluationId: _evaluationId,
+      practiceSessionId: _sessionId,
+      status: SessionEvaluationStatus.failed,
+      updatedAt: _completedAt,
+      failure: SessionEvaluationFailure(
+        code: 'PROVIDER_UNAVAILABLE',
+        retryable: retryable,
+        message: '评分服务暂不可用。',
+      ),
+    );
 
 const _sessionId = '30000000-0000-4000-8000-000000000003';
 const _evaluationId = '70000000-0000-4000-8000-000000000007';

--- a/server/cmd/server/evaluation_worker.go
+++ b/server/cmd/server/evaluation_worker.go
@@ -75,11 +75,9 @@ func (worker *evaluationLaneWorker) Run(ctx context.Context) {
 	for ctx.Err() == nil {
 		processed, err := worker.process(ctx)
 		if err != nil {
-			worker.logger.WarnContext(
-				ctx,
-				"evaluation processing failed",
-				slog.String("lane", worker.name),
-				slog.String("error_kind", evaluationErrorKind(err)),
+			worker.logger.LogAttrs(
+				ctx, slog.LevelWarn, "evaluation processing failed",
+				evaluationErrorAttributes(worker.name, err)...,
 			)
 		}
 		if processed {
@@ -89,6 +87,32 @@ func (worker *evaluationLaneWorker) Run(ctx context.Context) {
 			return
 		}
 	}
+}
+
+type evaluationFailureMetadata interface {
+	EvaluationID() string
+	EvaluationKind() evaluation.Kind
+	EvaluationAttemptCount() int
+	EvaluationJobError() evaluation.JobError
+}
+
+func evaluationErrorAttributes(lane string, err error) []slog.Attr {
+	attributes := []slog.Attr{
+		slog.String("lane", lane),
+		slog.String("error_kind", evaluationErrorKind(err)),
+	}
+	var metadata evaluationFailureMetadata
+	if errors.As(err, &metadata) {
+		failure := metadata.EvaluationJobError()
+		attributes = append(attributes,
+			slog.String("evaluation_id", metadata.EvaluationID()),
+			slog.String("evaluation_kind", string(metadata.EvaluationKind())),
+			slog.Int("attempt_count", metadata.EvaluationAttemptCount()),
+			slog.String("failure_code", failure.Code),
+			slog.Bool("retryable", failure.Retryable),
+		)
+	}
+	return attributes
 }
 
 func evaluationErrorKind(err error) string {

--- a/server/cmd/server/evaluation_worker_test.go
+++ b/server/cmd/server/evaluation_worker_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 )
 
 func TestEvaluationRuntimeUsesIndependentSpeechWorkers(t *testing.T) {
@@ -29,6 +31,29 @@ func TestEvaluationRuntimeUsesIndependentSpeechWorkers(t *testing.T) {
 	}
 }
 
+func TestEvaluationFailureAttributesExposeSafeDiagnosticMetadata(t *testing.T) {
+	attributes := evaluationErrorAttributes("session", evaluationFailureStub{})
+	values := make(map[string]string, len(attributes))
+	for _, attribute := range attributes {
+		values[attribute.Key] = attribute.Value.String()
+	}
+	for key, want := range map[string]string{
+		"lane":            "session",
+		"evaluation_id":   "70000000-0000-4000-8000-000000000001",
+		"evaluation_kind": "SESSION_REPORT",
+		"attempt_count":   "2",
+		"failure_code":    "PROVIDER_RESPONSE_INVALID",
+		"retryable":       "true",
+	} {
+		if values[key] != want {
+			t.Fatalf("%s = %q, want %q; attributes=%#v", key, values[key], want, values)
+		}
+	}
+	if _, leaked := values["error"]; leaked {
+		t.Fatalf("diagnostics leaked raw error: %#v", values)
+	}
+}
+
 type evaluationProcessorStub struct{}
 
 func (evaluationProcessorStub) ProcessSession(context.Context) (bool, error) {
@@ -37,4 +62,21 @@ func (evaluationProcessorStub) ProcessSession(context.Context) (bool, error) {
 
 func (evaluationProcessorStub) ProcessSpeech(context.Context) (bool, error) {
 	return false, nil
+}
+
+type evaluationFailureStub struct{}
+
+func (evaluationFailureStub) Error() string { return "sensitive provider output" }
+func (evaluationFailureStub) EvaluationID() string {
+	return "70000000-0000-4000-8000-000000000001"
+}
+func (evaluationFailureStub) EvaluationKind() evaluation.Kind {
+	return evaluation.KindSessionReport
+}
+func (evaluationFailureStub) EvaluationAttemptCount() int { return 2 }
+func (evaluationFailureStub) EvaluationJobError() evaluation.JobError {
+	return evaluation.JobError{
+		Code: "PROVIDER_RESPONSE_INVALID", Retryable: true,
+		Message: "Evaluation processing failed.",
+	}
 }

--- a/server/internal/coaching/evaluation/api/application.go
+++ b/server/internal/coaching/evaluation/api/application.go
@@ -10,6 +10,7 @@ import (
 
 type store interface {
 	GetRecordBySource(context.Context, string, evaluation.Kind, string) (evaluation.Record, error)
+	RetryFailedSessionReport(context.Context, string, string) (evaluation.Record, bool, error)
 	ListFeedbackItems(context.Context, string, string) ([]evaluation.FeedbackItem, error)
 	GetFormalReport(context.Context, string, string) (report.StoredFormalReport, error)
 	ListFormalReports(context.Context, string, report.HistoryQuery) (report.HistoryPage, error)
@@ -45,6 +46,24 @@ func (application *Application) GetBySource(
 		return Resource{}, err
 	}
 	return application.resource(ctx, userID, record)
+}
+
+func (application *Application) RetrySessionReport(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+) (Resource, bool, error) {
+	if application == nil || application.store == nil || ctx == nil {
+		return Resource{}, false, evaluation.ErrInvalidRequest
+	}
+	record, replayed, err := application.store.RetryFailedSessionReport(
+		ctx, userID, sessionID,
+	)
+	if err != nil {
+		return Resource{}, false, err
+	}
+	resource, err := application.resource(ctx, userID, record)
+	return resource, replayed, err
 }
 
 func (application *Application) resource(

--- a/server/internal/coaching/evaluation/api/http.go
+++ b/server/internal/coaching/evaluation/api/http.go
@@ -35,10 +35,37 @@ func NewHTTPHandler(application *Application) (*HTTPHandler, error) {
 
 func (handler *HTTPHandler) RegisterRoutes(routes gin.IRoutes) {
 	routes.GET("/v1/practice-sessions/:practice_session_id/evaluation", handler.getSession)
+	routes.POST("/v1/practice-sessions/:practice_session_id/evaluation/retry", handler.retrySession)
 	routes.GET("/v1/practice-turns/:turn_id/evaluation", handler.getTurn)
 	routes.GET("/v1/agent-messages/:message_id/evaluation", handler.getAgentMessage)
 	routes.GET("/v1/evaluation-reports", handler.listReports)
 	routes.GET("/v1/evaluation-reports/:report_id", handler.getReport)
+}
+
+func (handler *HTTPHandler) retrySession(c *gin.Context) {
+	privateHeaders(c)
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok || !actor.Valid() {
+		handler.writeError(c, authenticationRequired())
+		return
+	}
+	resource, replayed, err := handler.application.RetrySessionReport(
+		c.Request.Context(), actor.UserID, c.Param("practice_session_id"),
+	)
+	if err != nil {
+		handler.writeError(c, err)
+		return
+	}
+	response, err := resourceResponse(resource)
+	if err != nil {
+		handler.writeError(c, err)
+		return
+	}
+	status := http.StatusAccepted
+	if replayed {
+		status = http.StatusOK
+	}
+	c.JSON(status, response)
 }
 
 func (handler *HTTPHandler) getSession(c *gin.Context) {
@@ -313,6 +340,10 @@ func (handler *HTTPHandler) writeError(c *gin.Context, err error) {
 	case errors.Is(err, evaluation.ErrAccountUnavailable):
 		handler.errors.Write(c, apperror.New(
 			apperror.PermissionDenied, "account_unavailable", "The account is unavailable.",
+		))
+	case errors.Is(err, evaluation.ErrRetryNotAllowed):
+		handler.errors.Write(c, apperror.New(
+			apperror.Conflict, "resource_conflict", "The Evaluation cannot be retried.",
 		))
 	default:
 		handler.errors.Write(c, err)

--- a/server/internal/coaching/evaluation/api/http_test.go
+++ b/server/internal/coaching/evaluation/api/http_test.go
@@ -1,14 +1,18 @@
 package evaluationapi
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/report"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
 	"github.com/gin-gonic/gin"
 )
 
@@ -19,6 +23,90 @@ func TestEvaluationRoutesShareCanonicalResourceParameterNames(t *testing.T) {
 	router.GET("/v1/agent-messages/:message_id/translation", noop)
 
 	(&HTTPHandler{}).RegisterRoutes(router)
+}
+
+func TestRetrySessionEvaluationReturnsAcceptedThenReplaysCurrentResource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, test := range []struct {
+		name     string
+		replayed bool
+		status   int
+	}{
+		{name: "reset failed report", status: http.StatusAccepted},
+		{name: "replay current report", replayed: true, status: http.StatusOK},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &apiStoreStub{replayed: test.replayed}
+			application, err := NewApplication(store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			handler, err := NewHTTPHandler(application)
+			if err != nil {
+				t.Fatal(err)
+			}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Request = c.Request.WithContext(requestcontext.WithActor(
+					c.Request.Context(),
+					requestcontext.Actor{UserID: testAPIUserID, SessionID: "session-token"},
+				))
+				c.Next()
+			})
+			handler.RegisterRoutes(router)
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/v1/practice-sessions/"+testAPISessionID+"/evaluation/retry",
+				nil,
+			)
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != test.status || store.retryCalls != 1 ||
+				store.userID != testAPIUserID || store.sessionID != testAPISessionID {
+				t.Fatalf(
+					"status=%d body=%s store=%#v", response.Code,
+					response.Body.String(), store,
+				)
+			}
+			var payload map[string]any
+			if json.Unmarshal(response.Body.Bytes(), &payload) != nil ||
+				payload["status"] != string(evaluation.JobQueued) {
+				t.Fatalf("payload=%s", response.Body.String())
+			}
+		})
+	}
+}
+
+func TestRetrySessionEvaluationRejectsNonRetryableFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	application, err := NewApplication(&apiStoreStub{err: evaluation.ErrRetryNotAllowed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewHTTPHandler(application)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(requestcontext.WithActor(
+			c.Request.Context(),
+			requestcontext.Actor{UserID: testAPIUserID, SessionID: "session-token"},
+		))
+		c.Next()
+	})
+	handler.RegisterRoutes(router)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/practice-sessions/"+testAPISessionID+"/evaluation/retry",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusConflict ||
+		!strings.Contains(response.Body.String(), `"code":"resource_conflict"`) {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
 }
 
 func TestPublicSpeechResultDoesNotExposeProviderLineage(t *testing.T) {
@@ -84,3 +172,58 @@ func TestDecodeCursorRejectsTrailingJSON(t *testing.T) {
 		t.Fatal("decodeCursor accepted trailing JSON")
 	}
 }
+
+type apiStoreStub struct {
+	replayed   bool
+	err        error
+	retryCalls int
+	userID     string
+	sessionID  string
+}
+
+func (store *apiStoreStub) GetRecordBySource(
+	context.Context, string, evaluation.Kind, string,
+) (evaluation.Record, error) {
+	return evaluation.Record{}, evaluation.ErrNotFound
+}
+
+func (store *apiStoreStub) RetryFailedSessionReport(
+	_ context.Context, userID string, sessionID string,
+) (evaluation.Record, bool, error) {
+	store.retryCalls++
+	store.userID = userID
+	store.sessionID = sessionID
+	if store.err != nil {
+		return evaluation.Record{}, false, store.err
+	}
+	now := time.Date(2026, 8, 21, 1, 2, 3, 0, time.UTC)
+	return evaluation.Record{
+		ID: testAPIEvaluationID, UserID: userID,
+		Kind: evaluation.KindSessionReport, SourceID: sessionID, ContextID: sessionID,
+		Status: evaluation.JobQueued, CreatedAt: now, UpdatedAt: now,
+	}, store.replayed, nil
+}
+
+func (*apiStoreStub) ListFeedbackItems(
+	context.Context, string, string,
+) ([]evaluation.FeedbackItem, error) {
+	return []evaluation.FeedbackItem{}, nil
+}
+
+func (*apiStoreStub) GetFormalReport(
+	context.Context, string, string,
+) (report.StoredFormalReport, error) {
+	return report.StoredFormalReport{}, evaluation.ErrNotFound
+}
+
+func (*apiStoreStub) ListFormalReports(
+	context.Context, string, report.HistoryQuery,
+) (report.HistoryPage, error) {
+	return report.HistoryPage{}, evaluation.ErrNotFound
+}
+
+const (
+	testAPIUserID       = "10000000-0000-4000-8000-000000000001"
+	testAPISessionID    = "20000000-0000-4000-8000-000000000001"
+	testAPIEvaluationID = "70000000-0000-4000-8000-000000000001"
+)

--- a/server/internal/coaching/evaluation/model.go
+++ b/server/internal/coaching/evaluation/model.go
@@ -11,6 +11,7 @@ var (
 	ErrNotFound            = errors.New("evaluation: not found")
 	ErrIdempotencyConflict = errors.New("evaluation: idempotency conflict")
 	ErrAccountUnavailable  = errors.New("evaluation: account unavailable")
+	ErrRetryNotAllowed     = errors.New("evaluation: retry not allowed")
 )
 
 type SceneType string

--- a/server/internal/coaching/evaluation/postgres/store.go
+++ b/server/internal/coaching/evaluation/postgres/store.go
@@ -118,6 +118,63 @@ func (store *Store) GetRecordBySource(
 	return record, nil
 }
 
+// RetryFailedSessionReport atomically returns a retryable terminal Session
+// Report to the existing queue. Calls made after the first successful reset
+// replay the current resource instead of resetting its attempt counter again.
+func (store *Store) RetryFailedSessionReport(
+	ctx context.Context,
+	userID string,
+	sourceID string,
+) (evaluation.Record, bool, error) {
+	if store == nil || store.pool == nil || ctx == nil ||
+		!validUUID(userID) || !validUUID(sourceID) {
+		return evaluation.Record{}, false, evaluation.ErrInvalidRequest
+	}
+	tx, err := store.pool.Begin(ctx)
+	if err != nil {
+		return evaluation.Record{}, false, fmt.Errorf("begin Evaluation retry: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := lockActiveUser(ctx, tx, userID); err != nil {
+		return evaluation.Record{}, false, err
+	}
+	record, err := scanRecord(tx.QueryRow(ctx, `SELECT `+evaluationColumns+`
+		FROM evaluations
+		WHERE user_id = $1 AND kind = 'SESSION_REPORT' AND source_id = $2
+		FOR UPDATE`, userID, sourceID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return evaluation.Record{}, false, evaluation.ErrNotFound
+	}
+	if err != nil {
+		return evaluation.Record{}, false, fmt.Errorf("lock Evaluation retry: %w", err)
+	}
+	if record.Status != evaluation.JobFailed {
+		if err := tx.Commit(ctx); err != nil {
+			return evaluation.Record{}, false, fmt.Errorf("commit Evaluation retry replay: %w", err)
+		}
+		return record, true, nil
+	}
+	if record.Error == nil || !record.Error.Retryable {
+		return evaluation.Record{}, false, evaluation.ErrRetryNotAllowed
+	}
+	record, err = scanRecord(tx.QueryRow(ctx, `UPDATE evaluations
+		SET status = 'QUEUED', attempt_count = 0,
+			lease_token = NULL, lease_expires_at = NULL,
+			result = NULL, error = NULL,
+			available_at = transaction_timestamp(),
+			updated_at = transaction_timestamp(),
+			started_at = NULL, finished_at = NULL
+		WHERE id = $1 AND user_id = $2
+		RETURNING `+evaluationColumns, record.ID, userID))
+	if err != nil {
+		return evaluation.Record{}, false, fmt.Errorf("reset Evaluation retry: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return evaluation.Record{}, false, fmt.Errorf("commit Evaluation retry: %w", err)
+	}
+	return record, false, nil
+}
+
 func (store *Store) ClaimNext(
 	ctx context.Context,
 	lane evaluation.ClaimLane,

--- a/server/internal/coaching/evaluation/postgres/store_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/store_integration_test.go
@@ -277,6 +277,77 @@ func TestStoreRetryableFinalAndExpiredClaimsConverge(t *testing.T) {
 	}
 }
 
+func TestStoreRetriesFailedSessionReportOnceAndReplaysCurrentState(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, testUserA, "evaluation-session-retry@example.com")
+	insertEvaluationTestUser(t, pool, testUserB, "evaluation-session-other@example.com")
+	store := mustStore(t, pool)
+	command := sessionQueueCommand(t, testUserA, testSessionA)
+	if _, _, err := store.Queue(context.Background(), command); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.ClaimNext(context.Background(), sessionLane(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.FailClaim(context.Background(), evaluation.Failure{
+		UserID: testUserA, ID: claim.ID, LeaseToken: claim.LeaseToken,
+		Error: evaluation.JobError{
+			Code: "PROVIDER_RESPONSE_INVALID", Retryable: true,
+			Message: "Evaluation processing failed.",
+		},
+		RetryAt: time.Now().UTC(), MaxAttempts: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RetryFailedSessionReport(
+		context.Background(), testUserB, testSessionA,
+	); !errors.Is(err, evaluation.ErrNotFound) {
+		t.Fatalf("other owner retry = %v", err)
+	}
+	retried, replayed, err := store.RetryFailedSessionReport(
+		context.Background(), testUserA, testSessionA,
+	)
+	if err != nil || replayed || retried.Status != evaluation.JobQueued ||
+		retried.AttemptCount != 0 || retried.Error != nil ||
+		retried.StartedAt != nil || retried.FinishedAt != nil {
+		t.Fatalf("retried = %#v, replayed=%t, err=%v", retried, replayed, err)
+	}
+	replay, replayed, err := store.RetryFailedSessionReport(
+		context.Background(), testUserA, testSessionA,
+	)
+	if err != nil || !replayed || replay.Status != evaluation.JobQueued ||
+		replay.AttemptCount != 0 || replay.ID != retried.ID {
+		t.Fatalf("queued replay = %#v, replayed=%t, err=%v", replay, replayed, err)
+	}
+	reclaimed, err := store.ClaimNext(context.Background(), sessionLane(1))
+	if err != nil || reclaimed.ID != retried.ID || reclaimed.AttemptCount != 1 {
+		t.Fatalf("reclaimed = %#v, err=%v", reclaimed, err)
+	}
+	running, replayed, err := store.RetryFailedSessionReport(
+		context.Background(), testUserA, testSessionA,
+	)
+	if err != nil || !replayed || running.Status != evaluation.JobRunning ||
+		running.AttemptCount != 1 || running.LeaseToken != reclaimed.LeaseToken {
+		t.Fatalf("running replay = %#v, replayed=%t, err=%v", running, replayed, err)
+	}
+	if err := store.FailClaim(context.Background(), evaluation.Failure{
+		UserID: testUserA, ID: reclaimed.ID, LeaseToken: reclaimed.LeaseToken,
+		Error: evaluation.JobError{
+			Code: "INVALID_EVALUATION_INPUT", Retryable: false,
+			Message: "Evaluation processing failed.",
+		},
+		RetryAt: time.Now().UTC(), MaxAttempts: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RetryFailedSessionReport(
+		context.Background(), testUserA, testSessionA,
+	); !errors.Is(err, evaluation.ErrRetryNotAllowed) {
+		t.Fatalf("non-retryable failure retry = %v", err)
+	}
+}
+
 func TestStoreSessionAcousticsExposePendingFailedAndAssessed(t *testing.T) {
 	pool := evaluationTestDatabase(t)
 	insertEvaluationTestUser(t, pool, testUserA, "evaluation-acoustic@example.com")
@@ -421,6 +492,66 @@ func speechLane(maxAttempts int) evaluation.ClaimLane {
 	return evaluation.ClaimLane{
 		Kinds:         []evaluation.Kind{evaluation.KindPracticeTurnFeedback},
 		LeaseDuration: 30 * time.Second, MaxAttempts: maxAttempts,
+	}
+}
+
+func sessionLane(maxAttempts int) evaluation.ClaimLane {
+	return evaluation.ClaimLane{
+		Kinds:         []evaluation.Kind{evaluation.KindSessionReport},
+		LeaseDuration: 30 * time.Second, MaxAttempts: maxAttempts,
+	}
+}
+
+func sessionQueueCommand(
+	t *testing.T,
+	userID string,
+	sessionID string,
+) evaluation.QueueCommand {
+	t.Helper()
+	now := time.Now().UTC().Add(-time.Second)
+	input, inputHash, err := evaluation.EncodeStrict(evaluation.SessionInputSnapshot{
+		SchemaVersion:       evaluation.SessionInputSchemaVersion,
+		SessionID:           sessionID,
+		SessionVersion:      1,
+		EvaluationPolicyRef: evaluation.IELTSSpeakingPracticeEvaluationPolicyRef,
+		PracticeExperience:  "IELTS_SPEAKING",
+		SceneCategory:       "IELTS_SPEAKING",
+		PracticeMode:        "PART1",
+		CompletedAt:         now,
+		AcousticCapability:  evaluation.AcousticCapabilityNotConfigured,
+		PlanSnapshot:        []byte(`{}`),
+		Participants:        []byte(`[]`),
+		Questions: []evaluation.SessionEvidenceQuestion{{
+			ID: testQuestion, Position: 1, Text: "What music do you like?",
+			SpeakerParticipantID:    "examiner",
+			AddresseeParticipantIDs: []string{"candidate"},
+		}},
+		Turns: []evaluation.SessionEvidenceTurn{{
+			ID: testTurnA, Position: 1, QuestionID: testQuestion,
+			RespondentParticipantID: "candidate",
+			Transcript:              "I enjoy music.", Effective: true, ConfirmedAt: now,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, lineageHash, err := evaluation.EncodeStrict(evaluation.ConfigLineage{
+		SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
+		StrategyRef:     evaluation.IELTSStrategyRef,
+		PipelineVersion: "session-evaluation/v1",
+		PromptVersion:   "ielts-speaking/v2",
+		ResultSchema:    "formal-report/v1",
+		Provider:        "qianwen", Model: "qwen-plus",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return evaluation.QueueCommand{
+		UserID: userID, Kind: evaluation.KindSessionReport,
+		SourceID: sessionID, ContextID: sessionID,
+		InputSnapshot: input, InputHash: inputHash,
+		ConfigLineage: lineage, ConfigHash: lineageHash,
+		AvailableAt: now,
 	}
 }
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -735,7 +735,7 @@ const generalSystemPromptV2 = `You are an evidence-bound everyday or workplace E
 
 func (failure providerResponseFailure) Error() string          { return failure.message }
 func (failure providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
-func (failure providerResponseFailure) Retryable() bool        { return false }
+func (failure providerResponseFailure) Retryable() bool        { return true }
 
 type providerResponseFailure struct{ message string }
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -3,6 +3,7 @@ package sessionevaluation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -13,6 +14,18 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/report"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
 )
+
+func TestInvalidProviderReportRemainsRetryableAtTheJobBoundary(t *testing.T) {
+	var failure interface {
+		StableCategory() string
+		Retryable() bool
+	}
+	if !errors.As(ErrProviderResponse, &failure) ||
+		failure.StableCategory() != "PROVIDER_RESPONSE_INVALID" ||
+		!failure.Retryable() {
+		t.Fatalf("provider response failure = %#v", failure)
+	}
+}
 
 func TestIELTSEvaluatorUsesAssessedAcousticsForPronunciation(t *testing.T) {
 	generator := &reportGeneratorFake{}

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -21,6 +21,27 @@ func (acousticDependencyFailure) StableCategory() string {
 }
 func (acousticDependencyFailure) Retryable() bool { return false }
 
+type processingFailure struct {
+	record  Record
+	failure JobError
+	cause   error
+}
+
+func (failure *processingFailure) Error() string { return failure.cause.Error() }
+func (failure *processingFailure) Unwrap() error { return failure.cause }
+func (failure *processingFailure) EvaluationID() string {
+	return failure.record.ID
+}
+func (failure *processingFailure) EvaluationKind() Kind {
+	return failure.record.Kind
+}
+func (failure *processingFailure) EvaluationAttemptCount() int {
+	return failure.record.AttemptCount
+}
+func (failure *processingFailure) EvaluationJobError() JobError {
+	return failure.failure
+}
+
 type SessionEvaluators interface {
 	EvaluateInterview(context.Context, Record, SessionInputSnapshot, ConfigLineage) (json.RawMessage, error)
 	EvaluateIELTS(context.Context, Record, SessionInputSnapshot, ConfigLineage) (json.RawMessage, error)
@@ -422,6 +443,9 @@ func (worker *Worker) complete(
 
 func (worker *Worker) fail(ctx context.Context, claim Claim, cause error) error {
 	failure := stableJobError(cause)
+	processing := &processingFailure{
+		record: claim.Record, failure: failure, cause: cause,
+	}
 	finalizeContext, cancel := worker.finalizeContext(ctx)
 	defer cancel()
 	err := worker.store.FailClaim(finalizeContext, Failure{
@@ -433,9 +457,9 @@ func (worker *Worker) fail(ctx context.Context, claim Claim, cause error) error 
 		MaxAttempts: maxAttemptsFor(claim.Kind, worker.configuration),
 	})
 	if err != nil {
-		return errors.Join(cause, err)
+		return errors.Join(processing, err)
 	}
-	return cause
+	return processing
 }
 
 func (worker *Worker) finalizeContext(ctx context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
## 功能描述

修复雅思/面试 Session Report 在 provider 输出未通过契约校验后永久 FAILED、移动端“重新加载”却只 GET 同一终态资源的问题。

- PROVIDER_RESPONSE_INVALID 进入现有最多 3 次任务重试。
- 失败日志增加 evaluation_id、kind、attempt_count、failure_code、retryable，不记录原始对话或 provider 输出。
- 新增 actor-owned Session Evaluation retry 命令，原子重置同一 evaluation；重复请求只回放 QUEUED/RUNNING/READY。
- 移动端只对 retryable FAILED 显示“重新生成报告”，点击后真实重新入队并继续轮询。

## 实现思路

复用现有 Evaluation 状态机和唯一键，不增加平行任务表。Postgres 在 user + evaluation 行锁内完成 FAILED -> QUEUED 重置；非本人返回 404，非 retryable failure 返回 409。API 使用 session source 路径，避免恢复已退役的通用 re-evaluate 接口。

## 可复现测试

- Go：go vet ./...
- Go：go test -count=1 ./...
- Go coverage：44.7% statements
- Flutter：flutter analyze --no-pub
- Flutter：flutter test --no-pub（716 passed）
- API：npm run check
- 格式：gofmt + dart format + git diff --check

关键回归覆盖：malformed provider report 标记可重试；FAILED 原子重入队；跨用户隔离；重复点击不重置运行中任务；非 retryable 不显示按钮；POST 202/200 客户端解码与页面轮询。

Closes #795