### PR TITLE
ops(release): 晋升 Android 首发批次到 main

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -271,7 +271,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.deploy == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -311,6 +311,22 @@ jobs:
 
       - name: Validate Production deployment contract
         run: make check-production-deploy
+
+      - name: Validate Production PostgreSQL systemd units
+        run: |
+          sudo install -D -m 0755 \
+            deploy/production/xe3-postgres-backup \
+            /usr/local/sbin/xe3-postgres-backup
+          sudo install -D -m 0600 \
+            deploy/production/postgres-backup.env.example \
+            /etc/speakup/postgres-backup.env
+          systemd-analyze verify \
+            deploy/production/xe3-postgres-backup.service \
+            deploy/production/xe3-postgres-restore-check.service \
+            deploy/production/xe3-postgres-backup.timer
+
+      - name: Exercise Production PostgreSQL backup and isolated restore
+        run: make check-production-backup
 
       - name: Validate offline release contract
         run: make check-offline-release

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -283,6 +283,20 @@ jobs:
         with:
           node-version: "24.18.0"
 
+      - name: Set up Docker Engine
+        uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
+        with:
+          version: v29.6.2
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
       - name: Validate Android download publication contract
         run: make check-android-download
 
@@ -297,6 +311,9 @@ jobs:
 
       - name: Validate Production deployment contract
         run: make check-production-deploy
+
+      - name: Validate offline release contract
+        run: make check-offline-release
 
       - name: Validate rendered Production Nginx configuration
         run: make check-production-nginx

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-release-candidate \
+	check-offline-release \
 	check-android-download \
 	check-tls-lifecycle \
 	check-production-deploy \
