### PR TITLE
fix(agent): 录音期间实时展示流式转写

### DIFF
--- a/server/internal/agent/input/voice/http/draft_handler_test.go
+++ b/server/internal/agent/input/voice/http/draft_handler_test.go
@@ -120,6 +120,7 @@ func newDraftHTTPRouter(t *testing.T, application *draftHTTPApplication) http.Ha
 	handler, err := NewHandler(
 		application,
 		draftHTTPThreadReader{},
+		nil,
 		time.Second,
 		httpresponse.NewRenderer(func() string { return "corr_voice_draft" }),
 	)
@@ -158,6 +159,15 @@ func (application *draftHTTPApplication) UploadStream(
 	requestcontext.Actor,
 	agentvoice.UploadRequest,
 	agentvoice.TranscriptionObserver,
+) (agentvoice.Draft, error) {
+	return application.draft, nil
+}
+
+func (application *draftHTTPApplication) UploadRecognized(
+	context.Context,
+	requestcontext.Actor,
+	agentvoice.UploadRequest,
+	agentvoice.TranscriptionResult,
 ) (agentvoice.Draft, error) {
 	return application.draft, nil
 }

--- a/server/internal/agent/input/voice/http/ephemeral_realtime_test.go
+++ b/server/internal/agent/input/voice/http/ephemeral_realtime_test.go
@@ -91,6 +91,57 @@ func TestEphemeralTranscriptionStreamsBeforeFinishWithoutVoicePersistence(
 	}
 }
 
