### PR TITLE
fix(ios): unify IELTS Part 3 completion flow

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -383,7 +383,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   IeltsMockPhase _initialPhase() => switch (_mode) {
     PracticeMode.fullMock || PracticeMode.part1 => IeltsMockPhase.part1,
     PracticeMode.part2 => IeltsMockPhase.part2Intro,
-    PracticeMode.part3 => IeltsMockPhase.part3Intro,
+    PracticeMode.part3 => IeltsMockPhase.part3,
     PracticeMode.fullSimulation ||
     PracticeMode.focus => throw StateError('Non-IELTS mode in IELTS practice.'),
   };
@@ -404,8 +404,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return value.copyWith(
         phase: completed >= widget.controller.turnLimit
             ? IeltsMockPhase.complete
-            : completed == 0 && value.phase == IeltsMockPhase.part3Intro
-            ? IeltsMockPhase.part3Intro
             : IeltsMockPhase.part3,
         clearPreparationDeadline: true,
         clearSpeakingStartedAt: true,
@@ -422,8 +420,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         );
       }
       if (completed >= _partEnd(IeltsSpeakingPart.part2)) {
-        if (value.phase == IeltsMockPhase.part3 ||
-            value.phase == IeltsMockPhase.part3Intro) {
+        if (value.phase == IeltsMockPhase.part3) {
           return value.copyWith(
             phase: value.phase,
             clearPreparationDeadline: true,
@@ -444,7 +441,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         IeltsMockPhase.part2Preparation => value.phase,
         IeltsMockPhase.part2Complete => IeltsMockPhase.part2Complete,
         IeltsMockPhase.part2Speaking ||
-        IeltsMockPhase.part3Intro ||
         IeltsMockPhase.part3 => IeltsMockPhase.part2Speaking,
         _ => IeltsMockPhase.part2Intro,
       };
@@ -460,7 +456,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (completed >= _partEnd(IeltsSpeakingPart.part2)) {
       final phase = switch (value.phase) {
         IeltsMockPhase.part3 => IeltsMockPhase.part3,
-        IeltsMockPhase.part3Intro => IeltsMockPhase.part3Intro,
         _ => IeltsMockPhase.part2Complete,
       };
       return value.copyWith(
@@ -470,8 +465,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         clearSpeakingDeadline: true,
       );
     }
-    if (value.phase == IeltsMockPhase.part3 ||
-        value.phase == IeltsMockPhase.part3Intro) {
+    if (value.phase == IeltsMockPhase.part3) {
       return value.copyWith(
         phase: IeltsMockPhase.part2Speaking,
         clearPreparationDeadline: true,
@@ -485,8 +479,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         IeltsMockPhase.part2Intro ||
         IeltsMockPhase.part2CueCard ||
         IeltsMockPhase.part2Preparation ||
-        IeltsMockPhase.part2Complete ||
-        IeltsMockPhase.part3Intro => value.phase,
+        IeltsMockPhase.part2Complete => value.phase,
         IeltsMockPhase.part2Speaking
             when _part2RetryNeeded ||
                 widget.controller.errorMessage != null ||
@@ -551,7 +544,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     _confirmPendingTranscript();
     if ((_progress?.phase == IeltsMockPhase.part2Speaking ||
             _progress?.phase == IeltsMockPhase.part2Complete ||
-            _progress?.phase == IeltsMockPhase.part3Intro ||
             _progress?.phase == IeltsMockPhase.part3) &&
         widget.controller.recordingState == PracticeRecordingState.idle &&
         widget.controller.hasPendingPracticeAudio &&
@@ -1437,8 +1429,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
   }
 
-  Future<void> _beginStandalonePart3() => _beginPart3();
-
   Future<void> _requestExit({
     IeltsPracticeRouteResult? result,
     bool fromCompletion = false,
@@ -1566,11 +1556,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       );
     }
     final complete = progress.phase == IeltsMockPhase.complete;
-    final keepPart1CompletionConversation = _keepsPart1CompletionInConversation(
-      progress,
-    );
+    final keepSectionCompletionConversation =
+        _keepsSectionCompletionInConversation(progress);
     final keepCompletedConversation =
-        _preserveCompletedConversation || keepPart1CompletionConversation;
+        _preserveCompletedConversation || keepSectionCompletionConversation;
     final showCompletionPage = complete && !keepCompletedConversation;
     final completionSheet = _completionSheet(progress);
     final stagePhase = complete && keepCompletedConversation
@@ -1675,7 +1664,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       child:
           progress.phase == IeltsMockPhase.complete &&
               (_preserveCompletedConversation ||
-                  _keepsPart1CompletionInConversation(progress))
+                  _keepsSectionCompletionInConversation(progress))
           ? _completedConversationPhase()
           : _buildPhase(progress),
     );
@@ -1688,18 +1677,19 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     IeltsMockPhase.part2Preparation ||
     IeltsMockPhase.part2Speaking ||
     IeltsMockPhase.part2Complete => 'IELTS · Part 2',
-    IeltsMockPhase.part3Intro || IeltsMockPhase.part3 => 'IELTS · Part 3',
+    IeltsMockPhase.part3 => 'IELTS · Part 3',
     _ => 'IELTS Speaking',
   };
 
   Widget? _completionSheet(IeltsMockProgress progress) {
-    if (_showCompletionSheet || _keepsPart1CompletionInConversation(progress)) {
+    if (_showCompletionSheet ||
+        _keepsSectionCompletionInConversation(progress)) {
       return _SectionCompletionSheet(
         title: _completionTitle,
         message: '${widget.controller.completedTurns} 道回答已保存',
         primaryLabel: switch (_mode) {
           PracticeMode.fullMock => '查看报告状态',
-          PracticeMode.part1 => '查看复盘报告',
+          PracticeMode.part1 || PracticeMode.part3 => '查看复盘报告',
           _ => '查看专项复盘',
         },
         secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
@@ -1733,8 +1723,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     return null;
   }
 
-  bool _keepsPart1CompletionInConversation(IeltsMockProgress progress) {
-    return _mode == PracticeMode.part1 &&
+  bool _keepsSectionCompletionInConversation(IeltsMockProgress progress) {
+    return (_mode == PracticeMode.part1 || _mode == PracticeMode.part3) &&
         progress.phase == IeltsMockPhase.complete;
   }
 
@@ -1767,8 +1757,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _openCompletedReview() {
-    if (_mode == PracticeMode.part1) {
-      unawaited(_openPart1Review());
+    if (_mode == PracticeMode.part1 || _mode == PracticeMode.part3) {
+      unawaited(_openSectionReview());
       return;
     }
     setState(() {
@@ -1777,19 +1767,28 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
   }
 
-  Future<void> _openPart1Review() async {
+  Future<void> _openSectionReview() async {
     if (_openingReadyReport) return;
     _openingReadyReport = true;
     try {
       await Navigator.of(context).push<void>(
         MaterialPageRoute<void>(
-          builder: (_) => _Part1ReviewPage(
+          builder: (_) => _SectionReviewPage(
             controller: widget.reportStatusController,
             answerCount: widget.controller.completedTurns,
+            title: switch (_mode) {
+              PracticeMode.part1 => 'Part 1 专项复盘',
+              PracticeMode.part3 => 'Part 3 专项复盘',
+              _ => throw StateError(
+                'Only Part 1 and Part 3 use the section review page.',
+              ),
+            },
           ),
         ),
       );
-      if (mounted && widget.controller.practiceMode == PracticeMode.part1) {
+      if (mounted &&
+          (widget.controller.practiceMode == PracticeMode.part1 ||
+              widget.controller.practiceMode == PracticeMode.part3)) {
         await _finishSection(IeltsPracticeCompletionAction.list);
       }
     } finally {
@@ -1867,7 +1866,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       IeltsMockPhase.part2CueCard ||
       IeltsMockPhase.part2Preparation ||
       IeltsMockPhase.part2Speaking => 'IELTS · Part 2',
-      IeltsMockPhase.part3Intro || IeltsMockPhase.part3 => 'IELTS · Part 3',
+      IeltsMockPhase.part3 => 'IELTS · Part 3',
       IeltsMockPhase.complete =>
         _mode == PracticeMode.fullMock ? 'IELTS 口语报告' : '练习完成',
       _ => 'IELTS Speaking',
@@ -1988,12 +1987,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             ? _retryPart2Confirmation
             : _retryPart2Transcription,
         onRerecord: _rerecordPart2,
-      ),
-      IeltsMockPhase.part3Intro => _Part3Intro(
-        topicTitle: _currentTopicTitle(),
-        cueCardPrompt: _currentCueCard(),
-        ready: _part2TurnConfirmed,
-        onPressed: _beginStandalonePart3,
       ),
       IeltsMockPhase.part3 => _conversationPhase(
         key: const Key('ielts-mock-part-3'),
@@ -2150,14 +2143,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     return 'Describe a skill you would like to learn.';
   }
-
-  String _currentTopicTitle() =>
-      _assignment.part(IeltsSpeakingPart.part2)?.topicTitle ??
-      _assignment.part(IeltsSpeakingPart.part3)?.topicTitle ??
-      (throw StateError('IELTS topic title is missing from the assignment.'));
-
-  String? _currentCueCard() =>
-      _assignment.part(IeltsSpeakingPart.part2)?.cueCard;
 
   bool get _completionOverlayVisible {
     final progress = _progress;

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_review.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_review.dart
@@ -1,16 +1,21 @@
 part of 'ielts_mock_practice.dart';
 
-class _Part1ReviewPage extends StatefulWidget {
-  const _Part1ReviewPage({required this.controller, required this.answerCount});
+class _SectionReviewPage extends StatefulWidget {
+  const _SectionReviewPage({
+    required this.controller,
+    required this.answerCount,
+    required this.title,
+  });
 
   final SessionEvaluationController? controller;
   final int answerCount;
+  final String title;
 
   @override
-  State<_Part1ReviewPage> createState() => _Part1ReviewPageState();
+  State<_SectionReviewPage> createState() => _SectionReviewPageState();
 }
 
-class _Part1ReviewPageState extends State<_Part1ReviewPage> {
+class _SectionReviewPageState extends State<_SectionReviewPage> {
   EvaluationReport? _report;
 
   @override
@@ -21,7 +26,7 @@ class _Part1ReviewPageState extends State<_Part1ReviewPage> {
   }
 
   @override
-  void didUpdateWidget(covariant _Part1ReviewPage oldWidget) {
+  void didUpdateWidget(covariant _SectionReviewPage oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller == widget.controller) return;
     oldWidget.controller?.removeListener(_handleStatusChanged);
@@ -74,8 +79,8 @@ class _Part1ReviewPageState extends State<_Part1ReviewPage> {
         status == SessionEvaluationStatus.failed ||
         controller?.errorMessage != null && controller?.isLoading != true;
     return Scaffold(
-      key: const Key('part1-review-loading-page'),
-      appBar: AppBar(title: const Text('Part 1 专项复盘')),
+      key: const Key('section-review-loading-page'),
+      appBar: AppBar(title: Text(widget.title)),
       body: SafeArea(
         top: false,
         child: Center(
@@ -84,14 +89,14 @@ class _Part1ReviewPageState extends State<_Part1ReviewPage> {
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 460),
               child: failed
-                  ? _Part1ReviewFailure(
+                  ? _SectionReviewFailure(
                       message: controller?.errorMessage ?? '本次复盘暂时无法生成。',
                       canRetry: controller?.canRetry == true,
                       onRetry: controller == null
                           ? null
                           : () => unawaited(controller.retry()),
                     )
-                  : _Part1ReviewLoading(answerCount: widget.answerCount),
+                  : _SectionReviewLoading(answerCount: widget.answerCount),
             ),
           ),
         ),
@@ -100,16 +105,16 @@ class _Part1ReviewPageState extends State<_Part1ReviewPage> {
   }
 }
 
-class _Part1ReviewLoading extends StatefulWidget {
-  const _Part1ReviewLoading({required this.answerCount});
+class _SectionReviewLoading extends StatefulWidget {
+  const _SectionReviewLoading({required this.answerCount});
 
   final int answerCount;
 
   @override
-  State<_Part1ReviewLoading> createState() => _Part1ReviewLoadingState();
+  State<_SectionReviewLoading> createState() => _SectionReviewLoadingState();
 }
 
-class _Part1ReviewLoadingState extends State<_Part1ReviewLoading>
+class _SectionReviewLoadingState extends State<_SectionReviewLoading>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animation = AnimationController(
     vsync: this,
@@ -132,7 +137,7 @@ class _Part1ReviewLoadingState extends State<_Part1ReviewLoading>
           builder: (context, _) {
             final pulse = (math.sin(_animation.value * math.pi * 2) + 1) / 2;
             return SizedBox(
-              key: const Key('part1-review-loading-animation'),
+              key: const Key('section-review-loading-animation'),
               width: 184,
               height: 184,
               child: Stack(
@@ -270,8 +275,8 @@ class _LoadingConnector extends StatelessWidget {
   }
 }
 
-class _Part1ReviewFailure extends StatelessWidget {
-  const _Part1ReviewFailure({
+class _SectionReviewFailure extends StatelessWidget {
+  const _SectionReviewFailure({
     required this.message,
     required this.canRetry,
     required this.onRetry,

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -460,7 +460,6 @@ class _CompletionStep extends StatelessWidget {
     required this.message,
     required this.buttonLabel,
     required this.onPressed,
-    this.buttonKey = const Key('ielts-mock-continue'),
     super.key,
   });
 
@@ -468,7 +467,6 @@ class _CompletionStep extends StatelessWidget {
   final String message;
   final String buttonLabel;
   final VoidCallback? onPressed;
-  final Key buttonKey;
 
   @override
   Widget build(BuildContext context) {
@@ -503,7 +501,7 @@ class _CompletionStep extends StatelessWidget {
               ),
               const SizedBox(height: 36),
               FilledButton(
-                key: buttonKey,
+                key: const Key('ielts-mock-continue'),
                 onPressed: onPressed,
                 style: FilledButton.styleFrom(
                   minimumSize: const Size.fromHeight(52),
@@ -916,36 +914,6 @@ class _Part2Transition extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _Part3Intro extends StatelessWidget {
-  const _Part3Intro({
-    required this.topicTitle,
-    required this.cueCardPrompt,
-    required this.ready,
-    required this.onPressed,
-  });
-
-  final String topicTitle;
-  final String? cueCardPrompt;
-  final bool ready;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return _CompletionStep(
-      key: const Key('ielts-part3-topic-intro'),
-      title: ready ? 'Part 3 Ready' : '正在进入 Part 3',
-      message:
-          '${cueCardPrompt == null ? 'Discussion topic' : 'This discussion continues the Part 2 topic'}:\n'
-          '$topicTitle'
-          '${cueCardPrompt == null ? '' : '\n\n$cueCardPrompt'}'
-          '${ready ? '' : '\n\n请先等待 Part 2 作答处理完成。'}',
-      buttonLabel: ready ? 'Start Part 3' : '正在准备第一个问题…',
-      buttonKey: const Key('ielts-part3-start'),
-      onPressed: ready ? onPressed : null,
     );
   }
 }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_progress_store.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_progress_store.dart
@@ -11,7 +11,6 @@ enum IeltsMockPhase {
   part2Preparation,
   part2Speaking,
   part2Complete,
-  part3Intro,
   part3,
   complete,
 }
@@ -93,10 +92,16 @@ final class IeltsMockProgress {
     final part2SpokenSeconds = value['part_2_spoken_seconds'];
     final notes = value['notes'];
     IeltsMockPhase? phase;
-    for (final item in IeltsMockPhase.values) {
-      if (item.name == phaseName) {
-        phase = item;
-        break;
+    if (phaseName == 'part3Intro') {
+      // Migrate checkpoints written before the redundant Part 3 ready page
+      // was removed. The server session remains the source of truth.
+      phase = IeltsMockPhase.part3;
+    } else {
+      for (final item in IeltsMockPhase.values) {
+        if (item.name == phaseName) {
+          phase = item;
+          break;
+        }
       }
     }
     if (sessionId != expectedSessionId ||

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -179,7 +179,7 @@ void main() {
     },
   );
 
-  testWidgets('Part 3 starts with an auto-playing visible text bubble', (
+  testWidgets('Part 3 opens directly with an auto-playing text bubble', (
     tester,
   ) async {
     final speaker = _ImmediateExaminerSpeaker();
@@ -210,12 +210,11 @@ void main() {
       ),
     );
     await tester.pump();
-    expect(speaker.spoken, isEmpty);
-
-    await tester.tap(find.byKey(const Key('ielts-part3-start')));
-    await tester.pump();
     await tester.pump();
 
+    expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
+    expect(find.text('Part 3 Ready'), findsNothing);
+    expect(find.text('Start Part 3'), findsNothing);
     expect(speaker.spoken, [_question(1).text]);
     expect(media.loadedPaths, isEmpty);
     expect(player.playCount, 0);
@@ -1511,6 +1510,48 @@ void main() {
     expect(find.byKey(const Key('open-section-completion')), findsOneWidget);
   });
 
+  testWidgets('Part 1 opens the shared section review page', (tester) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 3, turnLimit: 4);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await _answerCurrentShortQuestion(tester, controller);
+
+    expect(find.text('查看复盘报告'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const Key('section-review-loading-page')),
+      findsOneWidget,
+    );
+    expect(find.text('Part 1 专项复盘'), findsOneWidget);
+    expect(
+      find.byKey(const Key('section-review-loading-animation')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('the full-mock PracticeOption opens the three-part flow', (
     tester,
   ) async {
@@ -1850,8 +1891,6 @@ void main() {
       );
       await tester.pump();
 
-      await tester.tap(find.byKey(const Key('ielts-part3-start')));
-      await tester.pump();
       expect(find.text('0/1'), findsOneWidget);
 
       await _answerCurrentShortQuestion(tester, controller);
@@ -1863,6 +1902,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Part 3 已完成'), findsOneWidget);
+      expect(find.text('查看复盘报告'), findsOneWidget);
       expect(
         find.byKey(const Key('ielts-section-practice-complete-part3')),
         findsNothing,
@@ -1870,14 +1910,18 @@ void main() {
 
       await tester.tap(find.byKey(const Key('ielts-section-review-action')));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
 
       expect(
-        find.byKey(const Key('ielts-section-completion-sheet')),
-        findsNothing,
+        find.byKey(const Key('section-review-loading-page')),
+        findsOneWidget,
       );
+      expect(find.text('Part 3 专项复盘'), findsOneWidget);
+      expect(find.text('正在生成你的专项复盘'), findsOneWidget);
+      expect(find.text('正在整理 1 道回答，分析表达表现并生成下一步建议'), findsOneWidget);
       expect(
         find.byKey(const Key('ielts-section-practice-complete-part3')),
-        findsOneWidget,
+        findsNothing,
       );
     },
   );
@@ -1974,7 +2018,7 @@ void main() {
       (
         mode: PracticeMode.part3,
         turnLimit: 5,
-        expected: const Key('ielts-part3-topic-intro'),
+        expected: const Key('ielts-mock-part-3'),
       ),
     ]) {
       final practice = _IeltsPracticeClient(

--- a/mobile/test/coaching/practice/ielts_mock_progress_store_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_progress_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -71,5 +72,28 @@ void main() {
     ).writeAsString('{not-json');
 
     expect(await store.read('session-a'), isNull);
+  });
+
+  test('migrates the removed Part 3 intro checkpoint into practice', () async {
+    const sessionId = 'session-part-3';
+    await File('${directory.path}/ielts-mock-progress-v1.json').writeAsString(
+      jsonEncode(<String, Object?>{
+        'version': 1,
+        'sessions': <String, Object?>{
+          sessionId: <String, Object?>{
+            'session_id': sessionId,
+            'phase': 'part3Intro',
+            'started_at': '2026-08-21T07:00:00.000Z',
+            'part_2_spoken_seconds': 0,
+            'notes': '',
+          },
+        },
+      }),
+    );
+
+    final restored = await store.read(sessionId);
+
+    expect(restored, isNotNull);
+    expect(restored!.phase, IeltsMockPhase.part3);
   });
 }


### PR DESCRIPTION
## 功能描述

- IELTS Part 3 训练完成后复用 Part 1 的结束交互和专项复盘页面
- 删除无实际作用的 “Part 3 Ready / Start Part 3” 中间页，专项训练直接进入 Part 3
- 保留 Part 3 对话记录，并统一报告生成、失败重试与继续练习入口
- 兼容历史 part3Intro 本地进度，恢复时自动迁移到 Part 3

## 实现思路

- 将 Part 1 专项复盘页抽为可配置的 Section 复盘页，供 Part 1/Part 3 共用
- 移除 _Part3Intro 组件及其阶段分支
- 调整独立 Part 3 初始化与进度恢复逻辑，直接进入 Part 3
- 补充专项完成流程和旧进度迁移测试

## 可复现测试

    cd mobile
    flutter test --no-pub test/coaching/practice/ielts_mock_practice_test.dart test/coaching/practice/ielts_mock_progress_store_test.dart
    flutter analyze --no-pub

结果：
- 42 个测试全部通过
- Flutter analyze 无问题

Closes #811