### PR TITLE
release: 发布 v0.1.1 候选版本

### DIFF
--- a/server/internal/providers/qianwen/speech_live_test.go
+++ b/server/internal/providers/qianwen/speech_live_test.go
@@ -176,7 +176,7 @@ func TestLiveRealtimeSpeechSynthesis(t *testing.T) {
 	firstChunkDelay := time.Duration(0)
 	chunkCount := 0
 	audioBytes := 0
-	err = synthesizer.streamRealtimePCM(
+	_, err = synthesizer.streamRealtimePCM(
 		context.Background(),
 		"Please repeat after me. This audio should start immediately.",
 		func(chunk []byte) error {

--- a/server/internal/providers/qianwen/speech_recognizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime.go
@@ -149,7 +149,7 @@ func (recognizer *speechRecognizer) transcribeRealtimeAudio(
 		_ = connection.SetReadDeadline(deadline)
 		_ = connection.SetWriteDeadline(deadline)
 	}
-	taskID, err := newRealtimeASRTaskID()
+	taskID, err := newRealtimeSpeechTaskID()
 	if err != nil {
 		return protocol.TranscriptionResult{}, err
 	}
@@ -439,7 +439,7 @@ func realtimeASREndpoint(baseURL string) string {
 	return parsed.String()
 }
 
-func newRealtimeASRTaskID() (string, error) {
+func newRealtimeSpeechTaskID() (string, error) {
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err != nil {
 		return "", err

--- a/server/internal/providers/qianwen/speech_synthesizer.go
+++ b/server/internal/providers/qianwen/speech_synthesizer.go
@@ -40,6 +40,7 @@ type TTSConfig struct {
 type speechSynthesizer struct {
 	endpoint         string
 	realtimeEndpoint string
+	synthesizeOverWS bool
 	model            string
 	voice            string
 	languageHint     string
@@ -86,9 +87,10 @@ func newSynthesizerWithClient(
 	if err != nil {
 		return nil, err
 	}
-	if !isBeijingDashScopeAPIBaseURL(baseURL) {
+	synthesizeOverWS := isSingaporeDashScopeWorkspaceAPIBaseURL(baseURL)
+	if !isBeijingDashScopeAPIBaseURL(baseURL) && !synthesizeOverWS {
 		return nil, errors.New(
-			"Qwen-Audio-TTS is available only through a China (Beijing) endpoint",
+			"Qwen-Audio-TTS requires a China (Beijing) or Singapore Workspace endpoint",
 		)
 	}
 	realtimeEndpoint, err := realtimeTTSEndpoint(baseURL)
@@ -120,6 +122,7 @@ func newSynthesizerWithClient(
 	return &speechSynthesizer{
 		endpoint:         baseURL + ttsSpeechSynthesizerPath,
 		realtimeEndpoint: realtimeEndpoint,
+		synthesizeOverWS: synthesizeOverWS,
 		model:            model,
 		voice:            voice,
 		languageHint:     language,
@@ -153,6 +156,12 @@ func (synthesizer *speechSynthesizer) Synthesize(
 			"",
 			"",
 			err,
+		)
+	}
+	if synthesizer.synthesizeOverWS {
+		return synthesizer.synthesizeRealtimeWAV(
+			ctx,
+			strings.TrimSpace(request.Text),
 		)
 	}
 	payload := ttsRequest{
@@ -617,6 +626,17 @@ func isBeijingDashScopeAPIBaseURL(baseURL string) bool {
 	workspaceID := strings.TrimSuffix(host, suffix)
 	return workspaceID != host &&
 		validDNSLabel(workspaceID)
+}
+
+func isSingaporeDashScopeWorkspaceAPIBaseURL(baseURL string) bool {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	const suffix = ".ap-southeast-1.maas.aliyuncs.com"
+	host := strings.ToLower(parsed.Hostname())
+	workspaceID := strings.TrimSuffix(host, suffix)
+	return workspaceID != host && validDNSLabel(workspaceID)
 }
 
 func validDNSLabel(value string) bool {

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime.go
@@ -3,8 +3,7 @@ package qianwen
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,7 +18,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-const ttsRealtimePath = "/api-ws/v1/inference/"
+const (
+	ttsRealtimePath        = "/api-ws/v1/inference"
+	pcmWAVHeaderBytes      = 44
+	maxRealtimeTTSPCMBytes = platformmedia.MaxAudioBytes - pcmWAVHeaderBytes
+)
 
 type speechRealtimeEnvelope struct {
 	Header speechRealtimeHeader `json:"header"`
@@ -45,20 +48,129 @@ func realtimeTTSEndpoint(baseURL string) (string, error) {
 	return parsed.String(), nil
 }
 
+func (synthesizer *speechSynthesizer) synthesizeRealtimeWAV(
+	ctx context.Context,
+	text string,
+) (protocol.SynthesisResult, error) {
+	var pcm bytes.Buffer
+	defer func() { clear(pcm.Bytes()) }()
+	taskID, err := synthesizer.streamRealtimePCM(
+		ctx,
+		text,
+		func(chunk []byte) error {
+			if len(chunk) == 0 ||
+				int64(pcm.Len()+len(chunk)) > maxRealtimeTTSPCMBytes {
+				return errors.New("Qianwen realtime TTS PCM exceeds the accepted size")
+			}
+			_, _ = pcm.Write(chunk)
+			return nil
+		},
+	)
+	if err != nil {
+		return protocol.SynthesisResult{}, realtimeSynthesisError(ctx, taskID, err)
+	}
+	wav, err := pcm16MonoWAV(pcm.Bytes())
+	if err != nil {
+		return protocol.SynthesisResult{}, invalidSpeechResponse(
+			protocol.SpeechOperationSynthesis,
+			0,
+			taskID,
+			"Qianwen realtime TTS returned invalid PCM",
+		)
+	}
+	defer clear(wav)
+	audio, err := platformmedia.CaptureTemporaryAudio(
+		synthesizer.tempDirectory,
+		platformmedia.ContentTypeWAV,
+		bytes.NewReader(wav),
+	)
+	if err != nil {
+		return protocol.SynthesisResult{}, invalidSpeechResponse(
+			protocol.SpeechOperationSynthesis,
+			0,
+			taskID,
+			"Qianwen realtime TTS WAV failed validation",
+		)
+	}
+	return protocol.SynthesisResult{
+		RequestID: taskID,
+		Provider:  providerName,
+		Model:     synthesizer.model,
+		AudioID:   taskID,
+		Audio:     audio,
+	}, nil
+}
+
 func (synthesizer *speechSynthesizer) streamRealtimePCM(
 	ctx context.Context,
 	text string,
 	consume func([]byte) error,
-) error {
+) (string, error) {
 	session, err := synthesizer.openRealtimeSpeech(ctx, consume)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer session.Close()
 	if err := session.AppendText(text); err != nil {
+		return session.taskID, err
+	}
+	return session.taskID, session.Finish()
+}
+
+func realtimeSynthesisError(ctx context.Context, taskID string, err error) error {
+	var speechError *protocol.SpeechError
+	if errors.As(err, &speechError) {
 		return err
 	}
-	return session.Finish()
+	if ctx.Err() != nil {
+		return speechTransportError(protocol.SpeechOperationSynthesis, ctx, err)
+	}
+	return invalidSpeechResponse(
+		protocol.SpeechOperationSynthesis,
+		0,
+		taskID,
+		"Qianwen realtime TTS failed",
+	)
+}
+
+func pcm16MonoWAV(pcm []byte) ([]byte, error) {
+	const bytesPerSample = agentconversation.AssistantSpeechBitsPerSample / 8
+	if len(pcm) == 0 || len(pcm)%bytesPerSample != 0 ||
+		int64(len(pcm)) > maxRealtimeTTSPCMBytes {
+		return nil, errors.New("Qianwen realtime TTS PCM is invalid")
+	}
+	wav := make([]byte, pcmWAVHeaderBytes+len(pcm))
+	copy(wav[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(wav[4:8], uint32(len(wav)-8))
+	copy(wav[8:12], "WAVE")
+	copy(wav[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(wav[16:20], 16)
+	binary.LittleEndian.PutUint16(wav[20:22], 1)
+	binary.LittleEndian.PutUint16(
+		wav[22:24],
+		agentconversation.AssistantSpeechChannelCount,
+	)
+	binary.LittleEndian.PutUint32(
+		wav[24:28],
+		agentconversation.AssistantSpeechSampleRate,
+	)
+	binary.LittleEndian.PutUint32(
+		wav[28:32],
+		agentconversation.AssistantSpeechSampleRate*
+			agentconversation.AssistantSpeechChannelCount*bytesPerSample,
+	)
+	binary.LittleEndian.PutUint16(
+		wav[32:34],
+		agentconversation.AssistantSpeechChannelCount*bytesPerSample,
+	)
+	binary.LittleEndian.PutUint16(
+		wav[34:36],
+		agentconversation.AssistantSpeechBitsPerSample,
+	)
+	copy(wav[36:40], "data")
+	binary.LittleEndian.PutUint32(wav[40:44], uint32(len(pcm)))
+	copy(wav[pcmWAVHeaderBytes:], pcm)
+	return wav, nil
 }
 
 type speechRealtimeSession struct {
@@ -81,7 +193,7 @@ func (synthesizer *speechSynthesizer) openRealtimeSpeech(
 	if synthesizer == nil || ctx == nil || consume == nil {
 		return nil, errors.New("Qianwen realtime TTS is unavailable")
 	}
-	taskID, err := newRealtimeTaskID()
+	taskID, err := newRealtimeSpeechTaskID()
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +218,6 @@ func (synthesizer *speechSynthesizer) openRealtimeSpeech(
 		)
 	}
 	if deadline, ok := callContext.Deadline(); ok {
-		_ = connection.SetReadDeadline(deadline)
 		_ = connection.SetWriteDeadline(deadline)
 	}
 	session := &speechRealtimeSession{
@@ -134,13 +245,34 @@ func (synthesizer *speechSynthesizer) openRealtimeSpeech(
 		return nil, err
 	}
 	if err := waitForSpeechRealtimeEvent(
+		callContext,
 		connection,
 		taskID,
 		"task-started",
 	); err != nil {
+		var speechError *protocol.SpeechError
+		if !errors.As(err, &speechError) {
+			if callContext.Err() != nil {
+				err = speechTransportError(
+					protocol.SpeechOperationSynthesis,
+					callContext,
+					err,
+				)
+			} else {
+				err = invalidSpeechResponse(
+					protocol.SpeechOperationSynthesis,
+					0,
+					taskID,
+					"Qianwen realtime TTS start event is invalid",
+				)
+			}
+		}
 		cancel()
 		_ = connection.Close()
 		return nil, err
+	}
+	if deadline, ok := callContext.Deadline(); ok {
+		_ = connection.SetReadDeadline(deadline)
 	}
 	session.reading = true
 	go session.readAudio()
@@ -258,11 +390,34 @@ func (session *speechRealtimeSession) Close() error {
 }
 
 func waitForSpeechRealtimeEvent(
+	ctx context.Context,
 	connection *websocket.Conn,
 	taskID string,
 	expected string,
 ) error {
-	messageType, payload, err := connection.ReadMessage()
+	type readResult struct {
+		messageType int
+		payload     []byte
+		err         error
+	}
+	result := make(chan readResult, 1)
+	go func() {
+		messageType, payload, err := connection.ReadMessage()
+		result <- readResult{
+			messageType: messageType,
+			payload:     payload,
+			err:         err,
+		}
+	}()
+	var read readResult
+	select {
+	case <-ctx.Done():
+		_ = connection.Close()
+		<-result
+		return ctx.Err()
+	case read = <-result:
+	}
+	messageType, payload, err := read.messageType, read.payload, read.err
 	if err != nil || messageType != websocket.TextMessage {
 		return errors.New("Qianwen realtime TTS start event is unavailable")
 	}
@@ -283,18 +438,18 @@ func decodeSpeechRealtimeEvent(payload []byte, taskID string) (string, error) {
 		return "", errors.New("Qianwen realtime TTS returned an invalid event")
 	}
 	if envelope.Header.Event == "task-failed" {
-		return "", errors.New("Qianwen realtime TTS task failed")
+		providerCode := sanitizeIdentifier(envelope.Header.ErrorCode)
+		return "", protocol.NewSpeechError(
+			protocol.SpeechOperationSynthesis,
+			classifyStatus(0, providerCode),
+			0,
+			providerCode,
+			sanitizeIdentifier(envelope.Header.TaskID),
+			errors.New("Qianwen realtime TTS task failed"),
+		)
 	}
 	if strings.TrimSpace(envelope.Header.Event) == "" {
 		return "", errors.New("Qianwen realtime TTS event type is missing")
 	}
 	return envelope.Header.Event, nil
-}
-
-func newRealtimeTaskID() (string, error) {
-	raw := make([]byte, 16)
-	if _, err := rand.Read(raw); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(raw), nil
 }

--- a/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_realtime_test.go
@@ -4,14 +4,35 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 	"github.com/gorilla/websocket"
 )
+
+var realtimeSpeechTaskIDPattern = regexp.MustCompile(
+	`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+)
+
+func TestRealtimeSpeechTaskIDUsesRFC4122UUID(t *testing.T) {
+	t.Parallel()
+	taskID, err := newRealtimeSpeechTaskID()
+	if err != nil {
+		t.Fatalf("generate realtime speech task ID: %v", err)
+	}
+	if !realtimeSpeechTaskIDPattern.MatchString(taskID) {
+		t.Fatalf("realtime speech task ID is not an RFC 4122 UUID: %q", taskID)
+	}
+}
 
 func TestRealtimeSynthesisStreamsTextThroughOneDocumentedTask(t *testing.T) {
 	t.Parallel()
@@ -160,5 +181,337 @@ func TestRealtimeSynthesisStreamsTextThroughOneDocumentedTask(t *testing.T) {
 	}
 	if err := session.Finish(); err != nil {
 		t.Fatalf("finish realtime synthesis: %v", err)
+	}
+}
+
+func TestSingaporeSynthesizeUsesRealtimeWebSocketAndReturnsValidatedWAV(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	pcm := make([]byte, ttsOutputSampleRate/10*2)
+	for index := range pcm {
+		pcm[index] = byte(index)
+	}
+	server := newRealtimeSynthesisServer(t, "Say hello.", realtimeSynthesisOutcome{
+		pcm: pcm,
+	})
+	directory := t.TempDir()
+	synthesizer := newSingaporeTestSynthesizer(
+		t,
+		server,
+		directory,
+		time.Second,
+	)
+	result, err := synthesizer.Synthesize(
+		context.Background(),
+		protocol.SynthesisRequest{Text: "  Say hello.  "},
+	)
+	if err != nil {
+		t.Fatalf("synthesize Singapore WAV: %v", err)
+	}
+	if result.RequestID == "" || result.AudioID != result.RequestID ||
+		result.Provider != providerName || result.Model != synthesizer.model ||
+		result.Audio == nil {
+		t.Fatalf("unexpected Singapore synthesis result: %#v", result)
+	}
+	if err := platformmedia.ValidateAudioSource(result.Audio); err != nil {
+		t.Fatalf("validate Singapore WAV: %v", err)
+	}
+	if result.Audio.Size() != int64(pcmWAVHeaderBytes+len(pcm)) ||
+		result.Audio.SampleRate() != ttsOutputSampleRate ||
+		result.Audio.Duration() != 100*time.Millisecond {
+		t.Fatalf(
+			"unexpected Singapore WAV metadata: size=%d rate=%d duration=%s",
+			result.Audio.Size(),
+			result.Audio.SampleRate(),
+			result.Audio.Duration(),
+		)
+	}
+	reader, err := result.Audio.Open()
+	if err != nil {
+		t.Fatalf("open Singapore WAV: %v", err)
+	}
+	wav, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("read Singapore WAV: %v", errors.Join(readErr, closeErr))
+	}
+	if string(wav[:4]) != "RIFF" || string(wav[8:12]) != "WAVE" ||
+		!bytes.Equal(wav[pcmWAVHeaderBytes:], pcm) {
+		t.Fatal("Singapore synthesis returned an invalid WAV payload")
+	}
+	if err := result.Audio.Close(); err != nil {
+		t.Fatalf("close Singapore WAV: %v", err)
+	}
+	assertDirectoryEmpty(t, directory)
+}
+
+func TestSingaporeSynthesizeFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		outcome realtimeSynthesisOutcome
+		timeout time.Duration
+		kind    protocol.ErrorKind
+		code    string
+	}{
+		{
+			name: "provider task failed",
+			outcome: realtimeSynthesisOutcome{
+				event:           "task-failed",
+				providerCode:    "InvalidParameter",
+				providerMessage: "must-not-appear",
+			},
+			timeout: time.Second,
+			kind:    protocol.ErrorInvalidResponse,
+			code:    "InvalidParameter",
+		},
+		{
+			name: "provider task failed before start",
+			outcome: realtimeSynthesisOutcome{
+				event:           "task-failed",
+				failBeforeStart: true,
+				providerCode:    "ModelNotFound",
+				providerMessage: "must-not-appear",
+			},
+			timeout: time.Second,
+			kind:    protocol.ErrorInvalidResponse,
+			code:    "ModelNotFound",
+		},
+		{
+			name:    "provider returned no audio",
+			outcome: realtimeSynthesisOutcome{},
+			timeout: time.Second,
+			kind:    protocol.ErrorInvalidResponse,
+		},
+		{
+			name:    "provider returned incomplete PCM frame",
+			outcome: realtimeSynthesisOutcome{pcm: []byte{1}},
+			timeout: time.Second,
+			kind:    protocol.ErrorInvalidResponse,
+		},
+		{
+			name:    "provider start timed out",
+			outcome: realtimeSynthesisOutcome{withholdStart: true},
+			timeout: 50 * time.Millisecond,
+			kind:    protocol.ErrorTimeout,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			server := newRealtimeSynthesisServer(t, "Say hello.", test.outcome)
+			directory := t.TempDir()
+			synthesizer := newSingaporeTestSynthesizer(
+				t,
+				server,
+				directory,
+				test.timeout,
+			)
+			result, err := synthesizer.Synthesize(
+				context.Background(),
+				protocol.SynthesisRequest{Text: "Say hello."},
+			)
+			if result.Audio != nil {
+				_ = result.Audio.Close()
+				t.Fatal("failed Singapore synthesis returned audio")
+			}
+			var speechError *protocol.SpeechError
+			if !errors.As(err, &speechError) || speechError.Kind != test.kind ||
+				speechError.ProviderCode != test.code {
+				t.Fatalf("synthesis error = %v, want kind %s", err, test.kind)
+			}
+			if strings.Contains(safeLiveSpeechError(err), "must-not-appear") {
+				t.Fatal("provider message leaked through live error")
+			}
+			assertDirectoryEmpty(t, directory)
+		})
+	}
+}
+
+type realtimeSynthesisOutcome struct {
+	pcm             []byte
+	event           string
+	withholdStart   bool
+	failBeforeStart bool
+	providerCode    string
+	providerMessage string
+}
+
+func newRealtimeSynthesisServer(
+	t *testing.T,
+	expectedText string,
+	outcome realtimeSynthesisOutcome,
+) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		connection, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer connection.Close()
+
+		_, payload, err := connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read run-task: %v", err)
+			return
+		}
+		var run struct {
+			Header struct {
+				Action string `json:"action"`
+				TaskID string `json:"task_id"`
+			} `json:"header"`
+			Payload struct {
+				Model      string `json:"model"`
+				Parameters struct {
+					Format     string `json:"format"`
+					SampleRate int    `json:"sample_rate"`
+				} `json:"parameters"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(payload, &run); err != nil ||
+			run.Header.Action != "run-task" ||
+			!realtimeSpeechTaskIDPattern.MatchString(run.Header.TaskID) ||
+			run.Payload.Model != "qwen-audio-3.0-tts-flash" ||
+			run.Payload.Parameters.Format != "pcm" ||
+			run.Payload.Parameters.SampleRate != ttsOutputSampleRate {
+			t.Errorf("unexpected run-task: %s", payload)
+			return
+		}
+		if outcome.withholdStart {
+			_, _, _ = connection.ReadMessage()
+			return
+		}
+		if outcome.failBeforeStart {
+			if err := writeRealtimeSynthesisEvent(connection, run.Header.TaskID, outcome); err != nil {
+				t.Errorf("write task-failed: %v", err)
+			}
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{
+			"header": map[string]any{
+				"task_id": run.Header.TaskID,
+				"event":   "task-started",
+			},
+		}); err != nil {
+			t.Errorf("write task-started: %v", err)
+			return
+		}
+
+		_, payload, err = connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read continue-task: %v", err)
+			return
+		}
+		var continued struct {
+			Header struct {
+				Action string `json:"action"`
+				TaskID string `json:"task_id"`
+			} `json:"header"`
+			Payload struct {
+				Input struct {
+					Text string `json:"text"`
+				} `json:"input"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(payload, &continued); err != nil ||
+			continued.Header.Action != "continue-task" ||
+			continued.Header.TaskID != run.Header.TaskID ||
+			continued.Payload.Input.Text != expectedText {
+			t.Errorf("unexpected continue-task: %s", payload)
+			return
+		}
+		if len(outcome.pcm) > 0 {
+			if err := connection.WriteMessage(websocket.BinaryMessage, outcome.pcm); err != nil {
+				t.Errorf("write PCM: %v", err)
+				return
+			}
+		}
+		_, payload, err = connection.ReadMessage()
+		if err != nil {
+			t.Errorf("read finish-task: %v", err)
+			return
+		}
+		var finished struct {
+			Header struct {
+				Action string `json:"action"`
+				TaskID string `json:"task_id"`
+			} `json:"header"`
+		}
+		if err := json.Unmarshal(payload, &finished); err != nil ||
+			finished.Header.Action != "finish-task" ||
+			finished.Header.TaskID != run.Header.TaskID {
+			t.Errorf("unexpected finish-task: %s", payload)
+			return
+		}
+		event := outcome.event
+		if event == "" {
+			event = "task-finished"
+		}
+		outcome.event = event
+		if err := writeRealtimeSynthesisEvent(connection, run.Header.TaskID, outcome); err != nil {
+			t.Errorf("write %s: %v", event, err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeRealtimeSynthesisEvent(
+	connection *websocket.Conn,
+	taskID string,
+	outcome realtimeSynthesisOutcome,
+) error {
+	return connection.WriteJSON(map[string]any{
+		"header": map[string]any{
+			"task_id":       taskID,
+			"event":         outcome.event,
+			"error_code":    outcome.providerCode,
+			"error_message": outcome.providerMessage,
+		},
+	})
+}
+
+func newSingaporeTestSynthesizer(
+	t *testing.T,
+	server *httptest.Server,
+	directory string,
+	timeout time.Duration,
+) *speechSynthesizer {
+	t.Helper()
+	synthesizer, err := newSynthesizerWithClient(TTSConfig{
+		BaseURL:       "https://workspace-123.ap-southeast-1.maas.aliyuncs.com/api/v1",
+		Model:         "qwen-audio-3.0-tts-flash",
+		Voice:         "loongeva_v3.6",
+		LanguageHint:  "en",
+		Timeout:       timeout,
+		TempDirectory: directory,
+	}, "test-realtime-tts-key", doerFunc(func(*http.Request) (*http.Response, error) {
+		t.Error("Singapore synthesis must not use HTTP generation")
+		return nil, errors.New("unexpected HTTP generation")
+	}))
+	if err != nil {
+		t.Fatalf("new Singapore synthesizer: %v", err)
+	}
+	synthesizer.realtimeEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
+	return synthesizer
+}
+
+func assertDirectoryEmpty(t *testing.T, directory string) {
+	t.Helper()
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("read temporary audio directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed synthesis left temporary audio: %v", entries)
 	}
 }

--- a/server/internal/providers/qianwen/speech_synthesizer_test.go
+++ b/server/internal/providers/qianwen/speech_synthesizer_test.go
@@ -810,9 +810,6 @@ func TestNewSynthesizerRejectsUnsupportedConfiguration(t *testing.T) {
 		{name: "Singapore legacy endpoint", mutate: func(config *TTSConfig) {
 			config.BaseURL = "https://dashscope-intl.aliyuncs.com/api/v1"
 		}},
-		{name: "Singapore workspace endpoint", mutate: func(config *TTSConfig) {
-			config.BaseURL = "https://workspace.ap-southeast-1.maas.aliyuncs.com/api/v1"
-		}},
 		{name: "US endpoint", mutate: func(config *TTSConfig) {
 			config.BaseURL = "https://dashscope-us.aliyuncs.com/api/v1"
 		}},
@@ -851,6 +848,33 @@ func TestNewSynthesizerAcceptsBeijingWorkspaceEndpoint(t *testing.T) {
 	if synthesizer.endpoint != "https://workspace-123.cn-beijing.maas.aliyuncs.com"+
 		"/api/v1/services/audio/tts/SpeechSynthesizer" {
 		t.Fatalf("unexpected Beijing endpoint: %s", synthesizer.endpoint)
+	}
+	if synthesizer.synthesizeOverWS {
+		t.Fatal("Beijing synthesis must keep using the HTTP API")
+	}
+}
+
+func TestNewSynthesizerAcceptsSingaporeWorkspaceEndpoint(t *testing.T) {
+	t.Parallel()
+
+	synthesizer, err := newSynthesizerWithClient(TTSConfig{
+		BaseURL:      "https://workspace-123.ap-southeast-1.maas.aliyuncs.com/api/v1",
+		Model:        "qwen-audio-3.0-tts-flash",
+		Voice:        "loongeva_v3.6",
+		LanguageHint: "en",
+		Timeout:      time.Second,
+	}, "test-api-key", doerFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	if err != nil {
+		t.Fatalf("new synthesizer: %v", err)
+	}
+	if !synthesizer.synthesizeOverWS {
+		t.Fatal("Singapore Workspace synthesis must use the realtime WebSocket API")
+	}
+	if synthesizer.realtimeEndpoint !=
+		"wss://workspace-123.ap-southeast-1.maas.aliyuncs.com/api-ws/v1/inference" {
+		t.Fatalf("unexpected Singapore endpoint: %s", synthesizer.realtimeEndpoint)
 	}
 }
 


### PR DESCRIPTION
## 功能描述

- 将当前已审核 `dev` 提升到 `main`，作为官方 `v0.1.1` Release Candidate 的唯一代码来源。
- 相对当前 `main` 仅增加已由 #884 审核和真实冒烟的新加坡 Workspace TTS 支持。
- 合并后再创建新的官方不可变 `v0.1.1` Tag；本 PR 不创建、不移动或删除 Tag。

## 实现思路

- 复用 `dev -> main` 的正式提升路径，不复制提交、不从个人 Fork 发布。
- Release Candidate workflow 将在正式 Tag 上重新执行全量质量、数据库、OCI 镜像、Android 签名和发布清单校验。
- Staging/Production 只消费该工作流产出的不可变制品。

## 可复现测试

- #884 全部 CI 通过并获得批准。
- `make check-go`
- `make check-api`
- `cd server && go test -race -count=1 ./internal/providers/qianwen`
- 新加坡生产 Workspace TTS 脱敏真实冒烟：PASS（WAV、24 kHz）。

## 合并后动作

- 在合并后的 `main` Commit 创建官方 `v0.1.1` Tag。
- 审核 Release Candidate workflow 和 Android signing Environment。
- 校验 APK、镜像摘要和 `release-manifest.json` 后再部署 Staging。

Closes #879
