### PR TITLE
fix(android): 显式签名正式 APK

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,8 +65,12 @@ jobs:
             deploy=true
           }
 
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_call" ]]; then
+            # Release Candidate runs the protected real-APK job downstream.
             set_all_checks
+          elif [[ "$EVENT_NAME" != "pull_request" ]]; then
+            set_all_checks
+            android_release=true
           elif [[ "$BASE_REF" == "main" ]]; then
             set_all_checks
             android_release=true

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,6 +31,7 @@ jobs:
       api: ${{ steps.scope.outputs.api }}
       portal: ${{ steps.scope.outputs.portal }}
       deploy: ${{ steps.scope.outputs.deploy }}
+      android_release: ${{ steps.scope.outputs.android_release }}
     steps:
       - name: Check out repository history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,6 +55,7 @@ jobs:
           api=false
           portal=false
           deploy=false
+          android_release=false
 
           set_all_checks() {
             flutter=true
@@ -63,8 +65,11 @@ jobs:
             deploy=true
           }
 
-          if [[ "$EVENT_NAME" != "pull_request" || "$BASE_REF" == "main" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
             set_all_checks
+          elif [[ "$BASE_REF" == "main" ]]; then
+            set_all_checks
+            android_release=true
           else
             git cat-file -e "${BASE_SHA}^{commit}"
             git cat-file -e "${HEAD_SHA}^{commit}"
@@ -78,14 +83,19 @@ jobs:
             while IFS= read -r -d '' file; do
               printf 'Changed file: %q\n' "$file"
               case "$file" in
-                Makefile|.github/workflows/quality.yml|.github/workflows/database.yml|.github/workflows/coverage-comment.yml)
+                Makefile|.github/workflows/quality.yml|.github/workflows/release-candidate.yml)
                   set_all_checks
+                  android_release=true
                   ;;
