### PR TITLE
ops(staging): 验证不可变运行态与数据库版本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ help:
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
-		'  make check-staging-deploy  Validate the immutable Staging deployment contract' \
+		'  make check-staging-deploy  Validate Staging runtime, schema, lock, and receipt contracts' \
 		'  make check-staging-nginx  Run nginx -t against the rendered Staging template' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
 		'  make dev-ios-simulator  Start the backend on an iOS Simulator' \

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -35,6 +35,7 @@ and server environment are externally injected and are not committed.
 ## Prerequisites
 
 - Bash, `jq`, `curl`, Docker Engine, and Docker Compose with `up --wait` support.
+- `flock`, plus either `sha256sum` or `shasum`, on the deployment host.
 - Nginx with the HTTP SSL, proxy, and Basic Auth modules.
 - A certificate whose SANs cover both Staging hostnames.
 - A populated htpasswd file and a real Staging Server environment file.
@@ -66,7 +67,27 @@ install -d -m 0750 /etc/speakup
 install -m 0600 staging.env.example /etc/speakup/staging.env
 install -m 0600 /secure/source/staging-server.env \
   /etc/speakup/staging-server.env
+install -d -o root -g root -m 0700 /run/lock/xe3-speakup-staging
 ```
+
+Run the contract as the same UID that owns all deployment inputs (normally
+`root` on the server). `staging.env`, the Server environment, and htpasswd file
+must be regular, non-symlink files owned by that UID with mode `0400` or
+`0600`. The TLS private key may be a regular file or Certbot's stable
+`live/.../privkey.pem` symlink; its resolved target must be regular, non-empty,
+owned by that UID, and mode `0400` or `0600`. The public certificate must be
+non-empty, owned by that UID, and not group- or world-writable. The ACME webroot
+must be a non-symlink directory owned by that UID with mode `0700`, `0750`, or
+`0755`. Validation checks these properties before a Docker pull, migration,
+container update, or shutdown. Keep the stable `live/` paths so Certbot renewal
+can advance their archive targets; never pin an `archive/.../privkeyN.pem`
+generation.
+
+The dedicated lock directory is mandatory and must be recreated at boot when
+`/run` is volatile. The deployment script never creates this directory and
+fails closed if it is missing, a symlink, owned by another UID, or group/world
+writable. Only the lock file inside that already-private directory may be
+created by the script.
 
 Before public verification, create A records for both selected hostnames (and
 AAAA records only when the host is intentionally IPv6-reachable) and point them
@@ -88,33 +109,53 @@ repository. Do not add HTTP Basic Auth to the API host: the Staging APK uses its
   --env-file /etc/speakup/staging.env
 ```
 
-Validation fails on a missing or malformed manifest, a mutable or placeholder
-image reference, a missing configuration value, an empty Server environment
-file, or an invalid Compose model. It does not pull images or contact the
-application providers.
+Validation accepts only the canonical v1 Release Candidate manifest with its
+exact key set; missing, unknown, or multiple JSON documents fail closed. It
+also fails on a malformed manifest, mutable or placeholder image reference,
+missing configuration value, invalid private input, or invalid Compose model.
+It does not pull images or contact the application providers.
 
 ## 3. Deploy the immutable Staging images
 
 ```sh
 ./deploy/staging/manage.sh deploy \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env
+  --env-file /etc/speakup/staging.env \
+  --receipt /opt/speakup/releases/v0.1.1/staging-deployment-receipt.json
 ```
 
 The command performs the following fail-closed sequence:
 
 1. validate the manifest, external configuration, Compose model, and Nginx
-   template;
-2. pull the pinned PostgreSQL, Portal, and Server images;
-3. start only PostgreSQL and wait for its health check;
-4. run `/usr/local/bin/speakup-migrate up` in a one-shot container;
-5. only after migration succeeds, update Portal and Server and wait for their
-   container health checks;
-6. verify Portal `/`, Server `/health`, and Server `/readyz` over loopback.
+   template, and require a new receipt path;
+2. acquire the exclusive
+   `/run/lock/xe3-speakup-staging/deploy.lock` lock shared by `deploy` and
+   `down` (the test harness alone overrides this path);
+3. pull the pinned PostgreSQL, Portal, and Server images;
+4. start only PostgreSQL with `--pull never` and wait for its health check;
+5. run `/usr/local/bin/speakup-migrate up` with `--pull never`, then run
+   `speakup-migrate version` and require the sole output to be exactly
+   `version=N dirty=false`, with `N` equal to `database_schema_version` in the
+   manifest;
+6. only after that exact schema check, update Portal and Server with
+   `--pull never` and wait for their container health checks;
+7. verify the exact project service set, running container identity and health,
+   pinned `Config.Image`, inspectable Linux/amd64 image and release OCI labels,
+   loopback ports, networks, internal database isolation, Staging volumes, the
+   live schema, Portal `/`, Server `/health`, and Server `/readyz`;
+8. atomically create the new receipt without overwriting any existing path.
+
+The receipt binds the manifest SHA-256, release version, Git SHA, schema,
+Portal and Server image digests, exact container IDs, and UTC deployment time.
+It contains no credentials. Its parent directory must already exist, be owned
+by the executing UID, and have mode `0700`, `0750`, or `0755`.
 
 If migration fails, the command exits before the Portal or Server update. A
-failed application health check is also an explicit deployment failure; this
-Issue does not add Production promotion or automatic rollback behavior.
+dirty or mismatched schema, invalid runtime, or failed application health check
+also prevents the receipt. Schema migrations are not automatically reversed:
+rolling an application image back across an unknown schema boundary is unsafe,
+so recovery requires the reviewed database restore or migration procedure for
+that release. This contract does not add Production promotion.
 
 ## 4. Render and install the Nginx configuration
 
@@ -158,6 +199,11 @@ business routes continue to enforce the application's Bearer authentication.
 Public HTTPS checks require DNS, certificate, and firewall setup that remain
 external to this repository.
 
+`verify` never pulls an image. It first verifies the exact runtime project,
+services, image digests and OCI labels, networks, ports, and volumes; it then
+runs the migration image with `--pull never` to confirm the live schema before
+checking the three loopback endpoints.
+
 ## 6. Stop or clean up Staging
 
 ```sh
@@ -173,6 +219,9 @@ reload Nginx if the public Staging entry points should also disappear. Volume
 deletion is intentionally not automated; inspect and back up these explicitly
 Staging-scoped volumes before deleting them by name.
 
+`down` uses the same exclusive lock as `deploy` and fails rather than running
+unlocked or concurrently with a release.
+
 ## Reproducible contract checks
 
 ```sh
