### PR TITLE
release: 发布 v0.1.4 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.3+4
+version: 0.1.4+5
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 功能描述

为已合入 `dev` 的新加坡实时 ASR 修复准备不可变 v0.1.4 候选版本，避免覆盖已经发布的 v0.1.3 Tag 和制品。

## 实现思路

- 将 Flutter `versionName` 从 `0.1.3` 升为 `0.1.4`；
- 将 Android `versionCode` 从 `4` 升为 `5`；
- 不修改 Portal、签名证书、application ID、API 域名或其他业务代码。

## 可复现测试

```bash
make check-release-candidate
```

结果：

- Android keystore verifier、显式签名和 APK verifier 测试通过；
- Release Candidate 共 31 个契约测试通过；
- 版本号/Tag、versionCode 单调递增、manifest、Quality Workflow 和离线制品契约均通过。

## 后续发布

本 PR 合入 `dev` 后，将以 `dev -> main` 的发布 PR 完成最终审核；合入 `main` 后才创建不可变 `v0.1.4` Tag 并触发正式 Release Candidate Workflow。

Closes #898
