### PR TITLE
release: promote Android signing fix for v0.1.1

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -188,6 +188,10 @@ jobs:
       - name: Prepare protected release keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.SPEAKUP_ANDROID_KEYSTORE_BASE64 }}
+          SPEAKUP_ANDROID_KEY_ALIAS: ${{ secrets.SPEAKUP_ANDROID_KEY_ALIAS }}
+          SPEAKUP_ANDROID_STORE_PASSWORD: ${{ secrets.SPEAKUP_ANDROID_STORE_PASSWORD }}
+          SPEAKUP_ANDROID_KEY_PASSWORD: ${{ secrets.SPEAKUP_ANDROID_KEY_PASSWORD }}
+          SPEAKUP_ANDROID_CERT_SHA256: ${{ secrets.SPEAKUP_ANDROID_CERT_SHA256 }}
         run: |
           set -euo pipefail
           if [[ -z "$KEYSTORE_BASE64" ]]; then
@@ -203,6 +207,7 @@ jobs:
             exit 1
           fi
           chmod 600 "$keystore_path"
+          ./tools/android-release/verify-keystore.sh "$keystore_path"
           echo "SPEAKUP_ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
 
       - name: Build signed Staging and Production APKs

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ check-api-contracts: check-api-dependencies
 	cd api && npm run check
 
 check-release-candidate:
+	./tools/android-release/verify-keystore.test.sh
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -30,7 +30,7 @@ Android 真机上运行 App。连接多台设备时，可通过
 首发网站分发基线为：
 
 - applicationId：`com.xengineer.speakup`
