### PR TITLE
fix(mobile): 练习退出后返回所属训练入口

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1436,6 +1436,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (_exitApproved || _exitPromptOpen || _exitInFlight || !mounted) {
       return;
     }
+    final exitMode = _mode;
     _exitPromptOpen = true;
     _part2TranscriptionRetryTimer?.cancel();
     _part2TranscriptionRetryTimer = null;
@@ -1493,14 +1494,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (!mounted) {
       return;
     }
-    final selection = _selection;
-    final shouldReturnToSectionList =
-        selection != null &&
-        _mode != PracticeMode.fullMock &&
-        (result == null || result.action == IeltsPracticeCompletionAction.list);
-    if (shouldReturnToSectionList) {
+    final shouldReturnToIeltsHub =
+        result == null || result.action == IeltsPracticeCompletionAction.list;
+    if (shouldReturnToIeltsHub) {
       widget.ieltsController?.requestNavigation(
-        IeltsPracticeNavigationRequest(mode: _mode),
+        IeltsPracticeNavigationRequest(mode: result?.mode ?? exitMode),
       );
     }
     _exitApproved = true;

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -24,6 +24,15 @@ import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 
 enum _PracticeHub { interview, ielts, workplace, life }
 
+_PracticeHub? _practiceHubForExperience(PracticeExperience? experience) =>
+    switch (experience) {
+      PracticeExperience.interview => _PracticeHub.interview,
+      PracticeExperience.ieltsSpeaking => _PracticeHub.ielts,
+      PracticeExperience.workplace => _PracticeHub.workplace,
+      PracticeExperience.lifeAndTravel => _PracticeHub.life,
+      null => null,
+    };
+
 enum ExistingPracticeAction { continuePractice, replace }
 
 typedef PracticeStartedCallback = FutureOr<void> Function();
@@ -300,6 +309,7 @@ class _PreparationPageState extends State<PreparationPage> {
       scenarioContext: scenarioContext,
     );
     if (started && mounted) {
+      final returnHub = _practiceHubForExperience(scene.experience);
       final bootstrap = launch.bootstrap;
       if (bootstrap != null && ieltsSelection != null) {
         await widget.ieltsController?.beginSession(
@@ -314,7 +324,7 @@ class _PreparationPageState extends State<PreparationPage> {
       }
       catalog.showSceneList();
       setState(() {
-        _selectedHub = null;
+        _selectedHub = returnHub;
         _launchingIeltsSelection = null;
       });
     }
@@ -324,6 +334,9 @@ class _PreparationPageState extends State<PreparationPage> {
     final started = await widget.launchController?.retry() ?? false;
     if (started && mounted) {
       final catalog = widget.preparationController;
+      final returnHub = _practiceHubForExperience(
+        catalog?.selectedScene?.experience,
+      );
       final bootstrap = widget.launchController?.bootstrap;
       final selection = _launchingIeltsSelection;
       if (catalog != null && bootstrap != null && selection != null) {
@@ -342,7 +355,7 @@ class _PreparationPageState extends State<PreparationPage> {
       }
       catalog?.showSceneList();
       setState(() {
-        _selectedHub = null;
+        _selectedHub = returnHub;
         _launchingIeltsSelection = null;
       });
     }
@@ -453,6 +466,11 @@ class _PreparationPageState extends State<PreparationPage> {
   Future<void> _continueCurrentPractice() async {
     final launch = widget.launchController;
     if (launch?.hasResumablePractice ?? false) {
+      final returnHub = _practiceHubForExperience(
+        PracticeExperience.fromWireValue(
+          launch?.resumablePracticeExperience ?? '',
+        ),
+      );
       final resumed = await launch!.resumeCurrentPractice();
       if (resumed && mounted) {
         await widget.onPracticeStarted?.call();
@@ -460,7 +478,7 @@ class _PreparationPageState extends State<PreparationPage> {
           return;
         }
         widget.preparationController?.showSceneList();
-        setState(() => _selectedHub = null);
+        setState(() => _selectedHub = returnHub);
       }
       return;
     }

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1630,7 +1630,7 @@ void main() {
     },
   );
 
-  testWidgets('save and exit returns from an in-progress full mock', (
+  testWidgets('save and exit returns an in-progress full mock to IELTS', (
     tester,
   ) async {
     final practice = _IeltsPracticeClient(initialCompleted: 0);
@@ -1638,7 +1638,11 @@ void main() {
       client: practice,
       recorder: _Recorder(),
     );
+    final preparation = IeltsPreparationController(
+      client: _UnusedQuestionBankClient(),
+    );
     addTearDown(controller.dispose);
+    addTearDown(preparation.dispose);
     await _activatePractice(controller, practice, _ieltsScene);
     var parkCalls = 0;
 
@@ -1653,9 +1657,10 @@ void main() {
                   builder: (_) => IeltsSpeakingMockPage(
                     controller: controller,
                     progressStore: _MemoryProgressStore(),
+                    ieltsController: preparation,
                     onExitRequested: () async {
                       parkCalls++;
-                      return true;
+                      return controller.parkPractice();
                     },
                   ),
                 ),
@@ -1684,6 +1689,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(parkCalls, 1);
+    expect(controller.practiceSessionId, isNull);
+    expect(preparation.takeNavigationRequest()?.mode, PracticeMode.fullMock);
     expect(find.byKey(const Key('open-mock')), findsOneWidget);
     expect(find.byKey(const Key('ielts-mock-page')), findsNothing);
   });

--- a/mobile/test/coaching/preparation/preparation_hub_test.dart
+++ b/mobile/test/coaching/preparation/preparation_hub_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import '../../support/scene_fixtures.dart';
+import '../../support/preparation_contract_fixtures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/design/speak_up_design.dart';
@@ -11,6 +14,14 @@ import 'package:speakup/features/coaching/ielts/ielts_question_bank_client.dart'
 import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dart';
 import 'package:speakup/features/coaching/ielts/ielts_catalog.dart';
 import 'package:speakup/features/coaching/ielts/ielts_set_detail.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/preparation/practice_launch_record_store.dart';
+import 'package:speakup/features/coaching/preparation/practice_workspace_controller.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_client.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_controller.dart';
+import 'package:speakup/features/coaching/preparation/preparation_launch_models.dart';
+import 'package:speakup/features/coaching/preparation/preparation_models.dart';
 
 void main() {
   testWidgets('shows exactly the four product-level practice entries', (
@@ -120,6 +131,144 @@ void main() {
 
     expect(find.byKey(const Key('ielts-browser-search')), findsOneWidget);
     expect(find.byKey(const Key('ielts-question-bank-retry')), findsNothing);
+  });
+
+  testWidgets('IELTS launch completion keeps the IELTS parent page', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _HubFixtureClient());
+    final ieltsController = IeltsPreparationController(
+      client: _HubQuestionBankClient(),
+    );
+    final practiceController = PracticeController(client: FakePracticeClient());
+    final workspaceController = PracticeWorkspaceController(
+      practiceController: practiceController,
+      recordStore: MemoryPracticeLaunchRecordStore(),
+    );
+    await workspaceController.activateAccount(contractUserId);
+    final launchController = PreparationLaunchController(
+      client: _HubLaunchClient(),
+      workspaceController: workspaceController,
+      voiceActivator:
+          ({
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+    );
+    final practiceOpened = Completer<void>();
+    final practiceClosed = Completer<void>();
+    addTearDown(controller.dispose);
+    addTearDown(ieltsController.dispose);
+    addTearDown(launchController.dispose);
+    addTearDown(workspaceController.dispose);
+    addTearDown(practiceController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: controller,
+          ieltsController: ieltsController,
+          practiceController: practiceController,
+          launchController: launchController,
+          onPracticeStarted: () async {
+            practiceOpened.complete();
+            await practiceClosed.future;
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _openModule(tester, const Key('practice-hub-exam'));
+
+    await tester.tap(find.byKey(const Key('ielts-mode-full')));
+    await tester.pump();
+    await practiceOpened.future;
+    ieltsController.requestNavigation(
+      const IeltsPracticeNavigationRequest(mode: PracticeMode.fullMock),
+    );
+    await tester.pump();
+    practiceClosed.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('practice-hub-title-ielts')), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mode-full')), findsOneWidget);
+    expect(find.byKey(const Key('practice-hub-carousel')), findsNothing);
+  });
+
+  testWidgets('scenario launch completion keeps its product parent page', (
+    tester,
+  ) async {
+    final controller = PreparationController(client: _HubFixtureClient());
+    final practiceController = PracticeController(client: FakePracticeClient());
+    final workspaceController = PracticeWorkspaceController(
+      practiceController: practiceController,
+      recordStore: MemoryPracticeLaunchRecordStore(),
+    );
+    await workspaceController.activateAccount(contractUserId);
+    final launchController = PreparationLaunchController(
+      client: _HubLaunchClient(),
+      workspaceController: workspaceController,
+      voiceActivator:
+          ({
+            required scene,
+            required bootstrap,
+            required clientOperationId,
+          }) async {},
+    );
+    final practiceOpened = Completer<void>();
+    final practiceClosed = Completer<void>();
+    addTearDown(controller.dispose);
+    addTearDown(launchController.dispose);
+    addTearDown(workspaceController.dispose);
+    addTearDown(practiceController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PreparationPage(
+          preparationController: controller,
+          practiceController: practiceController,
+          launchController: launchController,
+          onPracticeStarted: () async {
+            practiceOpened.complete();
+            await practiceClosed.future;
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _openModule(tester, const Key('practice-hub-workplace'));
+
+    final workplaceScene = find.byKey(
+      const Key('catalog-scene-scn_workplace_progress_risk_update'),
+    );
+    await tester.ensureVisible(workplaceScene);
+    await tester.pumpAndSettle();
+    await tester.tap(workplaceScene.hitTestable());
+    await tester.pump(const Duration(seconds: 1));
+    expect(
+      practiceOpened.isCompleted,
+      isTrue,
+      reason:
+          'scene=${controller.selectedScene?.id}, '
+          'detail=${controller.detail?.id}, '
+          'role=${controller.selectedRole?.id}, '
+          'option=${controller.selectedOption?.id}, '
+          'catalogError=${controller.errorMessage}, '
+          'launchError=${launchController.errorMessage}',
+    );
+    practiceClosed.complete();
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('practice-hub-title-workplace')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('catalog-scene-scn_workplace_progress_risk_update')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('practice-hub-carousel')), findsNothing);
   });
 
   testWidgets('opens the English interview module from the hub', (
@@ -627,9 +776,8 @@ Future<void> _showModule(WidgetTester tester, Key key) async {
 
 final class _HubFixtureClient implements SceneClient {
   @override
-  Future<SceneDefinition> getScene(String sceneId) {
-    throw UnimplementedError('The hub test does not open scene details.');
-  }
+  Future<SceneDefinition> getScene(String sceneId) async =>
+      _hubScenes.singleWhere((scene) => scene.id == sceneId);
 
   @override
   Future<List<SceneDefinition>> listScenes() async => _hubScenes;
@@ -638,6 +786,34 @@ final class _HubFixtureClient implements SceneClient {
   Future<List<RoleDefinition>> listRoles(String sceneId) {
     throw UnimplementedError('The hub test does not open scene details.');
   }
+}
+
+final class _HubLaunchClient implements PreparationLaunchClient {
+  @override
+  Future<PracticePlan> createPlan({
+    required CreatePracticePlanInput input,
+    required String idempotencyKey,
+  }) async => contractPlan();
+
+  @override
+  Future<PreparationPracticeBootstrap> createSession({
+    required PracticePlan plan,
+    required CreatePreparationSessionInput input,
+    required String idempotencyKey,
+  }) async => contractBootstrap(plan);
+
+  @override
+  Future<PracticePlan> getPlan(String planId) async => contractPlan();
+
+  @override
+  Future<PracticePlan> confirmPlan({
+    required String planId,
+    required int expectedVersion,
+    required String idempotencyKey,
+  }) async => contractPlan();
+
+  @override
+  Future<void> clearAccountState() async {}
 }
 
 final class _HubQuestionBankClient implements IeltsQuestionBankClient {
@@ -752,6 +928,21 @@ final _hubScenes = <SceneDefinition>[
     name: '进度与风险汇报',
     prompt: _hubPrompt('向直属领导汇报进展、风险和支持请求。'),
     version: 1,
+    practiceOptions: [
+      testPracticeOption(
+        id: 'option_workplace_full',
+        sceneId: 'scn_workplace_progress_risk_update',
+        mode: PracticeMode.fullSimulation,
+        displayName: '完整练习',
+      ),
+      testPracticeOption(
+        id: 'option_workplace_focus',
+        sceneId: 'scn_workplace_progress_risk_update',
+        mode: PracticeMode.focus,
+        displayName: '专项练习',
+        roleId: 'role-scn_workplace_progress_risk_update',
+      ),
+    ],
   ),
   testScene(
     id: 'scn_travel_hotel_checkin',


### PR DESCRIPTION
## 功能描述

- 练习退出后返回所属产品的上一级训练入口，而不是训练总首页。
- 英文面试、IELTS、职场英语、生活与旅行分别返回 Interview、IELTS、Workplace、Travel。
- IELTS 专项仍返回对应题单列表。
- 修复 IELTS 暂停清空控制器后再次读取模式导致的白色加载页。

## 实现思路

- 在 IELTS 退出动作开始时冻结 PracticeMode，避免 parkPractice 清空控制器后的时序读取。
- 统一发出 IELTS Hub/题单导航请求。
- 将 PracticeExperience 穷尽映射到四个产品 Hub，并在启动、重试和恢复练习的异步收尾阶段保留该上一级页面。

## 可复现测试

1. `cd mobile && flutter test --no-pub test/coaching/practice/ielts_mock_practice_test.dart test/coaching/preparation/preparation_hub_test.dart`
   - 57 tests passed.
2. `cd mobile && flutter analyze --no-pub`
   - No issues found.
3. 从当前任务 worktree 运行 `SPEAKUP_DEV_PORT=18081 make dev-ios-simulator`，使用真实后端且数字人禁用；确认 IELTS 练习退出后返回 IELTS 上一级，未再出现白屏。

Closes #814