### PR TITLE
fix(portal): expose validated Android download on home

### DIFF
--- a/portal/app/HomeAndroidRelease.tsx
+++ b/portal/app/HomeAndroidRelease.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadAndroidRelease } from "../lib/android-release-metadata.mjs";
+import { homeAndroidReleaseView } from "../lib/home-android-release.mjs";
+
+type AndroidReleaseMetadata = {
+  metadata_version: 1;
+  version: string;
+  version_code: number;
+  published_at: string;
+  file_name: string;
+  download_path: string;
+  size_bytes: number;
+  minimum_android_api: 24;
+  abis: ["arm64-v8a"];
+  apk_sha256: string;
+  apk_certificate_sha256: string;
+};
+
+type ReleaseState =
+  | { status: "preparing" }
+  | { status: "unavailable" }
+  | { status: "ready"; release: AndroidReleaseMetadata };
+
+type ReleaseAction =
+  | { kind: "disabled"; label: string }
+  | { kind: "download"; href: string; download: string; label: string };
+
+type HomeReleaseView = {
+  status: ReleaseState["status"];
+  action: ReleaseAction;
+  supportLine: string;
+};
+
+export function HomeAndroidDownloadAction() {
+  const [releaseState, setReleaseState] = useState<ReleaseState>({
+    status: "preparing",
+  });
+
+  useEffect(() => {
+    let active = true;
+    void loadAndroidRelease().then((nextState) => {
+      if (active) setReleaseState(nextState as ReleaseState);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const view = homeAndroidReleaseView(releaseState) as HomeReleaseView;
+
+  return (
+    <div className="release-actions">
+      {view.action.kind === "download" ? (
+        <a
+          className="button release-download-button"
+          href={view.action.href}
+          download={view.action.download}
+          aria-describedby="android-release-status"
+        >
+          {view.action.label} <span aria-hidden="true">↓</span>
+        </a>
+      ) : (
+        <button
+          className="button release-download-button"
+          type="button"
+          disabled
+        >
+          {view.action.label}
+        </button>
+      )}
+      <span
+        className={`release-status release-status-${view.status}`}
+        id="android-release-status"
+        role="status"
+        aria-live="polite"
+      >
+        <i aria-hidden="true" />
+        {view.supportLine}
+      </span>
+    </div>
+  );
+}

--- a/portal/app/marketing.css
+++ b/portal/app/marketing.css
@@ -7,7 +7,9 @@
 
 .release-site *,
 .release-site *::before,
-.release-site *::after { box-sizing: border-box; }
+.release-site *::after {
+  box-sizing: border-box;
+}
 
 .release-site h1,
 .release-site h2,
@@ -15,57 +17,392 @@
 .release-site p,
 .release-site figure,
 .release-site dl,
-.release-site dd { margin: 0; }
+.release-site dd {
+  margin: 0;
+}
 
-.release-nav { grid-template-columns: 1fr auto 1fr; }
-.release-nav > .button { justify-self: end; }
+.release-nav {
+  grid-template-columns: 1fr auto 1fr;
+}
 
-.release-hero,
-.release-method,
-.release-download,
-.release-faq,
-.download-hero,
-.download-section,
-.release-final {
+.release-nav > .button {
+  justify-self: end;
+}
+
+/* Public homepage. */
+.release-home {
+  --ink: #111;
+  --lumen: #fff;
+  --dawn: #f5f5f5;
+  --fathom: #111;
+  --glow: #111;
+  --muted: #6f7378;
+  --line: #e7e7e7;
+  background: #fff;
+}
+
+.release-home h1,
+.release-home h2 {
+  font-family: var(--font-sans);
+  letter-spacing: -0.05em;
+}
+
+.release-home .release-nav {
+  position: sticky;
+  z-index: 30;
+  top: 0;
+  width: 100%;
+  min-height: 88px;
+  margin: 0;
+  padding: 0 max(28px, calc((100% - 1280px) / 2));
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(14px);
+}
+
+.release-home .release-nav-simple {
+  grid-template-columns: 1fr auto;
+}
+
+.release-home .release-nav-simple .nav-links {
+  justify-self: end;
+}
+
+.release-home .release-nav .brand {
+  gap: 11px;
+  font-size: 22px;
+  font-weight: 720;
+}
+
+.release-home .release-nav .brand-mark,
+.release-home footer .brand-mark {
+  width: 38px;
+  height: 38px;
+}
+
+.release-home .release-nav .brand-mark img,
+.release-home footer .brand-mark img {
+  filter: grayscale(1) contrast(1.08);
+}
+
+.release-home .release-nav .nav-links {
+  gap: clamp(30px, 3vw, 48px);
+  color: #333;
+  font-size: 15px;
+  font-weight: 520;
+}
+
+.release-home .release-nav .nav-links a {
+  border: 0;
+}
+
+.release-home .release-nav .nav-links a:hover {
+  color: #000;
+}
+
+.release-home .release-hero,
+.release-home .release-method {
+  width: min(1280px, calc(100% - var(--page-gutter) * 2));
+  margin-inline: auto;
+}
+
+.release-home .release-hero {
+  min-height: calc(100svh - 88px);
+  padding: clamp(60px, 6vh, 82px) 0 clamp(72px, 8vh, 96px);
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(300px, 0.64fr);
+  align-items: center;
+  gap: clamp(64px, 8vw, 124px);
+}
+
+.release-home .release-hero-copy h1 {
+  max-width: 760px;
+  font-size: clamp(56px, 5.2vw, 76px);
+  font-weight: 720;
+  line-height: 1.12;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.release-home .release-hero-subtitle {
+  max-width: 650px;
+  margin-top: 28px !important;
+  color: var(--muted);
+  font-size: clamp(18px, 1.55vw, 21px);
+  line-height: 1.65;
+  letter-spacing: -0.012em;
+}
+
+.release-home .release-actions {
+  margin-top: 38px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.release-home .button {
+  min-height: 58px;
+  padding: 17px 25px;
+  border: 1px solid #111;
+  border-radius: 10px;
+  background: #111;
+  color: #fff;
+  font-weight: 650;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.release-home .button:hover {
+  background: #2a2a2a;
+  transform: translateY(-1px);
+}
+
+.release-home .release-download-button:disabled {
+  border-color: #dedede;
+  background: #f2f2f2;
+  color: #858585;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.release-home .release-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 520;
+}
+
+.release-home .release-status i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #111;
+  box-shadow: none;
+}
+
+.release-home .release-status-unavailable i {
+  background: #888;
+}
+
+.release-home .release-product {
+  position: relative;
+  width: 100%;
+  height: min(660px, calc(100svh - 190px));
+  min-height: 540px;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  place-items: stretch center;
+  gap: 18px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+  box-shadow: none;
+}
+
+.release-home .release-product img {
+  width: auto;
+  height: 100%;
+  min-height: 0;
+  max-height: 100%;
+  justify-self: center;
+  object-fit: contain;
+  transform: none;
+}
+
+.release-home .release-product figcaption {
+  position: static;
+  width: auto;
+  display: grid;
+  justify-items: center;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  text-align: center;
+}
+
+.release-home .release-product figcaption strong {
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.release-home .release-product figcaption span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.release-home .release-method {
+  padding: clamp(96px, 9vw, 132px) 0;
+  border-top: 1px solid var(--line);
+  background: #fff;
+}
+
+.release-home .release-method .release-section-heading {
+  max-width: 820px;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.release-home .release-method .release-section-heading h2 {
+  font-size: clamp(44px, 4.5vw, 60px);
+  font-weight: 680;
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+.release-home .release-method .eyebrow {
+  margin-bottom: 18px;
+  color: var(--muted);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+
+.release-home .release-steps {
+  margin: clamp(56px, 6vw, 76px) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(32px, 4vw, 56px);
+  list-style: none;
+}
+
+.release-home .release-steps li {
+  padding-top: 22px;
+  border-top: 1px solid #111;
+}
+
+.release-home .release-steps > li > span {
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+.release-home .release-steps h3 {
+  margin-top: 34px;
+  font-size: clamp(21px, 1.8vw, 25px);
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+
+.release-home .release-steps p {
+  margin-top: 14px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.release-home .release-memory {
+  width: 100%;
+  margin: 0;
+  padding: clamp(96px, 9vw, 132px)
+    max(var(--page-gutter), calc((100% - var(--content-width)) / 2));
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
+  gap: clamp(60px, 9vw, 132px);
+  border-radius: 0;
+  background: #111;
+  color: #fff;
+}
+
+.release-home .release-memory h2 {
+  max-width: 760px;
+  font-size: clamp(46px, 5vw, 68px);
+  font-weight: 680;
+  line-height: 1.08;
+  text-wrap: balance;
+}
+
+.release-home .release-memory dl > div {
+  padding: 22px 0 26px;
+  border-top: 1px solid rgba(255, 255, 255, 0.22);
+}
+
+.release-home .release-memory dl > div:last-child {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.22);
+}
+
+.release-home .release-memory dt {
+  margin-bottom: 7px;
+  font-size: 18px;
+  font-weight: 750;
+}
+
+.release-home .release-memory dd,
+.release-home .eyebrow-light {
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.release-home .release-memory dd {
+  line-height: 1.65;
+}
+
+.release-home footer {
+  border-top: 1px solid var(--line);
+  background: #fff;
+  color: #111;
+}
+
+/* Detailed Android release and verification page. */
+.download-page .download-hero,
+.download-page .download-section,
+.download-page .release-final {
   width: min(var(--content-width), calc(100% - var(--page-gutter) * 2));
   margin-inline: auto;
 }
 
-.release-hero {
-  min-height: 720px;
-  padding: clamp(82px, 8vw, 116px) 0 clamp(96px, 10vw, 140px);
+.download-page .download-hero {
+  padding: clamp(76px, 8vw, 112px) 0 clamp(92px, 10vw, 136px);
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.72fr);
-  align-items: center;
-  gap: clamp(54px, 8vw, 112px);
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
+  align-items: end;
+  gap: clamp(60px, 9vw, 132px);
 }
 
-.release-hero-copy h1 {
-  max-width: 720px;
-  font-size: clamp(58px, 6.2vw, 86px);
-  line-height: 0.98;
-  letter-spacing: -0.065em;
-  text-wrap: balance;
-}
-
-.release-hero-subtitle {
-  max-width: 650px;
-  margin-top: 30px !important;
+.download-page .download-back {
+  display: inline-block;
+  margin-bottom: clamp(62px, 7vw, 96px);
   color: var(--muted);
-  font-size: clamp(17px, 1.45vw, 20px);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.download-page .download-hero h1 {
+  max-width: 850px;
+  font-size: clamp(58px, 7.5vw, 104px);
+  line-height: 0.94;
+}
+
+.download-page .download-hero-copy > p:not(.eyebrow) {
+  max-width: 680px;
+  margin-top: 30px;
+  color: var(--muted);
+  font-size: 18px;
   line-height: 1.7;
 }
 
-.release-actions {
-  margin-top: 34px;
+.download-page .download-release-action {
+  margin-top: 38px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 18px;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
 }
 
-.release-status,
-.download-state > span {
+.download-page .download-state {
+  display: grid;
+  gap: 8px;
+}
+
+.download-page .download-state > span {
   display: inline-flex;
   align-items: center;
   gap: 9px;
@@ -74,8 +411,12 @@
   font-weight: 700;
 }
 
-.release-status i,
-.download-state i {
+.download-page .download-state small {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.download-page .download-state i {
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -83,135 +424,154 @@
   box-shadow: 0 0 0 4px rgba(255, 169, 70, 0.16);
 }
 
-.release-product {
-  position: relative;
-  height: 620px;
-  display: grid;
-  place-items: end center;
+.download-page .download-state-ready i {
+  background: var(--fathom);
+  box-shadow: 0 0 0 4px rgba(3, 79, 70, 0.14);
+}
+
+.download-page .download-state-unavailable i {
+  background: var(--muted);
+  box-shadow: 0 0 0 4px rgba(26, 26, 26, 0.1);
+}
+
+.download-page .download-primary-action {
+  flex: 0 0 auto;
+}
+
+.download-page .download-availability {
+  padding: 30px;
   border: 2px solid var(--ink);
-  border-radius: 42px;
+  border-radius: 28px;
   background: var(--dawn);
-  overflow: hidden;
-  box-shadow: 16px 18px 0 rgba(26, 26, 26, 0.09);
+  box-shadow: 10px 12px 0 rgba(26, 26, 26, 0.09);
 }
 
-.release-product img {
-  width: auto;
-  height: 550px;
-  object-fit: contain;
-  transform: translateY(58px);
+.download-page .download-availability h2 {
+  font-size: clamp(32px, 3.2vw, 44px);
 }
 
-.release-product-label {
-  position: absolute;
-  z-index: 2;
-  top: 24px;
-  left: 24px;
-  padding: 9px 13px;
-  border: 2px solid var(--ink);
-  border-radius: 999px;
-  background: var(--lumen);
-  font-size: 13px;
-  font-weight: 750;
+.download-page .download-availability ul {
+  margin: 30px 0 0;
+  padding: 0;
+  list-style: none;
 }
 
-.release-product figcaption {
-  position: absolute;
-  z-index: 2;
-  right: 22px;
-  bottom: 22px;
-  left: 22px;
-  display: grid;
-  gap: 4px;
-  padding: 16px 18px;
-  border: 2px solid var(--ink);
-  border-radius: 14px;
-  background: var(--lumen);
+.download-page .download-availability li {
+  padding: 13px 0;
+  border-top: 1px solid var(--line);
+  font-weight: 650;
 }
 
-.release-product figcaption strong { font-size: 16px; }
-.release-product figcaption span { color: var(--muted); font-size: 13px; }
+.download-page .download-availability li:last-child {
+  border-bottom: 1px solid var(--line);
+}
 
-.release-method,
-.release-download,
-.release-faq,
-.download-section {
+.download-page .download-section {
   padding: clamp(88px, 9vw, 128px) 0;
   border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: minmax(280px, 0.86fr) minmax(0, 1.14fr);
+  gap: clamp(60px, 9vw, 132px);
 }
 
-.release-section-heading { max-width: 840px; }
-.release-section-heading h2,
-.release-download h2,
-.download-section h2,
-.download-availability h2 {
+.download-page .download-section h2 {
   font-size: clamp(44px, 5vw, 68px);
   line-height: 1.03;
   letter-spacing: -0.055em;
   text-wrap: balance;
 }
 
-.release-steps {
-  margin: clamp(52px, 6vw, 78px) 0 0;
-  padding: 0;
+.download-page .download-section-heading > p:last-child {
+  margin-top: 22px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.download-page .download-facts > div {
+  padding: 20px 0;
+  border-top: 1px solid var(--line);
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(28px, 5vw, 70px);
+  grid-template-columns: minmax(180px, 0.75fr) minmax(170px, 1fr);
+  gap: 24px;
+}
+
+.download-page .download-facts > div:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.download-page .download-facts dt {
+  font-weight: 730;
+}
+
+.download-page .download-facts dd {
+  color: var(--muted);
+}
+
+.download-page .download-verify {
+  width: calc(100% - 32px);
+  padding-inline: max(var(--page-gutter), calc((100% - var(--content-width)) / 2));
+  border: 2px solid var(--ink);
+  border-radius: 56px;
+  background: var(--dawn);
+}
+
+.download-page .download-hashes > div {
+  padding: 28px 0;
+  border-top: 1px solid var(--line);
+}
+
+.download-page .download-hashes > div:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.download-page .download-hashes dt {
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: 760;
+}
+
+.download-page .download-hashes dd {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px;
+}
+
+.download-page .download-steps {
+  margin: 0;
+  padding: 0;
   list-style: none;
 }
 
-.release-steps li { padding-top: 24px; border-top: 2px solid var(--ink); }
-.release-steps > li > span { color: var(--fathom); font-family: var(--font-serif); font-size: 18px; }
-.release-steps h3 { margin-top: 46px; font-size: clamp(22px, 2vw, 28px); letter-spacing: -0.035em; }
-.release-steps p { margin-top: 14px; color: var(--muted); line-height: 1.7; }
-
-.release-memory {
-  width: calc(100% - 32px);
-  margin-inline: auto;
-  padding: clamp(88px, 9vw, 132px) max(var(--page-gutter), calc((100% - var(--content-width)) / 2));
+.download-page .download-steps li {
+  padding: 24px 0 28px;
+  border-top: 1px solid var(--line);
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
-  gap: clamp(60px, 9vw, 132px);
-  border-radius: 56px;
-  background: var(--ink);
-  color: var(--lumen);
+  grid-template-columns: 48px 1fr;
+  gap: 20px;
 }
 
-.release-memory h2 { max-width: 750px; font-size: clamp(48px, 6vw, 82px); line-height: 0.98; text-wrap: balance; }
-.release-memory dl > div { padding: 22px 0 26px; border-top: 1px solid rgba(255, 255, 235, 0.25); }
-.release-memory dl > div:last-child { border-bottom: 1px solid rgba(255, 255, 235, 0.25); }
-.release-memory dt { margin-bottom: 7px; font-size: 18px; font-weight: 750; }
-.release-memory dd { color: rgba(255, 255, 235, 0.66); line-height: 1.65; }
-
-.release-download {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
-  gap: clamp(62px, 9vw, 132px);
+.download-page .download-steps li:last-child {
+  border-bottom: 1px solid var(--line);
 }
 
-.release-download-copy > p:not(.eyebrow) { max-width: 620px; margin-top: 24px; color: var(--muted); line-height: 1.72; }
-.release-download-copy .button { margin-top: 30px; }
-.release-promises > div { padding: 24px 0 28px; border-top: 1px solid var(--line); }
-.release-promises > div:last-child { border-bottom: 1px solid var(--line); }
-.release-promises dt { margin-bottom: 8px; font-size: 19px; font-weight: 760; }
-.release-promises dd { color: var(--muted); line-height: 1.65; }
-
-.release-faq {
-  display: grid;
-  grid-template-columns: minmax(280px, 0.82fr) minmax(0, 1.18fr);
-  gap: clamp(62px, 9vw, 132px);
+.download-page .download-steps > li > span {
+  color: var(--fathom);
+  font-family: var(--font-serif);
 }
 
-.release-section-heading-small h2 { font-size: clamp(40px, 4.5vw, 60px); }
-.release-faq-list details { border-top: 1px solid var(--line); }
-.release-faq-list details:last-child { border-bottom: 1px solid var(--line); }
-.release-faq-list summary { min-height: 84px; display: flex; align-items: center; justify-content: space-between; gap: 24px; cursor: pointer; font-size: 18px; font-weight: 730; list-style: none; }
-.release-faq-list summary::-webkit-details-marker { display: none; }
-.release-faq-list summary span { font-size: 26px; font-weight: 400; }
-.release-faq-list details[open] summary span { transform: rotate(45deg); }
-.release-faq-list details p { max-width: 640px; padding: 0 44px 28px 0; color: var(--muted); line-height: 1.7; }
+.download-page .download-steps strong {
+  display: block;
+  margin-bottom: 7px;
+  font-size: 18px;
+}
 
-.release-final {
+.download-page .download-steps p {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.download-page .release-final {
   margin-bottom: clamp(72px, 8vw, 112px);
   padding: clamp(52px, 6vw, 76px);
   display: flex;
@@ -224,98 +584,197 @@
   box-shadow: 14px 16px 0 rgba(26, 26, 26, 0.09);
 }
 
-.release-final h2 { max-width: 760px; font-size: clamp(42px, 5vw, 66px); line-height: 1; }
-
-.download-hero {
-  padding: clamp(76px, 8vw, 112px) 0 clamp(92px, 10vw, 136px);
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.75fr);
-  align-items: end;
-  gap: clamp(60px, 9vw, 132px);
+.download-page .release-final h2 {
+  max-width: 760px;
+  font-size: clamp(42px, 5vw, 66px);
+  line-height: 1;
 }
 
-.download-back { display: inline-block; margin-bottom: clamp(62px, 7vw, 96px); color: var(--muted); font-size: 14px; font-weight: 700; }
-.download-hero h1 { max-width: 850px; font-size: clamp(58px, 7.5vw, 104px); line-height: 0.94; }
-.download-hero-copy > p:not(.eyebrow) { max-width: 680px; margin-top: 30px; color: var(--muted); font-size: 18px; line-height: 1.7; }
-.download-release-action { margin-top: 38px; padding-top: 20px; border-top: 1px solid var(--line); display: flex; align-items: end; justify-content: space-between; gap: 24px; }
-.download-state { display: grid; gap: 8px; }
-.download-state small { color: var(--muted); line-height: 1.55; }
-.download-state-ready i { background: var(--fathom); box-shadow: 0 0 0 4px rgba(3, 79, 70, 0.14); }
-.download-state-unavailable i { background: var(--muted); box-shadow: 0 0 0 4px rgba(26, 26, 26, 0.1); }
-.download-primary-action { flex: 0 0 auto; }
-
-.download-availability { padding: 30px; border: 2px solid var(--ink); border-radius: 28px; background: var(--dawn); box-shadow: 10px 12px 0 rgba(26, 26, 26, 0.09); }
-.download-availability h2 { font-size: clamp(32px, 3.2vw, 44px); }
-.download-availability ul { margin: 30px 0 0; padding: 0; list-style: none; }
-.download-availability li { padding: 13px 0; border-top: 1px solid var(--line); font-weight: 650; }
-.download-availability li:last-child { border-bottom: 1px solid var(--line); }
-
-.download-section { display: grid; grid-template-columns: minmax(280px, 0.86fr) minmax(0, 1.14fr); gap: clamp(60px, 9vw, 132px); }
-.download-section-heading > p:last-child { margin-top: 22px; color: var(--muted); line-height: 1.7; }
-.download-facts > div { padding: 20px 0; border-top: 1px solid var(--line); display: grid; grid-template-columns: minmax(180px, 0.75fr) minmax(170px, 1fr); gap: 24px; }
-.download-facts > div:last-child { border-bottom: 1px solid var(--line); }
-.download-facts dt { font-weight: 730; }
-.download-facts dd { color: var(--muted); }
-.download-verify { width: calc(100% - 32px); padding-inline: max(var(--page-gutter), calc((100% - var(--content-width)) / 2)); border: 2px solid var(--ink); border-radius: 56px; background: var(--dawn); }
-.download-hashes > div { padding: 28px 0; border-top: 1px solid var(--line); }
-.download-hashes > div:last-child { border-bottom: 1px solid var(--line); }
-.download-hashes dt { margin-bottom: 10px; font-size: 20px; font-weight: 760; }
-.download-hashes dd { color: var(--muted); overflow-wrap: anywhere; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; }
-.download-steps { margin: 0; padding: 0; list-style: none; }
-.download-steps li { padding: 24px 0 28px; border-top: 1px solid var(--line); display: grid; grid-template-columns: 48px 1fr; gap: 20px; }
-.download-steps li:last-child { border-bottom: 1px solid var(--line); }
-.download-steps > li > span { color: var(--fathom); font-family: var(--font-serif); }
-.download-steps strong { display: block; margin-bottom: 7px; font-size: 18px; }
-.download-steps p { color: var(--muted); line-height: 1.65; }
-
 @media (max-width: 900px) {
-  .release-hero { grid-template-columns: minmax(0, 1fr) 320px; gap: 34px; }
-  .release-hero-copy h1 { font-size: 58px; }
-  .release-product { height: 560px; }
-  .release-product img { height: 500px; }
-  .release-memory,
-  .release-download,
-  .release-faq,
-  .download-hero,
-  .download-section { grid-template-columns: 1fr; }
+  .release-home .release-hero {
+    grid-template-columns: minmax(0, 1fr) 300px;
+    gap: 44px;
+  }
+
+  .release-home .release-hero-copy h1 {
+    font-size: 54px;
+  }
+
+  .release-home .release-product {
+    height: 580px;
+    min-height: 0;
+  }
+
+  .release-home .release-memory,
+  .download-page .download-hero,
+  .download-page .download-section {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 640px) {
-  .release-nav .nav-links { display: none; }
-  .release-nav { grid-template-columns: 1fr auto; }
-  .release-hero { min-height: auto; padding: 72px 0 88px; grid-template-columns: 1fr; gap: 52px; }
-  .release-hero-copy h1 { font-size: clamp(43px, 12vw, 52px); line-height: 0.98; }
-  .release-hero-subtitle { margin-top: 24px !important; font-size: 16px; }
-  .release-actions { align-items: flex-start; flex-direction: column; }
-  .release-actions .button { width: 100%; }
-  .release-product { height: 520px; border-radius: 30px; box-shadow: 9px 10px 0 rgba(26, 26, 26, 0.09); }
-  .release-product img { height: 460px; transform: translateY(54px); }
-  .release-product-label { top: 16px; left: 16px; }
-  .release-product figcaption { right: 14px; bottom: 14px; left: 14px; }
-  .release-section-heading h2,
-  .release-download h2,
-  .download-section h2 { font-size: 40px; }
-  .release-steps { grid-template-columns: 1fr; gap: 36px; }
-  .release-steps h3 { margin-top: 24px; }
-  .release-memory { width: 100%; border-radius: 36px; }
-  .release-memory h2 { font-size: 46px; }
-  .release-download,
-  .release-faq { gap: 54px; }
-  .release-final { padding: 34px 26px; align-items: flex-start; flex-direction: column; border-radius: 28px; }
-  .release-final h2 { font-size: 40px; }
-  .release-final .button { width: 100%; }
-  .download-hero { padding: 58px 0 86px; gap: 50px; }
-  .download-back { margin-bottom: 58px; }
-  .download-hero h1 { font-size: 54px; }
-  .download-availability { padding: 24px 20px; }
-  .download-release-action { align-items: stretch; flex-direction: column; }
-  .download-primary-action { width: 100%; }
-  .download-verify { width: 100%; border-radius: 36px; }
-  .download-facts > div { grid-template-columns: 1fr; gap: 7px; }
-  .release-site footer { grid-template-columns: 1fr auto; padding: 28px 20px; }
-  .release-site footer p { display: none; }
+  .release-nav .nav-links {
+    display: none;
+  }
+
+  .release-nav {
+    grid-template-columns: 1fr auto;
+  }
+
+  .release-home .release-nav {
+    min-height: 72px;
+    padding: 0 20px;
+  }
+
+  .release-home .release-nav .brand {
+    font-size: 20px;
+  }
+
+  .release-home .release-nav .brand-mark {
+    width: 34px;
+    height: 34px;
+  }
+
+  .release-home .release-hero {
+    width: calc(100% - 40px);
+    min-height: 0;
+    padding: 58px 0 76px;
+    grid-template-columns: 1fr;
+    gap: 54px;
+  }
+
+  .release-home .release-hero-copy h1 {
+    max-width: 350px;
+    font-size: clamp(43px, 12vw, 52px);
+    line-height: 1.12;
+  }
+
+  .release-home .release-hero-subtitle {
+    margin-top: 22px !important;
+    font-size: 17px;
+  }
+
+  .release-home .release-actions {
+    margin-top: 32px;
+  }
+
+  .release-home .release-actions .button {
+    width: 100%;
+  }
+
+  .release-home .release-product {
+    height: 600px;
+    padding: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .release-home .release-product figcaption {
+    width: 100%;
+  }
+
+  .release-home .release-method {
+    padding: 82px 0;
+  }
+
+  .release-home .release-method .release-section-heading {
+    text-align: left;
+  }
+
+  .release-home .release-method .release-section-heading h2 {
+    font-size: 40px;
+  }
+
+  .release-home .release-steps {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+
+  .release-home .release-steps h3 {
+    margin-top: 24px;
+  }
+
+  .release-home .release-memory {
+    padding: 82px 20px;
+    border-radius: 0;
+  }
+
+  .release-home .release-memory h2 {
+    font-size: 44px;
+  }
+
+  .download-page .download-hero {
+    padding: 58px 0 86px;
+    gap: 50px;
+  }
+
+  .download-page .download-back {
+    margin-bottom: 58px;
+  }
+
+  .download-page .download-hero h1 {
+    font-size: 54px;
+  }
+
+  .download-page .download-availability {
+    padding: 24px 20px;
+  }
+
+  .download-page .download-release-action {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .download-page .download-primary-action {
+    width: 100%;
+  }
+
+  .download-page .download-section h2 {
+    font-size: 40px;
+  }
+
+  .download-page .download-verify {
+    width: 100%;
+    border-radius: 36px;
+  }
+
+  .download-page .download-facts > div {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+
+  .download-page .release-final {
+    padding: 34px 26px;
+    align-items: flex-start;
+    flex-direction: column;
+    border-radius: 28px;
+  }
+
+  .download-page .release-final h2 {
+    font-size: 40px;
+  }
+
+  .download-page .release-final .button {
+    width: 100%;
+  }
+
+  .release-site footer {
+    grid-template-columns: 1fr auto;
+    padding: 28px 20px;
+  }
+
+  .release-site footer p {
+    display: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .release-site * { scroll-behavior: auto !important; transition: none !important; }
+  .release-site * {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+
+  .release-home .button:hover {
+    transform: none;
+  }
 }

--- a/portal/app/page.tsx
+++ b/portal/app/page.tsx
@@ -1,90 +1,119 @@
-import Link from "next/link";
+import type { Metadata } from "next";
 import BrandMark from "./BrandMark";
+import { HomeAndroidDownloadAction } from "./HomeAndroidRelease";
+
+export const metadata: Metadata = {
+  title: "SpeakUp · 有记忆的 AI 口语老师",
+  description:
+    "围绕真实沟通场景练习、反馈和复盘，下载 SpeakUp Android APK。",
+};
 
 const steps = [
-  { number: "01", title: "说清楚你要面对什么", copy: "英文面试、工作汇报、考试或生活沟通——从下一件真实发生的事开始。" },
-  { number: "02", title: "围绕目标反复开口", copy: "SpeakUp 组织针对性练习、模拟对话并给出反馈，不让准备停在背答案。" },
-  { number: "03", title: "把进展带到下一次", copy: "你的目标、经历和卡点会成为后续练习的上下文，让每一轮真正接得上。" },
-];
-
-const releasePromises = [
-  ["唯一官方下载", "APK 就绪前不放空链接、临时二维码或未经核验的文件。"],
-  ["制品信息完整", "版本、发布时间、兼容范围、文件大小与 ABI 会随 APK 一起公开。"],
-  ["可以独立验证", "APK 文件 SHA-256 与签名证书 SHA-256 分开提供。"],
-];
-
-const faqs = [
-  ["现在可以下载 Android 版吗？", "还不可以。首个正式 APK 正在准备，完成正式签名和生产验证后才会开放入口。"],
-  ["为什么现在不先放一个测试包？", "公开下载页只承载可追溯的正式制品，避免测试包、临时链接和正式版本混在一起。"],
-  ["开放下载时会提供什么？", "会同时提供版本、系统要求、文件大小、ABI、文件 SHA-256、签名证书 SHA-256、安装说明与更新记录。"],
+  {
+    number: "01",
+    title: "说清楚你要面对什么",
+    copy: "英文面试、工作汇报、考试或生活沟通——从下一件真实发生的事开始。",
+  },
+  {
+    number: "02",
+    title: "围绕目标反复开口",
+    copy: "SpeakUp 组织针对性练习、模拟对话并给出反馈，不让准备停在背答案。",
+  },
+  {
+    number: "03",
+    title: "把进展带到下一次",
+    copy: "你的目标、经历和卡点会成为后续练习的上下文，让每一轮真正接得上。",
+  },
 ];
 
 export default function Home() {
   return (
-    <main className="release-site" id="top">
-      <nav className="site-nav release-nav" aria-label="主导航">
-        <a className="brand" href="#top" aria-label="SpeakUp 首页"><BrandMark /><span>SpeakUp</span></a>
-        <div className="nav-links"><a href="#method">怎么练</a><a href="#download">Android 发布</a></div>
-        <Link className="button button-small" href="/download/android">查看下载状态</Link>
+    <main className="release-site release-home" id="top">
+      <nav className="site-nav release-nav release-nav-simple" aria-label="主导航">
+        <a className="brand" href="#top" aria-label="SpeakUp 首页">
+          <BrandMark />
+          <span>SpeakUp</span>
+        </a>
+        <div className="nav-links">
+          <a href="#top">产品介绍</a>
+          <a href="#method">怎么练</a>
+          <a href="#memory">长期记忆</a>
+        </div>
       </nav>
 
-      <header className="release-hero">
+      <header className="release-hero" id="download">
         <div className="release-hero-copy">
-          <p className="eyebrow">有记忆的 AI 口语老师</p>
-          <h1>下一场重要的英文沟通，先和 SpeakUp 练一遍。</h1>
-          <p className="release-hero-subtitle">围绕你真正要面对的任务，准备、开口、复盘。不是背一套标准答案，而是把自己的经历练成说得出口的表达。</p>
-          <div className="release-actions">
-            <Link className="button" href="/download/android">查看 Android 发布状态 <span aria-hidden="true">↗</span></Link>
-            <span className="release-status"><i aria-hidden="true" />首个 APK 正在准备</span>
-          </div>
+          <h1>为下一场重要的英文沟通，先练一遍。</h1>
+          <p className="release-hero-subtitle">
+            有记忆的 AI 口语老师，围绕真实任务陪你准备、开口和复盘。
+          </p>
+          <HomeAndroidDownloadAction />
         </div>
 
         <figure className="release-product">
-          <span className="release-product-label">真实产品界面 · 英文面试</span>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/assets/portal-shots/portal-interview-practice.png" alt="SpeakUp 根据后端开发面试目标准备项目经历深挖练习" width="884" height="1832" />
-          <figcaption><strong>从一句真实需求开始</strong><span>按目标准备练习，准备好就直接开口。</span></figcaption>
+          <img
+            src="/assets/portal-shots/portal-interview-practice.png"
+            alt="SpeakUp 根据后端开发面试目标准备项目经历深挖练习"
+            width="884"
+            height="1832"
+          />
+          <figcaption>
+            <strong>真实产品界面 · 英文面试</strong>
+            <span>围绕真实任务练习、反馈和复盘。</span>
+          </figcaption>
         </figure>
       </header>
 
       <section className="release-method" id="method" aria-labelledby="method-title">
-        <div className="release-section-heading"><p className="eyebrow">怎么练</p><h2 id="method-title">把“我要学英语”，变成下一次具体的准备。</h2></div>
+        <div className="release-section-heading">
+          <p className="eyebrow">怎么练</p>
+          <h2 id="method-title">把“我要学英语”，变成下一次具体的准备。</h2>
+        </div>
         <ol className="release-steps">
-          {steps.map((step) => <li key={step.number}><span>{step.number}</span><h3>{step.title}</h3><p>{step.copy}</p></li>)}
+          {steps.map((step) => (
+            <li key={step.number}>
+              <span>{step.number}</span>
+              <h3>{step.title}</h3>
+              <p>{step.copy}</p>
+            </li>
+          ))}
         </ol>
       </section>
 
-      <section className="release-memory" aria-labelledby="memory-title">
-        <div><p className="eyebrow eyebrow-light">长期记忆</p><h2 id="memory-title">这次练习里发生的事，下一次还记得。</h2></div>
+      <section
+        className="release-memory"
+        id="memory"
+        aria-labelledby="memory-title"
+      >
+        <div>
+          <p className="eyebrow eyebrow-light">长期记忆</p>
+          <h2 id="memory-title">这次练习里发生的事，下一次还记得。</h2>
+        </div>
         <dl>
-          <div><dt>你的目标</dt><dd>下一次重要沟通是什么，想进入怎样的团队。</dd></div>
-          <div><dt>你的真实经历</dt><dd>做过哪些项目，哪些故事能成为表达素材。</dd></div>
-          <div><dt>你的能力变化</dt><dd>哪些问题反复卡住，哪些表达已经更自然。</dd></div>
+          <div>
+            <dt>你的目标</dt>
+            <dd>下一次重要沟通是什么，想进入怎样的团队。</dd>
+          </div>
+          <div>
+            <dt>你的真实经历</dt>
+            <dd>做过哪些项目，哪些故事能成为表达素材。</dd>
+          </div>
+          <div>
+            <dt>你的能力变化</dt>
+            <dd>哪些问题反复卡住，哪些表达已经更自然。</dd>
+          </div>
         </dl>
       </section>
 
-      <section className="release-download" id="download" aria-labelledby="download-title">
-        <div className="release-download-copy">
-          <p className="eyebrow">Android 官方发布</p><h2 id="download-title">下载要直接，制品也要说得清楚。</h2>
-          <p>当前没有可公开下载和验证的正式 APK。页面先把发布规则讲明白，制品完成后再把唯一入口放出来。</p>
-          <Link className="button" href="/download/android">查看完整发布状态 <span aria-hidden="true">↗</span></Link>
-        </div>
-        <dl className="release-promises">{releasePromises.map(([title, copy]) => <div key={title}><dt>{title}</dt><dd>{copy}</dd></div>)}</dl>
-      </section>
-
-      <section className="release-faq" aria-labelledby="faq-title">
-        <div className="release-section-heading release-section-heading-small"><p className="eyebrow">常见问题</p><h2 id="faq-title">下载前，先把关键问题讲明白。</h2></div>
-        <div className="release-faq-list">
-          {faqs.map(([question, answer]) => <details key={question}><summary>{question}<span aria-hidden="true">＋</span></summary><p>{answer}</p></details>)}
-        </div>
-      </section>
-
-      <section className="release-final" aria-labelledby="final-title">
-        <div><p className="eyebrow">Android 版本准备中</p><h2 id="final-title">准备完成后，只从这里下载。</h2></div>
-        <Link className="button" href="/download/android">前往 Android 下载页 <span aria-hidden="true">↗</span></Link>
-      </section>
-
-      <footer><a className="brand" href="#top"><BrandMark /><span>SpeakUp</span></a><p>为真实世界准备英文表达。</p><span>© 2026 SpeakUp</span></footer>
+      <footer>
+        <a className="brand" href="#top">
+          <BrandMark />
+          <span>SpeakUp</span>
+        </a>
+        <p>为真实世界准备英文表达。</p>
+        <span>© 2026 SpeakUp</span>
+      </footer>
     </main>
   );
 }

--- a/portal/design-qa.md
+++ b/portal/design-qa.md
@@ -1,17 +1,34 @@
 # Portal design QA
 
-- Reference: Kimi official download page, used for the compact navigation, clear release hierarchy, direct primary action, and restrained information density.
-- Brand continuity: retained SpeakUp's existing logo, cream/lavender palette, serif display type, black outlines, and real product screenshot.
-- Desktop and tablet: checked at 1440 × 900 and 768 × 1024; hero, product image, CTA, Android status, and download page render without overlap or clipping.
-- Mobile: checked at 390 × 844; navigation collapses, content becomes single-column, CTA remains full-width, and download metadata stays readable.
-- Android publication: rechecked the honest preparing state at 1440 × 900 and
-  390 × 844 after adding the metadata-driven download action; no overlap,
-  clipping, gradient, extra nested card, fake QR code, or `latest.apk` link was
-  introduced.
-- Interaction: Android CTA route and native FAQ expansion verified.
-- Release states: automated contract tests cover preparing, unavailable, and
-  ready results; only ready metadata carries the validated versioned APK path.
-- Runtime: no application console errors observed.
-- Automated verification: lint, tests, and production build passed.
+- Reference: ByteDance Seed's restrained editorial layout, adapted rather than
+  copied: quiet full-width navigation, black-and-white hierarchy, one primary
+  action, generous spacing, and product media on the right.
+- Product continuity: retained the existing SpeakUp mascot, real interview
+  practice screenshot, product positioning, practice method, and long-term
+  memory explanation.
+- Public homepage: presents one Android APK action at the top. It does not
+  expose signing, SHA-256, ABI, FAQ, release promises, or a second download
+  route.
+- Desktop: checked at 1440 × 900. The hero fits one viewport, the complete
+  phone remains visible, navigation anchors reach visible headings, and no
+  horizontal overflow occurs.
+- Tablet: checked at 768 × 1024. The hero remains two-column, the long-term
+  memory section becomes one-column, and no horizontal overflow occurs.
+- Mobile: checked at 390 × 844 and the 640 px breakpoint. Navigation collapses,
+  the CTA becomes full-width, the phone follows the release action, and no
+  clipping or horizontal overflow occurs.
+- Release states: preparing and unavailable states keep the action disabled;
+  ready metadata produces exactly one versioned APK link with the matching
+  download filename.
+- Android detail page: remains a separate technical verification surface at
+  `/download/android`; homepage selectors are scoped under `.release-home`
+  and no longer alter that page's navigation, buttons, typography, or theme.
+- Interaction: the ready-state action was verified to use the exact versioned
+  APK path and trigger a native download. Focus-visible styles remain available
+  for the brand, navigation links, and action.
+- Runtime: no application console errors were observed during the desktop and
+  mobile checks.
+- Automated verification: lint, unit tests, rendered HTML checks, production
+  build, and `git diff --check` must pass on the final clean worktree.
 
-final result: passed
+Final result: passed.

--- a/portal/lib/home-android-release.mjs
+++ b/portal/lib/home-android-release.mjs
@@ -1,0 +1,33 @@
+export function homeAndroidReleaseView(state) {
+  if (state.status === "ready") {
+    const { release } = state;
+    return {
+      status: "ready",
+      action: {
+        kind: "download",
+        href: release.download_path,
+        download: release.file_name,
+        label: "下载 Android APK",
+      },
+      supportLine: `Android 7.0 及以上 · 当前版本 v${release.version}`,
+    };
+  }
+
+  if (state.status === "unavailable") {
+    return {
+      status: "unavailable",
+      action: { kind: "disabled", label: "下载暂不可用" },
+      supportLine: "发布信息暂时无法验证，请稍后重试",
+    };
+  }
+
+  if (state.status === "preparing") {
+    return {
+      status: "preparing",
+      action: { kind: "disabled", label: "Android 版本准备中" },
+      supportLine: "正式 APK 就绪后开放下载",
+    };
+  }
+
+  throw new Error("Unknown Android release state");
+}

--- a/portal/tests/home-android-release.test.mjs
+++ b/portal/tests/home-android-release.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { homeAndroidReleaseView } from "../lib/home-android-release.mjs";
+
+const release = {
+  version: "0.1.2",
+  file_name: "speakup-v0.1.2-production-arm64.apk",
+  download_path:
+    "/downloads/android/v0.1.2/speakup-v0.1.2-production-arm64.apk",
+};
+
+test("ready homepage exposes one exact validated versioned APK action", () => {
+  const view = homeAndroidReleaseView({ status: "ready", release });
+
+  assert.equal(view.status, "ready");
+  assert.deepEqual(view.action, {
+    kind: "download",
+    href: release.download_path,
+    download: release.file_name,
+    label: "下载 Android APK",
+  });
+  assert.equal(view.supportLine, "Android 7.0 及以上 · 当前版本 v0.1.2");
+});
+
+test("preparing homepage keeps the APK action disabled", () => {
+  const view = homeAndroidReleaseView({ status: "preparing" });
+
+  assert.equal(view.status, "preparing");
+  assert.deepEqual(view.action, {
+    kind: "disabled",
+    label: "Android 版本准备中",
+  });
+  assert.match(view.supportLine, /正式 APK 就绪后开放下载/);
+  assert.doesNotMatch(JSON.stringify(view), /\.apk(?:"|\\)/i);
+});
+
+test("unavailable homepage fails closed without guessing an APK URL", () => {
+  const view = homeAndroidReleaseView({ status: "unavailable" });
+
+  assert.equal(view.status, "unavailable");
+  assert.deepEqual(view.action, {
+    kind: "disabled",
+    label: "下载暂不可用",
+  });
+  assert.match(view.supportLine, /无法验证/);
+  assert.doesNotMatch(JSON.stringify(view), /\/downloads\/.*\.apk/i);
+});
+
+test("unknown release states cannot silently look like preparing", () => {
+  assert.throws(
+    () => homeAndroidReleaseView({ status: "unknown" }),
+    /Unknown Android release state/,
+  );
+});

--- a/portal/tests/rendered-html.test.mjs
+++ b/portal/tests/rendered-html.test.mjs
@@ -19,16 +19,17 @@ test("renders the standalone SpeakUp portal", async () => {
   assert.equal(response.status, 200);
 
   const html = await response.text();
-  assert.match(html, /下一场重要的英文沟通，先和 SpeakUp 练一遍/);
+  assert.match(html, /为下一场重要的英文沟通，先练一遍/);
   assert.match(html, /有记忆的 AI 口语老师/);
+  assert.match(html, /Android 版本准备中/);
+  assert.match(html, /正式 APK 就绪后开放下载/);
+  assert.match(html, /怎么练/);
+  assert.match(html, /长期记忆/);
   assert.match(html, /portal-interview-practice\.png/);
-  assert.match(html, /href="\/download\/android"/);
-  assert.match(html, /首个 APK 正在准备/);
-  assert.doesNotMatch(html, /portal-memory-chat\.jpg/);
-  assert.doesNotMatch(html, /assets\/practice-screen\//);
-  assert.doesNotMatch(html, /latest\.apk/);
-  assert.doesNotMatch(html, /id="early-access"/);
-  assert.doesNotMatch(html, /href="\/pages\/prototype\.html/);
+  assert.doesNotMatch(html, /href="\/download\/android"/);
+  assert.doesNotMatch(html, /常见问题|唯一官方下载|制品信息完整/);
+  assert.doesNotMatch(html, /SHA-256|签名证书|ABI/);
+  assert.doesNotMatch(html, /\/downloads\/.*\.apk/);
 });
 
 test("renders an honest Android download preparing state", async () => {


### PR DESCRIPTION
## 功能描述

- Portal 首页读取并复用严格校验的 Android release metadata。
- ready 时在顶部展示唯一版本化 APK 下载入口和当前版本。
- metadata 404 时保持 preparing；网络、HTTP、JSON 或 schema 失败时 fail closed 为 unavailable，不猜测 APK 地址。
- 按已验收方案收敛为黑白产品发布首页，保留真实产品界面、“怎么练”和“长期记忆”。
- 移除首页重复下载区、发布承诺、FAQ、底部 CTA 及签名/SHA/ABI 等技术字段。
- /download/android 继续作为独立技术验证页，首页样式不再污染该路由。

## 实现思路

- 使用小型 Client Component 加载现有 /downloads/android/release.json。
- 通过纯函数将 ready / preparing / unavailable 映射为唯一可下载或禁用动作。
- 首页样式统一限定在 .release-home，下载详情页规则限定在 .download-page。
- 未新增接口、运行时依赖或 release metadata 字段。

## 可复现测试

~~~bash
cd portal
npm run lint
npm test
~~~

结果：19/19 tests passed，production build passed。

~~~bash
docker build --file portal/Dockerfile \
  --tag speakup-portal:issue-888-check portal
~~~

结果：Portal production Docker image build passed。

手动视觉与交互验证：

- 1440 × 900 desktop
- 768 × 1024 tablet
- 390 × 844 mobile
- 640 px mobile breakpoint
- ready fixture 下恰好一个 a[download]
- 版本化 href 与 download filename 精确匹配
- 点击触发原生下载
- 无横向溢出、旧文案残留或控制台错误
- /download/android desktop/mobile 无布局回归

## 提交边界

PR 不包含 APK、临时 release metadata、node_modules、Secret 或构建产物。

Closes #888
Related #869
Related #886