-- versionName/versionCode：`0.1.0` / `1`（Release Tag：`v0.1.0`）
+- versionName/versionCode：`0.1.1` / `2`（Release Tag：`v0.1.1`）
 - ABI：仅 `arm64-v8a`
 - staging API 发布契约：`https://staging-api.speak-up.top`
 - production API 发布契约：`https://api.speak-up.top`

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -14,7 +14,9 @@ val releaseSigningVariableNames = listOf(
 val releaseBuildRequested = gradle.startParameter.taskNames.any {
     it.contains("release", ignoreCase = true)
 }
-val releaseSigningValues = releaseSigningVariableNames.associateWith(System::getenv)
+val releaseSigningValues = releaseSigningVariableNames.associateWith {
+    providers.environmentVariable(it).orNull
+}
 val missingReleaseSigningVariables = releaseSigningValues
     .filterValues { it.isNullOrBlank() }
     .keys

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.0+1
+version: 0.1.1+2
 
 environment:
   sdk: ^3.12.2

--- a/tools/android-release/verify-keystore.sh
+++ b/tools/android-release/verify-keystore.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" != "1" ]]; then
+  printf 'Usage: %s <keystore>\n' "$0" >&2
+  exit 2
+fi
+
+keystore="$1"
+alias_name="${SPEAKUP_ANDROID_KEY_ALIAS:-}"
+expected_certificate_sha256="${SPEAKUP_ANDROID_CERT_SHA256:-}"
+
+if [[ ! -s "$keystore" ]]; then
+  printf 'Android release keystore is not a readable, non-empty file.\n' >&2
+  exit 1
+fi
+if [[ -z "$alias_name" ]]; then
+  printf 'SPEAKUP_ANDROID_KEY_ALIAS is required.\n' >&2
+  exit 1
+fi
+if [[ -z "${SPEAKUP_ANDROID_STORE_PASSWORD:-}" ]]; then
+  printf 'SPEAKUP_ANDROID_STORE_PASSWORD is required.\n' >&2
+  exit 1
+fi
+if [[ -z "${SPEAKUP_ANDROID_KEY_PASSWORD:-}" ]]; then
+  printf 'SPEAKUP_ANDROID_KEY_PASSWORD is required.\n' >&2
+  exit 1
+fi
+if [[ -z "$expected_certificate_sha256" ]]; then
+  printf 'SPEAKUP_ANDROID_CERT_SHA256 is required.\n' >&2
+  exit 1
+fi
+
+if [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/keytool" ]]; then
+  keytool="$JAVA_HOME/bin/keytool"
+elif command -v keytool >/dev/null 2>&1; then
+  keytool="$(command -v keytool)"
+else
+  printf 'Cannot locate keytool.\n' >&2
+  exit 1
+fi
+
+key_report="$(
+  "$keytool" \
+    -J-Duser.language=en \
+    -J-Duser.country=US \
+    -list \
+    -v \
+    -keystore "$keystore" \
+    -alias "$alias_name" \
+    -storepass:env SPEAKUP_ANDROID_STORE_PASSWORD
+)"
+if ! grep -Fq 'Entry type: PrivateKeyEntry' <<< "$key_report"; then
+  printf 'Android release alias is not a private key entry.\n' >&2
+  exit 1
+fi
+
+private_key_check_directory="$(mktemp -d)"
+private_key_check="$private_key_check_directory/private-key-check.jks"
+cleanup_private_key_check() {
+  rm -f "$private_key_check"
+  rmdir "$private_key_check_directory" 2>/dev/null || true
+}
+trap cleanup_private_key_check EXIT
+if ! "$keytool" \
+  -J-Duser.language=en \
+  -J-Duser.country=US \
+  -importkeystore \
+  -noprompt \
+  -srckeystore "$keystore" \
+  -srcalias "$alias_name" \
+  -srcstorepass:env SPEAKUP_ANDROID_STORE_PASSWORD \
+  -srckeypass:env SPEAKUP_ANDROID_KEY_PASSWORD \
+  -destkeystore "$private_key_check" \
+  -deststoretype JKS \
+  -deststorepass:env SPEAKUP_ANDROID_STORE_PASSWORD \
+  -destkeypass:env SPEAKUP_ANDROID_KEY_PASSWORD \
+  >/dev/null 2>&1; then
+  printf 'SPEAKUP_ANDROID_KEY_PASSWORD cannot unlock the Android release key.\n' >&2
+  exit 1
+fi
+cleanup_private_key_check
+trap - EXIT
+
+certificate_sha256="$(
+  sed -n 's/^[[:space:]]*SHA256: //p' <<< "$key_report" |
+    head -n 1 |
+    tr '[:upper:]' '[:lower:]' |
+    tr -d '[:space:]:'
+)"
+expected_certificate_sha256="$(
+  printf '%s' "$expected_certificate_sha256" |
+    tr '[:upper:]' '[:lower:]' |
+    tr -d '[:space:]:'
+)"
+
+[[ "$certificate_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+  printf 'Cannot read a valid SHA-256 certificate fingerprint from the keystore.\n' >&2
+  exit 1
+}
+[[ "$expected_certificate_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+  printf 'SPEAKUP_ANDROID_CERT_SHA256 must contain 64 hexadecimal digits.\n' >&2
+  exit 1
+}
+[[ "$certificate_sha256" == "$expected_certificate_sha256" ]] || {
+  printf 'Android release keystore certificate does not match the approved certificate.\n' >&2
+  exit 1
+}
+
+printf 'certificateSha256=%s\n' "$certificate_sha256"

--- a/tools/android-release/verify-keystore.test.sh
+++ b/tools/android-release/verify-keystore.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temporary_directory="$(mktemp -d)"
+readonly fake_bin="$temporary_directory/bin"
+readonly certificate_sha256="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$fake_bin"
+printf '%s\n' 'fixture keystore' > "$temporary_directory/release.keystore"
+cat > "$fake_bin/keytool" <<EOF
+#!/usr/bin/env bash
+if [[ " \$* " == *" -importkeystore "* ]]; then
+  [[ "\${SPEAKUP_ANDROID_KEY_PASSWORD:-}" == fixture-key-password ]]
+  exit
+fi
+cat <<'REPORT'
+Alias name: speakup-release
+Entry type: PrivateKeyEntry
+Certificate fingerprints:
+         SHA256: CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC:CC
+REPORT
+EOF
+chmod +x "$fake_bin/keytool"
+
+report="$(
+  PATH="$fake_bin:$PATH" \
+    JAVA_HOME="$temporary_directory" \
+    SPEAKUP_ANDROID_KEY_ALIAS=speakup-release \
+    SPEAKUP_ANDROID_STORE_PASSWORD=fixture-password \
+    SPEAKUP_ANDROID_KEY_PASSWORD=fixture-key-password \
+    SPEAKUP_ANDROID_CERT_SHA256="$certificate_sha256" \
+    "$script_directory/verify-keystore.sh" \
+      "$temporary_directory/release.keystore"
+)"
+grep -Fqx "certificateSha256=$certificate_sha256" <<< "$report"
+
+if PATH="$fake_bin:$PATH" \
+  JAVA_HOME="$temporary_directory" \
+  SPEAKUP_ANDROID_KEY_ALIAS=speakup-release \
+  SPEAKUP_ANDROID_STORE_PASSWORD=fixture-password \
+  SPEAKUP_ANDROID_KEY_PASSWORD=fixture-key-password \
+  SPEAKUP_ANDROID_CERT_SHA256="${certificate_sha256%?}d" \
+  "$script_directory/verify-keystore.sh" \
+    "$temporary_directory/release.keystore" \
+    > "$temporary_directory/rejected.out" 2>&1; then
+  printf 'A mismatched approved certificate was accepted.\n' >&2
+  exit 1
+fi
+grep -Fq \
+  'Android release keystore certificate does not match the approved certificate.' \
+  "$temporary_directory/rejected.out"
+
+if PATH="$fake_bin:$PATH" \
+  JAVA_HOME="$temporary_directory" \
+  SPEAKUP_ANDROID_KEY_ALIAS=speakup-release \
+  SPEAKUP_ANDROID_STORE_PASSWORD=fixture-password \
+  SPEAKUP_ANDROID_KEY_PASSWORD=wrong-key-password \
+  SPEAKUP_ANDROID_CERT_SHA256="$certificate_sha256" \
+  "$script_directory/verify-keystore.sh" \
+    "$temporary_directory/release.keystore" \
+    > "$temporary_directory/wrong-key-password.out" 2>&1; then
+  printf 'An incorrect Android release key password was accepted.\n' >&2
+  exit 1
+fi
+grep -Fq \
+  'SPEAKUP_ANDROID_KEY_PASSWORD cannot unlock the Android release key.' \
+  "$temporary_directory/wrong-key-password.out"
+
+printf '%s\n' 'Android release keystore verifier tests passed'


### PR DESCRIPTION
## 功能描述

- 将已审核的 Android 签名稳定性修复 #878 从 `dev` 提升到 `main`。
- 将移动端发布版本更新为 `0.1.1+2`，为新的不可变 `v0.1.1` Tag 做准备。
- 本 PR 不创建 Tag、不读取签名 Secret、不部署 Staging 或 Production。

## 实现思路

- 当前官方 `dev` 相对 `main` 仅包含 #878 的 7 个文件差异。
- 合并后从该正式 `main` Commit 创建 `v0.1.1`，触发全新的 Release Candidate；失败的 `v0.1.0` 保持原样。

## 可复现测试

- PR #878：9/9 CI checks passed，Review approved，所有线程已解决。
- `make check-release-candidate`
- `make check-flutter`：754 tests passed。
- 使用独立恢复的正式 keystore 构建并校验 Staging/Production APK，均为 `0.1.1+2`、arm64、批准证书。

Related #879
Related #877
