### PR TITLE
build(android): 建立网站分发 P0 发布基础

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 !.env.example
 *.pem
 *.key
+**/*.jks
+**/*.keystore
 **/*.p12
 
 # Operating systems and editors

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.env.example
 *.pem
 *.key
+**/*.p12
 
 # Operating systems and editors
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check-flutter-analyze: check-flutter-format
 check-flutter-test: check-flutter-analyze
 	cd mobile && flutter test --no-pub
 
-check-flutter-coverage: check-flutter-analyze
+check-flutter-coverage: check-flutter-analyze check-android-release-guard
 	cd mobile && flutter test --no-pub --coverage
 
 check-android-release-guard: check-flutter-dependencies

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SHELL := /bin/bash
 	check-flutter-analyze \
 	check-flutter-test \
 	check-flutter-coverage \
+	check-android-release-guard \
 	check-go \
 	check-go-coverage \
 	check-go-format \
@@ -24,6 +25,10 @@ SHELL := /bin/bash
 	check-api-contracts \
 	dev-android \
 	dev-ios-simulator \
+	build-android-release-staging \
+	build-android-release-production \
+	verify-android-release-staging \
+	verify-android-release-production \
 	test-ios-simulator-scenes
 
 help:
@@ -32,6 +37,7 @@ help:
 		'  make check          Run Flutter, Go, and API checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
 		'  make check-flutter-coverage  Run Flutter checks and write mobile/coverage/lcov.info' \
+		'  make check-android-release-guard  Verify release signing fails closed' \
 		'  make check-go       Run Go format, vet, and test checks' \
 		'  make check-go-coverage  Run Go checks and write server/coverage.out' \
 		'  make check-oss-live Run the real OSS lifecycle test with exported OSS_* variables' \
@@ -39,13 +45,16 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
-		'  make dev-ios-simulator  Start the backend on an iOS Simulator'
+		'  make dev-ios-simulator  Start the backend on an iOS Simulator' \
+		'  make build-android-release-staging  Build the signed staging arm64 APK' \
+		'  make build-android-release-production  Build the signed production arm64 APK'
 	@printf '%s\n' \
+		'  make verify-android-release-{staging,production}  Verify a release APK' \
 		'  make test-ios-simulator-scenes  Verify real scene and IELTS launch flows on an iOS Simulator'
 
 check: check-flutter check-go check-api
 
-check-flutter: check-flutter-test
+check-flutter: check-flutter-test check-android-release-guard
 
 check-flutter-dependencies:
 	cd mobile && flutter pub get --enforce-lockfile
@@ -61,6 +70,25 @@ check-flutter-test: check-flutter-analyze
 
 check-flutter-coverage: check-flutter-analyze
 	cd mobile && flutter test --no-pub --coverage
+
+check-android-release-guard: check-flutter-dependencies
+	@set -euo pipefail; \
+	output_file="$$(mktemp)"; \
+	trap 'rm -f "$$output_file"' EXIT; \
+	if cd mobile && env \
+		-u SPEAKUP_ANDROID_KEYSTORE_PATH \
+		-u SPEAKUP_ANDROID_KEY_ALIAS \
+		-u SPEAKUP_ANDROID_STORE_PASSWORD \
+		-u SPEAKUP_ANDROID_KEY_PASSWORD \
+		flutter build apk --release --flavor production \
+			--target-platform android-arm64 >"$$output_file" 2>&1; then \
+		printf '%s\n' 'Release build unexpectedly succeeded without signing secrets.' >&2; \
+		exit 1; \
+	fi; \
+	if ! grep -Fq 'Missing Android release signing environment variables' "$$output_file"; then \
+		printf '%s\n' 'Release build failed before the signing guard was reached.' >&2; \
+		exit 1; \
+	fi
 
 check-go: check-go-test
 
@@ -221,6 +249,40 @@ dev-android:
 
 dev-ios-simulator:
 	./tools/ios-simulator-dev/run.sh