-                .github/workflows/release-candidate.yml|tools/release-candidate/*)
+                .github/workflows/database.yml|.github/workflows/coverage-comment.yml|tools/release-candidate/*)
                   set_all_checks
                   ;;
                 tools/android-download/*)
                   deploy=true
+                  ;;
+                mobile/android/*|mobile/pubspec.yaml|mobile/pubspec.lock|tools/android-release/*)
+                  flutter=true
+                  android_release=true
                   ;;
                 mobile/*)
                   flutter=true
@@ -112,6 +122,7 @@ jobs:
             echo "api=$api"
             echo "portal=$portal"
             echo "deploy=$deploy"
+            echo "android_release=$android_release"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
@@ -158,6 +169,86 @@ jobs:
           path: mobile/coverage/lcov.info
           if-no-files-found: error
           retention-days: 14
+
+  android-release:
+    name: Android release signing fixture
+    needs: changes
+    if: needs.changes.outputs.android_release == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: "3.44.6"
+          channel: stable
+
+      - name: Restore Pub package cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-flutter-3.44.6-${{ hashFiles('mobile/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-flutter-3.44.6-
+
+      - name: Prepare disposable release signing fixture
+        run: |
+          set -euo pipefail
+          umask 077
+          signing_directory="$RUNNER_TEMP/android-release-fixture"
+          keystore_path="$signing_directory/release.jks"
+          install -d -m 700 "$signing_directory"
+          keytool -genkeypair \
+            -noprompt \
+            -storetype JKS \
+            -keystore "$keystore_path" \
+            -storepass fixture-password \
+            -keypass fixture-password \
+            -alias speakup-release \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity 3650 \
+            -dname "CN=SpeakUp CI Fixture,O=XE3,C=CN" \
+            >/dev/null 2>&1
+          certificate_sha256="$(
+            keytool \
+              -J-Duser.language=en \
+              -J-Duser.country=US \
+              -list \
+              -v \
+              -keystore "$keystore_path" \
+              -alias speakup-release \
+              -storepass fixture-password |
+              sed -n 's/^[[:space:]]*SHA256: //p' |
+              head -n 1 |
+              tr '[:upper:]' '[:lower:]' |
+              tr -d '[:space:]:'
+          )"
+          [[ "$certificate_sha256" =~ ^[0-9a-f]{64}$ ]]
+          {
+            echo "SPEAKUP_ANDROID_KEYSTORE_PATH=$keystore_path"
+            echo "SPEAKUP_ANDROID_KEY_ALIAS=speakup-release"
+            echo "SPEAKUP_ANDROID_STORE_PASSWORD=fixture-password"
+            echo "SPEAKUP_ANDROID_KEY_PASSWORD=fixture-password"
+            echo "SPEAKUP_ANDROID_CERT_SHA256=$certificate_sha256"
+          } >> "$GITHUB_ENV"
+
+      - name: Build and verify both explicitly signed APKs
+        run: |
+          set -euo pipefail
+          make build-android-release-staging
+          make build-android-release-production
+
+      - name: Remove disposable release signing fixture
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/android-release-fixture/release.jks"
+          rmdir "$RUNNER_TEMP/android-release-fixture" 2>/dev/null || true
 
   go:
     name: Go
@@ -620,6 +711,7 @@ jobs:
     needs:
       - changes
       - flutter
+      - android-release
       - go
       - api
       - portal
@@ -633,6 +725,8 @@ jobs:
       CHANGES_RESULT: ${{ needs.changes.result }}
       FLUTTER_REQUIRED: ${{ needs.changes.outputs.flutter }}
       FLUTTER_RESULT: ${{ needs.flutter.result }}
+      ANDROID_RELEASE_REQUIRED: ${{ needs.changes.outputs.android_release }}
+      ANDROID_RELEASE_RESULT: ${{ needs.android-release.result }}
       GO_REQUIRED: ${{ needs.changes.outputs.go }}
       GO_RESULT: ${{ needs.go.result }}
       API_REQUIRED: ${{ needs.changes.outputs.api }}
@@ -684,6 +778,10 @@ jobs:
           }
 
           require_result "Flutter" "$FLUTTER_REQUIRED" "$FLUTTER_RESULT"
+          require_result \
+            "Android release signing fixture" \
+            "$ANDROID_RELEASE_REQUIRED" \
+            "$ANDROID_RELEASE_RESULT"
           require_result "Go" "$GO_REQUIRED" "$GO_RESULT"
           require_result "API contracts" "$API_REQUIRED" "$API_RESULT"
           require_result "Portal" "$PORTAL_REQUIRED" "$PORTAL_RESULT"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -210,7 +210,7 @@ jobs:
           ./tools/android-release/verify-keystore.sh "$keystore_path"
           echo "SPEAKUP_ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
 
-      - name: Build signed Staging and Production APKs
+      - name: Build explicitly signed Staging and Production APKs
         env:
           SPEAKUP_ANDROID_KEY_ALIAS: ${{ secrets.SPEAKUP_ANDROID_KEY_ALIAS }}
           SPEAKUP_ANDROID_STORE_PASSWORD: ${{ secrets.SPEAKUP_ANDROID_STORE_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -93,20 +93,55 @@ check-android-release-guard: check-flutter-dependencies
 	@set -euo pipefail; \
 	output_file="$$(mktemp)"; \
 	trap 'rm -f "$$output_file"' EXIT; \
-	if cd mobile && env \
-		-u SPEAKUP_ANDROID_KEYSTORE_PATH \
-		-u SPEAKUP_ANDROID_KEY_ALIAS \
-		-u SPEAKUP_ANDROID_STORE_PASSWORD \
-		-u SPEAKUP_ANDROID_KEY_PASSWORD \
-		flutter build apk --release --flavor production \
-			--target-platform android-arm64 >"$$output_file" 2>&1; then \
-		printf '%s\n' 'Release build unexpectedly succeeded without signing secrets.' >&2; \
+	if ( \
+		cd mobile && \
+		env -u SPEAKUP_ANDROID_EXTERNAL_SIGNING \
+			flutter build apk --release --flavor production \
+				--target-platform android-arm64 \
+	) >"$$output_file" 2>&1; then \
+		printf '%s\n' 'Release build bypassed the explicit signing pipeline.' >&2; \
 		exit 1; \
 	fi; \
-	if ! grep -Fq 'Missing Android release signing environment variables' "$$output_file"; then \
+	if ! grep -Fq 'Android release APKs must use the explicit Makefile signing targets.' "$$output_file"; then \
 		printf '%s\n' 'Release build failed before the signing guard was reached.' >&2; \
+		cat "$$output_file" >&2; \
 		exit 1; \
-	fi
+	fi; \
+	gradle_java_home="$${JAVA_HOME:-$$( \
+		flutter config --machine | \
+			sed -n 's/^[[:space:]]*"jdk-dir": "\([^"]*\)".*/\1/p' \
+	)}"; \
+	if [[ ! -x "$$gradle_java_home/bin/java" ]]; then \
+		printf '%s\n' 'Cannot locate the JDK configured for Flutter.' >&2; \
+		exit 1; \
+	fi; \
+	for task in \
+		app:assembleStaging \
+		app:assembleProduction \
+		app:bundleStaging \
+		app:bundleProduction; do \
+		: >"$$output_file"; \
+		if ( \
+			cd mobile/android && \
+			env -u SPEAKUP_ANDROID_EXTERNAL_SIGNING \
+				JAVA_HOME="$$gradle_java_home" \
+				PATH="$$gradle_java_home/bin:$$PATH" \
+				./gradlew --dry-run "$$task" \
+		) >"$$output_file" 2>&1; then \
+			printf 'Gradle task bypassed the explicit signing pipeline: %s\n' \
+				"$$task" >&2; \
+			exit 1; \
+		fi; \
+		if ! grep -Fq \
+			'Android release APKs must use the explicit Makefile signing targets.' \
+			"$$output_file"; then \
+			printf 'Gradle task failed before the signing guard: %s\n' \
+				"$$task" >&2; \
+			cat "$$output_file" >&2; \
+			exit 1; \
+		fi; \
+	done
+	./tools/android-release/sign.test.sh
 
 check-go: check-go-test
 