@@ -180,10 +229,12 @@ make check-staging-deploy
 make check-staging-nginx
 ```
 
-The first command checks manifest and environment failure paths, the resolved
-Compose isolation model, endpoint verification, and the rule that a migration
-failure cannot switch applications. The second renders a temporary TLS config
-and runs `nginx -t` in a pinned Docker Official Nginx image.
+The first command checks private input ownership/modes and symlink rejection,
+lock conflicts, manifest and configuration failures, the resolved Compose
+isolation model, strict schema parsing, runtime identity and resources,
+no-pull verification, endpoint checks, and atomic no-clobber receipts. The
+second renders a temporary TLS config and runs `nginx -t` in a pinned Docker
+Official Nginx image.
 
 ## Official references
 

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -83,6 +83,14 @@ container update, or shutdown. Keep the stable `live/` paths so Certbot renewal
 can advance their archive targets; never pin an `archive/.../privkeyN.pem`
 generation.
 
+Every ancestor of these paths must be a real directory owned by `root` or the
+execution UID and must not be group- or world-writable. A sticky directory
+owned by one of those UIDs (for example `/tmp`) is the only writable-ancestor
+exception. Only the final TLS certificate and private-key components may be
+Certbot `live/*.pem` symlinks; their resolved `archive/` targets and target
+ancestors are checked under the same boundary. Any other symbolic-link path
+component fails closed.
+
 The dedicated lock directory is mandatory and must be recreated at boot when
 `/run` is volatile. The deployment script never creates this directory and
 fails closed if it is missing, a symlink, owned by another UID, or group/world

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -6,6 +6,12 @@ readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly compose_file="$staging_directory/compose.yaml"
 readonly nginx_template="$staging_directory/nginx.conf.template"
 readonly compose_project="xe3-speakup-staging"
+readonly portal_image_repository="ghcr.io/1024xengineer/xe3-esl-portal"
+readonly server_image_repository="ghcr.io/1024xengineer/xe3-esl-server"
+readonly postgres_image="postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly portal_data_volume="${compose_project}_portal_data"
+readonly postgres_data_volume="${compose_project}_postgres_data"
+readonly staging_lock_file="${SPEAKUP_STAGING_LOCK_FILE:-/run/lock/xe3-speakup-staging/deploy.lock}"
 readonly portal_health_url="http://127.0.0.1:28082/"
 readonly server_health_url="http://127.0.0.1:28083/health"
 readonly server_readiness_url="http://127.0.0.1:28083/readyz"
@@ -14,7 +20,7 @@ usage() {
   cat >&2 <<'EOF'
 Usage:
   manage.sh validate --manifest FILE --env-file FILE
-  manage.sh deploy --manifest FILE --env-file FILE
+  manage.sh deploy --manifest FILE --env-file FILE --receipt FILE
   manage.sh verify --manifest FILE --env-file FILE
   manage.sh status --manifest FILE --env-file FILE
   manage.sh down --manifest FILE --env-file FILE
@@ -29,6 +35,169 @@ fail() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+path_mode() {
+  local path=$1
+  local mode
+
+  if mode=$(stat -Lc '%a' -- "$path" 2>/dev/null); then
+    :
+  elif mode=$(stat -L -f '%Lp' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$mode"
+}
+
+path_owner() {
+  local path=$1
+  local owner
+
+  if owner=$(stat -Lc '%u' -- "$path" 2>/dev/null); then
+    :
+  elif owner=$(stat -L -f '%u' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$owner"
+}
+
+path_identity() {
+  local path=$1
+  local identity
+
+  if identity=$(stat -Lc '%i' -- "$path" 2>/dev/null); then
+    :
+  elif identity=$(stat -L -f '%i' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$identity"
+}
+
+require_current_owner() {
+  local description=$1
+  local path=$2
+  local owner
+
+  owner=$(path_owner "$path") ||
+    fail "cannot inspect owner for $description: $path"
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current execution UID: $path"
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+
+  [[ -f "$file" ]] || fail "$description is not a regular file: $file"
+  [[ -r "$file" ]] || fail "$description is not readable: $file"
+  [[ -s "$file" ]] || fail "$description is empty: $file"
+}
+
+require_private_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  [[ ! -L "$file" ]] || fail "$description must not be a symbolic link: $file"
+  require_regular_file "$description" "$file"
+  require_current_owner "$description" "$file"
+  mode=$(path_mode "$file") ||
+    fail "cannot inspect permissions for $description: $file"
+  case "$mode" in
+    400 | 600)
+      ;;
+    *)
+      fail "$description must have mode 0400 or 0600: $file"
+      ;;
+  esac
+}
+
+require_private_key_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  # Certbot's stable live/privkey.pem path is a symlink. All checks below use
+  # dereferencing stat and therefore apply to its current archive target.
+  require_regular_file "$description" "$file"
+  require_current_owner "$description target" "$file"
+  mode=$(path_mode "$file") ||
+    fail "cannot inspect permissions for $description target: $file"
+  case "$mode" in
+    400 | 600)
+      ;;
+    *)
+      fail "$description target must have mode 0400 or 0600: $file"
+      ;;
+  esac
+}
+
+require_public_certificate() {
+  local file=$1
+  local mode
+
+  require_regular_file "TLS certificate" "$file"
+  require_current_owner "TLS certificate" "$file"
+  mode=$(path_mode "$file") ||
+    fail "cannot inspect permissions for TLS certificate: $file"
+  case "$mode" in
+    400 | 440 | 444 | 600 | 640 | 644)
+      ;;
+    *)
+      fail "TLS certificate must not be group- or world-writable: $file"
+      ;;
+  esac
+}
+
+require_owned_directory() {
+  local description=$1
+  local directory=$2
+  local allowed_modes=$3
+  local mode
+
+  [[ ! -L "$directory" ]] ||
+    fail "$description must not be a symbolic link: $directory"
+  [[ -d "$directory" ]] || fail "$description does not exist: $directory"
+  [[ -x "$directory" ]] || fail "$description is not searchable: $directory"
+  require_current_owner "$description" "$directory"
+  mode=$(path_mode "$directory") ||
+    fail "cannot inspect permissions for $description: $directory"
+  case " $allowed_modes " in
+    *" $mode "*)
+      ;;
+    *)
+      fail "$description has unsafe permissions: $directory"
+      ;;
+  esac
+}
+
+path_parent() {
+  local path=$1
+  local parent=${path%/*}
+
+  [[ -n "$parent" ]] || parent=/
+  printf '%s\n' "$parent"
+}
+
+sha256_file() {
+  local file=$1
+  local digest
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(sha256sum -- "$file" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    digest=$(shasum -a 256 "$file" | awk '{print $1}')
+  else
+    fail "sha256sum or shasum is required"
+  fi
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || fail "cannot hash file: $file"
+  printf '%s\n' "$digest"
 }
 
 allowed_configuration_key() {
@@ -54,10 +223,9 @@ allowed_configuration_key() {
 
 load_configuration() {
   local file=$1
-  local line name value
+  local line name value line_number=0
 
-  [[ -f "$file" ]] || fail "environment file does not exist: $file"
-  [[ -r "$file" ]] || fail "environment file is not readable: $file"
+  require_private_file "environment file" "$file"
 
   unset \
     STAGING_POSTGRES_DB \
@@ -73,17 +241,21 @@ load_configuration() {
     STAGING_ACME_ROOT
 
   while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
     line=${line%$'\r'}
     case "$line" in
       "" | \#*)
         continue
         ;;
     esac
-    [[ "$line" == *=* ]] || fail "invalid environment line: $line"
+    [[ "$line" == *=* ]] ||
+      fail "invalid environment entry at line $line_number"
     name=${line%%=*}
     value=${line#*=}
-    [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]] || fail "invalid environment key: $name"
-    allowed_configuration_key "$name" || fail "unsupported environment key: $name"
+    [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]] ||
+      fail "invalid environment key at line $line_number"
+    allowed_configuration_key "$name" ||
+      fail "unsupported environment key at line $line_number"
     printf -v "$name" '%s' "$value"
     export "$name"
   done <"$file"
@@ -162,48 +334,88 @@ validate_configuration() {
     valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
   done
 
-  [[ -s "$STAGING_SERVER_ENV_FILE" ]] ||
-    fail "server environment file is missing or empty: $STAGING_SERVER_ENV_FILE"
+  require_private_file "server environment file" "$STAGING_SERVER_ENV_FILE"
+  require_public_certificate "$STAGING_TLS_CERTIFICATE"
+  require_private_key_file "TLS certificate key" "$STAGING_TLS_CERTIFICATE_KEY"
+  require_private_file "htpasswd file" "$STAGING_HTPASSWD_FILE"
+  require_owned_directory "ACME root directory" "$STAGING_ACME_ROOT" \
+    "700 750 755"
 }
 
 validate_manifest() {
   local file=$1
-  local digest hexadecimal
 
   require_command jq
-  [[ -f "$file" ]] || fail "release manifest does not exist: $file"
-  [[ -r "$file" ]] || fail "release manifest is not readable: $file"
+  require_regular_file "release manifest" "$file"
 
-  jq --exit-status '
-    type == "object" and
-    .manifest_version == 1 and
-    (.version | type == "string" and
-      test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
-    (.git_sha | type == "string" and test("^[0-9a-f]{40}$")) and
-    .portal_image == "ghcr.io/1024xengineer/xe3-esl-portal" and
-    (.portal_image_digest | type == "string" and
-      test("^sha256:[0-9a-f]{64}$")) and
-    .server_image == "ghcr.io/1024xengineer/xe3-esl-server" and
-    (.server_image_digest | type == "string" and
-      test("^sha256:[0-9a-f]{64}$")) and
-    (.database_schema_version | type == "number" and
-      . >= 1 and . == floor)
+  jq --exit-status --slurp '
+    length == 1 and
+    (.[0] |
+      type == "object" and
+      keys == [
+        "abis",
+        "apk_certificate_sha256",
+        "application_id",
+        "database_schema_version",
+        "git_sha",
+        "manifest_version",
+        "minimum_android_api",
+        "portal_image",
+        "portal_image_digest",
+        "production_apk_file",
+        "production_apk_sha256",
+        "production_apk_size_bytes",
+        "quality_run_url",
+        "server_image",
+        "server_image_digest",
+        "staging_apk_file",
+        "staging_apk_sha256",
+        "version",
+        "version_code"
+      ] and
+      .manifest_version == 1 and
+      (.version | type == "string" and
+        test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+      (.version_code | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.git_sha | type == "string" and
+        test("^[0-9a-f]{40}$") and test("[1-9a-f]")) and
+      .portal_image == "ghcr.io/1024xengineer/xe3-esl-portal" and
+      (.portal_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      .server_image == "ghcr.io/1024xengineer/xe3-esl-server" and
+      (.server_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      .staging_apk_file ==
+        ("speakup-v" + .version + "-staging-arm64.apk") and
+      (.staging_apk_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      .production_apk_file ==
+        ("speakup-v" + .version + "-production-arm64.apk") and
+      (.production_apk_size_bytes | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.production_apk_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      .application_id == "com.xengineer.speakup" and
+      .minimum_android_api == 24 and
+      .abis == ["arm64-v8a"] and
+      (.apk_certificate_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.database_schema_version | type == "number" and
+        . >= 1 and . <= 9007199254740991 and . == floor) and
+      (.quality_run_url | type == "string" and
+        test("^https://github\\.com/1024XEngineer/XE3-ESL/actions/runs/[1-9][0-9]*$"))
+    )
   ' "$file" >/dev/null || fail "release manifest is invalid"
-
-  for digest in \
-    "$(jq --raw-output '.portal_image_digest' "$file")" \
-    "$(jq --raw-output '.server_image_digest' "$file")"; do
-    hexadecimal=${digest#sha256:}
-    [[ "$hexadecimal" =~ [1-9a-f] ]] || fail "image digest cannot be a placeholder"
-  done
-  [[ "$(jq --raw-output '.git_sha' "$file")" =~ [1-9a-f] ]] ||
-    fail "git_sha cannot be a placeholder"
 
   PORTAL_IMAGE_DIGEST=$(jq --raw-output '.portal_image_digest' "$file")
   SERVER_IMAGE_DIGEST=$(jq --raw-output '.server_image_digest' "$file")
   RELEASE_VERSION=$(jq --raw-output '.version' "$file")
   RELEASE_GIT_SHA=$(jq --raw-output '.git_sha' "$file")
   RELEASE_SCHEMA_VERSION=$(jq --raw-output '.database_schema_version' "$file")
+  RELEASE_MANIFEST_SHA256=$(sha256_file "$file")
   export PORTAL_IMAGE_DIGEST SERVER_IMAGE_DIGEST
 }
 
@@ -220,6 +432,72 @@ validate_compose() {
   require_command docker
   docker compose version >/dev/null
   compose --profile migration config --quiet
+}
+
+validate_receipt_target() {
+  local receipt=$1
+  local directory
+
+  valid_absolute_path "$receipt" || fail "--receipt must be a safe absolute path"
+  [[ ! -e "$receipt" && ! -L "$receipt" ]] ||
+    fail "deployment receipt already exists: $receipt"
+  directory=$(path_parent "$receipt")
+  require_owned_directory "deployment receipt directory" "$directory" \
+    "700 750 755"
+  [[ -w "$directory" ]] ||
+    fail "deployment receipt directory is not writable: $directory"
+}
+
+require_safe_lock_file() {
+  local file=$1
+  local mode
+
+  [[ ! -L "$file" ]] || fail "deployment lock must not be a symbolic link: $file"
+  [[ -f "$file" ]] || fail "deployment lock is not a regular file: $file"
+  [[ -r "$file" && -w "$file" ]] ||
+    fail "deployment lock is not readable and writable: $file"
+  require_current_owner "deployment lock" "$file"
+  mode=$(path_mode "$file") ||
+    fail "cannot inspect permissions for deployment lock: $file"
+  [[ "$mode" == 600 ]] ||
+    fail "deployment lock must have mode 0600: $file"
+}
+
+require_lock_fd_matches_path() {
+  local opened_identity path_file_identity
+
+  require_safe_lock_file "$staging_lock_file"
+  opened_identity=$(path_identity /dev/fd/9) ||
+    fail "cannot inspect the opened deployment lock"
+  path_file_identity=$(path_identity "$staging_lock_file") ||
+    fail "cannot inspect deployment lock identity: $staging_lock_file"
+  [[ "$opened_identity" == "$path_file_identity" ]] ||
+    fail "deployment lock changed while it was being acquired"
+}
+
+acquire_deployment_lock() {
+  local directory
+
+  require_command flock
+  valid_absolute_path "$staging_lock_file" ||
+    fail "deployment lock must be a safe absolute path"
+  directory=$(path_parent "$staging_lock_file")
+  require_owned_directory "deployment lock directory" "$directory" \
+    "700 750 755"
+  if [[ ! -e "$staging_lock_file" && ! -L "$staging_lock_file" ]]; then
+    if ! (umask 077 && set -o noclobber && : > "$staging_lock_file") \
+      2>/dev/null; then
+      [[ -e "$staging_lock_file" || -L "$staging_lock_file" ]] ||
+        fail "cannot create deployment lock: $staging_lock_file"
+    fi
+  fi
+  require_safe_lock_file "$staging_lock_file"
+  exec 9>> "$staging_lock_file" ||
+    fail "cannot open deployment lock: $staging_lock_file"
+  require_lock_fd_matches_path
+  flock --nonblock 9 ||
+    fail "another Staging deploy or down operation is already running"
+  require_lock_fd_matches_path
 }
 
 render_nginx() {
@@ -269,6 +547,302 @@ verify_endpoints() {
   wait_for_endpoint "Server readiness" "$server_readiness_url"
 }
 
+verify_database_schema() {
+  local output version
+
+  if ! output=$(compose run --pull never --rm --no-deps migrate \
+    /usr/local/bin/speakup-migrate version); then
+    fail "cannot verify the Staging database schema"
+  fi
+  [[ "$output" =~ ^version=([1-9][0-9]*)\ dirty=false$ ]] ||
+    fail "database schema output must be exactly version=N dirty=false"
+  version=${BASH_REMATCH[1]}
+  [[ "$version" == "$RELEASE_SCHEMA_VERSION" ]] ||
+    fail "database schema version does not match the release manifest"
+}
+
+verify_project_service_set() {
+  local services
+
+  services=$(
+    docker ps --all \
+      --filter "label=com.docker.compose.project=$compose_project" \
+      --format '{{.Label "com.docker.compose.service"}}'
+  )
+  services=$(printf '%s\n' "$services" | LC_ALL=C sort)
+  [[ "$services" == $'portal\npostgres\nserver' ]] ||
+    fail "$compose_project must contain exactly portal, postgres, and server"
+}
+
+runtime_container_id() {
+  local service=$1
+  local containers
+
+  containers=$(
+    docker ps \
+      --filter "label=com.docker.compose.project=$compose_project" \
+      --filter "label=com.docker.compose.service=$service" \
+      --format '{{.ID}}'
+  )
+  [[ -n "$containers" ]] || fail "$compose_project/$service is not running"
+  [[ "$containers" != *$'\n'* ]] ||
+    fail "$compose_project/$service has multiple running containers"
+  [[ "$containers" =~ ^[0-9a-f]{12,64}$ ]] ||
+    fail "$compose_project/$service returned an invalid container ID"
+  printf '%s\n' "$containers"
+}
+
+verify_runtime_image() {
+  local service=$1
+  local expected_image=$2
+  local release_labels=$3
+  local inspection
+
+  inspection=$(docker image inspect "$expected_image") ||
+    fail "cannot inspect the pinned $service image"
+  jq --exit-status --slurp \
+    --arg expected_image "$expected_image" \
+    --arg release_labels "$release_labels" \
+    --arg source "https://github.com/1024XEngineer/XE3-ESL" \
+    --arg revision "$RELEASE_GIT_SHA" \
+    --arg version "$RELEASE_VERSION" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        (.[0] |
+          .Os == "linux" and
+          .Architecture == "amd64" and
+          ($release_labels != "true" or
+            (((.RepoDigests // []) | index($expected_image)) != null and
+             .Config.Labels["org.opencontainers.image.source"] == $source and
+             .Config.Labels["org.opencontainers.image.revision"] == $revision and
+             .Config.Labels["org.opencontainers.image.version"] == $version))
+        )
+      )
+    ' <<< "$inspection" >/dev/null ||
+    fail "$service image platform, digest, or OCI labels are invalid"
+}
+
+inspect_runtime_service() {
+  local service=$1
+  local expected_image=$2
+  local release_labels=$3
+  local container_id inspection
+
+  container_id=$(runtime_container_id "$service")
+  inspection=$(docker inspect "$container_id") ||
+    fail "cannot inspect $compose_project/$service"
+  jq --exit-status --slurp \
+    --arg container_id "$container_id" \
+    --arg project "$compose_project" \
+    --arg service "$service" \
+    --arg expected_image "$expected_image" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        (.[0] |
+          (.Id | type == "string" and
+            test("^[0-9a-f]{64}$") and startswith($container_id)) and
+          .Config.Labels["com.docker.compose.project"] == $project and
+          .Config.Labels["com.docker.compose.service"] == $service and
+          .Config.Image == $expected_image and
+          .State.Status == "running" and
+          .State.Running == true and
+          .State.Health.Status == "healthy"
+        )
+      )
+    ' <<< "$inspection" >/dev/null ||
+    fail "$compose_project/$service identity, image, or health is invalid"
+  verify_runtime_image "$service" "$expected_image" "$release_labels"
+  printf '%s\n' "$inspection"
+}
+
+verify_runtime_network() {
+  local logical_name=$1
+  local internal=$2
+  local name="${compose_project}_${logical_name}"
+  local inspection
+
+  inspection=$(docker network inspect "$name") ||
+    fail "cannot inspect Staging network: $name"
+  jq --exit-status --slurp \
+    --arg name "$name" \
+    --arg project "$compose_project" \
+    --arg logical_name "$logical_name" \
+    --argjson internal "$internal" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        (.[0] |
+          .Name == $name and
+          .Internal == $internal and
+          .Labels["com.docker.compose.project"] == $project and
+          .Labels["com.docker.compose.network"] == $logical_name
+        )
+      )
+    ' <<< "$inspection" >/dev/null ||
+    fail "Staging network identity or isolation is invalid: $name"
+}
+
+verify_runtime_volume() {
+  local logical_name=$1
+  local name="${compose_project}_${logical_name}"
+  local inspection
+
+  inspection=$(docker volume inspect "$name") ||
+    fail "cannot inspect Staging volume: $name"
+  jq --exit-status --slurp \
+    --arg name "$name" \
+    --arg project "$compose_project" \
+    --arg logical_name "$logical_name" '
+      length == 1 and
+      (.[0] |
+        type == "array" and length == 1 and
+        (.[0] |
+          .Name == $name and
+          .Labels["com.docker.compose.project"] == $project and
+          .Labels["com.docker.compose.volume"] == $logical_name
+        )
+      )
+    ' <<< "$inspection" >/dev/null ||
+    fail "Staging volume identity is invalid: $name"
+}
+
+verify_runtime() {
+  local portal server postgres
+
+  verify_project_service_set
+  verify_runtime_network portal_edge false
+  verify_runtime_network server_edge false
+  verify_runtime_network database true
+  verify_runtime_volume portal_data
+  verify_runtime_volume postgres_data
+
+  portal=$(inspect_runtime_service \
+    portal "$portal_image_repository@$PORTAL_IMAGE_DIGEST" true)
+  jq --exit-status --arg network "${compose_project}_portal_edge" '
+    def exact_env($key; $value):
+      [.Config.Env[]? | select(startswith($key + "="))] ==
+        [($key + "=" + $value)];
+    .[0] |
+    exact_env("PORTAL_ADMIN_PASSWORD"; env.PORTAL_ADMIN_PASSWORD) and
+    exact_env("PORTAL_SQLITE_PATH"; "/app/.wrangler/portal.sqlite") and
+    exact_env("VINEXT_TRUSTED_HOSTS"; env.STAGING_PORTAL_HOST) and
+    (.Mounts | length == 1) and
+    .Mounts[0].Type == "volume" and
+    .Mounts[0].Name == "xe3-speakup-staging_portal_data" and
+    .Mounts[0].Destination == "/app/.wrangler" and
+    .Mounts[0].RW == true and
+    .NetworkSettings.Ports == {
+      "3000/tcp": [{"HostIp": "127.0.0.1", "HostPort": "28082"}]
+    } and
+    (.NetworkSettings.Networks | keys) == [$network]
+  ' <<< "$portal" >/dev/null 2>&1 ||
+    fail "$compose_project/portal runtime configuration is invalid"
+
+  server=$(inspect_runtime_service \
+    server "$server_image_repository@$SERVER_IMAGE_DIGEST" true)
+  jq --exit-status \
+    --arg database "${compose_project}_database" \
+    --arg edge "${compose_project}_server_edge" '
+      def exact_env($key; $value):
+        [.Config.Env[]? | select(startswith($key + "="))] ==
+          [($key + "=" + $value)];
+      .[0] |
+      exact_env("DATABASE_URL";
+        "postgres://" + env.STAGING_POSTGRES_USER + ":" +
+        env.STAGING_POSTGRES_PASSWORD + "@postgres:5432/" +
+        env.STAGING_POSTGRES_DB + "?sslmode=disable") and
+      exact_env("SERVER_HOST"; "0.0.0.0") and
+      exact_env("SERVER_PORT"; "8080") and
+      (.Mounts | length == 0) and
+      .NetworkSettings.Ports == {
+        "8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "28083"}]
+      } and
+      (.NetworkSettings.Networks | keys) == ([$database, $edge] | sort)
+    ' <<< "$server" >/dev/null 2>&1 ||
+    fail "$compose_project/server runtime configuration is invalid"
+
+  postgres=$(inspect_runtime_service postgres "$postgres_image" false)
+  jq --exit-status --arg network "${compose_project}_database" '
+    def exact_env($key; $value):
+      [.Config.Env[]? | select(startswith($key + "="))] ==
+        [($key + "=" + $value)];
+    .[0] |
+    exact_env("POSTGRES_DB"; env.STAGING_POSTGRES_DB) and
+    exact_env("POSTGRES_USER"; env.STAGING_POSTGRES_USER) and
+    exact_env("POSTGRES_PASSWORD"; env.STAGING_POSTGRES_PASSWORD) and
+    (.Mounts | length == 1) and
+    .Mounts[0].Type == "volume" and
+    .Mounts[0].Name == "xe3-speakup-staging_postgres_data" and
+    .Mounts[0].Destination == "/var/lib/postgresql" and
+    .Mounts[0].RW == true and
+    ([.NetworkSettings.Ports // {} | to_entries[] | select(.value != null)] |
+      length == 0) and
+    (.NetworkSettings.Networks | keys) == [$network]
+  ' <<< "$postgres" >/dev/null 2>&1 ||
+    fail "$compose_project/postgres runtime configuration is invalid"
+
+  RUNTIME_PORTAL_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<< "$portal")
+  RUNTIME_SERVER_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<< "$server")
+  RUNTIME_POSTGRES_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<< "$postgres")
+}
+
+verify_deployment() {
+  verify_runtime
+  verify_database_schema
+  verify_endpoints
+}
+
+write_deployment_receipt() {
+  local manifest=$1
+  local receipt=$2
+  local current_manifest_sha timestamp directory temporary
+
+  current_manifest_sha=$(sha256_file "$manifest")
+  [[ "$current_manifest_sha" == "$RELEASE_MANIFEST_SHA256" ]] ||
+    fail "release manifest changed during deployment"
+  validate_receipt_target "$receipt"
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  directory=$(path_parent "$receipt")
+  temporary=$(mktemp "$directory/.staging-receipt.tmp.XXXXXX") ||
+    fail "cannot create temporary deployment receipt"
+  if ! jq --null-input \
+    --arg manifest_sha256 "$RELEASE_MANIFEST_SHA256" \
+    --arg version "$RELEASE_VERSION" \
+    --arg git_sha "$RELEASE_GIT_SHA" \
+    --argjson database_schema_version "$RELEASE_SCHEMA_VERSION" \
+    --arg portal_image_digest "$PORTAL_IMAGE_DIGEST" \
+    --arg server_image_digest "$SERVER_IMAGE_DIGEST" \
+    --arg portal_container_id "$RUNTIME_PORTAL_CONTAINER_ID" \
+    --arg server_container_id "$RUNTIME_SERVER_CONTAINER_ID" \
+    --arg postgres_container_id "$RUNTIME_POSTGRES_CONTAINER_ID" \
+    --arg deployed_at_utc "$timestamp" '
+      {
+        receipt_version: 1,
+        manifest_sha256: $manifest_sha256,
+        version: $version,
+        git_sha: $git_sha,
+        database_schema_version: $database_schema_version,
+        portal_image_digest: $portal_image_digest,
+        server_image_digest: $server_image_digest,
+        portal_container_id: $portal_container_id,
+        server_container_id: $server_container_id,
+        postgres_container_id: $postgres_container_id,
+        deployed_at_utc: $deployed_at_utc
+      }
+    ' > "$temporary"; then
+    rm -f "$temporary"
+    fail "cannot render deployment receipt"
+  fi
+  chmod 0644 "$temporary"
+  if ! ln "$temporary" "$receipt"; then
+    rm -f "$temporary"
+    fail "deployment receipt already exists: $receipt"
+  fi
+  rm -f "$temporary"
+}
+
 validate_all() {
   local manifest=$1
   local rendered
@@ -286,6 +860,7 @@ main() {
   local manifest=""
   local environment_file=""
   local output=""
+  local receipt=""
 
   [[ -n "$command" ]] || {
     usage
@@ -309,6 +884,11 @@ main() {
         output=$2
         shift 2
         ;;
+      --receipt)
+        (($# >= 2)) || fail "--receipt requires a value"
+        receipt=$2
+        shift 2
+        ;;
       *)
         fail "unknown argument: $1"
         ;;
@@ -321,6 +901,7 @@ main() {
   case "$command" in
     render-nginx)
       [[ -z "$manifest" ]] || fail "render-nginx does not accept --manifest"
+      [[ -z "$receipt" ]] || fail "render-nginx does not accept --receipt"
       [[ -n "$output" ]] || fail "render-nginx requires --output"
       validate_configuration
       render_nginx "$output"
@@ -329,6 +910,11 @@ main() {
     validate | deploy | verify | status | down)
       [[ -n "$manifest" ]] || fail "$command requires --manifest"
       [[ -z "$output" ]] || fail "$command does not accept --output"
+      if [[ "$command" == deploy ]]; then
+        [[ -n "$receipt" ]] || fail "deploy requires --receipt"
+      else
+        [[ -z "$receipt" ]] || fail "$command does not accept --receipt"
+      fi
       validate_all "$manifest"
       case "$command" in
         validate)
@@ -336,22 +922,32 @@ main() {
             "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION"
           ;;
         deploy)
+          validate_receipt_target "$receipt"
+          acquire_deployment_lock
+          validate_all "$manifest"
+          validate_receipt_target "$receipt"
           compose pull postgres migrate server portal
-          compose up --detach --no-build --wait --wait-timeout 90 postgres
-          compose run --rm --no-deps migrate
-          compose up --detach --no-build --wait --wait-timeout 90 portal server
-          verify_endpoints
-          printf 'version=%s git_sha=%s deployed=true\n' \
-            "$RELEASE_VERSION" "$RELEASE_GIT_SHA"
+          compose up --pull never --detach --no-build --wait --wait-timeout 90 \
+            postgres
+          compose run --pull never --rm --no-deps migrate
+          verify_database_schema
+          compose up --pull never --detach --no-build --wait --wait-timeout 90 \
+            portal server
+          verify_deployment
+          write_deployment_receipt "$manifest" "$receipt"
+          printf 'version=%s git_sha=%s receipt=%s deployed=true\n' \
+            "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$receipt"
           ;;
         verify)
-          verify_endpoints
+          verify_deployment
           printf 'version=%s verified=true\n' "$RELEASE_VERSION"
           ;;
         status)
           compose ps
           ;;
         down)
+          acquire_deployment_lock
+          validate_all "$manifest"
           compose down --remove-orphans
           ;;
       esac

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -79,6 +79,160 @@ path_identity() {
   printf '%s\n' "$identity"
 }
 
+path_lstat_mode() {
+  local path=$1
+  local mode
+
+  if mode=$(stat -c '%a' -- "$path" 2>/dev/null); then
+    :
+  elif mode=$(stat -f '%Lp' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$mode"
+}
+
+path_lstat_owner() {
+  local path=$1
+  local owner
+
+  if owner=$(stat -c '%u' -- "$path" 2>/dev/null); then
+    :
+  elif owner=$(stat -f '%u' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$owner"
+}
+
+path_lstat_identity() {
+  local path=$1
+  local identity
+
+  if identity=$(stat -c '%i' -- "$path" 2>/dev/null); then
+    :
+  elif identity=$(stat -f '%i' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$identity"
+}
+
+safe_ancestor_mode() {
+  local mode=$1
+  local permissions
+
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  permissions=${mode: -3}
+  if [[ "${permissions:1:1}" != [2367] &&
+    "${permissions:2:1}" != [2367] ]]; then
+    return 0
+  fi
+
+  # A root/current-UID sticky directory such as /tmp cannot have an existing
+  # child replaced by another UID. Other group/world-writable ancestors are
+  # unsafe for deployment inputs.
+  [[ ${#mode} -eq 4 && "${mode:0:1}" == [1357] ]]
+}
+
+require_safe_path_ancestors() {
+  local description=$1
+  local path=$2
+  local parent remaining component current=/ owner mode identity
+  local -a components
+
+  valid_absolute_path "$path" ||
+    fail "$description must use a safe absolute path: $path"
+  parent=$(path_parent "$path")
+  remaining=${parent#/}
+  IFS='/' read -r -a components <<< "$remaining"
+
+  for component in "" "${components[@]}"; do
+    if [[ -n "$component" ]]; then
+      if [[ "$current" == / ]]; then
+        current="/$component"
+      else
+        current="$current/$component"
+      fi
+    fi
+    [[ ! -L "$current" ]] ||
+      fail "$description has a symbolic-link ancestor: $current"
+    identity=$(path_lstat_identity "$current") ||
+      fail "cannot inspect identity for $description ancestor: $current"
+    [[ -d "$current" && -x "$current" ]] ||
+      fail "$description ancestor is not a searchable directory: $current"
+    owner=$(path_lstat_owner "$current") ||
+      fail "cannot inspect owner for $description ancestor: $current"
+    [[ "$owner" == 0 || "$owner" == "$(id -u)" ]] ||
+      fail "$description ancestor has an untrusted owner: $current"
+    mode=$(path_lstat_mode "$current") ||
+      fail "cannot inspect permissions for $description ancestor: $current"
+    safe_ancestor_mode "$mode" ||
+      fail "$description ancestor has unsafe permissions: $current"
+    [[ ! -L "$current" &&
+      "$(path_lstat_identity "$current")" == "$identity" ]] ||
+      fail "$description ancestor changed during validation: $current"
+  done
+}
+
+normalize_absolute_path() {
+  local path=$1
+  local component normalized=
+  local -a components stack
+
+  [[ "$path" == /* && "$path" =~ ^/[A-Za-z0-9._/-]+$ ]] || return 1
+  IFS='/' read -r -a components <<< "$path"
+  for component in "${components[@]}"; do
+    case "$component" in
+      "" | .)
+        ;;
+      ..)
+        ((${#stack[@]} > 0)) || return 1
+        unset "stack[$((${#stack[@]} - 1))]"
+        ;;
+      *)
+        stack+=("$component")
+        ;;
+    esac
+  done
+  for component in "${stack[@]}"; do
+    normalized="$normalized/$component"
+  done
+  printf '%s\n' "${normalized:-/}"
+}
+
+resolve_allowed_final_symlink() {
+  local description=$1
+  local file=$2
+  local link_target resolved
+
+  require_safe_path_ancestors "$description" "$file"
+  if [[ ! -L "$file" ]]; then
+    printf '%s\n' "$file"
+    return
+  fi
+
+  link_target=$(readlink "$file") ||
+    fail "cannot read $description symbolic link: $file"
+  if [[ "$link_target" == /* ]]; then
+    resolved=$(normalize_absolute_path "$link_target") ||
+      fail "$description symbolic-link target is unsafe: $file"
+  else
+    resolved=$(normalize_absolute_path \
+      "$(path_parent "$file")/$link_target") ||
+      fail "$description symbolic-link target is unsafe: $file"
+  fi
+  require_safe_path_ancestors "$description target" "$resolved"
+  [[ ! -L "$resolved" ]] ||
+    fail "$description symbolic-link target must not be another link: $resolved"
+  [[ -L "$file" && "$(readlink "$file")" == "$link_target" ]] ||
+    fail "$description symbolic link changed during validation: $file"
+  printf '%s\n' "$resolved"
+}
+
 require_current_owner() {
   local description=$1
   local path=$2
@@ -104,6 +258,7 @@ require_private_file() {
   local file=$2
   local mode
 
+  require_safe_path_ancestors "$description" "$file"
   [[ ! -L "$file" ]] || fail "$description must not be a symbolic link: $file"
   require_regular_file "$description" "$file"
   require_current_owner "$description" "$file"
@@ -121,14 +276,16 @@ require_private_file() {
 require_private_key_file() {
   local description=$1
   local file=$2
+  local target
   local mode
 
-  # Certbot's stable live/privkey.pem path is a symlink. All checks below use
-  # dereferencing stat and therefore apply to its current archive target.
-  require_regular_file "$description" "$file"
-  require_current_owner "$description target" "$file"
-  mode=$(path_mode "$file") ||
-    fail "cannot inspect permissions for $description target: $file"
+  # Only TLS inputs permit a final Certbot live/*.pem symlink. The declared
+  # path, resolved archive target, and both ancestor chains are validated.
+  target=$(resolve_allowed_final_symlink "$description" "$file")
+  require_regular_file "$description" "$target"
+  require_current_owner "$description target" "$target"
+  mode=$(path_mode "$target") ||
+    fail "cannot inspect permissions for $description target: $target"
   case "$mode" in
     400 | 600)
       ;;
@@ -140,12 +297,14 @@ require_private_key_file() {
 
 require_public_certificate() {
   local file=$1
+  local target
   local mode
 
-  require_regular_file "TLS certificate" "$file"
-  require_current_owner "TLS certificate" "$file"
-  mode=$(path_mode "$file") ||
-    fail "cannot inspect permissions for TLS certificate: $file"
+  target=$(resolve_allowed_final_symlink "TLS certificate" "$file")
+  require_regular_file "TLS certificate" "$target"
+  require_current_owner "TLS certificate target" "$target"
+  mode=$(path_mode "$target") ||
+    fail "cannot inspect permissions for TLS certificate target: $target"
   case "$mode" in
     400 | 440 | 444 | 600 | 640 | 644)
       ;;
@@ -161,6 +320,7 @@ require_owned_directory() {
   local allowed_modes=$3
   local mode
 
+  require_safe_path_ancestors "$description" "$directory"
   [[ ! -L "$directory" ]] ||
     fail "$description must not be a symbolic link: $directory"
   [[ -d "$directory" ]] || fail "$description does not exist: $directory"

--- a/deploy/staging/nginx.conf.template
+++ b/deploy/staging/nginx.conf.template
@@ -28,8 +28,8 @@ server {
     ssl_certificate __STAGING_TLS_CERTIFICATE__;
     ssl_certificate_key __STAGING_TLS_CERTIFICATE_KEY__;
 
-    access_log /var/log/nginx/xe3-speakup-staging-portal.access.log;
-    error_log /var/log/nginx/xe3-speakup-staging-portal.error.log warn;
+    access_log logs/xe3-speakup-staging-portal.access.log;
+    error_log logs/xe3-speakup-staging-portal.error.log warn;
 
     auth_basic "SpeakUp Staging";
     auth_basic_user_file __STAGING_HTPASSWD_FILE__;
@@ -62,8 +62,8 @@ server {
     ssl_certificate __STAGING_TLS_CERTIFICATE__;
     ssl_certificate_key __STAGING_TLS_CERTIFICATE_KEY__;
 
-    access_log /var/log/nginx/xe3-speakup-staging-api.access.log;
-    error_log /var/log/nginx/xe3-speakup-staging-api.error.log warn;
+    access_log logs/xe3-speakup-staging-api.access.log;
+    error_log logs/xe3-speakup-staging-api.error.log warn;
 
     add_header X-Content-Type-Options nosniff always;
     add_header Referrer-Policy no-referrer always;

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly manage="$staging_directory/manage.sh"
 readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
-readonly container_fixture_directory="/tmp/staging-nginx-test"
 
 command -v docker >/dev/null 2>&1 || {
   printf '%s\n' 'docker is required for the Nginx configuration check' >&2
@@ -32,6 +31,10 @@ openssl req \
   -keyout "$temporary_directory/privkey.pem" \
   -out "$temporary_directory/fullchain.pem" \
   >/dev/null 2>&1
+chmod 0600 \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/privkey.pem"
 
 printf '%s\n' \
   'STAGING_POSTGRES_DB=speakup_staging' \
@@ -41,11 +44,12 @@ printf '%s\n' \
   "STAGING_SERVER_ENV_FILE=$temporary_directory/server.env" \
   'STAGING_PORTAL_HOST=staging.speak-up.top' \
   'STAGING_API_HOST=staging-api.speak-up.top' \
-  "STAGING_TLS_CERTIFICATE=$container_fixture_directory/fullchain.pem" \
-  "STAGING_TLS_CERTIFICATE_KEY=$container_fixture_directory/privkey.pem" \
-  "STAGING_HTPASSWD_FILE=$container_fixture_directory/staging.htpasswd" \
-  "STAGING_ACME_ROOT=$container_fixture_directory/acme" \
+  "STAGING_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
+  "STAGING_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
+  "STAGING_HTPASSWD_FILE=$temporary_directory/staging.htpasswd" \
+  "STAGING_ACME_ROOT=$temporary_directory/acme" \
   >"$temporary_directory/staging.env"
+chmod 0600 "$temporary_directory/staging.env"
 
 "$manage" render-nginx \
   --env-file "$temporary_directory/staging.env" \
@@ -53,7 +57,7 @@ printf '%s\n' \
   >/dev/null
 
 docker run --rm \
-  --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory:$temporary_directory:ro" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   "$nginx_image" \
   nginx -t

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -20,7 +20,7 @@ temporary_directory=$(cd "$temporary_directory" && pwd -P)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 
-mkdir -p "$temporary_directory/acme"
+mkdir -p "$temporary_directory/acme" "$temporary_directory/logs"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
 printf '%s\n' 'staging:test-password-hash' >"$temporary_directory/staging.htpasswd"
 openssl req \
@@ -57,8 +57,20 @@ chmod 0600 "$temporary_directory/staging.env"
   --output "$temporary_directory/default.conf" \
   >/dev/null
 
+for expected in \
+  'access_log logs/xe3-speakup-staging-portal.access.log;' \
+  'error_log logs/xe3-speakup-staging-portal.error.log warn;' \
+  'access_log logs/xe3-speakup-staging-api.access.log;' \
+  'error_log logs/xe3-speakup-staging-api.error.log warn;'; do
+  grep -Fq -- "$expected" "$temporary_directory/default.conf" || {
+    printf 'missing expected Nginx log directive: %s\n' "$expected" >&2
+    exit 1
+  }
+done
+
 docker run --rm \
   --volume "$temporary_directory:$temporary_directory:ro" \
+  --volume "$temporary_directory/logs:/etc/nginx/logs" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   "$nginx_image" \
   nginx -t

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -16,6 +16,7 @@ command -v openssl >/dev/null 2>&1 || {
 }
 
 temporary_directory=$(mktemp -d)
+temporary_directory=$(cd "$temporary_directory" && pwd -P)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -77,6 +77,7 @@ write_manifest() {
 }
 
 temporary_directory=$(mktemp -d)
+temporary_directory=$(cd "$temporary_directory" && pwd -P)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 
@@ -220,6 +221,17 @@ expect_failure "symbolic-link Staging environment" \
     --manifest "$temporary_directory/release-manifest.json" \
     --env-file "$temporary_directory/symlink-staging.env"
 
+mkdir "$temporary_directory/staging-env-ancestor-target"
+cp "$temporary_directory/staging.env" \
+  "$temporary_directory/staging-env-ancestor-target/staging.env"
+chmod 0600 "$temporary_directory/staging-env-ancestor-target/staging.env"
+ln -s "$temporary_directory/staging-env-ancestor-target" \
+  "$temporary_directory/staging-env-ancestor-link"
+expect_failure "Staging environment with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging-env-ancestor-link/staging.env"
+
 cp "$temporary_directory/server.env" "$temporary_directory/insecure-server.env"
 chmod 0644 "$temporary_directory/insecure-server.env"
 write_environment "$temporary_directory/insecure-server-config.env" \
@@ -236,6 +248,77 @@ expect_failure "symbolic-link Server environment" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
     --env-file "$temporary_directory/server-link-config.env"
+
+mkdir -p \
+  "$temporary_directory/input-ancestor-target/nested/acme" \
+  "$temporary_directory/unsafe-input-ancestor/nested"
+cp "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/input-ancestor-target/nested/"
+chmod 0600 \
+  "$temporary_directory/input-ancestor-target/nested/server.env" \
+  "$temporary_directory/input-ancestor-target/nested/privkey.pem" \
+  "$temporary_directory/input-ancestor-target/nested/staging.htpasswd"
+ln -s "$temporary_directory/input-ancestor-target" \
+  "$temporary_directory/input-ancestor-link"
+
+write_environment "$temporary_directory/server-ancestor-link.env" \
+  "$temporary_directory/input-ancestor-link/nested/server.env"
+expect_failure "Server environment with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/server-ancestor-link.env"
+
+write_environment "$temporary_directory/certificate-ancestor-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/input-ancestor-link/nested/fullchain.pem"
+expect_failure "TLS certificate with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/certificate-ancestor-link.env"
+
+write_environment "$temporary_directory/key-ancestor-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/input-ancestor-link/nested/privkey.pem"
+expect_failure "TLS private key with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/key-ancestor-link.env"
+
+write_environment "$temporary_directory/htpasswd-ancestor-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/input-ancestor-link/nested/staging.htpasswd"
+expect_failure "htpasswd with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/htpasswd-ancestor-link.env"
+
+write_environment "$temporary_directory/acme-ancestor-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/input-ancestor-link/nested/acme"
+expect_failure "ACME root with a symbolic-link ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/acme-ancestor-link.env"
+
+chmod 0777 "$temporary_directory/unsafe-input-ancestor"
+cp "$temporary_directory/server.env" \
+  "$temporary_directory/unsafe-input-ancestor/nested/server.env"
+chmod 0600 "$temporary_directory/unsafe-input-ancestor/nested/server.env"
+write_environment "$temporary_directory/unsafe-server-ancestor.env" \
+  "$temporary_directory/unsafe-input-ancestor/nested/server.env"
+expect_failure "Server environment with an unsafe writable ancestor" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/unsafe-server-ancestor.env"
 
 cp "$temporary_directory/privkey.pem" "$temporary_directory/insecure-key.pem"
 chmod 0644 "$temporary_directory/insecure-key.pem"
@@ -259,6 +342,30 @@ write_environment "$temporary_directory/key-link.env" \
   > "$temporary_directory/key-link-validate.out"
 grep -Fq 'validated=true' "$temporary_directory/key-link-validate.out" ||
   fail "valid Certbot-style TLS private-key symlink was rejected"
+
+mkdir -p \
+  "$temporary_directory/certbot/live/staging.speak-up.top" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top"
+cp "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/fullchain1.pem"
+cp "$temporary_directory/privkey.pem" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
+chmod 0600 \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
+ln -s ../../archive/staging.speak-up.top/fullchain1.pem \
+  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem"
+ln -s ../../archive/staging.speak-up.top/privkey1.pem \
+  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
+write_environment "$temporary_directory/certbot-links.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem" \
+  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
+"$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/certbot-links.env" \
+  > "$temporary_directory/certbot-links.out"
+grep -Fq 'validated=true' "$temporary_directory/certbot-links.out" ||
+  fail "valid Certbot live/archive links were rejected"
 
 ln -s "$temporary_directory/not-there-key.pem" \
   "$temporary_directory/broken-key-link.pem"
@@ -395,7 +502,7 @@ done
 expect_failure "TLS private-key symlink target owned by another UID" \
   env \
     TEST_REAL_STAT="$real_stat" \
-    TEST_WRONG_OWNER_PATH="$temporary_directory/key-link.pem" \
+    TEST_WRONG_OWNER_PATH="$temporary_directory/privkey.pem" \
     PATH="$temporary_directory/fake-owner-bin:$PATH" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
@@ -1062,6 +1169,22 @@ expect_failure "symbolic-link deployment lock directory" env \
     --env-file "$temporary_directory/staging.env"
 [[ ! -e "$temporary_directory/real-lock-directory/deploy.lock" ]] ||
   fail "deployment followed a symbolic-link lock directory"
+
+mkdir -p "$temporary_directory/real-lock-ancestor/nested"
+chmod 0700 \
+  "$temporary_directory/real-lock-ancestor" \
+  "$temporary_directory/real-lock-ancestor/nested"
+ln -s "$temporary_directory/real-lock-ancestor" \
+  "$temporary_directory/symlink-lock-ancestor"
+expect_failure "deployment lock with a symbolic-link ancestor" env \
+  COMMAND_LOG="$temporary_directory/symlink-lock-ancestor.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/symlink-lock-ancestor/nested/deploy.lock" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+[[ ! -e "$temporary_directory/real-lock-ancestor/nested/deploy.lock" ]] ||
+  fail "deployment followed a symbolic-link lock ancestor"
 
 mkdir "$temporary_directory/race-lock-directory"
 chmod 0700 "$temporary_directory/race-lock-directory"

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -8,6 +8,9 @@ readonly compose_file="$staging_directory/compose.yaml"
 readonly portal_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 readonly server_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 readonly git_sha="cccccccccccccccccccccccccccccccccccccccc"
+readonly staging_apk_sha="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+readonly production_apk_sha="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+readonly certificate_sha="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 
 fail() {
   printf 'staging deploy test: %s\n' "$*" >&2
@@ -25,6 +28,10 @@ expect_failure() {
 write_environment() {
   local destination=$1
   local server_environment=$2
+  local certificate=${3:-$temporary_directory/fullchain.pem}
+  local certificate_key=${4:-$temporary_directory/privkey.pem}
+  local htpasswd=${5:-$temporary_directory/staging.htpasswd}
+  local acme_root=${6:-$temporary_directory/acme}
 
   printf '%s\n' \
     'STAGING_POSTGRES_DB=speakup_staging' \
@@ -34,10 +41,11 @@ write_environment() {
     "STAGING_SERVER_ENV_FILE=$server_environment" \
     'STAGING_PORTAL_HOST=staging.speak-up.top' \
     'STAGING_API_HOST=staging-api.speak-up.top' \
-    "STAGING_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
-    "STAGING_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
-    "STAGING_HTPASSWD_FILE=$temporary_directory/staging.htpasswd" \
-    "STAGING_ACME_ROOT=$temporary_directory/acme" >"$destination"
+    "STAGING_TLS_CERTIFICATE=$certificate" \
+    "STAGING_TLS_CERTIFICATE_KEY=$certificate_key" \
+    "STAGING_HTPASSWD_FILE=$htpasswd" \
+    "STAGING_ACME_ROOT=$acme_root" >"$destination"
+  chmod 0600 "$destination"
 }
 
 write_manifest() {
@@ -54,7 +62,17 @@ write_manifest() {
     "  \"portal_image_digest\": \"$selected_portal_digest\"," \
     '  "server_image": "ghcr.io/1024xengineer/xe3-esl-server",' \
     "  \"server_image_digest\": \"$server_digest\"," \
-    '  "database_schema_version": 7' \
+    '  "staging_apk_file": "speakup-v0.1.1-staging-arm64.apk",' \
+    "  \"staging_apk_sha256\": \"$staging_apk_sha\"," \
+    '  "production_apk_file": "speakup-v0.1.1-production-arm64.apk",' \
+    '  "production_apk_size_bytes": 123456,' \
+    "  \"production_apk_sha256\": \"$production_apk_sha\"," \
+    '  "application_id": "com.xengineer.speakup",' \
+    '  "minimum_android_api": 24,' \
+    '  "abis": ["arm64-v8a"],' \
+    "  \"apk_certificate_sha256\": \"$certificate_sha\"," \
+    '  "database_schema_version": 7,' \
+    '  "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"' \
     '}' >"$destination"
 }
 
@@ -67,6 +85,10 @@ printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/ser
 printf '%s\n' 'test-user:test-password-hash' >"$temporary_directory/staging.htpasswd"
 printf '%s\n' 'test-certificate-placeholder' >"$temporary_directory/fullchain.pem"
 printf '%s\n' 'test-key-placeholder' >"$temporary_directory/privkey.pem"
+chmod 0600 \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/privkey.pem"
 write_environment "$temporary_directory/staging.env" "$temporary_directory/server.env"
 write_manifest "$temporary_directory/release-manifest.json"
 
@@ -93,6 +115,31 @@ expect_failure "placeholder Portal digest" \
   --manifest "$temporary_directory/zero-digest-manifest.json" \
   --env-file "$temporary_directory/staging.env"
 
+jq 'del(.quality_run_url)' \
+  "$temporary_directory/release-manifest.json" \
+  > "$temporary_directory/incomplete-manifest.json"
+expect_failure "incomplete release manifest" \
+  "$manage" validate \
+    --manifest "$temporary_directory/incomplete-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+
+jq '.unexpected = true' \
+  "$temporary_directory/release-manifest.json" \
+  > "$temporary_directory/extended-manifest.json"
+expect_failure "release manifest with an unknown field" \
+  "$manage" validate \
+    --manifest "$temporary_directory/extended-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+
+printf '%s\n%s\n' \
+  "$(< "$temporary_directory/release-manifest.json")" \
+  "$(< "$temporary_directory/release-manifest.json")" \
+  > "$temporary_directory/multiple-manifests.json"
+expect_failure "multiple release manifest documents" \
+  "$manage" validate \
+    --manifest "$temporary_directory/multiple-manifests.json" \
+    --env-file "$temporary_directory/staging.env"
+
 expect_failure "missing release manifest" \
   "$manage" validate \
   --manifest "$temporary_directory/missing.json" \
@@ -105,6 +152,7 @@ expect_failure "missing environment file" \
 
 sed 's/^PORTAL_ADMIN_PASSWORD=.*/PORTAL_ADMIN_PASSWORD=/' \
   "$temporary_directory/staging.env" >"$temporary_directory/missing-value.env"