@@ -52,6 +53,7 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
+		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
@@ -262,6 +264,12 @@ check-release-candidate:
 	./tools/android-release/verify-keystore.test.sh
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
+
+check-offline-release:
+	./tools/release-candidate/build-offline-images.test.sh
+	./deploy/production/test-offline-images.sh
+	./deploy/production/test-offline-images-docker.sh
+	./deploy/production/test-offline-compose.sh
 
 check-android-download:
 	node --test tools/android-download/*.test.mjs

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SHELL := /bin/bash
 	check-api-dependencies \
 	check-api-contracts \
 	check-release-candidate \
+	check-production-backup \
 	check-offline-release \
 	check-android-download \
 	check-tls-lifecycle \
@@ -53,6 +54,7 @@ help:
 		'  make check-resume-ocr-live Run the PaddleOCR hosted API test with an explicit PDF' \
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
+		'  make check-production-backup  Exercise PostgreSQL backup and isolated restore' \
 		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
@@ -264,6 +266,9 @@ check-release-candidate:
 	./tools/android-release/verify-keystore.test.sh
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
+
+check-production-backup:
+	./deploy/production/test-backup.sh
 
 check-offline-release:
 	./tools/release-candidate/build-offline-images.test.sh

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -268,9 +268,121 @@ loopback bindings. Public HTTPS and business-route smoke tests belong to the
 release smoke contract. There is intentionally no `deploy` or `down` command in
 this directory yet.
 
+## PostgreSQL logical backup and isolated restore check
+
+The Production PostgreSQL data volume has a separate, fail-closed logical
+backup contract. The backup script discovers the running Production PostgreSQL
+container through its fixed Compose labels, verifies its image, database,
+healthy state, source volume, and clean migration version, then creates a
+custom-format `pg_dump`. The dump waits at most 30 seconds for any table lock
+instead of blocking indefinitely. Both `backup daily` and `backup predeploy`
+write the dump, checksum, and release-linked JSON metadata under a private
+`.partial-*` directory, then complete an isolated `pg_restore`. Only after that
+restore succeeds is the directory published atomically as a finalized backup
+and expired finalized backups pruned. A failed dump, checksum, or restore is
+never published and never triggers retention deletion. The current run's exact
+partial directory is removed on failure using only the three fixed contract
+file names; unexpected entries stop cleanup instead of allowing recursive
+deletion.
+
+The daily timer therefore creates and restore-verifies a new backup on every
+successful run. The separate `check [BACKUP_ID]` command revalidates the latest
+or named finalized backup later: it verifies age, metadata, and checksum, then
+restores with the exact digest-pinned PostgreSQL image recorded by that backup
+into a temporary Docker volume with networking disabled. Historical backup
+checks therefore require their recorded image to remain available locally;
+they do not silently substitute the current Production image. Neither path
+mounts or changes the Production PostgreSQL volume. Backup and restore-check
+processes share
+`/run/lock/xe3-postgres-backup.lock`, so they fail instead of overlapping.
+
+Install the script, private configuration, and systemd units on the Production
+host:
+
+```sh
+install -d -m 0750 /etc/speakup
+install -m 0755 deploy/production/xe3-postgres-backup \
+  /usr/local/sbin/xe3-postgres-backup
+install -m 0600 deploy/production/postgres-backup.env.example \
+  /etc/speakup/postgres-backup.env
+install -m 0644 deploy/production/xe3-postgres-backup.service \
+  deploy/production/xe3-postgres-backup.timer \
+  deploy/production/xe3-postgres-restore-check.service \
+  /etc/systemd/system/
+```
+
+Populate every value in `/etc/speakup/postgres-backup.env` before starting a
+unit. `POSTGRES_BACKUP_IMAGE` must be the exact repository digest used by the
+Production Compose contract; tag-only references and bare image IDs are
+rejected.
+The database, user, and source volume must match the running Production
+PostgreSQL service. Set `POSTGRES_BACKUP_DEPLOYMENT_VERSION` and
+`POSTGRES_BACKUP_GIT_SHA` from the deployed, reviewed release manifest and
+update both when Production is promoted. Choose explicit retention and maximum
+backup age values for the approved recovery policy; the script has no silent
+defaults. The file contains no database password because backup access stays
+inside the already-running PostgreSQL container through the local Docker Unix
+socket.
+
+Enable the daily backup only after a manual backup and isolated restore check
+both succeed:
+
+```sh
+systemctl daemon-reload
+systemctl start xe3-postgres-backup.service
+systemctl start xe3-postgres-restore-check.service
+systemctl enable --now xe3-postgres-backup.timer
+systemctl list-timers xe3-postgres-backup.timer
+```
+
+The backup unit runs `xe3-postgres-backup backup daily`; the restore-check unit
+runs `xe3-postgres-backup check`, which selects the latest finalized backup when
+no ID is given. `StateDirectory=speakup/postgres-backups` must create
+`/var/lib/speakup/postgres-backups` before the script starts, owned by the
+service user with mode `0700`; the script rejects a missing, symlinked,
+wrong-owner, or wrong-mode root instead of creating or repairing it. Both units
+use a `0077` umask and a two-hour start timeout. Their process network namespace
+is private and only `AF_UNIX` is permitted so the Docker Unix socket remains
+usable without granting the unit IP network access.
+
+The configured application database user is also the owner of objects created
+by the migration command. Dumps and isolated restores both use
+`--no-owner --no-privileges`: they preserve the application schema and data
+under that same database user without requiring cluster roles, ownership
+reassignment, or grant restoration. This is a deliberate single-application
+database boundary, not a backup of PostgreSQL cluster identities.
+
+Treat a non-zero result from either service, an overdue timer, a failed restore
+check, or insufficient space below `/var/lib/speakup/postgres-backups` as an
+alert. The exact evidence is available without exposing configuration values:
+
+```sh
+systemctl status xe3-postgres-backup.service \
+  xe3-postgres-restore-check.service xe3-postgres-backup.timer
+journalctl --unit xe3-postgres-backup.service \
+  --unit xe3-postgres-restore-check.service
+```
+
+Wire those systemd failure states and filesystem-capacity signals into the
+host's monitoring before relying on the timer. Run the isolated restore check
+after any image or PostgreSQL major-version change and as part of the audited
+pre-deployment gate. The daily service already proves its newly created backup;
+the later check proves that a selected finalized backup still passes the same
+restore contract. A backup that has not restored successfully is not valid
+release evidence.
+
+This contract deliberately provides **no Production restore command**. It also
+does not capture PostgreSQL roles or tablespaces and does not configure WAL
+archiving or point-in-time recovery (PITR). Restoring data can discard writes
+made after the selected backup, so an actual Production restore requires a
+separate reviewed disaster-recovery runbook, an explicit outage, a named backup
+ID, and operator approval. Image rollback must never silently restore this
+database.
+
 ## Reproducible checks
 
 ```sh
+make check-production-backup
 make check-android-download
 make check-production-deploy
 make check-production-nginx
@@ -292,3 +404,5 @@ the four pull policies, and fail-closed behavior without contacting Production.
 - [GitHub workflow API](https://docs.github.com/en/rest/actions/workflows#get-a-workflow)
 - [GitHub workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
 - [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
+- [PostgreSQL SQL dump backup](https://www.postgresql.org/docs/18/backup-dump.html)
+- [PostgreSQL `pg_restore`](https://www.postgresql.org/docs/18/app-pgrestore.html)

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -38,7 +38,8 @@ release. Its one-time creation belongs to the audited server bootstrap.
 - The existing `speak-up.top` certificate lineage safely expanded to the exact
   Portal, redirect, and API SAN set through [`deploy/tls/`](../tls/README.md).
 - A populated ACME web root.
-- Registry read access for the manifest's Portal and Server image digests.
+- Either Registry read access for the manifest's Portal and Server image
+  digests, or the verified offline bundle described below.
 - A real, current-UID-owned `PRODUCTION_PUBLIC_ROOT` that is not group- or
   world-writable.
 
@@ -100,6 +101,127 @@ resolved Compose model, both external volumes, the external Server edge network,
 and the rendered Nginx template. It does not pull images or create/update
 containers or networks.
 
+## Offline image transfer when GHCR access is unavailable
+
+The offline path creates one self-consistent, digest-addressed release from the
+Portal and Server images built on the trusted workstation. It does not loosen
+`release-manifest.json` checks or authorize a Production deployment. Run it only
+from the clean, reviewed release Tag commit with the complete official Git
+history, Docker Buildx, Node.js, and both signed APKs ready. The `upstream`
+remote must be exactly
+`https://github.com/1024XEngineer/XE3-ESL.git`; the release validator rejects a
+stale `upstream/main` and any Git URL rewrite that could redirect this URL:
+
+```sh
+release_tag=v0.1.0
+release_version="${release_tag#v}"
+release_dir=/secure/release-staging/speakup-v${release_version}
+release_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+./tools/release-candidate/build-offline-images.sh \
+  --version "$release_version" \
+  --git-sha "$release_sha" \
+  --output-dir "$release_dir/images"
+```
+
+Portal and Server are each built once without cache for `linux/amd64` from the
+exact clean commit. `offline-image-bundle.json` records the repositories,
+digests, archive sizes and SHA-256 values, plus the Buildx metadata files.
+Archive checksums protect transport; deployment identity remains the complete
+`repository@sha256:digest` recorded in the release manifest generated from this
+bundle. Vinext intentionally generates per-build security material, so this
+contract verifies and preserves the exact immutable artifacts rather than
+claiming byte-for-byte reproducibility from a separate rebuild.
+
+Generate the manifest through the single fail-closed offline wrapper. It
+snapshots and verifies both APKs, consumes the verifier reports rather than
+operator-supplied Android fields, validates the bundle, and atomically creates a
+new manifest without replacing an existing file. The certificate fingerprint
+file is public identity material, not a signing key. Replace the example run
+with the completed successful official `Quality` workflow for this exact commit
+on `main`; the wrapper verifies it through the fixed GitHub API before touching
+the APKs:
+
+```sh
+release_tag=v0.1.0
+release_version="${release_tag#v}"
+release_dir=/secure/release-staging/speakup-v${release_version}
+bundle_dir=${release_dir}/images
+certificate_file=${release_dir}/apk-certificate-sha256.txt
+staging_apk=${release_dir}/speakup-v${release_version}-staging-arm64.apk
+production_apk=${release_dir}/speakup-v${release_version}-production-arm64.apk
+quality_run_url=https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456789
+
+node tools/release-candidate/offline-manifest.mjs \
+  --tag "$release_tag" \
+  --staging-apk "$staging_apk" \
+  --production-apk "$production_apk" \
+  --offline-bundle "$bundle_dir/offline-image-bundle.json" \
+  --certificate-file "$certificate_file" \
+  --quality-run-url "$quality_run_url" \
+  --output "$release_dir/release-manifest.json"
+```
+
+The wrapper rejects a non-official, fork, PR, failed, incomplete, wrong-branch,
+or wrong-commit Quality run. It also rejects a failed APK verification, an APK
+changed during snapshotting, an existing output path, or a bundle whose
+version, Git SHA, filenames, sizes, checksums, or Buildx digests differ. Network
+or GitHub API errors fail closed and do not create a manifest.
+
+This manual manifest intentionally records the single-platform digest from the
+offline Docker archive. A GHCR workflow may instead publish an OCI index whose
+top-level digest differs even when it contains equivalent `linux/amd64` image
+content. Therefore, never combine a GHCR-generated manifest with this offline
+bundle or silently replace one digest with the other. If these images are later
+pushed to GHCR under the same version, the remote digest must be proven to match
+this immutable manifest; otherwise publish a new version.
+
+Transfer the complete directory and its matching `release-manifest.json` to the
+release directory on the host. Do not rename individual files, unpack the
+archives, or copy them through the repository.
+
+The offline Compose override also forbids pulling the fixed PostgreSQL image.
+The target host must provision that exact public image from Docker Hub before
+entering the offline release window; this is intentionally not handled by the
+application image bundle:
+
+```sh
+docker pull --platform linux/amd64 \
+  postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
+docker image inspect \
+  postgres@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
+```
+
+If either command fails, stop. A `docker save` / `docker load` transfer of this
+multi-platform public image is not an accepted fallback because it does not
+reliably preserve the Registry index RepoDigest required by the Production
+contract. Do not substitute a tag-only image or a platform-manifest digest. A
+fully disconnected PostgreSQL import needs a separately reviewed OCI-index
+transport contract; it is not silently approximated by this application bundle.
+
+On the host, validate every file and the pre-provisioned PostgreSQL image before
+either application image is loaded:
+
+```sh
+./deploy/production/load-offline-images.sh \
+  --manifest /opt/speakup/releases/v0.1.0/release-manifest.json \
+  --bundle /opt/speakup/releases/v0.1.0/images/offline-image-bundle.json \
+  --directory /opt/speakup/releases/v0.1.0/images
+```
+
+The loader rejects unknown bundle fields, path traversal, links or special
+archive members, unreferenced or invalid OCI blobs, checksum or manifest
+mismatches, a missing exact PostgreSQL or application RepoDigest, a non-amd64
+image, or incorrect source/revision/version labels. It never pulls and never
+falls back to a tag, image ID, local Registry, `latest`, or a host-side build.
+
+The reviewed deployment orchestration must combine `compose.yaml` with
+`compose.offline.yaml` and still pass `--pull never` explicitly to every
+state-changing `docker compose up` invocation. The override changes only the
+four pull policies for `postgres`, `migrate`, `server`, and `portal`. This
+repository intentionally does not add a Production `deploy` command in this
+Issue; backup, migration, health, rollback, and approval sequencing remain
+mandatory before that command is enabled.
+
 ## Render Nginx for review
 
 ```sh
@@ -152,11 +274,13 @@ this directory yet.
 make check-android-download
 make check-production-deploy
 make check-production-nginx
+make check-offline-release
 ```
 
 The tests resolve the Compose model and prove digest-only images, fixed project
 name, loopback ports, internal database network, external volume names, Nginx
-headers, and fail-closed validation without contacting Production.
+headers, strict offline bundle validation, an unchanged Compose model except for
+the four pull policies, and fail-closed behavior without contacting Production.
 
 ## References
 
@@ -164,4 +288,7 @@ headers, and fail-closed validation without contacting Production.
 - [Docker Compose external volumes](https://docs.docker.com/reference/compose-file/volumes/)
 - [Docker Compose project names](https://docs.docker.com/compose/how-tos/project-name/)
 - [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
+- [Docker image pull](https://docs.docker.com/reference/cli/docker/image/pull/)
+- [GitHub workflow API](https://docs.github.com/en/rest/actions/workflows#get-a-workflow)
+- [GitHub workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
 - [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)

--- a/deploy/production/compose.offline.yaml
+++ b/deploy/production/compose.offline.yaml
@@ -1,0 +1,9 @@
+services:
+  postgres:
+    pull_policy: never
+  migrate:
+    pull_policy: never
+  server:
+    pull_policy: never
+  portal:
+    pull_policy: never

--- a/deploy/production/load-offline-images.sh
+++ b/deploy/production/load-offline-images.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly expected_platform='linux/amd64'
+readonly expected_source='https://github.com/1024XEngineer/XE3-ESL'
+readonly postgres_reference='postgres@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  load-offline-images.sh --manifest FILE --bundle FILE --directory DIRECTORY
+EOF
+}
+
+fail() {
+  printf 'offline image contract: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+
+  [[ ! -L "$file" ]] || fail "$description must not be a symbolic link: $file"
+  [[ -f "$file" ]] || fail "$description is not a regular file: $file"
+  [[ -r "$file" ]] || fail "$description is not readable: $file"
+  [[ -s "$file" ]] || fail "$description is empty: $file"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    fail 'sha256sum or shasum is required'
+  fi
+}
+
+file_size() {
+  local file=$1
+  local size
+
+  if size=$(stat -c '%s' -- "$file" 2>/dev/null); then
+    :
+  elif size=$(stat -f '%z' "$file" 2>/dev/null); then
+    :
+  else
+    fail "cannot inspect file size: $file"
+  fi
+  printf '%s\n' "$size"
+}
+
+verify_blob() {
+  local description=$1
+  local file=$2
+  local digest=$3
+  local size=$4
+
+  require_regular_file "$description" "$file"
+  [[ "$(file_size "$file")" == "$size" ]] ||
+    fail "$description size does not match its descriptor"
+  [[ "sha256:$(sha256_file "$file")" == "$digest" ]] ||
+    fail "$description digest does not match its descriptor"
+}
+
+verify_image_archive() {
+  local name=$1
+  local repository=$2
+  local digest=$3
+  local archive=$4
+  local version=$5
+  local git_sha=$6
+  local validation_directory="$temporary_directory/$name-archive"
+  local extraction_directory="$validation_directory/extracted"
+  local members_file="$validation_directory/members"
+  local member_types_file="$validation_directory/member-types"
+  local regular_members_file="$validation_directory/regular-members"
+  local expected_members_file="$validation_directory/expected-members"
+  local index_file="$extraction_directory/index.json"
+  local docker_manifest_file="$extraction_directory/manifest.json"
+  local oci_layout_file="$extraction_directory/oci-layout"
+  local manifest_file
+  local manifest_size
+  local config_digest
+  local config_size
+  local config_file
+  local layer_contract_file="$validation_directory/layers.tsv"
+  local layer_paths_file="$validation_directory/layer-paths"
+  local member
+  local type
+  local layer_digest
+  local layer_size
+  local layer_path
+  local member_count
+  local member_type_count
+
+  mkdir -p "$extraction_directory"
+  LC_ALL=C tar -tf "$archive" > "$members_file" ||
+    fail "$name image archive cannot be listed"
+  LC_ALL=C tar -tvf "$archive" | cut -c 1 > "$member_types_file" ||
+    fail "$name image archive member types cannot be inspected"
+  member_count=$(wc -l < "$members_file" | tr -d '[:space:]')
+  member_type_count=$(wc -l < "$member_types_file" | tr -d '[:space:]')
+  [[ -s "$members_file" && "$member_count" == "$member_type_count" ]] ||
+    fail "$name image archive has an invalid member list"
+  [[ -z "$(LC_ALL=C sort "$members_file" | uniq -d)" ]] ||
+    fail "$name image archive contains duplicate paths"
+
+  exec 3< "$member_types_file"
+  while IFS= read -r member; do
+    IFS= read -r type <&3 || fail "$name image archive member types are incomplete"
+    [[ -n "$member" && "$member" != *$'\r'* && "$member" != *$'\t'* &&
+      "$member" != *'\\'* ]] ||
+      fail "$name image archive contains an unsafe path"
+    case "$member" in
+      blobs/ | blobs/sha256/)
+        [[ "$type" == d ]] ||
+          fail "$name image archive directory has an invalid type"
+        ;;
+      index.json | manifest.json | oci-layout)
+        [[ "$type" == - ]] ||
+          fail "$name image archive file has an invalid type"
+        ;;
+      blobs/sha256/*)
+        [[ "$type" == - &&
+          "${member#blobs/sha256/}" =~ ^[0-9a-f]{64}$ ]] ||
+          fail "$name image archive blob path or type is invalid"
+        ;;
+      *) fail "$name image archive contains an unexpected path: $member" ;;
+    esac
+  done < "$members_file"
+  if IFS= read -r type <&3; then
+    exec 3<&-
+    fail "$name image archive member types are not one-to-one"
+  fi
+  exec 3<&-
+
+  for member in index.json manifest.json oci-layout; do
+    [[ "$(grep -Fxc "$member" "$members_file")" == 1 ]] ||
+      fail "$name image archive must contain exactly one $member"
+  done
+  tar --no-same-owner --no-same-permissions -xf "$archive" -C "$extraction_directory" ||
+    fail "$name image archive cannot be extracted safely"
+  require_regular_file "$name OCI index" "$index_file"
+  require_regular_file "$name Docker manifest" "$docker_manifest_file"
+  require_regular_file "$name OCI layout" "$oci_layout_file"
+
+  jq --exit-status '
+      type == "object" and
+      keys == ["imageLayoutVersion"] and
+      .imageLayoutVersion == "1.0.0"
+    ' "$oci_layout_file" >/dev/null ||
+    fail "$name image archive has an invalid OCI layout"
+
+  jq --exit-status --arg digest "$digest" '
+      type == "object" and
+      .schemaVersion == 2 and
+      .mediaType == "application/vnd.oci.image.index.v1+json" and
+      (.manifests | type == "array" and length == 1) and
+      (.manifests[0] |
+        type == "object" and
+        .digest == $digest and
+        (.size | type == "number" and . >= 1 and . == floor) and
+        (.mediaType == "application/vnd.docker.distribution.manifest.v2+json" or
+          .mediaType == "application/vnd.oci.image.manifest.v1+json") and
+        .platform.os == "linux" and
+        .platform.architecture == "amd64")
+    ' "$index_file" >/dev/null ||
+    fail "$name image archive has an invalid OCI index"
+  manifest_size=$(jq --raw-output '.manifests[0].size' "$index_file")
+  manifest_file="$extraction_directory/blobs/sha256/${digest#sha256:}"
+  verify_blob "$name image manifest" "$manifest_file" "$digest" "$manifest_size"
+
+  jq --exit-status '
+      type == "object" and
+      .schemaVersion == 2 and
+      (.mediaType == "application/vnd.docker.distribution.manifest.v2+json" or
+        .mediaType == "application/vnd.oci.image.manifest.v1+json") and
+      (.config |
+        type == "object" and
+        (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
+        (.size | type == "number" and . >= 1 and . == floor) and
+        (.mediaType == "application/vnd.docker.container.image.v1+json" or
+          .mediaType == "application/vnd.oci.image.config.v1+json")) and
+      (.layers | type == "array") and
+      (all(.layers[];
+        type == "object" and
+        (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
+        (.size | type == "number" and . >= 0 and . == floor) and
+        (.mediaType == "application/vnd.docker.image.rootfs.diff.tar.gzip" or
+          .mediaType == "application/vnd.oci.image.layer.v1.tar+gzip")))
+    ' "$manifest_file" >/dev/null ||
+    fail "$name image archive has an invalid image manifest"
+  config_digest=$(jq --raw-output '.config.digest' "$manifest_file")
+  config_size=$(jq --raw-output '.config.size' "$manifest_file")
+  config_file="$extraction_directory/blobs/sha256/${config_digest#sha256:}"
+  verify_blob "$name image config" "$config_file" "$config_digest" "$config_size"
+  jq --exit-status \
+    --arg source "$expected_source" \
+    --arg git_sha "$git_sha" \
+    --arg version "$version" '
+      type == "object" and
+      .os == "linux" and
+      .architecture == "amd64" and
+      (.config.Labels | type == "object") and
+      .config.Labels["org.opencontainers.image.source"] == $source and
+      .config.Labels["org.opencontainers.image.revision"] == $git_sha and
+      .config.Labels["org.opencontainers.image.version"] == $version
+    ' "$config_file" >/dev/null ||
+    fail "$name image archive has invalid platform or OCI labels"
+
+  jq --raw-output '.layers[] | [.digest, (.size | tostring)] | @tsv' \
+    "$manifest_file" > "$layer_contract_file"
+  : > "$layer_paths_file"
+  while IFS=$'\t' read -r layer_digest layer_size; do
+    [[ -n "$layer_digest" && -n "$layer_size" ]] ||
+      fail "$name image archive has an incomplete layer descriptor"
+    layer_path="blobs/sha256/${layer_digest#sha256:}"
+    verify_blob \
+      "$name image layer" \
+      "$extraction_directory/$layer_path" \
+      "$layer_digest" \
+      "$layer_size"
+    printf '%s\n' "$layer_path" >> "$layer_paths_file"
+  done < "$layer_contract_file"
+
+  jq --exit-status \
+    --arg reference "$repository:$version" \
+    --arg config "blobs/sha256/${config_digest#sha256:}" \
+    --rawfile layer_paths "$layer_paths_file" '
+      ($layer_paths | split("\n") | map(select(length > 0))) as $layers |
+      type == "array" and length == 1 and
+      (.[0] |
+        type == "object" and
+        keys == ["Config", "Layers", "RepoTags"] and
+        .Config == $config and
+        .RepoTags == [$reference] and
+        .Layers == $layers)
+    ' "$docker_manifest_file" >/dev/null ||
+    fail "$name image archive has an invalid Docker manifest or tag set"
+
+  {
+    printf '%s\n' index.json manifest.json oci-layout
+    printf 'blobs/sha256/%s\n' "${digest#sha256:}" "${config_digest#sha256:}"
+    cat "$layer_paths_file"
+  } | LC_ALL=C sort -u > "$expected_members_file"
+  grep -v '/$' "$members_file" | LC_ALL=C sort -u > "$regular_members_file"
+  [[ "$(< "$regular_members_file")" == "$(< "$expected_members_file")" ]] ||
+    fail "$name image archive contains unreferenced or missing files"
+  rm -rf -- "$validation_directory"
+}
+
+verify_loaded_image() {
+  local description=$1
+  local reference=$2
+  local inspect_file=$3
+  local require_labels=$4
+  local version=${5:-}
+  local git_sha=${6:-}
+
+  docker image inspect "$reference" > "$inspect_file" ||
+    fail "$description is not inspectable as $reference"
+  if [[ "$require_labels" == true ]]; then
+    jq --exit-status --slurp \
+      --arg reference "$reference" \
+      --arg version "$version" \
+      --arg git_sha "$git_sha" \
+      --arg source "$expected_source" '
+        length == 1 and
+        (.[0] |
+          type == "array" and length == 1 and
+          (.[0] |
+            type == "object" and
+            (.RepoDigests | type == "array" and index($reference) != null) and
+            .Os == "linux" and
+            .Architecture == "amd64" and
+            (.Config.Labels | type == "object") and
+            .Config.Labels["org.opencontainers.image.source"] == $source and
+            .Config.Labels["org.opencontainers.image.revision"] == $git_sha and
+            .Config.Labels["org.opencontainers.image.version"] == $version))
+      ' "$inspect_file" >/dev/null ||
+      fail "$description identity does not match the offline release"
+  else
+    jq --exit-status --slurp \
+      --arg reference "$reference" '
+        length == 1 and
+        (.[0] |
+          type == "array" and length == 1 and
+          (.[0] |
+            type == "object" and
+            (.RepoDigests | type == "array" and index($reference) != null) and
+            .Os == "linux" and
+            .Architecture == "amd64"))
+      ' "$inspect_file" >/dev/null ||
+      fail "$description is not the required local linux/amd64 image"
+  fi
+}
+
+manifest_file=''
+bundle_file=''
+bundle_directory=''
+while (($# > 0)); do
+  case "$1" in
+    --manifest | --bundle | --directory)
+      (($# >= 2)) || {
+        usage
+        exit 2
+      }
+      case "$1" in
+        --manifest)
+          [[ -z "$manifest_file" ]] || fail '--manifest may only be provided once'
+          manifest_file=$2
+          ;;
+        --bundle)
+          [[ -z "$bundle_file" ]] || fail '--bundle may only be provided once'
+          bundle_file=$2
+          ;;
+        --directory)
+          [[ -z "$bundle_directory" ]] || fail '--directory may only be provided once'
+          bundle_directory=$2
+          ;;
+      esac
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$manifest_file" ]] || fail '--manifest is required'
+[[ -n "$bundle_file" ]] || fail '--bundle is required'
+[[ -n "$bundle_directory" ]] || fail '--directory is required'
+
+require_command awk
+require_command stat
+require_command docker
+require_command jq
+require_command tar
+require_regular_file 'release manifest' "$manifest_file"
+require_regular_file 'offline image bundle' "$bundle_file"
+[[ ! -L "$bundle_directory" ]] || \
+  fail "bundle directory must not be a symbolic link: $bundle_directory"
+[[ -d "$bundle_directory" && -r "$bundle_directory" && -x "$bundle_directory" ]] || \
+  fail "bundle directory is not readable and searchable: $bundle_directory"
+
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/xe3-offline-image-load.XXXXXX")
+readonly temporary_directory
+trap 'rm -rf -- "$temporary_directory"' EXIT INT TERM
+readonly contract_file="$temporary_directory/contract.tsv"
+
+jq --exit-status --slurp \
+  --slurpfile manifest "$manifest_file" '
+    def version:
+      type == "string" and
+      test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$");
+    def git_sha:
+      type == "string" and test("^[0-9a-f]{40}$") and test("[1-9a-f]");
+    def image_digest:
+      type == "string" and
+      test("^sha256:[0-9a-f]{64}$") and
+      (ltrimstr("sha256:") | test("[1-9a-f]"));
+    def sha256:
+      type == "string" and test("^[0-9a-f]{64}$") and test("[1-9a-f]");
+    def positive_integer:
+      type == "number" and
+      . >= 1 and . <= 9007199254740991 and . == floor;
+    def safe_basename:
+      type == "string" and
+      test("^[A-Za-z0-9][A-Za-z0-9._-]*$") and . != "." and . != "..";
+    length == 1 and
+    ($manifest | length == 1) and
+    (.[0] as $bundle |
+      $manifest[0] as $release |
+      ($release | type == "object") and
+      $release.manifest_version == 1 and
+      ($release.version | version) and
+      ($release.git_sha | git_sha) and
+      $release.portal_image == "ghcr.io/1024xengineer/xe3-esl-portal" and
+      ($release.portal_image_digest | image_digest) and
+      $release.server_image == "ghcr.io/1024xengineer/xe3-esl-server" and
+      ($release.server_image_digest | image_digest) and
+      ($bundle | type == "object") and
+      ($bundle | keys) == [
+        "bundle_version", "git_sha", "images", "platform",
+        "source_date_epoch", "version"
+      ] and
+      $bundle.bundle_version == 1 and
+      ($bundle.version | version) and
+      ($bundle.git_sha | git_sha) and
+      ($bundle.source_date_epoch | positive_integer) and
+      $bundle.platform == "linux/amd64" and
+      ($bundle.images | type == "array" and length == 2) and
+      ($bundle.images | map(.name)) == ["portal", "server"] and
+      (all($bundle.images[];
+        type == "object" and
+        keys == [
+          "archive_file", "archive_sha256", "archive_size_bytes",
+          "build_metadata_file", "build_metadata_sha256", "digest",
+          "name", "repository"
+        ] and
+        (.archive_file | safe_basename) and
+        (.archive_size_bytes | positive_integer) and
+        (.archive_sha256 | sha256) and
+        (.build_metadata_file | safe_basename) and
+        (.build_metadata_sha256 | sha256) and
+        (.digest | image_digest)
+      )) and
+      $bundle.version == $release.version and
+      $bundle.git_sha == $release.git_sha and
+      $bundle.images[0].repository == $release.portal_image and
+      $bundle.images[0].digest == $release.portal_image_digest and
+      $bundle.images[1].repository == $release.server_image and
+      $bundle.images[1].digest == $release.server_image_digest
+    )
+  ' "$bundle_file" >/dev/null || fail 'offline image bundle is invalid'
+
+jq --raw-output '
+    ([.version, .git_sha, (.source_date_epoch | tostring)] | @tsv),
+    (.images[] | ([
+      .name, .repository, .digest, .archive_file,
+      (.archive_size_bytes | tostring), .archive_sha256,
+      .build_metadata_file, .build_metadata_sha256
+    ] | @tsv))
+  ' "$bundle_file" > "$contract_file"
+
+[[ "$(wc -l < "$contract_file" | tr -d '[:space:]')" == 3 ]] || \
+  fail 'validated bundle did not produce the canonical image contract'
+
+IFS=$'\t' read -r release_version release_git_sha source_date_epoch < "$contract_file"
+IFS=$'\t' read -r \
+  portal_name portal_repository portal_digest portal_archive portal_size \
+  portal_archive_sha portal_metadata portal_metadata_sha \
+  < <(sed -n '2p' "$contract_file")
+IFS=$'\t' read -r \
+  server_name server_repository server_digest server_archive server_size \
+  server_archive_sha server_metadata server_metadata_sha \
+  < <(sed -n '3p' "$contract_file")
+
+image_names=("$portal_name" "$server_name")
+image_repositories=("$portal_repository" "$server_repository")
+image_digests=("$portal_digest" "$server_digest")
+archive_files=("$portal_archive" "$server_archive")
+archive_sizes=("$portal_size" "$server_size")
+archive_hashes=("$portal_archive_sha" "$server_archive_sha")
+metadata_files=("$portal_metadata" "$server_metadata")
+metadata_hashes=("$portal_metadata_sha" "$server_metadata_sha")
+archive_paths=()
+
+# Verify every artifact before loading either image. Invalid bundles therefore
+# cannot leave a partially loaded release on the host.
+for index in 0 1; do
+  archive_path="$bundle_directory/${archive_files[$index]}"
+  metadata_path="$bundle_directory/${metadata_files[$index]}"
+  require_regular_file "${image_names[$index]} image archive" "$archive_path"
+  require_regular_file "${image_names[$index]} build metadata" "$metadata_path"
+  [[ "$(file_size "$archive_path")" == "${archive_sizes[$index]}" ]] || \
+    fail "${image_names[$index]} image archive size does not match the bundle"
+  [[ "$(sha256_file "$archive_path")" == "${archive_hashes[$index]}" ]] || \
+    fail "${image_names[$index]} image archive checksum does not match the bundle"
+  [[ "$(sha256_file "$metadata_path")" == "${metadata_hashes[$index]}" ]] || \
+    fail "${image_names[$index]} build metadata checksum does not match the bundle"
+  jq --exit-status --slurp \
+    --arg digest "${image_digests[$index]}" '
+      length == 1 and
+      (.[0] | type == "object" and .["containerimage.digest"] == $digest)
+    ' "$metadata_path" >/dev/null || \
+    fail "${image_names[$index]} build metadata does not match its image digest"
+  archive_paths[$index]=$archive_path
+  verify_image_archive \
+    "${image_names[$index]}" \
+    "${image_repositories[$index]}" \
+    "${image_digests[$index]}" \
+    "$archive_path" \
+    "$release_version" \
+    "$release_git_sha"
+done
+
+verify_loaded_image \
+  'required Postgres image' \
+  "$postgres_reference" \
+  "$temporary_directory/postgres-inspect.json" \
+  false
+
+for index in 0 1; do
+  name=${image_names[$index]}
+  reference="${image_repositories[$index]}@${image_digests[$index]}"
+  inspect_file="$temporary_directory/$name-inspect.json"
+
+  docker image load --platform "$expected_platform" -i "${archive_paths[$index]}" \
+    >/dev/null || fail "failed to load the $name image archive"
+  verify_loaded_image \
+    "loaded $name image" \
+    "$reference" \
+    "$inspect_file" \
+    true \
+    "$release_version" \
+    "$release_git_sha"
+done
+
+printf '%s\n' \
+  "offline_images_loaded=true version=$release_version git_sha=$release_git_sha platform=$expected_platform source_date_epoch=$source_date_epoch"

--- a/deploy/production/postgres-backup.env.example
+++ b/deploy/production/postgres-backup.env.example
@@ -1,0 +1,10 @@
+# Raw KEY=value configuration. Do not use shell expressions or quote values.
+# This file contains no database password. Keep the populated copy mode 0600.
+POSTGRES_BACKUP_IMAGE=postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
+POSTGRES_BACKUP_DATABASE=speakup
+POSTGRES_BACKUP_USER=speakup
+POSTGRES_BACKUP_SOURCE_VOLUME=xe3-speakup-postgres-data
+POSTGRES_BACKUP_DEPLOYMENT_VERSION=
+POSTGRES_BACKUP_GIT_SHA=
+POSTGRES_BACKUP_RETENTION_DAYS=
+POSTGRES_BACKUP_MAX_AGE_SECONDS=

--- a/deploy/production/test-backup.sh
+++ b/deploy/production/test-backup.sh
@@ -1,0 +1,858 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly backup_command="$production_directory/xe3-postgres-backup"
+readonly backup_service="$production_directory/xe3-postgres-backup.service"
+readonly restore_check_service="$production_directory/xe3-postgres-restore-check.service"
+readonly backup_timer="$production_directory/xe3-postgres-backup.timer"
+readonly backup_environment_example="$production_directory/postgres-backup.env.example"
+readonly postgres_image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly compose_project='xe3-speakup-production'
+readonly compose_service='postgres'
+readonly database_network='xe3-speakup-production_database'
+readonly source_volume='xe3-speakup-postgres-data'
+readonly restore_label='com.xengineer.speakup.postgres-restore-check=true'
+readonly database_name='speakup_backup_test'
+readonly database_user='speakup_backup_test'
+readonly deployment_version='v0.1.1-backup-test'
+readonly git_sha='0123456789abcdef0123456789abcdef01234567'
+
+fail() {
+  printf 'PostgreSQL backup contract test: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null || fail "$1 is required"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+assert_unit_directive() {
+  local unit_file=$1
+  local section=$2
+  local directive=$3
+  local expected=$4
+  local actual
+  [[ -f "$unit_file" ]] || fail "$unit_file is required"
+  actual="$(
+    awk \
+      -v section="[$section]" \
+      -v directive="$directive" '
+        /^\[[^]]+\]$/ { current_section = $0; next }
+        current_section == section &&
+          substr($0, 1, length(directive) + 1) == directive "=" {
+            print substr($0, length(directive) + 2)
+          }
+      ' "$unit_file"
+  )"
+  [[ "$actual" == "$expected" ]] || \
+    fail "$unit_file must set [$section] $directive=$expected exactly once"
+}
+
+assert_unit_contracts() {
+  local service command
+  for service in "$backup_service" "$restore_check_service"; do
+    if [[ "$service" == "$backup_service" ]]; then
+      command='backup daily'
+    else
+      command='check'
+    fi
+    assert_unit_directive "$service" Service TimeoutStartSec 2h
+    assert_unit_directive \
+      "$service" Service EnvironmentFile /etc/speakup/postgres-backup.env
+    assert_unit_directive "$service" Service StateDirectory speakup/postgres-backups
+    assert_unit_directive "$service" Service StateDirectoryMode 0700
+    assert_unit_directive "$service" Service UMask 0077
+    assert_unit_directive \
+      "$service" Service ExecStart \
+      "/usr/bin/flock --nonblock /run/lock/xe3-postgres-backup.lock /usr/bin/env POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups /usr/local/sbin/xe3-postgres-backup $command"
+    assert_unit_directive "$service" Service PrivateNetwork true
+    assert_unit_directive "$service" Service RestrictAddressFamilies AF_UNIX
+  done
+
+  assert_unit_directive "$backup_timer" Timer OnCalendar daily
+  assert_unit_directive "$backup_timer" Timer Persistent true
+  assert_unit_directive "$backup_timer" Timer Unit xe3-postgres-backup.service
+}
+
+assert_environment_contract() {
+  local actual_keys expected_keys
+  [[ -f "$backup_environment_example" ]] || \
+    fail "$backup_environment_example is required"
+  actual_keys="$(
+    awk '
+      /^[[:space:]]*($|#)/ { next }
+      /^[A-Z][A-Z0-9_]*=/ {
+        key = $0
+        sub(/=.*/, "", key)
+        print key
+        next
+      }
+      { print "__INVALID_LINE__" NR }
+    ' "$backup_environment_example" | LC_ALL=C sort
+  )"
+  expected_keys="$(
+    printf '%s\n' \
+      POSTGRES_BACKUP_DATABASE \
+      POSTGRES_BACKUP_DEPLOYMENT_VERSION \
+      POSTGRES_BACKUP_GIT_SHA \
+      POSTGRES_BACKUP_IMAGE \
+      POSTGRES_BACKUP_MAX_AGE_SECONDS \
+      POSTGRES_BACKUP_RETENTION_DAYS \
+      POSTGRES_BACKUP_SOURCE_VOLUME \
+      POSTGRES_BACKUP_USER |
+      LC_ALL=C sort
+  )"
+  [[ "$actual_keys" == "$expected_keys" ]] || \
+    fail "$backup_environment_example has unexpected, missing, duplicate, or malformed keys"
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  failure_number=$((failure_number + 1))
+  local output="$temporary_directory/failure-$failure_number.log"
+  if "$@" >"$output" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  if grep -Fq "$database_password" "$output"; then
+    fail "$name exposed the PostgreSQL password"
+  fi
+}
+
+wait_for_healthy() {
+  local container=$1
+  local deadline=$((SECONDS + 90))
+  local process status
+  while ((SECONDS < deadline)); do
+    status="$(
+      docker container inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+        "$container" 2>/dev/null || true
+    )"
+    process="$(docker exec "$container" cat /proc/1/comm 2>/dev/null || true)"
+    case "$status" in
+      healthy)
+        if [[ "$process" == postgres ]]; then
+          return
+        fi
+        ;;
+      exited | dead)
+        docker logs "$container" >&2 || true
+        fail "$container stopped before becoming healthy"
+        ;;
+    esac
+    sleep 1
+  done
+  docker logs "$container" >&2 || true
+  fail "$container did not become healthy"
+}
+
+start_source() {
+  local project=$1
+  docker run --detach \
+    --name "$source_container" \
+    --label "com.docker.compose.project=$project" \
+    --label "com.docker.compose.service=$compose_service" \
+    --label "com.xengineer.speakup.test-run=$test_id" \
+    --network "$database_network" \
+    --mount "type=volume,src=$source_volume,dst=/var/lib/postgresql,volume-nocopy" \
+    --env "POSTGRES_DB=$database_name" \
+    --env "POSTGRES_USER=$database_user" \
+    --env "POSTGRES_PASSWORD=$database_password" \
+    --health-cmd "pg_isready --username=$database_user --dbname=$database_name" \
+    --health-interval 1s \
+    --health-timeout 5s \
+    --health-retries 30 \
+    --health-start-period 5s \
+    "$postgres_image" >/dev/null
+  wait_for_healthy "$source_container"
+}
+
+stop_source() {
+  remove_test_container "$source_container"
+}
+
+run_backup_command() {
+  env \
+    PATH="${TEST_COMMAND_PATH:-$PATH}" \
+    TEST_REAL_DOCKER="${TEST_REAL_DOCKER:-}" \
+    TEST_DOCKER_WRAPPER_MODE="${TEST_DOCKER_WRAPPER_MODE:-}" \
+    TEST_DOCKER_EVENT_MARKER="${TEST_DOCKER_EVENT_MARKER:-}" \
+    TEST_HISTORICAL_IMAGE_REFERENCE="${TEST_HISTORICAL_IMAGE_REFERENCE:-}" \
+    TEST_HISTORICAL_IMAGE_ID="${TEST_HISTORICAL_IMAGE_ID:-}" \
+    TEST_SOURCE_CONTAINER="${TEST_SOURCE_CONTAINER:-}" \
+    TEST_DATABASE_USER="${TEST_DATABASE_USER:-}" \
+    TEST_DATABASE_NAME="${TEST_DATABASE_NAME:-}" \
+    POSTGRES_BACKUP_ROOT="$backup_root" \
+    POSTGRES_BACKUP_IMAGE="${TEST_POSTGRES_BACKUP_IMAGE:-$postgres_image}" \
+    POSTGRES_BACKUP_SOURCE_VOLUME="${TEST_POSTGRES_BACKUP_SOURCE_VOLUME:-$source_volume}" \
+    POSTGRES_BACKUP_DATABASE="$database_name" \
+    POSTGRES_BACKUP_USER="$database_user" \
+    POSTGRES_BACKUP_DEPLOYMENT_VERSION="$deployment_version" \
+    POSTGRES_BACKUP_GIT_SHA="$git_sha" \
+    POSTGRES_BACKUP_RETENTION_DAYS=7 \
+    POSTGRES_BACKUP_MAX_AGE_SECONDS=300 \
+    "$backup_command" "$@"
+}
+
+partial_backup_entries() {
+  local entry
+  local -a entries
+
+  shopt -s nullglob dotglob
+  entries=("$backup_root"/.partial-*)
+  shopt -u nullglob dotglob
+  for entry in "${entries[@]}"; do
+    printf '%s\n' "${entry##*/}"
+  done | LC_ALL=C sort
+}
+
+finalized_backup_ids() {
+  local entry name
+  local -a entries
+
+  shopt -s nullglob dotglob
+  entries=("$backup_root"/*)
+  shopt -u nullglob dotglob
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    if [[ "$name" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]]; then
+      printf '%s\n' "$name"
+    fi
+  done | LC_ALL=C sort
+}
+
+copy_backup_with_identity() {
+  local source_directory=$1
+  local target_id=$2
+  local created_at=$3
+  local target_directory="$backup_root/$target_id"
+  local backup_type=${target_id##*-}
+
+  [[ ! -e "$target_directory" ]] || fail "test backup $target_id already exists"
+  mkdir -m 0700 "$target_directory"
+  cp "$source_directory/database.dump" "$target_directory/database.dump"
+  cp "$source_directory/database.dump.sha256" \
+    "$target_directory/database.dump.sha256"
+  jq \
+    --arg backup_id "$target_id" \
+    --arg backup_type "$backup_type" \
+    --arg created_at "$created_at" \
+    '.backup_id = $backup_id |
+     .backup_type = $backup_type |
+     .created_at = $created_at' \
+    "$source_directory/metadata.json" >"$target_directory/metadata.json"
+  chmod 0600 \
+    "$target_directory/database.dump" \
+    "$target_directory/database.dump.sha256" \
+    "$target_directory/metadata.json"
+}
+
+restore_resources() {
+  local selected_backup_id=$1
+  {
+    docker container ls --all --quiet \
+      --filter "label=$restore_label" \
+      --filter "label=com.xengineer.speakup.postgres-restore-backup-id=$selected_backup_id" \
+      | sed 's/^/container:/'
+    docker volume ls --quiet \
+      --filter "label=$restore_label" \
+      --filter "label=com.xengineer.speakup.postgres-restore-backup-id=$selected_backup_id" \
+      | sed 's/^/volume:/'
+  } | sort
+}
+
+assert_no_restore_resources() {
+  local selected_backup_id=$1
+  local leaked
+  leaked="$(restore_resources "$selected_backup_id")"
+  [[ -z "$leaked" ]] || fail "restore check leaked Docker resources: $leaked"
+}
+
+remove_test_container() {
+  local container=$1
+  if docker container inspect "$container" >/dev/null 2>&1; then
+    docker container inspect "$container" | jq --exit-status \
+      --arg name "$container" \
+      --arg test_id "$test_id" '
+        length == 1 and
+        .[0].Name == ("/" + $name) and
+        .[0].Config.Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker container rm --force "$container" >/dev/null
+  fi
+}
+
+remove_test_volume() {
+  local volume=$1
+  if docker volume inspect "$volume" >/dev/null 2>&1; then
+    docker volume inspect "$volume" | jq --exit-status \
+      --arg name "$volume" \
+      --arg test_id "$test_id" '
+        length == 1 and
+        .[0].Name == $name and
+        .[0].Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker volume rm "$volume" >/dev/null
+  fi
+}
+
+remove_test_database_network() {
+  if docker network inspect "$database_network" >/dev/null 2>&1; then
+    docker network inspect "$database_network" | jq --exit-status \
+      --arg name "$database_network" \
+      --arg test_id "$test_id" '
+        length == 1 and
+        .[0].Name == $name and
+        .[0].Internal == true and
+        .[0].Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker network rm "$database_network" >/dev/null
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  set +e
+  remove_test_container "$source_container" >/dev/null 2>&1 || status=1
+  remove_test_container "$ambiguous_container" >/dev/null 2>&1 || status=1
+  remove_test_container "$evidence_container" >/dev/null 2>&1 || status=1
+  remove_test_volume "$source_volume" >/dev/null 2>&1 || status=1
+  remove_test_volume "$wrong_volume" >/dev/null 2>&1 || status=1
+  remove_test_volume "$evidence_volume" >/dev/null 2>&1 || status=1
+  remove_test_database_network >/dev/null 2>&1 || status=1
+  if [[ "$temporary_directory" == */xe3-postgres-backup-test.* ]]; then
+    rm -rf -- "$temporary_directory"
+  fi
+  exit "$status"
+}
+
+require_command docker
+require_command jq
+require_command awk
+require_command sed
+require_command sort
+readonly real_docker="$(command -v docker)"
+[[ -x "$backup_command" ]] || fail "$backup_command must exist and be executable"
+assert_unit_contracts
+assert_environment_contract
+
+temporary_base=${TMPDIR:-/tmp}
+temporary_base=${temporary_base%/}
+temporary_directory="$(mktemp -d "$temporary_base/xe3-postgres-backup-test.XXXXXX")"
+readonly temporary_directory
+readonly test_id="$(basename "$temporary_directory")"
+readonly backup_root="$temporary_directory/postgres-backups"
+readonly source_container="$test_id-source"
+readonly ambiguous_container="$test_id-ambiguous"
+readonly evidence_container="$test_id-evidence"
+readonly wrong_volume="$test_id-wrong"
+readonly evidence_volume="$test_id-evidence"
+readonly database_password="backup-test-secret-$test_id"
+readonly docker_wrapper_directory="$temporary_directory/docker-wrapper"
+readonly docker_wrapper="$docker_wrapper_directory/docker"
+backup_id=''
+postgres_image_id=''
+failure_number=0
+trap cleanup EXIT INT TERM
+
+mkdir -m 0700 "$backup_root"
+mkdir -m 0700 "$docker_wrapper_directory"
+cat >"$docker_wrapper" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${TEST_DOCKER_WRAPPER_MODE:-}" == migration-change ]]; then
+  for argument in "$@"; do
+    if [[ "$argument" == pg_dump ]]; then
+      "$TEST_REAL_DOCKER" "$@"
+      "$TEST_REAL_DOCKER" container exec --user postgres "$TEST_SOURCE_CONTAINER" \
+        psql \
+          --no-psqlrc \
+          --set ON_ERROR_STOP=1 \
+          --username "$TEST_DATABASE_USER" \
+          --dbname "$TEST_DATABASE_NAME" \
+          --command 'UPDATE public.schema_migrations SET version = version + 1;' \
+        >/dev/null
+      : >"$TEST_DOCKER_EVENT_MARKER"
+      exit 0
+    fi
+  done
+fi
+
+if [[ "${TEST_DOCKER_WRAPPER_MODE:-}" == restore-inspect-failure &&
+  "$#" == 3 && "$1" == container && "$2" == inspect ]]; then
+  inspect_output="$("$TEST_REAL_DOCKER" "$@")"
+  if grep -Fq \
+    '"com.xengineer.speakup.postgres-restore-check": "true"' \
+    <<<"$inspect_output" && [[ ! -e "$TEST_DOCKER_EVENT_MARKER" ]]; then
+    : >"$TEST_DOCKER_EVENT_MARKER"
+    exit 75
+  fi
+  printf '%s\n' "$inspect_output"
+  exit 0
+fi
+
+if [[ "${TEST_DOCKER_WRAPPER_MODE:-}" == historical-image &&
+  "$#" == 5 && "$1" == image && "$2" == inspect &&
+  "$3" == --format && "$4" == '{{.Id}}' &&
+  "$5" == "$TEST_HISTORICAL_IMAGE_REFERENCE" ]]; then
+  "$TEST_REAL_DOCKER" image inspect "$TEST_HISTORICAL_IMAGE_ID" >/dev/null
+  printf '%s\n' "$TEST_HISTORICAL_IMAGE_ID"
+  : >"$TEST_DOCKER_EVENT_MARKER"
+  exit 0
+fi
+
+exec "$TEST_REAL_DOCKER" "$@"
+EOF
+chmod 0700 "$docker_wrapper"
+
+existing_production_containers="$(
+  docker container ls --all --quiet \
+    --filter "label=com.docker.compose.project=$compose_project" \
+    --filter "label=com.docker.compose.service=$compose_service"
+)"
+[[ -z "$existing_production_containers" ]] || \
+  fail 'refusing to run while a Production PostgreSQL container exists'
+if docker volume inspect "$source_volume" >/dev/null 2>&1; then
+  fail 'refusing to run while the Production PostgreSQL volume exists'
+fi
+if docker network inspect "$database_network" >/dev/null 2>&1; then
+  fail 'refusing to run while the Production database network exists'
+fi
+for container in "$source_container" "$ambiguous_container" "$evidence_container"; do
+  if docker container inspect "$container" >/dev/null 2>&1; then
+    fail "refusing to reuse existing test container $container"
+  fi
+done
+for volume in "$wrong_volume" "$evidence_volume"; do
+  if docker volume inspect "$volume" >/dev/null 2>&1; then
+    fail "refusing to reuse existing test volume $volume"
+  fi
+done
+
+docker network create \
+  --internal \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$database_network" >/dev/null
+docker volume create \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$source_volume" >/dev/null
+docker volume create \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$wrong_volume" >/dev/null
+docker volume create \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$evidence_volume" >/dev/null
+
+# A healthy PostgreSQL process with the wrong Compose identity must never be selected.
+start_source 'xe3-speakup-not-production'
+expect_failure 'wrong Compose project identity' run_backup_command backup daily
+stop_source
+postgres_image_id="$(docker image inspect --format '{{.Id}}' "$postgres_image")"
+[[ "$postgres_image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail 'PostgreSQL test image must have a content-addressed local ID'
+readonly postgres_image_id
+
+start_source "$compose_project"
+
+docker container inspect "$source_container" | jq --exit-status \
+  --arg project "$compose_project" \
+  --arg service "$compose_service" \
+  --arg volume "$source_volume" \
+  --arg network "$database_network" '
+    length == 1 and
+    .[0].Config.Labels["com.docker.compose.project"] == $project and
+    .[0].Config.Labels["com.docker.compose.service"] == $service and
+    .[0].State.Health.Status == "healthy" and
+    ([.[0].Mounts[] |
+      select(.Type == "volume" and
+             .Name == $volume and
+             .Destination == "/var/lib/postgresql" and
+             .RW == true)] | length) == 1 and
+    ((.[0].HostConfig.PortBindings // {}) == {}) and
+    (.[0].NetworkSettings.Networks | keys) == [$network]
+  ' >/dev/null || fail 'source PostgreSQL does not satisfy the isolated Production identity'
+
+docker exec "$source_container" psql \
+  --set ON_ERROR_STOP=1 \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  --command 'CREATE TABLE schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL);' \
+  --command 'INSERT INTO schema_migrations (version, dirty) VALUES (7, false);' \
+  --command 'CREATE TABLE users (id uuid PRIMARY KEY, canonical_email text NOT NULL);' \
+  --command "INSERT INTO users (id, canonical_email) VALUES ('00000000-0000-4000-8000-000000000861', 'backup-e2e@example.com');" \
+  >/dev/null
+
+# Interrupted output is never eligible as a finalized backup.
+mkdir "$backup_root/.partial-20260822T010203Z-daily-interrupted"
+printf '%s\n' '{"format_version":1}' \
+  >"$backup_root/.partial-20260822T010203Z-daily-interrupted/metadata.json"
+expect_failure 'partial output without a finalized backup' run_backup_command check
+
+docker exec "$source_container" psql \
+  --set ON_ERROR_STOP=1 \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  --command 'UPDATE schema_migrations SET dirty = true;' >/dev/null
+expect_failure 'dirty source schema' run_backup_command backup daily
+docker exec "$source_container" psql \
+  --set ON_ERROR_STOP=1 \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  --command 'UPDATE schema_migrations SET dirty = false;' >/dev/null
+
+TEST_POSTGRES_BACKUP_SOURCE_VOLUME="$wrong_volume" \
+  expect_failure 'configured source volume mismatch' run_backup_command backup daily
+
+TEST_POSTGRES_BACKUP_IMAGE='postgres:18-bookworm@sha256:0000000000000000000000000000000000000000000000000000000000000001' \
+  expect_failure 'configured PostgreSQL image mismatch' run_backup_command backup daily
+
+docker run --detach \
+  --name "$ambiguous_container" \
+  --label "com.docker.compose.project=$compose_project" \
+  --label "com.docker.compose.service=$compose_service" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --network "$database_network" \
+  --entrypoint sleep \
+  "$postgres_image" 300 >/dev/null
+expect_failure 'ambiguous Production PostgreSQL identity' run_backup_command backup daily
+remove_test_container "$ambiguous_container" || \
+  fail 'refusing to remove an ambiguous container not owned by this test run'
+
+expect_failure 'unsupported backup type' run_backup_command backup weekly
+
+# A migration that changes after pg_dump starts must fail and remove only the
+# partial directory created by that run.
+partial_entries_before="$(partial_backup_entries)"
+migration_marker="$temporary_directory/migration-change.marker"
+TEST_COMMAND_PATH="$docker_wrapper_directory:$PATH"
+TEST_REAL_DOCKER="$real_docker"
+TEST_DOCKER_WRAPPER_MODE='migration-change'
+TEST_DOCKER_EVENT_MARKER="$migration_marker"
+TEST_SOURCE_CONTAINER="$source_container"
+TEST_DATABASE_USER="$database_user"
+TEST_DATABASE_NAME="$database_name"
+expect_failure 'migration version changed during pg_dump' run_backup_command backup daily
+unset \
+  TEST_COMMAND_PATH \
+  TEST_REAL_DOCKER \
+  TEST_DOCKER_WRAPPER_MODE \
+  TEST_DOCKER_EVENT_MARKER \
+  TEST_SOURCE_CONTAINER \
+  TEST_DATABASE_USER \
+  TEST_DATABASE_NAME
+[[ -f "$migration_marker" ]] || fail 'migration change injection did not run'
+grep -Fq 'migration state changed during pg_dump' \
+  "$temporary_directory/failure-$failure_number.log" || \
+  fail 'migration change did not fail at the post-dump schema check'
+partial_entries_after="$(partial_backup_entries)"
+[[ "$partial_entries_after" == "$partial_entries_before" ]] || \
+  fail 'failed pg_dump run left a new partial backup behind'
+docker exec "$source_container" psql \
+  --set ON_ERROR_STOP=1 \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  --command 'UPDATE schema_migrations SET version = 7;' >/dev/null
+
+backup_output="$(run_backup_command backup daily)"
+backup_id="$(
+  printf '%s\n' "$backup_output" |
+    sed -nE 's/^backup_id=([0-9]{8}T[0-9]{6}Z-daily) restore=verified$/\1/p'
+)"
+[[ -n "$backup_id" ]] || fail 'backup did not return the canonical daily backup ID'
+[[ "$backup_output" == "backup_id=$backup_id restore=verified" ]] || \
+  fail 'backup emitted an unexpected success contract'
+assert_no_restore_resources "$backup_id"
+
+readonly finalized_directory="$backup_root/$backup_id"
+readonly dump_file="$finalized_directory/database.dump"
+readonly checksum_file="$finalized_directory/database.dump.sha256"
+readonly metadata_file="$finalized_directory/metadata.json"
+[[ -f "$dump_file" && -f "$checksum_file" && -f "$metadata_file" ]] || \
+  fail 'finalized backup is incomplete'
+[[ "$(dd if="$dump_file" bs=5 count=1 2>/dev/null)" == PGDMP ]] || \
+  fail 'database.dump is not PostgreSQL custom format'
+
+readonly dump_sha256="$(sha256_file "$dump_file")"
+readonly dump_size="$(wc -c <"$dump_file" | tr -d '[:space:]')"
+[[ "$(<"$checksum_file")" == "$dump_sha256  database.dump" ]] || \
+  fail 'database.dump.sha256 is not canonical'
+jq --exit-status \
+  --arg backup_id "$backup_id" \
+  --arg deployment_version "$deployment_version" \
+  --arg git_sha "$git_sha" \
+  --arg project "$compose_project" \
+  --arg service "$compose_service" \
+  --arg source_volume "$source_volume" \
+  --arg postgres_image "$postgres_image" \
+  --arg database_name "$database_name" \
+  --arg database_user "$database_user" \
+  --arg sha256 "$dump_sha256" \
+  --argjson size_bytes "$dump_size" '
+    (keys | sort) == ([
+      "backup_id", "backup_type", "created_at", "database_name",
+      "database_user", "deployment_version", "format_version", "git_sha",
+      "postgres_image", "postgres_version", "schema_dirty", "schema_version",
+      "sha256", "size_bytes", "source_compose_project",
+      "source_compose_service", "source_volume"
+    ] | sort) and
+    .format_version == 1 and
+    .backup_id == $backup_id and
+    (.created_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+    .backup_type == "daily" and
+    .deployment_version == $deployment_version and
+    .git_sha == $git_sha and
+    .source_compose_project == $project and
+    .source_compose_service == $service and
+    .source_volume == $source_volume and
+    .postgres_image == $postgres_image and
+    (.postgres_version | type == "string" and startswith("18.")) and
+    .database_name == $database_name and
+    .database_user == $database_user and
+    .schema_version == 7 and
+    .schema_dirty == false and
+    .size_bytes == $size_bytes and
+    .sha256 == $sha256
+  ' "$metadata_file" >/dev/null || fail 'metadata.json violates the canonical backup contract'
+
+# Historical backups keep the image they were created with. The wrapper maps
+# the safe historical digest reference to the locally present test image ID and
+# records that check used metadata rather than the current config.
+readonly historical_image='postgres:18-bookworm@sha256:1111111111111111111111111111111111111111111111111111111111111111'
+[[ "$historical_image" != "$postgres_image" ]] || \
+  fail 'historical PostgreSQL image fixture must differ from the current digest'
+cp "$metadata_file" "$temporary_directory/current-metadata.json"
+jq --arg postgres_image "$historical_image" \
+  '.postgres_image = $postgres_image' \
+  "$temporary_directory/current-metadata.json" >"$metadata_file"
+historical_image_marker="$temporary_directory/historical-image.marker"
+TEST_COMMAND_PATH="$docker_wrapper_directory:$PATH"
+TEST_REAL_DOCKER="$real_docker"
+TEST_DOCKER_WRAPPER_MODE='historical-image'
+TEST_DOCKER_EVENT_MARKER="$historical_image_marker"
+TEST_HISTORICAL_IMAGE_REFERENCE="$historical_image"
+TEST_HISTORICAL_IMAGE_ID="$postgres_image_id"
+historical_check_output="$(run_backup_command check "$backup_id")"
+unset \
+  TEST_COMMAND_PATH \
+  TEST_REAL_DOCKER \
+  TEST_DOCKER_WRAPPER_MODE \
+  TEST_DOCKER_EVENT_MARKER \
+  TEST_HISTORICAL_IMAGE_REFERENCE \
+  TEST_HISTORICAL_IMAGE_ID
+[[ "$historical_check_output" == "backup_id=$backup_id restore=verified" ]] || \
+  fail 'historical image restore check did not succeed'
+[[ -f "$historical_image_marker" ]] || \
+  fail 'restore check did not inspect the PostgreSQL image recorded in metadata'
+assert_no_restore_resources "$backup_id"
+cp "$temporary_directory/current-metadata.json" "$metadata_file"
+
+# A Docker inspect failure during restore cleanup must make the whole check
+# fail. The one-shot injection allows the EXIT trap to remove the exact
+# randomly owned resources on its second attempt.
+inspect_failure_marker="$temporary_directory/restore-inspect-failure.marker"
+TEST_COMMAND_PATH="$docker_wrapper_directory:$PATH"
+TEST_REAL_DOCKER="$real_docker"
+TEST_DOCKER_WRAPPER_MODE='restore-inspect-failure'
+TEST_DOCKER_EVENT_MARKER="$inspect_failure_marker"
+expect_failure 'restore cleanup inspect failure' run_backup_command check "$backup_id"
+unset \
+  TEST_COMMAND_PATH \
+  TEST_REAL_DOCKER \
+  TEST_DOCKER_WRAPPER_MODE \
+  TEST_DOCKER_EVENT_MARKER
+[[ -f "$inspect_failure_marker" ]] || \
+  fail 'restore cleanup inspect failure injection did not run'
+if grep -Fq 'restore=verified' "$temporary_directory/failure-$failure_number.log"; then
+  fail 'restore cleanup inspect failure reported success'
+fi
+assert_no_restore_resources "$backup_id"
+
+# Retention accepts a valid backup made by an older PostgreSQL image and
+# removes its three contract files plus the now-empty directory.
+readonly expired_exact_id='20000101T000000Z-daily'
+readonly expired_exact_directory="$backup_root/$expired_exact_id"
+copy_backup_with_identity \
+  "$finalized_directory" \
+  "$expired_exact_id" \
+  '2000-01-01T00:00:00Z'
+jq --arg postgres_image "$historical_image" \
+  '.postgres_image = $postgres_image' \
+  "$expired_exact_directory/metadata.json" \
+  >"$temporary_directory/expired-exact-metadata.json"
+mv "$temporary_directory/expired-exact-metadata.json" \
+  "$expired_exact_directory/metadata.json"
+chmod 0600 "$expired_exact_directory/metadata.json"
+retention_output="$(run_backup_command backup predeploy)"
+retention_backup_id="$(
+  printf '%s\n' "$retention_output" |
+    sed -nE 's/^backup_id=([0-9]{8}T[0-9]{6}Z-predeploy) restore=verified$/\1/p'
+)"
+[[ -n "$retention_backup_id" ]] || \
+  fail 'retention trigger backup did not return a canonical backup ID'
+[[ ! -e "$expired_exact_directory" ]] || \
+  fail 'expired exact three-file backup was not pruned'
+
+# An extra entry makes an otherwise valid expired backup ineligible for any
+# deletion. The directory and nested sentinel must remain byte-for-byte.
+readonly expired_extra_id='20000102T000000Z-daily'
+readonly expired_extra_directory="$backup_root/$expired_extra_id"
+copy_backup_with_identity \
+  "$finalized_directory" \
+  "$expired_extra_id" \
+  '2000-01-02T00:00:00Z'
+mkdir -m 0700 "$expired_extra_directory/unexpected"
+printf '%s\n' 'retention-must-not-delete' \
+  >"$expired_extra_directory/unexpected/sentinel.txt"
+partial_entries_before="$(partial_backup_entries)"
+sleep 1
+expect_failure 'retention backup with an extra entry' run_backup_command backup daily
+if grep -Fq 'restore=verified' "$temporary_directory/failure-$failure_number.log"; then
+  fail 'retention failure with an extra entry reported success'
+fi
+[[ -d "$expired_extra_directory" &&
+  -f "$expired_extra_directory/database.dump" &&
+  -f "$expired_extra_directory/database.dump.sha256" &&
+  -f "$expired_extra_directory/metadata.json" &&
+  "$(<"$expired_extra_directory/unexpected/sentinel.txt")" == \
+    'retention-must-not-delete' ]] || \
+  fail 'retention modified or deleted a backup containing an extra entry'
+partial_entries_after="$(partial_backup_entries)"
+[[ "$partial_entries_after" == "$partial_entries_before" ]] || \
+  fail 'failed retention run left a new partial backup behind'
+rm "$expired_extra_directory/unexpected/sentinel.txt"
+rmdir "$expired_extra_directory/unexpected"
+rm \
+  "$expired_extra_directory/database.dump" \
+  "$expired_extra_directory/database.dump.sha256" \
+  "$expired_extra_directory/metadata.json"
+rmdir "$expired_extra_directory"
+
+latest_finalized_backup_id="$(
+  finalized_backup_ids | awk 'NF { latest = $0 } END { print latest }'
+)"
+[[ -n "$latest_finalized_backup_id" ]] || fail 'no finalized backup remains'
+# From this point on, the backup is the only available copy of the test data.
+stop_source
+remove_test_volume "$source_volume" || \
+  fail 'refusing to remove a source volume not owned by this test run'
+
+# Independently restore the artifact and query the unique business row. This is
+# test-owned evidence and does not depend on the implementation's check output.
+docker run --detach \
+  --name "$evidence_container" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --network none \
+  --mount "type=volume,src=$evidence_volume,dst=/var/lib/postgresql,volume-nocopy" \
+  --env "POSTGRES_DB=$database_name" \
+  --env "POSTGRES_USER=$database_user" \
+  --env "POSTGRES_PASSWORD=$database_password" \
+  --health-cmd "pg_isready --username=$database_user --dbname=$database_name" \
+  --health-interval 1s \
+  --health-timeout 5s \
+  --health-retries 30 \
+  --health-start-period 5s \
+  "$postgres_image" >/dev/null
+wait_for_healthy "$evidence_container"
+docker cp "$dump_file" "$evidence_container:/tmp/database.dump"
+docker exec "$evidence_container" pg_restore \
+  --single-transaction \
+  --exit-on-error \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  /tmp/database.dump >/dev/null
+restored_user="$(
+  docker exec "$evidence_container" psql \
+    --tuples-only \
+    --no-align \
+    --set ON_ERROR_STOP=1 \
+    --username "$database_user" \
+    --dbname "$database_name" \
+    --command "SELECT id::text || '|' || canonical_email FROM users WHERE id = '00000000-0000-4000-8000-000000000861';"
+)"
+[[ "$restored_user" == '00000000-0000-4000-8000-000000000861|backup-e2e@example.com' ]] || \
+  fail 'independent restore did not recover the seeded user'
+restored_schema="$(
+  docker exec "$evidence_container" psql \
+    --tuples-only \
+    --no-align \
+    --set ON_ERROR_STOP=1 \
+    --username "$database_user" \
+    --dbname "$database_name" \
+    --command "SELECT version::text || '|' || dirty::text FROM schema_migrations;"
+)"
+[[ "$restored_schema" == '7|false' ]] || \
+  fail 'independent restore did not recover the clean schema state'
+remove_test_container "$evidence_container" || \
+  fail 'refusing to remove an evidence container not owned by this test run'
+remove_test_volume "$evidence_volume" || \
+  fail 'refusing to remove an evidence volume not owned by this test run'
+
+check_output="$(run_backup_command check "$backup_id")"
+[[ "$check_output" == "backup_id=$backup_id restore=verified" ]] || \
+  fail 'explicit backup restore check did not succeed'
+assert_no_restore_resources "$backup_id"
+
+check_output="$(run_backup_command check)"
+[[ "$check_output" == \
+  "backup_id=$latest_finalized_backup_id restore=verified" ]] || \
+  fail 'latest backup restore check did not select the newest finalized backup'
+assert_no_restore_resources "$latest_finalized_backup_id"
+
+cp "$checksum_file" "$temporary_directory/original.sha256"
+printf '%064d  database.dump\n' 0 >"$checksum_file"
+expect_failure 'tampered checksum' run_backup_command check "$backup_id"
+assert_no_restore_resources "$backup_id"
+cp "$temporary_directory/original.sha256" "$checksum_file"
+
+cp "$metadata_file" "$temporary_directory/original-metadata.json"
+jq '.created_at = "2000-01-01T00:00:00Z"' "$metadata_file" \
+  >"$temporary_directory/stale-metadata.json"
+mv "$temporary_directory/stale-metadata.json" "$metadata_file"
+expect_failure 'stale finalized backup' run_backup_command check "$backup_id"
+assert_no_restore_resources "$backup_id"
+cp "$temporary_directory/original-metadata.json" "$metadata_file"
+
+# Force a failure after isolated restoration, then prove the temporary resources are gone.
+jq '.schema_version = 8' "$metadata_file" >"$temporary_directory/wrong-schema-metadata.json"
+mv "$temporary_directory/wrong-schema-metadata.json" "$metadata_file"
+expect_failure 'restored schema version mismatch' run_backup_command check "$backup_id"
+assert_no_restore_resources "$backup_id"
+cp "$temporary_directory/original-metadata.json" "$metadata_file"
+
+# A corrupt payload with internally consistent metadata must reach pg_restore and fail closed.
+cp "$dump_file" "$temporary_directory/original.dump"
+printf '%s\n' 'PGDMP-invalid-test-payload' >"$dump_file"
+corrupt_sha256="$(sha256_file "$dump_file")"
+corrupt_size="$(wc -c <"$dump_file" | tr -d '[:space:]')"
+printf '%s  database.dump\n' "$corrupt_sha256" >"$checksum_file"
+jq \
+  --arg sha256 "$corrupt_sha256" \
+  --argjson size_bytes "$corrupt_size" \
+  '.sha256 = $sha256 | .size_bytes = $size_bytes' \
+  "$temporary_directory/original-metadata.json" >"$metadata_file"
+expect_failure 'corrupt custom-format payload' run_backup_command check "$backup_id"
+assert_no_restore_resources "$backup_id"
+
+cp "$temporary_directory/original.dump" "$dump_file"
+cp "$temporary_directory/original.sha256" "$checksum_file"
+cp "$temporary_directory/original-metadata.json" "$metadata_file"
+check_output="$(run_backup_command check "$backup_id")"
+[[ "$check_output" == "backup_id=$backup_id restore=verified" ]] || \
+  fail 'valid backup no longer restores after fail-closed checks'
+assert_no_restore_resources "$backup_id"
+
+printf '%s\n' 'PostgreSQL backup contract tests passed'