@@ -264,6 +299,7 @@ check-api-contracts: check-api-dependencies
 
 check-release-candidate:
 	./tools/android-release/verify-keystore.test.sh
+	./tools/android-release/sign.test.sh
 	./tools/android-release/verify.test.sh
 	node --test tools/release-candidate/*.test.mjs
 
@@ -303,28 +339,28 @@ dev-ios-simulator:
 	./tools/ios-simulator-dev/run.sh
 
 build-android-release-staging:
-	@test -n "$${SPEAKUP_ANDROID_CERT_SHA256:-}" || { \
-		printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 is required.' >&2; \
-		exit 1; \
-	}
-	cd mobile && flutter build apk \
+	./tools/android-release/verify-keystore.sh \
+		"$${SPEAKUP_ANDROID_KEYSTORE_PATH:-}"
+	cd mobile && SPEAKUP_ANDROID_EXTERNAL_SIGNING=true flutter build apk \
 		--release \
 		--flavor staging \
 		--target-platform android-arm64 \
 		--dart-define=SPEAKUP_API_BASE_URL=https://staging-api.speak-up.top
+	./tools/android-release/sign.sh \
+		mobile/build/app/outputs/flutter-apk/app-staging-release.apk
 	./tools/android-release/verify.sh \
 		mobile/build/app/outputs/flutter-apk/app-staging-release.apk
 
 build-android-release-production:
-	@test -n "$${SPEAKUP_ANDROID_CERT_SHA256:-}" || { \
-		printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 is required.' >&2; \
-		exit 1; \
-	}
-	cd mobile && flutter build apk \
+	./tools/android-release/verify-keystore.sh \
+		"$${SPEAKUP_ANDROID_KEYSTORE_PATH:-}"
+	cd mobile && SPEAKUP_ANDROID_EXTERNAL_SIGNING=true flutter build apk \
 		--release \
 		--flavor production \
 		--target-platform android-arm64 \
 		--dart-define=SPEAKUP_API_BASE_URL=https://api.speak-up.top
+	./tools/android-release/sign.sh \
+		mobile/build/app/outputs/flutter-apk/app-production-release.apk
 	./tools/android-release/verify.sh \
 		mobile/build/app/outputs/flutter-apk/app-production-release.apk
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -30,7 +30,7 @@ Android 真机上运行 App。连接多台设备时，可通过
 首发网站分发基线为：
 
 - applicationId：`com.xengineer.speakup`
-- versionName/versionCode：`0.1.2` / `3`（Release Tag：`v0.1.2`）
+- versionName/versionCode：`0.1.3` / `4`（Release Tag：`v0.1.3`）
 - ABI：仅 `arm64-v8a`
 - staging API 发布契约：`https://staging-api.speak-up.top`
 - production API 发布契约：`https://api.speak-up.top`
@@ -57,10 +57,14 @@ CI Secret 中提供以下环境变量：
 - `SPEAKUP_ANDROID_KEY_PASSWORD`
 - `SPEAKUP_ANDROID_CERT_SHA256`（公开证书指纹，仅用于产物校验）
 
-前四项有任一缺失、空值或 keystore 文件不可读时，release Gradle 配置立即失败；
-release 不再使用 debug signing。不要把 keystore、密码、`key.properties`、终端
-输出或 CI Secret 提交到仓库。首次网站发布后必须长期保管同一 app signing key，
-否则后续 APK 无法作为更新安装。
+五项有任一缺失、空值、密码不正确或 keystore 文件不可读时，专用构建入口会在
+耗时构建前失败。普通 Gradle/Flutter release 命令也会 fail closed；只能使用下方
+两个 Makefile 目标。目标先生成 unsigned APK，再执行 `zipalign -P 16`，最后由
+`apksigner` 使用批准 keystore 显式签名一次；输入若已签名会被拒绝，不会二次
+签名或回落到 debug signing。内部变量 `SPEAKUP_ANDROID_EXTERNAL_SIGNING` 只由
+Makefile 设置，不得手动绕过入口。不要把 keystore、密码、`key.properties`、
+终端输出或 CI Secret 提交到仓库。首次网站发布后必须长期保管同一 app signing
+key，否则后续 APK 无法作为更新安装。
 
 ### 构建与校验
 
@@ -72,7 +76,8 @@ make build-android-release-staging
 make build-android-release-production
 ```
 
-两个 build 入口都会在构建后立即执行完整校验；如果只需重新检查现有产物：
+两个 build 入口都会先校验 keystore，再构建、对齐、签名并立即执行完整产物
+校验；如果只需重新检查现有产物：
 
 ```shell
 make verify-android-release-staging
@@ -92,6 +97,7 @@ make check-android-release-guard
 参考：[Flutter Android flavors](https://docs.flutter.dev/deployment/flavors)、
 [Flutter Android 发布](https://docs.flutter.dev/deployment/android)、
 [Android App Signing](https://developer.android.com/studio/publish/app-signing)、
+[zipalign](https://developer.android.com/tools/zipalign)、
 [apksigner](https://developer.android.com/tools/apksigner)。
 
 ## iOS 模拟器调试

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -5,35 +5,22 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
-val releaseSigningVariableNames = listOf(
-    "SPEAKUP_ANDROID_KEYSTORE_PATH",
-    "SPEAKUP_ANDROID_KEY_ALIAS",
-    "SPEAKUP_ANDROID_STORE_PASSWORD",
-    "SPEAKUP_ANDROID_KEY_PASSWORD",
+val externalReleaseSigning =
+    providers.environmentVariable("SPEAKUP_ANDROID_EXTERNAL_SIGNING").orNull == "true"
+val applicationProjectPath = project.path
+gradle.taskGraph.whenReady(
+    org.gradle.api.Action<org.gradle.api.execution.TaskExecutionGraph> {
+        val releaseTaskRequested = allTasks.any { task ->
+            task.project.path == applicationProjectPath &&
+                task.name.contains("release", ignoreCase = true)
+        }
+        if (releaseTaskRequested && !externalReleaseSigning) {
+            throw GradleException(
+                "Android release APKs must use the explicit Makefile signing targets.",
+            )
+        }
+    },
 )
-val releaseBuildRequested = gradle.startParameter.taskNames.any {
-    it.contains("release", ignoreCase = true)
-}
-val releaseSigningValues = releaseSigningVariableNames.associateWith {
-    providers.environmentVariable(it).orNull
-}
-val missingReleaseSigningVariables = releaseSigningValues
-    .filterValues { it.isNullOrBlank() }
-    .keys
-
-if (releaseBuildRequested && missingReleaseSigningVariables.isNotEmpty()) {
-    throw GradleException(
-        "Missing Android release signing environment variables: " +
-            missingReleaseSigningVariables.joinToString(", "),
-    )
-}
-
-val releaseKeystore = releaseSigningValues["SPEAKUP_ANDROID_KEYSTORE_PATH"]
-    ?.takeIf { it.isNotBlank() }
-    ?.let(::file)
-if (releaseBuildRequested && releaseKeystore?.isFile != true) {
-    throw GradleException("Android release keystore is not a readable file.")
-}
 
 android {
     namespace = "com.xengineer.speakup"
@@ -65,20 +52,10 @@ android {
         }
     }
 
-    signingConfigs {
-        if (missingReleaseSigningVariables.isEmpty()) {
-            create("release") {
-                storeFile = releaseKeystore
-                keyAlias = releaseSigningValues.getValue("SPEAKUP_ANDROID_KEY_ALIAS")
-                storePassword = releaseSigningValues.getValue("SPEAKUP_ANDROID_STORE_PASSWORD")
-                keyPassword = releaseSigningValues.getValue("SPEAKUP_ANDROID_KEY_PASSWORD")
-            }
-        }
-    }
-
     buildTypes {
         release {
-            signingConfig = signingConfigs.findByName("release")
+            // Release APKs are aligned and signed exactly once by sign.sh.
+            signingConfig = null
         }
     }
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.2+3
+version: 0.1.3+4
 
 environment:
   sdk: ^3.12.2

--- a/tools/android-release/sign.sh
+++ b/tools/android-release/sign.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" != "1" ]]; then
+  printf 'Usage: %s <unsigned-apk>\n' "$0" >&2
+  exit 2
+fi
+
+apk="$1"
+keystore="${SPEAKUP_ANDROID_KEYSTORE_PATH:-}"
+alias_name="${SPEAKUP_ANDROID_KEY_ALIAS:-}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "$script_dir/../.." && pwd)"
+
+if [[ ! -s "$apk" ]]; then
+  printf 'Unsigned Android APK is not a readable, non-empty file: %s\n' "$apk" >&2
+  exit 1
+fi
+if [[ ! -s "$keystore" ]]; then
+  printf '%s\n' 'SPEAKUP_ANDROID_KEYSTORE_PATH must name a readable, non-empty keystore.' >&2
+  exit 1
+fi
+if [[ -z "$alias_name" ]]; then
+  printf '%s\n' 'SPEAKUP_ANDROID_KEY_ALIAS is required.' >&2
+  exit 1
+fi
+if [[ -z "${SPEAKUP_ANDROID_STORE_PASSWORD:-}" ]]; then
+  printf '%s\n' 'SPEAKUP_ANDROID_STORE_PASSWORD is required.' >&2
+  exit 1
+fi
+if [[ -z "${SPEAKUP_ANDROID_KEY_PASSWORD:-}" ]]; then
+  printf '%s\n' 'SPEAKUP_ANDROID_KEY_PASSWORD is required.' >&2
+  exit 1
+fi
+
+find_android_tool() {
+  local tool_name="$1"
+  local sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+  local local_properties="$repo_dir/mobile/android/local.properties"
+  local candidate
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return
+  fi
+  if [[ -z "$sdk_root" && -f "$local_properties" ]]; then
+    sdk_root="$(sed -n 's/^sdk.dir=//p' "$local_properties")"
+  fi
+  if [[ -z "$sdk_root" || ! -d "$sdk_root/build-tools" ]]; then
+    printf 'Cannot locate Android SDK build-tools for %s.\n' "$tool_name" >&2
+    return 1
+  fi
+  candidate="$(
+    find "$sdk_root/build-tools" -type f -name "$tool_name" -print |
+      LC_ALL=C sort |
+      tail -n 1
+  )"
+  if [[ -z "$candidate" ]]; then
+    printf 'Cannot locate Android SDK tool: %s.\n' "$tool_name" >&2
+    return 1
+  fi
+  printf '%s\n' "$candidate"
+}
+
+ensure_java_runtime() {
+  local flutter_config
+  local flutter_jdk
+
+  if java -version >/dev/null 2>&1; then
+    return
+  fi
+  if ! command -v flutter >/dev/null 2>&1; then
+    printf '%s\n' 'Java is required by apksigner.' >&2
+    return 1
+  fi
+  flutter_config="$(flutter config --machine)"
+  flutter_jdk="$(
+    printf '%s\n' "$flutter_config" |
+      sed -n 's/^[[:space:]]*"jdk-dir": "\([^"]*\)".*/\1/p'
+  )"
+  if [[ -z "$flutter_jdk" || ! -x "$flutter_jdk/bin/java" ]]; then
+    printf '%s\n' 'Cannot locate the JDK configured for Flutter.' >&2
+    return 1
+  fi
+  export JAVA_HOME="$flutter_jdk"
+  export PATH="$JAVA_HOME/bin:$PATH"
+}
+
+zipalign="$(find_android_tool zipalign)"
+apksigner="$(find_android_tool apksigner)"
+ensure_java_runtime
+
+if "$apksigner" verify "$apk" >/dev/null 2>&1; then
+  printf '%s\n' 'Release APK must be unsigned before explicit signing.' >&2
+  exit 1
+fi
+
+umask 077
+signing_directory="$(mktemp -d "$(dirname "$apk")/.speakup-apk-signing.XXXXXX")"
+aligned_apk="$signing_directory/aligned.apk"
+signed_apk="$signing_directory/signed.apk"
+cleanup_signing_directory() {
+  rm -f "$aligned_apk" "$signed_apk" "$signed_apk.idsig"
+  rmdir "$signing_directory" 2>/dev/null || true
+}
+trap cleanup_signing_directory EXIT
+
+"$zipalign" -P 16 -f 4 "$apk" "$aligned_apk" >/dev/null
+"$zipalign" -c -P 16 4 "$aligned_apk" >/dev/null
+"$apksigner" sign \
+  --ks "$keystore" \
+  --ks-key-alias "$alias_name" \
+  --ks-pass env:SPEAKUP_ANDROID_STORE_PASSWORD \
+  --key-pass env:SPEAKUP_ANDROID_KEY_PASSWORD \
+  --v4-signing-enabled false \
+  --out "$signed_apk" \
+  "$aligned_apk"
+"$apksigner" verify --verbose "$signed_apk" >/dev/null
+"$zipalign" -c -P 16 4 "$signed_apk" >/dev/null
+
+chmod 0644 "$signed_apk"
+mv -f "$signed_apk" "$apk"
+cleanup_signing_directory
+trap - EXIT
+
+printf 'signedApk=%s\n' "$apk"

