### PR TITLE
feat(practice): unify completion report entry

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -351,15 +351,21 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
   Future<CompletedPracticeRouteResult?> _openInterviewReport(
     InterviewPracticeCompletion completion,
   ) {
+    return _openSessionReport(completion.practiceSessionId);
+  }
+
+  Future<CompletedPracticeRouteResult?> _openSessionReport(
+    String practiceSessionId,
+  ) {
     final navigator = _navigatorKey.currentState;
     final reportController = widget.sessionEvaluationController;
     if (navigator == null || reportController == null) {
-      throw StateError('Interview report route is not configured.');
+      throw StateError('Practice report route is not configured.');
     }
     return navigator.push<CompletedPracticeRouteResult>(
       MaterialPageRoute<CompletedPracticeRouteResult>(
         builder: (_) => SessionEvaluationPage(
-          practiceSessionId: completion.practiceSessionId,
+          practiceSessionId: practiceSessionId,
           controller: reportController,
         ),
       ),
@@ -496,6 +502,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
           practiceController: _practiceController,
           avatarControllerFactory: factory,
           onPracticeCompleted: launchController?.parkCurrentPractice,
+          onOpenReport: widget.sessionEvaluationController == null
+              ? null
+              : _openSessionReport,
           speechFeedbackController: widget.speechFeedbackController,
           onExitRequested: launchController?.parkCurrentPractice,
         );
@@ -505,6 +514,9 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
         practiceController: _practiceController,
         questionSpeaker: _practiceController.promptSpeaker,
         onPracticeCompleted: launchController?.parkCurrentPractice,
+        onOpenReport: widget.sessionEvaluationController == null
+            ? null
+            : _openSessionReport,
         speechFeedbackController: widget.speechFeedbackController,
         onExitRequested: launchController?.parkCurrentPractice,
       );

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -451,6 +451,9 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       } else if (mounted &&
           result == CompletedPracticeRouteResult.returnToConversation) {
         setState(() => _selectedIndex = 0);
+      } else if (mounted &&
+          result == CompletedPracticeRouteResult.returnToTraining) {
+        setState(() => _selectedIndex = 1);
       }
     } finally {
       _practiceRouteInFlight = false;

--- a/mobile/lib/features/coaching/ielts/ielts_assignment_codec.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_assignment_codec.dart
@@ -33,10 +33,7 @@ IeltsPracticeAssignment decodeIeltsAssignment(Object? value) {
       IeltsSpeakingPart.part3,
     ],
     PracticeMode.part1 => const <IeltsSpeakingPart>[IeltsSpeakingPart.part1],
-    PracticeMode.part2 => const <IeltsSpeakingPart>[
-      IeltsSpeakingPart.part2,
-      IeltsSpeakingPart.part3,
-    ],
+    PracticeMode.part2 => const <IeltsSpeakingPart>[IeltsSpeakingPart.part2],
     PracticeMode.part3 => const <IeltsSpeakingPart>[IeltsSpeakingPart.part3],
     PracticeMode.fullSimulation ||
     PracticeMode.focus => const <IeltsSpeakingPart>[],

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -16,6 +16,7 @@ import 'package:speakup/features/coaching/ielts/ielts_preparation_controller.dar
 import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart';
 import 'package:speakup/features/coaching/ielts/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
@@ -855,9 +856,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         if (completed >= _partEnd(IeltsSpeakingPart.part2)) {
           complete(PracticeMode.part2);
         }
-        if (completed >= widget.controller.turnLimit) {
-          complete(PracticeMode.part3);
-        }
       case PracticeMode.part3:
         if (completed >= widget.controller.turnLimit) {
           complete(PracticeMode.part3);
@@ -1561,9 +1559,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     final showCompletionPage = complete && !keepCompletedConversation;
     final completionSheet = _completionSheet(progress);
     final stagePhase = complete && keepCompletedConversation
-        ? (_mode == PracticeMode.part1
-              ? IeltsMockPhase.part1
-              : IeltsMockPhase.part3)
+        ? switch (_mode) {
+            PracticeMode.part1 => IeltsMockPhase.part1,
+            PracticeMode.part2 => IeltsMockPhase.part2Speaking,
+            PracticeMode.part3 => IeltsMockPhase.part3,
+            _ => progress.phase,
+          }
         : _mode == PracticeMode.fullMock &&
               progress.phase == IeltsMockPhase.part1Complete
         ? IeltsMockPhase.part1
@@ -1615,19 +1616,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                             _buildRecorderDock(),
                         ],
                       ),
-                      if (completionSheet != null) ...[
-                        const Positioned.fill(
-                          child: ModalBarrier(
-                            dismissible: false,
-                            color: Color(0x14000000),
-                            semanticsLabel: '练习完成',
-                          ),
-                        ),
-                        Align(
-                          alignment: Alignment.bottomCenter,
-                          child: completionSheet,
-                        ),
-                      ],
+                      if (completionSheet != null)
+                        Positioned.fill(child: completionSheet),
                     ],
                   ),
                 ),
