### PR TITLE
build(release): add Android distribution metadata

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -314,6 +314,7 @@ jobs:
           path: ${{ runner.temp }}/release-apks
 
       - name: Reverify downloaded Android artifacts
+        id: apk_metadata
         env:
           APK_CERTIFICATE_FILE: ${{ runner.temp }}/release-apks/apk-certificate-sha256.txt
           VERSION: ${{ needs.metadata.outputs.version }}
@@ -325,16 +326,53 @@ jobs:
             cd "$RUNNER_TEMP/release-apks"
             sha256sum --check SHA256SUMS
           )
-          ./tools/android-release/verify.sh \
-            "$RUNNER_TEMP/release-apks/speakup-v$VERSION-staging-arm64.apk"
-          ./tools/android-release/verify.sh \
-            "$RUNNER_TEMP/release-apks/speakup-v$VERSION-production-arm64.apk"
+          staging_report="$(
+            ./tools/android-release/verify.sh \
+              "$RUNNER_TEMP/release-apks/speakup-v$VERSION-staging-arm64.apk"
+          )"
+          production_report="$(
+            ./tools/android-release/verify.sh \
+              "$RUNNER_TEMP/release-apks/speakup-v$VERSION-production-arm64.apk"
+          )"
+
+          report_value() {
+            local report=$1
+            local key=$2
+            local value
+            value="$(sed -n "s/^${key}=//p" <<< "$report")"
+            if [[ -z "$value" || "$value" == *$'\n'* ]]; then
+              printf 'APK verification report has invalid %s.\n' "$key" >&2
+              return 1
+            fi
+            printf '%s\n' "$value"
+          }
+
+          {
+            printf 'staging_application_id=%s\n' \
+              "$(report_value "$staging_report" applicationId)"
+            printf 'staging_minimum_android_api=%s\n' \
+              "$(report_value "$staging_report" minimumAndroidApi)"
+            printf 'staging_abis=%s\n' \
+              "$(report_value "$staging_report" abi)"
+            printf 'production_application_id=%s\n' \
+              "$(report_value "$production_report" applicationId)"
+            printf 'production_minimum_android_api=%s\n' \
+              "$(report_value "$production_report" minimumAndroidApi)"
+            printf 'production_abis=%s\n' \
+              "$(report_value "$production_report" abi)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate manifest from immutable build outputs
         env:
           APK_CERTIFICATE_FILE: ${{ runner.temp }}/release-apks/apk-certificate-sha256.txt
           PORTAL_IMAGE_DIGEST: ${{ needs.images.outputs.portal_digest }}
           SERVER_IMAGE_DIGEST: ${{ needs.images.outputs.server_digest }}
+          STAGING_APK_APPLICATION_ID: ${{ steps.apk_metadata.outputs.staging_application_id }}
+          STAGING_APK_MINIMUM_ANDROID_API: ${{ steps.apk_metadata.outputs.staging_minimum_android_api }}
+          STAGING_APK_ABIS: ${{ steps.apk_metadata.outputs.staging_abis }}
+          PRODUCTION_APK_APPLICATION_ID: ${{ steps.apk_metadata.outputs.production_application_id }}
+          PRODUCTION_APK_MINIMUM_ANDROID_API: ${{ steps.apk_metadata.outputs.production_minimum_android_api }}
+          PRODUCTION_APK_ABIS: ${{ steps.apk_metadata.outputs.production_abis }}
           QUALITY_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           VERSION: ${{ needs.metadata.outputs.version }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ check-api-contracts: check-api-dependencies
 	cd api && npm run check
 
 check-release-candidate:
+	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
 
 check-staging-deploy:

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -212,6 +212,10 @@ Check 严格模式已暂缓，不在本阶段擅自重新启用。
   "server_image_digest": "sha256:...",
   "staging_apk_sha256": "...",
   "production_apk_sha256": "...",
+  "production_apk_size_bytes": 12345678,
+  "application_id": "com.xengineer.speakup",
+  "minimum_android_api": 24,
+  "abis": ["arm64-v8a"],
   "database_schema_version": "...",
   "quality_run_url": "..."
 }

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -86,6 +86,7 @@ badging="$("$aapt" dump badging "$apk")"
 application_id="$(printf '%s\n' "$badging" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
 version_code="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionCode='\([^']*\)'.*/\1/p")"
 version_name="$(printf '%s\n' "$badging" | sed -n "s/^package: .* versionName='\([^']*\)'.*/\1/p")"
