### PR TITLE
ci(coverage): 在 PR 中报告并守护 Flutter 覆盖率

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -34,12 +34,16 @@ jobs:
                 per_page: 100,
               },
             );
-            if (!currentArtifacts.some(
+            const currentGoAvailable = currentArtifacts.some(
               (artifact) => artifact.name === "go-coverage-server",
-            )) {
-              core.warning("PR run has no Go coverage artifact; comment skipped");
+            );
+            const currentFlutterAvailable = currentArtifacts.some(
+              (artifact) => artifact.name === "flutter-coverage-mobile",
+            );
+            if (!currentGoAvailable && !currentFlutterAvailable) {
+              core.warning("PR run has no coverage artifacts; comment skipped");
               core.setOutput("available", "false");
-              core.setOutput("reason", "current Go coverage artifact is unavailable");
+              core.setOutput("reason", "current coverage artifacts are unavailable");
               return;
             }
 
@@ -93,10 +97,17 @@ jobs:
               },
             );
 
-            let baseline = null;
+            let goBaseline = null;
+            let flutterBaseline = null;
             for (const candidate of runs.filter(
               (item) => item.conclusion === "success",
             )) {
+              if (
+                (!currentGoAvailable || goBaseline) &&
+                (!currentFlutterAvailable || flutterBaseline)
+              ) {
+                break;
+              }
               const artifacts = await github.paginate(
                 github.rest.actions.listWorkflowRunArtifacts,
                 {
@@ -106,25 +117,61 @@ jobs:
                   per_page: 100,
                 },
               );
-              if (artifacts.some(
-                (artifact) => artifact.name === "go-coverage-server",
-              )) {
-                baseline = candidate;
-                break;
+              if (
+                currentGoAvailable &&
+                !goBaseline &&
+                artifacts.some(
+                  (artifact) => artifact.name === "go-coverage-server",
+                )
+              ) {
+                goBaseline = candidate;
+              }
+              if (
+                currentFlutterAvailable &&
+                !flutterBaseline &&
+                artifacts.some(
+                  (artifact) => artifact.name === "flutter-coverage-mobile",
+                )
+              ) {
+                flutterBaseline = candidate;
               }
             }
 
-            if (!baseline) {
+            if (currentGoAvailable && !goBaseline) {
               core.warning(
-                "Base branch has no successful Go coverage artifact; comment skipped",
+                "Base branch has no successful Go coverage artifact; Go comparison omitted",
               );
+            }
+            if (currentFlutterAvailable && !flutterBaseline) {
+              core.warning(
+                "Base branch has no successful Flutter coverage artifact; Flutter comparison omitted",
+              );
+            }
+
+            const goAvailable = currentGoAvailable && Boolean(goBaseline);
+            const flutterAvailable =
+              currentFlutterAvailable && Boolean(flutterBaseline);
+            if (!goAvailable && !flutterAvailable) {
               core.setOutput("available", "false");
-              core.setOutput("reason", "base branch coverage baseline is unavailable");
+              core.setOutput(
+                "reason",
+                "comparable base branch coverage artifacts are unavailable",
+              );
               return;
             }
 
             core.setOutput("available", "true");
-            core.setOutput("baseline_run_id", String(baseline.id));
+            core.setOutput("go_available", String(goAvailable));
+            core.setOutput("flutter_available", String(flutterAvailable));
+            if (goBaseline) {
+              core.setOutput("go_baseline_run_id", String(goBaseline.id));
+            }
+            if (flutterBaseline) {
+              core.setOutput(
+                "flutter_baseline_run_id",
+                String(flutterBaseline.id),
+              );
+            }
             core.setOutput("base_branch", pullRequest.base.ref);
             core.setOutput("pull_request_number", String(pullRequest.number));
 
@@ -135,21 +182,39 @@ jobs:
         run: echo "Coverage comment skipped because ${SKIP_REASON}."
 
       - name: Download current Go coverage
-        if: steps.context.outputs.available == 'true'
+        if: steps.context.outputs.go_available == 'true'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
-          path: coverage/current
+          path: coverage/current/go
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
       - name: Download baseline Go coverage
-        if: steps.context.outputs.available == 'true'
+        if: steps.context.outputs.go_available == 'true'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: go-coverage-server
-          path: coverage/baseline
-          run-id: ${{ steps.context.outputs.baseline_run_id }}
+          path: coverage/baseline/go
+          run-id: ${{ steps.context.outputs.go_baseline_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download current Flutter coverage
+        if: steps.context.outputs.flutter_available == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: flutter-coverage-mobile
+          path: coverage/current/flutter
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download baseline Flutter coverage
+        if: steps.context.outputs.flutter_available == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: flutter-coverage-mobile
+          path: coverage/baseline/flutter
+          run-id: ${{ steps.context.outputs.flutter_baseline_run_id }}
           github-token: ${{ github.token }}
 
       - name: Create or update PR coverage comment
@@ -157,6 +222,8 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BASE_BRANCH: ${{ steps.context.outputs.base_branch }}
+          FLUTTER_AVAILABLE: ${{ steps.context.outputs.flutter_available }}
+          GO_AVAILABLE: ${{ steps.context.outputs.go_available }}
           PULL_REQUEST_NUMBER: ${{ steps.context.outputs.pull_request_number }}
         with:
           script: |
@@ -167,17 +234,38 @@ jobs:
               "github.com/1024XEngineer/XE3-ESL/server/";
             const maxFiles = 5;
 
-            function displayPath(source) {
+            function displayGoPath(source) {
               if (source.startsWith(modulePrefix)) {
                 return `server/${source.slice(modulePrefix.length)}`;
               }
               return `server/${source}`;
             }
 
-            function readCoverage(profilePath) {
+            function displayFlutterPath(source) {
+              const normalized = source.replaceAll("\\", "/");
+              const mobileMarker = "/mobile/";
+              const mobileOffset = normalized.lastIndexOf(mobileMarker);
+              if (mobileOffset >= 0) {
+                return `mobile/${normalized.slice(
+                  mobileOffset + mobileMarker.length,
+                )}`;
+              }
+              if (normalized.startsWith("mobile/")) return normalized;
+              return `mobile/${normalized}`;
+            }
+
+            function emptyStats() {
+              return { totalUnits: 0, coveredUnits: 0 };
+            }
+
+            function addUnit(stats, units, covered) {
+              stats.totalUnits += units;
+              stats.coveredUnits += covered;
+            }
+
+            function readGoCoverage(profilePath) {
               const files = new Map();
-              let totalStatements = 0;
-              let coveredStatements = 0;
+              const total = emptyStats();
               const content = fs.readFileSync(profilePath, "utf8");
 
               for (const line of content.split(/\r?\n/)) {
@@ -188,29 +276,51 @@ jobs:
                 );
                 if (!match) continue;
 
-                const file = displayPath(match[1]);
+                const file = displayGoPath(match[1]);
                 const statements = Number(match[2]);
                 const hits = Number(match[3]);
                 const covered = hits > 0 ? statements : 0;
-                totalStatements += statements;
-                coveredStatements += covered;
+                addUnit(total, statements, covered);
 
-                const current = files.get(file) ?? {
-                  totalStatements: 0,
-                  coveredStatements: 0,
-                };
-                current.totalStatements += statements;
-                current.coveredStatements += covered;
+                const current = files.get(file) ?? emptyStats();
+                addUnit(current, statements, covered);
                 files.set(file, current);
               }
 
-              return { files, totalStatements, coveredStatements };
+              return { files, total };
+            }
+
+            function readFlutterCoverage(reportPath) {
+              const files = new Map();
+              const total = emptyStats();
+              const content = fs.readFileSync(reportPath, "utf8");
+              let activeFile = null;
+
+              for (const line of content.split(/\r?\n/)) {
+                if (line.startsWith("SF:")) {
+                  activeFile = displayFlutterPath(line.slice(3));
+                  continue;
+                }
+                if (!activeFile || !line.startsWith("DA:")) continue;
+
+                const fields = line.slice(3).split(",");
+                const hits = Number(fields[1]);
+                if (!Number.isFinite(hits)) continue;
+
+                const covered = hits > 0 ? 1 : 0;
+                addUnit(total, 1, covered);
+                const current = files.get(activeFile) ?? emptyStats();
+                addUnit(current, 1, covered);
+                files.set(activeFile, current);
+              }
+
+              return { files, total };
             }
 
             function percent(stats) {
-              return stats.totalStatements === 0
+              return stats.totalUnits === 0
                 ? 0
-                : (stats.coveredStatements / stats.totalStatements) * 100;
+                : (stats.coveredUnits / stats.totalUnits) * 100;
             }
 
             function formatPercent(value) {
@@ -222,49 +332,77 @@ jobs:
               return `${rounded >= 0 ? "+" : ""}${rounded.toFixed(1)}%`;
             }
 
-            const current = readCoverage(
-              path.join("coverage", "current", "coverage.out"),
-            );
-            const baseline = readCoverage(
-              path.join("coverage", "baseline", "coverage.out"),
-            );
-            const currentTotal = percent(current);
-            const baselineTotal = percent(baseline);
-            const totalDelta = currentTotal - baselineTotal;
+            function escapeCell(value) {
+              return value.replaceAll("|", "\\|").replace(/[\r\n]+/g, " ");
+            }
 
             const bodyLines = [
               marker,
-              "## Go coverage",
+              "## Test coverage",
               "",
               "| Scope | Current | Baseline | Delta |",
               "| --- | ---: | ---: | ---: |",
-              `| server | ${formatPercent(currentTotal)} | ` +
-                `${formatPercent(baselineTotal)} | ${formatDelta(totalDelta)} |`,
-              `| **Total** | **${formatPercent(currentTotal)}** | ` +
-                `**${formatPercent(baselineTotal)}** | ` +
-                `**${formatDelta(totalDelta)}** |`,
             ];
 
-            const lowFiles = [];
-            for (const [file, currentFile] of current.files) {
-              const baselineFile = baseline.files.get(file);
-              if (!baselineFile) continue;
+            const scopes = [];
+            if (process.env.GO_AVAILABLE === "true") {
+              scopes.push({
+                name: "server (Go)",
+                current: readGoCoverage(
+                  path.join("coverage", "current", "go", "coverage.out"),
+                ),
+                baseline: readGoCoverage(
+                  path.join("coverage", "baseline", "go", "coverage.out"),
+                ),
+              });
+            }
+            if (process.env.FLUTTER_AVAILABLE === "true") {
+              scopes.push({
+                name: "mobile (Flutter)",
+                current: readFlutterCoverage(
+                  path.join("coverage", "current", "flutter", "lcov.info"),
+                ),
+                baseline: readFlutterCoverage(
+                  path.join("coverage", "baseline", "flutter", "lcov.info"),
+                ),
+              });
+            }
 
-              const currentFilePercent = percent(currentFile);
-              const baselineFilePercent = percent(baselineFile);
-              const delta = currentFilePercent - baselineFilePercent;
-              if (Number(delta.toFixed(1)) < 0) {
-                lowFiles.push({
-                  file,
-                  current: currentFilePercent,
-                  baseline: baselineFilePercent,
-                  delta,
-                });
+            for (const scope of scopes) {
+              const currentTotal = percent(scope.current.total);
+              const baselineTotal = percent(scope.baseline.total);
+              bodyLines.push(
+                `| ${scope.name} | ${formatPercent(currentTotal)} | ` +
+                  `${formatPercent(baselineTotal)} | ` +
+                  `${formatDelta(currentTotal - baselineTotal)} |`,
+              );
+            }
+
+            const lowFiles = [];
+            for (const scope of scopes) {
+              for (const [file, currentFile] of scope.current.files) {
+                const baselineFile = scope.baseline.files.get(file);
+                if (!baselineFile) continue;
+
+                const currentFilePercent = percent(currentFile);
+                const baselineFilePercent = percent(baselineFile);
+                const delta = currentFilePercent - baselineFilePercent;
+                if (Number(delta.toFixed(1)) < 0) {
+                  lowFiles.push({
+                    scope: scope.name,
+                    file,
+                    current: currentFilePercent,
+                    baseline: baselineFilePercent,
+                    delta,
+                  });
+                }
               }
             }
             lowFiles.sort(
               (left, right) =>
-                left.delta - right.delta || left.file.localeCompare(right.file),
+                left.delta - right.delta ||
+                left.scope.localeCompare(right.scope) ||
+                left.file.localeCompare(right.file),
             );
 
             if (lowFiles.length > 0) {
@@ -274,12 +412,13 @@ jobs:
                 "",
                 `Showing up to ${maxFiles} largest file-level regressions.`,
                 "",
-                "| File | Current | Baseline | Delta |",
-                "| --- | ---: | ---: | ---: |",
+                "| Scope | File | Current | Baseline | Delta |",
+                "| --- | --- | ---: | ---: | ---: |",
               );
               for (const file of lowFiles.slice(0, maxFiles)) {
                 bodyLines.push(
-                  `| ${file.file} | ${formatPercent(file.current)} | ` +
+                  `| ${file.scope} | ${escapeCell(file.file)} | ` +
+                    `${formatPercent(file.current)} | ` +
                     `${formatPercent(file.baseline)} | ` +
                     `${formatDelta(file.delta)} |`,
                 );

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -119,8 +119,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pub-flutter-3.44.6-
 
-      - name: Check Flutter
-        run: make check-flutter
+      - name: Check Flutter and collect coverage
+        run: make check-flutter-coverage
+
+      - name: Upload Flutter coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: flutter-coverage-mobile
+          path: mobile/coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 14
 
   go:
     name: Go
@@ -328,6 +336,155 @@ jobs:
               );
             }
 
+  flutter-coverage-gate:
+    name: Flutter coverage gate
+    needs:
+      - changes
+      - flutter
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.flutter == 'true' &&
+      needs.flutter.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Download current Flutter coverage
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: flutter-coverage-mobile
+          path: coverage/current
+
+      - name: Resolve baseline run
+        id: baseline
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const baseBranch = context.payload.pull_request.base.ref;
+            const workflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const qualityWorkflow = workflows.find(
+              (workflow) => workflow.name === "Quality",
+            );
+            if (!qualityWorkflow) {
+              core.warning("Unable to find the Quality workflow; Flutter coverage gate skipped");
+              core.setOutput("available", "false");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: qualityWorkflow.id,
+                branch: baseBranch,
+                event: "push",
+                status: "completed",
+                per_page: 100,
+              },
+            );
+
+            let baseline = null;
+            for (const run of runs.filter(
+              (candidate) => candidate.conclusion === "success",
+            )) {
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100,
+                },
+              );
+              if (artifacts.some(
+                (artifact) => artifact.name === "flutter-coverage-mobile",
+              )) {
+                baseline = run;
+                break;
+              }
+            }
+
+            if (!baseline) {
+              core.warning(
+                "No successful Quality run has a Flutter coverage artifact; coverage gate skipped",
+              );
+              core.setOutput("available", "false");
+              return;
+            }
+
+            core.setOutput("run_id", String(baseline.id));
+            core.setOutput("available", "true");
+
+      - name: Explain missing Flutter coverage baseline
+        if: steps.baseline.outputs.available != 'true'
+        run: >-
+          echo "Flutter coverage gate skipped because the base branch has no
+          Flutter coverage artifact baseline yet."
+
+      - name: Download baseline Flutter coverage
+        if: steps.baseline.outputs.available == 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: flutter-coverage-mobile
+          path: coverage/baseline
+          run-id: ${{ steps.baseline.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Reject total Flutter coverage regression
+        if: steps.baseline.outputs.available == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            function readCoverage(reportPath) {
+              let totalLines = 0;
+              let coveredLines = 0;
+              const content = fs.readFileSync(reportPath, "utf8");
+
+              for (const line of content.split(/\r?\n/)) {
+                if (!line.startsWith("DA:")) continue;
+
+                const fields = line.slice(3).split(",");
+                const hits = Number(fields[1]);
+                if (!Number.isFinite(hits)) continue;
+
+                totalLines += 1;
+                coveredLines += hits > 0 ? 1 : 0;
+              }
+
+              return totalLines === 0
+                ? 0
+                : (coveredLines / totalLines) * 100;
+            }
+
+            const current = readCoverage(
+              path.join("coverage", "current", "lcov.info"),
+            );
+            const baseline = readCoverage(
+              path.join("coverage", "baseline", "lcov.info"),
+            );
+            const currentRounded = Number(current.toFixed(1));
+            const baselineRounded = Number(baseline.toFixed(1));
+
+            core.info(
+              `Current: ${current.toFixed(1)}%; baseline: ${baseline.toFixed(1)}%`,
+            );
+            if (currentRounded < baselineRounded) {
+              core.setFailed(
+                `Total Flutter coverage ${current.toFixed(1)}% is below baseline ` +
+                  `${baseline.toFixed(1)}%`,
+              );
+            }
+
   quality-gate:
     name: Quality gate
     needs:
@@ -336,6 +493,7 @@ jobs:
       - go
       - api
       - coverage-gate
+      - flutter-coverage-gate
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -347,7 +505,8 @@ jobs:
       GO_RESULT: ${{ needs.go.result }}
       API_REQUIRED: ${{ needs.changes.outputs.api }}
       API_RESULT: ${{ needs.api.result }}
-      COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
+      GO_COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
+      FLUTTER_COVERAGE_RESULT: ${{ needs.flutter-coverage-gate.result }}
     steps:
       - name: Require every selected check to pass
         shell: bash
@@ -392,11 +551,21 @@ jobs:
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
 
-          case "$COVERAGE_RESULT" in
-            success|skipped)
-              ;;
-            *)
-              echo "Coverage gate finished with unexpected result: $COVERAGE_RESULT"
-              exit 1
-              ;;
-          esac
+          require_coverage_result() {
+            local name=$1
+            local result=$2
+
+            case "$result" in
+              success|skipped)
+                ;;
+              *)
+                echo "$name finished with unexpected result: $result"
+                return 1
+                ;;
+            esac
+          }
+
+          require_coverage_result "Go coverage gate" "$GO_COVERAGE_RESULT"
+          require_coverage_result \
+            "Flutter coverage gate" \
+            "$FLUTTER_COVERAGE_RESULT"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ SHELL := /bin/bash
 	check-flutter-format \
 	check-flutter-analyze \
 	check-flutter-test \
+	check-flutter-coverage \
 	check-go \
 	check-go-coverage \
 	check-go-format \
@@ -30,6 +31,7 @@ help:
 		'SpeakUp quality checks:' \
 		'  make check          Run Flutter, Go, and API checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
+		'  make check-flutter-coverage  Run Flutter checks and write mobile/coverage/lcov.info' \
 		'  make check-go       Run Go format, vet, and test checks' \
 		'  make check-go-coverage  Run Go checks and write server/coverage.out' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
@@ -56,6 +58,9 @@ check-flutter-analyze: check-flutter-format
 
 check-flutter-test: check-flutter-analyze
 	cd mobile && flutter test --no-pub
+
+check-flutter-coverage: check-flutter-analyze
+	cd mobile && flutter test --no-pub --coverage
 
 check-go: check-go-test
 

--- a/server/internal/platform/media/vault_test.go
+++ b/server/internal/platform/media/vault_test.go
@@ -147,17 +147,22 @@ func TestTemporaryAudioVaultEnforcesCapacityAndExpiry(t *testing.T) {
 
 	deadline := time.Now().Add(time.Second)
 	for {
-		_, err := vault.Source(actor, first.ID)
-		if errors.Is(err, ErrTemporaryAudioNotFound) {
+		vault.mu.Lock()
+		_, exists := vault.entries[first.ID]
+		vault.mu.Unlock()
+		if !exists {
 			break
-		}
-		if err != nil {
-			t.Fatalf("source before expiry: %v", err)
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("temporary audio was not reaped")
 		}
 		time.Sleep(time.Millisecond)
+	}
+	if _, err := vault.Source(actor, first.ID); !errors.Is(
+		err,
+		ErrTemporaryAudioNotFound,
+	) {
+		t.Fatalf("source after expiry error = %v", err)
 	}
 	if _, err := vault.Capture(
 		context.Background(),


### PR DESCRIPTION
## 功能描述

- 让现有 Flutter Quality job 在同一次全量测试中生成并上传原生 LCOV Artifact，不重复运行测试。
- 为 Flutter 增加独立的目标分支 baseline 与回退门禁，按展示的 0.1 个百分点精度阻止覆盖率下降。
- 扩展现有唯一一条 PR 覆盖率评论：Go-only 显示 `server (Go)`，Flutter-only 显示 `mobile (Flutter)`，混合 PR 同时显示两行。
- 文件级回退表标明所属技术栈，并继续原地更新已有评论。
- 稳定临时音频后台过期回收测试，避免未改 Go 代码时总覆盖率在 44.5% / 44.6% 间随机波动。

## 实现思路

- 复用 Flutter 官方 `flutter test --coverage` 和现有全量测试入口，生成 `mobile/coverage/lcov.info`。
- Flutter 与 Go 分别解析原生格式、分别选择最近成功 baseline，不合成跨语言伪总覆盖率。
- 某一平台尚无 baseline 时只跳过该平台；另一平台仍可独立比较。
- 保持 PR Quality workflow 只读；写评论的 `workflow_run` 不 checkout、不执行 PR 代码，并继续使用原有 marker 避免产生第二条评论。
- 临时音频测试只观察内部条目是否被后台 reaper 删除，再验证公开 `Source` 结果；不再由轮询调用抢先完成清理。
- 不引入第三方覆盖率服务、依赖或密钥。

预期评论：

| Scope | Current | Baseline | Delta |
| --- | ---: | ---: | ---: |
| server (Go) | 44.6% | 44.6% | +0.0% |
| mobile (Flutter) | 76.3% | 76.3% | +0.0% |

首次合入后，`dev` push 会建立 Flutter baseline；负责写评论的安全工作流随下一次 `dev → main` 发布进入默认分支后，对后续 PR 自动生效。

## 可复现测试

- `make check-flutter-coverage`：通过；Flutter analyze 无问题，714 个测试通过，LCOV 为 76.3%（19,197 / 25,166 lines）。
- `make check-go-coverage`：通过；Go 全量测试与 vet 通过，总覆盖率 44.6%。
- `go test -count=1 -covermode=atomic -coverprofile=... ./internal/platform/media` 连续 10 次：通过；后台 reaper 三个语句块每次均命中。
- `make check-api`：通过。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/quality.yml .github/workflows/coverage-comment.yml`：通过。
- `git diff --check`：通过。
- 使用真实 Go profile 与 Flutter LCOV 离线执行评论脚本：Go-only、Flutter-only、混合三种输出正确。
- 使用合成的 100% baseline / 90% current LCOV 执行门禁脚本：正确失败并报告 `Total Flutter coverage 90.0% is below baseline 100.0%`。
- 将一个真实 Flutter 文件命中改为未命中后离线渲染：正确列出该文件的 Current、Baseline 与负 Delta。

## 范围

- 不修改生产代码；业务测试仅修正后台过期回收的观察方式，使覆盖率可重复。
- 不把 API 合约、数据库生命周期或人工流程测试伪装成代码覆盖率。
- 不生成独立静态图片作为门禁来源；GitHub PR 评论是可追溯的真实结果。

Closes #798