--- a/deploy/production/test-offline-compose.sh
+++ b/deploy/production/test-offline-compose.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly compose_file="$production_directory/compose.yaml"
+readonly offline_compose_file="$production_directory/compose.offline.yaml"
+readonly target_services='["migrate", "portal", "postgres", "server"]'
+
+fail() {
+  printf 'production offline Compose test: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+docker compose version >/dev/null 2>&1 || fail "docker compose is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+temporary_directory=$(mktemp -d /tmp/production-offline-compose-test.XXXXXX)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+readonly server_environment="$temporary_directory/server.env"
+readonly base_model="$temporary_directory/base.json"
+readonly offline_model="$temporary_directory/offline.json"
+
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' > "$server_environment"
+chmod 0600 "$server_environment"
+
+export PRODUCTION_POSTGRES_DB=speakup_production
+export PRODUCTION_POSTGRES_USER=speakup_production
+export PRODUCTION_POSTGRES_PASSWORD=production-postgres-password-for-tests
+export PRODUCTION_SERVER_ENV_FILE="$server_environment"
+export PRODUCTION_SERVER_EDGE_GATEWAY_CIDR=172.31.253.1/32
+export PRODUCTION_PORTAL_HOST=speak-up.top
+export PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests
+export SERVER_IMAGE_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+export PORTAL_IMAGE_DIGEST=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+docker compose \
+  --file "$compose_file" \
+  --profile migration \
+  config \
+  --format json > "$base_model"
+docker compose \
+  --file "$compose_file" \
+  --file "$offline_compose_file" \
+  --profile migration \
+  config \
+  --format json > "$offline_model"
+
+jq --exit-status \
+  --argjson services "$target_services" '
+    . as $model
+    | all($services[]; $model.services[.].pull_policy == "always")
+  ' "$base_model" >/dev/null ||
+  fail "base Compose model must use pull_policy=always for the four target services"
+
+jq --exit-status \
+  --argjson services "$target_services" '
+    . as $model
+    | all($services[]; $model.services[.].pull_policy == "never")
+  ' "$offline_model" >/dev/null ||
+  fail "offline Compose model must use pull_policy=never for the four target services"
+
+jq --exit-status \
+  --argjson services "$target_services" \
+  --slurpfile offline "$offline_model" '
+    . as $base
+    | ($offline[0] | reduce $services[] as $service (
+        .;
+        .services[$service].pull_policy = "always"
+      )) == $base
+  ' "$base_model" >/dev/null ||
+  fail "offline override changed fields other than the four pull policies"
+
+printf '%s\n' 'Production offline Compose contract tests passed'

--- a/deploy/production/test-offline-images-docker.sh
+++ b/deploy/production/test-offline-images-docker.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly loader="$production_directory/load-offline-images.sh"
+readonly portal_repository='ghcr.io/1024xengineer/xe3-esl-portal'
+readonly server_repository='ghcr.io/1024xengineer/xe3-esl-server'
+readonly postgres_reference='postgres@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly source_url='https://github.com/1024XEngineer/XE3-ESL'
+
+fail() {
+  printf 'offline image Docker test: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+file_size() {
+  local file=$1
+  stat -c '%s' -- "$file" 2>/dev/null || stat -f '%z' "$file"
+}
+
+require_command docker
+require_command jq
+require_command node
+require_command mktemp
+readonly real_docker="$(command -v docker)"
+"$real_docker" version >/dev/null 2>&1 || fail 'a reachable Docker Engine is required'
+"$real_docker" buildx version >/dev/null 2>&1 || fail 'Docker Buildx is required'
+
+readonly version="999.0.$$"
+git_sha=$(printf '%040x' "$$")
+readonly git_sha
+readonly temporary_directory="$(
+  mktemp -d "${TMPDIR:-/tmp}/xe3-offline-image-docker-test.XXXXXX"
+)"
+readonly bundle_directory="$temporary_directory/bundle"
+readonly manifest_file="$temporary_directory/release-manifest.json"
+readonly bundle_file="$bundle_directory/offline-image-bundle.json"
+readonly fake_bin="$temporary_directory/fake-bin"
+readonly portal_archive="$bundle_directory/portal-image.tar"
+readonly server_archive="$bundle_directory/server-image.tar"
+readonly portal_metadata="$bundle_directory/portal-build-metadata.json"
+readonly server_metadata="$bundle_directory/server-build-metadata.json"
+
+cleanup_image() {
+  local reference=$1
+  local identity
+  local image_id
+
+  identity="$(
+    "$real_docker" image inspect \
+      --format '{{index .Config.Labels "org.opencontainers.image.revision"}} {{index .Config.Labels "org.opencontainers.image.version"}} {{.Id}}' \
+      "$reference" 2>/dev/null
+  )" || return 0
+  [[ "$identity" == "$git_sha $version "* ]] || return 0
+  image_id=${identity##* }
+  "$real_docker" image rm "$reference" >/dev/null 2>&1 || true
+  if "$real_docker" image inspect "$image_id" >/dev/null 2>&1; then
+    identity="$(
+      "$real_docker" image inspect \
+        --format '{{index .Config.Labels "org.opencontainers.image.revision"}} {{index .Config.Labels "org.opencontainers.image.version"}}' \
+        "$image_id" 2>/dev/null
+    )" || return 0
+    if [[ "$identity" == "$git_sha $version" ]]; then
+      "$real_docker" image rm "$image_id" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+cleanup() {
+  local status=$?
+
+  trap - EXIT INT HUP TERM
+  set +e
+  cleanup_image "$portal_repository:$version"
+  cleanup_image "$server_repository:$version"
+  rm -rf -- "$temporary_directory"
+  exit "$status"
+}
+trap cleanup EXIT INT HUP TERM
+
+for repository in "$portal_repository" "$server_repository"; do
+  if "$real_docker" image inspect "$repository:$version" >/dev/null 2>&1; then
+    fail "fixture image reference already exists: $repository:$version"
+  fi
+done
+
+mkdir -p \
+  "$bundle_directory" \
+  "$fake_bin" \
+  "$temporary_directory/portal-context" \
+  "$temporary_directory/server-context"
+for name in portal server; do
+  printf '%s\n' "$name fixture layer" > "$temporary_directory/$name-context/payload.txt"
+  printf '%s\n' \
+    'FROM scratch' \
+    'COPY payload.txt /payload.txt' \
+    > "$temporary_directory/$name-context/Dockerfile"
+done
+
+build_fixture() {
+  local name=$1
+  local repository=$2
+  local archive=$3
+  local metadata=$4
+
+  SOURCE_DATE_EPOCH=1760000000 "$real_docker" buildx build \
+    --file "$temporary_directory/$name-context/Dockerfile" \
+    --platform linux/amd64 \
+    --provenance=false \
+    --sbom=false \
+    --build-arg SOURCE_DATE_EPOCH=1760000000 \
+    --label "org.opencontainers.image.source=$source_url" \
+    --label "org.opencontainers.image.revision=$git_sha" \
+    --label "org.opencontainers.image.version=$version" \
+    --tag "$repository:$version" \
+    --metadata-file "$metadata" \
+    --output "type=docker,dest=$archive,rewrite-timestamp=true" \
+    "$temporary_directory/$name-context" >/dev/null
+}
+
+build_fixture portal "$portal_repository" "$portal_archive" "$portal_metadata"
+build_fixture server "$server_repository" "$server_archive" "$server_metadata"
+portal_digest=$(jq --raw-output '."containerimage.digest"' "$portal_metadata")
+server_digest=$(jq --raw-output '."containerimage.digest"' "$server_metadata")
+readonly portal_digest server_digest
+
+export \
+  version git_sha portal_repository server_repository portal_digest server_digest \
+  portal_archive_size="$(file_size "$portal_archive")" \
+  server_archive_size="$(file_size "$server_archive")" \
+  portal_archive_sha="$(sha256_file "$portal_archive")" \
+  server_archive_sha="$(sha256_file "$server_archive")" \
+  portal_metadata_sha="$(sha256_file "$portal_metadata")" \
+  server_metadata_sha="$(sha256_file "$server_metadata")"
+node - "$manifest_file" "$bundle_file" <<'NODE'
+const fs = require("node:fs");
+const [manifestFile, bundleFile] = process.argv.slice(2);
+const value = (name) => process.env[name];
+const version = value("version");
+const gitSha = value("git_sha");
+const image = (name, repository, digest) => ({
+  name,
+  repository,
+  digest,
+  archive_file: `${name}-image.tar`,
+  archive_size_bytes: Number(value(`${name}_archive_size`)),
+  archive_sha256: value(`${name}_archive_sha`),
+  build_metadata_file: `${name}-build-metadata.json`,
+  build_metadata_sha256: value(`${name}_metadata_sha`),
+});
+fs.writeFileSync(manifestFile, `${JSON.stringify({
+  manifest_version: 1,
+  version,
+  version_code: 999000000,
+  git_sha: gitSha,
+  portal_image: value("portal_repository"),
+  portal_image_digest: value("portal_digest"),
+  server_image: value("server_repository"),
+  server_image_digest: value("server_digest"),
+  staging_apk_file: `speakup-v${version}-staging-arm64.apk`,
+  staging_apk_sha256: "d".repeat(64),
+  production_apk_file: `speakup-v${version}-production-arm64.apk`,
+  production_apk_size_bytes: 1,
+  production_apk_sha256: "e".repeat(64),
+  application_id: "com.xengineer.speakup",
+  minimum_android_api: 24,
+  abis: ["arm64-v8a"],
+  apk_certificate_sha256: "f".repeat(64),
+  database_schema_version: 1,
+  quality_run_url: "https://github.com/1024XEngineer/XE3-ESL/actions/runs/1",
+}, null, 2)}\n`);
+fs.writeFileSync(bundleFile, `${JSON.stringify({
+  bundle_version: 1,
+  version,
+  git_sha: gitSha,
+  source_date_epoch: 1760000000,
+  platform: "linux/amd64",
+  images: [
+    image("portal", value("portal_repository"), value("portal_digest")),
+    image("server", value("server_repository"), value("server_digest")),
+  ],
+}, null, 2)}\n`);
+NODE
+
+export REAL_DOCKER="$real_docker" POSTGRES_REFERENCE="$postgres_reference"
+cat > "$fake_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" == 3 && "$1" == image && "$2" == inspect &&
+      "$3" == "$POSTGRES_REFERENCE" ]]; then
+  node - "$POSTGRES_REFERENCE" <<'NODE'
+const reference = process.argv[2];
+process.stdout.write(`${JSON.stringify([{
+  RepoDigests: [reference],
+  Os: "linux",
+  Architecture: "amd64",
+  Config: { Labels: {} },
+}])}\n`);
+NODE
+  exit
+fi
+exec "$REAL_DOCKER" "$@"
+EOF
+chmod 0700 "$fake_bin/docker"
+
+output="$(
+  PATH="$fake_bin:$PATH" "$loader" \
+    --manifest "$manifest_file" \
+    --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+)"
+[[ "$output" == "offline_images_loaded=true version=$version git_sha=$git_sha platform=linux/amd64 source_date_epoch=1760000000" ]] ||
+  fail 'real Docker loader output is invalid'
+
+for reference in \
+  "$portal_repository@$portal_digest" \
+  "$server_repository@$server_digest"; do
+  "$real_docker" image inspect "$reference" >/dev/null ||
+    fail "real Docker did not preserve the exact RepoDigest: $reference"
+done
+
+printf '%s\n' 'Offline image real Docker round-trip passed'