+func TestDurableAgentVoiceStreamsBeforeFinishAndPersistsRecognizedAudio(
+	t *testing.T,
+) {
+	recognizer := newEphemeralTestRecognizer()
+	legacy := &voiceInputHTTPApplication{}
+	server := httptest.NewServer(newEphemeralHTTPTestRouter(
+		t, recognizer, &ephemeralThreadReader{}, legacy, time.Second,
+	))
+	defer server.Close()
+
+	connection := dialAgentVoiceDraft(
+		t, server.URL, ephemeralTestThreadID, "Bearer voice-token-a",
+	)
+	defer connection.Close()
+	writeEphemeralStart(t, connection, "durable-voice-1", 16_000)
+	if started := readEphemeralEvent(t, connection); started.Type != "transcription.started" {
+		t.Fatalf("started event = %#v", started)
+	}
+	pcm := make([]byte, 3_200)
+	if err := connection.WriteMessage(websocket.BinaryMessage, pcm); err != nil {
+		t.Fatalf("write PCM: %v", err)
+	}
+	// No finish frame has been sent: this update proves Agent voice reuses the
+	// live PCM recognizer instead of buffering the complete recording first.
+	updated := readEphemeralEvent(t, connection)
+	assertEphemeralTranscriptEvent(
+		t, updated, "transcription.updated", "partial transcript", false,
+	)
+	if err := connection.WriteJSON(map[string]string{"type": "finish"}); err != nil {
+		t.Fatalf("write finish: %v", err)
+	}
+	finalUpdate := readEphemeralEvent(t, connection)
+	assertEphemeralTranscriptEvent(
+		t, finalUpdate, "transcription.updated", "completed transcript", true,
+	)
+	if ready := readEphemeralEvent(t, connection); ready.Type != "draft.ready" {
+		t.Fatalf("ready event = %#v", ready)
+	}
+	if legacy.recognizedCalls != 1 || legacy.uploadBytes != 44+len(pcm) ||
+		legacy.result.Transcript != "completed transcript" ||
+		recognizer.Calls() != 1 {
+		t.Fatalf(
+			"durable calls = %d bytes = %d result = %#v recognizer calls = %d",
+			legacy.recognizedCalls,
+			legacy.uploadBytes,
+			legacy.result,
+			recognizer.Calls(),
+		)
+	}
+}
+
 func TestEphemeralTranscriptionRejectsAuthenticationOwnershipAndProtocol(
 	t *testing.T,
 ) {
@@ -405,6 +456,28 @@ func ephemeralWebSocketEndpoint(baseURL string, threadID string) string {
 		"/voice-transcriptions/realtime"
 }
 
+func dialAgentVoiceDraft(
+	t *testing.T,
+	baseURL string,
+	threadID string,
+	token string,
+) *websocket.Conn {
+	t.Helper()
+	header := http.Header{"Authorization": []string{token}}
+	endpoint := "ws" + strings.TrimPrefix(baseURL, "http") +
+		"/v1/agent-threads/" + threadID + "/voice-drafts/realtime"
+	connection, response, err := (&websocket.Dialer{
+		Subprotocols: []string{voiceInputWebSocketProtocol},
+	}).Dial(endpoint, header)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial status = %d: %v", response.StatusCode, err)
+		}
+		t.Fatalf("dial durable Agent voice: %v", err)
+	}
+	return connection
+}
+
 func writeEphemeralStart(
 	t *testing.T,
 	connection *websocket.Conn,
@@ -513,6 +586,7 @@ func newEphemeralHTTPTestRouter(
 		legacyHandler, legacyErr := NewHandler(
 			legacy,
 			threads,
+			recognizer,
 			readTimeout,
 			renderer,
 		)
@@ -553,7 +627,9 @@ type failingEphemeralRecognizer struct{}
 
 type voiceInputHTTPApplication struct {
 	streamCalls          int
+	recognizedCalls      int
 	uploadBytes          int
+	result               agentvoice.TranscriptionResult
 	confirmCalls         int
 	deleteCandidateCalls int
 }
@@ -566,6 +642,32 @@ func (application *voiceInputHTTPApplication) UploadStream(
 ) (agentvoice.Draft, error) {
 	application.streamCalls++
 	return agentvoice.Draft{}, errors.New("unexpected durable upload")
+}
+
+func (application *voiceInputHTTPApplication) UploadRecognized(
+	_ context.Context,
+	_ requestcontext.Actor,
+	request agentvoice.UploadRequest,
+	result agentvoice.TranscriptionResult,
+) (agentvoice.Draft, error) {
+	application.recognizedCalls++
+	payload, err := io.ReadAll(request.Audio)
+	if err != nil {
+		return agentvoice.Draft{}, err
+	}
+	application.uploadBytes = len(payload)
+	application.result = result
+	now := time.Now().UTC()
+	return agentvoice.Draft{
+		ID:      "20000000-0000-4000-8000-000000000002",
+		OwnerID: "user-a", ThreadID: request.ThreadID,
+		ContentType: request.ContentType, Size: int64(len(payload)),
+		Duration: 100 * time.Millisecond, SampleRate: 16_000,
+		Status: agentvoice.StatusReady, ASRAttempt: 1, Version: 1,
+		ASRRequestID: result.ID, ASRProvider: result.Provider,
+		ASRModel: result.Model, Transcript: result.Transcript,
+		ExpiresAt: now.Add(time.Hour), CreatedAt: now, UpdatedAt: now,
+	}, nil
 }
 
 func (*voiceInputHTTPApplication) GetDraft(

--- a/server/internal/agent/input/voice/http/handler.go
+++ b/server/internal/agent/input/voice/http/handler.go
@@ -29,6 +29,12 @@ type Application interface {
 		agentvoice.UploadRequest,
 		agentvoice.TranscriptionObserver,
 	) (agentvoice.Draft, error)
+	UploadRecognized(
+		context.Context,
+		requestcontext.Actor,
+		agentvoice.UploadRequest,
+		agentvoice.TranscriptionResult,
+	) (agentvoice.Draft, error)
 	GetDraft(
 		context.Context,
 		requestcontext.Actor,
@@ -64,6 +70,7 @@ type ThreadReader interface {
 type Handler struct {
 	application Application
 	threads     ThreadReader
+	recognizer  agentvoice.PCMStreamingSpeechRecognizer
 	readTimeout time.Duration
 	errors      *httpresponse.Renderer
 }
@@ -71,6 +78,7 @@ type Handler struct {
 func NewHandler(
 	application Application,
 	threads ThreadReader,
+	recognizer agentvoice.PCMStreamingSpeechRecognizer,
 	readTimeout time.Duration,
 	errorRenderer *httpresponse.Renderer,
 ) (*Handler, error) {
@@ -86,6 +94,7 @@ func NewHandler(
 	return &Handler{
 		application: application,
 		threads:     threads,
+		recognizer:  recognizer,
 		readTimeout: readTimeout,
 		errors:      errorRenderer,
 	}, nil

--- a/server/internal/agent/input/voice/http/realtime.go
+++ b/server/internal/agent/input/voice/http/realtime.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"time"
 
@@ -67,6 +68,10 @@ func (handler *Handler) uploadRealtime(c *gin.Context) {
 		writeRealtimeFailure(connection, "invalid_request", false)
 		return
 	}
+	if handler.recognizer != nil {
+		handler.uploadStreamingPCM(c, connection, actor, thread.ID, start)
+		return
+	}
 	pcm, err := readRealtimePCM(connection, handler.readTimeout)
 	if err != nil {
 		writeRealtimeFailure(connection, "stream_interrupted", true)
@@ -94,6 +99,99 @@ func (handler *Handler) uploadRealtime(c *gin.Context) {
 			Audio:          bytes.NewReader(wav),
 		},
 		observer,
+	)
+	if err != nil {
+		writeRealtimeFailure(connection, "stream_interrupted", true)
+		return
+	}
+	event := "draft.ready"
+	if draft.Status == agentvoice.StatusFailed {
+		event = "draft.failed"
+	}
+	_ = observer.write(event, gin.H{"draft": DraftResponse(draft)})
+}
+
+func (handler *Handler) uploadStreamingPCM(
+	c *gin.Context,
+	connection *websocket.Conn,
+	actor requestcontext.Actor,
+	threadID string,
+	start realtimeStartFrame,
+) {
+	observer := &realtimeTranscriptionWriter{
+		connection: connection,
+		timeout:    handler.readTimeout,
+	}
+	if err := observer.write("transcription.started", gin.H{}); err != nil {
+		return
+	}
+	streamContext, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+	reader, writer := io.Pipe()
+	var pcm bytes.Buffer
+	type transcriptionResult struct {
+		result agentvoice.TranscriptionResult
+		err    error
+	}
+	completed := make(chan transcriptionResult, 1)
+	go func() {
+		defer reader.Close()
+		result, transcribeErr := handler.recognizer.TranscribePCMStream(
+			streamContext,
+			agentvoice.PCMTranscriptionRequest{
+				PCM: reader, SampleRate: start.SampleRate,
+			},
+			observer,
+		)
+		completed <- transcriptionResult{result: result, err: transcribeErr}
+	}()
+
+	streamed := make(chan error, 1)
+	go func() {
+		streamed <- streamEphemeralPCM(
+			connection,
+			io.MultiWriter(writer, &pcm),
+			handler.readTimeout,
+		)
+	}()
+	var streamErr error
+	var transcription transcriptionResult
+	select {
+	case streamErr = <-streamed:
+		if streamErr != nil {
+			cancel()
+			_ = writer.CloseWithError(streamErr)
+		} else {
+			_ = writer.Close()
+		}
+		transcription = <-completed
+	case transcription = <-completed:
+		cancel()
+		if transcription.err != nil {
+			_ = writer.CloseWithError(transcription.err)
+		} else {
+			_ = writer.Close()
+		}
+		streamErr = <-streamed
+	}
+	if streamErr != nil || transcription.err != nil {
+		writeRealtimeFailure(connection, "stream_interrupted", true)
+		return
+	}
+	wav, err := pcm16MonoWAV(pcm.Bytes(), start.SampleRate)
+	if err != nil {
+		writeRealtimeFailure(connection, "invalid_audio", false)
+		return
+	}
+	draft, err := handler.application.UploadRecognized(
+		c.Request.Context(),
+		actor,
+		agentvoice.UploadRequest{
+			ThreadID: threadID, IdempotencyKey: start.IdempotencyKey,
+			ContentType: platformmedia.ContentTypeWAV,
+			Audio:       bytes.NewReader(wav),
+		},
+		transcription.result,
 	)
 	if err != nil {
 		writeRealtimeFailure(connection, "stream_interrupted", true)

--- a/server/internal/agent/input/voice/service.go
+++ b/server/internal/agent/input/voice/service.go
@@ -59,7 +59,7 @@ func (service *Service) Upload(
 	actor requestcontext.Actor,
 	request UploadRequest,
 ) (Draft, error) {
-	return service.upload(ctx, actor, request, nil)
+	return service.upload(ctx, actor, request, nil, nil)
 }
 
 func (service *Service) UploadStream(
@@ -71,7 +71,21 @@ func (service *Service) UploadStream(
 	if observer == nil {
 		return Draft{}, ErrInvalidRequest
 	}
-	return service.upload(ctx, actor, request, observer)
+	return service.upload(ctx, actor, request, observer, nil)
+}
+
+// UploadRecognized persists audio that was transcribed while it arrived. The
+// provider result becomes the durable Draft result without a second ASR pass.
+func (service *Service) UploadRecognized(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	request UploadRequest,
+	result TranscriptionResult,
+) (Draft, error) {
+	if !ValidTranscription(result) {
+		return Draft{}, ErrInvalidRequest
+	}
+	return service.upload(ctx, actor, request, nil, &result)
 }
 
 func (service *Service) upload(
@@ -79,6 +93,7 @@ func (service *Service) upload(
 	actor requestcontext.Actor,
 	request UploadRequest,
 	observer TranscriptionObserver,
+	recognized *TranscriptionResult,
 ) (Draft, error) {
 	if ctx == nil || !actor.Valid() || !ValidUUID(request.ThreadID) ||
 		!validIdempotencyKey(request.IdempotencyKey) || request.Audio == nil {
@@ -133,6 +148,17 @@ func (service *Service) upload(
 	}
 	if !acquired {
 		return claim.Draft, nil
+	}
+	if recognized != nil {
+		persistContext, cancel := runPersistenceContext(ctx)
+		defer cancel()
+		return service.repository.CompleteTranscription(
+			persistContext,
+			claim.Draft.OwnerID,
+			claim.Draft.ID,
+			claim.FencingToken,
+			*recognized,
+		)
 	}
 	return service.transcribeClaim(ctx, claim, audio, observer)
 }

--- a/server/internal/app/agent_data.go
+++ b/server/internal/app/agent_data.go
@@ -477,6 +477,7 @@ func buildIdentityAgentComposition(
 		voiceHTTP, voiceHTTPErr := agentvoicehttp.NewHandler(
 			voiceInput,
 			agentService,
+			realtimeRecognizer,
 			voiceConfigurations[0].AgentVoice.ReadTimeout,
 			errorRenderer,
 		)


### PR DESCRIPTION
## 功能描述

修复 Agent 首页录音期间没有实时转写的问题。Agent 语音消息现在会在用户仍在录音时持续返回 `transcription.updated`，底部输入栏可直接展示增量文字，同时继续保留原始音频、语音消息播放和逐条反馈语义。

## 实现思路

- 复用场景练习已经使用的 PCM WebSocket 流读取与实时识别链路。
- Agent durable voice 接口同时将 PCM 喂给实时 ASR 并保留为 WAV，不再等到 `finish` 后才开始识别。
- 将同一次实时 ASR 的最终结果直接持久化到 Voice Draft，避免停止录音后重复识别。
- 无实时 PCM recognizer 的配置继续保留原有缓冲兼容路径。
- 新增契约测试，明确断言发送 `finish` 前已经收到增量转写，并验证原声音频与最终识别结果仍被持久化且 ASR 只调用一次。

## 可复现测试

1. `cd server && go test ./...`
2. `cd server && go test -race ./internal/agent/input/voice/http ./internal/agent/input/voice`
3. `cd server && go vet ./...`
4. `cd mobile && flutter test test/agent/agent_voice_flow_test.dart test/agent/wire_agent_voice_client_test.dart test/design/practice_conversation_components_test.dart`
5. `make dev-ios-simulator`（iPhone 17 Pro / iOS 26.5 / 真实后端 / 数字人禁用），在 Agent 首页录音并确认发送前出现增量转写；已由提交者人工验收。

## 验证结果

- Server 全量测试：通过。
- Agent voice race 测试：通过。
- Go vet：通过。
- Flutter 定向测试：34 项通过。
- iOS 真实后端启动与人工交互验证：通过。
- `flutter analyze --no-pub`：Dart analysis server 在中文工作区路径解析 LSP 初始化 JSON 时异常退出，未产生代码诊断；本 PR 不包含 Dart 改动。

Closes #824