--- a/tools/android-release/sign.test.sh
+++ b/tools/android-release/sign.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temporary_directory="$(mktemp -d)"
+readonly fake_bin="$temporary_directory/bin"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p "$fake_bin"
+printf '%s\n' 'fixture keystore' > "$temporary_directory/release.jks"
+printf '%s\n' 'unsigned fixture apk' > "$temporary_directory/speakup.apk"
+
+cat > "$fake_bin/java" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$fake_bin/zipalign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "-c" ]]; then
+  [[ -s "${@: -1}" ]]
+  exit
+fi
+cp "${@: -2:1}" "${@: -1}"
+EOF
+cat > "$fake_bin/apksigner" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+command="$1"
+shift
+if [[ "$command" == "verify" ]]; then
+  grep -Fqx 'signed fixture apk' "${@: -1}"
+  exit
+fi
+[[ "$command" == "sign" ]]
+[[ " $* " == *" --ks-pass env:SPEAKUP_ANDROID_STORE_PASSWORD "* ]]
+[[ " $* " == *" --key-pass env:SPEAKUP_ANDROID_KEY_PASSWORD "* ]]
+[[ " $* " == *" --ks-key-alias speakup-release "* ]]
+output=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "--out" ]]; then
+    output="$2"
+    break
+  fi
+  shift
+done
+[[ -n "$output" ]]
+printf '%s\n' 'signed fixture apk' > "$output"
+EOF
+chmod +x "$fake_bin/java" "$fake_bin/zipalign" "$fake_bin/apksigner"
+
+report="$(
+  PATH="$fake_bin:$PATH" \
+    JAVA_HOME="$temporary_directory" \
+    SPEAKUP_ANDROID_KEYSTORE_PATH="$temporary_directory/release.jks" \
+    SPEAKUP_ANDROID_KEY_ALIAS=speakup-release \
+    SPEAKUP_ANDROID_STORE_PASSWORD=fixture-store-password \
+    SPEAKUP_ANDROID_KEY_PASSWORD=fixture-key-password \
+    "$script_directory/sign.sh" "$temporary_directory/speakup.apk"
+)"
+grep -Fqx "signedApk=$temporary_directory/speakup.apk" <<< "$report"
+grep -Fqx 'signed fixture apk' "$temporary_directory/speakup.apk"
+
+if PATH="$fake_bin:$PATH" \
+  JAVA_HOME="$temporary_directory" \
+  SPEAKUP_ANDROID_KEYSTORE_PATH="$temporary_directory/release.jks" \
+  SPEAKUP_ANDROID_KEY_ALIAS=speakup-release \
+  SPEAKUP_ANDROID_STORE_PASSWORD=fixture-store-password \
+  SPEAKUP_ANDROID_KEY_PASSWORD=fixture-key-password \
+  "$script_directory/sign.sh" "$temporary_directory/speakup.apk" \
+    > "$temporary_directory/already-signed.out" 2>&1; then
+  printf '%s\n' 'An already signed APK was signed again.' >&2
+  exit 1
+fi
+grep -Fq \
+  'Release APK must be unsigned before explicit signing.' \
+  "$temporary_directory/already-signed.out"
+
+printf '%s\n' 'unsigned fixture apk' > "$temporary_directory/missing-secret.apk"
+if PATH="$fake_bin:$PATH" \
+  JAVA_HOME="$temporary_directory" \
+  SPEAKUP_ANDROID_KEYSTORE_PATH="$temporary_directory/release.jks" \
+  SPEAKUP_ANDROID_STORE_PASSWORD=fixture-store-password \
+  SPEAKUP_ANDROID_KEY_PASSWORD=fixture-key-password \
+  "$script_directory/sign.sh" "$temporary_directory/missing-secret.apk" \
+    > "$temporary_directory/missing-secret.out" 2>&1; then
+  printf '%s\n' 'Signing succeeded without an Android key alias.' >&2
+  exit 1
+fi
+grep -Fq 'SPEAKUP_ANDROID_KEY_ALIAS is required.' "$temporary_directory/missing-secret.out"
+
+printf '%s\n' 'Android explicit signer tests passed'

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -130,7 +130,7 @@ fi
 certificate_sha256="$(
   printf '%s\n' "$signature_report" |
     sed -n -E \