+chmod 0600 "$temporary_directory/missing-value.env"
 expect_failure "missing required environment value" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
@@ -112,6 +160,7 @@ expect_failure "missing required environment value" \
 
 sed '/^PORTAL_ADMIN_PASSWORD=/d' \
   "$temporary_directory/staging.env" >"$temporary_directory/missing-key.env"
+chmod 0600 "$temporary_directory/missing-key.env"
 expect_failure "ambient value replacing a missing environment key" \
   env PORTAL_ADMIN_PASSWORD=ambient-password-must-not-be-used \
   "$manage" validate \
@@ -121,16 +170,236 @@ expect_failure "ambient value replacing a missing environment key" \
 printf '%s\n' \
   "$(<"$temporary_directory/staging.env")" \
   'UNKNOWN_SETTING=typo' >"$temporary_directory/unknown.env"
+chmod 0600 "$temporary_directory/unknown.env"
 expect_failure "unknown environment setting" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
   --env-file "$temporary_directory/unknown.env"
 
+readonly secret_sentinel='must-not-leak-environment-secret-sentinel'
+environment_leak_index=0
+for unsafe_environment_line in \
+  "$secret_sentinel" \
+  "INVALID-KEY=$secret_sentinel" \
+  "UNSUPPORTED_SECRET_KEY=$secret_sentinel"; do
+  environment_leak_index=$((environment_leak_index + 1))
+  leak_environment="$temporary_directory/leak-$environment_leak_index.env"
+  leak_output="$temporary_directory/leak-$environment_leak_index.out"
+  printf '%s\n%s\n' \
+    "$(< "$temporary_directory/staging.env")" \
+    "$unsafe_environment_line" > "$leak_environment"
+  chmod 0600 "$leak_environment"
+  if "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$leak_environment" > "$leak_output" 2>&1; then
+    fail "invalid environment entry unexpectedly succeeded"
+  fi
+  if grep -Fq "$secret_sentinel" "$leak_output"; then
+    fail "invalid environment entry leaked its raw content"
+  fi
+  grep -Eq 'at line [1-9][0-9]*' "$leak_output" ||
+    fail "invalid environment entry did not report a safe line number"
+done
+
 write_environment "$temporary_directory/missing-server.env" "$temporary_directory/not-there.env"
 expect_failure "missing Server environment file" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/missing-server.env"
