### PR TITLE
feat(practice): 支持下拉关闭最终练习完成弹窗

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -158,6 +158,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   int _observedCompletedTurns = 0;
   bool _preserveCompletedConversation = false;
   bool _showCompletionSheet = false;
+  bool _completionSheetDismissed = false;
   bool _openingReadyReport = false;
 
   IeltsPracticeSelection? get _selection {
@@ -265,6 +266,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _observedCompletedTurns = widget.controller.completedTurns;
       _preserveCompletedConversation = false;
       _showCompletionSheet = false;
+      _completionSheetDismissed = false;
       _openingReadyReport = false;
       _questionNarrationGeneration++;
       _autoNarratedQuestionId = null;
@@ -520,6 +522,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _observedCompletedTurns = 0;
       _preserveCompletedConversation = false;
       _showCompletionSheet = false;
+      _completionSheetDismissed = false;
       setState(() {});
       return;
     }
@@ -536,6 +539,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (justCompletedSession) {
       _preserveCompletedConversation = true;
       _showCompletionSheet = true;
+      _completionSheetDismissed = false;
     }
     if (_visibleTipQuestionId != widget.controller.currentQuestion?.id) {
       _visibleTipQuestionId = null;
@@ -1670,8 +1674,9 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   };
 
   Widget? _completionSheet(IeltsMockProgress progress) {
-    if (_showCompletionSheet ||
-        _keepsSectionCompletionInConversation(progress)) {
+    if (!_completionSheetDismissed &&
+        (_showCompletionSheet ||
+            _keepsSectionCompletionInConversation(progress))) {
       return PracticeCompletionOverlay(
         keyPrefix: 'ielts-${_mode.name}-completion',
         sheetKey: const Key('ielts-section-completion-sheet'),
@@ -1689,6 +1694,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
         secondaryLabel: _mode == PracticeMode.fullMock ? '返回训练' : '返回题单',
         onPrimary: _openCompletedReview,
         onSecondary: _leaveCompletedPractice,
+        onDismissed: _dismissCompletionSheet,
       );
     }
     if (_mode != PracticeMode.fullMock) {
@@ -1696,6 +1702,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     if (progress.phase == IeltsMockPhase.part1Complete) {
       return PracticeCompletionOverlay(
+        dismissible: false,
         keyPrefix: 'ielts-part1-transition',
         sheetKey: const Key('ielts-section-completion-sheet'),
         primaryKey: const Key('ielts-section-review-action'),
@@ -1710,6 +1717,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     if (progress.phase == IeltsMockPhase.part2Complete && _part2TurnConfirmed) {
       return PracticeCompletionOverlay(
+        dismissible: false,
         keyPrefix: 'ielts-part2-transition',
         sheetKey: const Key('ielts-section-completion-sheet'),
         primaryKey: const Key('ielts-section-review-action'),
@@ -1849,6 +1857,16 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     unawaited(_finishSection(IeltsPracticeCompletionAction.list));
+  }
+
+  void _dismissCompletionSheet() {
+    if (!mounted || _completionSheetDismissed) {
+      return;
+    }
+    setState(() {
+      _completionSheetDismissed = true;
+      _showCompletionSheet = false;
+    });
   }
 
   bool _usesShortAnswerRecorder(IeltsMockPhase phase) =>

--- a/mobile/lib/features/coaching/practice/practice_completion_sheet.dart
+++ b/mobile/lib/features/coaching/practice/practice_completion_sheet.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 
 /// Blocks the active practice surface and presents the available actions after
 /// the server has confirmed that the current practice session is complete.
-class PracticeCompletionOverlay extends StatelessWidget {
+class PracticeCompletionOverlay extends StatefulWidget {
   const PracticeCompletionOverlay({
     required this.title,
     required this.message,
@@ -11,6 +13,8 @@ class PracticeCompletionOverlay extends StatelessWidget {
     required this.secondaryLabel,
     required this.onPrimary,
     required this.onSecondary,
+    this.dismissible = true,
+    this.onDismissed,
     this.primaryLoading = false,
     this.keyPrefix = 'practice-completion',
     this.sheetKey,
@@ -25,6 +29,8 @@ class PracticeCompletionOverlay extends StatelessWidget {
   final String secondaryLabel;
   final VoidCallback? onPrimary;
   final VoidCallback? onSecondary;
+  final bool dismissible;
+  final VoidCallback? onDismissed;
   final bool primaryLoading;
   final String keyPrefix;
   final Key? sheetKey;
@@ -32,15 +38,138 @@ class PracticeCompletionOverlay extends StatelessWidget {
   final Key? secondaryKey;
 
   @override
+  State<PracticeCompletionOverlay> createState() =>
+      _PracticeCompletionOverlayState();
+}
+
+class _PracticeCompletionOverlayState extends State<PracticeCompletionOverlay>
+    with SingleTickerProviderStateMixin {
+  static const double _dismissDistanceRatio = 0.25;
+  static const double _dismissVelocity = 900;
+  static const Duration _dismissDuration = Duration(milliseconds: 220);
+  static const Duration _reboundDuration = Duration(milliseconds: 180);
+
+  final GlobalKey _sheetMeasureKey = GlobalKey();
+  late final AnimationController _animationController;
+  Animation<double>? _offsetAnimation;
+  double _dragOffset = 0;
+  double? _measuredSheetHeight;
+  bool _hidden = false;
+
+  double get _currentOffset => _offsetAnimation?.value ?? _dragOffset;
+
+  double _readSheetHeight() {
+    final measuredHeight = _sheetMeasureKey.currentContext?.size?.height;
+    if (measuredHeight != null) {
+      _measuredSheetHeight = measuredHeight;
+    }
+    return _measuredSheetHeight ?? MediaQuery.sizeOf(context).height * 0.45;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(vsync: this)
+      ..addListener(() {
+        if (mounted) {
+          setState(() {});
+        }
+      });
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    if (!widget.dismissible || _animationController.isAnimating) {
+      return;
+    }
+    _readSheetHeight();
+    setState(() {
+      _offsetAnimation = null;
+      _dragOffset = (_dragOffset + details.delta.dy).clamp(
+        0.0,
+        double.infinity,
+      );
+    });
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    if (!widget.dismissible || _animationController.isAnimating) {
+      return;
+    }
+    final downwardVelocity = details.primaryVelocity ?? 0;
+    final sheetHeight = _readSheetHeight();
+    final shouldDismiss =
+        _dragOffset >= sheetHeight * _dismissDistanceRatio ||
+        downwardVelocity >= _dismissVelocity;
+    if (shouldDismiss) {
+      unawaited(_animateDismiss());
+    } else {
+      unawaited(_animateBack());
+    }
+  }
+
+  Future<void> _animateBack() async {
+    _offsetAnimation = Tween<double>(begin: _dragOffset, end: 0).animate(
+      CurvedAnimation(parent: _animationController, curve: Curves.easeOutCubic),
+    );
+    _animationController.duration = _reboundDuration;
+    await _animationController.forward(from: 0);
+    if (!mounted) {
+      return;
+    }
+    _animationController.reset();
+    setState(() {
+      _dragOffset = 0;
+      _offsetAnimation = null;
+    });
+  }
+
+  Future<void> _animateDismiss() async {
+    if (!widget.dismissible || _hidden || _animationController.isAnimating) {
+      return;
+    }
+    final targetOffset = MediaQuery.sizeOf(context).height + _readSheetHeight();
+    _offsetAnimation = Tween<double>(begin: _dragOffset, end: targetOffset)
+        .animate(
+          CurvedAnimation(
+            parent: _animationController,
+            curve: Curves.easeOutCubic,
+          ),
+        );
+    _animationController.duration = _dismissDuration;
+    await _animationController.forward(from: 0);
+    if (!mounted || _hidden) {
+      return;
+    }
+    setState(() => _hidden = true);
+    widget.onDismissed?.call();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (_hidden) {
+      return const SizedBox.shrink();
+    }
+    final sheetHeight =
+        _measuredSheetHeight ?? MediaQuery.sizeOf(context).height * 0.45;
+    final dismissProgress = (_currentOffset / sheetHeight).clamp(0.0, 1.0);
     return Stack(
-      key: Key('$keyPrefix-overlay'),
+      key: Key('${widget.keyPrefix}-overlay'),
       fit: StackFit.expand,
       children: [
-        const ModalBarrier(
+        ModalBarrier(
           dismissible: false,
-          color: Color(0x14000000),
-          semanticsLabel: '练习完成',
+          color: Color.lerp(
+            const Color(0x14000000),
+            Colors.transparent,
+            dismissProgress,
+          ),
+          semanticsLabel: widget.title,
         ),
         Align(
           alignment: Alignment.bottomCenter,
@@ -51,95 +180,134 @@ class PracticeCompletionOverlay extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
               child: ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 560),
-                child: Material(
-                  key: sheetKey ?? Key('$keyPrefix-sheet'),
-                  color: SpeakUpDesign.surface,
-                  elevation: 12,
-                  shadowColor: const Color(0x26000000),
-                  borderRadius: BorderRadius.circular(28),
-                  clipBehavior: Clip.antiAlias,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Center(
-                          child: Container(
-                            width: 42,
-                            height: 4,
-                            decoration: BoxDecoration(
-                              color: SpeakUpDesign.border,
-                              borderRadius: BorderRadius.circular(99),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 18),
-                        Center(
-                          child: Container(
-                            width: 52,
-                            height: 52,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: SpeakUpDesign.ink,
-                                width: 2,
+                child: Transform.translate(
+                  offset: Offset(0, _currentOffset),
+                  child: KeyedSubtree(
+                    key: _sheetMeasureKey,
+                    child: Material(
+                      key: widget.sheetKey ?? Key('${widget.keyPrefix}-sheet'),
+                      color: SpeakUpDesign.surface,
+                      elevation: 12,
+                      shadowColor: const Color(0x26000000),
+                      borderRadius: BorderRadius.circular(28),
+                      clipBehavior: Clip.antiAlias,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            GestureDetector(
+                              key: Key('${widget.keyPrefix}-drag-region'),
+                              behavior: HitTestBehavior.opaque,
+                              onVerticalDragUpdate: widget.dismissible
+                                  ? _handleDragUpdate
+                                  : null,
+                              onVerticalDragEnd: widget.dismissible
+                                  ? _handleDragEnd
+                                  : null,
+                              child: Semantics(
+                                container: true,
+                                hint: widget.dismissible
+                                    ? '向下拖动可关闭完成提示并查看练习对话'
+                                    : null,
+                                onTap: widget.dismissible
+                                    ? () => unawaited(_animateDismiss())
+                                    : null,
+                                child: Column(
+                                  children: [
+                                    Center(
+                                      child: Container(
+                                        width: 42,
+                                        height: 4,
+                                        decoration: BoxDecoration(
+                                          color: SpeakUpDesign.border,
+                                          borderRadius: BorderRadius.circular(
+                                            99,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 18),
+                                    Center(
+                                      child: Container(
+                                        width: 52,
+                                        height: 52,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          border: Border.all(
+                                            color: SpeakUpDesign.ink,
+                                            width: 2,
+                                          ),
+                                        ),
+                                        child: const Icon(
+                                          Icons.check_rounded,
+                                          size: 34,
+                                          color: SpeakUpDesign.ink,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Text(
+                                      widget.title,
+                                      textAlign: TextAlign.center,
+                                      style: SpeakUpDesign.pageTitle.copyWith(
+                                        fontSize: 24,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 6),
+                                    Text(
+                                      widget.message,
+                                      textAlign: TextAlign.center,
+                                      style: SpeakUpDesign.body.copyWith(
+                                        color: SpeakUpDesign.secondary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
-                            child: const Icon(
-                              Icons.check_rounded,
-                              size: 34,
-                              color: SpeakUpDesign.ink,
+                            const SizedBox(height: 20),
+                            FilledButton(
+                              key:
+                                  widget.primaryKey ??
+                                  Key('${widget.keyPrefix}-primary'),
+                              onPressed: widget.primaryLoading
+                                  ? null
+                                  : widget.onPrimary,
+                              style: FilledButton.styleFrom(
+                                minimumSize: const Size.fromHeight(54),
+                                backgroundColor: SpeakUpDesign.ink,
+                                foregroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(14),
+                                ),
+                              ),
+                              child: widget.primaryLoading
+                                  ? const SizedBox.square(
+                                      dimension: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: Colors.white,
+                                      ),
+                                    )
+                                  : Text(widget.primaryLabel),
                             ),
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          title,
-                          textAlign: TextAlign.center,
-                          style: SpeakUpDesign.pageTitle.copyWith(fontSize: 24),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          message,
-                          textAlign: TextAlign.center,
-                          style: SpeakUpDesign.body.copyWith(
-                            color: SpeakUpDesign.secondary,
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        FilledButton(
-                          key: primaryKey ?? Key('$keyPrefix-primary'),
-                          onPressed: primaryLoading ? null : onPrimary,
-                          style: FilledButton.styleFrom(
-                            minimumSize: const Size.fromHeight(54),
-                            backgroundColor: SpeakUpDesign.ink,
-                            foregroundColor: Colors.white,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(14),
+                            const SizedBox(height: 4),
+                            TextButton(
+                              key:
+                                  widget.secondaryKey ??
+                                  Key('${widget.keyPrefix}-secondary'),
+                              onPressed: widget.onSecondary,
+                              style: TextButton.styleFrom(
+                                foregroundColor: SpeakUpDesign.ink,
+                                minimumSize: const Size.fromHeight(44),
+                              ),
+                              child: Text(widget.secondaryLabel),
                             ),
-                          ),
-                          child: primaryLoading
-                              ? const SizedBox.square(
-                                  dimension: 20,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: Colors.white,
-                                  ),
-                                )
-                              : Text(primaryLabel),
+                          ],
                         ),
-                        const SizedBox(height: 4),
-                        TextButton(
-                          key: secondaryKey ?? Key('$keyPrefix-secondary'),
-                          onPressed: onSecondary,
-                          style: TextButton.styleFrom(
-                            foregroundColor: SpeakUpDesign.ink,
-                            minimumSize: const Size.fromHeight(44),
-                          ),
-                          child: Text(secondaryLabel),
-                        ),
-                      ],
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -1510,6 +1510,56 @@ void main() {
     expect(find.byKey(const Key('open-section-completion')), findsOneWidget);
   });
 
+  testWidgets('Part 1 completion sheet dismisses to reveal the conversation', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 3, turnLimit: 4);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await _answerCurrentShortQuestion(tester, controller);
+
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('Answer 4'), findsOneWidget);
+
+    await tester.timedDrag(
+      find.byKey(const Key('ielts-part1-completion-drag-region')),
+      const Offset(0, 200),
+      const Duration(milliseconds: 600),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsNothing,
+    );
+    expect(find.byKey(const Key('ielts-mock-conversation')), findsOneWidget);
+    expect(find.text('Answer 4'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-exit')), findsOneWidget);
+  });
+
   testWidgets('Part 1 opens the shared section review page', (tester) async {
     final practice = _IeltsPracticeClient(initialCompleted: 3, turnLimit: 4);
     final controller = PracticeController(
@@ -1587,6 +1637,16 @@ void main() {
     expect(find.text(_question(9).text), findsNothing);
     expect(find.textContaining('You should say:'), findsNothing);
     expect(find.byKey(const Key('practice-page')), findsNothing);
+
+    await tester.drag(
+      find.byKey(const Key('ielts-part1-transition-drag-region')),
+      const Offset(0, 240),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
 
     await tester.tap(find.text('保存并退出'));
     await tester.pumpAndSettle();

--- a/mobile/test/coaching/practice/interview_practice_completion_test.dart
+++ b/mobile/test/coaching/practice/interview_practice_completion_test.dart
@@ -65,6 +65,10 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('面试练习已完成'), findsOneWidget);
       expect(find.text('1 道回答已保存'), findsOneWidget);
+      expect(
+        find.byKey(const Key('interview-completion-drag-region')),
+        findsOneWidget,
+      );
 
       await tester.tap(find.byKey(const Key('interview-completion-primary')));
       await tester.pumpAndSettle();

--- a/mobile/test/coaching/practice/practice_completion_sheet_test.dart
+++ b/mobile/test/coaching/practice/practice_completion_sheet_test.dart
@@ -78,4 +78,135 @@ void main() {
     expect(button.onPressed, isNull);
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
+
+  testWidgets('follows a downward drag and rebounds below the threshold', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeCompletionOverlay(
+            title: '练习已完成',
+            message: '回答已保存',
+            primaryLabel: '查看复盘报告',
+            secondaryLabel: '返回列表',
+            onPrimary: () {},
+            onSecondary: () {},
+          ),
+        ),
+      ),
+    );
+
+    final sheet = find.byKey(const Key('practice-completion-sheet'));
+    final dragRegion = find.byKey(const Key('practice-completion-drag-region'));
+    final initialTop = tester.getTopLeft(sheet).dy;
+    final gesture = await tester.startGesture(tester.getCenter(dragRegion));
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+
+    expect(tester.getTopLeft(sheet).dy, greaterThan(initialTop));
+    final barrierDuringDrag = tester.widget<ModalBarrier>(
+      find.descendant(
+        of: find.byKey(const Key('practice-completion-overlay')),
+        matching: find.byType(ModalBarrier),
+      ),
+    );
+    expect(barrierDuringDrag.color!.a, lessThan(const Color(0x14000000).a));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(sheet).dy, initialTop);
+  });
+
+  testWidgets('dismisses after a drag beyond the distance threshold', (
+    tester,
+  ) async {
+    var dismissCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeCompletionOverlay(
+            title: '练习已完成',
+            message: '回答已保存',
+            primaryLabel: '查看复盘报告',
+            secondaryLabel: '返回列表',
+            onPrimary: () {},
+            onSecondary: () {},
+            onDismissed: () => dismissCalls++,
+          ),
+        ),
+      ),
+    );
+
+    await tester.timedDrag(
+      find.byKey(const Key('practice-completion-drag-region')),
+      const Offset(0, 180),
+      const Duration(milliseconds: 600),
+    );
+    await tester.pumpAndSettle();
+
+    expect(dismissCalls, 1);
+    expect(find.byKey(const Key('practice-completion-sheet')), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('practice-completion-overlay')),
+        matching: find.byType(ModalBarrier),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('dismisses after a fast downward fling', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeCompletionOverlay(
+            title: '练习已完成',
+            message: '回答已保存',
+            primaryLabel: '查看复盘报告',
+            secondaryLabel: '返回列表',
+            onPrimary: () {},
+            onSecondary: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.fling(
+      find.byKey(const Key('practice-completion-drag-region')),
+      const Offset(0, 80),
+      2000,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('practice-completion-sheet')), findsNothing);
+  });
+
+  testWidgets('cannot dismiss a required transition sheet', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PracticeCompletionOverlay(
+            title: 'Part 1 已完成',
+            message: '回答已保存',
+            primaryLabel: '进入 Part 2',
+            secondaryLabel: '保存并退出',
+            onPrimary: () {},
+            onSecondary: () {},
+            dismissible: false,
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(
+      find.byKey(const Key('practice-completion-drag-region')),
+      const Offset(0, 240),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('practice-completion-sheet')), findsOneWidget);
+    expect(find.text('进入 Part 2'), findsOneWidget);
+  });
 }

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -516,6 +516,19 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('场景练习已完成'), findsOneWidget);
+
+      await tester.timedDrag(
+        find.byKey(const Key('scenario-completion-drag-region')),
+        const Offset(0, 200),
+        const Duration(milliseconds: 600),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('scenario-completion-sheet')), findsNothing);
+      expect(
+        find.byKey(const Key('scenario-conversation-history')),
+        findsOneWidget,
+      );
     },
   );
 


### PR DESCRIPTION
## 功能描述

- 所有复用 `PracticeCompletionOverlay` 的最终练习完成弹窗支持向下拖动关闭。
- 下拉超过弹窗高度 25%，或快速向下甩动时，弹窗跟手滑出屏幕。
- 未达到阈值时回弹，拖动过程中背景遮罩同步变淡。
- 关闭后保留完整练习对话，不提供从底部重新拉回的入口。
- IELTS 完整模考 Part 1 → Part 2、Part 2 → Part 3 阶段过渡仍不可关闭。

## 实现思路

- 将公共完成弹窗改为有状态组件，集中管理拖动距离、速度阈值、回弹和关闭动画。
- `dismissible` 默认开启，使面试、场景和未来复用该公共组件的最终完成场景自动获得一致行为。
- 阶段过渡调用点显式传入 `dismissible: false`。
- IELTS 页面记录完成弹窗已关闭状态，同时恢复对话列表正常底部留白。
- 为 VoiceOver 提供可关闭的语义操作。

## 可复现测试

```bash
cd mobile
dart format --output=none --set-exit-if-changed lib test
flutter analyze --no-pub
flutter test --no-pub
flutter test --no-pub \
  test/coaching/practice/practice_completion_sheet_test.dart \
  test/coaching/practice/ielts_mock_practice_test.dart \
  test/coaching/practice/scenario_practice_test.dart \
  test/coaching/practice/interview_practice_completion_test.dart
```

结果：

- Flutter analyze：通过，无问题。
- Flutter 全量测试：747 项通过。
- 相关测试：64 项通过。
- iPhone 17 Pro / iOS 26.5 模拟器、真实后端 `127.0.0.1:18082`：完成弹窗下拉关闭、历史对话保留、向上拖动不恢复均已验证。
- 模拟器通过项目临时运行目录启动，数字人已禁用，未提交本地运行配置。

Closes #836