-      's/^Signer (#[0-9]+|\(.*\)) certificate SHA-256 digest:[[:space:]]*(.*)$/\2/p' |
+      's/^.*certificate SHA-256 digest:[[:space:]]*([0-9A-Fa-f:]+)[[:space:]]*$/\1/p' |
     tr '[:upper:]' '[:lower:]' |
     sed 's/[[:space:]:]//g' |
     LC_ALL=C sort -u
@@ -150,6 +150,10 @@ expected_certificate_sha256="$(
     'APK signer certificate output is missing or contains multiple certificates.' >&2
   printf 'Observed signer certificate SHA-256 values: %s\n' \
     "${certificate_sha256:-<none>}" >&2
+  printf 'apksigner: %s\n' "$apksigner" >&2
+  "$apksigner" --version >&2 2>/dev/null || true
+  printf '%s\n' "$signature_report" |
+    sed -n '/certificate SHA-256 digest:/p' >&2
   exit 1
 }
 [[ "$certificate_sha256" == "$expected_certificate_sha256" ]] || {

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -130,7 +130,7 @@ fi
 certificate_sha256="$(
   printf '%s\n' "$signature_report" |
     sed -n -E \
-      's/^Signer (#[0-9]+|\([^)]*\)) certificate SHA-256 digest:[[:space:]]*(.*)$/\2/p' |
+      's/^Signer (#[0-9]+|\(.*\)) certificate SHA-256 digest:[[:space:]]*(.*)$/\2/p' |
     tr '[:upper:]' '[:lower:]' |
     sed 's/[[:space:]:]//g' |
     LC_ALL=C sort -u

--- a/tools/android-release/verify.sh
+++ b/tools/android-release/verify.sh
@@ -129,10 +129,11 @@ if printf '%s\n' "$signature_report" | grep -Eq 'certificate DN:.*CN=Android Deb
 fi
 certificate_sha256="$(
   printf '%s\n' "$signature_report" |
-    sed -n 's/^Signer #1 certificate SHA-256 digest: //p' |
-    head -n 1 |
+    sed -n -E \
+      's/^Signer (#[0-9]+|\([^)]*\)) certificate SHA-256 digest:[[:space:]]*(.*)$/\2/p' |
     tr '[:upper:]' '[:lower:]' |
-    tr -d '[:space:]:'
+    sed 's/[[:space:]:]//g' |
+    LC_ALL=C sort -u
 )"
 expected_certificate_sha256="$(
   printf '%s' "$expected_certificate_sha256" |