+minimum_android_api="$(printf '%s\n' "$badging" | sed -n "s/^sdkVersion:'\([^']*\)'.*/\1/p")"
 native_code="$(printf '%s\n' "$badging" | sed -n '/^native-code:/p')"
 pubspec_version="$(
   sed -n -E \
@@ -109,6 +110,10 @@ expected_version_code="${BASH_REMATCH[2]}"
 }
 [[ "$version_name" == "$expected_version_name" ]] || {
   printf 'Unexpected versionName: %s\n' "$version_name" >&2
+  exit 1
+}
+[[ "$minimum_android_api" == "24" ]] || {
+  printf 'Unexpected minimum Android API: %s\n' "$minimum_android_api" >&2
   exit 1
 }
 [[ "$native_code" == "native-code: 'arm64-v8a'" ]] || {
@@ -149,6 +154,7 @@ printf '%s\n' \
   "applicationId=$application_id" \
   "versionName=$version_name" \
   "versionCode=$version_code" \
+  "minimumAndroidApi=$minimum_android_api" \
   'abi=arm64-v8a' \
   'signature=verified' \
   "certificateSha256=$certificate_sha256" \

--- a/tools/android-release/verify.test.sh
+++ b/tools/android-release/verify.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temporary_directory="$(mktemp -d)"
+readonly fake_bin="$temporary_directory/bin"
+readonly certificate_sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$fake_bin"
+printf '%s\n' 'fixture apk' > "$temporary_directory/speakup.apk"
+printf '%s\n' 'name: speakup' 'version: 0.1.0+1' > "$temporary_directory/pubspec.yaml"
+
+cat > "$fake_bin/apksigner" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' 'Signer #1 certificate SHA-256 digest: $certificate_sha256'
+EOF
+cat > "$fake_bin/java" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fake_bin/apksigner" "$fake_bin/java"
+
+write_aapt() {
+  local minimum_android_api=$1
+  cat > "$fake_bin/aapt" <<EOF
+#!/usr/bin/env bash
+cat <<'BADGING'
+package: name='com.xengineer.speakup' versionCode='1' versionName='0.1.0'
+sdkVersion:'$minimum_android_api'
+native-code: 'arm64-v8a'
+BADGING
+EOF
+  chmod +x "$fake_bin/aapt"
+}
+
+write_aapt 24
+report="$(
+  PATH="$fake_bin:$PATH" \
+    SPEAKUP_ANDROID_CERT_SHA256="$certificate_sha256" \
+    "$script_directory/verify.sh" \
+      "$temporary_directory/speakup.apk" \
+      "$temporary_directory/pubspec.yaml"
+)"
+grep -Fqx 'applicationId=com.xengineer.speakup' <<< "$report"
+grep -Fqx 'versionName=0.1.0' <<< "$report"
+grep -Fqx 'versionCode=1' <<< "$report"
+grep -Fqx 'minimumAndroidApi=24' <<< "$report"
+grep -Fqx 'abi=arm64-v8a' <<< "$report"
+grep -Fqx 'signature=verified' <<< "$report"
+grep -Fqx "certificateSha256=$certificate_sha256" <<< "$report"
+artifact_sha256="$(shasum -a 256 "$temporary_directory/speakup.apk" | awk '{print $1}')"
+grep -Fqx "artifactSha256=$artifact_sha256" <<< "$report"
+
+write_aapt 23
+if PATH="$fake_bin:$PATH" \
+  SPEAKUP_ANDROID_CERT_SHA256="$certificate_sha256" \
+  "$script_directory/verify.sh" \
+    "$temporary_directory/speakup.apk" \
+    "$temporary_directory/pubspec.yaml" \
+    > "$temporary_directory/rejected.out" 2>&1; then
+  printf '%s\n' 'APK with an unexpected minimum Android API was accepted.' >&2
+  exit 1
+fi
+grep -Fq 'Unexpected minimum Android API: 23' "$temporary_directory/rejected.out"
+
+printf '%s\n' 'Android release verifier tests passed'