+
+build-android-release-staging:
+	@test -n "$${SPEAKUP_ANDROID_CERT_SHA256:-}" || { \
+		printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 is required.' >&2; \
+		exit 1; \
+	}
+	cd mobile && flutter build apk \
+		--release \
+		--flavor staging \
+		--target-platform android-arm64 \
+		--dart-define=SPEAKUP_API_BASE_URL=https://staging-api.speak-up.top
+	./tools/android-release/verify.sh \
+		mobile/build/app/outputs/flutter-apk/app-staging-release.apk
+
+build-android-release-production:
+	@test -n "$${SPEAKUP_ANDROID_CERT_SHA256:-}" || { \
+		printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 is required.' >&2; \
+		exit 1; \
+	}
+	cd mobile && flutter build apk \
+		--release \
+		--flavor production \
+		--target-platform android-arm64 \
+		--dart-define=SPEAKUP_API_BASE_URL=https://api.speak-up.top
+	./tools/android-release/verify.sh \
+		mobile/build/app/outputs/flutter-apk/app-production-release.apk
+
+verify-android-release-staging:
+	./tools/android-release/verify.sh \
+		mobile/build/app/outputs/flutter-apk/app-staging-release.apk
+
+verify-android-release-production:
+	./tools/android-release/verify.sh \
+		mobile/build/app/outputs/flutter-apk/app-production-release.apk
 
 test-ios-simulator-scenes:
 	./tools/ios-simulator-dev/run.sh test \

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -32,12 +32,18 @@ Android 真机上运行 App。连接多台设备时，可通过
 - applicationId：`com.xengineer.speakup`
 - versionName/versionCode：`0.1.0` / `1`（Release Tag：`v0.1.0`）
 - ABI：仅 `arm64-v8a`
-- staging API：`https://staging-api.speak-up.top`
-- production API：`https://api.speak-up.top`
+- staging API 发布契约：`https://staging-api.speak-up.top`
+- production API 发布契约：`https://api.speak-up.top`
+
+两个域名是首发构建契约；当前仓库没有 DNS 或后端部署就绪证据，解析与服务可用性
+仍待发布 Owner 在分发前单独验收。本仓库只校验构建注入值与契约一致，不声称服务
+已经上线。
 
 Android 使用 `staging`、`production` 两个 product flavor。release 构建根据
 flavor 注入固定 API；传入不一致的 `SPEAKUP_API_BASE_URL` 会在 App 启动前失败，
-未知 release flavor 也不会回落到 localhost。开发构建仍可显式覆盖本地 API。
+未知 Android release flavor 也不会回落到 localhost。未使用 Android flavor 的 iOS
+release 必须显式注入经校验的 HTTPS、非 loopback API；开发构建仍可显式覆盖本地
+API。
 
 ### 正式签名边界
 
@@ -73,10 +79,10 @@ make verify-android-release-staging
 make verify-android-release-production
 ```
 
-校验入口使用 Android SDK 的 `aapt` 和 `apksigner`，检查包名、版本、唯一 ABI、
-APK 签名有效性、拒绝 Android Debug 证书，并检查签名证书 SHA-256 是否与 Owner
-批准值一致，同时输出 APK
-文件 SHA-256。缺少正式私钥时只能运行 fail-closed 守卫，不能用 debug key 生成
+校验入口使用 Android SDK 的 `aapt` 和 `apksigner`，从 `mobile/pubspec.yaml` 读取
+唯一版本来源，并检查包名、版本、唯一 ABI、APK 签名有效性、拒绝 Android Debug
+证书，以及签名证书 SHA-256 是否与 Owner 批准值一致，同时输出 APK 文件
+SHA-256。缺少正式私钥时只能运行 fail-closed 守卫，不能用 debug key 生成
 “正式”APK：
 
 ```shell

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -25,6 +25,69 @@ Android 真机上运行 App。连接多台设备时，可通过
 本地调试后端默认使用 `18080` 端口，可通过
 `SPEAKUP_DEV_PORT=<端口> make dev-android` 覆盖。
 
+## Android 网站分发
+
+首发网站分发基线为：
+
+- applicationId：`com.xengineer.speakup`
+- versionName/versionCode：`0.1.0` / `1`（Release Tag：`v0.1.0`）
+- ABI：仅 `arm64-v8a`
+- staging API：`https://staging-api.speak-up.top`
+- production API：`https://api.speak-up.top`
+
+Android 使用 `staging`、`production` 两个 product flavor。release 构建根据
+flavor 注入固定 API；传入不一致的 `SPEAKUP_API_BASE_URL` 会在 App 启动前失败，
+未知 release flavor 也不会回落到 localhost。开发构建仍可显式覆盖本地 API。
+
+### 正式签名边界
+
+仓库不生成、保存或传递生产私钥。Owner 需要在批准的密码管理器中创建并备份
+网站分发使用的 app signing key，记录其公开证书 SHA-256，并在本地受控会话或
+CI Secret 中提供以下环境变量：
+
+- `SPEAKUP_ANDROID_KEYSTORE_PATH`
+- `SPEAKUP_ANDROID_KEY_ALIAS`
+- `SPEAKUP_ANDROID_STORE_PASSWORD`
+- `SPEAKUP_ANDROID_KEY_PASSWORD`
+- `SPEAKUP_ANDROID_CERT_SHA256`（公开证书指纹，仅用于产物校验）
+
+前四项有任一缺失、空值或 keystore 文件不可读时，release Gradle 配置立即失败；
+release 不再使用 debug signing。不要把 keystore、密码、`key.properties`、终端
+输出或 CI Secret 提交到仓库。首次网站发布后必须长期保管同一 app signing key，
+否则后续 APK 无法作为更新安装。
+
+### 构建与校验
+
+在已经安全注入上述环境变量的会话中，从仓库根目录执行：
+
+```shell
+make build-android-release-staging
+
+make build-android-release-production
+```
+
+两个 build 入口都会在构建后立即执行完整校验；如果只需重新检查现有产物：
+
+```shell
+make verify-android-release-staging
+make verify-android-release-production
+```
+
+校验入口使用 Android SDK 的 `aapt` 和 `apksigner`，检查包名、版本、唯一 ABI、
+APK 签名有效性、拒绝 Android Debug 证书，并检查签名证书 SHA-256 是否与 Owner
+批准值一致，同时输出 APK
+文件 SHA-256。缺少正式私钥时只能运行 fail-closed 守卫，不能用 debug key 生成
+“正式”APK：
+
+```shell
+make check-android-release-guard
+```
+
+参考：[Flutter Android flavors](https://docs.flutter.dev/deployment/flavors)、
+[Flutter Android 发布](https://docs.flutter.dev/deployment/android)、
+[Android App Signing](https://developer.android.com/studio/publish/app-signing)、
+[apksigner](https://developer.android.com/tools/apksigner)。
+
 ## iOS 模拟器调试
 
 AvatarKit 当前不提供 Intel Mac 所需的 x86_64 模拟器二进制。先启动一个

--- a/mobile/android/.gitignore
+++ b/mobile/android/.gitignore
@@ -11,5 +11,3 @@ GeneratedPluginRegistrant.java
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore
 key.properties
-**/*.keystore
-**/*.jks

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -5,6 +5,34 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val releaseSigningVariableNames = listOf(
+    "SPEAKUP_ANDROID_KEYSTORE_PATH",
+    "SPEAKUP_ANDROID_KEY_ALIAS",
+    "SPEAKUP_ANDROID_STORE_PASSWORD",
+    "SPEAKUP_ANDROID_KEY_PASSWORD",
+)
+val releaseBuildRequested = gradle.startParameter.taskNames.any {
+    it.contains("release", ignoreCase = true)
+}
+val releaseSigningValues = releaseSigningVariableNames.associateWith(System::getenv)
+val missingReleaseSigningVariables = releaseSigningValues
+    .filterValues { it.isNullOrBlank() }
+    .keys
+
+if (releaseBuildRequested && missingReleaseSigningVariables.isNotEmpty()) {
+    throw GradleException(
+        "Missing Android release signing environment variables: " +
+            missingReleaseSigningVariables.joinToString(", "),
+    )
+}
+
+val releaseKeystore = releaseSigningValues["SPEAKUP_ANDROID_KEYSTORE_PATH"]
+    ?.takeIf { it.isNotBlank() }
+    ?.let(::file)
+if (releaseBuildRequested && releaseKeystore?.isFile != true) {
+    throw GradleException("Android release keystore is not a readable file.")
+}
+
 android {
     namespace = "com.xengineer.speakup"
     compileSdk = flutter.compileSdkVersion
@@ -35,11 +63,30 @@ android {
         }
     }
 
+    signingConfigs {
+        if (missingReleaseSigningVariables.isEmpty()) {
+            create("release") {
+                storeFile = releaseKeystore
+                keyAlias = releaseSigningValues.getValue("SPEAKUP_ANDROID_KEY_ALIAS")
+                storePassword = releaseSigningValues.getValue("SPEAKUP_ANDROID_STORE_PASSWORD")
+                keyPassword = releaseSigningValues.getValue("SPEAKUP_ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.findByName("release")
+        }
+    }
+
+    flavorDimensions += "environment"
+    productFlavors {
+        create("staging") {
+            dimension = "environment"
+        }
+        create("production") {
+            dimension = "environment"
         }
     }
 }

--- a/mobile/lib/config/app_environment.dart
+++ b/mobile/lib/config/app_environment.dart
@@ -1,0 +1,32 @@
+const _developmentApiBaseUrl = 'http://127.0.0.1:8080';
+const _stagingApiBaseUrl = 'https://staging-api.speak-up.top';
+const _productionApiBaseUrl = 'https://api.speak-up.top';
+
+Uri resolveApiBaseUri({
+  required String? flavor,
+  required bool isReleaseMode,
+  required String explicitBaseUrl,
+}) {
+  if (!isReleaseMode && explicitBaseUrl.isNotEmpty) {
+    return Uri.parse(explicitBaseUrl);
+  }
+
+  final releaseBaseUrl = switch (flavor) {
+    'staging' => _stagingApiBaseUrl,
+    'production' => _productionApiBaseUrl,
+    _ => null,
+  };
+  if (releaseBaseUrl != null) {
+    if (explicitBaseUrl.isNotEmpty && explicitBaseUrl != releaseBaseUrl) {
+      throw StateError('Release API URL does not match the selected flavor.');
+    }
+    return Uri.parse(releaseBaseUrl);
+  }
+
+  if (isReleaseMode) {
+    throw StateError(
+      'Android release builds require a known environment flavor.',
+    );
+  }
+  return Uri.parse(_developmentApiBaseUrl);
+}

--- a/mobile/lib/config/app_environment.dart
+++ b/mobile/lib/config/app_environment.dart
@@ -5,6 +5,7 @@ const _productionApiBaseUrl = 'https://api.speak-up.top';
 Uri resolveApiBaseUri({
   required String? flavor,
   required bool isReleaseMode,
+  required bool isAndroid,
   required String explicitBaseUrl,
 }) {
   if (!isReleaseMode && explicitBaseUrl.isNotEmpty) {
@@ -23,10 +24,35 @@ Uri resolveApiBaseUri({
     return Uri.parse(releaseBaseUrl);
   }
 
-  if (isReleaseMode) {
+  if (isReleaseMode && isAndroid) {
     throw StateError(
       'Android release builds require a known environment flavor.',
     );
   }
+  if (isReleaseMode) {
+    return _parseUnflavoredReleaseApiBaseUri(explicitBaseUrl);
+  }
   return Uri.parse(_developmentApiBaseUrl);
+}
+
+Uri _parseUnflavoredReleaseApiBaseUri(String value) {
+  final uri = Uri.tryParse(value);
+  if (uri == null ||
+      uri.scheme != 'https' ||
+      uri.host.isEmpty ||
+      uri.userInfo.isNotEmpty ||
+      uri.hasFragment ||
+      _isLoopbackHost(uri.host)) {
+    throw StateError(
+      'Non-Android release builds require an explicit non-loopback HTTPS API URL.',
+    );
+  }
+  return uri;
+}
+
+bool _isLoopbackHost(String host) {
+  final normalized = host.toLowerCase();
+  return normalized == 'localhost' ||
+      normalized == '127.0.0.1' ||
+      normalized == '::1';
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -58,6 +58,7 @@ void main() {
   final apiBaseUri = resolveApiBaseUri(
     flavor: appFlavor,
     isReleaseMode: kReleaseMode,
+    isAndroid: defaultTargetPlatform == TargetPlatform.android,
     explicitBaseUrl: explicitApiBaseUrl,
   );
   final dependencies = createProductionAppDependencies(baseUri: apiBaseUri);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:speakup/config/app_environment.dart';
 import 'package:speakup/features/agent/audio/agent_audio_player.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
@@ -47,17 +50,17 @@ import 'package:speakup/features/coaching/scenario/scenario_practice_session.dar
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  const apiBaseUrl = String.fromEnvironment(
-    'SPEAKUP_API_BASE_URL',
-    defaultValue: 'http://127.0.0.1:8080',
-  );
+  const explicitApiBaseUrl = String.fromEnvironment('SPEAKUP_API_BASE_URL');
   const avatarEnabled = bool.fromEnvironment(
     'SPEAKUP_AVATAR_ENABLED',
     defaultValue: true,
   );
-  final dependencies = createProductionAppDependencies(
-    baseUri: Uri.parse(apiBaseUrl),
+  final apiBaseUri = resolveApiBaseUri(
+    flavor: appFlavor,
+    isReleaseMode: kReleaseMode,
+    explicitBaseUrl: explicitApiBaseUrl,
   );
+  final dependencies = createProductionAppDependencies(baseUri: apiBaseUri);
   runApp(
     SpeakUpApp(
       authController: dependencies.authController,

--- a/mobile/test/config/app_environment_test.dart
+++ b/mobile/test/config/app_environment_test.dart
@@ -8,18 +8,20 @@ void main() {
         resolveApiBaseUri(
           flavor: 'staging',
           isReleaseMode: true,
+          isAndroid: true,
           explicitBaseUrl: '',
         ),
         Uri.parse('https://staging-api.speak-up.top'),
       );
     });
 
-    test('injects the production API for production release', () {
+    test('accepts the contracted production API injection', () {
       expect(
         resolveApiBaseUri(
           flavor: 'production',
           isReleaseMode: true,
-          explicitBaseUrl: '',
+          isAndroid: true,
+          explicitBaseUrl: 'https://api.speak-up.top',
         ),
         Uri.parse('https://api.speak-up.top'),
       );
@@ -30,18 +32,20 @@ void main() {
         () => resolveApiBaseUri(
           flavor: 'production',
           isReleaseMode: true,
+          isAndroid: true,
           explicitBaseUrl: 'http://127.0.0.1:8080',
         ),
         throwsStateError,
       );
     });
 
-    test('rejects release builds without a known flavor', () {
+    test('rejects unflavored Android release even with an explicit API', () {
       expect(
         () => resolveApiBaseUri(
           flavor: null,
           isReleaseMode: true,
-          explicitBaseUrl: '',
+          isAndroid: true,
+          explicitBaseUrl: 'https://api.speak-up.top',
         ),
         throwsStateError,
       );
@@ -52,9 +56,34 @@ void main() {
         resolveApiBaseUri(
           flavor: 'staging',
           isReleaseMode: false,
+          isAndroid: true,
           explicitBaseUrl: 'http://127.0.0.1:18080',
         ),
         Uri.parse('http://127.0.0.1:18080'),
+      );
+    });
+
+    test('allows an explicit production API for unflavored iOS release', () {
+      expect(
+        resolveApiBaseUri(
+          flavor: null,
+          isReleaseMode: true,
+          isAndroid: false,
+          explicitBaseUrl: 'https://api.speak-up.top',
+        ),
+        Uri.parse('https://api.speak-up.top'),
+      );
+    });
+
+    test('rejects localhost for unflavored iOS release', () {
+      expect(
+        () => resolveApiBaseUri(
+          flavor: null,
+          isReleaseMode: true,
+          isAndroid: false,
+          explicitBaseUrl: 'https://localhost:8080',
+        ),
+        throwsStateError,
       );
     });
   });

--- a/mobile/test/config/app_environment_test.dart
+++ b/mobile/test/config/app_environment_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/config/app_environment.dart';
+
+void main() {
+  group('resolveApiBaseUri', () {
+    test('injects the staging API for staging release', () {
+      expect(
+        resolveApiBaseUri(
+          flavor: 'staging',
+          isReleaseMode: true,
+          explicitBaseUrl: '',
+        ),
+        Uri.parse('https://staging-api.speak-up.top'),
+      );
+    });
+
+    test('injects the production API for production release', () {
+      expect(
+        resolveApiBaseUri(
+          flavor: 'production',
+          isReleaseMode: true,
+          explicitBaseUrl: '',
+        ),
+        Uri.parse('https://api.speak-up.top'),
+      );
+    });
+
+    test('rejects an API override that disagrees with the release flavor', () {
+      expect(
+        () => resolveApiBaseUri(
+          flavor: 'production',
+          isReleaseMode: true,
+          explicitBaseUrl: 'http://127.0.0.1:8080',
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('rejects release builds without a known flavor', () {
+      expect(
+        () => resolveApiBaseUri(
+          flavor: null,
+          isReleaseMode: true,
+          explicitBaseUrl: '',
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('keeps explicit local API injection for development', () {
+      expect(
+        resolveApiBaseUri(
+          flavor: 'staging',
+          isReleaseMode: false,
+          explicitBaseUrl: 'http://127.0.0.1:18080',
+        ),
+        Uri.parse('http://127.0.0.1:18080'),
+      );
+    });
+  });
+}

--- a/tools/android-dev/run.sh
+++ b/tools/android-dev/run.sh
@@ -127,6 +127,7 @@ print "启动 SpeakUp；按 q 退出，修改代码后按 r 热重载。"
 cd "$mobile_dir"
 flutter build apk \
   --debug \
+  --flavor staging \
   --target-platform android-arm64 \
   --dart-define="SPEAKUP_API_BASE_URL=$base_url" \
   "$@"
@@ -134,7 +135,7 @@ adb -s "$device_id" install \
   --no-streaming \
   -t \
   -r \
-  "$mobile_dir/build/app/outputs/flutter-apk/app-debug.apk"
+  "$mobile_dir/build/app/outputs/flutter-apk/app-staging-debug.apk"
 adb -s "$device_id" shell am start \
   -S \
   -n com.xengineer.speakup/.MainActivity

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-if [[ "$#" != "1" ]]; then
-  printf 'Usage: SPEAKUP_ANDROID_CERT_SHA256=<fingerprint> %s <apk>\n' "$0" >&2
+if [[ "$#" -lt "1" || "$#" -gt "2" ]]; then
+  printf 'Usage: SPEAKUP_ANDROID_CERT_SHA256=<fingerprint> %s <apk> [pubspec]\n' "$0" >&2
   exit 2
 fi
 
@@ -11,9 +11,14 @@ apk="$1"
 expected_certificate_sha256="${SPEAKUP_ANDROID_CERT_SHA256:-}"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_dir="$(cd "$script_dir/../.." && pwd)"
+pubspec="${2:-$repo_dir/mobile/pubspec.yaml}"
 
 if [[ ! -f "$apk" ]]; then
   printf 'APK does not exist: %s\n' "$apk" >&2
+  exit 1
+fi
+if [[ ! -f "$pubspec" ]]; then
+  printf 'pubspec does not exist: %s\n' "$pubspec" >&2
   exit 1
 fi
 if [[ -z "$expected_certificate_sha256" ]]; then
@@ -76,23 +81,33 @@ ensure_java_runtime() {
 
 aapt="$(find_android_tool aapt)"
 apksigner="$(find_android_tool apksigner)"
-ensure_java_runtime
 badging="$("$aapt" dump badging "$apk")"
 
 application_id="$(printf '%s\n' "$badging" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
 version_code="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionCode='\([^']*\)'.*/\1/p")"
 version_name="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionName='\([^']*\)'.*/\1/p")"
 native_code="$(printf '%s\n' "$badging" | sed -n '/^native-code:/p')"
+pubspec_version="$(
+  sed -n -E \
+    "s/^version:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?[[:space:]]*$/\1/p" \
+    "$pubspec"
+)"
+if [[ ! "$pubspec_version" =~ ^([^+]+)\+([0-9]+)$ ]]; then
+  printf '%s\n' 'pubspec version must use <versionName>+<versionCode>.' >&2
+  exit 1
+fi
+expected_version_name="${BASH_REMATCH[1]}"
+expected_version_code="${BASH_REMATCH[2]}"
 
 [[ "$application_id" == "com.xengineer.speakup" ]] || {
   printf 'Unexpected applicationId: %s\n' "$application_id" >&2
   exit 1
 }
-[[ "$version_code" == "1" ]] || {
+[[ "$version_code" == "$expected_version_code" ]] || {
   printf 'Unexpected versionCode: %s\n' "$version_code" >&2
   exit 1
 }
-[[ "$version_name" == "0.1.0" ]] || {
+[[ "$version_name" == "$expected_version_name" ]] || {
   printf 'Unexpected versionName: %s\n' "$version_name" >&2
   exit 1
 }
@@ -101,6 +116,7 @@ native_code="$(printf '%s\n' "$badging" | sed -n '/^native-code:/p')"
   exit 1
 }
 
+ensure_java_runtime
 signature_report="$("$apksigner" verify --verbose --print-certs "$apk")"
 if printf '%s\n' "$signature_report" | grep -Eq 'certificate DN:.*CN=Android Debug'; then
   printf '%s\n' 'APK uses an Android debug signing certificate.' >&2

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" != "1" ]]; then
+  printf 'Usage: SPEAKUP_ANDROID_CERT_SHA256=<fingerprint> %s <apk>\n' "$0" >&2
+  exit 2
+fi
+
+apk="$1"
+expected_certificate_sha256="${SPEAKUP_ANDROID_CERT_SHA256:-}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "$script_dir/../.." && pwd)"
+
+if [[ ! -f "$apk" ]]; then
+  printf 'APK does not exist: %s\n' "$apk" >&2
+  exit 1
+fi
+if [[ -z "$expected_certificate_sha256" ]]; then
+  printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 is required.' >&2
+  exit 1
+fi
+
+find_android_tool() {
+  local tool_name="$1"
+  local sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+  local local_properties="$repo_dir/mobile/android/local.properties"
+  local candidate
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return
+  fi
+  if [[ -z "$sdk_root" && -f "$local_properties" ]]; then
+    sdk_root="$(sed -n 's/^sdk.dir=//p' "$local_properties")"
+  fi
+  if [[ -z "$sdk_root" || ! -d "$sdk_root/build-tools" ]]; then
+    printf 'Cannot locate Android SDK build-tools for %s.\n' "$tool_name" >&2
+    return 1
+  fi
+  candidate="$(
+    find "$sdk_root/build-tools" -type f -name "$tool_name" -print |
+      LC_ALL=C sort |
+      tail -n 1
+  )"
+  if [[ -z "$candidate" ]]; then
+    printf 'Cannot locate Android SDK tool: %s.\n' "$tool_name" >&2
+    return 1
+  fi
+  printf '%s\n' "$candidate"
+}
+
+ensure_java_runtime() {
+  local flutter_config
+  local flutter_jdk
+
+  if java -version >/dev/null 2>&1; then
+    return
+  fi
+  if ! command -v flutter >/dev/null 2>&1; then
+    printf '%s\n' 'Java is required by apksigner.' >&2
+    return 1
+  fi
+  flutter_config="$(flutter config --machine)"
+  flutter_jdk="$(
+    printf '%s\n' "$flutter_config" |
+      sed -n 's/^[[:space:]]*"jdk-dir": "\([^"]*\)".*/\1/p'
+  )"
+  if [[ -z "$flutter_jdk" || ! -x "$flutter_jdk/bin/java" ]]; then
+    printf '%s\n' 'Cannot locate the JDK configured for Flutter.' >&2
+    return 1
+  fi
+  export JAVA_HOME="$flutter_jdk"
+  export PATH="$JAVA_HOME/bin:$PATH"
+}
+
+aapt="$(find_android_tool aapt)"
+apksigner="$(find_android_tool apksigner)"
+ensure_java_runtime
+badging="$("$aapt" dump badging "$apk")"
+
+application_id="$(printf '%s\n' "$badging" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
+version_code="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionCode='\([^']*\)'.*/\1/p")"
+version_name="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionName='\([^']*\)'.*/\1/p")"
+native_code="$(printf '%s\n' "$badging" | sed -n '/^native-code:/p')"
+
+[[ "$application_id" == "com.xengineer.speakup" ]] || {
+  printf 'Unexpected applicationId: %s\n' "$application_id" >&2
+  exit 1
+}
+[[ "$version_code" == "1" ]] || {
+  printf 'Unexpected versionCode: %s\n' "$version_code" >&2
+  exit 1
+}
+[[ "$version_name" == "0.1.0" ]] || {
+  printf 'Unexpected versionName: %s\n' "$version_name" >&2
+  exit 1
+}
+[[ "$native_code" == "native-code: 'arm64-v8a'" ]] || {
+  printf 'Unexpected native ABIs: %s\n' "$native_code" >&2
+  exit 1
+}
+
+signature_report="$("$apksigner" verify --verbose --print-certs "$apk")"
+if printf '%s\n' "$signature_report" | grep -Eq 'certificate DN:.*CN=Android Debug'; then
+  printf '%s\n' 'APK uses an Android debug signing certificate.' >&2
+  exit 1
+fi
+certificate_sha256="$(
+  printf '%s\n' "$signature_report" |
+    sed -n 's/^Signer #1 certificate SHA-256 digest: //p' |
+    head -n 1 |
+    tr '[:upper:]' '[:lower:]' |
+    tr -d '[:space:]:'
+)"
+expected_certificate_sha256="$(
+  printf '%s' "$expected_certificate_sha256" |
+    tr '[:upper:]' '[:lower:]' |
+    tr -d '[:space:]:'
+)"
+
+[[ "$expected_certificate_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+  printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 must contain 64 hexadecimal digits.' >&2
+  exit 1
+}
+[[ "$certificate_sha256" == "$expected_certificate_sha256" ]] || {
+  printf '%s\n' 'APK signing certificate SHA-256 does not match the approved certificate.' >&2
+  exit 1
+}
+
+artifact_sha256="$(shasum -a 256 "$apk" | awk '{print $1}')"
+printf '%s\n' \
+  "applicationId=$application_id" \
+  "versionName=$version_name" \
+  "versionCode=$version_code" \
+  'abi=arm64-v8a' \
+  'signature=verified' \
+  "certificateSha256=$certificate_sha256" \
+  "artifactSha256=$artifact_sha256"


### PR DESCRIPTION
## 功能描述

为 SpeakUp 首次 Android 网站分发建立 P0 发布基础：正式 release 签名 fail-closed、staging/production API 发布契约明确注入、仅 arm64-v8a，并提供可复现 APK 验证入口。

`https://staging-api.speak-up.top` 与 `https://api.speak-up.top` 当前仅是首发构建契约；本 PR 没有 DNS 或后端部署就绪证据，不声称域名已经可解析或服务已经可用，发布前仍需 Owner 单独验收。

## 实现思路

- 保持 `com.xengineer.speakup` 与 `mobile/pubspec.yaml` 的 `0.1.0+1`，新增 `staging`/`production` product flavor；Flutter `appFlavor` 固定映射对应 HTTPS API，Android release 未知 flavor 或不一致覆盖会失败，不回落 localhost。
- 不把 Android flavor 约束扩散到 iOS：无 Android flavor 的非 Android release 只有显式提供经校验的 HTTPS、非 loopback API 才能启动。
- release signing 仅从本地受控会话或 CI Secret 的四个环境变量读取；缺失、空值或 keystore 不可读时 Gradle 配置失败，不再引用 debug signing。
- release 构建限定 `android-arm64`，构建后使用 `aapt` 与 `apksigner` 校验包名、从 `mobile/pubspec.yaml` 读取的版本、唯一 ABI、有效签名、非 Android Debug 证书、批准证书 SHA-256 与 APK SHA-256。
- `.jks`、`.keystore`、`.p12` 在仓库根级忽略；仓库无已跟踪同类文件。
- 文档明确 Owner 在密码管理器/CI 完成生产 app signing key 创建、备份与 Secret 注入的交付边界；本 PR 未生成、读取或提交生产私钥、密码、`key.properties` 或 Secret。

实现参考 Flutter 官方 Android flavors/发布文档及 Android 官方 App Signing/apksigner 文档。

## 测试方式

1. `make check-flutter`：依赖锁定、Dart 格式、`flutter analyze`、754 项 Flutter 测试全部通过，并验证清空签名变量后 production release 必须在签名守卫处失败。
2. `flutter test --no-pub test/config/app_environment_test.dart`：7 项通过，覆盖 Android release flavor、契约注入、不一致覆盖拒绝、Android 无 flavor fail-closed、iOS 无 flavor + 显式 production HTTPS 成功与 localhost 拒绝。
3. `check-flutter-coverage` 现依赖 `check-android-release-guard`，即 GitHub Flutter coverage CI 会实际运行门禁；热缓存实测 guard 14.63 秒。`make -n check-flutter-coverage` 证明共享依赖只安排一次 `flutter pub get --enforce-lockfile`。
4. `cd mobile && flutter build apk --debug --flavor staging --target-platform android-arm64 --dart-define=SPEAKUP_API_BASE_URL=http://127.0.0.1:18080`：成功生成非发布测试 APK；`aapt dump badging` 实测 `applicationId=com.xengineer.speakup`、`versionName=0.1.0`、`versionCode=1`、`native-code=arm64-v8a`。
5. APK 校验使用临时 `version: 0.1.0+2` pubspec 时明确报 `Unexpected versionCode: 1`；使用 debug 测试 APK 时明确拒绝 `Android Debug` 证书。
6. `git check-ignore -v --no-index mobile/android/release.jks mobile/signing.keystore release.p12` 均命中根 `.gitignore`，`git ls-files` 确认无已跟踪 `.jks`/`.keystore`/`.p12`。
7. `bash -n tools/android-release/verify.sh tools/android-dev/run.sh`、`git diff --check`：通过。
8. iOS Release 附加编译进入 CocoaPods 后需要下载 63.7MB AvatarKit，4 分钟仅完成 35%，已主动终止；不把它记录为通过。无 flavor 的 iOS 运行时分支由第 2 项焦点测试覆盖。
9. Reviewer 获得 Owner 安全注入的正式签名环境后，执行 `make build-android-release-staging` 和 `make build-android-release-production`；预期构建后自动完成完整签名与 SHA-256 校验。当前没有 Owner 生产密钥，因此没有生成或声称交付正式 APK。

## 相关 Issue / 备注

Closes #842

复审修正提交：`410050e9`。Release Tag 目标为 `v0.1.0`，Tag、DNS/后端部署与网站上传不在本 Issue 范围内。

## AI 辅助说明

使用 Codex 审查现有 Flutter/Gradle 配置、核对官方文档、实现最小安全改动并运行验证。提交者需人工检查 Gradle 签名边界、环境映射、脚本失败路径与测试结果，并能够解释全部配置。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置