### PR TITLE
fix(ci): fail when coverage baseline is unavailable

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -261,9 +261,7 @@ jobs:
               (workflow) => workflow.name === "Quality",
             );
             if (!qualityWorkflow) {
-              core.warning("Unable to find the Quality workflow; coverage gate skipped");
-              core.setOutput("available", "false");
-              return;
+              throw new Error("Unable to find the Quality workflow");
             }
 
             const runs = await github.paginate(
@@ -301,21 +299,13 @@ jobs:
             }
 
             if (!baseline) {
-              core.warning(
-                "No successful Quality run has a Go coverage artifact; coverage gate skipped",
+              throw new Error(
+                "No successful Quality run has a Go coverage artifact",
               );
-              core.setOutput("available", "false");
-              return;
             }
 
             core.setOutput("run_id", String(baseline.id));
             core.setOutput("available", "true");
-
-      - name: Explain missing coverage baseline
-        if: steps.baseline.outputs.available != 'true'
-        run: >-
-          echo "Coverage gate skipped because the base branch has no Go
-          coverage artifact baseline yet."
 
       - name: Download baseline Go coverage
         if: steps.baseline.outputs.available == 'true'
@@ -413,9 +403,7 @@ jobs:
               (workflow) => workflow.name === "Quality",
             );
             if (!qualityWorkflow) {
-              core.warning("Unable to find the Quality workflow; Flutter coverage gate skipped");
-              core.setOutput("available", "false");
-              return;
+              throw new Error("Unable to find the Quality workflow");
             }
 
             const runs = await github.paginate(
@@ -453,21 +441,13 @@ jobs:
             }
 
             if (!baseline) {
-              core.warning(
-                "No successful Quality run has a Flutter coverage artifact; coverage gate skipped",
+              throw new Error(
+                "No successful Quality run has a Flutter coverage artifact",
               );
-              core.setOutput("available", "false");
-              return;
             }
 
             core.setOutput("run_id", String(baseline.id));
             core.setOutput("available", "true");
-
-      - name: Explain missing Flutter coverage baseline
-        if: steps.baseline.outputs.available != 'true'
-        run: >-
-          echo "Flutter coverage gate skipped because the base branch has no
-          Flutter coverage artifact baseline yet."
 
       - name: Download baseline Flutter coverage
         if: steps.baseline.outputs.available == 'true'


### PR DESCRIPTION
## 功能

覆盖率比较所需的 base branch 基线不可用时阻止 PR 通过，不再静默跳过 Go 或 Flutter 覆盖率门禁。

## 实现思路

- 找不到 Quality workflow 时让对应 coverage gate 明确失败
- 找不到成功且包含对应覆盖率 artifact 的基线运行时明确失败
- 删除不再可达的“跳过基线”说明步骤
- 保持现有覆盖率计算、下降判断和 PR 评论逻辑不变

## 可复现测试

- `ruby -e 'require "yaml"; YAML.safe_load_file(ARGV.fetch(0), aliases: true); puts "workflow yaml: ok"' .github/workflows/quality.yml`
- `git diff --check`
- 使用 Node 标准库提取两个 `Resolve baseline run` 脚本并注入 GitHub API fake，验证：
  - Quality workflow 缺失：Go、Flutter 均抛错
  - 对应基线 artifact 缺失：Go、Flutter 均抛错
  - 合法基线存在：均输出 `available=true` 和 `run_id`
- 确认 `dev` 最新成功 Quality 运行同时包含未过期的 `go-coverage-server` 与 `flutter-coverage-mobile` artifact
- 提交后以本 PR 的真实 GitHub Actions 结果作为正常基线路径验收

Closes #830