--- a/tools/release-candidate/manifest.mjs
+++ b/tools/release-candidate/manifest.mjs
@@ -18,6 +18,13 @@ const sha256Pattern = /^[0-9a-f]{64}$/;
 const imageDigestPattern = /^sha256:[0-9a-f]{64}$/;
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const applicationIdPattern =
+  /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
+const androidReleaseContract = {
+  application_id: "com.xengineer.speakup",
+  minimum_android_api: 24,
+  abis: ["arm64-v8a"],
+};
 const imagePattern =
   /^ghcr\.io\/[a-z0-9]+(?:[._-][a-z0-9]+)*\/[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
 const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -84,8 +91,48 @@ function apkArtifact(filePath, expectedName, name) {
   }
   return {
     file: expectedName,
+    size_bytes: status.size,
     sha256: createHash("sha256").update(readFileSync(resolved)).digest("hex"),
   };
+}
+
+function androidApkMetadata(input, prefix) {
+  const applicationId = matches(
+    required(input, `${prefix}_APK_APPLICATION_ID`),
+    applicationIdPattern,
+    `${prefix}_APK_APPLICATION_ID`,
+  );
+  const minimumAndroidApi = Number(
+    required(input, `${prefix}_APK_MINIMUM_ANDROID_API`),
+  );
+  if (!Number.isSafeInteger(minimumAndroidApi) || minimumAndroidApi < 1) {
+    throw new Error(`${prefix}_APK_MINIMUM_ANDROID_API must be a positive integer`);
+  }
+  const abis = required(input, `${prefix}_APK_ABIS`).split(",");
+  const supportedAbis = new Set(["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]);
+  if (
+    abis.some((abi) => !supportedAbis.has(abi)) ||
+    new Set(abis).size !== abis.length
+  ) {
+    throw new Error(`${prefix}_APK_ABIS has an invalid value`);
+  }
+  return {
+    application_id: applicationId,
+    minimum_android_api: minimumAndroidApi,
+    abis,
+  };
+}
+
+function matchingAndroidApkMetadata(input) {
+  const staging = androidApkMetadata(input, "STAGING");
+  const production = androidApkMetadata(input, "PRODUCTION");
+  if (JSON.stringify(staging) !== JSON.stringify(production)) {
+    throw new Error("Staging and Production APK metadata do not match");
+  }
+  if (JSON.stringify(production) !== JSON.stringify(androidReleaseContract)) {
+    throw new Error("Android APK metadata does not match the release contract");
+  }
+  return production;
 }
 
 export function createReleaseManifest(input, metadata) {
@@ -115,6 +162,7 @@ export function createReleaseManifest(input, metadata) {
     `speakup-v${version}-production-arm64.apk`,
     "PRODUCTION_APK_PATH",
   );
+  const androidMetadata = matchingAndroidApkMetadata(input);
 
   return {
     manifest_version: 1,
@@ -136,7 +184,9 @@ export function createReleaseManifest(input, metadata) {
     staging_apk_file: stagingApk.file,
     staging_apk_sha256: stagingApk.sha256,
     production_apk_file: productionApk.file,
+    production_apk_size_bytes: productionApk.size_bytes,
     production_apk_sha256: productionApk.sha256,
+    ...androidMetadata,
     apk_certificate_sha256: certificateSha256(
       required(input, "APK_CERTIFICATE_SHA256"),
     ),

--- a/tools/release-candidate/release-candidate.test.mjs
+++ b/tools/release-candidate/release-candidate.test.mjs
@@ -58,6 +58,12 @@ function validManifestFixture() {
       SERVER_IMAGE_DIGEST: `sha256:${"b".repeat(64)}`,
       STAGING_APK_PATH: stagingApk,
       PRODUCTION_APK_PATH: productionApk,
+      STAGING_APK_APPLICATION_ID: "com.xengineer.speakup",
+      STAGING_APK_MINIMUM_ANDROID_API: "24",
+      STAGING_APK_ABIS: "arm64-v8a",
+      PRODUCTION_APK_APPLICATION_ID: "com.xengineer.speakup",
+      PRODUCTION_APK_MINIMUM_ANDROID_API: "24",
+      PRODUCTION_APK_ABIS: "arm64-v8a",
       APK_CERTIFICATE_SHA256: "c".repeat(64),
       GITHUB_REPOSITORY: "1024XEngineer/XE3-ESL",
       QUALITY_RUN_URL: "https://github.com/1024XEngineer/XE3-ESL/actions/runs/1",
@@ -274,6 +280,13 @@ test("derives the manifest from validated build artifacts", () => {
   );
   assert.equal(manifest.database_schema_version, 7);
   assert.equal(manifest.portal_image_digest, input.PORTAL_IMAGE_DIGEST);
+  assert.equal(
+    manifest.production_apk_size_bytes,
+    Buffer.byteLength("production apk"),
+  );
+  assert.equal(manifest.application_id, "com.xengineer.speakup");
+  assert.equal(manifest.minimum_android_api, 24);
+  assert.deepEqual(manifest.abis, ["arm64-v8a"]);
 });
 
 test("writes the validated manifest atomically through the CLI", () => {
@@ -382,4 +395,55 @@ test("rejects invalid APKs, image references, digests, and quality run URLs", ()
     ),
     /QUALITY_RUN_URL has an invalid value/,
   );
+});
+
+test("rejects missing, invalid, or inconsistent Android APK metadata", () => {
+  const { input, metadata } = validManifestFixture();
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PRODUCTION_APK_APPLICATION_ID: "" },
+      metadata,
+    ),
+    /PRODUCTION_APK_APPLICATION_ID is required/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PRODUCTION_APK_MINIMUM_ANDROID_API: "0" },
+      metadata,
+    ),
+    /must be a positive integer/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, PRODUCTION_APK_ABIS: "arm64-v8a,arm64-v8a" },
+      metadata,
+    ),
+    /PRODUCTION_APK_ABIS has an invalid value/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, STAGING_APK_APPLICATION_ID: "com.xengineer.staging" },
+      metadata,
+    ),
+    /Staging and Production APK metadata do not match/,
+  );
+  for (const forged of [
+    {
+      STAGING_APK_APPLICATION_ID: "com.example.fake",
+      PRODUCTION_APK_APPLICATION_ID: "com.example.fake",
+    },
+    {
+      STAGING_APK_MINIMUM_ANDROID_API: "25",
+      PRODUCTION_APK_MINIMUM_ANDROID_API: "25",
+    },
+    {
+      STAGING_APK_ABIS: "x86",
+      PRODUCTION_APK_ABIS: "x86",
+    },
+  ]) {
+    assert.throws(
+      () => createReleaseManifest({ ...input, ...forged }, metadata),
+      /Android APK metadata does not match the release contract/,
+    );
+  }
 });


