### PR TITLE
chore(release): 推进 Android 版本到 0.1.2+3

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -30,7 +30,7 @@ Android 真机上运行 App。连接多台设备时，可通过
 首发网站分发基线为：
 
 - applicationId：`com.xengineer.speakup`
-- versionName/versionCode：`0.1.1` / `2`（Release Tag：`v0.1.1`）
+- versionName/versionCode：`0.1.2` / `3`（Release Tag：`v0.1.2`）
 - ABI：仅 `arm64-v8a`
 - staging API 发布契约：`https://staging-api.speak-up.top`
 - production API 发布契约：`https://api.speak-up.top`

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.1+2
+version: 0.1.2+3
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 功能描述

- 将 Android 正式版本从 `0.1.1+2` 推进到 `0.1.2+3`。
- 同步移动端网站分发基线说明。
- 不修改 application ID、签名证书、最低 Android API、ABI 或业务代码。

## 实现思路

Staging 已存在不可覆盖的 `v0.1.1` 下载目录。新候选若复用同一版本会形成“同版本、不同 APK/校验和”，因此按照不可变发布契约递增 versionName 和 versionCode；后续正式 Tag 使用 `v0.1.2`。

## 可复现测试

- `make check-release-candidate`
- `make check-flutter`
- `git diff --check`

上述检查均通过；Flutter 共 754 项测试通过，Android release guard 通过。

Closes #886