@@ -144,8 +145,16 @@ expected_certificate_sha256="$(
   printf '%s\n' 'SPEAKUP_ANDROID_CERT_SHA256 must contain 64 hexadecimal digits.' >&2
   exit 1
 }
+[[ "$certificate_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+  printf '%s\n' \
+    'APK signer certificate output is missing or contains multiple certificates.' >&2
+  printf 'Observed signer certificate SHA-256 values: %s\n' \
+    "${certificate_sha256:-<none>}" >&2
+  exit 1
+}
 [[ "$certificate_sha256" == "$expected_certificate_sha256" ]] || {
   printf '%s\n' 'APK signing certificate SHA-256 does not match the approved certificate.' >&2
+  printf 'Observed signer certificate SHA-256: %s\n' "$certificate_sha256" >&2
   exit 1
 }
 

--- a/tools/android-release/verify.test.sh
+++ b/tools/android-release/verify.test.sh
@@ -16,7 +16,7 @@ cat > "$fake_bin/apksigner" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' \
   'Signer #1 certificate SHA-256 digest: $certificate_sha256' \
-  'Signer (minSdkVersion=24, maxSdkVersion=2147483647) certificate SHA-256 digest: $certificate_sha256'
+  'Signer (minSdkVersion=35 (dev release=true), maxSdkVersion=2147483647) certificate SHA-256 digest: $certificate_sha256'
 EOF
 cat > "$fake_bin/java" <<'EOF'
 #!/usr/bin/env bash

--- a/tools/android-release/verify.test.sh
+++ b/tools/android-release/verify.test.sh
@@ -14,7 +14,9 @@ printf '%s\n' 'name: speakup' 'version: 0.1.0+1' > "$temporary_directory/pubspec
 
 cat > "$fake_bin/apksigner" <<EOF
 #!/usr/bin/env bash
-printf '%s\n' 'Signer #1 certificate SHA-256 digest: $certificate_sha256'
+printf '%s\n' \
+  'Signer #1 certificate SHA-256 digest: $certificate_sha256' \
+  'Signer (minSdkVersion=24, maxSdkVersion=2147483647) certificate SHA-256 digest: $certificate_sha256'
 EOF
 cat > "$fake_bin/java" <<'EOF'
 #!/usr/bin/env bash
@@ -64,5 +66,26 @@ if PATH="$fake_bin:$PATH" \
   exit 1
 fi
 grep -Fq 'Unexpected minimum Android API: 23' "$temporary_directory/rejected.out"
+
+write_aapt 24
+cat > "$fake_bin/apksigner" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' \
+  'Signer #1 certificate SHA-256 digest: $certificate_sha256' \
+  'Signer (minSdkVersion=24, maxSdkVersion=2147483647) certificate SHA-256 digest: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+EOF
+chmod +x "$fake_bin/apksigner"
+if PATH="$fake_bin:$PATH" \
+  SPEAKUP_ANDROID_CERT_SHA256="$certificate_sha256" \
+  "$script_directory/verify.sh" \
+    "$temporary_directory/speakup.apk" \
+    "$temporary_directory/pubspec.yaml" \
+    > "$temporary_directory/multiple-signers.out" 2>&1; then
+  printf '%s\n' 'APK with multiple signer certificates was accepted.' >&2
+  exit 1
+fi
+grep -Fq \
+  'APK signer certificate output is missing or contains multiple certificates.' \
+  "$temporary_directory/multiple-signers.out"
 
 printf '%s\n' 'Android release verifier tests passed'

--- a/tools/android-release/verify.test.sh
+++ b/tools/android-release/verify.test.sh
@@ -16,7 +16,7 @@ cat > "$fake_bin/apksigner" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' \
   'Signer #1 certificate SHA-256 digest: $certificate_sha256' \
-  'Signer (minSdkVersion=35 (dev release=true), maxSdkVersion=2147483647) certificate SHA-256 digest: $certificate_sha256'
+  'Current signer for SDK range 35-2147483647 certificate SHA-256 digest: $certificate_sha256'
 EOF
 cat > "$fake_bin/java" <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
## 功能描述

修复 `v0.1.2` Release Candidate 在 GitHub Runner 上最终 APK signer 与批准证书不一致的问题，并将下一候选版本提升为 `0.1.3+4`。

正式 APK 改为确定性单次签名流程：Gradle/Flutter 只生成 unsigned APK，随后先执行 `zipalign -P 16`，再由官方 `apksigner` 使用受保护 keystore 显式签名。普通 Release 入口保持 fail closed。

## 已验证事实与根因边界

- `v0.1.2` 的 keystore alias、store/key password 与批准证书指纹前置校验均通过，但 GitHub Runner 的最终 Staging APK signer 不一致。
- 同一精确源码和加密备份在本机无法复现 mismatch；Flutter 可稳定生成 unsigned APK。
- 当前没有证据把历史故障归因于权限、JDK、证书损坏、`pub get` 顺序或 Flutter 输出复制。
- 本 PR 不宣称定位了历史 Runner 的单一根因；它通过移除 Gradle 隐式签名边界来消除该不确定性。

## 实现思路

- Release build type 不再绑定 Gradle `signingConfig`，只输出 unsigned APK。
- Makefile 专用目标先验证 keystore，再构建、P16 对齐、显式签名并执行批准证书与产物校验。
- `sign.sh` 拒绝已签名输入，密码仅通过环境变量传给 `apksigner`，中间文件使用私有临时目录并清理。
- Gradle 根据实际 task graph 拦截所有旁路 Release 任务，包括 flavor 聚合 `assemble` / `bundle` 入口。
- Required Quality gate 新增 Ubuntu 24.04 一次性 fixture JKS，对 Staging/Production 两份真实 APK 执行完整构建与验签；fixture 不上传、不持久化。
- `v0.1.2` Tag 不移动、不复用，下一次发布使用 `v0.1.3`。

## 可复现测试

- `make check-android-release-guard`
- `make check-release-candidate`
- `bash -n tools/android-release/sign.sh tools/android-release/sign.test.sh`
- `./tools/android-release/sign.test.sh`
- `./tools/android-release/verify-keystore.test.sh`
- `./tools/android-release/verify.test.sh`
- `git diff --check`
- Ruby 解析 `quality.yml` 与 `release-candidate.yml`
- 同一 Gradle daemon：带内部 flag 的 unsigned Release dry-run 成功，随后不带 flag 明确失败
- 聚合任务 `assembleStaging`、`assembleProduction`、`bundleStaging`、`bundleProduction` 均命中 fail-closed guard

PR CI 还会在干净 Ubuntu Runner 上构建并验证两份 fixture APK；CI 全绿前不视为完成。

Closes #892