--- a/deploy/production/test-offline-images.sh
+++ b/deploy/production/test-offline-images.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly loader="$production_directory/load-offline-images.sh"
+readonly version='0.1.1'
+readonly git_sha='cccccccccccccccccccccccccccccccccccccccc'
+readonly portal_repository='ghcr.io/1024xengineer/xe3-esl-portal'
+readonly server_repository='ghcr.io/1024xengineer/xe3-esl-server'
+readonly postgres_reference='postgres@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+
+fail() {
+  printf 'offline image contract test: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+file_size() {
+  local file=$1
+  stat -c '%s' -- "$file" 2>/dev/null || stat -f '%z' "$file"
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  : > "$command_log"
+  if "$@" > "$failure_output" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+}
+
+expect_preflight_failure() {
+  local name=$1
+  shift
+  expect_failure "$name" "$@"
+  [[ ! -s "$command_log" ]] || fail "$name reached Docker before failing"
+}
+
+mutate_json() {
+  local source=$1
+  local destination=$2
+  local operation=$3
+
+  node - "$source" "$destination" "$operation" <<'NODE'
+const fs = require("node:fs");
+
+const [source, destination, operation] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(source, "utf8"));
+switch (operation) {
+  case "traversal": value.images[0].archive_file = "../portal-image.tar"; break;
+  case "symlink": value.images[0].archive_file = "portal-image-link.tar"; break;
+  case "archive-sha": value.images[0].archive_sha256 = "f".repeat(64); break;
+  case "server-archive-sha": value.images[1].archive_sha256 = "f".repeat(64); break;
+  case "metadata-sha": value.images[0].build_metadata_sha256 = "e".repeat(64); break;
+  case "size": value.images[0].archive_size_bytes += 1; break;
+  case "version": value.version = "0.1.2"; break;
+  case "git-sha": value.git_sha = "d".repeat(40); break;
+  case "repository": value.images[0].repository = "ghcr.io/example/wrong"; break;
+  case "digest": value.images[0].digest = `sha256:${"9".repeat(64)}`; break;
+  case "platform": value.platform = "linux/arm64"; break;
+  case "reverse-images": value.images.reverse(); break;
+  case "extra-bundle-field": value.unexpected = true; break;
+  case "extra-image-field": value.images[0].unexpected = true; break;
+  case "manifest-version": value.manifest_version = 2; break;
+  case "manifest-git-sha": value.git_sha = "d".repeat(40); break;
+  case "manifest-repository": value.portal_image = "ghcr.io/example/wrong"; break;
+  default: throw new Error(`unsupported mutation: ${operation}`);
+}
+fs.writeFileSync(destination, `${JSON.stringify(value, null, 2)}\n`);
+NODE
+}
+
+create_image_archive() {
+  local name=$1
+  local repository=$2
+  local archive=$3
+  local variant=${4:-valid}
+  local root="$temporary_directory/archive-root-$name-$archive_number"
+  local digest_file="$temporary_directory/archive-digest-$archive_number"
+  local extra_member=''
+
+  archive_number=$((archive_number + 1))
+  node - \
+    "$root" \
+    "$repository" \
+    "$version" \
+    "$git_sha" \
+    "$variant" \
+    "$digest_file" <<'NODE'
+const { createHash } = require("node:crypto");
+const { mkdirSync, symlinkSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+
+const [root, repository, version, gitSha, variant, digestFile] =
+  process.argv.slice(2);
+const json = (value) => Buffer.from(`${JSON.stringify(value)}\n`);
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const blobs = path.join(root, "blobs", "sha256");
+mkdirSync(blobs, { recursive: true });
+const labels = {
+  "org.opencontainers.image.source": variant === "bad-source"
+    ? "https://github.com/example/wrong"
+    : "https://github.com/1024XEngineer/XE3-ESL",
+  "org.opencontainers.image.revision": variant === "bad-revision"
+    ? "d".repeat(40)
+    : gitSha,
+  "org.opencontainers.image.version": variant === "bad-version"
+    ? "0.1.2"
+    : version,
+};
+const config = json({
+  architecture: variant === "bad-architecture" ? "arm64" : "amd64",
+  os: "linux",
+  config: { Labels: labels },
+  rootfs: { type: "layers", diff_ids: [] },
+  history: [],
+});
+const configDigest = sha256(config);
+writeFileSync(path.join(blobs, configDigest), config);
+const manifest = json({
+  schemaVersion: 2,
+  mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+  config: {
+    mediaType: "application/vnd.docker.container.image.v1+json",
+    digest: `sha256:${configDigest}`,
+    size: config.length,
+  },
+  layers: [],
+});
+const manifestDigest = sha256(manifest);
+writeFileSync(path.join(blobs, manifestDigest), manifest);
+const descriptor = {
+  mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+  digest: `sha256:${manifestDigest}`,
+  size: manifest.length,
+  platform: { architecture: "amd64", os: "linux" },
+};
+const descriptors = [descriptor];
+if (variant === "extra-image") descriptors.push({ ...descriptor });
+if (variant === "descriptor-digest") {
+  descriptors[0] = { ...descriptor, digest: `sha256:${"f".repeat(64)}` };
+}
+writeFileSync(path.join(root, "index.json"), json({
+  schemaVersion: 2,
+  mediaType: "application/vnd.oci.image.index.v1+json",
+  manifests: descriptors,
+}));
+const tags = [`${repository}:${version}`];
+if (variant === "extra-tag") tags.push(`${repository}:unexpected`);
+writeFileSync(path.join(root, "manifest.json"), json([{
+  Config: `blobs/sha256/${configDigest}`,
+  RepoTags: tags,
+  Layers: [],
+}]));
+writeFileSync(path.join(root, "oci-layout"), json({ imageLayoutVersion: "1.0.0" }));
+if (variant === "extra-path") writeFileSync(path.join(root, "unexpected"), "x\n");
+if (variant === "symlink-member") {
+  symlinkSync("index.json", path.join(root, "unexpected-link"));
+}
+writeFileSync(digestFile, `sha256:${manifestDigest}\n`);
+NODE
+  case "$variant" in
+    extra-path) extra_member=unexpected ;;
+    symlink-member) extra_member=unexpected-link ;;
+  esac
+  if [[ -n "$extra_member" ]]; then
+    tar -cf "$archive" -C "$root" index.json manifest.json oci-layout blobs "$extra_member"
+  else
+    tar -cf "$archive" -C "$root" index.json manifest.json oci-layout blobs
+  fi
+  tr -d '[:space:]' < "$digest_file"
+}
+
+write_contract() {
+  local manifest=$1
+  local bundle=$2
+
+  export \
+    version git_sha portal_repository server_repository portal_digest server_digest \
+    portal_archive_size server_archive_size portal_archive_sha server_archive_sha \
+    portal_metadata_sha server_metadata_sha
+  node - "$manifest" "$bundle" <<'NODE'
+const fs = require("node:fs");
+const [manifestFile, bundleFile] = process.argv.slice(2);
+const value = (name) => process.env[name];
+const version = value("version");
+const gitSha = value("git_sha");
+const portalDigest = value("portal_digest");
+const serverDigest = value("server_digest");
+fs.writeFileSync(manifestFile, `${JSON.stringify({
+  manifest_version: 1,
+  version,
+  version_code: 2,
+  git_sha: gitSha,
+  portal_image: value("portal_repository"),
+  portal_image_digest: portalDigest,
+  server_image: value("server_repository"),
+  server_image_digest: serverDigest,
+  staging_apk_file: `speakup-v${version}-staging-arm64.apk`,
+  staging_apk_sha256: "d".repeat(64),
+  production_apk_file: `speakup-v${version}-production-arm64.apk`,
+  production_apk_size_bytes: 123456,
+  production_apk_sha256: "e".repeat(64),
+  application_id: "com.xengineer.speakup",
+  minimum_android_api: 24,
+  abis: ["arm64-v8a"],
+  apk_certificate_sha256: "f".repeat(64),
+  database_schema_version: 7,
+  quality_run_url: "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456",
+}, null, 2)}\n`);
+const image = (name, repository, digest) => ({
+  name,
+  repository,
+  digest,
+  archive_file: `${name}-image.tar`,
+  archive_size_bytes: Number(value(`${name}_archive_size`)),
+  archive_sha256: value(`${name}_archive_sha`),
+  build_metadata_file: `${name}-build-metadata.json`,
+  build_metadata_sha256: value(`${name}_metadata_sha`),
+});
+fs.writeFileSync(bundleFile, `${JSON.stringify({
+  bundle_version: 1,
+  version,
+  git_sha: gitSha,
+  source_date_epoch: 1760000000,
+  platform: "linux/amd64",
+  images: [
+    image("portal", value("portal_repository"), portalDigest),
+    image("server", value("server_repository"), serverDigest),
+  ],
+}, null, 2)}\n`);
+NODE
+}
+
+write_portal_variant_contract() {
+  local archive=$1
+  local digest=$2
+  local label=$3
+  local manifest="$temporary_directory/$label-release-manifest.json"
+  local bundle="$temporary_directory/$label-bundle.json"
+  local metadata="$bundle_directory/$label-build-metadata.json"
+
+  printf '{"containerimage.digest":"%s"}\n' "$digest" > "$metadata"
+  node - \
+    "$manifest_file" "$bundle_file" "$manifest" "$bundle" \
+    "${archive##*/}" "$(file_size "$archive")" "$(sha256_file "$archive")" \
+    "${metadata##*/}" "$(sha256_file "$metadata")" "$digest" <<'NODE'
+const fs = require("node:fs");
+const [
+  sourceManifest, sourceBundle, destinationManifest, destinationBundle,
+  archiveFile, archiveSize, archiveSha, metadataFile, metadataSha, digest,
+] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(sourceManifest, "utf8"));
+const bundle = JSON.parse(fs.readFileSync(sourceBundle, "utf8"));
+manifest.portal_image_digest = digest;
+Object.assign(bundle.images[0], {
+  digest,
+  archive_file: archiveFile,
+  archive_size_bytes: Number(archiveSize),
+  archive_sha256: archiveSha,
+  build_metadata_file: metadataFile,
+  build_metadata_sha256: metadataSha,
+});
+fs.writeFileSync(destinationManifest, `${JSON.stringify(manifest, null, 2)}\n`);
+fs.writeFileSync(destinationBundle, `${JSON.stringify(bundle, null, 2)}\n`);
+NODE
+  printf '%s\t%s\n' "$manifest" "$bundle"
+}
+
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/xe3-offline-image-test.XXXXXX")
+readonly temporary_directory
+trap 'rm -rf -- "$temporary_directory"' EXIT INT TERM
+readonly bundle_directory="$temporary_directory/bundle"
+readonly fake_bin="$temporary_directory/fake-bin"
+readonly command_log="$temporary_directory/docker.log"
+readonly failure_output="$temporary_directory/failure.out"
+readonly manifest_file="$temporary_directory/release-manifest.json"
+readonly bundle_file="$temporary_directory/offline-image-bundle.json"
+readonly portal_archive="$bundle_directory/portal-image.tar"
+readonly server_archive="$bundle_directory/server-image.tar"
+readonly portal_metadata="$bundle_directory/portal-build-metadata.json"
+readonly server_metadata="$bundle_directory/server-build-metadata.json"
+
+mkdir -p "$bundle_directory" "$fake_bin"
+archive_number=0
+portal_digest=$(create_image_archive portal "$portal_repository" "$portal_archive")
+server_digest=$(create_image_archive server "$server_repository" "$server_archive")
+printf '{"containerimage.digest":"%s"}\n' "$portal_digest" > "$portal_metadata"
+printf '{"containerimage.digest":"%s"}\n' "$server_digest" > "$server_metadata"
+portal_archive_size=$(file_size "$portal_archive")
+server_archive_size=$(file_size "$server_archive")
+portal_archive_sha=$(sha256_file "$portal_archive")
+server_archive_sha=$(sha256_file "$server_archive")
+portal_metadata_sha=$(sha256_file "$portal_metadata")
+server_metadata_sha=$(sha256_file "$server_metadata")
+write_contract "$manifest_file" "$bundle_file"
+
+export \
+  PORTAL_REFERENCE="$portal_repository@$portal_digest" \
+  SERVER_REFERENCE="$server_repository@$server_digest" \
+  POSTGRES_REFERENCE="$postgres_reference"
+cat > "$fake_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" == 6 && "$1" == image && "$2" == load && "$3" == --platform &&
+      "$4" == linux/amd64 && "$5" == -i ]]; then
+  printf 'load:%s\n' "$6" >> "$COMMAND_LOG"
+  [[ "${TEST_LOAD_FAILURE:-0}" != 1 ]]
+  exit
+fi
+
+if [[ "$#" == 3 && "$1" == image && "$2" == inspect ]]; then
+  reference=$3
+  printf 'inspect:%s\n' "$reference" >> "$COMMAND_LOG"
+  if [[ "$reference" == "$POSTGRES_REFERENCE" ]]; then
+    [[ "${TEST_POSTGRES_IMAGE:-valid}" != missing ]] || exit 1
+    repo_digest=$reference
+    architecture=amd64
+    case "${TEST_POSTGRES_IMAGE:-valid}" in
+      valid) ;;
+      wrong-digest) repo_digest="postgres@sha256:$(printf '9%.0s' {1..64})" ;;
+      wrong-architecture) architecture=arm64 ;;
+      *) exit 2 ;;
+    esac
+    node - "$repo_digest" "$architecture" <<'NODE'
+const [repoDigest, architecture] = process.argv.slice(2);
+process.stdout.write(`${JSON.stringify([{
+  RepoDigests: [repoDigest], Os: "linux", Architecture: architecture,
+  Config: { Labels: {} },
+}])}\n`);
+NODE
+    exit
+  fi
+
+  case "$reference" in
+    "$PORTAL_REFERENCE" | "$SERVER_REFERENCE") ;;
+    *) exit 1 ;;
+  esac
+  repo_digest=$reference
+  case "${TEST_REPO_DIGEST:-valid}" in
+    valid) ;;
+    missing) repo_digest='' ;;
+    wrong) repo_digest="${reference%@*}@sha256:$(printf '9%.0s' {1..64})" ;;
+    *) exit 2 ;;
+  esac
+  source_label='https://github.com/1024XEngineer/XE3-ESL'
+  revision_label='cccccccccccccccccccccccccccccccccccccccc'
+  version_label='0.1.1'
+  case "${TEST_BAD_LABEL:-}" in
+    '') ;;
+    source) source_label='https://github.com/example/wrong' ;;
+    revision) revision_label='dddddddddddddddddddddddddddddddddddddddd' ;;
+    version) version_label='0.1.2' ;;
+    *) exit 2 ;;
+  esac
+  node - \
+    "$repo_digest" "${TEST_IMAGE_OS:-linux}" \
+    "${TEST_IMAGE_ARCHITECTURE:-amd64}" "$source_label" \
+    "$revision_label" "$version_label" <<'NODE'
+const [repoDigest, os, architecture, source, revision, version] =
+  process.argv.slice(2);
+process.stdout.write(`${JSON.stringify([{
+  RepoDigests: repoDigest ? [repoDigest] : [], Os: os, Architecture: architecture,
+  Config: { Labels: {
+    "org.opencontainers.image.source": source,
+    "org.opencontainers.image.revision": revision,
+    "org.opencontainers.image.version": version,
+  } },
+}])}\n`);
+NODE
+  exit
+fi
+
+exit 2
+EOF
+chmod 0700 "$fake_bin/docker"
+
+export COMMAND_LOG="$command_log"
+export PATH="$fake_bin:$PATH"
+
+bash -n "$loader" "$0"
+
+: > "$command_log"
+success_output="$(
+  "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+)"
+[[ "$success_output" == "offline_images_loaded=true version=$version git_sha=$git_sha platform=linux/amd64 source_date_epoch=1760000000" ]] ||
+  fail 'valid offline image bundle did not return the canonical success contract'
+expected_log="$(
+  printf '%s\n' \
+    "inspect:$postgres_reference" \
+    "load:$portal_archive" \
+    "inspect:$portal_repository@$portal_digest" \
+    "load:$server_archive" \
+    "inspect:$server_repository@$server_digest"
+)"
+[[ "$(< "$command_log")" == "$expected_log" ]] ||
+  fail 'valid bundle did not preflight Postgres and load exact application digests'
+
+for mutation in \
+  traversal archive-sha server-archive-sha metadata-sha size version git-sha \
+  repository digest platform reverse-images extra-bundle-field extra-image-field; do
+  invalid_bundle="$temporary_directory/$mutation-bundle.json"
+  mutate_json "$bundle_file" "$invalid_bundle" "$mutation"
+  expect_preflight_failure "$mutation bundle" \
+    "$loader" --manifest "$manifest_file" --bundle "$invalid_bundle" \
+      --directory "$bundle_directory"
+done
+
+ln -s "$portal_archive" "$bundle_directory/portal-image-link.tar"
+symlink_bundle="$temporary_directory/symlink-bundle.json"
+mutate_json "$bundle_file" "$symlink_bundle" symlink
+expect_preflight_failure 'symbolic-link archive' \
+  "$loader" --manifest "$manifest_file" --bundle "$symlink_bundle" \
+    --directory "$bundle_directory"
+
+for mutation in manifest-version manifest-git-sha manifest-repository; do
+  invalid_manifest="$temporary_directory/$mutation-release-manifest.json"
+  mutate_json "$manifest_file" "$invalid_manifest" "$mutation"
+  expect_preflight_failure "$mutation" \
+    "$loader" --manifest "$invalid_manifest" --bundle "$bundle_file" \
+      --directory "$bundle_directory"
+done
+
+empty_manifest="$temporary_directory/empty-release-manifest.json"
+empty_bundle="$temporary_directory/empty-bundle.json"
+: > "$empty_manifest"
+: > "$empty_bundle"
+expect_preflight_failure 'empty release manifest' \
+  "$loader" --manifest "$empty_manifest" --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+expect_preflight_failure 'empty bundle' \
+  "$loader" --manifest "$manifest_file" --bundle "$empty_bundle" \
+    --directory "$bundle_directory"
+
+cp "$server_archive" "$temporary_directory/server-image.original"
+: > "$server_archive"
+expect_preflight_failure 'empty Server archive' \
+  "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+mv "$temporary_directory/server-image.original" "$server_archive"
+
+cp "$server_metadata" "$temporary_directory/server-metadata.original"
+: > "$server_metadata"
+expect_preflight_failure 'empty Server metadata' \
+  "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+mv "$temporary_directory/server-metadata.original" "$server_metadata"
+
+wrong_metadata="$bundle_directory/wrong-digest-build-metadata.json"
+printf '{"containerimage.digest":"sha256:%s"}\n' "$(printf '9%.0s' {1..64})" > "$wrong_metadata"
+wrong_metadata_bundle="$temporary_directory/wrong-metadata-bundle.json"
+node - "$bundle_file" "$wrong_metadata_bundle" "${wrong_metadata##*/}" \
+  "$(sha256_file "$wrong_metadata")" <<'NODE'
+const fs = require("node:fs");
+const [source, destination, file, sha] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(source, "utf8"));
+value.images[0].build_metadata_file = file;
+value.images[0].build_metadata_sha256 = sha;
+fs.writeFileSync(destination, `${JSON.stringify(value, null, 2)}\n`);
+NODE
+expect_preflight_failure 'build metadata content digest mismatch' \
+  "$loader" --manifest "$manifest_file" --bundle "$wrong_metadata_bundle" \
+    --directory "$bundle_directory"
+
+for variant in \
+  descriptor-digest extra-image extra-tag extra-path symlink-member \
+  bad-architecture bad-source bad-revision bad-version; do
+  variant_archive="$bundle_directory/$variant-portal-image.tar"
+  variant_digest=$(create_image_archive \
+    "$variant-portal" "$portal_repository" "$variant_archive" "$variant")
+  IFS=$'\t' read -r variant_manifest variant_bundle < <(
+    write_portal_variant_contract "$variant_archive" "$variant_digest" "$variant"
+  )
+  expect_preflight_failure "$variant image archive" \
+    "$loader" --manifest "$variant_manifest" --bundle "$variant_bundle" \
+      --directory "$bundle_directory"
+done
+
+for postgres_failure in missing wrong-digest wrong-architecture; do
+  expect_failure "Postgres $postgres_failure" \
+    env TEST_POSTGRES_IMAGE="$postgres_failure" \
+    "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+      --directory "$bundle_directory"
+  [[ "$(wc -l < "$command_log" | tr -d '[:space:]')" == 1 &&
+    "$(< "$command_log")" == "inspect:$postgres_reference" ]] ||
+    fail "Postgres $postgres_failure reached an application image load"
+done
+
+expect_failure 'Portal load failure' \
+  env TEST_LOAD_FAILURE=1 \
+  "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+    --directory "$bundle_directory"
+[[ "$(wc -l < "$command_log" | tr -d '[:space:]')" == 2 ]] ||
+  fail 'Portal load failure did not stop before image inspection'
+
+for runtime_failure in \
+  'TEST_IMAGE_ARCHITECTURE=arm64' 'TEST_IMAGE_OS=windows' \
+  'TEST_BAD_LABEL=source' 'TEST_BAD_LABEL=revision' 'TEST_BAD_LABEL=version' \
+  'TEST_REPO_DIGEST=wrong' 'TEST_REPO_DIGEST=missing'; do
+  name=${runtime_failure%%=*}
+  value=${runtime_failure#*=}
+  expect_failure "$runtime_failure" \
+    env "$name=$value" \
+    "$loader" --manifest "$manifest_file" --bundle "$bundle_file" \
+      --directory "$bundle_directory"
+  [[ "$(wc -l < "$command_log" | tr -d '[:space:]')" == 3 ]] ||
+    fail "$runtime_failure did not stop after the first exact image inspection"
+  grep -Fxq "inspect:$postgres_reference" "$command_log" ||
+    fail "$runtime_failure skipped the Postgres preflight"
+  grep -Fxq "load:$portal_archive" "$command_log" ||
+    fail "$runtime_failure did not load the Portal archive"
+  grep -Fxq "inspect:$portal_repository@$portal_digest" "$command_log" ||
+    fail "$runtime_failure did not inspect the Portal digest"
+done
+
+printf '%s\n' 'Offline image loading contract tests passed'

--- a/deploy/production/xe3-postgres-backup
+++ b/deploy/production/xe3-postgres-backup
@@ -1,0 +1,875 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly compose_project="xe3-speakup-production"
+readonly compose_service="postgres"
+readonly database_network="xe3-speakup-production_database"
+readonly production_postgres_image="postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly production_postgres_volume="xe3-speakup-postgres-data"
+readonly restore_label="com.xengineer.speakup.postgres-restore-check"
+readonly restore_backup_label="com.xengineer.speakup.postgres-restore-backup-id"
+readonly restore_run_label="com.xengineer.speakup.postgres-restore-run-id"
+readonly dump_file_name="database.dump"
+readonly checksum_file_name="database.dump.sha256"
+readonly metadata_file_name="metadata.json"
+
+restore_container=""
+restore_volume=""
+restore_backup_id=""
+restore_run_id=""
+active_partial_directory=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  xe3-postgres-backup backup <daily|predeploy>
+  xe3-postgres-backup check [BACKUP_ID]
+EOF
+}
+
+fail() {
+  printf 'Production PostgreSQL backup error: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup_restore_resources() {
+  local failed=0 inspect_output
+
+  if [[ -n "$restore_container" ]]; then
+    if inspect_output="$(docker container inspect "$restore_container")"; then
+      if jq --exit-status \
+        --arg container_id "$restore_container" \
+        --arg label "$restore_label" \
+        --arg backup_label "$restore_backup_label" \
+        --arg backup_id "$restore_backup_id" \
+        --arg run_label "$restore_run_label" \
+        --arg run_id "$restore_run_id" '
+          length == 1 and
+          .[0].Id == $container_id and
+          .[0].Config.Labels[$label] == "true" and
+          .[0].Config.Labels[$backup_label] == $backup_id and
+          .[0].Config.Labels[$run_label] == $run_id
+        ' <<< "$inspect_output" >/dev/null; then
+        if docker container rm --force "$restore_container" >/dev/null 2>&1; then
+          restore_container=""
+        else
+          failed=1
+        fi
+      else
+        failed=1
+      fi
+    else
+      failed=1
+    fi
+  fi
+
+  if [[ -n "$restore_volume" ]]; then
+    if [[ "$restore_volume" == "$production_postgres_volume" ]]; then
+      failed=1
+    elif inspect_output="$(docker volume inspect "$restore_volume")"; then
+      if jq --exit-status \
+        --arg volume "$restore_volume" \
+        --arg label "$restore_label" \
+        --arg backup_label "$restore_backup_label" \
+        --arg backup_id "$restore_backup_id" \
+        --arg run_label "$restore_run_label" \
+        --arg run_id "$restore_run_id" '
+          length == 1 and
+          .[0].Name == $volume and
+          .[0].Labels[$label] == "true" and
+          .[0].Labels[$backup_label] == $backup_id and
+          .[0].Labels[$run_label] == $run_id
+        ' <<< "$inspect_output" >/dev/null; then
+        if docker volume rm "$restore_volume" >/dev/null 2>&1; then
+          restore_volume=""
+        else
+          failed=1
+        fi
+      else
+        failed=1
+      fi
+    else
+      failed=1
+    fi
+  fi
+
+  if [[ -z "$restore_container" && -z "$restore_volume" ]]; then
+    restore_backup_id=""
+    restore_run_id=""
+  fi
+
+  ((failed == 0))
+}
+
+cleanup_partial_directory() {
+  local failed=0 entry name
+  local -a entries
+
+  [[ -n "$active_partial_directory" ]] || return 0
+  if [[ -z "${POSTGRES_BACKUP_ROOT:-}" ||
+    "${active_partial_directory%/*}" != "$POSTGRES_BACKUP_ROOT" ||
+    "${active_partial_directory##*/}" != .partial-* ||
+    ! -d "$active_partial_directory" || -L "$active_partial_directory" ]]; then
+    return 1
+  fi
+
+  shopt -s nullglob dotglob
+  entries=("$active_partial_directory"/*)
+  shopt -u nullglob dotglob
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      "$dump_file_name" | "$checksum_file_name" | "$metadata_file_name") ;;
+      *) return 1 ;;
+    esac
+    [[ -f "$entry" && ! -L "$entry" ]] || return 1
+  done
+  for entry in "${entries[@]}"; do
+    rm -- "$entry" || failed=1
+  done
+  if ((failed == 0)) && rmdir -- "$active_partial_directory"; then
+    active_partial_directory=""
+  else
+    failed=1
+  fi
+
+  ((failed == 0))
+}
+
+cleanup_on_exit() {
+  local status=$?
+
+  trap - EXIT
+  set +e
+  if ! cleanup_restore_resources; then
+    status=1
+  fi
+  if ! cleanup_partial_directory; then
+    status=1
+  fi
+  exit "$status"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit 130' INT HUP TERM
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_value() {
+  local name=$1
+
+  [[ -n "${!name:-}" ]] || fail "$name is required"
+  [[ "${!name}" != *$'\n'* && "${!name}" != *$'\r'* ]] ||
+    fail "$name must not contain newlines"
+}
+
+require_positive_integer() {
+  local name=$1
+
+  require_value "$name"
+  [[ "${!name}" =~ ^[1-9][0-9]*$ ]] ||
+    fail "$name must be a positive integer"
+}
+
+valid_absolute_path() {
+  local value=$1
+
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != "/" ]] &&
+    [[ "$value" != *//* ]] &&
+    [[ "$value" != */../* ]] &&
+    [[ "$value" != */./* ]] &&
+    [[ "$value" != */.. ]] &&
+    [[ "$value" != */. ]]
+}
+
+validate_common_configuration() {
+  require_value POSTGRES_BACKUP_ROOT
+  require_value POSTGRES_BACKUP_IMAGE
+  require_value POSTGRES_BACKUP_SOURCE_VOLUME
+  require_value POSTGRES_BACKUP_DATABASE
+  require_value POSTGRES_BACKUP_USER
+
+  valid_absolute_path "$POSTGRES_BACKUP_ROOT" ||
+    fail 'POSTGRES_BACKUP_ROOT must be a safe absolute non-root path'
+  [[ "$POSTGRES_BACKUP_IMAGE" == "$production_postgres_image" ]] ||
+    fail 'POSTGRES_BACKUP_IMAGE must match the audited Production PostgreSQL digest'
+  [[ "$POSTGRES_BACKUP_SOURCE_VOLUME" == "$production_postgres_volume" ]] ||
+    fail 'POSTGRES_BACKUP_SOURCE_VOLUME must match the Production PostgreSQL volume'
+  [[ "$POSTGRES_BACKUP_DATABASE" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail 'POSTGRES_BACKUP_DATABASE must be a lowercase PostgreSQL identifier'
+  [[ "$POSTGRES_BACKUP_USER" =~ ^[a-z_][a-z0-9_]{0,62}$ ]] ||
+    fail 'POSTGRES_BACKUP_USER must be a lowercase PostgreSQL identifier'
+}
+
+validate_backup_configuration() {
+  validate_common_configuration
+  require_value POSTGRES_BACKUP_DEPLOYMENT_VERSION
+  require_value POSTGRES_BACKUP_GIT_SHA
+  require_positive_integer POSTGRES_BACKUP_RETENTION_DAYS
+  require_positive_integer POSTGRES_BACKUP_MAX_AGE_SECONDS
+
+  [[ "$POSTGRES_BACKUP_DEPLOYMENT_VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] ||
+    fail 'POSTGRES_BACKUP_DEPLOYMENT_VERSION has an invalid format'
+  [[ "$POSTGRES_BACKUP_GIT_SHA" =~ ^[a-f0-9]{40}$ ]] ||
+    fail 'POSTGRES_BACKUP_GIT_SHA must be a full lowercase Git SHA'
+}
+
+validate_check_configuration() {
+  validate_common_configuration
+  require_positive_integer POSTGRES_BACKUP_MAX_AGE_SECONDS
+}
+
+image_id_for_reference() {
+  local image_reference=$1
+  local image_id
+
+  image_id="$(
+    docker image inspect --format '{{.Id}}' "$image_reference"
+  )" || fail 'required PostgreSQL image is not available locally'
+  [[ "$image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+    fail 'required PostgreSQL image ID is not content-addressed'
+  printf '%s\n' "$image_id"
+}
+
+configured_image_id() {
+  image_id_for_reference "$POSTGRES_BACKUP_IMAGE"
+}
+
+discover_source_container() {
+  local container_ids count
+
+  container_ids="$(
+    docker container ls --quiet \
+      --filter "label=com.docker.compose.project=$compose_project" \
+      --filter "label=com.docker.compose.service=$compose_service"
+  )" || fail 'cannot inspect the Production PostgreSQL container'
+  count="$(printf '%s\n' "$container_ids" | awk 'NF { count += 1 } END { print count + 0 }')"
+  [[ "$count" == "1" ]] ||
+    fail 'exactly one running Production PostgreSQL container is required'
+  printf '%s\n' "$container_ids"
+}
+
+validate_source_container() {
+  local container_id=$1
+  local image_id=$2
+  local state configured_reference mounted_volume
+
+  state="$(
+    docker container inspect --format \
+      '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' \
+      "$container_id"
+  )" || fail 'cannot inspect the Production PostgreSQL state'
+  [[ "$state" == "true|healthy" ]] ||
+    fail 'Production PostgreSQL must be running and healthy'
+
+  configured_reference="$(
+    docker container inspect --format '{{.Config.Image}}' "$container_id"
+  )"
+  [[ "$configured_reference" == "$POSTGRES_BACKUP_IMAGE" ]] ||
+    fail 'running PostgreSQL image reference does not match the audited digest'
+  [[ "$(docker container inspect --format '{{.Image}}' "$container_id")" == "$image_id" ]] ||
+    fail 'running PostgreSQL image ID does not match the audited digest'
+
+  docker volume inspect "$POSTGRES_BACKUP_SOURCE_VOLUME" >/dev/null ||
+    fail 'configured Production PostgreSQL volume does not exist'
+  mounted_volume="$(
+    docker container inspect --format \
+      '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql"}}{{.Type}}|{{.Name}}{{println}}{{end}}{{end}}' \
+      "$container_id"
+  )"
+  [[ "$mounted_volume" == "volume|$POSTGRES_BACKUP_SOURCE_VOLUME" ]] ||
+    fail 'configured volume is not the running PostgreSQL data mount'
+
+  docker container inspect "$container_id" | jq --exit-status \
+    --arg network "$database_network" '
+      length == 1 and
+      ((.[0].HostConfig.PortBindings // {}) == {}) and
+      ((.[0].NetworkSettings.Networks | keys) == [$network])
+    ' >/dev/null ||
+    fail 'Production PostgreSQL must have no published port and only the internal database network'
+  docker network inspect "$database_network" | jq --exit-status '
+    length == 1 and .[0].Internal == true
+  ' >/dev/null ||
+    fail 'Production database network must exist and remain internal'
+
+  docker container inspect "$container_id" | jq --exit-status \
+    --arg expected "POSTGRES_DB=$POSTGRES_BACKUP_DATABASE" '
+      [.[] | .Config.Env[] | select(startswith("POSTGRES_DB="))] == [$expected]
+    ' >/dev/null || fail 'running PostgreSQL database identity does not match backup configuration'
+  docker container inspect "$container_id" | jq --exit-status \
+    --arg expected "POSTGRES_USER=$POSTGRES_BACKUP_USER" '
+      [.[] | .Config.Env[] | select(startswith("POSTGRES_USER="))] == [$expected]
+    ' >/dev/null || fail 'running PostgreSQL user identity does not match backup configuration'
+}
+
+database_query() {
+  local container_id=$1
+  local sql=$2
+
+  docker container exec --user postgres "$container_id" \
+    psql \
+      --no-psqlrc \
+      --set ON_ERROR_STOP=1 \
+      --tuples-only \
+      --no-align \
+      --quiet \
+      --username "$POSTGRES_BACKUP_USER" \
+      --dbname "$POSTGRES_BACKUP_DATABASE" \
+      --command "$sql"
+}
+
+schema_state() {
+  local container_id=$1
+  local state
+
+  state="$(
+    database_query "$container_id" \
+      "SELECT version::text || '|' || CASE WHEN dirty THEN 'true' ELSE 'false' END FROM public.schema_migrations;"
+  )" || fail 'cannot read PostgreSQL migration state'
+  [[ "$state" =~ ^([1-9][0-9]*)\|false$ ]] ||
+    fail 'PostgreSQL migration state must contain exactly one clean positive version'
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+postgres_version() {
+  local container_id=$1
+  local version
+
+  version="$(database_query "$container_id" 'SHOW server_version;')" ||
+    fail 'cannot read PostgreSQL version'
+  [[ -n "$version" && ${#version} -le 128 ]] ||
+    fail 'PostgreSQL version is invalid'
+  [[ "$version" != *$'\n'* && "$version" != *$'\r'* && "$version" != *$'\t'* ]] ||
+    fail 'PostgreSQL version contains control characters'
+  printf '%s\n' "$version"
+}
+
+sha256_file() {
+  local file=$1
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+file_size() {
+  local file=$1
+  local size
+
+  if size="$(stat -c '%s' "$file" 2>/dev/null)"; then
+    :
+  elif size="$(stat -f '%z' "$file" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect backup file size'
+  fi
+  [[ "$size" =~ ^[1-9][0-9]*$ ]] || fail 'backup dump must not be empty'
+  printf '%s\n' "$size"
+}
+
+file_mode() {
+  local file=$1
+  local mode
+
+  if mode="$(stat -c '%a' "$file" 2>/dev/null)"; then
+    :
+  elif mode="$(stat -f '%Lp' "$file" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect backup file permissions'
+  fi
+  printf '%s\n' "$mode"
+}
+
+file_owner_id() {
+  local file=$1
+  local owner
+
+  if owner="$(stat -c '%u' "$file" 2>/dev/null)"; then
+    :
+  elif owner="$(stat -f '%u' "$file" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect backup path ownership'
+  fi
+  printf '%s\n' "$owner"
+}
+
+validate_backup_root() {
+  [[ -d "$POSTGRES_BACKUP_ROOT" && ! -L "$POSTGRES_BACKUP_ROOT" ]] ||
+    fail 'POSTGRES_BACKUP_ROOT must already exist as a real directory'
+  [[ "${POSTGRES_BACKUP_ROOT##*/}" == "postgres-backups" ]] ||
+    fail 'POSTGRES_BACKUP_ROOT must end with postgres-backups'
+  [[ "$(file_mode "$POSTGRES_BACKUP_ROOT")" == "700" ]] ||
+    fail 'POSTGRES_BACKUP_ROOT must have mode 0700'
+  [[ "$(file_owner_id "$POSTGRES_BACKUP_ROOT")" == "$EUID" ]] ||
+    fail 'POSTGRES_BACKUP_ROOT must be owned by the current service user'
+}
+
+write_metadata() {
+  local file=$1
+  local backup_id=$2
+  local created_at=$3
+  local backup_type=$4
+  local version=$5
+  local schema_version=$6
+  local size=$7
+  local checksum=$8
+
+  jq --null-input --sort-keys \
+    --arg backup_id "$backup_id" \
+    --arg backup_type "$backup_type" \
+    --arg created_at "$created_at" \
+    --arg database_name "$POSTGRES_BACKUP_DATABASE" \
+    --arg database_user "$POSTGRES_BACKUP_USER" \
+    --arg deployment_version "$POSTGRES_BACKUP_DEPLOYMENT_VERSION" \
+    --arg git_sha "$POSTGRES_BACKUP_GIT_SHA" \
+    --arg postgres_image "$POSTGRES_BACKUP_IMAGE" \
+    --arg postgres_version "$version" \
+    --arg sha256 "$checksum" \
+    --arg source_compose_project "$compose_project" \
+    --arg source_compose_service "$compose_service" \
+    --arg source_volume "$POSTGRES_BACKUP_SOURCE_VOLUME" \
+    --argjson schema_version "$schema_version" \
+    --argjson size_bytes "$size" '
+      {
+        format_version: 1,
+        backup_id: $backup_id,
+        created_at: $created_at,
+        backup_type: $backup_type,
+        deployment_version: $deployment_version,
+        git_sha: $git_sha,
+        source_compose_project: $source_compose_project,
+        source_compose_service: $source_compose_service,
+        source_volume: $source_volume,
+        postgres_image: $postgres_image,
+        postgres_version: $postgres_version,
+        database_name: $database_name,
+        database_user: $database_user,
+        schema_version: $schema_version,
+        schema_dirty: false,
+        size_bytes: $size_bytes,
+        sha256: $sha256
+      }
+    ' > "$file"
+}
+
+validate_metadata() {
+  local directory=$1
+  local backup_id=${2:-${directory##*/}}
+  local metadata="$directory/$metadata_file_name"
+
+  [[ -f "$metadata" && ! -L "$metadata" ]] ||
+    fail 'backup metadata is missing or is not a regular file'
+  jq --exit-status \
+    --arg backup_id "$backup_id" \
+    --arg database_name "$POSTGRES_BACKUP_DATABASE" \
+    --arg database_user "$POSTGRES_BACKUP_USER" \
+    --arg source_compose_project "$compose_project" \
+    --arg source_compose_service "$compose_service" \
+    --arg source_volume "$POSTGRES_BACKUP_SOURCE_VOLUME" '
+      type == "object" and
+      keys == [
+        "backup_id",
+        "backup_type",
+        "created_at",
+        "database_name",
+        "database_user",
+        "deployment_version",
+        "format_version",
+        "git_sha",
+        "postgres_image",
+        "postgres_version",
+        "schema_dirty",
+        "schema_version",
+        "sha256",
+        "size_bytes",
+        "source_compose_project",
+        "source_compose_service",
+        "source_volume"
+      ] and
+      .format_version == 1 and
+      .backup_id == $backup_id and
+      (.backup_type == "daily" or .backup_type == "predeploy") and
+      (.created_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") and (fromdateiso8601 | type == "number")) and
+      ((.created_at | gsub("[-:]"; "")) + "-" + .backup_type == .backup_id) and
+      (.deployment_version | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")) and
+      (.git_sha | type == "string" and test("^[a-f0-9]{40}$")) and
+      .source_compose_project == $source_compose_project and
+      .source_compose_service == $source_compose_service and
+      .source_volume == $source_volume and
+      (.postgres_image | type == "string" and test("^postgres:[1-9][0-9]*-bookworm@sha256:[a-f0-9]{64}$")) and
+      (.postgres_version | type == "string" and length > 0 and length <= 128 and test("^[1-9][0-9]*\\.") and ([explode[] | select(. < 32 or . == 127)] | length == 0)) and
+      ((.postgres_image | capture("^postgres:(?<major>[1-9][0-9]*)-bookworm@sha256:[a-f0-9]{64}$").major) ==
+       (.postgres_version | capture("^(?<major>[1-9][0-9]*)\\.").major)) and
+      .database_name == $database_name and
+      .database_user == $database_user and
+      (.schema_version | type == "number" and floor == . and . > 0) and
+      .schema_dirty == false and
+      (.size_bytes | type == "number" and floor == . and . > 0) and
+      (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+    ' "$metadata" >/dev/null || fail 'backup metadata is invalid or does not match this Production database'
+}
+
+metadata_fields() {
+  local directory=$1
+
+  jq --raw-output '
+    [
+      .created_at,
+      (.schema_version | tostring),
+      .postgres_version,
+      .postgres_image,
+      (.size_bytes | tostring),
+      .sha256
+    ] | @tsv
+  ' "$directory/$metadata_file_name"
+}
+
+validate_exact_backup_entries() {
+  local directory=$1
+  local entry name
+  local -a entries
+  local dump_count=0 checksum_count=0 metadata_count=0
+
+  shopt -s nullglob dotglob
+  entries=("$directory"/*)
+  shopt -u nullglob dotglob
+  [[ "${#entries[@]}" == 3 ]] ||
+    fail 'backup directory must contain exactly the three contract files'
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      "$dump_file_name") dump_count=$((dump_count + 1)) ;;
+      "$checksum_file_name") checksum_count=$((checksum_count + 1)) ;;
+      "$metadata_file_name") metadata_count=$((metadata_count + 1)) ;;
+      *) fail 'backup directory contains an unexpected entry' ;;
+    esac
+  done
+  [[ "$dump_count" == 1 && "$checksum_count" == 1 && "$metadata_count" == 1 ]] ||
+    fail 'backup directory contract files are incomplete'
+}
+
+verify_backup_files() {
+  local directory=$1
+  local require_freshness=$2
+  local backup_id=${3:-${directory##*/}}
+  local fields created_at schema_version version postgres_image expected_size expected_sha
+  local dump_file="$directory/$dump_file_name"
+  local checksum_file="$directory/$checksum_file_name"
+  local actual_size actual_sha
+
+  [[ -d "$directory" && ! -L "$directory" ]] ||
+    fail 'selected backup directory does not exist or is unsafe'
+  validate_exact_backup_entries "$directory"
+  validate_metadata "$directory" "$backup_id"
+  [[ -f "$dump_file" && ! -L "$dump_file" ]] || fail 'backup dump is missing or unsafe'
+  [[ -f "$checksum_file" && ! -L "$checksum_file" ]] || fail 'backup checksum is missing or unsafe'
+  [[ "$(file_mode "$directory")" == "700" ]] || fail 'backup directory must have mode 0700'
+  [[ "$(file_mode "$dump_file")" == "600" ]] || fail 'backup dump must have mode 0600'
+  [[ "$(file_mode "$checksum_file")" == "600" ]] || fail 'backup checksum must have mode 0600'
+  [[ "$(file_mode "$directory/$metadata_file_name")" == "600" ]] ||
+    fail 'backup metadata must have mode 0600'
+
+  fields="$(metadata_fields "$directory")"
+  IFS=$'\t' read -r \
+    created_at schema_version version postgres_image expected_size expected_sha <<< "$fields"
+  actual_size="$(file_size "$dump_file")"
+  [[ "$actual_size" == "$expected_size" ]] || fail 'backup dump size does not match metadata'
+  actual_sha="$(sha256_file "$dump_file")"
+  [[ "$actual_sha" == "$expected_sha" ]] || fail 'backup dump SHA-256 does not match metadata'
+  printf '%s  %s\n' "$expected_sha" "$dump_file_name" |
+    cmp -s - "$checksum_file" || fail 'backup checksum file does not match metadata'
+
+  if [[ "$require_freshness" == "true" ]]; then
+    jq --exit-status --arg max_age "$POSTGRES_BACKUP_MAX_AGE_SECONDS" '
+      (.created_at | fromdateiso8601) as $created |
+      now as $current |
+      ($created <= $current and ($current - $created) <= ($max_age | tonumber))
+    ' "$directory/$metadata_file_name" >/dev/null || fail 'backup is stale or has a future timestamp'
+  fi
+
+  printf '%s\t%s\t%s\n' "$schema_version" "$version" "$postgres_image"
+}
+
+backup_entries() {
+  local -a entries
+
+  shopt -s nullglob dotglob
+  entries=("$POSTGRES_BACKUP_ROOT"/*)
+  shopt -u nullglob dotglob
+  printf '%s\n' "${entries[@]}"
+}
+
+latest_backup_id() {
+  local entry name latest=""
+
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    name=${entry##*/}
+    if [[ "$name" == .partial-* ]]; then
+      [[ -d "$entry" && ! -L "$entry" ]] || fail 'partial backup entry is unsafe'
+      continue
+    fi
+    [[ "$name" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]] ||
+      fail 'backup root contains an unexpected entry'
+    [[ -d "$entry" && ! -L "$entry" ]] || fail 'finalized backup entry is unsafe'
+    if [[ -z "$latest" || "$name" > "$latest" ]]; then
+      latest=$name
+    fi
+  done < <(backup_entries)
+
+  [[ -n "$latest" ]] || fail 'no finalized PostgreSQL backup exists'
+  printf '%s\n' "$latest"
+}
+
+prune_expired_backups() {
+  local keep=$1
+  local entry name
+
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    name=${entry##*/}
+    if [[ "$name" == .partial-* || "$name" == "$keep" ]]; then
+      continue
+    fi
+    [[ "$name" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]] ||
+      fail 'backup root contains an unexpected entry'
+    verify_backup_files "$entry" false >/dev/null
+    if jq --exit-status --arg retention_days "$POSTGRES_BACKUP_RETENTION_DAYS" '
+      (now - (.created_at | fromdateiso8601)) > (($retention_days | tonumber) * 86400)
+    ' "$entry/$metadata_file_name" >/dev/null; then
+      [[ "${entry%/*}" == "$POSTGRES_BACKUP_ROOT" ]] ||
+        fail 'refusing to prune outside POSTGRES_BACKUP_ROOT'
+      rm -- \
+        "$entry/$dump_file_name" \
+        "$entry/$checksum_file_name" \
+        "$entry/$metadata_file_name" ||
+        fail 'cannot remove expired backup contract files'
+      rmdir -- "$entry" || fail 'cannot remove expired backup directory'
+    fi
+  done < <(backup_entries)
+}
+
+run_backup() {
+  local backup_type=$1
+  local image_id source_container schema_version schema_version_after version
+  local timestamp backup_id created_at partial_directory final_directory
+  local dump_file size checksum
+
+  validate_backup_configuration
+  validate_backup_root
+
+  image_id="$(configured_image_id)"
+  source_container="$(discover_source_container)"
+  validate_source_container "$source_container" "$image_id"
+  schema_version="$(schema_state "$source_container")"
+  version="$(postgres_version "$source_container")"
+
+  timestamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  backup_id="$timestamp-$backup_type"
+  created_at="${timestamp:0:4}-${timestamp:4:2}-${timestamp:6:2}T${timestamp:9:2}:${timestamp:11:2}:${timestamp:13:2}Z"
+  partial_directory="$POSTGRES_BACKUP_ROOT/.partial-$backup_id-$$-$RANDOM"
+  final_directory="$POSTGRES_BACKUP_ROOT/$backup_id"
+  [[ ! -e "$partial_directory" && ! -e "$final_directory" ]] ||
+    fail 'backup ID already exists'
+  mkdir -m 700 "$partial_directory"
+  active_partial_directory=$partial_directory
+  dump_file="$partial_directory/$dump_file_name"
+
+  if ! docker container exec --user postgres "$source_container" \
+    pg_dump \
+      --format=custom \
+      --lock-wait-timeout=30s \
+      --no-owner \
+      --no-privileges \
+      --username "$POSTGRES_BACKUP_USER" \
+      --dbname "$POSTGRES_BACKUP_DATABASE" > "$dump_file"; then
+    fail 'pg_dump failed; partial output was not finalized'
+  fi
+  schema_version_after="$(schema_state "$source_container")"
+  [[ "$schema_version_after" == "$schema_version" ]] ||
+    fail 'PostgreSQL migration state changed during pg_dump; partial output was not finalized'
+  chmod 600 "$dump_file"
+  size="$(file_size "$dump_file")"
+  checksum="$(sha256_file "$dump_file")"
+  [[ "$checksum" =~ ^[a-f0-9]{64}$ ]] || fail 'cannot calculate backup SHA-256'
+  printf '%s  %s\n' "$checksum" "$dump_file_name" > \
+    "$partial_directory/$checksum_file_name"
+  write_metadata \
+    "$partial_directory/$metadata_file_name" \
+    "$backup_id" \
+    "$created_at" \
+    "$backup_type" \
+    "$version" \
+    "$schema_version" \
+    "$size" \
+    "$checksum"
+  chmod 600 \
+    "$partial_directory/$checksum_file_name" \
+    "$partial_directory/$metadata_file_name"
+  sync
+  run_isolated_restore "$partial_directory" "$backup_id"
+  if mv "$partial_directory" "$final_directory"; then
+    active_partial_directory=""
+  else
+    fail 'cannot finalize the verified PostgreSQL backup'
+  fi
+  sync
+
+  prune_expired_backups "$backup_id"
+  printf 'backup_id=%s restore=verified\n' "$backup_id"
+}
+
+wait_for_restore_database() {
+  local attempt init_process
+
+  for ((attempt = 1; attempt <= 30; attempt += 1)); do
+    init_process="$(
+      docker container exec "$restore_container" cat /proc/1/comm 2>/dev/null || true
+    )"
+    if [[ "$init_process" == "postgres" ]] &&
+      docker container exec --user postgres "$restore_container" \
+      pg_isready \
+        --username "$POSTGRES_BACKUP_USER" \
+        --dbname "$POSTGRES_BACKUP_DATABASE" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail 'isolated PostgreSQL restore container did not become ready'
+}
+
+run_isolated_restore() {
+  local backup_directory=$1
+  local backup_id=$2
+  local image_id suffix
+  local restored_fields schema_version expected_version restore_image
+  local actual_schema actual_version restore_container_name
+
+  restored_fields="$(verify_backup_files "$backup_directory" true "$backup_id")"
+  IFS=$'\t' read -r schema_version expected_version restore_image <<< "$restored_fields"
+
+  image_id="$(image_id_for_reference "$restore_image")"
+  suffix="${backup_id//[^A-Za-z0-9_.-]/-}-$$-$RANDOM"
+  restore_container_name="xe3-postgres-restore-$suffix"
+  restore_volume="xe3-postgres-restore-$suffix"
+  restore_backup_id=$backup_id
+  restore_run_id="$$-$RANDOM-$RANDOM"
+  [[ "$restore_volume" != "$POSTGRES_BACKUP_SOURCE_VOLUME" ]] ||
+    fail 'isolated restore volume must not be the Production source volume'
+  if docker volume inspect "$restore_volume" >/dev/null 2>&1; then
+    fail 'isolated restore volume name already exists'
+  fi
+  [[ "$(docker volume create \
+    --label "$restore_label=true" \
+    --label "$restore_backup_label=$backup_id" \
+    --label "$restore_run_label=$restore_run_id" \
+    "$restore_volume")" == "$restore_volume" ]] ||
+    fail 'cannot create the isolated restore volume'
+  if docker container inspect "$restore_container_name" >/dev/null 2>&1; then
+    fail 'isolated restore container name already exists'
+  fi
+  restore_container="$(docker container run \
+    --detach \
+    --pull never \
+    --name "$restore_container_name" \
+    --network none \
+    --label "$restore_label=true" \
+    --label "$restore_backup_label=$backup_id" \
+    --label "$restore_run_label=$restore_run_id" \
+    --mount "type=volume,src=$restore_volume,dst=/var/lib/postgresql" \
+    --env "POSTGRES_DB=$POSTGRES_BACKUP_DATABASE" \
+    --env "POSTGRES_USER=$POSTGRES_BACKUP_USER" \
+    --env POSTGRES_HOST_AUTH_METHOD=trust \
+    "$image_id")" || fail 'cannot start the isolated restore container'
+  [[ "$restore_container" =~ ^[a-f0-9]{64}$ ]] ||
+    fail 'isolated restore container did not return an immutable ID'
+
+  wait_for_restore_database
+  docker container exec --interactive --user postgres "$restore_container" \
+    pg_restore \
+      --single-transaction \
+      --exit-on-error \
+      --no-owner \
+      --no-privileges \
+      --username "$POSTGRES_BACKUP_USER" \
+      --dbname "$POSTGRES_BACKUP_DATABASE" < \
+    "$backup_directory/$dump_file_name" || fail 'isolated pg_restore failed'
+
+  actual_schema="$(schema_state "$restore_container")"
+  actual_version="$(postgres_version "$restore_container")"
+  [[ "$actual_schema" == "$schema_version" ]] ||
+    fail 'isolated restore migration version does not match backup metadata'
+  [[ "$actual_version" == "$expected_version" ]] ||
+    fail 'isolated restore PostgreSQL version does not match backup metadata'
+
+  cleanup_restore_resources || fail 'cannot remove isolated restore resources'
+}
+
+run_check() {
+  local requested_id=${1:-}
+  local backup_id backup_directory
+
+  validate_check_configuration
+  validate_backup_root
+
+  if [[ -n "$requested_id" ]]; then
+    [[ "$requested_id" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]] ||
+      fail 'BACKUP_ID has an invalid format'
+    backup_id=$requested_id
+  else
+    backup_id="$(latest_backup_id)"
+  fi
+  backup_directory="$POSTGRES_BACKUP_ROOT/$backup_id"
+  run_isolated_restore "$backup_directory" "$backup_id"
+  printf 'backup_id=%s restore=verified\n' "$backup_id"
+}
+
+main() {
+  local command_name=${1:-}
+
+  require_command docker
+  require_command jq
+  require_command awk
+  require_command cmp
+  require_command date
+  require_command stat
+  require_command sync
+  if ! command -v sha256sum >/dev/null 2>&1 &&
+    ! command -v shasum >/dev/null 2>&1; then
+    fail 'sha256sum or shasum is required'
+  fi
+
+  case "$command_name" in
+    backup)
+      [[ $# == 2 ]] || {
+        usage
+        exit 1
+      }
+      [[ "$2" == "daily" || "$2" == "predeploy" ]] ||
+        fail 'backup type must be daily or predeploy'
+      run_backup "$2"
+      ;;
+    check)
+      [[ $# == 1 || $# == 2 ]] || {
+        usage
+        exit 1
+      }
+      run_check "${2:-}"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/production/xe3-postgres-backup.service
+++ b/deploy/production/xe3-postgres-backup.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Create a consistent SpeakUp Production PostgreSQL logical backup
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+TimeoutStartSec=2h
+EnvironmentFile=/etc/speakup/postgres-backup.env
+StateDirectory=speakup/postgres-backups
+StateDirectoryMode=0700
+UMask=0077
+ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-postgres-backup.lock /usr/bin/env POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups /usr/local/sbin/xe3-postgres-backup backup daily
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/lock
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true

--- a/deploy/production/xe3-postgres-backup.timer
+++ b/deploy/production/xe3-postgres-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the SpeakUp Production PostgreSQL logical backup daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+Unit=xe3-postgres-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/production/xe3-postgres-restore-check.service
+++ b/deploy/production/xe3-postgres-restore-check.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Verify freshness and isolated restore of the latest Production PostgreSQL backup
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+TimeoutStartSec=2h
+EnvironmentFile=/etc/speakup/postgres-backup.env
+StateDirectory=speakup/postgres-backups
+StateDirectoryMode=0700
+UMask=0077
+ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-postgres-backup.lock /usr/bin/env POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups /usr/local/sbin/xe3-postgres-backup check
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/lock
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true

--- a/portal/.gitignore
+++ b/portal/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .next/
+next-env.d.ts
 .wrangler/
 .DS_Store
 *.log

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS build
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS build
 
 WORKDIR /app
 
@@ -6,9 +6,10 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
+ARG NEXT_DEPLOYMENT_ID
 RUN npm run build
 
-FROM node:22-bookworm-slim AS runtime
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS runtime
 
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/portal/next.config.mjs
+++ b/portal/next.config.mjs
@@ -1,0 +1,8 @@
+const deploymentId = process.env.NEXT_DEPLOYMENT_ID || undefined;
+
+/** @type {import("next").NextConfig} */
+const nextConfig = deploymentId
+  ? { deploymentId, generateBuildId: async () => deploymentId }
+  : {};
+
+export default nextConfig;

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -8,26 +8,26 @@
       "name": "speakup-portal",
       "version": "0.1.0",
       "dependencies": {
-        "next": "16.2.6",
-        "react": "19.2.6",
-        "react-dom": "19.2.6"
+        "next": "16.3.2",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "react-server-dom-webpack": "19.2.8",
+        "vinext": "1.0.0-beta.8"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "1.37.1",
+        "@cloudflare/vite-plugin": "1.53.1",
         "@tailwindcss/postcss": "4.2.1",
         "@types/node": "22.19.19",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.2",
-        "@vitejs/plugin-rsc": "0.5.26",
+        "@vitejs/plugin-rsc": "0.5.34",
         "eslint": "9.39.4",
-        "eslint-config-next": "16.2.6",
-        "react-server-dom-webpack": "19.2.6",
+        "eslint-config-next": "16.3.2",
         "tailwindcss": "4.2.1",
         "typescript": "5.9.3",
-        "vinext": "0.0.50",
-        "vite": "8.0.13",
-        "wrangler": "4.92.0"
+        "vite": "8.2.2",
+        "wrangler": "4.125.0"
       },
       "engines": {
         "node": ">=22.16.0"
@@ -313,27 +313,31 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.37.1.tgz",
-      "integrity": "sha512-FldhsmkXyLsX3yI+p0aJDo/kGyY69pDdynz2JjcuH3eCiQ+G9XaY3CrN+UYEfCbWv8CiR2wL95lNg0fT/HfwWA==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.53.1.tgz",
+      "integrity": "sha512-eem83hLppqJAJUi4Nh5L6LQ5bC6ASSzN2zoI3ryooroLQIqhNJxx2ZgX/52CdAaF6emloJi/+tizEiVLsUKs+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/unenv-preset": "2.16.1",
-        "miniflare": "4.20260515.0",
+        "miniflare": "5.20260820.0-alpha",
         "unenv": "2.0.0-rc.24",
-        "wrangler": "4.92.0",
-        "ws": "8.18.0"
+        "workerd": "1.20260820.1",
+        "wrangler": "4.125.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "cf-vite": "bin/cf-vite"
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-        "wrangler": "^4.92.0"
+        "wrangler": "^4.125.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260515.1.tgz",
-      "integrity": "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
+      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +352,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260515.1.tgz",
-      "integrity": "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
       "cpu": [
         "arm64"
       ],
@@ -365,9 +369,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260515.1.tgz",
-      "integrity": "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
+      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
       "cpu": [
         "x64"
       ],
@@ -382,9 +386,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260515.1.tgz",
-      "integrity": "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
       "cpu": [
         "arm64"
       ],
@@ -399,9 +403,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260515.1.tgz",
-      "integrity": "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
+      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
       "cpu": [
         "x64"
       ],
@@ -452,9 +456,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -470,6 +474,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -693,56 +1113,79 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -753,12 +1196,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -769,12 +1213,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -788,12 +1233,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -807,12 +1253,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -826,12 +1273,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -845,12 +1293,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -864,12 +1313,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -883,12 +1333,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -902,12 +1353,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -921,12 +1373,13 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -936,22 +1389,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -961,22 +1415,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -986,22 +1441,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1011,22 +1467,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1036,22 +1493,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1061,22 +1519,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1086,22 +1545,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1111,86 +1571,107 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1200,7 +1681,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1222,7 +1702,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1232,7 +1711,6 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1244,14 +1722,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1272,25 +1748,26 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.2.tgz",
+      "integrity": "sha512-8k4YoG8cM7LWlkfzGNYCRBbFNlernLiMw4s0btVl+CmmWqn3VpYypA72/5Feb1UWdxe6tHqr5KHP4p4Y4m9luA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
-      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.2.tgz",
+      "integrity": "sha512-z+HW1cZgt8QhByw8p2EbxF94AImgsKIYUbtSkA7Zld2T9yrKAlys4jNOcAOCtv6csX2CoA/5qCVyesL5pHmJ0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-utils": "4.9.1",
         "fast-glob": "3.3.1"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.2.tgz",
+      "integrity": "sha512-ib5Llm93YCKoKWDh6ZaHq6QWTuOZ2bRkSnUwMmX8dsRIOkBNL1vVlSiUKSfixPL9SSh9pvukzqajk/klkn5vqg==",
       "cpu": [
         "arm64"
       ],
@@ -1304,9 +1781,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.2.tgz",
+      "integrity": "sha512-qd98fX2+I5nYJDioW2o7nSjoxM5KvWdeDefM80igia4+C/qSIEhH4MhTE+hO/7qKM7W37/Mq+dOWp8UePSyLHw==",
       "cpu": [
         "x64"
       ],
@@ -1320,9 +1797,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.2.tgz",
+      "integrity": "sha512-vqsgb6FAOzcrCccsLXiKtAy5t8EzO+uOazuFaSkQxeY0tNONG3vpHYy8pyBafcI5SNFPTeyard6yTr6SzNGo2A==",
       "cpu": [
         "arm64"
       ],
@@ -1339,9 +1816,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.2.tgz",
+      "integrity": "sha512-xIe1eujfHUB2XcxHGddxJyu6TJRPjC5NpIkQYB/32ESkt5VkQyIAjmLRS38c+s6QY+qjtY/4KarVDzXRuD7lZQ==",
       "cpu": [
         "arm64"
       ],
@@ -1358,9 +1835,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.2.tgz",
+      "integrity": "sha512-Fe0SA2j8X0kmc3aveuHD7UktO3AE2+mH3LguP60vGbz7u0z+MrDXbeb5iZFYAwR7EzzzXJ2Yk966w9mGTFMqfA==",
       "cpu": [
         "x64"
       ],
@@ -1377,9 +1854,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.2.tgz",
+      "integrity": "sha512-TFBipb+gyesI/2Ve4zVu7kGltBWN/R466G5/1gtt2lECfc22G1pjkTxu68Q9aFcOaXiRGTQfvDbQQFe7mYgxiQ==",
       "cpu": [
         "x64"
       ],
@@ -1396,9 +1873,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.2.tgz",
+      "integrity": "sha512-rVtmnNpBYIosDnKD/96dKxFsJnwnn1WRGG/HioSe8XCm2ksSHNrd2R6+hSjvTBxeMNhJ9pYeu/90cWB1nQLuNA==",
       "cpu": [
         "arm64"
       ],
@@ -1412,9 +1889,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.2.tgz",
+      "integrity": "sha512-H4Y2o2/JcHu8LtwzD5CXfHhwxwz8gfsx2HXDEw46Mtev5xHnEmB7HNtZtmriw5ReUOjRtcDqo7XSbU01FT9NlA==",
       "cpu": [
         "x64"
       ],
@@ -1431,7 +1908,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1445,7 +1921,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1455,7 +1930,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1476,10 +1950,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
-      "dev": true,
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1531,20 +2004,34 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
       "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
-      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,13 +2042,12 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,13 +2058,12 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,13 +2074,12 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,13 +2090,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,13 +2106,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1643,13 +2125,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1663,13 +2144,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1683,13 +2163,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1703,13 +2182,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1723,13 +2201,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1743,13 +2220,12 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,52 +2235,13 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,13 +2252,12 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1835,7 +2271,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
@@ -1849,7 +2284,6 @@
       "version": "1.4.0-beta.0",
       "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
       "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.7.3",
@@ -1876,16 +2310,16 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -2253,7 +2687,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2265,7 +2698,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2277,14 +2709,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2298,7 +2728,6 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2523,16 +2952,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2623,7 +3052,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@unpic/core/-/core-1.0.3.tgz",
       "integrity": "sha512-aum9YNVUGso7MjGLD0Rp/08kywCGLqZ03/q6VQBFFakDBOXWEc8D4kPGcZ8v5wEnGRex3lE+++bOuucBp3KJ/w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "unpic": "^4.2.2"
@@ -2633,7 +3061,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@unpic/react/-/react-1.0.2.tgz",
       "integrity": "sha512-5RmRfELwTF8w+4zjtQGqjpvX+RU2VLvis3xDCS1O2uWk0PZN2cvatL+3/KAR3mshAuRrkFGTX1XwyAezSXaoCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@unpic/core": "^1.0.3"
@@ -2946,7 +3373,6 @@
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.8.6.tgz",
       "integrity": "sha512-hBcWIOppZV14bi+eAmCZj8Elj8hVSUZJTpf1lgGBhVD85pervzQ1poM/qYfFUlPraYSZYP+ASg6To5BwYmUSGQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@resvg/resvg-wasm": "2.4.0",
@@ -2956,11 +3382,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/@vinext/types": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@vinext/types/-/types-1.0.0-beta.2.tgz",
+      "integrity": "sha512-kbKY/H1RWlf7yox4G6Vwk1JeM6x0Tv1EAv28f3tDYkK3brq+89vp5eZHbdw3L/pZMbAhG4oFyhT9C976y+jkhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
       "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rolldown/pluginutils": "^1.0.0"
@@ -2983,17 +3417,17 @@
       }
     },
     "node_modules/@vitejs/plugin-rsc": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-rsc/-/plugin-rsc-0.5.26.tgz",
-      "integrity": "sha512-T8W8ODEutblw9qXQB512LDPyv1tAbJRD/Gf0QEGsAoydl4nxEtIrghnhoI9oLY9R+7aw+cLk1ZEltxWHWf4aHw==",
-      "dev": true,
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-rsc/-/plugin-rsc-0.5.34.tgz",
+      "integrity": "sha512-95V6fyGQklQMYIWTr5qwwNmpDYxsHkTunuzq8i/keIcgdckL9zb6nyEgTnb1CEl1IPJWVxGgORMkTFHrct7XJg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.18",
-        "es-module-lexer": "^2.1.0",
+        "@rolldown/pluginutils": "^1.0.1",
+        "es-module-lexer": "^2.3.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21",
-        "srvx": "^0.11.15",
+        "srvx": "^0.12.4",
         "strip-literal": "^3.1.0",
         "turbo-stream": "^3.2.0",
         "vitefu": "^1.1.3"
@@ -3010,18 +3444,10 @@
         }
       }
     },
-    "node_modules/@vitejs/plugin-rsc/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3033,7 +3459,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3041,7 +3466,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3049,7 +3473,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3057,7 +3480,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3070,7 +3492,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3078,7 +3499,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3092,7 +3512,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3103,7 +3522,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -3114,7 +3532,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3122,7 +3539,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3140,7 +3556,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3155,7 +3570,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3169,7 +3583,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3185,7 +3598,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3197,7 +3609,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -3205,7 +3616,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -3213,7 +3623,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3226,7 +3635,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3250,7 +3658,6 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
       "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.15.0"
@@ -3280,7 +3687,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3299,7 +3705,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3317,7 +3722,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3578,7 +3982,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3604,9 +4007,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3618,7 +4021,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3631,7 +4033,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3665,7 +4066,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3733,7 +4133,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3780,7 +4179,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3810,14 +4208,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3868,21 +4264,18 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
       "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/css-box-shadow": {
       "version": "1.0.0-3",
       "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
       "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -3892,7 +4285,6 @@
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
       "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -3902,7 +4294,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
@@ -4043,7 +4434,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4081,7 +4471,6 @@
       "version": "1.5.358",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.358.tgz",
       "integrity": "sha512-EO7tKm3QxRqTs1lSuPXzl6yRAwznehp0AH9OoMOIC+4mQzTFday8FJCO5KU6J/TFSQXEOahNq4vTKpz1jmCVOA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4095,7 +4484,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
       "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4105,7 +4493,6 @@
       "version": "5.21.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
       "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4243,10 +4630,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -4309,11 +4695,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4323,7 +4750,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -4400,13 +4826,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
-      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.2.tgz",
+      "integrity": "sha512-gTABOJmyc6pEgSX1Z1VOjBxkSmo5Hkdj+ePclDf8HLGTsnVWzgtDdrOeQrAnUkf0JNJJhwPuXrsIwmFZRKJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.6",
+        "@next/eslint-plugin-next": "16.3.2",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -4716,7 +5142,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -4729,7 +5154,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -4739,7 +5163,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -4759,7 +5183,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4770,7 +5193,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4818,10 +5240,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4839,7 +5260,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4849,7 +5269,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
       "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -4869,7 +5288,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4936,7 +5354,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5095,7 +5512,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true
     },
@@ -5129,13 +5545,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5153,7 +5562,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -5173,7 +5581,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5271,7 +5678,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
       "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5288,19 +5694,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -5349,7 +5742,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
       "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -5517,7 +5909,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5563,7 +5954,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5602,7 +5992,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5806,7 +6195,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5822,7 +6210,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5839,7 +6226,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5853,10 +6240,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6259,7 +6656,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
       "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "0.0.8",
@@ -6270,7 +6666,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
       "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6331,7 +6726,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6351,7 +6745,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -6359,7 +6752,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6369,7 +6761,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6383,7 +6774,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6391,21 +6781,18 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260515.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260515.0.tgz",
-      "integrity": "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==",
+      "version": "5.20260820.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
+      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260515.1",
-        "ws": "8.18.0",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260820.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -6442,9 +6829,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6486,20 +6873,19 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.2.tgz",
+      "integrity": "sha512-/ZCaubUy17Lld1SiPWxuPbCk2ihqAxF2QNQaPZeEaEb7t1I58qhsJN187D7AfpapHAqUPXH0f/thtdW9dWgWFg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.2",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -6509,15 +6895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.2",
+        "@next/swc-darwin-x64": "16.3.2",
+        "@next/swc-linux-arm64-gnu": "16.3.2",
+        "@next/swc-linux-arm64-musl": "16.3.2",
+        "@next/swc-linux-x64-gnu": "16.3.2",
+        "@next/swc-linux-x64-musl": "16.3.2",
+        "@next/swc-win32-arm64-msvc": "16.3.2",
+        "@next/swc-win32-x64-msvc": "16.3.2",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6542,10 +6928,549 @@
         }
       }
     },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6562,12 +7487,75 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-exports-info": {
@@ -6593,7 +7581,6 @@
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -6791,7 +7778,6 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parent-module": {
@@ -6811,7 +7797,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
       "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.1.4",
@@ -6869,7 +7854,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6889,10 +7873,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6909,7 +7892,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6921,7 +7904,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6960,7 +7942,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6978,24 +7959,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -7006,10 +7987,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-dom-webpack": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.2.6.tgz",
-      "integrity": "sha512-762YXjBPc6hw2V16k4x1sdnw0mxghcSPzoiOhefGYjiTguJLCImGBUz6EjznPIfqKhWgLtpaQMlBhp66N8dKrw==",
-      "dev": true,
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.2.8.tgz",
+      "integrity": "sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==",
       "license": "MIT",
       "dependencies": {
         "acorn-loose": "^8.3.0",
@@ -7020,8 +8000,8 @@
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "webpack": "^5.59.0"
       }
     },
@@ -7073,7 +8053,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7128,7 +8107,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7136,13 +8114,12 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
-      "dev": true,
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -7152,28 +8129,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7252,7 +8228,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/satori/-/satori-0.16.0.tgz",
       "integrity": "sha512-ZvHN3ygzZ8FuxjSNB+mKBiF/NIoqHzlBGbD0MJiT+MvSsFOvotnWOhdTjxKzhHRT2wPC1QbhLzx2q/Y83VhfYQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@shuding/opentype.js": "1.4.0-beta.0",
@@ -7281,7 +8256,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7302,7 +8276,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7320,7 +8293,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7334,7 +8306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -7398,55 +8369,55 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
-      "hasInstallScript": true,
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.4"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "devOptional": true,
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7558,7 +8529,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
@@ -7578,7 +8548,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7587,10 +8556,10 @@
       }
     },
     "node_modules/srvx": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.15.tgz",
-      "integrity": "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==",
-      "dev": true,
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.12.7.tgz",
+      "integrity": "sha512-PIaq1pDGg3EU2OGSN3pzRfYVu9MJDzLdojlGN6E3lvhAdxqn/lNMJFMA1xGA38jYkBb0V9xw02QEVVMDb0PExA==",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "srvx": "bin/srvx.mjs"
@@ -7624,7 +8593,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
       "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -7767,7 +8735,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
@@ -7780,7 +8748,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/styled-jsx": {
@@ -7843,7 +8811,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7857,7 +8824,6 @@
       "version": "5.47.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
       "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -7877,7 +8843,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
       "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7939,14 +8904,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7963,7 +8926,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -7981,7 +8943,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7994,7 +8955,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8014,27 +8974,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -8073,7 +9012,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-3.2.0.tgz",
       "integrity": "sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/type-check": {
@@ -8225,9 +9164,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8238,7 +9177,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -8255,7 +9193,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
       "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pako": "^0.2.5",
@@ -8266,7 +9203,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/unpic/-/unpic-4.2.2.tgz",
       "integrity": "sha512-z6T2ScMgRV2y2H8MwwhY5xHZWXhUx/YxtOCGJwfURSl7ypVy4HpLIMWoIZKnnxQa/RKzM0kg8hUh0paIrpLfvw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8308,7 +9244,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8346,19 +9281,17 @@
       }
     },
     "node_modules/vinext": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/vinext/-/vinext-0.0.50.tgz",
-      "integrity": "sha512-uo72YNnq94NtogETWnhMdFSrkMLwWgeXh5PS6qh8ksajuvAaZX50bXYJ4a6dERQ/AnnXAlNByAGHCjjNxQrvig==",
-      "dev": true,
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/vinext/-/vinext-1.0.0-beta.8.tgz",
+      "integrity": "sha512-JXiyi0V13PkcIHWUiql3wO/UyNlI1R325RBwBx4CIDa8dd4lgnI90LN5bD2V1J6T+EU8eYCYnKDmtxWjRdL0cg==",
       "license": "MIT",
       "dependencies": {
         "@unpic/react": "^1.0.2",
         "@vercel/og": "^0.8.6",
-        "image-size": "2.0.2",
+        "@vinext/types": "^1.0.0-beta.2",
         "ipaddr.js": "^2.1.0",
         "magic-string": "^0.30.21",
         "vite-plugin-commonjs": "^0.10.4",
-        "vite-tsconfig-paths": "^6.1.1",
         "web-vitals": "^4.2.4"
       },
       "bin": {
@@ -8370,11 +9303,11 @@
       "peerDependencies": {
         "@mdx-js/rollup": "^3.0.0",
         "@vitejs/plugin-react": "^5.1.4 || ^6.0.0",
-        "@vitejs/plugin-rsc": "^0.5.23",
+        "@vitejs/plugin-rsc": "^0.5.34",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-server-dom-webpack": "^19.2.6",
-        "vite": "^7.0.0 || ^8.0.0"
+        "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "@mdx-js/rollup": {
@@ -8389,17 +9322,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
-      "dev": true,
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8415,7 +9347,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -8470,7 +9402,6 @@
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-commonjs/-/vite-plugin-commonjs-0.10.4.tgz",
       "integrity": "sha512-eWQuvQKCcx0QYB5e5xfxBNjQKyrjEWZIR9UOkOV6JAgxVhtbZvCOF+FNC2ZijBJ3U3Px04ZMMyyMyFBVWIJ5+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.12.1",
@@ -8482,7 +9413,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.6.0.tgz",
       "integrity": "sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.12.1",
@@ -8495,14 +9425,12 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite-plugin-dynamic-import/node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -8519,7 +9447,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -8528,26 +9455,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
     "node_modules/vite/node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -8560,27 +9471,26 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/vite/node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8595,13 +9505,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8616,13 +9525,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8637,13 +9545,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8658,13 +9565,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8679,13 +9585,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -8703,13 +9608,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -8727,13 +9631,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -8751,13 +9654,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -8775,13 +9677,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8796,13 +9697,12 @@
       }
     },
     "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8817,10 +9717,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8833,7 +9732,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
       "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -8853,7 +9752,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8868,14 +9766,12 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
       "version": "5.106.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8924,7 +9820,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
       "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -8934,7 +9829,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -8949,7 +9843,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
@@ -9072,9 +9965,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260515.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260515.1.tgz",
-      "integrity": "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
+      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -9085,30 +9978,31 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260515.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260515.1",
-        "@cloudflare/workerd-linux-64": "1.20260515.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260515.1",
-        "@cloudflare/workerd-windows-64": "1.20260515.1"
+        "@cloudflare/workerd-darwin-64": "1.20260820.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
+        "@cloudflare/workerd-linux-64": "1.20260820.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
+        "@cloudflare/workerd-windows-64": "1.20260820.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.92.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.92.0.tgz",
-      "integrity": "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==",
+      "version": "4.125.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
+      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260515.0",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260820.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260515.1"
+        "workerd": "1.20260820.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
@@ -9116,10 +10010,10 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260515.1"
+        "@cloudflare/workers-types": "^5.20260820.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -9127,494 +10021,10 @@
         }
       }
     },
