### PR TITLE
test(ios): align IELTS simulator smoke with detail flow

### DIFF
--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -385,6 +385,14 @@ void main() {
 
     await _waitForPreparationTarget(
       tester,
+      target: find.byKey(const Key('ielts-set-detail')),
+      operation: 'open the IELTS Part 1 question set details',
+      timeout: const Duration(seconds: 20),
+    );
+    await _tapPracticeControl(tester, const Key('ielts-set-detail-start'));
+
+    await _waitForPreparationTarget(
+      tester,
       target: find.byKey(const Key('ielts-mock-page')),
       operation: 'create and open the IELTS Part 1 Practice Session',
       timeout: const Duration(seconds: 90),
@@ -419,15 +427,36 @@ void main() {
     );
 
     await tester.tap(find.byKey(const Key('ielts-mock-exit')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Save & exit'));
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('ielts-mock-exit-sheet')),
+      operation: 'open the IELTS exit confirmation',
+      timeout: const Duration(seconds: 10),
+    );
+    await _tapPracticeControl(tester, const Key('ielts-mock-save-and-exit'));
+    await _waitForPreparationTarget(
+      tester,
+      target: examHub,
+      operation: 'return to the practice hubs after ending the first session',
+      timeout: const Duration(seconds: 20),
+    );
+    await _scrollPreparationIntoView(tester, examHub);
+    await tester.tap(examHub);
     await _waitForPreparationTarget(
       tester,
       target: questionSet,
-      operation: 'return to IELTS Part 1 after ending the first session',
+      operation: 'reload IELTS Part 1 after ending the first session',
+      timeout: const Duration(seconds: 30),
+    );
+    await _scrollPreparationIntoView(tester, questionSet);
+    await tester.tap(questionSet);
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('ielts-set-detail')),
+      operation: 'reopen the IELTS Part 1 question set details',
       timeout: const Duration(seconds: 20),
     );
-    await tester.tap(questionSet);
+    await _tapPracticeControl(tester, const Key('ielts-set-detail-start'));
     await _waitUntil(tester, () {
       final currentSessionId =
           dependencies.practiceController.practiceSessionId;


### PR DESCRIPTION
## 功能描述

- 更新真实后端 iOS 冒烟测试，覆盖当前 IELTS 题组详情启动路径。
- 会话被服务端置为终态后，从训练入口重新进入 IELTS，并验证能够创建新的 Practice Session。
- 使用稳定 Key 操作退出确认，不再依赖旧英文按钮文案或 `pumpAndSettle()`。

## 实现思路

产品现在要求先打开 `ielts-set-detail`，再点击 `ielts-set-detail-start`。测试在首次启动和终态恢复后都沿同一路径操作。由于测试会直接将首个会话置为终态，退出时已无原题组上下文，因此按真实 UI 从四个训练入口重新进入考试训练。

本 PR 只修改集成测试，不修改产品逻辑。

## 可复现测试

- `flutter analyze --no-pub`
- `flutter test --no-pub test/coaching/preparation/preparation_hub_test.dart`（17/17）
- `SPEAKUP_DEV_PORT=18082 make test-ios-simulator-scenes`（真实 PostgreSQL、真实后端、iOS Simulator；通过）
- `git diff --check`

Fixes #805