### PR TITLE
feat(portal): rebuild Android release landing

### DIFF
--- a/portal/app/download/android/page.tsx
+++ b/portal/app/download/android/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import BrandMark from "../../BrandMark";
+
+const releaseFields = [
+  ["版本名称（versionName）", "制品就绪后公开"],
+  ["版本号（versionCode）", "制品就绪后公开"],
+  ["发布时间", "制品就绪后公开"],
+  ["APK 大小", "制品就绪后公开"],
+  ["最低 Android 版本", "制品就绪后公开"],
+  ["支持的 ABI", "制品就绪后公开"],
+];
+
+const supportFields = [
+  ["更新状态", "首个正式版本发布后在本页持续更新"],
+  ["更新日志", "随每个可下载制品同步公开"],
+  ["隐私与权限", "开放下载前公开隐私说明与权限清单"],
+  ["问题反馈", "开放下载前公开正式反馈入口"],
+];
+
+export default function AndroidDownloadPage() {
+  return (
+    <main className="release-site download-page" id="top">
+      <nav className="site-nav release-nav" aria-label="主导航">
+        <Link className="brand" href="/" aria-label="返回 SpeakUp 首页"><BrandMark /><span>SpeakUp</span></Link>
+        <div className="nav-links"><Link href="/">产品首页</Link><a href="#verify">验证信息</a></div>
+        <Link className="button button-small" href="/">返回首页</Link>
+      </nav>
+
+      <header className="download-hero">
+        <div className="download-hero-copy">
+          <Link className="download-back" href="/">← 返回产品首页</Link>
+          <p className="eyebrow">Android 官方版</p><h1>SpeakUp for Android</h1>
+          <p>首个公开版本正在准备。当前还没有可公开下载和验证的 APK，完成签名与生产验证后，本页才会开放唯一入口。</p>
+          <div className="download-state" role="status"><span><i aria-hidden="true" />准备中</span><small>不会提供空链接、假二维码或未经核验的版本。</small></div>
+        </div>
+        <aside className="download-availability" aria-labelledby="available-title">
+          <p className="eyebrow">开放下载时同时提供</p><h2 id="available-title">文件之外，还有完整的验证信息。</h2>
+          <ul><li>版本、时间与兼容范围</li><li>APK 文件 SHA-256</li><li>签名证书 SHA-256</li><li>安装步骤与更新记录</li></ul>
+        </aside>
+      </header>
+
+      <section className="download-section" aria-labelledby="release-title">
+        <div className="download-section-heading"><p className="eyebrow">发布信息</p><h2 id="release-title">拿到文件前，先知道它是什么。</h2></div>
+        <dl className="download-facts">{releaseFields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>
+      </section>
+
+      <section className="download-section download-verify" id="verify" aria-labelledby="verify-title">
+        <div className="download-section-heading"><p className="eyebrow">验证信息</p><h2 id="verify-title">文件校验与签名校验，是两件不同的事。</h2><p>前者确认下载文件没有变化，后者确认应用由预期证书签名。</p></div>
+        <dl className="download-hashes"><div><dt>APK 文件 SHA-256</dt><dd>制品就绪后公开</dd></div><div><dt>签名证书 SHA-256</dt><dd>制品就绪后公开</dd></div></dl>
+      </section>
+
+      <section className="download-section" aria-labelledby="support-title">
+        <div className="download-section-heading"><p className="eyebrow">发布与支持</p><h2 id="support-title">每个版本，都能找到后续说明。</h2></div>
+        <dl className="download-facts">{supportFields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>
+      </section>
+
+      <section className="download-section" id="install" aria-labelledby="install-title">
+        <div className="download-section-heading"><p className="eyebrow">安装说明</p><h2 id="install-title">只从这里下载，只为可信来源授权。</h2></div>
+        <ol className="download-steps"><li><span>01</span><div><strong>下载并核验</strong><p>入口开放后，从本页获取 APK，并对照公开的文件 SHA-256。</p></div></li><li><span>02</span><div><strong>按来源临时授权</strong><p>Android 8.0 及以上版本会要求为当前浏览器或文件管理器允许“安装未知应用”。</p></div></li><li><span>03</span><div><strong>安装后收回权限</strong><p>完成安装后，可回到系统设置关闭该来源的安装权限。</p></div></li></ol>
+      </section>
+
+      <section className="release-final download-final"><div><p className="eyebrow">当前状态</p><h2>现在还不能下载，但发布信息不会含糊。</h2></div><Link className="button" href="/">返回产品首页</Link></section>
+      <footer><Link className="brand" href="/"><BrandMark /><span>SpeakUp</span></Link><p>Android 官方下载与验证信息。</p><span>© 2026 SpeakUp</span></footer>
+    </main>
+  );
+}

--- a/portal/app/layout.tsx
+++ b/portal/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import "./marketing.css";
 
 export const metadata: Metadata = {
   title: "SpeakUp · 有记忆的 AI Agent 口语老师",
-  description: "主动了解你的目标，陪你准备、模拟和复盘真实世界里的英语沟通，越用越懂你。",
+  description: "围绕真实任务陪你准备、开口和复盘，把重要的英文沟通先练到心里有底。",
   icons: {
     icon: "/assets/brand/speakup-mascot-v2.png",
     apple: "/assets/brand/speakup-mascot-v2.png",

--- a/portal/app/marketing.css
+++ b/portal/app/marketing.css
@@ -1,0 +1,315 @@
+.release-site {
+  min-height: 100vh;
+  overflow: clip;
+  background: var(--lumen);
+  color: var(--ink);
+}
+
+.release-site *,
+.release-site *::before,
+.release-site *::after { box-sizing: border-box; }
+
+.release-site h1,
+.release-site h2,
+.release-site h3,
+.release-site p,
+.release-site figure,
+.release-site dl,
+.release-site dd { margin: 0; }
+
+.release-nav { grid-template-columns: 1fr auto 1fr; }
+.release-nav > .button { justify-self: end; }
+
+.release-hero,
+.release-method,
+.release-download,
+.release-faq,
+.download-hero,
+.download-section,
+.release-final {
+  width: min(var(--content-width), calc(100% - var(--page-gutter) * 2));
+  margin-inline: auto;
+}
+
+.release-hero {
+  min-height: 720px;
+  padding: clamp(82px, 8vw, 116px) 0 clamp(96px, 10vw, 140px);
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.72fr);
+  align-items: center;
+  gap: clamp(54px, 8vw, 112px);
+}
+
+.release-hero-copy h1 {
+  max-width: 720px;
+  font-size: clamp(58px, 6.2vw, 86px);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+  text-wrap: balance;
+}
+
+.release-hero-subtitle {
+  max-width: 650px;
+  margin-top: 30px !important;
+  color: var(--muted);
+  font-size: clamp(17px, 1.45vw, 20px);
+  line-height: 1.7;
+}
+
+.release-actions {
+  margin-top: 34px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
+}
+
+.release-status,
+.download-state > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.release-status i,
+.download-state i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--glow);
+  box-shadow: 0 0 0 4px rgba(255, 169, 70, 0.16);
+}
+
+.release-product {
+  position: relative;
+  height: 620px;
+  display: grid;
+  place-items: end center;
+  border: 2px solid var(--ink);
+  border-radius: 42px;
+  background: var(--dawn);
+  overflow: hidden;
+  box-shadow: 16px 18px 0 rgba(26, 26, 26, 0.09);
+}
+
+.release-product img {
+  width: auto;
+  height: 550px;
+  object-fit: contain;
+  transform: translateY(58px);
+}
+
+.release-product-label {
+  position: absolute;
+  z-index: 2;
+  top: 24px;
+  left: 24px;
+  padding: 9px 13px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--lumen);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.release-product figcaption {
+  position: absolute;
+  z-index: 2;
+  right: 22px;
+  bottom: 22px;
+  left: 22px;
+  display: grid;
+  gap: 4px;
+  padding: 16px 18px;
+  border: 2px solid var(--ink);
+  border-radius: 14px;
+  background: var(--lumen);
+}
+
+.release-product figcaption strong { font-size: 16px; }
+.release-product figcaption span { color: var(--muted); font-size: 13px; }
+
+.release-method,
+.release-download,
+.release-faq,
+.download-section {
+  padding: clamp(88px, 9vw, 128px) 0;
+  border-top: 1px solid var(--line);
+}
+
+.release-section-heading { max-width: 840px; }
+.release-section-heading h2,
+.release-download h2,
+.download-section h2,
+.download-availability h2 {
+  font-size: clamp(44px, 5vw, 68px);
+  line-height: 1.03;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.release-steps {
+  margin: clamp(52px, 6vw, 78px) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(28px, 5vw, 70px);
+  list-style: none;
+}
+
+.release-steps li { padding-top: 24px; border-top: 2px solid var(--ink); }
+.release-steps > li > span { color: var(--fathom); font-family: var(--font-serif); font-size: 18px; }
+.release-steps h3 { margin-top: 46px; font-size: clamp(22px, 2vw, 28px); letter-spacing: -0.035em; }
+.release-steps p { margin-top: 14px; color: var(--muted); line-height: 1.7; }
+
+.release-memory {
+  width: calc(100% - 32px);
+  margin-inline: auto;
+  padding: clamp(88px, 9vw, 132px) max(var(--page-gutter), calc((100% - var(--content-width)) / 2));
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
+  gap: clamp(60px, 9vw, 132px);
+  border-radius: 56px;
+  background: var(--ink);
+  color: var(--lumen);
+}
+
+.release-memory h2 { max-width: 750px; font-size: clamp(48px, 6vw, 82px); line-height: 0.98; text-wrap: balance; }
+.release-memory dl > div { padding: 22px 0 26px; border-top: 1px solid rgba(255, 255, 235, 0.25); }
+.release-memory dl > div:last-child { border-bottom: 1px solid rgba(255, 255, 235, 0.25); }
+.release-memory dt { margin-bottom: 7px; font-size: 18px; font-weight: 750; }
+.release-memory dd { color: rgba(255, 255, 235, 0.66); line-height: 1.65; }
+
+.release-download {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  gap: clamp(62px, 9vw, 132px);
+}
+
+.release-download-copy > p:not(.eyebrow) { max-width: 620px; margin-top: 24px; color: var(--muted); line-height: 1.72; }
+.release-download-copy .button { margin-top: 30px; }
+.release-promises > div { padding: 24px 0 28px; border-top: 1px solid var(--line); }
+.release-promises > div:last-child { border-bottom: 1px solid var(--line); }
+.release-promises dt { margin-bottom: 8px; font-size: 19px; font-weight: 760; }
+.release-promises dd { color: var(--muted); line-height: 1.65; }
+
+.release-faq {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.82fr) minmax(0, 1.18fr);
+  gap: clamp(62px, 9vw, 132px);
+}
+
+.release-section-heading-small h2 { font-size: clamp(40px, 4.5vw, 60px); }
+.release-faq-list details { border-top: 1px solid var(--line); }
+.release-faq-list details:last-child { border-bottom: 1px solid var(--line); }
+.release-faq-list summary { min-height: 84px; display: flex; align-items: center; justify-content: space-between; gap: 24px; cursor: pointer; font-size: 18px; font-weight: 730; list-style: none; }
+.release-faq-list summary::-webkit-details-marker { display: none; }
+.release-faq-list summary span { font-size: 26px; font-weight: 400; }
+.release-faq-list details[open] summary span { transform: rotate(45deg); }
+.release-faq-list details p { max-width: 640px; padding: 0 44px 28px 0; color: var(--muted); line-height: 1.7; }
+
+.release-final {
+  margin-bottom: clamp(72px, 8vw, 112px);
+  padding: clamp(52px, 6vw, 76px);
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 40px;
+  border: 2px solid var(--ink);
+  border-radius: 40px;
+  background: var(--dawn);
+  box-shadow: 14px 16px 0 rgba(26, 26, 26, 0.09);
+}
+
+.release-final h2 { max-width: 760px; font-size: clamp(42px, 5vw, 66px); line-height: 1; }
+
+.download-hero {
+  padding: clamp(76px, 8vw, 112px) 0 clamp(92px, 10vw, 136px);
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
+  align-items: end;
+  gap: clamp(60px, 9vw, 132px);
+}
+
+.download-back { display: inline-block; margin-bottom: clamp(62px, 7vw, 96px); color: var(--muted); font-size: 14px; font-weight: 700; }
+.download-hero h1 { max-width: 850px; font-size: clamp(58px, 7.5vw, 104px); line-height: 0.94; }
+.download-hero-copy > p:not(.eyebrow) { max-width: 680px; margin-top: 30px; color: var(--muted); font-size: 18px; line-height: 1.7; }
+.download-state { margin-top: 38px; padding-top: 20px; border-top: 1px solid var(--line); display: grid; gap: 8px; }
+.download-state small { color: var(--muted); line-height: 1.55; }
+
+.download-availability { padding: 30px; border: 2px solid var(--ink); border-radius: 28px; background: var(--dawn); box-shadow: 10px 12px 0 rgba(26, 26, 26, 0.09); }
+.download-availability h2 { font-size: clamp(32px, 3.2vw, 44px); }
+.download-availability ul { margin: 30px 0 0; padding: 0; list-style: none; }
+.download-availability li { padding: 13px 0; border-top: 1px solid var(--line); font-weight: 650; }
+.download-availability li:last-child { border-bottom: 1px solid var(--line); }
+
+.download-section { display: grid; grid-template-columns: minmax(280px, 0.86fr) minmax(0, 1.14fr); gap: clamp(60px, 9vw, 132px); }
+.download-section-heading > p:last-child { margin-top: 22px; color: var(--muted); line-height: 1.7; }
+.download-facts > div { padding: 20px 0; border-top: 1px solid var(--line); display: grid; grid-template-columns: minmax(180px, 0.75fr) minmax(170px, 1fr); gap: 24px; }
+.download-facts > div:last-child { border-bottom: 1px solid var(--line); }
+.download-facts dt { font-weight: 730; }
+.download-facts dd { color: var(--muted); }
+.download-verify { width: calc(100% - 32px); padding-inline: max(var(--page-gutter), calc((100% - var(--content-width)) / 2)); border: 2px solid var(--ink); border-radius: 56px; background: var(--dawn); }
+.download-hashes > div { padding: 28px 0; border-top: 1px solid var(--line); }
+.download-hashes > div:last-child { border-bottom: 1px solid var(--line); }
+.download-hashes dt { margin-bottom: 10px; font-size: 20px; font-weight: 760; }
+.download-hashes dd { color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; }
+.download-steps { margin: 0; padding: 0; list-style: none; }
+.download-steps li { padding: 24px 0 28px; border-top: 1px solid var(--line); display: grid; grid-template-columns: 48px 1fr; gap: 20px; }
+.download-steps li:last-child { border-bottom: 1px solid var(--line); }
+.download-steps > li > span { color: var(--fathom); font-family: var(--font-serif); }
+.download-steps strong { display: block; margin-bottom: 7px; font-size: 18px; }
+.download-steps p { color: var(--muted); line-height: 1.65; }
+
+@media (max-width: 900px) {
+  .release-hero { grid-template-columns: minmax(0, 1fr) 320px; gap: 34px; }
+  .release-hero-copy h1 { font-size: 58px; }
+  .release-product { height: 560px; }
+  .release-product img { height: 500px; }
+  .release-memory,
+  .release-download,
+  .release-faq,
+  .download-hero,
+  .download-section { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .release-nav .nav-links { display: none; }
+  .release-nav { grid-template-columns: 1fr auto; }
+  .release-hero { min-height: auto; padding: 72px 0 88px; grid-template-columns: 1fr; gap: 52px; }
+  .release-hero-copy h1 { font-size: clamp(43px, 12vw, 52px); line-height: 0.98; }
+  .release-hero-subtitle { margin-top: 24px !important; font-size: 16px; }
+  .release-actions { align-items: flex-start; flex-direction: column; }
+  .release-actions .button { width: 100%; }
+  .release-product { height: 520px; border-radius: 30px; box-shadow: 9px 10px 0 rgba(26, 26, 26, 0.09); }
+  .release-product img { height: 460px; transform: translateY(54px); }
+  .release-product-label { top: 16px; left: 16px; }
+  .release-product figcaption { right: 14px; bottom: 14px; left: 14px; }
+  .release-section-heading h2,
+  .release-download h2,
+  .download-section h2 { font-size: 40px; }
+  .release-steps { grid-template-columns: 1fr; gap: 36px; }
+  .release-steps h3 { margin-top: 24px; }
+  .release-memory { width: 100%; border-radius: 36px; }
+  .release-memory h2 { font-size: 46px; }
+  .release-download,
+  .release-faq { gap: 54px; }
+  .release-final { padding: 34px 26px; align-items: flex-start; flex-direction: column; border-radius: 28px; }
+  .release-final h2 { font-size: 40px; }
+  .release-final .button { width: 100%; }
+  .download-hero { padding: 58px 0 86px; gap: 50px; }
+  .download-back { margin-bottom: 58px; }
+  .download-hero h1 { font-size: 54px; }
+  .download-availability { padding: 24px 20px; }
+  .download-verify { width: 100%; border-radius: 36px; }
+  .download-facts > div { grid-template-columns: 1fr; gap: 7px; }
+  .release-site footer { grid-template-columns: 1fr auto; padding: 28px 20px; }
+  .release-site footer p { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .release-site * { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/portal/app/page.tsx
+++ b/portal/app/page.tsx
@@ -1,177 +1,90 @@
-import EarlyAccessDialog from "./EarlyAccessDialog";
+import Link from "next/link";
 import BrandMark from "./BrandMark";
-import PracticeShowcase from "./PracticeShowcase";
 
-const earlyAccessHref = "#early-access";
-
-const flowingTasks = [
-  "我下周有一场英文面试",
-  "明天要第一次独自去医院",
-  "我要向海外客户汇报项目",
-  "帮我准备 IELTS Part 2",
-  "我要参加第一次全英文会议",
-  "帮我和房东说明维修问题",
-  "下周要做一次英文产品演示",
-  "我要准备海外大学课堂发言",
+const steps = [
+  { number: "01", title: "说清楚你要面对什么", copy: "英文面试、工作汇报、考试或生活沟通——从下一件真实发生的事开始。" },
+  { number: "02", title: "围绕目标反复开口", copy: "SpeakUp 组织针对性练习、模拟对话并给出反馈，不让准备停在背答案。" },
+  { number: "03", title: "把进展带到下一次", copy: "你的目标、经历和卡点会成为后续练习的上下文，让每一轮真正接得上。" },
 ];
 
-const flowingTaskLoop = `${flowingTasks.join(" · ")} · ${flowingTasks.join(" · ")} · `;
+const releasePromises = [
+  ["唯一官方下载", "APK 就绪前不放空链接、临时二维码或未经核验的文件。"],
+  ["制品信息完整", "版本、发布时间、兼容范围、文件大小与 ABI 会随 APK 一起公开。"],
+  ["可以独立验证", "APK 文件 SHA-256 与签名证书 SHA-256 分开提供。"],
+];
+
+const faqs = [
+  ["现在可以下载 Android 版吗？", "还不可以。首个正式 APK 正在准备，完成正式签名和生产验证后才会开放入口。"],
+  ["为什么现在不先放一个测试包？", "公开下载页只承载可追溯的正式制品，避免测试包、临时链接和正式版本混在一起。"],
+  ["开放下载时会提供什么？", "会同时提供版本、系统要求、文件大小、ABI、文件 SHA-256、签名证书 SHA-256、安装说明与更新记录。"],
+];
 
 export default function Home() {
   return (
-    <main>
-      <nav className="site-nav" aria-label="主导航">
-        <a className="brand" href="#top" aria-label="SpeakUp 首页">
-          <BrandMark />
-          <span>SpeakUp</span>
-        </a>
-        <div className="nav-links">
-          <a href="#use-cases">适用阶段</a>
-          <a href="#memory">长期记忆</a>
-        </div>
-        <a className="button button-small" href={earlyAccessHref} data-scenario="英文面试">
-          申请体验
-        </a>
+    <main className="release-site" id="top">
+      <nav className="site-nav release-nav" aria-label="主导航">
+        <a className="brand" href="#top" aria-label="SpeakUp 首页"><BrandMark /><span>SpeakUp</span></a>
+        <div className="nav-links"><a href="#method">怎么练</a><a href="#download">Android 发布</a></div>
+        <Link className="button button-small" href="/download/android">查看下载状态</Link>
       </nav>
 
-      <header className="hero" id="top">
-        <div className="hero-copy">
-          <h1>
-            <span className="headline-muted">下一场重要的英文沟通，</span>
-            <br />
-            先和 SpeakUp 练一遍。
-          </h1>
-          <p className="hero-subtitle">
-            一个有记忆、越用越懂你的 AI 口语老师。
-          </p>
-          <div className="button-group">
-            <a className="button" href={earlyAccessHref} data-scenario="英文面试">
-              告诉 SpeakUp，我要准备什么 <span aria-hidden="true">↗</span>
-            </a>
-            <a className="button button-secondary" href="#use-cases">
-              看看适用阶段
-            </a>
+      <header className="release-hero">
+        <div className="release-hero-copy">
+          <p className="eyebrow">有记忆的 AI 口语老师</p>
+          <h1>下一场重要的英文沟通，先和 SpeakUp 练一遍。</h1>
+          <p className="release-hero-subtitle">围绕你真正要面对的任务，准备、开口、复盘。不是背一套标准答案，而是把自己的经历练成说得出口的表达。</p>
+          <div className="release-actions">
+            <Link className="button" href="/download/android">查看 Android 发布状态 <span aria-hidden="true">↗</span></Link>
+            <span className="release-status"><i aria-hidden="true" />首个 APK 正在准备</span>
           </div>
         </div>
 
-        <div
-          className="scenario-flow"
-          role="img"
-          aria-label={`可以告诉 SpeakUp 的真实任务：${flowingTasks.join("；")}`}
-        >
-          <div className="scenario-flow-stage" aria-hidden="true">
-            <svg viewBox="0 0 1200 240" preserveAspectRatio="xMidYMid meet">
-              <defs>
-                <path
-                  id="scenario-flow-input-path"
-                  d="M -40 196 C 180 208 330 190 470 158 C 610 126 720 102 840 108 C 980 116 1100 82 1240 48"
-                />
-              </defs>
-
-              <text className="scenario-flow-copy scenario-flow-copy-muted scenario-flow-copy-motion">
-                <textPath href="#scenario-flow-input-path" startOffset="-50%">
-                  {flowingTaskLoop}
-                  <animate attributeName="startOffset" from="-50%" to="0%" dur="2.2s" repeatCount="indefinite" />
-                </textPath>
-              </text>
-              <text className="scenario-flow-copy scenario-flow-copy-muted scenario-flow-copy-static">
-                <textPath href="#scenario-flow-input-path" startOffset="4%">
-                  {flowingTaskLoop}
-                </textPath>
-              </text>
-            </svg>
-
-            <div className="scenario-flow-agent">
-              <span className="scenario-flow-listener">
-                <span className="scenario-flow-wave">
-                  <i /><i /><i /><i /><i /><i /><i /><i /><i />
-                </span>
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <div className="hero-product" aria-label="SpeakUp 根据目标准备后端开发英文面试练习示例">
-          <div className="hero-product-copy">
-            <span className="demo-label">一句话开始 · 后端开发面试</span>
-            <p className="demo-question">我下周要面试后端开发工程师，想提前练一下。</p>
-            <div className="voice-answer">
-              <span className="voice-icon" aria-hidden="true">●</span>
-              <div className="voice-bars" aria-hidden="true">
-                <i /><i /><i /><i /><i /><i /><i /><i />
-              </div>
-              <span>0:16</span>
-            </div>
-            <p className="demo-answer">可以。先选你最想练的方向，我会为你准备一场贴近真实面试的英文练习。</p>
-            <div className="instant-feedback">
-              <span>已为你准备好</span>
-              <p><strong>项目经历深挖</strong> · 你是候选人，AI 是英文技术面试官</p>
-            </div>
-          </div>
-          <div className="hero-phone">
-            <img
-              src="/assets/portal-shots/portal-interview-practice.png"
-              alt="SpeakUp 根据后端开发面试目标准备项目经历深挖练习"
-            />
-          </div>
-          <span className="floating-chip chip-top">按目标生成练习</span>
-          <span className="floating-chip chip-bottom">准备好就开练</span>
-        </div>
+        <figure className="release-product">
+          <span className="release-product-label">真实产品界面 · 英文面试</span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/assets/portal-shots/portal-interview-practice.png" alt="SpeakUp 根据后端开发面试目标准备项目经历深挖练习" width="884" height="1832" />
+          <figcaption><strong>从一句真实需求开始</strong><span>按目标准备练习，准备好就直接开口。</span></figcaption>
+        </figure>
       </header>
 
-      <PracticeShowcase />
+      <section className="release-method" id="method" aria-labelledby="method-title">
+        <div className="release-section-heading"><p className="eyebrow">怎么练</p><h2 id="method-title">把“我要学英语”，变成下一次具体的准备。</h2></div>
+        <ol className="release-steps">
+          {steps.map((step) => <li key={step.number}><span>{step.number}</span><h3>{step.title}</h3><p>{step.copy}</p></li>)}
+        </ol>
+      </section>
 
-      <section className="context-section" id="memory">
-        <div className="context-shot">
-          <div className="context-shot-frame">
-            <img
-              src="/assets/portal-shots/portal-memory-chat.jpg"
-              alt="SpeakUp Memory 记录用户目标、真实项目、能力变化与下一轮重点"
-            />
-          </div>
+      <section className="release-memory" aria-labelledby="memory-title">
+        <div><p className="eyebrow eyebrow-light">长期记忆</p><h2 id="memory-title">这次练习里发生的事，下一次还记得。</h2></div>
+        <dl>
+          <div><dt>你的目标</dt><dd>下一次重要沟通是什么，想进入怎样的团队。</dd></div>
+          <div><dt>你的真实经历</dt><dd>做过哪些项目，哪些故事能成为表达素材。</dd></div>
+          <div><dt>你的能力变化</dt><dd>哪些问题反复卡住，哪些表达已经更自然。</dd></div>
+        </dl>
+      </section>
+
+      <section className="release-download" id="download" aria-labelledby="download-title">
+        <div className="release-download-copy">
+          <p className="eyebrow">Android 官方发布</p><h2 id="download-title">下载要直接，制品也要说得清楚。</h2>
+          <p>当前没有可公开下载和验证的正式 APK。页面先把发布规则讲明白，制品完成后再把唯一入口放出来。</p>
+          <Link className="button" href="/download/android">查看完整发布状态 <span aria-hidden="true">↗</span></Link>
         </div>
-        <div className="context-copy">
-          <p className="eyebrow eyebrow-light">越用越懂你</p>
-          <h2>每一次练习，<br />都留给下一次。</h2>
-          <p>SpeakUp 记住的不只是聊天记录，而是那些会改变下一轮教学的真实信息。</p>
-          <ul className="context-list">
-            <li>
-              <span>01</span>
-              <div><strong>你的目标</strong><small>想进入怎样的团队，下一次重要沟通是什么。</small></div>
-            </li>
-            <li>
-              <span>02</span>
-              <div><strong>你的真实经历</strong><small>做过哪些项目，哪些故事可以成为你的表达素材。</small></div>
-            </li>
-            <li>
-              <span>03</span>
-              <div><strong>你的能力变化</strong><small>哪些问题反复卡住，哪些表达已经真正变得自然。</small></div>
-            </li>
-            <li>
-              <span>04</span>
-              <div><strong>现实带回来的结果</strong><small>哪些题命中了，哪些新问题需要补进下一轮。</small></div>
-            </li>
-          </ul>
+        <dl className="release-promises">{releasePromises.map(([title, copy]) => <div key={title}><dt>{title}</dt><dd>{copy}</dd></div>)}</dl>
+      </section>
+
+      <section className="release-faq" aria-labelledby="faq-title">
+        <div className="release-section-heading release-section-heading-small"><p className="eyebrow">常见问题</p><h2 id="faq-title">下载前，先把关键问题讲明白。</h2></div>
+        <div className="release-faq-list">
+          {faqs.map(([question, answer]) => <details key={question}><summary>{question}<span aria-hidden="true">＋</span></summary><p>{answer}</p></details>)}
         </div>
       </section>
 
-      <section className="final-cta">
-        <p className="eyebrow eyebrow-light">从下一件必须说清楚的事开始</p>
-        <h2>告诉 SpeakUp，<br />接下来要面对什么。</h2>
-        <p>可以是一场雅思口语考试、英文面试，也可以是海外生活和工作里马上要发生的关键沟通。</p>
-        <div className="button-group">
-          <a className="button" href={earlyAccessHref} data-scenario="英文面试">开始一次任务准备 ↗</a>
-          <a className="button button-dark-secondary" href="#top">回到顶部</a>
-        </div>
+      <section className="release-final" aria-labelledby="final-title">
+        <div><p className="eyebrow">Android 版本准备中</p><h2 id="final-title">准备完成后，只从这里下载。</h2></div>
+        <Link className="button" href="/download/android">前往 Android 下载页 <span aria-hidden="true">↗</span></Link>
       </section>
 
-      <EarlyAccessDialog />
-
-      <footer>
-        <a className="brand" href="#top"><BrandMark /><span>SpeakUp</span></a>
-        <p>有记忆的 AI Agent 口语老师</p>
-        <span>© 2026 SpeakUp</span>
-      </footer>
+      <footer><a className="brand" href="#top"><BrandMark /><span>SpeakUp</span></a><p>为真实世界准备英文表达。</p><span>© 2026 SpeakUp</span></footer>
     </main>
   );
 }

--- a/portal/design-qa.md
+++ b/portal/design-qa.md
@@ -1,0 +1,11 @@
+# Portal design QA
+
+- Reference: Kimi official download page, used for the compact navigation, clear release hierarchy, direct primary action, and restrained information density.
+- Brand continuity: retained SpeakUp's existing logo, cream/lavender palette, serif display type, black outlines, and real product screenshot.
+- Desktop and tablet: checked at 1440 × 900 and 768 × 1024; hero, product image, CTA, Android status, and download page render without overlap or clipping.
+- Mobile: checked at 390 × 844; navigation collapses, content becomes single-column, CTA remains full-width, and download metadata stays readable.
+- Interaction: Android CTA route and native FAQ expansion verified.
+- Runtime: no application console errors observed.
+- Automated verification: lint, tests, and production build passed.
+
+final result: passed

--- a/portal/tests/rendered-html.test.mjs
+++ b/portal/tests/rendered-html.test.mjs
@@ -19,18 +19,33 @@ test("renders the standalone SpeakUp portal", async () => {
   assert.equal(response.status, 200);
 
   const html = await response.text();
-  assert.match(html, /下一场重要的英文沟通/);
-  assert.match(html, /一个有记忆、越用越懂你的 AI 口语老师/);
+  assert.match(html, /下一场重要的英文沟通，先和 SpeakUp 练一遍/);
+  assert.match(html, /有记忆的 AI 口语老师/);
   assert.match(html, /portal-interview-practice\.png/);
-  assert.match(html, /项目经历深挖/);
-  assert.match(html, /你要面对什么/);
-  assert.match(html, /assets\/practice-screen\/ielts\.webp/);
-  assert.match(html, /assets\/practice-screen\/workplace\.webp/);
-  assert.doesNotMatch(html, /不只是一场面试/);
-  assert.doesNotMatch(html, /准备下一次口语考试/);
-  assert.match(html, /portal-memory-chat\.jpg/);
-  assert.match(html, /id="early-access"/);
+  assert.match(html, /href="\/download\/android"/);
+  assert.match(html, /首个 APK 正在准备/);
+  assert.doesNotMatch(html, /portal-memory-chat\.jpg/);
+  assert.doesNotMatch(html, /assets\/practice-screen\//);
+  assert.doesNotMatch(html, /latest\.apk/);
+  assert.doesNotMatch(html, /id="early-access"/);
   assert.doesNotMatch(html, /href="\/pages\/prototype\.html/);
+});
+
+test("renders an honest Android download preparing state", async () => {
+  const response = await render("/download/android");
+  assert.equal(response.status, 200);
+
+  const html = await response.text();
+  assert.match(html, /SpeakUp for Android/);
+  assert.match(html, /当前还没有可公开下载和验证的 APK/);
+  assert.match(html, /APK 文件 SHA-256/);
+  assert.match(html, /签名证书 SHA-256/);
+  assert.match(html, /更新日志/);
+  assert.match(html, /隐私与权限/);
+  assert.match(html, /问题反馈/);
+  assert.match(html, /安装未知应用/);
+  assert.doesNotMatch(html, /\.apk(?:"|\?)/);
+  assert.doesNotMatch(html, /versionName:\s*\d/);
 });
 
 test("renders the password-gated portal admin page", async () => {


### PR DESCRIPTION
## 功能描述

- 将 Portal 首页重构为紧凑的 SpeakUp 产品与 Android 发布入口。
- 新增 `/download/android`，在首个正式 APK 尚未就绪时明确展示 preparing 状态。
- 为后续正式制品预留版本、兼容范围、文件与签名校验、更新日志、隐私权限、反馈及安装说明。
- 不生成空下载链接、假二维码、假版本、假校验值或 `latest.apk`。

## 实现思路

- 延续现有 SpeakUp Logo、奶油黄/淡紫配色、衬线标题和真实产品截图，仅重排页面信息层级。
- 首页保留单一 Android 主路径，并将产品价值、练习方式、长期记忆和可信发布信息顺序呈现。
- 下载页将发布元数据、两类 SHA-256、发布支持和安装步骤拆成可独立核验的结构。
- 新增独立营销样式文件，避免影响管理后台和现有 API 页面。

## 可复现测试

1. `cd portal`
2. `npm run lint`
3. `npm test`
4. `npm run build`
5. 启动 Portal 后访问 `/` 与 `/download/android`。
6. 验证首页 CTA 路由、FAQ 展开以及 APK preparing 状态。

结果：Lint、5 项测试和生产构建均通过。

## 视觉验收

- 1440 × 900、768 × 1024、390 × 844 均已检查。
- 首页、Android 下载页、CTA 与 FAQ 已完成浏览器手测。
- 视觉 QA 记录见 `portal/design-qa.md`。
- 用户已确认当前视觉方向可以先按此版本推进。

Closes #845
Related #822