+    --env-file "$temporary_directory/missing-server.env"
+
+cp "$temporary_directory/staging.env" "$temporary_directory/insecure-staging.env"
+chmod 0640 "$temporary_directory/insecure-staging.env"
+expect_failure "group-readable Staging environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-staging.env"
+
+ln -s "$temporary_directory/staging.env" "$temporary_directory/symlink-staging.env"
+expect_failure "symbolic-link Staging environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/symlink-staging.env"
+
+cp "$temporary_directory/server.env" "$temporary_directory/insecure-server.env"
+chmod 0644 "$temporary_directory/insecure-server.env"
+write_environment "$temporary_directory/insecure-server-config.env" \
+  "$temporary_directory/insecure-server.env"
+expect_failure "world-readable Server environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-server-config.env"
+
+ln -s "$temporary_directory/server.env" "$temporary_directory/server-link.env"
+write_environment "$temporary_directory/server-link-config.env" \
+  "$temporary_directory/server-link.env"
+expect_failure "symbolic-link Server environment" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/server-link-config.env"
+
+cp "$temporary_directory/privkey.pem" "$temporary_directory/insecure-key.pem"
+chmod 0644 "$temporary_directory/insecure-key.pem"
+write_environment "$temporary_directory/insecure-key.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-key.pem"
+expect_failure "world-readable TLS private key" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-key.env"
+
+ln -s "$temporary_directory/privkey.pem" "$temporary_directory/key-link.pem"
+write_environment "$temporary_directory/key-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/key-link.pem"
+"$manage" validate \
+  --manifest "$temporary_directory/release-manifest.json" \
+  --env-file "$temporary_directory/key-link.env" \
+  > "$temporary_directory/key-link-validate.out"
+grep -Fq 'validated=true' "$temporary_directory/key-link-validate.out" ||
+  fail "valid Certbot-style TLS private-key symlink was rejected"
+
+ln -s "$temporary_directory/not-there-key.pem" \
+  "$temporary_directory/broken-key-link.pem"
+write_environment "$temporary_directory/broken-key-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/broken-key-link.pem"
+expect_failure "broken TLS private-key symlink" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/broken-key-link.env"
+
+ln -s "$temporary_directory/insecure-key.pem" \
+  "$temporary_directory/insecure-key-link.pem"
+write_environment "$temporary_directory/insecure-key-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-key-link.pem"
+expect_failure "TLS private-key symlink with an insecure target" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-key-link.env"
+
+cp "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/insecure.htpasswd"
+chmod 0644 "$temporary_directory/insecure.htpasswd"
+write_environment "$temporary_directory/insecure-htpasswd.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/insecure.htpasswd"
+expect_failure "world-readable htpasswd" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-htpasswd.env"
+
+ln -s "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/htpasswd-link"
+write_environment "$temporary_directory/htpasswd-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/htpasswd-link"
+expect_failure "symbolic-link htpasswd" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/htpasswd-link.env"
+
+cp "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-certificate.pem"
+chmod 0664 "$temporary_directory/insecure-certificate.pem"
+write_environment "$temporary_directory/insecure-certificate.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/insecure-certificate.pem"
+expect_failure "group-writable public certificate" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-certificate.env"
+
+mkdir "$temporary_directory/insecure-acme"
+chmod 0777 "$temporary_directory/insecure-acme"
+write_environment "$temporary_directory/insecure-acme.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/insecure-acme"
+expect_failure "world-writable ACME root" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/insecure-acme.env"
+
+mkdir "$temporary_directory/acme-target"
+ln -s "$temporary_directory/acme-target" "$temporary_directory/acme-link"
+write_environment "$temporary_directory/acme-link.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/acme-link"
+expect_failure "symbolic-link ACME root" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/acme-link.env"
+
+real_id=$(command -v id)
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ "${1:-}" == -u ]]; then' \
+  '  printf "%s\\n" 999999' \
+  '  exit' \
+  'fi' \
+  'exec "$TEST_REAL_ID" "$@"' > "$temporary_directory/fake-bin/id"
+chmod +x "$temporary_directory/fake-bin/id"
+expect_failure "Staging environment owned by another UID" \
+  env TEST_REAL_ID="$real_id" PATH="$temporary_directory/fake-bin:$PATH" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+rm "$temporary_directory/fake-bin/id"
+
+mkdir "$temporary_directory/fake-owner-bin"
+real_stat=$(command -v stat)
+cat > "$temporary_directory/fake-owner-bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+path=${!#}
+if [[ "$path" == "${TEST_WRONG_OWNER_PATH:-}" ]]; then
+  for argument in "$@"; do
+    if [[ "$argument" == '%u' ]]; then
+      printf '%s\n' 999999
+      exit
+    fi
+  done
+fi
+exec "$TEST_REAL_STAT" "$@"
+EOF
+chmod +x "$temporary_directory/fake-owner-bin/stat"
+for owner_case in \
+  "$temporary_directory/server.env|Server environment" \
+  "$temporary_directory/fullchain.pem|public certificate" \
+  "$temporary_directory/acme|ACME root"; do
+  owner_path=${owner_case%%|*}
+  owner_description=${owner_case#*|}
+  expect_failure "$owner_description owned by another UID" \
+    env \
+      TEST_REAL_STAT="$real_stat" \
+      TEST_WRONG_OWNER_PATH="$owner_path" \
+      PATH="$temporary_directory/fake-owner-bin:$PATH" \
+    "$manage" validate \
+      --manifest "$temporary_directory/release-manifest.json" \
+      --env-file "$temporary_directory/staging.env"
+done
+expect_failure "TLS private-key symlink target owned by another UID" \
+  env \
+    TEST_REAL_STAT="$real_stat" \
+    TEST_WRONG_OWNER_PATH="$temporary_directory/key-link.pem" \
+    PATH="$temporary_directory/fake-owner-bin:$PATH" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/key-link.env"
 
 "$manage" render-nginx \
   --env-file "$temporary_directory/staging.env" \
@@ -198,74 +467,647 @@ jq --exit-status \
   ' "$temporary_directory/compose.json" >/dev/null ||
   fail "resolved Compose model violates the isolation contract"
 
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'set -euo pipefail' \
-  'printf "docker %s\n" "$*" >>"$COMMAND_LOG"' \
-  'if [[ "${FAIL_MIGRATION:-0}" == 1 && "$*" == *"run --rm --no-deps migrate"* ]]; then' \
-  '  exit 71' \
-  'fi' >"$temporary_directory/fake-bin/docker"
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'set -euo pipefail' \
-  'printf "curl %s\n" "$*" >>"$COMMAND_LOG"' \
-  '[[ "${FAIL_HEALTH:-0}" != 1 ]]' >"$temporary_directory/fake-bin/curl"
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'exit 0' >"$temporary_directory/fake-bin/sleep"
+cat > "$temporary_directory/fake-bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'docker %s\n' "$*" >> "$COMMAND_LOG"
+
+readonly portal_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly server_id=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+readonly postgres_id=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+readonly project=xe3-speakup-staging
+
+if [[ "${1:-}" == compose ]]; then
+  command_line=" $* "
+  if [[ "$command_line" == *" run "* &&
+    "$command_line" == *"/usr/local/bin/speakup-migrate version"* ]]; then
+    printf '%s\n' "${SCHEMA_OUTPUT:-version=7 dirty=false}"
+    exit
+  fi
+  if [[ "$command_line" == *" run "* && "$command_line" == *" migrate "* ]]; then
+    [[ "${FAIL_MIGRATION:-0}" != 1 ]] || exit 71
+    printf '%s\n' 'migrations=applied'
+    exit
+  fi
+  exit
+fi
+
+if [[ "${1:-}" == ps ]]; then
+  all=0
+  service=""
+  requested_project=""
+  shift
+  while (($# > 0)); do
+    case "$1" in
+      --all)
+        all=1
+        shift
+        ;;
+      --filter)
+        case "$2" in
+          label=com.docker.compose.project=*)
+            requested_project=${2#label=com.docker.compose.project=}
+            ;;
+          label=com.docker.compose.service=*)
+            service=${2#label=com.docker.compose.service=}
+            ;;
+        esac
+        shift 2
+        ;;
+      --format)
+        shift 2
+        ;;
+      *)
+        exit 2
+        ;;
+    esac
+  done
+  runtime_project=${TEST_RUNTIME_PROJECT:-$project}
+  [[ "$requested_project" == "$runtime_project" ]] || exit
+  if ((all == 1)); then
+    for candidate in portal postgres server; do
+      [[ "$candidate" != "${TEST_MISSING_SERVICE:-}" ]] || continue
+      printf '%s\n' "$candidate"
+    done
+    [[ "${TEST_EXTRA_SERVICE:-0}" != 1 ]] || printf '%s\n' legacy
+    exit
+  fi
+  [[ "$service" != "${TEST_MISSING_SERVICE:-}" ]] || exit
+  case "$service" in
+    portal) printf '%.12s\n' "$portal_id" ;;
+    server) printf '%.12s\n' "$server_id" ;;
+    postgres) printf '%.12s\n' "$postgres_id" ;;
+    *) exit 2 ;;
+  esac
+  [[ "$service" != "${TEST_DUPLICATE_SERVICE:-}" ]] ||
+    printf '%s\n' dddddddddddd
+  exit
+fi
+
+if [[ "${1:-}" == inspect && "$#" == 2 ]]; then
+  case "$2" in
+    aaaaaaaaaaaa)
+      id=$portal_id
+      service=portal
+      image="ghcr.io/1024xengineer/xe3-esl-portal@${TEST_RUNTIME_PORTAL_DIGEST:-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+      mounts='[{"Type":"volume","Name":"xe3-speakup-staging_portal_data","Destination":"/app/.wrangler","RW":true}]'
+      ports='{"3000/tcp":[{"HostIp":"127.0.0.1","HostPort":"28082"}]}'
+      networks='{"xe3-speakup-staging_portal_edge":{}}'
+      environment='["NODE_ENV=production","PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests","PORTAL_SQLITE_PATH=/app/.wrangler/portal.sqlite","VINEXT_TRUSTED_HOSTS=staging.speak-up.top"]'
+      ;;
+    bbbbbbbbbbbb)
+      id=$server_id
+      service=server
+      image="ghcr.io/1024xengineer/xe3-esl-server@${TEST_RUNTIME_SERVER_DIGEST:-sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
+      mounts='[]'
+      ports='{"8080/tcp":[{"HostIp":"127.0.0.1","HostPort":"28083"}]}'
+      networks='{"xe3-speakup-staging_database":{},"xe3-speakup-staging_server_edge":{}}'
+      environment='["TEXT_GENERATION_PROVIDER=test-fixture","DATABASE_URL=postgres://speakup_staging:0123456789abcdef0123456789abcdef@postgres:5432/speakup_staging?sslmode=disable","SERVER_HOST=0.0.0.0","SERVER_PORT=8080"]'
+      ;;
+    cccccccccccc)
+      id=$postgres_id
+      service=postgres
+      image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+      mounts='[{"Type":"volume","Name":"xe3-speakup-staging_postgres_data","Destination":"/var/lib/postgresql","RW":true}]'
+      ports='{"5432/tcp":null}'
+      networks='{"xe3-speakup-staging_database":{}}'
+      environment='["PGDATA=/var/lib/postgresql/18/docker","POSTGRES_DB=speakup_staging","POSTGRES_USER=speakup_staging","POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef"]'
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  health=healthy
+  runtime_project=${TEST_RUNTIME_PROJECT:-$project}
+  project_label=$runtime_project
+  [[ "${TEST_BAD_CONTAINER_LABEL:-}" != "$service" ]] || project_label=wrong-project
+  [[ "${TEST_UNHEALTHY_SERVICE:-}" != "$service" ]] || health=unhealthy
+  if [[ "${TEST_BAD_RUNTIME_IMAGE:-}" == "$service" ]]; then
+    image="${image%sha256:*}sha256:9999999999999999999999999999999999999999999999999999999999999999"
+  fi
+  if [[ "${TEST_BAD_VOLUME_SERVICE:-}" == "$service" ]]; then
+    mounts='[{"Type":"volume","Name":"wrong-volume","Destination":"/wrong","RW":true}]'
+  fi
+  [[ "${TEST_BAD_PORT_SERVICE:-}" != "$service" ]] || ports='{}'
+  [[ "${TEST_BAD_NETWORK_SERVICE:-}" != "$service" ]] || networks='{}'
+  jq --null-input \
+    --arg id "$id" \
+    --arg project "$project_label" \
+    --arg service "$service" \
+    --arg image "$image" \
+    --arg health "$health" \
+    --argjson environment "$environment" \
+    --argjson mounts "$mounts" \
+    --argjson ports "$ports" \
+    --argjson networks "$networks" '
+      [{
+        Id: $id,
+        Config: {
+          Image: $image,
+          Env: $environment,
+          Labels: {
+            "com.docker.compose.project": $project,
+            "com.docker.compose.service": $service
+          }
+        },
+        State: {Status: "running", Running: true, Health: {Status: $health}},
+        Mounts: $mounts,
+        NetworkSettings: {Ports: $ports, Networks: $networks}
+      }]
+    '
+  exit
+fi
+
+if [[ "${1:-}" == image && "${2:-}" == inspect && "$#" == 3 ]]; then
+  expected_image=$3
+  case "$expected_image" in
+    ghcr.io/1024xengineer/xe3-esl-portal@*) service=portal ;;
+    ghcr.io/1024xengineer/xe3-esl-server@*) service=server ;;
+    postgres:18-bookworm@*) service=postgres ;;
+    *) exit 1 ;;
+  esac
+  [[ "${TEST_MISSING_IMAGE:-}" != "$service" ]] || exit 1
+  architecture=amd64
+  [[ "${TEST_BAD_IMAGE_PLATFORM:-}" != "$service" ]] || architecture=arm64
+  if [[ "$service" == postgres ]]; then
+    labels='{}'
+  else
+    version=0.1.1
+    [[ "${TEST_BAD_OCI_LABEL:-}" != "$service" ]] || version=9.9.9
+    labels=$(jq --null-input \
+      --arg version "$version" \
+      --arg revision cccccccccccccccccccccccccccccccccccccccc '
+        {
+          "org.opencontainers.image.source":
+            "https://github.com/1024XEngineer/XE3-ESL",
+          "org.opencontainers.image.revision": $revision,
+          "org.opencontainers.image.version": $version
+        }
+      ')
+  fi
+  repo_digests=$(jq --null-input --arg image "$expected_image" '[$image]')
+  [[ "${TEST_BAD_REPO_DIGEST:-}" != "$service" ]] || repo_digests='[]'
+  jq --null-input \
+    --arg image "$expected_image" \
+    --arg architecture "$architecture" \
+    --argjson labels "$labels" \
+    --argjson repo_digests "$repo_digests" '
+      [{
+        Id: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        RepoDigests: $repo_digests,
+        Os: "linux",
+        Architecture: $architecture,
+        Config: {Labels: $labels}
+      }]
+    '
+  exit
+fi
+
+if [[ "${1:-}" == network && "${2:-}" == inspect && "$#" == 3 ]]; then
+  name=$3
+  logical_name=${name#xe3-speakup-staging_}
+  case "$logical_name" in
+    portal_edge | server_edge) internal=false ;;
+    database) internal=true ;;
+    *) exit 1 ;;
+  esac
+  [[ "${TEST_DATABASE_NETWORK_PUBLIC:-0}" != 1 || "$logical_name" != database ]] ||
+    internal=false
+  project_label=$project
+  [[ "${TEST_BAD_NETWORK_LABEL:-}" != "$logical_name" ]] || project_label=wrong-project
+  jq --null-input \
+    --arg name "$name" \
+    --arg project "$project_label" \
+    --arg logical_name "$logical_name" \
+    --argjson internal "$internal" '
+      [{
+        Name: $name,
+        Internal: $internal,
+        Labels: {
+          "com.docker.compose.project": $project,
+          "com.docker.compose.network": $logical_name
+        }
+      }]
+    '
+  exit
+fi
+
+if [[ "${1:-}" == volume && "${2:-}" == inspect && "$#" == 3 ]]; then
+  name=$3
+  logical_name=${name#xe3-speakup-staging_}
+  case "$logical_name" in
+    portal_data | postgres_data) ;;
+    *) exit 1 ;;
+  esac
+  project_label=$project
+  [[ "${TEST_BAD_VOLUME_LABEL:-}" != "$logical_name" ]] || project_label=wrong-project
+  jq --null-input \
+    --arg name "$name" \
+    --arg project "$project_label" \
+    --arg logical_name "$logical_name" '
+      [{
+        Name: $name,
+        Labels: {
+          "com.docker.compose.project": $project,
+          "com.docker.compose.volume": $logical_name
+        }
+      }]
+    '
+  exit
+fi
+
+exit 2
+EOF
+
+cat > "$temporary_directory/fake-bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+[[ "${FAIL_HEALTH:-0}" != 1 ]]
+EOF
+
+cat > "$temporary_directory/fake-bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$temporary_directory/fake-bin/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'flock %s\n' "$*" >> "$COMMAND_LOG"
+if [[ "${TEST_FLOCK_BUSY:-0}" == 1 ]]; then
+  exit 1
+fi
+if [[ "${TEST_FLOCK_SWAP_SYMLINK:-0}" == 1 ]]; then
+  rm -f "$TEST_LOCK_PATH"
+  ln -s "$TEST_LOCK_SWAP_TARGET" "$TEST_LOCK_PATH"
+fi
+EOF
+
 chmod +x \
   "$temporary_directory/fake-bin/docker" \
   "$temporary_directory/fake-bin/curl" \
