### PR TITLE
fix(ci): allow one-time clean baseline release

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -89,22 +89,39 @@ jobs:
             server/migrations/000001_clean_baseline.down.sql
             server/migrations/000001_clean_baseline.up.sql
           )
+          migration_changes=$(
+            git diff --name-status "$BASE_SHA"...HEAD -- "server/migrations/*.sql"
+          )
           if (( ${#base_migrations[@]} > 2 )) &&
              [[ "${base_migrations[0]:-}" != "${clean_baseline[0]}" ]] &&
              [[ "${base_migrations[1]:-}" != "${clean_baseline[1]}" ]] &&
              [[ "${current_migrations[0]:-}" == "${clean_baseline[0]}" ]] &&
              [[ "${current_migrations[1]:-}" == "${clean_baseline[1]}" ]]; then
+            shared_migrations=$(
+              comm -12 \
+                <(printf '%s\n' "${base_migrations[@]}") \
+                <(printf '%s\n' "${current_migrations[@]}")
+            )
+            if [[ -n "$shared_migrations" ]]; then
+              echo "The clean baseline must fully replace the legacy migration history:"
+              echo "$shared_migrations"
+              exit 1
+            fi
+            invalid_changes=$(
+              printf '%s\n' "$migration_changes" |
+                awk '$1 !~ /^(A|D)$/ { print }'
+            )
             echo "Legacy migration history is being replaced by the clean baseline and its successors."
           else
             invalid_changes=$(
-              git diff --name-status "$BASE_SHA"...HEAD -- "server/migrations/*.sql" |
+              printf '%s\n' "$migration_changes" |
                 awk '$1 !~ /^A/ { print }'
             )
-            if [[ -n "$invalid_changes" ]]; then
-              echo "Merged SQL migrations are append-only:"
-              echo "$invalid_changes"
-              exit 1
-            fi
+          fi
+          if [[ -n "$invalid_changes" ]]; then
+            echo "Migration history policy rejected these changes:"
+            echo "$invalid_changes"
+            exit 1
           fi
 
       - name: Verify explicit migration lifecycle

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -90,8 +90,11 @@ jobs:
             server/migrations/000001_clean_baseline.up.sql
           )
           if (( ${#base_migrations[@]} > 2 )) &&
-             [[ "${current_migrations[*]}" == "${clean_baseline[*]}" ]]; then
-            echo "Legacy migration history is being replaced by the clean baseline."
+             [[ "${base_migrations[0]:-}" != "${clean_baseline[0]}" ]] &&
+             [[ "${base_migrations[1]:-}" != "${clean_baseline[1]}" ]] &&
+             [[ "${current_migrations[0]:-}" == "${clean_baseline[0]}" ]] &&
+             [[ "${current_migrations[1]:-}" == "${clean_baseline[1]}" ]]; then
+            echo "Legacy migration history is being replaced by the clean baseline and its successors."
           else
             invalid_changes=$(
               git diff --name-status "$BASE_SHA"...HEAD -- "server/migrations/*.sql" |


### PR DESCRIPTION
## 功能描述

- 允许本次 `dev → main` 发布把旧的 156 个历史迁移替换为 clean baseline 及其后续迁移。
- 保持 `dev` 以及 clean baseline 合入 `main` 之后的迁移历史为严格 append-only。
- 不修改任何 SQL、运行时代码或数据库升级策略。

## 实现思路

例外只在以下条件同时满足时生效：

1. PR 基分支仍是旧迁移历史，前两项不是 clean baseline；
2. 当前分支前两项是成对的 clean baseline；
3. 基分支迁移文件数量大于 2。

因此本次旧历史切换可以通过；而当前 `dev` 和未来更新后的 `main` 都以 clean baseline 开头，会继续进入原有 append-only 校验。迁移生命周期、PostgreSQL 测试和 Go vet 仍由后续步骤执行。

## 可复现测试

- `git diff --check`
- 已核对 `upstream/main`：156 个旧迁移文件，首项为 `000001_database_baseline.*`
- 已核对当前 `dev`：14 个迁移文件，首两项为 `000001_clean_baseline.down.sql` / `up.sql`
- 已验证 `main → 当前候选` 命中一次性切换，`dev → 当前分支` 回到原 append-only 分支

Fixes #806