### PR TITLE
fix(ci): include PostgreSQL integration coverage

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -347,7 +347,7 @@ jobs:
             const scopes = [];
             if (process.env.GO_AVAILABLE === "true") {
               scopes.push({
-                name: "server (Go)",
+                name: "server (Go + PostgreSQL)",
                 current: readGoCoverage(
                   path.join("coverage", "current", "go", "coverage.out"),
                 ),

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6ca361e3edaaacfada108
+        image: postgres:18-bookworm@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296
         env:
           POSTGRES_DB: xe3_esl
           POSTGRES_USER: xe3_esl

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -143,6 +143,25 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6ca361e3edaaacfada108
+        env:
+          POSTGRES_DB: xe3_esl
+          POSTGRES_USER: xe3_esl
+          POSTGRES_PASSWORD: ci-only-password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready --username=xe3_esl --dbname=xe3_esl"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+          --health-start-period 5s
+    env:
+      DATABASE_URL: postgres://xe3_esl:ci-only-password@127.0.0.1:5432/xe3_esl?sslmode=disable
+      MIGRATION_ENV: test
+      TEST_DATABASE_URL: postgres://xe3_esl:ci-only-password@127.0.0.1:5432/xe3_esl?sslmode=disable
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,35 @@ check-go-vet: check-go-format
 check-go-test: check-go-vet
 	cd server && go test -count=1 ./...
 
+# discipline: Coverage gates use executed/not-executed statements, so merge
+# repeated cross-package counters by OR before publishing the profile.
 check-go-coverage: check-go-vet
-	cd server && go test -count=1 -covermode=atomic -coverprofile=coverage.out ./...
+	@set -euo pipefail; \
+	cd server; \
+	cover_packages="$$(go list ./... | awk ' \
+		index($$0, "/server/test/") == 0 { \
+			if (count++ > 0) printf ","; \
+			printf "%s", $$0; \
+		} \
+	')"; \
+	go test -count=1 -covermode=atomic \
+		-coverpkg="$$cover_packages" \
+		-coverprofile=coverage.raw.out ./... 2>&1 | \
+		sed -E 's/(coverage: [^[:space:]]+ of statements) in .*/\1/'; \
+	{ \
+		printf '%s\n' 'mode: atomic'; \
+		awk ' \
+		NR > 1 { \
+			statements[$$1] = $$2; \
+			if ($$3 > 0) covered[$$1] = 1; \
+		} \
+		END { \
+			for (block in statements) \
+				print block, statements[block], covered[block] + 0; \
+		} \
+		' coverage.raw.out | LC_ALL=C sort; \
+	} > coverage.out; \
+	rm coverage.raw.out
 	cd server && go tool cover -func=coverage.out > coverage.txt && tail -n 1 coverage.txt
 
 check-oss-live:


### PR DESCRIPTION
## 功能描述

- 修正 Go 覆盖率口径，将跨包测试执行到的生产代码计入。
- 在 Quality Go job 中启动 PostgreSQL，使依赖 `TEST_DATABASE_URL` 的数据库集成测试进入同一覆盖率产物。
- PR 评论将服务端 scope 明确显示为 `server (Go + PostgreSQL)`。

Closes #838

## 实现思路

- `make check-go-coverage` 通过 `go list` 选择主模块生产包，排除 `server/test/**` 测试辅助代码，再使用 `-coverpkg` 统一 instrumentation。
- `go test` 对每个 test binary 产生的重复 legacy profile block 按“是否执行”合并，并排序输出确定的 `coverage.out`；raw profile 约 128 MB，发布产物约 2 MB。
- Quality 使用与 Database workflow 相同的 PostgreSQL service 和测试数据库环境；coverage gate 与 comment 继续消费同一 `go-coverage-server` artifact，现有不回退策略不变。

## 可复现测试

- `make check-go-coverage`：通过；无数据库时生产 Go 代码综合覆盖率 45.9%。
- 使用一次性 PostgreSQL 18 容器设置 `DATABASE_URL`、`TEST_DATABASE_URL`、`MIGRATION_ENV=test` 后运行 `make check-go-coverage`：通过；综合覆盖率 63.5%（12880/20289 statements）。
- `go tool cover -func=server/coverage.out` 与 coverage comment 的 statement parser 均得到 63.5%。
- `coverage.out` 包含 15025 个唯一 block，无重复 block，不包含 `server/test/**`。
- `git diff --check`：通过。
- Ruby YAML parser：`.github/workflows/quality.yml` 与 `.github/workflows/coverage-comment.yml` 均通过。

## 设计依据

- Go 官方支持通过 `-coverpkg` 选择跨包 instrumentation 范围，并以 `go tool cover` 读取 legacy profile。
- 本改动只修正统计与显示；针对修正后仍偏低模块的补测试将按独立 Issue/PR 推进。
