### PR TITLE
test(ios): align Agent draft smoke entry

### DIFF
--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -712,7 +712,7 @@ Future<void> _registerOrSignIn(
   await tester.enterText(find.byType(TextFormField).at(1), password);
   await _tapAuthSubmit(tester, '登录');
   if (requireFocusedConversation) {
-    await _ensureFocusedConversation(tester);
+    await _ensureWritableConversation(tester);
   } else {
     await _waitUntil(
       tester,
@@ -1152,7 +1152,7 @@ Future<bool> _signedInAccountMatches(
     return false;
   }
   await _tapPrimaryTab(tester, 0);
-  await _ensureFocusedConversation(tester);
+  await _ensureWritableConversation(tester);
   return true;
 }
 
@@ -1180,23 +1180,22 @@ bool _composerIsReady(WidgetTester tester) {
   return tester.widget<TextField>(composer).enabled == true;
 }
 
-Future<void> _ensureFocusedConversation(WidgetTester tester) async {
-  final createConversation = find.byKey(
-    const Key('no-focused-create-conversation'),
-  );
+Future<void> _ensureWritableConversation(WidgetTester tester) async {
+  final showTextComposer = find.byKey(const Key('agent-show-text-composer'));
   await _waitUntil(
     tester,
     () =>
         find.byKey(const Key('agent-home-page')).evaluate().isNotEmpty &&
         (_composerIsReady(tester) ||
-            createConversation.hitTestable().evaluate().length == 1),
+            showTextComposer.hitTestable().evaluate().length == 1),
     const Duration(seconds: 20),
   );
   if (_composerIsReady(tester)) {
     return;
   }
 
-  await tester.tap(createConversation);
+  await tester.tap(showTextComposer);
+  await tester.pump();
   await _waitUntil(
     tester,
     () => _composerIsReady(tester),


### PR DESCRIPTION
## 功能描述

- 让真实 iOS Agent 冒烟等待当前“无 focused Thread 仍可写”的首页状态。
- 复用现有产品入口 `agent-show-text-composer` 打开折叠文本输入，再等待 composer 可写。
- 删除已下线的 `no-focused-create-conversation` 依赖。

## 实现思路

当前 Thread 在首次发送时物化，测试不再预先创建 Thread。改动仅位于 integration test helper，不修改产品运行时。

## 已验证

- `flutter analyze --no-pub`
- `flutter test --no-pub test/speak_up_app_test.dart`（33/33）
- 精确 Widget 行为 `no focused Thread presents a writable new conversation draft`
- 真实 PostgreSQL/后端/iOS QA 模拟器：注册、登录和真实 Qianwen Agent 响应已通过，测试继续推进到后续专业面试旧入口。
- `git diff --check`

## Draft 原因

宽口径脚本后续仍引用已下线的 `interview-mode-professional` 入口。本 PR 暂不合并，也不宣称完整 voice/Review E2E 已恢复；先用于开放 PR 场景下的 Coverage Comment 实测，并继续按 Issue #810 收口测试范围。

Refs #810