### PR TITLE
fix(mobile): open Agent interview history plans

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -212,7 +212,20 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
 
   Future<void> _openSavedInterviewPlan(String planId) async {
     final controller = widget.jobPreparationController;
-    if (controller == null || !await controller.openSavedPlan(planId)) {
+    if (controller == null) {
+      return;
+    }
+    final opened = await controller.openSavedPlan(planId);
+    if (!mounted) return;
+    if (!opened) {
+      final navigatorContext = _navigatorKey.currentContext;
+      if (navigatorContext != null && navigatorContext.mounted) {
+        ScaffoldMessenger.of(navigatorContext)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(content: Text(controller.errorMessage ?? '暂时无法打开这场模拟面试。')),
+          );
+      }
       return;
     }
     _navigatorKey.currentState?.pushNamed(AppRoutes.jobPreparation);

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -250,9 +250,14 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
 
   Future<void> _openInterviewPlan(String planId) async {
     final controller = widget.jobPreparationController;
-    if (controller == null ||
-        !await controller.openSavedPlan(planId) ||
-        !mounted) {
+    if (controller == null) {
+      _showMockNotice('岗位准备流程尚未连接');
+      return;
+    }
+    final opened = await controller.openSavedPlan(planId);
+    if (!mounted) return;
+    if (!opened) {
+      _showMockNotice(controller.errorMessage ?? '暂时无法打开这场模拟面试。');
       return;
     }
     Navigator.of(context).pushNamed(AppRoutes.jobPreparation);

--- a/mobile/lib/features/coaching/interview/job_preparation_controller.dart
+++ b/mobile/lib/features/coaching/interview/job_preparation_controller.dart
@@ -61,6 +61,7 @@ final class JobPreparationController extends ChangeNotifier {
   String? _regeneratePreparationKey;
   String? _confirmPreparationKey;
   String? _planKey;
+  String? _savedPlanConfirmationKey;
   String? _sessionKey;
   String? _voiceKey;
   String? _workspaceKey;
@@ -153,17 +154,21 @@ final class JobPreparationController extends ChangeNotifier {
       final plan = await client.getPlan(planId);
       _requireCurrent(operationEpoch, _input);
       final interview = plan.preparationSnapshot.interview;
-      if (plan.status != PracticePlanStatus.ready ||
+      final openableStatus =
+          plan.status == PracticePlanStatus.ready ||
+          (plan.status == PracticePlanStatus.draft && interview == null);
+      if (!openableStatus ||
           plan.sceneSelection.scene.experience !=
-              PracticeExperience.interview ||
-          interview == null) {
+              PracticeExperience.interview) {
         throw const JobPreparationException(
           kind: JobPreparationFailureKind.invalidResponse,
           stage: JobPreparationOperationStage.plan,
         );
       }
-      _input = interview.input;
-      _candidate = interview.candidate;
+      if (interview != null) {
+        _input = interview.input;
+        _candidate = interview.candidate;
+      }
       _plan = plan;
       _openedSavedPlan = true;
       _errorMessage = null;
@@ -445,7 +450,7 @@ final class JobPreparationController extends ChangeNotifier {
   }
 
   Future<bool> startPractice() async {
-    final plan = _plan;
+    var plan = _plan;
     if (_disposed || isBusy || plan == null) return false;
     final operationEpoch = _epoch;
     var workspaceOperationId = _workspaceLease?.operationId;
@@ -494,6 +499,29 @@ final class JobPreparationController extends ChangeNotifier {
       }
       _workspaceLease = lease;
       _requireCurrent(operationEpoch, _input);
+      if (plan.status == PracticePlanStatus.draft) {
+        final confirmedPlan = await client.confirmPlan(
+          planId: plan.id,
+          expectedVersion: plan.version,
+          idempotencyKey: _savedPlanConfirmationKey ??= _newId(
+            'interview-plan-confirmation',
+          ),
+        );
+        _requireCurrent(operationEpoch, _input);
+        if (confirmedPlan.id != plan.id ||
+            confirmedPlan.version != plan.version + 1 ||
+            confirmedPlan.status != PracticePlanStatus.ready ||
+            confirmedPlan.sceneSelection.scene.experience !=
+                PracticeExperience.interview) {
+          throw const JobPreparationException(
+            kind: JobPreparationFailureKind.conflict,
+            stage: JobPreparationOperationStage.session,
+            retryable: true,
+          );
+        }
+        plan = confirmedPlan;
+        _plan = confirmedPlan;
+      }
       final bootstrap =
           _bootstrap ??
           await client.createSession(
@@ -634,6 +662,7 @@ final class JobPreparationController extends ChangeNotifier {
     _regeneratePreparationKey = null;
     _confirmPreparationKey = null;
     _planKey = null;
+    _savedPlanConfirmationKey = null;
     _sessionKey = null;
     _voiceKey = null;
     _workspaceKey = null;

--- a/mobile/test/coaching/preparation/job_preparation_controller_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_controller_test.dart
@@ -61,6 +61,48 @@ void main() {
     },
   );
 
+  test(
+    'saved Agent interview Plan opens without an Interview Preparation snapshot',
+    () async {
+      final harness = await _Harness.create(
+        savedPlan: contractPlan(includeInterview: false),
+      );
+      addTearDown(harness.dispose);
+
+      expect(await harness.controller.openSavedPlan(contractPlanId), isTrue);
+      expect(harness.controller.openedSavedPlan, isTrue);
+      expect(harness.controller.plan?.id, contractPlanId);
+      expect(harness.controller.candidate, isNull);
+      expect(await harness.controller.startPractice(), isTrue);
+      expect(harness.client.sessionInputs.single.expectedPlanVersion, 1);
+      expect(harness.practice.practicePlanId, contractPlanId);
+    },
+  );
+
+  test(
+    'saved draft Agent interview Plan is confirmed before starting',
+    () async {
+      final harness = await _Harness.create(
+        savedPlan: contractPlan(
+          status: PracticePlanStatus.draft,
+          includeInterview: false,
+        ),
+      );
+      addTearDown(harness.dispose);
+
+      expect(await harness.controller.openSavedPlan(contractPlanId), isTrue);
+      expect(harness.controller.plan?.status, PracticePlanStatus.draft);
+
+      expect(await harness.controller.startPractice(), isTrue);
+
+      expect(harness.client.confirmedPlanVersions, <int>[1]);
+      expect(harness.controller.plan?.status, PracticePlanStatus.ready);
+      expect(harness.controller.plan?.version, 2);
+      expect(harness.client.sessionInputs.single.expectedPlanVersion, 2);
+      expect(harness.practice.practicePlanId, contractPlanId);
+    },
+  );
+
   test('reopening the same saved Plan resumes its parked Session', () async {
     final harness = await _Harness.create();
     addTearDown(harness.dispose);
@@ -175,7 +217,10 @@ final class _Harness {
   final List<String> voiceActivations;
   final List<String> voiceActivationKeys;
 
-  static Future<_Harness> create({int voiceActivationFailures = 0}) async {
+  static Future<_Harness> create({
+    int voiceActivationFailures = 0,
+    PracticePlan? savedPlan,
+  }) async {
     final practice = PracticeController(
       client: FakePracticeClient(
         planId: contractPlanId,
@@ -189,7 +234,7 @@ final class _Harness {
       recordStore: MemoryPracticeLaunchRecordStore(),
     );
     await workspace.activateAccount(contractUserId);
-    final client = _FakeJobPreparationClient();
+    final client = _FakeJobPreparationClient(savedPlan: savedPlan);
     final voiceActivations = <String>[];
     final voiceActivationKeys = <String>[];
     var remainingVoiceActivationFailures = voiceActivationFailures;
@@ -237,6 +282,10 @@ final class _Harness {
 }
 
 final class _FakeJobPreparationClient implements JobPreparationClient {
+  _FakeJobPreparationClient({PracticePlan? savedPlan})
+    : _savedPlan = savedPlan ?? contractPlan(includeInterview: true);
+
+  final PracticePlan _savedPlan;
   final List<InterviewPreparationInput> createdInputs =
       <InterviewPreparationInput>[];
   InterviewResumeFile? createdResume;
@@ -244,6 +293,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   final List<CreatePracticePlanInput> planInputs = <CreatePracticePlanInput>[];
   final List<CreatePreparationSessionInput> sessionInputs =
       <CreatePreparationSessionInput>[];
+  final List<int> confirmedPlanVersions = <int>[];
   List<PracticePlanSummary> plans = <PracticePlanSummary>[];
   final List<String> deletedPlanIds = <String>[];
   Object? deleteFailure;
@@ -293,8 +343,7 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
   }
 
   @override
-  Future<PracticePlan> getPlan(String planId) async =>
-      contractPlan(includeInterview: true);
+  Future<PracticePlan> getPlan(String planId) async => _savedPlan;
 
   @override
   Future<List<PracticePlanSummary>> listPlans({
@@ -334,7 +383,15 @@ final class _FakeJobPreparationClient implements JobPreparationClient {
     required String planId,
     required int expectedVersion,
     required String idempotencyKey,
-  }) async => contractPlan();
+  }) async {
+    confirmedPlanVersions.add(expectedVersion);
+    return contractPlan(
+      status: PracticePlanStatus.ready,
+      version: expectedVersion + 1,
+      sourceThreadId: _savedPlan.sourceThreadId,
+      includeInterview: _savedPlan.preparationSnapshot.interview != null,
+    );
+  }
 
   @override
   Future<void> clearAccountState() async {}

--- a/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
+++ b/mobile/test/coaching/preparation/job_preparation_wizard_test.dart
@@ -76,9 +76,75 @@ void main() {
       expect(find.byKey(const Key('job-plan-advanced')), findsNothing);
     },
   );
+
+  testWidgets('wizard previews and starts a saved Agent interview Plan', (
+    tester,
+  ) async {
+    final practice = PracticeController(
+      client: FakePracticeClient(
+        planId: contractPlanId,
+        practiceExperience: PracticeExperience.interview,
+        sceneCategory: SceneCategory.interviewProfessional,
+        turnLimit: 6,
+      ),
+    );
+    final workspace = PracticeWorkspaceController(
+      practiceController: practice,
+      recordStore: MemoryPracticeLaunchRecordStore(),
+    );
+    await workspace.activateAccount(contractUserId);
+    final client = _WizardClient(savedPlanIncludesInterview: false);
+    var started = 0;
+    final controller = JobPreparationController(
+      client: client,
+      workspaceController: workspace,
+      idFactory: (scope) => '$scope-contract-key',
+      voiceActivator:
+          ({required scene, required bootstrap, required clientOperationId}) =>
+              practice.activateCreatedPractice(
+                scene: scene,
+                sessionId: bootstrap.session.id,
+                planId: bootstrap.session.planId,
+                practiceMode: bootstrap.session.practiceMode,
+                turnLimit: bootstrap.maxEffectiveTurns,
+                clientOperationId: clientOperationId,
+              ),
+    );
+    addTearDown(() {
+      controller.dispose();
+      workspace.dispose();
+      practice.dispose();
+    });
+
+    expect(await controller.openSavedPlan(contractPlanId), isTrue);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: JobPreparationWizard(
+          controller: controller,
+          onPracticeStarted: () => started++,
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('job-wizard-preview-step')), findsOneWidget);
+    expect(find.text(contractScene.name), findsWidgets);
+    expect(find.byKey(const Key('job-input-field')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('start-job-practice-button')));
+    await tester.pumpAndSettle();
+
+    expect(started, 1);
+    expect(client.preparationCreates, 0);
+    expect(client.planCreates, 0);
+    expect(client.sessionCreates, 1);
+    expect(practice.practicePlanId, contractPlanId);
+  });
 }
 
 final class _WizardClient implements JobPreparationClient {
+  _WizardClient({this.savedPlanIncludesInterview = true});
+
+  final bool savedPlanIncludesInterview;
   int preparationCreates = 0;
   int planCreates = 0;
   int sessionCreates = 0;
@@ -124,7 +190,7 @@ final class _WizardClient implements JobPreparationClient {
 
   @override
   Future<PracticePlan> getPlan(String planId) async =>
-      contractPlan(includeInterview: true);
+      contractPlan(includeInterview: savedPlanIncludesInterview);
 
   @override
   Future<List<PracticePlanSummary>> listPlans({


### PR DESCRIPTION
## 功能描述

修复 Agent 创建的 INTERVIEW 练习计划出现在面试历史后无法打开的问题。

- Agent 创建的通用面试计划可以复用现有模拟面试预览页打开。
- `ready` 计划直接使用原 Plan ID 和版本创建练习。
- `draft` Agent 计划在用户点击现有“开始模拟面试”按钮时确认，再创建练习。
- 手动创建的岗位准备计划继续使用原有岗位快照、页面、路由和启动流程。
- 打开失败时显示明确提示，避免点击后静默无响应。

## 实现思路

面试历史原先统一要求 `preparation_snapshot.interview`，但 Agent 创建的是不包含该岗位快照的通用 `INTERVIEW` Practice Plan。此次修改只放宽通用 Agent Plan 的打开校验，并复用 `JobPreparationWizard` 已有的无候选人回退展示。

启动 draft Agent Plan 时沿用现有 Plan 确认接口和幂等键，校验确认后的 ID、版本、状态与 experience，再通过原有 workspace/session/voice 链路启动。现有岗位准备 Plan 的成功路径不变。

本 PR 不修改后端列表接口、历史排序、卡片样式或手动创建交互。

## 可复现测试

1. 在 Agent 对话中生成一份面试练习计划。
2. 进入“训练”→“英文面试”。
3. 点击对应历史计划。
4. 验证进入现有模拟面试预览页。
5. 点击“开始模拟面试”，验证使用同一 Plan 创建或恢复练习。
6. 再打开一份手动创建的岗位准备计划，验证页面和启动行为保持不变。

自动化验证：

- `flutter test --no-pub test/coaching/preparation/job_preparation_controller_test.dart test/coaching/preparation/job_preparation_wizard_test.dart test/speak_up_app_test.dart`（43 项通过）
- `flutter analyze --no-pub`（无问题）
- `git diff --check`
- `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`，真实后端 `/readyz` 为 ready，数字人禁用

Closes #818