-  "$temporary_directory/fake-bin/sleep"
+  "$temporary_directory/fake-bin/sleep" \
+  "$temporary_directory/fake-bin/flock"
 
+readonly fake_path="$temporary_directory/fake-bin:$PATH"
+mkdir "$temporary_directory/lock-directory"
+chmod 0700 "$temporary_directory/lock-directory"
+readonly lock_file="$temporary_directory/lock-directory/deploy.lock"
+
+expect_failure "deploy without a receipt" \
+  env PATH="$fake_path" SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+
+receipt="$temporary_directory/staging-deploy-receipt.json"
 COMMAND_LOG="$temporary_directory/deploy.log" \
-PATH="$temporary_directory/fake-bin:$PATH" \
+PATH="$fake_path" \
+SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
     --env-file "$temporary_directory/staging.env" \
-    >"$temporary_directory/deploy.out"
+    --receipt "$receipt" \
+    > "$temporary_directory/deploy.out"
 
-postgres_line=$(grep -nF 'up --detach --no-build --wait --wait-timeout 90 postgres' \
-  "$temporary_directory/deploy.log" | cut -d: -f1)
-migration_line=$(grep -nF 'run --rm --no-deps migrate' \
-  "$temporary_directory/deploy.log" | cut -d: -f1)
-application_line=$(grep -nF 'up --detach --no-build --wait --wait-timeout 90 portal server' \
-  "$temporary_directory/deploy.log" | cut -d: -f1)
-[[ -n "$postgres_line" && -n "$migration_line" && -n "$application_line" ]] ||
-  fail "deployment steps were not recorded"
-((postgres_line < migration_line && migration_line < application_line)) ||
-  fail "migration did not finish before the application switch"
-grep -Fq -- '--project-name xe3-speakup-staging' "$temporary_directory/deploy.log" ||
+postgres_line=$(grep -nF \
+  'up --pull never --detach --no-build --wait --wait-timeout 90 postgres' \
+  "$temporary_directory/deploy.log" | head -n 1 | cut -d: -f1)
+migration_line=$(grep -nF \
+  'run --pull never --rm --no-deps migrate' \
+  "$temporary_directory/deploy.log" | head -n 1 | cut -d: -f1)
+schema_line=$(grep -nF \
+  'run --pull never --rm --no-deps migrate /usr/local/bin/speakup-migrate version' \
+  "$temporary_directory/deploy.log" | head -n 1 | cut -d: -f1)
+application_line=$(grep -nF \
+  'up --pull never --detach --no-build --wait --wait-timeout 90 portal server' \
+  "$temporary_directory/deploy.log" | head -n 1 | cut -d: -f1)
+[[ -n "$postgres_line" && -n "$migration_line" && -n "$schema_line" &&
+  -n "$application_line" ]] || fail "deployment steps were not recorded"
+((postgres_line < migration_line && migration_line < schema_line &&
+  schema_line < application_line)) ||
+  fail "the exact schema was not verified before the application update"
+grep -Fq -- '--project-name xe3-speakup-staging' \
+  "$temporary_directory/deploy.log" ||
   fail "deployment does not pin the isolated Compose project name"