@@ -1682,12 +1672,18 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   Widget? _completionSheet(IeltsMockProgress progress) {
     if (_showCompletionSheet ||
         _keepsSectionCompletionInConversation(progress)) {
-      return _SectionCompletionSheet(
+      return PracticeCompletionOverlay(
+        keyPrefix: 'ielts-${_mode.name}-completion',
+        sheetKey: const Key('ielts-section-completion-sheet'),
+        primaryKey: const Key('ielts-section-review-action'),
+        secondaryKey: const Key('ielts-section-list-action'),
         title: _completionTitle,
         message: '${widget.controller.completedTurns} 道回答已保存',
         primaryLabel: switch (_mode) {
           PracticeMode.fullMock => '查看报告状态',
-          PracticeMode.part1 || PracticeMode.part3 => '查看复盘报告',
+          PracticeMode.part1 ||
+          PracticeMode.part2 ||
+          PracticeMode.part3 => '查看复盘报告',
           _ => '查看专项复盘',
         },
         secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
@@ -1699,7 +1695,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return null;
     }
     if (progress.phase == IeltsMockPhase.part1Complete) {
-      return _SectionCompletionSheet(
+      return PracticeCompletionOverlay(
+        keyPrefix: 'ielts-part1-transition',
+        sheetKey: const Key('ielts-section-completion-sheet'),
+        primaryKey: const Key('ielts-section-review-action'),
+        secondaryKey: const Key('ielts-section-list-action'),
         title: 'Part 1 已完成',
         message: '$_part1Total 道回答已保存',
         primaryLabel: '进入 Part 2',
@@ -1709,7 +1709,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       );
     }
     if (progress.phase == IeltsMockPhase.part2Complete && _part2TurnConfirmed) {
-      return _SectionCompletionSheet(
+      return PracticeCompletionOverlay(
+        keyPrefix: 'ielts-part2-transition',
+        sheetKey: const Key('ielts-section-completion-sheet'),
+        primaryKey: const Key('ielts-section-review-action'),
+        secondaryKey: const Key('ielts-section-list-action'),
         title: 'Part 2 已完成',
         message: '$_part2Total 道回答已保存',
         primaryLabel: '继续 Part 3',
@@ -1722,13 +1726,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   bool _keepsSectionCompletionInConversation(IeltsMockProgress progress) {
-    return (_mode == PracticeMode.part1 || _mode == PracticeMode.part3) &&
+    return (_mode == PracticeMode.part1 ||
+            _mode == PracticeMode.part2 ||
+            _mode == PracticeMode.part3) &&
         progress.phase == IeltsMockPhase.complete;
   }
 
   String get _completionTitle => switch (_mode) {
     PracticeMode.part1 => 'Part 1 已完成',
-    PracticeMode.part2 => 'Part 2 + Part 3 已完成',
+    PracticeMode.part2 => 'Part 2 已完成',
     PracticeMode.part3 => 'Part 3 已完成',
     PracticeMode.fullMock => '口语模考已完成',
     PracticeMode.fullSimulation ||
@@ -1745,6 +1751,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         sectionStart: _partStart(IeltsSpeakingPart.part1),
       );
     }
+    if (_mode == PracticeMode.part2) {
+      return _conversationPhase(
+        key: const Key('ielts-mock-part-2'),
+        partLabel: 'Part 2 · Long Turn',
+        completed: _part2Total,
+        total: _part2Total,
+        sectionStart: _partStart(IeltsSpeakingPart.part2),
+      );
+    }
     return _conversationPhase(
       key: const Key('ielts-mock-part-3'),
       partLabel: 'Part 3 · Discussion',
@@ -1755,7 +1770,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _openCompletedReview() {
-    if (_mode == PracticeMode.part1 || _mode == PracticeMode.part3) {
+    if (_mode == PracticeMode.part1 ||
+        _mode == PracticeMode.part2 ||
+        _mode == PracticeMode.part3) {
       unawaited(_openSectionReview());
       return;
     }
@@ -1776,9 +1793,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
             answerCount: widget.controller.completedTurns,
             title: switch (_mode) {
               PracticeMode.part1 => 'Part 1 专项复盘',
+              PracticeMode.part2 => 'Part 2 专项复盘',
               PracticeMode.part3 => 'Part 3 专项复盘',
               _ => throw StateError(
-                'Only Part 1 and Part 3 use the section review page.',
+                'Only standalone IELTS parts use the section review page.',
               ),
             },
           ),
@@ -1786,6 +1804,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       );
       if (mounted &&
           (widget.controller.practiceMode == PracticeMode.part1 ||
+              widget.controller.practiceMode == PracticeMode.part2 ||
               widget.controller.practiceMode == PracticeMode.part3)) {
         await _finishSection(IeltsPracticeCompletionAction.list);
       }

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -525,115 +525,6 @@ class _CompletionStep extends StatelessWidget {
   }
 }
 
-class _SectionCompletionSheet extends StatelessWidget {
-  const _SectionCompletionSheet({
-    required this.title,
-    required this.message,
-    required this.primaryLabel,
-    required this.secondaryLabel,
-    required this.onPrimary,
-    required this.onSecondary,
-  });
-
-  final String title;
-  final String message;
-  final String primaryLabel;
-  final String secondaryLabel;
-  final VoidCallback onPrimary;
-  final VoidCallback onSecondary;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 560),
-        child: Material(
-          key: const Key('ielts-section-completion-sheet'),
-          color: SpeakUpDesign.surface,
-          elevation: 12,
-          shadowColor: const Color(0x26000000),
-          borderRadius: BorderRadius.circular(28),
-          clipBehavior: Clip.antiAlias,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Center(
-                  child: Container(
-                    width: 42,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: SpeakUpDesign.border,
-                      borderRadius: BorderRadius.circular(99),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 18),
-                Center(
-                  child: Container(
-                    width: 52,
-                    height: 52,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(color: SpeakUpDesign.ink, width: 2),
-                    ),
-                    child: const Icon(
-                      Icons.check_rounded,
-                      size: 34,
-                      color: SpeakUpDesign.ink,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  title,
-                  textAlign: TextAlign.center,
-                  style: SpeakUpDesign.pageTitle.copyWith(fontSize: 24),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  message,
-                  textAlign: TextAlign.center,
-                  style: SpeakUpDesign.body.copyWith(
-                    color: SpeakUpDesign.secondary,
-                  ),
-                ),
-                const SizedBox(height: 20),
-                FilledButton(
-                  key: const Key('ielts-section-review-action'),
-                  onPressed: onPrimary,
-                  style: FilledButton.styleFrom(
-                    minimumSize: const Size.fromHeight(54),
-                    backgroundColor: SpeakUpDesign.ink,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
-                  ),
-                  child: Text(primaryLabel),
-                ),
-                const SizedBox(height: 4),
-                TextButton(
-                  key: const Key('ielts-section-list-action'),
-                  onPressed: onSecondary,
-                  style: TextButton.styleFrom(
-                    foregroundColor: SpeakUpDesign.ink,
-                    minimumSize: const Size.fromHeight(44),
-                  ),
-                  child: Text(secondaryLabel),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _MockExitSheet extends StatelessWidget {
   const _MockExitSheet({required this.onContinue, required this.onSaveAndExit});
 
@@ -714,7 +605,7 @@ class _SectionPracticeComplete extends StatelessWidget {
   Widget build(BuildContext context) {
     final part = switch (mode) {
       PracticeMode.part1 => 'Part 1',
-      PracticeMode.part2 => 'Part 2 + Part 3',
+      PracticeMode.part2 => 'Part 2',
       PracticeMode.part3 => 'Part 3',
       PracticeMode.fullMock => 'IELTS Speaking',
       PracticeMode.fullSimulation || PracticeMode.focus => throw StateError(

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -14,6 +14,7 @@ import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_recordings.dart';
+import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 
@@ -77,6 +78,7 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
   int _recordingSeconds = 0;
   bool _speechFeedbackRebuildScheduled = false;
   bool _interviewReportRouteActive = false;
+  bool _completionInFlight = false;
   PracticePromptSpeaker? _ownedTipSpeaker;
 
   @override
@@ -234,6 +236,76 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
     } finally {
       _interviewReportRouteActive = false;
     }
+  }
+
+  Future<void> _requestUserControlledCompletion() async {
+    final controller = widget.practiceController;
+    if (!mounted ||
+        controller == null ||
+        _completionInFlight ||
+        !controller.canCompleteActivePractice) {
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('结束面试练习？'),
+        content: const Text('结束后将保存本次回答并生成面试复盘。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('继续练习'),
+          ),
+          FilledButton(
+            key: const Key('interview-confirm-completion'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('结束练习'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) {
+      return;
+    }
+    setState(() => _completionInFlight = true);
+    final completed = await controller.completeActivePractice();
+    if (!mounted) {
+      return;
+    }
+    setState(() => _completionInFlight = false);
+    if (!completed) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(const SnackBar(content: Text('面试暂时无法结束，请稍后重试。')));
+    }
+  }
+
+  Future<void> _leaveCompletedInterview() async {
+    if (!mounted || _completionInFlight) {
+      return;
+    }
+    setState(() => _completionInFlight = true);
+    final callback = widget.onReturnToConversation;
+    var parked = callback == null;
+    try {
+      if (callback != null) {
+        parked = await callback();
+      }
+    } on Object {
+      parked = false;
+    }
+    if (!mounted) {
+      return;
+    }
+    if (!parked) {
+      setState(() => _completionInFlight = false);
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(const SnackBar(content: Text('当前练习正在保存，请稍后再返回。')));
+      return;
+    }
+    _exitApproved = true;
+    Navigator.of(context).pop(CompletedPracticeRouteResult.returnToTraining);
   }
 
   void _syncSpeechFeedbackSources() {
@@ -489,47 +561,89 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
           title: scene == null || controller == null
               ? const Text('练习')
               : Text(scene.name),
-          actions: controller == null || controller.recordings.isEmpty
+          actions: controller == null
               ? null
               : [
-                  IconButton(
-                    key: const Key('practice-open-history'),
-                    tooltip: '本轮录音',
-                    onPressed:
-                        controller.recordingState == PracticeRecordingState.idle
-                        ? () => _showPracticeRecordings(controller)
-                        : null,
-                    icon: const Icon(Icons.more_horiz_rounded),
-                  ),
+                  if (controller.recordings.isNotEmpty)
+                    IconButton(
+                      key: const Key('practice-open-history'),
+                      tooltip: '本轮录音',
+                      onPressed:
+                          controller.recordingState ==
+                              PracticeRecordingState.idle
+                          ? () => _showPracticeRecordings(controller)
+                          : null,
+                      icon: const Icon(Icons.more_horiz_rounded),
+                    ),
+                  if (controller.completionMode ==
+                          PracticeCompletionMode.userControlled &&
+                      controller.recordingState !=
+                          PracticeRecordingState.completed)
+                    TextButton(
+                      key: const Key('interview-complete-practice'),
+                      onPressed:
+                          controller.canCompleteActivePractice &&
+                              !_completionInFlight
+                          ? _requestUserControlledCompletion
+                          : null,
+                      child: _completionInFlight
+                          ? const SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('结束练习'),
+                    ),
                 ],
         ),
         body: SafeArea(
           child: controller == null || scene == null
               ? const _NoScene()
-              : Column(
+              : Stack(
                   children: [
-                    _InterviewProgress(controller: controller),
-                    Expanded(
-                      child: _SceneConversationMessageList(
-                        controller: controller,
-                        scrollController: _messageScrollController,
-                        previewMode: widget.previewMode,
-                        speechFeedbackController:
-                            widget.speechFeedbackController,
-                        onRepractice: _startSpeechFeedbackRetry,
+                    Column(
+                      children: [
+                        _InterviewProgress(controller: controller),
+                        Expanded(
+                          child: _SceneConversationMessageList(
+                            controller: controller,
+                            scrollController: _messageScrollController,
+                            previewMode: widget.previewMode,
+                            speechFeedbackController:
+                                widget.speechFeedbackController,
+                            onRepractice: _startSpeechFeedbackRetry,
+                          ),
+                        ),
+                        _RecordingPanel(
+                          controller: controller,
+                          textController: _textAnswerController,
+                          textFocusNode: _textAnswerFocusNode,
+                          onSubmitText: _submitTextAnswer,
+                          textMode: _textAnswerMode,
+                          onToggleTextMode: _toggleTextAnswerMode,
+                          recordingSeconds: _recordingSeconds,
+                          onOpenReport: _openInterviewReport,
+                          onShowTip: _showQuestionTip,
+                        ),
+                      ],
+                    ),
+                    if (controller.recordingState ==
+                        PracticeRecordingState.completed)
+                      Positioned.fill(
+                        child: PracticeCompletionOverlay(
+                          keyPrefix: 'interview-completion',
+                          title: '面试练习已完成',
+                          message: '${controller.completedTurns} 道回答已保存',
+                          primaryLabel: '查看复盘报告',
+                          secondaryLabel: '返回面试列表',
+                          onPrimary: widget.onOpenInterviewReport == null
+                              ? null
+                              : _openInterviewReport,
+                          onSecondary: _completionInFlight
+                              ? null
+                              : _leaveCompletedInterview,
+                          primaryLoading: _interviewReportRouteActive,
+                        ),
                       ),
-                    ),
-                    _RecordingPanel(
-                      controller: controller,
-                      textController: _textAnswerController,
-                      textFocusNode: _textAnswerFocusNode,
-                      onSubmitText: _submitTextAnswer,
-                      textMode: _textAnswerMode,
-                      onToggleTextMode: _toggleTextAnswerMode,
-                      recordingSeconds: _recordingSeconds,
-                      onOpenReport: _openInterviewReport,
-                      onShowTip: _showQuestionTip,
-                    ),
                   ],
                 ),
         ),

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -229,8 +229,7 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
           ),
         ),
       );
-      if (mounted &&
-          result == CompletedPracticeRouteResult.returnToConversation) {
+      if (mounted && result != null) {
         Navigator.of(context).pop(result);
       }
     } finally {

--- a/mobile/lib/features/coaching/practice/practice_completion_sheet.dart
+++ b/mobile/lib/features/coaching/practice/practice_completion_sheet.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+
+/// Blocks the active practice surface and presents the available actions after
+/// the server has confirmed that the current practice session is complete.
+class PracticeCompletionOverlay extends StatelessWidget {
+  const PracticeCompletionOverlay({
+    required this.title,
+    required this.message,
+    required this.primaryLabel,
+    required this.secondaryLabel,
+    required this.onPrimary,
+    required this.onSecondary,
+    this.primaryLoading = false,
+    this.keyPrefix = 'practice-completion',
+    this.sheetKey,
+    this.primaryKey,
+    this.secondaryKey,
+    super.key,
+  });
+
+  final String title;
+  final String message;
+  final String primaryLabel;
+  final String secondaryLabel;
+  final VoidCallback? onPrimary;
+  final VoidCallback? onSecondary;
+  final bool primaryLoading;
+  final String keyPrefix;
+  final Key? sheetKey;
+  final Key? primaryKey;
+  final Key? secondaryKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      key: Key('$keyPrefix-overlay'),
+      fit: StackFit.expand,
+      children: [
+        const ModalBarrier(
+          dismissible: false,
+          color: Color(0x14000000),
+          semanticsLabel: '练习完成',
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            top: false,
+            child: SingleChildScrollView(
+              reverse: true,
+              padding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 560),
+                child: Material(
+                  key: sheetKey ?? Key('$keyPrefix-sheet'),
+                  color: SpeakUpDesign.surface,
+                  elevation: 12,
+                  shadowColor: const Color(0x26000000),
+                  borderRadius: BorderRadius.circular(28),
+                  clipBehavior: Clip.antiAlias,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Center(
+                          child: Container(
+                            width: 42,
+                            height: 4,
+                            decoration: BoxDecoration(
+                              color: SpeakUpDesign.border,
+                              borderRadius: BorderRadius.circular(99),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 18),
+                        Center(
+                          child: Container(
+                            width: 52,
+                            height: 52,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: SpeakUpDesign.ink,
+                                width: 2,
+                              ),
+                            ),
+                            child: const Icon(
+                              Icons.check_rounded,
+                              size: 34,
+                              color: SpeakUpDesign.ink,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          title,
+                          textAlign: TextAlign.center,
+                          style: SpeakUpDesign.pageTitle.copyWith(fontSize: 24),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          message,
+                          textAlign: TextAlign.center,
+                          style: SpeakUpDesign.body.copyWith(
+                            color: SpeakUpDesign.secondary,
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        FilledButton(
+                          key: primaryKey ?? Key('$keyPrefix-primary'),
+                          onPressed: primaryLoading ? null : onPrimary,
+                          style: FilledButton.styleFrom(
+                            minimumSize: const Size.fromHeight(54),
+                            backgroundColor: SpeakUpDesign.ink,
+                            foregroundColor: Colors.white,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                          ),
+                          child: primaryLoading
+                              ? const SizedBox.square(
+                                  dimension: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : Text(primaryLabel),
+                        ),
+                        const SizedBox(height: 4),
+                        TextButton(
+                          key: secondaryKey ?? Key('$keyPrefix-secondary'),
+                          onPressed: onSecondary,
+                          style: TextButton.styleFrom(
+                            foregroundColor: SpeakUpDesign.ink,
+                            minimumSize: const Size.fromHeight(44),
+                          ),
+                          child: Text(secondaryLabel),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -379,7 +379,7 @@ enum PracticeSessionLifecycleStatus {
   endedEarly,
 }
 
-enum CompletedPracticeRouteResult { returnToConversation }
+enum CompletedPracticeRouteResult { returnToConversation, returnToTraining }
 
 final class PracticeSessionLifecycle {
   const PracticeSessionLifecycle({

--- a/mobile/lib/features/coaching/review/evaluation_report_presentation.dart
+++ b/mobile/lib/features/coaching/review/evaluation_report_presentation.dart
@@ -45,7 +45,7 @@ String evaluationReportTitle(EvaluationReport report) {
     EvaluationReportSceneType.interview => '面试复盘',
     EvaluationReportSceneType.ieltsSpeaking => switch (report.practiceMode) {
       'PART_1' => 'Part 1 专项复盘',
-      'PART_2' => 'Part 2 + Part 3 联合复盘',
+      'PART_2' => 'Part 2 专项复盘',
       'PART_3' => 'Part 3 专项复盘',
       'FULL_MOCK' => 'IELTS 口语模考报告',
       _ => 'IELTS 口语复盘',

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -10,13 +10,17 @@ import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart'
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
+import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/scenario/scenario_assets.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
 
 typedef ScenarioAsyncAction = Future<void> Function();
 typedef ScenarioAvatarSurfaceBuilder = Widget Function(BuildContext context);
+typedef OpenScenarioPracticeReport =
+    Future<CompletedPracticeRouteResult?> Function(String practiceSessionId);
 
 class ScenarioPracticePage extends StatefulWidget {
   const ScenarioPracticePage({
@@ -28,6 +32,7 @@ class ScenarioPracticePage extends StatefulWidget {
     this.onReplayQuestion,
     this.questionSpeaker,
     this.onPracticeCompleted,
+    this.onOpenReport,
     this.speechFeedbackController,
     this.onExitRequested,
     this.previewMode = false,
@@ -44,6 +49,7 @@ class ScenarioPracticePage extends StatefulWidget {
   final ScenarioAsyncAction? onReplayQuestion;
   final PracticePromptSpeaker? questionSpeaker;
   final Future<bool> Function()? onPracticeCompleted;
+  final OpenScenarioPracticeReport? onOpenReport;
   final SpeechFeedbackController? speechFeedbackController;
   final Future<bool> Function()? onExitRequested;
   final bool previewMode;
@@ -69,12 +75,17 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
   final Map<String, String> _questionTranslations = <String, String>{};
   bool _feedbackRebuildScheduled = false;
   bool _completionInFlight = false;
+  bool _reportRouteActive = false;
   PracticePromptSpeaker? _ownedQuestionSpeaker;
   PracticePromptSpeaker? _ownedTipSpeaker;
   String? _visibleTipQuestionId;
   String? _playingQuestionId;
   String? _questionNarrationErrorId;
   int _questionNarrationGeneration = 0;
+
+  bool get _isInterview =>
+      widget.practiceController.practiceExperience ==
+      PracticeExperience.interview;
 
   @override
   void initState() {
@@ -436,9 +447,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     }
     setState(() => _completionInFlight = false);
     if (completed) {
-      Navigator.of(
-        context,
-      ).pop(CompletedPracticeRouteResult.returnToConversation);
+      Navigator.of(context).pop(CompletedPracticeRouteResult.returnToTraining);
       return;
     }
     ScaffoldMessenger.of(context)
@@ -454,8 +463,12 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('结束练习？'),
-        content: const Text('结束后将保存本次对话并生成练习报告，稍后可在“复盘”中查看。'),
+        title: Text(_isInterview ? '结束面试练习？' : '结束练习？'),
+        content: Text(
+          _isInterview
+              ? '结束后将保存本次回答并生成面试复盘。'
+              : '结束后将保存本次对话并生成练习报告，稍后可在“复盘”中查看。',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -477,12 +490,33 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       return;
     }
     if (completed) {
-      await _completePractice();
       return;
     }
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(const SnackBar(content: Text('练习暂时无法结束，请稍后重试。')));
+  }
+
+  Future<void> _openCompletedReport() async {
+    final callback = widget.onOpenReport;
+    final sessionId = widget.practiceController.practiceSessionId;
+    if (callback == null ||
+        sessionId == null ||
+        widget.practiceController.recordingState !=
+            PracticeRecordingState.completed ||
+        _reportRouteActive) {
+      return;
+    }
+    _reportRouteActive = true;
+    try {
+      final result = await callback(sessionId);
+      if (mounted &&
+          result == CompletedPracticeRouteResult.returnToConversation) {
+        Navigator.of(context).pop(result);
+      }
+    } finally {
+      _reportRouteActive = false;
+    }
   }
 
   Future<void> _submitText() async {
@@ -609,33 +643,59 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                     exitButtonKey: const Key('scenario-exit'),
                     onExit: _requestExit,
                   ),
-                  content: _ConversationPanel(
-                    controller: widget.practiceController,
-                    scrollController: _conversationScrollController,
-                    textController: _textController,
-                    textFocusNode: _textFocusNode,
-                    textMode: _textMode,
-                    recordingSeconds: _recordingSeconds,
-                    previewMode: widget.previewMode,
-                    onBeforeStartRecording: _beforeStartRecording,
-                    speechFeedbackController: widget.speechFeedbackController,
-                    playingQuestionId: _playingQuestionId,
-                    narrationErrorQuestionId: _questionNarrationErrorId,
-                    onPlayQuestion: _playQuestion,
-                    onToggleTextMode: _toggleTextMode,
-                    onSubmitText: _submitText,
-                    onTranslateQuestion:
-                        widget.practiceController.canTranslateQuestion &&
-                            widget.practiceController.client
-                                is PracticeQuestionTranslationClient
-                        ? _translateQuestion
-                        : null,
-                    onShowTip: _showQuestionTip,
-                    onHideTip: _hideQuestionTip,
-                    onSpeakTip: _speakQuestionTip,
-                    visibleTipQuestionId: _visibleTipQuestionId,
-                    onPracticeCompleted: _completePractice,
-                    onCompleteRequested: _requestUserControlledCompletion,
+                  content: Stack(
+                    children: [
+                      _ConversationPanel(
+                        controller: widget.practiceController,
+                        scrollController: _conversationScrollController,
+                        textController: _textController,
+                        textFocusNode: _textFocusNode,
+                        textMode: _textMode,
+                        recordingSeconds: _recordingSeconds,
+                        previewMode: widget.previewMode,
+                        onBeforeStartRecording: _beforeStartRecording,
+                        speechFeedbackController:
+                            widget.speechFeedbackController,
+                        playingQuestionId: _playingQuestionId,
+                        narrationErrorQuestionId: _questionNarrationErrorId,
+                        onPlayQuestion: _playQuestion,
+                        onToggleTextMode: _toggleTextMode,
+                        onSubmitText: _submitText,
+                        onTranslateQuestion:
+                            widget.practiceController.canTranslateQuestion &&
+                                widget.practiceController.client
+                                    is PracticeQuestionTranslationClient
+                            ? _translateQuestion
+                            : null,
+                        onShowTip: _showQuestionTip,
+                        onHideTip: _hideQuestionTip,
+                        onSpeakTip: _speakQuestionTip,
+                        visibleTipQuestionId: _visibleTipQuestionId,
+                        onCompleteRequested: _requestUserControlledCompletion,
+                      ),
+                      if (widget.practiceController.recordingState ==
+                          PracticeRecordingState.completed)
+                        Positioned.fill(
+                          child: PracticeCompletionOverlay(
+                            keyPrefix: _isInterview
+                                ? 'interview-completion'
+                                : 'scenario-completion',
+                            title: _isInterview ? '面试练习已完成' : '场景练习已完成',
+                            message: _isInterview
+                                ? '${widget.practiceController.completedTurns} 道回答已保存'
+                                : '${widget.practiceController.completedTurns} 轮对话已保存',
+                            primaryLabel: '查看复盘报告',
+                            secondaryLabel: _isInterview ? '返回面试列表' : '返回场景列表',
+                            onPrimary: widget.onOpenReport == null
+                                ? null
+                                : _openCompletedReport,
+                            onSecondary: _completionInFlight
+                                ? null
+                                : _completePractice,
+                            primaryLoading: _reportRouteActive,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
         ),
@@ -665,7 +725,6 @@ class _ConversationPanel extends StatelessWidget {
     required this.onHideTip,
     required this.onSpeakTip,
     required this.visibleTipQuestionId,
-    required this.onPracticeCompleted,
     required this.onCompleteRequested,
   });
 
@@ -688,7 +747,6 @@ class _ConversationPanel extends StatelessWidget {
   final VoidCallback onHideTip;
   final Future<void> Function() onSpeakTip;
   final String? visibleTipQuestionId;
-  final VoidCallback onPracticeCompleted;
   final VoidCallback onCompleteRequested;
 
   @override
@@ -839,7 +897,6 @@ class _ConversationPanel extends StatelessWidget {
             onBeforeStartRecording: onBeforeStartRecording,
             onToggleTextMode: onToggleTextMode,
             onSubmitText: onSubmitText,
-            onPracticeCompleted: onPracticeCompleted,
           ),
         ],
       ),
@@ -1045,7 +1102,6 @@ class _ScenarioComposer extends StatefulWidget {
     required this.onBeforeStartRecording,
     required this.onToggleTextMode,
     required this.onSubmitText,
-    required this.onPracticeCompleted,
   });
 
   final PracticeController controller;
@@ -1056,7 +1112,6 @@ class _ScenarioComposer extends StatefulWidget {
   final ScenarioAsyncAction? onBeforeStartRecording;
   final VoidCallback onToggleTextMode;
   final VoidCallback onSubmitText;
-  final VoidCallback onPracticeCompleted;
 
   @override
   State<_ScenarioComposer> createState() => _ScenarioComposerState();
@@ -1160,10 +1215,16 @@ class _ScenarioComposerState extends State<_ScenarioComposer> {
                 ? '正在提交最后一轮回答…'
                 : '回答已发送，Agent 正在回复…',
           ),
-          PracticeRecordingState.completed => PracticeComposerAction(
-            label: '练习已结束，报告生成后可在“复盘”中查看。',
-            actionLabel: '返回主聊天',
-            onPressed: widget.onPracticeCompleted,
+          PracticeRecordingState.completed => SizedBox(
+            height: 48,
+            child: Center(
+              child: Text(
+                '练习已完成',
+                style: SpeakUpDesign.body.copyWith(
+                  color: SpeakUpDesign.secondary,
+                ),
+              ),
+            ),
           ),
         },
       ),

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -510,8 +510,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     _reportRouteActive = true;
     try {
       final result = await callback(sessionId);
-      if (mounted &&
-          result == CompletedPracticeRouteResult.returnToConversation) {
+      if (mounted && result != null) {
         Navigator.of(context).pop(result);
       }
     } finally {

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -60,6 +60,7 @@ class ScenarioPracticeSession extends StatelessWidget {
     required this.practiceController,
     required this.avatarControllerFactory,
     this.onPracticeCompleted,
+    this.onOpenReport,
     this.speechFeedbackController,
     this.onExitRequested,
     super.key,
@@ -68,6 +69,7 @@ class ScenarioPracticeSession extends StatelessWidget {
   final PracticeController practiceController;
   final AvatarControllerFactory avatarControllerFactory;
   final Future<bool> Function()? onPracticeCompleted;
+  final OpenScenarioPracticeReport? onOpenReport;
   final SpeechFeedbackController? speechFeedbackController;
   final Future<bool> Function()? onExitRequested;
 
@@ -86,6 +88,7 @@ class ScenarioPracticeSession extends StatelessWidget {
         onBeforeSubmitText: avatar.interruptForUserTurn,
         onReplayQuestion: avatar.onReplayQuestion,
         onPracticeCompleted: onPracticeCompleted,
+        onOpenReport: onOpenReport,
         speechFeedbackController: speechFeedbackController,
         replayLoading: avatar.replayLoading,
         replayPlaying: avatar.replayPlaying,

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -309,7 +309,7 @@ void main() {
     'Part 2 section hides the Cue Card after formal recording starts',
     (tester) async {
       final now = DateTime.utc(2026, 8, 4, 8);
-      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 6);
+      final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
       final controller = PracticeController(
         client: practice,
         recorder: _Recorder(),
@@ -367,7 +367,7 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     final now = DateTime.utc(2026, 8, 4, 9);
     final startGate = Completer<void>();
-    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 6);
+    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 1);
     final recorder = _Recorder()..startGate = startGate;
     final controller = PracticeController(client: practice, recorder: recorder);
     final store = _MemoryProgressStore(
@@ -1755,44 +1755,47 @@ void main() {
     expect(find.byKey(const Key('open-section')), findsOneWidget);
   });
 
-  testWidgets(
-    'restored Part 2 completion asks before entering its bound Part 3',
-    (tester) async {
-      final practice = _IeltsPracticeClient(initialCompleted: 1, turnLimit: 6);
-      final controller = PracticeController(
-        client: practice,
-        recorder: _Recorder(),
-      );
-      addTearDown(controller.dispose);
-      await _activatePractice(
-        controller,
-        practice,
-        _ieltsScene,
-        mode: PracticeMode.part2,
-      );
+  testWidgets('restored Part 2 completion opens its independent review', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 1, turnLimit: 1);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part2,
+    );
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: IeltsSpeakingMockPage(
-            controller: controller,
-            progressStore: _MemoryProgressStore(),
-            examinerSpeaker: _ImmediateExaminerSpeaker(),
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
         ),
-      );
-      await tester.pump();
+      ),
+    );
+    await tester.pump();
 
-      expect(
-        find.byKey(const Key('ielts-mock-part-2-transition')),
-        findsOneWidget,
-      );
-      await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
-      await tester.pump();
-      expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
-      expect(find.text('Part 3 · Discussion'), findsOneWidget);
-      expect(find.text('继续对应 Part 3'), findsNothing);
-    },
-  );
+    expect(find.text('Part 2 已完成'), findsOneWidget);
+    expect(find.text('查看复盘报告'), findsOneWidget);
+    expect(find.text('继续 Part 3'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('ielts-section-review-action')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(find.text('Part 2 专项复盘'), findsOneWidget);
+    expect(
+      find.byKey(const Key('section-review-loading-page')),
+      findsOneWidget,
+    );
+  });
 
   testWidgets(
     'Part 2 completion can be parked and resumed before entering Part 3',
@@ -2019,7 +2022,7 @@ void main() {
       ),
       (
         mode: PracticeMode.part2,
-        turnLimit: 6,
+        turnLimit: 1,
         expected: const Key('ielts-mock-part-2-intro'),
       ),
       (

--- a/mobile/test/coaching/practice/interview_practice_completion_test.dart
+++ b/mobile/test/coaching/practice/interview_practice_completion_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/interview/interview_practice.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
+
+import '../../support/practice_fixtures.dart';
+import '../../support/scene_fixtures.dart';
+
+void main() {
+  testWidgets(
+    'manual interview completion opens the shared sheet and returns to training',
+    (tester) async {
+      final scene = testScenes.first;
+      final controller = PracticeController(
+        client: FakePracticeClient(
+          practiceExperience: scene.experience,
+          sceneCategory: scene.category,
+          completionMode: PracticeCompletionMode.userControlled,
+          turnLimit: 0,
+        ),
+      );
+      addTearDown(controller.dispose);
+      await controller.activateCreatedPractice(
+        scene: scene,
+        sessionId: 'session-direct-interview',
+        planId: testPracticePlanId('session-direct-interview'),
+        practiceMode: scene.practiceOptions.first.mode,
+        turnLimit: 0,
+        clientOperationId: 'activate-direct-interview',
+      );
+      await controller.submitPracticeText('I led the migration project.');
+
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('Training root')),
+        ),
+      );
+      final routeResult = navigatorKey.currentState!
+          .push<CompletedPracticeRouteResult>(
+            MaterialPageRoute<CompletedPracticeRouteResult>(
+              builder: (_) => InterviewPracticePage(
+                practiceController: controller,
+                onOpenInterviewReport: (completion) async {
+                  expect(
+                    completion.practiceSessionId,
+                    'session-direct-interview',
+                  );
+                  return CompletedPracticeRouteResult.returnToTraining;
+                },
+              ),
+            ),
+          );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('interview-complete-practice')));
+      await tester.pumpAndSettle();
+      expect(find.text('结束面试练习？'), findsOneWidget);
+      expect(find.text('结束后将保存本次回答并生成面试复盘。'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('interview-confirm-completion')));
+      await tester.pumpAndSettle();
+      expect(find.text('面试练习已完成'), findsOneWidget);
+      expect(find.text('1 道回答已保存'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('interview-completion-primary')));
+      await tester.pumpAndSettle();
+
+      expect(await routeResult, CompletedPracticeRouteResult.returnToTraining);
+      expect(find.text('Training root'), findsOneWidget);
+    },
+  );
+}

--- a/mobile/test/coaching/practice/practice_completion_sheet_test.dart
+++ b/mobile/test/coaching/practice/practice_completion_sheet_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
+
+void main() {
+  testWidgets('blocks practice content and exposes both completion actions', (
+    tester,
+  ) async {
+    var primaryCalls = 0;
+    var secondaryCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              const Positioned.fill(child: Text('练习内容')),
+              Positioned.fill(
+                child: PracticeCompletionOverlay(
+                  title: '练习已完成',
+                  message: '3 轮对话已保存',
+                  primaryLabel: '查看复盘报告',
+                  secondaryLabel: '返回列表',
+                  onPrimary: () => primaryCalls++,
+                  onSecondary: () => secondaryCalls++,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('practice-completion-overlay')),
+        matching: find.byType(ModalBarrier),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('practice-completion-sheet')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('practice-completion-primary')));
+    await tester.tap(find.byKey(const Key('practice-completion-secondary')));
+
+    expect(primaryCalls, 1);
+    expect(secondaryCalls, 1);
+  });
+
+  testWidgets('disables the primary action while it is loading', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: PracticeCompletionOverlay(
+                  title: '练习已完成',
+                  message: '回答已保存',
+                  primaryLabel: '查看复盘报告',
+                  secondaryLabel: '返回列表',
+                  onPrimary: null,
+                  onSecondary: null,
+                  primaryLoading: true,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final button = tester.widget<FilledButton>(
+      find.byKey(const Key('practice-completion-primary')),
+    );
+    expect(button.onPressed, isNull);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -143,6 +143,61 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('returns the report navigation result to the training shell', (
+    tester,
+  ) async {
+    final scene = testScene(
+      id: 'completed-open-practice',
+      experience: PracticeExperience.lifeAndTravel,
+      category: SceneCategory.lifeTravel,
+      name: 'Completed travel practice',
+    );
+    final controller = PracticeController(
+      client: FakePracticeClient(
+        practiceExperience: scene.experience,
+        sceneCategory: scene.category,
+        completionMode: PracticeCompletionMode.userControlled,
+        turnLimit: 0,
+      ),
+    );
+    addTearDown(controller.dispose);
+    await controller.activateCreatedPractice(
+      scene: scene,
+      sessionId: 'session-completed-scenario',
+      planId: testPracticePlanId('session-completed-scenario'),
+      practiceMode: scene.practiceOptions.first.mode,
+      turnLimit: 0,
+      clientOperationId: 'activate-completed-scenario',
+    );
+    await controller.submitPracticeText('I would like to check in.');
+    await controller.completeActivePractice();
+
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('Training root')),
+      ),
+    );
+    final routeResult = navigatorKey.currentState!
+        .push<CompletedPracticeRouteResult>(
+          MaterialPageRoute<CompletedPracticeRouteResult>(
+            builder: (_) => ScenarioPracticePage(
+              practiceController: controller,
+              onOpenReport: (_) async =>
+                  CompletedPracticeRouteResult.returnToTraining,
+            ),
+          ),
+        );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('scenario-completion-primary')));
+    await tester.pumpAndSettle();
+
+    expect(await routeResult, CompletedPracticeRouteResult.returnToTraining);
+    expect(find.text('Training root'), findsOneWidget);
+  });
+
   testWidgets('finishes an interview manually and opens its completion sheet', (
     tester,
   ) async {

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -86,8 +86,17 @@ void main() {
     );
     await controller.submitPracticeText('I would like to check in.');
 
+    String? openedReportSessionId;
     await tester.pumpWidget(
-      MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          onOpenReport: (sessionId) async {
+            openedReportSessionId = sessionId;
+            return null;
+          },
+        ),
+      ),
     );
     await tester.pump();
 
@@ -103,6 +112,12 @@ void main() {
 
     expect(controller.recordingState, PracticeRecordingState.completed);
     expect(controller.currentQuestion, isNull);
+    expect(find.text('场景练习已完成'), findsOneWidget);
+    expect(find.text('1 轮对话已保存'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('scenario-completion-primary')));
+    await tester.pump();
+    expect(openedReportSessionId, 'session-open-scenario');
     expect(tester.takeException(), isNull);
   });
 
@@ -126,6 +141,50 @@ void main() {
     expect(find.byKey(const Key('scenario-conversation-history')), findsOne);
     expect(find.byKey(const Key('scenario-record')).hitTestable(), findsOne);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('finishes an interview manually and opens its completion sheet', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final scene = testScenes.first;
+    final controller = PracticeController(
+      client: FakePracticeClient(
+        practiceExperience: scene.experience,
+        sceneCategory: scene.category,
+        completionMode: PracticeCompletionMode.userControlled,
+        turnLimit: 0,
+      ),
+    );
+    addTearDown(controller.dispose);
+    await controller.activateCreatedPractice(
+      scene: scene,
+      sessionId: 'session-open-interview',
+      planId: testPracticePlanId('session-open-interview'),
+      practiceMode: scene.practiceOptions.first.mode,
+      turnLimit: 0,
+      clientOperationId: 'activate-open-interview',
+    );
+    await controller.submitPracticeText('I led the migration project.');
+
+    await tester.pumpWidget(
+      MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
+    );
+
+    await tester.tap(find.byKey(const Key('scenario-complete-practice')));
+    await tester.pumpAndSettle();
+    expect(find.text('结束面试练习？'), findsOneWidget);
+    expect(find.text('结束后将保存本次回答并生成面试复盘。'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('scenario-confirm-completion')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('interview-completion-sheet')), findsOneWidget);
+    expect(find.text('面试练习已完成'), findsOneWidget);
+    expect(find.text('1 道回答已保存'), findsOneWidget);
+    expect(find.text('返回面试列表'), findsOneWidget);
   });
 
   testWidgets('translates a scenario question once and toggles the read aid', (
@@ -397,7 +456,11 @@ void main() {
       );
       expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
       expect(find.text('正在生成评分与纠错…'), findsNothing);
-      expect(find.text('返回主聊天'), findsOneWidget);
+      expect(
+        find.byKey(const Key('scenario-completion-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('场景练习已完成'), findsOneWidget);
     },
   );
 
@@ -425,7 +488,7 @@ void main() {
         ),
       ),
     );
-    await tester.tap(find.text('返回主聊天'));
+    await tester.tap(find.byKey(const Key('scenario-completion-secondary')));
     await tester.pump();
 
     expect(completionCalls, 1);

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -38,19 +38,16 @@ void main() {
 
     expect(snapshot.practiceExperience, PracticeExperience.ieltsSpeaking);
     expect(snapshot.practiceMode, PracticeMode.part2);
-    expect(snapshot.turnLimit, 3);
+    expect(snapshot.turnLimit, 1);
     expect(
       snapshot.ieltsAssignment?.parts.map((part) => part.part),
-      const <IeltsSpeakingPart>[
-        IeltsSpeakingPart.part2,
-        IeltsSpeakingPart.part3,
-      ],
+      const <IeltsSpeakingPart>[IeltsSpeakingPart.part2],
     );
     expect(
       snapshot.ieltsAssignment?.part(IeltsSpeakingPart.part2)?.cueCard,
       'Describe a useful skill you learned.',
     );
-    expect(snapshot.ieltsAssignment?.turnBlueprints, hasLength(3));
+    expect(snapshot.ieltsAssignment?.turnBlueprints, hasLength(1));
     transport.expectDone();
   });
 
@@ -60,7 +57,7 @@ void main() {
       final invalidStates = <Map<String, Object?>>[
         _ieltsPart2SessionJson()..remove('ielts_assignment'),
         _ieltsPart2SessionJson()..['practice_mode'] = 'PART_3',
-        _ieltsPart2SessionJson()..['turn_limit'] = 4,
+        _ieltsPart2SessionJson()..['turn_limit'] = 2,
         _sessionJson()..['ielts_assignment'] = _ieltsPart2AssignmentJson(),
       ];
 
@@ -1140,7 +1137,7 @@ Map<String, Object?> _ieltsPart2SessionJson() => <String, Object?>{
   'practice_experience': 'IELTS_SPEAKING',
   'scene_category': 'IELTS_SPEAKING',
   'practice_mode': 'PART_2',
-  'turn_limit': 3,
+  'turn_limit': 1,
   'ielts_assignment': _ieltsPart2AssignmentJson(),
 };
 
@@ -1155,15 +1152,6 @@ Map<String, Object?> _ieltsPart2AssignmentJson() => <String, Object?>{
       'topic_title': 'Learning skills',
       'cue_card': 'Describe a useful skill you learned.',
       'turn_blueprints': <String>['Describe a useful skill you learned.'],
-    },
-    <String, Object?>{
-      'part': 'PART_3',
-      'source_id': 'topic-group-test',
-      'topic_title': 'Learning skills',
-      'turn_blueprints': <String>[
-        'Why do people learn new skills?',
-        'Should employers support learning?',
-      ],
     },
   ],
 };

--- a/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
+++ b/mobile/test/coaching/preparation/wire_preparation_launch_client_test.dart
@@ -357,7 +357,7 @@ const _ieltsPlanInput = CreatePracticePlanInput(
   sceneVersion: 1,
   selectedRoleIds: <String>['ielts-examiner'],
   practiceOptionId: 'ielts-part-2',
-  maxEffectiveTurns: 7,
+  maxEffectiveTurns: 1,
   ieltsSelection: IeltsPracticeSelection(topicGroupId: 'famous-person'),
   ieltsPreparedAnswers: <IeltsPreparedAnswer>[
     IeltsPreparedAnswer(
@@ -383,7 +383,9 @@ Map<String, Object?> _ieltsPlanJson() {
   );
   response['session_policy'] = <String, Object?>{
     ...contractSessionPolicyJson(),
-    'max_effective_turns': 7,
+    'min_effective_turns': 1,
+    'max_effective_turns': 1,
+    'coverage_checkpoint_turn': 1,
   };
   response['ielts_assignment'] = _ieltsPart2AssignmentJson();
   return response;
@@ -421,19 +423,6 @@ Map<String, Object?> _ieltsPart2AssignmentJson() => <String, Object?>{
           'answer': 'I would like to meet a songwriter I admire.',
           'personalized': true,
         },
-      ],
-    },
-    <String, Object?>{
-      'part': 'PART_3',
-      'source_id': 'famous-person',
-      'topic_title': 'Famous people',
-      'turn_blueprints': <String>[
-        'Why do people become famous?',
-        'Is talent necessary for fame?',
-        'How does fame affect children?',
-        'What responsibilities do famous people have?',
-        'Is it easier to become famous today?',
-        'Would you like to be famous?',
       ],
     },
   ],

--- a/mobile/test/review/turn_feedback_page_integration_test.dart
+++ b/mobile/test/review/turn_feedback_page_integration_test.dart
@@ -151,64 +151,59 @@ void main() {
     },
   );
 
-  testWidgets('IELTS Part 2 English answer enters Part 3 after confirmation', (
-    tester,
-  ) async {
-    final feedback = _practiceFeedback();
-    final client = _Client(feedback);
-    final feedbackController = SpeechFeedbackController(
-      client: client,
-      pollInterval: Duration.zero,
-      maximumPollAttempts: 1,
-    );
-    final snapshot = _practiceSnapshot(
-      feedback.statusUrl,
-      practiceExperience: PracticeExperience.ieltsSpeaking,
-      sceneCategory: SceneCategory.ieltsSpeaking,
-      turnLimit: 6,
-    );
-    final practiceController = PracticeController(
-      client: _PracticeClient(snapshot),
-    );
-    addTearDown(feedbackController.dispose);
-    addTearDown(practiceController.dispose);
-    await _restorePractice(practiceController, snapshot);
+  testWidgets(
+    'IELTS Part 2 English answer keeps feedback behind independent completion',
+    (tester) async {
+      final feedback = _practiceFeedback();
+      final client = _Client(feedback);
+      final feedbackController = SpeechFeedbackController(
+        client: client,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 1,
+      );
+      final snapshot = _practiceSnapshot(
+        feedback.statusUrl,
+        practiceExperience: PracticeExperience.ieltsSpeaking,
+        sceneCategory: SceneCategory.ieltsSpeaking,
+        turnLimit: 1,
+      );
+      final practiceController = PracticeController(
+        client: _PracticeClient(snapshot),
+      );
+      addTearDown(feedbackController.dispose);
+      addTearDown(practiceController.dispose);
+      await _restorePractice(practiceController, snapshot);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: IeltsSpeakingMockPage(
-          controller: practiceController,
-          speechFeedbackController: feedbackController,
-          progressStore: _MemoryIeltsProgressStore(),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: practiceController,
+            speechFeedbackController: feedbackController,
+            progressStore: _MemoryIeltsProgressStore(),
+          ),
         ),
-      ),
-    );
-    await tester.pump();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
 
-    expect(client.calls, 1);
-    expect(
-      find.byKey(const Key('ielts-mock-part-2-transition')),
-      findsOneWidget,
-    );
-    await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
-    expect(find.text('Part 3 · Discussion'), findsOneWidget);
-    expect(
-      find.byKey(const Key('ielts-part2-practice-complete')),
-      findsNothing,
-    );
-    expect(
-      feedbackController.projectionFor(
-        'practice:practice_session_001:practice_turn_001',
-      ),
-      isNotNull,
-    );
-    expect(find.text('评分与纠错'), findsNothing);
-  });
+      expect(client.calls, 1);
+      expect(find.byKey(const Key('ielts-section-completion-sheet')), findsOne);
+      expect(find.text('Part 2 已完成'), findsOne);
+      expect(
+        find.byKey(const Key('ielts-mock-part-2-transition')),
+        findsNothing,
+      );
+      expect(find.byKey(const Key('ielts-part2-continue-part3')), findsNothing);
+      expect(
+        feedbackController.projectionFor(
+          'practice:practice_session_001:practice_turn_001',
+        ),
+        isNotNull,
+      );
+      expect(find.text('评分与纠错'), findsNothing);
+    },
+  );
 
   testWidgets('IELTS keeps a Chinese answer but hides insufficient feedback', (
     tester,
@@ -224,7 +219,7 @@ void main() {
       feedback.statusUrl,
       practiceExperience: PracticeExperience.ieltsSpeaking,
       sceneCategory: SceneCategory.ieltsSpeaking,
-      turnLimit: 6,
+      turnLimit: 1,
     );
     final practiceController = PracticeController(
       client: _PracticeClient(
@@ -253,7 +248,8 @@ void main() {
                 answerText: '然后，黄天宇主要来把这个。',
                 evidenceVersion: 1,
                 effectiveTurns: 1,
-                sessionCompleted: false,
+                sessionCompleted:
+                    snapshot.turnHistory.single.turn.sessionCompleted,
                 audioAssetId: 'audio_asset_001',
                 speechFeedbackStatusUrl: feedback.statusUrl,
               ),
@@ -279,18 +275,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(
-      find.byKey(const Key('ielts-mock-part-2-transition')),
-      findsOneWidget,
-    );
-    await tester.tap(find.byKey(const Key('ielts-part2-continue-part3')));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('ielts-mock-part-3')), findsOneWidget);
-    expect(
-      find.byKey(const Key('ielts-part2-practice-complete')),
-      findsNothing,
-    );
+    expect(find.byKey(const Key('ielts-section-completion-sheet')), findsOne);
+    expect(find.text('Part 2 已完成'), findsOne);
+    expect(find.byKey(const Key('ielts-mock-part-2-transition')), findsNothing);
+    expect(find.byKey(const Key('ielts-part2-continue-part3')), findsNothing);
     expect(find.textContaining('证据不足'), findsNothing);
     expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
   });
@@ -500,6 +488,7 @@ PracticeSessionSnapshot _practiceSnapshot(
   int turnLimit = 3,
 }) {
   const sessionId = 'practice_session_001';
+  final ielts = practiceExperience == PracticeExperience.ieltsSpeaking;
   const question = PracticeQuestion(
     id: 'practice_question_001',
     sessionId: sessionId,
@@ -510,25 +499,22 @@ PracticeSessionSnapshot _practiceSnapshot(
     planId: 'plan_practice_session_001',
     practiceExperience: practiceExperience,
     sceneCategory: sceneCategory,
-    practiceMode: practiceExperience == PracticeExperience.ieltsSpeaking
-        ? PracticeMode.part2
-        : PracticeMode.fullSimulation,
+    practiceMode: ielts ? PracticeMode.part2 : PracticeMode.fullSimulation,
     capabilities: testPracticeCapabilities,
     sessionVersion: 2,
     completedTurns: 1,
     turnLimit: turnLimit,
-    sessionCompleted: false,
-    ieltsAssignment: practiceExperience == PracticeExperience.ieltsSpeaking
-        ? testIeltsAssignment(
-            mode: PracticeMode.part2,
-            part3QuestionCount: turnLimit - 1,
-          )
+    sessionCompleted: ielts,
+    ieltsAssignment: ielts
+        ? testIeltsAssignment(mode: PracticeMode.part2)
         : null,
-    currentQuestion: const PracticeQuestion(
-      id: 'practice_question_002',
-      sessionId: sessionId,
-      text: 'What happened next?',
-    ),
+    currentQuestion: ielts
+        ? null
+        : const PracticeQuestion(
+            id: 'practice_question_002',
+            sessionId: sessionId,
+            text: 'What happened next?',
+          ),
     turnHistory: [
       PracticeTurnExchange(
         question: question,
@@ -541,7 +527,7 @@ PracticeSessionSnapshot _practiceSnapshot(
           answerText: 'I manage the release.',
           evidenceVersion: 1,
           effectiveTurns: 1,
-          sessionCompleted: false,
+          sessionCompleted: ielts,
           audioAssetId: 'audio_asset_001',
           speechFeedbackStatusUrl: statusUrl,
         ),

--- a/mobile/test/support/practice_fixtures.dart
+++ b/mobile/test/support/practice_fixtures.dart
@@ -68,10 +68,7 @@ IeltsPracticeAssignment testIeltsAssignment({
     PracticeMode.part1 => <IeltsPracticePartAssignment>[
       _testIeltsPart1(part1QuestionCount),
     ],
-    PracticeMode.part2 => <IeltsPracticePartAssignment>[
-      _testIeltsPart2(),
-      _testIeltsPart3(part3QuestionCount),
-    ],
+    PracticeMode.part2 => <IeltsPracticePartAssignment>[_testIeltsPart2()],
     PracticeMode.part3 => <IeltsPracticePartAssignment>[
       _testIeltsPart3(part3QuestionCount),
     ],

--- a/server/internal/coaching/ielts/catalog.go
+++ b/server/internal/coaching/ielts/catalog.go
@@ -284,11 +284,11 @@ func (catalog *Catalog) resolveQuestionSet(
 		if selection.Part1SetID != "" || selection.TopicGroupID == "" {
 			return ResolvedQuestionSet{}, ErrPracticeModeInvalid
 		}
-		part2, part3, err := catalog.resolvePart23Group(selection.TopicGroupID)
+		part2, _, err := catalog.resolvePart23Group(selection.TopicGroupID)
 		if err != nil {
 			return ResolvedQuestionSet{}, err
 		}
-		result.Parts = []ResolvedPart{part2, part3}
+		result.Parts = []ResolvedPart{part2}
 	case PracticeModePart3:
 		if selection.Part1SetID != "" || selection.TopicGroupID == "" {
 			return ResolvedQuestionSet{}, ErrPracticeModeInvalid

--- a/server/internal/coaching/ielts/question_bank_test.go
+++ b/server/internal/coaching/ielts/question_bank_test.go
@@ -65,7 +65,8 @@ func TestCatalogResolvesEveryPracticeMode(t *testing.T) {
 		context.Background(),
 		QuestionSetSelection{Mode: PracticeModePart2, TopicGroupID: "p23-new-001"},
 	)
-	if err != nil || len(part2.Parts) != 2 ||
+	if err != nil || len(part2.Parts) != 1 ||
+		part2.Parts[0].Part != PracticeModePart2 ||
 		!strings.Contains(part2.Parts[0].CueCard, "You should say:") {
 		t.Fatalf("Part 2 = %#v, error = %v", part2, err)
 	}

--- a/server/internal/coaching/practice/plan_projection.go
+++ b/server/internal/coaching/practice/plan_projection.go
@@ -301,7 +301,7 @@ func ValidIELTSAssignment(
 	case PracticeModePart1:
 		expected = []PracticeMode{PracticeModePart1}
 	case PracticeModePart2:
-		expected = []PracticeMode{PracticeModePart2, PracticeModePart3}
+		expected = []PracticeMode{PracticeModePart2}
 	case PracticeModePart3:
 		expected = []PracticeMode{PracticeModePart3}
 	default:

--- a/server/internal/coaching/preparation/service/plan.go
+++ b/server/internal/coaching/preparation/service/plan.go
@@ -661,10 +661,7 @@ func validIELTSAssignmentParts(
 	case scene.PracticeModePart1:
 		expected = []scene.PracticeMode{scene.PracticeModePart1}
 	case scene.PracticeModePart2:
-		expected = []scene.PracticeMode{
-			scene.PracticeModePart2,
-			scene.PracticeModePart3,
-		}
+		expected = []scene.PracticeMode{scene.PracticeModePart2}
 	case scene.PracticeModePart3:
 		expected = []scene.PracticeMode{scene.PracticeModePart3}
 	default:
@@ -753,7 +750,7 @@ func ieltsAssignmentSceneBrief(assignment preparation.IELTSAssignmentSnapshot) s
 	case scene.PracticeModePart1:
 		return "完成冻结的 Part 1 熟悉话题问答。"
 	case scene.PracticeModePart2:
-		return "完成“" + topicTitle + "”题卡，并可继续同主题 Part 3。"
+		return "完成“" + topicTitle + "”Part 2 题卡。"
 	case scene.PracticeModePart3:
 		return "围绕“" + topicTitle + "”完成同主题 Part 3 讨论。"
 	default:

--- a/server/internal/coaching/preparation/service/plan_ielts_catalog_test.go
+++ b/server/internal/coaching/preparation/service/plan_ielts_catalog_test.go
@@ -65,7 +65,12 @@ func TestStaticIELTSCatalogProducesPlanCompatibleAssignments(t *testing.T) {
 		scene.PracticeModePart3,
 	} {
 		t.Run(string(mode)+" random assignment", func(t *testing.T) {
-			assertCompatible(t, mode, nil)
+			assignment := assertCompatible(t, mode, nil)
+			if mode == scene.PracticeModePart2 &&
+				(len(assignment.Parts) != 1 ||
+					assignment.Parts[0].Part != scene.PracticeModePart2) {
+				t.Fatalf("Part 2 assignment = %#v", assignment.Parts)
+			}
 		})
 	}
 	for _, topic := range bank.Part1Topics {


### PR DESCRIPTION
## 功能描述

- 抽取可复用的练习完成弹窗，并复用到 IELTS Part 1、Part 2、Part 3、面试和普通场景练习。
- 将独立 Part 2 的题目快照与校验契约收紧为仅包含 Part 2，使 Part 2 可以单独完成并生成专项复盘；不保留未上线旧格式的兼容或数据迁移。
- 面试和普通场景在用户完成至少一轮回答后提供“结束练习”，服务端完成会话后弹出完成窗，可查看复盘或返回对应列表。

## 实现思路

- 新增 `PracticeCompletionOverlay`，统一遮罩、底部卡片、完成状态、主次操作和加载态。
- IELTS 专项模式继续使用现有会话与复盘页，仅调整 Part 2 assignment、完成判定和专项报告标题；完整模考仍保留 Part 2 → Part 3 过渡。
- 生产面试/场景路由共享同一完成流程，根据 `PracticeExperience` 展示不同文案，并复用现有 `SessionEvaluationPage`。
- 完成窗的返回动作新增训练页路由结果，确保返回对应训练列表。

## 可复现测试

- `cd mobile && PUB_HOSTED_URL=https://pub.dev flutter test --no-pub test/coaching/practice/practice_completion_sheet_test.dart test/coaching/practice/scenario_practice_test.dart test/coaching/practice/ielts_mock_practice_test.dart test/coaching/practice/wire_practice_client_test.dart test/speak_up_app_test.dart`
- 在 ASCII 临时副本执行 `PUB_HOSTED_URL=https://pub.dev flutter analyze --no-fatal-infos`
- `cd server && go test ./internal/coaching/ielts ./internal/coaching/preparation/service ./internal/coaching/practice/...`
- `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`：真实 PostgreSQL/后端 `/health`、`/readyz` 正常；iPhone 17 Pro 模拟器验证面试回答后“结束练习”确认框与完成窗。

Closes #828