-    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9657,7 +10067,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/youch": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -13,26 +13,26 @@
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next"
   },
   "dependencies": {
-    "next": "16.2.6",
-    "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "next": "16.3.2",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-server-dom-webpack": "19.2.8",
+    "vinext": "1.0.0-beta.8"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.37.1",
+    "@cloudflare/vite-plugin": "1.53.1",
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "22.19.19",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
-    "@vitejs/plugin-rsc": "0.5.26",
+    "@vitejs/plugin-rsc": "0.5.34",
     "eslint": "9.39.4",
-    "eslint-config-next": "16.2.6",
-    "react-server-dom-webpack": "19.2.6",
+    "eslint-config-next": "16.3.2",
     "tailwindcss": "4.2.1",
     "typescript": "5.9.3",
-    "vinext": "0.0.50",
-    "vite": "8.0.13",
-    "wrangler": "4.92.0"
+    "vite": "8.2.2",
+    "wrangler": "4.125.0"
   },
   "type": "module"
 }

--- a/portal/tests/build-id.test.mjs
+++ b/portal/tests/build-id.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("uses the deployment commit as the stable build ID", async (t) => {
+  const original = process.env.NEXT_DEPLOYMENT_ID;
+  const commit = "0123456789abcdef0123456789abcdef01234567";
+  process.env.NEXT_DEPLOYMENT_ID = commit;
+  t.after(() => {
+    if (original === undefined) delete process.env.NEXT_DEPLOYMENT_ID;
+    else process.env.NEXT_DEPLOYMENT_ID = original;
+  });
+
+  const { default: config } = await import("../next.config.mjs?build-id-test");
+
+  assert.equal(config.deploymentId, commit);
+  assert.equal(await config.generateBuildId(), commit);
+});