+grep -Fq 'http://127.0.0.1:28082/' "$temporary_directory/deploy.log" ||
+  fail "deployment did not verify the Portal loopback endpoint"
 grep -Fq 'http://127.0.0.1:28083/health' "$temporary_directory/deploy.log" ||
   fail "deployment did not verify /health"
 grep -Fq 'http://127.0.0.1:28083/readyz' "$temporary_directory/deploy.log" ||
   fail "deployment did not verify /readyz"
+[[ -f "$receipt" ]] || fail "successful deployment did not write a receipt"
+manifest_sha=$(shasum -a 256 "$temporary_directory/release-manifest.json" |
+  awk '{print $1}')
+jq --exit-status \
+  --arg manifest_sha "$manifest_sha" \
+  --arg portal_digest "$portal_digest" \
+  --arg server_digest "$server_digest" \
+  --arg git_sha "$git_sha" '
+    keys == [
+      "database_schema_version",
+      "deployed_at_utc",
+      "git_sha",
+      "manifest_sha256",
+      "portal_container_id",
+      "portal_image_digest",
+      "postgres_container_id",
+      "receipt_version",
+      "server_container_id",
+      "server_image_digest",
+      "version"
+    ] and
+    .receipt_version == 1 and
+    .manifest_sha256 == $manifest_sha and
+    .version == "0.1.1" and
+    .git_sha == $git_sha and
+    .database_schema_version == 7 and
+    .portal_image_digest == $portal_digest and
+    .server_image_digest == $server_digest and
+    (.portal_container_id | test("^[a-f0-9]{64}$")) and
+    (.server_container_id | test("^[a-f0-9]{64}$")) and
+    (.postgres_container_id | test("^[a-f0-9]{64}$")) and
+    (.deployed_at_utc | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+  ' "$receipt" >/dev/null || fail "deployment receipt is incomplete"
+if grep -Fq \
+  -e 'portal-admin-password-for-tests' \
+  -e '0123456789abcdef0123456789abcdef' \
+  -e 'postgres://' \
+  "$receipt"; then
+  fail "deployment receipt exposed a secret"
+fi
 
-if COMMAND_LOG="$temporary_directory/migration-failure.log" \
-  FAIL_MIGRATION=1 \
-  PATH="$temporary_directory/fake-bin:$PATH" \
+: > "$temporary_directory/no-clobber.log"
+expect_failure "existing deployment receipt" \
+  env \
+    COMMAND_LOG="$temporary_directory/no-clobber.log" \
+    PATH="$fake_path" \
+    SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
     --env-file "$temporary_directory/staging.env" \
-    >"$temporary_directory/migration-failure.out" 2>&1; then
-  fail "failed migration unexpectedly succeeded"
-fi
-if grep -Fq 'up --detach --no-build --wait --wait-timeout 90 portal server' \
-  "$temporary_directory/migration-failure.log"; then
-  fail "application switched after migration failure"
+    --receipt "$receipt"
+jq --exit-status '.receipt_version == 1' "$receipt" >/dev/null ||
+  fail "existing deployment receipt was changed"
+if grep -Eq ' compose .* (pull|up|run|down) ' \
+  "$temporary_directory/no-clobber.log"; then
+  fail "existing receipt was rejected only after a deployment side effect"
 fi
 
-if COMMAND_LOG="$temporary_directory/health-failure.log" \
-  FAIL_HEALTH=1 \
-  PATH="$temporary_directory/fake-bin:$PATH" \
+assert_failed_deploy_before_application() {
+  local name=$1
+  local log=$2
+  local failed_receipt=$3
+  shift 3
+
+  : > "$log"
+  expect_failure "$name" env \
+    COMMAND_LOG="$log" \
+    PATH="$fake_path" \
+    SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+    "$@" \
+    "$manage" deploy \
+      --manifest "$temporary_directory/release-manifest.json" \
+      --env-file "$temporary_directory/staging.env" \
+      --receipt "$failed_receipt"
+  [[ ! -e "$failed_receipt" && ! -L "$failed_receipt" ]] ||
+    fail "$name wrote a deployment receipt"
+  if grep -Fq \
+    'up --pull never --detach --no-build --wait --wait-timeout 90 portal server' \
+    "$log"; then
+    fail "$name updated application containers"
+  fi
+}
+
+assert_failed_deploy_before_application \
+  "failed migration" \
+  "$temporary_directory/migration-failure.log" \
+  "$temporary_directory/migration-failure-receipt.json" \
+  FAIL_MIGRATION=1
+assert_failed_deploy_before_application \
+  "dirty database schema" \
+  "$temporary_directory/dirty-schema.log" \
+  "$temporary_directory/dirty-schema-receipt.json" \
+  'SCHEMA_OUTPUT=version=7 dirty=true'
+assert_failed_deploy_before_application \
+  "wrong database schema" \
+  "$temporary_directory/wrong-schema.log" \
+  "$temporary_directory/wrong-schema-receipt.json" \
+  'SCHEMA_OUTPUT=version=6 dirty=false'
+assert_failed_deploy_before_application \
+  "multiple schema status lines" \
+  "$temporary_directory/multiple-schema.log" \
+  "$temporary_directory/multiple-schema-receipt.json" \
+  $'SCHEMA_OUTPUT=version=7 dirty=false\nversion=7 dirty=false'
+
+failed_runtime_receipt="$temporary_directory/runtime-failure-receipt.json"
+expect_failure "runtime verification failure after update" \
+  env \
+    COMMAND_LOG="$temporary_directory/runtime-failure.log" \
+    PATH="$fake_path" \
+    SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+    TEST_BAD_RUNTIME_IMAGE=portal \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
     --env-file "$temporary_directory/staging.env" \
-    >"$temporary_directory/health-failure.out" 2>&1; then
-  fail "failed health verification unexpectedly succeeded"
+    --receipt "$failed_runtime_receipt"
+[[ ! -e "$failed_runtime_receipt" ]] ||
+  fail "runtime verification failure wrote a deployment receipt"
+
+failed_health_receipt="$temporary_directory/health-failure-receipt.json"
+expect_failure "loopback verification failure after update" \
+  env \
+    COMMAND_LOG="$temporary_directory/health-failure.log" \
+    PATH="$fake_path" \
+    SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+    FAIL_HEALTH=1 \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    --receipt "$failed_health_receipt"
+[[ ! -e "$failed_health_receipt" ]] ||
+  fail "loopback verification failure wrote a deployment receipt"
+
+COMMAND_LOG="$temporary_directory/verify.log" \
+PATH="$fake_path" \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    > "$temporary_directory/verify.out"
+grep -Fq \
+  'run --pull never --rm --no-deps migrate /usr/local/bin/speakup-migrate version' \
+  "$temporary_directory/verify.log" ||
+  fail "verify did not validate the live database schema without pulling"
+if grep -Eq ' compose .* pull ' "$temporary_directory/verify.log"; then
+  fail "verify attempted to pull an image"
 fi
-grep -Fq 'did not become healthy' "$temporary_directory/health-failure.out" ||
-  fail "health verification failure was not reported explicitly"
+grep -Fq 'http://127.0.0.1:28083/readyz' \
+  "$temporary_directory/verify.log" ||
+  fail "verify did not check loopback endpoints"
+
+while IFS='|' read -r name variable value; do
+  runtime_log="$temporary_directory/runtime-negative.log"
+  : > "$runtime_log"
+  expect_failure "$name" env \
+    COMMAND_LOG="$runtime_log" \
+    PATH="$fake_path" \
+    "$variable=$value" \
+    "$manage" verify \
+      --manifest "$temporary_directory/release-manifest.json" \
+      --env-file "$temporary_directory/staging.env"
+  if grep -Fq 'curl ' "$runtime_log"; then
+    fail "$name reached endpoint checks before runtime identity validation"
+  fi
+done <<'EOF'
+unexpected extra project container|TEST_EXTRA_SERVICE|1
+wrong Compose project label|TEST_BAD_CONTAINER_LABEL|portal
+wrong Portal image|TEST_BAD_RUNTIME_IMAGE|portal
+wrong Server OCI release label|TEST_BAD_OCI_LABEL|server
+wrong Portal image platform|TEST_BAD_IMAGE_PLATFORM|portal
+unhealthy Server container|TEST_UNHEALTHY_SERVICE|server
+wrong Portal loopback port|TEST_BAD_PORT_SERVICE|portal
+wrong Server network membership|TEST_BAD_NETWORK_SERVICE|server
+public database network|TEST_DATABASE_NETWORK_PUBLIC|1
+wrong Portal volume mount|TEST_BAD_VOLUME_SERVICE|portal
+wrong PostgreSQL volume label|TEST_BAD_VOLUME_LABEL|postgres_data
+EOF
+
+: > "$temporary_directory/schema-verify.log"
+expect_failure "verify with wrong live schema" env \
+  COMMAND_LOG="$temporary_directory/schema-verify.log" \
+  PATH="$fake_path" \
+  'SCHEMA_OUTPUT=version=6 dirty=false' \
+  "$manage" verify \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+if grep -Fq 'curl ' "$temporary_directory/schema-verify.log"; then
+  fail "verify checked endpoints after the schema mismatch"
+fi
+
+busy_receipt="$temporary_directory/busy-receipt.json"
+: > "$temporary_directory/busy.log"
+expect_failure "concurrent Staging deploy" env \
+  COMMAND_LOG="$temporary_directory/busy.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+  TEST_FLOCK_BUSY=1 \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env" \
+    --receipt "$busy_receipt"
+[[ ! -e "$busy_receipt" ]] || fail "concurrent deploy wrote a receipt"
+if grep -Eq ' compose .* (pull|up|run|down) ' "$temporary_directory/busy.log"; then
+  fail "concurrent deploy reached a mutation after lock failure"
+fi
+
+insecure_lock="$temporary_directory/insecure.lock"
+: > "$insecure_lock"
+chmod 0644 "$insecure_lock"
+expect_failure "insecure deployment lock" env \
+  COMMAND_LOG="$temporary_directory/insecure-lock.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$insecure_lock" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+
+lock_target="$temporary_directory/lock-target"
+: > "$lock_target"
+chmod 0600 "$lock_target"
+ln -s "$lock_target" "$temporary_directory/lock-link"
+expect_failure "symbolic-link deployment lock" env \
+  COMMAND_LOG="$temporary_directory/symlink-lock.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/lock-link" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+
+missing_lock_directory="$temporary_directory/missing-lock-directory"
+expect_failure "missing dedicated deployment lock directory" env \
+  COMMAND_LOG="$temporary_directory/missing-lock-directory.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$missing_lock_directory/deploy.lock" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+[[ ! -e "$missing_lock_directory" ]] ||
+  fail "deployment created its missing lock directory"
+
+unsafe_lock_directory="$temporary_directory/unsafe-lock-directory"
+mkdir "$unsafe_lock_directory"
+chmod 0777 "$unsafe_lock_directory"
+expect_failure "world-writable deployment lock directory" env \
+  COMMAND_LOG="$temporary_directory/unsafe-lock-directory.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$unsafe_lock_directory/deploy.lock" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+[[ ! -e "$unsafe_lock_directory/deploy.lock" ]] ||
+  fail "deployment created a lock in a world-writable directory"
+
+mkdir "$temporary_directory/real-lock-directory"
+chmod 0700 "$temporary_directory/real-lock-directory"
+ln -s "$temporary_directory/real-lock-directory" \
+  "$temporary_directory/symlink-lock-directory"
+expect_failure "symbolic-link deployment lock directory" env \
+  COMMAND_LOG="$temporary_directory/symlink-lock-directory.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/symlink-lock-directory/deploy.lock" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+[[ ! -e "$temporary_directory/real-lock-directory/deploy.lock" ]] ||
+  fail "deployment followed a symbolic-link lock directory"
+
+mkdir "$temporary_directory/race-lock-directory"
+chmod 0700 "$temporary_directory/race-lock-directory"
+race_lock="$temporary_directory/race-lock-directory/deploy.lock"
+race_target="$temporary_directory/race-lock-target"
+: > "$race_target"
+chmod 0600 "$race_target"
+: > "$temporary_directory/race-lock.log"
+expect_failure "deployment lock replaced during acquisition" env \
+  COMMAND_LOG="$temporary_directory/race-lock.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$race_lock" \
+  TEST_FLOCK_SWAP_SYMLINK=1 \
+  TEST_LOCK_PATH="$race_lock" \
+  TEST_LOCK_SWAP_TARGET="$race_target" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+[[ -L "$race_lock" ]] || fail "lock replacement boundary was not exercised"
+if grep -Fq ' down ' "$temporary_directory/race-lock.log"; then
+  fail "deployment continued after the lock path was replaced"
+fi
+
+: > "$temporary_directory/down-busy.log"
+expect_failure "concurrent Staging down" env \
+  COMMAND_LOG="$temporary_directory/down-busy.log" \
+  PATH="$fake_path" \
+  SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+  TEST_FLOCK_BUSY=1 \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+if grep -Fq ' compose ' "$temporary_directory/down-busy.log" &&
+  grep -Fq ' down ' "$temporary_directory/down-busy.log"; then
+  fail "concurrent down mutated the Staging project"
+fi
+
+COMMAND_LOG="$temporary_directory/down.log" \
+PATH="$fake_path" \
+SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
+  "$manage" down \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+grep -Fq 'flock --nonblock 9' "$temporary_directory/down.log" ||
+  fail "down did not acquire the shared Staging lock"
+grep -Fq 'down --remove-orphans' "$temporary_directory/down.log" ||
+  fail "down did not target the isolated Staging project"
 
 printf '%s\n' 'staging deploy contract tests passed'


### PR DESCRIPTION
## 功能描述

- 在 Staging 部署中强制核对 Release Manifest、数据库 schema、容器运行态和不可变镜像身份。
- 为 deploy/down 增加专用独占锁，并为成功部署生成原子、不可覆盖且不含 Secret 的回执。
- 在任何 Docker 变更前校验私有输入的 owner、mode 与 symlink 边界。

## 实现思路

- 只接受 canonical v1 Release Manifest 的精确字段集合，并绑定版本、Git SHA、镜像 digest 与数据库 schema。
- 迁移后要求 `speakup-migrate version` 唯一输出 `version=N dirty=false`，且 N 与 Manifest 一致，之后才更新 Portal 和 Server。
- `verify` 使用 `--pull never`，逐项核对 Compose project/service、RepoDigest、OCI labels、linux/amd64、健康状态、端口、网络、卷和三个 loopback 端点。
- deploy/down 共用预先创建的私有锁目录；锁文件打开前后核对路径与 fd 身份，拒绝共享目录、symlink 和不安全权限。
- env 解析错误只报告安全行号，不回显可能含密码的原始内容。

## 可复现测试

- `make check-staging-deploy`
- `make check-staging-nginx`
- `bash -n deploy/staging/manage.sh deploy/staging/test.sh deploy/staging/test-nginx.sh`
- `git diff --check upstream/dev...HEAD`

本地已使用真实 pinned Nginx 容器完成 `nginx -t`。本 PR 不连接服务器、不部署环境、不修改数据库。

Closes #868