### PR DESCRIPTION
## 功能描述

补齐 Android APK 对外分发所需的可追溯元数据。Release Candidate 现在会把 Production APK 文件大小、applicationId、最低 Android API 和 ABI 写入 `release-manifest.json`，供后续服务器版本化发布和 Portal 下载页直接消费。

## 实现思路

- 扩展 Android APK 校验报告，读取并强制验证 `sdkVersion: 24`。
- 在 manifest 生成前分别提取 Staging 与 Production APK 元数据，两者不一致时 fail closed。
- manifest 再次强制当前正式契约：`com.xengineer.speakup`、Android API 24、`arm64-v8a`，避免两个报告同时被伪造成一致错误值。
- 保持 `manifest_version: 1`，只增加向后兼容字段，不影响现有 Staging consumer。
- 增加无真实签名 Secret 的 verifier fixture 测试与 manifest 负例测试。

## 测试方式

1. `make check-release-candidate`
2. `make check-staging-deploy`
3. `bash -n tools/android-release/verify.sh tools/android-release/verify.test.sh`
4. `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-candidate.yml", aliases: true)'`
5. 预期 verifier 测试通过、Node 16/16 通过、Staging 部署契约通过，Shell/YAML 语法检查无错误。

## 相关 Issue / 备注

Closes #857

真实签名 Tag Workflow 仍需 #853 的 Environment 和 Secrets；本 PR 不创建 Tag、不发布 APK、不连接服务器。

## AI 辅助说明

使用 AI 协助审查现有 RC、APK verifier 和 Staging consumer，并生成最小实现与测试。人工复核确认字段来自已验证 APK、manifest 拒绝一致伪造值、旧 v1 consumer 继续兼容且未包含 Secret。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
