### PR TITLE
ops(production): 建立不可变 Production 宿主契约

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -264,7 +264,7 @@ jobs:
         run: docker build --tag speakup-portal:ci .
 
   deploy:
-    name: Staging deploy contract
+    name: Deployment contracts
     needs: changes
     if: needs.changes.outputs.deploy == 'true'
     runs-on: ubuntu-24.04
@@ -280,6 +280,12 @@ jobs:
 
       - name: Validate rendered Nginx configuration
         run: make check-staging-nginx
+
+      - name: Validate Production deployment contract
+        run: make check-production-deploy
+
+      - name: Validate rendered Production Nginx configuration
+        run: make check-production-nginx
 
   coverage-gate:
     name: Coverage gate
@@ -634,7 +640,7 @@ jobs:
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
           require_result "Portal" "$PORTAL_REQUIRED" "$PORTAL_RESULT"
-          require_result "Staging deploy" "$DEPLOY_REQUIRED" "$DEPLOY_RESULT"
+          require_result "Deployment contracts" "$DEPLOY_REQUIRED" "$DEPLOY_RESULT"
 
           require_coverage_result() {
             local name=$1

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-release-candidate \
+	check-production-deploy \
+	check-production-nginx \
 	check-staging-deploy \
 	check-staging-nginx \
 	dev-android \
@@ -48,6 +50,8 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
+		'  make check-production-deploy  Validate the immutable Production contract' \
+		'  make check-production-nginx  Run nginx -t against the Production template' \
 		'  make check-staging-deploy  Validate the immutable Staging deployment contract' \
 		'  make check-staging-nginx  Run nginx -t against the rendered Staging template' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
@@ -253,6 +257,12 @@ check-api-contracts: check-api-dependencies
 check-release-candidate:
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
+
+check-production-deploy:
+	./deploy/production/test.sh
+
+check-production-nginx:
+	./deploy/production/test-nginx.sh
 
 check-staging-deploy:
 	./deploy/staging/test.sh

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -1,0 +1,142 @@
+# SpeakUp immutable Production contract
+
+This directory defines the host-side Production topology for an already built
+Release Candidate. It validates immutable inputs and renders Nginx, but it does
+not deploy containers, run a migration, alter Nginx, or connect to a server.
+Those state-changing steps remain unavailable until backup and rollback
+orchestration is reviewed separately.
+
+## Verified boundaries
+
+- Compose project: `xe3-speakup-production`.
+- Portal loopback: `127.0.0.1:18082`.
+- Server loopback: `127.0.0.1:18083`.
+- Portal data: existing external volume `xe3-speakup-portal-data`.
+- PostgreSQL data: explicitly provisioned external volume
+  `xe3-speakup-postgres-data`.
+- Server edge: pre-provisioned external network
+  `xe3-speakup-production-server-edge`; its exact gateway `/32` is the only
+  trusted reverse-proxy peer.
+- Portal and Server images: exact repositories and `sha256` digests from
+  `release-manifest.json`; there is no `build` or mutable image tag.
+- PostgreSQL has no host port. Its network is internal to this Compose project.
+- Nginx is the only public HTTP/TLS entry point; `/metrics` is not public.
+
+The external Portal volume name is the currently verified Production data
+volume. If it is missing, stop and recover the existing volume; do **not** create
+an empty volume with the same name. The PostgreSQL volume is also external so a
+missing volume cannot silently initialize an empty Production database during a
+release. Its one-time creation belongs to the audited server bootstrap.
+
+## Prerequisites
+
+- Bash, `jq`, `curl`, Docker Engine, and Docker Compose.
+- The two external volumes above already exist on the intended host.
+- The external Server edge network exists with an audited, non-conflicting
+  subnet and fixed gateway.
+- A non-empty Server environment file outside the repository.
+- A TLS certificate/key covering the selected Portal, redirect, and API hosts.
+- A populated ACME web root.
+- Registry read access for the manifest's Portal and Server image digests.
+
+Do not copy local `.env` defaults into Production and do not commit any filled
+environment file. The Server environment file contains real provider
+configuration; Compose owns `DATABASE_URL`, `SERVER_HOST`, and `SERVER_PORT`.
+
+## Prepare configuration
+
+Copy `production.env.example` outside the repository and populate every value:
+
+```sh
+install -d -m 0750 /etc/speakup
+install -m 0600 deploy/production/production.env.example \
+  /etc/speakup/production.env
+install -m 0600 /secure/source/production-server.env \
+  /etc/speakup/production-server.env
+```
+
+`PRODUCTION_POSTGRES_PASSWORD` is restricted to at least 24 URL-safe
+characters because it is inserted into a PostgreSQL URL. `PORTAL_ADMIN_PASSWORD`
+must contain at least 16 characters. Hostnames and file paths are validated and
+unknown configuration keys are rejected.
+
+Set `PRODUCTION_SERVER_EDGE_GATEWAY_CIDR` to the external network's exact IPv4
+gateway followed by `/32`. For example, if `docker network inspect` reports
+`172.31.253.1`, configure `172.31.253.1/32`. Validation compares this value to
+the live network; broad RFC1918 ranges are rejected. A host Nginx request sent
+through a loopback-published Docker port reaches the container from that bridge
+gateway, so the Server trusts only this one peer when reading
+`X-Forwarded-For`.
+
+## Validate without changing Production
+
+Acquire the exact manifest produced by the selected successful Release
+Candidate, then run:
+
+```sh
+./deploy/production/manage.sh validate \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/production.env
+```
+
+Validation checks configuration, manifest repositories and digests, the
+resolved Compose model, both external volumes, the external Server edge network,
+and the rendered Nginx template. It does not pull images or create/update
+containers or networks.
+
+## Render Nginx for review
+
+```sh
+./deploy/production/manage.sh render-nginx \
+  --env-file /etc/speakup/production.env \
+  --output /opt/speakup/releases/v0.1.1/production-nginx.conf
+```
+
+Rendering only writes the requested file. It never installs or reloads Nginx.
+The template preserves Portal request limits, canonical-host redirect, API
+Bearer authentication, WebSocket upgrade headers, ACME challenges, and exact
+`/metrics` denial. APK static delivery is intentionally absent until its own
+versioned publication contract is reviewed.
+
+Install this vhost in place of the legacy Portal vhost; do not load both at the
+same time. The rate-limit zones and public hostnames intentionally have one
+owner. The relative `logs/` paths preserve the existing `/usr/local/nginx`
+prefix used by the Production host.
+
+## Read-only runtime checks
+
+After a later audited deployment has installed this stack:
+
+```sh
+./deploy/production/manage.sh status \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/production.env
+
+./deploy/production/manage.sh verify \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --env-file /etc/speakup/production.env
+```
+
+`verify` checks Portal `/`, Server `/health`, and Server `/readyz` over the
+loopback bindings. Public HTTPS and business-route smoke tests belong to the
+release smoke contract. There is intentionally no `deploy` or `down` command in
+this directory yet.
+
+## Reproducible checks
+
+```sh
+make check-production-deploy
+make check-production-nginx
+```
+
+The tests resolve the Compose model and prove digest-only images, fixed project
+name, loopback ports, internal database network, external volume names, Nginx
+headers, and fail-closed validation without contacting Production.
+
+## References
+
+- [Docker Compose services](https://docs.docker.com/reference/compose-file/services/)
+- [Docker Compose external volumes](https://docs.docker.com/reference/compose-file/volumes/)
+- [Docker Compose project names](https://docs.docker.com/compose/how-tos/project-name/)
+- [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
+- [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)

--- a/deploy/production/compose.yaml
+++ b/deploy/production/compose.yaml
@@ -1,0 +1,123 @@
+name: xe3-speakup-production
+
+services:
+  postgres:
+    image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${PRODUCTION_POSTGRES_DB:?PRODUCTION_POSTGRES_DB is required}
+      POSTGRES_USER: ${PRODUCTION_POSTGRES_USER:?PRODUCTION_POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${PRODUCTION_POSTGRES_PASSWORD:?PRODUCTION_POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    networks:
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'pg_isready --username="$${POSTGRES_USER}" --dbname="$${POSTGRES_DB}"',
+        ]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
+
+  migrate:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: always
+    profiles:
+      - migration
+    restart: "no"
+    command:
+      - /usr/local/bin/speakup-migrate
+      - up
+    environment:
+      DATABASE_URL: postgres://${PRODUCTION_POSTGRES_USER:?PRODUCTION_POSTGRES_USER is required}:${PRODUCTION_POSTGRES_PASSWORD:?PRODUCTION_POSTGRES_PASSWORD is required}@postgres:5432/${PRODUCTION_POSTGRES_DB:?PRODUCTION_POSTGRES_DB is required}?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - database
+
+  server:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: always
+    restart: unless-stopped
+    init: true
+    env_file:
+      - ${PRODUCTION_SERVER_ENV_FILE:?PRODUCTION_SERVER_ENV_FILE is required}
+    environment:
+      DATABASE_URL: postgres://${PRODUCTION_POSTGRES_USER:?PRODUCTION_POSTGRES_USER is required}:${PRODUCTION_POSTGRES_PASSWORD:?PRODUCTION_POSTGRES_PASSWORD is required}@postgres:5432/${PRODUCTION_POSTGRES_DB:?PRODUCTION_POSTGRES_DB is required}?sslmode=disable
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: "8080"
+      TRUSTED_PROXY_CIDRS: ${PRODUCTION_SERVER_EDGE_GATEWAY_CIDR:?PRODUCTION_SERVER_EDGE_GATEWAY_CIDR is required}
+      TRUSTED_PROXY_HEADER: x-forwarded-for
+    ports:
+      - "127.0.0.1:18083:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - server_edge
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "-T",
+          "2",
+          "--spider",
+          "http://127.0.0.1:8080/readyz",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+  portal:
+    image: ghcr.io/1024xengineer/xe3-esl-portal@${PORTAL_IMAGE_DIGEST:?PORTAL_IMAGE_DIGEST is required}
+    pull_policy: always
+    restart: unless-stopped
+    init: true
+    environment:
+      PORTAL_ADMIN_PASSWORD: ${PORTAL_ADMIN_PASSWORD:?PORTAL_ADMIN_PASSWORD is required}
+      PORTAL_SQLITE_PATH: /app/.wrangler/portal.sqlite
+      VINEXT_TRUSTED_HOSTS: ${PRODUCTION_PORTAL_HOST:?PRODUCTION_PORTAL_HOST is required}
+    ports:
+      - "127.0.0.1:18082:3000"
+    volumes:
+      - portal_data:/app/.wrangler
+    networks:
+      - portal_edge
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/',{signal:AbortSignal.timeout(2000)}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+networks:
+  portal_edge:
+  server_edge:
+    external: true
+    name: xe3-speakup-production-server-edge
+  database:
+    internal: true
+
+volumes:
+  portal_data:
+    external: true
+    name: xe3-speakup-portal-data
+  postgres_data:
+    external: true
+    name: xe3-speakup-postgres-data

--- a/deploy/production/manage.sh
+++ b/deploy/production/manage.sh
@@ -1,0 +1,602 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly compose_file="$production_directory/compose.yaml"
+readonly nginx_template="$production_directory/nginx.conf.template"
+readonly compose_project="xe3-speakup-production"
+readonly portal_data_volume="xe3-speakup-portal-data"
+readonly postgres_data_volume="xe3-speakup-postgres-data"
+readonly server_edge_network="xe3-speakup-production-server-edge"
+readonly portal_image_repository="ghcr.io/1024xengineer/xe3-esl-portal"
+readonly server_image_repository="ghcr.io/1024xengineer/xe3-esl-server"
+readonly postgres_image="postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly portal_health_url="http://127.0.0.1:18082/"
+readonly server_health_url="http://127.0.0.1:18083/health"
+readonly server_readiness_url="http://127.0.0.1:18083/readyz"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  manage.sh validate --manifest FILE --env-file FILE
+  manage.sh verify --manifest FILE --env-file FILE
+  manage.sh status --manifest FILE --env-file FILE
+  manage.sh render-nginx --env-file FILE --output FILE
+EOF
+}
+
+fail() {
+  printf 'production contract: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+
+  [[ -f "$file" ]] || fail "$description is not a regular file: $file"
+  [[ -r "$file" ]] || fail "$description is not readable: $file"
+  [[ -s "$file" ]] || fail "$description is empty: $file"
+}
+
+require_private_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  require_regular_file "$description" "$file"
+  if mode=$(stat -c '%a' -- "$file" 2>/dev/null); then
+    :
+  elif mode=$(stat -f '%Lp' "$file" 2>/dev/null); then
+    :
+  else
+    fail "cannot inspect permissions for $description: $file"
+  fi
+  case "$mode" in
+    400 | 600)
+      ;;
+    *)
+      fail "$description must have mode 0400 or 0600: $file"
+      ;;
+  esac
+}
+
+allowed_configuration_key() {
+  case "$1" in
+    PRODUCTION_POSTGRES_DB | \
+      PRODUCTION_POSTGRES_USER | \
+      PRODUCTION_POSTGRES_PASSWORD | \
+      PORTAL_ADMIN_PASSWORD | \
+      PRODUCTION_SERVER_ENV_FILE | \
+      PRODUCTION_SERVER_EDGE_GATEWAY_CIDR | \
+      PRODUCTION_PORTAL_HOST | \
+      PRODUCTION_PORTAL_REDIRECT_HOST | \
+      PRODUCTION_API_HOST | \
+      PRODUCTION_TLS_CERTIFICATE | \
+      PRODUCTION_TLS_CERTIFICATE_KEY | \
+      PRODUCTION_ACME_ROOT)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+load_configuration() {
+  local file=$1
+  local line name value
+
+  require_private_file "environment file" "$file"
+
+  unset \
+    PRODUCTION_POSTGRES_DB \
+    PRODUCTION_POSTGRES_USER \
+    PRODUCTION_POSTGRES_PASSWORD \
+    PORTAL_ADMIN_PASSWORD \
+    PRODUCTION_SERVER_ENV_FILE \
+    PRODUCTION_SERVER_EDGE_GATEWAY_CIDR \
+    PRODUCTION_PORTAL_HOST \
+    PRODUCTION_PORTAL_REDIRECT_HOST \
+    PRODUCTION_API_HOST \
+    PRODUCTION_TLS_CERTIFICATE \
+    PRODUCTION_TLS_CERTIFICATE_KEY \
+    PRODUCTION_ACME_ROOT
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=${line%$'\r'}
+    case "$line" in
+      "" | \#*)
+        continue
+        ;;
+    esac
+    [[ "$line" == *=* ]] || fail "invalid environment line: $line"
+    name=${line%%=*}
+    value=${line#*=}
+    [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]] || fail "invalid environment key: $name"
+    allowed_configuration_key "$name" || fail "unsupported environment key: $name"
+    printf -v "$name" '%s' "$value"
+    export "$name"
+  done < "$file"
+}
+
+require_value() {
+  local name=$1
+  [[ -n "${!name:-}" ]] || fail "$name is required"
+}
+
+valid_hostname() {
+  local value=$1
+  local label
+  local -a labels
+
+  [[ ${#value} -le 253 ]] || return 1
+  [[ "$value" != *..* ]] || return 1
+  IFS='.' read -r -a labels <<< "$value"
+  ((${#labels[@]} >= 2)) || return 1
+  for label in "${labels[@]}"; do
+    [[ "$label" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]] || return 1
+  done
+}
+
+valid_absolute_path() {
+  local value=$1
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != *//* ]] &&
+    [[ "$value" != */../* ]] &&
+    [[ "$value" != */./* ]] &&
+    [[ "$value" != */.. ]] &&
+    [[ "$value" != */. ]]
+}
+
+valid_ipv4_gateway_cidr() {
+  local value=$1
+  local address octet
+  local -a octets
+
+  [[ "$value" == */32 ]] || return 1
+  address=${value%/32}
+  IFS='.' read -r -a octets <<<"$address"
+  ((${#octets[@]} == 4)) || return 1
+  for octet in "${octets[@]}"; do
+    [[ "$octet" =~ ^(0|[1-9][0-9]{0,2})$ ]] || return 1
+    ((10#$octet <= 255)) || return 1
+  done
+}
+
+validate_configuration() {
+  local name
+  local required=(
+    PRODUCTION_POSTGRES_DB
+    PRODUCTION_POSTGRES_USER
+    PRODUCTION_POSTGRES_PASSWORD
+    PORTAL_ADMIN_PASSWORD
+    PRODUCTION_SERVER_ENV_FILE
+    PRODUCTION_SERVER_EDGE_GATEWAY_CIDR
+    PRODUCTION_PORTAL_HOST
+    PRODUCTION_PORTAL_REDIRECT_HOST
+    PRODUCTION_API_HOST
+    PRODUCTION_TLS_CERTIFICATE
+    PRODUCTION_TLS_CERTIFICATE_KEY
+    PRODUCTION_ACME_ROOT
+  )
+  for name in "${required[@]}"; do
+    require_value "$name"
+  done
+
+  [[ "$PRODUCTION_POSTGRES_DB" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail "PRODUCTION_POSTGRES_DB must be a lowercase PostgreSQL identifier"
+  [[ "$PRODUCTION_POSTGRES_USER" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail "PRODUCTION_POSTGRES_USER must be a lowercase PostgreSQL identifier"
+  [[ "$PRODUCTION_POSTGRES_PASSWORD" =~ ^[A-Za-z0-9._~-]{24,}$ ]] ||
+    fail "PRODUCTION_POSTGRES_PASSWORD must be at least 24 URL-safe characters"
+  [[ ${#PORTAL_ADMIN_PASSWORD} -ge 16 ]] ||
+    fail "PORTAL_ADMIN_PASSWORD must be at least 16 characters"
+  valid_ipv4_gateway_cidr "$PRODUCTION_SERVER_EDGE_GATEWAY_CIDR" ||
+    fail "PRODUCTION_SERVER_EDGE_GATEWAY_CIDR must be a canonical IPv4 gateway/32"
+
+  for name in \
+    PRODUCTION_PORTAL_HOST \
+    PRODUCTION_PORTAL_REDIRECT_HOST \
+    PRODUCTION_API_HOST; do
+    valid_hostname "${!name}" || fail "$name must be a lowercase DNS hostname"
+  done
+  [[ "$PRODUCTION_PORTAL_HOST" != "$PRODUCTION_PORTAL_REDIRECT_HOST" ]] ||
+    fail "Production Portal hosts must be different"
+  [[ "$PRODUCTION_PORTAL_HOST" != "$PRODUCTION_API_HOST" ]] ||
+    fail "Production Portal and API hosts must be different"
+  [[ "$PRODUCTION_PORTAL_REDIRECT_HOST" != "$PRODUCTION_API_HOST" ]] ||
+    fail "Production redirect and API hosts must be different"
+
+  for name in \
+    PRODUCTION_SERVER_ENV_FILE \
+    PRODUCTION_TLS_CERTIFICATE \
+    PRODUCTION_TLS_CERTIFICATE_KEY \
+    PRODUCTION_ACME_ROOT; do
+    valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
+  done
+
+  require_private_file "server environment file" "$PRODUCTION_SERVER_ENV_FILE"
+  require_regular_file "TLS certificate" "$PRODUCTION_TLS_CERTIFICATE"
+  require_private_file "TLS certificate key" "$PRODUCTION_TLS_CERTIFICATE_KEY"
+  [[ -d "$PRODUCTION_ACME_ROOT" ]] ||
+    fail "ACME root directory does not exist: $PRODUCTION_ACME_ROOT"
+}
+
+validate_manifest() {
+  local file=$1
+
+  require_command jq
+  require_regular_file "release manifest" "$file"
+
+  jq --exit-status --slurp '
+    length == 1 and
+    (.[0] |
+      type == "object" and
+      keys == [
+        "abis",
+        "apk_certificate_sha256",
+        "application_id",
+        "database_schema_version",
+        "git_sha",
+        "manifest_version",
+        "minimum_android_api",
+        "portal_image",
+        "portal_image_digest",
+        "production_apk_file",
+        "production_apk_sha256",
+        "production_apk_size_bytes",
+        "quality_run_url",
+        "server_image",
+        "server_image_digest",
+        "staging_apk_file",
+        "staging_apk_sha256",
+        "version",
+        "version_code"
+      ] and
+      .manifest_version == 1 and
+      (.version | type == "string" and
+        test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+      (.version_code | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.git_sha | type == "string" and
+        test("^[0-9a-f]{40}$") and test("[1-9a-f]")) and
+      .portal_image == "ghcr.io/1024xengineer/xe3-esl-portal" and
+      (.portal_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      .server_image == "ghcr.io/1024xengineer/xe3-esl-server" and
+      (.server_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      .staging_apk_file ==
+        ("speakup-v" + .version + "-staging-arm64.apk") and
+      (.staging_apk_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      .production_apk_file ==
+        ("speakup-v" + .version + "-production-arm64.apk") and
+      (.production_apk_size_bytes | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.production_apk_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      .application_id == "com.xengineer.speakup" and
+      .minimum_android_api == 24 and
+      .abis == ["arm64-v8a"] and
+      (.apk_certificate_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.database_schema_version | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.quality_run_url | type == "string" and
+        test("^https://github\\.com/1024XEngineer/XE3-ESL/actions/runs/[1-9][0-9]*$"))
+    )
+  ' "$file" >/dev/null || fail "release manifest is invalid"
+
+  PORTAL_IMAGE_DIGEST=$(jq --raw-output '.portal_image_digest' "$file")
+  SERVER_IMAGE_DIGEST=$(jq --raw-output '.server_image_digest' "$file")
+  RELEASE_VERSION=$(jq --raw-output '.version' "$file")
+  RELEASE_GIT_SHA=$(jq --raw-output '.git_sha' "$file")
+  RELEASE_SCHEMA_VERSION=$(jq --raw-output '.database_schema_version' "$file")
+  export PORTAL_IMAGE_DIGEST SERVER_IMAGE_DIGEST
+}
+
+compose() {
+  docker compose \
+    --env-file /dev/null \
+    --project-name "$compose_project" \
+    --project-directory "$production_directory" \
+    --file "$compose_file" \
+    "$@"
+}
+
+validate_compose() {
+  require_command docker
+  docker compose version >/dev/null
+  compose --profile migration config --quiet
+}
+
+validate_external_volumes() {
+  docker volume inspect "$portal_data_volume" >/dev/null 2>&1 ||
+    fail "required existing Portal data volume is missing: $portal_data_volume"
+  docker volume inspect "$postgres_data_volume" >/dev/null 2>&1 ||
+    fail "required Production PostgreSQL volume is missing: $postgres_data_volume"
+}
+
+validate_server_edge_network() {
+  local inspection gateway
+
+  gateway=${PRODUCTION_SERVER_EDGE_GATEWAY_CIDR%/32}
+  inspection=$(docker network inspect "$server_edge_network") ||
+    fail "required Production Server edge network is missing: $server_edge_network"
+  jq --exit-status --slurp \
+    --arg name "$server_edge_network" \
+    --arg gateway "$gateway" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        .[0].Name == $name and
+        ([.[0].IPAM.Config[]? | .Gateway? // empty] == [$gateway])
+      )
+    ' <<<"$inspection" >/dev/null 2>&1 ||
+    fail "$server_edge_network gateway does not match PRODUCTION_SERVER_EDGE_GATEWAY_CIDR"
+}
+
+render_nginx() {
+  local output=$1
+  local temporary
+
+  [[ -d "$(dirname "$output")" ]] || fail "Nginx output directory does not exist"
+  temporary=$(mktemp "${output}.tmp.XXXXXX")
+  if ! sed \
+    -e "s|__PRODUCTION_PORTAL_HOST__|$PRODUCTION_PORTAL_HOST|g" \
+    -e "s|__PRODUCTION_PORTAL_REDIRECT_HOST__|$PRODUCTION_PORTAL_REDIRECT_HOST|g" \
+    -e "s|__PRODUCTION_API_HOST__|$PRODUCTION_API_HOST|g" \
+    -e "s|__PRODUCTION_TLS_CERTIFICATE__|$PRODUCTION_TLS_CERTIFICATE|g" \
+    -e "s|__PRODUCTION_TLS_CERTIFICATE_KEY__|$PRODUCTION_TLS_CERTIFICATE_KEY|g" \
+    -e "s|__PRODUCTION_ACME_ROOT__|$PRODUCTION_ACME_ROOT|g" \
+    "$nginx_template" > "$temporary"; then
+    rm -f "$temporary"
+    fail "failed to render Nginx template"
+  fi
+  if grep -q '__PRODUCTION_[A-Z_]*__' "$temporary"; then
+    rm -f "$temporary"
+    fail "Nginx template contains an unresolved placeholder"
+  fi
+  chmod 0644 "$temporary"
+  mv -f "$temporary" "$output"
+}
+
+wait_for_endpoint() {
+  local name=$1
+  local url=$2
+  local attempt
+
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 3 "$url" >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  curl --fail --show-error --max-time 3 "$url" >/dev/null || true
+  fail "$name did not become healthy: $url"
+}
+
+verify_endpoints() {
+  require_command curl
+  wait_for_endpoint "Portal" "$portal_health_url"
+  wait_for_endpoint "Server liveness" "$server_health_url"
+  wait_for_endpoint "Server readiness" "$server_readiness_url"
+}
+
+runtime_container_id() {
+  local service=$1
+  local containers
+
+  containers=$(
+    docker ps \
+      --filter "label=com.docker.compose.project=$compose_project" \
+      --filter "label=com.docker.compose.service=$service" \
+      --format '{{.ID}}'
+  )
+  [[ -n "$containers" ]] ||
+    fail "$compose_project/$service is not running"
+  [[ "$containers" != *$'\n'* ]] ||
+    fail "$compose_project/$service has multiple running containers"
+  [[ "$containers" =~ ^[0-9a-f]{12,64}$ ]] ||
+    fail "$compose_project/$service returned an invalid container ID"
+  printf '%s\n' "$containers"
+}
+
+inspect_runtime_service() {
+  local service=$1
+  local expected_image=$2
+  local container_id inspection
+
+  container_id=$(runtime_container_id "$service")
+  inspection=$(docker inspect "$container_id") ||
+    fail "cannot inspect $compose_project/$service"
+  jq --exit-status --slurp \
+    --arg container_id "$container_id" \
+    --arg project "$compose_project" \
+    --arg service "$service" \
+    --arg expected_image "$expected_image" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        (.[0] |
+          (.Id | startswith($container_id)) and
+          .Config.Labels["com.docker.compose.project"] == $project and
+          .Config.Labels["com.docker.compose.service"] == $service and
+          .Config.Image == $expected_image and
+          .State.Status == "running" and
+          .State.Running == true and
+          .State.Health.Status == "healthy"
+        )
+      )
+    ' <<<"$inspection" >/dev/null ||
+    fail "$compose_project/$service identity, image, or health is invalid"
+  printf '%s\n' "$inspection"
+}
+
+verify_runtime() {
+  local portal server postgres
+
+  portal=$(inspect_runtime_service \
+    portal "$portal_image_repository@$PORTAL_IMAGE_DIGEST")
+  jq --exit-status --arg network "${compose_project}_portal_edge" '
+    def exact_env($key; $value):
+      [.Config.Env[]? | select(startswith($key + "="))] ==
+        [($key + "=" + $value)];
+    .[0] |
+    exact_env("PORTAL_ADMIN_PASSWORD"; env.PORTAL_ADMIN_PASSWORD) and
+    exact_env("PORTAL_SQLITE_PATH"; "/app/.wrangler/portal.sqlite") and
+    exact_env("VINEXT_TRUSTED_HOSTS"; env.PRODUCTION_PORTAL_HOST) and
+    (.Mounts | length == 1) and
+    .Mounts[0].Type == "volume" and
+    .Mounts[0].Name == "xe3-speakup-portal-data" and
+    .Mounts[0].Destination == "/app/.wrangler" and
+    .Mounts[0].RW == true and
+    .NetworkSettings.Ports == {
+      "3000/tcp": [{"HostIp": "127.0.0.1", "HostPort": "18082"}]
+    } and
+    (.NetworkSettings.Networks | keys) == [$network]
+  ' <<<"$portal" >/dev/null 2>&1 ||
+    fail "$compose_project/portal runtime configuration is invalid"
+
+  server=$(inspect_runtime_service \
+    server "$server_image_repository@$SERVER_IMAGE_DIGEST")
+  jq --exit-status \
+    --arg database "${compose_project}_database" \
+    --arg edge "$server_edge_network" '
+      def exact_env($key; $value):
+        [.Config.Env[]? | select(startswith($key + "="))] ==
+          [($key + "=" + $value)];
+      .[0] |
+      exact_env("DATABASE_URL";
+        "postgres://" + env.PRODUCTION_POSTGRES_USER + ":" +
+        env.PRODUCTION_POSTGRES_PASSWORD + "@postgres:5432/" +
+        env.PRODUCTION_POSTGRES_DB + "?sslmode=disable") and
+      exact_env("SERVER_HOST"; "0.0.0.0") and
+      exact_env("SERVER_PORT"; "8080") and
+      exact_env("TRUSTED_PROXY_CIDRS";
+        env.PRODUCTION_SERVER_EDGE_GATEWAY_CIDR) and
+      exact_env("TRUSTED_PROXY_HEADER"; "x-forwarded-for") and
+      (.Mounts | length == 0) and
+      .NetworkSettings.Ports == {
+        "8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "18083"}]
+      } and
+      (.NetworkSettings.Networks | keys) == ([$database, $edge] | sort)
+    ' <<<"$server" >/dev/null 2>&1 ||
+    fail "$compose_project/server runtime configuration is invalid"
+
+  postgres=$(inspect_runtime_service postgres "$postgres_image")
+  jq --exit-status --arg network "${compose_project}_database" '
+    def exact_env($key; $value):
+      [.Config.Env[]? | select(startswith($key + "="))] ==
+        [($key + "=" + $value)];
+    .[0] |
+    exact_env("POSTGRES_DB"; env.PRODUCTION_POSTGRES_DB) and
+    exact_env("POSTGRES_USER"; env.PRODUCTION_POSTGRES_USER) and
+    exact_env("POSTGRES_PASSWORD"; env.PRODUCTION_POSTGRES_PASSWORD) and
+    (.Mounts | length == 1) and
+    .Mounts[0].Type == "volume" and
+    .Mounts[0].Name == "xe3-speakup-postgres-data" and
+    .Mounts[0].Destination == "/var/lib/postgresql" and
+    .Mounts[0].RW == true and
+    ([.NetworkSettings.Ports // {} | to_entries[] | select(.value != null)] |
+      length == 0) and
+    (.NetworkSettings.Networks | keys) == [$network]
+  ' <<<"$postgres" >/dev/null 2>&1 ||
+    fail "$compose_project/postgres runtime configuration is invalid"
+}
+
+validate_all() {
+  local manifest=$1
+  local rendered
+
+  validate_configuration
+  validate_manifest "$manifest"
+  validate_compose
+  validate_external_volumes
+  validate_server_edge_network
+  rendered=$(mktemp)
+  render_nginx "$rendered"
+  rm -f "$rendered"
+}
+
+main() {
+  local command=${1:-}
+  local manifest=""
+  local environment_file=""
+  local output=""
+
+  [[ -n "$command" ]] || {
+    usage
+    exit 2
+  }
+  shift
+  while (($# > 0)); do
+    case "$1" in
+      --manifest)
+        (($# >= 2)) || fail "--manifest requires a value"
+        manifest=$2
+        shift 2
+        ;;
+      --env-file)
+        (($# >= 2)) || fail "--env-file requires a value"
+        environment_file=$2
+        shift 2
+        ;;
+      --output)
+        (($# >= 2)) || fail "--output requires a value"
+        output=$2
+        shift 2
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$environment_file" ]] || fail "--env-file is required"
+  load_configuration "$environment_file"
+
+  case "$command" in
+    render-nginx)
+      [[ -z "$manifest" ]] || fail "render-nginx does not accept --manifest"
+      [[ -n "$output" ]] || fail "render-nginx requires --output"
+      validate_configuration
+      render_nginx "$output"
+      printf 'rendered=%s\n' "$output"
+      ;;
+    validate | verify | status)
+      [[ -n "$manifest" ]] || fail "$command requires --manifest"
+      [[ -z "$output" ]] || fail "$command does not accept --output"
+      validate_all "$manifest"
+      case "$command" in
+        validate)
+          printf 'version=%s git_sha=%s schema=%s validated=true\n' \
+            "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION"
+          ;;
+        verify)
+          verify_runtime
+          verify_endpoints
+          printf 'version=%s verified=true\n' "$RELEASE_VERSION"
+          ;;
+        status)
+          compose ps
+          ;;
+      esac
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/production/nginx.conf.template
+++ b/deploy/production/nginx.conf.template
@@ -1,0 +1,193 @@
+map $http_upgrade $speakup_production_connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+limit_req_zone $binary_remote_addr zone=speakup_portal_events:10m rate=30r/m;
+limit_req_zone $binary_remote_addr zone=speakup_portal_waitlist:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=speakup_portal_admin:10m rate=5r/m;
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __PRODUCTION_PORTAL_HOST__;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root __PRODUCTION_ACME_ROOT__;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://__PRODUCTION_PORTAL_HOST__$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __PRODUCTION_API_HOST__;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root __PRODUCTION_ACME_ROOT__;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://__PRODUCTION_API_HOST__$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __PRODUCTION_PORTAL_REDIRECT_HOST__;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root __PRODUCTION_ACME_ROOT__;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://__PRODUCTION_PORTAL_HOST__$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name __PRODUCTION_PORTAL_REDIRECT_HOST__;
+
+    ssl_certificate __PRODUCTION_TLS_CERTIFICATE__;
+    ssl_certificate_key __PRODUCTION_TLS_CERTIFICATE_KEY__;
+
+    return 301 https://__PRODUCTION_PORTAL_HOST__$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name __PRODUCTION_PORTAL_HOST__;
+
+    ssl_certificate __PRODUCTION_TLS_CERTIFICATE__;
+    ssl_certificate_key __PRODUCTION_TLS_CERTIFICATE_KEY__;
+
+    access_log logs/xe3-speakup-production-portal.access.log;
+    error_log logs/xe3-speakup-production-portal.error.log warn;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    limit_req_status 429;
+
+    location = /metrics {
+        return 404;
+    }
+
+    location = /pages {
+        return 404;
+    }
+
+    location ^~ /pages/ {
+        return 404;
+    }
+
+    location = /tests {
+        return 404;
+    }
+
+    location ^~ /tests/ {
+        return 404;
+    }
+
+    location = /WISPR-FLOW-DESIGN-preview.html {
+        return 404;
+    }
+
+    location = /WISPR-FLOW-DESIGN.md {
+        return 404;
+    }
+
+    location = /api/events {
+        client_max_body_size 16k;
+        limit_req zone=speakup_portal_events burst=10 nodelay;
+
+        proxy_pass http://127.0.0.1:18082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 15s;
+    }
+
+    location = /api/waitlist {
+        client_max_body_size 16k;
+        limit_req zone=speakup_portal_waitlist burst=3 nodelay;
+
+        proxy_pass http://127.0.0.1:18082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 15s;
+    }
+
+    location ^~ /api/admin/ {
+        client_max_body_size 1k;
+        limit_req zone=speakup_portal_admin burst=3 nodelay;
+
+        proxy_pass http://127.0.0.1:18082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 15s;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:18082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name __PRODUCTION_API_HOST__;
+
+    ssl_certificate __PRODUCTION_TLS_CERTIFICATE__;
+    ssl_certificate_key __PRODUCTION_TLS_CERTIFICATE_KEY__;
+
+    access_log logs/xe3-speakup-production-api.access.log;
+    error_log logs/xe3-speakup-production-api.error.log warn;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer always;
+    client_max_body_size 12m;
+
+    location = /metrics {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:18083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $speakup_production_connection_upgrade;
+        proxy_read_timeout 180s;
+    }
+}

--- a/deploy/production/production.env.example
+++ b/deploy/production/production.env.example
@@ -1,0 +1,17 @@
+# Raw KEY=value configuration. Do not use shell expressions or quote values.
+# Copy this file outside the repository and keep the populated copy mode 0600.
+PRODUCTION_POSTGRES_DB=speakup
+PRODUCTION_POSTGRES_USER=speakup
+PRODUCTION_POSTGRES_PASSWORD=
+PORTAL_ADMIN_PASSWORD=
+PRODUCTION_SERVER_ENV_FILE=/etc/speakup/production-server.env
+# Exact /32 gateway of the pre-provisioned external server-edge network.
+PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=
+
+# DNS, certificate, and reverse-proxy choices are injected by the operator.
+PRODUCTION_PORTAL_HOST=speak-up.top
+PRODUCTION_PORTAL_REDIRECT_HOST=www.speak-up.top
+PRODUCTION_API_HOST=api.speak-up.top
+PRODUCTION_TLS_CERTIFICATE=/etc/letsencrypt/live/speak-up.top/fullchain.pem
+PRODUCTION_TLS_CERTIFICATE_KEY=/etc/letsencrypt/live/speak-up.top/privkey.pem
+PRODUCTION_ACME_ROOT=/var/www/production-acme

--- a/deploy/production/test-nginx.sh
+++ b/deploy/production/test-nginx.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly manage="$production_directory/manage.sh"
+readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
+
+command -v docker >/dev/null 2>&1 || {
+  printf '%s\n' 'docker is required for the Nginx configuration check' >&2
+  exit 1
+}
+command -v openssl >/dev/null 2>&1 || {
+  printf '%s\n' 'openssl is required for the Nginx configuration check' >&2
+  exit 1
+}
+
+temporary_directory=$(mktemp -d /tmp/production-nginx-test.XXXXXX)
+readonly temporary_directory
+readonly rendered_configuration="$temporary_directory/default.conf"
+readonly upstream_configuration="$temporary_directory/upstream-stub.conf"
+readonly runtime_container="xe3-production-nginx-test-${PPID}-$$"
+
+cleanup() {
+  docker rm --force "$runtime_container" >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+assert_contains() {
+  local expected=$1
+  grep -Fq -- "$expected" "$rendered_configuration" || {
+    printf 'missing expected Nginx directive: %s\n' "$expected" >&2
+    exit 1
+  }
+}
+
+assert_count() {
+  local expected=$1
+  local wanted=$2
+  local actual
+
+  actual=$(grep -Fc -- "$expected" "$rendered_configuration" || true)
+  [[ "$actual" == "$wanted" ]] || {
+    printf 'unexpected count for Nginx directive %s: wanted %s, got %s\n' \
+      "$expected" "$wanted" "$actual" >&2
+    exit 1
+  }
+}
+
+assert_response_header() {
+  local response_file=$1
+  local expected=$2
+
+  grep -Fqi -- "$expected" "$response_file" || {
+    printf 'missing expected response header: %s\n' "$expected" >&2
+    return 1
+  }
+}
+
+mkdir -p "$temporary_directory/acme"
+mkdir -p "$temporary_directory/logs"
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
+chmod 600 "$temporary_directory/server.env"
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -subj '/CN=speak-up.top' \
+  -days 1 \
+  -keyout "$temporary_directory/privkey.pem" \
+  -out "$temporary_directory/fullchain.pem" \
+  >/dev/null 2>&1
+chmod 600 "$temporary_directory/privkey.pem"
+
+printf '%s\n' \
+  'PRODUCTION_POSTGRES_DB=speakup_production' \
+  'PRODUCTION_POSTGRES_USER=speakup_production' \
+  'PRODUCTION_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
+  'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
+  "PRODUCTION_SERVER_ENV_FILE=$temporary_directory/server.env" \
+  'PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=172.31.253.1/32' \
+  'PRODUCTION_PORTAL_HOST=speak-up.top' \
+  'PRODUCTION_PORTAL_REDIRECT_HOST=www.speak-up.top' \
+  'PRODUCTION_API_HOST=api.speak-up.top' \
+  "PRODUCTION_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
+  "PRODUCTION_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
+  "PRODUCTION_ACME_ROOT=$temporary_directory/acme" \
+  >"$temporary_directory/production.env"
+chmod 600 "$temporary_directory/production.env"
+
+"$manage" render-nginx \
+  --env-file "$temporary_directory/production.env" \
+  --output "$rendered_configuration" \
+  >/dev/null
+
+assert_count 'server_name speak-up.top;' 2
+assert_count 'server_name api.speak-up.top;' 2
+assert_count 'server_name www.speak-up.top;' 2
+assert_count 'return 301 https://speak-up.top$request_uri;' 3
+assert_count 'return 301 https://api.speak-up.top$request_uri;' 1
+assert_count "root $temporary_directory/acme;" 3
+assert_count "ssl_certificate $temporary_directory/fullchain.pem;" 3
+assert_count "ssl_certificate_key $temporary_directory/privkey.pem;" 3
+assert_count 'location = /metrics {' 2
+assert_count 'proxy_pass http://127.0.0.1:18082;' 4
+assert_count 'proxy_pass http://127.0.0.1:18083;' 1
+assert_contains 'limit_req zone=speakup_portal_events burst=10 nodelay;'
+assert_contains 'limit_req zone=speakup_portal_waitlist burst=3 nodelay;'
+assert_contains 'limit_req zone=speakup_portal_admin burst=3 nodelay;'
+assert_count 'proxy_set_header Host $host;' 5
+assert_count 'proxy_set_header X-Real-IP $remote_addr;' 5
+assert_count 'proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;' 5
+assert_count 'proxy_set_header X-Forwarded-Proto $scheme;' 5
+assert_count 'proxy_set_header Authorization $http_authorization;' 1
+assert_count 'proxy_set_header Upgrade $http_upgrade;' 1
+assert_count 'proxy_set_header Connection $speakup_production_connection_upgrade;' 1
+assert_contains 'access_log logs/xe3-speakup-production-portal.access.log;'
+assert_contains 'access_log logs/xe3-speakup-production-api.access.log;'
+
+if grep -Eq '__PRODUCTION_[A-Z_]+__' "$rendered_configuration"; then
+  printf '%s\n' 'rendered Nginx configuration contains a placeholder' >&2
+  exit 1
+fi
+
+docker run --rm \
+  --volume "$temporary_directory:$temporary_directory:ro" \
+  --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  --volume "$rendered_configuration:/etc/nginx/conf.d/default.conf:ro" \
+  "$nginx_image" \
+  nginx -t
+
+printf '%s\n' \
+  'server {' \
+  '    listen 18082;' \
+  '    location / {' \
+  '        add_header X-SpeakUp-Upstream portal always;' \
+  '        return 200 "portal\n";' \
+  '    }' \
+  '}' \
+  'server {' \
+  '    listen 18083;' \
+  '    location / {' \
+  '        add_header X-SpeakUp-Upstream api always;' \
+  '        add_header X-Seen-Authorization $http_authorization always;' \
+  '        add_header X-Seen-Upgrade $http_upgrade always;' \
+  '        add_header X-Seen-Connection $http_connection always;' \
+  '        add_header X-Seen-XFF $http_x_forwarded_for always;' \
+  '        add_header X-Seen-Host $http_host always;' \
+  '        return 200 "api\n";' \
+  '    }' \
+  '}' \
+  >"$upstream_configuration"
+
+docker run --detach \
+  --name "$runtime_container" \
+  --publish 127.0.0.1::80 \
+  --publish 127.0.0.1::443 \
+  --volume "$temporary_directory:$temporary_directory:ro" \
+  --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  --volume "$rendered_configuration:/etc/nginx/conf.d/default.conf:ro" \
+  --volume "$upstream_configuration:/etc/nginx/conf.d/upstream-stub.conf:ro" \
+  "$nginx_image" \
+  >/dev/null
+
+http_port=$(docker port "$runtime_container" 80/tcp | sed -n 's/.*://p')
+https_port=$(docker port "$runtime_container" 443/tcp | sed -n 's/.*://p')
+readonly http_port https_port
+[[ "$http_port" =~ ^[0-9]+$ && "$https_port" =~ ^[0-9]+$ ]] || {
+  printf '%s\n' 'failed to resolve runtime Nginx ports' >&2
+  exit 1
+}
+
+runtime_ready=false
+for _ in {1..30}; do
+  if curl \
+    --fail \
+    --insecure \
+    --silent \
+    --output /dev/null \
+    --resolve "speak-up.top:$https_port:127.0.0.1" \
+    "https://speak-up.top:$https_port/"; then
+    runtime_ready=true
+    break
+  fi
+  sleep 0.2
+done
+[[ "$runtime_ready" == true ]] || {
+  docker logs "$runtime_container" >&2
+  printf '%s\n' 'runtime Nginx did not become ready' >&2
+  exit 1
+}
+
+redirect_headers="$temporary_directory/redirect.headers"
+curl \
+  --silent \
+  --show-error \
+  --dump-header "$redirect_headers" \
+  --output /dev/null \
+  --header 'Host: attacker.example' \
+  "http://127.0.0.1:$http_port/release?source=test"
+grep -Fqi 'Location: https://speak-up.top/release?source=test' "$redirect_headers" || {
+  printf '%s\n' 'HTTP redirect did not use the fixed canonical host' >&2
+  exit 1
+}
+if grep -Fqi 'attacker.example' "$redirect_headers"; then
+  printf '%s\n' 'HTTP redirect reflected an untrusted Host header' >&2
+  exit 1
+fi
+
+for host in speak-up.top api.speak-up.top; do
+  metrics_status=$(curl \
+    --insecure \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --resolve "$host:$https_port:127.0.0.1" \
+    "https://$host:$https_port/metrics")
+  [[ "$metrics_status" == 404 ]] || {
+    printf '%s /metrics returned %s instead of 404\n' "$host" "$metrics_status" >&2
+    exit 1
+  }
+done
+
+api_headers="$temporary_directory/api.headers"
+curl \
+  --fail \
+  --http1.1 \
+  --insecure \
+  --silent \
+  --dump-header "$api_headers" \
+  --output /dev/null \
+  --resolve "api.speak-up.top:$https_port:127.0.0.1" \
+  --header 'Authorization: Bearer release-smoke' \
+  --header 'Upgrade: websocket' \
+  --header 'Connection: Upgrade' \
+  --header 'X-Forwarded-For: 198.51.100.7' \
+  "https://api.speak-up.top:$https_port/v1/smoke"
+assert_response_header "$api_headers" 'X-SpeakUp-Upstream: api'
+assert_response_header "$api_headers" \
+  'X-Seen-Authorization: Bearer release-smoke'
+assert_response_header "$api_headers" 'X-Seen-Upgrade: websocket'
+assert_response_header "$api_headers" 'X-Seen-Connection: upgrade'
+assert_response_header "$api_headers" 'X-Seen-XFF: 198.51.100.7,'
+assert_response_header "$api_headers" 'X-Seen-Host: api.speak-up.top'
+
+rate_limited=false
+for _ in {1..14}; do
+  event_status=$(curl \
+    --insecure \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --resolve "speak-up.top:$https_port:127.0.0.1" \
+    --request POST \
+    "https://speak-up.top:$https_port/api/events")
+  if [[ "$event_status" == 429 ]]; then
+    rate_limited=true
+    break
+  fi
+done
+[[ "$rate_limited" == true ]] || {
+  printf '%s\n' 'Portal event endpoint did not enforce its request limit' >&2
+  exit 1
+}
+
+printf '%s\n' 'production Nginx configuration check passed'

--- a/deploy/production/test.sh
+++ b/deploy/production/test.sh
@@ -1,0 +1,628 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly manage="$production_directory/manage.sh"
+readonly compose_file="$production_directory/compose.yaml"
+readonly portal_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+readonly server_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+readonly git_sha="cccccccccccccccccccccccccccccccccccccccc"
+readonly staging_apk_sha="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+readonly production_apk_sha="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+readonly certificate_sha="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+fail() {
+  printf 'production contract test: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" > "$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+}
+
+write_environment() {
+  local destination=$1
+  local server_environment=$2
+  local certificate=${3:-$temporary_directory/fullchain.pem}
+  local certificate_key=${4:-$temporary_directory/privkey.pem}
+
+  printf '%s\n' \
+    'PRODUCTION_POSTGRES_DB=speakup' \
+    'PRODUCTION_POSTGRES_USER=speakup' \
+    'PRODUCTION_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
+    'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
+    "PRODUCTION_SERVER_ENV_FILE=$server_environment" \
+    'PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=172.31.0.1/32' \
+    'PRODUCTION_PORTAL_HOST=speak-up.top' \
+    'PRODUCTION_PORTAL_REDIRECT_HOST=www.speak-up.top' \
+    'PRODUCTION_API_HOST=api.speak-up.top' \
+    "PRODUCTION_TLS_CERTIFICATE=$certificate" \
+    "PRODUCTION_TLS_CERTIFICATE_KEY=$certificate_key" \
+    "PRODUCTION_ACME_ROOT=$temporary_directory/acme" > "$destination"
+  chmod 0600 "$destination"
+}
+
+write_manifest() {
+  local destination=$1
+  local selected_portal_digest=${2:-$portal_digest}
+
+  printf '%s\n' \
+    '{' \
+    '  "manifest_version": 1,' \
+    '  "version": "0.1.1",' \
+    "  \"git_sha\": \"$git_sha\"," \
+    '  "version_code": 2,' \
+    '  "portal_image": "ghcr.io/1024xengineer/xe3-esl-portal",' \
+    "  \"portal_image_digest\": \"$selected_portal_digest\"," \
+    '  "server_image": "ghcr.io/1024xengineer/xe3-esl-server",' \
+    "  \"server_image_digest\": \"$server_digest\"," \
+    '  "staging_apk_file": "speakup-v0.1.1-staging-arm64.apk",' \
+    "  \"staging_apk_sha256\": \"$staging_apk_sha\"," \
+    '  "production_apk_file": "speakup-v0.1.1-production-arm64.apk",' \
+    '  "production_apk_size_bytes": 123456,' \
+    "  \"production_apk_sha256\": \"$production_apk_sha\"," \
+    '  "application_id": "com.xengineer.speakup",' \
+    '  "minimum_android_api": 24,' \
+    '  "abis": ["arm64-v8a"],' \
+    "  \"apk_certificate_sha256\": \"$certificate_sha\"," \
+    '  "database_schema_version": 7,' \
+    '  "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"' \
+    '}' > "$destination"
+}
+
+temporary_directory=$(mktemp -d)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$temporary_directory/acme" "$temporary_directory/fake-bin"
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' > "$temporary_directory/server.env"
+printf '%s\n' 'test-certificate-placeholder' > "$temporary_directory/fullchain.pem"
+printf '%s\n' 'test-key-placeholder' > "$temporary_directory/privkey.pem"
+chmod 0600 "$temporary_directory/server.env" "$temporary_directory/privkey.pem"
+write_environment "$temporary_directory/production.env" "$temporary_directory/server.env"
+write_manifest "$temporary_directory/release-manifest.json"
+
+real_docker="$(command -v docker)"
+readonly real_docker
+cat > "$temporary_directory/fake-bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == volume && "${2:-}" == inspect ]]; then
+  volume=${3:-}
+  [[ "$volume" == xe3-speakup-portal-data || "$volume" == xe3-speakup-postgres-data ]] || exit 1
+  [[ "${TEST_MISSING_VOLUME:-}" != "$volume" ]]
+  exit
+fi
+if [[ "${1:-}" == network && "${2:-}" == inspect ]]; then
+  [[ "${3:-}" == xe3-speakup-production-server-edge ]] || exit 1
+  [[ "${TEST_MISSING_NETWORK:-0}" != 1 ]] || exit 1
+  jq --null-input \
+    --arg gateway "${TEST_RUNTIME_GATEWAY:-172.31.0.1}" '
+      [{
+        Name: "xe3-speakup-production-server-edge",
+        IPAM: {Config: [{Subnet: "172.31.0.0/24", Gateway: $gateway}]}
+      }]
+    '
+  exit
+fi
+if [[ "${1:-}" == ps ]]; then
+  service=""
+  requested_project=""
+  shift
+  while (($# > 0)); do
+    case "$1" in
+      --filter)
+        case "$2" in
+          label=com.docker.compose.project=*)
+            requested_project=${2#label=com.docker.compose.project=}
+            ;;
+          label=com.docker.compose.service=*)
+            service=${2#label=com.docker.compose.service=}
+            ;;
+        esac
+        shift 2
+        ;;
+      --format)
+        shift 2
+        ;;
+      *)
+        exit 2
+        ;;
+    esac
+  done
+  runtime_project=${TEST_RUNTIME_PROJECT:-xe3-speakup-production}
+  [[ "$requested_project" == "$runtime_project" ]] || exit 0
+  [[ "$service" != "${TEST_MISSING_SERVICE:-}" ]] || exit 0
+  case "$service" in
+    portal) printf '%s\n' aaaaaaaaaaaa ;;
+    server) printf '%s\n' bbbbbbbbbbbb ;;
+    postgres) printf '%s\n' cccccccccccc ;;
+    *) exit 2 ;;
+  esac
+  exit
+fi
+if [[ "${1:-}" == inspect && "$#" == 2 ]]; then
+  case "$2" in
+    aaaaaaaaaaaa)
+      service=portal
+      image="ghcr.io/1024xengineer/xe3-esl-portal@${TEST_RUNTIME_PORTAL_DIGEST:-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+      mounts='[{"Type":"volume","Name":"xe3-speakup-portal-data","Destination":"/app/.wrangler","RW":true}]'
+      ports='{"3000/tcp":[{"HostIp":"127.0.0.1","HostPort":"18082"}]}'
+      networks='{"xe3-speakup-production_portal_edge":{}}'
+      environment='["NODE_ENV=production","PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests","PORTAL_SQLITE_PATH=/app/.wrangler/portal.sqlite","VINEXT_TRUSTED_HOSTS=speak-up.top"]'
+      ;;
+    bbbbbbbbbbbb)
+      service=server
+      image="ghcr.io/1024xengineer/xe3-esl-server@${TEST_RUNTIME_SERVER_DIGEST:-sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
+      mounts='[]'
+      ports='{"8080/tcp":[{"HostIp":"127.0.0.1","HostPort":"18083"}]}'
+      networks='{"xe3-speakup-production-server-edge":{},"xe3-speakup-production_database":{}}'
+      environment='["TEXT_GENERATION_PROVIDER=test-fixture","DATABASE_URL=postgres://speakup:0123456789abcdef0123456789abcdef@postgres:5432/speakup?sslmode=disable","SERVER_HOST=0.0.0.0","SERVER_PORT=8080","TRUSTED_PROXY_CIDRS=172.31.0.1/32","TRUSTED_PROXY_HEADER=x-forwarded-for"]'
+      ;;
+    cccccccccccc)
+      service=postgres
+      image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+      mounts='[{"Type":"volume","Name":"xe3-speakup-postgres-data","Destination":"/var/lib/postgresql","RW":true}]'
+      ports='{"5432/tcp":null}'
+      networks='{"xe3-speakup-production_database":{}}'
+      environment='["PGDATA=/var/lib/postgresql/18/docker","POSTGRES_DB=speakup","POSTGRES_USER=speakup","POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef"]'
+      ;;
+    *) exit 1 ;;
+  esac
+  health=healthy
+  [[ "${TEST_UNHEALTHY_SERVICE:-}" != "$service" ]] || health=unhealthy
+  [[ "${TEST_BAD_MOUNT_SERVICE:-}" != "$service" ]] || mounts='[]'
+  [[ "${TEST_BAD_PORT_SERVICE:-}" != "$service" ]] || ports='{}'
+  [[ "${TEST_BAD_NETWORK_SERVICE:-}" != "$service" ]] || networks='{}'
+  if [[ "${TEST_BAD_ENV_SERVICE:-}" == "$service" ]]; then
+    case "$service" in
+      portal)
+        environment='["PORTAL_ADMIN_PASSWORD=wrong","PORTAL_SQLITE_PATH=/app/.wrangler/portal.sqlite","VINEXT_TRUSTED_HOSTS=speak-up.top"]'
+        ;;
+      server)
+        environment='["DATABASE_URL=postgres://wrong","SERVER_HOST=0.0.0.0","SERVER_PORT=8080","TRUSTED_PROXY_CIDRS=172.31.0.1/32","TRUSTED_PROXY_HEADER=x-forwarded-for"]'
+        ;;
+      postgres)
+        environment='["POSTGRES_DB=speakup","POSTGRES_USER=speakup","POSTGRES_PASSWORD=wrong"]'
+        ;;
+    esac
+  fi
+  jq --null-input \
+    --arg id "$2" \
+    --arg project "${TEST_RUNTIME_PROJECT:-xe3-speakup-production}" \
+    --arg service "$service" \
+    --arg image "$image" \
+    --arg health "$health" \
+    --argjson environment "$environment" \
+    --argjson mounts "$mounts" \
+    --argjson ports "$ports" \
+    --argjson networks "$networks" '
+      [{
+        Id: $id,
+        Config: {
+          Image: $image,
+          Env: $environment,
+          Labels: {
+            "com.docker.compose.project": $project,
+            "com.docker.compose.service": $service
+          }
+        },
+        State: {Status: "running", Running: true, Health: {Status: $health}},
+        Mounts: $mounts,
+        NetworkSettings: {Ports: $ports, Networks: $networks}
+      }]
+    '
+  exit
+fi
+exec "$TEST_REAL_DOCKER" "$@"
+EOF
+cat > "$temporary_directory/fake-bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+[[ "${FAIL_HEALTH:-0}" != 1 ]]
+EOF
+cat > "$temporary_directory/fake-bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x \
+  "$temporary_directory/fake-bin/docker" \
+  "$temporary_directory/fake-bin/curl" \
+  "$temporary_directory/fake-bin/sleep"
+
+export TEST_REAL_DOCKER="$real_docker"
+export PATH="$temporary_directory/fake-bin:$PATH"
+
+bash -n "$manage" "$0"
+
+"$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/production.env" \
+  > "$temporary_directory/validate.out"
+grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
+  fail "valid Production contract was not accepted"
+
+expect_failure "missing existing Portal data volume" \
+  env TEST_MISSING_VOLUME=xe3-speakup-portal-data \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+expect_failure "missing existing PostgreSQL data volume" \
+  env TEST_MISSING_VOLUME=xe3-speakup-postgres-data \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+expect_failure "missing Server edge network" \
+  env TEST_MISSING_NETWORK=1 \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+expect_failure "mismatched Server edge gateway" \
+  env TEST_RUNTIME_GATEWAY=172.31.0.2 \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+sed 's/^PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=.*/PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=172.031.0.1\/32/' \
+  "$temporary_directory/production.env" > "$temporary_directory/invalid-gateway.env"
+chmod 0600 "$temporary_directory/invalid-gateway.env"
+expect_failure "non-canonical Server edge gateway" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/invalid-gateway.env"
+
+write_manifest "$temporary_directory/invalid-manifest.json" latest
+expect_failure "mutable Portal image reference" \
+  "$manage" validate \
+    --manifest "$temporary_directory/invalid-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+write_manifest \
+  "$temporary_directory/zero-digest-manifest.json" \
+  'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+expect_failure "placeholder Portal digest" \
+  "$manage" validate \
+    --manifest "$temporary_directory/zero-digest-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+jq 'del(.quality_run_url)' \
+  "$temporary_directory/release-manifest.json" > "$temporary_directory/incomplete-manifest.json"
+expect_failure "incomplete release manifest" \
+  "$manage" validate \
+    --manifest "$temporary_directory/incomplete-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+printf '%s\n%s\n' \
+  "$(< "$temporary_directory/release-manifest.json")" \
+  "$(< "$temporary_directory/release-manifest.json")" \
+  > "$temporary_directory/multiple-manifests.json"
+expect_failure "multiple JSON documents" \
+  "$manage" validate \
+    --manifest "$temporary_directory/multiple-manifests.json" \
+    --env-file "$temporary_directory/production.env"
+
+jq '.unexpected = true' \
+  "$temporary_directory/release-manifest.json" > "$temporary_directory/extended-manifest.json"
+expect_failure "non-canonical release manifest field" \
+  "$manage" validate \
+    --manifest "$temporary_directory/extended-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+expect_failure "missing release manifest" \
+  "$manage" validate \
+    --manifest "$temporary_directory/missing.json" \
+    --env-file "$temporary_directory/production.env"
+expect_failure "missing environment file" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/not-there.env"
+expect_failure "manifest directory path" \
+  "$manage" validate \
+    --manifest "$temporary_directory" \
+    --env-file "$temporary_directory/production.env"
+expect_failure "environment directory path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory"
+
+: > "$temporary_directory/empty-manifest.json"
+expect_failure "empty release manifest" \
+  "$manage" validate \
+    --manifest "$temporary_directory/empty-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+cp "$temporary_directory/production.env" "$temporary_directory/insecure-production.env"
+chmod 0640 "$temporary_directory/insecure-production.env"
+expect_failure "group-readable Production environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-production.env"
+
+sed 's/^PORTAL_ADMIN_PASSWORD=.*/PORTAL_ADMIN_PASSWORD=/' \
+  "$temporary_directory/production.env" > "$temporary_directory/missing-value.env"
+chmod 0600 "$temporary_directory/missing-value.env"
+expect_failure "missing required environment value" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/missing-value.env"
+
+sed '/^PORTAL_ADMIN_PASSWORD=/d' \
+  "$temporary_directory/production.env" > "$temporary_directory/missing-key.env"
+chmod 0600 "$temporary_directory/missing-key.env"
+expect_failure "ambient value replacing a missing environment key" \
+  env PORTAL_ADMIN_PASSWORD=ambient-password-must-not-be-used \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/missing-key.env"
+
+printf '%s\n' \
+  "$(< "$temporary_directory/production.env")" \
+  'UNKNOWN_SETTING=typo' > "$temporary_directory/unknown.env"
+chmod 0600 "$temporary_directory/unknown.env"
+expect_failure "unknown environment setting" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/unknown.env"
+
+write_environment "$temporary_directory/missing-server.env" "$temporary_directory/not-there.env"
+expect_failure "missing Server environment file" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/missing-server.env"
+
+write_environment "$temporary_directory/server-directory.env" "$temporary_directory"
+expect_failure "Server environment directory path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/server-directory.env"
+
+cp "$temporary_directory/server.env" "$temporary_directory/insecure-server.env"
+chmod 0644 "$temporary_directory/insecure-server.env"
+write_environment \
+  "$temporary_directory/insecure-server-config.env" \
+  "$temporary_directory/insecure-server.env"
+expect_failure "world-readable Server environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-server-config.env"
+
+write_environment \
+  "$temporary_directory/missing-certificate.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/not-there.pem"
+expect_failure "missing TLS certificate" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/missing-certificate.env"
+
+write_environment \
+  "$temporary_directory/certificate-directory.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory"
+expect_failure "TLS certificate directory path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/certificate-directory.env"
+
+write_environment \
+  "$temporary_directory/key-directory.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory"
+expect_failure "TLS certificate key directory path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/key-directory.env"
+
+cp "$temporary_directory/privkey.pem" "$temporary_directory/insecure-key.pem"
+chmod 0644 "$temporary_directory/insecure-key.pem"
+write_environment \
+  "$temporary_directory/insecure-key.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-key.pem"
+expect_failure "world-readable TLS certificate key" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-key.env"
+
+"$manage" render-nginx \
+  --env-file "$temporary_directory/production.env" \
+  --output "$temporary_directory/production.conf" \
+  > "$temporary_directory/render.out"
+if grep -Eq '__PRODUCTION_[A-Z_]+' "$temporary_directory/production.conf"; then
+  fail "rendered Nginx configuration contains a placeholder"
+fi
+grep -Fq 'server_name speak-up.top;' "$temporary_directory/production.conf" ||
+  fail "rendered Nginx configuration is missing the canonical Portal host"
+grep -Fq 'server_name api.speak-up.top;' "$temporary_directory/production.conf" ||
+  fail "rendered Nginx configuration is missing the API host"
+
+PRODUCTION_POSTGRES_DB=speakup \
+PRODUCTION_POSTGRES_USER=speakup \
+PRODUCTION_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef \
+PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests \
+PRODUCTION_SERVER_ENV_FILE="$temporary_directory/server.env" \
+PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=172.31.0.1/32 \
+PRODUCTION_PORTAL_HOST=speak-up.top \
+PORTAL_IMAGE_DIGEST="$portal_digest" \
+SERVER_IMAGE_DIGEST="$server_digest" \
+COMPOSE_PROJECT_NAME=untrusted-project \
+  "$real_docker" compose \
+    --env-file /dev/null \
+    --project-name xe3-speakup-production \
+    --file "$compose_file" \
+    --profile migration \
+    config --format json > "$temporary_directory/compose.json"
+
+jq --exit-status \
+  --arg portal_digest "$portal_digest" \
+  --arg server_digest "$server_digest" '
+    .name == "xe3-speakup-production" and
+    .services.portal.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-portal@" + $portal_digest) and
+    .services.server.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
+    .services.migrate.image ==
+      ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
+    ([.services[] | has("build")] | any | not) and
+    ([.services[] | has("container_name")] | any | not) and
+    .services.portal.ports[0].host_ip == "127.0.0.1" and
+    (.services.portal.ports[0].published | tostring) == "18082" and
+    .services.server.ports[0].host_ip == "127.0.0.1" and
+    (.services.server.ports[0].published | tostring) == "18083" and
+    (.services.postgres | has("ports") | not) and
+    .networks.database.internal == true and
+    .networks.server_edge.external == true and
+    .networks.server_edge.name == "xe3-speakup-production-server-edge" and
+    (.services.portal.networks | keys) == ["portal_edge"] and
+    (.services.postgres.networks | keys) == ["database"] and
+    (.services.migrate.networks | keys) == ["database"] and
+    (.services.server.networks | keys | sort) == ["database", "server_edge"] and
+    .services.server.environment.TRUSTED_PROXY_CIDRS == "172.31.0.1/32" and
+    .services.server.environment.TRUSTED_PROXY_HEADER == "x-forwarded-for" and
+    .services.portal.healthcheck.test == [
+      "CMD",
+      "node",
+      "-e",
+      "fetch(\u0027http://127.0.0.1:3000/\u0027,{signal:AbortSignal.timeout(2000)}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+    ] and
+    .services.server.healthcheck.test == [
+      "CMD", "wget", "-q", "-T", "2", "--spider",
+      "http://127.0.0.1:8080/readyz"
+    ] and
+    .services.postgres.healthcheck.test == [
+      "CMD-SHELL",
+      "pg_isready --username=\"$${POSTGRES_USER}\" --dbname=\"$${POSTGRES_DB}\""
+    ] and
+    .services.server.depends_on.postgres.condition == "service_healthy" and
+    .services.migrate.depends_on.postgres.condition == "service_healthy" and
+    .volumes.portal_data.external == true and
+    .volumes.portal_data.name == "xe3-speakup-portal-data" and
+    .volumes.postgres_data.external == true and
+    .volumes.postgres_data.name == "xe3-speakup-postgres-data"
+  ' "$temporary_directory/compose.json" >/dev/null ||
+  fail "resolved Compose model violates the Production isolation contract"
+
+COMMAND_LOG="$temporary_directory/verify.log" \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    > "$temporary_directory/verify.out"
+grep -Fq 'http://127.0.0.1:18082/' "$temporary_directory/verify.log" ||
+  fail "Production verification did not check Portal"
+grep -Fq 'http://127.0.0.1:18083/health' "$temporary_directory/verify.log" ||
+  fail "Production verification did not check Server liveness"
+grep -Fq 'http://127.0.0.1:18083/readyz' "$temporary_directory/verify.log" ||
+  fail "Production verification did not check Server readiness"
+
+: > "$temporary_directory/wrong-project.log"
+expect_failure "healthy legacy process outside the Production project" \
+  env \
+    COMMAND_LOG="$temporary_directory/wrong-project.log" \
+    TEST_RUNTIME_PROJECT=xe3-speakup-legacy \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/wrong-project.log" ]] ||
+  fail "endpoint checks ran before the Production project identity check"
+
+: > "$temporary_directory/wrong-digest.log"
+expect_failure "Portal running an unapproved digest" \
+  env \
+    COMMAND_LOG="$temporary_directory/wrong-digest.log" \
+    TEST_RUNTIME_PORTAL_DIGEST=sha256:9999999999999999999999999999999999999999999999999999999999999999 \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/wrong-digest.log" ]] ||
+  fail "endpoint checks ran before the image digest check"
+
+: > "$temporary_directory/unhealthy.log"
+expect_failure "unhealthy Production Server" \
+  env \
+    COMMAND_LOG="$temporary_directory/unhealthy.log" \
+    TEST_UNHEALTHY_SERVICE=server \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/unhealthy.log" ]] ||
+  fail "endpoint checks ran before the container health check"
+
+: > "$temporary_directory/bad-mount.log"
+expect_failure "Portal missing its external data mount" \
+  env \
+    COMMAND_LOG="$temporary_directory/bad-mount.log" \
+    TEST_BAD_MOUNT_SERVICE=portal \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/bad-mount.log" ]] ||
+  fail "endpoint checks ran before the external mount check"
+
+: > "$temporary_directory/bad-port.log"
+expect_failure "Portal missing its loopback port" \
+  env \
+    COMMAND_LOG="$temporary_directory/bad-port.log" \
+    TEST_BAD_PORT_SERVICE=portal \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/bad-port.log" ]] ||
+  fail "endpoint checks ran before the loopback port check"
+
+: > "$temporary_directory/bad-network.log"
+expect_failure "Server missing its audited edge network" \
+  env \
+    COMMAND_LOG="$temporary_directory/bad-network.log" \
+    TEST_BAD_NETWORK_SERVICE=server \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/bad-network.log" ]] ||
+  fail "endpoint checks ran before the runtime network check"
+
+for service in portal server postgres; do
+  runtime_environment_log="$temporary_directory/bad-${service}-environment.log"
+  : > "$runtime_environment_log"
+  expect_failure "$service runtime environment mismatch" \
+    env \
+      COMMAND_LOG="$runtime_environment_log" \
+      TEST_BAD_ENV_SERVICE="$service" \
+    "$manage" verify \
+      --manifest "$temporary_directory/release-manifest.json" \
+      --env-file "$temporary_directory/production.env"
+  [[ ! -s "$runtime_environment_log" ]] ||
+    fail "endpoint checks ran before the $service runtime environment check"
+  if grep -Fq \
+    -e 'portal-admin-password-for-tests' \
+    -e '0123456789abcdef0123456789abcdef' \
+    -e 'postgres://speakup:' \
+    "$temporary_directory/failure.out"; then
+    fail "$service runtime environment failure exposed a sensitive value"
+  fi
+done
+
+: > "$temporary_directory/missing-postgres.log"
+expect_failure "missing Production PostgreSQL container" \
+  env \
+    COMMAND_LOG="$temporary_directory/missing-postgres.log" \
+    TEST_MISSING_SERVICE=postgres \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+[[ ! -s "$temporary_directory/missing-postgres.log" ]] ||
+  fail "endpoint checks ran before all Production services were identified"
+
+expect_failure "unsupported deployment mutation" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+
+printf '%s\n' 'Production contract tests passed'

--- a/portal/deploy/README.md
+++ b/portal/deploy/README.md
@@ -1,4 +1,9 @@
-# SpeakUp Portal 生产部署
+# SpeakUp Portal legacy 生产部署
+
+> 本目录只保留现网 Portal-only 启动和 SQLite 备份的历史说明。新的 Release
+> Candidate 禁止执行本目录的源码 `up --build`；请使用仓库根目录
+> `deploy/production/` 的不可变制品契约。该契约当前只有只读校验入口，正式切换必须
+> 等生产备份、migration 与回滚编排完成审核。
 
 本目录用于把 `prototype/` 作为独立的外部 Live Demo 部署到
 `speak-up.top`。正式 Flutter 客户端和 Go 服务不依赖此部署。
@@ -170,7 +175,7 @@ curl --fail --location https://speak-up.top/
 /usr/local/nginx/sbin/nginx -t
 ```
 
-更新代码后，在 `/opt/xe3-speakup-portal/` 重新执行：
+以下旧命令仅用于识别历史部署方式，禁止用于新的 Release Candidate：
 
 ```sh
 docker compose -f deploy/compose.yaml up -d --build


### PR DESCRIPTION
## 功能描述

- 建立固定项目名的 Production Compose 契约，Portal、Server 仅部署 Release manifest 中的不可变镜像 digest。
- 显式复用现有 Portal SQLite 数据卷，并要求 PostgreSQL 数据卷和 Server edge 网络预先存在；缺失时 fail closed。
- 提供 Production Nginx 模板，覆盖 Portal、API、HTTPS、固定主域跳转、限流、代理 Header 和 `/metrics` 拒绝。
- 提供只读 `validate`、`status`、`verify` 和 `render-nginx` 入口，不包含部署、migration、停止或回滚命令。
- 将 Production 契约测试接入现有 `Quality` 的 Deployment contracts job。

## 实现思路

- 完整校验 Release manifest v1、镜像仓库/digest、Android 元数据、数据库 schema 版本和 Quality run URL。
- `validate` 只解析 Compose、检查外部卷/网络及渲染 Nginx，不执行 `pull`、`up`、`run` 或资源创建。
- `verify` 在请求健康端点前，核对三个运行容器的 Compose 身份、镜像、健康状态、关键运行环境、挂载、loopback 端口和网络。
- Server 只信任预创建 edge 网络的精确 gateway `/32`，避免错误信任整个私网段。
- Nginx 测试实际启动隔离容器，验证固定跳转、`/metrics`、Authorization/WebSocket/XFF 转发和限流行为。

## 可复现测试

```sh
make check-release-candidate
make check-production-deploy
make check-production-nginx
make check-staging-deploy
make check-staging-nginx
bash -n deploy/production/manage.sh deploy/production/test.sh deploy/production/test-nginx.sh
git diff --check upstream/dev...HEAD
```

以上检查均已在最新 `upstream/dev`（包含 #858）上通过。

## 范围边界

- 不连接或修改 Production。
- 不创建数据卷、Docker 网络、证书或 Secret。
- 不执行数据库 migration、备份、恢复、部署或回滚；这些能力按独立 Issue 审核。
- 不加入 APK 静态下载路由。

Closes #859
