### PR TITLE
feat(release): 发布可验证 Android 下载入口

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -84,6 +84,9 @@ jobs:
                 .github/workflows/release-candidate.yml|tools/release-candidate/*)
                   set_all_checks
                   ;;
+                tools/android-download/*)
+                  deploy=true
+                  ;;
                 mobile/*)
                   flutter=true
                   ;;
@@ -274,6 +277,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.18.0"
+
+      - name: Validate Android download publication contract
+        run: make check-android-download
 
       - name: Validate Staging deployment contract
         run: make check-staging-deploy

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-release-candidate \
+	check-android-download \
 	check-production-deploy \
 	check-production-nginx \
 	check-staging-deploy \
@@ -50,6 +51,7 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
+		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
 		'  make check-staging-deploy  Validate the immutable Staging deployment contract' \
@@ -257,6 +259,10 @@ check-api-contracts: check-api-dependencies
 check-release-candidate:
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
+
+check-android-download:
+	node --test tools/android-download/*.test.mjs
+	./deploy/android-download/test.sh
 
 check-production-deploy:
 	./deploy/production/test.sh

--- a/deploy/android-download/README.md
+++ b/deploy/android-download/README.md
@@ -1,0 +1,120 @@
+# Android public download publication
+
+This directory contains the host-side contract for publishing the already
+signed Production APK. It does not build or sign an APK, change Nginx, deploy
+containers, or infer a publication time.
+
+## Inputs and public layout
+
+Use the strict v1 `release-manifest.json` and the Production APK from the same
+successful Release Candidate run. The bundle builder rejects a mismatched
+filename, size, SHA-256, package contract, minimum API, ABI, certificate
+fingerprint, or manifest schema. The operator must also supply a real canonical
+RFC3339 UTC time without fractional seconds.
+
+```sh
+node tools/android-download/bundle.mjs \
+  --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
+  --production-apk \
+    /opt/speakup/releases/v0.1.1/speakup-v0.1.1-production-arm64.apk \
+  --published-at 2026-08-23T12:34:56Z \
+  --output /opt/speakup/releases/v0.1.1/android-download-bundle
+```
+
+The output is deterministic for identical inputs and contains only:
+
+```text
+bundle-manifest.json
+downloads/android/v0.1.1/release.json
+downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk
+downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk.sha256
+```
+
+The builder creates a new output directory atomically and refuses to replace an
+existing path. Record the printed bundle manifest SHA-256 in the release
+record. Transfer the whole bundle without editing it.
+
+## Prepare a host public root
+
+The publisher must run as the owner of the public root. The root and any
+existing `downloads` and `downloads/android` directories must be real
+directories owned by the current UID and must not be group- or world-writable.
+New publication directories are mode `0755`; public files are mode `0644`.
+
+```sh
+install -d -m 0755 /var/www/speakup-staging-public
+install -d -m 0755 /var/www/speakup-production-public
+```
+
+Configure the corresponding absolute path as `STAGING_PUBLIC_ROOT` or
+`PRODUCTION_PUBLIC_ROOT`. Nginx serves these files; the Portal container does
+not contain the APK.
+
+## Validate, publish, and activate
+
+First validate the complete bundle and destination without changing the
+destination:
+
+```sh
+./deploy/android-download/manage.sh validate \
+  --bundle /opt/speakup/releases/v0.1.1/android-download-bundle \
+  --root /var/www/speakup-staging-public
+```
+
+Publish reserves a new version directory and never overwrites an existing one.
+Omit `--activate` until the versioned URLs have been verified:
+
+```sh
+./deploy/android-download/manage.sh publish \
+  --bundle /opt/speakup/releases/v0.1.1/android-download-bundle \
+  --root /var/www/speakup-staging-public
+
+./deploy/android-download/manage.sh activate \
+  --root /var/www/speakup-staging-public \
+  --version 0.1.1
+```
+
+Run the same validate/publish sequence with the exact same bundle in
+Production only after Staging acceptance and the separate Production approval.
+The Production validation output must repeat the bundle manifest SHA-256
+recorded during Staging; stop if it differs.
+Publishing a version does not change the public Portal link. Activation copies
+that version's validated metadata to `downloads/android/release.json` through a
+same-directory atomic rename; the versioned APK and metadata remain immutable.
+
+The Portal hostname exposes only the following Android paths:
+
+- `/downloads/android/release.json`: current metadata, `Cache-Control: no-store`;
+- the exact versioned `release.json`, APK, and `.sha256`: one-year immutable
+  cache;
+- every directory, unknown filename, mismatched version, and `latest.apk`:
+  `404`.
+
+Staging applies its existing HTTP Basic Authentication to all of these routes.
+The API host always returns `404` for the Android download namespace.
+
+## Roll back the public link
+
+Reactivate any previously published and still-valid version:
+
+```sh
+./deploy/android-download/manage.sh activate \
+  --root /var/www/speakup-production-public \
+  --version 0.1.0
+```
+
+This atomically restores the previous metadata link without deleting either
+version. It cannot downgrade devices that already installed a higher
+`versionCode`; those devices require a newly signed hotfix with a higher code.
+
+## Reproducible checks
+
+```sh
+make check-android-download
+make check-staging-nginx
+make check-production-nginx
+```
+
+The checks cover valid publication and reactivation plus malformed manifests,
+tampering, unsafe roots, symlinks, no-clobber behavior, Nginx route exposure,
+cache headers, MIME type, Basic Auth, and API denial.

--- a/deploy/android-download/manage.sh
+++ b/deploy/android-download/manage.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+temporary_current=""
+created_version_directory=""
+lock_directory=""
+
+cleanup() {
+  [[ -z "$temporary_current" ]] || rm -f -- "$temporary_current"
+  [[ -z "$created_version_directory" ]] || rm -rf -- "$created_version_directory"
+  [[ -z "$lock_directory" ]] || rmdir -- "$lock_directory" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  manage.sh validate --bundle DIRECTORY --root DIRECTORY
+  manage.sh publish --bundle DIRECTORY --root DIRECTORY [--activate]
+  manage.sh activate --root DIRECTORY --version X.Y.Z
+EOF
+}
+
+fail() {
+  printf 'android download: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+valid_absolute_path() {
+  local value=$1
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != *//* ]] &&
+    [[ "$value" != */../* ]] &&
+    [[ "$value" != */./* ]] &&
+    [[ "$value" != */.. ]] &&
+    [[ "$value" != */. ]]
+}
+
+valid_version() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  else
+    fail "sha256sum or shasum is required"
+  fi
+}
+
+file_size() {
+  local size
+  if size=$(stat -c '%s' -- "$1" 2>/dev/null); then
+    :
+  elif size=$(stat -f '%z' "$1" 2>/dev/null); then
+    :
+  else
+    fail "cannot inspect file size: $1"
+  fi
+  printf '%s\n' "$size"
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+  [[ ! -L "$file" ]] || fail "$description cannot be a symlink: $file"
+  [[ -f "$file" ]] || fail "$description is not a regular file: $file"
+  [[ -r "$file" ]] || fail "$description is not readable: $file"
+  [[ -s "$file" ]] || fail "$description is empty: $file"
+}
+
+require_real_directory() {
+  local description=$1
+  local directory=$2
+  [[ ! -L "$directory" ]] || fail "$description cannot be a symlink: $directory"
+  [[ -d "$directory" ]] || fail "$description is not a directory: $directory"
+}
+
+require_owned_public_directory() {
+  local description=$1
+  local directory=$2
+  local owner mode
+
+  require_real_directory "$description" "$directory"
+  if owner=$(stat -c '%u' -- "$directory" 2>/dev/null); then
+    mode=$(stat -c '%a' -- "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  elif owner=$(stat -f '%u' "$directory" 2>/dev/null); then
+    mode=$(stat -f '%Lp' "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  else
+    fail "cannot inspect ownership for $description: $directory"
+  fi
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $directory"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $directory"
+}
+
+assert_exact_entries() {
+  local directory=$1
+  shift
+  local actual expected
+  actual=$(find "$directory" -mindepth 1 -maxdepth 1 -print |
+    sed "s|^$directory/||" | LC_ALL=C sort)
+  expected=$(printf '%s\n' "$@" | LC_ALL=C sort)
+  [[ "$actual" == "$expected" ]] || fail "unexpected entries in $directory"
+}
+
+validate_public_metadata() {
+  local file=$1
+  local expected_version=$2
+  local expected_file="speakup-v${expected_version}-production-arm64.apk"
+  local expected_path="/downloads/android/v${expected_version}/${expected_file}"
+
+  require_regular_file "public release metadata" "$file"
+  jq --exit-status --slurp \
+    --arg version "$expected_version" \
+    --arg file "$expected_file" \
+    --arg path "$expected_path" '
+      length == 1 and
+      (.[0] |
+        type == "object" and
+        keys == [
+          "abis",
+          "apk_certificate_sha256",
+          "apk_sha256",
+          "download_path",
+          "file_name",
+          "metadata_version",
+          "minimum_android_api",
+          "published_at",
+          "size_bytes",
+          "version",
+          "version_code"
+        ] and
+        .metadata_version == 1 and
+        .version == $version and
+        (.version_code | type == "number" and
+          . >= 1 and . <= 9007199254740991 and . == floor) and
+        (.published_at | type == "string" and
+          test("^[0-9]{4}-(0[1-9]|1[0-2])-([012][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$") and
+          (. as $timestamp |
+            try ((fromdateiso8601 | todateiso8601) == $timestamp) catch false)) and
+        .file_name == $file and
+        .download_path == $path and
+        (.size_bytes | type == "number" and
+          . >= 1 and . <= 9007199254740991 and . == floor) and
+        .minimum_android_api == 24 and
+        .abis == ["arm64-v8a"] and
+        (.apk_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+        (.apk_certificate_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$") and test("[1-9a-f]"))
+      )
+    ' "$file" >/dev/null || fail "public release metadata is invalid: $file"
+}
+
+validate_version_directory() {
+  local directory=$1
+  local version=$2
+  local apk_name="speakup-v${version}-production-arm64.apk"
+  local apk="$directory/$apk_name"
+  local checksum="$apk.sha256"
+  local metadata="$directory/release.json"
+  local expected_size expected_sha checksum_line
+
+  require_owned_public_directory "version directory" "$directory"
+  assert_exact_entries "$directory" "$apk_name" "$apk_name.sha256" release.json
+  require_regular_file "versioned APK" "$apk"
+  require_regular_file "APK checksum" "$checksum"
+  validate_public_metadata "$metadata" "$version"
+
+  expected_size=$(jq --raw-output '.size_bytes' "$metadata")
+  expected_sha=$(jq --raw-output '.apk_sha256' "$metadata")
+  [[ "$(file_size "$apk")" == "$expected_size" ]] ||
+    fail "versioned APK size does not match public metadata"
+  [[ "$(sha256_file "$apk")" == "$expected_sha" ]] ||
+    fail "versioned APK SHA-256 does not match public metadata"
+  IFS= read -r checksum_line <"$checksum" || fail "APK checksum is not newline terminated"
+  [[ "$checksum_line" == "$expected_sha  $apk_name" ]] ||
+    fail "APK checksum contents are invalid"
+  [[ "$(wc -l <"$checksum" | tr -d ' ')" == 1 ]] ||
+    fail "APK checksum must contain exactly one line"
+}
+
+validate_bundle() {
+  local bundle=$1
+  local manifest="$bundle/bundle-manifest.json"
+  local apk_name metadata_path
+  local entry_path entry_size entry_sha source
+
+  require_command jq
+  require_real_directory "download bundle" "$bundle"
+  require_regular_file "bundle manifest" "$manifest"
+
+  jq --exit-status --slurp '
+    length == 1 and
+    (.[0] |
+      type == "object" and
+      keys == [
+        "bundle_version",
+        "files",
+        "published_at",
+        "release_manifest_sha256",
+        "version"
+      ] and
+      .bundle_version == 1 and
+      (.version | type == "string" and
+        test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+      (.published_at | type == "string" and
+        test("^[0-9]{4}-(0[1-9]|1[0-2])-([012][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$") and
+        (. as $timestamp |
+          try ((fromdateiso8601 | todateiso8601) == $timestamp) catch false)) and
+      (.release_manifest_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.files | type == "array" and length == 3 and
+        all(.[];
+          type == "object" and keys == ["path", "sha256", "size_bytes"] and
+          (.size_bytes | type == "number" and
+            . >= 1 and . <= 9007199254740991 and . == floor) and
+          (.sha256 | type == "string" and
+            test("^[0-9a-f]{64}$") and test("[1-9a-f]")))) and
+      .files[0].path ==
+        ("downloads/android/v" + .version + "/speakup-v" + .version +
+          "-production-arm64.apk") and
+      .files[1].path == (.files[0].path + ".sha256") and
+      .files[2].path ==
+        ("downloads/android/v" + .version + "/release.json")
+    )
+  ' "$manifest" >/dev/null || fail "bundle manifest is invalid"
+
+  BUNDLE_VERSION=$(jq --raw-output '.version' "$manifest")
+  apk_name="speakup-v${BUNDLE_VERSION}-production-arm64.apk"
+  metadata_path="downloads/android/v${BUNDLE_VERSION}/release.json"
+
+  require_real_directory "bundle downloads directory" "$bundle/downloads"
+  require_real_directory "bundle Android directory" "$bundle/downloads/android"
+  require_real_directory \
+    "bundle version directory" "$bundle/downloads/android/v${BUNDLE_VERSION}"
+  assert_exact_entries "$bundle" bundle-manifest.json downloads
+  assert_exact_entries "$bundle/downloads" android
+  assert_exact_entries "$bundle/downloads/android" "v${BUNDLE_VERSION}"
+  assert_exact_entries \
+    "$bundle/downloads/android/v${BUNDLE_VERSION}" \
+    "$apk_name" "$apk_name.sha256" release.json
+
+  while IFS=$'\t' read -r entry_path entry_size entry_sha; do
+    source="$bundle/$entry_path"
+    require_regular_file "bundle file" "$source"
+    [[ "$(file_size "$source")" == "$entry_size" ]] ||
+      fail "bundle file size does not match its manifest: $entry_path"
+    [[ "$(sha256_file "$source")" == "$entry_sha" ]] ||
+      fail "bundle file SHA-256 does not match its manifest: $entry_path"
+  done < <(jq --raw-output '.files[] | [.path, .size_bytes, .sha256] | @tsv' "$manifest")
+
+  validate_public_metadata "$bundle/$metadata_path" "$BUNDLE_VERSION"
+  BUNDLE_PUBLISHED_AT=$(jq --raw-output '.published_at' "$manifest")
+  [[ "$(jq --raw-output '.published_at' "$bundle/$metadata_path")" == \
+    "$BUNDLE_PUBLISHED_AT" ]] ||
+    fail "bundle and public metadata publication times do not match"
+  validate_version_directory \
+    "$bundle/downloads/android/v${BUNDLE_VERSION}" "$BUNDLE_VERSION"
+  BUNDLE_MANIFEST_SHA256=$(sha256_file "$manifest")
+  BUNDLE_APK_SIZE=$(jq --raw-output '.files[0].size_bytes' "$manifest")
+  BUNDLE_APK_SHA256=$(jq --raw-output '.files[0].sha256' "$manifest")
+  BUNDLE_CHECKSUM_SIZE=$(jq --raw-output '.files[1].size_bytes' "$manifest")
+  BUNDLE_CHECKSUM_SHA256=$(jq --raw-output '.files[1].sha256' "$manifest")
+  BUNDLE_METADATA_SIZE=$(jq --raw-output '.files[2].size_bytes' "$manifest")
+  BUNDLE_METADATA_SHA256=$(jq --raw-output '.files[2].sha256' "$manifest")
+}
+
+verify_installed_bundle_bytes() {
+  local directory=$1
+  local apk="$directory/speakup-v${BUNDLE_VERSION}-production-arm64.apk"
+  local checksum="$apk.sha256"
+  local metadata="$directory/release.json"
+
+  [[ "$(file_size "$apk")" == "$BUNDLE_APK_SIZE" &&
+    "$(sha256_file "$apk")" == "$BUNDLE_APK_SHA256" ]] ||
+    fail "installed APK does not match the validated bundle"
+  [[ "$(file_size "$checksum")" == "$BUNDLE_CHECKSUM_SIZE" &&
+    "$(sha256_file "$checksum")" == "$BUNDLE_CHECKSUM_SHA256" ]] ||
+    fail "installed checksum does not match the validated bundle"
+  [[ "$(file_size "$metadata")" == "$BUNDLE_METADATA_SIZE" &&
+    "$(sha256_file "$metadata")" == "$BUNDLE_METADATA_SHA256" ]] ||
+    fail "installed metadata does not match the validated bundle"
+}
+
+validate_root() {
+  local root=$1
+  valid_absolute_path "$root" || fail "--root must be a safe absolute path"
+  require_owned_public_directory "public root" "$root"
+  [[ -w "$root" ]] || fail "public root is not writable: $root"
+  for directory in "$root/downloads" "$root/downloads/android"; do
+    if [[ -e "$directory" || -L "$directory" ]]; then
+      require_owned_public_directory "public download directory" "$directory"
+    fi
+  done
+  if [[ -e "$root/downloads/android/release.json" ||
+    -L "$root/downloads/android/release.json" ]]; then
+    require_regular_file \
+      "current public release metadata" "$root/downloads/android/release.json"
+  fi
+}
+
+install_version_file() {
+  local source=$1
+  local destination=$2
+  local temporary
+
+  [[ ! -e "$destination" && ! -L "$destination" ]] ||
+    fail "versioned file already exists and will not be overwritten: $destination"
+  temporary=$(mktemp "$(dirname "$destination")/.publish.tmp.XXXXXX")
+  install -m 0644 "$source" "$temporary"
+  if ! ln -- "$temporary" "$destination"; then
+    fail "versioned file already exists and will not be overwritten: $destination"
+  fi
+  rm -f -- "$temporary"
+  require_regular_file "installed versioned file" "$destination"
+}
+
+acquire_lock() {
+  local root=$1
+  local candidate="$root/.android-download.lock"
+
+  mkdir -m 0700 -- "$candidate" 2>/dev/null ||
+    fail "another Android download operation is active"
+  lock_directory=$candidate
+}
+
+activate_version() {
+  local root=$1
+  local version=$2
+  local android_root="$root/downloads/android"
+  local version_directory="$android_root/v${version}"
+  local source="$version_directory/release.json"
+  local current="$android_root/release.json"
+
+  validate_version_directory "$version_directory" "$version"
+  if [[ -e "$current" || -L "$current" ]]; then
+    require_regular_file "current public release metadata" "$current"
+  fi
+
+  temporary_current=$(mktemp "$android_root/.release.json.tmp.XXXXXX")
+  install -m 0644 "$source" "$temporary_current"
+  [[ "$(sha256_file "$temporary_current")" == "$(sha256_file "$source")" ]] ||
+    fail "temporary current metadata verification failed"
+  mv -f -- "$temporary_current" "$current"
+  temporary_current=""
+  printf 'version=%s activated=true\n' "$version"
+}
+
+publish_bundle() {
+  local bundle=$1
+  local root=$2
+  local activate=$3
+  local android_root="$root/downloads/android"
+  local source="$bundle/downloads/android/v${BUNDLE_VERSION}"
+  local destination="$android_root/v${BUNDLE_VERSION}"
+
+  [[ ! -e "$destination" && ! -L "$destination" ]] ||
+    fail "version already exists and will not be overwritten: $destination"
+  if [[ ! -e "$root/downloads" && ! -L "$root/downloads" ]]; then
+    mkdir -m 0755 -- "$root/downloads"
+  fi
+  require_owned_public_directory "public downloads directory" "$root/downloads"
+  if [[ ! -e "$android_root" && ! -L "$android_root" ]]; then
+    mkdir -m 0755 -- "$android_root"
+  fi
+  require_owned_public_directory "public Android directory" "$android_root"
+  mkdir -m 0755 -- "$destination" ||
+    fail "version already exists and will not be overwritten: $destination"
+  created_version_directory=$destination
+
+  install_version_file \
+    "$source/speakup-v${BUNDLE_VERSION}-production-arm64.apk" \
+    "$destination/speakup-v${BUNDLE_VERSION}-production-arm64.apk"
+  install_version_file \
+    "$source/speakup-v${BUNDLE_VERSION}-production-arm64.apk.sha256" \
+    "$destination/speakup-v${BUNDLE_VERSION}-production-arm64.apk.sha256"
+  install_version_file \
+    "$source/release.json" \
+    "$destination/release.json"
+  validate_version_directory "$destination" "$BUNDLE_VERSION"
+  verify_installed_bundle_bytes "$destination"
+  created_version_directory=""
+
+  printf 'version=%s bundle_manifest_sha256=%s published=true\n' \
+    "$BUNDLE_VERSION" "$BUNDLE_MANIFEST_SHA256"
+  if [[ "$activate" == true ]]; then
+    activate_version "$root" "$BUNDLE_VERSION"
+  fi
+}
+
+main() {
+  local command=${1:-}
+  local bundle=""
+  local root=""
+  local version=""
+  local activate=false
+
+  [[ -n "$command" ]] || {
+    usage
+    exit 2
+  }
+  shift
+  while (($# > 0)); do
+    case "$1" in
+      --bundle)
+        (($# >= 2)) || fail "--bundle requires a value"
+        bundle=$2
+        shift 2
+        ;;
+      --root)
+        (($# >= 2)) || fail "--root requires a value"
+        root=$2
+        shift 2
+        ;;
+      --version)
+        (($# >= 2)) || fail "--version requires a value"
+        version=$2
+        shift 2
+        ;;
+      --activate)
+        activate=true
+        shift
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$root" ]] || fail "--root is required"
+  validate_root "$root"
+  case "$command" in
+    validate | publish)
+      local initial_manifest_sha256
+      [[ -n "$bundle" ]] || fail "$command requires --bundle"
+      [[ -z "$version" ]] || fail "$command does not accept --version"
+      [[ "$command" == publish || "$activate" == false ]] ||
+        fail "validate does not accept --activate"
+      valid_absolute_path "$bundle" || fail "--bundle must be a safe absolute path"
+      validate_bundle "$bundle"
+      if [[ "$command" == validate ]]; then
+        printf 'version=%s bundle_manifest_sha256=%s validated=true\n' \
+          "$BUNDLE_VERSION" "$BUNDLE_MANIFEST_SHA256"
+      else
+        initial_manifest_sha256=$BUNDLE_MANIFEST_SHA256
+        acquire_lock "$root"
+        validate_root "$root"
+        validate_bundle "$bundle"
+        [[ "$BUNDLE_MANIFEST_SHA256" == "$initial_manifest_sha256" ]] ||
+          fail "bundle changed while waiting for the publish lock"
+        publish_bundle "$bundle" "$root" "$activate"
+      fi
+      ;;
+    activate)
+      [[ -z "$bundle" ]] || fail "activate does not accept --bundle"
+      [[ "$activate" == false ]] || fail "activate does not accept --activate"
+      [[ -n "$version" ]] || fail "activate requires --version"
+      valid_version "$version" || fail "--version is invalid"
+      validate_version_directory "$root/downloads/android/v${version}" "$version"
+      acquire_lock "$root"
+      validate_root "$root"
+      activate_version "$root" "$version"
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/android-download/test.sh
+++ b/deploy/android-download/test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repository_directory="$(cd "$script_directory/../.." && pwd)"
+readonly manage="$script_directory/manage.sh"
+readonly bundle_builder="$repository_directory/tools/android-download/bundle.mjs"
+
+fail() {
+  printf 'android download test: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+file_size() {
+  stat -c '%s' "$1" 2>/dev/null || stat -f '%z' "$1"
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" >"$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+}
+
+build_bundle() {
+  local version=$1
+  local version_code=$2
+  local destination=$3
+  local apk="$temporary_directory/speakup-v${version}-production-arm64.apk"
+  local manifest="$temporary_directory/release-${version}.json"
+  local apk_sha apk_size
+
+  printf 'signed-production-apk-%s\n' "$version" >"$apk"
+  apk_sha=$(sha256_file "$apk")
+  apk_size=$(file_size "$apk")
+  jq --null-input \
+    --arg version "$version" \
+    --argjson version_code "$version_code" \
+    --arg apk_file "speakup-v${version}-production-arm64.apk" \
+    --arg apk_sha "$apk_sha" \
+    --argjson apk_size "$apk_size" '
+      {
+        manifest_version: 1,
+        version: $version,
+        version_code: $version_code,
+        git_sha: ("c" * 40),
+        portal_image: "ghcr.io/1024xengineer/xe3-esl-portal",
+        portal_image_digest: ("sha256:" + ("a" * 64)),
+        server_image: "ghcr.io/1024xengineer/xe3-esl-server",
+        server_image_digest: ("sha256:" + ("b" * 64)),
+        staging_apk_file: ("speakup-v" + $version + "-staging-arm64.apk"),
+        staging_apk_sha256: ("d" * 64),
+        production_apk_file: $apk_file,
+        production_apk_size_bytes: $apk_size,
+        production_apk_sha256: $apk_sha,
+        application_id: "com.xengineer.speakup",
+        minimum_android_api: 24,
+        abis: ["arm64-v8a"],
+        apk_certificate_sha256: ("e" * 64),
+        database_schema_version: 7,
+        quality_run_url:
+          "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456789"
+      }
+    ' >"$manifest"
+  node "$bundle_builder" \
+    --manifest "$manifest" \
+    --production-apk "$apk" \
+    --published-at "2026-08-23T12:34:56Z" \
+    --output "$destination" \
+    >/dev/null
+}
+
+temporary_directory=$(mktemp -d)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+bash -n "$manage" "$0"
+mkdir -p "$temporary_directory/public"
+build_bundle 0.1.0 1 "$temporary_directory/bundle-0.1.0"
+build_bundle 0.1.1 2 "$temporary_directory/bundle-0.1.1"
+
+"$manage" validate \
+  --bundle "$temporary_directory/bundle-0.1.0" \
+  --root "$temporary_directory/public" \
+  >"$temporary_directory/validate.out"
+grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
+  fail "valid bundle was rejected"
+
+cp -R "$temporary_directory/bundle-0.1.0" "$temporary_directory/tampered"
+jq '.unexpected = true' \
+  "$temporary_directory/tampered/downloads/android/v0.1.0/release.json" \
+  >"$temporary_directory/tampered/release.tmp"
+mv "$temporary_directory/tampered/release.tmp" \
+  "$temporary_directory/tampered/downloads/android/v0.1.0/release.json"
+tampered_metadata="$temporary_directory/tampered/downloads/android/v0.1.0/release.json"
+tampered_size=$(file_size "$tampered_metadata")
+tampered_sha=$(sha256_file "$tampered_metadata")
+jq \
+  --argjson size "$tampered_size" \
+  --arg sha "$tampered_sha" \
+  '.files[2].size_bytes = $size | .files[2].sha256 = $sha' \
+  "$temporary_directory/tampered/bundle-manifest.json" \
+  >"$temporary_directory/tampered/manifest.tmp"
+mv "$temporary_directory/tampered/manifest.tmp" \
+  "$temporary_directory/tampered/bundle-manifest.json"
+expect_failure "extra public metadata field" \
+  "$manage" publish \
+    --bundle "$temporary_directory/tampered" \
+    --root "$temporary_directory/public"
+[[ ! -e "$temporary_directory/public/downloads" ]] ||
+  fail "invalid bundle wrote to the public root"
+
+cp -R "$temporary_directory/bundle-0.1.0" "$temporary_directory/time-tampered"
+jq '.published_at = "2026-08-23T12:35:56Z"' \
+  "$temporary_directory/time-tampered/downloads/android/v0.1.0/release.json" \
+  >"$temporary_directory/time-tampered/release.tmp"
+mv "$temporary_directory/time-tampered/release.tmp" \
+  "$temporary_directory/time-tampered/downloads/android/v0.1.0/release.json"
+time_metadata="$temporary_directory/time-tampered/downloads/android/v0.1.0/release.json"
+time_size=$(file_size "$time_metadata")
+time_sha=$(sha256_file "$time_metadata")
+jq \
+  --argjson size "$time_size" \
+  --arg sha "$time_sha" \
+  '.files[2].size_bytes = $size | .files[2].sha256 = $sha' \
+  "$temporary_directory/time-tampered/bundle-manifest.json" \
+  >"$temporary_directory/time-tampered/manifest.tmp"
+mv "$temporary_directory/time-tampered/manifest.tmp" \
+  "$temporary_directory/time-tampered/bundle-manifest.json"
+expect_failure "inconsistent publication time" \
+  "$manage" validate \
+    --bundle "$temporary_directory/time-tampered" \
+    --root "$temporary_directory/public"
+
+mkdir "$temporary_directory/world-writable-root"
+chmod 0777 "$temporary_directory/world-writable-root"
+expect_failure "world-writable public root" \
+  "$manage" publish \
+    --bundle "$temporary_directory/bundle-0.1.0" \
+    --root "$temporary_directory/world-writable-root"
+[[ -z "$(find "$temporary_directory/world-writable-root" -mindepth 1 -print -quit)" ]] ||
+  fail "world-writable root was modified"
+
+mkdir -p "$temporary_directory/unsafe-nested-root/downloads/android"
+chmod 0777 "$temporary_directory/unsafe-nested-root/downloads/android"
+expect_failure "world-writable Android public directory" \
+  "$manage" validate \
+    --bundle "$temporary_directory/bundle-0.1.0" \
+    --root "$temporary_directory/unsafe-nested-root"
+
+mkdir "$temporary_directory/public/.android-download.lock"
+expect_failure "existing publication lock" \
+  "$manage" publish \
+    --bundle "$temporary_directory/bundle-0.1.0" \
+    --root "$temporary_directory/public"
+[[ -d "$temporary_directory/public/.android-download.lock" ]] ||
+  fail "a failed lock acquisition removed another operation's lock"
+rmdir "$temporary_directory/public/.android-download.lock"
+[[ ! -e "$temporary_directory/public/downloads" ]] ||
+  fail "lock contention wrote to the public download tree"
+
+"$manage" publish \
+  --bundle "$temporary_directory/bundle-0.1.0" \
+  --root "$temporary_directory/public" \
+  --activate \
+  >"$temporary_directory/publish-one.out"
+grep -Fq 'published=true' "$temporary_directory/publish-one.out" ||
+  fail "first version was not published"
+grep -Fq 'activated=true' "$temporary_directory/publish-one.out" ||
+  fail "first version was not activated"
+cmp \
+  "$temporary_directory/public/downloads/android/release.json" \
+  "$temporary_directory/public/downloads/android/v0.1.0/release.json"
+
+current_before=$(sha256_file "$temporary_directory/public/downloads/android/release.json")
+expect_failure "existing version overwrite" \
+  "$manage" publish \
+    --bundle "$temporary_directory/bundle-0.1.0" \
+    --root "$temporary_directory/public" \
+    --activate
+[[ "$(sha256_file "$temporary_directory/public/downloads/android/release.json")" == \
+  "$current_before" ]] || fail "failed republish changed the current release"
+
+"$manage" publish \
+  --bundle "$temporary_directory/bundle-0.1.1" \
+  --root "$temporary_directory/public" \
+  --activate \
+  >"$temporary_directory/publish-two.out"
+[[ "$(jq --raw-output '.version' "$temporary_directory/public/downloads/android/release.json")" == \
+  "0.1.1" ]] || fail "second version was not activated"
+
+"$manage" activate \
+  --root "$temporary_directory/public" \
+  --version 0.1.0 \
+  >"$temporary_directory/rollback.out"
+[[ "$(jq --raw-output '.version' "$temporary_directory/public/downloads/android/release.json")" == \
+  "0.1.0" ]] || fail "previous version was not reactivated"
+
+printf 'tampered\n' >> \
+  "$temporary_directory/public/downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk"
+expect_failure "tampered installed APK activation" \
+  "$manage" activate \
+    --root "$temporary_directory/public" \
+    --version 0.1.1
+[[ "$(jq --raw-output '.version' "$temporary_directory/public/downloads/android/release.json")" == \
+  "0.1.0" ]] || fail "failed activation changed the current release"
+
+mkdir -p "$temporary_directory/symlink-root/downloads/android" "$temporary_directory/outside"
+symlink_target="$temporary_directory/symlink-root/downloads/android/v0.1.0"
+ln -s "$temporary_directory/outside" "$symlink_target"
+expect_failure "symlink version target" \
+  "$manage" publish \
+    --bundle "$temporary_directory/bundle-0.1.0" \
+    --root "$temporary_directory/symlink-root"
+[[ -L "$symlink_target" ]] || fail "symlink target was replaced"
+[[ -z "$(find "$temporary_directory/outside" -mindepth 1 -print -quit)" ]] ||
+  fail "publish followed a version-directory symlink"
+
+printf '%s\n' 'Android download publish contract tests passed'

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -38,6 +38,8 @@ release. Its one-time creation belongs to the audited server bootstrap.
 - A TLS certificate/key covering the selected Portal, redirect, and API hosts.
 - A populated ACME web root.
 - Registry read access for the manifest's Portal and Server image digests.
+- A real, current-UID-owned `PRODUCTION_PUBLIC_ROOT` that is not group- or
+  world-writable.
 
 Do not copy local `.env` defaults into Production and do not commit any filled
 environment file. The Server environment file contains real provider
@@ -53,6 +55,7 @@ install -m 0600 deploy/production/production.env.example \
   /etc/speakup/production.env
 install -m 0600 /secure/source/production-server.env \
   /etc/speakup/production-server.env
+install -d -m 0755 /var/www/speakup-production-public
 ```
 
 `PRODUCTION_POSTGRES_PASSWORD` is restricted to at least 24 URL-safe
@@ -95,8 +98,16 @@ containers or networks.
 Rendering only writes the requested file. It never installs or reloads Nginx.
 The template preserves Portal request limits, canonical-host redirect, API
 Bearer authentication, WebSocket upgrade headers, ACME challenges, and exact
-`/metrics` denial. APK static delivery is intentionally absent until its own
-versioned publication contract is reviewed.
+`/metrics` denial. It serves only the strict versioned Android APK, checksum,
+and metadata routes from `PRODUCTION_PUBLIC_ROOT`; current metadata is not
+cached, versioned files are immutable, and unknown or directory paths return
+`404`. The API host returns `404` for the complete Android download namespace.
+
+Nginx rendering does not publish or activate an APK. Build, validate, publish,
+activate, and roll back that separate state with the
+[Android publication contract](../android-download/README.md). Publish a new
+version without activation first; switch the current metadata only after the
+Production smoke checks pass.
 
 Install this vhost in place of the legacy Portal vhost; do not load both at the
 same time. The rate-limit zones and public hostnames intentionally have one
@@ -125,6 +136,7 @@ this directory yet.
 ## Reproducible checks
 
 ```sh
+make check-android-download
 make check-production-deploy
 make check-production-nginx
 ```

--- a/deploy/production/manage.sh
+++ b/deploy/production/manage.sh
@@ -66,6 +66,28 @@ require_private_file() {
   esac
 }
 
+require_owned_public_directory() {
+  local description=$1
+  local directory=$2
+  local owner mode
+
+  [[ ! -L "$directory" && -d "$directory" ]] ||
+    fail "$description must be a real directory: $directory"
+  if owner=$(stat -c '%u' -- "$directory" 2>/dev/null); then
+    mode=$(stat -c '%a' -- "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  elif owner=$(stat -f '%u' "$directory" 2>/dev/null); then
+    mode=$(stat -f '%Lp' "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  else
+    fail "cannot inspect ownership for $description: $directory"
+  fi
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $directory"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $directory"
+}
+
 allowed_configuration_key() {
   case "$1" in
     PRODUCTION_POSTGRES_DB | \
@@ -79,7 +101,8 @@ allowed_configuration_key() {
       PRODUCTION_API_HOST | \
       PRODUCTION_TLS_CERTIFICATE | \
       PRODUCTION_TLS_CERTIFICATE_KEY | \
-      PRODUCTION_ACME_ROOT)
+      PRODUCTION_ACME_ROOT | \
+      PRODUCTION_PUBLIC_ROOT)
       return 0
       ;;
     *)
@@ -106,7 +129,8 @@ load_configuration() {
     PRODUCTION_API_HOST \
     PRODUCTION_TLS_CERTIFICATE \
     PRODUCTION_TLS_CERTIFICATE_KEY \
-    PRODUCTION_ACME_ROOT
+    PRODUCTION_ACME_ROOT \
+    PRODUCTION_PUBLIC_ROOT
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line=${line%$'\r'}
@@ -184,6 +208,7 @@ validate_configuration() {
     PRODUCTION_TLS_CERTIFICATE
     PRODUCTION_TLS_CERTIFICATE_KEY
     PRODUCTION_ACME_ROOT
+    PRODUCTION_PUBLIC_ROOT
   )
   for name in "${required[@]}"; do
     require_value "$name"
@@ -217,7 +242,8 @@ validate_configuration() {
     PRODUCTION_SERVER_ENV_FILE \
     PRODUCTION_TLS_CERTIFICATE \
     PRODUCTION_TLS_CERTIFICATE_KEY \
-    PRODUCTION_ACME_ROOT; do
+    PRODUCTION_ACME_ROOT \
+    PRODUCTION_PUBLIC_ROOT; do
     valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
   done
 
@@ -226,6 +252,14 @@ validate_configuration() {
   require_private_file "TLS certificate key" "$PRODUCTION_TLS_CERTIFICATE_KEY"
   [[ -d "$PRODUCTION_ACME_ROOT" ]] ||
     fail "ACME root directory does not exist: $PRODUCTION_ACME_ROOT"
+  require_owned_public_directory "PRODUCTION_PUBLIC_ROOT" "$PRODUCTION_PUBLIC_ROOT"
+  for name in \
+    "$PRODUCTION_PUBLIC_ROOT/downloads" \
+    "$PRODUCTION_PUBLIC_ROOT/downloads/android"; do
+    if [[ -e "$name" || -L "$name" ]]; then
+      require_owned_public_directory "Production public download directory" "$name"
+    fi
+  done
 }
 
 validate_manifest() {
@@ -358,6 +392,7 @@ render_nginx() {
     -e "s|__PRODUCTION_TLS_CERTIFICATE__|$PRODUCTION_TLS_CERTIFICATE|g" \
     -e "s|__PRODUCTION_TLS_CERTIFICATE_KEY__|$PRODUCTION_TLS_CERTIFICATE_KEY|g" \
     -e "s|__PRODUCTION_ACME_ROOT__|$PRODUCTION_ACME_ROOT|g" \
+    -e "s|__PRODUCTION_PUBLIC_ROOT__|$PRODUCTION_PUBLIC_ROOT|g" \
     "$nginx_template" > "$temporary"; then
     rm -f "$temporary"
     fail "failed to render Nginx template"

--- a/deploy/production/nginx.conf.template
+++ b/deploy/production/nginx.conf.template
@@ -102,8 +102,8 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
     }
 
-    location ~ "^/downloads/android/v(?<production_checksum_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<production_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
-        if ($production_checksum_directory_version != $production_checksum_file_version) {
+    location ~ "^/downloads/android/v(?<production_checksum_dir_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<production_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
+        if ($production_checksum_dir_version != $production_checksum_file_version) {
             return 404;
         }
         root __PRODUCTION_PUBLIC_ROOT__;

--- a/deploy/production/nginx.conf.template
+++ b/deploy/production/nginx.conf.template
@@ -84,6 +84,56 @@ server {
         return 404;
     }
 
+    location = /downloads/android/release.json {
+        root __PRODUCTION_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/json;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "no-store" always;
+    }
+
+    location ~ "^/downloads/android/v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)/release\.json$" {
+        root __PRODUCTION_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/json;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location ~ "^/downloads/android/v(?<production_checksum_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<production_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
+        if ($production_checksum_directory_version != $production_checksum_file_version) {
+            return 404;
+        }
+        root __PRODUCTION_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type text/plain;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location ~ "^/downloads/android/v(?<production_apk_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<production_apk_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk$" {
+        if ($production_apk_directory_version != $production_apk_file_version) {
+            return 404;
+        }
+        root __PRODUCTION_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/vnd.android.package-archive;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location = /downloads/android {
+        return 404;
+    }
+
+    location /downloads/android/ {
+        return 404;
+    }
+
     location = /pages {
         return 404;
     }
@@ -175,6 +225,14 @@ server {
     client_max_body_size 12m;
 
     location = /metrics {
+        return 404;
+    }
+
+    location = /downloads/android {
+        return 404;
+    }
+
+    location ^~ /downloads/android/ {
         return 404;
     }
 

--- a/deploy/production/production.env.example
+++ b/deploy/production/production.env.example
@@ -15,3 +15,4 @@ PRODUCTION_API_HOST=api.speak-up.top
 PRODUCTION_TLS_CERTIFICATE=/etc/letsencrypt/live/speak-up.top/fullchain.pem
 PRODUCTION_TLS_CERTIFICATE_KEY=/etc/letsencrypt/live/speak-up.top/privkey.pem
 PRODUCTION_ACME_ROOT=/var/www/production-acme
+PRODUCTION_PUBLIC_ROOT=/var/www/speakup-production-public

--- a/deploy/production/test-nginx.sh
+++ b/deploy/production/test-nginx.sh
@@ -58,6 +58,17 @@ assert_response_header() {
   }
 }
 
+assert_curl_succeeds() {
+  local description=$1
+  shift
+
+  curl --fail --show-error "$@" || {
+    printf 'failed HTTP check: %s\n' "$description" >&2
+    docker logs "$runtime_container" >&2
+    exit 1
+  }
+}
+
 mkdir -p "$temporary_directory/acme"
 mkdir -p "$temporary_directory/logs"
 mkdir -p "$temporary_directory/public/downloads/android/v0.1.0"
@@ -164,8 +175,11 @@ if grep -Eq '__PRODUCTION_[A-Z_]+__' "$rendered_configuration"; then
 fi
 
 docker run --rm \
-  --volume "$temporary_directory:$temporary_directory:ro" \
+  --volume "$temporary_directory/acme:$temporary_directory/acme:ro" \
+  --volume "$temporary_directory/fullchain.pem:$temporary_directory/fullchain.pem:ro" \
+  --volume "$temporary_directory/privkey.pem:$temporary_directory/privkey.pem:ro" \
   --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  --volume "$temporary_directory/public:$temporary_directory/public:ro" \
   --volume "$rendered_configuration:/etc/nginx/conf.d/default.conf:ro" \
   "$nginx_image" \
   nginx -t
@@ -196,8 +210,11 @@ docker run --detach \
   --name "$runtime_container" \
   --publish 127.0.0.1::80 \
   --publish 127.0.0.1::443 \
-  --volume "$temporary_directory:$temporary_directory:ro" \
+  --volume "$temporary_directory/acme:$temporary_directory/acme:ro" \
+  --volume "$temporary_directory/fullchain.pem:$temporary_directory/fullchain.pem:ro" \
+  --volume "$temporary_directory/privkey.pem:$temporary_directory/privkey.pem:ro" \
   --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  --volume "$temporary_directory/public:$temporary_directory/public:ro" \
   --volume "$rendered_configuration:/etc/nginx/conf.d/default.conf:ro" \
   --volume "$upstream_configuration:/etc/nginx/conf.d/upstream-stub.conf:ro" \
   "$nginx_image" \
@@ -264,8 +281,7 @@ done
 
 current_headers="$temporary_directory/current-release.headers"
 current_body="$temporary_directory/current-release.json"
-curl \
-  --fail \
+assert_curl_succeeds 'current release metadata request' \
   --insecure \
   --silent \
   --dump-header "$current_headers" \
@@ -279,8 +295,7 @@ cmp \
   "$temporary_directory/public/downloads/android/release.json"
 
 version_headers="$temporary_directory/version-release.headers"
-curl \
-  --fail \
+assert_curl_succeeds 'versioned release metadata request' \
   --insecure \
   --silent \
   --dump-header "$version_headers" \
@@ -291,8 +306,7 @@ assert_response_header "$version_headers" \
   'Cache-Control: public, max-age=31536000, immutable'
 
 checksum_body="$temporary_directory/downloaded.sha256"
-curl \
-  --fail \
+assert_curl_succeeds 'checksum download request' \
   --insecure \
   --silent \
   --output "$checksum_body" \
@@ -304,8 +318,7 @@ cmp \
 
 apk_headers="$temporary_directory/apk.headers"
 apk_body="$temporary_directory/downloaded.apk"
-curl \
-  --fail \
+assert_curl_succeeds 'APK HEAD request' \
   --head \
   --insecure \
   --silent \
@@ -318,8 +331,7 @@ assert_response_header "$apk_headers" \
 assert_response_header "$apk_headers" \
   'Cache-Control: public, max-age=31536000, immutable'
 assert_response_header "$apk_headers" "Content-Length: $apk_size"
-curl \
-  --fail \
+assert_curl_succeeds 'APK download request' \
   --insecure \
   --silent \
   --output "$apk_body" \
@@ -363,8 +375,7 @@ api_download_status=$(curl \
 }
 
 api_headers="$temporary_directory/api.headers"
-curl \
-  --fail \
+assert_curl_succeeds 'API proxy request' \
   --http1.1 \
   --insecure \
   --silent \

--- a/deploy/production/test-nginx.sh
+++ b/deploy/production/test-nginx.sh
@@ -60,7 +60,41 @@ assert_response_header() {
 
 mkdir -p "$temporary_directory/acme"
 mkdir -p "$temporary_directory/logs"
+mkdir -p "$temporary_directory/public/downloads/android/v0.1.0"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
+printf '%s\n' 'signed-production-apk-fixture' > \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+apk_sha=$(sha256sum \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" |
+  awk '{print $1}')
+apk_size=$(stat -c '%s' \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" 2>/dev/null ||
+  stat -f '%z' \
+    "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk")
+printf '%s  %s\n' "$apk_sha" 'speakup-v0.1.0-production-arm64.apk' > \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+jq --null-input --arg sha "$apk_sha" --argjson size "$apk_size" '
+  {
+    metadata_version: 1,
+    version: "0.1.0",
+    version_code: 1,
+    published_at: "2026-08-23T12:34:56Z",
+    file_name: "speakup-v0.1.0-production-arm64.apk",
+    download_path:
+      "/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk",
+    size_bytes: $size,
+    minimum_android_api: 24,
+    abis: ["arm64-v8a"],
+    apk_sha256: $sha,
+    apk_certificate_sha256: ("e" * 64)
+  }
+' >"$temporary_directory/public/downloads/android/v0.1.0/release.json"
+cp \
+  "$temporary_directory/public/downloads/android/v0.1.0/release.json" \
+  "$temporary_directory/public/downloads/android/release.json"
+cp \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.1-production-arm64.apk"
 chmod 600 "$temporary_directory/server.env"
 openssl req \
   -x509 \
@@ -86,6 +120,7 @@ printf '%s\n' \
   "PRODUCTION_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
   "PRODUCTION_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
   "PRODUCTION_ACME_ROOT=$temporary_directory/acme" \
+  "PRODUCTION_PUBLIC_ROOT=$temporary_directory/public" \
   >"$temporary_directory/production.env"
 chmod 600 "$temporary_directory/production.env"
 
@@ -100,6 +135,7 @@ assert_count 'server_name www.speak-up.top;' 2
 assert_count 'return 301 https://speak-up.top$request_uri;' 3
 assert_count 'return 301 https://api.speak-up.top$request_uri;' 1
 assert_count "root $temporary_directory/acme;" 3
+assert_count "root $temporary_directory/public;" 4
 assert_count "ssl_certificate $temporary_directory/fullchain.pem;" 3
 assert_count "ssl_certificate_key $temporary_directory/privkey.pem;" 3
 assert_count 'location = /metrics {' 2
@@ -117,6 +153,10 @@ assert_count 'proxy_set_header Upgrade $http_upgrade;' 1
 assert_count 'proxy_set_header Connection $speakup_production_connection_upgrade;' 1
 assert_contains 'access_log logs/xe3-speakup-production-portal.access.log;'
 assert_contains 'access_log logs/xe3-speakup-production-api.access.log;'
+assert_contains 'default_type application/vnd.android.package-archive;'
+assert_contains 'add_header Cache-Control "no-store" always;'
+assert_contains 'add_header Cache-Control "public, max-age=31536000, immutable" always;'
+assert_contains 'location ^~ /downloads/android/'
 
 if grep -Eq '__PRODUCTION_[A-Z_]+__' "$rendered_configuration"; then
   printf '%s\n' 'rendered Nginx configuration contains a placeholder' >&2
@@ -221,6 +261,106 @@ for host in speak-up.top api.speak-up.top; do
     exit 1
   }
 done
+
+current_headers="$temporary_directory/current-release.headers"
+current_body="$temporary_directory/current-release.json"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --dump-header "$current_headers" \
+  --output "$current_body" \
+  --resolve "speak-up.top:$https_port:127.0.0.1" \
+  "https://speak-up.top:$https_port/downloads/android/release.json"
+assert_response_header "$current_headers" 'Content-Type: application/json'
+assert_response_header "$current_headers" 'Cache-Control: no-store'
+cmp \
+  "$current_body" \
+  "$temporary_directory/public/downloads/android/release.json"
+
+version_headers="$temporary_directory/version-release.headers"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --dump-header "$version_headers" \
+  --output /dev/null \
+  --resolve "speak-up.top:$https_port:127.0.0.1" \
+  "https://speak-up.top:$https_port/downloads/android/v0.1.0/release.json"
+assert_response_header "$version_headers" \
+  'Cache-Control: public, max-age=31536000, immutable'
+
+checksum_body="$temporary_directory/downloaded.sha256"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --output "$checksum_body" \
+  --resolve "speak-up.top:$https_port:127.0.0.1" \
+  "https://speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+cmp \
+  "$checksum_body" \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+
+apk_headers="$temporary_directory/apk.headers"
+apk_body="$temporary_directory/downloaded.apk"
+curl \
+  --fail \
+  --head \
+  --insecure \
+  --silent \
+  --dump-header "$apk_headers" \
+  --output /dev/null \
+  --resolve "speak-up.top:$https_port:127.0.0.1" \
+  "https://speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+assert_response_header "$apk_headers" \
+  'Content-Type: application/vnd.android.package-archive'
+assert_response_header "$apk_headers" \
+  'Cache-Control: public, max-age=31536000, immutable'
+assert_response_header "$apk_headers" "Content-Length: $apk_size"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --output "$apk_body" \
+  --resolve "speak-up.top:$https_port:127.0.0.1" \
+  "https://speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+[[ "$(sha256sum "$apk_body" | awk '{print $1}')" == "$apk_sha" ]] || {
+  printf '%s\n' 'downloaded APK SHA-256 is incorrect' >&2
+  exit 1
+}
+
+for path in \
+  /downloads/android \
+  /downloads/android/ \
+  /downloads/android/latest.apk \
+  /downloads/android/v0.1.0/unknown.txt \
+  /downloads/android/v0.1.0/speakup-v0.1.1-production-arm64.apk; do
+  status=$(curl \
+    --insecure \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --resolve "speak-up.top:$https_port:127.0.0.1" \
+    "https://speak-up.top:$https_port$path")
+  [[ "$status" == 404 ]] || {
+    printf 'unexpected Android download path %s returned %s\n' "$path" "$status" >&2
+    exit 1
+  }
+done
+
+api_download_status=$(curl \
+  --insecure \
+  --silent \
+  --output /dev/null \
+  --write-out '%{http_code}' \
+  --resolve "api.speak-up.top:$https_port:127.0.0.1" \
+  "https://api.speak-up.top:$https_port/downloads/android/release.json")
+[[ "$api_download_status" == 404 ]] || {
+  printf 'API Android download route returned %s instead of 404\n' \
+    "$api_download_status" >&2
+  exit 1
+}
 
 api_headers="$temporary_directory/api.headers"
 curl \

--- a/deploy/production/test-nginx.sh
+++ b/deploy/production/test-nginx.sh
@@ -35,6 +35,18 @@ assert_contains() {
   }
 }
 
+assert_pcre_capture_name_lengths() {
+  local match name
+
+  while IFS= read -r match; do
+    name=${match:3:${#match}-4}
+    ((${#name} <= 32)) || {
+      printf 'PCRE capture name exceeds 32 characters: %s\n' "$name" >&2
+      exit 1
+    }
+  done < <(grep -oE '\(\?<[^>]+>' "$rendered_configuration" || true)
+}
+
 assert_count() {
   local expected=$1
   local wanted=$2
@@ -139,6 +151,8 @@ chmod 600 "$temporary_directory/production.env"
   --env-file "$temporary_directory/production.env" \
   --output "$rendered_configuration" \
   >/dev/null
+
+assert_pcre_capture_name_lengths
 
 assert_count 'server_name speak-up.top;' 2
 assert_count 'server_name api.speak-up.top;' 2

--- a/deploy/production/test.sh
+++ b/deploy/production/test.sh
@@ -43,7 +43,8 @@ write_environment() {
     'PRODUCTION_API_HOST=api.speak-up.top' \
     "PRODUCTION_TLS_CERTIFICATE=$certificate" \
     "PRODUCTION_TLS_CERTIFICATE_KEY=$certificate_key" \
-    "PRODUCTION_ACME_ROOT=$temporary_directory/acme" > "$destination"
+    "PRODUCTION_ACME_ROOT=$temporary_directory/acme" \
+    "PRODUCTION_PUBLIC_ROOT=$temporary_directory/public" > "$destination"
   chmod 0600 "$destination"
 }
 
@@ -79,7 +80,10 @@ temporary_directory=$(mktemp -d)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 
-mkdir -p "$temporary_directory/acme" "$temporary_directory/fake-bin"
+mkdir -p \
+  "$temporary_directory/acme" \
+  "$temporary_directory/fake-bin" \
+  "$temporary_directory/public"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' > "$temporary_directory/server.env"
 printf '%s\n' 'test-certificate-placeholder' > "$temporary_directory/fullchain.pem"
 printf '%s\n' 'test-key-placeholder' > "$temporary_directory/privkey.pem"
@@ -247,6 +251,24 @@ bash -n "$manage" "$0"
   > "$temporary_directory/validate.out"
 grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
   fail "valid Production contract was not accepted"
+
+chmod 0777 "$temporary_directory/public"
+expect_failure "world-writable public root" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+chmod 0700 "$temporary_directory/public"
+
+mkdir -p "$temporary_directory/public/downloads/android"
+chmod 0777 "$temporary_directory/public/downloads/android"
+expect_failure "world-writable Android public directory" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env"
+chmod 0700 "$temporary_directory/public/downloads/android"
+rmdir \
+  "$temporary_directory/public/downloads/android" \
+  "$temporary_directory/public/downloads"
 
 expect_failure "missing existing Portal data volume" \
   env TEST_MISSING_VOLUME=xe3-speakup-portal-data \

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -39,6 +39,8 @@ and server environment are externally injected and are not committed.
 - A certificate whose SANs cover both Staging hostnames.
 - A populated htpasswd file and a real Staging Server environment file.
 - Registry credentials with read access to the two GHCR images.
+- A real, current-UID-owned `STAGING_PUBLIC_ROOT` that is not group- or
+  world-writable.
 
 The Server environment file must contain the real Staging provider and secret
 configuration required by the application. Use the repository `.env.example`
@@ -66,6 +68,7 @@ install -d -m 0750 /etc/speakup
 install -m 0600 staging.env.example /etc/speakup/staging.env
 install -m 0600 /secure/source/staging-server.env \
   /etc/speakup/staging-server.env
+install -d -m 0755 /var/www/speakup-staging-public
 ```
 
 Before public verification, create A records for both selected hostnames (and
@@ -131,8 +134,15 @@ then test and reload Nginx using the paths appropriate to that host. The
 committed template keeps ACME HTTP challenges reachable, redirects other HTTP
 traffic to HTTPS, protects the Portal with Basic Auth, preserves the API Bearer
 header and WebSocket upgrades, and returns `404` for exact `/metrics` requests
-before they reach either application. The API host intentionally has no
-`auth_basic` directive.
+before they reach either application. It also serves only the strict versioned
+Android APK, checksum, and metadata routes from `STAGING_PUBLIC_ROOT`; the
+current metadata is not cached, versioned files are immutable, and unknown or
+directory paths return `404`. These Portal download routes inherit Basic Auth.
+The API host intentionally has no `auth_basic` directive and returns `404` for
+the complete Android download namespace.
+
+Build, validate, publish, activate, and roll back the public APK bundle with
+the separate [Android publication contract](../android-download/README.md).
 
 ## 5. Verify
 
@@ -146,6 +156,8 @@ before they reach either application. The API host intentionally has no
   --env-file /etc/speakup/staging.env
 
 curl --fail --user staging-user https://staging.speak-up.top/
+curl --fail --user staging-user \
+  https://staging.speak-up.top/downloads/android/release.json
 curl --fail https://staging-api.speak-up.top/health
 curl --fail https://staging-api.speak-up.top/readyz
 test "$(curl --silent --output /dev/null --write-out '%{http_code}' \
@@ -176,6 +188,7 @@ Staging-scoped volumes before deleting them by name.
 ## Reproducible contract checks
 
 ```sh
+make check-android-download
 make check-staging-deploy
 make check-staging-nginx
 ```

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -31,6 +31,28 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
 }
 
+require_owned_public_directory() {
+  local description=$1
+  local directory=$2
+  local owner mode
+
+  [[ ! -L "$directory" && -d "$directory" ]] ||
+    fail "$description must be a real directory: $directory"
+  if owner=$(stat -c '%u' -- "$directory" 2>/dev/null); then
+    mode=$(stat -c '%a' -- "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  elif owner=$(stat -f '%u' "$directory" 2>/dev/null); then
+    mode=$(stat -f '%Lp' "$directory") ||
+      fail "cannot inspect permissions for $description: $directory"
+  else
+    fail "cannot inspect ownership for $description: $directory"
+  fi
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $directory"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $directory"
+}
+
 allowed_configuration_key() {
   case "$1" in
     STAGING_POSTGRES_DB | \
@@ -43,7 +65,8 @@ allowed_configuration_key() {
       STAGING_TLS_CERTIFICATE | \
       STAGING_TLS_CERTIFICATE_KEY | \
       STAGING_HTPASSWD_FILE | \
-      STAGING_ACME_ROOT)
+      STAGING_ACME_ROOT | \
+      STAGING_PUBLIC_ROOT)
       return 0
       ;;
     *)
@@ -70,7 +93,8 @@ load_configuration() {
     STAGING_TLS_CERTIFICATE \
     STAGING_TLS_CERTIFICATE_KEY \
     STAGING_HTPASSWD_FILE \
-    STAGING_ACME_ROOT
+    STAGING_ACME_ROOT \
+    STAGING_PUBLIC_ROOT
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line=${line%$'\r'}
@@ -132,6 +156,7 @@ validate_configuration() {
     STAGING_TLS_CERTIFICATE_KEY
     STAGING_HTPASSWD_FILE
     STAGING_ACME_ROOT
+    STAGING_PUBLIC_ROOT
   )
   for name in "${required[@]}"; do
     require_value "$name"
@@ -158,12 +183,21 @@ validate_configuration() {
     STAGING_TLS_CERTIFICATE \
     STAGING_TLS_CERTIFICATE_KEY \
     STAGING_HTPASSWD_FILE \
-    STAGING_ACME_ROOT; do
+    STAGING_ACME_ROOT \
+    STAGING_PUBLIC_ROOT; do
     valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
   done
 
   [[ -s "$STAGING_SERVER_ENV_FILE" ]] ||
     fail "server environment file is missing or empty: $STAGING_SERVER_ENV_FILE"
+  require_owned_public_directory "STAGING_PUBLIC_ROOT" "$STAGING_PUBLIC_ROOT"
+  for name in \
+    "$STAGING_PUBLIC_ROOT/downloads" \
+    "$STAGING_PUBLIC_ROOT/downloads/android"; do
+    if [[ -e "$name" || -L "$name" ]]; then
+      require_owned_public_directory "Staging public download directory" "$name"
+    fi
+  done
 }
 
 validate_manifest() {
@@ -235,6 +269,7 @@ render_nginx() {
     -e "s|__STAGING_TLS_CERTIFICATE_KEY__|$STAGING_TLS_CERTIFICATE_KEY|g" \
     -e "s|__STAGING_HTPASSWD_FILE__|$STAGING_HTPASSWD_FILE|g" \
     -e "s|__STAGING_ACME_ROOT__|$STAGING_ACME_ROOT|g" \
+    -e "s|__STAGING_PUBLIC_ROOT__|$STAGING_PUBLIC_ROOT|g" \
     "$nginx_template" >"$temporary"; then
     rm -f "$temporary"
     fail "failed to render Nginx template"

--- a/deploy/staging/nginx.conf.template
+++ b/deploy/staging/nginx.conf.template
@@ -42,6 +42,56 @@ server {
         return 404;
     }
 
+    location = /downloads/android/release.json {
+        root __STAGING_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/json;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "no-store" always;
+    }
+
+    location ~ "^/downloads/android/v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)/release\.json$" {
+        root __STAGING_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/json;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location ~ "^/downloads/android/v(?<staging_checksum_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<staging_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
+        if ($staging_checksum_directory_version != $staging_checksum_file_version) {
+            return 404;
+        }
+        root __STAGING_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type text/plain;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location ~ "^/downloads/android/v(?<staging_apk_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<staging_apk_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk$" {
+        if ($staging_apk_directory_version != $staging_apk_file_version) {
+            return 404;
+        }
+        root __STAGING_PUBLIC_ROOT__;
+        try_files $uri =404;
+        default_type application/vnd.android.package-archive;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location = /downloads/android {
+        return 404;
+    }
+
+    location /downloads/android/ {
+        return 404;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:28082;
         proxy_http_version 1.1;
@@ -70,6 +120,14 @@ server {
     client_max_body_size 12m;
 
     location = /metrics {
+        return 404;
+    }
+
+    location = /downloads/android {
+        return 404;
+    }
+
+    location ^~ /downloads/android/ {
         return 404;
     }
 

--- a/deploy/staging/nginx.conf.template
+++ b/deploy/staging/nginx.conf.template
@@ -60,8 +60,8 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
     }
 
-    location ~ "^/downloads/android/v(?<staging_checksum_directory_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<staging_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
-        if ($staging_checksum_directory_version != $staging_checksum_file_version) {
+    location ~ "^/downloads/android/v(?<staging_checksum_dir_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))/speakup-v(?<staging_checksum_file_version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-production-arm64\.apk\.sha256$" {
+        if ($staging_checksum_dir_version != $staging_checksum_file_version) {
             return 404;
         }
         root __STAGING_PUBLIC_ROOT__;

--- a/deploy/staging/staging.env.example
+++ b/deploy/staging/staging.env.example
@@ -13,3 +13,4 @@ STAGING_TLS_CERTIFICATE=/etc/letsencrypt/live/staging.speak-up.top/fullchain.pem
 STAGING_TLS_CERTIFICATE_KEY=/etc/letsencrypt/live/staging.speak-up.top/privkey.pem
 STAGING_HTPASSWD_FILE=/etc/nginx/staging.htpasswd
 STAGING_ACME_ROOT=/var/www/staging-acme
+STAGING_PUBLIC_ROOT=/var/www/speakup-staging-public

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -185,11 +185,30 @@ printf '%s\n' \
   '}' \
   >"$temporary_directory/upstream.conf"
 
+# The production host explicitly runs Nginx workers as root, which is required
+# to read the deployment contract's owner-only htpasswd file.
+printf '%s\n' \
+  'user root;' \
+  'worker_processes 1;' \
+  'error_log /dev/stderr notice;' \
+  'pid /tmp/nginx.pid;' \
+  'events { worker_connections 1024; }' \
+  'http {' \
+  '    include /etc/nginx/mime.types;' \
+  '    default_type application/octet-stream;' \
+  '    access_log /dev/stdout;' \
+  '    sendfile on;' \
+  '    keepalive_timeout 65;' \
+  '    include /etc/nginx/conf.d/*.conf;' \
+  '}' \
+  >"$temporary_directory/nginx.conf"
+
 docker run --detach \
   --name "$runtime_container" \
   --publish 127.0.0.1::443 \
   --volume "$temporary_directory:$temporary_directory:ro" \
   --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  --volume "$temporary_directory/nginx.conf:/etc/nginx/nginx.conf:ro" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   --volume "$temporary_directory/upstream.conf:/etc/nginx/conf.d/upstream.conf:ro" \
   "$nginx_image" \

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -6,6 +6,29 @@ readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly manage="$staging_directory/manage.sh"
 readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
 readonly container_fixture_directory="/tmp/staging-nginx-test"
+readonly runtime_container="xe3-staging-nginx-test-${PPID}-$$"
+
+cleanup() {
+  docker rm --force "$runtime_container" >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+
+assert_contains() {
+  local expected=$1
+  grep -Fq -- "$expected" "$temporary_directory/default.conf" || {
+    printf 'missing expected Nginx directive: %s\n' "$expected" >&2
+    exit 1
+  }
+}
+
+assert_response_header() {
+  local response_file=$1
+  local expected=$2
+  grep -Fqi -- "$expected" "$response_file" || {
+    printf 'missing expected response header: %s\n' "$expected" >&2
+    exit 1
+  }
+}
 
 command -v docker >/dev/null 2>&1 || {
   printf '%s\n' 'docker is required for the Nginx configuration check' >&2
@@ -18,11 +41,46 @@ command -v openssl >/dev/null 2>&1 || {
 
 temporary_directory=$(mktemp -d)
 readonly temporary_directory
-trap 'rm -rf "$temporary_directory"' EXIT
+trap cleanup EXIT
 
-mkdir -p "$temporary_directory/acme"
+mkdir -p "$temporary_directory/acme" \
+  "$temporary_directory/public/downloads/android/v0.1.0"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
-printf '%s\n' 'staging:test-password-hash' >"$temporary_directory/staging.htpasswd"
+password_hash=$(openssl passwd -apr1 'test-password')
+printf 'staging:%s\n' "$password_hash" >"$temporary_directory/staging.htpasswd"
+printf '%s\n' 'signed-production-apk-fixture' > \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+apk_sha=$(sha256sum \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" |
+  awk '{print $1}')
+apk_size=$(stat -c '%s' \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" 2>/dev/null ||
+  stat -f '%z' \
+    "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk")
+printf '%s  %s\n' "$apk_sha" 'speakup-v0.1.0-production-arm64.apk' > \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+jq --null-input --arg sha "$apk_sha" --argjson size "$apk_size" '
+  {
+    metadata_version: 1,
+    version: "0.1.0",
+    version_code: 1,
+    published_at: "2026-08-23T12:34:56Z",
+    file_name: "speakup-v0.1.0-production-arm64.apk",
+    download_path:
+      "/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk",
+    size_bytes: $size,
+    minimum_android_api: 24,
+    abis: ["arm64-v8a"],
+    apk_sha256: $sha,
+    apk_certificate_sha256: ("e" * 64)
+  }
+' >"$temporary_directory/public/downloads/android/v0.1.0/release.json"
+cp \
+  "$temporary_directory/public/downloads/android/v0.1.0/release.json" \
+  "$temporary_directory/public/downloads/android/release.json"
+cp \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk" \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.1-production-arm64.apk"
 openssl req \
   -x509 \
   -newkey rsa:2048 \
@@ -45,6 +103,7 @@ printf '%s\n' \
   "STAGING_TLS_CERTIFICATE_KEY=$container_fixture_directory/privkey.pem" \
   "STAGING_HTPASSWD_FILE=$container_fixture_directory/staging.htpasswd" \
   "STAGING_ACME_ROOT=$container_fixture_directory/acme" \
+  "STAGING_PUBLIC_ROOT=$temporary_directory/public" \
   >"$temporary_directory/staging.env"
 
 "$manage" render-nginx \
@@ -52,10 +111,186 @@ printf '%s\n' \
   --output "$temporary_directory/default.conf" \
   >/dev/null
 
+assert_contains "root $temporary_directory/public;"
+assert_contains 'default_type application/vnd.android.package-archive;'
+assert_contains 'add_header Cache-Control "no-store" always;'
+assert_contains 'add_header Cache-Control "public, max-age=31536000, immutable" always;'
+api_configuration="$temporary_directory/api.conf"
+sed -n '/server_name staging-api.speak-up.top;/,$p' \
+  "$temporary_directory/default.conf" >"$api_configuration"
+if grep -Fq "root $temporary_directory/public;" "$api_configuration"; then
+  printf '%s\n' 'Staging API host exposes the Android public root' >&2
+  exit 1
+fi
+assert_contains 'location ^~ /downloads/android/'
+
 docker run --rm \
   --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory/public:$temporary_directory/public:ro" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   "$nginx_image" \
   nginx -t
+
+printf '%s\n' \
+  'server {' \
+  '    listen 28082;' \
+  '    location / { return 200 "portal\n"; }' \
+  '}' \
+  'server {' \
+  '    listen 28083;' \
+  '    location / { return 200 "api\n"; }' \
+  '}' \
+  >"$temporary_directory/upstream.conf"
+
+docker run --detach \
+  --name "$runtime_container" \
+  --publish 127.0.0.1::443 \
+  --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory/public:$temporary_directory/public:ro" \
+  --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
+  --volume "$temporary_directory/upstream.conf:/etc/nginx/conf.d/upstream.conf:ro" \
+  "$nginx_image" \
+  >/dev/null
+
+https_port=$(docker port "$runtime_container" 443/tcp | sed -n 's/.*://p')
+[[ "$https_port" =~ ^[0-9]+$ ]] || {
+  printf '%s\n' 'failed to resolve Staging Nginx HTTPS port' >&2
+  exit 1
+}
+
+runtime_ready=false
+for _ in {1..30}; do
+  status=$(curl \
+    --insecure \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+    "https://staging.speak-up.top:$https_port/")
+  if [[ "$status" == 401 ]]; then
+    runtime_ready=true
+    break
+  fi
+  sleep 0.2
+done
+[[ "$runtime_ready" == true ]] || {
+  docker logs "$runtime_container" >&2
+  printf '%s\n' 'Staging Nginx did not become ready' >&2
+  exit 1
+}
+
+unauthenticated_status=$(curl \
+  --insecure \
+  --silent \
+  --output /dev/null \
+  --write-out '%{http_code}' \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/release.json")
+[[ "$unauthenticated_status" == 401 ]] || {
+  printf 'Staging download without Basic Auth returned %s\n' \
+    "$unauthenticated_status" >&2
+  exit 1
+}
+
+current_headers="$temporary_directory/current.headers"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --user 'staging:test-password' \
+  --dump-header "$current_headers" \
+  --output /dev/null \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/release.json"
+assert_response_header "$current_headers" 'Content-Type: application/json'
+assert_response_header "$current_headers" 'Cache-Control: no-store'
+
+version_headers="$temporary_directory/version.headers"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --user 'staging:test-password' \
+  --dump-header "$version_headers" \
+  --output /dev/null \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/v0.1.0/release.json"
+assert_response_header "$version_headers" \
+  'Cache-Control: public, max-age=31536000, immutable'
+
+checksum_body="$temporary_directory/downloaded.sha256"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --user 'staging:test-password' \
+  --output "$checksum_body" \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+cmp \
+  "$checksum_body" \
+  "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256"
+
+apk_headers="$temporary_directory/apk.headers"
+apk_body="$temporary_directory/downloaded.apk"
+curl \
+  --fail \
+  --head \
+  --insecure \
+  --silent \
+  --user 'staging:test-password' \
+  --dump-header "$apk_headers" \
+  --output /dev/null \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+assert_response_header "$apk_headers" \
+  'Content-Type: application/vnd.android.package-archive'
+assert_response_header "$apk_headers" \
+  'Cache-Control: public, max-age=31536000, immutable'
+assert_response_header "$apk_headers" "Content-Length: $apk_size"
+curl \
+  --fail \
+  --insecure \
+  --silent \
+  --user 'staging:test-password' \
+  --output "$apk_body" \
+  --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging.speak-up.top:$https_port/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
+[[ "$(sha256sum "$apk_body" | awk '{print $1}')" == "$apk_sha" ]] || {
+  printf '%s\n' 'downloaded Staging APK SHA-256 is incorrect' >&2
+  exit 1
+}
+
+for path in \
+  /downloads/android \
+  /downloads/android/ \
+  /downloads/android/latest.apk \
+  /downloads/android/v0.1.0/unknown.txt \
+  /downloads/android/v0.1.0/speakup-v0.1.1-production-arm64.apk; do
+  status=$(curl \
+    --insecure \
+    --silent \
+    --user 'staging:test-password' \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --resolve "staging.speak-up.top:$https_port:127.0.0.1" \
+    "https://staging.speak-up.top:$https_port$path")
+  [[ "$status" == 404 ]] || {
+    printf 'unexpected Staging Android path %s returned %s\n' "$path" "$status" >&2
+    exit 1
+  }
+done
+
+api_status=$(curl \
+  --insecure \
+  --silent \
+  --output /dev/null \
+  --write-out '%{http_code}' \
+  --resolve "staging-api.speak-up.top:$https_port:127.0.0.1" \
+  "https://staging-api.speak-up.top:$https_port/downloads/android/release.json")
+[[ "$api_status" == 404 ]] || {
+  printf 'Staging API download route returned %s instead of 404\n' "$api_status" >&2
+  exit 1
+}
 
 printf '%s\n' 'staging Nginx configuration check passed'

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -6,6 +6,7 @@ readonly staging_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly manage="$staging_directory/manage.sh"
 readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
 readonly container_fixture_directory="/tmp/staging-nginx-test"
+readonly container_htpasswd_file="/etc/nginx/staging.htpasswd"
 readonly runtime_container="xe3-staging-nginx-test-${PPID}-$$"
 
 cleanup() {
@@ -30,6 +31,17 @@ assert_response_header() {
   }
 }
 
+assert_curl_succeeds() {
+  local description=$1
+  shift
+
+  curl --fail --show-error "$@" || {
+    printf 'failed HTTP check: %s\n' "$description" >&2
+    docker logs "$runtime_container" >&2
+    exit 1
+  }
+}
+
 command -v docker >/dev/null 2>&1 || {
   printf '%s\n' 'docker is required for the Nginx configuration check' >&2
   exit 1
@@ -48,6 +60,7 @@ mkdir -p "$temporary_directory/acme" \
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
 password_hash=$(openssl passwd -apr1 'test-password')
 printf 'staging:%s\n' "$password_hash" >"$temporary_directory/staging.htpasswd"
+chmod 0644 "$temporary_directory/staging.htpasswd"
 printf '%s\n' 'signed-production-apk-fixture' > \
   "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
 apk_sha=$(sha256sum \
@@ -101,7 +114,7 @@ printf '%s\n' \
   'STAGING_API_HOST=staging-api.speak-up.top' \
   "STAGING_TLS_CERTIFICATE=$container_fixture_directory/fullchain.pem" \
   "STAGING_TLS_CERTIFICATE_KEY=$container_fixture_directory/privkey.pem" \
-  "STAGING_HTPASSWD_FILE=$container_fixture_directory/staging.htpasswd" \
+  "STAGING_HTPASSWD_FILE=$container_htpasswd_file" \
   "STAGING_ACME_ROOT=$container_fixture_directory/acme" \
   "STAGING_PUBLIC_ROOT=$temporary_directory/public" \
   >"$temporary_directory/staging.env"
@@ -126,6 +139,7 @@ assert_contains 'location ^~ /downloads/android/'
 
 docker run --rm \
   --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory/staging.htpasswd:$container_htpasswd_file:ro" \
   --volume "$temporary_directory/public:$temporary_directory/public:ro" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   "$nginx_image" \
@@ -146,6 +160,7 @@ docker run --detach \
   --name "$runtime_container" \
   --publish 127.0.0.1::443 \
   --volume "$temporary_directory:$container_fixture_directory:ro" \
+  --volume "$temporary_directory/staging.htpasswd:$container_htpasswd_file:ro" \
   --volume "$temporary_directory/public:$temporary_directory/public:ro" \
   --volume "$temporary_directory/default.conf:/etc/nginx/conf.d/default.conf:ro" \
   --volume "$temporary_directory/upstream.conf:/etc/nginx/conf.d/upstream.conf:ro" \
@@ -193,8 +208,7 @@ unauthenticated_status=$(curl \
 }
 
 current_headers="$temporary_directory/current.headers"
-curl \
-  --fail \
+assert_curl_succeeds 'authenticated current release metadata request' \
   --insecure \
   --silent \
   --user 'staging:test-password' \
@@ -206,8 +220,7 @@ assert_response_header "$current_headers" 'Content-Type: application/json'
 assert_response_header "$current_headers" 'Cache-Control: no-store'
 
 version_headers="$temporary_directory/version.headers"
-curl \
-  --fail \
+assert_curl_succeeds 'authenticated versioned release metadata request' \
   --insecure \
   --silent \
   --user 'staging:test-password' \
@@ -219,8 +232,7 @@ assert_response_header "$version_headers" \
   'Cache-Control: public, max-age=31536000, immutable'
 
 checksum_body="$temporary_directory/downloaded.sha256"
-curl \
-  --fail \
+assert_curl_succeeds 'authenticated checksum download request' \
   --insecure \
   --silent \
   --user 'staging:test-password' \
@@ -233,8 +245,7 @@ cmp \
 
 apk_headers="$temporary_directory/apk.headers"
 apk_body="$temporary_directory/downloaded.apk"
-curl \
-  --fail \
+assert_curl_succeeds 'authenticated APK HEAD request' \
   --head \
   --insecure \
   --silent \
@@ -248,8 +259,7 @@ assert_response_header "$apk_headers" \
 assert_response_header "$apk_headers" \
   'Cache-Control: public, max-age=31536000, immutable'
 assert_response_header "$apk_headers" "Content-Length: $apk_size"
-curl \
-  --fail \
+assert_curl_succeeds 'authenticated APK download request' \
   --insecure \
   --silent \
   --user 'staging:test-password' \

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -22,6 +22,18 @@ assert_contains() {
   }
 }
 
+assert_pcre_capture_name_lengths() {
+  local match name
+
+  while IFS= read -r match; do
+    name=${match:3:${#match}-4}
+    ((${#name} <= 32)) || {
+      printf 'PCRE capture name exceeds 32 characters: %s\n' "$name" >&2
+      exit 1
+    }
+  done < <(grep -oE '\(\?<[^>]+>' "$temporary_directory/default.conf" || true)
+}
+
 assert_response_header() {
   local response_file=$1
   local expected=$2
@@ -123,6 +135,8 @@ printf '%s\n' \
   --env-file "$temporary_directory/staging.env" \
   --output "$temporary_directory/default.conf" \
   >/dev/null
+
+assert_pcre_capture_name_lengths
 
 assert_contains "root $temporary_directory/public;"
 assert_contains 'default_type application/vnd.android.package-archive;'

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -37,7 +37,8 @@ write_environment() {
     "STAGING_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
     "STAGING_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
     "STAGING_HTPASSWD_FILE=$temporary_directory/staging.htpasswd" \
-    "STAGING_ACME_ROOT=$temporary_directory/acme" >"$destination"
+    "STAGING_ACME_ROOT=$temporary_directory/acme" \
+    "STAGING_PUBLIC_ROOT=$temporary_directory/public" >"$destination"
 }
 
 write_manifest() {
@@ -62,7 +63,10 @@ temporary_directory=$(mktemp -d)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 
-mkdir -p "$temporary_directory/acme" "$temporary_directory/fake-bin"
+mkdir -p \
+  "$temporary_directory/acme" \
+  "$temporary_directory/fake-bin" \
+  "$temporary_directory/public"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
 printf '%s\n' 'test-user:test-password-hash' >"$temporary_directory/staging.htpasswd"
 printf '%s\n' 'test-certificate-placeholder' >"$temporary_directory/fullchain.pem"
@@ -78,6 +82,24 @@ bash -n "$manage" "$0"
   >"$temporary_directory/validate.out"
 grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
   fail "valid deployment contract was not accepted"
+
+chmod 0777 "$temporary_directory/public"
+expect_failure "world-writable public root" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+chmod 0700 "$temporary_directory/public"
+
+mkdir -p "$temporary_directory/public/downloads/android"
+chmod 0777 "$temporary_directory/public/downloads/android"
+expect_failure "world-writable Android public directory" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/staging.env"
+chmod 0700 "$temporary_directory/public/downloads/android"
+rmdir \
+  "$temporary_directory/public/downloads/android" \
+  "$temporary_directory/public/downloads"
 
 write_manifest "$temporary_directory/invalid-manifest.json" 'latest'
 expect_failure "mutable Portal image reference" \

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -326,16 +326,23 @@ Production APK 要求：
 - CI 验证 APK 签名、SHA-256、包名、版本和 arm64 架构。
 - 正式签名私钥只存在于密码管理器与受保护的 GitHub Environment Secret。
 
-APK 不打入 Portal Docker 镜像。Deploy Workflow 将它上传到版本目录：
+APK 不打入 Portal Docker 镜像。严格的公开 bundle 由同一次 Release Candidate
+运行产生的 v1 `release-manifest.json`、Production APK 和人工明确给出的规范 UTC
+发布时间生成。构建器核对文件名、大小、APK SHA-256、签名证书指纹与 Android
+契约，并输出以下固定目录：
 
 ```text
-/downloads/v0.1.1/speakup-v0.1.1-arm64.apk
-/downloads/v0.1.1/speakup-v0.1.1-arm64.apk.sha256
-/downloads/latest.json
+/downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk
+/downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk.sha256
+/downloads/android/v0.1.1/release.json
+/downloads/android/release.json
 ```
 
-Portal 读取 `latest.json` 展示当前版本、文件大小、发布日期、SHA-256、更新说明
-与安装入口。只有生产冒烟成功后才原子更新 `latest.json`。
+版本目录不覆盖。Portal 同源读取当前 `release.json`，只有严格校验元数据后才展示
+唯一的版本化 APK 链接、版本、文件大小、发布日期、兼容范围、APK SHA-256 和签名
+证书 SHA-256。缺失元数据表示准备中；网络、JSON 或协议错误表示不可用，均不猜测
+下载地址。Production 先发布并验证版本目录，只有生产冒烟成功后才原子切换当前
+`release.json`；不存在 `latest.apk` 或可变 APK 路径。
 
 首版是网页直接分发 APK，用户需要允许浏览器安装未知来源应用。它不提供 iOS
 安装，也不等同于 Google Play 发布。
@@ -393,7 +400,7 @@ Portal 报名和访问事件继续使用独立 SQLite。它与产品核心业务
 
 ### 11.3 APK
 
-- 问题版本尚未公开时，不更新 `latest.json`。
+- 问题版本尚未公开时，不激活它的当前 `release.json`。
 - 已公开时立即停止分发问题 APK并恢复上一版本下载入口。
 - 已经安装新版的 Android 用户通常不能安装更低 versionCode；需要发布更高
   versionCode 的 hotfix，不能把“恢复下载链接”误认为完成客户端回滚。

--- a/portal/README.md
+++ b/portal/README.md
@@ -15,7 +15,14 @@ npm install
 npm run dev
 ```
 
-默认首页为 `/`，运营后台为 `/admin`。
+默认首页为 `/`，Android 发布页为 `/download/android`，运营后台为 `/admin`。
+
+Android 发布页只从同源 `/downloads/android/release.json` 读取当前正式版本。
+`404` 显示“准备中”；网络、HTTP、JSON 或严格协议校验失败时显示“暂不可用”；只有
+元数据完整有效时才展示其中的版本化 APK 地址与真实版本、大小、时间、兼容范围及
+SHA-256。页面不会猜测下载地址，也不使用 `latest.apk`。APK 与发布元数据由宿主机
+Nginx 提供，不放入 Portal Docker 镜像；发布操作见
+[`deploy/android-download/README.md`](../deploy/android-download/README.md)。
 
 如需在本地持久化报名和事件数据：
 

--- a/portal/app/download/android/page.tsx
+++ b/portal/app/download/android/page.tsx
@@ -1,66 +1,282 @@
-import Link from "next/link";
-import BrandMark from "../../BrandMark";
+"use client";
 
-const releaseFields = [
-  ["版本名称（versionName）", "制品就绪后公开"],
-  ["版本号（versionCode）", "制品就绪后公开"],
-  ["发布时间", "制品就绪后公开"],
-  ["APK 大小", "制品就绪后公开"],
-  ["最低 Android 版本", "制品就绪后公开"],
-  ["支持的 ABI", "制品就绪后公开"],
-];
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import BrandMark from "../../BrandMark";
+import { loadAndroidRelease } from "../../../lib/android-release-metadata.mjs";
+
+type AndroidReleaseMetadata = {
+  metadata_version: 1;
+  version: string;
+  version_code: number;
+  published_at: string;
+  file_name: string;
+  download_path: string;
+  size_bytes: number;
+  minimum_android_api: 24;
+  abis: ["arm64-v8a"];
+  apk_sha256: string;
+  apk_certificate_sha256: string;
+};
+
+type ReleaseState =
+  | { status: "preparing" }
+  | { status: "unavailable" }
+  | { status: "ready"; release: AndroidReleaseMetadata };
 
 const supportFields = [
-  ["更新状态", "首个正式版本发布后在本页持续更新"],
-  ["更新日志", "随每个可下载制品同步公开"],
-  ["隐私与权限", "开放下载前公开隐私说明与权限清单"],
-  ["问题反馈", "开放下载前公开正式反馈入口"],
+  ["更新状态", "当前下载状态与版本信息以本页为准"],
+  ["更新日志", "独立更新日志尚未提供"],
+  ["隐私与权限", "正式隐私说明与权限清单尚未提供"],
+  ["问题反馈", "正式反馈入口尚未提供"],
 ];
 
+function formatBytes(bytes: number) {
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(megabytes >= 10 ? 1 : 2)} MB（${bytes.toLocaleString("zh-CN")} 字节）`;
+}
+
+function formatPublishedAt(value: string) {
+  return `${new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(new Date(value))}（UTC+8）`;
+}
+
+function unavailableValue(status: ReleaseState["status"]) {
+  return status === "unavailable" ? "发布信息暂不可用" : "制品就绪后公开";
+}
+
 export default function AndroidDownloadPage() {
+  const [releaseState, setReleaseState] = useState<ReleaseState>({
+    status: "preparing",
+  });
+
+  useEffect(() => {
+    let active = true;
+    void loadAndroidRelease().then((nextState) => {
+      if (active) setReleaseState(nextState as ReleaseState);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const release =
+    releaseState.status === "ready" ? releaseState.release : undefined;
+  const placeholder = unavailableValue(releaseState.status);
+  const releaseFields = release
+    ? [
+        ["版本名称（versionName）", `v${release.version}`],
+        ["版本号（versionCode）", String(release.version_code)],
+        ["发布时间", formatPublishedAt(release.published_at)],
+        ["APK 大小", formatBytes(release.size_bytes)],
+        ["最低 Android 版本", `API ${release.minimum_android_api} 及以上`],
+        ["支持的 ABI", release.abis.join(", ")],
+      ]
+    : [
+        ["版本名称（versionName）", placeholder],
+        ["版本号（versionCode）", placeholder],
+        ["发布时间", placeholder],
+        ["APK 大小", placeholder],
+        ["最低 Android 版本", placeholder],
+        ["支持的 ABI", placeholder],
+      ];
+
+  const stateCopy = release
+    ? {
+        label: "可下载",
+        detail: `v${release.version} 已通过发布清单校验，下载后请继续核对下方指纹。`,
+      }
+    : releaseState.status === "unavailable"
+      ? {
+          label: "暂不可用",
+          detail: "发布信息当前无法验证，因此不会提供下载链接，请稍后重试。",
+        }
+      : {
+          label: "准备中",
+          detail: "不会提供空链接、假二维码或未经核验的版本。",
+        };
+
   return (
     <main className="release-site download-page" id="top">
       <nav className="site-nav release-nav" aria-label="主导航">
-        <Link className="brand" href="/" aria-label="返回 SpeakUp 首页"><BrandMark /><span>SpeakUp</span></Link>
-        <div className="nav-links"><Link href="/">产品首页</Link><a href="#verify">验证信息</a></div>
-        <Link className="button button-small" href="/">返回首页</Link>
+        <Link className="brand" href="/" aria-label="返回 SpeakUp 首页">
+          <BrandMark />
+          <span>SpeakUp</span>
+        </Link>
+        <div className="nav-links">
+          <Link href="/">产品首页</Link>
+          <a href="#verify">验证信息</a>
+        </div>
+        <Link className="button button-small" href="/">
+          返回首页
+        </Link>
       </nav>
 
       <header className="download-hero">
         <div className="download-hero-copy">
-          <Link className="download-back" href="/">← 返回产品首页</Link>
-          <p className="eyebrow">Android 官方版</p><h1>SpeakUp for Android</h1>
-          <p>首个公开版本正在准备。当前还没有可公开下载和验证的 APK，完成签名与生产验证后，本页才会开放唯一入口。</p>
-          <div className="download-state" role="status"><span><i aria-hidden="true" />准备中</span><small>不会提供空链接、假二维码或未经核验的版本。</small></div>
+          <Link className="download-back" href="/">
+            ← 返回产品首页
+          </Link>
+          <p className="eyebrow">Android 官方版</p>
+          <h1>SpeakUp for Android</h1>
+          <p>
+            {release
+              ? "正式 Android arm64 APK 已开放下载。安装前请核对文件与签名证书 SHA-256，确认拿到的是本页发布的版本。"
+              : releaseState.status === "unavailable"
+                ? "发布入口暂时无法读取或验证。为避免把错误文件交给你，本页不会生成猜测链接。"
+                : "首个公开版本正在准备。当前还没有可公开下载和验证的 APK，完成签名与生产验证后，本页才会开放唯一入口。"}
+          </p>
+          <div className="download-release-action">
+            <div
+              className={`download-state download-state-${releaseState.status}`}
+              role="status"
+              aria-live="polite"
+            >
+              <span>
+                <i aria-hidden="true" />
+                {stateCopy.label}
+              </span>
+              <small>{stateCopy.detail}</small>
+            </div>
+            {release ? (
+              <a
+                className="button download-primary-action"
+                href={release.download_path}
+                download={release.file_name}
+              >
+                下载 Android APK
+              </a>
+            ) : null}
+          </div>
         </div>
         <aside className="download-availability" aria-labelledby="available-title">
-          <p className="eyebrow">开放下载时同时提供</p><h2 id="available-title">文件之外，还有完整的验证信息。</h2>
-          <ul><li>版本、时间与兼容范围</li><li>APK 文件 SHA-256</li><li>签名证书 SHA-256</li><li>安装步骤与更新记录</li></ul>
+          <p className="eyebrow">开放下载时同时提供</p>
+          <h2 id="available-title">文件之外，还有完整的验证信息。</h2>
+          <ul>
+            <li>版本、时间与兼容范围</li>
+            <li>APK 文件 SHA-256</li>
+            <li>签名证书 SHA-256</li>
+            <li>安装步骤与校验说明</li>
+          </ul>
         </aside>
       </header>
 
       <section className="download-section" aria-labelledby="release-title">
-        <div className="download-section-heading"><p className="eyebrow">发布信息</p><h2 id="release-title">拿到文件前，先知道它是什么。</h2></div>
-        <dl className="download-facts">{releaseFields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>
+        <div className="download-section-heading">
+          <p className="eyebrow">发布信息</p>
+          <h2 id="release-title">拿到文件前，先知道它是什么。</h2>
+        </div>
+        <dl className="download-facts">
+          {releaseFields.map(([label, value]) => (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
       </section>
 
-      <section className="download-section download-verify" id="verify" aria-labelledby="verify-title">
-        <div className="download-section-heading"><p className="eyebrow">验证信息</p><h2 id="verify-title">文件校验与签名校验，是两件不同的事。</h2><p>前者确认下载文件没有变化，后者确认应用由预期证书签名。</p></div>
-        <dl className="download-hashes"><div><dt>APK 文件 SHA-256</dt><dd>制品就绪后公开</dd></div><div><dt>签名证书 SHA-256</dt><dd>制品就绪后公开</dd></div></dl>
+      <section
+        className="download-section download-verify"
+        id="verify"
+        aria-labelledby="verify-title"
+      >
+        <div className="download-section-heading">
+          <p className="eyebrow">验证信息</p>
+          <h2 id="verify-title">文件校验与签名校验，是两件不同的事。</h2>
+          <p>前者确认下载文件没有变化，后者确认应用由预期证书签名。</p>
+        </div>
+        <dl className="download-hashes">
+          <div>
+            <dt>APK 文件 SHA-256</dt>
+            <dd>{release?.apk_sha256 ?? placeholder}</dd>
+          </div>
+          <div>
+            <dt>签名证书 SHA-256</dt>
+            <dd>{release?.apk_certificate_sha256 ?? placeholder}</dd>
+          </div>
+        </dl>
       </section>
 
       <section className="download-section" aria-labelledby="support-title">
-        <div className="download-section-heading"><p className="eyebrow">发布与支持</p><h2 id="support-title">每个版本，都能找到后续说明。</h2></div>
-        <dl className="download-facts">{supportFields.map(([label, value]) => <div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl>
+        <div className="download-section-heading">
+          <p className="eyebrow">发布与支持</p>
+          <h2 id="support-title">已提供与待补充的信息，都明确说明。</h2>
+        </div>
+        <dl className="download-facts">
+          {supportFields.map(([label, value]) => (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
       </section>
 
       <section className="download-section" id="install" aria-labelledby="install-title">
-        <div className="download-section-heading"><p className="eyebrow">安装说明</p><h2 id="install-title">只从这里下载，只为可信来源授权。</h2></div>
-        <ol className="download-steps"><li><span>01</span><div><strong>下载并核验</strong><p>入口开放后，从本页获取 APK，并对照公开的文件 SHA-256。</p></div></li><li><span>02</span><div><strong>按来源临时授权</strong><p>Android 8.0 及以上版本会要求为当前浏览器或文件管理器允许“安装未知应用”。</p></div></li><li><span>03</span><div><strong>安装后收回权限</strong><p>完成安装后，可回到系统设置关闭该来源的安装权限。</p></div></li></ol>
+        <div className="download-section-heading">
+          <p className="eyebrow">安装说明</p>
+          <h2 id="install-title">只从这里下载，只为可信来源授权。</h2>
+        </div>
+        <ol className="download-steps">
+          <li>
+            <span>01</span>
+            <div>
+              <strong>下载并核验</strong>
+              <p>从本页获取 APK，并对照公开的文件 SHA-256。</p>
+            </div>
+          </li>
+          <li>
+            <span>02</span>
+            <div>
+              <strong>按来源临时授权</strong>
+              <p>
+                Android 8.0
+                及以上版本会要求为当前浏览器或文件管理器允许“安装未知应用”。
+              </p>
+            </div>
+          </li>
+          <li>
+            <span>03</span>
+            <div>
+              <strong>安装后收回权限</strong>
+              <p>完成安装后，可回到系统设置关闭该来源的安装权限。</p>
+            </div>
+          </li>
+        </ol>
       </section>
 
-      <section className="release-final download-final"><div><p className="eyebrow">当前状态</p><h2>现在还不能下载，但发布信息不会含糊。</h2></div><Link className="button" href="/">返回产品首页</Link></section>
-      <footer><Link className="brand" href="/"><BrandMark /><span>SpeakUp</span></Link><p>Android 官方下载与验证信息。</p><span>© 2026 SpeakUp</span></footer>
+      <section className="release-final download-final">
+        <div>
+          <p className="eyebrow">当前状态</p>
+          <h2>
+            {release
+              ? `v${release.version} 已开放下载，校验信息同步可查。`
+              : releaseState.status === "unavailable"
+                ? "发布信息暂不可用，下载入口保持关闭。"
+                : "现在还不能下载，但发布信息不会含糊。"}
+          </h2>
+        </div>
+        <Link className="button" href="/">
+          返回产品首页
+        </Link>
+      </section>
+      <footer>
+        <Link className="brand" href="/">
+          <BrandMark />
+          <span>SpeakUp</span>
+        </Link>
+        <p>Android 官方下载与验证信息。</p>
+        <span>© 2026 SpeakUp</span>
+      </footer>
     </main>
   );
 }

--- a/portal/app/marketing.css
+++ b/portal/app/marketing.css
@@ -237,8 +237,12 @@
 .download-back { display: inline-block; margin-bottom: clamp(62px, 7vw, 96px); color: var(--muted); font-size: 14px; font-weight: 700; }
 .download-hero h1 { max-width: 850px; font-size: clamp(58px, 7.5vw, 104px); line-height: 0.94; }
 .download-hero-copy > p:not(.eyebrow) { max-width: 680px; margin-top: 30px; color: var(--muted); font-size: 18px; line-height: 1.7; }
-.download-state { margin-top: 38px; padding-top: 20px; border-top: 1px solid var(--line); display: grid; gap: 8px; }
+.download-release-action { margin-top: 38px; padding-top: 20px; border-top: 1px solid var(--line); display: flex; align-items: end; justify-content: space-between; gap: 24px; }
+.download-state { display: grid; gap: 8px; }
 .download-state small { color: var(--muted); line-height: 1.55; }
+.download-state-ready i { background: var(--fathom); box-shadow: 0 0 0 4px rgba(3, 79, 70, 0.14); }
+.download-state-unavailable i { background: var(--muted); box-shadow: 0 0 0 4px rgba(26, 26, 26, 0.1); }
+.download-primary-action { flex: 0 0 auto; }
 
 .download-availability { padding: 30px; border: 2px solid var(--ink); border-radius: 28px; background: var(--dawn); box-shadow: 10px 12px 0 rgba(26, 26, 26, 0.09); }
 .download-availability h2 { font-size: clamp(32px, 3.2vw, 44px); }
@@ -256,7 +260,7 @@
 .download-hashes > div { padding: 28px 0; border-top: 1px solid var(--line); }
 .download-hashes > div:last-child { border-bottom: 1px solid var(--line); }
 .download-hashes dt { margin-bottom: 10px; font-size: 20px; font-weight: 760; }
-.download-hashes dd { color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; }
+.download-hashes dd { color: var(--muted); overflow-wrap: anywhere; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; }
 .download-steps { margin: 0; padding: 0; list-style: none; }
 .download-steps li { padding: 24px 0 28px; border-top: 1px solid var(--line); display: grid; grid-template-columns: 48px 1fr; gap: 20px; }
 .download-steps li:last-child { border-bottom: 1px solid var(--line); }
@@ -304,6 +308,8 @@
   .download-back { margin-bottom: 58px; }
   .download-hero h1 { font-size: 54px; }
   .download-availability { padding: 24px 20px; }
+  .download-release-action { align-items: stretch; flex-direction: column; }
+  .download-primary-action { width: 100%; }
   .download-verify { width: 100%; border-radius: 36px; }
   .download-facts > div { grid-template-columns: 1fr; gap: 7px; }
   .release-site footer { grid-template-columns: 1fr auto; padding: 28px 20px; }

--- a/portal/design-qa.md
+++ b/portal/design-qa.md
@@ -4,7 +4,13 @@
 - Brand continuity: retained SpeakUp's existing logo, cream/lavender palette, serif display type, black outlines, and real product screenshot.
 - Desktop and tablet: checked at 1440 × 900 and 768 × 1024; hero, product image, CTA, Android status, and download page render without overlap or clipping.
 - Mobile: checked at 390 × 844; navigation collapses, content becomes single-column, CTA remains full-width, and download metadata stays readable.
+- Android publication: rechecked the honest preparing state at 1440 × 900 and
+  390 × 844 after adding the metadata-driven download action; no overlap,
+  clipping, gradient, extra nested card, fake QR code, or `latest.apk` link was
+  introduced.
 - Interaction: Android CTA route and native FAQ expansion verified.
+- Release states: automated contract tests cover preparing, unavailable, and
+  ready results; only ready metadata carries the validated versioned APK path.
 - Runtime: no application console errors observed.
 - Automated verification: lint, tests, and production build passed.
 

--- a/portal/lib/android-release-metadata.mjs
+++ b/portal/lib/android-release-metadata.mjs
@@ -1,0 +1,93 @@
+const metadataKeys = [
+  "abis",
+  "apk_certificate_sha256",
+  "apk_sha256",
+  "download_path",
+  "file_name",
+  "metadata_version",
+  "minimum_android_api",
+  "published_at",
+  "size_bytes",
+  "version",
+  "version_code",
+];
+
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const canonicalUtcPattern =
+  /^\d{4}-(0[1-9]|1[0-2])-([012]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$/;
+
+function invalid() {
+  throw new Error("Android release metadata is invalid");
+}
+
+function positiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 1;
+}
+
+function nonzeroSha(value) {
+  return (
+    typeof value === "string" &&
+    sha256Pattern.test(value) &&
+    !/^0+$/.test(value)
+  );
+}
+
+function canonicalPublishedAt(value) {
+  if (typeof value !== "string" || !canonicalUtcPattern.test(value)) return false;
+  const parsed = new Date(value);
+  return (
+    !Number.isNaN(parsed.valueOf()) &&
+    parsed.toISOString().replace(".000Z", "Z") === value
+  );
+}
+
+export function parseAndroidReleaseMetadata(value) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    JSON.stringify(Object.keys(value).sort()) !==
+      JSON.stringify(metadataKeys)
+  ) {
+    invalid();
+  }
+
+  const metadata = value;
+  if (
+    metadata.metadata_version !== 1 ||
+    typeof metadata.version !== "string" ||
+    !versionPattern.test(metadata.version) ||
+    !positiveSafeInteger(metadata.version_code) ||
+    !canonicalPublishedAt(metadata.published_at) ||
+    metadata.file_name !==
+      `speakup-v${metadata.version}-production-arm64.apk` ||
+    metadata.download_path !==
+      `/downloads/android/v${metadata.version}/${metadata.file_name}` ||
+    !positiveSafeInteger(metadata.size_bytes) ||
+    metadata.minimum_android_api !== 24 ||
+    JSON.stringify(metadata.abis) !== JSON.stringify(["arm64-v8a"]) ||
+    !nonzeroSha(metadata.apk_sha256) ||
+    !nonzeroSha(metadata.apk_certificate_sha256)
+  ) {
+    invalid();
+  }
+  return metadata;
+}
+
+export async function loadAndroidRelease(fetcher = fetch) {
+  try {
+    const response = await fetcher("/downloads/android/release.json", {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+    });
+    if (response.status === 404) return { status: "preparing" };
+    if (!response.ok) return { status: "unavailable" };
+    return {
+      status: "ready",
+      release: parseAndroidReleaseMetadata(await response.json()),
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/portal/tests/android-release-metadata.test.mjs
+++ b/portal/tests/android-release-metadata.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  loadAndroidRelease,
+  parseAndroidReleaseMetadata,
+} from "../lib/android-release-metadata.mjs";
+
+const validMetadata = {
+  metadata_version: 1,
+  version: "0.1.0",
+  version_code: 1,
+  published_at: "2026-08-23T12:34:56Z",
+  file_name: "speakup-v0.1.0-production-arm64.apk",
+  download_path:
+    "/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk",
+  size_bytes: 12345678,
+  minimum_android_api: 24,
+  abis: ["arm64-v8a"],
+  apk_sha256: "a".repeat(64),
+  apk_certificate_sha256: "b".repeat(64),
+};
+
+test("accepts only the exact versioned Android release contract", () => {
+  assert.deepEqual(parseAndroidReleaseMetadata(validMetadata), validMetadata);
+
+  const invalidValues = [
+    { ...validMetadata, extra: true },
+    { ...validMetadata, download_path: "https://example.com/app.apk" },
+    { ...validMetadata, download_path: "/downloads/android/latest.apk" },
+    { ...validMetadata, file_name: "speakup-v0.1.1-production-arm64.apk" },
+    { ...validMetadata, published_at: "2026-02-30T12:34:56Z" },
+    { ...validMetadata, published_at: "2026-08-23T12:34:56+00:00" },
+    { ...validMetadata, size_bytes: 0 },
+    { ...validMetadata, minimum_android_api: 23 },
+    { ...validMetadata, abis: ["arm64-v8a", "x86_64"] },
+    { ...validMetadata, apk_sha256: "A".repeat(64) },
+    { ...validMetadata, apk_certificate_sha256: "0".repeat(64) },
+  ];
+  for (const value of invalidValues) {
+    assert.throws(
+      () => parseAndroidReleaseMetadata(value),
+      /Android release metadata is invalid/,
+    );
+  }
+});
+
+test("maps a missing release to the honest preparing state", async () => {
+  const fetcher = async () => new Response(null, { status: 404 });
+  assert.deepEqual(await loadAndroidRelease(fetcher), { status: "preparing" });
+});
+
+test("returns ready only after strict metadata validation", async () => {
+  const fetcher = async () => Response.json(validMetadata);
+  assert.deepEqual(await loadAndroidRelease(fetcher), {
+    status: "ready",
+    release: validMetadata,
+  });
+});
+
+test("maps network, HTTP, JSON, and schema failures to unavailable", async () => {
+  const cases = [
+    async () => {
+      throw new Error("network unavailable");
+    },
+    async () => new Response(null, { status: 503 }),
+    async () => new Response("not-json", { status: 200 }),
+    async () => Response.json({ ...validMetadata, unexpected: true }),
+  ];
+  for (const fetcher of cases) {
+    assert.deepEqual(await loadAndroidRelease(fetcher), {
+      status: "unavailable",
+    });
+  }
+});

--- a/portal/tests/rendered-html.test.mjs
+++ b/portal/tests/rendered-html.test.mjs
@@ -43,6 +43,11 @@ test("renders an honest Android download preparing state", async () => {
   assert.match(html, /更新日志/);
   assert.match(html, /隐私与权限/);
   assert.match(html, /问题反馈/);
+  assert.match(html, /独立更新日志尚未提供/);
+  assert.match(html, /正式隐私说明与权限清单尚未提供/);
+  assert.match(html, /正式反馈入口尚未提供/);
+  assert.doesNotMatch(html, /开放下载前公开/);
+  assert.doesNotMatch(html, /安装步骤与更新记录/);
   assert.match(html, /安装未知应用/);
   assert.doesNotMatch(html, /\.apk(?:"|\?)/);
   assert.doesNotMatch(html, /versionName:\s*\d/);

--- a/tools/android-download/bundle.mjs
+++ b/tools/android-download/bundle.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  constants,
+  lstatSync,
+  fstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  closeSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const imageDigestPattern = /^sha256:[0-9a-f]{64}$/;
+const gitShaPattern = /^[0-9a-f]{40}$/;
+const canonicalUtcPattern =
+  /^\d{4}-(0[1-9]|1[0-2])-([012]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$/;
+
+const releaseManifestKeys = [
+  "abis",
+  "apk_certificate_sha256",
+  "application_id",
+  "database_schema_version",
+  "git_sha",
+  "manifest_version",
+  "minimum_android_api",
+  "portal_image",
+  "portal_image_digest",
+  "production_apk_file",
+  "production_apk_sha256",
+  "production_apk_size_bytes",
+  "quality_run_url",
+  "server_image",
+  "server_image_digest",
+  "staging_apk_file",
+  "staging_apk_sha256",
+  "version",
+  "version_code",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactKeys(value, expected, name) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...expected].sort())
+  ) {
+    fail(`${name} has an invalid schema`);
+  }
+}
+
+function positiveSafeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    fail(`${name} must be a positive safe integer`);
+  }
+}
+
+function nonzeroSha(value, pattern, name) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    fail(`${name} has an invalid value`);
+  }
+  const hexadecimal = value.startsWith("sha256:") ? value.slice(7) : value;
+  if (/^0+$/.test(hexadecimal)) fail(`${name} cannot be a placeholder digest`);
+}
+
+function readRegularFileSnapshot(file, name) {
+  let status;
+  try {
+    status = lstatSync(file);
+  } catch (error) {
+    if (error && error.code !== "ENOENT") throw error;
+    fail(`${name} does not exist: ${file}`);
+  }
+  if (status.isSymbolicLink()) {
+    fail(`${name} cannot be a symlink`);
+  }
+
+  let descriptor;
+  try {
+    descriptor = openSync(
+      file,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    if (error && error.code === "ELOOP") fail(`${name} cannot be a symlink`);
+    fail(`${name} cannot be opened as a regular file`);
+  }
+
+  try {
+    status = fstatSync(descriptor);
+    if (!status.isFile() || status.size === 0) {
+      fail(`${name} must be a non-empty regular file`);
+    }
+    const bytes = readFileSync(descriptor);
+    if (bytes.length !== status.size) {
+      fail(`${name} changed while it was being read`);
+    }
+    return { bytes, size: status.size };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseJsonSnapshot(snapshot, name) {
+  try {
+    return JSON.parse(snapshot.bytes.toString("utf8"));
+  } catch {
+    fail(`${name} is not valid JSON`);
+  }
+}
+
+function sha256File(file) {
+  return sha256Bytes(readFileSync(file));
+}
+
+export function validateReleaseManifest(value) {
+  exactKeys(value, releaseManifestKeys, "release manifest");
+  if (value.manifest_version !== 1) fail("release manifest version must be 1");
+  if (typeof value.version !== "string" || !versionPattern.test(value.version)) {
+    fail("release manifest version is invalid");
+  }
+  positiveSafeInteger(value.version_code, "release manifest version_code");
+  nonzeroSha(value.git_sha, gitShaPattern, "release manifest git_sha");
+  if (value.portal_image !== "ghcr.io/1024xengineer/xe3-esl-portal") {
+    fail("release manifest Portal image is invalid");
+  }
+  nonzeroSha(
+    value.portal_image_digest,
+    imageDigestPattern,
+    "release manifest portal_image_digest",
+  );
+  if (value.server_image !== "ghcr.io/1024xengineer/xe3-esl-server") {
+    fail("release manifest Server image is invalid");
+  }
+  nonzeroSha(
+    value.server_image_digest,
+    imageDigestPattern,
+    "release manifest server_image_digest",
+  );
+  if (value.staging_apk_file !== `speakup-v${value.version}-staging-arm64.apk`) {
+    fail("release manifest Staging APK name is invalid");
+  }
+  nonzeroSha(
+    value.staging_apk_sha256,
+    sha256Pattern,
+    "release manifest staging_apk_sha256",
+  );
+  if (
+    value.production_apk_file !==
+    `speakup-v${value.version}-production-arm64.apk`
+  ) {
+    fail("release manifest Production APK name is invalid");
+  }
+  positiveSafeInteger(
+    value.production_apk_size_bytes,
+    "release manifest production_apk_size_bytes",
+  );
+  nonzeroSha(
+    value.production_apk_sha256,
+    sha256Pattern,
+    "release manifest production_apk_sha256",
+  );
+  if (
+    value.application_id !== "com.xengineer.speakup" ||
+    value.minimum_android_api !== 24 ||
+    JSON.stringify(value.abis) !== JSON.stringify(["arm64-v8a"])
+  ) {
+    fail("release manifest Android contract is invalid");
+  }
+  nonzeroSha(
+    value.apk_certificate_sha256,
+    sha256Pattern,
+    "release manifest apk_certificate_sha256",
+  );
+  positiveSafeInteger(
+    value.database_schema_version,
+    "release manifest database_schema_version",
+  );
+  if (
+    typeof value.quality_run_url !== "string" ||
+    !/^https:\/\/github\.com\/1024XEngineer\/XE3-ESL\/actions\/runs\/[1-9]\d*$/.test(
+      value.quality_run_url,
+    )
+  ) {
+    fail("release manifest quality_run_url is invalid");
+  }
+  return value;
+}
+
+export function validatePublishedAt(value) {
+  if (typeof value !== "string" || !canonicalUtcPattern.test(value)) {
+    fail("published time must be canonical RFC3339 UTC without fractional seconds");
+  }
+  const parsed = new Date(value);
+  if (
+    Number.isNaN(parsed.valueOf()) ||
+    parsed.toISOString().replace(".000Z", "Z") !== value
+  ) {
+    fail("published time is not a real UTC timestamp");
+  }
+  return value;
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o644,
+  });
+}
+
+function fileEntry(root, relativePath) {
+  const file = path.join(root, relativePath);
+  return {
+    path: relativePath,
+    size_bytes: statSync(file).size,
+    sha256: sha256File(file),
+  };
+}
+
+function outputMustNotExist(output) {
+  try {
+    lstatSync(output);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return;
+    throw error;
+  }
+  fail(`output already exists: ${output}`);
+}
+
+export function buildAndroidDownloadBundle({
+  manifestPath,
+  productionApkPath,
+  publishedAt,
+  outputPath,
+}) {
+  const manifestFile = path.resolve(manifestPath);
+  const apkFile = path.resolve(productionApkPath);
+  const output = path.resolve(outputPath);
+  const outputParent = path.dirname(output);
+  const outputName = path.basename(output);
+
+  const manifestSnapshot = readRegularFileSnapshot(manifestFile, "release manifest");
+  const releaseManifestSha256 = sha256Bytes(manifestSnapshot.bytes);
+  const manifest = validateReleaseManifest(
+    parseJsonSnapshot(manifestSnapshot, "release manifest"),
+  );
+  const apkSnapshot = readRegularFileSnapshot(apkFile, "Production APK");
+  const timestamp = validatePublishedAt(publishedAt);
+
+  if (path.basename(apkFile) !== manifest.production_apk_file) {
+    fail(`Production APK must be named ${manifest.production_apk_file}`);
+  }
+  if (apkSnapshot.size !== manifest.production_apk_size_bytes) {
+    fail("Production APK size does not match the release manifest");
+  }
+  const apkSha256 = sha256Bytes(apkSnapshot.bytes);
+  if (apkSha256 !== manifest.production_apk_sha256) {
+    fail("Production APK SHA-256 does not match the release manifest");
+  }
+
+  const parentStatus = lstatSync(outputParent);
+  if (parentStatus.isSymbolicLink() || !parentStatus.isDirectory()) {
+    fail("output parent must be a real directory");
+  }
+  outputMustNotExist(output);
+
+  const lock = path.join(outputParent, `.${outputName}.lock`);
+  let lockDescriptor;
+  let lockCreated = false;
+  let temporary;
+  try {
+    lockDescriptor = openSync(
+      lock,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    lockCreated = true;
+    temporary = mkdtempSync(path.join(outputParent, `.${outputName}.tmp-`));
+    const versionDirectory = path.join(
+      temporary,
+      "downloads",
+      "android",
+      `v${manifest.version}`,
+    );
+    mkdirSync(versionDirectory, { recursive: true, mode: 0o755 });
+
+    const apkRelativePath = path.posix.join(
+      "downloads",
+      "android",
+      `v${manifest.version}`,
+      manifest.production_apk_file,
+    );
+    const checksumRelativePath = `${apkRelativePath}.sha256`;
+    const metadataRelativePath = path.posix.join(
+      "downloads",
+      "android",
+      `v${manifest.version}`,
+      "release.json",
+    );
+
+    writeFileSync(path.join(temporary, apkRelativePath), apkSnapshot.bytes, {
+      flag: "wx",
+      mode: 0o644,
+    });
+    writeFileSync(
+      path.join(temporary, checksumRelativePath),
+      `${apkSha256}  ${manifest.production_apk_file}\n`,
+      { encoding: "utf8", flag: "wx", mode: 0o644 },
+    );
+
+    const publicMetadata = {
+      metadata_version: 1,
+      version: manifest.version,
+      version_code: manifest.version_code,
+      published_at: timestamp,
+      file_name: manifest.production_apk_file,
+      download_path: `/${apkRelativePath}`,
+      size_bytes: manifest.production_apk_size_bytes,
+      minimum_android_api: manifest.minimum_android_api,
+      abis: manifest.abis,
+      apk_sha256: manifest.production_apk_sha256,
+      apk_certificate_sha256: manifest.apk_certificate_sha256,
+    };
+    writeJson(path.join(temporary, metadataRelativePath), publicMetadata);
+
+    const files = [apkRelativePath, checksumRelativePath, metadataRelativePath].map(
+      (relativePath) => fileEntry(temporary, relativePath),
+    );
+    writeJson(path.join(temporary, "bundle-manifest.json"), {
+      bundle_version: 1,
+      version: manifest.version,
+      published_at: timestamp,
+      release_manifest_sha256: releaseManifestSha256,
+      files,
+    });
+
+    outputMustNotExist(output);
+    renameSync(temporary, output);
+    temporary = undefined;
+    return {
+      output,
+      version: manifest.version,
+      bundleManifestSha256: sha256File(path.join(output, "bundle-manifest.json")),
+    };
+  } finally {
+    if (lockDescriptor !== undefined) closeSync(lockDescriptor);
+    if (temporary) rmSync(temporary, { recursive: true, force: true });
+    if (lockCreated) {
+      try {
+        unlinkSync(lock);
+      } catch (error) {
+        if (!error || error.code !== "ENOENT") throw error;
+      }
+    }
+  }
+}
+
+function readArguments(arguments_) {
+  const values = {};
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const flag = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!flag?.startsWith("--") || value === undefined || values[flag.slice(2)]) {
+      fail(
+        "Usage: bundle.mjs --manifest FILE --production-apk FILE " +
+          "--published-at RFC3339_UTC --output DIRECTORY",
+      );
+    }
+    values[flag.slice(2)] = value;
+  }
+  return values;
+}
+
+function main() {
+  const arguments_ = readArguments(process.argv.slice(2));
+  const allowed = ["manifest", "production-apk", "published-at", "output"];
+  for (const name of allowed) {
+    if (!arguments_[name]) fail(`--${name} is required`);
+  }
+  for (const name of Object.keys(arguments_)) {
+    if (!allowed.includes(name)) fail(`unknown argument: --${name}`);
+  }
+  const result = buildAndroidDownloadBundle({
+    manifestPath: arguments_.manifest,
+    productionApkPath: arguments_["production-apk"],
+    publishedAt: arguments_["published-at"],
+    outputPath: arguments_.output,
+  });
+  process.stdout.write(
+    `version=${result.version} bundle_manifest_sha256=${result.bundleManifestSha256} output=${result.output}\n`,
+  );
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tools/android-download/bundle.test.mjs
+++ b/tools/android-download/bundle.test.mjs
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildAndroidDownloadBundle } from "./bundle.mjs";
+
+const publishedAt = "2026-08-23T12:34:56Z";
+const nonzeroDigest = (character) => `sha256:${character.repeat(64)}`;
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+function fixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "android-download-bundle-"));
+  const apkName = "speakup-v0.1.0-production-arm64.apk";
+  const apk = path.join(root, apkName);
+  const apkBytes = Buffer.from("signed-production-apk-fixture\n");
+  writeFileSync(apk, apkBytes);
+  const manifest = {
+    manifest_version: 1,
+    version: "0.1.0",
+    version_code: 1,
+    git_sha: "c".repeat(40),
+    portal_image: "ghcr.io/1024xengineer/xe3-esl-portal",
+    portal_image_digest: nonzeroDigest("a"),
+    server_image: "ghcr.io/1024xengineer/xe3-esl-server",
+    server_image_digest: nonzeroDigest("b"),
+    staging_apk_file: "speakup-v0.1.0-staging-arm64.apk",
+    staging_apk_sha256: "d".repeat(64),
+    production_apk_file: apkName,
+    production_apk_size_bytes: apkBytes.length,
+    production_apk_sha256: sha256(apkBytes),
+    application_id: "com.xengineer.speakup",
+    minimum_android_api: 24,
+    abis: ["arm64-v8a"],
+    apk_certificate_sha256: "e".repeat(64),
+    database_schema_version: 7,
+    quality_run_url:
+      "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456789",
+  };
+  const manifestPath = path.join(root, "release-manifest.json");
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { apk, apkBytes, manifest, manifestPath, root };
+}
+
+function build(input, outputName = "public-bundle") {
+  return buildAndroidDownloadBundle({
+    manifestPath: input.manifestPath,
+    productionApkPath: input.apk,
+    publishedAt,
+    outputPath: path.join(input.root, outputName),
+  });
+}
+
+function rewriteManifest(input, mutate) {
+  const changed = structuredClone(input.manifest);
+  mutate(changed);
+  writeFileSync(input.manifestPath, `${JSON.stringify(changed, null, 2)}\n`);
+}
+
+test("builds a deterministic strict public Android download bundle", () => {
+  const input = fixture();
+  try {
+    const first = build(input, "bundle-one");
+    const second = build(input, "bundle-two");
+    const expectedDirectory = path.join(
+      input.root,
+      "bundle-one",
+      "downloads",
+      "android",
+      "v0.1.0",
+    );
+    assert.deepEqual(readdirSync(expectedDirectory).sort(), [
+      "release.json",
+      "speakup-v0.1.0-production-arm64.apk",
+      "speakup-v0.1.0-production-arm64.apk.sha256",
+    ]);
+
+    const metadata = JSON.parse(
+      readFileSync(path.join(expectedDirectory, "release.json"), "utf8"),
+    );
+    assert.deepEqual(metadata, {
+      metadata_version: 1,
+      version: "0.1.0",
+      version_code: 1,
+      published_at: publishedAt,
+      file_name: "speakup-v0.1.0-production-arm64.apk",
+      download_path:
+        "/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk",
+      size_bytes: input.apkBytes.length,
+      minimum_android_api: 24,
+      abis: ["arm64-v8a"],
+      apk_sha256: input.manifest.production_apk_sha256,
+      apk_certificate_sha256: input.manifest.apk_certificate_sha256,
+    });
+    assert.equal(
+      readFileSync(
+        path.join(
+          expectedDirectory,
+          "speakup-v0.1.0-production-arm64.apk.sha256",
+        ),
+        "utf8",
+      ),
+      `${input.manifest.production_apk_sha256}  ${input.manifest.production_apk_file}\n`,
+    );
+
+    const bundleManifest = JSON.parse(
+      readFileSync(path.join(input.root, "bundle-one", "bundle-manifest.json")),
+    );
+    assert.deepEqual(
+      bundleManifest.files.map((entry) => entry.path),
+      [
+        "downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk",
+        "downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk.sha256",
+        "downloads/android/v0.1.0/release.json",
+      ],
+    );
+    assert.equal(first.bundleManifestSha256, second.bundleManifestSha256);
+    assert.equal(
+      readFileSync(path.join(input.root, "bundle-one", "bundle-manifest.json"), "utf8"),
+      readFileSync(path.join(input.root, "bundle-two", "bundle-manifest.json"), "utf8"),
+    );
+  } finally {
+    rmSync(input.root, { recursive: true, force: true });
+  }
+});
+
+test("binds parsed release metadata and provenance hash to one manifest snapshot", () => {
+  const input = fixture();
+  const originalParse = JSON.parse;
+  try {
+    const originalManifestBytes = readFileSync(input.manifestPath);
+    const replacement = structuredClone(input.manifest);
+    replacement.git_sha = "f".repeat(40);
+    const replacementBytes = Buffer.from(`${JSON.stringify(replacement, null, 2)}\n`);
+    const replacementPath = path.join(input.root, "replacement-manifest.json");
+    writeFileSync(replacementPath, replacementBytes);
+
+    let replaced = false;
+    JSON.parse = function parseAndReplacePath(value, ...arguments_) {
+      const parsed = originalParse(value, ...arguments_);
+      if (!replaced) {
+        renameSync(replacementPath, input.manifestPath);
+        replaced = true;
+      }
+      return parsed;
+    };
+
+    build(input);
+    JSON.parse = originalParse;
+    assert.equal(replaced, true);
+
+    const bundleManifest = JSON.parse(
+      readFileSync(
+        path.join(input.root, "public-bundle", "bundle-manifest.json"),
+        "utf8",
+      ),
+    );
+    assert.equal(bundleManifest.release_manifest_sha256, sha256(originalManifestBytes));
+    assert.notEqual(
+      bundleManifest.release_manifest_sha256,
+      sha256(replacementBytes),
+    );
+  } finally {
+    JSON.parse = originalParse;
+    rmSync(input.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects symlinked release manifest and APK inputs", () => {
+  const input = fixture();
+  try {
+    const links = path.join(input.root, "links");
+    mkdirSync(links);
+    const manifestLink = path.join(links, "release-manifest.json");
+    const apkLink = path.join(
+      links,
+      "speakup-v0.1.0-production-arm64.apk",
+    );
+    symlinkSync(input.manifestPath, manifestLink);
+    symlinkSync(input.apk, apkLink);
+
+    assert.throws(
+      () =>
+        buildAndroidDownloadBundle({
+          manifestPath: manifestLink,
+          productionApkPath: input.apk,
+          publishedAt,
+          outputPath: path.join(input.root, "manifest-link-bundle"),
+        }),
+      /release manifest cannot be a symlink/,
+    );
+    assert.throws(
+      () =>
+        buildAndroidDownloadBundle({
+          manifestPath: input.manifestPath,
+          productionApkPath: apkLink,
+          publishedAt,
+          outputPath: path.join(input.root, "apk-link-bundle"),
+        }),
+      /Production APK cannot be a symlink/,
+    );
+  } finally {
+    rmSync(input.root, { recursive: true, force: true });
+  }
+});
+
+test("never overwrites an existing output file, directory, or symlink", () => {
+  for (const kind of ["file", "directory", "symlink"]) {
+    const input = fixture();
+    try {
+      const output = path.join(input.root, "public-bundle");
+      if (kind === "file") writeFileSync(output, "keep\n");
+      if (kind === "directory") mkdirSync(output);
+      if (kind === "symlink") symlinkSync(input.apk, output);
+      assert.throws(() => build(input), /output already exists/);
+      assert.ok(lstatSync(output));
+    } finally {
+      rmSync(input.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("rejects malformed manifests and mismatched APK evidence", () => {
+  const cases = [
+    ["extra field", (value) => (value.unknown = true), /invalid schema/],
+    ["package", (value) => (value.application_id = "com.example.fake"), /Android contract/],
+    ["ABI", (value) => (value.abis = ["x86_64"]), /Android contract/],
+    ["certificate", (value) => (value.apk_certificate_sha256 = "0".repeat(64)), /placeholder/],
+    ["size", (value) => (value.production_apk_size_bytes += 1), /size does not match/],
+    ["hash", (value) => (value.production_apk_sha256 = "f".repeat(64)), /SHA-256/],
+    ["name", (value) => (value.production_apk_file = "renamed.apk"), /APK name/],
+  ];
+  for (const [name, mutate, expected] of cases) {
+    const input = fixture();
+    try {
+      rewriteManifest(input, mutate);
+      assert.throws(() => build(input), expected, name);
+    } finally {
+      rmSync(input.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("rejects non-canonical or impossible publication timestamps", () => {
+  const input = fixture();
+  try {
+    for (const value of [
+      "2026-08-23T12:34:56+00:00",
+      "2026-08-23T12:34:56.000Z",
+      "2026-02-30T12:34:56Z",
+    ]) {
+      assert.throws(
+        () =>
+          buildAndroidDownloadBundle({
+            manifestPath: input.manifestPath,
+            productionApkPath: input.apk,
+            publishedAt: value,
+            outputPath: path.join(input.root, `bundle-${value.length}`),
+          }),
+        /published time/,
+      );
+    }
+  } finally {
+    rmSync(input.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 功能描述

- 为 Portal 增加严格的 Android 正式 APK 发布状态与版本化下载入口。
- 下载开放前保持真实“准备中/暂不可用”状态，不生成空链接、假二维码或未校验版本。
- 同步公开版本、兼容范围、APK SHA-256 与签名证书 SHA-256。
- 关联 #869。

## 实现思路

- 从已验证的 Release Candidate 清单与 Production APK 构建确定性公开 bundle；同一文件快照同时用于解析、校验、哈希与写入，拒绝 symlink 和路径替换竞态。
- 服务器端以不可覆盖的版本目录发布 APK、校验文件和版本元数据；通过原子替换 current metadata 激活或回滚版本。
- Staging 与 Production Nginx 只开放精确的版本化下载路径，APK 使用正确 MIME 与 immutable 缓存，current metadata 使用 `no-store`，未知路径和 API 域下载路径返回 404。
- Portal 仅在同源 `release.json` 通过严格 schema 校验后显示真实下载链接；404 显示准备中，网络、HTTP、JSON 或 schema 异常均 fail closed。

## 可复现测试

- `make check-android-download`
- `make check-staging-deploy`
- `make check-production-deploy`
- `make check-staging-nginx`
- `make check-production-nginx`
- `cd portal && npm run lint`
- `cd portal && npm test`
- 桌面与 390px 手机视口逐屏视觉检查通过。

## 验收说明

- Android bundle 测试覆盖确定性输出、manifest/APK 单快照追溯、symlink 拒绝、禁止覆盖、字段/大小/哈希不一致和非法发布时间。
- Staging 下载仍继承 Basic Auth；Production 下载公开；API 域不提供 APK。
- 本 PR 不包含真实 APK、签名密钥、密码、环境文件或生产部署操作。

Closes #869
