### PR TITLE
release: promote v0.1.4 to main

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.3+4
+version: 0.1.4+5
 
 environment:
   sdk: ^3.12.2

--- a/server/internal/providers/qianwen/speech_recognizer_realtime.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime.go
@@ -434,7 +434,7 @@ func realtimeASREndpoint(baseURL string) string {
 	} else {
 		parsed.Scheme = "ws"
 	}
-	parsed.Path = "/api-ws/v1/inference/"
+	parsed.Path = "/api-ws/v1/inference"
 	parsed.RawQuery = "heartbeat=true"
 	return parsed.String()
 }

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -247,7 +247,7 @@ func (observer *recordingTranscriptionObserver) Updates() []protocol.Transcripti
 func TestRealtimeEndpointDerivesFromDashScopeHTTPBase(t *testing.T) {
 	t.Parallel()
 	got := realtimeASREndpoint("https://dashscope.aliyuncs.com/api/v1")
-	if got != "wss://dashscope.aliyuncs.com/api-ws/v1/inference/?heartbeat=true" {
+	if got != "wss://dashscope.aliyuncs.com/api-ws/v1/inference?heartbeat=true" {
 		t.Fatalf("endpoint = %q", got)
 	}
 }


### PR DESCRIPTION
## 发布范围

将当前官方 `dev` 提升到 `main`，作为 `v0.1.4` 的唯一候选源。

GitHub `main...dev` 的内容 diff 已核对，只有 3 个文件各 1 行变更：

- #897：去掉新加坡实时 ASR WebSocket inference 路径的尾斜杠，并更新精确端点测试；
- #899：Android 版本从 `0.1.3+4` 递增为 `0.1.4+5`。

## 发布约束

- 合并前必须获得真实 Approval，且当前 head 的最终 Quality gate 必须成功；
- 合并后核对 `main` merge commit、tree 与 `0.1.4+5`，再创建一次性 annotated Tag `v0.1.4`；
- Tag 不移动、不删除、不复用，v0.1.3 及其制品保持不变；
- Release Candidate 必须从 Tag 构建固定 digest 镜像、两份正式签名 APK 和 manifest；
- 不使用 `latest`，不在服务器临时重建；
- 本 PR 不部署 Staging 或 Production，也不更新生产公开下载入口。

## 已有验证

### 实时 ASR

- 同一生产配置、模型、16 kHz WAV 和分块方式的单变量对照，带尾斜杠稳定返回 `InvalidParameter`；去掉尾斜杠后收到 10 次 `result-generated`、`task-finished`，转写非空；
- 仓库真实适配器 live test 通过；
- `make check-go`：`go vet ./...` 和 `go test -count=1 ./...` 全部通过；
- #897 已获 Approval，所有 PR checks 通过后合入 `dev`。

### 版本与 Android 制品契约

- `make check-release-candidate`：3 个 Android 签名校验与 31 个 RC 契约测试通过；
- #899 的 Flutter、覆盖率、Staging/Production 两份真实签名 APK fixture 和最终 Quality gate 全部通过；
- #899 已获 Approval 后合入 `dev`。

Closes #900
Related #896
Related #898
Related #897
Related #899
