### PR TITLE
docs(repo): clarify agent review and simulator rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,10 @@
 - `upstream` 必须指向官方主仓 `https://github.com/1024XEngineer/XE3-ESL.git`，`origin` 指向个人 Fork；禁止直接推送官方 `dev` 或 `main`。
 - 每项改动先创建范围单一、验收清楚且关联当前 Milestone 的 Issue；一个 Issue 对应一个从最新 `upstream/dev` 创建的短分支和一个 PR。
 - 保留用户未提交的代码；主工作区不干净或存在并行任务时使用独立 worktree。
-- 涉及移动端交互或视觉验证时，启动前将当前任务分支更新到最新 `upstream/dev` 并保留当前修改，然后从同一 worktree 运行 `make dev-ios-simulator`；使用真实后端，模拟器禁用数字人。
-- iOS 模拟器因代理无法访问 OSS 时，仅在当前 worktree 的本地 `.env` 中设置 `OSS_ENABLED=0` 和 `RESUME_OCR_ENABLED=0`，不得提交该配置或改用 mock。
+- 涉及移动端交互或视觉验证时，启动前将当前任务分支更新到最新 `upstream/dev` 并保留当前修改，然后从同一 worktree 运行 `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`；iOS 模拟器统一使用本地端口 `18082` 启动真实后端，并禁用数字人。
 - 只修改当前 Issue 范围，优先复用现有组件及官方或主流实现，不提交密钥、`.env`、缓存、构建产物或无关文件。
-- Commit 使用 `<type>(<scope>): <subject>`；PR 必须包含功能描述、实现思路、可复现测试和关联 Issue，默认邀请 `gangcaiyoule`、`jyqin0203`、`zhiwilliam1-cell`、`Scorbunny2`、`Lq0412`；合入前，相关分析、测试、构建和契约校验通过，Reviewer 可复现，Review 意见已解决且范围一致，AI 修改经人工检查且提交者能够解释。
+- 设计与实现应以正确、可持续的领域模型和长期演进方向为先，不得为迁就当前代码限制而采用需要未来推翻的妥协方案；“最小设计”只指在正确方向上的最小完整实现。
+- 首次给出架构、领域模型、协议、流程或关键技术方案前，必须先审查当前代码与文档，并联网对照官方资料及 GitHub 主流实现完成审核；明确区分已验证事实、推断与设计取舍，不得先交付未经审核、可能误导决策的半成品方案，再事后补充验证或推翻。
+- Commit 使用 `<type>(<scope>): <subject>`；PR 必须包含功能描述、实现思路、可复现测试和关联 Issue，默认邀请 `gangcaiyoule`、`jyqin0203`、`Scorbunny2`；合入前，相关分析、测试、构建和契约校验通过，Reviewer 可复现，Review 意见已解决且范围一致，AI 修改经人工检查且提交者能够解释。
 - 提 PR 后必须检查 CI 和 Review；CI 未全部通过或 Review 尚有未解决意见时，只能报告实际状态，不得宣称完成。
 - 视觉改动除非已明确要求直接提交，否则先启动并截图确认；PR 合并后关闭对应 Issue、同步个人 Fork，并仅删除当前任务创建且确认干净、已同步的分支和 worktree。


### PR DESCRIPTION
## 功能描述

- 统一 iOS 模拟器视觉验收使用本地 `18082` 真实后端并禁用数字人。
- 移除关闭 OSS/OCR 的代理例外，避免验收范围随本地网络条件漂移。
- 增加关键方案的代码、文档与外部资料审查要求。
- 明确可持续领域模型与最小完整设计边界。
- 更新默认 Reviewer 邀请名单。

## 实现思路

仅修改根级 `AGENTS.md`，把当前团队采用的执行边界收敛为稳定的仓库级规则；不修改脚本、业务代码、CI 或部署配置。

## 可复现测试

1. `git diff --check upstream/dev...HEAD`
2. `git diff --stat upstream/dev...HEAD`
3. 核对 `tools/ios-simulator-dev/run.sh`：支持 `SPEAKUP_DEV_PORT`，并使用真实后端及 `SPEAKUP_AVATAR_ENABLED=false`。

预期：无空白错误；仅 `AGENTS.md` 发生 4 行新增、3 行删除。

Closes #903

