### PR TITLE
feat(deploy): add immutable staging stack

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,6 +30,7 @@ jobs:
       go: ${{ steps.scope.outputs.go }}
       api: ${{ steps.scope.outputs.api }}
       portal: ${{ steps.scope.outputs.portal }}
+      deploy: ${{ steps.scope.outputs.deploy }}
     steps:
       - name: Check out repository history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,12 +53,14 @@ jobs:
           go=false
           api=false
           portal=false
+          deploy=false
 
           set_all_checks() {
             flutter=true
             go=true
             api=true
             portal=true
+            deploy=true
           }
 
           if [[ "$EVENT_NAME" != "pull_request" || "$BASE_REF" == "main" ]]; then
@@ -93,6 +96,9 @@ jobs:
                 portal/*)
                   portal=true
                   ;;
+                deploy/*)
+                  deploy=true
+                  ;;
               esac
             done < "$changed_files"
           fi
@@ -102,6 +108,7 @@ jobs:
             echo "go=$go"
             echo "api=$api"
             echo "portal=$portal"
+            echo "deploy=$deploy"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
@@ -255,6 +262,24 @@ jobs:
 
       - name: Build Portal Docker image
         run: docker build --tag speakup-portal:ci .
+
+  deploy:
+    name: Staging deploy contract
+    needs: changes
+    if: needs.changes.outputs.deploy == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate Staging deployment contract
+        run: make check-staging-deploy
+
+      - name: Validate rendered Nginx configuration
+        run: make check-staging-nginx
 
   coverage-gate:
     name: Coverage gate
@@ -545,6 +570,7 @@ jobs:
       - go
       - api
       - portal
+      - deploy
       - coverage-gate
       - flutter-coverage-gate
     if: always()
@@ -560,6 +586,8 @@ jobs:
       API_RESULT: ${{ needs.api.result }}
       PORTAL_REQUIRED: ${{ needs.changes.outputs.portal }}
       PORTAL_RESULT: ${{ needs.portal.result }}
+      DEPLOY_REQUIRED: ${{ needs.changes.outputs.deploy }}
+      DEPLOY_RESULT: ${{ needs.deploy.result }}
       GO_COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
       FLUTTER_COVERAGE_RESULT: ${{ needs.flutter-coverage-gate.result }}
     steps:
@@ -606,6 +634,7 @@ jobs:
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
           require_result "Portal" "$PORTAL_REQUIRED" "$PORTAL_RESULT"
+          require_result "Staging deploy" "$DEPLOY_REQUIRED" "$DEPLOY_RESULT"
 
           require_coverage_result() {
             local name=$1

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-release-candidate \
+	check-staging-deploy \
+	check-staging-nginx \
 	dev-android \
 	dev-ios-simulator \
 	build-android-release-staging \
@@ -46,6 +48,8 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
+		'  make check-staging-deploy  Validate the immutable Staging deployment contract' \
+		'  make check-staging-nginx  Run nginx -t against the rendered Staging template' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
 		'  make dev-ios-simulator  Start the backend on an iOS Simulator' \
 		'  make build-android-release-staging  Build the signed staging arm64 APK' \
@@ -248,6 +252,12 @@ check-api-contracts: check-api-dependencies
 
 check-release-candidate:
 	node --test tools/release-candidate/*.test.mjs
+
+check-staging-deploy:
+	./deploy/staging/test.sh
+
+check-staging-nginx:
+	./deploy/staging/test-nginx.sh
 
 dev-android:
 	./tools/android-dev/run.sh

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -1,0 +1,197 @@
+# SpeakUp immutable Staging stack
+
+This directory is the host-side contract for running a Release Candidate in an
+isolated Staging environment. It does not connect to a server, install Nginx,
+issue a certificate, or change Production by itself.
+
+## Verified inputs and design choices
+
+The Release Candidate workflow emits `release-manifest.json` with the exact
+Portal and Server repositories and their `sha256` digests. The Server image
+contains both `/usr/local/bin/speakup-server` and the explicit
+`/usr/local/bin/speakup-migrate` command, and exposes `/health` and `/readyz`.
+PostgreSQL 18 stores its versioned data below `/var/lib/postgresql`, so the
+named volume is mounted at that parent path.
+
+This Staging contract deliberately uses:
+
+- Compose project `xe3-speakup-staging`, never the Production project name;
+- loopback ports `28082` for Portal and `28083` for Server;
+- project-scoped Portal and PostgreSQL volumes;
+- separate Portal, Server-egress, and internal database networks;
+- image references of the form `repository@sha256:digest`, with no `build`;
+- a one-shot migration before either application container is updated;
+- HTTP Basic Authentication on the Staging Portal only;
+- TLS plus the application's Bearer authentication on the Staging API, so the
+  mobile client's `Authorization` header is never consumed by Nginx;
+- an exact public `/metrics` denial, while internal metrics work remains in
+  its own Issue.
+
+The selected hostnames are `staging.speak-up.top` for Portal and
+`staging-api.speak-up.top` for API; the latter matches the Staging APK's fixed
+API base URL. Their DNS targets, TLS paths, htpasswd path, provider credentials,
+and server environment are externally injected and are not committed.
+
+## Prerequisites
+
+- Bash, `jq`, `curl`, Docker Engine, and Docker Compose with `up --wait` support.
+- Nginx with the HTTP SSL, proxy, and Basic Auth modules.
+- A certificate whose SANs cover both Staging hostnames.
+- A populated htpasswd file and a real Staging Server environment file.
+- Registry credentials with read access to the two GHCR images.
+
+The Server environment file must contain the real Staging provider and secret
+configuration required by the application. Use the repository `.env.example`
+only as a key reference; do not copy local defaults as deployment values and do
+not disable OSS or OCR to bypass missing configuration. It must not define
+`DATABASE_URL`, `SERVER_HOST`, or `SERVER_PORT`; Compose owns those three values.
+
+## 1. Acquire a manifest and configuration
+
+Download the manifest artifact from the selected, successful Release Candidate
+run. For example:
+
+```sh
+gh run download RUN_ID \
+  --repo 1024XEngineer/XE3-ESL \
+  --name speakup-v0.1.1-release-manifest \
+  --dir /opt/speakup/releases/v0.1.1
+```
+
+Copy `staging.env.example` to a location outside the repository, populate every
+blank value, and restrict both environment files:
+
+```sh
+install -d -m 0750 /etc/speakup
+install -m 0600 staging.env.example /etc/speakup/staging.env
+install -m 0600 /secure/source/staging-server.env \
+  /etc/speakup/staging-server.env
+```
+
+Before public verification, create A records for both selected hostnames (and
+AAAA records only when the host is intentionally IPv6-reachable) and point them
+to the Staging host. IP addresses stay in the DNS/operations system, not this
+repository.
+
+`STAGING_POSTGRES_PASSWORD` accepts URL-safe characters and must contain at
+least 24 characters. A suitable value can be generated with
+`openssl rand -hex 32`. Create the Portal access file with the host's `htpasswd`
+tool; neither plaintext credentials nor the generated file belong in the
+repository. Do not add HTTP Basic Auth to the API host: the Staging APK uses its
+`Authorization: Bearer` header for application identity.
+
+## 2. Validate without changing containers
+
+```sh
+./deploy/staging/manage.sh validate \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/staging.env
+```
+
+Validation fails on a missing or malformed manifest, a mutable or placeholder
+image reference, a missing configuration value, an empty Server environment
+file, or an invalid Compose model. It does not pull images or contact the
+application providers.
+
+## 3. Deploy the immutable Staging images
+
+```sh
+./deploy/staging/manage.sh deploy \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/staging.env
+```
+
+The command performs the following fail-closed sequence:
+
+1. validate the manifest, external configuration, Compose model, and Nginx
+   template;
+2. pull the pinned PostgreSQL, Portal, and Server images;
+3. start only PostgreSQL and wait for its health check;
+4. run `/usr/local/bin/speakup-migrate up` in a one-shot container;
+5. only after migration succeeds, update Portal and Server and wait for their
+   container health checks;
+6. verify Portal `/`, Server `/health`, and Server `/readyz` over loopback.
+
+If migration fails, the command exits before the Portal or Server update. A
+failed application health check is also an explicit deployment failure; this
+Issue does not add Production promotion or automatic rollback behavior.
+
+## 4. Render and install the Nginx configuration
+
+Rendering writes only the requested output file. It never reloads Nginx:
+
+```sh
+./deploy/staging/manage.sh render-nginx \
+  --env-file /etc/speakup/staging.env \
+  --output /opt/speakup/releases/v0.1.1/staging-nginx.conf
+```
+
+Review the rendered file, install it at the host's configured include path,
+then test and reload Nginx using the paths appropriate to that host. The
+committed template keeps ACME HTTP challenges reachable, redirects other HTTP
+traffic to HTTPS, protects the Portal with Basic Auth, preserves the API Bearer
+header and WebSocket upgrades, and returns `404` for exact `/metrics` requests
+before they reach either application. The API host intentionally has no
+`auth_basic` directive.
+
+## 5. Verify
+
+```sh
+./deploy/staging/manage.sh status \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/staging.env
+
+./deploy/staging/manage.sh verify \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/staging.env
+
+curl --fail --user staging-user https://staging.speak-up.top/
+curl --fail https://staging-api.speak-up.top/health
+curl --fail https://staging-api.speak-up.top/readyz
+test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  https://staging-api.speak-up.top/metrics)" = 404
+```
+
+The Portal command prompts for the Basic Auth password instead of placing it in
+the command. `/health` and `/readyz` stay directly verifiable over API HTTPS;
+business routes continue to enforce the application's Bearer authentication.
+Public HTTPS checks require DNS, certificate, and firewall setup that remain
+external to this repository.
+
+## 6. Stop or clean up Staging
+
+```sh
+./deploy/staging/manage.sh down \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/staging.env
+```
+
+`down` removes only the `xe3-speakup-staging` containers and networks and keeps
+`xe3-speakup-staging_portal_data` and
+`xe3-speakup-staging_postgres_data`. Remove the rendered Nginx include and
+reload Nginx if the public Staging entry points should also disappear. Volume
+deletion is intentionally not automated; inspect and back up these explicitly
+Staging-scoped volumes before deleting them by name.
+
+## Reproducible contract checks
+
+```sh
+make check-staging-deploy
+make check-staging-nginx
+```
+
+The first command checks manifest and environment failure paths, the resolved
+Compose isolation model, endpoint verification, and the rule that a migration
+failure cannot switch applications. The second renders a temporary TLS config
+and runs `nginx -t` in a pinned Docker Official Nginx image.
+
+## Official references
+
+- [Docker Compose image and healthcheck reference](https://docs.docker.com/reference/compose-file/services/)
+- [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
+- [Docker Compose project isolation](https://docs.docker.com/compose/how-tos/project-name/)
+- [Docker Official PostgreSQL image storage contract](https://github.com/docker-library/docs/blob/master/postgres/content.md)
+- [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
+- [Nginx TLS module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html)
+- [Nginx Basic Auth module](https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html)
+- [GitHub Actions artifact download](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/download-workflow-artifacts)

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -1,0 +1,115 @@
+name: xe3-speakup-staging
+
+services:
+  postgres:
+    image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${STAGING_POSTGRES_DB:?STAGING_POSTGRES_DB is required}
+      POSTGRES_USER: ${STAGING_POSTGRES_USER:?STAGING_POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${STAGING_POSTGRES_PASSWORD:?STAGING_POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    networks:
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'pg_isready --username="$${POSTGRES_USER}" --dbname="$${POSTGRES_DB}"',
+        ]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
+
+  migrate:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: always
+    profiles:
+      - migration
+    restart: "no"
+    command:
+      - /usr/local/bin/speakup-migrate
+      - up
+    environment:
+      DATABASE_URL: postgres://${STAGING_POSTGRES_USER:?STAGING_POSTGRES_USER is required}:${STAGING_POSTGRES_PASSWORD:?STAGING_POSTGRES_PASSWORD is required}@postgres:5432/${STAGING_POSTGRES_DB:?STAGING_POSTGRES_DB is required}?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - database
+
+  server:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: always
+    restart: unless-stopped
+    init: true
+    env_file:
+      - ${STAGING_SERVER_ENV_FILE:?STAGING_SERVER_ENV_FILE is required}
+    environment:
+      DATABASE_URL: postgres://${STAGING_POSTGRES_USER:?STAGING_POSTGRES_USER is required}:${STAGING_POSTGRES_PASSWORD:?STAGING_POSTGRES_PASSWORD is required}@postgres:5432/${STAGING_POSTGRES_DB:?STAGING_POSTGRES_DB is required}?sslmode=disable
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: "8080"
+    ports:
+      - "127.0.0.1:28083:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - server_edge
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "-T",
+          "2",
+          "--spider",
+          "http://127.0.0.1:8080/readyz",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+  portal:
+    image: ghcr.io/1024xengineer/xe3-esl-portal@${PORTAL_IMAGE_DIGEST:?PORTAL_IMAGE_DIGEST is required}
+    pull_policy: always
+    restart: unless-stopped
+    init: true
+    environment:
+      PORTAL_ADMIN_PASSWORD: ${PORTAL_ADMIN_PASSWORD:?PORTAL_ADMIN_PASSWORD is required}
+      PORTAL_SQLITE_PATH: /app/.wrangler/portal.sqlite
+      VINEXT_TRUSTED_HOSTS: ${STAGING_PORTAL_HOST:?STAGING_PORTAL_HOST is required}
+    ports:
+      - "127.0.0.1:28082:3000"
+    volumes:
+      - portal_data:/app/.wrangler
+    networks:
+      - portal_edge
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/',{signal:AbortSignal.timeout(2000)}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+networks:
+  portal_edge:
+  server_edge:
+  database:
+    internal: true
+
+volumes:
+  portal_data:
+  postgres_data:

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly compose_file="$staging_directory/compose.yaml"
+readonly nginx_template="$staging_directory/nginx.conf.template"
+readonly compose_project="xe3-speakup-staging"
+readonly portal_health_url="http://127.0.0.1:28082/"
+readonly server_health_url="http://127.0.0.1:28083/health"
+readonly server_readiness_url="http://127.0.0.1:28083/readyz"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  manage.sh validate --manifest FILE --env-file FILE
+  manage.sh deploy --manifest FILE --env-file FILE
+  manage.sh verify --manifest FILE --env-file FILE
+  manage.sh status --manifest FILE --env-file FILE
+  manage.sh down --manifest FILE --env-file FILE
+  manage.sh render-nginx --env-file FILE --output FILE
+EOF
+}
+
+fail() {
+  printf 'staging deploy: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+allowed_configuration_key() {
+  case "$1" in
+    STAGING_POSTGRES_DB | \
+      STAGING_POSTGRES_USER | \
+      STAGING_POSTGRES_PASSWORD | \
+      PORTAL_ADMIN_PASSWORD | \
+      STAGING_SERVER_ENV_FILE | \
+      STAGING_PORTAL_HOST | \
+      STAGING_API_HOST | \
+      STAGING_TLS_CERTIFICATE | \
+      STAGING_TLS_CERTIFICATE_KEY | \
+      STAGING_HTPASSWD_FILE | \
+      STAGING_ACME_ROOT)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+load_configuration() {
+  local file=$1
+  local line name value
+
+  [[ -f "$file" ]] || fail "environment file does not exist: $file"
+  [[ -r "$file" ]] || fail "environment file is not readable: $file"
+
+  unset \
+    STAGING_POSTGRES_DB \
+    STAGING_POSTGRES_USER \
+    STAGING_POSTGRES_PASSWORD \
+    PORTAL_ADMIN_PASSWORD \
+    STAGING_SERVER_ENV_FILE \
+    STAGING_PORTAL_HOST \
+    STAGING_API_HOST \
+    STAGING_TLS_CERTIFICATE \
+    STAGING_TLS_CERTIFICATE_KEY \
+    STAGING_HTPASSWD_FILE \
+    STAGING_ACME_ROOT
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=${line%$'\r'}
+    case "$line" in
+      "" | \#*)
+        continue
+        ;;
+    esac
+    [[ "$line" == *=* ]] || fail "invalid environment line: $line"
+    name=${line%%=*}
+    value=${line#*=}
+    [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]] || fail "invalid environment key: $name"
+    allowed_configuration_key "$name" || fail "unsupported environment key: $name"
+    printf -v "$name" '%s' "$value"
+    export "$name"
+  done <"$file"
+}
+
+require_value() {
+  local name=$1
+  [[ -n "${!name:-}" ]] || fail "$name is required"
+}
+
+valid_hostname() {
+  local value=$1
+  local label
+  local -a labels
+
+  [[ ${#value} -le 253 ]] || return 1
+  [[ "$value" != *..* ]] || return 1
+  IFS='.' read -r -a labels <<<"$value"
+  ((${#labels[@]} >= 2)) || return 1
+  for label in "${labels[@]}"; do
+    [[ "$label" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]] || return 1
+  done
+}
+
+valid_absolute_path() {
+  local value=$1
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != *//* ]] &&
+    [[ "$value" != */../* ]] &&
+    [[ "$value" != */./* ]] &&
+    [[ "$value" != */.. ]] &&
+    [[ "$value" != */. ]]
+}
+
+validate_configuration() {
+  local name
+  local required=(
+    STAGING_POSTGRES_DB
+    STAGING_POSTGRES_USER
+    STAGING_POSTGRES_PASSWORD
+    PORTAL_ADMIN_PASSWORD
+    STAGING_SERVER_ENV_FILE
+    STAGING_PORTAL_HOST
+    STAGING_API_HOST
+    STAGING_TLS_CERTIFICATE
+    STAGING_TLS_CERTIFICATE_KEY
+    STAGING_HTPASSWD_FILE
+    STAGING_ACME_ROOT
+  )
+  for name in "${required[@]}"; do
+    require_value "$name"
+  done
+
+  [[ "$STAGING_POSTGRES_DB" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail "STAGING_POSTGRES_DB must be a lowercase PostgreSQL identifier"
+  [[ "$STAGING_POSTGRES_USER" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail "STAGING_POSTGRES_USER must be a lowercase PostgreSQL identifier"
+  [[ "$STAGING_POSTGRES_PASSWORD" =~ ^[A-Za-z0-9._~-]{24,}$ ]] ||
+    fail "STAGING_POSTGRES_PASSWORD must be at least 24 URL-safe characters"
+  [[ ${#PORTAL_ADMIN_PASSWORD} -ge 16 ]] ||
+    fail "PORTAL_ADMIN_PASSWORD must be at least 16 characters"
+
+  valid_hostname "$STAGING_PORTAL_HOST" ||
+    fail "STAGING_PORTAL_HOST must be a lowercase DNS hostname"
+  valid_hostname "$STAGING_API_HOST" ||
+    fail "STAGING_API_HOST must be a lowercase DNS hostname"
+  [[ "$STAGING_PORTAL_HOST" != "$STAGING_API_HOST" ]] ||
+    fail "Staging Portal and API hostnames must be different"
+
+  for name in \
+    STAGING_SERVER_ENV_FILE \
+    STAGING_TLS_CERTIFICATE \
+    STAGING_TLS_CERTIFICATE_KEY \
+    STAGING_HTPASSWD_FILE \
+    STAGING_ACME_ROOT; do
+    valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
+  done
+
+  [[ -s "$STAGING_SERVER_ENV_FILE" ]] ||
+    fail "server environment file is missing or empty: $STAGING_SERVER_ENV_FILE"
+}
+
+validate_manifest() {
+  local file=$1
+  local digest hexadecimal
+
+  require_command jq
+  [[ -f "$file" ]] || fail "release manifest does not exist: $file"
+  [[ -r "$file" ]] || fail "release manifest is not readable: $file"
+
+  jq --exit-status '
+    type == "object" and
+    .manifest_version == 1 and
+    (.version | type == "string" and
+      test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+    (.git_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+    .portal_image == "ghcr.io/1024xengineer/xe3-esl-portal" and
+    (.portal_image_digest | type == "string" and
+      test("^sha256:[0-9a-f]{64}$")) and
+    .server_image == "ghcr.io/1024xengineer/xe3-esl-server" and
+    (.server_image_digest | type == "string" and
+      test("^sha256:[0-9a-f]{64}$")) and
+    (.database_schema_version | type == "number" and
+      . >= 1 and . == floor)
+  ' "$file" >/dev/null || fail "release manifest is invalid"
+
+  for digest in \
+    "$(jq --raw-output '.portal_image_digest' "$file")" \
+    "$(jq --raw-output '.server_image_digest' "$file")"; do
+    hexadecimal=${digest#sha256:}
+    [[ "$hexadecimal" =~ [1-9a-f] ]] || fail "image digest cannot be a placeholder"
+  done
+  [[ "$(jq --raw-output '.git_sha' "$file")" =~ [1-9a-f] ]] ||
+    fail "git_sha cannot be a placeholder"
+
+  PORTAL_IMAGE_DIGEST=$(jq --raw-output '.portal_image_digest' "$file")
+  SERVER_IMAGE_DIGEST=$(jq --raw-output '.server_image_digest' "$file")
+  RELEASE_VERSION=$(jq --raw-output '.version' "$file")
+  RELEASE_GIT_SHA=$(jq --raw-output '.git_sha' "$file")
+  RELEASE_SCHEMA_VERSION=$(jq --raw-output '.database_schema_version' "$file")
+  export PORTAL_IMAGE_DIGEST SERVER_IMAGE_DIGEST
+}
+
+compose() {
+  docker compose \
+    --env-file /dev/null \
+    --project-name "$compose_project" \
+    --project-directory "$staging_directory" \
+    --file "$compose_file" \
+    "$@"
+}
+
+validate_compose() {
+  require_command docker
+  docker compose version >/dev/null
+  compose --profile migration config --quiet
+}
+
+render_nginx() {
+  local output=$1
+  local temporary
+
+  [[ -d "$(dirname "$output")" ]] || fail "Nginx output directory does not exist"
+  temporary=$(mktemp "${output}.tmp.XXXXXX")
+  if ! sed \
+    -e "s|__STAGING_PORTAL_HOST__|$STAGING_PORTAL_HOST|g" \
+    -e "s|__STAGING_API_HOST__|$STAGING_API_HOST|g" \
+    -e "s|__STAGING_TLS_CERTIFICATE__|$STAGING_TLS_CERTIFICATE|g" \
+    -e "s|__STAGING_TLS_CERTIFICATE_KEY__|$STAGING_TLS_CERTIFICATE_KEY|g" \
+    -e "s|__STAGING_HTPASSWD_FILE__|$STAGING_HTPASSWD_FILE|g" \
+    -e "s|__STAGING_ACME_ROOT__|$STAGING_ACME_ROOT|g" \
+    "$nginx_template" >"$temporary"; then
+    rm -f "$temporary"
+    fail "failed to render Nginx template"
+  fi
+  if grep -q '__STAGING_[A-Z_]*__' "$temporary"; then
+    rm -f "$temporary"
+    fail "Nginx template contains an unresolved placeholder"
+  fi
+  chmod 0644 "$temporary"
+  mv -f "$temporary" "$output"
+}
+
+wait_for_endpoint() {
+  local name=$1
+  local url=$2
+  local attempt
+
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 3 "$url" >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  curl --fail --show-error --max-time 3 "$url" >/dev/null || true
+  fail "$name did not become healthy: $url"
+}
+
+verify_endpoints() {
+  require_command curl
+  wait_for_endpoint "Portal" "$portal_health_url"
+  wait_for_endpoint "Server liveness" "$server_health_url"
+  wait_for_endpoint "Server readiness" "$server_readiness_url"
+}
+
+validate_all() {
+  local manifest=$1
+  local rendered
+
+  validate_configuration
+  validate_manifest "$manifest"
+  validate_compose
+  rendered=$(mktemp)
+  render_nginx "$rendered"
+  rm -f "$rendered"
+}
+
+main() {
+  local command=${1:-}
+  local manifest=""
+  local environment_file=""
+  local output=""
+
+  [[ -n "$command" ]] || {
+    usage
+    exit 2
+  }
+  shift
+  while (($# > 0)); do
+    case "$1" in
+      --manifest)
+        (($# >= 2)) || fail "--manifest requires a value"
+        manifest=$2
+        shift 2
+        ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file requires a value"
+        environment_file=$2
+        shift 2
+        ;;
+      --output)
+        (($# >= 2)) || fail "--output requires a value"
+        output=$2
+        shift 2
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$environment_file" ]] || fail "--env-file is required"
+  load_configuration "$environment_file"
+
+  case "$command" in
+    render-nginx)
+      [[ -z "$manifest" ]] || fail "render-nginx does not accept --manifest"
+      [[ -n "$output" ]] || fail "render-nginx requires --output"
+      validate_configuration
+      render_nginx "$output"
+      printf 'rendered=%s\n' "$output"
+      ;;
+    validate | deploy | verify | status | down)
+      [[ -n "$manifest" ]] || fail "$command requires --manifest"
+      [[ -z "$output" ]] || fail "$command does not accept --output"
+      validate_all "$manifest"
+      case "$command" in
+        validate)
+          printf 'version=%s git_sha=%s schema=%s validated=true\n' \
+            "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION"
+          ;;
+        deploy)
+          compose pull postgres migrate server portal
+          compose up --detach --no-build --wait --wait-timeout 90 postgres
+          compose run --rm --no-deps migrate
+          compose up --detach --no-build --wait --wait-timeout 90 portal server
+          verify_endpoints
+          printf 'version=%s git_sha=%s deployed=true\n' \
+            "$RELEASE_VERSION" "$RELEASE_GIT_SHA"
+          ;;
+        verify)
+          verify_endpoints
+          printf 'version=%s verified=true\n' "$RELEASE_VERSION"
+          ;;
+        status)
+          compose ps
+          ;;
+        down)
+          compose down --remove-orphans
+          ;;
+      esac
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/staging/nginx.conf.template
+++ b/deploy/staging/nginx.conf.template
@@ -1,0 +1,88 @@
+map $http_upgrade $speakup_staging_connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __STAGING_PORTAL_HOST__ __STAGING_API_HOST__;
+
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        root __STAGING_ACME_ROOT__;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name __STAGING_PORTAL_HOST__;
+
+    ssl_certificate __STAGING_TLS_CERTIFICATE__;
+    ssl_certificate_key __STAGING_TLS_CERTIFICATE_KEY__;
+
+    access_log /var/log/nginx/xe3-speakup-staging-portal.access.log;
+    error_log /var/log/nginx/xe3-speakup-staging-portal.error.log warn;
+
+    auth_basic "SpeakUp Staging";
+    auth_basic_user_file __STAGING_HTPASSWD_FILE__;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+    location = /metrics {
+        auth_basic off;
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:28082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name __STAGING_API_HOST__;
+
+    ssl_certificate __STAGING_TLS_CERTIFICATE__;
+    ssl_certificate_key __STAGING_TLS_CERTIFICATE_KEY__;
+
+    access_log /var/log/nginx/xe3-speakup-staging-api.access.log;
+    error_log /var/log/nginx/xe3-speakup-staging-api.error.log warn;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer always;
+    client_max_body_size 12m;
+
+    location = /metrics {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:28083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $speakup_staging_connection_upgrade;
+        proxy_read_timeout 180s;
+    }
+}

--- a/deploy/staging/staging.env.example
+++ b/deploy/staging/staging.env.example
@@ -1,0 +1,15 @@
+# Raw KEY=value configuration. Do not use shell expressions or quote values.
+# Copy this file outside the repository and keep the populated copy mode 0600.
+STAGING_POSTGRES_DB=speakup_staging
+STAGING_POSTGRES_USER=speakup_staging
+STAGING_POSTGRES_PASSWORD=
+PORTAL_ADMIN_PASSWORD=
+STAGING_SERVER_ENV_FILE=/etc/speakup/staging-server.env
+
+# DNS, certificate, and access-control choices are injected by the operator.
+STAGING_PORTAL_HOST=staging.speak-up.top
+STAGING_API_HOST=staging-api.speak-up.top
+STAGING_TLS_CERTIFICATE=/etc/letsencrypt/live/staging.speak-up.top/fullchain.pem
+STAGING_TLS_CERTIFICATE_KEY=/etc/letsencrypt/live/staging.speak-up.top/privkey.pem
+STAGING_HTPASSWD_FILE=/etc/nginx/staging.htpasswd
+STAGING_ACME_ROOT=/var/www/staging-acme

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly manage="$staging_directory/manage.sh"
+readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
+readonly container_fixture_directory="/tmp/staging-nginx-test"
+
+command -v docker >/dev/null 2>&1 || {
+  printf '%s\n' 'docker is required for the Nginx configuration check' >&2
+  exit 1
+}
+command -v openssl >/dev/null 2>&1 || {
+  printf '%s\n' 'openssl is required for the Nginx configuration check' >&2
+  exit 1
+}
+
+temporary_directory=$(mktemp -d)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$temporary_directory/acme"
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
+printf '%s\n' 'staging:test-password-hash' >"$temporary_directory/staging.htpasswd"
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -subj '/CN=staging.speak-up.top' \
+  -days 1 \
+  -keyout "$temporary_directory/privkey.pem" \
+  -out "$temporary_directory/fullchain.pem" \
+  >/dev/null 2>&1
+
+printf '%s\n' \
+  'STAGING_POSTGRES_DB=speakup_staging' \
+  'STAGING_POSTGRES_USER=speakup_staging' \
+  'STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
+  'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
+  "STAGING_SERVER_ENV_FILE=$temporary_directory/server.env" \
+  'STAGING_PORTAL_HOST=staging.speak-up.top' \
+  'STAGING_API_HOST=staging-api.speak-up.top' \
+  "STAGING_TLS_CERTIFICATE=$container_fixture_directory/fullchain.pem" \
+  "STAGING_TLS_CERTIFICATE_KEY=$container_fixture_directory/privkey.pem" \
+  "STAGING_HTPASSWD_FILE=$container_fixture_directory/staging.htpasswd" \
+  "STAGING_ACME_ROOT=$container_fixture_directory/acme" \
+  >"$temporary_directory/staging.env"
+
+"$manage" render-nginx \
+  --env-file "$temporary_directory/staging.env" \
+  --output "$temporary_directory/default.conf" \
+  >/dev/null
+
+docker run --rm \
+  --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
+  "$nginx_image" \
+  nginx -t
+
+printf '%s\n' 'staging Nginx configuration check passed'

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly manage="$staging_directory/manage.sh"
+readonly compose_file="$staging_directory/compose.yaml"
+readonly portal_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+readonly server_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+readonly git_sha="cccccccccccccccccccccccccccccccccccccccc"
+
+fail() {
+  printf 'staging deploy test: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" >"$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+}
+
+write_environment() {
+  local destination=$1
+  local server_environment=$2
+
+  printf '%s\n' \
+    'STAGING_POSTGRES_DB=speakup_staging' \
+    'STAGING_POSTGRES_USER=speakup_staging' \
+    'STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
+    'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
+    "STAGING_SERVER_ENV_FILE=$server_environment" \
+    'STAGING_PORTAL_HOST=staging.speak-up.top' \
+    'STAGING_API_HOST=staging-api.speak-up.top' \
+    "STAGING_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
+    "STAGING_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
+    "STAGING_HTPASSWD_FILE=$temporary_directory/staging.htpasswd" \
+    "STAGING_ACME_ROOT=$temporary_directory/acme" >"$destination"
+}
+
+write_manifest() {
+  local destination=$1
+  local selected_portal_digest=${2:-$portal_digest}
+
+  printf '%s\n' \
+    '{' \
+    '  "manifest_version": 1,' \
+    '  "version": "0.1.1",' \
+    "  \"git_sha\": \"$git_sha\"," \
+    '  "version_code": 2,' \
+    '  "portal_image": "ghcr.io/1024xengineer/xe3-esl-portal",' \
+    "  \"portal_image_digest\": \"$selected_portal_digest\"," \
+    '  "server_image": "ghcr.io/1024xengineer/xe3-esl-server",' \
+    "  \"server_image_digest\": \"$server_digest\"," \
+    '  "database_schema_version": 7' \
+    '}' >"$destination"
+}
+
+temporary_directory=$(mktemp -d)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$temporary_directory/acme" "$temporary_directory/fake-bin"
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
+printf '%s\n' 'test-user:test-password-hash' >"$temporary_directory/staging.htpasswd"
+printf '%s\n' 'test-certificate-placeholder' >"$temporary_directory/fullchain.pem"
+printf '%s\n' 'test-key-placeholder' >"$temporary_directory/privkey.pem"
+write_environment "$temporary_directory/staging.env" "$temporary_directory/server.env"
+write_manifest "$temporary_directory/release-manifest.json"
+
+bash -n "$manage" "$0"
+
+"$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/staging.env" \
+  >"$temporary_directory/validate.out"
+grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
+  fail "valid deployment contract was not accepted"
+
+write_manifest "$temporary_directory/invalid-manifest.json" 'latest'
+expect_failure "mutable Portal image reference" \
+  "$manage" validate \
+  --manifest "$temporary_directory/invalid-manifest.json" \
+  --env-file "$temporary_directory/staging.env"
+
+write_manifest \
+  "$temporary_directory/zero-digest-manifest.json" \
+  'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+expect_failure "placeholder Portal digest" \
+  "$manage" validate \
+  --manifest "$temporary_directory/zero-digest-manifest.json" \
+  --env-file "$temporary_directory/staging.env"
+
+expect_failure "missing release manifest" \
+  "$manage" validate \
+  --manifest "$temporary_directory/missing.json" \
+  --env-file "$temporary_directory/staging.env"
+
+expect_failure "missing environment file" \
+  "$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/not-there.env"
+
+sed 's/^PORTAL_ADMIN_PASSWORD=.*/PORTAL_ADMIN_PASSWORD=/' \
+  "$temporary_directory/staging.env" >"$temporary_directory/missing-value.env"
+expect_failure "missing required environment value" \
+  "$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/missing-value.env"
+
+sed '/^PORTAL_ADMIN_PASSWORD=/d' \
+  "$temporary_directory/staging.env" >"$temporary_directory/missing-key.env"
+expect_failure "ambient value replacing a missing environment key" \
+  env PORTAL_ADMIN_PASSWORD=ambient-password-must-not-be-used \
+  "$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/missing-key.env"
+
+printf '%s\n' \
+  "$(<"$temporary_directory/staging.env")" \
+  'UNKNOWN_SETTING=typo' >"$temporary_directory/unknown.env"
+expect_failure "unknown environment setting" \
+  "$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/unknown.env"
+
+write_environment "$temporary_directory/missing-server.env" "$temporary_directory/not-there.env"
+expect_failure "missing Server environment file" \
+  "$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/missing-server.env"
+
+"$manage" render-nginx \
+  --env-file "$temporary_directory/staging.env" \
+  --output "$temporary_directory/staging.conf" \
+  >"$temporary_directory/render.out"
+if grep -Eq '__STAGING_[A-Z_]+__' "$temporary_directory/staging.conf"; then
+  fail "rendered Nginx configuration contains a placeholder"
+fi
+[[ $(grep -Fc 'auth_basic "SpeakUp Staging";' "$temporary_directory/staging.conf") -eq 1 ]] ||
+  fail "Nginx Basic Auth must apply only to the Portal host"
+sed -n '/server_name staging-api.speak-up.top;/,$p' \
+  "$temporary_directory/staging.conf" >"$temporary_directory/api-server.conf"
+if grep -Fq 'auth_basic' "$temporary_directory/api-server.conf"; then
+  fail "API host must preserve application Bearer auth without HTTP Basic Auth"
+fi
+grep -Fq 'proxy_set_header Authorization $http_authorization;' \
+  "$temporary_directory/api-server.conf" ||
+  fail "API proxy does not explicitly preserve the Authorization header"
+[[ $(grep -Fc 'location = /metrics {' "$temporary_directory/staging.conf") -eq 2 ]] ||
+  fail "Nginx does not block /metrics on both hosts"
+grep -Fq 'proxy_pass http://127.0.0.1:28082;' "$temporary_directory/staging.conf" ||
+  fail "Portal proxy is not loopback-only"
+grep -Fq 'proxy_pass http://127.0.0.1:28083;' "$temporary_directory/staging.conf" ||
+  fail "Server proxy is not loopback-only"
+
+STAGING_POSTGRES_DB=speakup_staging \
+STAGING_POSTGRES_USER=speakup_staging \
+STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef \
+PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests \
+STAGING_SERVER_ENV_FILE="$temporary_directory/server.env" \
+STAGING_PORTAL_HOST=staging.speak-up.top \
+PORTAL_IMAGE_DIGEST="$portal_digest" \
+SERVER_IMAGE_DIGEST="$server_digest" \
+COMPOSE_PROJECT_NAME=xe3-speakup-production \
+  docker compose \
+    --env-file /dev/null \
+    --project-name xe3-speakup-staging \
+    --file "$compose_file" \
+    --profile migration \
+    config --format json >"$temporary_directory/compose.json"
+
+jq --exit-status \
+  --arg portal_digest "$portal_digest" \
+  --arg server_digest "$server_digest" '
+    .name == "xe3-speakup-staging" and
+    .services.portal.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-portal@" + $portal_digest) and
+    .services.server.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
+    .services.migrate.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
+    ([.services[] | has("build")] | any | not) and
+    ([.services[] | has("container_name")] | any | not) and
+    .services.portal.ports[0].host_ip == "127.0.0.1" and
+    (.services.portal.ports[0].published | tostring) == "28082" and
+    .services.server.ports[0].host_ip == "127.0.0.1" and
+    (.services.server.ports[0].published | tostring) == "28083" and
+    (.services.postgres | has("ports") | not) and
+    .networks.database.internal == true and
+    (.services.portal.networks | keys) == ["portal_edge"] and
+    (.services.postgres.networks | keys) == ["database"] and
+    (.services.migrate.networks | keys) == ["database"] and
+    (.services.server.networks | keys | sort) == ["database", "server_edge"] and
+    (.volumes | keys | sort) == ["portal_data", "postgres_data"]
+  ' "$temporary_directory/compose.json" >/dev/null ||
+  fail "resolved Compose model violates the isolation contract"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "docker %s\n" "$*" >>"$COMMAND_LOG"' \
+  'if [[ "${FAIL_MIGRATION:-0}" == 1 && "$*" == *"run --rm --no-deps migrate"* ]]; then' \
+  '  exit 71' \
+  'fi' >"$temporary_directory/fake-bin/docker"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "curl %s\n" "$*" >>"$COMMAND_LOG"' \
+  '[[ "${FAIL_HEALTH:-0}" != 1 ]]' >"$temporary_directory/fake-bin/curl"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'exit 0' >"$temporary_directory/fake-bin/sleep"
+chmod +x \
+  "$temporary_directory/fake-bin/docker" \
+  "$temporary_directory/fake-bin/curl" \
+  "$temporary_directory/fake-bin/sleep"
+
+COMMAND_LOG="$temporary_directory/deploy.log" \
+PATH="$temporary_directory/fake-bin:$PATH" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    >"$temporary_directory/deploy.out"
+
+postgres_line=$(grep -nF 'up --detach --no-build --wait --wait-timeout 90 postgres' \
+  "$temporary_directory/deploy.log" | cut -d: -f1)
+migration_line=$(grep -nF 'run --rm --no-deps migrate' \
+  "$temporary_directory/deploy.log" | cut -d: -f1)
+application_line=$(grep -nF 'up --detach --no-build --wait --wait-timeout 90 portal server' \
+  "$temporary_directory/deploy.log" | cut -d: -f1)
+[[ -n "$postgres_line" && -n "$migration_line" && -n "$application_line" ]] ||
+  fail "deployment steps were not recorded"
+((postgres_line < migration_line && migration_line < application_line)) ||
+  fail "migration did not finish before the application switch"
+grep -Fq -- '--project-name xe3-speakup-staging' "$temporary_directory/deploy.log" ||
+  fail "deployment does not pin the isolated Compose project name"
+grep -Fq 'http://127.0.0.1:28083/health' "$temporary_directory/deploy.log" ||
+  fail "deployment did not verify /health"
+grep -Fq 'http://127.0.0.1:28083/readyz' "$temporary_directory/deploy.log" ||
+  fail "deployment did not verify /readyz"
+
+if COMMAND_LOG="$temporary_directory/migration-failure.log" \
+  FAIL_MIGRATION=1 \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    >"$temporary_directory/migration-failure.out" 2>&1; then
+  fail "failed migration unexpectedly succeeded"
+fi
+if grep -Fq 'up --detach --no-build --wait --wait-timeout 90 portal server' \
+  "$temporary_directory/migration-failure.log"; then
+  fail "application switched after migration failure"
+fi
+
+if COMMAND_LOG="$temporary_directory/health-failure.log" \
+  FAIL_HEALTH=1 \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    >"$temporary_directory/health-failure.out" 2>&1; then
+  fail "failed health verification unexpectedly succeeded"
+fi
+grep -Fq 'did not become healthy' "$temporary_directory/health-failure.out" ||
+  fail "health verification failure was not reported explicitly"
+
+printf '%s\n' 'staging deploy contract tests passed'


### PR DESCRIPTION
## 功能描述

为 RC 制品增加一套独立、不可变、可复现的 Staging 运行栈。部署只接受 release manifest 中的 Portal/Server image@sha256，不在目标主机从源码构建，也不接触生产栈。

Closes #850

## 实现思路

- 新增隔离的 Docker Compose 项目 xe3-speakup-staging：Portal、Server、Postgres、命名卷与内部网络均独立；外部端口仅绑定 127.0.0.1:28082/28083。
- 以显式一次性 migration 作为应用启动前置步骤；migration、拉取或健康检查失败均以非零状态停止，Portal/Server 不启动。
- 校验 RC manifest 的 schema、版本、仓库与完整 sha256 digest，拒绝 mutable tag、占位 digest、缺失配置和未知环境键。
- 提供 Nginx/TLS 模板：Basic Auth 仅保护 Portal；API 保留应用 Bearer Authorization；Portal/API 的精确 /metrics 均返回 404。
- 验证 Portal 根路径、Server /health 与 /readyz；增加 Compose/Nginx/失败关闭契约测试并接入 quality workflow。
- 所有 DNS、TLS、htpasswd、数据库密码与 Server 能力配置均由管理员外部注入，不提交 secret，也不禁用 OSS/OCR。

## 可复现测试

    make check-staging-deploy
    make check-staging-nginx
    make check-release-candidate
    ruby -e "require \"psych\"; Psych.parse_file(\".github/workflows/quality.yml\")"
    bash -n deploy/staging/manage.sh deploy/staging/test.sh deploy/staging/test-nginx.sh
    make help
    git diff --check

本地结果：Staging 契约测试全部通过；Docker Official Nginx nginx -t 通过；release candidate 15/15 通过；YAML/Bash 语法、Make 帮助与 whitespace 检查通过。

## 部署边界

本 PR 只交付 Staging 运行栈与验证工具，没有连接或修改任何服务器、DNS、TLS、生产配置或秘密。真实上线仍需管理员提供文档列出的外部配置并在 PR 合入及 CI/Review 通过后执行。