--- a/tools/release-candidate/build-offline-images.sh
+++ b/tools/release-candidate/build-offline-images.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly bundle_file_name='offline-image-bundle.json'
+readonly platform='linux/amd64'
+readonly source_url='https://github.com/1024XEngineer/XE3-ESL'
+readonly portal_repository='ghcr.io/1024xengineer/xe3-esl-portal'
+readonly server_repository='ghcr.io/1024xengineer/xe3-esl-server'
+
+version=''
+git_sha=''
+output_directory_input=''
+temporary_directory=''
+output_parent=''
+output_name=''
+portal_archive_file=''
+server_archive_file=''
+portal_metadata_file=''
+server_metadata_file=''
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: build-offline-images.sh \
+  --version <X.Y.Z> \
+  --git-sha <40-lowercase-hex-commit> \
+  --output-dir <new-directory>
+EOF
+}
+
+fail() {
+  printf 'Offline image build error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+set_argument() {
+  local name=$1
+  local value=$2
+
+  [[ -n "$value" ]] || fail "--$name requires a non-empty value"
+  case "$name" in
+    version)
+      [[ -z "$version" ]] || fail '--version may only be provided once'
+      version=$value
+      ;;
+    git-sha)
+      [[ -z "$git_sha" ]] || fail '--git-sha may only be provided once'
+      git_sha=$value
+      ;;
+    output-dir)
+      [[ -z "$output_directory_input" ]] ||
+        fail '--output-dir may only be provided once'
+      output_directory_input=$value
+      ;;
+    *) fail "unknown argument: --$name" ;;
+  esac
+}
+
+cleanup() {
+  local status=$?
+
+  trap - EXIT INT HUP TERM
+  set +e
+  if [[ -n "$temporary_directory" ]]; then
+    if [[ -n "$output_parent" && -n "$output_name" &&
+      "${temporary_directory%/*}" == "$output_parent" &&
+      "${temporary_directory##*/}" == ".${output_name}.tmp."* ]]; then
+      rm -f \
+        "$temporary_directory/$bundle_file_name" \
+        "$temporary_directory/$portal_archive_file" \
+        "$temporary_directory/$server_archive_file" \
+        "$temporary_directory/$portal_metadata_file" \
+        "$temporary_directory/$server_metadata_file" || status=1
+      rmdir "$temporary_directory" || status=1
+    else
+      status=1
+    fi
+  fi
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT HUP TERM
+
+while (($# > 0)); do
+  [[ "$1" == --* ]] || {
+    usage
+    fail "unexpected positional argument: $1"
+  }
+  [[ $# -ge 2 ]] || {
+    usage
+    fail "$1 requires a value"
+  }
+  set_argument "${1#--}" "$2"
+  shift 2
+done
+
+[[ -n "$version" && -n "$git_sha" && -n "$output_directory_input" ]] || {
+  usage
+  fail '--version, --git-sha, and --output-dir are all required'
+}
+[[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+  fail '--version must use X.Y.Z without a v prefix or prerelease suffix'
+[[ "$git_sha" =~ ^[a-f0-9]{40}$ ]] ||
+  fail '--git-sha must be a full lowercase 40-character Git SHA'
+[[ "$output_directory_input" != *$'\n'* &&
+  "$output_directory_input" != *$'\r'* &&
+  "$output_directory_input" != *,* ]] ||
+  fail '--output-dir must not contain commas or newlines'
+portal_archive_file="speakup-portal-v${version}-linux-amd64.tar"
+server_archive_file="speakup-server-v${version}-linux-amd64.tar"
+portal_metadata_file="speakup-portal-v${version}-linux-amd64-build-metadata.json"
+server_metadata_file="speakup-server-v${version}-linux-amd64-build-metadata.json"
+readonly \
+  portal_archive_file \
+  server_archive_file \
+  portal_metadata_file \
+  server_metadata_file
+
+require_command docker
+require_command git
+require_command mktemp
+require_command node
+
+repository_root_input="$(git rev-parse --show-toplevel 2>/dev/null)" ||
+  fail 'the current directory must belong to a Git worktree'
+repository_root="$(cd "$repository_root_input" && pwd -P)" ||
+  fail 'cannot resolve the Git worktree root'
+readonly repository_root
+cd "$repository_root"
+
+head_sha="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" ||
+  fail 'HEAD must resolve to a Git commit'
+[[ "$head_sha" == "$git_sha" ]] ||
+  fail "HEAD $head_sha does not match --git-sha $git_sha"
+worktree_status="$(
+  git status --porcelain=v1 --untracked-files=all --ignore-submodules=none
+)" || fail 'cannot inspect the Git worktree status'
+[[ -z "$worktree_status" ]] ||
+  fail 'the Git worktree must be clean before building release images'
+
+source_date_epoch="$(git show -s --format=%ct "$git_sha" 2>/dev/null)" ||
+  fail 'cannot read the release commit timestamp'
+[[ "$source_date_epoch" =~ ^[1-9][0-9]*$ ]] ||
+  fail 'the release commit timestamp must be a positive integer'
+readonly source_date_epoch
+
+[[ -f "$repository_root/portal/Dockerfile" &&
+  -f "$repository_root/server/Dockerfile" ]] ||
+  fail 'portal/Dockerfile and server/Dockerfile are required'
+
+output_directory="$(
+  node -e 'process.stdout.write(require("node:path").resolve(process.argv[1]))' \
+    "$output_directory_input"
+)" || fail 'cannot resolve --output-dir'
+output_parent_input="$(dirname "$output_directory")"
+output_name="$(basename "$output_directory")"
+[[ "$output_name" != / && "$output_name" != . && "$output_name" != .. ]] ||
+  fail '--output-dir must name a new non-root directory'
+mkdir -p "$output_parent_input"
+output_parent="$(cd "$output_parent_input" && pwd -P)" ||
+  fail 'cannot resolve the output parent directory'
+output_directory="$output_parent/$output_name"
+readonly output_parent output_name output_directory
+[[ ! -e "$output_directory" && ! -L "$output_directory" ]] ||
+  fail '--output-dir must not already exist'
+case "$output_directory/" in
+  "$repository_root/"*)
+    fail '--output-dir must be outside the Git worktree'
+    ;;
+esac
+
+temporary_directory="$(
+  mktemp -d "$output_parent/.${output_name}.tmp.XXXXXX"
+)" || fail 'cannot create the temporary bundle directory'
+
+metadata_digest() {
+  local metadata=$1
+  local digest
+
+  if ! digest="$(node - "$metadata" <<'NODE'
+const { readFileSync } = require("node:fs");
+
+const file = process.argv[2];
+const metadata = JSON.parse(readFileSync(file, "utf8"));
+const digest = metadata?.["containerimage.digest"];
+if (!/^sha256:[0-9a-f]{64}$/.test(digest ?? "")) {
+  throw new Error(`${file} has an invalid containerimage.digest`);
+}
+process.stdout.write(digest);
+NODE
+  )"; then
+    fail "cannot validate Docker build metadata: ${metadata##*/}"
+  fi
+  printf '%s\n' "$digest"
+}
+
+run_image_build() {
+  local context=$1
+  local repository=$2
+  local archive=$3
+  local metadata=$4
+  local -a build_arguments=(
+    --build-arg "SOURCE_DATE_EPOCH=$source_date_epoch"
+  )
+
+  if [[ "$repository" == "$portal_repository" ]]; then
+    build_arguments+=(
+      --build-arg "NEXT_DEPLOYMENT_ID=$git_sha"
+    )
+  fi
+
+  SOURCE_DATE_EPOCH="$source_date_epoch" docker buildx build \
+    --file "$context/Dockerfile" \
+    --platform "$platform" \
+    --pull \
+    --no-cache \
+    --provenance=false \
+    --sbom=false \
+    "${build_arguments[@]}" \
+    --label "org.opencontainers.image.source=$source_url" \
+    --label "org.opencontainers.image.revision=$git_sha" \
+    --label "org.opencontainers.image.version=$version" \
+    --tag "$repository:$version" \
+    --metadata-file "$metadata" \
+    --output "type=docker,dest=$archive,rewrite-timestamp=true" \
+    "$context"
+}
+
+build_verified_image() {
+  local name=$1
+  local context=$2
+  local repository=$3
+  local archive_file=$4
+  local metadata_file=$5
+  local result_variable=$6
+  local archive="$temporary_directory/$archive_file"
+  local metadata="$temporary_directory/$metadata_file"
+  local digest
+
+  run_image_build "$context" "$repository" "$archive" "$metadata"
+  digest="$(metadata_digest "$metadata")"
+  [[ -s "$archive" && -s "$metadata" ]] ||
+    fail "$name image build did not produce every required file"
+
+  printf -v "$result_variable" '%s' "$digest"
+}
+
+portal_digest=''
+server_digest=''
+build_verified_image \
+  portal \
+  "$repository_root/portal" \
+  "$portal_repository" \
+  "$portal_archive_file" \
+  "$portal_metadata_file" \
+  portal_digest
+build_verified_image \
+  server \
+  "$repository_root/server" \
+  "$server_repository" \
+  "$server_archive_file" \
+  "$server_metadata_file" \
+  server_digest
+
+node - \
+  "$temporary_directory" \
+  "$version" \
+  "$git_sha" \
+  "$source_date_epoch" \
+  "$portal_digest" \
+  "$server_digest" \
+  "$portal_archive_file" \
+  "$server_archive_file" \
+  "$portal_metadata_file" \
+  "$server_metadata_file" <<'NODE'
+const { createHash } = require("node:crypto");
+const {
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} = require("node:fs");
+const path = require("node:path");
+
+const [
+  directory,
+  version,
+  gitSha,
+  sourceDateEpochInput,
+  portalDigest,
+  serverDigest,
+  portalArchiveFile,
+  serverArchiveFile,
+  portalMetadataFile,
+  serverMetadataFile,
+] = process.argv.slice(2);
+const sourceDateEpoch = Number(sourceDateEpochInput);
+const digestPattern = /^sha256:[0-9a-f]{64}$/;
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const topLevelKeys = [
+  "bundle_version",
+  "version",
+  "git_sha",
+  "source_date_epoch",
+  "platform",
+  "images",
+];
+const imageKeys = [
+  "name",
+  "repository",
+  "digest",
+  "archive_file",
+  "archive_size_bytes",
+  "archive_sha256",
+  "build_metadata_file",
+  "build_metadata_sha256",
+];
+
+if (!Number.isSafeInteger(sourceDateEpoch) || sourceDateEpoch < 1) {
+  throw new Error("source_date_epoch must be a positive safe integer");
+}
+
+function sha256(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function assertFileName(file) {
+  if (path.basename(file) !== file || file.includes("/") || file.includes("\\")) {
+    throw new Error(`bundle file name must not contain a path: ${file}`);
+  }
+}
+
+function image(name, repository, digest, archiveFile, metadataFile) {
+  assertFileName(archiveFile);
+  assertFileName(metadataFile);
+  if (!digestPattern.test(digest)) {
+    throw new Error(`${name} digest is invalid`);
+  }
+  const archivePath = path.join(directory, archiveFile);
+  const metadataPath = path.join(directory, metadataFile);
+  const archiveStatus = statSync(archivePath);
+  const metadataStatus = statSync(metadataPath);
+  if (!archiveStatus.isFile() || archiveStatus.size < 1 ||
+      !metadataStatus.isFile() || metadataStatus.size < 1) {
+    throw new Error(`${name} build artifacts must be non-empty regular files`);
+  }
+  const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+  if (metadata?.["containerimage.digest"] !== digest) {
+    throw new Error(`${name} build metadata does not match its image digest`);
+  }
+  const entry = {
+    name,
+    repository,
+    digest,
+    archive_file: archiveFile,
+    archive_size_bytes: archiveStatus.size,
+    archive_sha256: sha256(archivePath),
+    build_metadata_file: metadataFile,
+    build_metadata_sha256: sha256(metadataPath),
+  };
+  if (
+    JSON.stringify(Object.keys(entry)) !== JSON.stringify(imageKeys) ||
+    !sha256Pattern.test(entry.archive_sha256) ||
+    !sha256Pattern.test(entry.build_metadata_sha256)
+  ) {
+    throw new Error(`${name} manifest entry violates the bundle schema`);
+  }
+  return entry;
+}
+
+const manifest = {
+  bundle_version: 1,
+  version,
+  git_sha: gitSha,
+  source_date_epoch: sourceDateEpoch,
+  platform: "linux/amd64",
+  images: [
+    image(
+      "portal",
+      "ghcr.io/1024xengineer/xe3-esl-portal",
+      portalDigest,
+      portalArchiveFile,
+      portalMetadataFile,
+    ),
+    image(
+      "server",
+      "ghcr.io/1024xengineer/xe3-esl-server",
+      serverDigest,
+      serverArchiveFile,
+      serverMetadataFile,
+    ),
+  ],
+};
+if (
+  JSON.stringify(Object.keys(manifest)) !== JSON.stringify(topLevelKeys) ||
+  manifest.images.length !== 2 ||
+  manifest.images[0].name !== "portal" ||
+  manifest.images[1].name !== "server"
+) {
+  throw new Error("offline image bundle violates the strict schema");
+}
+
+const manifestPath = path.join(directory, "offline-image-bundle.json");
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+const expectedFiles = [
+  "offline-image-bundle.json",
+  portalArchiveFile,
+  serverArchiveFile,
+  portalMetadataFile,
+  serverMetadataFile,
+].sort();
+const actualFiles = readdirSync(directory).sort();
+if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+  throw new Error("temporary bundle directory contains unexpected files");
+}
+JSON.parse(readFileSync(manifestPath, "utf8"));
+NODE
+
+[[ ! -e "$output_directory" && ! -L "$output_directory" ]] ||
+  fail '--output-dir appeared before atomic publication'
+node -e \
+  'require("node:fs").renameSync(process.argv[1], process.argv[2])' \
+  "$temporary_directory" \
+  "$output_directory"
+temporary_directory=''
+
+printf 'offline_image_bundle=%s\n' "$output_directory/$bundle_file_name"

--- a/tools/release-candidate/build-offline-images.test.sh
+++ b/tools/release-candidate/build-offline-images.test.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly build_script="$script_directory/build-offline-images.sh"
+
+fail() {
+  printf 'Offline image build test: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_command git
+require_command node
+require_command mktemp
+[[ -f "$build_script" ]] || fail "$build_script is required"
+
+temporary_base=${TMPDIR:-/tmp}
+temporary_base=${temporary_base%/}
+temporary_directory_created="$(
+  mktemp -d "$temporary_base/xe3-offline-images-test.XXXXXX"
+)"
+temporary_directory="$(cd "$temporary_directory_created" && pwd -P)"
+readonly temporary_directory
+readonly repository="$temporary_directory/repository"
+readonly fake_bin="$temporary_directory/fake-bin"
+readonly fake_counter="$temporary_directory/docker-counter"
+readonly fake_log="$temporary_directory/docker.log"
+readonly artifacts_parent="$temporary_directory/artifacts"
+
+cleanup() {
+  local status=$?
+
+  trap - EXIT INT HUP TERM
+  if [[ "$temporary_directory" == */xe3-offline-images-test.* ]]; then
+    rm -rf "$temporary_directory"
+  else
+    status=1
+  fi
+  exit "$status"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+mkdir -p \
+  "$repository/portal" \
+  "$repository/server" \
+  "$fake_bin" \
+  "$artifacts_parent"
+printf '%s\n' 'FROM scratch' >"$repository/portal/Dockerfile"
+printf '%s\n' 'FROM scratch' >"$repository/server/Dockerfile"
+git -C "$repository" init --initial-branch=main >/dev/null
+git -C "$repository" config user.name 'Offline Build Test'
+git -C "$repository" config user.email 'offline-build-test@example.invalid'
+git -C "$repository" add portal/Dockerfile server/Dockerfile
+GIT_AUTHOR_DATE='2026-08-22T12:34:56Z' \
+GIT_COMMITTER_DATE='2026-08-22T12:34:56Z' \
+  git -C "$repository" commit -m 'test release source' >/dev/null
+readonly head_sha="$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')"
+readonly source_date_epoch="$(git -C "$repository" show -s --format=%ct HEAD)"
+readonly version='1.2.3'
+
+cat >"$fake_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  printf 'Fake Docker error: %s\n' "$*" >&2
+  exit 64
+}
+
+[[ $# -ge 2 && "$1" == buildx && "$2" == build ]] ||
+  fail 'expected docker buildx build'
+shift 2
+
+file=''
+platform=''
+pull=false
+no_cache=false
+provenance=false
+sbom=false
+source_date_epoch_build_arg=''
+deployment_id_build_arg=''
+source_label=''
+revision_label=''
+version_label=''
+tag=''
+metadata=''
+output=''
+context=''
+
+while (($# > 0)); do
+  case "$1" in
+    --file | --platform | --build-arg | --label | --tag | --metadata-file | --output)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
+      case "$1" in
+        --file) [[ -z "$file" ]] || fail 'duplicate --file'; file=$2 ;;
+        --platform) [[ -z "$platform" ]] || fail 'duplicate --platform'; platform=$2 ;;
+        --build-arg)
+          case "$2" in
+            SOURCE_DATE_EPOCH=*)
+              [[ -z "$source_date_epoch_build_arg" ]] ||
+                fail 'duplicate SOURCE_DATE_EPOCH build argument'
+              source_date_epoch_build_arg=$2
+              ;;
+            NEXT_DEPLOYMENT_ID=*)
+              [[ -z "$deployment_id_build_arg" ]] ||
+                fail 'duplicate NEXT_DEPLOYMENT_ID build argument'
+              deployment_id_build_arg=$2
+              ;;
+            *) fail "unexpected build argument: $2" ;;
+          esac
+          ;;
+        --label)
+          case "$2" in
+            org.opencontainers.image.source=*)
+              [[ -z "$source_label" ]] || fail 'duplicate source label'
+              source_label=$2
+              ;;
+            org.opencontainers.image.revision=*)
+              [[ -z "$revision_label" ]] || fail 'duplicate revision label'
+              revision_label=$2
+              ;;
+            org.opencontainers.image.version=*)
+              [[ -z "$version_label" ]] || fail 'duplicate version label'
+              version_label=$2
+              ;;
+            *) fail "unexpected label: $2" ;;
+          esac
+          ;;
+        --tag) [[ -z "$tag" ]] || fail 'duplicate --tag'; tag=$2 ;;
+        --metadata-file)
+          [[ -z "$metadata" ]] || fail 'duplicate --metadata-file'
+          metadata=$2
+          ;;
+        --output) [[ -z "$output" ]] || fail 'duplicate --output'; output=$2 ;;
+      esac
+      shift 2
+      ;;
+    --pull)
+      [[ "$pull" == false ]] || fail 'duplicate --pull'
+      pull=true
+      shift
+      ;;
+    --no-cache)
+      [[ "$no_cache" == false ]] || fail 'duplicate --no-cache'
+      no_cache=true
+      shift
+      ;;
+    --provenance=false)
+      [[ "$provenance" == false ]] || fail 'duplicate --provenance=false'
+      provenance=true
+      shift
+      ;;
+    --sbom=false)
+      [[ "$sbom" == false ]] || fail 'duplicate --sbom=false'
+      sbom=true
+      shift
+      ;;
+    --*) fail "unexpected build flag: $1" ;;
+    *)
+      [[ -z "$context" && $# == 1 ]] || fail "unexpected build argument: $1"
+      context=$1
+      shift
+      ;;
+  esac
+done
+
+[[ "$platform" == linux/amd64 ]] || fail 'platform must be linux/amd64'
+[[ "$pull" == true && "$no_cache" == true &&
+  "$provenance" == true && "$sbom" == true ]] ||
+  fail 'pull/no-cache/provenance/sbom flags are incomplete'
+[[ "$source_date_epoch_build_arg" == \
+  "SOURCE_DATE_EPOCH=$FAKE_EXPECTED_EPOCH" ]] ||
+  fail 'SOURCE_DATE_EPOCH build argument is incorrect'
+[[ "${SOURCE_DATE_EPOCH:-}" == "$FAKE_EXPECTED_EPOCH" ]] ||
+  fail 'SOURCE_DATE_EPOCH environment is incorrect'
+[[ "$source_label" == \
+  'org.opencontainers.image.source=https://github.com/1024XEngineer/XE3-ESL' ]] ||
+  fail 'OCI source label is incorrect'
+[[ "$revision_label" == "org.opencontainers.image.revision=$FAKE_EXPECTED_SHA" ]] ||
+  fail 'OCI revision label is incorrect'
+[[ "$version_label" == "org.opencontainers.image.version=$FAKE_EXPECTED_VERSION" ]] ||
+  fail 'OCI version label is incorrect'
+[[ -n "$metadata" &&
+  "$output" == type=docker,dest=*,rewrite-timestamp=true ]] ||
+  fail 'Docker archive output or metadata file is missing'
+archive=${output#type=docker,dest=}
+archive=${archive%,rewrite-timestamp=true}
+[[ "$archive" != "$output" && -n "$archive" ]] || fail 'archive destination is invalid'
+
+case "$tag" in
+  "ghcr.io/1024xengineer/xe3-esl-portal:$FAKE_EXPECTED_VERSION")
+    name=portal
+    digest="sha256:$(printf 'a%.0s' {1..64})"
+    [[ "$deployment_id_build_arg" == \
+      "NEXT_DEPLOYMENT_ID=$FAKE_EXPECTED_SHA" ]] ||
+      fail 'Portal deployment ID build argument is incorrect'
+    ;;
+  "ghcr.io/1024xengineer/xe3-esl-server:$FAKE_EXPECTED_VERSION")
+    name=server
+    digest="sha256:$(printf 'b%.0s' {1..64})"
+    [[ -z "$deployment_id_build_arg" ]] ||
+      fail 'Server must not receive the Portal deployment ID build argument'
+    ;;
+  *) fail "unexpected image tag: $tag" ;;
+esac
+[[ "$context" == "$FAKE_REPOSITORY_ROOT/$name" ]] ||
+  fail "$name build context is incorrect"
+[[ "$file" == "$context/Dockerfile" ]] || fail "$name Dockerfile is incorrect"
+
+count=0
+if [[ -f "$FAKE_DOCKER_COUNTER" ]]; then
+  count=$(<"$FAKE_DOCKER_COUNTER")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FAKE_DOCKER_COUNTER"
+printf '%s\t%s\t%s\t%s\n' \
+  "$count" "$name" "$SOURCE_DATE_EPOCH" "$tag" >>"$FAKE_DOCKER_LOG"
+
+if [[ "${FAKE_DOCKER_MODE:-success}" == failure && "$count" == 2 ]]; then
+  exit 70
+fi
+if [[ "${FAKE_DOCKER_MODE:-success}" == invalid-metadata &&
+  "$count" == 1 ]]; then
+  digest='invalid'
+fi
+
+printf 'fake docker archive: %s build %s\n' "$tag" "$count" >"$archive"
+printf '{"containerimage.digest":"%s","fake.build.number":%s}\n' \
+  "$digest" "$count" >"$metadata"
+EOF
+chmod 0700 "$fake_bin/docker"
+
+reset_fake_docker() {
+  rm -f "$fake_counter" "$fake_log"
+}
+
+run_build() {
+  local mode=$1
+  shift
+
+  (
+    cd "$repository"
+    env \
+      PATH="$fake_bin:$PATH" \
+      FAKE_DOCKER_MODE="$mode" \
+      FAKE_DOCKER_COUNTER="$fake_counter" \
+      FAKE_DOCKER_LOG="$fake_log" \
+      FAKE_EXPECTED_EPOCH="$source_date_epoch" \
+      FAKE_EXPECTED_SHA="$head_sha" \
+      FAKE_EXPECTED_VERSION="$version" \
+      FAKE_REPOSITORY_ROOT="$repository" \
+      bash "$build_script" "$@"
+  )
+}
+
+failure_number=0
+expect_failure() {
+  local name=$1
+  local mode=$2
+  local output=$3
+  shift 3
+  local failure_log
+
+  failure_number=$((failure_number + 1))
+  failure_log="$temporary_directory/failure-$failure_number.log"
+  reset_fake_docker
+  if run_build "$mode" "$@" >"$failure_log" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  [[ ! -e "$output" && ! -L "$output" ]] ||
+    fail "$name published an output directory after failure"
+}
+
+missing_output="$artifacts_parent/missing-arguments"
+expect_failure 'missing arguments' success "$missing_output"
+[[ ! -e "$fake_counter" ]] || fail 'missing arguments invoked Docker'
+
+invalid_version_output="$artifacts_parent/invalid-version"
+expect_failure \
+  'invalid version' \
+  success \
+  "$invalid_version_output" \
+  --version v1.2.3 \
+  --git-sha "$head_sha" \
+  --output-dir "$invalid_version_output"
+[[ ! -e "$fake_counter" ]] || fail 'invalid version invoked Docker'
+
+unknown_argument_output="$artifacts_parent/unknown-argument"
+expect_failure \
+  'unknown argument' \
+  success \
+  "$unknown_argument_output" \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$unknown_argument_output" \
+  --unexpected value
+[[ ! -e "$fake_counter" ]] || fail 'unknown argument invoked Docker'
+
+dirty_output="$artifacts_parent/dirty-worktree"
+printf '%s\n' dirty >"$repository/untracked.txt"
+expect_failure \
+  'dirty worktree' \
+  success \
+  "$dirty_output" \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$dirty_output"
+rm "$repository/untracked.txt"
+[[ ! -e "$fake_counter" ]] || fail 'dirty worktree invoked Docker'
+
+sha_mismatch_output="$artifacts_parent/sha-mismatch"
+expect_failure \
+  'HEAD SHA mismatch' \
+  success \
+  "$sha_mismatch_output" \
+  --version "$version" \
+  --git-sha "$(printf '0%.0s' {1..40})" \
+  --output-dir "$sha_mismatch_output"
+[[ ! -e "$fake_counter" ]] || fail 'HEAD SHA mismatch invoked Docker'
+
+inside_repository_output="$repository/offline-release-output"
+expect_failure \
+  'output inside Git worktree' \
+  success \
+  "$inside_repository_output" \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$inside_repository_output"
+[[ ! -e "$fake_counter" ]] || fail 'in-worktree output invoked Docker'
+
+invalid_metadata_output="$artifacts_parent/invalid-metadata"
+expect_failure \
+  'invalid Docker metadata digest' \
+  invalid-metadata \
+  "$invalid_metadata_output" \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$invalid_metadata_output"
+if [[ ! -f "$fake_counter" ]]; then
+  cat "$temporary_directory/failure-$failure_number.log" >&2
+  fail 'invalid metadata did not invoke Docker'
+fi
+[[ "$(<"$fake_counter")" == 1 ]] ||
+  fail 'invalid metadata did not stop after the Portal build'
+
+build_failure_output="$artifacts_parent/build-failure"
+expect_failure \
+  'Server Docker build failure' \
+  failure \
+  "$build_failure_output" \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$build_failure_output"
+if [[ ! -f "$fake_counter" ]]; then
+  cat "$temporary_directory/failure-$failure_number.log" >&2
+  fail 'Docker failure test did not invoke Docker'
+fi
+[[ "$(<"$fake_counter")" == 2 ]] ||
+  fail 'Docker failure did not stop after the failing build'
+
+success_output="$artifacts_parent/success"
+reset_fake_docker
+success_log="$temporary_directory/success.log"
+run_build \
+  success \
+  --version "$version" \
+  --git-sha "$head_sha" \
+  --output-dir "$success_output" >"$success_log"
+[[ "$(<"$success_log")" == \
+  "offline_image_bundle=$success_output/offline-image-bundle.json" ]] ||
+  fail 'success output did not identify the published bundle manifest'
+[[ "$(<"$fake_counter")" == 2 ]] ||
+  fail 'success did not build Portal and Server exactly once each'
+[[ "$(wc -l <"$fake_log" | tr -d '[:space:]')" == 2 ]] ||
+  fail 'fake Docker did not record exactly two buildx invocations'
+
+node - \
+  "$success_output" \
+  "$version" \
+  "$head_sha" \
+  "$source_date_epoch" <<'NODE'
+const assert = require("node:assert/strict");
+const { createHash } = require("node:crypto");
+const { readdirSync, readFileSync, statSync } = require("node:fs");
+const path = require("node:path");
+
+const [directory, version, gitSha, sourceDateEpoch] = process.argv.slice(2);
+const manifest = JSON.parse(
+  readFileSync(path.join(directory, "offline-image-bundle.json"), "utf8"),
+);
+const topLevelKeys = [
+  "bundle_version",
+  "version",
+  "git_sha",
+  "source_date_epoch",
+  "platform",
+  "images",
+];
+const imageKeys = [
+  "name",
+  "repository",
+  "digest",
+  "archive_file",
+  "archive_size_bytes",
+  "archive_sha256",
+  "build_metadata_file",
+  "build_metadata_sha256",
+];
+const expectedRepositories = [
+  "ghcr.io/1024xengineer/xe3-esl-portal",
+  "ghcr.io/1024xengineer/xe3-esl-server",
+];
+const expectedDigests = [
+  `sha256:${"a".repeat(64)}`,
+  `sha256:${"b".repeat(64)}`,
+];
+
+assert.deepEqual(Object.keys(manifest), topLevelKeys);
+assert.equal(manifest.bundle_version, 1);
+assert.equal(manifest.version, version);
+assert.equal(manifest.git_sha, gitSha);
+assert.equal(manifest.source_date_epoch, Number(sourceDateEpoch));
+assert.equal(manifest.platform, "linux/amd64");
+assert.equal(manifest.images.length, 2);
+assert.deepEqual(manifest.images.map(({ name }) => name), ["portal", "server"]);
+
+for (const [index, image] of manifest.images.entries()) {
+  assert.deepEqual(Object.keys(image), imageKeys);
+  assert.equal(image.repository, expectedRepositories[index]);
+  assert.equal(image.digest, expectedDigests[index]);
+  for (const file of [image.archive_file, image.build_metadata_file]) {
+    assert.equal(path.basename(file), file);
+    assert.equal(file.includes("/"), false);
+    assert.equal(file.includes("\\"), false);
+  }
+  const archivePath = path.join(directory, image.archive_file);
+  const metadataPath = path.join(directory, image.build_metadata_file);
+  assert.equal(statSync(archivePath).isFile(), true);
+  assert.equal(statSync(metadataPath).isFile(), true);
+  assert.equal(image.archive_size_bytes, statSync(archivePath).size);
+  assert.match(image.archive_sha256, /^[0-9a-f]{64}$/);
+  assert.match(image.build_metadata_sha256, /^[0-9a-f]{64}$/);
+  assert.equal(
+    image.archive_sha256,
+    createHash("sha256").update(readFileSync(archivePath)).digest("hex"),
+  );
+  assert.equal(
+    image.build_metadata_sha256,
+    createHash("sha256").update(readFileSync(metadataPath)).digest("hex"),
+  );
+  assert.equal(
+    JSON.parse(readFileSync(metadataPath, "utf8"))["containerimage.digest"],
+    image.digest,
+  );
+}
+
+assert.deepEqual(readdirSync(directory).sort(), [
+  "offline-image-bundle.json",
+  `speakup-portal-v${version}-linux-amd64-build-metadata.json`,
+  `speakup-portal-v${version}-linux-amd64.tar`,
+  `speakup-server-v${version}-linux-amd64-build-metadata.json`,
+  `speakup-server-v${version}-linux-amd64.tar`,
+]);
+NODE
+
+if find "$artifacts_parent" -maxdepth 1 -name '.*.tmp.*' -print -quit |
+  grep -q .; then
+  fail 'a temporary bundle directory leaked after the tests'
+fi
+
+printf '%s\n' 'Offline image build tests passed'

--- a/tools/release-candidate/cli.mjs
+++ b/tools/release-candidate/cli.mjs
@@ -1,0 +1,24 @@
+export function readArguments(arguments_, allowedNames, usage) {
+  const allowed = new Set(allowedNames);
+  const values = {};
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const flag = arguments_[index];
+    const value = arguments_[index + 1];
+    if (
+      !flag?.startsWith("--") ||
+      value === undefined ||
+      value.startsWith("--")
+    ) {
+      throw new Error(usage);
+    }
+    const name = flag.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+    if (Object.hasOwn(values, name)) {
+      throw new Error(`Option may only be provided once: ${flag}`);
+    }
+    values[name] = value;
+  }
+  return values;
+}

