### PR TITLE
ci(release): build traceable release candidates

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -19,6 +19,7 @@ on:
       - ".env.example"
       - "compose.yaml"
       - "server/**"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,7 @@ on:
       - dev
       - main
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   actions: read
@@ -74,7 +75,10 @@ jobs:
             while IFS= read -r -d '' file; do
               printf 'Changed file: %q\n' "$file"
               case "$file" in
-                Makefile|.github/workflows/quality.yml|.github/workflows/coverage-comment.yml)
+                Makefile|.github/workflows/quality.yml|.github/workflows/database.yml|.github/workflows/coverage-comment.yml)
+                  set_all_checks
+                  ;;
+                .github/workflows/release-candidate.yml|tools/release-candidate/*)
                   set_all_checks
                   ;;
                 mobile/*)
@@ -99,6 +103,14 @@ jobs:
             echo "api=$api"
             echo "portal=$portal"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.18.0"
+
+      - name: Check release candidate tooling
+        run: make check-release-candidate
 
   flutter:
     name: Flutter

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,361 @@
+name: Release Candidate
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PORTAL_IMAGE: ghcr.io/1024xengineer/xe3-esl-portal
+  SERVER_IMAGE: ghcr.io/1024xengineer/xe3-esl-server
+
+jobs:
+  metadata:
+    name: Validate release metadata
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      version_code: ${{ steps.release.outputs.version_code }}
+      git_sha: ${{ steps.release.outputs.git_sha }}
+      database_schema_version: ${{ steps.release.outputs.database_schema_version }}
+    steps:
+      - name: Check out complete release history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.18.0"
+
+      - name: Reject moved or deleted Tag events
+        env:
+          TAG_CREATED: ${{ github.event.created }}
+          TAG_DELETED: ${{ github.event.deleted }}
+          TAG_FORCED: ${{ github.event.forced }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_TYPE" != "tag" ||
+                "$TAG_CREATED" != "true" ||
+                "$TAG_DELETED" == "true" ||
+                "$TAG_FORCED" == "true" ]]; then
+            echo "Release Candidate requires a newly created immutable Tag." >&2
+            exit 1
+          fi
+
+      - name: Validate Tag, version, commit, and database schema
+        id: release
+        run: >-
+          node tools/release-candidate/metadata.mjs
+          --tag "$GITHUB_REF_NAME"
+          --main-ref refs/remotes/origin/main
+
+  quality:
+    name: Full quality checks
+    needs: metadata
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/quality.yml
+
+  database:
+    name: Database checks
+    needs: metadata
+    permissions:
+      contents: read
+    uses: ./.github/workflows/database.yml
+
+  images:
+    name: Build content-addressed OCI images
+    needs:
+      - metadata
+      - quality
+      - database
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      portal_digest: ${{ steps.portal.outputs.digest }}
+      server_digest: ${{ steps.server.outputs.digest }}
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Sign in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build and push Portal image
+        id: portal
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: portal
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.metadata.outputs.git_sha }}
+            org.opencontainers.image.version=${{ needs.metadata.outputs.version }}
+          platforms: linux/amd64
+          provenance: mode=min
+          push: true
+          tags: |
+            ${{ env.PORTAL_IMAGE }}:${{ needs.metadata.outputs.version }}
+            ${{ env.PORTAL_IMAGE }}:${{ needs.metadata.outputs.git_sha }}
+
+      - name: Verify Portal image digest
+        env:
+          IMAGE_DIGEST: ${{ steps.portal.outputs.digest }}
+        run: docker buildx imagetools inspect "$PORTAL_IMAGE@$IMAGE_DIGEST"
+
+      - name: Build and push Server image
+        id: server
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: server
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.metadata.outputs.git_sha }}
+            org.opencontainers.image.version=${{ needs.metadata.outputs.version }}
+          platforms: linux/amd64
+          provenance: mode=min
+          push: true
+          tags: |
+            ${{ env.SERVER_IMAGE }}:${{ needs.metadata.outputs.version }}
+            ${{ env.SERVER_IMAGE }}:${{ needs.metadata.outputs.git_sha }}
+
+      - name: Verify Server image digest
+        env:
+          IMAGE_DIGEST: ${{ steps.server.outputs.digest }}
+        run: docker buildx imagetools inspect "$SERVER_IMAGE@$IMAGE_DIGEST"
+
+  android:
+    name: Build signed Android APKs
+    needs:
+      - metadata
+      - quality
+      - database
+    environment:
+      name: android-release-signing
+      deployment: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: "3.44.6"
+          channel: stable
+
+      - name: Restore Pub package cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-flutter-3.44.6-${{ hashFiles('mobile/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-flutter-3.44.6-
+
+      - name: Validate locked Flutter dependencies
+        working-directory: mobile
+        run: flutter pub get --enforce-lockfile
+
+      - name: Prepare protected release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.SPEAKUP_ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$KEYSTORE_BASE64" ]]; then
+            echo "SPEAKUP_ANDROID_KEYSTORE_BASE64 is required." >&2
+            exit 1
+          fi
+          signing_directory="$RUNNER_TEMP/android-release-signing"
+          keystore_path="$signing_directory/release.keystore"
+          install -d -m 700 "$signing_directory"
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          if [[ ! -s "$keystore_path" ]]; then
+            echo "Decoded Android release keystore is empty." >&2
+            exit 1
+          fi
+          chmod 600 "$keystore_path"
+          echo "SPEAKUP_ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
+
+      - name: Build signed Staging and Production APKs
+        env:
+          SPEAKUP_ANDROID_KEY_ALIAS: ${{ secrets.SPEAKUP_ANDROID_KEY_ALIAS }}
+          SPEAKUP_ANDROID_STORE_PASSWORD: ${{ secrets.SPEAKUP_ANDROID_STORE_PASSWORD }}
+          SPEAKUP_ANDROID_KEY_PASSWORD: ${{ secrets.SPEAKUP_ANDROID_KEY_PASSWORD }}
+          SPEAKUP_ANDROID_CERT_SHA256: ${{ secrets.SPEAKUP_ANDROID_CERT_SHA256 }}
+        run: |
+          set -euo pipefail
+          required_variables=(
+            SPEAKUP_ANDROID_KEY_ALIAS
+            SPEAKUP_ANDROID_STORE_PASSWORD
+            SPEAKUP_ANDROID_KEY_PASSWORD
+            SPEAKUP_ANDROID_CERT_SHA256
+          )
+          for variable in "${required_variables[@]}"; do
+            if [[ -z "${!variable}" ]]; then
+              printf '%s is required.\n' "$variable" >&2
+              exit 1
+            fi
+          done
+          make build-android-release-staging
+          make build-android-release-production
+
+      - name: Freeze and verify uploaded APKs
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+          SPEAKUP_ANDROID_CERT_SHA256: ${{ secrets.SPEAKUP_ANDROID_CERT_SHA256 }}
+        run: |
+          set -euo pipefail
+          artifact_directory="$RUNNER_TEMP/release-apks"
+          install -d -m 755 "$artifact_directory"
+          staging_apk="$artifact_directory/speakup-v$VERSION-staging-arm64.apk"
+          production_apk="$artifact_directory/speakup-v$VERSION-production-arm64.apk"
+          install -m 644 \
+            mobile/build/app/outputs/flutter-apk/app-staging-release.apk \
+            "$staging_apk"
+          install -m 644 \
+            mobile/build/app/outputs/flutter-apk/app-production-release.apk \
+            "$production_apk"
+
+          staging_report="$(./tools/android-release/verify.sh "$staging_apk")"
+          production_report="$(./tools/android-release/verify.sh "$production_apk")"
+          staging_certificate="$(
+            sed -n 's/^certificateSha256=//p' <<< "$staging_report"
+          )"
+          production_certificate="$(
+            sed -n 's/^certificateSha256=//p' <<< "$production_report"
+          )"
+          if [[ -z "$staging_certificate" || \
+                "$staging_certificate" != "$production_certificate" ]]; then
+            echo "Staging and Production APK certificates do not match." >&2
+            exit 1
+          fi
+          printf '%s\n' "$production_certificate" > \
+            "$artifact_directory/apk-certificate-sha256.txt"
+          (
+            cd "$artifact_directory"
+            sha256sum \
+              "$(basename "$staging_apk")" \
+              "$(basename "$production_apk")" > SHA256SUMS
+          )
+
+      - name: Upload signed Android artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: speakup-v${{ needs.metadata.outputs.version }}-android
+          path: |
+            ${{ runner.temp }}/release-apks/speakup-v${{ needs.metadata.outputs.version }}-staging-arm64.apk
+            ${{ runner.temp }}/release-apks/speakup-v${{ needs.metadata.outputs.version }}-production-arm64.apk
+            ${{ runner.temp }}/release-apks/apk-certificate-sha256.txt
+            ${{ runner.temp }}/release-apks/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+      - name: Remove release keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/android-release-signing/release.keystore"
+
+  manifest:
+    name: Record release manifest
+    needs:
+      - metadata
+      - images
+      - android
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out complete release history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.18.0"
+
+      - name: Download signed Android artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: speakup-v${{ needs.metadata.outputs.version }}-android
+          path: ${{ runner.temp }}/release-apks
+
+      - name: Reverify downloaded Android artifacts
+        env:
+          APK_CERTIFICATE_FILE: ${{ runner.temp }}/release-apks/apk-certificate-sha256.txt
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          SPEAKUP_ANDROID_CERT_SHA256="$(tr -d '[:space:]' < "$APK_CERTIFICATE_FILE")"
+          export SPEAKUP_ANDROID_CERT_SHA256
+          (
+            cd "$RUNNER_TEMP/release-apks"
+            sha256sum --check SHA256SUMS
+          )
+          ./tools/android-release/verify.sh \
+            "$RUNNER_TEMP/release-apks/speakup-v$VERSION-staging-arm64.apk"
+          ./tools/android-release/verify.sh \
+            "$RUNNER_TEMP/release-apks/speakup-v$VERSION-production-arm64.apk"
+
+      - name: Generate manifest from immutable build outputs
+        env:
+          APK_CERTIFICATE_FILE: ${{ runner.temp }}/release-apks/apk-certificate-sha256.txt
+          PORTAL_IMAGE_DIGEST: ${{ needs.images.outputs.portal_digest }}
+          SERVER_IMAGE_DIGEST: ${{ needs.images.outputs.server_digest }}
+          QUALITY_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          manifest_directory="$RUNNER_TEMP/release-manifest"
+          install -d -m 755 "$manifest_directory"
+          APK_CERTIFICATE_SHA256="$(tr -d '[:space:]' < "$APK_CERTIFICATE_FILE")"
+          export APK_CERTIFICATE_SHA256
+          node tools/release-candidate/manifest.mjs \
+            --tag "$GITHUB_REF_NAME" \
+            --main-ref refs/remotes/origin/main \
+            --staging-apk \
+              "$RUNNER_TEMP/release-apks/speakup-v$VERSION-staging-arm64.apk" \
+            --production-apk \
+              "$RUNNER_TEMP/release-apks/speakup-v$VERSION-production-arm64.apk" \
+            --output "$manifest_directory/release-manifest.json"
+
+      - name: Upload release manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: speakup-v${{ needs.metadata.outputs.version }}-release-manifest
+          path: ${{ runner.temp }}/release-manifest/release-manifest.json
+          if-no-files-found: error
+          retention-days: 90

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SHELL := /bin/bash
 	check-api \
 	check-api-dependencies \
 	check-api-contracts \
+	check-release-candidate \
 	dev-android \
 	dev-ios-simulator \
 	build-android-release-staging \
@@ -44,6 +45,7 @@ help:
 		'  make check-kodo-live Run the real Kodo lifecycle test with exported QINIU_* variables' \
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
+		'  make check-release-candidate  Validate release metadata and manifest tooling' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
 		'  make dev-ios-simulator  Start the backend on an iOS Simulator' \
 		'  make build-android-release-staging  Build the signed staging arm64 APK' \
@@ -243,6 +245,9 @@ check-api-dependencies:
 
 check-api-contracts: check-api-dependencies
 	cd api && npm run check
+
+check-release-candidate:
+	node --test tools/release-candidate/*.test.mjs
 
 dev-android:
 	./tools/android-dev/run.sh

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -220,6 +220,30 @@ Check 严格模式已暂缓，不在本阶段擅自重新启用。
 镜像可使用语义版本标签方便识别，但部署必须引用 digest，不能引用可变
 `latest`。
 
+Android 正式签名采用以下已确认边界：
+
+- GitHub Environment 固定为 `android-release-signing`。
+- Required reviewer 为 `Lq0412`；当前单人发布阶段允许本人审核，未来增加独立
+  发布负责人后再启用禁止自审。
+- 正式签名证书 Owner 为 `Lq0412`。
+- 证书与密码均保存两份：团队密码管理器一份、离线加密备份一份，不能只保存在
+  GitHub Secret。
+- keystore 只以 `SPEAKUP_ANDROID_KEYSTORE_BASE64` Environment Secret 注入临时
+  Runner；构建结束后删除，不进入 Artifact、日志或仓库。
+
+首次运行前，管理员必须先创建该 Environment，将 Deployment branches and tags
+设为 Selected branches and tags、Tag pattern 设为 `v*.*.*`，并配置 Required
+reviewer；随后才能添加以下 Environment Secrets：
+
+- `SPEAKUP_ANDROID_KEYSTORE_BASE64`
+- `SPEAKUP_ANDROID_KEY_ALIAS`
+- `SPEAKUP_ANDROID_STORE_PASSWORD`
+- `SPEAKUP_ANDROID_KEY_PASSWORD`
+- `SPEAKUP_ANDROID_CERT_SHA256`
+
+正式 Tag 还需要单独的 Tag ruleset 禁止更新和删除。Workflow 会严格校验 Tag
+格式及其 commit 是否位于 `main`，但 Workflow 本身不能阻止有权限的人移动 Tag。
+
 ### 7.3 Staging 与 Production Deploy
 
 Deploy Workflow 接收确定的 `version` 和 `environment`，读取 Release manifest
@@ -509,11 +533,8 @@ Portal 报名和访问事件继续使用独立 SQLite。它与产品核心业务
 16. 建立日志轮转、HTTP/第三方 API/业务指标、基础看板与告警。
 17. 建立旧 App API 兼容窗口、最低支持版本和 Android hotfix 流程。
 
-## 16. 实施前待确认
+## 16. 后续阶段仍待确认
 
-- Android 正式 application ID 是否继续使用当前值。
-- 首次公开 versionName 与 versionCode。
-- 正式签名证书的 Account Owner 与双重备份位置。
 - Android Developer Console 使用个人或组织账号，以及 package name 注册负责人。
 - Staging 使用独立子域名还是仅内部可达的预览入口。
 - Production 审批人及应急替代审批人。

--- a/tools/release-candidate/manifest.mjs
+++ b/tools/release-candidate/manifest.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { collectReleaseMetadata } from "./metadata.mjs";
+
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const imageDigestPattern = /^sha256:[0-9a-f]{64}$/;
+const gitShaPattern = /^[0-9a-f]{40}$/;
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const imagePattern =
+  /^ghcr\.io\/[a-z0-9]+(?:[._-][a-z0-9]+)*\/[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function required(input, name) {
+  const value = input[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function matches(value, pattern, name) {
+  if (!pattern.test(value)) throw new Error(`${name} has an invalid value`);
+  return value;
+}
+
+function nonzeroSha(value, pattern, name) {
+  const validated = matches(value, pattern, name);
+  const hexadecimal = validated.startsWith("sha256:")
+    ? validated.slice("sha256:".length)
+    : validated;
+  if (/^0+$/.test(hexadecimal)) {
+    throw new Error(`${name} cannot be a placeholder digest`);
+  }
+  return validated;
+}
+
+function qualityRunUrl(value, repository) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("QUALITY_RUN_URL has an invalid value");
+  }
+  const expectedPath = `/${repository}/actions/runs/`;
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "github.com" ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    !url.pathname.toLowerCase().startsWith(expectedPath.toLowerCase()) ||
+    !/^\d+$/.test(url.pathname.slice(expectedPath.length))
+  ) {
+    throw new Error("QUALITY_RUN_URL has an invalid value");
+  }
+  return value;
+}
+
+function certificateSha256(value) {
+  const normalized = value.toLowerCase().replace(/[:\s]/g, "");
+  return nonzeroSha(normalized, sha256Pattern, "APK_CERTIFICATE_SHA256");
+}
+
+function apkArtifact(filePath, expectedName, name) {
+  const resolved = path.resolve(required({ filePath }, "filePath"));
+  const status = statSync(resolved);
+  if (!status.isFile() || status.size === 0) {
+    throw new Error(`${name} must be a non-empty file`);
+  }
+  if (path.basename(resolved) !== expectedName) {
+    throw new Error(`${name} must be named ${expectedName}`);
+  }
+  return {
+    file: expectedName,
+    sha256: createHash("sha256").update(readFileSync(resolved)).digest("hex"),
+  };
+}
+
+export function createReleaseManifest(input, metadata) {
+  const version = matches(metadata.version, versionPattern, "version");
+  const gitSha = nonzeroSha(metadata.git_sha, gitShaPattern, "git_sha");
+  const versionCode = Number(metadata.version_code);
+  const schemaVersion = Number(metadata.database_schema_version);
+  if (!Number.isSafeInteger(versionCode) || versionCode < 1) {
+    throw new Error("version_code must be a positive integer");
+  }
+  if (!Number.isSafeInteger(schemaVersion) || schemaVersion < 1) {
+    throw new Error("database_schema_version must be a positive integer");
+  }
+  const repository = matches(
+    required(input, "GITHUB_REPOSITORY"),
+    repositoryPattern,
+    "GITHUB_REPOSITORY",
+  );
+
+  const stagingApk = apkArtifact(
+    input.STAGING_APK_PATH,
+    `speakup-v${version}-staging-arm64.apk`,
+    "STAGING_APK_PATH",
+  );
+  const productionApk = apkArtifact(
+    input.PRODUCTION_APK_PATH,
+    `speakup-v${version}-production-arm64.apk`,
+    "PRODUCTION_APK_PATH",
+  );
+
+  return {
+    manifest_version: 1,
+    version,
+    version_code: versionCode,
+    git_sha: gitSha,
+    portal_image: matches(required(input, "PORTAL_IMAGE"), imagePattern, "PORTAL_IMAGE"),
+    portal_image_digest: nonzeroSha(
+      required(input, "PORTAL_IMAGE_DIGEST"),
+      imageDigestPattern,
+      "PORTAL_IMAGE_DIGEST",
+    ),
+    server_image: matches(required(input, "SERVER_IMAGE"), imagePattern, "SERVER_IMAGE"),
+    server_image_digest: nonzeroSha(
+      required(input, "SERVER_IMAGE_DIGEST"),
+      imageDigestPattern,
+      "SERVER_IMAGE_DIGEST",
+    ),
+    staging_apk_file: stagingApk.file,
+    staging_apk_sha256: stagingApk.sha256,
+    production_apk_file: productionApk.file,
+    production_apk_sha256: productionApk.sha256,
+    apk_certificate_sha256: certificateSha256(
+      required(input, "APK_CERTIFICATE_SHA256"),
+    ),
+    database_schema_version: schemaVersion,
+    quality_run_url: qualityRunUrl(
+      required(input, "QUALITY_RUN_URL"),
+      repository,
+    ),
+  };
+}
+
+function readArguments(arguments_) {
+  const values = {};
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const flag = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "Usage: manifest.mjs --tag <vX.Y.Z> --main-ref <ref> " +
+          "--staging-apk <file> --production-apk <file> --output <file>",
+      );
+    }
+    values[flag.slice(2)] = value;
+  }
+  return values;
+}
+
+function main() {
+  const arguments_ = readArguments(process.argv.slice(2));
+  for (const name of ["tag", "main-ref", "staging-apk", "production-apk", "output"]) {
+    if (!arguments_[name]) throw new Error(`--${name} is required`);
+  }
+  const repoDir = path.resolve(arguments_.repo ?? ".");
+  const metadata = collectReleaseMetadata({
+    repoDir,
+    tag: arguments_.tag,
+    mainRef: arguments_["main-ref"],
+  });
+  const manifest = createReleaseManifest(
+    {
+      ...process.env,
+      STAGING_APK_PATH: arguments_["staging-apk"],
+      PRODUCTION_APK_PATH: arguments_["production-apk"],
+    },
+    metadata,
+  );
+  const output = path.resolve(arguments_.output);
+  const temporaryDirectory = mkdtempSync(`${output}.tmp-`);
+  const temporaryOutput = path.join(temporaryDirectory, "release-manifest.json");
+  try {
+    writeFileSync(temporaryOutput, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    renameSync(temporaryOutput, output);
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tools/release-candidate/metadata.mjs
+++ b/tools/release-candidate/metadata.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const stableTagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const pubspecVersionPattern = /^version:\s*["']?([^+\s"']+)\+(\d+)["']?\s*$/gm;
+const migrationPattern = /^server\/migrations\/(\d{6})_[^/]+\.up\.sql$/;
+
+export function parseStableTag(tag) {
+  const match = stableTagPattern.exec(tag);
+  if (!match) {
+    throw new Error(`Release tag must use vX.Y.Z: ${tag}`);
+  }
+  const version = match.slice(1).map(Number);
+  if (!version.every(Number.isSafeInteger)) {
+    throw new Error(`Release tag contains an unsupported numeric component: ${tag}`);
+  }
+  return version;
+}
+
+export function parsePubspecVersion(content) {
+  const matches = [...content.matchAll(pubspecVersionPattern)];
+  if (matches.length !== 1) {
+    throw new Error(
+      "mobile/pubspec.yaml must contain exactly one versionName+versionCode",
+    );
+  }
+  const match = matches[0];
+  return { version: match[1], versionCode: Number(match[2]) };
+}
+
+export function databaseSchemaVersion(files) {
+  const versions = [];
+  const seenVersions = new Set();
+  for (const file of files.filter((candidate) => candidate.endsWith(".up.sql"))) {
+    const match = migrationPattern.exec(file);
+    if (!match) {
+      throw new Error(`Invalid server migration filename: ${file}`);
+    }
+    const version = Number(match[1]);
+    if (seenVersions.has(version)) {
+      throw new Error(`Duplicate server migration version: ${match[1]}`);
+    }
+    seenVersions.add(version);
+    versions.push(version);
+  }
+  if (versions.length === 0) {
+    throw new Error("No server migration .up.sql files were found");
+  }
+  return Math.max(...versions);
+}
+
+function compareVersion(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function validateVersionCode(versionCode, source) {
+  if (
+    !Number.isSafeInteger(versionCode) ||
+    versionCode < 1 ||
+    versionCode > 2_100_000_000
+  ) {
+    throw new Error(`${source} versionCode must be between 1 and 2100000000`);
+  }
+}
+
+function git(repoDir, args) {
+  return execFileSync("git", args, {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function isAncestor(repoDir, commit, mainRef) {
+  return spawnSync("git", ["merge-base", "--is-ancestor", commit, mainRef], {
+    cwd: repoDir,
+    stdio: "ignore",
+  }).status === 0;
+}
+
+function stableTagRefs(repoDir) {
+  const local = new Map(
+    git(repoDir, ["tag", "--list", "v*"])
+      .split("\n")
+      .filter((tag) => stableTagPattern.test(tag))
+      .map((tag) => [
+        tag,
+        git(repoDir, ["rev-parse", "--verify", `refs/tags/${tag}`]),
+      ]),
+  );
+  const remote = new Map(
+    git(repoDir, ["ls-remote", "--tags", "--refs", "origin", "refs/tags/v*"])
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split("\t"))
+      .map(([object, ref]) => [ref.replace("refs/tags/", ""), object])
+      .filter(([tag]) => stableTagPattern.test(tag)),
+  );
+  if (
+    local.size !== remote.size ||
+    [...remote].some(([tag, object]) => local.get(tag) !== object)
+  ) {
+    throw new Error("Local stable release tags do not match origin");
+  }
+  return [...local.keys()];
+}
+
+export function collectReleaseMetadata({ repoDir, tag, mainRef }) {
+  if (git(repoDir, ["rev-parse", "--is-shallow-repository"]) === "true") {
+    throw new Error("Release validation requires the complete Git history");
+  }
+  parseStableTag(tag);
+  const tagCommit = git(repoDir, [
+    "rev-parse",
+    "--verify",
+    `refs/tags/${tag}^{commit}`,
+  ]);
+  const headCommit = git(repoDir, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (headCommit !== tagCommit) {
+    throw new Error(`HEAD ${headCommit} does not match release tag ${tag}`);
+  }
+  const mainCommit = git(repoDir, ["rev-parse", "--verify", `${mainRef}^{commit}`]);
+  if (!isAncestor(repoDir, tagCommit, mainCommit)) {
+    throw new Error(`Release tag ${tag} is not contained in ${mainRef}`);
+  }
+  const mainHistory = git(repoDir, [
+    "rev-list",
+    "--first-parent",
+    "--reverse",
+    mainCommit,
+  ]).split("\n");
+  const firstParentCommits = new Set(mainHistory);
+  if (!firstParentCommits.has(tagCommit)) {
+    throw new Error(`Release tag ${tag} is not on the first-parent history of ${mainRef}`);
+  }
+  const allStableTags = stableTagRefs(repoDir);
+
+  const pubspec = git(repoDir, ["show", `${tagCommit}:mobile/pubspec.yaml`]);
+  const current = parsePubspecVersion(pubspec);
+  if (`v${current.version}` !== tag) {
+    throw new Error(`Release tag ${tag} does not match versionName ${current.version}`);
+  }
+  validateVersionCode(current.versionCode, "Current release");
+
+  const releasesOnMain = allStableTags
+    .map((candidate) => ({
+      tag: candidate,
+      commit: git(repoDir, [
+        "rev-parse",
+        "--verify",
+        `refs/tags/${candidate}^{commit}`,
+      ]),
+      version: parseStableTag(candidate),
+    }))
+    .filter((candidate) => isAncestor(repoDir, candidate.commit, mainCommit));
+
+  const sideHistoryTag = releasesOnMain.find(
+    (candidate) => !firstParentCommits.has(candidate.commit),
+  );
+  if (sideHistoryTag) {
+    throw new Error(
+      `Previous release tag ${sideHistoryTag.tag} is not on the first-parent history of ${mainRef}`,
+    );
+  }
+  const historyOrder = new Map(
+    mainHistory.map((commit, index) => [commit, index]),
+  );
+  const releases = releasesOnMain.map((candidate) => {
+    let version = current;
+    if (candidate.tag !== tag) {
+      version = parsePubspecVersion(
+        git(repoDir, [
+          "show",
+          `refs/tags/${candidate.tag}^{commit}:mobile/pubspec.yaml`,
+        ]),
+      );
+    }
+    if (`v${version.version}` !== candidate.tag) {
+      throw new Error(
+        `Previous release tag ${candidate.tag} does not match versionName ${version.version}`,
+      );
+    }
+    validateVersionCode(version.versionCode, candidate.tag);
+    return { ...candidate, versionCode: version.versionCode };
+  }).sort(
+    (left, right) => historyOrder.get(left.commit) - historyOrder.get(right.commit),
+  );
+  for (let index = 1; index < releases.length; index += 1) {
+    const previous = releases[index - 1];
+    const release = releases[index];
+    if (release.commit === previous.commit) {
+      throw new Error(`Stable release Tags ${previous.tag} and ${release.tag} share a commit`);
+    }
+    if (compareVersion(release.version, previous.version) <= 0) {
+      throw new Error(`Release version ${release.tag} must be newer than ${previous.tag}`);
+    }
+    if (release.versionCode <= previous.versionCode) {
+      throw new Error(
+        `versionCode ${release.versionCode} must be greater than ` +
+          `${previous.versionCode} from ${previous.tag}`,
+      );
+    }
+  }
+
+  const migrationFiles = git(repoDir, [
+    "ls-tree",
+    "-r",
+    "--name-only",
+    tagCommit,
+    "--",
+    "server/migrations",
+  ]).split("\n");
+
+  return {
+    tag,
+    version: current.version,
+    version_code: String(current.versionCode),
+    git_sha: tagCommit,
+    database_schema_version: String(databaseSchemaVersion(migrationFiles)),
+  };
+}
+
+function readArguments(arguments_) {
+  const values = {};
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const flag = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error("Usage: metadata.mjs --tag <vX.Y.Z> --main-ref <ref> [--repo <path>]");
+    }
+    values[flag.slice(2)] = value;
+  }
+  return values;
+}
+
+function main() {
+  const arguments_ = readArguments(process.argv.slice(2));
+  if (!arguments_.tag || !arguments_["main-ref"]) {
+    throw new Error("Both --tag and --main-ref are required");
+  }
+  const metadata = collectReleaseMetadata({
+    repoDir: path.resolve(arguments_.repo ?? "."),
+    tag: arguments_.tag,
+    mainRef: arguments_["main-ref"],
+  });
+  const output = Object.entries(metadata)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  console.log(output);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`, "utf8");
+  }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tools/release-candidate/release-candidate.test.mjs
+++ b/tools/release-candidate/release-candidate.test.mjs
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createReleaseManifest } from "./manifest.mjs";
+import {
+  collectReleaseMetadata,
+  databaseSchemaVersion,
+  parseStableTag,
+} from "./metadata.mjs";
+
+const manifestScript = fileURLToPath(new URL("./manifest.mjs", import.meta.url));
+
+function git(repo, ...arguments_) {
+  return execFileSync("git", arguments_, {
+    cwd: repo,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function writeReleaseFiles(repo, version) {
+  mkdirSync(path.join(repo, "mobile"), { recursive: true });
+  mkdirSync(path.join(repo, "server", "migrations"), { recursive: true });
+  writeFileSync(path.join(repo, "mobile", "pubspec.yaml"), `name: speakup\nversion: ${version}\n`);
+  writeFileSync(path.join(repo, "server", "migrations", "000001_baseline.up.sql"), "SELECT 1;\n");
+  writeFileSync(path.join(repo, "server", "migrations", "000007_current.up.sql"), "SELECT 1;\n");
+}
+
+function createRepository(version = "0.1.0+1") {
+  const repo = mkdtempSync(path.join(tmpdir(), "speakup-release-"));
+  git(repo, "init", "--initial-branch=main");
+  git(repo, "config", "user.name", "Release Test");
+  git(repo, "config", "user.email", "release-test@example.invalid");
+  writeReleaseFiles(repo, version);
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "initial release");
+  git(repo, "remote", "add", "origin", repo);
+  return repo;
+}
+
+function validManifestFixture() {
+  const artifacts = mkdtempSync(path.join(tmpdir(), "speakup-artifacts-"));
+  const stagingApk = path.join(artifacts, "speakup-v0.1.0-staging-arm64.apk");
+  const productionApk = path.join(artifacts, "speakup-v0.1.0-production-arm64.apk");
+  writeFileSync(stagingApk, "staging apk");
+  writeFileSync(productionApk, "production apk");
+  return {
+    input: {
+      PORTAL_IMAGE: "ghcr.io/1024xengineer/xe3-esl-portal",
+      PORTAL_IMAGE_DIGEST: `sha256:${"a".repeat(64)}`,
+      SERVER_IMAGE: "ghcr.io/1024xengineer/xe3-esl-server",
+      SERVER_IMAGE_DIGEST: `sha256:${"b".repeat(64)}`,
+      STAGING_APK_PATH: stagingApk,
+      PRODUCTION_APK_PATH: productionApk,
+      APK_CERTIFICATE_SHA256: "c".repeat(64),
+      GITHUB_REPOSITORY: "1024XEngineer/XE3-ESL",
+      QUALITY_RUN_URL: "https://github.com/1024XEngineer/XE3-ESL/actions/runs/1",
+    },
+    metadata: {
+      version: "0.1.0",
+      version_code: "1",
+      git_sha: "d".repeat(40),
+      database_schema_version: "7",
+    },
+    stagingApk,
+  };
+}
+
+test("accepts the first stable release and ignores prerelease tags", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0-alpha.1");
+  git(repo, "tag", "v0.1.0");
+
+  assert.deepEqual(
+    collectReleaseMetadata({ repoDir: repo, tag: "v0.1.0", mainRef: "main" }),
+    {
+      tag: "v0.1.0",
+      version: "0.1.0",
+      version_code: "1",
+      git_sha: git(repo, "rev-parse", "HEAD"),
+      database_schema_version: "7",
+    },
+  );
+});
+
+test("rejects a release tag that is not contained in main", () => {
+  const repo = createRepository();
+  git(repo, "checkout", "-b", "feature");
+  writeReleaseFiles(repo, "0.1.1+2");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "feature release");
+  git(repo, "tag", "v0.1.1");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.1.1", mainRef: "main" }),
+    /not contained in main/,
+  );
+});
+
+test("rejects a tag checkout that does not match HEAD", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  writeReleaseFiles(repo, "0.1.1+2");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "unreleased change");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.1.0", mainRef: "main" }),
+    /does not match release tag/,
+  );
+});
+
+test("rejects non-stable tags and tag/versionName mismatches", () => {
+  assert.throws(() => parseStableTag("v0.1.0-rc.1"), /must use vX.Y.Z/);
+
+  const repo = createRepository();
+  git(repo, "tag", "v0.2.0");
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.2.0", mainRef: "main" }),
+    /does not match versionName/,
+  );
+});
+
+test("rejects a versionCode that does not increase", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  writeReleaseFiles(repo, "0.1.1+1");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "next release");
+  git(repo, "tag", "v0.1.1");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.1.1", mainRef: "main" }),
+    /versionCode 1 must be greater than 1/,
+  );
+});
+
+test("accepts an increased versionCode and permits rebuilding an older stable tag", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  writeReleaseFiles(repo, "0.1.1+2");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "next release");
+  git(repo, "tag", "v0.1.1");
+
+  assert.equal(
+    collectReleaseMetadata({ repoDir: repo, tag: "v0.1.1", mainRef: "main" })
+      .version_code,
+    "2",
+  );
+
+  git(repo, "checkout", "--detach", "v0.1.0");
+  assert.equal(
+    collectReleaseMetadata({ repoDir: repo, tag: "v0.1.0", mainRef: "main" }).version,
+    "0.1.0",
+  );
+});
+
+test("rejects shallow repositories", () => {
+  const source = createRepository();
+  git(source, "tag", "v0.1.0");
+  const cloneParent = mkdtempSync(path.join(tmpdir(), "speakup-shallow-parent-"));
+  const shallow = path.join(cloneParent, "repo");
+  execFileSync(
+    "git",
+    ["clone", "--depth", "1", "--branch", "v0.1.0", `file://${source}`, shallow],
+    { stdio: "ignore" },
+  );
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: shallow, tag: "v0.1.0", mainRef: "main" }),
+    /complete Git history/,
+  );
+});
+
+test("rejects an incomplete local stable Tag set", () => {
+  const source = createRepository("0.1.0+100");
+  git(source, "tag", "v0.1.0");
+  writeReleaseFiles(source, "0.2.0+1");
+  git(source, "add", ".");
+  git(source, "commit", "-m", "invalid lower version code");
+  git(source, "tag", "v0.2.0");
+
+  const cloneParent = mkdtempSync(path.join(tmpdir(), "speakup-no-tags-parent-"));
+  const clone = path.join(cloneParent, "repo");
+  execFileSync("git", ["clone", "--no-tags", source, clone], { stdio: "ignore" });
+  git(clone, "fetch", "origin", "refs/tags/v0.2.0:refs/tags/v0.2.0");
+  git(clone, "checkout", "--detach", "v0.2.0");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: clone, tag: "v0.2.0", mainRef: "main" }),
+    /stable release tags do not match origin/,
+  );
+});
+
+test("rejects a release Tag on merged side history", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  git(repo, "checkout", "-b", "feature");
+  writeReleaseFiles(repo, "0.2.0+2");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "side release");
+  git(repo, "tag", "v0.2.0");
+  git(repo, "checkout", "main");
+  git(repo, "merge", "--no-ff", "feature", "-m", "merge feature");
+  git(repo, "checkout", "--detach", "v0.2.0");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.2.0", mainRef: "main" }),
+    /not on the first-parent history/,
+  );
+});
+
+test("rejects release ordering that regresses later on main", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  writeReleaseFiles(repo, "0.3.0+2");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "backdated future release");
+  const backdatedCommit = git(repo, "rev-parse", "HEAD");
+  writeReleaseFiles(repo, "0.2.0+3");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "existing later release");
+  git(repo, "tag", "v0.2.0");
+  git(repo, "tag", "v0.3.0", backdatedCommit);
+  git(repo, "checkout", "--detach", "v0.3.0");
+
+  assert.throws(
+    () => collectReleaseMetadata({ repoDir: repo, tag: "v0.3.0", mainRef: "main" }),
+    /Release version v0\.2\.0 must be newer than v0\.3\.0/,
+  );
+});
+
+test("rejects missing, malformed, and duplicate migration versions", () => {
+  assert.throws(() => databaseSchemaVersion([]), /No server migration/);
+  assert.throws(
+    () => databaseSchemaVersion(["server/migrations/not_numbered.up.sql"]),
+    /Invalid server migration filename/,
+  );
+  assert.throws(
+    () => databaseSchemaVersion([
+      "server/migrations/000001_first.up.sql",
+      "server/migrations/000001_second.up.sql",
+    ]),
+    /Duplicate server migration version/,
+  );
+  assert.equal(
+    databaseSchemaVersion([
+      "server/migrations/000001_first.up.sql",
+      "server/migrations/999999_ignored.down.sql",
+      "server/migrations/embed.go",
+    ]),
+    1,
+  );
+});
+
+test("derives the manifest from validated build artifacts", () => {
+  const { input, metadata } = validManifestFixture();
+  const manifest = createReleaseManifest(input, metadata);
+
+  assert.equal(
+    manifest.staging_apk_sha256,
+    createHash("sha256").update("staging apk").digest("hex"),
+  );
+  assert.equal(
+    manifest.production_apk_sha256,
+    createHash("sha256").update("production apk").digest("hex"),
+  );
+  assert.equal(manifest.database_schema_version, 7);
+  assert.equal(manifest.portal_image_digest, input.PORTAL_IMAGE_DIGEST);
+});
+
+test("writes the validated manifest atomically through the CLI", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  const { input } = validManifestFixture();
+  const output = path.join(repo, "release-manifest.json");
+  execFileSync(
+    process.execPath,
+    [
+      manifestScript,
+      "--tag",
+      "v0.1.0",
+      "--main-ref",
+      "main",
+      "--staging-apk",
+      input.STAGING_APK_PATH,
+      "--production-apk",
+      input.PRODUCTION_APK_PATH,
+      "--output",
+      output,
+      "--repo",
+      repo,
+    ],
+    { env: { ...process.env, ...input }, stdio: "pipe" },
+  );
+
+  const manifest = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(manifest.version, "0.1.0");
+  assert.equal(manifest.git_sha, git(repo, "rev-parse", "HEAD"));
+
+  const rejectedOutput = path.join(repo, "rejected-manifest.json");
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [
+        manifestScript,
+        "--tag",
+        "v0.1.0",
+        "--main-ref",
+        "main",
+        "--staging-apk",
+        input.STAGING_APK_PATH,
+        "--production-apk",
+        input.PRODUCTION_APK_PATH,
+        "--output",
+        rejectedOutput,
+        "--repo",
+        repo,
+      ],
+      {
+        env: { ...process.env, ...input, PORTAL_IMAGE_DIGEST: "sha256:pending" },
+        stdio: "pipe",
+      },
+    ),
+  );
+  assert.equal(existsSync(rejectedOutput), false);
+});
+
+test("rejects placeholder or malformed manifest values", () => {
+  assert.throws(
+    () => createReleaseManifest({}, {
+      version: "pending",
+      version_code: "1",
+      git_sha: "c".repeat(40),
+      database_schema_version: "7",
+    }),
+    /version has an invalid value/,
+  );
+});
+
+test("rejects invalid APKs, image references, digests, and quality run URLs", () => {
+  const { input, metadata, stagingApk } = validManifestFixture();
+  writeFileSync(stagingApk, "");
+  assert.throws(() => createReleaseManifest(input, metadata), /non-empty file/);
+
+  writeFileSync(stagingApk, "staging apk");
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PORTAL_IMAGE_DIGEST: "sha256:pending" },
+      metadata,
+    ),
+    /PORTAL_IMAGE_DIGEST has an invalid value/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PORTAL_IMAGE: "ghcr.io/1024xengineer//" },
+      metadata,
+    ),
+    /PORTAL_IMAGE has an invalid value/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PORTAL_IMAGE_DIGEST: `sha256:${"0".repeat(64)}` },
+      metadata,
+    ),
+    /cannot be a placeholder digest/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      {
+        ...input,
+        QUALITY_RUN_URL: "https://github.com/another/repo/actions/runs/1",
+      },
+      metadata,
+    ),
+    /QUALITY_RUN_URL has an invalid value/,
+  );
+});


### PR DESCRIPTION
## 功能说明

- 新增仅由正式 `vX.Y.Z` Tag 触发的 Release Candidate Workflow。
- 从同一 Tag commit 执行全量 Quality 与 Database 门禁。
- 构建 Portal、Server GHCR 镜像并记录真实 digest，不发布 `latest`。
- 在受保护的 `android-release-signing` Environment 审批后，构建并复验 Staging/Production arm64 APK。
- 上传两个 APK、`SHA256SUMS` 和由真实构建结果生成的 `release-manifest.json`，保留 90 天。

## 实现思路

- Tag 校验严格匹配 SemVer，拒绝移动、删除、非 `main` first-parent 及历史不完整的 Tag。
- 对 `main` 上全部正式 Tag 校验 SemVer 与 Android `versionCode` 全局递增；alpha/beta/rc 不参与正式版本比较。
- Manifest 从 Buildx digest、下载后的 APK、签名证书和当前 Actions run 直接派生，不接受占位 digest。
- keystore 仅从 Environment Secret 解码到 Runner 临时目录，构建结束后删除，不进入仓库、日志或 Artifact。
- 复用现有 Quality/Database Workflow，避免复制质量检查逻辑。

## 可复现测试

- `make check-release-candidate`：15/15 通过。
- `make check-android-release-guard`：通过，缺少正式签名配置时构建保持 fail closed。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/quality.yml .github/workflows/database.yml .github/workflows/release-candidate.yml`：通过。
- `docker build --tag speakup-portal:issue-848-test portal`：通过。
- `docker build --tag speakup-server:issue-848-test server`：通过。
- `git diff --check` 与 Node 语法检查：通过。

## 首次正式 Tag 前的管理员配置

这些是外部前置条件，当前 PR 不伪装为已经完成：

1. 创建 `android-release-signing` Environment，Tag pattern 设为 `v*.*.*`，Required reviewer 设为 `Lq0412`。
2. 仅在该 Environment 中配置五项 Secret：
   - `SPEAKUP_ANDROID_KEYSTORE_BASE64`
   - `SPEAKUP_ANDROID_KEY_ALIAS`
   - `SPEAKUP_ANDROID_STORE_PASSWORD`
   - `SPEAKUP_ANDROID_KEY_PASSWORD`
   - `SPEAKUP_ANDROID_CERT_SHA256`
3. 创建 `v*` Tag ruleset，禁止正式 Tag 更新和删除。
4. 证书与密码保存两份：团队密码管理器一份、离线加密备份一份。

## 范围边界

- 不部署 Staging 或 Production。
- 不连接服务器、执行 migration、更新 Portal 下载入口或创建 GitHub Release。
- 不包含任何 Secret、keystore、`.env` 或服务器访问资料。

Closes #848
