### PR TITLE
fix(asr): 修正新加坡实时识别端点

### DIFF
--- a/server/internal/providers/qianwen/speech_recognizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime.go
@@ -434,7 +434,7 @@ func realtimeASREndpoint(baseURL string) string {
 	} else {
 		parsed.Scheme = "ws"
 	}
-	parsed.Path = "/api-ws/v1/inference/"
+	parsed.Path = "/api-ws/v1/inference"
 	parsed.RawQuery = "heartbeat=true"
 	return parsed.String()
 }

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -247,7 +247,7 @@ func (observer *recordingTranscriptionObserver) Updates() []protocol.Transcripti
 func TestRealtimeEndpointDerivesFromDashScopeHTTPBase(t *testing.T) {
 	t.Parallel()
 	got := realtimeASREndpoint("https://dashscope.aliyuncs.com/api/v1")
-	if got != "wss://dashscope.aliyuncs.com/api-ws/v1/inference/?heartbeat=true" {
+	if got != "wss://dashscope.aliyuncs.com/api-ws/v1/inference?heartbeat=true" {
 		t.Fatalf("endpoint = %q", got)
 	}
 }


### PR DESCRIPTION
## 功能描述

修复新加坡百炼工作空间的实时 ASR：当前适配器生成的 WebSocket 路径带有尾斜杠，Provider 会在 `task-started` 后返回 `InvalidParameter`。

## 实现思路

- 将推导路径从 `/api-ws/v1/inference/` 改为 `/api-ws/v1/inference`；
- 同步更新端点单元测试，防止尾斜杠回归；
- 不修改模型、环境变量、16 KiB 分块、音频节流或其他 Provider 行为。

## 可复现测试

```bash
make check-go
```

结果：`go vet ./...` 与 `go test -count=1 ./...` 全部通过。

使用新加坡生产同配置执行仓库真实适配器 live test：

```bash
QIANWEN_ASR_LIVE_TEST=1 \
  go test ./internal/providers/qianwen \
  -run '^TestLiveSpeechRecognition$' -v -count=1 -timeout=8m
```

结果：WebSocket 握手成功，收到 `task-started`、非空转写和 `task-finished`；3.50625 秒、16 kHz WAV 正常完成。测试未输出 API Key 或转写原文。

单变量对照还确认：保留尾斜杠时稳定失败；仅去掉尾斜杠后，快发与节流均成功。因此无需修改生产配置或音频分块。

Closes #896
