### PR TITLE
ci(portal): add Portal checks to quality gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,7 @@ jobs:
       flutter: ${{ steps.scope.outputs.flutter }}
       go: ${{ steps.scope.outputs.go }}
       api: ${{ steps.scope.outputs.api }}
+      portal: ${{ steps.scope.outputs.portal }}
     steps:
       - name: Check out repository history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,11 +50,13 @@ jobs:
           flutter=false
           go=false
           api=false
+          portal=false
 
           set_all_checks() {
             flutter=true
             go=true
             api=true
+            portal=true
           }
 
           if [[ "$EVENT_NAME" != "pull_request" || "$BASE_REF" == "main" ]]; then
@@ -83,6 +86,9 @@ jobs:
                 api/*)
                   api=true
                   ;;
+                portal/*)
+                  portal=true
+                  ;;
               esac
             done < "$changed_files"
           fi
@@ -91,6 +97,7 @@ jobs:
             echo "flutter=$flutter"
             echo "go=$go"
             echo "api=$api"
+            echo "portal=$portal"
           } >> "$GITHUB_OUTPUT"
 
   flutter:
@@ -183,6 +190,40 @@ jobs:
 
       - name: Check API contracts
         run: make check-api
+
+  portal:
+    name: Portal
+    needs: changes
+    if: needs.changes.outputs.portal == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: portal
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: portal/package-lock.json
+
+      - name: Install Portal dependencies
+        run: npm ci
+
+      - name: Lint Portal
+        run: npm run lint
+
+      - name: Build and test Portal
+        run: npm test
+
+      - name: Build Portal Docker image
+        run: docker build --tag speakup-portal:ci .
 
   coverage-gate:
     name: Coverage gate
@@ -492,6 +533,7 @@ jobs:
       - flutter
       - go
       - api
+      - portal
       - coverage-gate
       - flutter-coverage-gate
     if: always()
@@ -505,6 +547,8 @@ jobs:
       GO_RESULT: ${{ needs.go.result }}
       API_REQUIRED: ${{ needs.changes.outputs.api }}
       API_RESULT: ${{ needs.api.result }}
+      PORTAL_REQUIRED: ${{ needs.changes.outputs.portal }}
+      PORTAL_RESULT: ${{ needs.portal.result }}
       GO_COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
       FLUTTER_COVERAGE_RESULT: ${{ needs.flutter-coverage-gate.result }}
     steps:
@@ -550,6 +594,7 @@ jobs:
           require_result "Flutter" "$FLUTTER_REQUIRED" "$FLUTTER_RESULT"
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
+          require_result "Portal" "$PORTAL_REQUIRED" "$PORTAL_RESULT"
 
           require_coverage_result() {
             local name=$1


### PR DESCRIPTION
## 功能描述

- 将 `portal/**` 纳入现有 Quality 变更识别。
- 新增 Portal CI 作业，使用 Node 22 执行依赖安装、Lint、生产构建/测试和 Docker build。
- 将 Portal 作业结果纳入最终 `Quality gate`，被选中时必须成功。

## 实现思路

- 复用现有单 Workflow、按变更范围选作业、最终统一汇总的结构。
- `quality.yml` 自身变更和非 PR push 继续触发全量检查，因此会生成 Portal 基线运行记录。
- 使用现有 `actions/setup-node` 固定 SHA 和 `portal/package-lock.json` 缓存路径。
- 直接使用 `ubuntu-24.04` runner 提供的 Docker 验证现有 Dockerfile，不推送镜像。

## 可复现测试

- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/quality.yml")'`：YAML 解析通过。
- 执行 Workflow 内原始 scope/gate 脚本：workflow 变更选中 Portal；Portal failure 被最终门禁拒绝；未选中的 skipped 作业可通过。
- `cd portal && npm ci`：通过。
- `cd portal && npm run lint`：0 error；保留 2 个已有 img warning。
- `cd portal && npm test`：生产构建通过，4/4 测试通过。
- `cd portal && docker build --tag speakup-portal:issue-825-ci .`：通过。
- `git diff --check upstream/dev...HEAD`：通过。

## 范围说明

- 本 PR 不修改 Portal 业务代码、依赖版本或 npm audit 结果。
- 本 PR 不发布镜像，也不修改 GitHub Ruleset；将 `Quality gate` 配为 Required Status Check 另行实施。

Closes #825