--- a/tools/release-candidate/manifest.mjs
+++ b/tools/release-candidate/manifest.mjs
@@ -2,9 +2,13 @@
 
 import { createHash } from "node:crypto";
 import {
+  closeSync,
+  linkSync,
+  lstatSync,
   mkdtempSync,
+  openSync,
+  readSync,
   readFileSync,
-  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -12,6 +16,7 @@ import {
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { readArguments } from "./cli.mjs";
 import { collectReleaseMetadata } from "./metadata.mjs";
 
 const sha256Pattern = /^[0-9a-f]{64}$/;
@@ -28,6 +33,36 @@ const androidReleaseContract = {
 const imagePattern =
   /^ghcr\.io\/[a-z0-9]+(?:[._-][a-z0-9]+)*\/[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
 const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const offlineBundleKeys = [
+  "bundle_version",
+  "git_sha",
+  "images",
+  "platform",
+  "source_date_epoch",
+  "version",
+];
+const offlineImageKeys = [
+  "archive_file",
+  "archive_sha256",
+  "archive_size_bytes",
+  "build_metadata_file",
+  "build_metadata_sha256",
+  "digest",
+  "name",
+  "repository",
+];
+const offlineImages = [
+  {
+    name: "portal",
+    repository: "ghcr.io/1024xengineer/xe3-esl-portal",
+    environmentPrefix: "PORTAL",
+  },
+  {
+    name: "server",
+    repository: "ghcr.io/1024xengineer/xe3-esl-server",
+    environmentPrefix: "SERVER",
+  },
+];
 
 function required(input, name) {
   const value = input[name]?.trim();
@@ -96,6 +131,165 @@ function apkArtifact(filePath, expectedName, name) {
   };
 }
 
+function verifyApkHash(input, prefix, artifact) {
+  const name = `${prefix}_APK_VERIFIED_SHA256`;
+  if (!Object.hasOwn(input, name)) return;
+  const expected = nonzeroSha(required(input, name), sha256Pattern, name);
+  if (artifact.sha256 !== expected) {
+    throw new Error(`${name} does not match the APK file`);
+  }
+}
+
+function exactObject(value, expectedKeys, name) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(expectedKeys)
+  ) {
+    throw new Error(`${name} must contain the exact field set`);
+  }
+  return value;
+}
+
+function nonemptyRegularFile(file, name) {
+  let status;
+  try {
+    status = lstatSync(file);
+  } catch {
+    throw new Error(`${name} must be a non-empty regular file`);
+  }
+  if (status.isSymbolicLink() || !status.isFile() || status.size < 1) {
+    throw new Error(`${name} must be a non-empty regular file`);
+  }
+  return status;
+}
+
+function sha256File(file) {
+  const descriptor = openSync(file, "r");
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
+function readJson(file, name) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    throw new Error(`${name} must contain valid JSON`);
+  }
+}
+
+export function offlineBundleImageInput(filePath, releaseMetadata) {
+  const bundlePath = path.resolve(filePath);
+  nonemptyRegularFile(bundlePath, "offline bundle");
+  const bundle = exactObject(
+    readJson(bundlePath, "offline bundle"),
+    offlineBundleKeys,
+    "offline bundle",
+  );
+  if (bundle.bundle_version !== 1) {
+    throw new Error("offline bundle version must be 1");
+  }
+  const bundleVersion = matches(bundle.version, versionPattern, "offline bundle version");
+  if (bundleVersion !== releaseMetadata.version) {
+    throw new Error("offline bundle version does not match release metadata");
+  }
+  const bundleGitSha = nonzeroSha(
+    bundle.git_sha,
+    gitShaPattern,
+    "offline bundle git_sha",
+  );
+  if (bundleGitSha !== releaseMetadata.git_sha) {
+    throw new Error("offline bundle git_sha does not match release metadata");
+  }
+  if (
+    !Number.isSafeInteger(bundle.source_date_epoch) ||
+    bundle.source_date_epoch < 1
+  ) {
+    throw new Error("offline bundle source_date_epoch must be a positive integer");
+  }
+  if (bundle.platform !== "linux/amd64") {
+    throw new Error("offline bundle platform must be linux/amd64");
+  }
+  if (!Array.isArray(bundle.images) || bundle.images.length !== offlineImages.length) {
+    throw new Error("offline bundle must contain ordered portal and server images");
+  }
+
+  const bundleDirectory = path.dirname(bundlePath);
+  const imageInput = {};
+  for (const [index, expected] of offlineImages.entries()) {
+    const image = exactObject(
+      bundle.images[index],
+      offlineImageKeys,
+      `offline ${expected.name} image`,
+    );
+    if (image.name !== expected.name || image.repository !== expected.repository) {
+      throw new Error(`offline ${expected.name} image identity is invalid`);
+    }
+    const digest = nonzeroSha(
+      image.digest,
+      imageDigestPattern,
+      `offline ${expected.name} image digest`,
+    );
+    const archiveFile =
+      `speakup-${expected.name}-v${bundleVersion}-linux-amd64.tar`;
+    const metadataFile =
+      `speakup-${expected.name}-v${bundleVersion}-linux-amd64-build-metadata.json`;
+    if (
+      image.archive_file !== archiveFile ||
+      image.build_metadata_file !== metadataFile
+    ) {
+      throw new Error(`offline ${expected.name} image file names are invalid`);
+    }
+    if (!Number.isSafeInteger(image.archive_size_bytes) || image.archive_size_bytes < 1) {
+      throw new Error(`offline ${expected.name} archive size is invalid`);
+    }
+    const archiveSha256 = nonzeroSha(
+      image.archive_sha256,
+      sha256Pattern,
+      `offline ${expected.name} archive SHA-256`,
+    );
+    const metadataSha256 = nonzeroSha(
+      image.build_metadata_sha256,
+      sha256Pattern,
+      `offline ${expected.name} metadata SHA-256`,
+    );
+    const archivePath = path.join(bundleDirectory, archiveFile);
+    const metadataPath = path.join(bundleDirectory, metadataFile);
+    const archiveStatus = nonemptyRegularFile(
+      archivePath,
+      `offline ${expected.name} archive`,
+    );
+    nonemptyRegularFile(metadataPath, `offline ${expected.name} metadata`);
+    if (archiveStatus.size !== image.archive_size_bytes) {
+      throw new Error(`offline ${expected.name} archive size does not match`);
+    }
+    if (sha256File(archivePath) !== archiveSha256) {
+      throw new Error(`offline ${expected.name} archive SHA-256 does not match`);
+    }
+    if (sha256File(metadataPath) !== metadataSha256) {
+      throw new Error(`offline ${expected.name} metadata SHA-256 does not match`);
+    }
+    const buildMetadata = readJson(metadataPath, `offline ${expected.name} metadata`);
+    if (buildMetadata?.["containerimage.digest"] !== digest) {
+      throw new Error(`offline ${expected.name} metadata digest does not match`);
+    }
+    imageInput[`${expected.environmentPrefix}_IMAGE`] = expected.repository;
+    imageInput[`${expected.environmentPrefix}_IMAGE_DIGEST`] = digest;
+  }
+  return imageInput;
+}
+
 function androidApkMetadata(input, prefix) {
   const applicationId = matches(
     required(input, `${prefix}_APK_APPLICATION_ID`),
@@ -162,6 +356,8 @@ export function createReleaseManifest(input, metadata) {
     `speakup-v${version}-production-arm64.apk`,
     "PRODUCTION_APK_PATH",
   );
+  verifyApkHash(input, "STAGING", stagingApk);
+  verifyApkHash(input, "PRODUCTION", productionApk);
   const androidMetadata = matchingAndroidApkMetadata(input);
 
   return {
@@ -198,24 +394,43 @@ export function createReleaseManifest(input, metadata) {
   };
 }
 
-function readArguments(arguments_) {
-  const values = {};
-  for (let index = 0; index < arguments_.length; index += 2) {
-    const flag = arguments_[index];
-    const value = arguments_[index + 1];
-    if (!flag?.startsWith("--") || value === undefined) {
-      throw new Error(
-        "Usage: manifest.mjs --tag <vX.Y.Z> --main-ref <ref> " +
-          "--staging-apk <file> --production-apk <file> --output <file>",
-      );
+export function writeReleaseManifest(outputInput, manifest) {
+  const output = path.resolve(outputInput);
+  const temporaryDirectory = mkdtempSync(`${output}.tmp-`);
+  const temporaryOutput = path.join(temporaryDirectory, "release-manifest.json");
+  try {
+    writeFileSync(temporaryOutput, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    try {
+      linkSync(temporaryOutput, output);
+    } catch (error) {
+      if (error?.code === "EEXIST") {
+        throw new Error(`output already exists: ${output}`);
+      }
+      throw error;
     }
-    values[flag.slice(2)] = value;
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
   }
-  return values;
 }
 
 function main() {
-  const arguments_ = readArguments(process.argv.slice(2));
+  const usage =
+    "Usage: manifest.mjs --tag <vX.Y.Z> --main-ref <ref> " +
+    "--staging-apk <file> --production-apk <file> --output <file> " +
+    "[--repo <path>] [--tag-remote <name>]";
+  const arguments_ = readArguments(
+    process.argv.slice(2),
+    [
+      "tag",
+      "main-ref",
+      "staging-apk",
+      "production-apk",
+      "output",
+      "repo",
+      "tag-remote",
+    ],
+    usage,
+  );
   for (const name of ["tag", "main-ref", "staging-apk", "production-apk", "output"]) {
     if (!arguments_[name]) throw new Error(`--${name} is required`);
   }
@@ -224,6 +439,7 @@ function main() {
     repoDir,
     tag: arguments_.tag,
     mainRef: arguments_["main-ref"],
+    tagRemote: arguments_["tag-remote"] ?? "origin",
   });
   const manifest = createReleaseManifest(
     {
@@ -233,15 +449,7 @@ function main() {
     },
     metadata,
   );
-  const output = path.resolve(arguments_.output);
-  const temporaryDirectory = mkdtempSync(`${output}.tmp-`);
-  const temporaryOutput = path.join(temporaryDirectory, "release-manifest.json");
-  try {
-    writeFileSync(temporaryOutput, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
-    renameSync(temporaryOutput, output);
-  } finally {
-    rmSync(temporaryDirectory, { force: true, recursive: true });
-  }
+  writeReleaseManifest(arguments_.output, manifest);
 }
 
 if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {

--- a/tools/release-candidate/metadata.mjs
+++ b/tools/release-candidate/metadata.mjs
@@ -5,9 +5,13 @@ import { appendFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { readArguments } from "./cli.mjs";
+
 const stableTagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const pubspecVersionPattern = /^version:\s*["']?([^+\s"']+)\+(\d+)["']?\s*$/gm;
 const migrationPattern = /^server\/migrations\/(\d{6})_[^/]+\.up\.sql$/;
+const tagRemotePattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const officialUpstreamUrl = "https://github.com/1024XEngineer/XE3-ESL.git";
 
 export function parseStableTag(tag) {
   const match = stableTagPattern.exec(tag);
@@ -85,7 +89,7 @@ function isAncestor(repoDir, commit, mainRef) {
   }).status === 0;
 }
 
-function stableTagRefs(repoDir) {
+function stableTagRefs(repoDir, tagRemote) {
   const local = new Map(
     git(repoDir, ["tag", "--list", "v*"])
       .split("\n")
@@ -96,7 +100,7 @@ function stableTagRefs(repoDir) {
       ]),
   );
   const remote = new Map(
-    git(repoDir, ["ls-remote", "--tags", "--refs", "origin", "refs/tags/v*"])
+    git(repoDir, ["ls-remote", "--tags", "--refs", tagRemote, "refs/tags/v*"])
       .split("\n")
       .filter(Boolean)
       .map((line) => line.split("\t"))
@@ -107,12 +111,91 @@ function stableTagRefs(repoDir) {
     local.size !== remote.size ||
     [...remote].some(([tag, object]) => local.get(tag) !== object)
   ) {
-    throw new Error("Local stable release tags do not match origin");
+    throw new Error(`Local stable release tags do not match ${tagRemote}`);
   }
   return [...local.keys()];
 }
 
-export function collectReleaseMetadata({ repoDir, tag, mainRef }) {
+function officialUpstreamMain(repoDir) {
+  let urls;
+  try {
+    urls = git(repoDir, ["config", "--get-all", "remote.upstream.url"])
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    throw new Error(`upstream must use ${officialUpstreamUrl}`);
+  }
+  if (urls.length !== 1 || urls[0] !== officialUpstreamUrl) {
+    throw new Error(`upstream must use ${officialUpstreamUrl}`);
+  }
+  const rewrites = spawnSync(
+    "git",
+    [
+      "config",
+      "--null",
+      "--get-regexp",
+      "^url\\..*\\.(insteadof|pushinsteadof)$",
+    ],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (rewrites.error) throw rewrites.error;
+  if (
+    rewrites.status !== 0 &&
+    !(rewrites.status === 1 && rewrites.stdout === "")
+  ) {
+    throw new Error("cannot inspect Git URL rewrite configuration");
+  }
+  for (const record of rewrites.stdout.split("\0").filter(Boolean)) {
+    const separator = record.indexOf("\n");
+    if (separator < 1) {
+      throw new Error("Git URL rewrite configuration is malformed");
+    }
+    const prefix = record.slice(separator + 1);
+    if (officialUpstreamUrl.startsWith(prefix)) {
+      throw new Error("Git URL rewrites must not affect the official upstream URL");
+    }
+  }
+  const lines = git(repoDir, [
+    "ls-remote",
+    "--heads",
+    "--refs",
+    "upstream",
+    "refs/heads/main",
+  ])
+    .split("\n")
+    .filter(Boolean);
+  if (lines.length !== 1) {
+    throw new Error("upstream must expose exactly one refs/heads/main");
+  }
+  const [commit, ref, extra] = lines[0].split("\t");
+  if (
+    extra !== undefined ||
+    ref !== "refs/heads/main" ||
+    !/^[0-9a-f]{40}$/.test(commit)
+  ) {
+    throw new Error("upstream refs/heads/main is invalid");
+  }
+  return commit;
+}
+
+export function collectReleaseMetadata({
+  repoDir,
+  tag,
+  mainRef,
+  tagRemote = "origin",
+}) {
+  if (
+    typeof tagRemote !== "string" ||
+    !tagRemotePattern.test(tagRemote) ||
+    tagRemote === "." ||
+    tagRemote === ".."
+  ) {
+    throw new Error("tagRemote must be a plain Git remote name");
+  }
   if (git(repoDir, ["rev-parse", "--is-shallow-repository"]) === "true") {
     throw new Error("Release validation requires the complete Git history");
   }
@@ -127,6 +210,9 @@ export function collectReleaseMetadata({ repoDir, tag, mainRef }) {
     throw new Error(`HEAD ${headCommit} does not match release tag ${tag}`);
   }
   const mainCommit = git(repoDir, ["rev-parse", "--verify", `${mainRef}^{commit}`]);
+  if (tagRemote === "upstream" && mainCommit !== officialUpstreamMain(repoDir)) {
+    throw new Error(`${mainRef} does not match live upstream main`);
+  }
   if (!isAncestor(repoDir, tagCommit, mainCommit)) {
     throw new Error(`Release tag ${tag} is not contained in ${mainRef}`);
   }
@@ -140,7 +226,7 @@ export function collectReleaseMetadata({ repoDir, tag, mainRef }) {
   if (!firstParentCommits.has(tagCommit)) {
     throw new Error(`Release tag ${tag} is not on the first-parent history of ${mainRef}`);
   }
-  const allStableTags = stableTagRefs(repoDir);
+  const allStableTags = stableTagRefs(repoDir, tagRemote);
 
   const pubspec = git(repoDir, ["show", `${tagCommit}:mobile/pubspec.yaml`]);
   const current = parsePubspecVersion(pubspec);
@@ -227,21 +313,15 @@ export function collectReleaseMetadata({ repoDir, tag, mainRef }) {
   };
 }
 
-function readArguments(arguments_) {
-  const values = {};
-  for (let index = 0; index < arguments_.length; index += 2) {
-    const flag = arguments_[index];
-    const value = arguments_[index + 1];
-    if (!flag?.startsWith("--") || value === undefined) {
-      throw new Error("Usage: metadata.mjs --tag <vX.Y.Z> --main-ref <ref> [--repo <path>]");
-    }
-    values[flag.slice(2)] = value;
-  }
-  return values;
-}
-
 function main() {
-  const arguments_ = readArguments(process.argv.slice(2));
+  const usage =
+    "Usage: metadata.mjs --tag <vX.Y.Z> --main-ref <ref> " +
+    "[--repo <path>] [--tag-remote <name>]";
+  const arguments_ = readArguments(
+    process.argv.slice(2),
+    ["tag", "main-ref", "repo", "tag-remote"],
+    usage,
+  );
   if (!arguments_.tag || !arguments_["main-ref"]) {
     throw new Error("Both --tag and --main-ref are required");
   }
@@ -249,6 +329,7 @@ function main() {
     repoDir: path.resolve(arguments_.repo ?? "."),
     tag: arguments_.tag,
     mainRef: arguments_["main-ref"],
+    tagRemote: arguments_["tag-remote"] ?? "origin",
   });
   const output = Object.entries(metadata)
     .map(([key, value]) => `${key}=${value}`)

--- a/tools/release-candidate/offline-manifest.mjs
+++ b/tools/release-candidate/offline-manifest.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { readArguments } from "./cli.mjs";
+import {
+  createReleaseManifest,
+  offlineBundleImageInput,
+  writeReleaseManifest,
+} from "./manifest.mjs";
+import { collectReleaseMetadata } from "./metadata.mjs";
+
+const verifierScript = fileURLToPath(
+  new URL("../android-release/verify.sh", import.meta.url),
+);
+const officialRepository = "1024XEngineer/XE3-ESL";
+const upstreamMainRef = "refs/remotes/upstream/main";
+const qualityWorkflowPath = ".github/workflows/quality.yml";
+const githubApiBase = "https://api.github.com";
+const githubApiVersion = "2026-03-10";
+const reportKeys = [
+  "abi",
+  "applicationId",
+  "artifactSha256",
+  "certificateSha256",
+  "minimumAndroidApi",
+  "signature",
+  "versionCode",
+  "versionName",
+];
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const gitShaPattern = /^[0-9a-f]{40}$/;
+
+function required(input, name) {
+  const value = input[name]?.trim();
+  if (!value) throw new Error(`--${name} is required`);
+  return value;
+}
+
+function nonemptyRegularFile(file, name) {
+  let status;
+  try {
+    status = lstatSync(file);
+  } catch {
+    throw new Error(`${name} must be a non-empty regular file`);
+  }
+  if (status.isSymbolicLink() || !status.isFile() || status.size < 1) {
+    throw new Error(`${name} must be a non-empty regular file`);
+  }
+  return status;
+}
+
+function approvedCertificate(fileInput) {
+  const file = path.resolve(fileInput);
+  nonemptyRegularFile(file, "certificate fingerprint file");
+  const fingerprint = readFileSync(file, "utf8")
+    .toLowerCase()
+    .replace(/[:\s]/g, "");
+  if (!sha256Pattern.test(fingerprint) || /^0+$/.test(fingerprint)) {
+    throw new Error("certificate fingerprint file has an invalid SHA-256 value");
+  }
+  return fingerprint;
+}
+
+function snapshotArtifact(sourceInput, expectedName, directory, name) {
+  const source = path.resolve(sourceInput);
+  if (path.basename(source) !== expectedName) {
+    throw new Error(`${name} must be named ${expectedName}`);
+  }
+  nonemptyRegularFile(source, name);
+  const destination = path.join(directory, expectedName);
+  let sourceDescriptor;
+  let destinationDescriptor;
+  try {
+    sourceDescriptor = openSync(
+      source,
+      constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0),
+    );
+    const before = fstatSync(sourceDescriptor);
+    if (!before.isFile() || before.size < 1) {
+      throw new Error(`${name} must be a non-empty regular file`);
+    }
+    destinationDescriptor = openSync(
+      destination,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+      0o400,
+    );
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    let copied = 0;
+    for (;;) {
+      const bytesRead = readSync(
+        sourceDescriptor,
+        buffer,
+        0,
+        buffer.length,
+        null,
+      );
+      if (bytesRead === 0) break;
+      let written = 0;
+      while (written < bytesRead) {
+        written += writeSync(
+          destinationDescriptor,
+          buffer,
+          written,
+          bytesRead - written,
+          null,
+        );
+      }
+      copied += bytesRead;
+    }
+    const after = fstatSync(sourceDescriptor);
+    if (
+      copied !== before.size ||
+      after.size !== before.size ||
+      after.mtimeMs !== before.mtimeMs ||
+      after.ctimeMs !== before.ctimeMs
+    ) {
+      throw new Error(`${name} changed while it was being copied`);
+    }
+  } finally {
+    if (destinationDescriptor !== undefined) closeSync(destinationDescriptor);
+    if (sourceDescriptor !== undefined) closeSync(sourceDescriptor);
+  }
+  nonemptyRegularFile(destination, `${name} snapshot`);
+  return destination;
+}
+
+function sha256File(file) {
+  const descriptor = openSync(file, "r");
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
+function parseVerifierReport(output, name) {
+  const report = {};
+  const lines = output.trimEnd().split("\n");
+  for (const line of lines) {
+    const separator = line.indexOf("=");
+    if (separator < 1) throw new Error(`${name} verifier report is malformed`);
+    const key = line.slice(0, separator);
+    const value = line.slice(separator + 1);
+    if (!reportKeys.includes(key) || Object.hasOwn(report, key) || !value) {
+      throw new Error(`${name} verifier report is malformed`);
+    }
+    report[key] = value;
+  }
+  if (
+    JSON.stringify(Object.keys(report).sort()) !== JSON.stringify(reportKeys)
+  ) {
+    throw new Error(`${name} verifier report has an invalid field set`);
+  }
+  return report;
+}
+
+function verifyArtifact(name, apk, pubspec, certificate, metadata) {
+  const result = spawnSync(verifierScript, [apk, pubspec], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SPEAKUP_ANDROID_CERT_SHA256: certificate,
+    },
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = result.stderr.trim();
+    throw new Error(
+      `${name} APK verification failed${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  const report = parseVerifierReport(result.stdout, name);
+  const expected = {
+    applicationId: "com.xengineer.speakup",
+    versionName: metadata.version,
+    versionCode: metadata.version_code,
+    minimumAndroidApi: "24",
+    abi: "arm64-v8a",
+    signature: "verified",
+    certificateSha256: certificate,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (report[key] !== value) {
+      throw new Error(`${name} verifier report has an unexpected ${key}`);
+    }
+  }
+  if (
+    !sha256Pattern.test(report.artifactSha256) ||
+    /^0+$/.test(report.artifactSha256) ||
+    report.artifactSha256 !== sha256File(apk)
+  ) {
+    throw new Error(`${name} verifier report does not match the APK snapshot`);
+  }
+  return report;
+}
+
+async function githubJson(fetchImplementation, url, name) {
+  if (typeof fetchImplementation !== "function") {
+    throw new Error("GitHub API fetch implementation is unavailable");
+  }
+  let response;
+  try {
+    response = await fetchImplementation(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "SpeakUp-Release-Candidate",
+        "X-GitHub-Api-Version": githubApiVersion,
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : "";
+    throw new Error(`${name} request failed${detail}`);
+  }
+  if (!response || response.ok !== true) {
+    const status = Number.isInteger(response?.status)
+      ? response.status
+      : "unknown";
+    throw new Error(`${name} request failed with HTTP ${status}`);
+  }
+  let value;
+  try {
+    value = await response.json();
+  } catch {
+    throw new Error(`${name} response must contain valid JSON`);
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} response must be a JSON object`);
+  }
+  return value;
+}
+
+export async function validateQualityRun(
+  qualityRunUrlInput,
+  releaseGitSha,
+  fetchImplementation = globalThis.fetch,
+) {
+  const qualityRunUrl = required(
+    { "quality-run-url": qualityRunUrlInput },
+    "quality-run-url",
+  );
+  if (!gitShaPattern.test(releaseGitSha)) {
+    throw new Error("release Git SHA is invalid");
+  }
+  const runUrlPattern = new RegExp(
+    `^https://github\\.com/${officialRepository.replace("/", "\\/")}` +
+      "/actions/runs/([1-9]\\d*)$",
+  );
+  const runUrlMatch = runUrlPattern.exec(qualityRunUrl);
+  const runId = Number(runUrlMatch?.[1]);
+  if (!runUrlMatch || !Number.isSafeInteger(runId)) {
+    throw new Error("quality run URL must identify an official workflow run");
+  }
+
+  const workflowApiUrl =
+    `${githubApiBase}/repos/${officialRepository}/actions/workflows/quality.yml`;
+  const workflow = await githubJson(
+    fetchImplementation,
+    workflowApiUrl,
+    "Quality workflow",
+  );
+  if (
+    !Number.isSafeInteger(workflow.id) ||
+    workflow.id < 1 ||
+    workflow.name !== "Quality" ||
+    workflow.path !== qualityWorkflowPath ||
+    workflow.state !== "active"
+  ) {
+    throw new Error("Quality workflow response does not match the release contract");
+  }
+
+  const runApiUrl =
+    `${githubApiBase}/repos/${officialRepository}/actions/runs/${runId}`;
+  const run = await githubJson(
+    fetchImplementation,
+    runApiUrl,
+    "Quality workflow run",
+  );
+  if (
+    run.id !== runId ||
+    run.url !== runApiUrl ||
+    run.html_url !== qualityRunUrl ||
+    run.workflow_id !== workflow.id ||
+    run.repository?.full_name !== officialRepository ||
+    run.head_repository?.full_name !== officialRepository ||
+    run.path !== qualityWorkflowPath ||
+    run.head_sha !== releaseGitSha ||
+    run.head_branch !== "main" ||
+    !["push", "workflow_dispatch"].includes(run.event) ||
+    run.status !== "completed" ||
+    run.conclusion !== "success"
+  ) {
+    throw new Error("Quality workflow run does not match the release contract");
+  }
+  return qualityRunUrl;
+}
+
+export async function generateOfflineManifest(
+  argv = process.argv.slice(2),
+  fetchImplementation = globalThis.fetch,
+) {
+  const usage =
+    "Usage: offline-manifest.mjs --tag <vX.Y.Z> --staging-apk <file> " +
+    "--production-apk <file> --offline-bundle <file> " +
+    "--certificate-file <file> --quality-run-url <url> --output <new-file> " +
+    "[--repo <path>]";
+  const arguments_ = readArguments(
+    argv,
+    [
+      "tag",
+      "staging-apk",
+      "production-apk",
+      "offline-bundle",
+      "certificate-file",
+      "quality-run-url",
+      "output",
+      "repo",
+    ],
+    usage,
+  );
+  for (const name of [
+    "tag",
+    "staging-apk",
+    "production-apk",
+    "offline-bundle",
+    "certificate-file",
+    "quality-run-url",
+    "output",
+  ]) {
+    required(arguments_, name);
+  }
+
+  const repoDir = path.resolve(arguments_.repo ?? ".");
+  const metadata = collectReleaseMetadata({
+    repoDir,
+    tag: arguments_.tag,
+    mainRef: upstreamMainRef,
+    tagRemote: "upstream",
+  });
+  const certificate = approvedCertificate(arguments_["certificate-file"]);
+  const qualityRunUrl = await validateQualityRun(
+    arguments_["quality-run-url"],
+    metadata.git_sha,
+    fetchImplementation,
+  );
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "speakup-offline-manifest-"),
+  );
+  chmodSync(temporaryDirectory, 0o700);
+  try {
+    const stagingApk = snapshotArtifact(
+      arguments_["staging-apk"],
+      `speakup-v${metadata.version}-staging-arm64.apk`,
+      temporaryDirectory,
+      "staging APK",
+    );
+    const productionApk = snapshotArtifact(
+      arguments_["production-apk"],
+      `speakup-v${metadata.version}-production-arm64.apk`,
+      temporaryDirectory,
+      "production APK",
+    );
+    chmodSync(temporaryDirectory, 0o500);
+
+    const pubspec = path.join(repoDir, "mobile", "pubspec.yaml");
+    const stagingReport = verifyArtifact(
+      "staging",
+      stagingApk,
+      pubspec,
+      certificate,
+      metadata,
+    );
+    const productionReport = verifyArtifact(
+      "production",
+      productionApk,
+      pubspec,
+      certificate,
+      metadata,
+    );
+    const imageInput = offlineBundleImageInput(
+      arguments_["offline-bundle"],
+      metadata,
+    );
+    const manifest = createReleaseManifest(
+      {
+        ...imageInput,
+        GITHUB_REPOSITORY: officialRepository,
+        QUALITY_RUN_URL: qualityRunUrl,
+        APK_CERTIFICATE_SHA256: certificate,
+        STAGING_APK_APPLICATION_ID: stagingReport.applicationId,
+        STAGING_APK_MINIMUM_ANDROID_API: stagingReport.minimumAndroidApi,
+        STAGING_APK_ABIS: stagingReport.abi,
+        STAGING_APK_VERIFIED_SHA256: stagingReport.artifactSha256,
+        PRODUCTION_APK_APPLICATION_ID: productionReport.applicationId,
+        PRODUCTION_APK_MINIMUM_ANDROID_API: productionReport.minimumAndroidApi,
+        PRODUCTION_APK_ABIS: productionReport.abi,
+        PRODUCTION_APK_VERIFIED_SHA256: productionReport.artifactSha256,
+        STAGING_APK_PATH: stagingApk,
+        PRODUCTION_APK_PATH: productionApk,
+      },
+      metadata,
+    );
+    writeReleaseManifest(arguments_.output, manifest);
+    process.stdout.write(
+      `offline_manifest=${path.resolve(arguments_.output)} version=${metadata.version} git_sha=${metadata.git_sha}\n`,
+    );
+  } finally {
+    chmodSync(temporaryDirectory, 0o700);
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+) {
+  generateOfflineManifest().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tools/release-candidate/release-candidate.test.mjs
+++ b/tools/release-candidate/release-candidate.test.mjs
@@ -1,13 +1,31 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { createReleaseManifest } from "./manifest.mjs";
+import {
+  createReleaseManifest,
+  offlineBundleImageInput,
+} from "./manifest.mjs";
+import {
+  generateOfflineManifest,
+  validateQualityRun,
+} from "./offline-manifest.mjs";
 import {
   collectReleaseMetadata,
   databaseSchemaVersion,
@@ -15,6 +33,18 @@ import {
 } from "./metadata.mjs";
 
 const manifestScript = fileURLToPath(new URL("./manifest.mjs", import.meta.url));
+const metadataScript = fileURLToPath(new URL("./metadata.mjs", import.meta.url));
+const offlineManifestScript = fileURLToPath(
+  new URL("./offline-manifest.mjs", import.meta.url),
+);
+const officialUpstreamUrl = "https://github.com/1024XEngineer/XE3-ESL.git";
+const officialRepository = "1024XEngineer/XE3-ESL";
+const qualityWorkflowPath = ".github/workflows/quality.yml";
+const githubApiVersion = "2026-03-10";
+const realGit = process.env.PATH
+  .split(path.delimiter)
+  .map((directory) => path.join(directory, "git"))
+  .find(existsSync);
 
 function git(repo, ...arguments_) {
   return execFileSync("git", arguments_, {
@@ -42,6 +72,116 @@ function createRepository(version = "0.1.0+1") {
   git(repo, "commit", "-m", "initial release");
   git(repo, "remote", "add", "origin", repo);
   return repo;
+}
+
+function configureOfficialUpstream(repo) {
+  git(repo, "remote", "add", "upstream", officialUpstreamUrl);
+  git(repo, "update-ref", "refs/remotes/upstream/main", "HEAD");
+}
+
+function officialGitProxy() {
+  assert.ok(realGit, "git executable is required");
+  const directory = mkdtempSync(path.join(tmpdir(), "speakup-git-proxy-"));
+  const script = path.join(directory, "git");
+  writeFileSync(script, `#!/bin/sh
+if [ "$1" = ls-remote ] && [ "$4" = upstream ]; then
+  exec "$SPEAKUP_TEST_REAL_GIT" "$1" "$2" "$3" \\
+    "$SPEAKUP_TEST_REMOTE_REPO" "$5"
+fi
+exec "$SPEAKUP_TEST_REAL_GIT" "$@"
+`);
+  chmodSync(script, 0o755);
+  return directory;
+}
+
+function withOfficialGitProxy(repo, callback) {
+  const proxy = officialGitProxy();
+  const previous = {
+    PATH: process.env.PATH,
+    realGit: process.env.SPEAKUP_TEST_REAL_GIT,
+    remoteRepo: process.env.SPEAKUP_TEST_REMOTE_REPO,
+  };
+  process.env.PATH = `${proxy}:${process.env.PATH}`;
+  process.env.SPEAKUP_TEST_REAL_GIT = realGit;
+  process.env.SPEAKUP_TEST_REMOTE_REPO = repo;
+  try {
+    return callback();
+  } finally {
+    process.env.PATH = previous.PATH;
+    if (previous.realGit === undefined) {
+      delete process.env.SPEAKUP_TEST_REAL_GIT;
+    } else {
+      process.env.SPEAKUP_TEST_REAL_GIT = previous.realGit;
+    }
+    if (previous.remoteRepo === undefined) {
+      delete process.env.SPEAKUP_TEST_REMOTE_REPO;
+    } else {
+      process.env.SPEAKUP_TEST_REMOTE_REPO = previous.remoteRepo;
+    }
+  }
+}
+
+async function withEnvironment(values, callback) {
+  const previous = Object.fromEntries(
+    Object.keys(values).map((name) => [name, process.env[name]]),
+  );
+  for (const [name, value] of Object.entries(values)) {
+    process.env[name] = value;
+  }
+  try {
+    return await callback();
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
+async function withOfflineWrapperTools(repo, androidTools, extra, callback) {
+  const gitProxy = officialGitProxy();
+  return withEnvironment(
+    {
+      PATH: `${gitProxy}:${androidTools}:${process.env.PATH}`,
+      SPEAKUP_TEST_REAL_GIT: realGit,
+      SPEAKUP_TEST_REMOTE_REPO: repo,
+      ...extra,
+    },
+    callback,
+  );
+}
+
+function fakeAndroidTools(certificate, { failProduction = false } = {}) {
+  const directory = mkdtempSync(path.join(tmpdir(), "speakup-android-tools-"));
+  const tools = {
+    aapt: `#!/bin/sh
+cat <<'EOF'
+package: name='com.xengineer.speakup' versionCode='1' versionName='0.1.0'
+sdkVersion:'24'
+native-code: 'arm64-v8a'
+EOF
+`,
+    apksigner: `#!/bin/sh
+last=''
+for argument do last=$argument; done
+${failProduction ? `case "$last" in
+  *-production-arm64.apk) printf '%s\\n' 'production signature failure' >&2; exit 1 ;;
+esac
+` : ""}printf '%s\n' \\
+  'Signer #1 certificate DN: CN=SpeakUp Release' \\
+  'Signer #1 certificate SHA-256 digest: ${certificate}'
+`,
+    java: "#!/bin/sh\nexit 0\n",
+  };
+  for (const [name, content] of Object.entries(tools)) {
+    const file = path.join(directory, name);
+    writeFileSync(file, content);
+    chmodSync(file, 0o755);
+  }
+  return directory;
 }
 
 function validManifestFixture() {
@@ -78,6 +218,175 @@ function validManifestFixture() {
   };
 }
 
+function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function offlineBundleFixture(version, gitSha) {
+  const directory = mkdtempSync(path.join(tmpdir(), "speakup-offline-bundle-"));
+  const definitions = [
+    {
+      name: "portal",
+      repository: "ghcr.io/1024xengineer/xe3-esl-portal",
+      digest: `sha256:${"e".repeat(64)}`,
+    },
+    {
+      name: "server",
+      repository: "ghcr.io/1024xengineer/xe3-esl-server",
+      digest: `sha256:${"f".repeat(64)}`,
+    },
+  ];
+  const artifacts = definitions.map(({ name, repository, digest }) => {
+    const archiveFile = `speakup-${name}-v${version}-linux-amd64.tar`;
+    const metadataFile =
+      `speakup-${name}-v${version}-linux-amd64-build-metadata.json`;
+    const archivePath = path.join(directory, archiveFile);
+    const metadataPath = path.join(directory, metadataFile);
+    writeFileSync(archivePath, `${name} Docker archive fixture\n`);
+    writeJson(metadataPath, { "containerimage.digest": digest });
+    return {
+      name,
+      repository,
+      digest,
+      archive_file: archiveFile,
+      archive_size_bytes: readFileSync(archivePath).length,
+      archive_sha256: sha256File(archivePath),
+      build_metadata_file: metadataFile,
+      build_metadata_sha256: sha256File(metadataPath),
+      archivePath,
+      metadataPath,
+    };
+  });
+  const bundle = {
+    bundle_version: 1,
+    version,
+    git_sha: gitSha,
+    source_date_epoch: 1760000000,
+    platform: "linux/amd64",
+    images: artifacts.map(({
+      archivePath: _archivePath,
+      metadataPath: _metadataPath,
+      ...image
+    }) => image),
+  };
+  const bundlePath = path.join(directory, "offline-image-bundle.json");
+  writeJson(bundlePath, bundle);
+  return { artifacts, bundle, bundlePath, directory };
+}
+
+function qualityApiFixture(gitSha, runId = 32_456_953_876) {
+  const workflowId = 319_521_814;
+  const qualityRunUrl =
+    `https://github.com/${officialRepository}/actions/runs/${runId}`;
+  const workflowApiUrl =
+    `https://api.github.com/repos/${officialRepository}/actions/workflows/quality.yml`;
+  const runApiUrl =
+    `https://api.github.com/repos/${officialRepository}/actions/runs/${runId}`;
+  const workflow = {
+    id: workflowId,
+    name: "Quality",
+    path: qualityWorkflowPath,
+    state: "active",
+  };
+  const run = {
+    id: runId,
+    workflow_id: workflowId,
+    path: qualityWorkflowPath,
+    head_sha: gitSha,
+    head_branch: "main",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    url: runApiUrl,
+    html_url: qualityRunUrl,
+    repository: { full_name: officialRepository },
+    head_repository: { full_name: officialRepository },
+  };
+  const calls = [];
+  const fetchImplementation = async (url, options) => {
+    calls.push({ url, options });
+    const value = url === workflowApiUrl
+      ? workflow
+      : url === runApiUrl
+        ? run
+        : undefined;
+    return {
+      ok: value !== undefined,
+      status: value === undefined ? 404 : 200,
+      async json() {
+        return structuredClone(value);
+      },
+    };
+  };
+  return {
+    calls,
+    fetchImplementation,
+    qualityRunUrl,
+    run,
+    runApiUrl,
+    workflow,
+    workflowApiUrl,
+  };
+}
+
+function manifestArguments(repo, input, output) {
+  return [
+    manifestScript,
+    "--tag",
+    "v0.1.0",
+    "--main-ref",
+    "main",
+    "--staging-apk",
+    input.STAGING_APK_PATH,
+    "--production-apk",
+    input.PRODUCTION_APK_PATH,
+    "--output",
+    output,
+    "--repo",
+    repo,
+  ];
+}
+
+function offlineManifestArguments(
+  repo,
+  input,
+  bundle,
+  certificateFile,
+  qualityRunUrl,
+  output,
+) {
+  return [
+    "--tag",
+    "v0.1.0",
+    "--staging-apk",
+    input.STAGING_APK_PATH,
+    "--production-apk",
+    input.PRODUCTION_APK_PATH,
+    "--offline-bundle",
+    bundle.bundlePath,
+    "--certificate-file",
+    certificateFile,
+    "--quality-run-url",
+    qualityRunUrl,
+    "--output",
+    output,
+    "--repo",
+    repo,
+  ];
+}
+
+function runManifestCli(repo, input, output) {
+  return execFileSync(
+    process.execPath,
+    manifestArguments(repo, input, output),
+    { env: { ...process.env, ...input }, stdio: "pipe" },
+  );
+}
+
 test("accepts the first stable release and ignores prerelease tags", () => {
   const repo = createRepository();
   git(repo, "tag", "v0.1.0-alpha.1");
@@ -93,6 +402,174 @@ test("accepts the first stable release and ignores prerelease tags", () => {
       database_schema_version: "7",
     },
   );
+});
+
+test("validates stable tags against an explicitly selected remote", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  git(repo, "remote", "remove", "origin");
+  git(repo, "remote", "add", "mirror", repo);
+
+  assert.equal(
+    collectReleaseMetadata({
+      repoDir: repo,
+      tag: "v0.1.0",
+      mainRef: "main",
+      tagRemote: "mirror",
+    }).version,
+    "0.1.0",
+  );
+});
+
+test("validates the official upstream URL and live main commit", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  configureOfficialUpstream(repo);
+
+  assert.equal(
+    withOfficialGitProxy(repo, () => collectReleaseMetadata({
+      repoDir: repo,
+      tag: "v0.1.0",
+      mainRef: "refs/remotes/upstream/main",
+      tagRemote: "upstream",
+    })).git_sha,
+    git(repo, "rev-parse", "HEAD"),
+  );
+});
+
+test("rejects a non-official upstream URL and stale upstream main", () => {
+  const wrongRemote = createRepository();
+  git(wrongRemote, "tag", "v0.1.0");
+  git(wrongRemote, "remote", "add", "upstream", wrongRemote);
+  assert.throws(
+    () => collectReleaseMetadata({
+      repoDir: wrongRemote,
+      tag: "v0.1.0",
+      mainRef: "main",
+      tagRemote: "upstream",
+    }),
+    /upstream must use https:\/\/github\.com\/1024XEngineer\/XE3-ESL\.git/,
+  );
+
+  const staleMain = createRepository();
+  git(staleMain, "tag", "v0.1.0");
+  configureOfficialUpstream(staleMain);
+  writeReleaseFiles(staleMain, "0.1.1+2");
+  git(staleMain, "add", ".");
+  git(staleMain, "commit", "-m", "advance live main");
+  git(staleMain, "checkout", "--detach", "v0.1.0");
+  assert.throws(
+    () => withOfficialGitProxy(staleMain, () => collectReleaseMetadata({
+      repoDir: staleMain,
+      tag: "v0.1.0",
+      mainRef: "refs/remotes/upstream/main",
+      tagRemote: "upstream",
+    })),
+    /does not match live upstream main/,
+  );
+
+  const rewritten = createRepository();
+  git(rewritten, "tag", "v0.1.0");
+  configureOfficialUpstream(rewritten);
+  git(
+    rewritten,
+    "config",
+    `url.file://${rewritten}.insteadOf`,
+    officialUpstreamUrl,
+  );
+  assert.throws(
+    () => collectReleaseMetadata({
+      repoDir: rewritten,
+      tag: "v0.1.0",
+      mainRef: "refs/remotes/upstream/main",
+      tagRemote: "upstream",
+    }),
+    /Git URL rewrites must not affect the official upstream URL/,
+  );
+});
+
+test("rejects unsafe stable Tag remote names", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+
+  for (const tagRemote of [
+    "",
+    "-upstream",
+    "team/upstream",
+    "../upstream",
+    ".",
+    "..",
+  ]) {
+    assert.throws(
+      () => collectReleaseMetadata({
+        repoDir: repo,
+        tag: "v0.1.0",
+        mainRef: "main",
+        tagRemote,
+      }),
+      /tagRemote must be a plain Git remote name/,
+      tagRemote,
+    );
+  }
+});
+
+test("metadata and manifest CLIs reject unknown and duplicate options", () => {
+  const cases = [
+    {
+      script: metadataScript,
+      arguments_: ["--tag-remtoe", "upstream"],
+      pattern: /Unknown option: --tag-remtoe/,
+    },
+    {
+      script: metadataScript,
+      arguments_: ["--tag", "v0.1.0", "--tag", "v0.1.0"],
+      pattern: /Option may only be provided once: --tag/,
+    },
+    {
+      script: manifestScript,
+      arguments_: ["--offline-bunlde", "bundle.json"],
+      pattern: /Unknown option: --offline-bunlde/,
+    },
+    {
+      script: manifestScript,
+      arguments_: ["--offline-bundle", "bundle.json"],
+      pattern: /Unknown option: --offline-bundle/,
+    },
+    {
+      script: manifestScript,
+      arguments_: ["--output", "one.json", "--output", "two.json"],
+      pattern: /Option may only be provided once: --output/,
+    },
+    {
+      script: offlineManifestScript,
+      arguments_: ["--quality-run-urll", "https://example.invalid"],
+      pattern: /Unknown option: --quality-run-urll/,
+    },
+    {
+      script: offlineManifestScript,
+      arguments_: ["--repo", "one", "--repo", "two"],
+      pattern: /Option may only be provided once: --repo/,
+    },
+    {
+      script: offlineManifestScript,
+      arguments_: ["--github-api-url", "https://example.invalid"],
+      pattern: /Unknown option: --github-api-url/,
+    },
+  ];
+
+  for (const scenario of cases) {
+    assert.throws(
+      () => execFileSync(
+        process.execPath,
+        [scenario.script, ...scenario.arguments_],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+      (error) => {
+        assert.match(error.stderr, scenario.pattern);
+        return true;
+      },
+    );
+  }
 });
 
 test("rejects a release tag that is not contained in main", () => {
@@ -317,6 +794,10 @@ test("writes the validated manifest atomically through the CLI", () => {
   const manifest = JSON.parse(readFileSync(output, "utf8"));
   assert.equal(manifest.version, "0.1.0");
   assert.equal(manifest.git_sha, git(repo, "rev-parse", "HEAD"));
+  assert.equal(manifest.portal_image, input.PORTAL_IMAGE);
+  assert.equal(manifest.portal_image_digest, input.PORTAL_IMAGE_DIGEST);
+  assert.equal(manifest.server_image, input.SERVER_IMAGE);
+  assert.equal(manifest.server_image_digest, input.SERVER_IMAGE_DIGEST);
 
   const rejectedOutput = path.join(repo, "rejected-manifest.json");
   assert.throws(
@@ -344,6 +825,597 @@ test("writes the validated manifest atomically through the CLI", () => {
     ),
   );
   assert.equal(existsSync(rejectedOutput), false);
+});
+
+test("refuses to replace an existing manifest file, directory, or symbolic link", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  const { input } = validManifestFixture();
+  const existingFile = path.join(repo, "existing-manifest.json");
+  const existingDirectory = path.join(repo, "existing-manifest-directory");
+  const linkTarget = path.join(repo, "manifest-link-target.json");
+  const existingLink = path.join(repo, "existing-manifest-link.json");
+  writeFileSync(existingFile, "original manifest\n");
+  mkdirSync(existingDirectory);
+  writeFileSync(linkTarget, "link target\n");
+  symlinkSync(linkTarget, existingLink);
+
+  for (const output of [existingFile, existingDirectory, existingLink]) {
+    let failure;
+    try {
+      runManifestCli(repo, input, output);
+    } catch (error) {
+      failure = error;
+    }
+    assert.ok(failure, `${output} was unexpectedly replaced`);
+    assert.match(failure.stderr.toString(), /output already exists/);
+  }
+
+  assert.equal(readFileSync(existingFile, "utf8"), "original manifest\n");
+  assert.equal(lstatSync(existingDirectory).isDirectory(), true);
+  assert.equal(lstatSync(existingLink).isSymbolicLink(), true);
+  assert.equal(readlinkSync(existingLink), linkTarget);
+  assert.equal(readFileSync(linkTarget, "utf8"), "link target\n");
+});
+
+test("derives image references from a validated offline bundle", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  const gitSha = git(repo, "rev-parse", "HEAD");
+  const { input, metadata } = validManifestFixture();
+  const fixture = offlineBundleFixture("0.1.0", gitSha);
+
+  input.PORTAL_IMAGE = "invalid-environment-value";
+  input.PORTAL_IMAGE_DIGEST = "sha256:pending";
+  input.SERVER_IMAGE = "invalid-environment-value";
+  input.SERVER_IMAGE_DIGEST = "sha256:pending";
+  metadata.git_sha = gitSha;
+  const imageInput = offlineBundleImageInput(fixture.bundlePath, metadata);
+  const manifest = createReleaseManifest({ ...input, ...imageInput }, metadata);
+
+  assert.equal(manifest.manifest_version, 1);
+  assert.equal(manifest.version, "0.1.0");
+  assert.equal(manifest.git_sha, gitSha);
+  assert.equal(
+    manifest.portal_image,
+    "ghcr.io/1024xengineer/xe3-esl-portal",
+  );
+  assert.equal(manifest.portal_image_digest, `sha256:${"e".repeat(64)}`);
+  assert.equal(
+    manifest.server_image,
+    "ghcr.io/1024xengineer/xe3-esl-server",
+  );
+  assert.equal(manifest.server_image_digest, `sha256:${"f".repeat(64)}`);
+  assert.equal(Object.hasOwn(manifest, "offline_bundle"), false);
+});
+
+test("offline manifest wrapper derives APK fields from fail-closed verifier reports", async () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  configureOfficialUpstream(repo);
+  const gitSha = git(repo, "rev-parse", "HEAD");
+  const { input, stagingApk } = validManifestFixture();
+  const originalStagingSha = sha256File(stagingApk);
+  const bundle = offlineBundleFixture("0.1.0", gitSha);
+  const certificate = "c".repeat(64);
+  const certificateFile = path.join(bundle.directory, "certificate-sha256.txt");
+  const output = path.join(repo, "offline-wrapper-manifest.json");
+  writeFileSync(certificateFile, `${certificate}\n`);
+  const androidTools = fakeAndroidTools(certificate);
+  const quality = qualityApiFixture(gitSha);
+
+  await withOfflineWrapperTools(
+    repo,
+    androidTools,
+    {
+      STAGING_APK_APPLICATION_ID: "caller.must.not.win",
+      PRODUCTION_APK_APPLICATION_ID: "caller.must.not.win",
+      APK_CERTIFICATE_SHA256: "0".repeat(64),
+      GITHUB_API_URL: "https://example.invalid/must-not-win",
+    },
+    () => generateOfflineManifest(
+      offlineManifestArguments(
+        repo,
+        input,
+        bundle,
+        certificateFile,
+        quality.qualityRunUrl,
+        output,
+      ),
+      quality.fetchImplementation,
+    ),
+  );
+
+  const manifest = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(manifest.application_id, "com.xengineer.speakup");
+  assert.equal(manifest.minimum_android_api, 24);
+  assert.deepEqual(manifest.abis, ["arm64-v8a"]);
+  assert.equal(manifest.apk_certificate_sha256, certificate);
+  assert.equal(manifest.staging_apk_sha256, originalStagingSha);
+  assert.equal(manifest.quality_run_url, quality.qualityRunUrl);
+  assert.deepEqual(
+    quality.calls.map(({ url }) => url),
+    [quality.workflowApiUrl, quality.runApiUrl],
+  );
+  for (const { options } of quality.calls) {
+    assert.equal(options.method, "GET");
+    assert.equal(options.redirect, "error");
+    assert.equal(options.headers.Accept, "application/vnd.github+json");
+    assert.equal(
+      options.headers["X-GitHub-Api-Version"],
+      githubApiVersion,
+    );
+    assert.equal(options.headers["User-Agent"], "SpeakUp-Release-Candidate");
+  }
+});
+
+test("accepts only the fixed official successful Quality workflow contract", async () => {
+  const gitSha = "d".repeat(40);
+  const fixture = qualityApiFixture(gitSha);
+  fixture.run.event = "workflow_dispatch";
+
+  assert.equal(
+    await validateQualityRun(
+      fixture.qualityRunUrl,
+      gitSha,
+      fixture.fetchImplementation,
+    ),
+    fixture.qualityRunUrl,
+  );
+  assert.deepEqual(
+    fixture.calls.map(({ url }) => url),
+    [fixture.workflowApiUrl, fixture.runApiUrl],
+  );
+});
+
+test("rejects malformed or non-official Quality workflow run URLs", async () => {
+  const gitSha = "d".repeat(40);
+  const urls = [
+    "http://github.com/1024XEngineer/XE3-ESL/actions/runs/1",
+    "https://github.com/1024xengineer/XE3-ESL/actions/runs/1",
+    "https://github.com/1024XEngineer/XE3-ESL/actions/runs/0",
+    "https://github.com/1024XEngineer/XE3-ESL/actions/runs/01",
+    "https://github.com/1024XEngineer/XE3-ESL/actions/runs/9007199254740992",
+    "https://github.com/1024XEngineer/XE3-ESL/actions/runs/1?attempt=2",
+    "https://github.com/1024XEngineer/XE3-ESL/actions/runs/1/attempts/2",
+  ];
+
+  for (const url of urls) {
+    let called = false;
+    await assert.rejects(
+      validateQualityRun(url, gitSha, async () => {
+        called = true;
+      }),
+      /quality run URL must identify an official workflow run/,
+      url,
+    );
+    assert.equal(called, false, url);
+  }
+});
+
+test("rejects mismatched Quality workflow and run response fields", async () => {
+  const gitSha = "d".repeat(40);
+  const cases = [
+    {
+      name: "workflow id",
+      pattern: /Quality workflow response does not match/,
+      mutate(fixture) { fixture.workflow.id = 0; },
+    },
+    {
+      name: "workflow name",
+      pattern: /Quality workflow response does not match/,
+      mutate(fixture) { fixture.workflow.name = "Other"; },
+    },
+    {
+      name: "workflow path",
+      pattern: /Quality workflow response does not match/,
+      mutate(fixture) { fixture.workflow.path = ".github/workflows/other.yml"; },
+    },
+    {
+      name: "workflow state",
+      pattern: /Quality workflow response does not match/,
+      mutate(fixture) { fixture.workflow.state = "disabled_manually"; },
+    },
+    {
+      name: "run id",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.id += 1; },
+    },
+    {
+      name: "run API URL",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.url = "https://api.github.com/forged"; },
+    },
+    {
+      name: "run browser URL",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.html_url += "?attempt=2"; },
+    },
+    {
+      name: "workflow id binding",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.workflow_id += 1; },
+    },
+    {
+      name: "repository",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.repository.full_name = "example/fork"; },
+    },
+    {
+      name: "head repository",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.head_repository = null; },
+    },
+    {
+      name: "run workflow path",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.path = `${qualityWorkflowPath}@main`; },
+    },
+    {
+      name: "release SHA",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.head_sha = "e".repeat(40); },
+    },
+    {
+      name: "release branch",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.head_branch = "dev"; },
+    },
+    {
+      name: "event",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.event = "pull_request"; },
+    },
+    {
+      name: "status",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.status = "in_progress"; },
+    },
+    {
+      name: "conclusion",
+      pattern: /Quality workflow run does not match/,
+      mutate(fixture) { fixture.run.conclusion = "failure"; },
+    },
+  ];
+
+  for (const scenario of cases) {
+    const fixture = qualityApiFixture(gitSha);
+    scenario.mutate(fixture);
+    await assert.rejects(
+      validateQualityRun(
+        fixture.qualityRunUrl,
+        gitSha,
+        fixture.fetchImplementation,
+      ),
+      scenario.pattern,
+      scenario.name,
+    );
+  }
+});
+
+test("fails closed on Quality workflow API and JSON errors", async () => {
+  const gitSha = "d".repeat(40);
+  const fixture = qualityApiFixture(gitSha);
+
+  await assert.rejects(
+    validateQualityRun(fixture.qualityRunUrl, gitSha, async () => {
+      throw new Error("network unavailable");
+    }),
+    /Quality workflow request failed: network unavailable/,
+  );
+  await assert.rejects(
+    validateQualityRun(fixture.qualityRunUrl, gitSha, async () => ({
+      ok: false,
+      status: 403,
+    })),
+    /Quality workflow request failed with HTTP 403/,
+  );
+  await assert.rejects(
+    validateQualityRun(fixture.qualityRunUrl, gitSha, async () => ({
+      ok: true,
+      status: 200,
+      async json() { throw new Error("invalid JSON"); },
+    })),
+    /Quality workflow response must contain valid JSON/,
+  );
+
+  let calls = 0;
+  await assert.rejects(
+    validateQualityRun(fixture.qualityRunUrl, gitSha, async (url, options) => {
+      calls += 1;
+      if (calls === 1) return fixture.fetchImplementation(url, options);
+      return { ok: false, status: 502 };
+    }),
+    /Quality workflow run request failed with HTTP 502/,
+  );
+  assert.equal(calls, 2);
+});
+
+test("offline manifest wrapper does not write output when Quality validation fails", async () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  configureOfficialUpstream(repo);
+  const gitSha = git(repo, "rev-parse", "HEAD");
+  const { input } = validManifestFixture();
+  const bundle = offlineBundleFixture("0.1.0", gitSha);
+  const certificate = "c".repeat(64);
+  const certificateFile = path.join(bundle.directory, "certificate-sha256.txt");
+  const output = path.join(repo, "quality-rejected-offline-manifest.json");
+  writeFileSync(certificateFile, `${certificate}\n`);
+  const androidTools = fakeAndroidTools(certificate);
+  const quality = qualityApiFixture(gitSha);
+  quality.run.conclusion = "failure";
+
+  await assert.rejects(
+    withOfflineWrapperTools(
+      repo,
+      androidTools,
+      {},
+      () => generateOfflineManifest(
+        offlineManifestArguments(
+          repo,
+          input,
+          bundle,
+          certificateFile,
+          quality.qualityRunUrl,
+          output,
+        ),
+        quality.fetchImplementation,
+      ),
+    ),
+    /Quality workflow run does not match the release contract/,
+  );
+  assert.equal(existsSync(output), false);
+});
+
+test("offline manifest wrapper does not write output when APK verification fails", async () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  configureOfficialUpstream(repo);
+  const gitSha = git(repo, "rev-parse", "HEAD");
+  const { input } = validManifestFixture();
+  const bundle = offlineBundleFixture("0.1.0", gitSha);
+  const certificate = "c".repeat(64);
+  const certificateFile = path.join(bundle.directory, "certificate-sha256.txt");
+  const output = path.join(repo, "rejected-offline-wrapper-manifest.json");
+  writeFileSync(certificateFile, `${certificate}\n`);
+  const androidTools = fakeAndroidTools(certificate, { failProduction: true });
+  const quality = qualityApiFixture(gitSha);
+
+  await assert.rejects(
+    withOfflineWrapperTools(
+      repo,
+      androidTools,
+      {},
+      () => generateOfflineManifest(
+        offlineManifestArguments(
+          repo,
+          input,
+          bundle,
+          certificateFile,
+          quality.qualityRunUrl,
+          output,
+        ),
+        quality.fetchImplementation,
+      ),
+    ),
+    /production APK verification failed/,
+  );
+  assert.equal(existsSync(output), false);
+});
+
+test("rejects invalid offline bundles and artifacts", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  const gitSha = git(repo, "rev-parse", "HEAD");
+  const cases = [
+    {
+      name: "bundle version",
+      pattern: /offline bundle version must be 1/,
+      mutate(fixture) {
+        fixture.bundle.bundle_version = 2;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "release version mismatch",
+      pattern: /offline bundle version does not match release metadata/,
+      mutate(fixture) {
+        fixture.bundle.version = "0.1.1";
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "release Git SHA mismatch",
+      pattern: /offline bundle git_sha does not match release metadata/,
+      mutate(fixture) {
+        fixture.bundle.git_sha = "a".repeat(40);
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "platform",
+      pattern: /offline bundle platform must be linux\/amd64/,
+      mutate(fixture) {
+        fixture.bundle.platform = "linux/arm64";
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "source date epoch",
+      pattern: /source_date_epoch must be a positive integer/,
+      mutate(fixture) {
+        fixture.bundle.source_date_epoch = 0;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "unknown bundle field",
+      pattern: /offline bundle must contain the exact field set/,
+      mutate(fixture) {
+        fixture.bundle.unexpected = true;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "unknown image field",
+      pattern: /offline portal image must contain the exact field set/,
+      mutate(fixture) {
+        fixture.bundle.images[0].unexpected = true;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "image order",
+      pattern: /offline portal image identity is invalid/,
+      mutate(fixture) {
+        fixture.bundle.images.reverse();
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "repository",
+      pattern: /offline portal image identity is invalid/,
+      mutate(fixture) {
+        fixture.bundle.images[0].repository = "ghcr.io/example/portal";
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "digest",
+      pattern: /cannot be a placeholder digest/,
+      mutate(fixture) {
+        fixture.bundle.images[0].digest = `sha256:${"0".repeat(64)}`;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "versioned file name",
+      pattern: /offline portal image file names are invalid/,
+      mutate(fixture) {
+        fixture.bundle.images[0].archive_file = "portal.tar";
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "bundle symbolic link",
+      pattern: /offline bundle must be a non-empty regular file/,
+      mutate(fixture) {
+        const link = path.join(fixture.directory, "offline-bundle-link.json");
+        symlinkSync(fixture.bundlePath, link);
+        return link;
+      },
+    },
+    {
+      name: "empty bundle",
+      pattern: /offline bundle must be a non-empty regular file/,
+      mutate(fixture) {
+        writeFileSync(fixture.bundlePath, "");
+      },
+    },
+    {
+      name: "bundle directory",
+      pattern: /offline bundle must be a non-empty regular file/,
+      mutate(fixture) {
+        rmSync(fixture.bundlePath);
+        mkdirSync(fixture.bundlePath);
+      },
+    },
+    {
+      name: "archive symbolic link",
+      pattern: /offline portal archive must be a non-empty regular file/,
+      mutate(fixture) {
+        const archive = fixture.artifacts[0].archivePath;
+        const target = path.join(fixture.directory, "portal-archive-target.tar");
+        writeFileSync(target, readFileSync(archive));
+        rmSync(archive);
+        symlinkSync(target, archive);
+      },
+    },
+    {
+      name: "empty archive",
+      pattern: /offline portal archive must be a non-empty regular file/,
+      mutate(fixture) {
+        writeFileSync(fixture.artifacts[0].archivePath, "");
+      },
+    },
+    {
+      name: "archive size",
+      pattern: /offline portal archive size does not match/,
+      mutate(fixture) {
+        fixture.bundle.images[0].archive_size_bytes += 1;
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "archive SHA-256",
+      pattern: /offline portal archive SHA-256 does not match/,
+      mutate(fixture) {
+        fixture.bundle.images[0].archive_sha256 = "9".repeat(64);
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "server archive SHA-256",
+      pattern: /offline server archive SHA-256 does not match/,
+      mutate(fixture) {
+        fixture.bundle.images[1].archive_sha256 = "9".repeat(64);
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "metadata symbolic link",
+      pattern: /offline portal metadata must be a non-empty regular file/,
+      mutate(fixture) {
+        const metadata = fixture.artifacts[0].metadataPath;
+        const target = path.join(fixture.directory, "portal-metadata-target.json");
+        writeFileSync(target, readFileSync(metadata));
+        rmSync(metadata);
+        symlinkSync(target, metadata);
+      },
+    },
+    {
+      name: "metadata SHA-256",
+      pattern: /offline portal metadata SHA-256 does not match/,
+      mutate(fixture) {
+        fixture.bundle.images[0].build_metadata_sha256 = "9".repeat(64);
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+    {
+      name: "metadata directory",
+      pattern: /offline portal metadata must be a non-empty regular file/,
+      mutate(fixture) {
+        rmSync(fixture.artifacts[0].metadataPath);
+        mkdirSync(fixture.artifacts[0].metadataPath);
+      },
+    },
+    {
+      name: "metadata digest",
+      pattern: /offline portal metadata digest does not match/,
+      mutate(fixture) {
+        const metadata = fixture.artifacts[0].metadataPath;
+        writeJson(metadata, {
+          "containerimage.digest": `sha256:${"9".repeat(64)}`,
+        });
+        fixture.bundle.images[0].build_metadata_sha256 = sha256File(metadata);
+        writeJson(fixture.bundlePath, fixture.bundle);
+      },
+    },
+  ];
+
+  for (const scenario of cases) {
+    const fixture = offlineBundleFixture("0.1.0", gitSha);
+    const selectedBundle = scenario.mutate(fixture) ?? fixture.bundlePath;
+    assert.throws(
+      () => offlineBundleImageInput(selectedBundle, {
+        version: "0.1.0",
+        git_sha: gitSha,
+      }),
+      scenario.pattern,
+      scenario.name,
+    );
+  }
 });
 
 test("rejects placeholder or malformed manifest values", () => {
@@ -394,6 +1466,13 @@ test("rejects invalid APKs, image references, digests, and quality run URLs", ()
       metadata,
     ),
     /QUALITY_RUN_URL has an invalid value/,
+  );
+  assert.throws(
+    () => createReleaseManifest(
+      { ...input, STAGING_APK_VERIFIED_SHA256: "e".repeat(64) },
+      metadata,
+    ),
+    /STAGING_APK_VERIFIED_SHA256 does not match the APK file/,
   );
 });
 


### PR DESCRIPTION
## 功能描述

将 Android 首次上线需要的三个已审核发布改动从 `dev` 晋升到 `main`：

- Portal 高危运行时依赖升级（#865）；
- 可校验、可离线传输与导入的 Portal/Server 镜像发布能力（#866）；
- Production PostgreSQL 原子备份、隔离恢复验证与定时任务（#862）。

## 实现思路

本 PR 不引入额外业务修改，只晋升官方 `dev` 中上述三个已审核提交。合并后固定 `main` 的唯一 Commit，后续手动构建 Portal、Go Server、Staging APK 与正式签名 Production APK；本次不推送正式 Tag，不触发集成 Release Candidate Workflow。

## 可复现测试

- `make check-production-backup`
- `make check-offline-release`
- PR Quality workflow 全部通过
- `git log --oneline upstream/main..upstream/dev` 仅包含 #865、#866、#862

## 关联 Issue

Closes #881
Related #861
Related #863
Related #864
